### PR TITLE
Allow `runToTag` to omit irrelevant runs

### DIFF
--- a/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
+++ b/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
@@ -116,7 +116,7 @@ export function categorizeTags(
     tagToRuns[tag] = [];
   });
   selectedRuns.forEach(run => {
-    runToTag[run].forEach(tag => {
+    (runToTag[run] || []).forEach(tag => {
       tagToRuns[tag].push(run);
     });
   });


### PR DESCRIPTION
Summary:
The categorization utils require that any run in selectedRuns have a
corresponding entry in runToTag. By relaxing this requirement (and
defaulting to []) we make it easier for alternate backends to
implement the /tags routes.

Test Plan:
Verified that when the output of /data/plugin/histograms/tags is
changed to not include runs without histogram tags, the categorization
functions still work without raising "cannot read property forEach of
undefined."