### PR TITLE
Fix timestamps in the image dashboard

### DIFF
--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -284,7 +284,9 @@ future for loading older images.
         return {
           width: imageMetadata.width,
           height: imageMetadata.height,
-          wall_time: new Date(imageMetadata.wall_time),
+          // The wall time within the metadata is in seconds. The Date
+          // constructor accepts a time in milliseconds, so we multiply by 1000.
+          wall_time: new Date(imageMetadata.wall_time * 1000),
           step: imageMetadata.step,
           url: individualImageUrl,
         };


### PR DESCRIPTION
Previously, the timestamp shown for each image had been Sun Jan 18 1970 00:38:34 GMT-0800 (PST) because a time in seconds (instead of milliseconds) had been passed to the Date constructor.

This fixes issue #225. This screenshot is from a demo with some data generated last year:
![hw1bqlyyhbm](https://user-images.githubusercontent.com/4221553/28150842-071559a2-674c-11e7-8e35-2eba885641cb.png)
