### PR TITLE
Don't show search results when there's no data

### DIFF
--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
@@ -70,28 +70,28 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
           >
             <iron-icon prefix icon="search"></iron-icon>
           </paper-input>
-        </template>
-        <template is="dom-repeat" items="[[_categories]]" as="category">
-          <tf-category-pane category="[[category]]">
-            <tf-paginated-view
-              items="[[category.items]]"
-              pages="{{category._pages}}"
-            >
-              <template is="dom-repeat" items="[[category._pages]]" as="page">
-                <template is="dom-if" if="[[page.active]]">
-                  <div class="layout horizontal wrap">
-                    <template is="dom-repeat" items="[[page.items]]">
-                      <tf-audio-loader
-                        run="[[item.run]]"
-                        tag="[[item.tag]]"
-                        request-manager="[[_requestManager]]"
-                        show-actual-size="[[_showActualSize]]"
-                      ></tf-audio-loader>
-                  </div>
+          <template is="dom-repeat" items="[[_categories]]" as="category">
+            <tf-category-pane category="[[category]]">
+              <tf-paginated-view
+                items="[[category.items]]"
+                pages="{{category._pages}}"
+              >
+                <template is="dom-repeat" items="[[category._pages]]" as="page">
+                  <template is="dom-if" if="[[page.active]]">
+                    <div class="layout horizontal wrap">
+                      <template is="dom-repeat" items="[[page.items]]">
+                        <tf-audio-loader
+                          run="[[item.run]]"
+                          tag="[[item.tag]]"
+                          request-manager="[[_requestManager]]"
+                          show-actual-size="[[_showActualSize]]"
+                        ></tf-audio-loader>
+                    </div>
+                  </template>
                 </template>
-              </template>
-            </tf-paginated-view>
-          </tf-category-pane>
+              </tf-paginated-view>
+            </tf-category-pane>
+          </template>
         </template>
       </div>
     </tf-dashboard-layout>

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
@@ -88,29 +88,29 @@ limitations under the License.
           >
             <iron-icon prefix icon="search"></iron-icon>
           </paper-input>
-        </template>
-        <template is="dom-repeat" items="[[_categories]]" as="category">
-          <tf-category-pane category="[[category]]">
-            <tf-paginated-view
-              items="[[category.items]]"
-              pages="{{category._pages}}"
-            >
-              <template is="dom-repeat" items="[[category._pages]]" as="page">
-                <template is="dom-if" if="[[page.active]]">
-                  <div class="layout horizontal wrap">
-                    <template is="dom-repeat" items="[[page.items]]">
-                      <tf-distribution-loader
-                        run="[[item.run]]"
-                        tag="[[item.tag]]"
-                        x-type="[[_xType]]"
-                        request-manager="[[_requestManager]]"
-                      ></tf-distribution-loader>
-                    </template>
-                  </div>
+          <template is="dom-repeat" items="[[_categories]]" as="category">
+            <tf-category-pane category="[[category]]">
+              <tf-paginated-view
+                items="[[category.items]]"
+                pages="{{category._pages}}"
+              >
+                <template is="dom-repeat" items="[[category._pages]]" as="page">
+                  <template is="dom-if" if="[[page.active]]">
+                    <div class="layout horizontal wrap">
+                      <template is="dom-repeat" items="[[page.items]]">
+                        <tf-distribution-loader
+                          run="[[item.run]]"
+                          tag="[[item.tag]]"
+                          x-type="[[_xType]]"
+                          request-manager="[[_requestManager]]"
+                        ></tf-distribution-loader>
+                      </template>
+                    </div>
+                  </template>
                 </template>
-              </template>
-            </tf-paginated-view>
-          </tf-collapsable-pane>
+              </tf-paginated-view>
+            </tf-collapsable-pane>
+          </template>
         </template>
       </div>
     </tf-dashboard-layout>

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -95,30 +95,30 @@ limitations under the License.
           >
             <iron-icon prefix icon="search"></iron-icon>
           </paper-input>
-        </template>
-        <template is="dom-repeat" items="[[_categories]]" as="category">
-          <tf-category-pane category="[[category]]">
-            <tf-paginated-view
-              items="[[category.items]]"
-              pages="{{category._pages}}"
-            >
-              <template is="dom-repeat" items="[[category._pages]]" as="page">
-                <template is="dom-if" if="[[page.active]]">
-                  <div class="layout horizontal wrap">
-                    <template is="dom-repeat" items="[[page.items]]">
-                      <tf-histogram-loader
-                        run="[[item.run]]"
-                        tag="[[item.tag]]"
-                        time-property="[[_timeProperty]]"
-                        histogram-mode="[[_histogramMode]]"
-                        request-manager="[[_requestManager]]"
-                        ></tf-histogram-loader>
-                    </template>
-                  </div>
+          <template is="dom-repeat" items="[[_categories]]" as="category">
+            <tf-category-pane category="[[category]]">
+              <tf-paginated-view
+                items="[[category.items]]"
+                pages="{{category._pages}}"
+              >
+                <template is="dom-repeat" items="[[category._pages]]" as="page">
+                  <template is="dom-if" if="[[page.active]]">
+                    <div class="layout horizontal wrap">
+                      <template is="dom-repeat" items="[[page.items]]">
+                        <tf-histogram-loader
+                          run="[[item.run]]"
+                          tag="[[item.tag]]"
+                          time-property="[[_timeProperty]]"
+                          histogram-mode="[[_histogramMode]]"
+                          request-manager="[[_requestManager]]"
+                          ></tf-histogram-loader>
+                      </template>
+                    </div>
+                  </template>
                 </template>
-              </template>
-            </tf-paginated-view>
-          </tf-category-pane>
+              </tf-paginated-view>
+            </tf-category-pane>
+          </template>
         </template>
       </div>
     </tf-dashboard-layout>

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
@@ -73,29 +73,29 @@ TensorFlow run.
           >
             <iron-icon prefix icon="search"></iron-icon>
           </paper-input>
-        </template>
-        <template is="dom-repeat" items="[[_categories]]" as="category">
-          <tf-category-pane category="[[category]]">
-            <tf-paginated-view
-              items="[[category.items]]"
-              pages="{{category._pages}}"
-            >
-              <template is="dom-repeat" items="[[category._pages]]" as="page">
-                <template is="dom-if" if="[[page.active]]">
-                  <div class="layout horizontal wrap">
-                    <template is="dom-repeat" items="[[page.items]]">
-                      <tf-image-loader
-                        run="[[item.run]]"
-                        tag="[[item.tag]]"
-                        request-manager="[[_requestManager]]"
-                        show-actual-size="[[_showActualSize]]"
-                      ></tf-image-loader>
-                    </template>
-                  </div>
+          <template is="dom-repeat" items="[[_categories]]" as="category">
+            <tf-category-pane category="[[category]]">
+              <tf-paginated-view
+                items="[[category.items]]"
+                pages="{{category._pages}}"
+              >
+                <template is="dom-repeat" items="[[category._pages]]" as="page">
+                  <template is="dom-if" if="[[page.active]]">
+                    <div class="layout horizontal wrap">
+                      <template is="dom-repeat" items="[[page.items]]">
+                        <tf-image-loader
+                          run="[[item.run]]"
+                          tag="[[item.tag]]"
+                          request-manager="[[_requestManager]]"
+                          show-actual-size="[[_showActualSize]]"
+                        ></tf-image-loader>
+                      </template>
+                    </div>
+                  </template>
                 </template>
-              </template>
-            </tf-paginated-view>
-          </tf-category-pane>
+              </tf-paginated-view>
+            </tf-category-pane>
+          </template>
         </template>
       </div>
     </tf-dashboard-layout>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -125,34 +125,34 @@ limitations under the License.
           >
             <iron-icon prefix icon="search"></iron-icon>
           </paper-input>
-        </template>
-        <template is="dom-repeat" items="[[_categories]]" as="category">
-          <tf-category-pane category="[[category]]">
-            <tf-paginated-view
-              items="[[category.items]]"
-              pages="{{category._pages}}"
-            >
-              <template is="dom-repeat" items="[[category._pages]]" as="page">
-                <template is="dom-if" if="[[page.active]]">
-                  <div class="layout horizontal wrap">
-                    <template is="dom-repeat" items="[[page.items]]">
-                      <tf-scalar-chart
-                        x-type="[[_xType]]"
-                        smoothing-enabled="[[_smoothingEnabled]]"
-                        smoothing-weight="[[_smoothingWeight]]"
-                        tooltip-sorting-method="[[_tooltipSortingMethod]]"
-                        ignore-y-outliers="[[_ignoreYOutliers]]"
-                        show-download-links="[[_showDownloadLinks]]"
-                        request-manager="[[_requestManager]]"
-                        runs="[[item.runs]]"
-                        tag="[[item.tag]]"
-                      ></tf-scalar-chart>
-                    </template>
-                  </div>
+          <template is="dom-repeat" items="[[_categories]]" as="category">
+            <tf-category-pane category="[[category]]">
+              <tf-paginated-view
+                items="[[category.items]]"
+                pages="{{category._pages}}"
+              >
+                <template is="dom-repeat" items="[[category._pages]]" as="page">
+                  <template is="dom-if" if="[[page.active]]">
+                    <div class="layout horizontal wrap">
+                      <template is="dom-repeat" items="[[page.items]]">
+                        <tf-scalar-chart
+                          x-type="[[_xType]]"
+                          smoothing-enabled="[[_smoothingEnabled]]"
+                          smoothing-weight="[[_smoothingWeight]]"
+                          tooltip-sorting-method="[[_tooltipSortingMethod]]"
+                          ignore-y-outliers="[[_ignoreYOutliers]]"
+                          show-download-links="[[_showDownloadLinks]]"
+                          request-manager="[[_requestManager]]"
+                          runs="[[item.runs]]"
+                          tag="[[item.tag]]"
+                        ></tf-scalar-chart>
+                      </template>
+                    </div>
+                  </template>
                 </template>
-              </template>
-            </tf-paginated-view>
-          </tf-category-pane>
+              </tf-paginated-view>
+            </tf-category-pane>
+          </template>
         </template>
       </div>
     </tf-dashboard-layout>

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
@@ -68,28 +68,28 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
           >
             <iron-icon prefix icon="search"></iron-icon>
           </paper-input>
-        </template>
-        <template is="dom-repeat" items="[[_categories]]" as="category">
-          <tf-category-pane category="[[category]]">
-            <tf-paginated-view
-              items="[[category.items]]"
-              pages="{{category._pages}}"
-            >
-              <template is="dom-repeat" items="[[category._pages]]" as="page">
-                <template is="dom-if" if="[[page.active]]">
-                  <div class="layout horizontal wrap">
-                    <template is="dom-repeat" items="[[page.items]]">
-                      <tf-text-loader
-                        tag="[[item.tag]]"
-                        run="[[item.run]]"
-                        request-manager="[[_requestManager]]"
-                      ></tf-text-loader>
-                    </template>
-                  </div>
+          <template is="dom-repeat" items="[[_categories]]" as="category">
+            <tf-category-pane category="[[category]]">
+              <tf-paginated-view
+                items="[[category.items]]"
+                pages="{{category._pages}}"
+              >
+                <template is="dom-repeat" items="[[category._pages]]" as="page">
+                  <template is="dom-if" if="[[page.active]]">
+                    <div class="layout horizontal wrap">
+                      <template is="dom-repeat" items="[[page.items]]">
+                        <tf-text-loader
+                          tag="[[item.tag]]"
+                          run="[[item.run]]"
+                          request-manager="[[_requestManager]]"
+                        ></tf-text-loader>
+                      </template>
+                    </div>
+                  </template>
                 </template>
-              </template>
-            </tf-paginated-view>
-          </tf-collapsable-pane>
+              </tf-paginated-view>
+            </tf-collapsable-pane>
+          </template>
         </template>
       </div>
     </tf-dashboard-layout>


### PR DESCRIPTION
Don't show search results when there's no data

Summary:
The current behavior is to show a no-data warning and also an (empty)
search results pane:

![A screenshot of the old behavior.](https://user-images.githubusercontent.com/4317806/27937708-f6c504fe-626d-11e7-81e9-a1a348917b19.png)

This behavior was a holdover from when we had tag groups: if you had a
tag group called `.*`, it would show up under the no-data warning. But
this really isn't something that we want to do, so we should gate all
the categories behind `!_dataNotFound`.

I recommend viewing this diff with `git diff -w` (ignore whitespace-only
changes), which shows only a 12-line delta.

Test Plan:
Launch TensorBoard with no data, some data, and all data. Check that all
dashboards appear correctly in each case.

wchargin-branch: no-data-no-categories

