### PR TITLE
Make Travis go faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
+dist: trusty
+sudo: required
+
 language: python
 python:
   - "2.7"
   - "3.4"
-# trusty beta image has jdk8, gcc4.8.4
-dist: trusty
-sudo: required
 
 os:
   - linux
@@ -12,11 +12,15 @@ os:
 env:
   - BAZEL=0.5.1 TF=NIGHTLY
 
+cache:
+  directories:
+    - $HOME/.bazel-output-base
+
 before_install:
   - |
     set -e
     BAZEL_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-installer-linux-x86_64.sh"
-    wget -O install.sh "${BAZEL_URL}"
+    wget -t 3 -O install.sh "${BAZEL_URL}"
     chmod +x install.sh
     ./install.sh --user
     rm -f install.sh
@@ -40,20 +44,45 @@ before_install:
 script:
   - |
     bazel \
-      --output_base=$HOME/.cache/bazel \
+      --output_base="${HOME}/.bazel-output-base" \
+      --batch \
+      --host_jvm_args=-Xmx500m \
+      --host_jvm_args=-Xms500m \
+      build \
+      tensorboard/... \
+      --worker_verbose \
+      --verbose_failures \
+      --spawn_strategy=sandboxed \
+      --genrule_strategy=sandboxed \
+      --local_resources=400,2,1.0 \
+      --worker_max_instances=2 \
+      --strategy=Javac=worker \
+      --strategy=Closure=worker
+  - |
+    bazel \
+      --output_base="${HOME}/.bazel-output-base" \
       --batch \
       --host_jvm_args=-Xmx500m \
       --host_jvm_args=-Xms500m \
       test \
       tensorboard/... \
-      --worker_verbose \
       --verbose_failures \
       --test_output=errors \
       --spawn_strategy=sandboxed \
-      --genrule_strategy=sandboxed \
-      --local_resources=400,2,1.0 \
-      --strategy=Javac=worker \
-      --strategy=Closure=worker
+      --local_resources=400,2,1.0
+
+before_cache:
+  - |
+    find "${HOME}/.bazel-output-base" \
+      -name \*.runfiles -print0 \
+      -or -name \*.tar.gz -print0 \
+      -or -name \*-execroot.json -print0 \
+      -or -name \*-tsc.json -print0 \
+      -or -name \*-params.pbtxt -print0 \
+      -or -name \*-args.txt -print0 \
+      -or -name \*.runfiles_manifest -print0 \
+      -or -name \*.server_params.pbtxt -print0 \
+      | xargs -0 rm -rf
 
 notifications:
   email: false


### PR DESCRIPTION
Since we're compiling things like protobuf from scratch, it makes a lot of sense to cache the blaze-bin directories. This really plays to Bazel's strengths, which is that it solves the cache invalidation problem.

Results: Rather than taking 8 minutes, Travis now takes somewhere between two minutes and eight minutes. The [proof is in the pudding](https://travis-ci.org/tensorflow/tensorboard/builds/243572006).