### PR TITLE
Fix 18 Closure Compiler warnings

### DIFF
--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -147,6 +147,8 @@ export function getURIStorageName(
  * (1) Initializes a Polymer boolean property with a default value, if its
  *     value is not already set
  * (2) Sets up listener that updates Polymer property on hash change.
+ *
+ * @param {boolean=} useLocalStorage
  */
 export function getBooleanInitializer(
     propertyName: string, defaultVal: boolean,
@@ -160,6 +162,8 @@ export function getBooleanInitializer(
  * (1) Initializes a Polymer string property with a default value, if its
  *     value is not already set
  * (2) Sets up listener that updates Polymer property on hash change.
+ *
+ * @param {boolean=} useLocalStorage
  */
 export function getStringInitializer(
     propertyName: string, defaultVal: string,
@@ -173,6 +177,8 @@ export function getStringInitializer(
  * (1) Initializes a Polymer number property with a default value, if its
  *     value is not already set
  * (2) Sets up listener that updates Polymer property on hash change.
+ *
+ * @param {boolean=} useLocalStorage
  */
 export function getNumberInitializer(
     propertyName: string, defaultVal: number,
@@ -188,6 +194,8 @@ export function getNumberInitializer(
  * (2) Sets up listener that updates Polymer property on hash change.
  *
  * Generates a deep clone of the defaultVal to avoid mutation issues.
+ *
+ * @param {boolean=} useLocalStorage
  */
 export function getObjectInitializer(
     propertyName: string, defaultVal: {}, useLocalStorage = false): Function {
@@ -197,6 +205,8 @@ export function getObjectInitializer(
 
 /**
  * Return a function that updates URIStorage when a string property changes.
+ *
+ * @param {boolean=} useLocalStorage
  */
 export function getBooleanObserver(
     propertyName: string, defaultVal: boolean,
@@ -207,6 +217,8 @@ export function getBooleanObserver(
 
 /**
  * Return a function that updates URIStorage when a string property changes.
+ *
+ * @param {boolean=} useLocalStorage
  */
 export function getStringObserver(
     propertyName: string, defaultVal: string,
@@ -217,6 +229,8 @@ export function getStringObserver(
 
 /**
  * Return a function that updates URIStorage when a number property changes.
+ *
+ * @param {boolean=} useLocalStorage
  */
 export function getNumberObserver(
     propertyName: string, defaultVal: number,
@@ -228,6 +242,8 @@ export function getNumberObserver(
 /**
  * Return a function that updates URIStorage when an object property changes.
  * Generates a deep clone of the defaultVal to avoid mutation issues.
+ *
+ * @param {boolean=} useLocalStorage
  */
 export function getObjectObserver(
     propertyName: string, defaultVal: {}, useLocalStorage = false): Function {

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -215,9 +215,10 @@ allows the user to toggle between various dashboards.
             // For now, Tensorboard only shows debugger data if the debugger_data GET param is set
             // to enabled.
             let match = window.location.href.match(/[&\?]debugger_data=enabled/);
-            return match && match.length == 1;
+            return !!match && match.length == 1;
           },
         },
+        modeIndex: Number,  // upward-bound from paper-tabs
         // Which tab is selected (scalars, graph, images etc).
         mode: {
           type: String,
@@ -253,7 +254,7 @@ allows the user to toggle between various dashboards.
       },
       _getModeFromIndex: function(modeIndex) {
         var mode = this.tabs[modeIndex];
-        setString(TAB, mode);
+        setString(TAB, mode, /*useLocalStorage=*/false);
         return mode;
       },
       _isReloadDisabled: function(mode) {
@@ -296,11 +297,11 @@ allows the user to toggle between various dashboards.
         this._getModeFromHash();
         window.addEventListener('hashchange', function() {
           this._getModeFromHash();
-        }.bind(this));
+        }.bind(this), /*useCapture=*/false);
         fetchRuns();
       },
       _getModeFromHash: function() {
-        var tabName = getString(TAB);
+        var tabName = getString(TAB, /*useLocalStorage=*/false);
         var modeIndex = this.tabs.indexOf(tabName);
         if (modeIndex == -1 && this.modeIndex == null) {
           // Select the first tab as default.

--- a/tensorboard/plugins/graphs/tf_graph/tf-graph-minimap.html
+++ b/tensorboard/plugins/graphs/tf_graph/tf-graph-minimap.html
@@ -77,7 +77,7 @@ Polymer({
    * @param svg The main svg element.
    * @param zoomG The svg group used for panning and zooming the main svg.
    * @param mainZoom The main zoom behavior.
-   * @param maxWandH The maximum width/height for the minimap.
+   * @param maxWAndH The maximum width/height for the minimap.
    * @param labelPadding Padding in pixels due to the main graph labels.
    */
   init: function(svg, zoomG, mainZoom, maxWAndH, labelPadding) {

--- a/tensorboard/plugins/graphs/tf_graph/tf-graph-scene.html
+++ b/tensorboard/plugins/graphs/tf_graph/tf-graph-scene.html
@@ -675,12 +675,20 @@ Polymer({
       observer: '_onZoomChanged',
       value: false
     },
-    /** Keeps track of the starting coordinates of a graph zoom/pan */
+    /**
+     * Keeps track of the starting coordinates of a graph zoom/pan.
+     *
+     * @private {{x: number, y: number}?}
+     */
     _zoomStartCoords: {
       type: Object,
       value: null
     },
-    /** Keeps track of the current coordinates of a graph zoom/pan */
+    /**
+     * Keeps track of the current coordinates of a graph zoom/pan
+     *
+     * @private {{x: number, y: number}?}
+     */
     _zoomTransform: {
       type: Object,
       value: null

--- a/tensorboard/plugins/graphs/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graphs/tf_graph_dashboard/tf-graph-dashboard.html
@@ -166,7 +166,12 @@ Polymer({
     // A strictly increasing ID. Each request for health pills has a unique ID. This helps us
     // identify stale requests.
     _healthPillRequestId: {type: Number, value: 1},
-    // The setTimeout ID for the pending request for health pills at a specific step.
+    /**
+     * The setTimeout ID for the pending request for health pills at a
+     * specific step.
+     *
+     * @type {number?}
+     */
     _healthPillStepRequestTimerId: Number,
     // The request for health pills at a specific step (as opposed to all sampled health pills) may
     // involve slow disk reads. Hence, we throttle to 1 of those requests every this many ms.

--- a/tensorboard/plugins/graphs/tf_graph_info/tf-graph-info.html
+++ b/tensorboard/plugins/graphs/tf_graph_info/tf-graph-info.html
@@ -91,6 +91,7 @@ h2 {
         type: String,
         notify: true
       },
+      /** @type {string?} */
       highlightedNode: {
         type: String,
         notify: true

--- a/tensorboard/plugins/graphs/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graphs/tf_graph_loader/tf-graph-loader.html
@@ -31,7 +31,7 @@ Polymer({
 
   properties: {
     /**
-     * @type {value: number, msg: string}
+     * @type {{value: number, msg: string}}
      *
      * A number between 0 and 100 denoting the % of progress
      * for the progress bar and the displayed message.
@@ -61,6 +61,7 @@ Polymer({
       readOnly: true,
       notify: true
     },
+    /** @type {Object} */
     outStats: {
       type: Object,
       readOnly: true, // This property produces data.
@@ -90,6 +91,10 @@ Polymer({
       this._setOutStats(stats);
     }.bind(this));
   },
+  /**
+   * @param {string?} path
+   * @param {string=} pbTxtFile
+   */
   _parseAndConstructHierarchicalGraph: function(path, pbTxtFile) {
     // Reset the progress bar to 0.
     this.set('progress', {

--- a/tensorboard/plugins/images/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/images/tf_image_dashboard/tf-image-loader.html
@@ -146,7 +146,8 @@ future for loading older images.
       properties: {
         run: String,
         tag: String,
-        showActualSize: Object,  // function: (img: Node) => void
+        /** @type {function(Node)} */
+        showActualSize: Object,
 
         _runColor: {
           type: String,


### PR DESCRIPTION
Summary:
This eliminates all warnings except for the following:
  - warnings from library code, like `paper-input-container`
    (10 occurrences);
  - warnings of the form "Bad type annotation. Unknown type $foo", where
    $foo is a qualified type expression like `tf.scene.Minimap` or
    `d3.scale.ordinal` (7 occurrences).

The former we should not fix, and should instead instruct the compiler
to ignore. The latter I'm not sure how to fix.

Most fixes in this patch simply required specifying nullability
constraints on Polymer properties and functions from TypeScript code.
(Ideally, the existence of a default value for a TypeScript parameter
would inform the Closure Compiler, but this is not the case.) Others
involved specifying default values of arguments (e.g., explicitly
setting `false` instead of leaving a boolean argument absent).

Test Plan:
Perform a clean build, and see that all warnings are of the form
described in the summary. Then, check that the three places in which I
added `false` as an argument, this is in fact the default value.

wchargin-branch: fix-some-warnings