### PR TITLE
Mark webdriver tests as flaky

### DIFF
--- a/tensorboard/functionaltests/BUILD
+++ b/tensorboard/functionaltests/BUILD
@@ -11,10 +11,11 @@ py_web_test_suite(
     data = [
         "//tensorboard",
     ],
+    flaky = True,
     srcs_version = "PY2AND3",
     deps = [
-        "@io_bazel_rules_webtesting//testing/web",
-        "//tensorboard/plugins/scalar:scalars_demo",
         "//tensorboard/plugins/audio:audio_demo",
+        "//tensorboard/plugins/scalar:scalars_demo",
+        "@io_bazel_rules_webtesting//testing/web",
     ],
 )


### PR DESCRIPTION
Summary:
Per the [Bazel docs], this should let the test run up to three times
until it's marked as failed. A stopgap to reduce build failures and
overall build times (we won't have to wait for a full 10-minute build,
just a 100-second re-test…(“just”…)).

[Bazel docs]: https://docs.bazel.build/versions/master/be/common-definitions.html#test.flaky

Test Plan:
None.

wchargin-branch: mark-webdriver-flaky