### PR TITLE
Fixing issue #222 Proper np array object to string conversion

### DIFF
--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -226,7 +226,7 @@ def text_array_to_html(text_arr):
   """
   if not text_arr.shape:
     # It is a scalar. No need to put it in a table, just apply markdown
-    return markdown_and_sanitize(text_arr.astype(np.dtype(str)).tostring())
+    return markdown_and_sanitize(np.array_str(text_arr.astype(np.dtype(str))))
   warning = ''
   if len(text_arr.shape) > 2:
     warning = markdown_and_sanitize(WARNING_TEMPLATE % len(text_arr.shape))


### PR DESCRIPTION
tostring() function return bytes which cannot be properly decoded with decode('utf-8') in markdown_and_sanitize function.

```python
def markdown_and_sanitize(markdown_string):
  if isinstance(markdown_string, six.binary_type):
  markdown_string = markdown_string.decode('utf-8')
```
decoded **markdown_string** contains 3 NULL padding per every character and 8 NULL trailing padding at the end of the string. And **markdown module** cannot propery handle this null padded string, hence the #222 and other erronous markdown behavior.

This pull request change **"tostring"** function to np.array_str which return a plain string without any null padding. 

**markdown module** can handle this plain string without any problem, so that fixes #222 and other markdown problems.
