### PR TITLE
Adds width, height, and toolbar / sidebar visibility support

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
+++ b/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
@@ -70,7 +70,16 @@ The pbtxt format is the stringified version of the graphdef.
 .container {
   height: 650px;
 }
+    
+/* The no-toolbar class will hide the div.side element, and move div.main over
+to the left hand side. */
+.container.no-toolbar .main {
+  left: 0;
+}
 
+.container.no-toolbar .side {
+  display: none;
+}  
 </style>
 <div class="container">
   <div class="all">
@@ -126,9 +135,31 @@ Polymer({
       type: String,
       observer: '_updateGraph',
     },
+      
+    width: {
+      type: Number,
+      observer: '_updateWidth'
+    },
+    height: {
+      type: Number,
+      observer: '_updateHeight'
+    },
+    toolbar: {
+      type: Boolean,
+      observer: '_updateToolbar'
+    },
 
     _renderHierarchy: Object,
     _progress: Object,
+  },
+  _updateToolbar: function() {
+    this.$$('.container').classList.toggle('no-toolbar', !this.toolbar);
+  },
+  _updateWidth: function() {
+    this.$$('.container').style.width = this.width + 'px';
+  },
+  _updateHeight: function() {
+    this.$$('.container').style.height = this.height + 'px';
   },
   _updateGraph: function() {
     if (this.pbtxtFileLocation) {

--- a/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
+++ b/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
@@ -72,7 +72,7 @@ The pbtxt format is the stringified version of the graphdef.
 }
     
 /* The no-toolbar class will hide the div.side element, and move div.main over
-to the left hand side. */
+   to the left hand side. */
 .container.no-toolbar .main {
   left: 0;
 }


### PR DESCRIPTION
The current tf-graph-app element defaults to 100% width, 650px height, and includes a toolbar with a number of features. This PR add the ability for someone to specify width & height values in pixels, as well as toggle the toolbar visibility. The reason for this is that some instances of the graph need to be a particular size and often need to avoid using the toolbar.

To test:
```html
<tf-graph-app width="400" height="450" toolbar="false"></tf-graph-app>
```
And you should have a graph 400px x 450px sans toolbar! :+1: 