### PR TITLE
Fix scalar chart tooltips when smoothing disabled

### DIFF
--- a/tensorboard/plugins/scalar/vz_line_chart/vz-line-chart.html
+++ b/tensorboard/plugins/scalar/vz_line_chart/vz-line-chart.html
@@ -36,11 +36,9 @@ such as different X scales (linear and temporal), tooltips and smoothing.
       <table>
         <thead>
           <tr>
-            <th></th>
+            <th><!-- run color swatch --></th>
             <th>Name</th>
-            <template is="dom-if" if="{{smoothingEnabled}}">
-              <th>Smoothed</th>
-            </template>
+            <th>Smoothed</th>
             <th>Value</th>
             <th>Step</th>
             <th>Time</th>

--- a/tensorboard/plugins/scalar/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/plugins/scalar/vz_line_chart/vz-line-chart.ts
@@ -629,13 +629,13 @@ class LineChart {
             'background-color',
             (d) => this.colorScale.scale(d.dataset.metadata().name));
     rows.append('td').text((d) => d.dataset.metadata().name);
+    const formatValueOrNaN = (x) => isNaN(x) ? 'NaN' : valueFormatter(x);
     if (this.smoothingEnabled) {
-      rows.append('td').text(
-          (d) => isNaN(d.datum.smoothed) ? 'NaN' :
-                                           valueFormatter(d.datum.smoothed));
+      rows.append('td').text((d) => formatValueOrNaN(d.datum.smoothed));
+    } else {
+      rows.append('td').text((d) => formatValueOrNaN(d.datum.scalar));
     }
-    rows.append('td').text(
-        (d) => isNaN(d.datum.scalar) ? 'NaN' : valueFormatter(d.datum.scalar));
+    rows.append('td').text((d) => formatValueOrNaN(d.datum.scalar));
     rows.append('td').text((d) => ChartHelpers.stepFormatter(d.datum.step));
     rows.append('td').text(
         (d) => ChartHelpers.timeFormatter(d.datum.wall_time));


### PR DESCRIPTION
Summary:
Fixes #183. We now render the actual value in the "Smoothed" column
when smoothing is disabled. (This makes sense: in the limit as the
smoothing factor goes to zero, the smoothed value approaches the scalar
value, so this just makes the column continuous. It also makes the UI
less dynamic and more predictable, which is nice.)

The existing code tries to remove the "Smoothed" column altogether when
smoothing is disabled. Although the data bindings are wired correctly,
the column continues to render in the tooltip even when the `dom-if`
flips to `false`. It's completely unclear to me and @dandelionmane why
this is the case: the code certainly looks correct, and copying the
table structure verbatim into a fresh document demonstrates the right
behavior.

We're pretty sure that this is a bug in Polymer, and we've opted not to
poke the beast, instead just taking our easy solution (which we like
more, anyway). That said, here is some more precise information about
this bug, should anyone feel an urge to investigate it.

We tried the following variations. The common factor seems to be that
the `dom-if` cannot properly hide when its child is a `<th>`.

```html
<!-- These three headings properly hide when smoothing is disabled -->
<th><template is="dom-if" if="[[smoothingEnabled]]">Smoothed1</template></th>
<th><template is="dom-if" if="[[smoothingEnabled]]"><span>Smoothed2</span></template></th>
<th><template is="dom-if" if="[[smoothingEnabled]]"><span>Smoothed3</span></template></th>

<!-- These six headings do _not_ properly hide when smoothing is disabled -->
<template is="dom-if" if="[[smoothingEnabled]]"><th>Smoothed4</th></template>
<template is="dom-if" if="[[smoothingEnabled]]" restamp><th>Smoothed5</th></template>
<th><template is="dom-if" if="[[smoothingEnabled]]"><th>Smoothed6</th></template></th>
<th><template is="dom-if" if="[[smoothingEnabled]]" restamp><th>Smoothed7</th></template></th>
<div><template is="dom-if" if="[[smoothingEnabled]]"><th>Smoothed8</th></template></div>
<div><template is="dom-if" if="[[smoothingEnabled]]" restamp><th>Smoothed9</th></template></div>
<!-- (end) -->
```

(This is unfortunate, because enclosing a `<th>` is exactly what we need
the template to do.)

Here is a simple example wherein the bug _does not manifest_;
everything works as expected:
```html
<link rel="import" href="/polymer10/polymer/polymer.html">

<dom-module id="example-table">
  <template>
    <table>
      <thead>
        <tr>
          <th><!-- run color swatch --></th>
          <th>Name</th>
          <th><template is="dom-if" if="[[smoothingEnabled]]">Smoothed1</template></th>
          <th><template is="dom-if" if="[[smoothingEnabled]]"><span>Smoothed2</span></template></th>
          <th><template is="dom-if" if="[[smoothingEnabled]]"><span>Smoothed3</span></template></th>
          <template is="dom-if" if="[[smoothingEnabled]]"><th>Smoothed4</th></template>
          <template is="dom-if" if="[[smoothingEnabled]]" restamp><th>Smoothed5</th></template>
          <th><template is="dom-if" if="[[smoothingEnabled]]"><th>Smoothed6</th></template></th>
          <th><template is="dom-if" if="[[smoothingEnabled]]" restamp><th>Smoothed7</th></template></th>
          <div><template is="dom-if" if="[[smoothingEnabled]]"><th>Smoothed8</th></template></div>
          <div><template is="dom-if" if="[[smoothingEnabled]]" restamp><th>Smoothed9</th></template></div>
          <th>Step</th>
          <th>Time</th>
          <th>Relative</th>
        </tr>
      </thead>
      <tbody>
        <tr><td colspan="13">(content)</td></tr>
      </tbody>
    </table>
    <style>
      table {
        margin-bottom: 20px;
        outline: thin red solid;
      }
    </style>
  </template>
  <script>
    Polymer({
      is: "example-table",
      properties: {
        smoothingEnabled: Boolean,
      },
    });
  </script>
</dom-module>

<dom-module id="example-host">
  <template>
    <paper-checkbox checked="{{smoothingEnabled}}"></paper-checkbox>
    <example-table smoothing-enabled="[[smoothingEnabled]]"></example-table>
  </template>
  <script>
    Polymer({
      is: 'example-host',
      properties: {
        smoothingEnabled: Boolean,
      },
    });
  </script>
</dom-module>

<example-table></example-table>
<example-table smoothing-enabled></example-table>
<example-host></example-host>
```

Test Plan:
Mouse over a plot with a bunch of noisy data to bring up its tooltip.
Set smoothing to 0.6, and note that the "Smoothing" and "Value" values
are significantly different. Set smoothing to 0.01, and note that the
values are closer together. Then, set smoothing to 0.0, and note that
the values are identical.

wchargin-branch: fix-smoothed-tooltip