### PR TITLE
Cleanup TensorBoard to satisfy Google-internal checks

### DIFF
--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/backend/__init__.py
+++ b/tensorboard/backend/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/backend/event_processing/__init__.py
+++ b/tensorboard/backend/event_processing/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/pip_package/__init__.py
+++ b/tensorboard/pip_package/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/plugins/__init__.py
+++ b/tensorboard/plugins/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/plugins/audio/__init__.py
+++ b/tensorboard/plugins/audio/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/plugins/core/__init__.py
+++ b/tensorboard/plugins/core/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/plugins/distribution/__init__.py
+++ b/tensorboard/plugins/distribution/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/plugins/graph/__init__.py
+++ b/tensorboard/plugins/graph/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/plugins/graph/tf_graph/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph/demo/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:web.bzl", "ts_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-# bazel run //third_party/tensorflow/tensorboard/plugins/graph/tf_graph/demo
+# bazel run //tensorboard/plugins/graph/tf_graph/demo
 ts_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),

--- a/tensorboard/plugins/graph/tf_graph_app/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_app/demo/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:web.bzl", "ts_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-# bazel run //third_party/tensorflow/tensorboard/plugins/graph/tf_graph_app/demo
+# bazel run //tensorboard/plugins/graph/tf_graph_app/demo
 ts_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),

--- a/tensorboard/plugins/graph/tf_graph_board/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_board/demo/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:web.bzl", "ts_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-# bazel run //third_party/tensorflow/tensorboard/plugins/graph/tf_graph_board/demo
+# bazel run //tensorboard/plugins/graph/tf_graph_board/demo
 ts_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),

--- a/tensorboard/plugins/graph/tf_graph_controls/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_controls/demo/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:web.bzl", "ts_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-# bazel run //third_party/tensorflow/tensorboard/plugins/graph/tf_graph_controls/demo
+# bazel run //tensorboard/plugins/graph/tf_graph_controls/demo
 ts_web_library(
     name = "demo",
     srcs = ["index.html"],

--- a/tensorboard/plugins/graph/tf_graph_dashboard/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/demo/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:web.bzl", "ts_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-# bazel run //third_party/tensorflow/tensorboard/plugins/graph/tf_graph_dashboard/demo
+# bazel run //tensorboard/plugins/graph/tf_graph_dashboard/demo
 ts_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),

--- a/tensorboard/plugins/graph/tf_graph_debugger_data_card/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_debugger_data_card/demo/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:web.bzl", "ts_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-# bazel run //third_party/tensorflow/tensorboard/plugins/graph/tf_graph_debugger_data_card/demo
+# bazel run //tensorboard/plugins/graph/tf_graph_debugger_data_card/demo
 ts_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),

--- a/tensorboard/plugins/graph/tf_graph_info/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_info/demo/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:web.bzl", "ts_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-# bazel run //third_party/tensorflow/tensorboard/plugins/graph/tf_graph_info/demo
+# bazel run //tensorboard/plugins/graph/tf_graph_info/demo
 ts_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),

--- a/tensorboard/plugins/graph/tf_graph_loader/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_loader/demo/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:web.bzl", "ts_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-# bazel run //third_party/tensorflow/tensorboard/plugins/graph/tf_graph_loader/demo
+# bazel run //tensorboard/plugins/graph/tf_graph_loader/demo
 ts_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),

--- a/tensorboard/plugins/histogram/__init__.py
+++ b/tensorboard/plugins/histogram/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/plugins/image/__init__.py
+++ b/tensorboard/plugins/image/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/plugins/projector/__init__.py
+++ b/tensorboard/plugins/projector/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,51 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Public API for the Embedding Projector.
-
-@@ProjectorPluginAsset
-@@ProjectorConfig
-@@EmbeddingInfo
-@@EmbeddingMetadata
-@@SpriteMetadata
-"""
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-import os
-import tensorflow as tf
-
-from google.protobuf import text_format as _text_format
-from tensorboard.plugins.projector import projector_plugin as _projector_plugin
-from tensorboard.plugins.projector.projector_config_pb2 import EmbeddingInfo
-from tensorboard.plugins.projector.projector_config_pb2 import SpriteMetadata
-from tensorboard.plugins.projector.projector_config_pb2 import ProjectorConfig
-
-
-def visualize_embeddings(summary_writer, config):
-  """Stores a config file used by the embedding projector.
-
-  Args:
-    summary_writer: The summary writer used for writing events.
-    config: `tf.contrib.tensorboard.plugins.projector.ProjectorConfig`
-      proto that holds the configuration for the projector such as paths to
-      checkpoint files and metadata files for the embeddings. If
-      `config.model_checkpoint_path` is none, it defaults to the
-      `logdir` used by the summary_writer.
-
-  Raises:
-    ValueError: If the summary writer does not have a `logdir`.
-  """
-  logdir = summary_writer.get_logdir()
-
-  # Sanity checks.
-  if logdir is None:
-    raise ValueError('Summary writer must have a logdir')
-
-  # Saving the config file in the logdir.
-  config_pbtxt = _text_format.MessageToString(config)
-  path = os.path.join(logdir, _projector_plugin.PROJECTOR_FILENAME)
-  with tf.gfile.Open(path, 'w') as f:
-    f.write(config_pbtxt)

--- a/tensorboard/plugins/projector/__init__.py
+++ b/tensorboard/plugins/projector/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,3 +12,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+"""Public API for the Embedding Projector.
+
+@@ProjectorPluginAsset
+@@ProjectorConfig
+@@EmbeddingInfo
+@@EmbeddingMetadata
+@@SpriteMetadata
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import tensorflow as tf
+
+from google.protobuf import text_format as _text_format
+from tensorboard.plugins.projector import projector_plugin as _projector_plugin
+from tensorboard.plugins.projector.projector_config_pb2 import EmbeddingInfo
+from tensorboard.plugins.projector.projector_config_pb2 import SpriteMetadata
+from tensorboard.plugins.projector.projector_config_pb2 import ProjectorConfig
+
+
+def visualize_embeddings(summary_writer, config):
+  """Stores a config file used by the embedding projector.
+
+  Args:
+    summary_writer: The summary writer used for writing events.
+    config: `tf.contrib.tensorboard.plugins.projector.ProjectorConfig`
+      proto that holds the configuration for the projector such as paths to
+      checkpoint files and metadata files for the embeddings. If
+      `config.model_checkpoint_path` is none, it defaults to the
+      `logdir` used by the summary_writer.
+
+  Raises:
+    ValueError: If the summary writer does not have a `logdir`.
+  """
+  logdir = summary_writer.get_logdir()
+
+  # Sanity checks.
+  if logdir is None:
+    raise ValueError('Summary writer must have a logdir')
+
+  # Saving the config file in the logdir.
+  config_pbtxt = _text_format.MessageToString(config)
+  path = os.path.join(logdir, _projector_plugin.PROJECTOR_FILENAME)
+  with tf.gfile.Open(path, 'w') as f:
+    f.write(config_pbtxt)

--- a/tensorboard/plugins/scalar/__init__.py
+++ b/tensorboard/plugins/scalar/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/plugins/text/__init__.py
+++ b/tensorboard/plugins/text/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/scripts/__init__.py
+++ b/tensorboard/scripts/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================


### PR DESCRIPTION
- Add license headers to __init__.py files.
- Remove outdated references to //third_party/tensorflow