### PR TITLE
Remove vestigial all_files rules.

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -86,15 +86,3 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(
-        ["**"],
-        exclude = [
-            "METADATA",
-            "OWNERS",
-            "tensorboard.google.bzl",
-        ],
-    ),
-    tags = ["notsan"],
-)

--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -95,13 +95,3 @@ py_library(
         "//tensorboard:expect_tensorflow_installed",
     ],
 )
-
-filegroup(
-    name = "all_files",
-    srcs = glob(
-        [
-            "*",
-        ],
-    ),
-    visibility = ["//third_party/tensorflow:__subpackages__"],
-)

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -155,13 +155,3 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
     ],
 )
-
-filegroup(
-    name = "all_files",
-    srcs = glob(
-        [
-            "*",
-        ],
-    ),
-    visibility = ["//third_party/tensorflow:__subpackages__"],
-)

--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -42,8 +42,3 @@ tensorboard_html_binary(
     deps = [":trace_viewer"],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_backend/BUILD
+++ b/tensorboard/components/tf_backend/BUILD
@@ -39,8 +39,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_backend/test/BUILD
+++ b/tensorboard/components/tf_backend/test/BUILD
@@ -24,9 +24,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    testonly = 0,
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_card_heading/BUILD
+++ b/tensorboard/components/tf_card_heading/BUILD
@@ -15,8 +15,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_categorization_utils/BUILD
+++ b/tensorboard/components/tf_categorization_utils/BUILD
@@ -19,8 +19,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_color_scale/BUILD
+++ b/tensorboard/components/tf_color_scale/BUILD
@@ -19,8 +19,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_color_scale/test/BUILD
+++ b/tensorboard/components/tf_color_scale/test/BUILD
@@ -22,9 +22,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    testonly = 0,
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_dashboard_common/BUILD
+++ b/tensorboard/components/tf_dashboard_common/BUILD
@@ -101,8 +101,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_dashboard_common/test/BUILD
+++ b/tensorboard/components/tf_dashboard_common/test/BUILD
@@ -22,9 +22,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    testonly = 0,
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_globals/BUILD
+++ b/tensorboard/components/tf_globals/BUILD
@@ -20,8 +20,3 @@ tensorboard_webcomponent_library(
     destdir = "tf-globals",
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_imports/BUILD
+++ b/tensorboard/components/tf_imports/BUILD
@@ -492,8 +492,3 @@ genrule(
     cmd = "sed '/^declare module/d' $< | awk '/^}$$/ && !p {p++;next}1' >$@",
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_option_selector/BUILD
+++ b/tensorboard/components/tf_option_selector/BUILD
@@ -14,8 +14,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_profile_dashboard/BUILD
+++ b/tensorboard/components/tf_profile_dashboard/BUILD
@@ -21,8 +21,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_profile_dashboard/demo/BUILD
+++ b/tensorboard/components/tf_profile_dashboard/demo/BUILD
@@ -18,8 +18,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_runs_selector/BUILD
+++ b/tensorboard/components/tf_runs_selector/BUILD
@@ -19,8 +19,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_storage/BUILD
+++ b/tensorboard/components/tf_storage/BUILD
@@ -29,8 +29,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_storage/test/BUILD
+++ b/tensorboard/components/tf_storage/test/BUILD
@@ -22,9 +22,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    testonly = 0,
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -58,8 +58,3 @@ tensorboard_html_binary(
     deps = [":demo"],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_trace_viewer/BUILD
+++ b/tensorboard/components/tf_trace_viewer/BUILD
@@ -23,8 +23,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/tf_trace_viewer/data/BUILD
+++ b/tensorboard/components/tf_trace_viewer/data/BUILD
@@ -10,8 +10,3 @@ web_library(
     path = "/tf-trace-viewer/data/plugin/profile",
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/vz_sorting/BUILD
+++ b/tensorboard/components/vz_sorting/BUILD
@@ -21,8 +21,3 @@ tensorboard_webcomponent_library(
     destdir = "vz-sorting",
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/components/vz_sorting/test/BUILD
+++ b/tensorboard/components/vz_sorting/test/BUILD
@@ -29,9 +29,3 @@ tensorboard_html_binary(
     deps = [":test"],
 )
 
-filegroup(
-    name = "all_files",
-    testonly = 0,
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/demo/BUILD
+++ b/tensorboard/demo/BUILD
@@ -13,8 +13,3 @@ web_library(
     path = "/",
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
@@ -49,8 +49,3 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/BUILD
+++ b/tensorboard/plugins/BUILD
@@ -12,9 +12,3 @@ py_library(
     srcs = ["base_plugin.py"],
     srcs_version = "PY2AND3",
 )
-
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    visibility = ["//third_party/tensorflow:__pkg__"],
-)

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -50,9 +50,3 @@ py_binary(
         "@six_archive//:six",
     ],
 )
-
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    visibility = ["//third_party/tensorflow:__pkg__"],
-)

--- a/tensorboard/plugins/audio/tf_audio_dashboard/BUILD
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/BUILD
@@ -48,8 +48,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/audio/tf_audio_dashboard/test/BUILD
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/test/BUILD
@@ -25,9 +25,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    testonly = 0,
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/distributions/BUILD
+++ b/tensorboard/plugins/distributions/BUILD
@@ -60,9 +60,3 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
     ],
 )
-
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    visibility = ["//third_party/tensorflow:__pkg__"],
-)

--- a/tensorboard/plugins/distributions/tf_distribution_dashboard/BUILD
+++ b/tensorboard/plugins/distributions/tf_distribution_dashboard/BUILD
@@ -42,8 +42,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/distributions/vz_distribution_chart/BUILD
+++ b/tensorboard/plugins/distributions/vz_distribution_chart/BUILD
@@ -32,8 +32,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/BUILD
+++ b/tensorboard/plugins/graphs/BUILD
@@ -42,9 +42,3 @@ py_test(
         "@six_archive//:six",
     ],
 )
-
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    visibility = ["//third_party/tensorflow:__pkg__"],
-)

--- a/tensorboard/plugins/graphs/tf_graph/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph/BUILD
@@ -49,8 +49,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph/demo/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph/demo/BUILD
@@ -19,8 +19,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_app/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_app/BUILD
@@ -36,8 +36,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_app/demo/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_app/demo/BUILD
@@ -16,8 +16,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_board/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_board/BUILD
@@ -31,8 +31,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_board/demo/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_board/demo/BUILD
@@ -19,8 +19,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_common/BUILD
@@ -47,8 +47,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_controls/BUILD
@@ -41,8 +41,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_controls/demo/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_controls/demo/BUILD
@@ -17,8 +17,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_dashboard/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_dashboard/BUILD
@@ -37,8 +37,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_dashboard/demo/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_dashboard/demo/BUILD
@@ -18,8 +18,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_debugger_data_card/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_debugger_data_card/BUILD
@@ -39,8 +39,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_debugger_data_card/demo/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_debugger_data_card/demo/BUILD
@@ -17,8 +17,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_info/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_info/BUILD
@@ -48,8 +48,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_info/demo/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_info/demo/BUILD
@@ -19,8 +19,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_loader/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_loader/BUILD
@@ -25,8 +25,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/graphs/tf_graph_loader/demo/BUILD
+++ b/tensorboard/plugins/graphs/tf_graph_loader/demo/BUILD
@@ -17,8 +17,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/histograms/BUILD
+++ b/tensorboard/plugins/histograms/BUILD
@@ -51,9 +51,3 @@ py_binary(
         "@six_archive//:six",
     ],
 )
-
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    visibility = ["//third_party/tensorflow:__pkg__"],
-)

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/BUILD
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/BUILD
@@ -44,8 +44,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/histograms/tf_histogram_dashboard/test/BUILD
+++ b/tensorboard/plugins/histograms/tf_histogram_dashboard/test/BUILD
@@ -21,9 +21,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    testonly = 0,
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/histograms/vz_histogram_timeseries/BUILD
+++ b/tensorboard/plugins/histograms/vz_histogram_timeseries/BUILD
@@ -39,8 +39,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/images/BUILD
+++ b/tensorboard/plugins/images/BUILD
@@ -40,9 +40,3 @@ py_test(
         "@six_archive//:six",
     ],
 )
-
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    visibility = ["//third_party/tensorflow:__pkg__"],
-)

--- a/tensorboard/plugins/images/tf_image_dashboard/BUILD
+++ b/tensorboard/plugins/images/tf_image_dashboard/BUILD
@@ -41,8 +41,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -29,7 +29,7 @@ py_library(
   srcs_version = "PY2AND3",
   visibility = ["//visibility:public"],
   deps = [
-    ":protos_all_py", 
+    ":protos_all_py",
     ":projector_plugin",
     "//tensorboard:expect_tensorflow_installed",
   ]
@@ -62,12 +62,6 @@ py_test(
         "//tensorboard/plugins:base_plugin",
         "@org_pocoo_werkzeug//:werkzeug",
     ],
-)
-
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    visibility = ["//third_party/tensorflow:__pkg__"],
 )
 
 tb_proto_library(

--- a/tensorboard/plugins/projector/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/BUILD
@@ -104,8 +104,3 @@ ts_web_library(
     deps = [":sptree"],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/projector/vz_projector/test/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/test/BUILD
@@ -28,9 +28,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    testonly = 0,
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/scalars/BUILD
+++ b/tensorboard/plugins/scalars/BUILD
@@ -51,9 +51,3 @@ py_binary(
         "@six_archive//:six",
     ],
 )
-
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    visibility = ["//third_party/tensorflow:__pkg__"],
-)

--- a/tensorboard/plugins/scalars/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalars/tf_scalar_dashboard/BUILD
@@ -36,8 +36,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/scalars/tf_scalar_dashboard/demo/BUILD
+++ b/tensorboard/plugins/scalars/tf_scalar_dashboard/demo/BUILD
@@ -20,8 +20,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/scalars/vz_line_chart/BUILD
+++ b/tensorboard/plugins/scalars/vz_line_chart/BUILD
@@ -46,8 +46,3 @@ tensorboard_webcomponent_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -42,9 +42,3 @@ py_test(
         "@six_archive//:six",
     ],
 )
-
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    visibility = ["//third_party/tensorflow:__pkg__"],
-)

--- a/tensorboard/plugins/text/tf_text_dashboard/BUILD
+++ b/tensorboard/plugins/text/tf_text_dashboard/BUILD
@@ -42,8 +42,3 @@ ts_web_library(
     ],
 )
 
-filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
-    tags = ["notsan"],
-)

--- a/tensorboard/scripts/BUILD
+++ b/tensorboard/scripts/BUILD
@@ -24,9 +24,3 @@ py_binary(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )
-
-filegroup(
-    name = "all_files",
-    srcs = glob(["*"]),
-    visibility = ["//third_party/tensorflow:__subpackages__"],
-)


### PR DESCRIPTION
I don't believe this rule has any purpose. (In many cases it erroneously references third_party/tensorflow for visibility.)