### PR TITLE
Make tf-tensorboard less hard coded

### DIFF
--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -15,14 +15,7 @@ ts_web_library(
     deps = [
         "//tensorboard/components/tf_imports:webcomponentsjs",
         "//tensorboard/components/tf_tensorboard",
-        "//tensorboard/plugins/audio/tf_audio_dashboard",
-        "//tensorboard/plugins/distribution/tf_distribution_dashboard",
-        "//tensorboard/plugins/graph/tf_graph_dashboard",
-        "//tensorboard/plugins/histogram/tf_histogram_dashboard",
-        "//tensorboard/plugins/image/tf_image_dashboard",
-        "//tensorboard/plugins/projector/vz_projector",
-        "//tensorboard/plugins/scalar/tf_scalar_dashboard",
-        "//tensorboard/plugins/text/tf_text_dashboard",
+        "//tensorboard/components/tf_tensorboard:default_plugins",
     ],
 )
 

--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -15,6 +15,14 @@ ts_web_library(
     deps = [
         "//tensorboard/components/tf_imports:webcomponentsjs",
         "//tensorboard/components/tf_tensorboard",
+        "//tensorboard/plugins/audio/tf_audio_dashboard",
+        "//tensorboard/plugins/distribution/tf_distribution_dashboard",
+        "//tensorboard/plugins/graph/tf_graph_dashboard",
+        "//tensorboard/plugins/histogram/tf_histogram_dashboard",
+        "//tensorboard/plugins/image/tf_image_dashboard",
+        "//tensorboard/plugins/projector/vz_projector",
+        "//tensorboard/plugins/scalar/tf_scalar_dashboard",
+        "//tensorboard/plugins/text/tf_text_dashboard",
     ],
 )
 
@@ -41,4 +49,3 @@ tensorboard_html_binary(
     output_path = "/trace_viewer_index.html",
     deps = [":trace_viewer"],
 )
-

--- a/tensorboard/components/tensorboard.html
+++ b/tensorboard/components/tensorboard.html
@@ -21,31 +21,7 @@ limitations under the License.
 <link rel="shortcut icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMQAAADECAMAAAD3eH5ZAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAD/UExURfFlKfaELvFmKfNyK/67NvWALf68Nv69NvNxK/20NfyyNP22NfN0K/JrKvqhMv2zNf25Nf24Nf23NfeOL/yzNPyvNPJoKviWMPmeMfN1K/WBLfePL/FnKfeML/qlMvR7LPmcMfeLL/aJLvR5LPFoKfJuKvR3LP66NvywNPeNL/V/LfaILv21Nf26NfNzK/NvK/R6LPmaMfyxNPqfMvV+LfurM/iSMPmbMfJvKvmdMfumM/qiMvmZMfytNPJqKvysNPN2K/iYMPNwK/upM/JtKvJsKviVMPaHLvaGLvJpKvR8LPaKLvqkMvuqM/aFLvR4LPuoM/iTMPWDLfiRMPmYMXS0ngkAAALoSURBVHja7drnctpAFIbhFUISSKJ3MKYa0+y4xTW9937/15JkJhlTjhrSrHRmvuf/as6L0YLFCgEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMBJ6njenqspzgnPrsrGX9Zpi2tCrmnc6+dYNthVY5WpMmxQLWPdMsOuYVwzNj3ei2t3mQwaV43BJPDCS2NbJ5aEeuX/+9qcjQOtfFIkIkrvY2g4MVcmOBsFWbowKO/kNyj62gRpJcDaPBlxLr1B0zdG0C/8LzbJiJrshuvy1gzlA9+rD8mIkuyIJjFE3/dqnYwoSm7IUEPoD/wut8iIguSIDjlFxe/yfXL5vuSI21BTZLLhXoOILMO8Hxwa/L8bI0LfmUdhGowb2ZvT0e57pFNDgB06IlVyjmmIBl2T/nl9Rw6SD9GgSG/Q0uQkaW3XhmovKQ3eFQ4N2Uo9OQ1eFZsNerf7vP+rO4rhmY1Lg3vFVoP8+8BXg1sFnwbnCk4NThW8GuiKBDdkVVtTNFvNelVsNqTbyWnIOM2oeTRoyWvwmpJHg/ucXBrcJuXT4DwrpwZi2vy0VCx8YtXg/D2bU4OfiuQ3eFfE2KD4bfCqiLNB993gXsGlwa2CT4NzBacGIVQ6YsipQdh0xEdODUKjIxrSp88onZ8zbbFLg1DoiFO5BXvDGv2My9/JhUT8JUZTI0yDaNHLBzIbvqTDNYhUiVw/kdjQ1kM2CHFDPjKW+KzyRTF0g/ga9w9y+fANQpxvX8CU+Ny7FUWDeF3Y+g3lROIf4k0UDX9eCyvO531PyYhHga9zvPZJU5b73Y/eXj8Hv9D48n6HaF5LbcjRt8TZTtda5M1DfXnbkX1C0SHCFKzQB5Fe8op4GNGNHavvZESbVwT5r6W1xyuCPBY3Y9YgDqzknH/e3YfNzzuL30l0IebrZ5kKtuDIXt1n868ET6kf3/49tLvrCcZyF8Pu215dAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcPIbNrBhOaBXucoAAAAASUVORK5CYII=">
 <script src="webcomponentsjs/webcomponents-lite.min.js"></script>
 <link rel="import" href="tf-tensorboard/style.html">
-
-<!-- Import web component for each plugin; they'll be loaded dynamically. -->
-<link rel="import" href="tf-audio-dashboard/tf-audio-dashboard.html">
-<link rel="import" href="tf-distribution-dashboard/tf-distribution-dashboard.html">
-<link rel="import" href="tf-graph-dashboard/tf-graph-dashboard.html">
-<link rel="import" href="tf-histogram-dashboard/tf-histogram-dashboard.html">
-<link rel="import" href="tf-image-dashboard/tf-image-dashboard.html">
-<link rel="import" href="tf-scalar-dashboard/tf-scalar-dashboard.html">
-<link rel="import" href="tf-text-dashboard/tf-text-dashboard.html">
-<link rel="import" href="vz-projector/vz-projector-dashboard.html">
-
-<!-- Tell tf-tensorboard what plugins exist. -->
-<script>
-  const TENSORBOARD_PLUGINS = {
-    'scalars': 'tf-scalar-dashboard',
-    'images': 'tf-image-dashboard',
-    'audio': 'tf-audio-dashboard',
-    'graphs': 'tf-graph-dashboard',
-    'distributions': 'tf-distribution-dashboard',
-    'histograms': 'tf-histogram-dashboard',
-    'projector': 'vz-projector-dashboard',
-    'text': 'tf-text-dashboard',
-  };
-</script>
-
+<link rel="import" href="tf-tensorboard/default-plugins.html">
 <link rel="import" href="tf-tensorboard/tf-tensorboard.html">
 <link rel="import" href="analytics.html">
 <body>

--- a/tensorboard/components/tensorboard.html
+++ b/tensorboard/components/tensorboard.html
@@ -19,8 +19,33 @@ limitations under the License.
 <meta charset="utf-8">
 <title>TensorBoard</title>
 <link rel="shortcut icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMQAAADECAMAAAD3eH5ZAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAD/UExURfFlKfaELvFmKfNyK/67NvWALf68Nv69NvNxK/20NfyyNP22NfN0K/JrKvqhMv2zNf25Nf24Nf23NfeOL/yzNPyvNPJoKviWMPmeMfN1K/WBLfePL/FnKfeML/qlMvR7LPmcMfeLL/aJLvR5LPFoKfJuKvR3LP66NvywNPeNL/V/LfaILv21Nf26NfNzK/NvK/R6LPmaMfyxNPqfMvV+LfurM/iSMPmbMfJvKvmdMfumM/qiMvmZMfytNPJqKvysNPN2K/iYMPNwK/upM/JtKvJsKviVMPaHLvaGLvJpKvR8LPaKLvqkMvuqM/aFLvR4LPuoM/iTMPWDLfiRMPmYMXS0ngkAAALoSURBVHja7drnctpAFIbhFUISSKJ3MKYa0+y4xTW9937/15JkJhlTjhrSrHRmvuf/as6L0YLFCgEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMBJ6njenqspzgnPrsrGX9Zpi2tCrmnc6+dYNthVY5WpMmxQLWPdMsOuYVwzNj3ei2t3mQwaV43BJPDCS2NbJ5aEeuX/+9qcjQOtfFIkIkrvY2g4MVcmOBsFWbowKO/kNyj62gRpJcDaPBlxLr1B0zdG0C/8LzbJiJrshuvy1gzlA9+rD8mIkuyIJjFE3/dqnYwoSm7IUEPoD/wut8iIguSIDjlFxe/yfXL5vuSI21BTZLLhXoOILMO8Hxwa/L8bI0LfmUdhGowb2ZvT0e57pFNDgB06IlVyjmmIBl2T/nl9Rw6SD9GgSG/Q0uQkaW3XhmovKQ3eFQ4N2Uo9OQ1eFZsNerf7vP+rO4rhmY1Lg3vFVoP8+8BXg1sFnwbnCk4NThW8GuiKBDdkVVtTNFvNelVsNqTbyWnIOM2oeTRoyWvwmpJHg/ucXBrcJuXT4DwrpwZi2vy0VCx8YtXg/D2bU4OfiuQ3eFfE2KD4bfCqiLNB993gXsGlwa2CT4NzBacGIVQ6YsipQdh0xEdODUKjIxrSp88onZ8zbbFLg1DoiFO5BXvDGv2My9/JhUT8JUZTI0yDaNHLBzIbvqTDNYhUiVw/kdjQ1kM2CHFDPjKW+KzyRTF0g/ga9w9y+fANQpxvX8CU+Ny7FUWDeF3Y+g3lROIf4k0UDX9eCyvO531PyYhHga9zvPZJU5b73Y/eXj8Hv9D48n6HaF5LbcjRt8TZTtda5M1DfXnbkX1C0SHCFKzQB5Fe8op4GNGNHavvZESbVwT5r6W1xyuCPBY3Y9YgDqzknH/e3YfNzzuL30l0IebrZ5kKtuDIXt1n868ET6kf3/49tLvrCcZyF8Pu215dAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcPIbNrBhOaBXucoAAAAASUVORK5CYII=">
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="webcomponentsjs/webcomponents-lite.min.js"></script>
 <link rel="import" href="tf-tensorboard/style.html">
+
+<!-- Import web component for each plugin; they'll be loaded dynamically. -->
+<link rel="import" href="tf-audio-dashboard/tf-audio-dashboard.html">
+<link rel="import" href="tf-distribution-dashboard/tf-distribution-dashboard.html">
+<link rel="import" href="tf-graph-dashboard/tf-graph-dashboard.html">
+<link rel="import" href="tf-histogram-dashboard/tf-histogram-dashboard.html">
+<link rel="import" href="tf-image-dashboard/tf-image-dashboard.html">
+<link rel="import" href="tf-scalar-dashboard/tf-scalar-dashboard.html">
+<link rel="import" href="tf-text-dashboard/tf-text-dashboard.html">
+<link rel="import" href="vz-projector/vz-projector-dashboard.html">
+
+<!-- Tell tf-tensorboard what plugins exist. -->
+<script>
+  const TENSORBOARD_PLUGINS = {
+    'scalars': 'tf-scalar-dashboard',
+    'images': 'tf-image-dashboard',
+    'audio': 'tf-audio-dashboard',
+    'graphs': 'tf-graph-dashboard',
+    'distributions': 'tf-distribution-dashboard',
+    'histograms': 'tf-histogram-dashboard',
+    'projector': 'vz-projector-dashboard',
+    'text': 'tf-text-dashboard',
+  };
+</script>
+
 <link rel="import" href="tf-tensorboard/tf-tensorboard.html">
 <link rel="import" href="analytics.html">
 <body>

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -21,14 +21,6 @@ ts_web_library(
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_storage",
-        "//tensorboard/plugins/audio/tf_audio_dashboard",
-        "//tensorboard/plugins/distribution/tf_distribution_dashboard",
-        "//tensorboard/plugins/graph/tf_graph_dashboard",
-        "//tensorboard/plugins/histogram/tf_histogram_dashboard",
-        "//tensorboard/plugins/image/tf_image_dashboard",
-        "//tensorboard/plugins/projector/vz_projector",
-        "//tensorboard/plugins/scalar/tf_scalar_dashboard",
-        "//tensorboard/plugins/text/tf_text_dashboard",
         "@org_polymer_font_roboto",
         "@org_polymer_iron_icons",
         "@org_polymer_paper_button",
@@ -58,4 +50,3 @@ tensorboard_html_binary(
     output_path = "/index.html",
     deps = [":demo"],
 )
-

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -34,10 +34,27 @@ ts_web_library(
 )
 
 ts_web_library(
+    name = "default_plugins",
+    srcs = ["default-plugins.html"],
+    path = "/tf-tensorboard",
+    deps = [
+        "//tensorboard/plugins/audio/tf_audio_dashboard",
+        "//tensorboard/plugins/distribution/tf_distribution_dashboard",
+        "//tensorboard/plugins/graph/tf_graph_dashboard",
+        "//tensorboard/plugins/histogram/tf_histogram_dashboard",
+        "//tensorboard/plugins/image/tf_image_dashboard",
+        "//tensorboard/plugins/projector/vz_projector",
+        "//tensorboard/plugins/scalar/tf_scalar_dashboard",
+        "//tensorboard/plugins/text/tf_text_dashboard",
+    ],
+)
+
+ts_web_library(
     name = "demo",
     srcs = ["demo.html"],
     path = "/tf-tensorboard",
     deps = [
+        ":default_plugins",
         ":tf_tensorboard",
         "//tensorboard/demo:demo_data",
     ],

--- a/tensorboard/components/tf_tensorboard/default-plugins.html
+++ b/tensorboard/components/tf_tensorboard/default-plugins.html
@@ -1,0 +1,40 @@
+<!--
+@license
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!-- Import web component for each plugin; they'll be loaded dynamically. -->
+<link rel="import" href="../tf-audio-dashboard/tf-audio-dashboard.html">
+<link rel="import" href="../tf-distribution-dashboard/tf-distribution-dashboard.html">
+<link rel="import" href="../tf-graph-dashboard/tf-graph-dashboard.html">
+<link rel="import" href="../tf-histogram-dashboard/tf-histogram-dashboard.html">
+<link rel="import" href="../tf-image-dashboard/tf-image-dashboard.html">
+<link rel="import" href="../tf-scalar-dashboard/tf-scalar-dashboard.html">
+<link rel="import" href="../tf-text-dashboard/tf-text-dashboard.html">
+<link rel="import" href="../vz-projector/vz-projector-dashboard.html">
+
+<!-- Tell tf-tensorboard what plugins exist. -->
+<script>
+  const TENSORBOARD_PLUGINS = {
+    'scalars': 'tf-scalar-dashboard',
+    'images': 'tf-image-dashboard',
+    'audio': 'tf-audio-dashboard',
+    'graphs': 'tf-graph-dashboard',
+    'distributions': 'tf-distribution-dashboard',
+    'histograms': 'tf-histogram-dashboard',
+    'projector': 'vz-projector-dashboard',
+    'text': 'tf-text-dashboard',
+  };
+</script>

--- a/tensorboard/components/tf_tensorboard/demo.html
+++ b/tensorboard/components/tf_tensorboard/demo.html
@@ -19,6 +19,7 @@ limitations under the License.
 <meta charset="utf-8">
 <title>TensorBoard Demo</title>
 <link rel="import" href="style.html">
+<link rel="import" href="default-plugins.html">
 <link rel="import" href="tf-tensorboard.html">
 <body>
 <tf-tensorboard demo-dir="/data" use-hash></tf-tensorboard>

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -24,19 +24,11 @@ limitations under the License.
 <link rel="import" href="../paper-tabs/paper-tabs.html">
 <link rel="import" href="../paper-toolbar/paper-toolbar.html">
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../tf-audio-dashboard/tf-audio-dashboard.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
-<link rel="import" href="../tf-distribution-dashboard/tf-distribution-dashboard.html">
 <link rel="import" href="../tf-globals/tf-globals.html">
-<link rel="import" href="../tf-graph-dashboard/tf-graph-dashboard.html">
-<link rel="import" href="../tf-histogram-dashboard/tf-histogram-dashboard.html">
-<link rel="import" href="../tf-image-dashboard/tf-image-dashboard.html">
 <link rel="import" href="../tf-imports/lodash.html">
-<link rel="import" href="../tf-scalar-dashboard/tf-scalar-dashboard.html">
 <link rel="import" href="../tf-storage/tf-storage.html">
-<link rel="import" href="../tf-text-dashboard/tf-text-dashboard.html">
-<link rel="import" href="../vz-projector/vz-projector-dashboard.html">
 
 <!--
   tf-tensorboard is the frontend entry point for TensorBoard.
@@ -313,28 +305,6 @@ limitations under the License.
     import {getRouter, setRouter, createRouter} from "../tf-backend/router.js";
     import {fetchRuns} from "../tf-backend/runsStore.js";
 
-    // The names of TensorBoard tabs.
-    const TABS = [
-      'scalars', 'images', 'audio', 'graphs', 'distributions', 'histograms',
-      'projector', 'text'
-    ];
-
-    // A map from dashboard name to Polymer component name.
-    const COMPONENTS = {
-      'scalars': 'tf-scalar-dashboard',
-      'images': 'tf-image-dashboard',
-      'audio': 'tf-audio-dashboard',
-      'graphs': 'tf-graph-dashboard',
-      'distributions': 'tf-distribution-dashboard',
-      'histograms': 'tf-histogram-dashboard',
-      'projector': 'vz-projector-dashboard',
-      'text': 'tf-text-dashboard',
-    };
-    if (!_.isEqual(Object.keys(COMPONENTS), TABS)) {
-      throw new Error(
-        `Bad set of components: ${Object.keys(COMPONENTS)} vs. ${TABS}`);
-    }
-
     /** @enum {string} */ const ActiveDashboardsLoadState = {
       NOT_LOADED: 'NOT_LOADED',
       LOADED: 'LOADED',
@@ -394,12 +364,12 @@ limitations under the License.
         /**
          * The set of all possible dashboard names.
          *
-         * @type {Array<string>!}
+         * @type {!Array<string>}
          */
         _dashboards: {
           type: Array,
           readOnly: true,
-          value: TABS,
+          value: Object.keys(TENSORBOARD_PLUGINS),
         },
 
         /**
@@ -616,7 +586,7 @@ limitations under the License.
           return;
         }
         if (container.childNodes.length === 0) {
-          const component = document.createElement(COMPONENTS[dashboard]);
+          const component = document.createElement(TENSORBOARD_PLUGINS[dashboard]);
           component.id = 'dashboard';  // used in `_selectedDashboardComponent`
           container.appendChild(component);
         };

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -463,8 +463,9 @@ limitations under the License.
       },
       observers: [
         '_updateSelectedDashboard(_selectedDashboard, _activeDashboards)',
-        '_ensureSelectedDashboardStamped(' +
-          '_dashboardContainersStamped, _activeDashboards, _selectedDashboard)',
+        ('_ensureSelectedDashboardStamped(' +
+         '_dashboardContainersStamped, _activeDashboards, ' +
+         '_selectedDashboard, _debuggerDataEnabled)'),
       ],
 
       _activeDashboardsUpdated(activeDashboards, selectedDashboard) {
@@ -575,7 +576,8 @@ limitations under the License.
        * If the currently selected dashboard is not a real dashboard,
        * this does nothing.
        */
-      _ensureSelectedDashboardStamped(containersStamped, activeDashboards, dashboard) {
+      _ensureSelectedDashboardStamped(containersStamped, activeDashboards,
+                                      dashboard, debuggerDataEnabled) {
         if (!containersStamped || !activeDashboards || !dashboard) {
           return;
         }
@@ -590,7 +592,9 @@ limitations under the License.
           component.id = 'dashboard';  // used in `_selectedDashboardComponent`
           container.appendChild(component);
         }
-        this.set('_isReloadDisabled', !!container.childNodes[0].isReloadDisabled);
+        this.set('_isReloadDisabled',
+                 (!debuggerDataEnabled &&
+                  !!container.childNodes[0].isReloadDisabled));
       },
 
       /**

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -437,6 +437,11 @@ limitations under the License.
           value: false,
         },
 
+        _isReloadDisabled: {
+          type: Boolean,
+          value: false,
+        },
+
         _lastReloadTime: {
           type: String,
           value: "not yet loaded",
@@ -584,7 +589,8 @@ limitations under the License.
           const component = document.createElement(TENSORBOARD_PLUGINS[dashboard]);
           component.id = 'dashboard';  // used in `_selectedDashboardComponent`
           container.appendChild(component);
-        };
+        }
+        this.set('_isReloadDisabled', !!container.childNodes[0].isReloadDisabled);
       },
 
       /**
@@ -685,6 +691,9 @@ limitations under the License.
       },
 
       reload() {
+        if (this._isReloadDisabled) {
+          return;
+        }
         this._fetchLogdir();
         Promise.all([this._fetchActiveDashboards(), fetchRuns()]).then(() => {
           const dashboard = this._selectedDashboardComponent();

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -437,11 +437,6 @@ limitations under the License.
           value: false,
         },
 
-        _isReloadDisabled: {
-          type: Boolean,
-          computed: '_computeIsReloadDisabled(_debuggerDataEnabled, _selectedDashboard)',
-        },
-
         _lastReloadTime: {
           type: String,
           value: "not yet loaded",
@@ -592,17 +587,6 @@ limitations under the License.
         };
       },
 
-      _computeIsReloadDisabled(debuggerDataEnabled, selectedDashboard) {
-        if (selectedDashboard == null) {
-          // No dashboards available. Let the user refresh to try to
-          // load more data.
-          return false;
-        }
-        // TODO(@wchargin): Refactor to remove these explicit plugin names.
-        const disabledForModes = ['graphs', 'projector'];
-        return !debuggerDataEnabled && disabledForModes.includes(selectedDashboard);
-      },
-
       /**
        * Get the Polymer component corresponding to the currently
        * selected dashboard. For instance, the result might be an
@@ -701,9 +685,6 @@ limitations under the License.
       },
 
       reload() {
-        if (this._isReloadDisabled) {
-          return;
-        }
         this._fetchLogdir();
         Promise.all([this._fetchActiveDashboards(), fetchRuns()]).then(() => {
           const dashboard = this._selectedDashboardComponent();

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -132,7 +132,7 @@ import {queryEncoder} from "../tf-backend/urlPathHelpers.js";
 
 Polymer({
   is: 'tf-graph-dashboard',
-  properties: {
+   properties: {
     _datasets: Object,
     _renderHierarchy: {type: Object, observer: '_renderHierarchyChanged'},
     _requestManager: {
@@ -181,6 +181,13 @@ Polymer({
       readOnly: true,
     },
     runs: Array,
+    // Whether or not the reload button in the tf-tensorboard GUI should be
+    // shaded out.
+    isReloadDisabled: {
+      type: Boolean,
+      value: true,  // TODO(@chihuahua): Reconcile this setting with Health Pills.
+      readOnly: true,
+    },
   },
   listeners: {
     'node-toggle-expand': '_handleNodeToggleExpand',

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.html
@@ -67,6 +67,13 @@ Polymer({
   is: 'vz-projector-dashboard',
   properties: {
     dataNotFound: Boolean,
+    // Whether or not the reload button in the tf-tensorboard GUI should be
+    // shaded out.
+    isReloadDisabled: {
+      type: Boolean,
+      value: true,
+      readOnly: true,
+    },
     _routePrefix: {
       type: String,
       value: () => getRouter().pluginRoute('projector', ''),


### PR DESCRIPTION
This is going to allow our friend in chrisranderson/beholder#4 to build a
custom TensorBoard, without needing to copy the whole of tf-tensorboard.html
into his repository.