### PR TITLE
Fix typo in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,7 @@ bazel run //tensorboard -- --logdir /path/to/logs
 If you need to generate fake data, run:
 
 ```sh
-bazel run //tensorboard/plugins/scalars:scalars_demo
+bazel run //tensorboard/plugins/scalar:scalars_demo
 ```
 
 This will generate some fake scalar data in `/tmp/scalars_demo`.


### PR DESCRIPTION
Not found `plugins/scalars` dir.