### PR TITLE
Decouple the embeddings projector from TB core

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-no-data-warning.html
+++ b/tensorboard/components/tf_dashboard_common/tf-no-data-warning.html
@@ -24,45 +24,21 @@ Display a warning when there is no data found.
   <template>
     <template is="dom-if" if="[[showWarning]]">
       <div class="warning">
-        <template is="dom-if" if="[[_isProjector(dataType)]]">
-          <h3>
-            No checkpoint was found.
-          </h3>
-          <p>
-            Probable causes:
-            <ul>
-              <li>
-                No checkpoint has been saved yet. Please refresh the page periodically.
-              </li>
-              <li>
-                You are not saving any checkpoint. To save your model,
-                create a
-                <a href="https://www.tensorflow.org/api_docs/python/tf/train/Saver">
-                  <code>tf.train.Saver</code>
-                </a>
-                and save your model periodically
-                by calling <code>saver.save(session, LOG_DIR/model.ckpt, step)</code>.
-              </li>
-            </ul>
-          </p>
-        </template>
-        <template is="dom-if" if="[[_isOther(dataType)]]">
-          <h3>
-            No <span>[[dataType]]</span> data was found.
-          </h3>
-          <p>
-            Probable causes:
-            <ul>
-              <li>
-                You haven't written any <span>[[dataType]]</span> data
-                to your event files.
-              </li>
-              <li>
-                TensorBoard can't find your event files.
-              </li>
-            </ul>
-          </p>
-        </template>
+        <h3>
+          No <span>[[dataType]]</span> data was found.
+        </h3>
+        <p>
+          Probable causes:
+          <ul>
+            <li>
+              You haven't written any <span>[[dataType]]</span> data
+              to your event files.
+            </li>
+            <li>
+              TensorBoard can't find your event files.
+            </li>
+          </ul>
+        </p>
         <p>
           If you're new to using TensorBoard, and want to find out how to add
           data and set up your event files, check out the
@@ -82,7 +58,6 @@ Display a warning when there is no data found.
           </a>
           and consider filing an issue on GitHub.
         </p>
-
       </div>
     </template>
     <style>
@@ -100,12 +75,6 @@ Display a warning when there is no data found.
         dataType: String,
         showWarning: Boolean
       },
-      _isProjector: function(dataType) {
-        return dataType === "projector";
-      },
-      _isOther: function(dataType) {
-        return !this._isProjector(dataType);
-      }
     });
   </script>
 </dom-module>

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -127,9 +127,7 @@ allows the user to toggle between various dashboards.
         </template>
 
         <template is="dom-if" if="[[_modeIsEmbeddings(mode)]]">
-          <vz-projector-dashboard
-            id="projector"
-            route-prefix="/data/plugin/projector">
+          <vz-projector-dashboard id="projector">
           </vz-projector-dashboard>
         </template>
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.html
@@ -22,14 +22,38 @@ limitations under the License.
 
 <dom-module id="vz-projector-dashboard">
 <template>
-  <tf-no-data-warning
-    data-type="projector"
-    show-warning="[[dataNotFound]]"
-  ></tf-no-data-warning>
+  <template is="dom-if" if="[[dataNotFound]]">
+    <div style="max-width: 540px; margin: 80px auto 0 auto;">
+      <h3>
+        No checkpoint was found.
+      </h3>
+      <p>Probable causes:
+      <ul>
+        <li>No checkpoint has been saved yet. Please refresh the page
+          periodically.
+        <li>You are not saving any checkpoint. To save your model,
+          create a
+          <a
+            href="https://www.tensorflow.org/api_docs/python/tf/train/Saver"
+          ><code>tf.train.Saver</code></a>
+          and save your model periodically
+          by calling <code>saver.save(session, LOG_DIR/model.ckpt, step)</code>.
+      </ul>
+      <p>
+      If you’re new to using TensorBoard, and want to find out how
+      to add data and set up your event files, check out the
+      <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md">README</a>
+      and perhaps the <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard">TensorBoard tutorial</a>.
+      <p>
+      If you think TensorBoard is configured properly, please see
+      <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong">the section of the README devoted to missing data problems</a>
+      and consider filing an issue on GitHub.
+    </div>
+  </template>
   <template is="dom-if" if="[[!dataNotFound]]">
     <vz-projector
       id="projector"
-      route-prefix="[[routePrefix]]"
+      route-prefix="[[_routePrefix]]"
       serving-mode="server"
       page-view-logging
       event-logging
@@ -37,31 +61,28 @@ limitations under the License.
   </template>
 </template>
 <script>
-import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior.js";
+import {getRouter} from '../tf-backend/router.js';
 
 Polymer({
   is: 'vz-projector-dashboard',
-  factoryImpl: function(routePrefix) {
-    this.routePrefix = routePrefix;
-  },
   properties: {
     dataNotFound: Boolean,
-    routePrefix: String,
+    _routePrefix: {
+      type: String,
+      value: () => getRouter().pluginRoute('projector', ''),
+    },
     // Whether this dashboard is initialized. This dashboard should only be initialized once.
     _initialized: Boolean,
   },
-  behaviors: [
-    DashboardBehavior("embeddings"),
-  ],
-  reload: function() {
+  reload() {
     // Do not reload the embedding projector. Reloading could take a long time.
   },
-  attached: function() {
+  attached() {
     if (this._initialized) {
       return;
     }
     let xhr = new XMLHttpRequest();
-    xhr.open('GET', this.routePrefix + '/runs');
+    xhr.open('GET', this._routePrefix + '/runs');
     xhr.onload = () => {
       // Set this to true so we only initialize once.
       this._initialized = true;


### PR DESCRIPTION
Summary:
The most straightforward dashboard of them all! My only nit is the
existence of the `_routePrefix` Polymer property; ideally, all
subcomponents should use `getRouter().pluginRoute('projector', '/foo')`,
because setting the route prefix to an empty plugin route is somewhat
hacky. But that can be a low-priority change for another day.

Test Plan:
PCA and t-SNE work fine. The no-data warning appears correctly.

wchargin-branch: refactor-embeddings-projector