### PR TITLE
Add op compatibility graph coloring option

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
@@ -151,6 +151,7 @@ paper-progress {
     <tf-graph-info id="graph-info"
               title="selected"
               graph-hierarchy="[[graphHierarchy]]"
+              hierarchy-params="[[hierarchyParams]]"
               render-hierarchy="[[renderHierarchy]]"
               graph="[[graph]]"
               selected-node="{{selectedNode}}"

--- a/tensorboard/plugins/graph/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_common/BUILD
@@ -19,6 +19,7 @@ ts_web_library(
         "layout.ts",
         "minimap.ts",
         "node.ts",
+        "op.ts",
         "parser.ts",
         "proto.ts",
         "render.ts",

--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -160,7 +160,11 @@ export interface OpNode extends Node {
   outputShapes: TensorShape[];
   // The XLA Cluster on which the op ran. Null if it is unknown.
   xlaCluster: string;
-  // Whether op is compatible with device
+  // Whether op is compatible with its assigned device.  Currently, if an op
+  // is not specified a device, the device is defaulted to the TPU.
+  // Furthermore, all ops are considered compatible for CPU and GPU devices,
+  // while a whitelist of compatible ops are specifed for the TPU.
+  // Reference: opValid func in op.ts.
   compatible: boolean;
 }
 

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -479,8 +479,8 @@ export function joinAndAggregateStats(
   });
 }
 
-export function getIncompatOps(hierarchy: Hierarchy,
-                               hierarchyParams: HierarchyParams) {
+export function getIncompatibleOps(hierarchy: Hierarchy,
+                                   hierarchyParams: HierarchyParams) {
   let nodes: (GroupNode | OpNode)[] = [];
   let addedSeriesNodes: { [seriesName: string]: SeriesNode } = {};
   _.each(hierarchy.root.leaves(), leaf => {

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -479,6 +479,55 @@ export function joinAndAggregateStats(
   });
 }
 
+export function getIncompatOps(hierarchy: Hierarchy,
+                               hierarchyParams: HierarchyParams) {
+  let nodes: (GroupNode | OpNode)[] = [];
+  let addedSeriesNodes: { [seriesName: string]: SeriesNode } = {};
+  _.each(hierarchy.root.leaves(), leaf => {
+    let node = hierarchy.node(leaf);
+    if (node.type == NodeType.OP) {
+      let opNode = <OpNode> node;
+
+      if (!opNode.compatible) {
+        if (opNode.owningSeries) {
+          if (hierarchyParams &&
+              hierarchyParams.seriesMap[opNode.owningSeries]
+              === tf.graph.SeriesGroupingType.UNGROUP) {
+            // For un-grouped series node, add each node individually
+            nodes.push(opNode)
+          } else {
+            if (!addedSeriesNodes[opNode.owningSeries]) {
+              let series = <SeriesNode>hierarchy.node(opNode.owningSeries);
+              if (series) {
+                addedSeriesNodes[opNode.owningSeries] = series;
+                nodes.push(series);
+              }
+            }
+          }
+        } else {
+          nodes.push(opNode);
+        }
+      }
+
+      // Check the embeddings for invalid operations
+      _.each(opNode.inEmbeddings, (inNode) => {
+        if (!inNode.compatible) {
+          nodes.push(inNode);
+        }
+      });
+
+      _.each(opNode.outEmbeddings, (outNode) => {
+        if (!outNode.compatible) {
+          nodes.push(outNode);
+        }
+      });
+
+    }
+  });
+  return nodes;
+}
+
+
 /**
  * Creates the metanodes in the hierarchical graph and assigns parent-child
  * relationship between them.
@@ -501,6 +550,37 @@ function addNodes(h: Hierarchy, graph: SlimGraph) {
         parent.deviceHistogram[node.device] =
             (parent.deviceHistogram[node.device] || 0) + 1;
       }
+
+      // Increment parents appropriate compatibility count
+      if (node.compatible) {
+        parent.compatibilityHistogram.compatible =
+            (parent.compatibilityHistogram.compatible || 0) + 1;
+      } else {
+        parent.compatibilityHistogram.incompatible =
+            (parent.compatibilityHistogram.incompatible || 0) + 1;
+      }
+
+      // Increment capability counts for in and out embeddings
+      _.each(node.inEmbeddings, (inNode) => {
+        if (inNode.compatible) {
+          parent.compatibilityHistogram.compatible =
+              (parent.compatibilityHistogram.compatible || 0) + 1;
+        } else {
+          parent.compatibilityHistogram.incompatible =
+              (parent.compatibilityHistogram.incompatible || 0) + 1;
+        }
+      });
+
+      _.each(node.outEmbeddings, (outNode) => {
+        if (outNode.compatible) {
+          parent.compatibilityHistogram.compatible =
+              (parent.compatibilityHistogram.compatible || 0) + 1;
+        } else {
+          parent.compatibilityHistogram.incompatible =
+              (parent.compatibilityHistogram.incompatible || 0) + 1;
+        }
+      });
+
       if (i === path.length - 1) { break; }
       let name = path[i];
       let child = <Metanode>h.node(name);
@@ -669,6 +749,37 @@ function groupSeries(metanode: Metanode, hierarchy: Hierarchy,
         seriesNode.deviceHistogram[child.device] =
             (seriesNode.deviceHistogram[child.device] || 0) + 1;
       }
+
+      // Increment parents appropriate compatibility count
+      if (child.compatible) {
+        seriesNode.compatibilityHistogram.compatible =
+            (seriesNode.compatibilityHistogram.compatible || 0) + 1;
+      } else {
+        seriesNode.compatibilityHistogram.incompatible =
+            (seriesNode.compatibilityHistogram.incompatible || 0) + 1;
+      }
+
+      // Increment capability counts for in and out embeddings
+      _.each(child.inEmbeddings, (inNode) => {
+        if (inNode.compatible) {
+          seriesNode.compatibilityHistogram.compatible =
+              (seriesNode.compatibilityHistogram.compatible || 0) + 1;
+        } else {
+          seriesNode.compatibilityHistogram.incompatible =
+              (seriesNode.compatibilityHistogram.incompatible || 0) + 1;
+        }
+      });
+
+      _.each(child.outEmbeddings, (outNode) => {
+        if (outNode.compatible) {
+          seriesNode.compatibilityHistogram.compatible =
+              (seriesNode.compatibilityHistogram.compatible || 0) + 1;
+        } else {
+          seriesNode.compatibilityHistogram.incompatible =
+              (seriesNode.compatibilityHistogram.incompatible || 0) + 1;
+        }
+      });
+
       child.parentNode = seriesNode;
       seriesNames[n] = seriesName;
       // Remove now-grouped node from its original parent's metagraph.

--- a/tensorboard/plugins/graph/tf_graph_common/op.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/op.ts
@@ -1,0 +1,71 @@
+module tf.graph.op {
+
+  /**
+   * Whitelist of current Tensorflow ops valid on the TPU
+   */
+  export const WHITELIST = [
+    'Abs','Add','AddN','All','Any','ArgMax','Assert','Assign',
+    'AssignAddVariableOp','AssignSubVariableOp','AssignVariableOp','AvgPool',
+    'AvgPool3D','AvgPool3DGrad','AvgPoolGrad','BatchMatMul','BatchToSpace',
+    'BatchToSpaceND','BiasAdd','BiasAddGrad','BiasAddV1',
+    'BroadcastGradientArgs','Cast','Ceil','CheckNumerics','Concat',
+    'ConcatOffset','ConcatV2','Const','Conv2D','Conv2DBackpropFilter',
+    'Conv2DBackpropInput','Conv3D','Conv3DBackpropFilterV2',
+    'Conv3DBackpropInputV2','CrossReplicaSum','DepthwiseConv2dNative',
+    'Diag','DiagPart','Div','DummyReadResource',
+    'DynamicStitch','Elu','EluGrad','Equal',
+    'Exp','ExpandDims','Fill','Floor','FloorDiv','FloorMod','Gather','Greater',
+    'GreaterEqual','Identity','InfeedDequeue','InfeedDequeueTuple',
+    'Inv','InvertPermutation','L2Loss','LRN','LRNGrad','Less',
+    'LessEqual','LinSpace','Log','Log1p','LogSoftmax','LogicalAnd','LogicalNot',
+    'LogicalOr','MatMul','MatrixDiag','MatrixDiagPart','Max','MaxPool',
+    'MaxPool3D','MaxPool3DGrad','MaxPoolGrad','Maximum','Mean','Min','Minimum',
+    'Mod','Mul','Neg','NoOp','NotEqual','OneHot','OnesLike','OutfeedEnqueue',
+    'OutfeedEnqueueTuple','Pack','Pad','Placeholder','Pow','PreventGradient',
+    'Prod','RandomStandardNormal','RandomUniform','RandomUniformInt','Range',
+    'Rank','ReadVariableOp','RealDiv','Reciprocal','Relu','Relu6','Relu6Grad',
+    'ReluGrad','Reshape','ApplyAdagrad','ApplyAdam',
+    'ApplyGradientDescent','ApplyMomentum',
+    'ApplyRMSProp','StridedSliceAssign','Reverse',
+    'ReverseV2','Round','Rsqrt','RsqrtGrad','Select','Shape','ShapeN','Sigmoid',
+    'SigmoidGrad','Sign','Size','Slice','Softmax',
+    'SoftmaxCrossEntropyWithLogits','Softplus','SoftplusGrad','SpaceToBatch',
+    'SpaceToBatchND','SparseMatMul',
+    'SparseSoftmaxCrossEntropyWithLogits','Split','SplitV','Sqrt','Square',
+    'SquaredDifference','Squeeze','StopGradient','StridedSlice',
+    'StridedSliceGrad','Sub','Sum','SymbolicGradient',
+    'Tanh','TanhGrad','Tile','Transpose',
+    'TruncateDiv','TruncateMod','TruncatedNormal','Unpack','VarIsInitializedOp',
+    'Variable', 'VariableV2', 'ZerosLike','_ArrayToList','_ListToArray',
+    '_TPURecv','_TPUSend','_UnsafeReadVariable'
+  ];
+
+  /**
+   * Returns true if OpNode graph object represents a
+   * Tensorflow operation that is valid for the TPU.
+   *
+   * @param opNode OpNode graph object
+   * @returns {boolean}
+   */
+  export function opValid(opNode: OpNode) : boolean {
+    // If assigned a device, and it is not the TPU, assume op is valid
+    if (opNode.device && opNode.device.toLowerCase().search("tpu") == -1) {
+      return true;
+    }
+    return WHITELIST.indexOf(opNode.op) != -1;
+  }
+
+  export function checkOpsForCompatibility(graph: SlimGraph) {
+    _.each(graph.nodes, (node) => {
+      node.compatible = opValid(node);
+      _.each(node.inEmbeddings, (node) => {
+        node.compatible = opValid(node);
+      });
+
+      _.each(node.outEmbeddings, (node) => {
+        node.compatible = opValid(node);
+      });
+    });
+  }
+
+} // close module tf.graph.op

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -22,7 +22,7 @@ export type Point = {x: number, y: number};
 /**
  * Color parameters for op nodes.
  */
-export let OpNodeColors = {DEFAULT_FILL: 'white', DEFAULT_STROKE: '#b2b2b2',
+export let OpNodeColors = {DEFAULT_FILL: '#ffffff', DEFAULT_STROKE: '#b2b2b2',
                            COMPATIBLE: '#0f9d58', INCOMPATIBLE: '#db4437'};
 
 /**

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -22,7 +22,8 @@ export type Point = {x: number, y: number};
 /**
  * Color parameters for op nodes.
  */
-export let OpNodeColors = {DEFAULT_FILL: 'white', DEFAULT_STROKE: '#b2b2b2'};
+export let OpNodeColors = {DEFAULT_FILL: 'white', DEFAULT_STROKE: '#b2b2b2',
+                           COMPATIBLE: '#0f9d58', INCOMPATIBLE: '#db4437'};
 
 /**
  * Color parameters for node encoding.

--- a/tensorboard/plugins/graph/tf_graph_common/tf-graph-common.html
+++ b/tensorboard/plugins/graph/tf_graph_common/tf-graph-common.html
@@ -26,6 +26,7 @@ limitations under the License.
 <script src="graph.js"></script>
 <script src="hierarchy.js"></script>
 <script src="layout.js"></script>
+<script src="op.js"></script>
 <script src="parser.js"></script>
 <script src="proto.js"></script>
 <script src="render.js"></script>

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -372,15 +372,13 @@ table.tf-graph-controls td.input-element-table-data {
         FileWriter when a specific session is run.
       </paper-tooltip>
 
-      <template is="dom-if" if="[[opCompatFeatureEnabled]]">
-        <paper-radio-button id="tpu-compatibility-radio-button"
-                            name="op_compatibility">
-          TPU Compatibility
-        </paper-radio-button>
-        <paper-tooltip animation-delay="0" for="tpu-compatibility-radio-button" position="right">
-          Coloring by whether an operation is compatible for the TPU device.
-        </paper-tooltip>
-      </template>
+      <paper-radio-button id="tpu-compatibility-radio-button"
+                          name="op_compatibility">
+        TPU Compatibility
+      </paper-radio-button>
+      <paper-tooltip animation-delay="0" for="tpu-compatibility-radio-button" position="right">
+        Coloring by whether an operation is compatible for the TPU device.
+      </paper-tooltip>
 
     </paper-radio-group>
   </div>
@@ -795,8 +793,6 @@ Polymer({
       type: Boolean,
       notify: true,
     },
-    // This stores whether to allow the color-by op compatibility option
-    opCompatFeatureEnabled: Boolean,
   },
   listeners: {
     'trace-inputs.change': '_traceInputToggleChanged'

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -371,6 +371,17 @@ table.tf-graph-controls td.input-element-table-data {
         Coloring by memory is only enabled if the RunMetadata proto is passed to the
         FileWriter when a specific session is run.
       </paper-tooltip>
+
+      <template is="dom-if" if="[[opCompatFeatureEnabled]]">
+        <paper-radio-button id="tpu-compatibility-radio-button"
+                            name="op_compatibility">
+          TPU Compatibility
+        </paper-radio-button>
+        <paper-tooltip animation-delay="0" for="tpu-compatibility-radio-button" position="right">
+          Coloring by whether an operation is compatible for the TPU device.
+        </paper-tooltip>
+      </template>
+
     </paper-radio-group>
   </div>
   <div>
@@ -480,6 +491,26 @@ table.tf-graph-controls td.input-element-table-data {
                  xlink:href="#grey-rect" x="0" y="0"/>
           </svg>
           <span class="color-legend-value">unknown XLA cluster</span>
+        </div>
+      </div>
+    </template>
+    <template is="dom-if" if="[[_equals(colorBy, 'op_compatibility')]]">
+      <div class="color-text">
+        <div class="color-legend-row">
+          <svg class="icon" preserveAspectRatio="xMinYMid meet"
+               viewBox="0 0 10 10">
+            <use xlink:href="#op-node-stamp" fill="#0f9d58" stroke="#ccc" x="9.5"
+                 y="6" />
+          </svg>
+          <span class="color-legend-value">Valid Op</span>
+        </div>
+        <div class="color-legend-row">
+          <svg class="icon" preserveAspectRatio="xMinYMid meet"
+               viewBox="0 0 10 10">
+            <use xlink:href="#op-node-stamp" fill="#db4437" stroke="#ccc" x="9.5"
+                 y="6" />
+          </svg>
+          <span class="color-legend-value">Invalid Op</span>
         </div>
       </div>
     </template>
@@ -764,6 +795,8 @@ Polymer({
       type: Boolean,
       notify: true,
     },
+    // This stores whether to allow the color-by op compatibility option
+    opCompatFeatureEnabled: Boolean,
   },
   listeners: {
     'trace-inputs.change': '_traceInputToggleChanged'

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -73,7 +73,6 @@ by default. The user can select a different run from a dropdown menu.
         selected-metadata-tag="{{_selectedMetadataTag}}"
         health-pills-feature-enabled="[[debuggerDataEnabled]]"
         health-pills-toggled-on="{{healthPillsToggledOn}}"
-        op-compat-feature-enabled="[[debuggerDataEnabled]]"
   ></tf-graph-controls>
   <tf-graph-loader id="loader"
         datasets="[[_datasets]]"
@@ -85,7 +84,6 @@ by default. The user can select a different run from a dropdown menu.
         out-stats="{{_stats}}"
         progress="{{_progress}}"
         out-hierarchy-params="{{_hierarchyParams}}"
-        op-compat-feature-enabled="[[debuggerDataEnabled]]"
   ></tf-graph-loader>
 </div>
 <div class="center">

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -73,6 +73,7 @@ by default. The user can select a different run from a dropdown menu.
         selected-metadata-tag="{{_selectedMetadataTag}}"
         health-pills-feature-enabled="[[debuggerDataEnabled]]"
         health-pills-toggled-on="{{healthPillsToggledOn}}"
+        op-compat-feature-enabled="[[debuggerDataEnabled]]"
   ></tf-graph-controls>
   <tf-graph-loader id="loader"
         datasets="[[_datasets]]"
@@ -83,7 +84,8 @@ by default. The user can select a different run from a dropdown menu.
         out-graph="{{_graph}}"
         out-stats="{{_stats}}"
         progress="{{_progress}}"
-out-hierarchy-params="{{_hierarchyParams}}"
+        out-hierarchy-params="{{_hierarchyParams}}"
+        op-compat-feature-enabled="[[debuggerDataEnabled]]"
   ></tf-graph-loader>
 </div>
 <div class="center">
@@ -132,7 +134,7 @@ import {queryEncoder} from "../tf-backend/urlPathHelpers.js";
 
 Polymer({
   is: 'tf-graph-dashboard',
-   properties: {
+  properties: {
     _datasets: Object,
     _renderHierarchy: {type: Object, observer: '_renderHierarchyChanged'},
     _requestManager: {

--- a/tensorboard/plugins/graph/tf_graph_info/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_info/BUILD
@@ -8,17 +8,18 @@ licenses(["notice"])  # Apache 2.0
 ts_web_library(
     name = "tf_graph_info",
     srcs = [
-        "tf-graph-icon.html",
         "tf-graph-info.html",
         "tf-node-info.html",
         "tf-node-list-item.html",
     ],
     path = "/tf-graph-info",
     deps = [
+        ":tf_graph_icon",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/plugins/graph/tf_graph_common",
         "//tensorboard/plugins/graph/tf_graph_debugger_data_card",
+        "//tensorboard/plugins/graph/tf_graph_op_compat_card",
         "@org_polymer_iron_collapse",
         "@org_polymer_iron_list",
         "@org_polymer_paper_button",
@@ -30,6 +31,18 @@ ts_web_library(
     ],
 )
 
+ts_web_library(
+    name = "tf_graph_icon",
+    srcs = [
+        "tf-graph-icon.html",
+    ],
+    path = "/tf-graph-info",
+    deps = [
+        "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_imports:polymer",
+    ],
+)
+
 tensorboard_webcomponent_library(
     name = "legacy",
     srcs = [":tf_graph_info"],
@@ -38,6 +51,7 @@ tensorboard_webcomponent_library(
         "//tensorboard/components/tf_dashboard_common:legacy",
         "//tensorboard/plugins/graph/tf_graph_common:legacy",
         "//tensorboard/plugins/graph/tf_graph_debugger_data_card:legacy",
+        "//tensorboard/plugins/graph/tf_graph_op_compat_card:legacy",
         "//third_party/javascript/polymer/v1/iron-collapse:lib",
         "//third_party/javascript/polymer/v1/iron-list:lib",
         "//third_party/javascript/polymer/v1/paper-icon-button:lib",
@@ -48,3 +62,18 @@ tensorboard_webcomponent_library(
     ],
 )
 
+tensorboard_webcomponent_library(
+    name = "tf_graph_icon_legacy",
+    srcs = [":tf_graph_icon"],
+    destdir = "tf-graph-info",
+    deps = [
+        "//tensorboard/components/tf_dashboard_common:legacy",
+        "//third_party/javascript/polymer/v1/iron-collapse:lib",
+        "//third_party/javascript/polymer/v1/iron-list:lib",
+        "//third_party/javascript/polymer/v1/paper-icon-button:lib",
+        "//third_party/javascript/polymer/v1/paper-item:lib",
+        "//third_party/javascript/polymer/v1/paper-slider:lib",
+        "//third_party/javascript/polymer/v1/paper-spinner:lib",
+        "//third_party/javascript/polymer/v1/polymer:lib",
+    ],
+)

--- a/tensorboard/plugins/graph/tf_graph_info/tf-graph-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-graph-info.html
@@ -21,6 +21,7 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-graph-common/tf-graph-common.html">
 <link rel="import" href="../tf-graph-debugger-data-card/tf-graph-debugger-data-card.html">
+<link rel="import" href="../tf-graph-op-compat-card/tf-graph-op-compat-card.html">
 <link rel="import" href="tf-node-info.html">
 
 <dom-module id="tf-graph-info">
@@ -53,6 +54,13 @@ h2 {
                   color-by="[[colorBy]]">
     </tf-node-info>
   </paper-material>
+</template>
+<template is="dom-if" if="[[_equals(colorBy, 'op_compatibility')]]">
+  <tf-graph-op-compat-card graph-hierarchy="[[graphHierarchy]]"
+                           hierarchy-params="[[hierarchyParams]]"
+                           render-hierarchy="[[renderHierarchy]]"
+                           color-by="[[colorBy]]">
+  </tf-graph-op-compat-card>
 </template>
 <template is="dom-if" if="[[_healthPillsAvailable(debuggerDataEnabled, nodeNamesToHealthPills)]]">
   <tf-graph-debugger-data-card render-hierarchy="[[renderHierarchy]]"
@@ -125,6 +133,9 @@ h2 {
       // legend and slider. We do that because, even if no health pills exist at the current step,
       // the user may desire to change steps, and the slider must show for the user to do that.
       return debuggerDataEnabled && nodeNamesToHealthPills;
+    },
+    _equals: function(a, b) {
+      return a === b;
     },
   });
 })();

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -66,7 +66,9 @@ Polymer({
       type: Object,
       readOnly: true, // This property produces data.
       notify: true
-    }
+    },
+    // This stores whether to allow the color-by op compatibility option
+    opCompatFeatureEnabled: Boolean,
   },
   observers: [
     '_selectedDatasetChanged(selectedDataset, datasets)',
@@ -151,6 +153,9 @@ Polymer({
       return tf.graph.build(graph, buildParams, graphTracker);
     })
     .then(function(graph) {
+      if (this.opCompatFeatureEnabled) {
+        tf.graph.op.checkOpsForCompatibility(graph);
+      }
       this._setOutGraph(graph);
       var hierarchyTracker = tf.graph.util.getSubtaskTracker(tracker, 50,
           'Namespace hierarchy');

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -67,8 +67,6 @@ Polymer({
       readOnly: true, // This property produces data.
       notify: true
     },
-    // This stores whether to allow the color-by op compatibility option
-    opCompatFeatureEnabled: Boolean,
   },
   observers: [
     '_selectedDatasetChanged(selectedDataset, datasets)',
@@ -153,9 +151,9 @@ Polymer({
       return tf.graph.build(graph, buildParams, graphTracker);
     })
     .then(function(graph) {
-      if (this.opCompatFeatureEnabled) {
-        tf.graph.op.checkOpsForCompatibility(graph);
-      }
+      // Populate compatibile field of OpNode based on whitelist
+      tf.graph.op.checkOpsForCompatibility(graph);
+
       this._setOutGraph(graph);
       var hierarchyTracker = tf.graph.util.getSubtaskTracker(tracker, 50,
           'Namespace hierarchy');

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/BUILD
@@ -1,0 +1,42 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
+load("//tensorboard/defs:web.bzl", "ts_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+ts_web_library(
+    name = "tf_graph_op_compat_card",
+    srcs = [
+        "tf-graph-op-compat-card.html",
+        "tf-graph-op-compat-list-item.html",
+    ],
+    path = "/tf-graph-op-compat-card",
+    deps = [
+        "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/plugins/graph/tf_graph_common",
+        "//tensorboard/plugins/graph/tf_graph_info:tf_graph_icon",
+        "@org_polymer_iron_collapse",
+        "@org_polymer_iron_list",
+        "@org_polymer_paper_icon_button",
+        "@org_polymer_paper_item",
+    ],
+)
+
+tensorboard_webcomponent_library(
+    name = "legacy",
+    srcs = [":tf_graph_op_compat_card"],
+    destdir = "tf_graph_op_compat_card",
+    deps = [
+        "//tensorboard/components/tf_dashboard_common:legacy",
+        "//tensorboard/plugins/graph/tf_graph_common:legacy",
+        "//third_party/tensorboard/plugins/graph/tf_graph_info:tf_graph_icon_legacy",
+        "//third_party/javascript/polymer/v1/iron-collapse:lib",
+        "//third_party/javascript/polymer/v1/iron-list:lib",
+        "//third_party/javascript/polymer/v1/paper-icon-button:lib",
+        "//third_party/javascript/polymer/v1/paper-item:lib",
+        "//third_party/javascript/polymer/v1/polymer:lib",
+    ],
+)
+

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.html
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.html
@@ -31,7 +31,7 @@ limitations under the License.
   max-height: 500px;
 }
 
-.incompat-ops-list {
+.incompatible-ops-list {
   height: 350px;
   max-height: 400px;
   overflow-y: scroll;
@@ -141,8 +141,8 @@ div.op-compat-value {
   <div class="expandedInfo">
     Incompatible Operations:
     (<span>[[_totalIncompatOps]]</span>)
-    <iron-list class="incompat-ops-list" id ="incompatOpsList"
-               items="[[_incompatOpNodes]]">
+    <iron-list class="incompatible-ops-list" id ="incompatibleOpsList"
+               items="[[_incompatibleOpNodes]]">
       <template>
         <tf-graph-op-compat-list-item
             class="non-control-list-item"
@@ -151,7 +151,7 @@ div.op-compat-value {
             name="[[item.name]]"
             template-index="[[_templateIndex]]"
             color-by="[[colorBy]]"
-            item-type="incompat-ops">
+            item-type="incompatible-ops">
         </tf-graph-op-compat-list-item>
       </template>
     </iron-list>
@@ -173,9 +173,9 @@ div.op-compat-value {
         type: Function,
         computed: '_getTemplateIndex(graphHierarchy)'
       },
-      _incompatOpNodes: {
+      _incompatibleOpNodes: {
         type: Object,
-        computed: '_getIncompatOpNodes(graphHierarchy, hierarchyParams)'
+        computed: '_getIncompatibleOpNodes(graphHierarchy, hierarchyParams)'
       },
       _expanded: {
         type: Boolean,
@@ -199,7 +199,7 @@ div.op-compat-value {
       },
       _totalIncompatOps: {
         type: Number,
-        computed: '_getTotalIncompatOps(graphHierarchy)'
+        computed: '_getTotalIncompatibleOps(graphHierarchy)'
       }
     },
     _getTemplateIndex: function(graphHierarchy) {
@@ -228,10 +228,10 @@ div.op-compat-value {
         list.fire('iron-resize');
       }
     },
-    _getIncompatOpNodes: function(graphHierarchy, hierarchyParams) {
+    _getIncompatibleOpNodes: function(graphHierarchy, hierarchyParams) {
       if (graphHierarchy && graphHierarchy.root) {
-        this.async(this._resizeList.bind(this, "#incompatOpsList"));
-        return tf.graph.hierarchy.getIncompatOps(graphHierarchy, hierarchyParams);
+        this.async(this._resizeList.bind(this, "#incompatibleOpsList"));
+        return tf.graph.hierarchy.getIncompatibleOps(graphHierarchy, hierarchyParams);
       }
     },
     _computeOpCompatScore: function(graphHierarchy) {
@@ -248,7 +248,7 @@ div.op-compat-value {
     _getOpCompatScoreLabel: function(opCompatScore) {
       return d3.format(".0%")(opCompatScore);
     },
-    _getTotalIncompatOps: function (graphHierarchy) {
+    _getTotalIncompatibleOps: function (graphHierarchy) {
       if (graphHierarchy && graphHierarchy.root) {
         return graphHierarchy.root.compatibilityHistogram.incompatible;
       }

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.html
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.html
@@ -1,0 +1,260 @@
+<!--
+@license
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../iron-collapse/iron-collapse.html">
+<link rel="import" href="../iron-list/iron-list.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../paper-item/paper-item.html">
+<link rel="import" href="../paper-item/paper-item-body.html">
+<link rel="import" href="../tf-graph-common/tf-graph-common.html">
+<link rel="import" href="tf-graph-op-compat-list-item.html">
+
+<dom-module id="tf-graph-op-compat-card">
+<template>
+<style>
+:host {
+  max-height: 500px;
+}
+
+.incompat-ops-list {
+  height: 350px;
+  max-height: 400px;
+  overflow-y: scroll;
+  display: flex;
+  flex-direction: column;
+}
+
+iron-list {
+  flex: 1 1 auto;
+}
+
+paper-item {
+  padding: 0;
+  background: #e9e9e9;
+}
+
+paper-item-body[two-line] {
+  min-height: 0;
+  padding: 8px 12px 4px;
+}
+
+.expandedInfo {
+  padding: 8px 12px;
+  font-weight: 500;
+  font-size: 12pt;
+  width: 100%;
+}
+
+.node-name {
+  white-space: normal;
+  word-wrap: break-word;
+  font-size: 14pt;
+  font-weight: 500;
+}
+
+.subtitle {
+  font-size: 12pt;
+  color: #5e5e5e;
+}
+
+.toggle-button {
+  float: right;
+  max-height: 20px;
+  max-width: 20px;
+  padding: 0;
+}
+
+.non-control-list-item {
+  padding-left: 10px;
+}
+
+div.op-compat-display {
+  margin-top: 10px;
+  display: inline-block;
+}
+
+svg.op-compat {
+  width: 250px;
+  height: 25px;
+  float: left;
+}
+
+div.op-compat-value {
+  float: right;
+  height: 100%;
+  font-size: 14px;
+  color: black;
+  margin-left: 10px;
+}
+</style>
+
+<paper-item>
+  <paper-item-body two-line>
+    <div>
+      <paper-icon-button
+        icon="{{_getToggleIcon(_expanded)}}"
+        on-click="_toggleExpanded"
+        class="toggle-button">
+      </paper-icon-button>
+      <div class="node-name" id="nodetitle">TPU Compatibility</div>
+    </div>
+    <div secondary>
+      <div class="subtitle">
+        <div class="op-compat-display">
+          <svg class="op-compat" preserveAspectRatio="xMinYMid meet"
+               viewBox="0 0 250 25">
+            <defs>
+              <linearGradient id="op-compat-fill">
+                <stop offset="0" stop-color$="[[_opCompatColor]]"></stop>
+                <stop offset$="[[_opCompatScore]]" stop-color$="[[_opCompatColor]]"></stop>
+                <stop offset$="[[_opCompatScore]]" stop-color$="[[_opIncompatColor]]"></stop>
+                <stop offset="1" stop-color$="[[_opIncompatColor ]]"></stop>
+              </linearGradient>
+            </defs>
+            <rect height="25" width="250"
+                  rx="5" ry="5" style="fill: url('#op-compat-fill');" />
+          </svg>
+          <div class="op-compat-value">[[_opCompatScoreLabel]]</div>
+        </div>
+      </div>
+    </div>
+  </paper-item-body>
+</paper-item>
+
+<iron-collapse opened="{{_expanded}}">
+<template is="dom-if" if="{{_expanded}}" restamp="true">
+  <div class="expandedInfo">
+    Incompatible Operations:
+    (<span>[[_totalIncompatOps]]</span>)
+    <iron-list class="incompat-ops-list" id ="incompatOpsList"
+               items="[[_incompatOpNodes]]">
+      <template>
+        <tf-graph-op-compat-list-item
+            class="non-control-list-item"
+            item-node="[[item]]"
+            item-render-info="[[_getRenderInfo(item.name, renderHierarchy)]]"
+            name="[[item.name]]"
+            template-index="[[_templateIndex]]"
+            color-by="[[colorBy]]"
+            item-type="incompat-ops">
+        </tf-graph-op-compat-list-item>
+      </template>
+    </iron-list>
+  </div>
+</template>
+</iron-collapse>
+
+</template>
+
+<script>
+(function() {
+  Polymer({
+    is: 'tf-graph-op-compat-card',
+    properties: {
+      graphHierarchy: Object,
+      hierarchyParams: Object,
+      renderHierarchy: Object,
+      _templateIndex: {
+        type: Function,
+        computed: '_getTemplateIndex(graphHierarchy)'
+      },
+      _incompatOpNodes: {
+        type: Object,
+        computed: '_getIncompatOpNodes(graphHierarchy, hierarchyParams)'
+      },
+      _expanded: {
+        type: Boolean,
+        value: true
+      },
+      _opCompatScore: {
+        type: Number,
+        computed: '_computeOpCompatScore(graphHierarchy)'
+      },
+      _opCompatScoreLabel: {
+        type: String,
+        computed: '_getOpCompatScoreLabel(_opCompatScore)'
+      },
+      _opCompatColor: {
+        type: String,
+        value: tf.graph.render.OpNodeColors.COMPATIBLE
+      },
+      _opIncompatColor: {
+        type: String,
+        value: tf.graph.render.OpNodeColors.INCOMPATIBLE
+      },
+      _totalIncompatOps: {
+        type: Number,
+        computed: '_getTotalIncompatOps(graphHierarchy)'
+      }
+    },
+    _getTemplateIndex: function(graphHierarchy) {
+      return graphHierarchy.getTemplateIndex();
+    },
+    _getNode: function(nodeName, graphHierarchy) {
+      return graphHierarchy.node(nodeName);
+    },
+    _getPrintableHTMLNodeName: function(nodeName) {
+      // Insert an optional line break before each slash so that
+      // long node names wrap cleanly at path boundaries.
+      return (nodeName || '').replace(/\//g, '<wbr>/');
+    },
+    _getRenderInfo: function(nodeName, renderHierarchy) {
+      return this.renderHierarchy.getOrCreateRenderNodeByName(nodeName);
+    },
+    _toggleExpanded: function() {
+      this._expanded = !this._expanded;
+    },
+    _getToggleIcon: function(expanded) {
+      return expanded ? "expand-less" : "expand-more";
+    },
+    _resizeList: function(selector) {
+      var list = document.querySelector(selector);
+      if (list) {
+        list.fire('iron-resize');
+      }
+    },
+    _getIncompatOpNodes: function(graphHierarchy, hierarchyParams) {
+      if (graphHierarchy && graphHierarchy.root) {
+        this.async(this._resizeList.bind(this, "#incompatOpsList"));
+        return tf.graph.hierarchy.getIncompatOps(graphHierarchy, hierarchyParams);
+      }
+    },
+    _computeOpCompatScore: function(graphHierarchy) {
+      if (graphHierarchy && graphHierarchy.root) {
+        var root = graphHierarchy.root;
+        var numCompat = root.compatibilityHistogram.compatible;
+        var numIncompat = root.compatibilityHistogram.incompatible;
+        if (numCompat == 0 && numIncompat == 0)
+          return 0;
+        return numCompat / (numCompat + numIncompat);
+      }
+      return 0;
+    },
+    _getOpCompatScoreLabel: function(opCompatScore) {
+      return d3.format(".0%")(opCompatScore);
+    },
+    _getTotalIncompatOps: function (graphHierarchy) {
+      if (graphHierarchy && graphHierarchy.root) {
+        return graphHierarchy.root.compatibilityHistogram.incompatible;
+      }
+      return 0;
+    }
+  });
+})();
+</script>
+</dom-module>

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-list-item.html
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-list-item.html
@@ -1,0 +1,139 @@
+<!--
+@license
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
+<link rel="import" href="../tf-graph-info/tf-graph-icon.html">
+
+<dom-module id="tf-graph-op-compat-list-item">
+<template>
+<style>
+#list-item {
+  width: 100%;
+  color: #565656;
+  font-size: 11pt;
+  font-weight: 400;
+  position: relative;
+  display: inline-block;
+}
+
+#list-item:hover {
+  background-color: var(--google-yellow-100);
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+#list-item span {
+  margin-left: 40px;
+}
+
+#list-item.excluded span {
+  color: #999;
+}
+
+#list-item span.edge-label {
+  float: right;
+  font-size: 10px;
+  margin-left: 3px;
+  margin-right: 5px;
+}
+
+.node-icon {
+  position: absolute;
+  top: 1px;
+  left: 2px;
+}
+
+.faded span {
+  color: var(--tb-graph-faded);
+}
+</style>
+
+<div id="list-item"
+     on-mouseover="_nodeListener"
+     on-mouseout="_nodeListener"
+     on-click="_nodeListener">
+  <div class$="{{_fadedClass(itemRenderInfo)}}">
+    <tf-graph-icon class="node-icon" height="12"
+                   color-by="[[colorBy]]"
+                   color-by-params="[[colorByParams]]"
+                   node="[[itemNode]]" render-info="[[itemRenderInfo]]"
+                   template-index="[[templateIndex]]">
+    </tf-graph-icon>
+    <span title$="[[name]]">[[name]]</span>
+  </div>
+</div>
+</template>
+
+<script>
+(function() {
+  Polymer({
+    is: 'tf-graph-op-compat-list-item',
+
+    properties: {
+      /**
+       * The Node for the card itself, on which this item is being drawn.
+       * @type {tf.graph.Node}
+       */
+      cardNode: Object,
+      /**
+       * The Node for the item within the card, somehow related to cardNode.
+       * @type {tf.graph.Node}
+       */
+      itemNode: Object,
+      /** The edge label associated with this item. */
+      edgeLabel: String,
+      /**
+       * The render node information for the item node. Used by the graph
+       * icon in determining fill color.
+       */
+      itemRenderInfo: Object,
+      name: String,
+      itemType: {
+        type: String,
+        observer: '_itemTypeChanged'
+      },
+      colorBy: String,
+      colorByParams: Object,
+      templateIndex: Function
+    },
+
+    _itemTypeChanged: function() {
+      if (this.itemType !== 'subnode') {
+        this.$['list-item'].classList.add('clickable');
+      } else {
+        this.$['list-item'].classList.remove('clickable');
+      }
+    },
+
+    _nodeListener: function(event) {
+      // fire node.click/mouseover/mouseout
+      this.fire('node-list-item-' + event.type, {
+        nodeName: this.name,
+        type: this.itemType
+      });
+    },
+
+    _fadedClass: function(itemRenderInfo) {
+      return itemRenderInfo && itemRenderInfo.isFadedOut ? 'faded' : '';
+    }
+  });
+})();
+</script>
+</dom-module>


### PR DESCRIPTION
This feature allows the user to view the graph with the new
compatibility coloring option. This option will color the nodes on the
graph by whether they are compatible for their assigned Device. This
feature is only viewable based on the debuggerData flag.

Currently, if an op is not specified a device, the device is defaulted
to the TPU. Furthermore, all ops are considered compatible for CPU and
GPU devices, while a whitelist of compatible ops are specifed for the
TPU.