### PR TITLE
Create a tensor histogram summary

### DIFF
--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -14,6 +14,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        ":metadata",
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",
@@ -30,6 +31,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":histograms_plugin",
+        ":summary",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_accumulator",
@@ -40,11 +42,50 @@ py_test(
     ],
 )
 
+py_library(
+    name = "metadata",
+    srcs = ["metadata.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//tensorboard:internal",
+    ],
+    deps = [
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_library(
+    name = "summary",
+    srcs = ["summary.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":metadata",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_test(
+    name = "summary_test",
+    size = "small",
+    srcs = ["summary_test.py"],
+    main = "summary_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":summary",
+        "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
+    ],
+)
+
 py_binary(
     name = "histograms_demo",
     srcs = ["histograms_demo.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":summary",
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -21,6 +21,8 @@ from __future__ import print_function
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
+from tensorboard.plugins.histogram import summary as histogram_summary
+
 # Directory into which to write tensorboard data.
 LOGDIR = '/tmp/histograms_demo'
 
@@ -29,40 +31,42 @@ def run_all(logdir, verbose=False):
   """Generate a bunch of histogram data, and write it to logdir."""
   del verbose
 
+  tf.set_random_seed(0)
+
   k = tf.placeholder(tf.float32)
 
   # Make a normal distribution, with a shifting mean
   mean_moving_normal = tf.random_normal(shape=[1000], mean=(5*k), stddev=1)
   # Record that distribution into a histogram summary
-  tf.summary.histogram("normal/moving_mean", mean_moving_normal)
+  histogram_summary.op("normal/moving_mean", mean_moving_normal)
 
   # Make a normal distribution with shrinking variance
   shrinking_normal = tf.random_normal(shape=[1000], mean=0, stddev=1-(k))
   # Record that distribution too
-  tf.summary.histogram("normal/shrinking_variance", shrinking_normal)
+  histogram_summary.op("normal/shrinking_variance", shrinking_normal)
 
   # Let's combine both of those distributions into one dataset
   normal_combined = tf.concat([mean_moving_normal, shrinking_normal], 0)
   # We add another histogram summary to record the combined distribution
-  tf.summary.histogram("normal/bimodal", normal_combined)
+  histogram_summary.op("normal/bimodal", normal_combined)
 
   # Add a gamma distribution
   gamma = tf.random_gamma(shape=[1000], alpha=k)
-  tf.summary.histogram("gamma", gamma)
+  histogram_summary.op("gamma", gamma)
 
   # And a poisson distribution
   poisson = tf.random_poisson(shape=[1000], lam=k)
-  tf.summary.histogram("poisson", poisson)
+  histogram_summary.op("poisson", poisson)
 
   # And a uniform distribution
   uniform = tf.random_uniform(shape=[1000], maxval=k*10)
-  tf.summary.histogram("uniform", uniform)
+  histogram_summary.op("uniform", uniform)
 
   # Finally, combine everything together!
   all_distributions = [mean_moving_normal, shrinking_normal,
                        gamma, poisson, uniform]
   all_combined = tf.concat(all_distributions, 0)
-  tf.summary.histogram("all_combined", all_combined)
+  histogram_summary.op("all_combined", all_combined)
 
   summaries = tf.summary.merge_all()
 

--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -12,25 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""The TensorBoard Histograms plugin."""
+"""The TensorBoard Histograms plugin.
+
+This plugin's `/histograms` route returns a result of the form
+
+    [wall_time, step, [left0, right0, count0], ...],
+
+where each inner array corresponds to a single bucket in the histogram.
+"""
 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import six
 from werkzeug import wrappers
+
+import numpy as np
+import tensorflow as tf
 
 from tensorboard.backend import http_util
 from tensorboard.backend.event_processing import event_accumulator
 from tensorboard.plugins import base_plugin
-
-_PLUGIN_PREFIX_ROUTE = event_accumulator.HISTOGRAMS
+from tensorboard.plugins.histogram import metadata
 
 
 class HistogramsPlugin(base_plugin.TBPlugin):
-  """Histograms Plugin for TensorBoard."""
+  """Histograms Plugin for TensorBoard.
 
-  plugin_name = _PLUGIN_PREFIX_ROUTE
+  This supports both old-style summaries (created with TensorFlow ops
+  that output directly to the `histo` field of the proto) and new-style
+  summaries (as created by the `tensorboard.plugins.histogram.summary`
+  module).
+  """
+
+  plugin_name = metadata.PLUGIN_NAME
 
   def __init__(self, context):
     """Instantiates HistogramsPlugin via TensorBoard core.
@@ -51,16 +67,64 @@ class HistogramsPlugin(base_plugin.TBPlugin):
     return bool(self._multiplexer) and any(self.index_impl().values())
 
   def index_impl(self):
-    return {
-        run_name: run_data[event_accumulator.HISTOGRAMS]
-        for (run_name, run_data) in self._multiplexer.Runs().items()
-        if event_accumulator.HISTOGRAMS in run_data
-    }
+    """Return {runName: {tagName: {displayName: ..., description: ...}}}."""
+    runs = self._multiplexer.Runs()
+    result = {run: {} for run in runs}
+
+    # Old-style runs
+    for (run, run_data) in six.iteritems(runs):
+      for tag in run_data.get(event_accumulator.HISTOGRAMS, []):
+        result[run][tag] = {'displayName': tag, 'description': ''}
+
+    # New-style runs
+    mapping = self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME)
+    for (run, tag_to_content) in six.iteritems(mapping):
+      for (tag, content) in six.iteritems(tag_to_content):
+        content = metadata.parse_summary_metadata(content)
+        summary_metadata = self._multiplexer.SummaryMetadata(run, tag)
+        result[run][tag] = {'displayName': summary_metadata.display_name,
+                            'description': summary_metadata.summary_description}
+
+    return result
 
   def histograms_impl(self, tag, run):
-    """Result of the form `(body, mime_type)`."""
-    values = self._multiplexer.Histograms(run, tag)
-    return (values, 'application/json')
+    """Result of the form `(body, mime_type)`, or `ValueError`."""
+    #
+    # Reconcile results from old-style and new-style runs (preferring
+    # new-style runs if there's a conflict).
+    tensor_events = None
+    try:
+      tensor_events = self._multiplexer.Tensors(run, tag)
+    except KeyError:
+      try:
+        old_style_events = self._multiplexer.Histograms(run, tag)
+      except KeyError:
+        pass
+      else:
+        tensor_events = [self._convert_old_style_histogram_event(ev)
+                         for ev in old_style_events]
+    if tensor_events is None:
+      raise ValueError('No histogram tag %r for run %r' % (tag, run))
+    return ([[ev.wall_time, ev.step, tf.make_ndarray(ev.tensor_proto).tolist()]
+             for ev in tensor_events],
+            'application/json')
+
+  def _convert_tensor_event_to_json(self, ev):
+    return [ev.wall_time, ev.step, tf.make_ndarray(ev.tensor_proto).tolist()]
+
+  def _convert_old_style_histogram_event(self, ev):
+    tensor_proto = self._convert_old_style_histogram_value(ev.histogram_value)
+    return event_accumulator.TensorEvent(
+        wall_time=ev.wall_time,
+        step=ev.step,
+        tensor_proto=tensor_proto)
+
+  def _convert_old_style_histogram_value(self, histogram_value):
+    bucket_lefts = [histogram_value.min] + histogram_value.bucket_limit[:-1]
+    bucket_rights = histogram_value.bucket_limit[:-1] + [histogram_value.max]
+    bucket_counts = histogram_value.bucket
+    buckets = np.array(list(zip(bucket_lefts, bucket_rights, bucket_counts)))
+    return tf.make_tensor_proto(buckets)
 
   @wrappers.Request.application
   def tags_route(self, request):
@@ -72,5 +136,10 @@ class HistogramsPlugin(base_plugin.TBPlugin):
     """Given a tag and single run, return array of histogram values."""
     tag = request.args.get('tag')
     run = request.args.get('run')
-    (body, mime_type) = self.histograms_impl(tag, run)
-    return http_util.Respond(request, body, mime_type)
+    try:
+      (body, mime_type) = self.histograms_impl(tag, run)
+      code = 200
+    except ValueError as e:
+      (body, mime_type) = (str(e), 'text/plain')
+      code = 400
+    return http_util.Respond(request, body, mime_type, code=code)

--- a/tensorboard/plugins/histogram/metadata.py
+++ b/tensorboard/plugins/histogram/metadata.py
@@ -1,0 +1,43 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Information about histogram summaries."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+import json
+
+import tensorflow as tf
+
+
+PLUGIN_NAME = 'histograms'
+
+
+HistogramMetadata = collections.namedtuple('HistogramMetadata', ())
+
+
+def create_summary_metadata(display_name, description):
+  content = HistogramMetadata()
+  metadata = tf.SummaryMetadata(display_name=display_name,
+                                summary_description=description)
+  metadata.plugin_data.add(plugin_name=PLUGIN_NAME,
+                           content=json.dumps(content._asdict()))  # pylint: disable=protected-access
+  return metadata
+
+
+def parse_summary_metadata(content):
+  return HistogramMetadata(**json.loads(content))

--- a/tensorboard/plugins/histogram/summary.py
+++ b/tensorboard/plugins/histogram/summary.py
@@ -1,0 +1,195 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Histogram summaries and TensorFlow operations to create them.
+
+A histogram summary stores a list of buckets. Each bucket is encoded as
+a triple `[left_edge, right_edge, count]`. Thus, a full histogram is
+encoded as a tensor of dimension `[k, 3]`.
+
+In general, the value of `k` (the number of buckets) will be a constant,
+like 30. There are two edge cases: if there is no data, then there are
+no buckets (the shape is `[0, 3]`); and if there is data but all points
+have the same value, then there is one bucket whose left and right
+endpoints are the same (the shape is `[1, 3]`).
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+import numpy as np
+
+from tensorboard.plugins.histogram import metadata
+
+
+DEFAULT_BUCKET_COUNT = 30
+
+
+def _buckets(data, bucket_count=None):
+  """Create a TensorFlow op to group data into histogram buckets.
+
+  Arguments:
+    data: A `Tensor` of any shape. Must be compatible with `float64`.
+    bucket_count: Optional positive `int` or scalar `int32` `Tensor`.
+  Returns:
+    A `Tensor` of shape `[k, 3]` and type `float64`. The `i`th row is
+    a triple `[left_edge, right_edge, count]` for a single bucket.
+    The value of `k` is either `bucket_count` or `1` or `0`.
+  """
+  if bucket_count is None:
+    bucket_count = DEFAULT_BUCKET_COUNT
+  with tf.name_scope('buckets', values=[data, bucket_count]), \
+       tf.control_dependencies([tf.assert_scalar(bucket_count),
+                                tf.assert_type(bucket_count, tf.int32)]):
+    data = tf.reshape(data, shape=[-1])  # flatten
+    data = tf.cast(data, tf.float64)
+    is_empty = tf.equal(tf.size(data), 0)
+
+    def when_empty():
+      return tf.constant([], shape=(0, 3), dtype=tf.float64)
+
+    def when_nonempty():
+      min_ = tf.reduce_min(data)
+      max_ = tf.reduce_max(data)
+      range_ = max_ - min_
+      is_singular = tf.equal(range_, 0)
+
+      def when_nonsingular():
+        bucket_width = range_ / tf.cast(bucket_count, tf.float64)
+        offsets = data - min_
+        bucket_indices = tf.cast(tf.floor(offsets / bucket_width),
+                                 dtype=tf.int32)
+        clamped_indices = tf.minimum(bucket_indices, bucket_count - 1)
+        one_hots = tf.one_hot(clamped_indices, depth=bucket_count)
+        bucket_counts = tf.cast(tf.reduce_sum(one_hots, axis=0),
+                                dtype=tf.float64)
+        edges = tf.lin_space(min_, max_, bucket_count + 1)
+        left_edges = edges[:-1]
+        right_edges = edges[1:]
+        return tf.transpose(tf.stack(
+            [left_edges, right_edges, bucket_counts]))
+
+      def when_singular():
+        center = min_
+        bucket_starts = tf.stack([center - 0.5])
+        bucket_ends = tf.stack([center + 0.5])
+        bucket_counts = tf.stack([tf.cast(tf.size(data), tf.float64)])
+        return tf.transpose(
+            tf.stack([bucket_starts, bucket_ends, bucket_counts]))
+
+      return tf.cond(is_singular, when_singular, when_nonsingular)
+
+    return tf.cond(is_empty, when_empty, when_nonempty)
+
+
+def op(name,
+       data,
+       bucket_count=None,
+       display_name=None,
+       description=None,
+       collections=None):
+  """Create a histogram summary op.
+
+  Arguments:
+    name: A unique name for the generated summary node.
+    data: A `Tensor` of any shape. Must be compatible with `float64`.
+    bucket_count: Optional positive `int`. The output will have this
+      many buckets, except in two edge cases. If there is no data, then
+      there are no buckets. If there is data but all points have the
+      same value, then there is one bucket whose left and right
+      endpoints are the same.
+    display_name: Not yet supported; do not use. (Eventually: Optional
+      name for this summary in TensorBoard. Defaults to `name`.)
+    description: Not yet supported; do not use. (Eventually: Optional
+      long-form description for this summary. Markdown is supported.)
+    collections: Optional list of graph collections keys. The new
+      summary op is added to these collections. Defaults to
+      `[Graph Keys.SUMMARIES]`.
+
+  Returns:
+    A TensorFlow summary op.
+  """
+  if display_name is None:
+    display_name = name
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=display_name, description=description)
+  with tf.name_scope(name):
+    tensor = _buckets(data, bucket_count=bucket_count)
+    return tf.summary.tensor_summary(name='histogram_summary',
+                                     tensor=tensor,
+                                     collections=collections,
+                                     summary_metadata=summary_metadata)
+
+
+def pb(name, data, bucket_count=None, display_name=None, description=None):
+  """Create a histogram summary protobuf.
+
+  Arguments:
+    name: A unique name for the generated summary, including any desired
+      name scopes.
+    data: A `np.array` or array-like form of any shape. Must have type
+      compatible with `float`.
+    bucket_count: Optional positive `int`. The output will have this
+      many buckets, except in two edge cases. If there is no data, then
+      there are no buckets. If there is data but all points have the
+      same value, then there is one bucket whose left and right
+      endpoints are the same.
+    display_name: Not yet supported; do not use. (Eventually: Optional
+      name for this summary in TensorBoard. Defaults to `name`.)
+    description: Not yet supported; do not use. (Eventually: Optional
+      long-form description for this summary. Markdown is supported.)
+
+  Returns:
+    A `tf.Summary` protobuf object.
+  """
+  if bucket_count is None:
+    bucket_count = DEFAULT_BUCKET_COUNT
+  data = np.array(data).flatten().astype(float)
+  if data.size == 0:
+    buckets = np.array([]).reshape((0, 3))
+  else:
+    min_ = np.min(data)
+    max_ = np.max(data)
+    range_ = max_ - min_
+    if range_ == 0:
+      center = min_
+      buckets = np.array([[center - 0.5, center + 0.5, float(data.size)]])
+    else:
+      bucket_width = range_ / bucket_count
+      offsets = data - min_
+      bucket_indices = np.floor(offsets / bucket_width).astype(int)
+      clamped_indices = np.minimum(bucket_indices, bucket_count - 1)
+      one_hots = (np.array([clamped_indices]).transpose()
+                  == np.arange(0, bucket_count))  # broadcast
+      assert one_hots.shape == (data.size, bucket_count), (
+          one_hots.shape, (data.size, bucket_count))
+      bucket_counts = np.sum(one_hots, axis=0)
+      edges = np.linspace(min_, max_, bucket_count + 1)
+      left_edges = edges[:-1]
+      right_edges = edges[1:]
+      buckets = np.array([left_edges, right_edges, bucket_counts]).transpose()
+  tensor = tf.make_tensor_proto(buckets, dtype=tf.float64)
+
+  if display_name is None:
+    display_name = name
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=display_name, description=description)
+
+  summary = tf.Summary()
+  summary.value.add(tag='%s/histogram_summary' % name,
+                    metadata=summary_metadata,
+                    tensor=tensor)
+  return summary

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the histogram plugin summary generation functions."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+
+from tensorboard.plugins.histogram import metadata
+from tensorboard.plugins.histogram import summary
+
+
+class SummaryTest(tf.test.TestCase):
+
+  def setUp(self):
+    super(SummaryTest, self).setUp()
+    tf.reset_default_graph()
+
+    np.random.seed(0)
+    self.gaussian = np.random.normal(size=[500])
+
+  def pb_via_op(self, summary_op, feed_dict=None):
+    actual_pbtxt = tf.Session().run(summary_op, feed_dict=feed_dict or {})
+    actual_proto = tf.Summary()
+    actual_proto.ParseFromString(actual_pbtxt)
+    return actual_proto
+
+  def compute_and_check_summary_pb(self,
+                                   name='nemo',
+                                   data=None,
+                                   bucket_count=None,
+                                   display_name=None,
+                                   description=None,
+                                   data_tensor=None,
+                                   bucket_count_tensor=None,
+                                   feed_dict=None):
+    """Use both `op` and `pb` to get a summary, asserting equality.
+
+    Returns:
+      a `Summary` protocol buffer
+    """
+    if data is None:
+      data = self.gaussian
+    if data_tensor is None:
+      data_tensor = tf.constant(data)
+    if bucket_count_tensor is None:
+      bucket_count_tensor = bucket_count
+    op = summary.op(name, data_tensor, bucket_count=bucket_count_tensor,
+                    display_name=display_name, description=description)
+    pb = summary.pb(name, data, bucket_count=bucket_count,
+                    display_name=display_name, description=description)
+    pb_via_op = self.pb_via_op(op, feed_dict=feed_dict)
+    self.assertProtoEquals(pb, pb_via_op)
+    return pb
+
+  def test_metadata(self):
+    # We're going to assume that the basic metadata is handled the same
+    # across all data cases (unless explicitly changed).
+    pb = self.compute_and_check_summary_pb(name='widgets')
+    self.assertEqual(len(pb.value), 1)
+    self.assertEqual(pb.value[0].tag, 'widgets/histogram_summary')
+    summary_metadata = pb.value[0].metadata
+    self.assertEqual(summary_metadata.display_name, 'widgets')
+    self.assertEqual(summary_metadata.summary_description, '')
+    plugin_data = summary_metadata.plugin_data[0]
+    self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
+    self.assertEqual(summary_metadata.plugin_data[0].content, '{}')
+
+  def test_explicit_display_name_and_description(self):
+    display_name = 'Widget metrics'
+    description = 'Tracks widget production; *units*: MacGuffins/hr'
+    pb = self.compute_and_check_summary_pb(name='widgets',
+                                           display_name=display_name,
+                                           description=description)
+    summary_metadata = pb.value[0].metadata
+    self.assertEqual(summary_metadata.display_name, display_name)
+    self.assertEqual(summary_metadata.summary_description, description)
+    plugin_data = summary_metadata.plugin_data[0]
+    self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
+    self.assertEqual(plugin_data.content, '{}')
+
+  def test_empty_input(self):
+    pb = self.compute_and_check_summary_pb('nothing_to_see_here', [])
+    buckets = tf.make_ndarray(pb.value[0].tensor)
+    np.testing.assert_allclose(buckets, np.array([]).reshape((0, 3)))
+
+  def test_empty_input_of_high_rank(self):
+    pb = self.compute_and_check_summary_pb('move_along', [[[], []], [[], []]])
+    buckets = tf.make_ndarray(pb.value[0].tensor)
+    np.testing.assert_allclose(buckets, np.array([]).reshape((0, 3)))
+
+  def test_singleton_input(self):
+    pb = self.compute_and_check_summary_pb('twelve', [12])
+    buckets = tf.make_ndarray(pb.value[0].tensor)
+    np.testing.assert_allclose(buckets, np.array([[11.5, 12.5, 1]]))
+
+  def test_input_with_all_same_values(self):
+    pb = self.compute_and_check_summary_pb('twelven', [12, 12, 12])
+    buckets = tf.make_ndarray(pb.value[0].tensor)
+    np.testing.assert_allclose(buckets, np.array([[11.5, 12.5, 3]]))
+
+  def test_normal_input(self):
+    bucket_count = 44
+    pb = self.compute_and_check_summary_pb(data=self.gaussian.reshape((5, -1)),
+                                           bucket_count=bucket_count)
+    buckets = tf.make_ndarray(pb.value[0].tensor)
+    self.assertEqual(buckets[:, 0].min(), self.gaussian.min())
+    self.assertEqual(buckets[:, 1].max(), self.gaussian.max())
+    self.assertEqual(buckets[:, 2].sum(), self.gaussian.size)
+    np.testing.assert_allclose(buckets[1:, 0], buckets[:-1, 1])
+
+  def test_when_shape_not_statically_known(self):
+    placeholder = tf.placeholder(tf.float64, shape=None)
+    reshaped = self.gaussian.reshape((25, -1))
+    self.compute_and_check_summary_pb(data=reshaped,
+                                      data_tensor=placeholder,
+                                      feed_dict={placeholder: reshaped})
+    # The proto-equality check is all we need.
+
+  def test_when_bucket_count_not_statically_known(self):
+    placeholder = tf.placeholder(tf.int32, shape=())
+    bucket_count = 44
+    pb = self.compute_and_check_summary_pb(
+        bucket_count=bucket_count,
+        bucket_count_tensor=placeholder,
+        feed_dict={placeholder: bucket_count})
+    buckets = tf.make_ndarray(pb.value[0].tensor)
+    self.assertEqual(buckets.shape, (bucket_count, 3))
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -154,6 +154,7 @@ limitations under the License.
 
         _selectedRuns: Array,
         _runToTag: Object,  // map<run: string, tags: string[]>
+        _runToTagInfo: Object,
         _dataNotFound: Boolean,
 
         _tagFilter: {
@@ -182,14 +183,16 @@ limitations under the License.
       },
       _fetchTags() {
         const url = getRouter().pluginRoute('histograms', '/tags');
-        return this._requestManager.request(url).then(runToTag => {
-          if (_.isEqual(runToTag, this._runToTag)) {
+        return this._requestManager.request(url).then(runToTagInfo => {
+          if (_.isEqual(runToTagInfo, this._runToTagInfo)) {
             // No need to update anything if there are no changes.
             return;
           }
+          const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
           const tags = getTags(runToTag);
           this.set('_dataNotFound', tags.length === 0);
           this.set('_runToTag', runToTag);
+          this.set('_runToTagInfo', runToTagInfo);
         });
       },
       _reloadHistograms() {
@@ -199,6 +202,8 @@ limitations under the License.
       },
 
       _makeCategories(runToTag, selectedRuns, tagFilter) {
+        // TODO(@wchargin): Incorporate the tags' display names and
+        // descriptions.
         return categorizeRunTagCombinations(runToTag, selectedRuns, tagFilter);
       },
     });


### PR DESCRIPTION
Summary:
This commit introduces a new-style summary for histograms, which new
code should prefer over `tf.summary.histogram`. The new summary is not
privileged and is built on top of `tensor_summary`.

I've updated the histogram dashboard to support both the old and new
forms.

Once `display_name` and `description` are implemented, we can start
using those in the API, backend, and frontend. Doing so will give us the
opportunity to strip out the ugly `.../histogram_summary` from the tag
on the frontend. (I could have done this in this commit, but wanted to
keep it reasonably sized.)

Note: we don't have a way to run the `histogramTests` on the frontend,
and per #174 they don't pass anyway. I tried to make them valid but did
not run them and provide no guarantees!

Test Plan:
Generate test data by changing the demo's log directory to
`/tmp/new_histograms_demo` and re-running the demo. (Make sure to keep
your old data for comparison.) Change the event accumulator's size
guidance for tensors to `50` to match that of the old-style histograms.
Then, launch TensorBoard and make sure that the histograms render
correctly, both new and old. (There may be some minor bucketing
differences because the old-style histograms create their buckets in a
different way and also have different `min` and `max` than new-style
histograms, but the representations should be qualitatively the same.)

Screenshot:
![Example screenshot (new and old data).](https://user-images.githubusercontent.com/4317806/28437087-3763d16c-6d4e-11e7-9740-73ad563a4af1.png)

Also, run tests!

wchargin-branch: tensor-histogram-summary