### PR TITLE
Reduce unnecessary fetches in scalar chart

### DIFF
--- a/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-chart.html
+++ b/tensorboard/plugins/scalars/tf_scalar_dashboard/tf-scalar-chart.html
@@ -178,6 +178,25 @@ limitations under the License.
           type: Function,
           value: () => getRouter().pluginRunTagRoute('scalars', '/scalars'),
         },
+
+        /*
+         * A map such that `_loadedRuns[run] === true` iff we've loaded
+         * `run` already, or are in the process of loading it. This
+         * exists so that when there are 100 runs selected and the user
+         * selects an additional run, we only fetch 1 more run instead
+         * of 101.
+         *
+         * `reload` clears this cache.
+         *
+         * Equivalently, this is the set of runs for which, after
+         * callbacks in-flight resolve, the most recent call to
+         * `setSeriesData(run, data)` on the chart object (a) exists
+         * and (b) occurred after all reloads so far.
+         */
+        _loadedRuns: {
+          type: Object,
+          value: () => ({}),
+        },
       },
       observers: [
         'reload(tag)',
@@ -188,6 +207,10 @@ limitations under the License.
         this._changeSeries();
       },
       reload() {
+        this._loadedRuns = {};
+        this._loadData();
+      },
+      _loadData() {
         if (!this._attached) {
           return;
         }
@@ -196,6 +219,10 @@ limitations under the License.
         // prevent race conditions where older data stomps newer data.
         this._canceller.cancelAll();
         this.runs.forEach(run => {
+          if (this._loadedRuns[run]) {
+            return;
+          }
+          this._loadedRuns[run] = true;
           const url = this._scalarUrl(this.tag, run);
           const updateSeries = this._canceller.cancellable(result => {
             if (result.cancelled) {
@@ -214,7 +241,7 @@ limitations under the License.
       },
       _changeSeries() {
         this.$$('vz-line-chart').setVisibleSeries(this.runs);
-        this.reload();
+        this._loadData();
       },
       redraw() {
         this.$$('vz-line-chart').redraw();


### PR DESCRIPTION
Summary:
Remember which runs we've fetched since the last explicit reload. If we
need to load more data, don't fetch those runs again.

More details on docstring on new property.

Test Plan:
Open the network panel. Open a category with a dozen or so tags. Then,
in the list of runs, go down the list and check each run one at a time
(starting from all disabled).

Before this change:
![pre_change](https://user-images.githubusercontent.com/4317806/27566867-cb3284f2-5a9c-11e7-8b7e-f8ec299ebcf5.png)
You can see that the number of network requests is linear in the number
of selected runs, so the total number of requests is quadratic in the
number of selections you make.

After this change:
![post_change](https://user-images.githubusercontent.com/4317806/27566871-d3704974-5a9c-11e7-9a7f-6505ce23a041.png)
You can see that the number of network requests is constant in the number
of selected runs, so the total number of requests is linear in the
number of selections you make.

Also, deselecting runs now causes zero requests instead of $n$,
where $n$ is the number of runs that remain selected.

Clicking "reload" or waiting 30 seconds does issue a big blob of
requests, as desired.

wchargin-branch: scalars-remember-fetches