### PR TITLE
Fix the broken graph plugin test

### DIFF
--- a/tensorboard/plugins/graphs/graphs_plugin_test.py
+++ b/tensorboard/plugins/graphs/graphs_plugin_test.py
@@ -118,6 +118,7 @@ class GraphsPluginTest(tf.test.TestCase):
     self.assertEqual({
         'k1', 'k2', 'pow', 'sub', 'expected', 'sub_1', 'error',
         'message_prefix', 'error_string', 'error_message', 'summary_message',
+        'summary_message/tag', 'summary_message/serialized_summary_metadata',
     }, node_names)
 
   def test_graph_large_attrs(self):


### PR DESCRIPTION
Chi's code originally included these lines, but they broke the test when I merged yesterday. I now realize that this is because the modified code is needed once the tf.summary.text switches over from the TensorSummaryV1 implementation to the TensorSummaryV2, which generate different graphs. Apparently the switch happened in last night's nightly.