### PR TITLE
Make inactive dashboard UI subtler

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -74,7 +74,7 @@ limitations under the License.
               if="[[_inactiveDashboardsExist(_dashboards, disabledDashboards, _activeDashboards)]]"
             >
               <paper-dropdown-menu
-                label="Inactive dashboards"
+                label="Inactive"
                 no-label-float
                 noink
                 style="margin-left: 12px"
@@ -211,6 +211,7 @@ limitations under the License.
       }
 
       .toolbar-message {
+        opacity: 0.7;
         -webkit-font-smoothing: antialiased;
         font-size: 14px;
         font-weight: 500;


### PR DESCRIPTION
The inactive menu dropdown now just says "Inactive" so the text doesn't render
with ellipsis. The brightness of the "Loading active dashboards" text has also
been reduced. This is so we draw less attention to the fact that TensorBoard is
loading.