### PR TITLE
Add file extension to ES6 imports

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,14 +2,13 @@ workspace(name = "org_tensorflow_tensorboard")
 
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "bc41b80486413aaa551860fc37471dbc0666e1dbb5236fb6177cb83b0c105846",
-    strip_prefix = "rules_closure-dec425a4ff3faf09a56c85d082e4eed05d8ce38f",
+    sha256 = "e9e2538b1f7f27de73fa2914b7d2cb1ce2ac01d1abe8390cfe51fb2558ef8b27",
+    strip_prefix = "rules_closure-4c559574447f90751f05155faba4f3344668f666",
     urls = [
-        "http://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/dec425a4ff3faf09a56c85d082e4eed05d8ce38f.tar.gz",  # 2017-06-02
-        "https://github.com/bazelbuild/rules_closure/archive/dec425a4ff3faf09a56c85d082e4eed05d8ce38f.tar.gz",
+        "http://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/4c559574447f90751f05155faba4f3344668f666.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/4c559574447f90751f05155faba4f3344668f666.tar.gz",  # 2017-06-21
     ],
 )
-
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")
 

--- a/tensorboard/components/tf_backend/backend.ts
+++ b/tensorboard/components/tf_backend/backend.ts
@@ -13,10 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {compareTagNames} from '../vz-sorting/sorting';
-import {RequestManager} from './requestManager';
-import {getRouter} from './router';
-import {demoify, queryEncoder} from './urlPathHelpers';
+import {compareTagNames} from '../vz-sorting/sorting.js';
+import {RequestManager} from './requestManager.js';
+import {getRouter} from './router.js';
+import {demoify, queryEncoder} from './urlPathHelpers.js';
 
 export interface RunEnumeration {
   images: string[];

--- a/tensorboard/components/tf_backend/behavior.ts
+++ b/tensorboard/components/tf_backend/behavior.ts
@@ -12,7 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {getRuns, getTags, TYPES} from './backend';
+
+import {getRuns, getTags, TYPES} from './backend.js';
 
 /** @polymerBehavior */
 export const BackendBehavior = {

--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {demoify, queryEncoder} from './urlPathHelpers'
+import {demoify, queryEncoder} from './urlPathHelpers.js';
 
 export type RunTagUrlFn = (tag: string, run: string) => string;
 

--- a/tensorboard/components/tf_backend/runsStore.ts
+++ b/tensorboard/components/tf_backend/runsStore.ts
@@ -12,8 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {RequestManager} from './requestManager';
-import {getRouter} from './router';
+
+import {RequestManager} from './requestManager.js';
+import {getRouter} from './router.js';
 
 let runs: string[] = [];
 

--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -12,10 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Backend, filterTags, getRuns, getTags, RunToTag, TYPES} from '../backend';
-import {RequestManager} from '../requestManager';
-import {createRouter, setRouter} from '../router';
-import {BAD_CHARACTERS, demoify, queryEncoder} from '../urlPathHelpers';
+
+import {Backend, filterTags, getRuns, getTags, RunToTag, TYPES} from '../backend.js';
+import {RequestManager} from '../requestManager.js';
+import {createRouter, setRouter} from '../router.js';
+import {BAD_CHARACTERS, demoify, queryEncoder} from '../urlPathHelpers.js';
 
 describe('urlPathHelpers', () => {
   it('demoify works as expected', () => {

--- a/tensorboard/components/tf_backend/test/behaviorTests.ts
+++ b/tensorboard/components/tf_backend/test/behaviorTests.ts
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Backend, getRuns, getTags, RunToTag} from '../backend'
-import {BackendBehavior} from '../behavior'
+import {Backend, getRuns, getTags, RunToTag} from '../backend.js';
+import {BackendBehavior} from '../behavior.js';
 
 declare function fixture(id: string): void;
 

--- a/tensorboard/components/tf_backend/test/requestManagerTests.ts
+++ b/tensorboard/components/tf_backend/test/requestManagerTests.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {RequestManager, RequestNetworkError} from '../requestManager';
+import {RequestManager, RequestNetworkError} from '../requestManager.js';
 
 interface MockRequest {
   resolve: Function;

--- a/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
+++ b/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {getTags} from '../tf-backend/backend';
-import {categorizer as makeCategorizer} from '../tf-dashboard-common/tf-categorizer';
+import {getTags} from '../tf-backend/backend.js';
+import {categorizer as makeCategorizer} from '../tf-dashboard-common/tf-categorizer.js';
 
 /**
  * Functions to extract categories of tags and/or run-tag combinations

--- a/tensorboard/components/tf_color_scale/colorScale.ts
+++ b/tensorboard/components/tf_color_scale/colorScale.ts
@@ -13,16 +13,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import * as RunsStore from '../tf-backend/runsStore.js';
+import {palettes} from './palettes.js';
+
 // Example usage:
 // runs = ["train", "test", "test1", "test2"]
 // ccs = new ColorScale();
 // ccs.domain(runs);
 // ccs.getColor("train");
 // ccs.getColor("test1");
-
-import * as RunsStore from '../tf-backend/runsStore';
-
-import {palettes} from './palettes';
 
 export class ColorScale {
   private identifiers = d3.map();

--- a/tensorboard/components/tf_color_scale/test/colorScaleTests.ts
+++ b/tensorboard/components/tf_color_scale/test/colorScaleTests.ts
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-let assert = chai.assert;
+import {ColorScale} from '../colorScale.js';
 
-import {ColorScale} from '../colorScale'
+let assert = chai.assert;
 
 describe('ColorScale', function() {
   let ccs: ColorScale;

--- a/tensorboard/components/tf_dashboard_common/test/tf-categorizer-tests.ts
+++ b/tensorboard/components/tf_dashboard_common/test/tf-categorizer-tests.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import * as cat from '../tf-categorizer';
+import * as cat from '../tf-categorizer.js';
 
 let assert = chai.assert;
 

--- a/tensorboard/components/tf_dashboard_common/tf-categorizer.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-categorizer.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {compareTagNames} from '../vz-sorting/sorting';
+import {compareTagNames} from '../vz-sorting/sorting.js';
 
 /**
  * This module contains methods that allow sorting tags into 'categories'.

--- a/tensorboard/components/tf_dashboard_common/tf-chart-scaffold.html
+++ b/tensorboard/components/tf_dashboard_common/tf-chart-scaffold.html
@@ -56,7 +56,7 @@ plugin is required to implement two functions:
   </template>
   <script>
     "use strict";
-    import {Canceller} from "../tf-backend/canceller";
+    import {Canceller} from "../tf-backend/canceller.js";
 
     Polymer({
       is: "tf-chart-scaffold",

--- a/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.ts
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {runsColorScale} from '../tf-color-scale/colorScale';
-import * as storage from '../tf-storage/storage';
+import {runsColorScale} from '../tf-color-scale/colorScale.js';
+import * as storage from '../tf-storage/storage.js';
 
 Polymer({
   is: 'tf-multi-checkbox',

--- a/tensorboard/components/tf_dashboard_common/tf-panes-helper.html
+++ b/tensorboard/components/tf_dashboard_common/tf-panes-helper.html
@@ -181,7 +181,7 @@ downloadLinkUrlFunction property to an appropriate value.
     </style>
   </template>
   <script>
-    import {runsColorScale} from '../tf-color-scale/colorScale';
+    import {runsColorScale} from '../tf-color-scale/colorScale.js';
     Polymer({
       is: "tf-panes-helper",
       properties: {

--- a/tensorboard/components/tf_dashboard_common/tf-regex-group.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-regex-group.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import * as storage from '../tf-storage/storage';
+import * as storage from '../tf-storage/storage.js';
 
 Polymer({
   is: 'tf-regex-group',

--- a/tensorboard/components/tf_profile_dashboard/demo/index.html
+++ b/tensorboard/components/tf_profile_dashboard/demo/index.html
@@ -46,8 +46,8 @@ limitations under the License.
             </tf-profile-dashboard>
           </template>
           <script>
-            import {Backend} from "../../tf-backend/backend";
-            import {createRouter, setRouter} from "../../tf-backend/router";
+            import {Backend} from "../../tf-backend/backend.js";
+            import {createRouter, setRouter} from "../../tf-backend/router.js";
 
             Polymer({
               is: "profile-dash-demo",

--- a/tensorboard/components/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/components/tf_profile_dashboard/tf-profile-dashboard.html
@@ -87,10 +87,10 @@ profile run can have multiple tools that present the performance profile as diff
 <script>
   "use strict";
 
-  import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior";
-  import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior";
-  import {BackendBehavior} from "../tf-backend/behavior";
-  import {getRouter} from '../tf-backend/router';
+  import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior.js";
+  import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior.js";
+  import {BackendBehavior} from "../tf-backend/behavior.js";
+  import {getRouter} from '../tf-backend/router.js';
 
   Polymer({
     is: "tf-profile-dashboard",

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -115,9 +115,9 @@ Properties out:
     </style>
   </template>
   <script>
-  import {RequestManager} from "../tf-backend/requestManager";
-  import {getRouter} from "../tf-backend/router";
-  import * as RunsStore from "../tf-backend/runsStore";
+  import {RequestManager} from "../tf-backend/requestManager.js";
+  import {getRouter} from "../tf-backend/router.js";
+  import * as RunsStore from "../tf-backend/runsStore.js";
 
   var requestManager = new RequestManager();
   Polymer({

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {getFakeHash, setFakeHash, TABS, useHash} from '../tf-globals/globals';
+import {getFakeHash, setFakeHash, TABS, useHash} from '../tf-globals/globals.js';
 
 
 /* tslint:disable:no-namespace variable-name */

--- a/tensorboard/components/tf_storage/test/storageTests.ts
+++ b/tensorboard/components/tf_storage/test/storageTests.ts
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {TAB, getString, getNumber, getObject, setString, setNumber, setObject} from '../storage';
-import {TABS} from '../../tf-globals/globals';
+import {TAB, getString, getNumber, getObject, setString, setNumber, setObject} from '../storage.js';
+import {TABS} from '../../tf-globals/globals.js';
 
 /* tslint:disable:no-namespace */
 describe('URIStorage', () => {

--- a/tensorboard/components/tf_tensorboard/test/autoReloadTests.ts
+++ b/tensorboard/components/tf_tensorboard/test/autoReloadTests.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {AUTORELOAD_LOCALSTORAGE_KEY, AutoReloadBehavior} from '../autoReloadBehavior';
+import {AUTORELOAD_LOCALSTORAGE_KEY, AutoReloadBehavior} from '../autoReloadBehavior.js';
 
 declare function fixture(id: string): void;
 

--- a/tensorboard/components/tf_tensorboard/test/e2eTests.ts
+++ b/tensorboard/components/tf_tensorboard/test/e2eTests.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {TABS} from '../../tf-globals/globals';
+import {TABS} from '../../tf-globals/globals.js';
 
 describe('end-to-end test', () => {
   window.HTMLImports.whenReady(() => {

--- a/tensorboard/components/tf_tensorboard/test/fastTabSwitch.ts
+++ b/tensorboard/components/tf_tensorboard/test/fastTabSwitch.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {TABS} from '../../tf-globals/globals';
+import {TABS} from '../../tf-globals/globals.js';
 
 describe('fast tab switch', () => {
   window.HTMLImports.whenReady(() => {

--- a/tensorboard/components/tf_tensorboard/test/tensorboardTests.ts
+++ b/tensorboard/components/tf_tensorboard/test/tensorboardTests.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {TABS} from '../../tf-globals/globals';
+import {TABS} from '../../tf-globals/globals.js';
 
 describe('tf-tensorboard tests', () => {
   window.HTMLImports.whenReady(() => {

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -209,12 +209,12 @@ allows the user to toggle between various dashboards.
   </template>
   <script src="autoReloadBehavior.js"></script>
   <script>
-    import {AutoReloadBehavior} from "./autoReloadBehavior";
-    import {Backend} from "../tf-backend/backend";
-    import {TABS, setUseHash} from "../tf-globals/globals";
-    import {getString, setString, TAB} from "../tf-storage/storage";
-    import {setRouter, createRouter} from "../tf-backend/router";
-    import {fetchRuns} from "../tf-backend/runsStore";
+    import {AutoReloadBehavior} from "./autoReloadBehavior.js";
+    import {Backend} from "../tf-backend/backend.js";
+    import {TABS, setUseHash} from "../tf-globals/globals.js";
+    import {getString, setString, TAB} from "../tf-storage/storage.js";
+    import {setRouter, createRouter} from "../tf-backend/router.js";
+    import {fetchRuns} from "../tf-backend/runsStore.js";
 
     Polymer({
       is: "tf-tensorboard",

--- a/tensorboard/components/vz_sorting/test/sortingTests.ts
+++ b/tensorboard/components/vz_sorting/test/sortingTests.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {compareTagNames} from '../sorting';
+import {compareTagNames} from '../sorting.js';
 
 describe('compareTagNames', () => {
 

--- a/tensorboard/plugins/audio/tf_audio_dashboard/demo/index.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/demo/index.html
@@ -42,8 +42,8 @@ limitations under the License.
         <tf-audio-dashboard id="demo" backend="[[backend]]"></tf-audio-dashboard>
       </template>
       <script>
-        import {Backend} from '../tf-backend/backend';
-        import {createRouter, setRouter} from '../tf-backend/router';
+        import {Backend} from '../tf-backend/backend.js';
+        import {createRouter, setRouter} from '../tf-backend/router.js';
 
         Polymer({
           is: "audio-dash-demo",

--- a/tensorboard/plugins/audio/tf_audio_dashboard/test/audioDashboardTests.ts
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/test/audioDashboardTests.ts
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import * as backend_backend from '../../tf-backend/backend';
-import {createRouter, setRouter} from '../../tf-backend/router';
+import * as backend_backend from '../../tf-backend/backend.js';
+import {createRouter, setRouter} from '../../tf-backend/router.js';
 
 // TODO(dandelion): Fix me.
 declare function fixture(id: string): any;

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
@@ -59,9 +59,9 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
     </style>
   </template>
   <script>
-    import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior";
-    import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior";
-    import {BackendBehavior} from "../tf-backend/behavior";
+    import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior.js";
+    import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior.js";
+    import {BackendBehavior} from "../tf-backend/behavior.js";
 
     Polymer({
       is: "tf-audio-dashboard",

--- a/tensorboard/plugins/distributions/tf_distribution_dashboard/index.html
+++ b/tensorboard/plugins/distributions/tf_distribution_dashboard/index.html
@@ -43,8 +43,8 @@ limitations under the License.
         <tf-distribution-dashboard id="demo" backend="[[backend]]"></tf-distribution-dashboard>
       </template>
       <script>
-        import {Backend} from "../../tf-backend/backend";
-        import {createRouter, setRouter} from "../../tf-backend/router";
+        import {Backend} from "../../tf-backend/backend.js";
+        import {createRouter, setRouter} from "../../tf-backend/router.js";
 
         Polymer({
           is: "distribution-dash-demo",

--- a/tensorboard/plugins/distributions/tf_distribution_dashboard/tf-distribution-dashboard.html
+++ b/tensorboard/plugins/distributions/tf_distribution_dashboard/tf-distribution-dashboard.html
@@ -123,10 +123,10 @@ contains vz-distribution-charts embedded inside tf-panes-helper's.
   <script>
     "use strict";
 
-    import {RequestManager} from '../tf-backend/requestManager';
-    import {getTags} from '../tf-backend/backend';
-    import {getRouter} from '../tf-backend/router';
-    import {categorizeRunTagCombinations} from '../tf-categorization-utils/categorizationUtils';
+    import {RequestManager} from '../tf-backend/requestManager.js';
+    import {getTags} from '../tf-backend/backend.js';
+    import {getRouter} from '../tf-backend/router.js';
+    import {categorizeRunTagCombinations} from '../tf-categorization-utils/categorizationUtils.js';
 
     Polymer({
       is: "tf-distribution-dashboard",

--- a/tensorboard/plugins/distributions/tf_distribution_dashboard/tf-distribution-loader.html
+++ b/tensorboard/plugins/distributions/tf_distribution_dashboard/tf-distribution-loader.html
@@ -78,9 +78,9 @@ limitations under the License.
     </style>
   </template>
   <script>
-    import {Canceller} from "../tf-backend/canceller";
-    import {getRouter} from "../tf-backend/router";
-    import {runsColorScale} from "../tf-color-scale/colorScale";
+    import {Canceller} from "../tf-backend/canceller.js";
+    import {getRouter} from "../tf-backend/router.js";
+    import {runsColorScale} from "../tf-color-scale/colorScale.js";
 
     Polymer({
       is: "tf-distribution-loader",

--- a/tensorboard/plugins/distributions/vz_distribution_chart/vz-distribution-chart.ts
+++ b/tensorboard/plugins/distributions/vz_distribution_chart/vz-distribution-chart.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import * as ChartHelpers from '../vz-line-chart/vz-chart-helpers';
+import * as ChartHelpers from '../vz-line-chart/vz-chart-helpers.js';
 
 export class DistributionChart {
   private run2datasets: {[run: string]: Plottable.Dataset};

--- a/tensorboard/plugins/graphs/tf_graph_app/tf-graph-app.html
+++ b/tensorboard/plugins/graphs/tf_graph_app/tf-graph-app.html
@@ -27,7 +27,7 @@ The pbtxt format is the stringified version of the graphdef.
 
     <tf-graph-app pbtxt="[[pbtxt]]"></tf-graph-app>
 
-    import tensorflow as tf
+    import tensorflow as tf.js
     life = tf.constant(2, name='life')
     universe = tf.constant(40, name='universe')
     everything = tf.constant(0, name='everything')

--- a/tensorboard/plugins/graphs/tf_graph_dashboard/demo/index.html
+++ b/tensorboard/plugins/graphs/tf_graph_dashboard/demo/index.html
@@ -37,8 +37,8 @@ limitations under the License.
         <tf-graph-dashboard backend="[[backend]]"></tf-graph-dashboard>
       </template>
       <script>
-        import {Backend} from "../../tf-backend/backend";
-        import {createRouter, setRouter} from "../../tf-backend/router";
+        import {Backend} from "../../tf-backend/backend.js";
+        import {createRouter, setRouter} from "../../tf-backend/router.js";
 
         Polymer({
           is: "graph-dashboard-demo",

--- a/tensorboard/plugins/graphs/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graphs/tf_graph_dashboard/tf-graph-dashboard.html
@@ -106,10 +106,10 @@ out-hierarchy-params="{{_hierarchyParams}}"
 </dom-module>
 
 <script>
-import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior";
-import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior";
-import {BackendBehavior} from "../tf-backend/behavior";
-import {compareTagNames} from "../vz-sorting/sorting";
+import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior.js";
+import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior.js";
+import {BackendBehavior} from "../tf-backend/behavior.js";
+import {compareTagNames} from "../vz-sorting/sorting.js";
 
 Polymer({
   is: 'tf-graph-dashboard',

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/index.html
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/index.html
@@ -42,8 +42,8 @@ limitations under the License.
         <tf-histogram-dashboard id="demo" backend="[[backend]]"></tf-histogram-dashboard>
       </template>
       <script>
-        import {Backend} from "../../tf-backend/backend";
-        import {createRouter, setRouter} from "../../tf-backend/router";
+        import {Backend} from "../../tf-backend/backend.js";
+        import {createRouter, setRouter} from "../../tf-backend/router.js";
 
         Polymer({
           is: "histogram-dash-demo",

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/test/histogramTests.ts
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/test/histogramTests.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {intermediateToD3} from '../histogramCore';
+import {intermediateToD3} from '../histogramCore.js';
 
 describe('Verify that the histogram format conversion works.', () => {
 

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -121,10 +121,10 @@ limitations under the License.
   <script>
     "use strict";
 
-    import {RequestManager} from '../tf-backend/requestManager';
-    import {getTags} from '../tf-backend/backend';
-    import {getRouter} from '../tf-backend/router';
-    import {categorizeRunTagCombinations} from '../tf-categorization-utils/categorizationUtils';
+    import {RequestManager} from '../tf-backend/requestManager.js';
+    import {getTags} from '../tf-backend/backend.js';
+    import {getRouter} from '../tf-backend/router.js';
+    import {categorizeRunTagCombinations} from '../tf-categorization-utils/categorizationUtils.js';
 
     Polymer({
       is: "tf-histogram-dashboard",

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/tf-histogram-loader.html
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/tf-histogram-loader.html
@@ -83,10 +83,10 @@ limitations under the License.
   <script>
     "use strict";
 
-    import {Canceller} from "../tf-backend/canceller";
-    import {getRouter} from "../tf-backend/router";
-    import {runsColorScale} from "../tf-color-scale/colorScale";
-    import {backendToVz} from "./histogramCore";
+    import {Canceller} from "../tf-backend/canceller.js";
+    import {getRouter} from "../tf-backend/router.js";
+    import {runsColorScale} from "../tf-color-scale/colorScale.js";
+    import {backendToVz} from "./histogramCore.js";
 
     Polymer({
       is: "tf-histogram-loader",

--- a/tensorboard/plugins/images/tf_image_dashboard/index.html
+++ b/tensorboard/plugins/images/tf_image_dashboard/index.html
@@ -42,8 +42,8 @@ limitations under the License.
             </tf-image-dashboard>
           </template>
           <script>
-            import {Backend} from "../../tf-backend/backend";
-            import {createRouter, setRouter} from "../../tf-backend/router";
+            import {Backend} from "../../tf-backend/backend.js";
+            import {createRouter, setRouter} from "../../tf-backend/router.js";
 
             Polymer({
               is: "image-dash-demo",

--- a/tensorboard/plugins/images/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/plugins/images/tf_image_dashboard/tf-image-dashboard.html
@@ -95,10 +95,10 @@ TensorFlow run.
   <script>
     "use strict";
 
-    import {RequestManager} from '../tf-backend/requestManager';
-    import {getTags} from '../tf-backend/backend';
-    import {getRouter} from '../tf-backend/router';
-    import {categorizeRunTagCombinations} from '../tf-categorization-utils/categorizationUtils';
+    import {RequestManager} from '../tf-backend/requestManager.js';
+    import {getTags} from '../tf-backend/backend.js';
+    import {getRouter} from '../tf-backend/router.js';
+    import {categorizeRunTagCombinations} from '../tf-categorization-utils/categorizationUtils.js';
 
     Polymer({
       is: 'tf-image-dashboard',

--- a/tensorboard/plugins/images/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/images/tf_image_dashboard/tf-image-loader.html
@@ -132,10 +132,10 @@ future for loading older images.
   </template>
   <script>
     "use strict";
-    import {Canceller} from "../tf-backend/canceller";
-    import {getRouter} from "../tf-backend/router";
-    import {runsColorScale} from "../tf-color-scale/colorScale";
-    import * as urlPathHelpers from "../tf-backend/urlPathHelpers";
+    import {Canceller} from "../tf-backend/canceller.js";
+    import {getRouter} from "../tf-backend/router.js";
+    import {runsColorScale} from "../tf-color-scale/colorScale.js";
+    import * as urlPathHelpers from "../tf-backend/urlPathHelpers.js";
 
     Polymer({
       is: "tf-image-loader",

--- a/tensorboard/plugins/projector/vz_projector/analyticsLogger.ts
+++ b/tensorboard/plugins/projector/vz_projector/analyticsLogger.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {ProjectionType} from './data';
+import {ProjectionType} from './data.js';
 
 export class AnalyticsLogger {
   private eventLogging: boolean;

--- a/tensorboard/plugins/projector/vz_projector/bh_tsne.ts
+++ b/tensorboard/plugins/projector/vz_projector/bh_tsne.ts
@@ -43,7 +43,7 @@ limitations under the License.
  * THE SOFTWARE.
  */
 
-import {SPNode, SPTree} from './sptree';
+import {SPNode, SPTree} from './sptree.js';
 
 type AugmSPNode = SPNode&{numCells: number, yCell: number[], rCell: number};
 

--- a/tensorboard/plugins/projector/vz_projector/data-provider-demo.ts
+++ b/tensorboard/plugins/projector/vz_projector/data-provider-demo.ts
@@ -13,10 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DataSet, SpriteAndMetadataInfo, State} from './data';
-import {ProjectorConfig, DataProvider, EmbeddingInfo, TENSORS_MSG_ID} from './data-provider';
-import * as dataProvider from './data-provider';
-import * as logging from './logging';
+import {DataSet, SpriteAndMetadataInfo, State} from './data.js';
+import {ProjectorConfig, DataProvider, EmbeddingInfo, TENSORS_MSG_ID} from './data-provider.js';
+import * as dataProvider from './data-provider.js';
+import * as logging from './logging.js';
 
 const BYTES_EXTENSION = '.bytes';
 

--- a/tensorboard/plugins/projector/vz_projector/data-provider-proto.ts
+++ b/tensorboard/plugins/projector/vz_projector/data-provider-proto.ts
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DataPoint, DataProto, DataSet, SpriteAndMetadataInfo, PointMetadata, State} from './data';
-import {analyzeMetadata, ProjectorConfig, DataProvider} from './data-provider';
+import {DataPoint, DataProto, DataSet, SpriteAndMetadataInfo, PointMetadata, State} from './data.js';
+import {analyzeMetadata, ProjectorConfig, DataProvider} from './data-provider.js';
 
 
 export class ProtoDataProvider implements DataProvider {

--- a/tensorboard/plugins/projector/vz_projector/data-provider-server.ts
+++ b/tensorboard/plugins/projector/vz_projector/data-provider-server.ts
@@ -13,10 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DataSet, SpriteAndMetadataInfo, State} from './data';
-import * as dataProvider from './data-provider';
-import {DataProvider, EmbeddingInfo, ProjectorConfig} from './data-provider';
-import * as logging from './logging';
+import {DataSet, SpriteAndMetadataInfo, State} from './data.js';
+import * as dataProvider from './data-provider.js';
+import {DataProvider, EmbeddingInfo, ProjectorConfig} from './data-provider.js';
+import * as logging from './logging.js';
 
 // Limit for the number of data points we receive from the server.
 export const LIMIT_NUM_POINTS = 100000;

--- a/tensorboard/plugins/projector/vz_projector/data-provider.ts
+++ b/tensorboard/plugins/projector/vz_projector/data-provider.ts
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {ColumnStats, DataPoint, DataSet, SpriteAndMetadataInfo, PointMetadata, State} from './data';
-import * as logging from './logging';
-import {runAsyncTask} from './util';
+import {ColumnStats, DataPoint, DataSet, SpriteAndMetadataInfo, PointMetadata, State} from './data.js';
+import * as logging from './logging.js';
+import {runAsyncTask} from './util.js';
 
 /** Maximum number of colors supported in the color map. */
 const NUM_COLORS_COLOR_MAP = 50;

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -13,13 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {TSNE} from './bh_tsne';
-import {SpriteMetadata} from './data-provider';
-import * as knn from './knn';
-import * as logging from './logging';
-import * as scatterPlot from './scatterPlot';
-import * as util from './util';
-import * as vector from './vector';
+import {TSNE} from './bh_tsne.js';
+import {SpriteMetadata} from './data-provider.js';
+import * as knn from './knn.js';
+import * as logging from './logging.js';
+import * as scatterPlot from './scatterPlot.js';
+import * as util from './util.js';
+import * as vector from './vector.js';
 
 export type DistanceFunction = (a: number[], b: number[]) => number;
 export type ProjectionComponents3D = [string, string, string];

--- a/tensorboard/plugins/projector/vz_projector/knn.ts
+++ b/tensorboard/plugins/projector/vz_projector/knn.ts
@@ -13,11 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {runAsyncTask} from './util';
-import * as logging from './logging';
-import {KMin} from './heap';
-import {Vector} from './vector';
-import * as vector from './vector';
+import {runAsyncTask} from './util.js';
+import * as logging from './logging.js';
+import {KMin} from './heap.js';
+import {Vector} from './vector.js';
+import * as vector from './vector.js';
 
 export type NearestEntry = {
   index: number,

--- a/tensorboard/plugins/projector/vz_projector/projectorEventContext.ts
+++ b/tensorboard/plugins/projector/vz_projector/projectorEventContext.ts
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DistanceFunction, Projection} from './data';
-import {NearestEntry} from './knn';
+import {DistanceFunction, Projection} from './data.js';
+import {NearestEntry} from './knn.js';
 
 export type HoverListener = (index: number) => void;
 export type SelectionChangedListener =

--- a/tensorboard/plugins/projector/vz_projector/projectorScatterPlotAdapter.ts
+++ b/tensorboard/plugins/projector/vz_projector/projectorScatterPlotAdapter.ts
@@ -13,16 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DataSet, DistanceFunction, Projection, ProjectionComponents3D, State} from './data';
-import {NearestEntry} from './knn';
-import {ProjectorEventContext} from './projectorEventContext';
-import {LabelRenderParams} from './renderContext';
-import {ScatterPlot} from './scatterPlot';
-import {ScatterPlotVisualizer3DLabels} from './scatterPlotVisualizer3DLabels';
-import {ScatterPlotVisualizerCanvasLabels} from './scatterPlotVisualizerCanvasLabels';
-import {ScatterPlotVisualizerPolylines} from './scatterPlotVisualizerPolylines';
-import {ScatterPlotVisualizerSprites} from './scatterPlotVisualizerSprites';
-import * as vector from './vector';
+import {DataSet, DistanceFunction, Projection, ProjectionComponents3D, State} from './data.js';
+import {NearestEntry} from './knn.js';
+import {ProjectorEventContext} from './projectorEventContext.js';
+import {LabelRenderParams} from './renderContext.js';
+import {ScatterPlot} from './scatterPlot.js';
+import {ScatterPlotVisualizer3DLabels} from './scatterPlotVisualizer3DLabels.js';
+import {ScatterPlotVisualizerCanvasLabels} from './scatterPlotVisualizerCanvasLabels.js';
+import {ScatterPlotVisualizerPolylines} from './scatterPlotVisualizerPolylines.js';
+import {ScatterPlotVisualizerSprites} from './scatterPlotVisualizerSprites.js';
+import * as vector from './vector.js';
 
 const LABEL_FONT_SIZE = 10;
 const LABEL_SCALE_DEFAULT = 1.0;

--- a/tensorboard/plugins/projector/vz_projector/scatterPlot.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlot.ts
@@ -13,12 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {ProjectorEventContext} from './projectorEventContext';
-import {CameraType, LabelRenderParams, RenderContext} from './renderContext';
-import {BoundingBox, ScatterPlotRectangleSelector} from './scatterPlotRectangleSelector';
-import {ScatterPlotVisualizer} from './scatterPlotVisualizer';
-import * as util from './util';
-import {Point2D, Point3D} from './vector';
+import {ProjectorEventContext} from './projectorEventContext.js';
+import {CameraType, LabelRenderParams, RenderContext} from './renderContext.js';
+import {BoundingBox, ScatterPlotRectangleSelector} from './scatterPlotRectangleSelector.js';
+import {ScatterPlotVisualizer} from './scatterPlotVisualizer.js';
+import * as util from './util.js';
+import {Point2D, Point3D} from './vector.js';
 
 const BACKGROUND_COLOR = 0xffffff;
 

--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizer.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizer.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {RenderContext} from './renderContext';
+import {RenderContext} from './renderContext.js';
 
 /**
  * ScatterPlotVisualizer is an interface used by ScatterPlotContainer

--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizer3DLabels.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizer3DLabels.ts
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {RenderContext} from './renderContext';
-import {ScatterPlotVisualizer} from './scatterPlotVisualizer';
-import * as util from './util';
+import {RenderContext} from './renderContext.js';
+import {ScatterPlotVisualizer} from './scatterPlotVisualizer.js';
+import * as util from './util.js';
 
 const FONT_SIZE = 80;
 const ONE_OVER_FONT_SIZE = 1 / FONT_SIZE;

--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerCanvasLabels.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerCanvasLabels.ts
@@ -13,10 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {BoundingBox, CollisionGrid} from './label';
-import {CameraType, RenderContext} from './renderContext';
-import {ScatterPlotVisualizer} from './scatterPlotVisualizer';
-import * as util from './util';
+import {BoundingBox, CollisionGrid} from './label.js';
+import {CameraType, RenderContext} from './renderContext.js';
+import {ScatterPlotVisualizer} from './scatterPlotVisualizer.js';
+import * as util from './util.js';
 
 const MAX_LABELS_ON_SCREEN = 10000;
 const LABEL_STROKE_WIDTH = 3;

--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerPolylines.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerPolylines.ts
@@ -13,10 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DataSet} from './data';
-import {RenderContext} from './renderContext';
-import {ScatterPlotVisualizer} from './scatterPlotVisualizer';
-import * as util from './util';
+import {DataSet} from './data.js';
+import {RenderContext} from './renderContext.js';
+import {ScatterPlotVisualizer} from './scatterPlotVisualizer.js';
+import * as util from './util.js';
 
 const RGB_NUM_ELEMENTS = 3;
 const XYZ_NUM_ELEMENTS = 3;

--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerSprites.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerSprites.ts
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {CameraType, RenderContext} from './renderContext';
-import {ScatterPlotVisualizer} from './scatterPlotVisualizer';
-import * as util from './util';
+import {CameraType, RenderContext} from './renderContext.js';
+import {ScatterPlotVisualizer} from './scatterPlotVisualizer.js';
+import * as util from './util.js';
 
 const NUM_POINTS_FOG_THRESHOLD = 5000;
 const MIN_POINT_SIZE = 5.0;

--- a/tensorboard/plugins/projector/vz_projector/test/data-provider_test.ts
+++ b/tensorboard/plugins/projector/vz_projector/test/data-provider_test.ts
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DataPoint, SpriteAndMetadataInfo} from '../data';
-import * as data_provider from '../data-provider';
+import {DataPoint, SpriteAndMetadataInfo} from '../data.js';
+import * as data_provider from '../data-provider.js';
 
 /**
  * Converts a string to an ArrayBuffer.

--- a/tensorboard/plugins/projector/vz_projector/test/data_test.ts
+++ b/tensorboard/plugins/projector/vz_projector/test/data_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DataPoint, DataSet, State, stateGetAccessorDimensions} from '../data';
+import {DataPoint, DataSet, State, stateGetAccessorDimensions} from '../data.js';
 
 /**
  * Helper method that makes a list of points given an array of

--- a/tensorboard/plugins/projector/vz_projector/test/scatterPlotRectangleSelector_test.ts
+++ b/tensorboard/plugins/projector/vz_projector/test/scatterPlotRectangleSelector_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {BoundingBox, ScatterPlotRectangleSelector} from '../scatterPlotRectangleSelector';
+import {BoundingBox, ScatterPlotRectangleSelector} from '../scatterPlotRectangleSelector.js';
 
 describe('selector callbacks make bounding box start bottom left', () => {
   let containerElement: HTMLElement;

--- a/tensorboard/plugins/projector/vz_projector/test/sptree_test.ts
+++ b/tensorboard/plugins/projector/vz_projector/test/sptree_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {SPTree} from '../sptree';
+import {SPTree} from '../sptree.js';
 
 it('simple 2D data', () => {
   let data = [

--- a/tensorboard/plugins/projector/vz_projector/test/util_test.ts
+++ b/tensorboard/plugins/projector/vz_projector/test/util_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import * as util from '../util';
+import * as util from '../util.js';
 
 describe('getURLParams', () => {
   it('search query with valid param returns correct object', () => {

--- a/tensorboard/plugins/projector/vz_projector/test/vz-projector-projections-panel_test.ts
+++ b/tensorboard/plugins/projector/vz_projector/test/vz-projector-projections-panel_test.ts
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {State} from '../data';
-import {ProjectionsPanel} from '../vz-projector-projections-panel';
+import {State} from '../data.js';
+import {ProjectionsPanel} from '../vz-projector-projections-panel.js';
 
 describe('restoreUIFromBookmark', () => {
   let projectionsPanel: ProjectionsPanel;

--- a/tensorboard/plugins/projector/vz_projector/util.ts
+++ b/tensorboard/plugins/projector/vz_projector/util.ts
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DataPoint} from './data';
-import * as logging from './logging';
-import {Point2D} from './vector';
+import {DataPoint} from './data.js';
+import * as logging from './logging.js';
+import {Point2D} from './vector.js';
 
 /**
  * Delay for running expensive tasks, in milliseconds.

--- a/tensorboard/plugins/projector/vz_projector/vector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vector.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {assert} from './util';
+import {assert} from './util.js';
 
 /**
  * @fileoverview Useful vector utilities.

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-bookmark-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-bookmark-panel.ts
@@ -12,13 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {State} from './data';
-import {DataProvider, EmbeddingInfo} from './data-provider';
-import * as logging from './logging';
-import {ProjectorEventContext} from './projectorEventContext';
-import {Projector} from './vz-projector';
+import {State} from './data.js';
+import {DataProvider, EmbeddingInfo} from './data-provider.js';
+import * as logging from './logging.js';
+import {ProjectorEventContext} from './projectorEventContext.js';
+import {Projector} from './vz-projector.js';
 // tslint:disable-next-line:no-unused-variable
-import {PolymerElement, PolymerHTMLElement} from './vz-projector-util';
+import {PolymerElement, PolymerHTMLElement} from './vz-projector-util.js';
 
 // tslint:disable-next-line
 export let BookmarkPanelPolymer = PolymerElement({

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.html
@@ -37,7 +37,7 @@ limitations under the License.
   </template>
 </template>
 <script>
-import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior";
+import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior.js";
 
 Polymer({
   is: 'vz-projector-dashboard',

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
@@ -13,13 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {ColorOption, ColumnStats, SpriteAndMetadataInfo} from './data';
-import {DataProvider, EmbeddingInfo, parseRawMetadata, parseRawTensors, ProjectorConfig} from './data-provider';
-import * as util from './util';
-import {Projector} from './vz-projector';
-import {ColorLegendRenderInfo, ColorLegendThreshold} from './vz-projector-legend';
+import {ColorOption, ColumnStats, SpriteAndMetadataInfo} from './data.js';
+import {DataProvider, EmbeddingInfo, parseRawMetadata, parseRawTensors, ProjectorConfig} from './data-provider.js';
+import * as util from './util.js';
+import {Projector} from './vz-projector.js';
+import {ColorLegendRenderInfo, ColorLegendThreshold} from './vz-projector-legend.js';
 // tslint:disable-next-line:no-unused-variable
-import {PolymerElement, PolymerHTMLElement} from './vz-projector-util';
+import {PolymerElement, PolymerHTMLElement} from './vz-projector-util.js';
 
 export let DataPanelPolymer = PolymerElement({
   is: 'vz-projector-data-panel',

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-input.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-input.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 // tslint:disable-next-line:no-unused-variable
-import {PolymerElement, PolymerHTMLElement} from './vz-projector-util';
+import {PolymerElement, PolymerHTMLElement} from './vz-projector-util.js';
 
 // tslint:disable-next-line
 export let PolymerClass = PolymerElement(

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
@@ -13,16 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DistanceFunction, SpriteAndMetadataInfo, State} from './data';
-import * as knn from './knn';
-import {ProjectorEventContext} from './projectorEventContext';
-import * as adapter from './projectorScatterPlotAdapter';
-import * as util from './util';
-import * as vector from './vector';
-import {Projector} from './vz-projector';
-import {ProjectorInput} from './vz-projector-input';
+import {DistanceFunction, SpriteAndMetadataInfo, State} from './data.js';
+import * as knn from './knn.js';
+import {ProjectorEventContext} from './projectorEventContext.js';
+import * as adapter from './projectorScatterPlotAdapter.js';
+import * as util from './util.js';
+import * as vector from './vector.js';
+import {Projector} from './vz-projector.js';
+import {ProjectorInput} from './vz-projector-input.js';
 // tslint:disable-next-line:no-unused-variable
-import {PolymerElement, PolymerHTMLElement} from './vz-projector-util';
+import {PolymerElement, PolymerHTMLElement} from './vz-projector-util.js';
 
 /** Limit the number of search results we show to the user. */
 const LIMIT_RESULTS = 100;

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-legend.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-legend.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 // tslint:disable-next-line:no-unused-variable
-import {PolymerElement, PolymerHTMLElement} from './vz-projector-util';
+import {PolymerElement, PolymerHTMLElement} from './vz-projector-util.js';
 
 // tslint:disable-next-line
 export let LegendPolymer = PolymerElement({

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-metadata-card.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-metadata-card.ts
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {PointMetadata} from './data';
+import {PointMetadata} from './data.js';
 // tslint:disable-next-line:no-unused-variable
-import {PolymerElement, PolymerHTMLElement} from './vz-projector-util';
+import {PolymerElement, PolymerHTMLElement} from './vz-projector-util.js';
 
 // tslint:disable-next-line
 export let MetadataCardPolymer = PolymerElement({

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -13,15 +13,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import * as data from './data';
-import {DataSet, Projection, ProjectionType, SpriteAndMetadataInfo, State} from './data';
-import * as util from './util';
-import * as vector from './vector';
-import {Vector} from './vector';
-import {Projector} from './vz-projector';
-import {ProjectorInput} from './vz-projector-input';
+import * as data from './data.js';
+import {DataSet, Projection, ProjectionType, SpriteAndMetadataInfo, State} from './data.js';
+import * as util from './util.js';
+import * as vector from './vector.js';
+import {Vector} from './vector.js';
+import {Projector} from './vz-projector.js';
+import {ProjectorInput} from './vz-projector-input.js';
 // tslint:disable-next-line:no-unused-variable
-import {PolymerElement, PolymerHTMLElement} from './vz-projector-util';
+import {PolymerElement, PolymerHTMLElement} from './vz-projector-util.js';
 
 const NUM_PCA_COMPONENTS = 10;
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -13,26 +13,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {AnalyticsLogger} from './analyticsLogger';
-import * as data from './data';
-import {ColorOption, ColumnStats, DataPoint, DataProto, DataSet, DistanceFunction, PointMetadata, Projection, SpriteAndMetadataInfo, State, stateGetAccessorDimensions} from './data';
-import {DataProvider, EmbeddingInfo, ServingMode} from './data-provider';
-import {DemoDataProvider} from './data-provider-demo';
-import {ProtoDataProvider} from './data-provider-proto';
-import {ServerDataProvider} from './data-provider-server';
-import * as knn from './knn';
-import * as logging from './logging';
-import {DistanceMetricChangedListener, HoverListener, ProjectionChangedListener, ProjectorEventContext, SelectionChangedListener} from './projectorEventContext';
-import {ProjectorScatterPlotAdapter} from './projectorScatterPlotAdapter';
-import {MouseMode} from './scatterPlot';
-import * as util from './util';
-import {BookmarkPanel} from './vz-projector-bookmark-panel';
-import {DataPanel} from './vz-projector-data-panel';
-import {InspectorPanel} from './vz-projector-inspector-panel';
-import {MetadataCard} from './vz-projector-metadata-card';
-import {ProjectionsPanel} from './vz-projector-projections-panel';
+import {AnalyticsLogger} from './analyticsLogger.js';
+import * as data from './data.js';
+import {ColorOption, ColumnStats, DataPoint, DataProto, DataSet, DistanceFunction, PointMetadata, Projection, SpriteAndMetadataInfo, State, stateGetAccessorDimensions} from './data.js';
+import {DataProvider, EmbeddingInfo, ServingMode} from './data-provider.js';
+import {DemoDataProvider} from './data-provider-demo.js';
+import {ProtoDataProvider} from './data-provider-proto.js';
+import {ServerDataProvider} from './data-provider-server.js';
+import * as knn from './knn.js';
+import * as logging from './logging.js';
+import {DistanceMetricChangedListener, HoverListener, ProjectionChangedListener, ProjectorEventContext, SelectionChangedListener} from './projectorEventContext.js';
+import {ProjectorScatterPlotAdapter} from './projectorScatterPlotAdapter.js';
+import {MouseMode} from './scatterPlot.js';
+import * as util from './util.js';
+import {BookmarkPanel} from './vz-projector-bookmark-panel.js';
+import {DataPanel} from './vz-projector-data-panel.js';
+import {InspectorPanel} from './vz-projector-inspector-panel.js';
+import {MetadataCard} from './vz-projector-metadata-card.js';
+import {ProjectionsPanel} from './vz-projector-projections-panel.js';
 // tslint:disable-next-line:no-unused-variable
-import {PolymerElement, PolymerHTMLElement} from './vz-projector-util';
+import {PolymerElement, PolymerHTMLElement} from './vz-projector-util.js';
 
 /**
  * The minimum number of dimensions the data should have to automatically

--- a/tensorboard/plugins/scalars/tf_scalar_dashboard/demo/index.html
+++ b/tensorboard/plugins/scalars/tf_scalar_dashboard/demo/index.html
@@ -45,8 +45,8 @@ limitations under the License.
         <tf-scalar-dashboard id="demo" backend="[[backend]]"></tf-scalar-dashboard>
       </template>
       <script>
-        import {Backend} from "../tf-backend/backend";
-        import {createRouter, setRouter} from "../tf-backend/router";
+        import {Backend} from "../tf-backend/backend.js";
+        import {createRouter, setRouter} from "../tf-backend/router.js";
 
         Polymer({
           is: "scalar-dash-demo",

--- a/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-chart.html
+++ b/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-chart.html
@@ -123,9 +123,9 @@ limitations under the License.
     </style>
   </template>
   <script>
-    import {Canceller} from '../tf-backend/canceller';
-    import {getRouter} from '../tf-backend/router';
-    import {runsColorScale} from '../tf-color-scale/colorScale';
+    import {Canceller} from '../tf-backend/canceller.js';
+    import {getRouter} from '../tf-backend/router.js';
+    import {runsColorScale} from '../tf-color-scale/colorScale.js';
 
     /** @enum {string} */ const X_TYPE = {
       STEP: 'step',

--- a/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -172,11 +172,11 @@ limitations under the License.
   </template>
 
   <script>
-    import {RequestManager} from '../tf-backend/requestManager';
-    import {getTags} from '../tf-backend/backend';
-    import {getRouter} from '../tf-backend/router';
-    import {categorizeTags} from '../tf-categorization-utils/categorizationUtils';
-    import * as storage from '../tf-storage/storage';
+    import {RequestManager} from '../tf-backend/requestManager.js';
+    import {getTags} from '../tf-backend/backend.js';
+    import {getRouter} from '../tf-backend/router.js';
+    import {categorizeTags} from '../tf-categorization-utils/categorizationUtils.js';
+    import * as storage from '../tf-storage/storage.js';
 
     /** @enum {string} */ const X_TYPE = {
       STEP: 'step',

--- a/tensorboard/plugins/scalars/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/plugins/scalars/vz_line_chart/vz-line-chart.ts
@@ -14,8 +14,8 @@ limitations under the License.
 ==============================================================================*/
 /* tslint:disable:no-namespace variable-name */
 
-import {DragZoomLayer} from './dragZoomInteraction'
-import * as ChartHelpers from './vz-chart-helpers'
+import {DragZoomLayer} from './dragZoomInteraction.js';
+import * as ChartHelpers from './vz-chart-helpers.js';
 
 Polymer({
   is: 'vz-line-chart',

--- a/tensorboard/plugins/text/tf_text_dashboard/index.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/index.html
@@ -44,8 +44,8 @@ limitations under the License.
             </tf-text-dashboard>
           </template>
           <script>
-            import * as backend_backend from '../tf-backend/backend';
-            import {createRouter, setRouter} from '../tf-backend/router';
+            import * as backend_backend from '../tf-backend/backend.js';
+            import {createRouter, setRouter} from '../tf-backend/router.js';
 
             Polymer({
               is: "text-dash-demo",

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
@@ -73,9 +73,9 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
     </style>
   </template>
   <script>
-    import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior";
-    import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior";
-    import {BackendBehavior} from "../tf-backend/behavior";
+    import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior.js";
+    import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior.js";
+    import {BackendBehavior} from "../tf-backend/behavior.js";
 
     Polymer({
       is: "tf-text-dashboard",

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
@@ -103,7 +103,7 @@ tf-text-loader displays markdown text data from the Text plugin.
 
   </template>
   <script>
-    import {runsColorScale} from "../tf-color-scale/colorScale";
+    import {runsColorScale} from "../tf-color-scale/colorScale.js";
     Polymer({
       is: "tf-text-loader",
       properties: {


### PR DESCRIPTION
According to @blickly browsers are planning to standardize ES6 imports to
require the file extension, rather than doing things the Node way. The syntax
for this in TypeScript is, surprisingly enough, the .js extension. I verified
that type checking and everything still works when we do this.