### PR TITLE
Extract dashboard data from tf-tensorboard

### DIFF
--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -9,6 +9,8 @@ ts_web_library(
     name = "tf_tensorboard",
     srcs = [
         "autoReloadBehavior.ts",
+        "dashboards.html",
+        "dashboards.ts",
         "style.html",
         "tf-tensorboard.html",
     ],

--- a/tensorboard/components/tf_tensorboard/dashboards.html
+++ b/tensorboard/components/tf_tensorboard/dashboards.html
@@ -1,0 +1,38 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+  Polymer imports for each of the available dashboards. The set of
+  Polymer components imported here must exactly equal the result of
+
+      DASHBOARDS.map(dashboard => dashboard.component)
+
+  where `DASHBOARDS` is the array exported by `dashboards.ts`.
+
+  TODO(@wchargin): Create this module at build time.
+-->
+
+<link rel="import" href="../tf-audio-dashboard/tf-audio-dashboard.html">
+<link rel="import" href="../tf-distribution-dashboard/tf-distribution-dashboard.html">
+<link rel="import" href="../tf-graph-dashboard/tf-graph-dashboard.html">
+<link rel="import" href="../tf-histogram-dashboard/tf-histogram-dashboard.html">
+<link rel="import" href="../tf-image-dashboard/tf-image-dashboard.html">
+<link rel="import" href="../tf-scalar-dashboard/tf-scalar-dashboard.html">
+<link rel="import" href="../tf-text-dashboard/tf-text-dashboard.html">
+<link rel="import" href="../vz-projector/vz-projector-dashboard.html">
+
+<script src="dashboards.js"></script>

--- a/tensorboard/components/tf_tensorboard/dashboards.ts
+++ b/tensorboard/components/tf_tensorboard/dashboards.ts
@@ -1,0 +1,85 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/*
+ * This module holds the list of available dashboards and associated
+ * metadata.
+ *
+ * TODO(@wchargin): Create this module at build time.
+ */
+export interface Dashboard {
+  name: string;
+  component: string;  // name of a Polymer component
+  reloadEnabled: boolean;
+}
+
+/*
+ * An array of all known dashboards, listed in the order in which they
+ * should be rendered.
+ *
+ * TODO(@wchargin): Decentralize these, so that each dashboard
+ * declares its own metadata and we simply aggregate them here.
+ */
+export const DASHBOARDS: Dashboard[] = [
+  {
+    name: 'scalars',
+    component: 'tf-scalar-dashboard',
+    reloadEnabled: true,
+  },
+  {
+    name: 'images',
+    component: 'tf-image-dashboard',
+    reloadEnabled: true,
+  },
+  {
+    name: 'audio',
+    component: 'tf-audio-dashboard',
+    reloadEnabled: true,
+  },
+  {
+    name: 'graphs',
+    component: 'tf-graph-dashboard',
+    reloadEnabled: false,
+  },
+  {
+    name: 'distributions',
+    component: 'tf-distribution-dashboard',
+    reloadEnabled: true,
+  },
+  {
+    name: 'histograms',
+    component: 'tf-histogram-dashboard',
+    reloadEnabled: true,
+  },
+  {
+    name: 'projector',
+    component: 'vz-projector-dashboard',
+    reloadEnabled: false,
+  },
+  {
+    name: 'text',
+    component: 'tf-text-dashboard',
+    reloadEnabled: true,
+  },
+];
+
+/**
+ * An index for `DASHBOARDS` keyed against the name.
+ */
+export const DASHBOARDS_BY_NAME: {[name: string]: Dashboard} =
+  Object.assign.apply(null, [
+    {},
+    ...DASHBOARDS.map((dashboard) => ({[dashboard.name]: dashboard})),
+  ]);

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -24,19 +24,12 @@ limitations under the License.
 <link rel="import" href="../paper-tabs/paper-tabs.html">
 <link rel="import" href="../paper-toolbar/paper-toolbar.html">
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../tf-audio-dashboard/tf-audio-dashboard.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
-<link rel="import" href="../tf-distribution-dashboard/tf-distribution-dashboard.html">
 <link rel="import" href="../tf-globals/tf-globals.html">
-<link rel="import" href="../tf-graph-dashboard/tf-graph-dashboard.html">
-<link rel="import" href="../tf-histogram-dashboard/tf-histogram-dashboard.html">
-<link rel="import" href="../tf-image-dashboard/tf-image-dashboard.html">
 <link rel="import" href="../tf-imports/lodash.html">
-<link rel="import" href="../tf-scalar-dashboard/tf-scalar-dashboard.html">
 <link rel="import" href="../tf-storage/tf-storage.html">
-<link rel="import" href="../tf-text-dashboard/tf-text-dashboard.html">
-<link rel="import" href="../vz-projector/vz-projector-dashboard.html">
+<link rel="import" href="dashboards.html">
 
 <!--
   tf-tensorboard is the frontend entry point for TensorBoard.
@@ -306,34 +299,13 @@ limitations under the License.
   <script src="autoReloadBehavior.js"></script>
   <script>
     import {AutoReloadBehavior} from "./autoReloadBehavior.js";
-    import {setUseHash} from "../tf-globals/globals.js";
-    import {getString, setString, TAB} from "../tf-storage/storage.js";
     import {Canceller} from "../tf-backend/canceller.js";
+    import {DASHBOARDS, DASHBOARDS_BY_NAME} from "./dashboards.js";
     import {RequestManager} from "../tf-backend/requestManager.js";
-    import {getRouter, setRouter, createRouter} from "../tf-backend/router.js";
     import {fetchRuns} from "../tf-backend/runsStore.js";
-
-    // The names of TensorBoard tabs.
-    const TABS = [
-      'scalars', 'images', 'audio', 'graphs', 'distributions', 'histograms',
-      'projector', 'text'
-    ];
-
-    // A map from dashboard name to Polymer component name.
-    const COMPONENTS = {
-      'scalars': 'tf-scalar-dashboard',
-      'images': 'tf-image-dashboard',
-      'audio': 'tf-audio-dashboard',
-      'graphs': 'tf-graph-dashboard',
-      'distributions': 'tf-distribution-dashboard',
-      'histograms': 'tf-histogram-dashboard',
-      'projector': 'vz-projector-dashboard',
-      'text': 'tf-text-dashboard',
-    };
-    if (!_.isEqual(Object.keys(COMPONENTS), TABS)) {
-      throw new Error(
-        `Bad set of components: ${Object.keys(COMPONENTS)} vs. ${TABS}`);
-    }
+    import {getRouter, setRouter, createRouter} from "../tf-backend/router.js";
+    import {getString, setString, TAB} from "../tf-storage/storage.js";
+    import {setUseHash} from "../tf-globals/globals.js";
 
     /** @enum {string} */ const ActiveDashboardsLoadState = {
       NOT_LOADED: 'NOT_LOADED',
@@ -399,7 +371,7 @@ limitations under the License.
         _dashboards: {
           type: Array,
           readOnly: true,
-          value: TABS,
+          value: DASHBOARDS.map(dashboard => dashboard.name),
         },
 
         /**
@@ -616,7 +588,8 @@ limitations under the License.
           return;
         }
         if (container.childNodes.length === 0) {
-          const component = document.createElement(COMPONENTS[dashboard]);
+          const componentName = DASHBOARDS_BY_NAME[dashboard].component;
+          const component = document.createElement(componentName);
           component.id = 'dashboard';  // used in `_selectedDashboardComponent`
           container.appendChild(component);
         };
@@ -628,9 +601,12 @@ limitations under the License.
           // load more data.
           return false;
         }
-        // TODO(@wchargin): Refactor to remove these explicit plugin names.
-        const disabledForModes = ['graphs', 'projector'];
-        return !debuggerDataEnabled && disabledForModes.includes(selectedDashboard);
+        if (debuggerDataEnabled) {
+          // Reload is always enabled if debugger data is enabled.
+          return false;
+        }
+        const dashboardMetadata = DASHBOARDS_BY_NAME[selectedDashboard];
+        return dashboardMetadata && !dashboardMetadata.reloadEnabled;
       },
 
       /**


### PR DESCRIPTION
Summary:
This commit makes it so that `tf-tensorboard` no longer knows anything
about any particular dashboards. Instead, this data is moved into two
separate files. We do this so that we can eventually create these files
at build time with a Skylark rule that aggregates data from a set of
plugins that is also defined at build time.

In doing so, we also clean up some representational cruft in
`tf-tensorboard`.

Test Plan:
Launch TensorBoard and check that every dashboard still loads
correctly, and that reloading is enabled on exactly those dashboards
where it should be. Also, run `//tensorboard/functionaltests:core_test`.

wchargin-branch: extract-dashboards