### PR TITLE
Fix logging and error handling

### DIFF
--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -155,7 +155,9 @@ def make_simple_server(tb_app, host, port):
       specified. Also logs an error message.
   """
   # Mute the werkzeug logging.
-  base_logging.getLogger('werkzeug').setLevel(base_logging.WARNING)
+  werkzeug_logger = base_logging.getLogger('werkzeug')
+  werkzeug_logger.setLevel(base_logging.WARNING)
+  werkzeug_logger.addHandler(base_logging.StreamHandler())
 
   try:
     if host:


### PR DESCRIPTION
Summary:
We attempt to quiet the Werkzeug logger, because it's quite verbose. But
our patch to do so wasn't robust: Werkzeug only initializes its log
handlers if we don't touch the logger at all [1]. The result of this was
that any calls to Werkzeug's log function would yield an error, 'no
handlers could be found for logger "werkzeug"'. This is particularly
problematic because the Werkzeug log function is used whenever there's
an internal server error, so the effective result was that any 500s
wouldn't print tracebacks, but instead just yield the above message.

[1]: https://github.com/pallets/werkzeug/blob/423a356d4a49a50179a2be7ba131570dbc607a34/werkzeug/_internal.py#L80-L86

This patch fixes that by emulating [1] and reinstating the default
logging handler.

Test Plan:
Apply the following patch:
```diff
diff --git a/tensorboard/plugins/core/core_plugin.py b/tensorboard/plugins/core/core_plugin.py
index 16d9bce..d5b7b3f 100644
--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -88,6 +88,7 @@ class CorePlugin(base_plugin.TBPlugin):
   @wrappers.Request.application
   def _serve_logdir(self, request):
     """Respond with a JSON object containing this TensorBoard's logdir."""
+    raise Exception('Exception!')
     return http_util.Respond(
         request, {'logdir': self._logdir}, 'application/json')
```
Then curl `/data/logdir`. Before this patch, you'd get no useful
information from the backend. Now, you get a traceback, and there's no
logger-failed message.

wchargin-branch: fix-werkzeug-logging