### PR TITLE
Remove all `factoryImpl`s

### DIFF
--- a/tensorboard/components/tf_audio_dashboard/tf-audio-dashboard.html
+++ b/tensorboard/components/tf_audio_dashboard/tf-audio-dashboard.html
@@ -65,9 +65,6 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
 
     Polymer({
       is: "tf-audio-dashboard",
-      factoryImpl: function(backend) {
-        this.backend = backend;
-      },
       properties: {
         dataType: {
           type: Object,

--- a/tensorboard/components/tf_distribution_dashboard/tf-distribution-dashboard.html
+++ b/tensorboard/components/tf_distribution_dashboard/tf-distribution-dashboard.html
@@ -101,9 +101,6 @@ contains vz-distribution-charts embedded inside tf-panes-helper's.
 
     Polymer({
       is: "tf-distribution-dashboard",
-      factoryImpl: function(backend) {
-        this.backend = backend;
-      },
       behaviors: [
         DashboardBehavior("distributions"),
         ReloadBehavior("tf-chart-scaffold"),

--- a/tensorboard/components/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/components/tf_graph_dashboard/tf-graph-dashboard.html
@@ -113,10 +113,6 @@ import {compareTagNames} from "../vz-sorting/sorting";
 
 Polymer({
   is: 'tf-graph-dashboard',
-  factoryImpl: function(backend, debuggerDataEnabled) {
-    this.backend = backend;
-    this.debuggerDataEnabled = debuggerDataEnabled;
-  },
   behaviors: [
     DashboardBehavior("graphs"),
     ReloadBehavior("tf-graph-dashboard"),

--- a/tensorboard/components/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/components/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -121,9 +121,6 @@ contains vz-histogram-timeseries embedded inside tf-panes-helper's.
 
     Polymer({
       is: "tf-histogram-dashboard",
-      factoryImpl: function(backend) {
-        this.backend = backend;
-      },
       behaviors: [
         DashboardBehavior("histograms"),
         ReloadBehavior("tf-chart-scaffold"),

--- a/tensorboard/components/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/components/tf_image_dashboard/tf-image-dashboard.html
@@ -106,9 +106,6 @@ tf-image-dashboard displays a dashboard that loads images from a TensorFlow run.
 
     Polymer({
       is: "tf-image-dashboard",
-      factoryImpl: function(backend) {
-        this.backend = backend;
-      },
       properties: {
         backend: Object,
         dataType: {

--- a/tensorboard/components/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/components/tf_profile_dashboard/tf-profile-dashboard.html
@@ -94,9 +94,6 @@ profile run can have multiple tools that present the performance profile as diff
 
   Polymer({
     is: "tf-profile-dashboard",
-    factoryImpl: function(backend) {
-      this.backend = backend;
-    },
     behaviors: [
       DashboardBehavior("profile"),
       ReloadBehavior("tf-profile-dashboard"),

--- a/tensorboard/components/tf_text_dashboard/tf-text-dashboard.html
+++ b/tensorboard/components/tf_text_dashboard/tf-text-dashboard.html
@@ -79,9 +79,6 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
 
     Polymer({
       is: "tf-text-dashboard",
-      factoryImpl: function(backend) {
-        this.backend = backend;
-      },
       properties: {
         backend: Object,
         dataType: {


### PR DESCRIPTION
Summary:
The `factoryImpl` method is called when the constructor of a Polymer
component is invoked. The constructor is the object returned by the call
to `Polymer({...})`. But we always immediately discard this constructor,
so the constructor is never called and these functions are unused.

I remember that these were a significant red herring when I was first
looking at the code base. We should remove them to prevent further
confusion.

Test Plan:
I loaded TensorBoard with enough logdirs to provide data from all
dashboards, then tested that the basic functionality of each dashboard
still worked.