### PR TITLE
Decouple the text plugin from TensorBoard core

### DIFF
--- a/tensorboard/components/tf_backend/backend.ts
+++ b/tensorboard/components/tf_backend/backend.ts
@@ -36,9 +36,6 @@ export interface Datum {
   step: number;
 }
 
-export interface Text { text: string; }
-export type TextDatum = Datum & Text;
-
 export type AudioDatum = Datum & Audio;
 export interface Audio {
   content_type: string;
@@ -61,7 +58,7 @@ export interface DebuggerNumericsAlertReport {
 // when bad values first appeared in the model.
 export type DebuggerNumericsAlertReportResponse = DebuggerNumericsAlertReport[];
 
-export const TYPES = ['audio', 'text'];
+export const TYPES = ['audio'];
 /**
  * The Backend class provides a convenient and typed interface to the backend.
  *
@@ -114,26 +111,6 @@ export class Backend {
       url += '.json';
     }
     return this.requestManager.request(url);
-  }
-
-  /**
-   * Returns a promise showing the Run-to-Tag mapping for text data.
-   */
-  public textRuns(): Promise<RunToTag> {
-    return this.requestManager.request(getRouter().textRuns());
-  }
-
-
-  /**
-   * Returns a promise containing TextDatums for given run and tag.
-   */
-  public text(tag: string, run: string): Promise<TextDatum[]> {
-    const url = getRouter().text(tag, run);
-    // tslint:disable-next-line:no-any it's convenient and harmless here
-    return this.requestManager.request(url).then(map((x: any) => {
-      x.wall_time = timeToDate(x.wall_time);
-      return x;
-    }));
   }
 
   /**

--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -21,8 +21,6 @@ export interface Router {
   logdir: () => string;
   runs: () => string;
   isDemoMode: () => boolean;
-  textRuns: () => string;
-  text: RunTagUrlFn;
   pluginRoute: (pluginName: string, route: string) => string;
   pluginRunTagRoute: (pluginName: string, route: string) => RunTagUrlFn;
 }
@@ -63,8 +61,6 @@ export function createRouter(dataDir = 'data', demoMode = false): Router {
     logdir: () => dataDir + '/logdir',
     runs: () => dataDir + '/runs' + (demoMode ? '.json' : ''),
     isDemoMode: () => demoMode,
-    textRuns: () => dataDir + '/plugin/text/runs' + (demoMode ? '.json' : ''),
-    text: standardRoute('plugin/text/text'),
     pluginRoute,
     pluginRunTagRoute,
   };

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -43,7 +43,7 @@ from tensorboard.plugins import base_plugin
 _PLUGIN_PREFIX_ROUTE = 'text'
 
 # HTTP routes
-RUNS_ROUTE = '/runs'
+TAGS_ROUTE = '/tags'
 TEXT_ROUTE = '/text'
 
 ALLOWED_TAGS = [
@@ -276,6 +276,8 @@ class TextPlugin(base_plugin.TBPlugin):
             run, name, 'tensors.json')
         tensors = json.loads(tensors_json)
         run_to_series[run] = tensors
+      else:
+        run_to_series[run] = []
 
     # TensorBoard is obtaining summaries related to the text plugin based on
     # SummaryMetadata stored within Value protos.
@@ -289,7 +291,7 @@ class TextPlugin(base_plugin.TBPlugin):
     return run_to_series
 
   @wrappers.Request.application
-  def runs_route(self, request):
+  def tags_route(self, request):
     # Map from run to a list of tags.
     response = {
         run: tag_listing
@@ -314,7 +316,7 @@ class TextPlugin(base_plugin.TBPlugin):
 
   def get_plugin_apps(self):
     return {
-        RUNS_ROUTE: self.runs_route,
+        TAGS_ROUTE: self.tags_route,
         TEXT_ROUTE: self.text_route,
     }
 

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -46,7 +46,7 @@ class TextPluginTest(tf.test.TestCase):
 
   def testRoutesProvided(self):
     routes = self.plugin.get_plugin_apps()
-    self.assertIsInstance(routes['/runs'], collections.Callable)
+    self.assertIsInstance(routes['/tags'], collections.Callable)
     self.assertIsInstance(routes['/text'], collections.Callable)
 
   def assertConverted(self, actual, expected):

--- a/tensorboard/plugins/text/tf_text_dashboard/BUILD
+++ b/tensorboard/plugins/text/tf_text_dashboard/BUILD
@@ -13,6 +13,7 @@ ts_web_library(
     path = "/tf-text-dashboard",
     deps = [
         "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_categorization_utils",
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:d3",

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
@@ -16,11 +16,11 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../paper-dialog/paper-dialog.html">
-<link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
-<link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
-<link rel="import" href="../tf-dashboard-common/tf-panes-helper.html">
+<link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
+<link rel="import" href="../tf-dashboard-common/tf-collapsable-pane.html">
+<link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 <link rel="import" href="tf-text-loader.html">
 
@@ -29,15 +29,15 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
 -->
 <dom-module id="tf-text-dashboard">
   <template>
-    <paper-dialog with-backdrop id="actual-text-size-dialog"></paper-dialog>
     <tf-dashboard-layout>
       <div class="sidebar">
         <div class="sidebar-section">
-          <tf-categorizer
-            id="categorizer"
-            tags="[[tags]]"
-            categories="{{_categories}}"
-          ></tf-categorizer>
+          <!--
+            TODO(wchargin): Remove tag groups. Replace them with a
+            search/filter bar in the main content pane.
+          -->
+          <tf-regex-group regexes="{{_tagGroupRegexes}}">
+          </tf-regex-group>
         </div>
         <div class="sidebar-section">
           <tf-runs-selector selected-runs="{{_selectedRuns}}">
@@ -45,56 +45,103 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
         </div>
       </div>
       <div class="center">
-        <tf-panes-helper
-          categories="[[_categories]]"
-          data-type="[[dataType]]"
-          data-provider="[[dataProvider]]"
-          data-not-found="[[dataNotFound]]"
-          run2tag="[[run2tag]]"
-          selected-runs="[[_selectedRuns]]"
-          repeat-for-runs
+        <template is="dom-if" if="[[_dataNotFound]]">
+          <div class="no-data-warning">
+            <h3>No text data was found.</h3>
+            <p>Probable causes:</p>
+            <ul>
+              <li>You haven’t written any text data to your event files.
+              <li>TensorBoard can’t find your event files.
+            </ul>
+            <p>
+            If you’re new to using TensorBoard, and want to find out how
+            to add data and set up your event files, check out the
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md">README</a>
+            and perhaps the <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard">TensorBoard tutorial</a>.
+            <p>
+            If you think TensorBoard is configured properly, please see
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong">the section of the README devoted to missing data problems</a>
+            and consider filing an issue on GitHub.
+          </div>
+        </template>
+        <template is="dom-repeat" items="[[_categories]]" as="category">
+          <tf-collapsable-pane
+            name="[[category.name]]"
+            count="[[category.count]]"
           >
-          <template>
-            <tf-text-loader></tf-text-loader>
-          </template>
-        </tf-panes-helper>
+            <div class="layout horizontal wrap">
+              <template is="dom-repeat" items="[[category.items]]">
+                <tf-text-loader
+                  tag="[[item.tag]]"
+                  run="[[item.run]]"
+                  request-manager="[[_requestManager]]"
+                ></tf-text-loader>
+              </template>
+            </div>
+          </tf-collapsable-pane>
+        </template>
       </div>
     </tf-dashboard-layout>
     <style include="dashboard-style"></style>
     <style>
-      tf-panes-helper {
-        --card-width: 100%;
-        --card-height: auto;
-        --card-expanded-width: 100%;
-        --card-expanded-height: 1000px;
-        --card-padding: 0 5px 5px 5px;
-        --show-expand-button: none;
+      .no-data-warning {
+        max-width: 540px;
+        margin: 80px auto 0 auto;
       }
     </style>
   </template>
   <script>
-    import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior.js";
-    import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior.js";
-    import {BackendBehavior} from "../tf-backend/behavior.js";
+    import {RequestManager} from '../tf-backend/requestManager.js';
+    import {getTags} from '../tf-backend/backend.js';
+    import {getRouter} from '../tf-backend/router.js';
+    import {categorizeRunTagCombinations} from '../tf-categorization-utils/categorizationUtils.js';
 
     Polymer({
       is: "tf-text-dashboard",
       properties: {
-        backend: Object,
-        dataType: {
-          type: String,
-          value: "text"
+        _selectedRuns: Array,
+        _runToTag: Object,  // map<run: string, tags: string[]>
+        _dataNotFound: Boolean,
+
+        _categories: {
+          type: Array,
+          computed:
+            '_makeCategories(_runToTag, _selectedRuns, _tagGroupRegexes)',
+        },
+
+        _requestManager: {
+          type: Object,
+          value: () => new RequestManager(),
         },
       },
-      behaviors: [
-        DashboardBehavior("text"),
-        ReloadBehavior("tf-chart-scaffold"),
-        BackendBehavior,
-      ],
-      attached: function() {
-        this.async(function() {
-          this.fire("rendered");
+      ready() {
+        this.reload();
+      },
+      reload() {
+        this._fetchTags().then(() => {
+          this._reloadTexts();
         });
+      },
+      _fetchTags() {
+        const url = getRouter().pluginRoute('text', '/tags');
+        return this._requestManager.request(url).then(runToTag => {
+          if (_.isEqual(runToTag, this._runToTag)) {
+            // No need to update anything if there are no changes.
+            return;
+          }
+          const tags = getTags(runToTag);
+          this.set('_dataNotFound', tags.length === 0);
+          this.set('_runToTag', runToTag);
+        });
+      },
+      _reloadTexts() {
+        this.querySelectorAll('tf-text-loader').forEach(textLoader => {
+          textLoader.reload();
+        });
+      },
+      _makeCategories(runToTag, selectedRuns, tagGroupRegexes) {
+        return categorizeRunTagCombinations(
+          runToTag, selectedRuns, tagGroupRegexes);
       },
     });
   </script>

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
@@ -25,30 +25,29 @@ limitations under the License.
 tf-text-loader displays markdown text data from the Text plugin.
 -->
 
+<!--
+  The following selectors override Polymer's shadow/shady/local DOMs and
+  directly style the text summaries. This selection is necessary because
+  we bind to `innerHTML` to set the contents of the relevant element to
+  some raw Markdown. This raw Markdown does not include the appropriate
+  classes on its elements, so any normal Polymer styles simply will not
+  apply.
+-->
 <style>
-  tf-text-loader p {
-    margin: 0.3em 0;
+  /*
+   * Reduce topmost and bottommost margins from 16px to 0.3em (renders
+   * at about 4.8px) to keep the layout compact. All text from the
+   * backend is rendered as Markdown, so is enclosed in `<p>` elements.
+   * By targeting only the top-level, extremal elements, we preserve any
+   * actual paragraph breaks and only change the padding against the
+   * card edges.
+   */
+  tf-text-loader .text > p:first-child {
+    margin-top: 0.3em;
   }
-
-  tf-text-loader table {
-    border-collapse: collapse;
+  tf-text-loader .text > p:last-child {
+    margin-bottom: 0.3em;
   }
-
-  tf-text-loader table th {
-    font-weight: 600;
-  }
-
-  tf-text-loader table th,
-  tf-text-loader table td {
-    padding: 6px 13px;
-    border: 1px solid #dfe2e5;
-  }
-
-  tf-text-loader table tr {
-    background-color: #fff;
-    border-top: 1px solid #c6cbd1;
-  }
-
 </style>
 <dom-module id="tf-text-loader">
 
@@ -57,86 +56,126 @@ tf-text-loader displays markdown text data from the Text plugin.
    sanitized by the backend, so xss attacks are not possible.
   -->
   <template>
-    <style include="scrollbar-style"></style>
-    <paper-material elevation="1" id="outer" class="container scrollbar">
-      <template id="repeater" is="dom-repeat" items="[[_texts]]">
-      <paper-material elevation="1" class="step-container">
-        step <span class="step-value">[[_numfmt(item.step)]]</span>
-      </paper-material>
-      <paper-material elevation="1" inner-h-t-m-l="[[item.text]]" class="text">
+    <tf-card-heading title="[[tag]]" color="[[_runColor]]">
+      [[run]]
+    </tf-card-heading>
+    <paper-material
+      elevation="1"
+      id="steps-container"
+      class="container scrollbar"
+      style="border-color: [[_runColor]]"
+    >
+      <template is="dom-repeat" items="[[_texts]]">
+        <paper-material elevation="1" class="step-container">
+          step <span class="step-value">[[_formatStep(item.step)]]</span>
         </paper-material>
+        <paper-material
+          elevation="1"
+          inner-h-t-m-l="[[item.text]]"
+          class="text"></paper-material>
       </template>
     </paper-material>
-
-
+    <style include="scrollbar-style"></style>
     <style>
-      #outer {
-        display: block;
-        overflow: auto;
-        max-height: 500px;
-        position: relative;
+      :host {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        height: auto;
+        margin-right: 10px;
+        margin-bottom: 15px;
+      }
+      #steps-container {
         border-radius: 3px;
-        border: 2px solid black;
+        border: 2px solid  /* color computed and set as inline style */;
+        display: block;
+        max-height: 500px;
+        overflow: auto;
+        padding: 10px;
       }
       .text {
-        margin: 0 10px 10px 10px;
-        border-radius: 0 3px 3px 3px;
         background-color: white;
+        border-radius: 0 3px 3px 3px;
         padding: 5px;
         word-break: break-word;
       }
       .step-container {
-        border-left: 1px solid #ccc;
-        border-right: 1px solid #ccc;
-        border-top: 1px solid #ccc;
-        border-radius: 3px 3px 0 0;
-        font-style: italic;
-        margin-top: 10px;
         background-color: var(--tb-ui-light-accent);
+        border-bottom: none;
+        border-radius: 3px 3px 0 0;
+        border: 1px solid #ccc;
         display: inline-block;
-        margin-left: 9px;
-        padding: 3px;
         font-size: 12px;
+        font-style: italic;
+        margin-left: -1px;  /* to correct for border */
+        padding: 3px;
       }
-
+      .step-container:not(:first-child) {
+        margin-top: 15px;
+      }
     </style>
-
   </template>
   <script>
+    import {Canceller} from "../tf-backend/canceller.js";
+    import {getRouter} from "../tf-backend/router.js";
     import {runsColorScale} from "../tf-color-scale/colorScale.js";
+
     Polymer({
       is: "tf-text-loader",
       properties: {
         run: String,
-        // This is an array of Tensorboard Text&Datum objects (See backend.ts for details). The
-        // properties of objects in this array are
-        // {
+        tag: String,
+        _runColor: {
+          type: String,
+          computed: '_computeRunColor(run)',
+        },
+
+        // _texts: {
         //   wall_time: Date,
         //   step: number,
         //   text: string,
-        // }
-        // they are ordered from most recent to oldest
+        // }[]
+        // Ordered from newest to oldest.
         _texts: {
           type: Array,
           value: [],
         },
 
+        requestManager: Object,
+        _canceller: {
+          type: Object,
+          value: () => new Canceller(),
+        },
       },
-      redraw: function() {
-        // Other dashboards logic requires a redraw method to be defined.
+      _computeRunColor(run) {
+        return runsColorScale(run);
       },
-      setVisibleSeries: function(runs) {
-        // Do nothing.
+      attached() {
+        this._attached = true;
+        this.reload();
       },
-      setSeriesData: function(run, texts) {
-        this.set("run", run);
-        this.set("_texts", texts.reverse());
-
-        // Update the border color based on the run.
-        var color = runsColorScale(run);
-        this.$$("#outer").style.borderColor = color;
+      reload() {
+        if (!this._attached) {
+          return;
+        }
+        this._canceller.cancelAll();
+        const router = getRouter();
+        const url = router.pluginRunTagRoute("text", "/text")(
+          this.tag, this.run);
+        const updateTexts = this._canceller.cancellable(result => {
+          if (result.cancelled) {
+            return;
+          }
+          const data = result.value.map(datum => ({
+            wall_time: new Date(datum.wall_time * 1000),
+            step: datum.step,
+            text: datum.text,
+          }));
+          this.set("_texts", data.slice().reverse());
+        });
+        this.requestManager.request(url).then(updateTexts);
       },
-      _numfmt: function(n) {
+      _formatStep(n) {
         return d3.format(",")(n);
       }
     });


### PR DESCRIPTION
Summary:
This removes references to text-related stuff from the backend and
router, and removes references to old-style TensorBoard components like
`tf-panes-helper` and `tf-chart-scaffold`. The text dashboard, like
other dashboards, now uses only the API components that we'll want to
keep supporting (with the exception of `tf-regex-group`).

I also took the liberty of improving the implementation of the CSS for
the text loader. The appearance should be the same (with the exception
of a bugfix relating to paragraph margins), but the code is now cleaner.

Test Plan:
Tested on runs with just one tag, runs with multiple tags, and tags that
contain long values (http://lipsum.lipsum.com/). You can select and copy
text, scroll through summaries, etc.

wchargin-branch: refactor-text-plugin