### PR TITLE
Keep inactive dashboards list up-to-date over time

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -97,6 +97,7 @@ limitations under the License.
                     <template
                       is="dom-if"
                       if="[[_isDashboardInactive(disabledDashboards, _activeDashboards, dashboard)]]"
+                      restamp
                     >
                       <paper-item
                         data-dashboard$="[[dashboard]]"


### PR DESCRIPTION
Summary:
If an inactive dashboard becomes active, it should be removed from the
list of inactive dashboards. We use a `dom-if` to control the
`paper-item`s corresponding to each inactive dashboard, so these
elements were being `display: none`d as desired. However, they still
existed in the DOM, so when the selected dashboard was set to such an
was-inactive-now-active dashboard, the inactive dashboards dropdown menu
would still display this dashboard as its currently selected item.
By restamping, we force these elements to be torn down.

Test Plan:
 1. Create an empty directory `/tmp/slow`.
 2. Launch TensorBoard with logdir `/tmp/slow`.
 3. Load TensorBoard in the browser, and see that there are no active
    dashboards.
 4. Generate, copy, or symlink a run into `/tmp/slow`.
 5. Click the "Reload" button in TensorBoard and select, say, the
    "Graphs" dashboard.

Before this patch: the newly-added Graphs tab is selected, and the
inactive dashboards dropdown _also_ reads "Graphs."

After this patch: the newly-added Graphs tab is selected, and the
inactive dashboards dropdown reads "Inactive dashboards" (deselected
state).

wchargin-branch: restamp-inactive-dashboards-items