### PR TITLE
Strip ANSI codes from non-terminal log records

### DIFF
--- a/tensorboard/util.py
+++ b/tensorboard/util.py
@@ -107,7 +107,7 @@ class Ansi(object):
   """ANSI terminal codes container."""
 
   ESCAPE = '\x1b['
-  ESCAPE_PATTERN = re.compile(re.escape(ESCAPE) + r'\??(\d+)(;\d+)*[mlh]')
+  ESCAPE_PATTERN = re.compile(re.escape(ESCAPE) + r'\??(?:\d+)(?:;\d+)*[mlh]')
   RESET = ESCAPE + '0m'
   BOLD = ESCAPE + '1m'
   FLIP = ESCAPE + '7m'
@@ -149,12 +149,12 @@ class LogHandler(logging.StreamHandler):
       logging.DEBUG: Ansi.MAGENTA,
   }
 
-  def __init__(self, stream, type='detect'):
+  def __init__(self, stream, type_='detect'):
     """Creates new instance.
 
     Args:
       stream: A file-like object.
-      type: If "detect", will call stream.isatty() and perform system
+      type_: If "detect", will call stream.isatty() and perform system
           checks to determine if it's safe to output ANSI terminal
           codes. If type is "ansi" then this forces the use of ANSI
           terminal codes.
@@ -162,12 +162,12 @@ class LogHandler(logging.StreamHandler):
     Raises:
       ValueError: If type is not "detect" or "ansi".
     """
-    if type not in ('detect', 'ansi'):
+    if type_ not in ('detect', 'ansi'):
       raise ValueError('type should be detect or ansi')
     super(LogHandler, self).__init__(stream)
     self._stream = stream
     self._disable_flush = False
-    self._is_tty = (type == 'ansi' or
+    self._is_tty = (type_ == 'ansi' or
                     (hasattr(stream, 'isatty') and
                      stream.isatty() and
                      os.name != 'nt'))

--- a/tensorboard/util.py
+++ b/tensorboard/util.py
@@ -128,7 +128,7 @@ class LogHandler(logging.StreamHandler):
   This handler will also strip ANSI color codes from emitted log
   records automatically when the output stream is not a terminal.
 
-  Ephemeral log records, when emitted to a teletype emulator, only
+  Ephemeral log records are only emitted to a teletype emulator, only
   display on the final row, and get overwritten as soon as another
   ephemeral record is outputted. Ephemeral records are also sticky. If
   a normal record is written then the previous ephemeral record is
@@ -182,17 +182,18 @@ class LogHandler(logging.StreamHandler):
     try:
       is_ephemeral = record.name.endswith(LogHandler.EPHEMERAL)
       color = LogHandler.COLORS.get(record.levelno)
-      if is_ephemeral and self._is_tty:
-        ephemeral = record.getMessage()
-        if ephemeral:
-          if color:
-            ephemeral = color + ephemeral + Ansi.RESET
-          self._clear_line()
-          self._stream.write(ephemeral)
-        else:
-          if self._ephemeral:
-            self._stream.write('\n')
-        self._ephemeral = ephemeral
+      if is_ephemeral:
+        if self._is_tty:
+          ephemeral = record.getMessage()
+          if ephemeral:
+            if color:
+              ephemeral = color + ephemeral + Ansi.RESET
+            self._clear_line()
+            self._stream.write(ephemeral)
+          else:
+            if self._ephemeral:
+              self._stream.write('\n')
+          self._ephemeral = ephemeral
       else:
         self._clear_line()
         if self._is_tty and color:
@@ -202,8 +203,8 @@ class LogHandler(logging.StreamHandler):
         self._disable_flush = False
         if self._is_tty and color:
           self._stream.write(Ansi.RESET)
-      if not is_ephemeral and self._ephemeral:
-        self._stream.write(self._ephemeral)
+        if self._ephemeral:
+          self._stream.write(self._ephemeral)
       self.flush()
     finally:
       self._disable_flush = False

--- a/tensorboard/util.py
+++ b/tensorboard/util.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 
 import logging
 import os
+import re
 import sys
 
 import tensorflow as tf
@@ -106,6 +107,7 @@ class Ansi(object):
   """ANSI terminal codes container."""
 
   ESCAPE = '\x1b['
+  ESCAPE_PATTERN = re.compile(re.escape(ESCAPE) + r'\??(\d+)(;\d+)*[mlh]')
   RESET = ESCAPE + '0m'
   BOLD = ESCAPE + '1m'
   FLIP = ESCAPE + '7m'
@@ -122,6 +124,9 @@ class LogHandler(logging.StreamHandler):
   Colors are applied on a line-by-line basis to non-INFO records. The
   goal is to help the user visually distinguish meaningful information,
   even when logging is verbose.
+
+  This handler will also strip ANSI color codes from emitted log
+  records automatically when the output stream is not a terminal.
 
   Ephemeral log records, when emitted to a teletype emulator, only
   display on the final row, and get overwritten as soon as another
@@ -144,13 +149,28 @@ class LogHandler(logging.StreamHandler):
       logging.DEBUG: Ansi.MAGENTA,
   }
 
-  def __init__(self, stream):
+  def __init__(self, stream, type='detect'):
+    """Creates new instance.
+
+    Args:
+      stream: A file-like object.
+      type: If "detect", will call stream.isatty() and perform system
+          checks to determine if it's safe to output ANSI terminal
+          codes. If type is "ansi" then this forces the use of ANSI
+          terminal codes.
+
+    Raises:
+      ValueError: If type is not "detect" or "ansi".
+    """
+    if type not in ('detect', 'ansi'):
+      raise ValueError('type should be detect or ansi')
     super(LogHandler, self).__init__(stream)
     self._stream = stream
     self._disable_flush = False
-    self._is_tty = (hasattr(stream, 'isatty') and
-                    stream.isatty() and
-                    os.name != 'nt')
+    self._is_tty = (type == 'ansi' or
+                    (hasattr(stream, 'isatty') and
+                     stream.isatty() and
+                     os.name != 'nt'))
     self._ephemeral = ''
 
   def emit(self, record):
@@ -160,14 +180,13 @@ class LogHandler(logging.StreamHandler):
     """
     self.acquire()
     try:
-      is_ephemeral = (self._is_tty and
-                      record.name.endswith(LogHandler.EPHEMERAL))
-      color = LogHandler.COLORS[record.levelno]
-      if self._is_tty and color:
-        self._stream.write(color)
-      if is_ephemeral:
+      is_ephemeral = record.name.endswith(LogHandler.EPHEMERAL)
+      color = LogHandler.COLORS.get(record.levelno)
+      if is_ephemeral and self._is_tty:
         ephemeral = record.getMessage()
         if ephemeral:
+          if color:
+            ephemeral = color + ephemeral + Ansi.RESET
           self._clear_line()
           self._stream.write(ephemeral)
         else:
@@ -176,17 +195,30 @@ class LogHandler(logging.StreamHandler):
         self._ephemeral = ephemeral
       else:
         self._clear_line()
+        if self._is_tty and color:
+          self._stream.write(color)
         self._disable_flush = True  # prevent double flush
         super(LogHandler, self).emit(record)
         self._disable_flush = False
-      if self._is_tty and color:
-        self._stream.write(Ansi.RESET)
+        if self._is_tty and color:
+          self._stream.write(Ansi.RESET)
       if not is_ephemeral and self._ephemeral:
         self._stream.write(self._ephemeral)
       self.flush()
     finally:
       self._disable_flush = False
       self.release()
+
+  def format(self, record):
+    """Turns a log record into a string.
+
+    :type record: logging.LogRecord
+    :rtype: str
+    """
+    message = super(LogHandler, self).format(record)
+    if not self._is_tty:
+      message = Ansi.ESCAPE_PATTERN.sub('', message)
+    return message
 
   def flush(self):
     """Flushes output stream."""
@@ -199,9 +231,9 @@ class LogHandler(logging.StreamHandler):
 
   def _clear_line(self):
     if self._is_tty and self._ephemeral:
-      # Our calculation of length won't be perfect due to ANSI codes,
-      # but we can make it a little bit better by scrubbing these.
-      text = self._ephemeral.replace(Ansi.ESCAPE, '')
+      # We're counting columns in the terminal, not bytes. So we don't
+      # want to take UTF-8 or color codes into consideration.
+      text = Ansi.ESCAPE_PATTERN.sub('', tf.compat.as_text(self._ephemeral))
       self._stream.write('\r' + ' ' * len(text) + '\r')
 
 

--- a/tensorboard/util_test.py
+++ b/tensorboard/util_test.py
@@ -137,6 +137,20 @@ class LogHandlerTest(tf.test.TestCase):
     handler.emit(make_record(logging.INFO, 'yo'))
     self.assertEqual('hi\nBOO! yo\n', stream.getvalue())
 
+  def testLogAnsiCodesWhenNotLoggingToATerminal_stripsAnsiCodes(self):
+    stream = six.StringIO()
+    handler = util.LogHandler(stream)
+    handler.setFormatter(logging.Formatter('%(message)s'))
+    handler.emit(make_record(logging.INFO, util.Ansi.RED + 'hi'))
+    self.assertEqual('hi\n', stream.getvalue())
+
+  def testLogAnsiCodesWhenLoggingToATerminal_keepsAnsiCodes(self):
+    stream = TerminalStringIO()
+    handler = util.LogHandler(stream)
+    handler.setFormatter(logging.Formatter('%(message)s'))
+    handler.emit(make_record(logging.INFO, util.Ansi.RED + 'hi'))
+    self.assertEqual(util.Ansi.RED + 'hi\n', stream.getvalue())
+
 
 def make_record(level, msg, *args):
   record = logging.LogRecord(

--- a/tensorboard/util_test.py
+++ b/tensorboard/util_test.py
@@ -151,6 +151,13 @@ class LogHandlerTest(tf.test.TestCase):
     handler.emit(make_record(logging.INFO, util.Ansi.RED + 'hi'))
     self.assertEqual(util.Ansi.RED + 'hi\n', stream.getvalue())
 
+  def testLogEphemeralOnNonTerminal_doesNothing(self):
+    stream = six.StringIO()
+    handler = util.LogHandler(stream)
+    handler.setFormatter(logging.Formatter('%(message)s'))
+    handler.emit(make_ephemeral_record(logging.INFO, 'hi'))
+    self.assertEqual('', stream.getvalue())
+
 
 def make_record(level, msg, *args):
   record = logging.LogRecord(


### PR DESCRIPTION
1. This way the progress bar class doesn't need to worry about calling isatty()
   and os.name.

2. We can configure the logger to go to both stderr and a file, and not end up
   with ANSI codes in the log file.