### PR TITLE
Set TensorBoard version to match TF version.

### DIFF
--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -32,7 +32,6 @@ REQUIRED_PACKAGES = [
     'html5lib == 0.9999999',  # identical to 1.0b8
     'markdown >= 2.6.8',
     'bleach == 1.5.0',
-    'tensorflow >= 1.3.0',
 ]
 
 # python3 requires wheel 0.26
@@ -61,7 +60,7 @@ setup(
     package_data={
         'tensorboard': [
             'components/index.html',
-            'TAG',
+            'webfiles.zip',
         ],
     },
     install_requires=REQUIRED_PACKAGES,

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -32,7 +32,7 @@ REQUIRED_PACKAGES = [
     'html5lib == 0.9999999',  # identical to 1.0b8
     'markdown >= 2.6.8',
     'bleach == 1.5.0',
-    'tensorflow >= 1.2.0',
+    'tensorflow >= 1.3.0',
 ]
 
 # python3 requires wheel 0.26

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '0.1.3'
+VERSION = '1.3.0'

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '1.3.0'
+VERSION = '1.3.1rc'

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '1.3.1rc'
+VERSION = '1.3.1'


### PR DESCRIPTION
This is for the `tensorflow-tensorboard` pip package, which `tensorflow` will start depending on as of r1.3.

My thinking is that once the summary APIs are fully ported to TensorBoard, and the new SQL data ingestion pipeline is live, we will switch TensorBoard to 2.0, and use the `tensorboard` pypi package. We aren't using the `tensorboard` pypi package immediately, because we want to make sure we have tf-free APIs set up first so that users of that package continue to have a way to use TensorBoard independently from the TensorFlow API. 