### PR TITLE
Display the run on each image summary

### DIFF
--- a/tensorboard/plugins/images/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/images/tf_image_dashboard/tf-image-loader.html
@@ -33,6 +33,7 @@ future for loading older images.
 <dom-module id="tf-image-loader">
   <template>
     <tf-card-heading title="[[tag]]" color="[[_runColor]]">
+      <div>[[run]]</div>
       <template is="dom-if" if="[[_hasAtLeastOneStep]]">
         step
         <span style="font-weight: bold">[[_stepValue]]</span>


### PR DESCRIPTION
Summary:
This got lost when I migrated the image dashboard away from using the
chart scaffold: the chart scaffold used to include the run, and I forgot
to reinstate it after removing the scaffold. Easy fix, though.

Test Plan:
Load the image dashboard with any dataset that has image summaries. Look
for a run name in the card heading. Note that the run name changes
appropriately as you adjust which runs are selected.

wchargin-branch: display-run-on-images