### PR TITLE
Fixed annotation coloring when node is expanded.

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -668,7 +668,7 @@ export function stylize(nodeGroup, renderInfo: render.RenderNodeInfo,
   let isHighlighted = sceneElement.isNodeHighlighted(renderInfo.node.name);
   let isSelected = sceneElement.isNodeSelected(renderInfo.node.name);
   let isExtract = renderInfo.isInExtract || renderInfo.isOutExtract;
-  let isExpanded = renderInfo.expanded;
+  let isExpanded = renderInfo.expanded && nodeClass !== Class.Annotation.NODE;
   let isFadedOut = renderInfo.isFadedOut;
   nodeGroup.classed('highlighted', isHighlighted);
   nodeGroup.classed('selected', isSelected);


### PR DESCRIPTION
Originally, when expanding a node, all annotation nodes representing that node
would take on the expanded color. Now, the annotation nodes will retain the
color of the non-expanded node.