### PR TITLE
Bump Travis TensorFlow nightly URL: 1.2.1 → 1.3.0rc0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before_install:
         ;;
       NIGHTLY)
         if [[ "${TRAVIS_PYTHON_VERSION}" == 2* ]]; then
-          NIGHTLY_URL='https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-1.2.1-cp27-none-linux_x86_64.whl'
+          NIGHTLY_URL='https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-1.3.0rc0-cp27-none-linux_x86_64.whl'
         else
-          NIGHTLY_URL='https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-1.2.1-cp34-cp34m-linux_x86_64.whl'
+          NIGHTLY_URL='https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-1.3.0rc0-cp34-cp34m-linux_x86_64.whl'
         fi
         pip install "${NIGHTLY_URL}"
         ;;


### PR DESCRIPTION
Summary:
Re-application of #182.

Test Plan:
Consider the following command:
```sh
grep -F NIGHTLY_URL= .travis.yml | \
    cut -d \' -f 2 | \
    xargs curl -sI | \
    grep -F 'HTTP/1.1'
```
Before this commit, it outputs:
```
HTTP/1.1 404 Not Found
HTTP/1.1 404 Not Found
```
After this commit, it outputs:
```
HTTP/1.1 200 OK
HTTP/1.1 200 OK
```

wchargin-branch: bump-tf-nightly-to-1.3.0rc0