### PR TITLE
Expose `SummaryMetadata` from event multiplexer

### DIFF
--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -426,6 +426,25 @@ class EventMultiplexer(object):
       mapping[run] = tag_to_content
     return mapping
 
+  def SummaryMetadata(self, run, tag):
+    """Return the summary metadata for the given tag on the given run.
+
+    Args:
+      run: A string name of the run for which summary metadata is to be
+        retrieved.
+      tag: A string name of the tag whose summary metadata is to be
+        retrieved.
+
+    Raises:
+      KeyError: If the run is not found, or the tag is not available for
+        the given run.
+
+    Returns:
+      A `tf.SummaryMetadata` protobuf.
+    """
+    accumulator = self.GetAccumulator(run)
+    return accumulator.SummaryMetadata(tag)
+
   def Runs(self):
     """Return all the run names in the `EventMultiplexer`.
 


### PR DESCRIPTION
Summary:
Now that there is data stored in the `SummaryMetadata` that is not part
of the `plugin_data[*].content`, we need to expose this data to plugins.
This commit adds a `SummaryMetadata` function to return the entire
metadata proto, from which interested parties can pick out the display
name and summary description.

Test Plan:
`bazel test //tensorboard/...`

wchargin-branch: expose-summary-metadata-from-multiplexer