### PR TITLE
Update images in response to data binding changes

### DIFF
--- a/tensorboard/plugins/images/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/images/tf_image_dashboard/tf-image-loader.html
@@ -211,6 +211,7 @@ future for loading older images.
         },
       },
       observers: [
+        "reload(run, tag)",
         "_updateImageUrl(_steps, _stepIndex)",
       ],
 
@@ -238,7 +239,7 @@ future for loading older images.
         this.reload();
       },
       reload() {
-        if (!this.attached) {
+        if (!this._attached) {
           return;
         }
         this._metadataCanceller.cancelAll();


### PR DESCRIPTION
Summary:
In some cases, Polymer's reconciler opts to update components' data
bindings when the behavior actually intended is to shuffle components
around. The image dashboard should listen for those changes and update
appropriately.

(Also, a typo in the reload handler made the attached-guard a no-op.)

wchargin-branch: image-dashboard-data-bindings