### PR TITLE
Remove TensorBoard framework from scalar dashboard

### DIFF
--- a/tensorboard/components/tf_card_heading/BUILD
+++ b/tensorboard/components/tf_card_heading/BUILD
@@ -1,0 +1,22 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "ts_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+ts_web_library(
+    name = "tf_card_heading",
+    srcs = [
+        "tf-card-heading.html",
+    ],
+    path = "/tf-card-heading",
+    deps = [
+        "//tensorboard/components/tf_imports:polymer",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    tags = ["notsan"],
+)

--- a/tensorboard/components/tf_card_heading/tf-card-heading.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading.html
@@ -1,0 +1,80 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<link rel="import" href="../polymer/polymer.html">
+
+<!--
+  A compact heading to appear above a single visualization, often
+  corresponding to either a single tag or a single run-tag combination.
+
+  Properties:
+    `title` does just what it says on the tin.
+    `color` can be set to display a colored border at the left of the
+        card; if left unset, no border will be displayed:
+    Any contents of the heading will be rendered below the title, and
+        can be used to display a subtitle, some small control widgets,
+        or similar.
+-->
+<dom-module id="tf-card-heading">
+  <template>
+    <div class="title-container" style="border-color: [[_borderColor]]">
+      <div
+        class="title"
+        inner-h-t-m-l="[[_break(title)]]"></div>
+      <div class="content">
+        <content></content>
+      </div>
+    </div>
+    <style>
+      .title-container {
+        border-left: 4px solid;
+        padding-left: 5px;
+        margin-bottom: 10px;
+      }
+      .title {
+        font-size: 14px;
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
+      .content {
+        font-size: 12px;
+      }
+    </style>
+  </template>
+  <script>
+    Polymer({
+      is: "tf-card-heading",
+      properties: {
+        title: String,
+        color: {
+          type: String,
+          value: null,   // this property is optional
+        },
+        _borderColor: {
+          type: String,
+          computed: '_computeBorderColor(color)',
+          readOnly: true,
+        },
+      },
+      _computeBorderColor(color) {
+        return color || 'rgba(255, 255, 255, 0.0)';  // 100% transparent white
+      },
+      _break: function(input) {
+        return input.replace(/([\/_-])/g, "$1<wbr>")
+      },
+    });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/scalars/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalars/tf_scalar_dashboard/BUILD
@@ -7,12 +7,14 @@ licenses(["notice"])  # Apache 2.0
 ts_web_library(
     name = "tf_scalar_dashboard",
     srcs = [
+        "tf-scalar-chart.html",
         "tf-scalar-dashboard.html",
         "tf-smoothing-input.html",
     ],
     path = "/tf-scalar-dashboard",
     deps = [
         "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_card_heading",
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:lodash",

--- a/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-chart.html
+++ b/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-chart.html
@@ -1,0 +1,261 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
+<link rel="import" href="../tf-card-heading/tf-card-heading.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../vz-line-chart/vz-line-chart.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+
+<!--
+  A component that fetches scalar data from the TensorBoard server and
+  renders it into a vz-line-chart.
+-->
+<dom-module id="tf-scalar-chart">
+  <template>
+    <!--
+      Uncomment these to test the behavior of tf-card-heading.
+      They render like this:
+          card expanded:  http://i.imgur.com/Q7lbvxk.png
+          not expanded:   http://i.imgur.com/M38yshU.png
+      (In the "not expanded" one, the vz-line-chart is way too small,
+      but that's just because the headings take up too much space. It
+      doesn't indicate any problems with the headings.)
+    -->
+    <!--
+    <tf-card-heading title="[[tag]]" color="red">
+      I'm a subtitle, for testing.
+    </tf-card-heading>
+    <tf-card-heading title="[[tag]]" color="blue">
+      Look, I'm like the image dashboard. It's also fine if my content becomes really exorbitantly wide. Nothing to see here.<br />
+      step <strong>500</strong><br />
+      <input type="range" style="width: 100%"></input>
+    </tf-card-heading>
+    -->
+    <tf-card-heading title="[[tag]]"></tf-card-heading>
+    <vz-line-chart
+      x-type="[[xType]]"
+      color-scale="[[_runsColorScale]]"
+      smoothing-enabled="[[smoothingEnabled]]"
+      smoothing-weight="[[smoothingWeight]]"
+      tooltip-sorting-method="[[tooltipSortingMethod]]"
+      ignore-y-outliers="[[ignoreYOutliers]]"
+    ></vz-line-chart>
+    <div style="display: flex; flex-direction: row;">
+      <paper-icon-button
+        selected$="[[_expanded]]"
+        icon="fullscreen"
+        on-tap="_toggleExpanded"
+      ></paper-icon-button>
+      <paper-icon-button
+        selected$="[[_logScaleActive]]"
+        icon="line-weight"
+        on-tap="_toggleLogScale"
+        title="Toggle y-axis log scale"
+      ></paper-icon-button>
+      <span style="flex-grow: 1"></span>
+      <template is="dom-if" if="[[showDownloadLinks]]">
+        <div class="download-links">
+          <paper-dropdown-menu
+            no-label-float="true"
+            label="run to download"
+            selected-item-label="{{_runToDownload}}"
+          >
+            <paper-menu class="dropdown-content">
+              <template is="dom-repeat" items="[[runs]]">
+                <paper-item no-label-float=true>[[item]]</paper-item>
+              </template>
+            </paper-menu>
+          </paper-dropdown-menu>
+          <a
+            download="run_[[_runToDownload]]-tag-[[tag]].csv"
+            href="[[_csvUrl(_runToDownload)]]"
+          >CSV</a> <a
+            download="run_[[_runToDownload]]-tag-[[tag]].json"
+            href="[[_jsonUrl(_runToDownload)]]"
+          >JSON</a>
+          </div>
+        </div>
+      </template>
+    </div>
+    <style>
+      :host {
+        height: 235px;
+        width: 330px;
+        margin: 5px;
+        display: flex;
+        flex-direction: column;
+      }
+      :host[_expanded] {
+        height: 400px;
+        width: 100%;
+      }
+      vz-line-chart {
+        -webkit-user-select: none;
+        -moz-user-select: none;
+      }
+      paper-icon-button {
+        color: #2196F3;
+        border-radius: 100%;
+        pointer-events: auto;  /* TODO(wchargin): why? */
+        width: 32px;
+        height: 32px;
+        padding: 4px;
+      }
+      paper-icon-button[selected] {
+        background: var(--tb-ui-light-accent);
+      }
+
+      .download-links {
+        display: flex;
+        height: 32px;
+      }
+      .download-links a {
+        font-size: 10px;
+        align-self: center;
+        margin: 2px;
+      }
+      .download-links paper-dropdown-menu {
+        width: 100px;
+        --paper-input-container-label: {
+          font-size: 10px;
+        }
+        --paper-input-container-input: {
+          font-size: 10px;
+        }
+      }
+    </style>
+  </template>
+  <script>
+    import {Canceller} from '../tf-backend/canceller';
+    import {getRouter} from '../tf-backend/router';
+    import {runsColorScale} from '../tf-color-scale/colorScale';
+
+    /** @enum {string} */ const X_TYPE = {
+      STEP: 'step',
+      RELATIVE: 'relative',
+      WALL: 'wall',
+    };
+
+    Polymer({
+      is: 'tf-scalar-chart',
+      properties: {
+        runs: Array,  // of String
+        tag: String,
+
+        /** @type {X_TYPE} */ xType: String,
+        smoothingEnabled: Boolean,
+        smoothingWeight: Number,
+        tooltipSortingMethod: String,
+        ignoreYOutliers: Boolean,
+        showDownloadLinks: Boolean,
+
+        requestManager: Object,
+
+        _logScaleActive: {
+          type: Boolean,
+          observer: '_logScaleChanged',
+        },
+
+        _expanded: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,  // for CSS
+        },
+
+        _runsColorScale: {
+          type: Object,
+          value: () => ({scale: runsColorScale}),
+        },
+
+        _canceller: {
+          type: Object,
+          value: () => new Canceller(),
+        },
+
+        // Usage: this._scalarUrl('tag', 'run') yields the URL to the
+        // scalar data for the appropriate run and tag.
+        _scalarUrl: {
+          type: Function,
+          value: () => getRouter().pluginRunTagRoute('scalars', '/scalars'),
+        },
+      },
+      observers: [
+        'reload(tag)',
+        '_changeSeries(runs.*)'
+      ],
+      attached() {
+        this._attached = true;
+        this._changeSeries();
+      },
+      reload() {
+        if (!this._attached) {
+          return;
+        }
+        //
+        // Before updating, cancel any network-pending updates, to
+        // prevent race conditions where older data stomps newer data.
+        this._canceller.cancelAll();
+        this.runs.forEach(run => {
+          const url = this._scalarUrl(this.tag, run);
+          const updateSeries = this._canceller.cancellable(result => {
+            if (result.cancelled) {
+              return;
+            }
+            const data = result.value;
+            const formattedData = data.map(datum => ({
+              wall_time: new Date(datum[0] * 1000),
+              step: datum[1],
+              scalar: datum[2],
+            }));
+            this.$$('vz-line-chart').setSeriesData(run, formattedData);
+          });
+          this.requestManager.request(url).then(updateSeries);
+        });
+      },
+      _changeSeries() {
+        this.$$('vz-line-chart').setVisibleSeries(this.runs);
+        this.reload();
+      },
+      redraw() {
+        this.$$('vz-line-chart').redraw();
+      },
+
+      _toggleLogScale() {
+        this.set('_logScaleActive', !this._logScaleActive);
+      },
+      _logScaleChanged(logScaleActive) {
+        var chart = this.$$('vz-line-chart');
+        chart.yScaleType = logScaleActive ? 'log' : 'linear';
+        this.redraw();
+      },
+
+      _toggleExpanded(e) {
+        this.set('_expanded', !this._expanded);
+        this.redraw();
+      },
+
+      _csvUrl(run) {
+        return this._scalarUrl(this.tag, run) + '&format=csv';
+      },
+      _jsonUrl(run) {
+        return this._scalarUrl(this.tag, run);
+      },
+    });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -16,48 +16,42 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="tf-scalar-chart.html">
 <link rel="import" href="tf-smoothing-input.html">
+<link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
+<link rel="import" href="../paper-item/paper-item.html">
+<link rel="import" href="../paper-menu/paper-menu.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
-<link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
-<link rel="import" href="../tf-dashboard-common/tf-panes-helper.html">
-<link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 <link rel="import" href="../tf-imports/lodash.html">
-<link rel="import" href="../vz-line-chart/vz-line-chart.html">
-<link rel="import" href="../iron-collapse/iron-collapse.html">
-<link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
-<link rel="import" href="../paper-icon-button/paper-icon-button.html">
-<link rel="import" href="../paper-menu/paper-menu.html">
-<link rel="import" href="../paper-item/paper-item.html">
+<link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 
 <!--
-tf-scalar-dashboard is a complete frontend that loads runs from a backend,
-and creates chart panes that display data for those runs.
-
-It provides a categorizer, run selector, and x type selector, by which the user
-can customize how data is organized and displayed.
-
-Each chart has a button that can toggle whether it is "expanded"; expanded
-charts are larger.
+  A frontend that displays a set of tf-scalar-charts, each of which
+  represents the time series for a particular tag. This dashboard
+  provides a categorizer, run selector, and abcissa selector, by which
+  the user can customize how data is organized and displayed.
 -->
 <dom-module id="tf-scalar-dashboard">
   <template>
     <tf-dashboard-layout>
       <div class="sidebar">
         <div class="sidebar-section">
-          <tf-categorizer tags="[[tags]]" categories="{{_categories}}">
+          <!--
+            TODO(wchargin): Remove the categorizer. Replace it with a
+            search/filter bar in the main content pane.
+          -->
+          <tf-categorizer tags="[[_tags]]" categories="{{_categories}}">
           </tf-categorizer>
           <div class="line-item">
             <paper-checkbox
-            id="download-option"
-            checked="{{_showDownloadLinks}}"
+              checked="{{_showDownloadLinks}}"
             >Show data download links</paper-checkbox>
           </div>
           <div class="line-item">
             <paper-checkbox
-            id="outliersCheckbox"
-            checked="{{_ignoreYOutliers}}"
+              checked="{{_ignoreYOutliers}}"
             >Ignore outliers in chart scaling</paper-checkbox>
           </div>
           <div id="tooltip-sorting">
@@ -65,7 +59,7 @@ charts are larger.
             <paper-dropdown-menu
               no-label-float
               selected-item-label="{{_tooltipSortingMethod}}"
-              >
+            >
               <paper-menu class="dropdown-content" selected="0">
                 <paper-item>default</paper-item>
                 <paper-item>descending</paper-item>
@@ -81,17 +75,17 @@ charts are larger.
             step="0.001"
             min="0"
             max="1"
-            ></tf-smoothing-input>
+          ></tf-smoothing-input>
         </div>
         <div class="sidebar-section">
           <tf-option-selector
-            id="xTypeSelector"
+            id="x-type-selector"
             name="Horizontal Axis"
             selected-id="{{_xType}}"
-            >
-            <paper-button id="step">step</paper-button>
-            <paper-button id="relative">relative</paper-button>
-            <paper-button id="wall_time">wall</paper-button>
+          >
+            <paper-button id="step">step</paper-button><!--
+            --><paper-button id="relative">relative</paper-button><!--
+            --><paper-button id="wall_time">wall</paper-button>
           </tf-option-selector>
         </div>
         <div class="sidebar-section">
@@ -100,147 +94,143 @@ charts are larger.
         </div>
       </div>
       <div class="center">
-        <tf-panes-helper
-          categories="[[_categories]]"
-          data-type="[[dataType]]"
-          data-provider="[[dataProvider]]"
-          data-not-found="[[dataNotFound]]"
-          run2tag="[[run2tag]]"
-          selected-runs="[[_selectedRuns]]"
-          show-download-links="[[_showDownloadLinks]]"
-          download-link-url-function="[[scalarUrl]]"
-        >
-          <template>
-            <vz-line-chart
-              x-type="[[_xType]]"
-              color-scale="[[_runsColorScale]]"
-              smoothing-enabled="[[_smoothingEnabled]]"
-              smoothing-weight="[[_smoothingWeight]]"
-              tooltip-sorting-method="[[_tooltipSortingMethod]]"
-              ignore-y-outliers="[[_ignoreYOutliers]]"
-              ></vz-line-chart>
-            <paper-icon-button
-              class="log-button"
-              icon="line-weight"
-              on-tap="toggleLogScale"
-              title="Toggle y-axis log scale"
-              ></paper-icon-button>
-          </template>
-        </tf-panes-helper>
+        <template is="dom-if" if="[[_dataNotFound]]">
+          <div class="no-data-warning">
+            <h3>No scalar data was found.</h3>
+            <p>Probable causes:</p>
+            <ul>
+              <li>You haven’t written any scalar data to your event files.
+              <li>TensorBoard can’t find your event files.
+            </ul>
+            <p>
+            If you’re new to using TensorBoard, and want to find out how
+            to add data and set up your event files, check out the
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md">README</a>
+            and perhaps the <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard">TensorBoard tutorial</a>.
+            <p>
+            If you think TensorBoard is configured properly, please see
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong">the section of the README devoted to missing data problems</a>
+            and consider filing an issue on GitHub.
+          </div>
+        </template>
+        <!--
+          TODO(wchargin): Consider the extent to which this logic should
+          be extracted to framework code. I think that `_categoryCards`
+          should certainly be extracted and given a better name, but
+          perhaps we don't even need `tf-foreach-run` and
+          `tf-foreach-run-tag`: plugins can simply use a `dom-repeat`
+          over the output of the library-extracted `_categoryCards`
+          function.
+        -->
+        <template is="dom-repeat" items="[[_categories]]" as="category">
+          <tf-collapsable-pane
+            name="[[category.name]]"
+            count="[[_count(category.tags, _selectedRuns.*)]]"
+          >
+            <div class="layout horizontal wrap">
+              <template
+                is="dom-repeat"
+                items="[[_categoryCards(
+                    category, _selectedRuns.*, _runToTag.*)]]"
+              >
+                <tf-scalar-chart
+                  x-type="[[_xType]]"
+                  smoothing-enabled="[[_smoothingEnabled]]"
+                  smoothing-weight="[[_smoothingWeight]]"
+                  tooltip-sorting-method="[[_tooltipSortingMethod]]"
+                  ignore-y-outliers="[[_ignoreYOutliers]]"
+                  show-download-links="[[_showDownloadLinks]]"
+                  request-manager="[[_requestManager]]"
+                  runs="[[item.runs]]"
+                  tag="[[item.tag]]"
+                ></tf-scalar-chart>
+              </template>
+            </div>
+          </tf-collapsable-pane>
+        </template>
       </div>
     </tf-dashboard-layout>
 
     <style include="dashboard-style"></style>
     <style>
-      .log-button {
-        position: absolute;
-        left: 35px;
-        bottom: -35px;
-        color: #2196F3;
-        background: #fff;
-        width: 32px;
-        height: 32px;
-        padding: 4px;
-        border-radius: 100%;
-      }
-
-      .log-button-selected {
-        background: var(--tb-ui-light-accent);
-      }
-
       #tooltip-sorting {
         display: flex;
         font-size: 14px;
         margin-top: 5px;
       }
-
       #tooltip-sorting-label {
         margin-top: 13px;
-        margin-left: 28px;
       }
-
       #tooltip-sorting paper-dropdown-menu {
         margin-left: 10px;
         --paper-input-container-focus-color: var(--tb-orange-strong);
         width: 105px;
       }
+      #x-type-selector paper-button {
+        margin: 5px 3px;
+      }
       .line-item {
         display: block;
         padding-top: 5px;
       }
-
-      .sidebar-section {
-        border-top: solid 1px rgba(0, 0, 0, 0.12);
-        padding: 20px 0px 20px 30px;
+      .no-data-warning {
+        max-width: 540px;
+        margin: 80px auto 0 auto;
       }
     </style>
   </template>
 
   <script>
-    import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior";
-    import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior";
-    import {BackendBehavior} from "../tf-backend/behavior";
-    import {getRouter} from "../tf-backend/router";
-    import {runsColorScale} from "../tf-color-scale/colorScale";
-    import * as storage from "../tf-storage/storage";
+    import {RequestManager} from '../tf-backend/requestManager';
+    import {getTags} from '../tf-backend/backend';
+    import {getRouter} from '../tf-backend/router';
+    import * as storage from '../tf-storage/storage';
+
+    /** @enum {string} */ const X_TYPE = {
+      STEP: 'step',
+      RELATIVE: 'relative',
+      WALL: 'wall',
+    };
 
     Polymer({
-      is: "tf-scalar-dashboard",
-      behaviors: [
-        DashboardBehavior("scalars"),
-        ReloadBehavior("tf-chart-scaffold"),
-        BackendBehavior,
-      ],
+      is: 'tf-scalar-dashboard',
       properties: {
-        backend: Object,
-        dataType: {
-          type: String,
-          value: "scalar"
-        },
-        scalarUrl: {
-          type: Function,
-          value: function() {
-            return getRouter().pluginRunTagRoute('scalars', '/scalars');
-          },
-        },
         _showDownloadLinks: {
           type: Boolean,
           notify: true,
           value: storage.getBooleanInitializer('_showDownloadLinks', false, true),
-          observer: '_showDownloadLinksObserver'
+          observer: '_showDownloadLinksObserver',
         },
         _smoothingWeight: {
           type: Number,
           notify: true,
           value: storage.getNumberInitializer('_smoothingWeight', 0.6),
-          observer: '_smoothingWeightObserver'
+          observer: '_smoothingWeightObserver',
         },
         _smoothingEnabled: {
           type: Boolean,
-          computed: '_computeSmoothingEnabled(_smoothingWeight)'
+          computed: '_computeSmoothingEnabled(_smoothingWeight)',
         },
         _ignoreYOutliers: {
           type: Boolean,
           value: storage.getBooleanInitializer('_ignoreYOutliers', true, true),
           observer: '_ignoreYOutliersObserver',
         },
+        /** @type {X_TYPE} */
         _xType: {
           type: String,
-          value: "step"
+          value: X_TYPE.STEP,
         },
-        _runsColorScale: {
+
+        _selectedRuns: Array,
+        _tags: Array,       // string[]
+        _runToTag: Object,  // map<run: string, tags: string[]>
+        _dataNotFound: Boolean,
+
+        _requestManager: {
           type: Object,
-          value: function() {
-            return {
-              scale: runsColorScale,
-            };
-          },
+          value: () => new RequestManager(50),
         },
-      },
-      attached: function() {
-        this.async(function() {
-          this.fire("rendered");
-        });
       },
       _showDownloadLinksObserver: storage.getBooleanObserver(
           '_showDownloadLinks', /*default=*/ false, /*useLocalStorage=*/ true),
@@ -248,17 +238,51 @@ charts are larger.
           '_smoothingWeight', 0.6),
       _ignoreYOutliersObserver: storage.getBooleanObserver(
           '_ignoreYOutliers', /*default=*/ true, /*useLocalStorage=*/true),
-      _computeSmoothingEnabled: function(_smoothingWeight) {
+      _computeSmoothingEnabled(_smoothingWeight) {
         return _smoothingWeight > 0;
       },
-      toggleLogScale: function(e) {
-        var currentTarget = Polymer.dom(e.currentTarget);
-        var button = currentTarget.parentNode.querySelector('.log-button');
-        var chart = currentTarget.parentNode.querySelector('vz-line-chart');
 
-        button.classList.toggle("log-button-selected");
-        chart.yScaleType = chart.yScaleType === 'log' ? 'linear' : 'log';
-        chart.redraw();
+
+      // DESTINATION: Similar code to be written in each plugin.
+      ready() {
+        this.reload();
+      },
+      reload() {
+        this._fetchTags().then(() => {
+          this._reloadCharts();
+        });
+      },
+      _fetchTags() {
+        const url = getRouter().pluginRoute('scalars', '/tags');
+        return this._requestManager.request(url).then(runToTag => {
+          if (_.isEqual(runToTag, this._runToTag)) {
+            // No need to update anything if there are no changes.
+            return;
+          }
+          const tags = getTags(runToTag);
+          this.set('_tags', tags);
+          this.set('_dataNotFound', tags.length === 0);
+          this.set('_runToTag', runToTag);
+        });
+      },
+      _reloadCharts() {
+        this.querySelectorAll('tf-scalar-chart').forEach(chart => {
+          chart.reload();
+        });
+      },
+
+      // DESTINATION: To be pulled out into framework code.
+      _categoryCards(category) {
+        const cards = [];
+        category.tags.forEach(tag => {
+          const runs = this._selectedRuns.filter(r =>
+            (this._runToTag[r] || []).indexOf(tag) !== -1);
+          cards.push({tag, runs});
+        });
+        return cards;
+      },
+      _count(tags) {
+        return tags.length;
       },
     });
   </script>


### PR DESCRIPTION
Summary:
This commit rewrites the scalars dashboard so that it does not have any
essential dependencies on TensorBoard framework components like
`tf-panes-helper`. There are two purposes to this commit: first, this
commit enables us to inspect where the essential complexities of the
dashboard are and better evaluate what parts might merit being pulled
into framework code; second, it will be far easier to implement new
framework code if we do not have to tear the old stuff down at the same
time.

I have marked some sections with `// DESTINATION` comments when I think
that they should be pulled into framework components. Other than those,
the resulting code is complete and functional.

Test Plan:
Run TensorBoard on a directory with ample scalar summaries. Most data
bindings have been rewired, so be sure to check that things like
download links and the abscissa selector still work. Basically, press
all the buttons on the scalars dashboard! No need to check other
dashboards; their code was not changed.

Also run a log directory with no scalar summaries (`/tmp/askdfwie` will
probably work) to test the no-data message.