### PR TITLE
Have TensorBoard read metadata from SummaryMetadata

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -44,7 +44,6 @@ DEFAULT_SIZE_GUIDANCE = {
     event_accumulator.IMAGES: 10,
     event_accumulator.AUDIO: 10,
     event_accumulator.SCALARS: 1000,
-    event_accumulator.HEALTH_PILLS: 100,
     event_accumulator.HISTOGRAMS: 50,
 }
 

--- a/tensorboard/backend/event_processing/event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/event_accumulator_test.py
@@ -702,9 +702,9 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
     writer = tf.summary.FileWriter(self.get_temp_dir())
     writer.event_writer = event_sink
     with self.test_session() as sess:
-      tf.summary._tensor_summary_v2('scalar', tf.constant(1.0))
-      tf.summary._tensor_summary_v2('vector', tf.constant([1.0, 2.0, 3.0]))
-      tf.summary._tensor_summary_v2('string', tf.constant(six.b('foobar')))
+      tf.summary.tensor_summary('scalar', tf.constant(1.0))
+      tf.summary.tensor_summary('vector', tf.constant([1.0, 2.0, 3.0]))
+      tf.summary.tensor_summary('string', tf.constant(six.b('foobar')))
       merged = tf.summary.merge_all()
       summ = sess.run(merged)
       writer.add_summary(summ, 0)

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -269,38 +269,6 @@ class EventMultiplexer(object):
     accumulator = self._GetAccumulator(run)
     return accumulator.Scalars(tag)
 
-  def HealthPills(self, run, node_name):
-    """Retrieve the health pill events associated with a run and node name.
-
-    Args:
-      run: A string name of the run for which health pills are retrieved.
-      node_name: A string name of the node for which health pills are retrieved.
-
-    Raises:
-      KeyError: If the run is not found, or the node name is not available for
-        the given run.
-
-    Returns:
-      An array of `event_accumulator.HealthPillEvents`.
-    """
-    accumulator = self._GetAccumulator(run)
-    return accumulator.HealthPills(node_name)
-
-  def GetOpsWithHealthPills(self, run):
-    """Determines which ops have at least 1 health pill event for a given run.
-
-    Args:
-      run: The name of the run.
-
-    Raises:
-      KeyError: If the run is not found, or the node name is not available for
-        the given run.
-
-    Returns:
-      The list of names of ops with health pill events.
-    """
-    return self._GetAccumulator(run).GetOpsWithHealthPills()
-
   def Graph(self, run):
     """Retrieve the graph associated with the provided run.
 
@@ -434,6 +402,29 @@ class EventMultiplexer(object):
     """
     accumulator = self._GetAccumulator(run)
     return accumulator.Tensors(tag)
+
+  def PluginRunToTagToContent(self, plugin_name):
+    """Returns a 2-layer dictionary of the form {run: {tag: content}}.
+
+    The `content` referred above is the content field of the PluginData proto
+    for the specified plugin within a Summary.Value proto.
+
+    Args:
+      plugin_name: The name of the plugin for which to fetch content.
+
+    Returns:
+      A dictionary of the form {run: {tag: content}}.
+    """
+    mapping = {}
+    for run in self.Runs():
+      try:
+        tag_to_content = self._GetAccumulator(run).PluginTagToContent(
+            plugin_name)
+      except KeyError:
+        # This run lacks content for the plugin. Try the next run.
+        continue
+      mapping[run] = tag_to_content
+    return mapping
 
   def Runs(self):
     """Return all the run names in the `EventMultiplexer`.

--- a/tensorboard/backend/event_processing/event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/event_multiplexer_test.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import functools
 import os
 import os.path
 import shutil
@@ -45,16 +44,20 @@ def _CreateCleanDirectory(path):
 
 class _FakeAccumulator(object):
 
-  def __init__(self, path, health_pill_mapping=None):
+  def __init__(self, path):
     """Constructs a fake accumulator with some fake events.
 
     Args:
       path: The path for the run that this accumulator is for.
-      health_pill_mapping: An optional mapping from Op to health pill strings.
     """
     self._path = path
     self.reload_called = False
-    self._node_names_to_health_pills = health_pill_mapping or {}
+    self._plugin_to_tag_to_content = {
+        'baz_plugin': {
+            'foo': 'foo_content',
+            'bar': 'bar_content',
+        }
+    }
 
   def Tags(self):
     return {event_accumulator.IMAGES: ['im1', 'im2'],
@@ -74,15 +77,6 @@ class _FakeAccumulator(object):
   def Scalars(self, tag_name):
     return self._TagHelper(tag_name, event_accumulator.SCALARS)
 
-  def HealthPills(self, node_name):
-    if node_name not in self._node_names_to_health_pills:
-      raise KeyError
-    health_pills = self._node_names_to_health_pills[node_name]
-    return [self._path + '/' + health_pill for health_pill in health_pills]
-
-  def GetOpsWithHealthPills(self):
-    return self._node_names_to_health_pills.keys()
-
   def Histograms(self, tag_name):
     return self._TagHelper(tag_name, event_accumulator.HISTOGRAMS)
 
@@ -98,6 +92,15 @@ class _FakeAccumulator(object):
   def Tensors(self, tag_name):
     return self._TagHelper(tag_name, event_accumulator.TENSORS)
 
+  def PluginTagToContent(self, plugin_name):
+    # We pre-pend the runs with the path and '_' so that we can verify that the
+    # tags are associated with the correct runs.
+    return {
+        self._path + '_' + run: content_mapping
+        for (run, content_mapping
+            ) in self._plugin_to_tag_to_content[plugin_name].items()
+    }
+
   def Reload(self):
     self.reload_called = True
 
@@ -105,10 +108,9 @@ class _FakeAccumulator(object):
 def _GetFakeAccumulator(path,
                         size_guidance=None,
                         compression_bps=None,
-                        purge_orphaned_data=None,
-                        health_pill_mapping=None):
+                        purge_orphaned_data=None):
   del size_guidance, compression_bps, purge_orphaned_data  # Unused.
-  return _FakeAccumulator(path, health_pill_mapping=health_pill_mapping)
+  return _FakeAccumulator(path)
 
 
 class EventMultiplexerTest(tf.test.TestCase):
@@ -152,28 +154,19 @@ class EventMultiplexerTest(tf.test.TestCase):
 
     self.assertEqual(run1_expected, run1_actual)
 
-  def testHealthPills(self):
-    """Tests HealthPills() returns events associated with run1/Add."""
-    self.stubs.Set(event_accumulator, 'EventAccumulator',
-                   functools.partial(
-                       _GetFakeAccumulator,
-                       health_pill_mapping={'Add': ['hp1', 'hp2']}))
+  def testPluginRunToTagToContent(self):
+    """Tests the method that produces the run to tag to content mapping."""
     x = event_multiplexer.EventMultiplexer({'run1': 'path1', 'run2': 'path2'})
-    self.assertEqual(['path1/hp1', 'path1/hp2'], x.HealthPills('run1', 'Add'))
-
-  def testGetOpsWithHealthPillsWhenHealthPillsAreNotAvailable(self):
-    # The event accumulator lacks health pills for the run.
-    x = event_multiplexer.EventMultiplexer({'run1': 'path1', 'run2': 'path2'})
-    self.assertItemsEqual([], x.GetOpsWithHealthPills('run1'))
-
-  def testGetOpsWithHealthPillsWhenHealthPillsAreAvailable(self):
-    # The event accumulator has health pills for the run.
-    self.stubs.Set(event_accumulator, 'EventAccumulator',
-                   functools.partial(
-                       _GetFakeAccumulator,
-                       health_pill_mapping={'Add': ['hp1', 'hp2']}))
-    x = event_multiplexer.EventMultiplexer({'run1': 'path1', 'run2': 'path2'})
-    self.assertItemsEqual(['Add'], x.GetOpsWithHealthPills('run1'))
+    self.assertDictEqual({
+        'run1': {
+            'path1_foo': 'foo_content',
+            'path1_bar': 'bar_content',
+        },
+        'run2': {
+            'path2_foo': 'foo_content',
+            'path2_bar': 'bar_content',
+        }
+    }, x.PluginRunToTagToContent('baz_plugin'))
 
   def testExceptions(self):
     """KeyError should be raised when accessing non-existing keys."""

--- a/tensorboard/plugins/graphs/graphs_plugin_test.py
+++ b/tensorboard/plugins/graphs/graphs_plugin_test.py
@@ -115,10 +115,11 @@ class GraphsPluginTest(tf.test.TestCase):
   def test_graph_simple(self):
     graph = self._get_graph()
     node_names = set(node.name for node in graph.node)
-    self.assertEqual({'k1', 'k2', 'pow', 'sub', 'expected', 'sub_1', 'error',
-                      'message_prefix', 'error_string', 'error_message',
-                      'summary_message'},
-                     node_names)
+    self.assertEqual({
+        'k1', 'k2', 'pow', 'sub', 'expected', 'sub_1', 'error',
+        'message_prefix', 'error_string', 'error_message', 'summary_message',
+        'summary_message/tag', 'summary_message/serialized_summary_metadata'
+    }, node_names)
 
   def test_graph_large_attrs(self):
     key = 'o---;;-;'

--- a/tensorboard/plugins/graphs/graphs_plugin_test.py
+++ b/tensorboard/plugins/graphs/graphs_plugin_test.py
@@ -118,7 +118,6 @@ class GraphsPluginTest(tf.test.TestCase):
     self.assertEqual({
         'k1', 'k2', 'pow', 'sub', 'expected', 'sub_1', 'error',
         'message_prefix', 'error_string', 'error_message', 'summary_message',
-        'summary_message/tag', 'summary_message/serialized_summary_metadata'
     }, node_names)
 
   def test_graph_large_attrs(self):

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
 import json
 import textwrap
 
@@ -262,24 +263,39 @@ class TextPlugin(base_plugin.TBPlugin):
     self._multiplexer = context.multiplexer
 
   def index_impl(self):
-    run_to_series = {}
+    # A previous system of collecting and serving text summaries involved
+    # storing the tags of text summaries within tensors.json files. See if we
+    # are currently using that system. We do not want to drop support for that
+    # use case.
+    run_to_series = collections.defaultdict(list)
     name = 'tensorboard_text'
     run_to_assets = self._multiplexer.PluginAssets(name)
-
     for run, assets in run_to_assets.items():
       if 'tensors.json' in assets:
         tensors_json = self._multiplexer.RetrievePluginAsset(
             run, name, 'tensors.json')
         tensors = json.loads(tensors_json)
         run_to_series[run] = tensors
-      else:
-        run_to_series[run] = []
+
+    # TensorBoard is obtaining summaries related to the text plugin based on
+    # SummaryMetadata stored within Value protos.
+    mapping = self._multiplexer.PluginRunToTagToContent(_PLUGIN_PREFIX_ROUTE)
+
+    # Augment the summaries created via the deprecated (plugin asset based)
+    # method with these summaries created with the new method. When they
+    # conflict, the summaries created via the new method overrides.
+    for (run, tags) in mapping.items():
+      run_to_series[run] += tags.keys()
     return run_to_series
 
   @wrappers.Request.application
   def runs_route(self, request):
-    index = self.index_impl()
-    return http_util.Respond(request, index, 'application/json')
+    # Map from run to a list of tags.
+    response = {
+        run: tag_listing
+        for (run, tag_listing) in self.index_impl().items()
+    }
+    return http_util.Respond(request, response, 'application/json')
 
   def text_impl(self, run, tag):
     try:

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -60,27 +60,6 @@ class TextPluginTest(tf.test.TestCase):
     summary_tensor = tf.summary.text('message', placeholder)
     vector_summary = tf.summary.text('vector', placeholder)
 
-    # Previously, we had used a means of creating text summaries that used
-    # plugin assets (which loaded JSON files containing runs and tags). The
-    # plugin must continue to be able to load summaries of that format, so we
-    # create a summary using that old plugin asset-based method here.
-    plugin_asset_summary = tf.summary.tensor_summary('old_plugin_asset_summary',
-                                                     placeholder)
-    assets_directory = os.path.join(self.logdir, 'fry', 'plugins',
-                                    'tensorboard_text')
-    # Make the directory of assets if it does not exist.
-    if not os.path.isdir(assets_directory):
-      try:
-        os.makedirs(assets_directory)
-      except OSError as err:
-        self.assertFail('Could not make assets directory %r: %r',
-                        assets_directory, err)
-    json_path = os.path.join(assets_directory, 'tensors.json')
-    with open(json_path, 'w+') as tensors_json_file:
-      # Write the op name to a JSON file that the text plugin later uses to
-      # determine the tag names of tensors to fetch.
-      tensors_json_file.write(json.dumps([plugin_asset_summary.op.name]))
-
     run_names = ['fry', 'leela']
     for run_name in run_names:
       subdir = os.path.join(self.logdir, run_name)
@@ -101,11 +80,6 @@ class TextPluginTest(tf.test.TestCase):
       summ = sess.run(vector_summary, feed_dict={placeholder: vector_message})
       writer.add_summary(summ)
 
-      summ = sess.run(
-          plugin_asset_summary, feed_dict={
-              placeholder: 'I am deprecated.',
-          })
-      writer.add_summary(summ)
       writer.close()
 
   def testIndex(self):
@@ -113,7 +87,7 @@ class TextPluginTest(tf.test.TestCase):
     self.assertItemsEqual(['fry', 'leela'], index.keys())
     # The summary made via plugin assets (the old method being phased out) is
     # only available for run 'fry'.
-    self.assertItemsEqual(['old_plugin_asset_summary', 'message', 'vector'],
+    self.assertItemsEqual(['message', 'vector'],
                           index['fry'])
     self.assertItemsEqual(['message', 'vector'], index['leela'])
 
@@ -147,12 +121,6 @@ class TextPluginTest(tf.test.TestCase):
       </tr>
       </tbody>
       </table>"""))
-
-    # Test the text obtained from a summary produced via plugin assets.
-    # TensorBoard must continue to be able to load such summaries.
-    text_entries = self.plugin.text_impl('leela', 'old_plugin_asset_summary')
-    self.assertEqual(len(text_entries), 1)
-    self.assertEqual('<p>I am deprecated.</p>', text_entries[0]['text'])
 
   def assertTextConverted(self, actual, expected):
     self.assertEqual(text_plugin.markdown_and_sanitize(actual), expected)
@@ -446,6 +414,68 @@ class TextPluginTest(tf.test.TestCase):
   def testUnicode(self):
     self.assertConverted(u'<p>Iñtërnâtiônàlizætiøn⚡💩</p>',
                          'Iñtërnâtiônàlizætiøn⚡💩')
+
+
+class TextPluginBackwardsCompatibilityTest(tf.test.TestCase):
+
+  def setUp(self):
+    self.logdir = self.get_temp_dir()
+    self.generate_testdata()
+    multiplexer = event_multiplexer.EventMultiplexer()
+    multiplexer.AddRunsFromDirectory(self.logdir)
+    multiplexer.Reload()
+    context = base_plugin.TBContext(logdir=self.logdir, multiplexer=multiplexer)
+    self.plugin = text_plugin.TextPlugin(context)
+
+  def generate_testdata(self):
+    tf.reset_default_graph()
+    sess = tf.Session()
+    placeholder = tf.constant('I am deprecated.')
+
+    # Previously, we had used a means of creating text summaries that used
+    # plugin assets (which loaded JSON files containing runs and tags). The
+    # plugin must continue to be able to load summaries of that format, so we
+    # create a summary using that old plugin asset-based method here.
+    plugin_asset_summary = tf.summary.tensor_summary('old_plugin_asset_summary',
+                                                     placeholder)
+    assets_directory = os.path.join(self.logdir, 'fry', 'plugins',
+                                    'tensorboard_text')
+    # Make the directory of assets if it does not exist.
+    if not os.path.isdir(assets_directory):
+      try:
+        os.makedirs(assets_directory)
+      except OSError as err:
+        self.assertFail('Could not make assets directory %r: %r',
+                        assets_directory, err)
+    json_path = os.path.join(assets_directory, 'tensors.json')
+    with open(json_path, 'w+') as tensors_json_file:
+      # Write the op name to a JSON file that the text plugin later uses to
+      # determine the tag names of tensors to fetch.
+      tensors_json_file.write(json.dumps([plugin_asset_summary.op.name]))
+
+    run_name = 'fry'
+    subdir = os.path.join(self.logdir, run_name)
+    writer = tf.summary.FileWriter(subdir)
+    writer.add_graph(sess.graph)
+
+    summ = sess.run(plugin_asset_summary)
+    writer.add_summary(summ)
+    writer.close()
+
+  def testIndex(self):
+    index = self.plugin.index_impl()
+    self.assertItemsEqual(['fry'], index.keys())
+    # The summary made via plugin assets (the old method being phased out) is
+    # only available for run 'fry'.
+    self.assertItemsEqual(['old_plugin_asset_summary'],
+                          index['fry'])
+
+  def testText(self):
+    fry = self.plugin.text_impl('fry', 'old_plugin_asset_summary')
+    self.assertEqual(len(fry), 1)
+    self.assertEqual(fry[0]['step'], 0)
+    self.assertEqual(fry[0]['text'],  u'<p>I am deprecated.</p>')
+
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -474,7 +474,7 @@ class TextPluginBackwardsCompatibilityTest(tf.test.TestCase):
     fry = self.plugin.text_impl('fry', 'old_plugin_asset_summary')
     self.assertEqual(len(fry), 1)
     self.assertEqual(fry[0]['step'], 0)
-    self.assertEqual(fry[0]['text'],  u'<p>I am deprecated.</p>')
+    self.assertEqual(fry[0]['text'], u'<p>I am deprecated.</p>')
 
 
 


### PR DESCRIPTION
This is an import of @chihuahua's code from inside Google. Here's his original change description:

> Use the new SummaryMetadata field of the Value proto to pass per-plugin information.
> This will let TensorBoard figure out which plugins should handle which types of summaries.