### PR TITLE
Change Werkzeug and Six build labels

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -34,7 +34,7 @@ py_binary(
         "//tensorboard/plugins/projector:projector_plugin",
         "//tensorboard/plugins/scalar:scalars_plugin",
         "//tensorboard/plugins/text:text_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
+        "@org_pocoo_werkzeug",
     ],
 )
 
@@ -119,7 +119,7 @@ py_test(
         ":test_util",
         ":util",
         "//tensorboard:expect_tensorflow_installed",
-        "@six_archive//:six",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -131,7 +131,7 @@ py_library(
     deps = [
         ":util",
         "//tensorboard:expect_tensorflow_installed",
-        "@six_archive//:six",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -15,8 +15,8 @@ py_library(
     deps = [
         ":json_util",
         "//tensorboard:expect_tensorflow_installed",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -28,8 +28,8 @@ py_test(
     deps = [
         ":http_util",
         "//tensorboard:expect_tensorflow_installed",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -68,8 +68,8 @@ py_library(
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins/core:core_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -84,7 +84,7 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
+        "@org_pocoo_werkzeug",
     ],
 )
 

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -27,7 +27,6 @@ import json
 import os
 import re
 import sqlite3
-import sys
 import threading
 import time
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -109,7 +109,7 @@ py_library(
         ":event_accumulator",
         ":io_wrapper",
         "//tensorboard:expect_tensorflow_installed",
-        "@six_archive//:six",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -13,7 +13,7 @@ filegroup(
         "@org_pocoo_werkzeug//:LICENSE",
         "@org_pythonhosted_markdown//:LICENSE.md",
         "@protobuf//:LICENSE",
-        "@six_archive//:LICENSE",
+        "@org_pythonhosted_six//:LICENSE",
     ]
 )
 

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -17,8 +17,8 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -34,8 +34,8 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -45,6 +45,6 @@ py_binary(
     srcs_version = "PY2AND3",
     deps = [
         "//tensorboard:expect_tensorflow_installed",
-        "@six_archive//:six",
+        "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/plugins/core/BUILD
+++ b/tensorboard/plugins/core/BUILD
@@ -16,8 +16,8 @@ py_library(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:http_util",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -32,7 +32,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/plugins/distribution/BUILD
+++ b/tensorboard/plugins/distribution/BUILD
@@ -17,8 +17,8 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -35,8 +35,8 @@ py_test(
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -19,8 +19,8 @@ py_library(
         "//tensorboard/backend:process_graph",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -36,7 +36,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -17,8 +17,8 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -35,8 +35,8 @@ py_test(
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -46,6 +46,6 @@ py_binary(
     srcs_version = "PY2AND3",
     deps = [
         "//tensorboard:expect_tensorflow_installed",
-        "@six_archive//:six",
+        "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -17,8 +17,8 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -34,7 +34,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/plugins/profile/BUILD
+++ b/tensorboard/plugins/profile/BUILD
@@ -28,7 +28,7 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:plugin_asset_util",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
+        "@org_pocoo_werkzeug",
     ],
 )
 
@@ -50,7 +50,7 @@ py_library(
     srcs = ["trace_events_json.py"],
     srcs_version = "PY2AND3",
     deps = [
-        "@six_archive//:six",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -19,7 +19,7 @@ py_library(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:http_util",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
+        "@org_pocoo_werkzeug",
     ],
 )
 
@@ -60,7 +60,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
+        "@org_pocoo_werkzeug",
     ],
 )
 

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -18,8 +18,8 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -35,8 +35,8 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -46,6 +46,6 @@ py_binary(
     srcs_version = "PY2AND3",
     deps = [
         "//tensorboard:expect_tensorflow_installed",
-        "@six_archive//:six",
+        "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -18,9 +18,9 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/plugins:base_plugin",
         "@org_mozilla_bleach",
-        "@org_pocoo_werkzeug//:werkzeug",
+        "@org_pocoo_werkzeug",
         "@org_pythonhosted_markdown",
-        "@six_archive//:six",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -36,7 +36,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
-        "@org_pocoo_werkzeug//:werkzeug",
-        "@six_archive//:six",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/scripts/BUILD
+++ b/tensorboard/scripts/BUILD
@@ -14,7 +14,7 @@ py_binary(
     deps = [
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
-        "@six_archive//:six",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/third_party/html5lib.BUILD
+++ b/third_party/html5lib.BUILD
@@ -12,6 +12,6 @@ py_library(
     srcs = glob(["html5lib/**/*.py"]),
     srcs_version = "PY2AND3",
     deps = [
-        "@six_archive//:six",
+        "@org_pythonhosted_six",
     ],
 )

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -60,3 +60,14 @@ def tensorboard_python_workspace():
       sha256 = "cc64dafbacc716cdd42503cf6c44cb5a35576443d82f29f6829e5c49264aeeee",
       build_file = str(Label("//third_party:werkzeug.BUILD")),
   )
+
+  native.new_http_archive(
+      name = "org_pythonhosted_six",
+      urls = [
+          "http://mirror.bazel.build/pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
+          "http://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
+      ],
+      sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
+      strip_prefix = "six-1.10.0",
+      build_file = str(Label("//third_party:six.BUILD")),
+  )

--- a/third_party/six.BUILD
+++ b/third_party/six.BUILD
@@ -7,7 +7,7 @@ licenses(["notice"])  # MIT
 exports_files(["LICENSE"])
 
 py_library(
-    name = "six",
+    name = "org_pythonhosted_six",
     srcs = ["six.py"],
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],

--- a/third_party/werkzeug.BUILD
+++ b/third_party/werkzeug.BUILD
@@ -7,7 +7,7 @@ exports_files(["LICENSE"])
 
 # Note: this library includes test code. Consider creating a testonly target.
 py_library(
-    name = "werkzeug",
+    name = "org_pocoo_werkzeug",
     srcs = glob(["werkzeug/**/*.py"]),
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -27,21 +27,7 @@ def tensorboard_workspace():
   tensorboard_python_workspace()
   tensorboard_typings_workspace()
   tensorboard_js_workspace()
-  native.new_http_archive(
-      name = "six_archive",
-      urls = [
-          "http://mirror.bazel.build/pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
-          "http://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
-      ],
-      sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
-      strip_prefix = "six-1.10.0",
-      build_file = str(Label("//third_party:six.BUILD")),
-  )
 
-  native.bind(
-      name = "six",
-      actual = "@six_archive//:six",
-  )
   native.http_archive(
       name = "protobuf",
       urls = [
@@ -70,6 +56,12 @@ def tensorboard_workspace():
       strip_prefix = "protobuf-2b7430d96aeff2bb624c8d52182ff5e4b9f7f18a",
   )
 
+  # Protobuf's BUILD file depends on //external:six.
+  native.bind(
+      name = "six",
+      actual = "@org_pythonhosted_six",
+  )
+
   filegroup_external(
       name = "org_chromium_chromedriver",
       licenses = ["notice"],  # Apache 2.0
@@ -87,8 +79,6 @@ def tensorboard_workspace():
       },
       generated_rule_name = "archive",
   )
-
-
 
   # Roughly corresponds to Chrome 55
   filegroup_external(


### PR DESCRIPTION
This is slight breaking change. BUILD files must be updated as follows:

- @six_archive//:six             -> @org_pythonhosted_six
- @org_pocoo_werkzeug//:werkzeug -> @org_pocoo_werkzeug

We want repository names to be consistently canonicalized with DNS. We also
want the primary build rule in a repository to have the same name as the
repository itself. This allows us to take advantage of Bazel's elegant label
shortening.