### PR TITLE
Fix issue where scalar charts can become tiny.

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
@@ -103,6 +103,11 @@ limitations under the License.
         height: 400px;
         width: 100%;
       }
+
+      :host[_maybe-rendered-in-bad-state] vz-line-chart {
+        visibility: hidden;
+      };
+
       #chart-and-spinner-container {
         display: flex;
         flex-grow: 1;
@@ -161,6 +166,24 @@ limitations under the License.
     import {getRouter} from '../tf-backend/router.js';
     import {runsColorScale} from '../tf-color-scale/colorScale.js';
 
+    // The chart can sometimes get in a bad state, when it redraws while
+    // it is display: none due to the user having switched to a different
+    // page. This code implements a cascading queue to redraw the bad charts
+    // one-by-one once they are active again.
+    // We use a cascading queue becuase we don't want to block the UI / make the
+    // ripples very slow while everything synchronously redraws.
+    const redrawQueue = [];
+    const cascadingRedraw = _.throttle(function internalRedraw() {
+      if (redrawQueue.length > 0) {
+        const x = redrawQueue.shift();
+        if (x.active) {
+          x.redraw();
+          x._maybeRenderedInBadState = false;
+        }
+        window.setTimeout(internalRedraw, 32);
+      }
+    }, 100);
+
     /** @enum {string} */ const X_TYPE = {
       STEP: 'step',
       RELATIVE: 'relative',
@@ -179,6 +202,11 @@ limitations under the License.
         tooltipSortingMethod: String,
         ignoreYOutliers: Boolean,
         showDownloadLinks: Boolean,
+
+        active: {
+          type: Boolean,
+          observer: '_fixBadStateWhenActive',
+        },
 
         requestManager: Object,
 
@@ -237,6 +265,12 @@ limitations under the License.
         _loadedRuns: {
           type: Object,
           value: () => ({}),
+        },
+
+        _maybeRenderedInBadState: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,
         },
       },
       observers: [
@@ -317,7 +351,13 @@ limitations under the License.
                 this._resetDomainOnNextLoad = false;
                 chart.resetDomain();
               }
-              chart.redraw();
+              if (!this.active) {
+                // If we reached a point where we should render while the page
+                // is not active, we've gotten into a bad state.
+                this._maybeRenderedInBadState = true;
+              } else {
+                this.redraw();
+              }
             }
           });
           return Promise.all(runPromises).then(finish);
@@ -347,6 +387,17 @@ limitations under the License.
 
       _computeLineChartStyle(loading) {
         return loading ? 'opacity: 0.3;' : '';
+      },
+
+      _fixBadStateWhenActive() {
+        // When the chart enters a potentially bad state (because it should
+        // redraw, but the page is not currently active), we set the
+        // _maybeRenderedInBadState flag. Whenever the chart becomes active,
+        // we test this and schedule a redraw of the bad charts.
+        if (this.active && this._maybeRenderedInBadState) {
+          redrawQueue.push(this);
+          cascadingRedraw();
+        }
       },
 
       _resetDomain() {

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -145,6 +145,7 @@ limitations under the License.
                           request-manager="[[_requestManager]]"
                           runs="[[item.runs]]"
                           tag="[[item.tag]]"
+                          active="[[page.active]]"
                         ></tf-scalar-chart>
                       </template>
                     </div>


### PR DESCRIPTION
There is a general issue across TensorBoard: with the tf-paginated-view, if you
switch pages quickly, it's likely that some charts will be rendered when they
are `display: none`. Data visualizations often depend on measurement code to
layout properly, and the measurements break when the item is not being
displayed. As a consequence, the chart renders wih strange and broken
proportions.

When @wchargin and I were pair-programming this, we initially tried to work
around the measurement issue so that the chart would layout properly even if it
were `display:none`, but that proved infeasible. So instead we decided to write
code to detect when the chart gets in a bad state, and fix it.

This code marks scalar charts as being in a bad state if their data finishes
loading when the chart is no longer in an active pane. When the chart's pane
becomes active, an observer redraws the chart. Rather than redrawing
synchronously, we've set up an asynchronous redraw cascade with a 32ms timeout;
this way, we don't block the UI or unduly slow down the ripple on the
"next page" button.

Note, the bug actually exists on other dashboards (distributions and histograms
both repro it), and this fix only works on the scalar dashboard. We may fix it
on other dashboards in the future.

Fixes #190 

Test Plan: 
Load TensorBoard with >24 scalar charts, or set the number of charts per pane in tf-paginated-view to 1 and have >=3 scalar charts.
Click "next pane" twice in quick succession. Wait for load to finish
Click "previous pane" and verify that the chart(s) are not stuck in a tiny state, as seen in #190.