### PR TITLE
Fix the text plugin's `is_active` route

### DIFF
--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -328,4 +328,4 @@ class TextPlugin(base_plugin.TBPlugin):
     Returns:
       Whether this plugin is active.
     """
-    return bool(self._multiplexer and self.index_impl())
+    return bool(self._multiplexer and any(self.index_impl().values()))


### PR DESCRIPTION
Summary:
The text plugin was checking whether any runs existed, not whether any
runs with text summaries existed.

Test Plan:
Load `/data/plugins_listing` on a data set with text summaries and one
without. Before this change, both results included `"text": true`. After
this change, the data set without text summaries has `"text": false`.

Also, the new unit test fails before this change and passes after it.

wchargin-branch: fix-text-is-active