### PR TITLE
Clean up the scalars dashboard

### DIFF
--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -63,18 +63,6 @@ describe('backend tests', () => {
     });
   });
 
-  it('scalars are loaded properly', (done) => {
-    backend.scalar('cross_entropy (1)', 'run1').then((s) => {
-      // just check the data got reformatted properly
-      const aScalar = s[s.length - 1];
-      assertIsDatum(aScalar);
-      chai.assert.isNumber(aScalar.scalar);
-      // verify date conversion works
-      chai.assert.equal(aScalar.wall_time.valueOf(), 40000);
-      done();
-    });
-  });
-
   it('histograms are loaded properly', (done) => {
     backend.histogram('histo1', 'run1').then((histos) => {
       const histo = histos[0];
@@ -116,7 +104,6 @@ describe('backend tests', () => {
   });
 
   it('run helper methods work', (done) => {
-    const scalar = {run1: ['cross_entropy (1)'], fake_run_no_data: ['scalar2']};
     const image = {run1: ['im1'], fake_run_no_data: ['im1', 'im2']};
     const audio = {run1: ['audio1'], fake_run_no_data: ['audio1', 'audio2']};
     const runMetadata = {run1: ['step99'], fake_run_no_data: ['step99']};
@@ -128,10 +115,6 @@ describe('backend tests', () => {
         done();
       }
     }
-    backend.scalarTags().then((x) => {
-      chai.assert.deepEqual(x, scalar);
-      next();
-    });
     backend.imageTags().then((x) => {
       chai.assert.deepEqual(x, image);
       next();

--- a/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-chart.html
+++ b/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-chart.html
@@ -28,25 +28,6 @@ limitations under the License.
 -->
 <dom-module id="tf-scalar-chart">
   <template>
-    <!--
-      Uncomment these to test the behavior of tf-card-heading.
-      They render like this:
-          card expanded:  http://i.imgur.com/Q7lbvxk.png
-          not expanded:   http://i.imgur.com/M38yshU.png
-      (In the "not expanded" one, the vz-line-chart is way too small,
-      but that's just because the headings take up too much space. It
-      doesn't indicate any problems with the headings.)
-    -->
-    <!--
-    <tf-card-heading title="[[tag]]" color="red">
-      I'm a subtitle, for testing.
-    </tf-card-heading>
-    <tf-card-heading title="[[tag]]" color="blue">
-      Look, I'm like the image dashboard. It's also fine if my content becomes really exorbitantly wide. Nothing to see here.<br />
-      step <strong>500</strong><br />
-      <input type="range" style="width: 100%"></input>
-    </tf-card-heading>
-    -->
     <tf-card-heading title="[[tag]]"></tf-card-heading>
     <vz-line-chart
       x-type="[[xType]]"

--- a/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -240,7 +240,6 @@ limitations under the License.
       },
 
 
-      // DESTINATION: Similar code to be written in each plugin.
       ready() {
         this.reload();
       },
@@ -270,7 +269,6 @@ limitations under the License.
       _makeCategories(runToTag, selectedRuns, tagGroupRegexes) {
         return categorizeTags(runToTag, selectedRuns, tagGroupRegexes);
       },
-
     });
   </script>
 </dom-module>


### PR DESCRIPTION
Summary:
This commit removes references to scalars from `backend.ts` and related
tests, and also removes temporary comments from the scalars dashboard.

Test Plan:
`bazel test //tensorboard/...` and interact with the TensorBoard
dashboard.

wchargin-branch: clean-up-scalars-dashboard