### PR TITLE
Have Travis show test size warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ script:
       test \
       tensorboard/... \
       --verbose_failures \
+      --test_verbose_timeout_warnings \
       --test_output=errors \
       --spawn_strategy=sandboxed \
       --local_resources=400,2,1.0


### PR DESCRIPTION
These warnings are nice because they tell us when we should do things like have
size="small" on our test rules. That allows our internal CI system to schedule
tests more effectively.