### PR TITLE
Fix werkzeug by recursively finding python sources

### DIFF
--- a/third_party/werkzeug.BUILD
+++ b/third_party/werkzeug.BUILD
@@ -8,7 +8,7 @@ exports_files(["LICENSE"])
 # Note: this library includes test code. Consider creating a testonly target.
 py_library(
     name = "werkzeug",
-    srcs = glob(["werkzeug/*.py"]),
+    srcs = glob(["werkzeug/**/*.py"]),
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Fixes the following error:
ImportError: No module named debug.tbtools