### PR TITLE
Decouple the graph dashboard from TensorBoard core

### DIFF
--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -23,7 +23,6 @@ export interface Router {
   isDemoMode: () => boolean;
   textRuns: () => string;
   text: RunTagUrlFn;
-  healthPills: () => string;
   pluginRoute: (pluginName: string, route: string) => string;
   pluginRunTagRoute: (pluginName: string, route: string) => RunTagUrlFn;
 }
@@ -64,7 +63,6 @@ export function createRouter(dataDir = 'data', demoMode = false): Router {
     logdir: () => dataDir + '/logdir',
     runs: () => dataDir + '/runs' + (demoMode ? '.json' : ''),
     isDemoMode: () => demoMode,
-    healthPills: () => dataDir + '/plugin/debugger/health_pills',
     textRuns: () => dataDir + '/plugin/text/runs' + (demoMode ? '.json' : ''),
     text: standardRoute('plugin/text/text'),
     pluginRoute,

--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -87,8 +87,6 @@ describe('backend tests', () => {
 
   it('run helper methods work', (done) => {
     const audio = {run1: ['audio1'], fake_run_no_data: ['audio1', 'audio2']};
-    const runMetadata = {run1: ['step99'], fake_run_no_data: ['step99']};
-    const graph = ['fake_run_no_data'];
     let count = 0;
     function next() {
       count++;
@@ -98,14 +96,6 @@ describe('backend tests', () => {
     }
     backend.audioTags().then((x) => {
       chai.assert.deepEqual(x, audio);
-      next();
-    });
-    backend.runMetadataTags().then((x) => {
-      chai.assert.deepEqual(x, runMetadata);
-      next();
-    });
-    backend.graphRuns().then((x) => {
-      chai.assert.deepEqual(x, graph);
       next();
     });
   });

--- a/tensorboard/components/tf_dashboard_common/tf-no-data-warning.html
+++ b/tensorboard/components/tf_dashboard_common/tf-no-data-warning.html
@@ -24,21 +24,6 @@ Display a warning when there is no data found.
   <template>
     <template is="dom-if" if="[[showWarning]]">
       <div class="warning">
-        <template is="dom-if" if="[[_isGraph(dataType)]]">
-          <h3>
-            No graph definition files were found.
-          </h3>
-          <p>
-            To store a graph, create a
-            <code>tf.summary.FileWriter</code>
-            and pass the graph either via the constructor, or by calling its
-            <code>add_graph()</code> method.
-            You may want to check out the
-            <a href="https://www.tensorflow.org/get_started/graph_viz">
-              graph visualizer tutorial
-            </a>.
-          </p>
-        </template>
         <template is="dom-if" if="[[_isProjector(dataType)]]">
           <h3>
             No checkpoint was found.
@@ -115,14 +100,11 @@ Display a warning when there is no data found.
         dataType: String,
         showWarning: Boolean
       },
-      _isGraph: function(dataType) {
-        return dataType === "graph";
-      },
       _isProjector: function(dataType) {
         return dataType === "projector";
       },
       _isOther: function(dataType) {
-        return !this._isGraph(dataType) && !this._isProjector(dataType);
+        return !this._isProjector(dataType);
       }
     });
   </script>

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -108,7 +108,6 @@ allows the user to toggle between various dashboards.
         <template is="dom-if" if="[[_modeIsGraphs(mode)]]">
           <tf-graph-dashboard
             id="graphs"
-            backend="[[_backend]]"
             debugger-data-enabled="[[_debuggerDataEnabled]]"
           ></tf-graph-dashboard>
         </template>

--- a/tensorboard/plugins/graphs/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graphs/tf_graph_dashboard/tf-graph-dashboard.html
@@ -35,10 +35,29 @@ by default. The user can select a different run from a dropdown menu.
 -->
 <dom-module id="tf-graph-dashboard">
 <template>
-<tf-no-data-warning
-  data-type="graph"
-  show-warning="[[_datasetsEmpty(_datasets)]]"
-></tf-no-data-warning>
+<template is="dom-if" if="[[_datasetsEmpty(_datasets)]]">
+  <div style="max-width: 540px; margin: 80px auto 0 auto;">
+    <h3>No graph definition files were found.</h3>
+    <p>
+    To store a graph, create a
+    <code>tf.summary.FileWriter</code>
+    and pass the graph either via the constructor, or by calling its
+    <code>add_graph()</code> method.
+    You may want to check out the
+    <a
+      href="https://www.tensorflow.org/get_started/graph_viz"
+    >graph visualizer tutorial</a>.
+    <p>
+    If you’re new to using TensorBoard, and want to find out how
+    to add data and set up your event files, check out the
+    <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md">README</a>
+    and perhaps the <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard">TensorBoard tutorial</a>.
+    <p>
+    If you think TensorBoard is configured properly, please see
+    <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong">the section of the README devoted to missing data problems</a>
+    and consider filing an issue on GitHub.
+  </div>
+</template>
 <template is="dom-if" if="[[!_datasetsEmpty(_datasets)]]">
 <tf-dashboard-layout>
 <div class="sidebar">
@@ -106,22 +125,20 @@ out-hierarchy-params="{{_hierarchyParams}}"
 </dom-module>
 
 <script>
-import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior.js";
-import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior.js";
-import {BackendBehavior} from "../tf-backend/behavior.js";
+import {RequestManager} from "../tf-backend/requestManager.js";
 import {compareTagNames} from "../vz-sorting/sorting.js";
+import {getRouter} from "../tf-backend/router.js";
+import {queryEncoder} from "../tf-backend/urlPathHelpers.js";
 
 Polymer({
   is: 'tf-graph-dashboard',
-  behaviors: [
-    DashboardBehavior("graphs"),
-    ReloadBehavior("tf-graph-dashboard"),
-    BackendBehavior,
-  ],
   properties: {
     _datasets: Object,
     _renderHierarchy: {type: Object, observer: '_renderHierarchyChanged'},
-    backend: Object,
+    _requestManager: {
+      type: Object,
+      value: () => new RequestManager(),
+    },
     debuggerDataEnabled: Boolean,
     allStepsModeEnabled: Boolean,
     specificHealthPillStep: {type: Number, value: 0},
@@ -165,7 +182,7 @@ Polymer({
   },
   observers: [
     '_maybeFetchHealthPills(allStepsModeEnabled, specificHealthPillStep, _selectedNode)',
-    '_maybeInitializeDashboard(backend, _isAttached)',
+    '_maybeInitializeDashboard(_isAttached)',
   ],
   attached: function() {
     this.set('_isAttached', true);
@@ -176,6 +193,49 @@ Polymer({
   reload: function() {
     this._maybeFetchHealthPills();
   },
+  _fetchGraphRuns() {
+    return this._requestManager.request(
+        getRouter().pluginRoute('graphs', '/runs'));
+  },
+  _fetchRunMetadataTags() {
+    return this._requestManager.request(
+        getRouter().pluginRoute('graphs', '/run_metadata_tags'));
+  },
+  /*
+   * See also _maybeFetchHealthPills, _initiateNetworkRequestForHealthPills.
+   * This function returns a promise with the raw health pill data.
+   */
+  _fetchHealthPills(nodeNames, step) {
+    const postData = {
+      'node_names': JSON.stringify(nodeNames),
+
+      // Events files with debugger data fall under this special run.
+      'run': '__debugger_data__',
+    };
+    if (step !== undefined) {
+      // The user requested health pills for a specific step. This request
+      // might be slow since the backend reads events sequentially from disk.
+      postData['step'] = step;
+    }
+    const url = getRouter().pluginRoute('debugger', '/health_pills');
+    return this._requestManager.request(url, postData);
+  },
+  _fetchDebuggerNumericsAlerts() {
+    return this._requestManager.request(
+        getRouter().pluginRoute('debugger', '/numerics_alert_report'));
+  },
+  _graphUrl(run, limitAttrSize, largeAttrsKey) {
+    const demoMode = getRouter().isDemoMode();
+    const base = getRouter().pluginRoute('graphs', '/graph');
+    const optional = (p) => (p != null && !demoMode || undefined) && p;
+    const parameters = {
+      'run': run,
+      'limit_attr_size': optional(limitAttrSize),
+      'large_attrs_key': optional(largeAttrsKey),
+    };
+    const extension = demoMode ? '.pbtxt' : '';
+    return base + queryEncoder(parameters) + extension;
+  },
   _shouldRequestHealthPills: function() {
     // Do not load debugger data if the feature is disabled, if the user toggled off the feature,
     // or if the graph itself has not loaded yet. We need the graph to load so that we know which
@@ -185,8 +245,8 @@ Polymer({
         this._renderHierarchy &&
         !this._datasetsEmpty(this._datasets);
   },
-  _maybeInitializeDashboard: function(backend, isAttached) {
-    if (this._initialized || !backend || !isAttached) {
+  _maybeInitializeDashboard: function(isAttached) {
+    if (this._initialized || !isAttached) {
       // Either this dashboard is already initialized ... or we are not yet ready to initialize.
       return;
     }
@@ -195,26 +255,24 @@ Polymer({
     }
     // Set this to true so we only initialize once.
     this._initialized = true;
-    Promise.all([backend.graphRuns(), backend.runMetadataTags()])
-      .then(function(result) {
-        var runsWithGraph = result[0].sort(compareTagNames);
-        var runToMetadata = result[1];
-        var datasets = _.map(runsWithGraph, function(runName) {
-          return {
-            name: runName,
-            path: backend.graphUrl(
-                runName, tf.graph.LIMIT_ATTR_SIZE, tf.graph.LARGE_ATTRS_KEY),
-            runMetadata: runToMetadata[runName] ? _.map(
-              runToMetadata[runName].sort(compareTagNames), function(tag) {
-                return {
-                  tag: tag,
-                  path: backend.runMetadataUrl(tag, runName)
-                };
-              }, this) : []
-          };
-        }, this);
+    Promise.all([this._fetchGraphRuns(), this._fetchRunMetadataTags()])
+      .then(result => {
+        const runsWithGraph = result[0].sort(compareTagNames);
+        const runToMetadata = result[1];
+        const datasets = _.map(runsWithGraph, runName => ({
+          name: runName,
+          path: this._graphUrl(
+              runName, tf.graph.LIMIT_ATTR_SIZE, tf.graph.LARGE_ATTRS_KEY),
+          runMetadata: _.map(
+            (runToMetadata[runName] || []).sort(compareTagNames),
+            tag => ({
+              tag: tag,
+              path: getRouter().pluginRunTagRoute(
+                'graphs', '/run_metadata')(tag, runName),
+            })),
+        }));
         this.set('_datasets', datasets);
-      }.bind(this));
+      });
   },
   _requestHealthPills: function() {
     this.set('_areHealthPillsLoading', true);
@@ -249,11 +307,12 @@ Polymer({
       return;
     }
 
-    var specificStep = this.allStepsModeEnabled ? this.specificHealthPillStep : undefined;
+    const specificStep =
+      this.allStepsModeEnabled ? this.specificHealthPillStep : undefined;
 
-    var healthPillsPromise = this.backend.healthPills(
+    const healthPillsPromise = this._fetchHealthPills(
         this._renderHierarchy.getNamesOfRenderedOps(), specificStep);
-    var alertsPromise = this.backend.debuggerNumericsAlerts();
+    const alertsPromise = this._fetchDebuggerNumericsAlerts();
 
     Promise.all([healthPillsPromise, alertsPromise]).then(
         function(result) {


### PR DESCRIPTION
Summary:
This commit mostly consists of inlining functions from `backend.ts` and
`router.ts` into `tf-graph-dashboard.html`. The graph dashboard was
already reasonably self-contained: it didn't use `tf-panes-helper` or
other similar components, and it didn't use the Polymer behaviors. (It
had them enabled, but overrode the provide functions in such a way that
simply removing the behaviors had no observable effect.)

Test Plan:
I can load and manipulate graphs. I can load and view run metadata, like
compute time and memory usage. I can change the session run under
display, and I can change the graph under display. When I add
`debugger_data=enabled` to the URL, the graph dashboard fails in the
same way before and after this commit: it 404s on the health pills route
and the numerics route. Also, the backend tests still build.

wchargin-branch: refactor-graph-dashboard