### PR TITLE
Strengthen imports

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.html
+++ b/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.html
@@ -16,14 +16,15 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-storage/tf-storage.html">
-<link rel="import" href="../tf-imports/lodash.html">
-<link rel="import" href="scrollbar-style.html">
 <link rel="import" href="run-color-style.html">
+<link rel="import" href="scrollbar-style.html">
 
 <!--
 tf-multi-checkbox creates a list of checkboxes that can be used to toggle on or off

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
@@ -16,10 +16,9 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../paper-icon-button/paper-icon-button.html">
-<link rel="import" href="tf-audio-grid.html">
-<link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
+<link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
+<link rel="import" href="tf-audio-grid.html">
 
 <!--
 tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.

--- a/tensorboard/plugins/distributions/tf_distribution_dashboard/BUILD
+++ b/tensorboard/plugins/distributions/tf_distribution_dashboard/BUILD
@@ -14,6 +14,7 @@ ts_web_library(
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_card_heading",
+        "//tensorboard/components/tf_categorization_utils",
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:lodash",

--- a/tensorboard/plugins/distributions/tf_distribution_dashboard/tf-distribution-dashboard.html
+++ b/tensorboard/plugins/distributions/tf_distribution_dashboard/tf-distribution-dashboard.html
@@ -16,11 +16,14 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
-<link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
+<link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
+<link rel="import" href="../tf-dashboard-common/tf-collapsable-pane.html">
+<link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
-<link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="tf-distribution-loader.html">
 
 <!--

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/BUILD
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/BUILD
@@ -14,6 +14,8 @@ ts_web_library(
     path = "/tf-histogram-dashboard",
     deps = [
         "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_card_heading",
+        "//tensorboard/components/tf_categorization_utils",
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:d3",

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -17,8 +17,10 @@ limitations under the License.
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
-<link rel="import" href="../tf-dashboard-common/tf-categorizer.html">
-<link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
+<link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
+<link rel="import" href="../tf-dashboard-common/tf-collapsable-pane.html">
+<link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 <link rel="import" href="tf-histogram-loader.html">

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/tf-histogram-loader.html
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/tf-histogram-loader.html
@@ -17,9 +17,10 @@ limitations under the License.
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../tf-card-heading/tf-card-heading.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
-<link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../tf-imports/d3.html">
+<link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../vz-histogram-timeseries/vz-histogram-timeseries.html">
 
 <!--

--- a/tensorboard/plugins/images/tf_image_dashboard/BUILD
+++ b/tensorboard/plugins/images/tf_image_dashboard/BUILD
@@ -13,6 +13,7 @@ ts_web_library(
     path = "/tf-image-dashboard",
     deps = [
         "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_card_heading",
         "//tensorboard/components/tf_categorization_utils",
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",

--- a/tensorboard/plugins/images/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/plugins/images/tf_image_dashboard/tf-image-dashboard.html
@@ -17,8 +17,10 @@ limitations under the License.
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-dialog/paper-dialog.html">
-<link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
 <link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
+<link rel="import" href="../tf-dashboard-common/tf-collapsable-pane.html">
+<link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 <link rel="import" href="tf-image-loader.html">
 

--- a/tensorboard/plugins/images/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/images/tf_image_dashboard/tf-image-loader.html
@@ -16,12 +16,13 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/d3.html">
+<link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../paper-slider/paper-slider.html">
 <link rel="import" href="../paper-spinner/paper-spinner-lite.html">
+<link rel="import" href="../tf-card-heading/tf-card-heading.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
-<link rel="import" href="../tf-imports/lodash.html">
-<link rel="import" href="../tf-imports/d3.html">
 
 <!--
 tf-image-loader loads an individual image from the TensorBoard backend.

--- a/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -16,17 +16,19 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="tf-scalar-chart.html">
-<link rel="import" href="tf-smoothing-input.html">
+<link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../paper-item/paper-item.html">
 <link rel="import" href="../paper-menu/paper-menu.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
-<link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
+<link rel="import" href="../tf-dashboard-common/tf-collapsable-pane.html">
+<link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
-<link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
+<link rel="import" href="tf-scalar-chart.html">
+<link rel="import" href="tf-smoothing-input.html">
 
 <!--
   A frontend that displays a set of tf-scalar-charts, each of which


### PR DESCRIPTION
Summary:
Some files were not importing all the things that they depended on.
Instead, these dependencies were being set by unrelated files.

Amusingly, the audio dashboard is the only one that had _extra_ imports!
I'll go ahead and give it a real dashboard soon...

Test Plan:
My procedure to create this was to comment out all but one plugin at a
time in `tf-tensorboard.html`, including the import tags. Then, I ran
TensorBoard, saw that everything looked awful, and added back inputs
until it looked correct again. To test post hoc, I just checked that
everything builds and still looks correct.

wchargin-branch: strengthen-imports