### PR TITLE
Bring the image dashboard into the new world

### DIFF
--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -79,16 +79,6 @@ describe('backend tests', () => {
     });
   });
 
-  it('images are loaded properly', (done) => {
-    backend.image('im1', 'run1').then((images) => {
-      const image = images[0];
-      assertIsDatum(image);
-      chai.assert.isNumber(image.width);
-      chai.assert.isNumber(image.height);
-      done();
-    });
-  });
-
   it('audio is loaded properly', (done) => {
     backend.audio('audio1', 'run1').then((audioClips) => {
       const audio = audioClips[0];
@@ -104,7 +94,6 @@ describe('backend tests', () => {
   });
 
   it('run helper methods work', (done) => {
-    const image = {run1: ['im1'], fake_run_no_data: ['im1', 'im2']};
     const audio = {run1: ['audio1'], fake_run_no_data: ['audio1', 'audio2']};
     const runMetadata = {run1: ['step99'], fake_run_no_data: ['step99']};
     const graph = ['fake_run_no_data'];
@@ -115,10 +104,6 @@ describe('backend tests', () => {
         done();
       }
     }
-    backend.imageTags().then((x) => {
-      chai.assert.deepEqual(x, image);
-      next();
-    });
     backend.audioTags().then((x) => {
       chai.assert.deepEqual(x, audio);
       next();

--- a/tensorboard/plugins/images/tf_image_dashboard/BUILD
+++ b/tensorboard/plugins/images/tf_image_dashboard/BUILD
@@ -13,6 +13,7 @@ ts_web_library(
     path = "/tf-image-dashboard",
     deps = [
         "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_categorization_utils",
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:d3",

--- a/tensorboard/plugins/images/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/plugins/images/tf_image_dashboard/tf-image-dashboard.html
@@ -17,15 +17,14 @@ limitations under the License.
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-dialog/paper-dialog.html">
-<link rel="import" href="../paper-icon-button/paper-icon-button.html">
-<link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
-<link rel="import" href="../tf-dashboard-common/tf-panes-helper.html">
+<link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 <link rel="import" href="tf-image-loader.html">
 
 <!--
-tf-image-dashboard displays a dashboard that loads images from a TensorFlow run.
+tf-image-dashboard displays a dashboard that loads images from a
+TensorFlow run.
 -->
 <dom-module id="tf-image-dashboard">
   <template>
@@ -33,11 +32,8 @@ tf-image-dashboard displays a dashboard that loads images from a TensorFlow run.
     <tf-dashboard-layout>
       <div class="sidebar">
         <div class="sidebar-section">
-          <tf-categorizer
-            id="categorizer"
-            tags="[[tags]]"
-            categories="{{_categories}}"
-          ></tf-categorizer>
+          <tf-regex-group regexes="{{_tagGroupRegexes}}">
+          </tf-regex-group>
         </div>
         <div class="sidebar-section">
           <tf-runs-selector
@@ -47,105 +43,138 @@ tf-image-dashboard displays a dashboard that loads images from a TensorFlow run.
         </div>
       </div>
       <div class="center">
-        <tf-panes-helper
-          categories="[[_categories]]"
-          data-type="[[dataType]]"
-          data-provider="[[dataProvider]]"
-          data-not-found="[[dataNotFound]]"
-          run2tag="[[run2tag]]"
-          selected-runs="[[_selectedRuns]]"
-          repeat-for-runs
+        <template is="dom-if" if="[[_dataNotFound]]">
+          <div class="no-data-warning">
+            <h3>No image data was found.</h3>
+            <p>Probable causes:</p>
+            <ul>
+              <li>You haven’t written any image data to your event files.
+              <li>TensorBoard can’t find your event files.
+            </ul>
+            <p>
+            If you’re new to using TensorBoard, and want to find out how
+            to add data and set up your event files, check out the
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md">README</a>
+            and perhaps the <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard">TensorBoard tutorial</a>.
+            <p>
+            If you think TensorBoard is configured properly, please see
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong">the section of the README devoted to missing data problems</a>
+            and consider filing an issue on GitHub.
+          </div>
+        </template>
+        <template is="dom-repeat" items="[[_categories]]" as="category">
+          <tf-collapsable-pane
+            name="[[category.name]]"
+            count="[[category.count]]"
           >
-          <template>
-            <tf-image-loader></tf-image-loader>
-            <paper-icon-button
-              class="actual-size-button"
-              icon="aspect-ratio"
-              on-tap="_showActualSize"
-              title="Show the image at its true pixel size"
-              ></paper-icon-button>
-          </template>
-        </tf-panes-helper>
+            <div class="layout horizontal wrap">
+              <template
+                is="dom-repeat"
+                items="[[category.items]]"
+              >
+                <tf-image-loader
+                  run="[[item.run]]"
+                  tag="[[item.tag]]"
+                  request-manager="[[_requestManager]]"
+                  show-actual-size="[[_showActualSize]]"
+                ></tf-image-loader>
+              </template>
+            </div>
+          </tf-collapsable-pane>
+        </template>
       </div>
     </tf-dashboard-layout>
     <style include="dashboard-style"></style>
     <style>
-      tf-panes-helper {
-        --card-width: 340px;
-        --card-height: auto;
-        --card-expanded-width: 700px;
-        --card-expanded-height: auto;
-      }
-
-      .actual-size-button {
-        background: #fff;
-        border-radius: 100%;
-        bottom: -35px;
-        color: #2196f3;
-        height: 32px;
-        left: 35px;
-        padding: 4px;
-        pointer-events: auto;
-        position: absolute;
-        width: 32px;
-      }
-
-      .actual-size-button-selected {
-        background: var(--tb-ui-light-accent);
-      }
-
-      #actual-image-size-dialog {
-        overflow: auto;
+      .no-data-warning {
+        max-width: 540px;
+        margin: 80px auto 0 auto;
       }
     </style>
   </template>
   <script>
-    import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior";
-    import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior";
-    import {BackendBehavior} from "../tf-backend/behavior";
+    "use strict";
+
+    import {RequestManager} from '../tf-backend/requestManager';
+    import {getTags} from '../tf-backend/backend';
+    import {getRouter} from '../tf-backend/router';
+    import {categorizeRunTagCombinations} from '../tf-categorization-utils/categorizationUtils';
 
     Polymer({
-      is: "tf-image-dashboard",
+      is: 'tf-image-dashboard',
       properties: {
-        backend: Object,
-        dataType: {
-          type: String,
-          value: "image"
+        _selectedRuns: Array,
+        _runToTag: Object,  // map<run: string, tags: string[]>
+        _dataNotFound: Boolean,
+
+        _categories: {
+          type: Array,
+          computed:
+            '_makeCategories(_runToTag, _selectedRuns, _tagGroupRegexes)',
+        },
+
+        _requestManager: {
+          type: Object,
+          value: () => new RequestManager(),
+        },
+        _showActualSize: {
+          type: Object,
+          readOnly: true,
+          value: function() {
+            return (imageNode) => {
+              // Create a full-size copy of the image.
+              const newImage = imageNode.cloneNode();
+              newImage.style.height = 'auto';
+              newImage.style.width = 'auto';
+              newImage.style.margin = 0;
+              newImage.style.padding = 0;
+              newImage.classList.add('actual-size-image');  // TODO(wchargin): Why?
+
+              // When the user clicks on the image, empty and close the dialog.
+              const dialog = this.$$('#actual-image-size-dialog');
+              newImage.addEventListener('click', () => {
+                dialog.close();
+              });
+
+              // Update dialog content. Show the dialog.
+              dialog.innerHTML = '';
+              dialog.appendChild(newImage);
+              dialog.open();
+            };
+          },
         },
       },
-      behaviors: [
-        DashboardBehavior("images"),
-        ReloadBehavior("tf-chart-scaffold"),
-        BackendBehavior,
-      ],
-      attached: function() {
-        this.async(function() {
-          this.fire("rendered");
+
+      ready() {
+        this.reload();
+      },
+      reload() {
+        this._fetchTags().then(() => {
+          this._reloadImages();
         });
       },
-      _showActualSize: function(e) {
-        var currentTarget = Polymer.dom(e.currentTarget);
-        var card = currentTarget.node.closest('.card');
-
-        // Create a full-size copy of the image.
-        var newImage = card.querySelector('#img').cloneNode();
-        newImage.style.height = 'auto';
-        newImage.style.width = 'auto';
-        newImage.style.margin = 0;
-        newImage.style.padding = 0;
-        newImage.classList.add("actual-size-image");
-
-        // When the user clicks on the image, empty and close the dialog.
-        var dialog = this.$$('#actual-image-size-dialog');
-        newImage.addEventListener('click', function() {
-          dialog.close();
+      _fetchTags() {
+        const url = getRouter().pluginRoute('images', '/tags');
+        return this._requestManager.request(url).then(runToTag => {
+          if (_.isEqual(runToTag, this._runToTag)) {
+            // No need to update anything if there are no changes.
+            return;
+          }
+          const tags = getTags(runToTag);
+          this.set('_dataNotFound', tags.length === 0);
+          this.set('_runToTag', runToTag);
         });
+      },
+      _reloadImages() {
+        this.querySelectorAll('tf-image-loader').forEach(image => {
+          image.reload();
+        });
+      },
 
-        // Update dialog content. Show the dialog.
-        dialog.innerHTML = '';
-        dialog.appendChild(newImage);
-        dialog.open();
-      }
+      _makeCategories(runToTag, selectedRuns, tagGroupRegexes) {
+        return categorizeRunTagCombinations(
+          runToTag, selectedRuns, tagGroupRegexes);
+      },
     });
   </script>
 </dom-module>

--- a/tensorboard/plugins/images/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/images/tf_image_dashboard/tf-image-loader.html
@@ -31,16 +31,15 @@ future for loading older images.
 -->
 <dom-module id="tf-image-loader">
   <template>
-    <div id="image-annotation">
+    <tf-card-heading title="[[tag]]" color="[[_runColor]]">
       <template is="dom-if" if="[[_hasAtLeastOneStep]]">
         step
-        <span class="step-value">
-          [[_stepValue]]
-        </span>
+        <span style="font-weight: bold">[[_stepValue]]</span>
         <template is="dom-if" if="[[_currentWallTime]]">
           ([[_currentWallTime]])
         </template>
-        <paper-spinner-lite active hidden$=[[!_isImageLoading]]></paper-spinner-lite>
+        <paper-spinner-lite active hidden$=[[!_isImageLoading]]>
+        </paper-spinner-lite>
       </template>
       <template is="dom-if" if="[[_hasMultipleSteps]]">
         <paper-slider
@@ -50,45 +49,55 @@ future for loading older images.
           max-markers="[[_maxStepIndex]]"
           snaps
           step="1"
-          value="{{_stepIndex}}"></paper-slider>
+          value="{{_stepIndex}}"
+        ></paper-slider>
       </template>
-    </div>
-
+    </tf-card-heading>
     <div id="main-image-container"></div>
+    <div style="display: flex; flex-direction: row;">
+      <paper-icon-button
+        selected$="[[_expanded]]"
+        icon="fullscreen"
+        on-tap="_toggleExpanded"
+      ></paper-icon-button>
+      <paper-icon-button
+        icon="aspect-ratio"
+        on-tap="_showActualSize"
+        title="Show the image at its true pixel size"
+      ></paper-icon-button>
+    </div>
 
     <style>
       :host {
         display: block;
-        width: 100%;
+        width: 330px;
         height: auto;
         position: relative;
         --step-slider-knob-color: #424242;
+        margin-right: 15px;
+        margin-bottom: 10px;
+      }
+      :host[_expanded] {
+        width: 700px;
       }
 
-      #image-annotation {
-        border-left: 4px solid;
-        padding-left: 5px;
-        font-size: 12px;
-        margin: -10px 0 10px 0;
-      }
-
-      #image-annotation .step-value {
-        font-weight: bold;
-      }
-
-      #image-annotation paper-spinner-lite {
+      paper-spinner-lite {
         width: 14px;
         height: 14px;
         vertical-align: text-bottom;
-        --paper-spinner-color: var(--tb-orange-strong)
+        --paper-spinner-color: var(--tb-orange-strong);
       }
 
       #steps {
         height: 15px;
         margin: 0 0 0 -15px;
-        /* 31 comes from adding a padding of 15px from both sides of the paper-slider, subtracting
-         * 1px so that the slider width aligns with the image (the last slider marker takes up 1px),
-         * and adding 2px to account for a border of 1px on both sides of the image. 30 - 1 + 2. */
+        /*
+         * 31 comes from adding a padding of 15px from both sides of the
+         * paper-slider, subtracting 1px so that the slider width aligns
+         * with the image (the last slider marker takes up 1px), and
+         * adding 2px to account for a border of 1px on both sides of
+         * the image. 30 - 1 + 2.
+         */
         width: calc(100% + 31px);
         --paper-slider-active-color: var(--step-slider-knob-color);
         --paper-slider-knob-color: var(--step-slider-knob-color);
@@ -107,25 +116,62 @@ future for loading older images.
         height: auto;
         max-height: 500px;
       }
+
+      paper-icon-button {
+        color: #2196F3;
+        border-radius: 100%;
+        pointer-events: auto;  /* TODO(wchargin): why? */
+        width: 32px;
+        height: 32px;
+        padding: 4px;
+      }
+      paper-icon-button[selected] {
+        background: var(--tb-ui-light-accent);
+      }
     </style>
   </template>
   <script>
     "use strict";
+    import {Canceller} from "../tf-backend/canceller";
+    import {getRouter} from "../tf-backend/router";
     import {runsColorScale} from "../tf-color-scale/colorScale";
+    import * as urlPathHelpers from "../tf-backend/urlPathHelpers";
 
     Polymer({
       is: "tf-image-loader",
       properties: {
         run: String,
-        // This is an array of Tensorboard Image&Datum objects (See backend.ts for details). The
-        // properties of objects in this array are
-        // {
+        tag: String,
+        showActualSize: Object,  // function: (img: Node) => void
+
+        _runColor: {
+          type: String,
+          computed: '_computeRunColor(run)',
+        },
+        _expanded: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,  // for CSS
+        },
+
+
+        requestManager: Object,
+        _metadataCanceller: {
+          type: Object,
+          value: () => new Canceller(),
+        },
+        _imageCanceller: {
+          type: Object,
+          value: () => new Canceller(),
+        },
+
+        // steps: {
         //   width: number,
         //   height: number,
         //   wall_time: Date,
         //   step: number,
         //   url: string,
-        // }
+        // }[]
         _steps: {
           type: Array,
           value: [],
@@ -155,11 +201,6 @@ future for loading older images.
           type: Number,
           computed: "_computeMaxStepIndex(_steps)",
         },
-        // We use a strictly increasing index to make sure that we don't settle on a stale image.
-        _currentImageLoadIndex: {
-          type: Number,
-          value: 1,
-        },
         _isImageLoading: {
           type: Boolean,
           value: false,
@@ -168,46 +209,97 @@ future for loading older images.
       observers: [
         "_updateImageUrl(_steps, _stepIndex)",
       ],
-      redraw: function() {
-        // Other dashboards logic requires a redraw method to be defined. redraw is called at
-        // various places such as when the image is expanded.
-        this.setSeriesData(this.run, this._steps);
-      },
-      setVisibleSeries: function(runs) {
-        // Do nothing.
-      },
-      setSeriesData: function(run, steps) {
-        this.set("run", run);
-        this.set("_steps", steps);
-        this.set("_stepIndex", steps.length - 1);
 
-        // Update the border color based on the run.
-        var color = runsColorScale(run);
-        this.$$("#image-annotation").style.borderColor = color;
+      _computeRunColor(run) {
+        return runsColorScale(run);
       },
-      _updateImageUrl: function(steps, stepIndex) {
-        // We manually change the image URL (instead of binding to the image's src attribute)
-        // because we would like to manage what happens when the image starts to / finishes loading.
+      _computeHasAtLeastOneStep(steps) {
+        return !!steps && steps.length > 0;
+      },
+      _computeHasMultipleSteps(steps) {
+        return !!steps && steps.length > 1;
+      },
+      _computeStepValue(stepIndex) {
+        return this._steps[stepIndex].step;
+      },
+      _computeCurrentWallTime(stepIndex) {
+        return this._steps[stepIndex].wall_time.toString();
+      },
+      _computeMaxStepIndex(steps) {
+        return steps.length - 1;
+      },
+
+      attached() {
+        this._attached = true;
+        this.reload();
+      },
+      reload() {
+        if (!this.attached) {
+          return;
+        }
+        this._metadataCanceller.cancelAll();
+        const router = getRouter();
+        const url =
+          router.pluginRunTagRoute("images", "/images")(this.tag, this.run);
+        const updateSteps = this._metadataCanceller.cancellable(result => {
+          if (result.cancelled) {
+            return;
+          }
+          const data = result.value;
+          const steps = data.map(this._createStepDatum.bind(this));
+          this.set("_steps", steps);
+          this.set("_stepIndex", steps.length - 1);
+        });
+        this.requestManager.request(url).then(updateSteps);
+      },
+      _createStepDatum(imageMetadata) {
+        const route = getRouter().pluginRoute('images', '/individualImage');
+        let query = imageMetadata.query;
+        if (route.indexOf('?') > -1) {
+          // The route already has GET parameters. Append ours.
+          query = '&' + query;
+        } else {
+          // The route lacks GET parameters. Just use ours.
+          query = '?' + query;
+        }
+        if (getRouter().isDemoMode()) {
+          query = urlPathHelpers.demoify(query);
+        }
+
+        let individualImageUrl = route + query;
+        if (getRouter().isDemoMode()) {
+          individualImageUrl += '.png';
+        } else {
+          // Include wall_time just to disambiguate the URL and force
+          // the browser to reload the image when the URL changes. The
+          // backend doesn't care about the value.
+          individualImageUrl += `&ts=${imageMetadata.wall_time}`;
+        }
+        return {
+          width: imageMetadata.width,
+          height: imageMetadata.height,
+          wall_time: new Date(imageMetadata.wall_time),
+          step: imageMetadata.step,
+          url: individualImageUrl,
+        };
+      },
+      _updateImageUrl(steps, stepIndex) {
+        // We manually change the image URL (instead of binding to the
+        // image's src attribute) because we would like to manage what
+        // happens when the image starts and stops loading.
         if (!steps.length) {
           return;
         }
 
-        let img = new Image();
-        img.id = "img"; // '#img' used to select the image in tf-image-dashboard.
-
-        const loadIndex = ++this._currentImageLoadIndex;
-        img.onload = img.onerror = (function() {
-          if (loadIndex != this._currentImageLoadIndex) {
-            // This load is no longer relevant.
+        const img = new Image();
+        this._imageCanceller.cancelAll();
+        img.onload = img.onerror = this._imageCanceller.cancellable(result => {
+          if (result.cancelled) {
             return;
           }
-
-          // The new image has finished loading. Remove the old image. Add the new one.
-          let mainImageContainer = this.$$("#main-image-container");
+          const mainImageContainer = this.$$("#main-image-container");
           mainImageContainer.innerHTML = "";
           Polymer.dom(mainImageContainer).appendChild(img);
-
-          // The image has finished loading (or has erred and failed to load).
           this.set("_isImageLoading", false);
         }).bind(this);
 
@@ -215,20 +307,13 @@ future for loading older images.
         this.set("_isImageLoading", true);
         img.src = steps[stepIndex].url;
       },
-      _computeHasAtLeastOneStep: function(steps) {
-        return !!steps && steps.length > 0;
+
+      _toggleExpanded(e) {
+        this.set('_expanded', !this._expanded);
       },
-      _computeHasMultipleSteps: function(steps) {
-        return !!steps && steps.length > 1;
-      },
-      _computeStepValue: function(stepIndex) {
-        return this._steps[stepIndex].step;
-      },
-      _computeCurrentWallTime: function(stepIndex) {
-        return this._steps[stepIndex].wall_time.toString();
-      },
-      _computeMaxStepIndex: function(steps) {
-        return steps.length - 1;
+      _showActualSize() {
+        const img = this.$$("#main-image-container img");
+        this.showActualSize(img);
       },
     });
   </script>


### PR DESCRIPTION
Summary:
This commit removes the image dashboard's dependencies on such old-style
framework components as `tf-panes-helper`, `tf-chart-scaffold`, and
`tf-categorizer`.

Test Plan:
Tested tag groups, run selection (shared with scalars and other
dashboards), expanding and collapsing panes, expanding and collapsing
cards (the individual images), showing actual size, and adjusting the
step slider. Also tested the view when there is no image data.

wchargin-branch: refactor-image-dashboard