### PR TITLE
Migrate the profile/trace viewer dashboard

### DIFF
--- a/tensorboard/components/tf_backend/backend.ts
+++ b/tensorboard/components/tf_backend/backend.ts
@@ -85,29 +85,6 @@ export class Backend {
   public runs(): Promise<RunsResponse> {
     return this.requestManager.request(getRouter().runs());
   }
-
-  /**
-   * Returns a promise showing the Run-to-Tag mapping for profile data.
-   */
-  public profileTags(): Promise<RunToTag> {
-    let url = getRouter().pluginRoute('profile', '/tags');
-    if (getRouter().isDemoMode()) {
-      url += '.json';
-    }
-    return this.requestManager.request(url);
-  }
-
-  /**
-   * Returns a promise containing profile data for given run and tag.
-   */
-  public profile(tag: string, run: string): Promise<string> {
-    let url = (getRouter().pluginRunTagRoute('profile', '/data')(tag, run));
-    if (getRouter().isDemoMode()) {
-      url += '.json';
-    }
-    return this.requestManager.request(url);
-  }
-
 }
 
 /** Given a RunToTag, return sorted array of all runs */

--- a/tensorboard/components/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/components/tf_profile_dashboard/tf-profile-dashboard.html
@@ -91,20 +91,16 @@ profile run can have multiple tools that present the performance profile as diff
 <script>
   "use strict";
 
-  import {DashboardBehavior} from "../tf-dashboard-common/dashboard-behavior.js";
-  import {ReloadBehavior} from "../tf-dashboard-common/reload-behavior.js";
-  import {BackendBehavior} from "../tf-backend/behavior.js";
+  import {RequestManager} from '../tf-backend/requestManager.js';
   import {getRouter} from '../tf-backend/router.js';
 
   Polymer({
     is: "tf-profile-dashboard",
-    behaviors: [
-      DashboardBehavior("profile"),
-      ReloadBehavior("tf-profile-dashboard"),
-      BackendBehavior,
-    ],
     properties: {
-      backend: Object,
+      _requestManager: {
+        type: Object,
+        value: () => new RequestManager(),
+      },
       _isAttached: Boolean,
       // Whether this dashboard is initialized. This dashboard should only be
       // initialized once.
@@ -112,9 +108,7 @@ profile run can have multiple tools that present the performance profile as diff
       // The endpoint that serves trace viewer app.
       traceViewerBaseUrl: {
         type: String,
-        value: function() {
-          return getRouter().pluginRoute("profile", "/trace_viewer");
-        },
+        value: () => getRouter().pluginRoute("profile", "/trace_viewer"),
       },
       // The URL for the trace data being display.
       _traceDataUrl: {
@@ -151,7 +145,7 @@ profile run can have multiple tools that present the performance profile as diff
     ready: function() {
     },
     observers: [
-      '_maybeInitializeDashboard(backend, _isAttached)',
+      '_maybeInitializeDashboard(_isAttached)',
       '_maybeUpdateTool(_datasets, selectedDataset, _currentTool)',
     ],
     attached: function() {
@@ -160,21 +154,22 @@ profile run can have multiple tools that present the performance profile as diff
     detached: function() {
       this.set('_isAttached', false);
     },
-    _maybeInitializeDashboard: function(backend, isAttached) {
-      if (this._initialized || !backend || !isAttached) {
+    _maybeInitializeDashboard: function(isAttached) {
+      if (this._initialized || !isAttached) {
         // Either this dashboard is already initialized ... or we are not yet
         // ready to initialize.
         return;
       }
       // Set this to true so we only initialize once.
       this._initialized = true;
-      backend.profileTags().then((runToTool) => {
-        var datasets = _.map(runToTool, function(tools, run) {
-          return {
-            name: run,
-            activeTools: tools,
-          };
-        }, this);
+      const profileTagsURL =
+        getRouter().pluginRoute('profile', '/tags') +
+        (getRouter().isDemoMode() ? '.json' : '');
+      this._requestManager.request(url).then((runToTool) => {
+        const datasets = _.map(runToTool, (tools, run) => ({
+          name: run,
+          activeTools: tools,
+        }));
         this.set('_datasets', datasets);
       });
     },


### PR DESCRIPTION
Summary:
Similar to the graph plugin, only simpler.

Note that the `BackendBehavior` was not actually used at all (it
provides `runs`, `tags`, `runToTag`, and `dataNotFound`, none of which
was used). The `ReloadBehavior` was also useless, as it provided a
`frontendReload` method that (a) did nothing and (b) wasn't called. And
`DashboardBehavior` has always done nothing! So this was really just a
matter of inlining the methods from `backend.ts`, one of which was not
actually used.

Test Plan:
**None: I am not able to test this change.** I'm not able to run this
dashboard: even if I were to hook it up, I don't have the backend plugin
or the appropriate data.

I mean, it builds, I guess.

wchargin-branch: migrate-profile-dashboard