### PR TITLE
Make tf-collapsable-pane look good in Firefox

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-collapsable-pane.html
+++ b/tensorboard/components/tf_dashboard_common/tf-collapsable-pane.html
@@ -20,13 +20,11 @@ limitations under the License.
 
 <dom-module id="tf-collapsable-pane">
   <template>
-    <button
-      class="heading"
-      on-tap="togglePane"
-      open-button$="[[opened]]"
-    >
-    <span class="name">[[name]]</span>
-    <span class="count">
+    <button class="heading"
+            on-tap="togglePane"
+            open-button$="[[opened]]">
+      <span class="name">[[name]]</span>
+      <span class="count">
       <span>[[count]]</span>
     </span>
   </button>
@@ -59,6 +57,10 @@ limitations under the License.
         font-size: 15px;
         line-height: 1;
         box-shadow: 0 1px 5px rgba(0,0,0,0.2);
+        padding: 10px 15px;
+      }
+
+      .heading::-moz-focus-inner {
         padding: 10px 15px;
       }
 


### PR DESCRIPTION
It looks sooo much better now. Here are the [before](https://kek.gg/i/j3J-.png) and [after](https://kek.gg/i/3_tQCK.png) screenshots.