### PR TITLE
Add missing data dependency in pagination view

### DIFF
--- a/tensorboard/components/tf_paginated_view/test/BUILD
+++ b/tensorboard/components/tf_paginated_view/test/BUILD
@@ -1,0 +1,26 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//tensorboard:internal"],
+)
+
+# load("//tensorboard/defs:mocha_test.bzl", "mocha_test")
+
+licenses(["notice"])  # Apache 2.0
+
+# TODO(@dandelionmane): Enable this once `mocha_test` is implemented.
+#mocha_test(
+#    name = "test",
+#    srcs = [
+#        "tests.html",
+#        "paginatedViewTests.html",
+#        "paginatedViewTests.ts",
+#    ],
+#    test_file = "tests.html",
+#    path = "/tf-paginated-view/test",
+#    deps = [
+#        "//tensorboard/components/tf_paginated_view",
+#        "//tensorboard/components/tf_imports:lodash",
+#        "//tensorboard/components/tf_imports:polymer",
+#        "//tensorboard/components/tf_imports:webcomponentsjs",
+#    ],
+#)

--- a/tensorboard/components/tf_paginated_view/test/paginatedViewTests.html
+++ b/tensorboard/components/tf_paginated_view/test/paginatedViewTests.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<html>
+<head>
+  <link rel="import" href="../../polymer/polymer.html">
+  <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../tf-paginated-view.html">
+</head>
+<body>
+  <test-fixture id="paginatedViewFixture">
+    <template>
+      <tf-paginated-view>
+        <span id="child">Content within the paginated view.</span>
+      </tf-paginated-view>
+    </template>
+  </test-fixture>
+  <script src="paginatedViewTests.js"></script>
+</body>
+</html>

--- a/tensorboard/components/tf_paginated_view/test/paginatedViewTests.ts
+++ b/tensorboard/components/tf_paginated_view/test/paginatedViewTests.ts
@@ -1,0 +1,69 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+declare function fixture(id: string): void;
+
+describe('tf-paginated-view tests', () => {
+  window.HTMLImports.whenReady(() => {
+    let view: any;
+    beforeEach(() => {
+      view = fixture('paginatedViewFixture');
+      view.limit = 5;
+      view.items = _.range(13);
+    });
+
+    it('renders its subcomponents', () => {
+      const child = view.querySelector('#child');
+      chai.assert.isNotNull(child);
+      chai.assert.equal(child.innerHTML, 'Content within the paginated view.');
+    });
+
+    it('emits a list of pages', () => {
+      chai.assert.deepEqual(view.pages, [
+        {active: true, items: [0, 1, 2, 3, 4]},
+        {active: false, items: [5, 6, 7, 8, 9]},
+        {active: false, items: [10, 11, 12]},
+      ]);
+    });
+
+    it('changes its pages when the items change', () => {
+      view.items = view.items.slice().reverse();
+      chai.assert.deepEqual(view.pages, [
+        {active: true, items: [12, 11, 10, 9, 8]},
+        {active: false, items: [7, 6, 5, 4, 3]},
+        {active: false, items: [2, 1, 0]},
+      ]);
+    });
+
+    it('handles shrinking the number of pages', () => {
+      view.items = _.range(7).map(x => 10 * x);
+      chai.assert.deepEqual(view.pages, [
+        {active: true, items: [0, 10, 20, 30, 40]},
+        {active: false, items: [50, 60]},
+      ]);
+    });
+
+    it('handles enlarging the number of pages', () => {
+      view.items = _.range(22).map(x => 10 * x);
+      chai.assert.deepEqual(view.pages, [
+        {active: true, items: [0, 10, 20, 30, 40]},
+        {active: false, items: [50, 60, 70, 80, 90]},
+        {active: false, items: [100, 110, 120, 130, 140]},
+        {active: false, items: [150, 160, 170, 180, 190]},
+        {active: false, items: [200, 210]},
+      ]);
+    });
+  });
+});

--- a/tensorboard/components/tf_paginated_view/test/tests.html
+++ b/tensorboard/components/tf_paginated_view/test/tests.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<html>
+<head>
+  <meta charset="utf-8">
+  <script vulcanize-noinline src="../../web-component-tester/browser.js"></script>
+</head>
+<body>
+<script>
+// Run the tests for each main component in tensorboard.
+WCT.loadSuites([
+  'paginatedViewTests.html',
+]);
+</script>
+</body>
+</html>

--- a/tensorboard/components/tf_paginated_view/tf-paginated-view.html
+++ b/tensorboard/components/tf_paginated_view/tf-paginated-view.html
@@ -173,7 +173,7 @@ limitations under the License.
       pages: {
         type: Array,
         notify: true,
-        computed: '_computePages(items, limit, _activeIndex)',
+        computed: '_computePages(items, limit, _activeIndex, _pageCount)',
       },
 
       // At any time we'll mark one particular item('s index) as
@@ -246,9 +246,9 @@ limitations under the License.
       }
     },
 
-    _computePages(items, limit, activeIndex) {
+    _computePages(items, limit, activeIndex, pageCount) {
       const activePageIndex = Math.floor(activeIndex / limit);
-      return _.range(this._pageCount).map(pageIndex => ({
+      return _.range(pageCount).map(pageIndex => ({
         active: pageIndex === activePageIndex,
         items: (items || []).slice(pageIndex * limit, (pageIndex + 1) * limit),
       }));


### PR DESCRIPTION
Summary:
Because the observer didn't explicitly note that `pages` depends on the
value of `_pageCount`, Polymer could sometimes update `pages` before
updating `_pageCount`. In the case that the true value of `_pageCount`
changed from `0` to `1`, this resulted in an empty array of pages being
returned.

Test Plan:
Create a category that has zero tags. Expand it. Then, update the
category to have a tag (and reload the plugin data). Before this patch,
nothing would appear in the paginated view. After this patch, the data
appears correctly.

wchargin-branch: fix-pagination-data-dependency