### PR TITLE
Fix minor typographical issues in ADDING_A_PLUGIN

### DIFF
--- a/ADDING_A_PLUGIN.md
+++ b/ADDING_A_PLUGIN.md
@@ -5,7 +5,7 @@ reviewed occasionally to make sure it stays up-to-date. -->
 
 ## Overview
 
-You know (and, we hope, love!) TensorBoard's core features like the scalar dashboard, the graph explorer, and the embedding projector. However, in every TensorBoard user's life, there comes a time when they want some cool new visualization that just…doesn't exist yet. That's what this plugin system is for.
+You know (and, we hope, love!) TensorBoard’s core features like the scalar dashboard, the graph explorer, and the embedding projector. However, in every TensorBoard user’s life, there comes a time when they want some cool new visualization that just…doesn’t exist yet. That’s what this plugin system is for.
 
 We want to enable everyone in the TensorFlow community to add new dashboards and visualizations to TensorBoard. You can do this by writing a TensorBoard plugin. Doing so requires you to have some familiarity with JavaScript development (for building a web-based visualization) and with Python development (for writing the plugin backend).
 
@@ -13,7 +13,7 @@ This document is a living guide on best practices for adding a plugin to TensorB
 
 ## Background
 
-To be successful writing a TensorBoard Plugin, you'll need to be familiar with general TensorBoard usage. We recommend starting with Dandelion Mané's [Hands-on TensorBoard] tutorial at the 2017 TensorFlow Dev Summit. We then recommend taking a look at the [TensorBoard README] and working through the tutorial.
+To be successful writing a TensorBoard Plugin, you’ll need to be familiar with general TensorBoard usage. We recommend starting with Dandelion Mané’s [Hands-on TensorBoard] tutorial at the 2017 TensorFlow Dev Summit. We then recommend taking a look at the [TensorBoard README] and working through the tutorial.
 
 [Hands-on TensorBoard]: https://www.youtube.com/watch?v=eBbEDRsCmv4&t=5s
 [TensorBoard README]: https://github.com/tensorflow/tensorboard/blob/master/README.md
@@ -29,7 +29,7 @@ The TensorFlow summary system captures tensors as they flow through the graph, a
 
 The following three fields of the `Summary` protobuf are the most important:
 
-  - The `tag`, which is a string that is uniquely associated with a certain "stream" of related data.
+  - The `tag`, which is a string that is uniquely associated with a certain “stream” of related data.
   - The [`SummaryMetadata` object], which contains metadata associated with that `tag`, including plugin-specific metadata. You can store your own arbitrary binary encoded protobufs in its fields.
   - The [`TensorProto`] content field. We use `TensorProto` because they are generally a natural way of representing data in TensorFlow. Since `TensorProtos` support arbitrary byte arrays, you can put any kind of data in them.
 
@@ -42,11 +42,11 @@ The following three fields of the `Summary` protobuf are the most important:
 
 ### TensorBoard data model: runs and tags
 
-Let's say you train a model with three sets of hyperparameters. Logically, you want to keep track of which data was associated with which set of hyperparameters, or which 'run' of TensorFlow. That gives us the TensorBoard concept of a `run`.
+Let’s say you train a model with three sets of hyperparameters. Logically, you want to keep track of which data was associated with which set of hyperparameters, or which ‘run’ of TensorFlow. That gives us the TensorBoard concept of a `run`.
 
 A `run` describes a sequence of events that came from a single execution context of TensorFlow. Each event has a timestamp and a monotonically increasing step counter, which was passed to the [`add_summary`] method.
 
-You'll probably track multiple parameters in your model: say, the accuracy, precision, and cross-entropy. Each of these will have its own `tag`. Each `tag` tracks how a particular metric or measurement evolves over time. Each run may have many `tag`s.
+You’ll probably track multiple parameters in your model: say, the accuracy, precision, and cross-entropy. Each of these will have its own `tag`. Each `tag` tracks how a particular metric or measurement evolves over time. Each run may have many `tag`s.
 
 Finally, the data for each run is stored in event files within a directory corresponding to that run. The directory name becomes the name of the run. When you launch TensorBoard, you specify a log directory (`logdir`); any runs under this directory will be picked up and loaded into TensorBoard.
 
@@ -65,9 +65,9 @@ Now that we have the background out of the way, we can talk about plugins! Each 
 
 Users of your plugin will use your API to emit protocol buffers containing the data that your plugin will visualize. In general, you should expose two ways of doing this: via a TensorFlow summary op, and by directly creating a protocol buffer.
 
-For example, let's create a `Greeter` plugin. It provides a greeter `op` method, which creates a TensorFlow op that emits a string-tensor summary. It also provides a `pb` function that creates this directly, outside of a TensorFlow context. Standard TensorBoard plugins should follow this API.
+For example, let’s create a `Greeter` plugin. It provides a greeter `op` method, which creates a TensorFlow op that emits a string-tensor summary. It also provides a `pb` function that creates this directly, outside of a TensorFlow context. Standard TensorBoard plugins should follow this API.
 
-Here's the code; we'll explain it below:
+Here’s the code; we’ll explain it below:
 
 ```python
 """This module provides summaries for the Greeter plugin."""
@@ -141,28 +141,28 @@ def pb(tag, guest, display_name=None, description=None):
 
 The `op` and `pb` methods above are two different ways of creating the same data: `Summary` protobufs containing `"Hello, $guest"` as a string tensor, with a unique `tag`, and with the appropriate metadata.
 
-We've discussed above why we need the `tag` (to distinguish data series from each other) and the `tensor` (to hold the actual payload data). But why do we need metadata?
+We’ve discussed above why we need the `tag` (to distinguish data series from each other) and the `tensor` (to hold the actual payload data). But why do we need metadata?
 
-Without the metadata, there is no way for plugins to know which `Summary`s they are interested in. How would the `Greeter` plugin know that these `Summary`s weren't intended for a different plugin that also handles text data, and just happened to have "Hello" in the beginning of the message?
+Without the metadata, there is no way for plugins to know which `Summary`s they are interested in. How would the `Greeter` plugin know that these `Summary`s weren’t intended for a different plugin that also handles text data, and just happened to have “Hello” in the beginning of the message?
 
-The `Greeter` plugin's summaries are distinguished by the fact that they all have a `plugin_data` entry in the `SummaryMetadata` which is marked with the `Greeter` `plugin_name`, which is, appropriately, `"greeter"`.
+The `Greeter` plugin’s summaries are distinguished by the fact that they all have a `plugin_data` entry in the `SummaryMetadata` which is marked with the `Greeter` `plugin_name`, which is, appropriately, `"greeter"`.
 
 The `SummaryMetadata` can also contain additional information describing each series. TensorBoard uses it to store the `display_name` and `description`. These both describe the series of data as a whole, rather than individual data points, so it makes sense to put them in the metadata. Your plugin could also define some additional metadata—that can go in the `metadata_content` field. Traditionally, if you have `metadata_content`, you should put in either
-- a custom protocol buffer for your plugin, serialized as a ByteString or String
-- a JSON object, serialized as a string
+  - a custom protocol buffer for your plugin, serialized as a ByteString or String, or
+  - a JSON object, serialized as a string.
 
-The metadata may be quite long—imagine writing a long description (with hyperlinks, Markdown code blocks, et cetera) which explains exactly how a certain data series is calculated in your model. To save space, we don't write the metadata every time. The `tf.summary.FileWriter` only writes metadata once per tag. (Specifically: the `FileWriter` only writes metadata the *first* time it encounters a given tag. Afterwards, it discards the metadata.) Thus, changing the metadata for a given tag is a bad idea.
+The metadata may be quite long—imagine writing a long description (with hyperlinks, Markdown code blocks, et cetera) which explains exactly how a certain data series is calculated in your model. To save space, we don’t write the metadata every time. The `tf.summary.FileWriter` only writes metadata once per tag. (Specifically: the `FileWriter` only writes metadata the *first* time it encounters a given tag. Afterwards, it discards the metadata.) Thus, changing the metadata for a given tag is a bad idea.
 
 You might be wondering why we have `tag` and `display_name` as separate concepts. Why not always use the `tag` as the display name in TensorBoard?
 
-This happens because we can't allow tags to collide. If tag collision happens, it's impossible to tell which data came from which series. TensorFlow prevents tag collision by using the summary op's node name as the tag; that means it is guaranteed to be unique by the TensorFlow naming system. But that also means implementation noise from the graph is included in a tag. If you add a scalar op with the name `"loss"` deep inside your graph, its tag might become something like `"tower1/layer8/loss"`. Keeping the display name as a separate concept ensures that your TensorBoard will still be easy to read.
+This happens because we can’t allow tags to collide. If tag collision happens, it’s impossible to tell which data came from which series. TensorFlow prevents tag collision by using the summary op’s node name as the tag; that means it is guaranteed to be unique by the TensorFlow naming system. But that also means implementation noise from the graph is included in a tag. If you add a scalar op with the name `"loss"` deep inside your graph, its tag might become something like `"tower1/layer8/loss"`. Keeping the display name as a separate concept ensures that your TensorBoard will still be easy to read.
 
 For examples of some more realistic plugins, check out the [scalar][scalar plugin backend] and [histogram][histogram plugin backend] plugins included with TensorBoard.
 
 [scalar plugin backend]: https://github.com/tensorflow/tensorboard/tree/c82300f188e4d2f4e1e2e029ce4019fd9e89a1e9/tensorboard/plugins/scalar/scalars_plugin.py
 [histogram plugin backend]:https://github.com/tensorflow/tensorboard/tree/c82300f188e4d2f4e1e2e029ce4019fd9e89a1e9/tensorboard/plugins/histogram/histograms_plugin.py
 
-Along with this module, you should include a demo module that generates representative data for your plugin, and which exercises all of your plugin's features. This script serves multiple purposes. First, it's useful for users of your plugin: they can inspect this script to see how to adapt it for their own uses. Second, it's useful for you as you're testing: you can always invoke this script to generate your test data. Third, you can use this in conjunction with your frontend unit tests: your demo script generates test data and your unit tests interact with your dashboard. Finally, by combining the demo scripts from various plugins, we can create a "mega-demo" that shows off all the features of TensorBoard.
+Along with this module, you should include a demo module that generates representative data for your plugin, and which exercises all of your plugin’s features. This script serves multiple purposes. First, it’s useful for users of your plugin: they can inspect this script to see how to adapt it for their own uses. Second, it’s useful for you as you’re testing: you can always invoke this script to generate your test data. Third, you can use this in conjunction with your frontend unit tests: your demo script generates test data and your unit tests interact with your dashboard. Finally, by combining the demo scripts from various plugins, we can create a “mega-demo” that shows off all the features of TensorBoard.
 
 As inspiration, here are the [scalar plugin demo] and [histogram plugin demo] included with TensorBoard.
 
@@ -172,26 +172,27 @@ As inspiration, here are the [scalar plugin demo] and [histogram plugin demo] in
 
 ### Backend: How the plugin processes data, and sends it to the browser
 
-> **Note:** The backend APIs are under active development and might change. If you [create a GitHub issue] telling us that you're working on a plugin, then we can proactively reach out and help you update your code when API changes occur.
+> **Note:** The backend APIs are under active development and might change. If you [create a GitHub issue] telling us that you’re working on a plugin, then we can proactively reach out and help you update your code when API changes occur.
 
 [create a GitHub issue]: https://github.com/tensorflow/tensorboard/issues/new
 
-To provide routes (endpoints) for your plugin, create a subclass of `BasePlugin`. Your subclass must have a static `plugin_name` property, and you'll need to implement the following methods:
+To provide routes (endpoints) for your plugin, create a subclass of `BasePlugin`. Your subclass must have a static `plugin_name` property, and you’ll need to implement the following methods:
 
-  - `__init__`: Your plugin will be passed a [`TBContext`] when it is constructed. Among other things, this context exposes an *[event multiplexer]*, which is used to access the actual summary data. You'll probably want to store this onto your plugin object for later use.
+  - `__init__`: Your plugin will be passed a [`TBContext`] when it is constructed. Among other things, this context exposes an *[event multiplexer]*, which is used to access the actual summary data. You’ll probably want to store this onto your plugin object for later use.
   - `is_active`: This should return whether the plugin is active (whether there exists relevant data for the plugin to process). TensorBoard will exclude inactive plugins from the main navigation bar.
   - `get_plugin_apps`: This should return a dictionary mapping routes to WSGI applications.
 
-> Each entry in the result of get_plugin_apps should have its key a route name string, like /tags, and its value a WSGI application for handling that route. A WSGI application is just a Python function that handles HTTP traffic. The easiest way to create such a function is to use the @werkzeug.wrappers.Request.application decorator, which lets you write a simple function that takes a Request object and returns a Response object. (See below for an example.) You can read about the WSGI spec [here](https://www.python.org/dev/peps/pep-3333/).
+Each entry in the result of `get_plugin_apps` should have its key a route name string, like `/tags`, and its value a WSGI application for handling that route. A WSGI application is just a Python function that handles HTTP traffic. The easiest way to create such a function is to use the `@werkzeug.wrappers.Request.application` decorator, which lets you write a simple function that takes a `Request` object and returns a `Response` object. (See below for an example.) You can consult the [WSGI spec] for more detailed informaiton.
 
 [`TBContext`]: https://github.com/tensorflow/tensorboard/blob/c82300f188e4d2f4e1e2e029ce4019fd9e89a1e9/tensorboard/plugins/base_plugin.py#L72
 [event multiplexer]: https://github.com/tensorflow/tensorboard/blob/c82300f188e4d2f4e1e2e029ce4019fd9e89a1e9/tensorboard/backend/event_processing/event_multiplexer.py
+[WSGI spec]: https://www.python.org/dev/peps/pep-3333/
 
-To retrieve relevant data (tensors) read from summaries, the logic of your plugin's route should call `PluginRunToTagToContent` with the `plugin_name`. This returns a dictionary mapping from run name to all of the tags that are associated with your plugin. The tag names themselves map to the `content` from the `PluginData` proto.
+To retrieve relevant data (tensors) read from summaries, the logic of your plugin’s route should call `PluginRunToTagToContent` with the `plugin_name`. This returns a dictionary mapping from run name to all of the tags that are associated with your plugin. The tag names themselves map to the `content` from the `PluginData` proto.
 
 Subsequently, with knowledge of which tags are relevant, your plugin can retrieve the tensors relevant to each tag. Call the `Tensors` method of the `Multiplexer` object to retrieve the tensors sampled by TensorBoard.
 
-Below, `GreeterPlugin` demonstrates how a very basic plugin works. To peruse the code of a real plugin, see [`TextPlugin`](https://github.com/tensorflow/tensorboard/blob/c82300f188e4d2f4e1e2e029ce4019fd9e89a1e9/tensorboard/plugins/text/text_plugin.py) or any of the plugins within TensorBoard's GitHub repository.
+Below, `GreeterPlugin` demonstrates how a very basic plugin works. To peruse the code of a real plugin, see [`TextPlugin`](https://github.com/tensorflow/tensorboard/blob/c82300f188e4d2f4e1e2e029ce4019fd9e89a1e9/tensorboard/plugins/text/text_plugin.py) or any of the plugins within TensorBoard’s GitHub repository.
 
 ```python
 import tensorflow as tf
@@ -307,13 +308,13 @@ class GreeterPlugin(base_plugin.TBPlugin):
 ```
 
 Note that the TensorBoard team is actively developing SQL databases as a backend
-for TensorBoard plugins. Once that lands, we'll update the example plugin to use
+for TensorBoard plugins. Once that lands, we’ll update the example plugin to use
 a SQL backend. See [TensorBoard#92](https://github.com/tensorflow/tensorboard/issues/92)
 for context.
 
 ### Frontend: How the plugin visualizes your new data
 
-Now that we have an API and a Backend, it's time for the cool part: adding a visualization.
+Now that we have an API and a Backend, it’s time for the cool part: adding a visualization.
 
 TensorBoard is built on [Polymer](https://www.polymer-project.org/) (1.x). Polymer makes it easy to define new custom components and embed them within other applications, which makes it great for embedding new visualizations and new dashboards into TensorBoard.
 
@@ -321,26 +322,26 @@ The first question to ask as you work on your plugin is: do you want to create a
 
 Either way, TensorBoard provides some shared frontend components to help you. You can find them at [tensorboard/components]. For example, `tf_backend` provides a `RequestManager` and other methods that make it convenient to request data from the TensorBoard backend, and `tf_color_scale` provides a single coordinated color scale for mapping runs to colors, in a way that is consistent across TensorBoard.
 
-If you're planning on rolling your own dashboard without re-using much of the TensorBoard UI, you can pick and choose a few components that suit you, and mostly ignore the rest. Note that the TensorBoard toolbar and plugin selector at the top of the screen is not a part of any individual plugin, so it will always be there.
+If you’re planning on rolling your own dashboard without re-using much of the TensorBoard UI, you can pick and choose a few components that suit you, and mostly ignore the rest. Note that the TensorBoard toolbar and plugin selector at the top of the screen is not a part of any individual plugin, so it will always be there.
 
-On the other hand, you might find it convenient to re-use the core TensorBoard UI pieces, like the categorizer and run selector. We've made it easy to do that. There are two kinds of plugins that we expect will re-use these UI elements: plugins that render a visualization for every (run, tag) combination, like the Histograms dashboard, and plugins that render a single visualization for every tag, displaying multiple runs all in the same chart. The Scalar dashboard is an example.
+On the other hand, you might find it convenient to re-use the core TensorBoard UI pieces, like the categorizer and run selector. We’ve made it easy to do that. There are two kinds of plugins that we expect will re-use these UI elements: plugins that render a visualization for every `(run, tag)` combination, like the Histograms dashboard, and plugins that render a single visualization for every tag, displaying multiple runs all in the same chart. The Scalar dashboard is an example.
 
-In either of these cases, we recommend starting with an existing dashboard that is relatively close to your use case, and modifying it to do what you need. We'll take a look at the [scalar dashboard code] and explain the key concepts.
+In either of these cases, we recommend starting with an existing dashboard that is relatively close to your use case, and modifying it to do what you need. We’ll take a look at the [scalar dashboard code] and explain the key concepts.
 
-First, you'll notice that the code imports a lot of components - both generic Polymer components like paper-input, and shared TensorBoard components like `tf-dashboard-layout` and `tf-category-pane`, and finally some plugin specific components like `tf-scalar-chart`.
+First, you’ll notice that the code imports a lot of components—both generic Polymer components like paper-input, and shared TensorBoard components like `tf-dashboard-layout` and `tf-category-pane`, and finally some plugin specific components like `tf-scalar-chart`.
 
 Next, we dive in with setting up a standard dashboard layout. Here is an overview of some important components, described in the order they appear in the scalar dashboard:
-- `tf-dashboard-layout`: Makes it easy to set up a sidebar section and main section within TensorBoard. The sidebar should hold configuration options, and the run selector.
-- `tf-runs-selector`: The canonical way to enable or disable various runs in the TensorBoard frontend.
-- `tf-category-pane`: After the tags have been grouped into `categories`, it displays a single category.
-- `tf-paginated-view`: Paginates the elements in a category, so you can't overload the browser by instantiating hundreds at once.
-- `tf-scalar-chart`: The actual visualization to instantiate. Swap this out in your own dashboards.
+  - `tf-dashboard-layout`: Makes it easy to set up a sidebar section and main section within TensorBoard. The sidebar should hold configuration options, and the run selector.
+  - `tf-runs-selector`: The canonical way to enable or disable various runs in the TensorBoard frontend.
+  - `tf-category-pane`: After the tags have been grouped into `categories`, it displays a single category.
+  - `tf-paginated-view`: Paginates the elements in a category, so you can’t overload the browser by instantiating hundreds at once.
+  - `tf-scalar-chart`: The actual visualization to instantiate. Swap this out in your own dashboards.
 
 
-[tensorboard/components]:https://github.com/tensorflow/tensorboard/tree/master/tensorboard/components
+[tensorboard/components]: https://github.com/tensorflow/tensorboard/tree/master/tensorboard/components
 
-[scalar dashboard code]:https://github.com/tensorflow/tensorboard/tree/c82300f188e4d2f4e1e2e029ce4019fd9e89a1e9/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html#L128
+[scalar dashboard code]: https://github.com/tensorflow/tensorboard/tree/c82300f188e4d2f4e1e2e029ce4019fd9e89a1e9/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html#L128
 
 ## Integration
 
-We're still polishing out how you integrate a new plugin into TensorBoard. For now, take a look at @jart's [TensorBoard Plugin Example](https://github.com/jart/tensorboard_plugin_example).
+We’re still polishing out how you integrate a new plugin into TensorBoard. For now, take a look at @jart’s [TensorBoard Plugin Example](https://github.com/jart/tensorboard_plugin_example).


### PR DESCRIPTION
Summary:
  - Fixed straight-to-smart quotes (‘like’ “this”)
  - Replaced spaced hyphens with em dashes—like this
  - Added some code formatting where appropriate
  - Replaced useless link text (for a11y)

I highly recommend examining this diff with `git show --word-diff`.

wchargin-branch: plugin-typography