### PR TITLE
Upgrade pip dependency on Markdown

### DIFF
--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -30,7 +30,7 @@ REQUIRED_PACKAGES = [
     'protobuf >= 3.2.0',
     'werkzeug >= 0.11.10',
     'html5lib == 0.9999999',  # identical to 1.0b8
-    'markdown == 2.2.0',
+    'markdown >= 2.6.8',
     'bleach == 1.5.0',
     'tensorflow >= 1.2.0',
 ]

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -49,7 +49,7 @@ def tensorboard_python_workspace():
       sha256 = "0d68713d02ba4148c417ab1637dd819333d96929a34401d0233947bec0881ad8",
       build_file = str(Label("//third_party:bleach.BUILD")),
   )
-  
+
   native.new_http_archive(
       name = "org_pocoo_werkzeug",
       urls = [


### PR DESCRIPTION
Strangely, we load a recent version of markdown in our workspace files, but we have an outdated pip dependency.