### PR TITLE
Remove the "new" label from the runs selector

### DIFF
--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -43,14 +43,7 @@ Properties out:
       <div inner-h-t-m-l="{{_breakString(logdir)}}"></div>
     </paper-dialog>
     <div id="top-text">
-      <h3 id="tooltip-help" class="tooltip-container">
-        Runs<!--
-        - TODO(wchargin): Remove the "new" notice when we remove the old
-        - selector. This is just so that we can tell them apart.
-        -->&#x2003;<span
-          style="text-transform:uppercase;color:red;font-size:smaller"
-        >new</span>
-      </h3>
+      <h3 id="tooltip-help" class="tooltip-container">Runs</h3>
     </div>
     <tf-multi-checkbox
       id="multiCheckbox"


### PR DESCRIPTION
Summary:
Now that we've removed the `tf-sidebar-helper`, the new runs selector is
the only runs selector in use. Thus, we can remove the "new" label, as
we no longer need to tell it apart from anything else.

Test Plan:
Run TensorBoard, and look at the scalars and images dashboards. They
should each have a functioning runs selector that uses the Polymer
component tf-runs-selector (not tf-run-selector), and this component
should not have a bright red "new" label.