### PR TITLE
Add open source logging infrastructure

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -23,6 +23,7 @@ py_binary(
     main = "main.py",
     srcs_version = "PY2AND3",
     deps = [
+        ":util",
         ":version",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_file_inspector",
@@ -96,4 +97,24 @@ py_library(
     testonly = 1,
     srcs = ["test_util.py"],
     srcs_version = "PY2AND3",
+)
+
+py_library(
+    name = "util",
+    srcs = ["util.py"],
+    srcs_version = "PY2AND3",
+    deps = ["//tensorboard:expect_tensorflow_installed"],
+)
+
+py_test(
+    name = "util_test",
+    size = "small",
+    srcs = ["util_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":test_util",
+        ":util",
+        "//tensorboard:expect_tensorflow_installed",
+        "@six_archive//:six",
+    ],
 )

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -308,7 +308,7 @@ def start_reloading_multiplexer(multiplexer, path_to_run, load_interval):
       reload_multiplexer(multiplexer, path_to_run)
       time.sleep(load_interval)
 
-  thread = threading.Thread(target=_reload_forever)
+  thread = threading.Thread(target=_reload_forever, name='Reloader')
   thread.daemon = True
   thread.start()
   return thread

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -29,6 +29,7 @@ import sys
 import tensorflow as tf
 from werkzeug import serving
 
+from tensorboard import util
 from tensorboard import version
 from tensorboard.backend import application
 from tensorboard.backend.event_processing import event_file_inspector as efi
@@ -156,11 +157,6 @@ def make_simple_server(tb_app, host, port):
     socket.error: If a server could not be constructed with the host and port
       specified. Also logs an error message.
   """
-  # Mute the werkzeug logging.
-  werkzeug_logger = base_logging.getLogger('werkzeug')
-  werkzeug_logger.setLevel(base_logging.WARNING)
-  werkzeug_logger.addHandler(base_logging.StreamHandler())
-
   try:
     if host:
       # The user gave us an explicit host
@@ -207,16 +203,18 @@ def run_simple_server(tb_app):
     # An error message was already logged
     # TODO(jart): Remove log and throw anti-pattern.
     sys.exit(-1)
-  msg = 'Starting TensorBoard %s at %s' % (version.VERSION, url)
-  print(msg)
-  tf.logging.info(msg)
-  print('(Press CTRL+C to quit)')
-  sys.stdout.flush()
-
-  server.serve_forever()
+  logger = base_logging.getLogger('tensorflow' + util.LogHandler.EPHEMERAL)
+  logger.setLevel(base_logging.INFO)
+  logger.info('TensorBoard %s at %s (Press CTRL+C to quit) ',
+              version.VERSION, url)
+  try:
+    server.serve_forever()
+  finally:
+    logger.info('')
 
 
 def main(unused_argv=None):
+  util.setup_logging()
   if FLAGS.inspect:
     tf.logging.info('Not bringing up TensorBoard, but inspecting event files.')
     event_file = os.path.expanduser(FLAGS.event_file)

--- a/tensorboard/util.py
+++ b/tensorboard/util.py
@@ -1,0 +1,226 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TensorBoard helper routine module.
+
+This module is a trove of succinct generic helper routines that don't
+pull in any heavyweight dependencies aside from TensorFlow.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import os
+import sys
+
+import tensorflow as tf
+
+
+def setup_logging(streams=(sys.stderr,)):
+  """Configures Python logging the way the TensorBoard team likes it.
+
+  This should be called exactly once at the beginning of main().
+
+  Args:
+    streams: An iterable of open files. Logs are written to each.
+
+  :type streams: tuple[file]
+  """
+  # NOTE: Adding a level parameter to this method would be a bad idea
+  #       because Python and ABSL disagree on the level numbers.
+  tf.logging.set_verbosity(tf.logging.WARN)
+  # TODO(jart): Make the default TensorFlow logger behavior great again.
+  logging.currentframe = _hack_the_main_frame
+  handlers = [LogHandler(s) for s in streams]
+  tensorflow_logger = logging.getLogger('tensorflow')
+  tensorflow_logger.handlers = handlers
+  werkzeug_logger = logging.getLogger('werkzeug')
+  werkzeug_logger.setLevel(logging.WARNING)
+  for handler in handlers:
+    handler.setFormatter(LogFormatter())
+    werkzeug_logger.addHandler(handler)
+
+
+class LogFormatter(logging.Formatter):
+  """Google style log formatter.
+
+  The format is in essence the following:
+
+      [DIWEF]mmdd hh:mm:ss.uuuuuu thread_name file:line] msg
+
+  This class is meant to be used with LogHandler.
+  """
+
+  DATE_FORMAT = '%m%d %H:%M:%S'
+  LOG_FORMAT = ('%(levelname)s%(asctime)s %(threadName)s '
+                '%(filename)s:%(lineno)d] %(message)s')
+
+  LEVEL_NAMES = {
+      logging.FATAL: 'F',
+      logging.ERROR: 'E',
+      logging.WARN: 'W',
+      logging.INFO: 'I',
+      logging.DEBUG: 'D',
+  }
+
+  def __init__(self):
+    """Creates new instance."""
+    super(LogFormatter, self).__init__(LogFormatter.LOG_FORMAT,
+                                       LogFormatter.DATE_FORMAT)
+
+  def format(self, record):
+    """Formats the log record.
+
+    :type record: logging.LogRecord
+    :rtype: str
+    """
+    record.levelname = LogFormatter.LEVEL_NAMES[record.levelno]
+    return super(LogFormatter, self).format(record)
+
+  def formatTime(self, record, datefmt=None):
+    """Return creation time of the specified LogRecord as formatted text.
+
+    This override adds microseconds.
+
+    :type record: logging.LogRecord
+    :rtype: str
+    """
+    return (super(LogFormatter, self).formatTime(record, datefmt) +
+            '.%06d' % (record.created * 1e6 % 1e6))
+
+
+class Ansi(object):
+  """ANSI terminal codes container."""
+
+  ESCAPE = '\x1b['
+  RESET = ESCAPE + '0m'
+  BOLD = ESCAPE + '1m'
+  FLIP = ESCAPE + '7m'
+  RED = ESCAPE + '31m'
+  YELLOW = ESCAPE + '33m'
+  MAGENTA = ESCAPE + '35m'
+  CURSOR_HIDE = ESCAPE + '?25l'
+  CURSOR_SHOW = ESCAPE + '?25h'
+
+
+class LogHandler(logging.StreamHandler):
+  """Log handler that supports ANSI colors and ephemeral records.
+
+  Colors are applied on a line-by-line basis to non-INFO records. The
+  goal is to help the user visually distinguish meaningful information,
+  even when logging is verbose.
+
+  Ephemeral log records, when emitted to a teletype emulator, only
+  display on the final row, and get overwritten as soon as another
+  ephemeral record is outputted. Ephemeral records are also sticky. If
+  a normal record is written then the previous ephemeral record is
+  restored right beneath it. When an ephemeral record with an empty
+  message is emitted, then the last ephemeral record turns into a
+  normal record and is allowed to spool.
+
+  This class is thread safe.
+  """
+
+  EPHEMERAL = '.ephemeral'  # Name suffix for ephemeral loggers.
+
+  COLORS = {
+      logging.FATAL: Ansi.BOLD + Ansi.RED,
+      logging.ERROR: Ansi.RED,
+      logging.WARN: Ansi.YELLOW,
+      logging.INFO: '',
+      logging.DEBUG: Ansi.MAGENTA,
+  }
+
+  def __init__(self, stream):
+    super(LogHandler, self).__init__(stream)
+    self._stream = stream
+    self._disable_flush = False
+    self._is_tty = (hasattr(stream, 'isatty') and
+                    stream.isatty() and
+                    os.name != 'nt')
+    self._ephemeral = ''
+
+  def emit(self, record):
+    """Emits a log record.
+
+    :type record: logging.LogRecord
+    """
+    self.acquire()
+    try:
+      is_ephemeral = (self._is_tty and
+                      record.name.endswith(LogHandler.EPHEMERAL))
+      color = LogHandler.COLORS[record.levelno]
+      if self._is_tty and color:
+        self._stream.write(color)
+      if is_ephemeral:
+        ephemeral = record.getMessage()
+        if ephemeral:
+          self._clear_line()
+          self._stream.write(ephemeral)
+        else:
+          if self._ephemeral:
+            self._stream.write('\n')
+        self._ephemeral = ephemeral
+      else:
+        self._clear_line()
+        self._disable_flush = True  # prevent double flush
+        super(LogHandler, self).emit(record)
+        self._disable_flush = False
+      if self._is_tty and color:
+        self._stream.write(Ansi.RESET)
+      if not is_ephemeral and self._ephemeral:
+        self._stream.write(self._ephemeral)
+      self.flush()
+    finally:
+      self._disable_flush = False
+      self.release()
+
+  def flush(self):
+    """Flushes output stream."""
+    self.acquire()
+    try:
+      if not self._disable_flush:
+        super(LogHandler, self).flush()
+    finally:
+      self.release()
+
+  def _clear_line(self):
+    if self._is_tty and self._ephemeral:
+      # Our calculation of length won't be perfect due to ANSI codes,
+      # but we can make it a little bit better by scrubbing these.
+      text = self._ephemeral.replace(Ansi.ESCAPE, '')
+      self._stream.write('\r' + ' ' * len(text) + '\r')
+
+
+def _hack_the_main_frame():
+  """Returns caller frame and skips over tf_logging.
+
+  This works around a bug in TensorFlow's open source logging module
+  where the Python logging module attributes log entries to the
+  delegate functions in tf_logging.py.
+  """
+  if hasattr(sys, '_getframe'):
+    frame = sys._getframe(3)
+  else:
+    try:
+      raise Exception
+    except Exception:  # pylint: disable=broad-except
+      frame = sys.exc_info()[2].tb_frame.f_back
+  if (frame is not None and
+      hasattr(frame.f_back, 'f_code') and
+      'tf_logging.py' in frame.f_back.f_code.co_filename):
+    return frame.f_back
+  return frame

--- a/tensorboard/util_test.py
+++ b/tensorboard/util_test.py
@@ -1,0 +1,166 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import time
+
+import six
+import tensorflow as tf
+
+from tensorboard import test_util
+from tensorboard import util
+
+
+class LogFormatterTest(tf.test.TestCase):
+
+  def __init__(self, *args, **kwargs):
+    super(LogFormatterTest, self).__init__(*args, **kwargs)
+    self.clock = test_util.FakeClock()
+    self.stubs = tf.test.StubOutForTesting()
+    self.formatter = util.LogFormatter()
+    self.formatter.converter = time.gmtime
+
+  def setUp(self):
+    super(LogFormatterTest, self).setUp()
+    self.clock.set_time(1.0)
+    self.stubs.Set(time, 'time', self.clock)
+
+  def tearDown(self):
+    self.stubs.CleanUp()
+    super(LogFormatterTest, self).tearDown()
+
+  def testTimeZero(self):
+    self.clock.set_time(0.0)
+    record = make_record(logging.INFO, 'hello %s', 'world')
+    self.assertEqual(
+        'I0101 00:00:00.000000 %s util_test.py:23] hello world' % (
+            record.threadName),
+        self.formatter.format(record))
+
+  def testTimeNonZero_padsZeroWithNoFloatMathError(self):
+    self.clock.set_time(1.0 * 31 * 24 * 60 * 60 +
+                        2.0 * 24 * 60 * 60 +
+                        4.0 * 60 * 60 +
+                        5.0 * 60 +
+                        6.0 +
+                        1e-6)
+    record = make_record(logging.WARNING, '%d %d', 123, 456)
+    self.assertEqual(
+        'W0203 04:05:06.000001 %s util_test.py:23] 123 456' % (
+            record.threadName),
+        self.formatter.format(record))
+
+
+class LogHandlerTest(tf.test.TestCase):
+
+  def testLogToNonTerminal_doesNothingFancy(self):
+    stream = six.StringIO()
+    handler = util.LogHandler(stream)
+    handler.setFormatter(logging.Formatter('BOO! %(message)s'))
+    handler.emit(make_record(logging.INFO, 'hi'))
+    self.assertEqual('BOO! hi\n', stream.getvalue())
+
+  def testLogInfoToTerminal_doesNothingFancy(self):
+    stream = TerminalStringIO()
+    handler = util.LogHandler(stream)
+    handler.setFormatter(logging.Formatter('BOO! %(message)s'))
+    handler.emit(make_record(logging.INFO, 'hi'))
+    self.assertEqual('BOO! hi\n', stream.getvalue())
+
+  def testLogErrorToTerminal_isRed(self):
+    stream = TerminalStringIO()
+    handler = util.LogHandler(stream)
+    handler.setFormatter(logging.Formatter('BOO! %(message)s'))
+    handler.emit(make_record(logging.ERROR, 'hi'))
+    self.assertEqual(util.Ansi.RED + 'BOO! hi\n' + util.Ansi.RESET,
+                     stream.getvalue())
+
+  def testLogEphemeral_doesntCallFormatterOrInsertLineFeed(self):
+    stream = TerminalStringIO()
+    handler = util.LogHandler(stream)
+    handler.setFormatter(logging.Formatter('BOO! %(message)s'))
+    handler.emit(make_ephemeral_record(logging.INFO, 'hi'))
+    self.assertEqual('hi', stream.getvalue())
+
+  def testEmitEmptyEphemeral_closesEphemeralState(self):
+    stream = TerminalStringIO()
+    handler = util.LogHandler(stream)
+    handler.setFormatter(logging.Formatter('BOO! %(message)s'))
+    handler.emit(make_ephemeral_record(logging.INFO, 'hi'))
+    handler.emit(make_ephemeral_record(logging.INFO, ''))
+    self.assertEqual('hi\n', stream.getvalue())
+
+  def testCloseEphemeralWithNoEphemeralState_doesNothing(self):
+    stream = TerminalStringIO()
+    handler = util.LogHandler(stream)
+    handler.setFormatter(logging.Formatter('BOO! %(message)s'))
+    handler.emit(make_ephemeral_record(logging.INFO, ''))
+    self.assertEqual('', stream.getvalue())
+
+  def testLogEphemeralTwice_overwritesPreviousLine(self):
+    stream = TerminalStringIO()
+    handler = util.LogHandler(stream)
+    handler.setFormatter(logging.Formatter('BOO! %(message)s'))
+    handler.emit(make_ephemeral_record(logging.INFO, 'hi'))
+    handler.emit(make_ephemeral_record(logging.INFO, 'hi'))
+    self.assertEqual('hi\r  \rhi', stream.getvalue())
+
+  def testLogEphemeralAndNormal_ressurectsEphemeralRecord(self):
+    stream = TerminalStringIO()
+    handler = util.LogHandler(stream)
+    handler.setFormatter(logging.Formatter('BOO! %(message)s'))
+    handler.emit(make_ephemeral_record(logging.INFO, 'hi'))
+    handler.emit(make_record(logging.INFO, 'yo'))
+    self.assertEqual('hi\r  \rBOO! yo\nhi', stream.getvalue())
+
+  def testCloseEphemeralAndLogNormal_doesntRessurect(self):
+    stream = TerminalStringIO()
+    handler = util.LogHandler(stream)
+    handler.setFormatter(logging.Formatter('BOO! %(message)s'))
+    handler.emit(make_ephemeral_record(logging.INFO, 'hi'))
+    handler.emit(make_ephemeral_record(logging.INFO, ''))
+    handler.emit(make_record(logging.INFO, 'yo'))
+    self.assertEqual('hi\nBOO! yo\n', stream.getvalue())
+
+
+def make_record(level, msg, *args):
+  record = logging.LogRecord(
+      name='tensorflow',
+      level=level,
+      pathname=__file__,
+      lineno=23,
+      msg=msg,
+      args=args,
+      exc_info=None)
+  return record
+
+
+def make_ephemeral_record(level, msg, *args):
+  record = make_record(level, msg, *args)
+  record.name = 'tensorflow' + util.LogHandler.EPHEMERAL
+  return record
+
+
+def TerminalStringIO():
+  stream = six.StringIO()
+  stream.isatty = lambda: True
+  return stream
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/49262/27898100-1ded356e-61d9-11e7-8285-ed2c16f070d8.png)

Open source logs now:

- Use the same format as Google logs
- Use ANSI color for non-INFO records
- Get emitted *above* the line with the TensorBoard URL

The functionality that makes the TensorBoard URL stick to the last line in the
terminal is ironically called "ephemeral logging" because it was designed to
meet the requirements of FileLoader's progress bar.

Please note that ephemeral logging and ANSI colors do not happen on Windows or
anything that isn't a TTY. For example, piping stderr to a file will cause
everything to look normal.

In the future, flags will be added so open source users can configure the
verbosity of the logger.