### PR TITLE
Track selected dashboard by name, not index

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -57,7 +57,8 @@ limitations under the License.
         <div id="toolbar-content">
           <div class="toolbar-title">TensorBoard</div>
           <paper-tabs
-            selected="{{_activeDashboardIndex}}"
+            selected="{{_selectedDashboard}}"
+            attr-for-selected="data-dashboard"
             noink
             id="tabs"
           >
@@ -66,7 +67,7 @@ limitations under the License.
                 is="dom-if"
                 if="[[_isDashboardEnabled(disabledDashboards, dashboard)]]"
               >
-                <paper-tab>[[dashboard]]</paper-tab>
+                <paper-tab data-dashboard="[[dashboard]]">[[dashboard]]</paper-tab>
               </template>
             </template>
           </paper-tabs>
@@ -100,7 +101,7 @@ limitations under the License.
           <div
             class="dashboard-container"
             data-dashboard$="[[dashboard]]"
-            style="display: [[_displayStyle(_activeDashboard, dashboard)]]"
+            style="display: [[_displayStyle(_selectedDashboard, dashboard)]]"
           ><!-- Dashboards will be injected here dynamically. --></div>
         </template>
       </div>
@@ -251,16 +252,16 @@ limitations under the License.
           type: Array,
           readOnly: true,
           value: TABS,
+          observer: '_dashboardsUpdated',
         },
 
         /**
-         * The index into `dashboards` of the currently active
-         * dashboard. (Upward-bound from the `paper-tabs` component.)
+         * The name of the currently selected dashboard, or `null` if no
+         * dashboard is selected.
          */
-        _activeDashboardIndex: Number,
-        _activeDashboard: {
+        _selectedDashboard: {
           type: String,
-          computed: '_getDashboardFromIndex(_dashboards, _activeDashboardIndex)',
+          value: null,
           observer: '_updateCurrentDashboard',
           notify: true,
         },
@@ -277,12 +278,18 @@ limitations under the License.
 
         _isReloadDisabled: {
           type: Boolean,
-          computed: '_computeIsReloadDisabled(_debuggerDataEnabled, _activePlugin)',
+          computed: '_computeIsReloadDisabled(_debuggerDataEnabled, _selectedDashboard)',
         },
       },
       observers: [
-        '_ensureActiveDashboardStamped(_dashboardContainersStamped, _activeDashboard)',
+        '_ensureSelectedDashboardStamped(_dashboardContainersStamped, _selectedDashboard)',
       ],
+
+      _dashboardsUpdated(dashboards) {
+        if (this._selectedDashboard == null) {
+          this._selectedDashboard = dashboards[0];
+        }
+      },
 
       _isDashboardEnabled(disabledDashboards, dashboard) {
         return (disabledDashboards || '').split(',').indexOf(dashboard) < 0;
@@ -293,7 +300,7 @@ limitations under the License.
       },
 
       _displayStyle(currentDashboard, candidateDashboard) {
-         // Display only the active dashboard.
+         // Display only the selected dashboard.
         return currentDashboard === candidateDashboard ? 'inherit' : 'none';
       },
 
@@ -302,8 +309,8 @@ limitations under the License.
       },
 
       /**
-       * Make sure that the currently active dashboard actually has an
-       * active Polymer component; if it doesn't, create one.
+       * Make sure that the currently selected dashboard actually has a
+       * Polymer component; if it doesn't, create one.
        *
        * We have to stamp each dashboard before we can interact with it:
        * for instance, to ask it to reload. Conversely, we can't stamp a
@@ -311,7 +318,7 @@ limitations under the License.
        * are stamped declaratively by a `<dom-repeat>` in the HTML
        * template.)
        */
-      _ensureActiveDashboardStamped(containersStamped, dashboard) {
+      _ensureSelectedDashboardStamped(containersStamped, dashboard) {
         if (!containersStamped) {
           return;
         }
@@ -319,7 +326,7 @@ limitations under the License.
           `.dashboard-container[data-dashboard=${dashboard}]`);
         if (container.childNodes.length === 0) {
           const component = document.createElement(COMPONENTS[dashboard]);
-          component.id = 'dashboard';  // used in `_activeDashboardComponent`
+          component.id = 'dashboard';  // used in `_selectedDashboardComponent`
           container.appendChild(component);
         };
       },
@@ -331,21 +338,21 @@ limitations under the License.
       },
 
       /**
-       * Get the Polymer component corresponding to the currently active
-       * dashboard. For instance, the result might be an instance of
-       * `<tf-scalar-dashboard>`.
+       * Get the Polymer component corresponding to the currently
+       * selected dashboard. For instance, the result might be an
+       * instance of `<tf-scalar-dashboard>`.
        */
-      _activeDashboardComponent() {
+      _selectedDashboardComponent() {
         if (!this._dashboardContainersStamped) {
           throw new Error(
             'There is no "selected dashboard" before containers are stamped.');
         }
-        const activeDashboard = this._activeDashboard;
+        const selectedDashboard = this._selectedDashboard;
         var dashboard = this.$$(
-          `.dashboard-container[data-dashboard=${activeDashboard}] #dashboard`);
+          `.dashboard-container[data-dashboard=${selectedDashboard}] #dashboard`);
         if (dashboard == null) {
           throw new Error(
-            `Unable to find dashboard for mode: ${activeDashboard}`);
+            `Unable to find dashboard for mode: ${selectedDashboard}`);
         }
         return dashboard;
       },
@@ -360,23 +367,21 @@ limitations under the License.
           // This will trigger an observer that kicks off everything.
           this._dashboardContainersStamped = true;
 
-          this._updateActiveDashboardFromHash();
+          this._updateSelectedDashboardFromHash();
           window.addEventListener('hashchange', () => {
-            this._updateActiveDashboardFromHash();
+            this._updateSelectedDashboardFromHash();
           }, /*useCapture=*/false);
           fetchRuns();
         }, /*useCapture=*/false);
       },
 
-      _updateActiveDashboardFromHash() {
+      _updateSelectedDashboardFromHash() {
         const dashboardName = getString(TAB, /*useLocalStorage=*/false);
-        const index = this._dashboards.indexOf(dashboardName);
-        if (index == -1 && this._activeDashboardIndex == null) {
-          // Select the first tab as default.
-          this.set('_activeDashboardIndex', 0);
-        }
-        if (index != -1 && index != this._activeDashboardIndex) {
-          this.set('_activeDashboardIndex', index);
+        if (this._dashboards.includes(dashboardName)) {
+          this.set('_selectedDashboard', dashboardName);
+        } else {
+          // Select the first dashboard as default.
+          this.set('_selectedDashboard', this._dashboards[0]);
         }
       },
 
@@ -389,7 +394,7 @@ limitations under the License.
           return;
         }
         fetchRuns().then(() => {
-          this._activeDashboardComponent().reload();
+          this._selectedDashboardComponent().reload();
         });
       },
 


### PR DESCRIPTION
Summary:
This removes the `_activeDashboardIndex` property from `tf-tensorboard`,
instead directly binding `_selectedDashboard` (the name) from the tab
selector component.

This simplification is nice-to-have now, but once we start using the
`is_active` method of plugins on the backend, the set of tabs shown on
the frontend will not be constant; this change will then be significant.

While I'm at it, I changed `active` to `selected` everywhere, because
"active" means "can be selected" in our parlance.

Test Plan:
Note that there are no console errors when TensorBoard is launched, and
that you can still switch among tabs.

wchargin-branch: select-dashboards-by-name