### PR TITLE
Pull categorization logic into categorizationUtils

### DIFF
--- a/tensorboard/components/tf_categorization_utils/test/BUILD
+++ b/tensorboard/components/tf_categorization_utils/test/BUILD
@@ -1,0 +1,24 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//tensorboard:internal"],
+)
+
+load("//tensorboard/defs:web.bzl", "ts_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+ts_web_library(
+    name = "test",
+    srcs = [
+        "tests.html",
+        "categorizationUtilsTests.ts",
+    ],
+    path = "/tf-categorization-utils/test",
+    deps = [
+        "//tensorboard/components/tf_categorization_utils",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_imports:web_component_tester",
+        "//tensorboard/components/tf_imports:webcomponentsjs",
+    ],
+)
+

--- a/tensorboard/components/tf_categorization_utils/test/categorizationUtilsTests.ts
+++ b/tensorboard/components/tf_categorization_utils/test/categorizationUtilsTests.ts
@@ -1,0 +1,126 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {categorize} from '../categorizationUtils';
+
+const assert = chai.assert;
+
+describe('categorizationUtils', () => {
+
+  describe('categorize', () => {
+
+    it('returns empty array on empty tags', () => {
+      assert.lengthOf(categorize([], []), 0);
+    });
+
+    it('handles the singleton case', () => {
+      assert.deepEqual(categorize(['a'], []), [{name: 'a', items: ['a']}]);
+    });
+
+    it('handles a simple case', () => {
+      const input = [
+        'foo1/bar', 'foo1/zod', 'foo2/bar', 'foo2/zod', 'gosh/lod/mar',
+        'gosh/lod/ned',
+      ];
+      const expected = [
+        {name: 'foo1', items: ['foo1/bar', 'foo1/zod']},
+        {name: 'foo2', items: ['foo2/bar', 'foo2/zod']},
+        {name: 'gosh', items: ['gosh/lod/mar', 'gosh/lod/ned']},
+      ];
+      assert.deepEqual(categorize(input, []), expected);
+    });
+
+    it('presents categories in first-occurrence order', () => {
+      const input = ['e', 'f/1', 'g', 'a', 'f/2', 'b', 'c'];
+      const expected = [
+        {name: 'e', items: ['e']},
+        {name: 'f', items: ['f/1', 'f/2']},
+        {name: 'g', items: ['g']},
+        {name: 'a', items: ['a']},
+        {name: 'b', items: ['b']},
+        {name: 'c', items: ['c']},
+      ];
+      assert.deepEqual(categorize(input, []), expected);
+    });
+
+    it('handles cases where category names overlap item names', () => {
+      const input = ['a', 'a/a', 'a/b', 'a/c', 'b', 'b/a'];
+      const actual = categorize(input, []);
+      const expected = [
+        {name: 'a', items: ['a', 'a/a', 'a/b', 'a/c']},
+        {name: 'b', items: ['b', 'b/a']},
+      ];
+      assert.deepEqual(actual, expected);
+    });
+
+    it('categorizes by regular expression', () => {
+      const regexes = ['foo..', 'bar..'];
+      const items = ['foods', 'fools', 'barts', 'barms'];
+      const actual = categorize(items, regexes);
+      const expected = [
+        {name: 'foo..', items: ['foods', 'fools']},
+        {name: 'bar..', items: ['barts', 'barms']},
+        {name: 'foods', items: ['foods']},
+        {name: 'fools', items: ['fools']},
+        {name: 'barts', items: ['barts']},
+        {name: 'barms', items: ['barms']},
+      ];
+      assert.deepEqual(actual, expected);
+    });
+
+    it('matches non-exclusively', () => {
+      const regexes = ['...', 'bar'];
+      const items = ['abc', 'bar', 'zod'];
+      const actual = categorize(items, regexes);
+      const expected = [
+        {name: '...', items: ['abc', 'bar', 'zod']},
+        {name: 'bar', items: ['bar']},
+        {name: 'abc', items: ['abc']},
+        {name: 'bar', items: ['bar']},
+        {name: 'zod', items: ['zod']},
+      ];
+      assert.deepEqual(actual, expected);
+    });
+
+    it('creates categories for unmatched rules', () => {
+      const regexes = ['a', 'b', 'c'];
+      const items = [];
+      const actual = categorize(items, regexes);
+      const expected = [
+        {name: 'a', items: []},
+        {name: 'b', items: []},
+        {name: 'c', items: []},
+      ];
+      assert.deepEqual(actual, expected);
+    });
+
+    it('works with special characters in regexes', () => {
+      const regexes = ['^\\w+$', '^\\d+$', '^\\/..$'];
+      const items = ['foo', '3243', '/xa'];
+      const actual = categorize(items, regexes);
+      const expected = [
+        {name: '^\\w+$', items: ['foo', '3243']},
+        {name: '^\\d+$', items: ['3243']},
+        {name: '^\\/..$', items: ['/xa']},
+        {name: 'foo', items: ['foo']},
+        {name: '3243', items: ['3243']},
+        {name: '', items: ['/xa']},
+      ];
+      assert.deepEqual(actual, expected);
+    });
+
+  });
+
+});

--- a/tensorboard/components/tf_categorization_utils/test/tests.html
+++ b/tensorboard/components/tf_categorization_utils/test/tests.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<meta charset="utf-8">
+<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../web-component-tester/browser.js"></script>
+<link rel="import" href="../tf-categorization-utils.html">
+<body>
+<script src="categorizationUtilsTests.js"></script>


### PR DESCRIPTION
Summary:
This change moves the core categorization logic from `tf-categorizer`
into `categorizationUtils`. In doing so, we can strip away much of the
complexity: no one's using nonstandard categorizers, nor do we ever want
to do that, so we can remove a lot of indirection. Not coincidentally,
this change fixes #41.

After this change, nothing will be using `tf-categorizer`, so we will be
able to remove it.

Test Plan:
I included tests! Here is how to run them...

Make the following changes to `categorizationUtilsTests.ts`:
 1. Replace the import statement with the literal contents of
   `categorizationUtils.ts`.
 2. This will add another import statement for `getTags`. Inline that
    function, too. Change `.sort(compareTagNames)` to `.sort()` (it
    doesn't affect any functions under test, and we don't want to keep
    inlining).
 3. Replace the Chai import with the script below [1].

Then:
 1. Go to an online TypeScript transpiler and paste the whole file in.
 2. Go to https://lodash.com and paste the whole thing into the console.
 3. Fix test failures. Repeat until all "OK" and no "FAIL". :-)
    ![Desired outcome](https://user-images.githubusercontent.com/4317806/27496831-8843c54e-580c-11e7-8852-452c655f12b5.png)

Also, exploring TensorBoard indicates that categories are still, in
fact, being generated reasonably.

My mini-Chai implementation [1]:
```typescript
let _currentTest = [];
function describe(name, cb) {
  _currentTest.push(name);
  cb();
  _currentTest.pop();
}
function it(name, cb) {
  _currentTest.push(name);
  let success = true;
  try {
    cb();
  } catch (e) {
    success = false;
    // pass
  }
  if (success) {
    console.log("OK", _currentTest);
  } else {
    console.warn("FAIL", _currentTest);
  }
  _currentTest.pop();
};
function fail(...msg) {
  console.error(_currentTest, ...msg);
  throw new Error("Assertion failure: " + msg);
}
const assert = {
  equal(x, y, ...msg) {
    if (x !== y) {
      fail("unequal", x, y, ...msg);
    }
  },
  lengthOf(a, n) {
    this.equal(a.length, n, "lengthOf");
  },
  deepEqual(x, y, baseX, baseY) {
    if (baseX === undefined) baseX = x;
    if (baseY === undefined) baseY = y;
    if (Array.isArray(x)) {
      this.equal(x.length, y.length, "array length", baseX, baseY);
      for (let i = 0; i < x.length; i++) {
        this.deepEqual(x[i], y[i], baseX, baseY);
      }
    } else if (typeof x === 'object') {
      for (const k of Object.keys(x)) {
        this.deepEqual(x[k], y[k], baseX, baseY);
      }
      for (const k of Object.keys(y)) {
        this.deepEqual(x[k], y[k], baseX, baseY);
      }
    } else {
      this.equal(x, y, typeof x, typeof y, baseX, baseY);
    }
  },
};
```

wchargin-branch: recategorize-categorization