### PR TITLE
Make custom TensorBoard builds possible

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -8,10 +8,6 @@ load("//tensorboard/defs:zipper.bzl", "tensorboard_zip_file")
 
 licenses(["notice"])  # Apache 2.0
 
-exports_files([
-    "LICENSE",
-])
-
 package_group(
     name = "internal",
     packages = ["//tensorboard/..."],
@@ -22,6 +18,7 @@ py_binary(
     srcs = ["main.py"],
     main = "main.py",
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":util",
         ":version",
@@ -45,6 +42,7 @@ py_binary(
     name = "version",
     srcs = ["version.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
 )
 
 tensorboard_zip_file(
@@ -66,6 +64,7 @@ py_library(
     # This is a dummy rule used as a numpy dependency in open-source.
     # We expect numpy to already be installed on the system, e.g. via
     # `pip install numpy`
+    visibility = ["//visibility:public"],
 )
 
 py_library(
@@ -73,6 +72,7 @@ py_library(
     # This is a dummy rule used as a sqlite3 dependency in open-source.
     # We expect sqlite3 to already be present, as it is part of the standard
     # library.
+    visibility = ["//visibility:public"],
 )
 
 py_library(
@@ -80,6 +80,7 @@ py_library(
     # This is a dummy rule used as a TensorFlow dependency in open-source.
     # We expect TensorFlow to already be installed on the system, e.g. via
     # `pip install tensorflow`
+    visibility = ["//visibility:public"],
 )
 
 filegroup(
@@ -97,6 +98,7 @@ py_library(
     name = "db",
     srcs = ["db.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = ["//tensorboard:expect_sqlite3_installed"],
 )
 
@@ -104,6 +106,7 @@ py_library(
     name = "util",
     srcs = ["util.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = ["//tensorboard:expect_tensorflow_installed"],
 )
 
@@ -124,6 +127,7 @@ py_library(
     name = "loader",
     srcs = ["loader.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":util",
         "//tensorboard:expect_tensorflow_installed",

--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -59,6 +59,7 @@ py_library(
     srcs = ["application.py"],
     data = ["//tensorboard:webfiles.zip"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":http_util",
         "//tensorboard:db",

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -27,6 +27,7 @@ import json
 import os
 import re
 import sqlite3
+import sys
 import threading
 import time
 
@@ -174,6 +175,7 @@ class TensorBoardWSGI(object):
         plugin_apps = plugin.get_plugin_apps()
       except Exception as e:  # pylint: disable=broad-except
         if type(plugin) is core_plugin.CorePlugin:  # pylint: disable=unidiomatic-typecheck
+          six.reraise(*sys.exc_info())
           raise e
         tf.logging.warning('Plugin %s failed. Exception: %s',
                            plugin.plugin_name, str(e))

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -175,8 +175,7 @@ class TensorBoardWSGI(object):
         plugin_apps = plugin.get_plugin_apps()
       except Exception as e:  # pylint: disable=broad-except
         if type(plugin) is core_plugin.CorePlugin:  # pylint: disable=unidiomatic-typecheck
-          six.reraise(*sys.exc_info())
-          raise e
+          raise
         tf.logging.warning('Plugin %s failed. Exception: %s',
                            plugin.plugin_name, str(e))
         continue

--- a/tensorboard/components/tensorboard.html
+++ b/tensorboard/components/tensorboard.html
@@ -25,4 +25,4 @@ limitations under the License.
 <link rel="import" href="tf-tensorboard/tf-tensorboard.html">
 <link rel="import" href="analytics.html">
 <body>
-<tf-tensorboard use-hash></tf-tensorboard>
+<tf-tensorboard use-hash title="TensorBoard"></tf-tensorboard>

--- a/tensorboard/components/tf_card_heading/BUILD
+++ b/tensorboard/components/tf_card_heading/BUILD
@@ -10,8 +10,8 @@ ts_web_library(
         "tf-card-heading.html",
     ],
     path = "/tf-card-heading",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_imports:polymer",
     ],
 )
-

--- a/tensorboard/components/tf_categorization_utils/BUILD
+++ b/tensorboard/components/tf_categorization_utils/BUILD
@@ -13,6 +13,7 @@ ts_web_library(
         "tf-category-pane.html",
     ],
     path = "/tf-categorization-utils",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_dashboard_common",
@@ -21,4 +22,3 @@ ts_web_library(
         "@org_polymer_iron_collapse",
     ],
 )
-

--- a/tensorboard/components/tf_color_scale/BUILD
+++ b/tensorboard/components/tf_color_scale/BUILD
@@ -12,10 +12,10 @@ ts_web_library(
         "tf-color-scale.html",
     ],
     path = "/tf-color-scale",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_imports:d3",
         "//tensorboard/components/tf_imports:polymer",
     ],
 )
-

--- a/tensorboard/components/tf_dashboard_common/BUILD
+++ b/tensorboard/components/tf_dashboard_common/BUILD
@@ -22,6 +22,7 @@ ts_web_library(
         "tf-regex-group.ts",
     ],
     path = "/tf-dashboard-common",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_color_scale",
@@ -89,4 +90,3 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )
-

--- a/tensorboard/components/tf_paginated_view/BUILD
+++ b/tensorboard/components/tf_paginated_view/BUILD
@@ -8,6 +8,7 @@ ts_web_library(
     name = "tf_paginated_view",
     srcs = ["tf-paginated-view.html"],
     path = "/tf-paginated-view",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:polymer",
@@ -16,4 +17,3 @@ ts_web_library(
         "@org_polymer_paper_styles",
     ],
 )
-

--- a/tensorboard/components/tf_runs_selector/BUILD
+++ b/tensorboard/components/tf_runs_selector/BUILD
@@ -8,6 +8,7 @@ ts_web_library(
     name = "tf_runs_selector",
     srcs = ["tf-runs-selector.html"],
     path = "/tf-runs-selector",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_color_scale",
@@ -18,4 +19,3 @@ ts_web_library(
         "@org_polymer_paper_styles",
     ],
 )
-

--- a/tensorboard/components/tf_storage/BUILD
+++ b/tensorboard/components/tf_storage/BUILD
@@ -12,6 +12,7 @@ ts_web_library(
         "tf-storage.html",
     ],
     path = "/tf-storage",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_globals",
         "//tensorboard/components/tf_imports:lodash",
@@ -28,4 +29,3 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )
-

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -47,7 +47,7 @@ limitations under the License.
     <paper-header-panel>
       <paper-toolbar id="toolbar" slot="header">
         <div id="toolbar-content" slot="top">
-          <div class="toolbar-title">TensorBoard</div>
+          <div class="toolbar-title">[[title]]</div>
           <template is="dom-if" if="[[_activeDashboardsNotLoaded]]">
             <span class="toolbar-message">
               Loading active dashboards&hellip;
@@ -315,6 +315,18 @@ limitations under the License.
       is: "tf-tensorboard",
       behaviors: [AutoReloadBehavior],
       properties: {
+
+        /**
+         * Title name displayed in top left corner of GUI.
+         *
+         * This defaults to TensorBoard-X because we recommend against custom
+         * builds being branded as TensorBoard.
+         */
+        title: {
+          type: String,
+          value: 'TensorBoard-X',
+        },
+
         /**
          * We accept a router property only for backward compatibility:
          * setting it triggers an observer that simply calls

--- a/tensorboard/functionaltests/browsers/BUILD
+++ b/tensorboard/functionaltests/browsers/BUILD
@@ -3,7 +3,7 @@ package(default_visibility = ["//tensorboard:internal"])
 load("@io_bazel_rules_webtesting//web:web.bzl", "browser")
 load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_archive")
 
-licenses(["notice"])
+licenses(["notice"])  # Apache 2.0
 
 config_setting(
     name = "mac",
@@ -24,9 +24,9 @@ browser(
         ":mac": {"DISABLE_X_DISPLAY": "1"},
     }),
     metadata = "chromium.json",
+    visibility = ["//visibility:public"],
     deps = [
-        "//third_party/chromium:chromedriver",
         "//third_party/chromium",
+        "//third_party/chromium:chromedriver",
     ],
 )
-

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -139,25 +139,32 @@ def create_tb_app(plugins, assets_zip_provider=None):
       plugins=plugins)
 
 
-def make_simple_server(tb_app, host, port):
+def make_simple_server(tb_app, host=None, port=None):
   """Create an HTTP server for TensorBoard.
 
   Args:
     tb_app: The TensorBoard WSGI application to create a server for.
     host: Indicates the interfaces to bind to ('::' or '0.0.0.0' for all
         interfaces, '::1' or '127.0.0.1' for localhost). A blank value ('')
-        indicates protocol-agnostic all interfaces.
+        indicates protocol-agnostic all interfaces. If not specified, will
+        default to the flag value.
     port: The port to bind to (0 indicates an unused port selected by the
-        operating system).
+        operating system). If not specified, will default to the flag value.
+
   Returns:
     A tuple of (server, url):
       server: An HTTP server object configured to host TensorBoard.
       url: A best guess at a URL where TensorBoard will be accessible once the
         server has been started.
+
   Raises:
     socket.error: If a server could not be constructed with the host and port
       specified. Also logs an error message.
   """
+  if host is None:
+    host = FLAGS.host
+  if port is None:
+    port = FLAGS.port
   try:
     if host:
       # The user gave us an explicit host
@@ -199,7 +206,7 @@ def make_simple_server(tb_app, host, port):
 def run_simple_server(tb_app):
   """Run a TensorBoard HTTP server, and print some messages to the console."""
   try:
-    server, url = make_simple_server(tb_app, FLAGS.host, FLAGS.port)
+    server, url = make_simple_server(tb_app)
   except socket.error:
     # An error message was already logged
     # TODO(@jart): Remove log and throw anti-pattern.

--- a/tensorboard/plugins/BUILD
+++ b/tensorboard/plugins/BUILD
@@ -11,4 +11,5 @@ py_library(
     name = "base_plugin",
     srcs = ["base_plugin.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
 )

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -11,9 +11,7 @@ py_library(
     name = "audio_plugin",
     srcs = ["audio_plugin.py"],
     srcs_version = "PY2AND3",
-    visibility = [
-        "//tensorboard:internal",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:http_util",

--- a/tensorboard/plugins/audio/tf_audio_dashboard/BUILD
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/BUILD
@@ -12,6 +12,7 @@ ts_web_library(
         "tf-audio-loader.html",
     ],
     path = "/tf-audio-dashboard",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_card_heading",
@@ -50,4 +51,3 @@ ts_web_library(
         "@org_polymer_paper_styles",
     ],
 )
-

--- a/tensorboard/plugins/core/BUILD
+++ b/tensorboard/plugins/core/BUILD
@@ -11,6 +11,7 @@ py_library(
     name = "core_plugin",
     srcs = ["core_plugin.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:http_util",

--- a/tensorboard/plugins/distribution/BUILD
+++ b/tensorboard/plugins/distribution/BUILD
@@ -12,9 +12,7 @@ py_library(
     name = "distributions_plugin",
     srcs = ["distributions_plugin.py"],
     srcs_version = "PY2AND3",
-    visibility = [
-        "//tensorboard:internal",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:event_accumulator",

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/BUILD
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/BUILD
@@ -11,6 +11,7 @@ ts_web_library(
         "tf-distribution-loader.html",
     ],
     path = "/tf-distribution-dashboard",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_card_heading",
@@ -25,8 +26,8 @@ ts_web_library(
         "@org_polymer_iron_collapse",
         "@org_polymer_iron_icon",
         "@org_polymer_paper_button",
-        "@org_polymer_paper_input",
         "@org_polymer_paper_icon_button",
+        "@org_polymer_paper_input",
         "@org_polymer_paper_styles",
     ],
 )
@@ -44,4 +45,3 @@ ts_web_library(
         "@org_polymer_paper_styles",
     ],
 )
-

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -12,9 +12,7 @@ py_library(
     name = "graphs_plugin",
     srcs = ["graphs_plugin.py"],
     srcs_version = "PY2AND3",
-    visibility = [
-        "//tensorboard:internal",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:http_util",

--- a/tensorboard/plugins/graph/tf_graph_dashboard/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/BUILD
@@ -9,15 +9,16 @@ ts_web_library(
     name = "tf_graph_dashboard",
     srcs = ["tf-graph-dashboard.html"],
     path = "/tf-graph-dashboard",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/vz_sorting",
         "//tensorboard/plugins/graph/tf_graph",
         "//tensorboard/plugins/graph/tf_graph_board",
         "//tensorboard/plugins/graph/tf_graph_controls",
         "//tensorboard/plugins/graph/tf_graph_loader",
-        "//tensorboard/components/tf_imports:polymer",
-        "//tensorboard/components/vz_sorting",
     ],
 )
 
@@ -28,12 +29,11 @@ tensorboard_webcomponent_library(
     deps = [
         "//tensorboard/components/tf_backend:legacy",
         "//tensorboard/components/tf_dashboard_common:legacy",
+        "//tensorboard/components/vz_sorting:legacy",
         "//tensorboard/plugins/graph/tf_graph:legacy",
         "//tensorboard/plugins/graph/tf_graph_board:legacy",
         "//tensorboard/plugins/graph/tf_graph_controls:legacy",
         "//tensorboard/plugins/graph/tf_graph_loader:legacy",
-        "//tensorboard/components/vz_sorting:legacy",
         "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )
-

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -12,9 +12,7 @@ py_library(
     name = "histograms_plugin",
     srcs = ["histograms_plugin.py"],
     srcs_version = "PY2AND3",
-    visibility = [
-        "//tensorboard:internal",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:event_accumulator",

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
@@ -12,6 +12,7 @@ ts_web_library(
         "tf-histogram-loader.html",
     ],
     path = "/tf-histogram-dashboard",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_card_heading",
@@ -46,4 +47,3 @@ ts_web_library(
         "@org_polymer_paper_styles",
     ],
 )
-

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -11,9 +11,7 @@ py_library(
     name = "images_plugin",
     srcs = ["images_plugin.py"],
     srcs_version = "PY2AND3",
-    visibility = [
-        "//tensorboard:internal",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:http_util",

--- a/tensorboard/plugins/image/tf_image_dashboard/BUILD
+++ b/tensorboard/plugins/image/tf_image_dashboard/BUILD
@@ -11,6 +11,7 @@ ts_web_library(
         "tf-image-loader.html",
     ],
     path = "/tf-image-dashboard",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_card_heading",
@@ -23,9 +24,9 @@ ts_web_library(
         "//tensorboard/components/tf_paginated_view",
         "//tensorboard/components/tf_runs_selector",
         "@org_polymer_iron_icon",
-        "@org_polymer_paper_input",
         "@org_polymer_paper_dialog",
         "@org_polymer_paper_icon_button",
+        "@org_polymer_paper_input",
         "@org_polymer_paper_slider",
         "@org_polymer_paper_spinner",
     ],
@@ -43,4 +44,3 @@ ts_web_library(
         "@org_polymer_paper_styles",
     ],
 )
-

--- a/tensorboard/plugins/profile/BUILD
+++ b/tensorboard/plugins/profile/BUILD
@@ -20,9 +20,10 @@ py_library(
     name = "profile_plugin",
     srcs = ["profile_plugin.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
-        ":trace_events_py",
         ":trace_events_json",
+        ":trace_events_py",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:plugin_asset_util",
@@ -36,8 +37,8 @@ py_test(
     srcs = ["profile_plugin_test.py"],
     srcs_version = "PY2AND3",
     deps = [
-        ":trace_events_py",
         ":profile_plugin",
+        ":trace_events_py",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend/event_processing:plugin_asset_util",
         "//tensorboard/plugins:base_plugin",
@@ -60,8 +61,8 @@ py_test(
     main = "trace_events_json_test.py",
     srcs_version = "PY2AND3",
     deps = [
-        ":trace_events_py",
         ":trace_events_json",
+        ":trace_events_py",
         "//tensorboard:expect_tensorflow_installed",
     ],
 )

--- a/tensorboard/plugins/profile/tf_profile_dashboard/BUILD
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/BUILD
@@ -6,10 +6,9 @@ licenses(["notice"])  # Apache 2.0
 
 ts_web_library(
     name = "tf_profile_dashboard",
-    srcs = [
-        "tf-profile-dashboard.html",
-    ],
+    srcs = ["tf-profile-dashboard.html"],
     path = "/tf-profile-dashboard",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_dashboard_common",
@@ -20,4 +19,3 @@ ts_web_library(
         "@org_polymer_paper_menu",
     ],
 )
-

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -12,7 +12,7 @@ py_library(
     name = "projector_plugin",
     srcs = ["projector_plugin.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//tensorboard:internal"],
+    visibility = ["//visibility:public"],
     deps = [
         ":protos_all_py",
         "//tensorboard:expect_numpy_installed",
@@ -24,27 +24,27 @@ py_library(
 )
 
 py_library(
-  name = "projector",
-  srcs = ["__init__.py"],
-  srcs_version = "PY2AND3",
-  visibility = ["//visibility:public"],
-  deps = [
-    ":protos_all_py",
-    ":projector_plugin",
-    "//tensorboard:expect_tensorflow_installed",
-  ]
+    name = "projector",
+    srcs = ["__init__.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":projector_plugin",
+        ":protos_all_py",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
 )
 
 py_test(
-  name = "projector_api_test",
-  size = "small",
-  srcs = ["projector_api_test.py"],
-  main = "projector_api_test.py",
-  srcs_version = "PY2AND3",
-  deps = [
-      ":projector",
-      "//tensorboard:expect_tensorflow_installed",
-  ]
+    name = "projector_api_test",
+    size = "small",
+    srcs = ["projector_api_test.py"],
+    main = "projector_api_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":projector",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
 )
 
 py_test(

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -12,9 +12,7 @@ py_library(
     name = "scalars_plugin",
     srcs = ["scalars_plugin.py"],
     srcs_version = "PY2AND3",
-    visibility = [
-        "//tensorboard:internal",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:http_util",

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -12,6 +12,7 @@ ts_web_library(
         "tf-smoothing-input.html",
     ],
     path = "/tf-scalar-dashboard",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_card_heading",
@@ -38,4 +39,3 @@ ts_web_library(
         "@org_polymer_paper_styles",
     ],
 )
-

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -12,9 +12,7 @@ py_library(
     name = "text_plugin",
     srcs = ["text_plugin.py"],
     srcs_version = "PY2AND3",
-    visibility = [
-        "//tensorboard:internal",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:http_util",

--- a/tensorboard/plugins/text/tf_text_dashboard/BUILD
+++ b/tensorboard/plugins/text/tf_text_dashboard/BUILD
@@ -11,6 +11,7 @@ ts_web_library(
         "tf-text-loader.html",
     ],
     path = "/tf-text-dashboard",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_card_heading",
@@ -44,4 +45,3 @@ ts_web_library(
         "@org_polymer_paper_styles",
     ],
 )
-


### PR DESCRIPTION
https://github.com/jart/tensorboard_plugin_example is being created as an
example of how people outside the TensorBoard team can create custom builds of
TensorBoard, with their own plugins, independently of the TensorBoard team. The
following changes are necessary for it to work properly.

The visibility of all rules others might want to link against has been changed
to public. Most of these libraries already have de facto public visibility via
the pip package, so we're essentially formalizing the status quo.

The branding in the TensorBoard GUI can now be customized. We encourage members
of the community to call their custom builds TensorBoard-X, to avoid confusing
users.

The main.py API has been tweaked just a tiny bit, to make it easier to use. A
minor bug was also fixed in exception re-raising.