### PR TITLE
Centralize a `markdown_to_safe_html` function

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -105,6 +105,30 @@ py_library(
 )
 
 py_library(
+    name = "plugin_util",
+    srcs = ["plugin_util.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_mozilla_bleach",
+        "@org_pythonhosted_markdown",
+        "@org_pythonhosted_six",
+    ],
+)
+
+py_test(
+    name = "plugin_util_test",
+    size = "small",
+    srcs = ["plugin_util_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":plugin_util",
+        "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
+    ],
+)
+
+py_library(
     name = "util",
     srcs = ["util.py"],
     srcs_version = "PY2AND3",

--- a/tensorboard/plugin_util.py
+++ b/tensorboard/plugin_util.py
@@ -1,0 +1,80 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Provides utilities that may be especially useful to plugins."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import bleach
+# pylint: disable=g-bad-import-order
+# Google-only: import markdown_freewisdom
+import markdown
+import six
+
+
+_ALLOWED_ATTRIBUTES = {
+    'a': ['href', 'title'],
+    'img': ['src', 'title', 'alt'],
+}
+
+_ALLOWED_TAGS = [
+    'ul',
+    'ol',
+    'li',
+    'p',
+    'pre',
+    'code',
+    'blockquote',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'hr',
+    'br',
+    'strong',
+    'em',
+    'a',
+    'img',
+    'table',
+    'thead',
+    'tbody',
+    'td',
+    'tr',
+    'th',
+]
+
+
+def markdown_to_safe_html(markdown_string):
+  """Convert Markdown to HTML that's safe to splice into the DOM.
+
+  Arguments:
+    markdown_string: A Unicode string or UTF-8--encoded bytestring
+      containing Markdown source. Markdown tables are supported.
+
+  Returns:
+    A string containing safe HTML.
+  """
+  # Convert to utf-8 whenever we have a binary input.
+  if isinstance(markdown_string, six.binary_type):
+    markdown_string = markdown_string.decode('utf-8')
+
+  string_html = markdown.markdown(
+      markdown_string, extensions=['markdown.extensions.tables'])
+  string_sanitized = bleach.clean(
+      string_html, tags=_ALLOWED_TAGS, attributes=_ALLOWED_ATTRIBUTES)
+  return string_sanitized

--- a/tensorboard/plugin_util_test.py
+++ b/tensorboard/plugin_util_test.py
@@ -1,0 +1,113 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import textwrap
+
+import six
+import tensorflow as tf
+
+from tensorboard import plugin_util
+
+
+class MarkdownToSafeHTMLTest(tf.test.TestCase):
+
+  def _test(self, markdown_string, expected):
+    actual = plugin_util.markdown_to_safe_html(markdown_string)
+    self.assertEqual(expected, actual)
+
+  def test_empty_input(self):
+    self._test(u'', u'')
+
+  def test_basic_formatting(self):
+    self._test(u'# _Hello_, **world!**\n\n'
+               'Check out [my website](http://example.com)!',
+               u'<h1><em>Hello</em>, <strong>world!</strong></h1>\n'
+               '<p>Check out <a href="http://example.com">my website</a>!</p>')
+
+  def test_table_formatting(self):
+    self._test(
+        textwrap.dedent(
+            u"""\
+            Here is some data:
+
+            TensorBoard usage | Happiness
+            ------------------|----------
+                          0.0 |       0.0
+                          0.5 |       0.5
+                          1.0 |       1.0
+
+            Wouldn't you agree?"""),
+        textwrap.dedent(
+            u"""\
+            <p>Here is some data:</p>
+            <table>
+            <thead>
+            <tr>
+            <th>TensorBoard usage</th>
+            <th>Happiness</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+            <td>0.0</td>
+            <td>0.0</td>
+            </tr>
+            <tr>
+            <td>0.5</td>
+            <td>0.5</td>
+            </tr>
+            <tr>
+            <td>1.0</td>
+            <td>1.0</td>
+            </tr>
+            </tbody>
+            </table>
+            <p>Wouldn't you agree?</p>"""))
+
+  def test_whitelisted_tags_and_attributes_allowed(self):
+    s = (u'Check out <a href="http://example.com" title="do it">'
+         'my website</a>!')
+    self._test(s, u'<p>%s</p>' % s)
+
+  def test_arbitrary_tags_and_attributes_removed(self):
+    self._test(u'We should bring back the <blink>blink tag</blink>; '
+               '<a name="bookmark" href="http://please-dont.com">'
+               'sign the petition!</a>',
+               u'<p>We should bring back the '
+               '&lt;blink&gt;blink tag&lt;/blink&gt;; '
+               '<a href="http://please-dont.com">sign the petition!</a></p>')
+
+  def test_javascript_hrefs_sanitized(self):
+    self._test(u'A <a href="javascript:void0">sketchy link</a> for you',
+               u'<p>A <a>sketchy link</a> for you</p>')
+
+  def test_byte_strings_interpreted_as_utf8(self):
+    s = u'> Look\u2014some UTF-8!'.encode('utf-8')
+    assert isinstance(s, six.binary_type), (type(s), six.binary_type)
+    self._test(s,
+               u'<blockquote>\n<p>Look\u2014some UTF-8!</p>\n</blockquote>')
+
+  def test_unicode_strings_passed_through(self):
+    s = u'> Look\u2014some UTF-8!'
+    assert not isinstance(s, six.binary_type), (type(s), six.binary_type)
+    self._test(s,
+               u'<blockquote>\n<p>Look\u2014some UTF-8!</p>\n</blockquote>')
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -15,6 +15,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":metadata",
+        "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",

--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -31,6 +31,7 @@ from werkzeug import wrappers
 import numpy as np
 import tensorflow as tf
 
+from tensorboard import plugin_util
 from tensorboard.backend import http_util
 from tensorboard.backend.event_processing import event_accumulator
 from tensorboard.plugins import base_plugin
@@ -83,7 +84,8 @@ class HistogramsPlugin(base_plugin.TBPlugin):
         content = metadata.parse_summary_metadata(content)
         summary_metadata = self._multiplexer.SummaryMetadata(run, tag)
         result[run][tag] = {'displayName': summary_metadata.display_name,
-                            'description': summary_metadata.summary_description}
+                            'description': plugin_util.markdown_to_safe_html(
+                                summary_metadata.summary_description)}
 
     return result
 

--- a/tensorboard/plugins/histogram/histograms_plugin_test.py
+++ b/tensorboard/plugins/histogram/histograms_plugin_test.py
@@ -42,7 +42,8 @@ class HistogramsPluginTest(tf.test.TestCase):
   _SCALAR_TAG = 'my-boring-scalars'
 
   _DISPLAY_NAME = 'Important production statistics'
-  _DESCRIPTION = 'quod erat scribendum'
+  _DESCRIPTION = 'quod *erat* scribendum'
+  _HTML_DESCRIPTION = '<p>quod <em>erat</em> scribendum</p>'
 
   _RUN_WITH_LEGACY_HISTOGRAM = '_RUN_WITH_LEGACY_HISTOGRAM'
   _RUN_WITH_HISTOGRAM = '_RUN_WITH_HISTOGRAM'
@@ -115,7 +116,7 @@ class HistogramsPluginTest(tf.test.TestCase):
         self._RUN_WITH_HISTOGRAM: {
             '%s/histogram_summary' % self._HISTOGRAM_TAG: {
                 'displayName': self._DISPLAY_NAME,
-                'description': self._DESCRIPTION,
+                'description': self._HTML_DESCRIPTION,
             },
         },
     }, self.plugin.index_impl())

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -15,6 +15,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/plugins:base_plugin",
         "@org_mozilla_bleach",
@@ -33,6 +34,7 @@ py_test(
     deps = [
         ":text_plugin",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:plugin_util",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",


### PR DESCRIPTION
Summary:
Now that every summary has a `summary_description` field, plugins will
need to serve rendered Markdown to the frontend (assuming that we don't
want to do Markdown rendering in JavaScript, which we don't). This
has security implications (sanitization), so TensorBoard should expose a
function that does the right thing.

An alternative would be to provide a route that provides rendered
Markdown for the `summary_description` only. This has disadvantages:
(1) it would require at least one extra network roundtrip (plugins must
first request the list of tags, then request the rendered description),
(2) it would induce a FoUC-like state where the tags have been fetched
but their metadata has not; and (3) it would not generalize to plugins
that want to safely render other kinds of Markdown, like the text
plugin.

Test Plan:
Run unit tests, and verify that the text and histogram plugins continue
to work.

wchargin-branch: markdown-to-safe-html