### PR TITLE
Enforce a minimum width on the sidebar

### DIFF
--- a/tensorboard/components/tf_dashboard_common/dashboard-style.html
+++ b/tensorboard/components/tf_dashboard_common/dashboard-style.html
@@ -26,6 +26,7 @@ limitations under the License.
         flex-direction: column;
         height: 100%;
         margin-right: 20px;
+        min-width: 350px;
       }
 
       tf-runs-selector {


### PR DESCRIPTION
Summary:
This width is wide enough that the runs selector has enough space, and
also that the "offset time axis" on the histogram dashboard shows all
dashboards on one line. No existing dashboard has controls that
naturally exceed this width.

![Screenshot: Scalars](https://user-images.githubusercontent.com/4317806/27981998-19e5a360-634c-11e7-9233-fcd8629fb2ab.png)

![Screenshot: Histograms](https://user-images.githubusercontent.com/4317806/27981996-127e85ec-634c-11e7-9fb3-b5a523481bd4.png)

Test Plan:
Check the conditions noted above.

wchargin-branch: sidebar-min-width