### PR TITLE
Correct path for assets to be relative to the tensorboard directory

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -379,8 +379,14 @@ def get_tensorboard_tag():
 def hacky_loader(path):
   """Load an asset from the tensorboard directory, in a platform-generic way."""
   try:
-    return tf.resource_loader.load_resource(path)
+    # load_resource fetches resources relative to the tensorflow directory.
+    # Thus, we must go down 1 level (into the tensorboard directory). This case
+    # usually applies for running within Google.
+    return tf.resource_loader.load_resource(os.path.join('tensorboard', path))
   except IOError:
+    # We may be trying to load resources relative to the directory containing
+    # the TensorBoard binary (like in most of the open source world). Fetch the
+    # resource locally.
     tensorboard_root = os.path.join(os.path.dirname(__file__), os.pardir)
     path = os.path.join(tensorboard_root, path)
     path = os.path.abspath(path)


### PR DESCRIPTION
Previously, the hacky_loader had loaded assets such as the TAG file relative to the tensorflow directory when tf.resource_loader.load_resource was to be used. This resulted in the file not being found and thus TensorBoard failing to start up when running in certain self-contained environments.