### PR TITLE
Bring histograms back to the future

### DIFF
--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Backend, convertBins, filterTags, getRuns, getTags, RunToTag, TYPES} from '../backend';
+import {Backend, filterTags, getRuns, getTags, RunToTag, TYPES} from '../backend';
 import {RequestManager} from '../requestManager';
 import {createRouter, setRouter} from '../router';
 import {BAD_CHARACTERS, demoify, queryEncoder} from '../urlPathHelpers';
@@ -59,15 +59,6 @@ describe('backend tests', () => {
     const actualRuns = rm.request(demoRouter.runs());
     Promise.all([runsResponse, actualRuns]).then((values) => {
       chai.assert.deepEqual(values[0], values[1]);
-      done();
-    });
-  });
-
-  it('histograms are loaded properly', (done) => {
-    backend.histogram('histo1', 'run1').then((histos) => {
-      const histo = histos[0];
-      assertIsDatum(histo);
-      chai.assert.instanceOf(histo.bins, Array);
       done();
     });
   });
@@ -139,124 +130,4 @@ describe('backend tests', () => {
     chai.assert.deepEqual(getRuns(empty2), ['run1', 'run2']);
     chai.assert.deepEqual(getTags(empty2), []);
   });
-});
-
-describe('Verify that the histogram format conversion works.', () => {
-
-  function assertHistogramEquality(h1, h2) {
-    h1.forEach((b1, i) => {
-      const b2 = h2[i];
-      chai.assert.closeTo(b1.x, b2.x, 1e-10);
-      chai.assert.closeTo(b1.dx, b2.dx, 1e-10);
-      chai.assert.closeTo(b1.y, b2.y, 1e-10);
-    });
-  }
-
-  it('Throws and error if the inputs are of different lengths', () => {
-    chai.assert.throws(() => {
-      convertBins(
-          {bucketRightEdges: [0], bucketCounts: [1, 2], min: 1, max: 2}, 1, 2,
-          2);
-    }, 'Edges and counts are of different lengths.');
-  });
-
-  it('Handles data with no bins', () => {
-    chai.assert.deepEqual(
-        convertBins(
-            {bucketRightEdges: [], bucketCounts: [], min: 0, max: 0}, 0, 0, 0),
-        []);
-  });
-
-  it('Handles data with one bin', () => {
-    const counts = [1];
-    const rightEdges = [1.21e-12];
-    const histogram = [{x: 1.1e-12, dx: 1.21e-12 - 1.1e-12, y: 1}];
-    const newHistogram = convertBins(
-        {
-          bucketRightEdges: rightEdges,
-          bucketCounts: counts,
-          min: 1.1e-12,
-          max: 1.21e-12
-        },
-        1.1e-12, 1.21e-12, 1);
-    assertHistogramEquality(newHistogram, histogram);
-  });
-
-  it('Handles data with two bins.', () => {
-    const counts = [1, 2];
-    const rightEdges = [1.1e-12, 1.21e-12];
-    const histogram = [
-      {x: 1.0e-12, dx: 1.05e-13, y: 1.09090909090909},
-      {x: 1.105e-12, dx: 1.05e-13, y: 1.9090909090909}
-    ];
-    const newHistogram = convertBins(
-        {
-          bucketRightEdges: rightEdges,
-          bucketCounts: counts,
-          min: 1.0e-12,
-          max: 1.21e-12
-        },
-        1.0e-12, 1.21e-12, 2);
-    assertHistogramEquality(newHistogram, histogram);
-  });
-
-  it('Handles a domain that crosses zero, but doesn\'t include zero as ' +
-         'an edge.',
-     () => {
-       const counts = [1, 2];
-       const rightEdges = [-1.0e-12, 1.0e-12];
-       const histogram = [
-         {x: -1.1e-12, dx: 1.05e-12, y: 1.95},
-         {x: -0.5e-13, dx: 1.05e-12, y: 1.05}
-       ];
-       const newHistogram = convertBins(
-           {
-             bucketRightEdges: rightEdges,
-             bucketCounts: counts,
-             min: -1.1e-12,
-             max: 1.0e-12
-           },
-           -1.1e-12, 1.0e-12, 2);
-       assertHistogramEquality(newHistogram, histogram);
-     });
-
-  it('Handles a histogram of all zeros', () => {
-    const h = {
-      min: 0,
-      max: 0,
-      nItems: 51200,
-      sum: 0,
-      sumSquares: 0,
-      bucketRightEdges: [0, 1e-12, 1.7976931348623157e+308],
-      bucketCounts: [0, 51200, 0],
-      wall_time: '2017-01-25T02:30:11.257Z',
-      step: 0
-    };
-    const newHistogram = convertBins(h, 0, 0, 5);
-    const expectedHistogram = [
-      {x: -1, dx: 0.4, y: 0}, {x: -0.6, dx: 0.4, y: 0},
-      {x: -0.2, dx: 0.4, y: 51200}, {x: 0.2, dx: 0.4, y: 0},
-      {x: 0.6, dx: 0.4, y: 0}
-    ];
-    assertHistogramEquality(newHistogram, expectedHistogram);
-  });
-
-  it('Handles a right-most right edge that extends to very large number.',
-     () => {
-       const counts = [1, 2, 3];
-       const rightEdges = [0, 1.0e-12, 1.0e14];
-       const histogram = [
-         {x: -1.0e-12, dx: 0.7e-12, y: 0.7}, {x: -0.3e-12, dx: 0.7e-12, y: 1.1},
-         {x: 0.4e-12, dx: 0.7e-12, y: 4.2}
-       ];
-       const newHistogram = convertBins(
-           {
-             bucketRightEdges: rightEdges,
-             bucketCounts: counts,
-             min: -1.0e-12,
-             max: 1.1e-12
-           },
-           -1.0e-12, 1.1e-12, 3);
-       assertHistogramEquality(newHistogram, histogram);
-     });
 });

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/BUILD
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/BUILD
@@ -6,12 +6,17 @@ licenses(["notice"])  # Apache 2.0
 
 ts_web_library(
     name = "tf_histogram_dashboard",
-    srcs = ["tf-histogram-dashboard.html"],
+    srcs = [
+        "histogramCore.ts",
+        "tf-histogram-dashboard.html",
+        "tf-histogram-loader.html",
+    ],
     path = "/tf-histogram-dashboard",
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_imports:d3",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_runs_selector",

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/histogramCore.ts
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/histogramCore.ts
@@ -1,0 +1,137 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/**
+ * Functions for converting between the different representations of
+ * histograms.
+ */
+export type BackendHistogram = [
+  number,  // wall_time, in seconds
+  number,  // step
+  // min, max, nItems, sum, sumSquares, bucketRightEdges, bucketCounts
+  [number, number, number, number, number, number[], number[]]
+];
+export type IntermediateHistogram = {
+  wall_time: number,  // in seconds
+  step: number,
+  min: number,
+  max: number,
+  // We drop `nItems`, `sum`, and `sumSquares`. They're not used.
+  bucketRightEdges: number[],
+  bucketCounts: number[],
+};
+export type D3HistogramBin = {
+  x: number,
+  dx: number,
+  y: number,
+};
+export type VzHistogram = {
+  wall_time: number,  // in seconds
+  step: number,
+  bins: D3HistogramBin[],
+};
+
+export function backendToIntermediate(histogram: BackendHistogram):
+    IntermediateHistogram {
+  const [
+    wall_time,
+    step,
+    [min, max, , , , bucketRightEdges, bucketCounts],
+  ] = histogram;
+  return {wall_time, step, min, max, bucketRightEdges, bucketCounts};
+}
+
+/**
+ * Convert histogram data to the standard D3 format to make it more
+ * compatible and easier to visualize. When rendering histograms, having
+ * access to the left edge and width of each bin makes things quite a
+ * bit easier, so we include these in the result. We also convert the
+ * bins to have a uniform width, which makes the visualization easier to
+ * understand.
+ *
+ * @param histogram A histogram from tensorboard backend.
+ * @param min The leftmost edge. The binning will start on it.
+ * @param max The rightmost edge. The binning will end on it.
+ * @param numBins The number of bins of the converted data. The default
+ * of 30 is sensible: if you use more, you start to get artifacts
+ * because the event data is stored in buckets, and you start being able
+ * to see the aliased borders between each bucket.
+ *
+ * @return A list of histogram bins. Each bin has an `x` (left
+ *     edge), a `dx` (width), and a `y` (count). If the given
+ *     right edges are inclusive, then these left edges (`x`) are
+ *     exclusive.
+ */
+export function intermediateToD3(
+    histogram: IntermediateHistogram, min: number, max: number,
+    numBins = 30): D3HistogramBin[] {
+  if (histogram.bucketRightEdges.length !== histogram.bucketCounts.length) {
+    throw new Error("Edges and counts are of different lengths.");
+  }
+
+  if (max === min) {
+    // Create bins even if all the data has a single value.
+    max = min * 1.1 + 1;
+    min = min / 1.1 - 1;
+  }
+  const binWidth = (max - min) / numBins;
+
+  // Use the min as the starting point for the bins.
+  let bucketLeft = min;
+  let bucketPos = 0;
+  return d3.range(min, max, binWidth).map((binLeft) => {
+    const binRight = binLeft + binWidth;
+
+    // Take the count of each existing bucket, multiply it by the
+    // proportion of overlap with the new bin, then sum and store as the
+    // count for the new bin. If no overlap, will add to zero; if 100%
+    // overlap, will include the full count into new bin.
+    let binY = 0;
+    while (bucketPos < histogram.bucketRightEdges.length) {
+      // Clip the right edge because right-most edge can be
+      // infinite-sized.
+      const bucketRight = Math.min(
+        max, histogram.bucketRightEdges[bucketPos]);
+
+      const intersect =
+          Math.min(bucketRight, binRight) - Math.max(bucketLeft, binLeft);
+      const count = (intersect / (bucketRight - bucketLeft)) *
+          histogram.bucketCounts[bucketPos];
+
+      binY += intersect > 0 ? count : 0;
+
+      // If `bucketRight` is bigger than `binRight`, then this bin is
+      // finished and there is data for the next bin, so don't increment
+      // `bucketPos`.
+      if (bucketRight > binRight) {
+        break;
+      }
+      bucketLeft = Math.max(min, bucketRight);
+      bucketPos++;
+    }
+    return {x: binLeft, dx: binWidth, y: binY};
+  });
+}
+
+export function backendToVz(histograms: BackendHistogram[]): VzHistogram[] {
+  const intermediateHistograms = histograms.map(backendToIntermediate);
+  const minmin = d3.min(intermediateHistograms, h => h.min);
+  const maxmax = d3.max(intermediateHistograms, h => h.max);
+  return intermediateHistograms.map(h => ({
+    wall_time: h.wall_time,
+    step: h.step,
+    bins: intermediateToD3(h, minmin, maxmax),
+  }));
+}

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/test/BUILD
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/test/BUILD
@@ -1,0 +1,29 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//tensorboard:internal"],
+)
+
+load("//tensorboard/defs:web.bzl", "ts_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+ts_web_library(
+    name = "test",
+    srcs = [
+        "tests.html",
+        "histogramTests.ts",
+    ] + glob(["data/**"]),
+    path = "/tf-histogram-dashboard/test",
+    deps = [
+        "//tensorboard/plugins/histograms/tf_histogram_dashboard",
+        "//tensorboard/components/tf_imports:web_component_tester",
+        "//tensorboard/components/tf_imports:webcomponentsjs",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    testonly = 0,
+    srcs = glob(["**"]),
+    tags = ["notsan"],
+)

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/test/histogramTests.ts
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/test/histogramTests.ts
@@ -1,0 +1,142 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {intermediateToD3} from '../histogramCore';
+
+describe('Verify that the histogram format conversion works.', () => {
+
+  function assertHistogramEquality(h1, h2) {
+    h1.forEach((b1, i) => {
+      const b2 = h2[i];
+      chai.assert.closeTo(b1.x, b2.x, 1e-10);
+      chai.assert.closeTo(b1.dx, b2.dx, 1e-10);
+      chai.assert.closeTo(b1.y, b2.y, 1e-10);
+    });
+  }
+
+  it('Throws an error if the inputs are of different lengths', () => {
+    chai.assert.throws(() => {
+      intermediateToD3({
+        wall_time: 1234.5,
+        step: 0,
+        bucketRightEdges: [0],
+        bucketCounts: [1, 2],
+        min: 1,
+        max: 2,
+      }, 1, 2, 2);
+    }, 'Edges and counts are of different lengths.');
+  });
+
+  it('Handles data with no bins', () => {
+    chai.assert.deepEqual(intermediateToD3({
+      wall_time: 1234.5,
+      step: 0,
+      bucketRightEdges: [],
+      bucketCounts: [],
+      min: 0,
+      max: 0,
+    }, 0, 0, 0), []);
+  });
+
+  it('Handles data with one bin', () => {
+    const counts = [1];
+    const rightEdges = [1.21e-12];
+    const expected = [{x: 1.1e-12, dx: 1.21e-12 - 1.1e-12, y: 1}];
+    const actual = intermediateToD3({
+      wall_time: 1234.5,
+      step: 0,
+      bucketRightEdges: rightEdges,
+      bucketCounts: counts,
+      min: 1.1e-12,
+      max: 1.21e-12,
+    }, 1.1e-12, 1.21e-12, 1);
+    assertHistogramEquality(actual, expected);
+  });
+
+  it('Handles data with two bins.', () => {
+    const counts = [1, 2];
+    const rightEdges = [1.1e-12, 1.21e-12];
+    const expected = [
+      {x: 1.0e-12, dx: 1.05e-13, y: 1.09090909090909},
+      {x: 1.105e-12, dx: 1.05e-13, y: 1.9090909090909},
+    ];
+    const newHistogram = intermediateToD3({
+      wall_time: 1234.5,
+      step: 0,
+      bucketRightEdges: rightEdges,
+      bucketCounts: counts,
+      min: 1.0e-12,
+      max: 1.21e-12,
+    }, 1.0e-12, 1.21e-12, 2);
+    assertHistogramEquality(newHistogram, expected);
+  });
+
+  it('Handles a domain that crosses zero, but doesn\'t include zero as ' +
+         'an edge.', () => {
+    const counts = [1, 2];
+    const rightEdges = [-1.0e-12, 1.0e-12];
+    const expected = [
+      {x: -1.1e-12, dx: 1.05e-12, y: 1.95},
+      {x: -0.5e-13, dx: 1.05e-12, y: 1.05},
+    ];
+    const actual = intermediateToD3({
+      wall_time: 1234.5,
+      step: 0,
+      bucketRightEdges: rightEdges,
+      bucketCounts: counts,
+      min: -1.1e-12,
+      max: 1.0e-12,
+    }, -1.1e-12, 1.0e-12, 2);
+    assertHistogramEquality(actual, expected);
+  });
+
+  it('Handles a histogram of all zeros', () => {
+    const h = {
+      wall_time: +new Date('2017-01-25T02:30:11.257Z') / 1000,
+      step: 0,
+      min: 0,
+      max: 0,
+      bucketRightEdges: [0, 1e-12, 1.7976931348623157e+308],
+      bucketCounts: [0, 51200, 0],
+    };
+    const newHistogram = intermediateToD3(h, 0, 0, 5);
+    const expectedHistogram = [
+      {x: -1, dx: 0.4, y: 0}, {x: -0.6, dx: 0.4, y: 0},
+      {x: -0.2, dx: 0.4, y: 51200}, {x: 0.2, dx: 0.4, y: 0},
+      {x: 0.6, dx: 0.4, y: 0},
+    ];
+    assertHistogramEquality(newHistogram, expectedHistogram);
+  });
+
+  it('Handles a right-most right edge that extends to very large number.',
+      () => {
+    const counts = [1, 2, 3];
+    const rightEdges = [0, 1.0e-12, 1.0e14];
+    const expected = [
+      {x: -1.0e-12, dx: 0.7e-12, y: 0.7},
+      {x: -0.3e-12, dx: 0.7e-12, y: 1.1},
+      {x: 0.4e-12, dx: 0.7e-12, y: 4.2},
+    ];
+    const actual = intermediateToD3({
+      wall_time: 1234.5,
+      step: 0,
+      bucketRightEdges: rightEdges,
+      bucketCounts: counts,
+      min: -1.0e-12,
+      max: 1.1e-12
+    }, -1.0e-12, 1.1e-12, 3);
+    assertHistogramEquality(actual, expected);
+  });
+});

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/test/tests.html
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/test/tests.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../../../webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../../../web-component-tester/browser.js"></script>
+  <script src="../histogramCore.js"></script>
+</head>
+<body>
+  <script src="histogramTests.js"></script>
+</body>
+</html>

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -17,48 +17,34 @@ limitations under the License.
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
-<link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/tf-categorizer.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
-<link rel="import" href="../tf-dashboard-common/tf-panes-helper.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
-<link rel="import" href="../tf-imports/lodash.html">
-<link rel="import" href="../vz-histogram-timeseries/vz-histogram-timeseries.html">
-<link rel="import" href="../iron-collapse/iron-collapse.html">
-<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="tf-histogram-loader.html">
 
 <!--
-tf-histogram-dashboard is a complete frontend that loads runs from a backend,
-and creates chart panes that display data for those runs.
-
-It provides a mode and time property selector, together with the selectors
-provided by tf-sidebar-helper, by which the user can customize how data is
-organized and displayed.
-
-Each chart has a button that can toggle whether it is "selected"; selectedRuns
-charts are larger.
-
-Organizationally, the #plumbing div contains components that have no concrete
-manifestation and just effect data bindings or data loading. The .sidebar div
-contains shared controls provided by tf-sidebar-helper. The .center div
-contains vz-histogram-timeseries embedded inside tf-panes-helper's.
+  A frontend that displays a set of tf-histogram-loaders, each of which
+  displays the histogram for a single tag on a single run. This
+  dashboard provides a categorizer, histogram mode selector (overlay or
+  offset), and abcissa seletor (step, relative, or wall time).
 -->
 <dom-module id="tf-histogram-dashboard">
   <template>
     <tf-dashboard-layout>
       <div class="sidebar">
         <div class="sidebar-section">
-          <tf-categorizer
-            id="categorizer"
-            tags="[[tags]]"
-            categories="{{_categories}}"
-          ></tf-categorizer>
+          <!--
+            TODO(wchargin): Remove tag groups. Replace them with a
+            search/filter bar in the main content pane.
+          -->
+          <tf-regex-group regexes="{{_tagGroupRegexes}}">
+          </tf-regex-group>
         </div>
         <div class="sidebar-section">
           <tf-option-selector
             id="histogramModeSelector"
-            name="Histogram Mode"
+            name="Histogram mode"
             selected-id="{{_histogramMode}}"
             >
             <paper-button id="overlay">overlay</paper-button>
@@ -68,9 +54,9 @@ contains vz-histogram-timeseries embedded inside tf-panes-helper's.
         <div class="sidebar-section">
           <tf-option-selector
             id="timePropertySelector"
-            name="Offset Time Axis"
+            name="Offset time axis"
             selected-id="{{_timeProperty}}"
-            >
+          >
             <paper-button id="step">step</paper-button>
             <paper-button id="relative">relative</paper-button>
             <paper-button id="wall_time">wall</paper-button>
@@ -82,81 +68,121 @@ contains vz-histogram-timeseries embedded inside tf-panes-helper's.
         </div>
        </div>
       </div>
-
       <div class="center">
-        <tf-panes-helper
-          categories="[[_categories]]"
-          data-type="[[dataType]]"
-          data-provider="[[dataProvider]]"
-          data-not-found="[[dataNotFound]]"
-          run2tag="[[run2tag]]"
-          selected-runs="[[_selectedRuns]]"
-          repeat-for-runs
+        <template is="dom-if" if="[[_dataNotFound]]">
+          <div class="no-data-warning">
+            <h3>No histogram data was found.</h3>
+            <p>Probable causes:</p>
+            <ul>
+              <li>You haven’t written any histogram data to your event files.
+              <li>TensorBoard can’t find your event files.
+            </ul>
+            <p>
+            If you’re new to using TensorBoard, and want to find out how
+            to add data and set up your event files, check out the
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md">README</a>
+            and perhaps the <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard">TensorBoard tutorial</a>.
+            <p>
+            If you think TensorBoard is configured properly, please see
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong">the section of the README devoted to missing data problems</a>
+            and consider filing an issue on GitHub.
+          </div>
+        </template>
+        <template is="dom-repeat" items="[[_categories]]" as="category">
+          <tf-collapsable-pane
+            name="[[category.name]]"
+            count="[[category.count]]"
           >
-          <template>
-            <vz-histogram-timeseries
-              time-property="[[_timeProperty]]"
-              mode="[[_histogramMode]]"
-              color-scale="[[_colorScaleFunction]]"
-              ></vz-histogram-timeseries>
-          </template>
-        </tf-panes-helper>
+            <div class="layout horizontal wrap">
+              <template is="dom-repeat" items="[[category.items]]">
+                <tf-histogram-loader
+                  run="[[item.run]]"
+                  tag="[[item.tag]]"
+                  time-property="[[_timeProperty]]"
+                  histogram-mode="[[_histogramMode]]"
+                  request-manager="[[_requestManager]]"
+                  ></tf-histogram-loader>
+              </template>
+            </div>
+          </tf-collapsable-pane>
+        </template>
       </div>
     </tf-dashboard-layout>
 
     <style include="dashboard-style"></style>
     <style>
-      tf-panes-helper {
-        --card-expanded-height: 500px;
-        --card-expanded-width: 700px;
+      .no-data-warning {
+        max-width: 540px;
+        margin: 80px auto 0 auto;
       }
     </style>
   </template>
 
   <script>
-    import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior";
-    import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior";
-    import {BackendBehavior} from "../tf-backend/behavior";
-    import {runsColorScale} from "../tf-color-scale/colorScale";
+    "use strict";
+
+    import {RequestManager} from '../tf-backend/requestManager';
+    import {getTags} from '../tf-backend/backend';
+    import {getRouter} from '../tf-backend/router';
+    import {categorizeRunTagCombinations} from '../tf-categorization-utils/categorizationUtils';
 
     Polymer({
       is: "tf-histogram-dashboard",
-      behaviors: [
-        DashboardBehavior("histograms"),
-        ReloadBehavior("tf-chart-scaffold"),
-        BackendBehavior,
-      ],
       properties: {
-        backend: Object,
-        dataType: {
-          type: String,
-          value: "histogram"
-        },
         _histogramMode: {
           type: String,
-          value: "offset"
+          value: "offset",
         },
         _timeProperty: {
           type: String,
-          value: "step"
+          value: "step",
         },
-        _colorScaleFunction: {
-          type: Function,
-          value: function() {
-            // NOTE: Because the result is a function, we can't just write
-            //
-            //     value: runsColorScale,
-            //
-            // above. If we did, Polymer would try to invoke _that_ to
-            // get an initial property value.
-            return runsColorScale;
-          },
+
+        _selectedRuns: Array,
+        _runToTag: Object,  // map<run: string, tags: string[]>
+        _dataNotFound: Boolean,
+
+        _categories: {
+          type: Array,
+          computed:
+            '_makeCategories(_runToTag, _selectedRuns, _tagGroupRegexes)',
+        },
+
+        _requestManager: {
+          type: Object,
+          value: () => new RequestManager(),
         },
       },
-      attached: function() {
-        this.async(function() {
-          this.fire("rendered");
+
+      ready() {
+        this.reload();
+      },
+      reload() {
+        this._fetchTags().then(() => {
+          this._reloadHistograms();
         });
+      },
+      _fetchTags() {
+        const url = getRouter().pluginRoute('histograms', '/tags');
+        return this._requestManager.request(url).then(runToTag => {
+          if (_.isEqual(runToTag, this._runToTag)) {
+            // No need to update anything if there are no changes.
+            return;
+          }
+          const tags = getTags(runToTag);
+          this.set('_dataNotFound', tags.length === 0);
+          this.set('_runToTag', runToTag);
+        });
+      },
+      _reloadHistograms() {
+        this.querySelectorAll('tf-histogram-loader').forEach(histogram => {
+          histogram.reload();
+        });
+      },
+
+      _makeCategories(runToTag, selectedRuns, tagGroupRegexes) {
+        return categorizeRunTagCombinations(
+          runToTag, selectedRuns, tagGroupRegexes);
       },
     });
   </script>

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/tf-histogram-loader.html
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/tf-histogram-loader.html
@@ -1,0 +1,159 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../tf-imports/lodash.html">
+<link rel="import" href="../tf-imports/d3.html">
+<link rel="import" href="../vz-histogram-timeseries/vz-histogram-timeseries.html">
+
+<!--
+  tf-histogram-loader loads an individual histogram from the TensorBoard
+  backend, and renders it into a vz-histogram-timeseries.
+-->
+<dom-module id="tf-histogram-loader">
+  <template>
+    <tf-card-heading title="[[tag]]" color="[[_runColor]]">
+      [[run]]
+    </tf-card-heading>
+    <!--
+      The main histogram that we render. Data is set directly with
+      `setSeriesData`, not with a bound property.
+    -->
+    <vz-histogram-timeseries
+      time-property="[[timeProperty]]"
+      mode="[[histogramMode]]"
+      color-scale="[[_colorScaleFunction]]"
+    ></vz-histogram-timeseries>
+    <div style="display: flex; flex-direction: row;">
+      <paper-icon-button
+        selected$="[[_expanded]]"
+        icon="fullscreen"
+        on-tap="_toggleExpanded"
+      ></paper-icon-button>
+    </div>
+    <style>
+      :host {
+        display: flex;
+        flex-direction: column;
+        width: 330px;
+        height: 235px;
+        margin-right: 10px;
+        margin-bottom: 15px;
+      }
+      :host[_expanded] {
+        width: 700px;
+        height: 500px;
+      }
+
+      vz-histogram-timeseries {
+        -moz-user-select: none;
+        -webkit-user-select: none;
+      }
+
+      paper-icon-button {
+        color: #2196F3;
+        border-radius: 100%;
+        pointer-events: auto;  /* TODO(wchargin): why? */
+        width: 32px;
+        height: 32px;
+        padding: 4px;
+      }
+      paper-icon-button[selected] {
+        background: var(--tb-ui-light-accent);
+      }
+    </style>
+  </template>
+  <script src="histogramCore.js"></script>
+  <script>
+    "use strict";
+
+    import {Canceller} from "../tf-backend/canceller";
+    import {getRouter} from "../tf-backend/router";
+    import {runsColorScale} from "../tf-color-scale/colorScale";
+    import {backendToVz} from "./histogramCore";
+
+    Polymer({
+      is: "tf-histogram-loader",
+      properties: {
+        run: String,
+        tag: String,
+        timeProperty: String,
+        histogramMode: String,
+
+        /** @type {Function} */
+        _colorScaleFunction: {
+          type: Object,  // function: string => string
+          value: () => runsColorScale,
+        },
+        _runColor: {
+          type: String,
+          computed: '_computeRunColor(run)',
+        },
+        _expanded: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,  // for CSS
+        },
+
+        requestManager: Object,
+        _canceller: {
+          type: Object,
+          value: () => new Canceller(),
+        },
+      },
+
+      observers: ['reload(run, tag)'],
+
+      _computeRunColor(run) {
+        return this._colorScaleFunction(run);
+      },
+
+      attached() {
+        this._attached = true;
+        this.reload();
+      },
+      reload() {
+        if (!this._attached) {
+          return;
+        }
+        this._canceller.cancelAll();
+        const router = getRouter();
+        const url = router.pluginRunTagRoute("histograms", "/histograms")(
+          this.tag, this.run);
+        const updateData = this._canceller.cancellable(result => {
+          if (result.cancelled) {
+            return;
+          }
+          const backendData = result.value;
+          const d3Data = backendToVz(backendData);
+          this.$$('vz-histogram-timeseries').setSeriesData(this.run, d3Data);
+        });
+        this.requestManager.request(url).then(updateData);
+      },
+      redraw() {
+        this.$$('vz-histogram-timeseries').redraw();
+      },
+
+      _toggleExpanded(e) {
+        this.set('_expanded', !this._expanded);
+        this.redraw();
+      },
+    });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/histograms/vz_histogram_timeseries/vz-histogram-timeseries.html
+++ b/tensorboard/plugins/histograms/vz_histogram_timeseries/vz-histogram-timeseries.html
@@ -254,6 +254,8 @@ visualization.
          * Scale that maps series names to colors. The default colors are from
          * d3.schemeCategory10() scale. Use this property to replace the default
          * line colors with colors of your own choice.
+         *
+         * @type {Function}
          */
         colorScale: {
           type: Object,
@@ -287,9 +289,6 @@ visualization.
       },
       detached: function() {
         this._attached = false;
-      },
-      setVisibleSeries: function(names) {
-        // Do nothing.
       },
       setSeriesData: function(name, data) {
         this._name = name;


### PR DESCRIPTION
Summary:
This commit removes the histogram dashboard's dependencies on old-style
framework code, and removes mentions of histograms from core code like
`backend.ts`.

As usual (e.g., #108), I had to delete some minimal tests in
`backendTests.ts` to do this. Unfortunately, this time there were also
some substantive tests of the `convertBins` function, which I regret
leaving behind. I've included a TODO in the code to add them back in
once our frontend tests work again, which will of course be Soon™.

Note that both the old and new versions of the histogram dashboard have
an unfortunate behavior regarding graphical updates after changing run
selection state. Specifically, suppose that Histogram A and Histogram B
appear side-by-side, and the run for Histogram A is toggled off. Then we
would like Histogram B to seamlessly move into the position of
Histogram A. However, due to Polymer's data binding, the actual action
is that Histogram B is deleted and Histogram A's data bindings are set
to those of the former Histogram B. The result is that the title, tag,
and card color of Histogram A immediately update to those of
Histogram B, but the actual data takes a while to fetch. Furthermore,
this means that _all_ histograms that are affected will re-render their
data. (So if the line goes down to Histogram Z, then removing the run
for Histogram A will cause 25 network requests.)

Essentially, we want [React's keys behavior][1], but it doesn't look
like we can get it. I'm leaving this wontfix for now.

[1]: https://facebook.github.io/react/docs/lists-and-keys.html#keys

Finally, while I'm at it, I fixed all closure compiler warnings in
`vz-histogram-timeseries` and `tf-histogram-dashboard`.

Test Plan:
Tested with the MNIST data combined with the histogram demo data.
Toggled runs, changed histogram modes and time modes, used tag groups,
expanded and collapsed categories. All bazel tests pass, but there
aren't actually any of interest, so that really just means that
everything still builds.

wchargin-branch: refactor-histograms-dashboard