### PR TITLE
Renovate the distributions dashboard

### DIFF
--- a/tensorboard/components/tf_backend/backend.ts
+++ b/tensorboard/components/tf_backend/backend.ts
@@ -19,7 +19,6 @@ import {getRouter} from './router';
 import {demoify, queryEncoder} from './urlPathHelpers';
 
 export interface RunEnumeration {
-  compressedHistogramTuples: string[];
   images: string[];
   audio: string[];
   graph: boolean;
@@ -82,7 +81,7 @@ export interface DebuggerNumericsAlertReport {
 export type DebuggerNumericsAlertReportResponse = DebuggerNumericsAlertReport[];
 
 export const TYPES = [
-  'compressedHistogram', 'graph', 'audio', 'runMetadata', 'text'
+  'graph', 'audio', 'runMetadata', 'text'
 ];
 /**
  * The Backend class provides a convenient and typed interface to the backend.
@@ -125,15 +124,6 @@ export class Backend {
   public audioTags(): Promise<RunToTag> {
     return this.requestManager.request(
         getRouter().pluginRoute('audio', '/tags'));
-  }
-
-  /**
-   * Return a promise showing the Run-to-Tag mapping for compressedHistogram
-   * data.
-   */
-  public compressedHistogramTags(): Promise<RunToTag> {
-    return this.requestManager.request(
-        getRouter().pluginRoute('distributions', '/tags'));
   }
 
   /**
@@ -273,20 +263,6 @@ export class Backend {
     return this.requestManager.request(url);
   }
 
-  /**
-   * Get compressedHistogram data.
-   * Unlike other methods, don't bother reprocessing this data into a nicer
-   * format. This is because we will deprecate this route.
-   */
-  private compressedHistogram(tag: string, run: string):
-      Promise<Array<Datum&CompressedHistogramTuple>> {
-    const url = (getRouter().pluginRunTagRoute(
-        'distributions', '/distributions')(tag, run));
-    let p: Promise<TupleData<CompressedHistogramTuple>[]>;
-    p = this.requestManager.request(url);
-    return p.then(map(detupler((x) => x)));
-  }
-
   private createAudio(x: AudioMetadata): Audio&Datum {
     const pluginRoute = getRouter().pluginRoute('audio', '/individualAudio');
 
@@ -369,11 +345,10 @@ function detupler<T, G>(xform: (x: T) => G): (t: TupleData<T>) => Datum & G {
 
 
 /**
- * The following interfaces (TupleData, CompressedHistogramTuple, and
- * AudioMetadata) describe how the data is sent over from the backend.
+ * The following interfaces (TupleData and AudioMetadata) describe how
+ * the data is sent over from the backend.
  */
 type TupleData<T> = [number, number, T];  // wall_time, step
-type CompressedHistogramTuple = [number, number][];  // percentile, value
 interface AudioMetadata {
   content_type: string;
   wall_time: number;

--- a/tensorboard/plugins/distributions/tf_distribution_dashboard/BUILD
+++ b/tensorboard/plugins/distributions/tf_distribution_dashboard/BUILD
@@ -6,10 +6,14 @@ licenses(["notice"])  # Apache 2.0
 
 ts_web_library(
     name = "tf_distribution_dashboard",
-    srcs = ["tf-distribution-dashboard.html"],
+    srcs = [
+        "tf-distribution-dashboard.html",
+        "tf-distribution-loader.html",
+    ],
     path = "/tf-distribution-dashboard",
     deps = [
         "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_card_heading",
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:lodash",

--- a/tensorboard/plugins/distributions/tf_distribution_dashboard/tf-distribution-dashboard.html
+++ b/tensorboard/plugins/distributions/tf_distribution_dashboard/tf-distribution-dashboard.html
@@ -17,19 +17,17 @@ limitations under the License.
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
-<link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
-<link rel="import" href="../tf-dashboard-common/tf-panes-helper.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 <link rel="import" href="../tf-imports/lodash.html">
-<link rel="import" href="../vz-distribution-chart/vz-distribution-chart.html">
-<link rel="import" href="../iron-collapse/iron-collapse.html">
-<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="tf-distribution-loader.html">
 
 <!--
-tf-distribution-dashboard is a complete frontend that loads runs from a backend,
-and creates chart panes that display data for those runs.
+  A frontend that displays a set of tf-distribution-loaders, each of
+  which displays the distribution for a single tag on a single run. This
+  dashboard provides a categorizer and abcissa seletor (step, relative,
+  or wall time).
 
 It provides a x type selector and the normal tf-sidebar-helper options, by
 which the user can customize how data is organized and displayed.
@@ -47,16 +45,17 @@ contains vz-distribution-charts embedded inside tf-panes-helper's.
     <tf-dashboard-layout>
       <div class="sidebar">
         <div class="sidebar-section">
-          <tf-categorizer
-            id="categorizer"
-            tags="[[tags]]"
-            categories="{{_categories}}"
-          ></tf-categorizer>
+          <!--
+            TODO(wchargin): Remove tag groups. Replace them with a
+            search/filter bar in the main content pane.
+          -->
+          <tf-regex-group regexes="{{_tagGroupRegexes}}">
+          </tf-regex-group>
         </div>
         <div class="sidebar-section">
           <tf-option-selector
             id="xTypeSelector"
-            name="Horizontal Axis"
+            name="Horizontal axis"
             selected-id="{{_xType}}"
           >
             <paper-button id="step">step</paper-button>
@@ -71,60 +70,116 @@ contains vz-distribution-charts embedded inside tf-panes-helper's.
       </div>
 
       <div class="center">
-        <tf-panes-helper
-          categories="[[_categories]]"
-          data-type="[[dataType]]"
-          data-provider="[[dataProvider]]"
-          data-not-found="[[dataNotFound]]"
-          run2tag="[[run2tag]]"
-          selected-runs="[[_selectedRuns]]"
-          repeat-for-runs
+        <template is="dom-if" if="[[_dataNotFound]]">
+          <div class="no-data-warning">
+            <h3>No distribution data was found.</h3>
+            <p>Probable causes:</p>
+            <ul>
+              <li>You haven’t written any histogram data to your event
+              files. (Histograms and distributions both use the
+              histogram summary operation.)
+              <li>TensorBoard can’t find your event files.
+            </ul>
+            <p>
+            If you’re new to using TensorBoard, and want to find out how
+            to add data and set up your event files, check out the
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md">README</a>
+            and perhaps the <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard">TensorBoard tutorial</a>.
+            <p>
+            If you think TensorBoard is configured properly, please see
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong">the section of the README devoted to missing data problems</a>
+            and consider filing an issue on GitHub.
+          </div>
+        </template>
+        <template is="dom-repeat" items="[[_categories]]" as="category">
+          <tf-collapsable-pane
+            name="[[category.name]]"
+            count="[[category.count]]"
           >
-          <template>
-            <vz-distribution-chart
-              x-type="[[_xType]]"
-              color-scale="[[_runsColorScale]]"
-            ></vz-distribution-chart>
-          </template>
-        </tf-panes-helper>
+            <div class="layout horizontal wrap">
+              <template is="dom-repeat" items="[[category.items]]">
+                <tf-distribution-loader
+                  run="[[item.run]]"
+                  tag="[[item.tag]]"
+                  x-type="[[_xType]]"
+                  request-manager="[[_requestManager]]"
+                ></tf-distribution-loader>
+              </template>
+            </div>
+          </tf-collapsable-pane>
+        </template>
       </div>
     </tf-dashboard-layout>
 
     <style include="dashboard-style"></style>
+    <style>
+      .no-data-warning {
+        max-width: 540px;
+        margin: 80px auto 0 auto;
+      }
+    </style>
   </template>
 
   <script>
-    import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior";
-    import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior";
-    import {BackendBehavior} from "../tf-backend/behavior";
-    import {runsColorScale} from "../tf-color-scale/colorScale";
+    "use strict";
+
+    import {RequestManager} from '../tf-backend/requestManager';
+    import {getTags} from '../tf-backend/backend';
+    import {getRouter} from '../tf-backend/router';
+    import {categorizeRunTagCombinations} from '../tf-categorization-utils/categorizationUtils';
 
     Polymer({
       is: "tf-distribution-dashboard",
-      behaviors: [
-        DashboardBehavior("distributions"),
-        ReloadBehavior("tf-chart-scaffold"),
-        BackendBehavior,
-      ],
       properties: {
-        backend: Object,
         _xType: {
           type: String,
-          value: "step"
+          value: "step",
         },
-        dataType: {
+
+        _selectedRuns: Array,
+        _runToTag: Object,  // map<run: string, tags: string[]>
+        _dataNotFound: Boolean,
+
+        _categories: {
+          type: Array,
+          computed:
+            '_makeCategories(_runToTag, _selectedRuns, _tagGroupRegexes)',
+        },
+
+        _requestManager: {
           type: Object,
-          value: "compressedHistogram",
+          value: () => new RequestManager(),
         },
-        _runsColorScale: {
-          type: Object,
-          value: function() {
-            return {
-              scale: runsColorScale,
-            };
-          },
-          readOnly: true,
-        },
+      },
+      ready() {
+        this.reload();
+      },
+      reload() {
+        this._fetchTags().then(() => {
+          this._reloadDistributions();
+        });
+      },
+      _fetchTags() {
+        const url = getRouter().pluginRoute('distributions', '/tags');
+        return this._requestManager.request(url).then(runToTag => {
+          if (_.isEqual(runToTag, this._runToTag)) {
+            // No need to update anything if there are no changes.
+            return;
+          }
+          const tags = getTags(runToTag);
+          this.set('_dataNotFound', tags.length === 0);
+          this.set('_runToTag', runToTag);
+        });
+      },
+      _reloadDistributions() {
+        this.querySelectorAll('tf-distribution-loader').forEach(loader => {
+          loader.reload();
+        });
+      },
+
+      _makeCategories(runToTag, selectedRuns, tagGroupRegexes) {
+        return categorizeRunTagCombinations(
+          runToTag, selectedRuns, tagGroupRegexes);
       },
     });
   </script>

--- a/tensorboard/plugins/distributions/tf_distribution_dashboard/tf-distribution-loader.html
+++ b/tensorboard/plugins/distributions/tf_distribution_dashboard/tf-distribution-loader.html
@@ -1,0 +1,172 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../tf-card-heading/tf-card-heading.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../vz-distribution-chart/vz-distribution-chart.html">
+
+<!--
+  tf-distribution-loader loads an individual distribution from the
+  TensorBoard backend, and renders it into a vz-distribution-chart.
+-->
+<dom-module id="tf-distribution-loader">
+  <template>
+    <tf-card-heading title="[[tag]]" color="[[_runColor]]">
+      [[run]]
+    </tf-card-heading>
+    <!--
+      The main distribution that we render. Data is set directly with
+      `setSeriesData`, not with a bound property.
+    -->
+    <vz-distribution-chart
+      x-type="[[xType]]"
+      color-scale="[[_colorScale]]"
+    ></vz-distribution-chart>
+    <div style="display: flex; flex-direction: row;">
+      <paper-icon-button
+        selected$="[[_expanded]]"
+        icon="fullscreen"
+        on-tap="_toggleExpanded"
+      ></paper-icon-button>
+    </div>
+    <style>
+      :host {
+        display: flex;
+        flex-direction: column;
+        width: 330px;
+        height: 235px;
+        margin-right: 10px;
+        margin-bottom: 15px;
+      }
+      :host[_expanded] {
+        width: 700px;
+        height: 500px;
+      }
+
+      vz-histogram-timeseries {
+        -moz-user-select: none;
+        -webkit-user-select: none;
+      }
+
+      paper-icon-button {
+        color: #2196F3;
+        border-radius: 100%;
+        pointer-events: auto;  /* TODO(wchargin): why? */
+        width: 32px;
+        height: 32px;
+        padding: 4px;
+      }
+      paper-icon-button[selected] {
+        background: var(--tb-ui-light-accent);
+      }
+    </style>
+  </template>
+  <script>
+    import {Canceller} from "../tf-backend/canceller";
+    import {getRouter} from "../tf-backend/router";
+    import {runsColorScale} from "../tf-color-scale/colorScale";
+
+    Polymer({
+      is: "tf-distribution-loader",
+      properties: {
+        run: String,
+        tag: String,
+        xType: String,
+
+        _colorScale: {
+          type: Object,
+          value: () => ({scale: runsColorScale}),
+          readOnly: true,
+        },
+        _runColor: {
+          type: String,
+          computed: '_computeRunColor(run)',
+        },
+        _expanded: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,  // for CSS
+        },
+
+        requestManager: Object,
+        _canceller: {
+          type: Object,
+          value: () => new Canceller(),
+        },
+      },
+
+      observers: ['reload(run, tag)'],
+
+      _computeRunColor(run) {
+        return this._colorScale.scale(run);
+      },
+
+      attached() {
+        this._attached = true;
+        this.reload();
+      },
+
+      /**
+       * Reload data from the backend, updating the distribution chart's
+       * series when the response resolves.
+       */
+      reload() {
+        if (!this._attached) {
+          return;
+        }
+        this._canceller.cancelAll();
+        const router = getRouter();
+        const url = router.pluginRunTagRoute("distributions", "/distributions")(
+          this.tag, this.run);
+        const updateData = this._canceller.cancellable(result => {
+          if (result.cancelled) {
+            return;
+          }
+          const backendData = result.value;
+          const data = backendData.map(datum => {
+            // `vz-distribution-chart` wants each datum as an array with
+            // extra `wall_time` and `step` properties.
+            const [wall_time, step, bins] = datum;
+            bins.wall_time = new Date(wall_time * 1000);
+            bins.step = step;
+            return bins;
+          });
+          this.$$('vz-distribution-chart').setVisibleSeries([this.run]);
+          this.$$('vz-distribution-chart').setSeriesData(this.run, data);
+        });
+        this.requestManager.request(url).then(updateData);
+      },
+
+      /**
+       * Ask the distribution chart to redraw itself. This should be
+       * called whenever the dimensions of the view change (e.g., when
+       * the card is expanded), as the distribution chart will need to
+       * recalculate its layout.
+       */
+      redraw() {
+        this.$$('vz-distribution-chart').redraw();
+      },
+
+      _toggleExpanded(e) {
+        this.set('_expanded', !this._expanded);
+        this.redraw();
+      },
+    });
+  </script>
+</dom-module>


### PR DESCRIPTION
Summary:
Like #107 and #108 and #110, but now for distributions.

This change was pretty straightforward; not too much to mention. There
weren't any distribution-related tests in `backendTests.ts`, so I didn't
need to remove anything there.

wchargin-branch: refactor-distributions-dashboard