### PR TITLE
Fixed annotation node hover/highlighting bug

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -335,7 +335,7 @@ export class RenderGraphInfo {
   getNearestVisibleAncestor(name: string): string {
     let path = getHierarchicalPath(name);
     let i = 0;
-    let renderNode : RenderNodeInfo = null;
+    let renderNode: RenderNodeInfo = null;
     // Fallthrough. If everything was expanded return the node.
     let nodeName = name;
     for (; i < path.length; i++) {
@@ -353,11 +353,13 @@ export class RenderGraphInfo {
     // displayed.
     if (i == path.length - 2) {
       let nextName = path[i + 1];
-      if (renderNode.inAnnotations.nodeNames[nextName])
+      if (renderNode.inAnnotations.nodeNames[nextName]) {
         return nextName;
+      }
 
-      if (renderNode.outAnnotations.nodeNames[nextName])
+      if (renderNode.outAnnotations.nodeNames[nextName]) {
         return nextName;
+      }
     }
 
     return nodeName;

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -334,15 +334,33 @@ export class RenderGraphInfo {
    */
   getNearestVisibleAncestor(name: string): string {
     let path = getHierarchicalPath(name);
-    for (let i = 0; i < path.length; i++) {
-      let nodeName = path[i];
+    let i = 0;
+    let renderNode : RenderNodeInfo = null;
+    // Fallthrough. If everything was expanded return the node.
+    let nodeName = name;
+    for (; i < path.length; i++) {
+      nodeName = path[i];
+      renderNode = this.getRenderNodeByName(nodeName);
       // Op nodes have expanded set to false by default.
-      if (!this.getRenderNodeByName(nodeName).expanded) {
-        return nodeName;
+      if (!renderNode.expanded) {
+        break;
       }
     }
-    // Fallthrough. If everything was expanded return the node.
-    return name;
+
+    // Check case where highlighted node is an embedded node whose parent node
+    // is also its hierarchical parent. In this case, we want to return the
+    // embedded node name, as it is also displayed if its parent has been
+    // displayed.
+    if (i == path.length - 2) {
+      let nextName = path[i + 1];
+      if (renderNode.inAnnotations.nodeNames[nextName])
+        return nextName;
+
+      if (renderNode.outAnnotations.nodeNames[nextName])
+        return nextName;
+    }
+
+    return nodeName;
   }
 
   // TODO: Delete this an any code it touches (all deprecated).


### PR DESCRIPTION
Annotation nodes were not being properly highlighted if there parent's
name was a substring of their hierarchical path name. Say we had a node
'A/B/C' who is an annotation node for node 'A/B'. Originally, when we
hovered over the node 'A/B/C', the node 'A/B' would be highlighted. We
fix this bug by first finding the first non-expanded node, and then
checking to see if the next node is an annotation of the first
non-expanded node, which means that it is also visible.