### PR TITLE
Ignore Closure Compiler warnings from library code

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -412,6 +412,13 @@ public final class Vulcanize {
               // part of our build process.
               return CheckLevel.OFF;
             }
+            if (error.getDefaultLevel() == CheckLevel.WARNING
+                && (error.sourceName.startsWith("/iron-")
+                    || error.sourceName.startsWith("/neon-")
+                    || error.sourceName.startsWith("/paper-"))) {
+              // Suppress warnings in the Polymer standard libraries.
+              return CheckLevel.OFF;
+            }
             if (error.sourceName.startsWith("javascript/externs")
                 || error.sourceName.contains("com_google_javascript_closure_compiler_externs")) {
               // TODO(@jart): Figure out why these "mismatch of the removeEventListener property on


### PR DESCRIPTION
Summary:
This removes warnings from files like iron-a11y-announcer.html,
neon-animation-runner-behavior.html, and paper-input-container.html,
leaving us just with warnings that actually come from our own code!

The Vulcanizer is already TensorBoard-aware with respect to error
suppression (e.g., the "/tf-graph" check), so it seems fine to me to
hard-code these libraries.

Test Plan:
Run `bazel build tensorboard` and inspect the warning count. This brings
us down from 17 warnings to 7 warnings, and—just as importantly—has the
effect that the warnings all fit on a single screen! (As long as your
terminal has at least 27 rows.)

wchargin-branch: suppress-closure-warnings-from-libraries