### PR TITLE
Redesign the audio dashboard

### DIFF
--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -71,33 +71,9 @@ describe('backend tests', () => {
     });
   });
 
-  it('audio is loaded properly', (done) => {
-    backend.audio('audio1', 'run1').then((audioClips) => {
-      const audio = audioClips[0];
-      assertIsDatum(audio);
-      chai.assert.equal(audio.content_type, 'audio/wav');
-      done();
-    });
-  });
-
   it('trailing slash removed from base route', () => {
     const r = createRouter('foo/');
     chai.assert.equal(r.runs(), 'foo/runs');
-  });
-
-  it('run helper methods work', (done) => {
-    const audio = {run1: ['audio1'], fake_run_no_data: ['audio1', 'audio2']};
-    let count = 0;
-    function next() {
-      count++;
-      if (count === 4) {
-        done();
-      }
-    }
-    backend.audioTags().then((x) => {
-      chai.assert.deepEqual(x, audio);
-      next();
-    });
   });
 
   it('runToTag helpers work', () => {

--- a/tensorboard/plugins/audio/tf_audio_dashboard/BUILD
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/BUILD
@@ -14,6 +14,10 @@ ts_web_library(
     path = "/tf-audio-dashboard",
     deps = [
         "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_card_heading",
+        "//tensorboard/components/tf_categorization_utils",
+        "//tensorboard/components/tf_color_scale",
+        "//tensorboard/components/tf_runs_selector",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:d3",
         "//tensorboard/components/tf_imports:lodash",

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
@@ -16,74 +16,137 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../tf-backend/tf-backend.html">
-<link rel="import" href="../tf-dashboard-common/tf-dashboard.html">
-<link rel="import" href="tf-audio-grid.html">
+<link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
+<link rel="import" href="../tf-dashboard-common/tf-collapsable-pane.html">
+<link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
+<link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
+<link rel="import" href="tf-audio-loader.html">
 
 <!--
 tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
-
-@element tf-audio-dashboard
-@demo demo/index.html
 -->
 <dom-module id="tf-audio-dashboard">
   <template>
-    <div class="center">
-      <tf-no-data-warning
-        data-type="audio"
-        show-warning="[[dataNotFound]]"
-      ></tf-no-data-warning>
-      <tf-audio-grid
-        id="audioGrid"
-        run-to-audio="[[run2tag]]"
-        audio-generator="[[dataProvider]]"
-        tags="[[tags]]"
-        runs="[[runs]]"
-      ></tf-audio-grid>
-    </div>
-
+    <tf-dashboard-layout>
+      <div class="sidebar">
+        <div class="sidebar-section">
+          <tf-regex-group regexes="{{_tagGroupRegexes}}">
+          </tf-regex-group>
+        </div>
+        <div class="sidebar-section">
+          <tf-runs-selector
+            id="runs-selector"
+            selected-runs="{{_selectedRuns}}"
+          ></tf-runs-selector>
+        </div>
+      </div>
+      <div class="center">
+        <template is="dom-if" if="[[_dataNotFound]]">
+          <div class="no-data-warning">
+            <h3>No audio data was found.</h3>
+            <p>Probable causes:</p>
+            <ul>
+              <li>You haven’t written any audio data to your event files.
+              <li>TensorBoard can’t find your event files.
+            </ul>
+            <p>
+            If you’re new to using TensorBoard, and want to find out how
+            to add data and set up your event files, check out the
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md">README</a>
+            and perhaps the <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard">TensorBoard tutorial</a>.
+            <p>
+            If you think TensorBoard is configured properly, please see
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong">the section of the README devoted to missing data problems</a>
+            and consider filing an issue on GitHub.
+          </div>
+        </template>
+        <template is="dom-repeat" items="[[_categories]]" as="category">
+          <tf-collapsable-pane
+            name="[[category.name]]"
+            count="[[category.count]]"
+          >
+            <div class="layout horizontal wrap">
+              <template
+                is="dom-repeat"
+                items="[[category.items]]"
+              >
+                <tf-audio-loader
+                  run="[[item.run]]"
+                  tag="[[item.tag]]"
+                  request-manager="[[_requestManager]]"
+                  show-actual-size="[[_showActualSize]]"
+                ></tf-audio-loader>
+              </template>
+            </div>
+          </tf-collapsable-pane>
+        </template>
+      </div>
+    </tf-dashboard-layout>
+    <style include="dashboard-style"></style>
     <style>
-      .center {
-        height: 100%;
-        width: 100%;
-        -webkit-box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        box-sizing: border-box;
+      .no-data-warning {
+        max-width: 540px;
+        margin: 80px auto 0 auto;
       }
-      :host {
-        height: 100%;
-        display: block;
-      }
-
     </style>
   </template>
   <script>
-    import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior.js";
-    import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior.js";
-    import {BackendBehavior} from "../tf-backend/behavior.js";
+    "use strict";
+
+    import {RequestManager} from '../tf-backend/requestManager.js';
+    import {getTags} from '../tf-backend/backend.js';
+    import {getRouter} from '../tf-backend/router.js';
+    import {categorizeRunTagCombinations} from '../tf-categorization-utils/categorizationUtils.js';
 
     Polymer({
-      is: "tf-audio-dashboard",
+      is: 'tf-audio-dashboard',
       properties: {
-        dataType: {
+        _selectedRuns: Array,
+        _runToTag: Object,  // map<run: string, tags: string[]>
+        _dataNotFound: Boolean,
+
+        _categories: {
+          type: Array,
+          computed:
+            '_makeCategories(_runToTag, _selectedRuns, _tagGroupRegexes)',
+        },
+
+        _requestManager: {
           type: Object,
-          value: "audio",
+          value: () => new RequestManager(),
         },
       },
-      behaviors: [
-        DashboardBehavior("audio"),
-        ReloadBehavior("tf-audio-loader"),
-        BackendBehavior,
-      ],
-      attached: function() {
-        this.async(function() {
-          this.fire("rendered");
+
+      ready() {
+        this.reload();
+      },
+      reload() {
+        this._fetchTags().then(() => {
+          this._reloadAudio();
         });
       },
-      _hasAudio: function(runToAudioChange) {
-        return _.values(runToAudioChange.base).some(function(arr) {
-          return arr.length > 0;
+      _fetchTags() {
+        const url = getRouter().pluginRoute('audio', '/tags');
+        return this._requestManager.request(url).then(runToTag => {
+          if (_.isEqual(runToTag, this._runToTag)) {
+            // No need to update anything if there are no changes.
+            return;
+          }
+          const tags = getTags(runToTag);
+          this.set('_dataNotFound', tags.length === 0);
+          this.set('_runToTag', runToTag);
         });
+      },
+      _reloadAudio() {
+        this.querySelectorAll('tf-audio-loader').forEach(audio => {
+          audio.reload();
+        });
+      },
+
+      _makeCategories(runToTag, selectedRuns, tagGroupRegexes) {
+        return categorizeRunTagCombinations(
+          runToTag, selectedRuns, tagGroupRegexes);
       },
     });
   </script>

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
@@ -16,221 +16,207 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/d3.html">
+<link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../paper-slider/paper-slider.html">
 <link rel="import" href="../paper-spinner/paper-spinner-lite.html">
+<link rel="import" href="../tf-card-heading/tf-card-heading.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
-<link rel="import" href="../tf-imports/lodash.html">
 
 <!--
-tf-audio-loader loads an individual audio clip from the TensorBoard backend.
-
-Right now it always loads the most recent audio clip. We should add support in the
-future for loading older clips.
-
-@element tf-audio-loader
+tf-audio-loader loads an individual audio clip from the TensorBoard
+backend.
 -->
 <dom-module id="tf-audio-loader">
-  <style>
-    :host {
-      display: block;
-      --step-slider-knob-color: #424242;
-    }
-
-    img {
-      width: 100%;
-      height: 100%;
-      image-rendering: pixelated;
-    }
-
-    .step-description {
-      font-size: 12px;
-    }
-
-    .step-value {
-      font-weight: bold;
-    }
-
-    #audio-loading-spinner {
-      width: 14px;
-      height: 14px;
-      vertical-align: text-bottom;
-      --paper-spinner-color: var(--tb-orange-strong)
-    }
-
-    #steps {
-      height: 15px;
-      margin: 0 0 0 -15px;
-      /* 31 comes from adding a padding of 15px from both sides of the paper-slider, subtracting
-       * 1px so that the slider width aligns with the image (the last slider marker takes up 1px),
-       * and adding 2px to account for a border of 1px on both sides of the image. 30 - 1 + 2. */
-      width: calc(100% + 31px);
-      --paper-slider-active-color: var(--step-slider-knob-color);
-      --paper-slider-knob-color: var(--step-slider-knob-color);
-      --paper-slider-pin-color: var(--step-slider-knob-color);
-      --paper-slider-knob-start-color: var(--step-slider-knob-color);
-      --paper-slider-knob-start-border-color: var(--step-slider-knob-color);
-      --paper-slider-pin-start-color: var(--step-slider-knob-color);
-    }
-
-    #individual-audio-container audio {
-      margin: 5px 0 0 -10px;
-      width: calc(100% + 20px);
-    }
-  </style>
   <template>
-    <template is="dom-if" if="[[_metadatas]]">
-      <template is="dom-if" if="[[_hasAtLeastOneStep(_metadatas)]]">
-        <div class="step-description">
-          step
-          <span class="step-value">
-            [[_stepValue]]
-          </span><br>
-          <template is="dom-if" if="[[_stepWallTime]]">
-            [[_stepWallTime]]
-          </template>
-          <paper-spinner-lite active
-                              id="audio-loading-spinner"
-                              hidden$=[[!_isAudioLoading]]></paper-spinner-lite>
-        </div>
+    <tf-card-heading title="[[tag]]" color="[[_runColor]]">
+      <div>[[run]]</div>
+      <template is="dom-if" if="[[_hasAtLeastOneStep]]">
+        step
+        <span style="font-weight: bold">[[_currentDatum.step]]</span>
+        <template is="dom-if" if="[[_currentDatum.wall_time]]">
+          ([[_currentDatum.wall_time]])
+        </template>
       </template>
-      <template is="dom-if" if="[[_maxStepIndex]]">
+      <template is="dom-if" if="[[_hasMultipleSteps]]">
         <paper-slider
-            id="steps"
-            immediate-value="{{_stepIndex}}"
-            max="[[_maxStepIndex]]"
-            max-markers="[[_maxStepIndex]]"
-            snaps
-            step="1"
-            value="{{_stepIndex}}"></paper-slider>
+          id="steps"
+          immediate-value="{{_stepIndex}}"
+          max="[[_maxStepIndex]]"
+          max-markers="[[_maxStepIndex]]"
+          snaps
+          step="1"
+          value="{{_stepIndex}}"
+        ></paper-slider>
       </template>
-      <div id="individual-audio-container"></div>
+    </tf-card-heading>
+    <template is="dom-if" if="[[_hasAtLeastOneStep]]">
+      <audio
+        controls
+        loop="loop"
+        src$="[[_currentDatum.url]]"
+        type="[[_currentDatum.content_type]]"
+      ></audio>
     </template>
+    <div id="main-audio-container">
+    </div>
+
+    <style>
+      :host {
+        display: block;
+        width: 330px;
+        height: auto;
+        position: relative;
+        --step-slider-knob-color: #424242;
+        margin-right: 15px;
+        margin-bottom: 15px;
+      }
+
+      #steps {
+        height: 15px;
+        margin: 0 0 0 -15px;
+        width: 100%;
+        box-sizing: border-box;
+        padding: 0 5px;  /* so the slider knob doesn't butt out */
+        margin-top: 5px;
+        --paper-slider-active-color: var(--step-slider-knob-color);
+        --paper-slider-knob-color: var(--step-slider-knob-color);
+        --paper-slider-pin-color: var(--step-slider-knob-color);
+        --paper-slider-knob-start-color: var(--step-slider-knob-color);
+        --paper-slider-knob-start-border-color: var(--step-slider-knob-color);
+        --paper-slider-pin-start-color: var(--step-slider-knob-color);
+      }
+    </style>
   </template>
   <script>
     "use strict";
+    import {Canceller} from "../tf-backend/canceller.js";
+    import {getRouter} from "../tf-backend/router.js";
+    import {runsColorScale} from "../tf-color-scale/colorScale.js";
+    import * as urlPathHelpers from "../tf-backend/urlPathHelpers.js";
 
     Polymer({
       is: "tf-audio-loader",
       properties: {
         run: String,
         tag: String,
-        audioGenerator: Function,
-        // todo: document.
-        _metadatas: Array,
+
+        _runColor: {
+          type: String,
+          computed: '_computeRunColor(run)',
+        },
+
+        requestManager: Object,
+        _metadataCanceller: {
+          type: Object,
+          value: () => new Canceller(),
+        },
+
+        // steps: {
+        //   wall_time: string,
+        //   step: number,
+        //   content_type: string,
+        //   url: string,
+        // }[]
+        _steps: {
+          type: Array,
+          value: () => [],
+        },
         _stepIndex: Number,
+        _hasAtLeastOneStep: {
+          type: Boolean,
+          computed: "_computeHasAtLeastOneStep(_steps)",
+        },
+        _hasMultipleSteps: {
+          type: Boolean,
+          computed: "_computeHasMultipleSteps(_steps)",
+        },
         _stepValue: {
           type: Number,
-          computed: "_computeStepValue(_metadatas, _stepIndex)",
-          value: 0,
+          computed: "_computeStepValue(_stepIndex)",
         },
-        _stepWallTime: {
-          type: Number,
-          computed: "_computeStepWallTime(_metadatas, _stepIndex)",
-          value: 0,
+        _currentDatum: {
+          type: Object,  // {wall_time, step, content_type, url}
+          computed: "_computeCurrentDatum(_steps, _stepIndex)",
         },
         _maxStepIndex: {
           type: Number,
-          computed: "_computeMaxStepIndex(_metadatas)",
-          value: 0,
-        },
-        _isAudioLoading: Boolean,
-        // Used to identify stale requests for audio.
-        _audioRequestId: {
-          type: Number,
-          value: 1
+          computed: "_computeMaxStepIndex(_steps)",
         },
       },
-      observers: [
-        "_updateAudio(_metadatas, _stepIndex)",
-      ],
-      reload: function() {
-        this.audioGenerator(this.tag, this.run).then(function(metadatas) {
-          // Set the list of available metadata.
-          this.set("_metadatas", metadatas);
+      observers: ['reload(run, tag)'],
+      _computeRunColor(run) {
+        return runsColorScale(run);
+      },
+      _computeHasAtLeastOneStep(steps) {
+        return !!steps && steps.length > 0;
+      },
+      _computeHasMultipleSteps(steps) {
+        return !!steps && steps.length > 1;
+      },
+      _computeStepValue(stepIndex) {
+        return this._steps[stepIndex].step;
+      },
+      _computeMaxStepIndex(steps) {
+        return steps.length - 1;
+      },
+      _computeCurrentDatum(steps, stepIndex) {
+        return steps[stepIndex];
+      },
 
-          // Set the index to be the last one.
-          this.set("_stepIndex", this._maxStepIndex);
-        }.bind(this));
+      attached() {
+        this._attached = true;
+        this.reload();
       },
-      ready: function() {
-        // Need to test so that it will not error if it is constructed w/o
-        // all properties (so that it's possible to use stub to mock it out)
-        if (this.run != null && this.tag != null && this.audioGenerator != null) {
-          this.reload();
-        }
-      },
-      _updateAudio: function(metadatas, stepIndex) {
-        if (!metadatas || stepIndex >= metadatas.length) {
-          // No audio to show. The audio section should be hidden.
+      reload() {
+        if (!this._attached) {
           return;
         }
-
-        // Load new audio.
-        const requestId = ++this._audioRequestId;
-        this.set("_isAudioLoading", true);
-
-        // Create a new audio element. Only replace the previous one once the new audio loads.
-        let audioElement = document.createElement("audio");
-        audioElement.setAttribute("controls", true);
-        audioElement.setAttribute("loop", "loop");
-        let canPlayHandler = function() {
-          if (requestId !== this._audioRequestId) {
-            // This request is no longer relevant.
+        this._metadataCanceller.cancelAll();
+        const router = getRouter();
+        const url =
+          router.pluginRunTagRoute("audio", "/audio")(this.tag, this.run);
+        const updateSteps = this._metadataCanceller.cancellable(result => {
+          if (result.cancelled) {
             return;
           }
-
-          // Remove this event listener: "canplay" apparently fires in Chrome every time playing
-          // begins again on loop. So, if we create a new audio element every time that happens, we
-          // don't actually loop.
-          audioElement.removeEventListener("canplay", canPlayHandler);
-
-          let individualAudioContainer = this.$$("#individual-audio-container");
-          individualAudioContainer.innerHTML = "";
-          Polymer.dom(individualAudioContainer).appendChild(audioElement);
-          this.set("_isAudioLoading", false);
-        }.bind(this);
-        audioElement.addEventListener("canplay", canPlayHandler);
-        audioElement.addEventListener("error", function() {
-          if (requestId !== this._audioRequestId) {
-            // This request is no longer relevant.
-            return;
-          }
-
-          // The audio could not be loaded.
-          this.$$("#individual-audio-container").innerHTML = "";
-          this.set("_isAudioLoading", false);
-        }.bind(this));
-
-        // Initiate the request for new audio.
-        var sourceElement = document.createElement("source");
-        let metadata = metadatas[stepIndex];
-        sourceElement.setAttribute("src", metadata.url);
-        sourceElement.setAttribute("type", metadata.content_type);
-        audioElement.appendChild(sourceElement);
+          const data = result.value;
+          const steps = data.map(this._createStepDatum.bind(this));
+          this.set("_steps", steps);
+          this.set("_stepIndex", steps.length - 1);
+        });
+        this.requestManager.request(url).then(updateSteps);
       },
-      _computeStepValue: function(metadatas, stepIndex) {
-        if (!metadatas || stepIndex >= metadatas.length) {
-          // No audio to show. The audio section should be hidden.
-          return 0;
+      _createStepDatum(audioMetadata) {
+        const route = getRouter().pluginRoute('audio', '/individualAudio');
+        let query = audioMetadata.query;
+        if (route.indexOf('?') > -1) {
+          // The route already has GET parameters. Append ours.
+          query = '&' + query;
+        } else {
+          // The route lacks GET parameters. Just use ours.
+          query = '?' + query;
         }
-        return metadatas[stepIndex].step;
-      },
-      _computeStepWallTime: function(metadatas, stepIndex) {
-        if (!metadatas || stepIndex >= metadatas.length) {
-          // No audio to show. The audio section should be hidden.
-          return 0;
+        if (getRouter().isDemoMode()) {
+          query = urlPathHelpers.demoify(query);
         }
-        return metadatas[stepIndex].wall_time.toString();
-      },
-      _computeMaxStepIndex: function(metadatas) {
-        if (!metadatas || metadatas.length === 0) {
-          // No audio to show. The audio section should be hidden.
-          return 0;
+
+        let individualAudioURL = route + query;
+        if (getRouter().isDemoMode()) {
+          individualAudioURL += '.png';
+        } else {
+          // Include wall_time just to disambiguate the URL and force
+          // the browser to reload the audio when the URL changes. The
+          // backend doesn't care about the value.
+          individualAudioURL += `&ts=${audioMetadata.wall_time}`;
         }
-        return metadatas.length - 1;
-      },
-      _hasAtLeastOneStep: function(metadatas) {
-        return metadatas && metadatas.length > 0;
+        return {
+          wall_time: new Date(audioMetadata.wall_time).toString(),
+          step: audioMetadata.step,
+          content_type: audioMetadata.content_type,
+          url: individualAudioURL,
+        };
       },
     });
   </script>


### PR DESCRIPTION
Redesign the audio dashboard

Summary:
The audio dashboard used to be laid out in a grid, with tags by row and
runs by column. This made it inconsistent with all other dashboards, and
also gave it some bizarre behaviors (e.g., if you have ten runs without
any audio summaries and then five runs with the summaries, you'd have
to scroll horizontally past all ten runs without summaries before
getting to anything interesting). The implementation also had some
needlessly complicated behavior, like generating `<source>` elements and
manually listening for onload events instead of letting the browser do
what it does best.

This commit replaces it with a clone of the image dashboard adapted to
serve audio instead. The implementation is just like the image
dashboard, but considerably simpler because the audio dashboard needs
fewer features: cards needn't expand, nor can audio clips show an
"actual size"; we don't need a loading spinner, because the browser
already has a loading state for audio elements that will be familiar and
consistent across applications; etc.

I think it looks rather nice!
![Image of the audio dashboard][image]

[image]: https://user-images.githubusercontent.com/4317806/27458714-422a77ea-575f-11e7-80da-d957d3b0d5cf.png

Test Plan:
Run `bazel run //tensorboard/plugins/audio:audio_demo` to generate data
in `/tmp/audio_demo` if you don't have any audio summaries handy. Then,
launch TensorBoard and interact with all the features of the audio
dashboard, including toggling runs and making sure that the clips update
their sources correctly.

wchargin-branch: redesign-audio-dashboard
