### PR TITLE
Display summaries' `displayName` and `description`

### DIFF
--- a/tensorboard/components/tf_card_heading/BUILD
+++ b/tensorboard/components/tf_card_heading/BUILD
@@ -13,5 +13,9 @@ ts_web_library(
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_markdown_view",
+        "@org_polymer_paper_dialog",
+        "@org_polymer_paper_dialog_scrollable",
+        "@org_polymer_paper_icon_button",
     ],
 )

--- a/tensorboard/components/tf_card_heading/tf-card-heading.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading.html
@@ -15,66 +15,122 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../paper-dialog/paper-dialog.html">
+<link rel="import" href="../paper-dialog-scrollable/paper-dialog-scrollable.html">
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-markdown-view/tf-markdown-view.html">
 
 <!--
-  A compact heading to appear above a single visualization, often
-  corresponding to either a single tag or a single run-tag combination.
+  A compact heading to appear above a single visualization, summarizing
+  the metadata about a tag or run-tag combination.
 
-  Properties:
-    `title` does just what it says on the tin.
-    `color` can be set to display a colored border at the left of the
-        card; if left unset, no border will be displayed:
-    Any contents of the heading will be rendered below the title, and
-        can be used to display a subtitle, some small control widgets,
-        or similar.
+  Properties (all optional):
+    - `displayName`, `tag`, and `description` are properties from the
+      relevant Summary protobuf.
+    - `run` is the name of the TensorFlow run, if applicable.
+    - `color` can be set to display a colored border at the left of the
+      card; if left unset, no border will be displayed.
+    - Any children of this component will be rendered below the above
+      information, and can be used to display (for example) some small
+      control widgets.
 -->
 <dom-module id="tf-card-heading">
   <template>
-    <div class="title-container" style="border-color: [[_borderColor]]">
-      <div
-        class="title"
-        inner-h-t-m-l="[[_break(title)]]"></div>
+    <div class="container" style="border-color: [[_borderColor]]">
       <div class="content">
+        <template is="dom-repeat" items="[[_labels]]">
+          <span class="label">[[item]]</span>
+        </template>
         <content></content>
       </div>
+      <template is="dom-if" if="[[description]]">
+        <paper-icon-button
+          icon="info"
+          on-tap="_toggleDescriptionDialog"
+          title="Show summary description"
+        ></paper-icon-button>
+      </template>
+      <paper-dialog
+        id="descriptionDialog"
+        no-overlap
+        horizontal-align="auto"
+        vertical-align="auto"
+      >
+        <paper-dialog-scrollable>
+          <tf-markdown-view html="[[description]]"></tf-markdown-view>
+        </paper-dialog-scrollable>
+      </paper-dialog>
     </div>
     <style>
-      .title-container {
-        border-left: 4px solid;
+      .container {
+        border-left: 4px solid;  /* border-color set as inline style */
         padding-left: 5px;
         margin-bottom: 10px;
-      }
-      .title {
-        font-size: 14px;
-        text-overflow: ellipsis;
-        overflow: hidden;
+        display: flex;
       }
       .content {
         font-size: 12px;
+        flex-grow: 1;
+      }
+      .label {
+        display: block;
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
+      .label:first-child {
+        font-size: 14px;
+      }
+      paper-icon-button {
+        flex-grow: 0;
+      }
+      paper-dialog-scrollable {
+        max-width: 640px;
       }
     </style>
   </template>
   <script>
     Polymer({
       is: "tf-card-heading",
+
       properties: {
-        title: String,
-        color: {
-          type: String,
-          value: null,   // this property is optional
-        },
+        displayName: {type: String, value: null},
+        tag: {type: String, value: null},
+        run: {type: String, value: null},
+        description: {type: String, value: null},
+        color: {type: String, value: null},  // a CSS color (e.g., '#abcdef')
+
         _borderColor: {
           type: String,
           computed: '_computeBorderColor(color)',
           readOnly: true,
         },
+        /** @type {!Array<!string>} */
+        _labels: {
+          type: Array,
+          computed: '_computeLabels(displayName, tag, run)',
+        },
       },
+
       _computeBorderColor(color) {
         return color || 'rgba(255, 255, 255, 0.0)';  // 100% transparent white
       },
-      _break: function(input) {
-        return input.replace(/([\/_-])/g, "$1<wbr>")
+      _computeLabels(displayName, tag, run) {
+        const results = [];
+        if (displayName) {
+          results.push(displayName);
+        }
+        if (tag && tag !== displayName) {
+          results.push(results.length ? `tag: ${tag}` : tag);
+        }
+        if (run) {
+          results.push(results.length ? `run: ${run}` : run);
+        }
+        return results;
+      },
+      _toggleDescriptionDialog(e) {
+        this.$.descriptionDialog.positionTarget = e.target;
+        this.$.descriptionDialog.toggle();
       },
     });
   </script>

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
@@ -30,8 +30,7 @@ backend.
 -->
 <dom-module id="tf-audio-loader">
   <template>
-    <tf-card-heading title="[[tag]]" color="[[_runColor]]">
-      <div>[[run]]</div>
+    <tf-card-heading run="[[run]]" tag="[[tag]]" color="[[_runColor]]">
       <template is="dom-if" if="[[_hasAtLeastOneStep]]">
         step
         <span style="font-weight: bold">[[_currentDatum.step]]</span>

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-loader.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-loader.html
@@ -28,8 +28,7 @@ limitations under the License.
 -->
 <dom-module id="tf-distribution-loader">
   <template>
-    <tf-card-heading title="[[tag]]" color="[[_runColor]]">
-      [[run]]
+    <tf-card-heading run="[[run]]" tag="[[tag]]" color="[[_runColor]]">
     </tf-card-heading>
     <!--
       The main distribution that we render. Data is set directly with

--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2017 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,35 +39,54 @@ def run_all(logdir, verbose=False):
   # Make a normal distribution, with a shifting mean
   mean_moving_normal = tf.random_normal(shape=[1000], mean=(5*k), stddev=1)
   # Record that distribution into a histogram summary
-  histogram_summary.op("normal/moving_mean", mean_moving_normal)
+  histogram_summary.op("normal/moving_mean",
+                       mean_moving_normal,
+                       description="A normal distribution whose mean changes "
+                                   "over time.")
 
   # Make a normal distribution with shrinking variance
   shrinking_normal = tf.random_normal(shape=[1000], mean=0, stddev=1-(k))
   # Record that distribution too
-  histogram_summary.op("normal/shrinking_variance", shrinking_normal)
+  histogram_summary.op("normal/shrinking_variance", shrinking_normal,
+                       description="A normal distribution whose variance "
+                                   "shrinks over time.")
 
   # Let's combine both of those distributions into one dataset
   normal_combined = tf.concat([mean_moving_normal, shrinking_normal], 0)
   # We add another histogram summary to record the combined distribution
-  histogram_summary.op("normal/bimodal", normal_combined)
+  histogram_summary.op("normal/bimodal", normal_combined,
+                       description="A combination of two normal distributions, "
+                                   "one with a moving mean and one with  "
+                                   "shrinking variance. The result is a "
+                                   "distribution that starts as unimodal and "
+                                   "becomes more and more bimodal over time.")
 
   # Add a gamma distribution
   gamma = tf.random_gamma(shape=[1000], alpha=k)
-  histogram_summary.op("gamma", gamma)
+  histogram_summary.op("gamma", gamma,
+                       description="A gamma distribution whose shape "
+                                   "parameter, α, changes over time.")
 
   # And a poisson distribution
   poisson = tf.random_poisson(shape=[1000], lam=k)
-  histogram_summary.op("poisson", poisson)
+  histogram_summary.op("poisson", poisson,
+                       description="A Poisson distribution, which only "
+                                   "takes on integer values.")
 
   # And a uniform distribution
   uniform = tf.random_uniform(shape=[1000], maxval=k*10)
-  histogram_summary.op("uniform", uniform)
+  histogram_summary.op("uniform", uniform,
+                       description="A simple uniform distribution.")
 
   # Finally, combine everything together!
   all_distributions = [mean_moving_normal, shrinking_normal,
                        gamma, poisson, uniform]
   all_combined = tf.concat(all_distributions, 0)
-  histogram_summary.op("all_combined", all_combined)
+  histogram_summary.op("all_combined", all_combined,
+                       description="An amalgamation of five distributions: a "
+                                   "uniform distribution, a gamma "
+                                   "distribution, a Poisson distribution, and "
+                                   "two normal distributions.")
 
   summaries = tf.summary.merge_all()
 

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -108,10 +108,11 @@ limitations under the License.
                         <tf-histogram-loader
                           run="[[item.run]]"
                           tag="[[item.tag]]"
+                          tag-metadata="[[_tagMetadata(_runToTagInfo, item.run, item.tag)]]"
                           time-property="[[_timeProperty]]"
                           histogram-mode="[[_histogramMode]]"
                           request-manager="[[_requestManager]]"
-                          ></tf-histogram-loader>
+                        ></tf-histogram-loader>
                       </template>
                     </div>
                   </template>
@@ -202,9 +203,10 @@ limitations under the License.
       },
 
       _makeCategories(runToTag, selectedRuns, tagFilter) {
-        // TODO(@wchargin): Incorporate the tags' display names and
-        // descriptions.
         return categorizeRunTagCombinations(runToTag, selectedRuns, tagFilter);
+      },
+      _tagMetadata(runToTagInfo, run, tag) {
+        return runToTagInfo[run][tag];
       },
     });
   </script>

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
@@ -30,9 +30,13 @@ limitations under the License.
 -->
 <dom-module id="tf-histogram-loader">
   <template>
-    <tf-card-heading title="[[tag]]" color="[[_runColor]]">
-      [[run]]
-    </tf-card-heading>
+    <tf-card-heading
+      tag="[[tag]]"
+      run="[[run]]"
+      display-name="[[tagMetadata.displayName]]"
+      description="[[tagMetadata.description]]"
+      color="[[_runColor]]"
+    ></tf-card-heading>
     <!--
       The main histogram that we render. Data is set directly with
       `setSeriesData`, not with a bound property.
@@ -95,6 +99,8 @@ limitations under the License.
       properties: {
         run: String,
         tag: String,
+        /** @type {{description: string, displayName: string}} */
+        tagMetadata: Object,
         timeProperty: String,
         histogramMode: String,
 

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -34,8 +34,7 @@ future for loading older images.
 -->
 <dom-module id="tf-image-loader">
   <template>
-    <tf-card-heading title="[[tag]]" color="[[_runColor]]">
-      <div>[[run]]</div>
+    <tf-card-heading tag="[[tag]]" run="[[run]]" color="[[_runColor]]">
       <template is="dom-if" if="[[_hasAtLeastOneStep]]">
         step
         <span style="font-weight: bold">[[_stepValue]]</span>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
@@ -32,7 +32,7 @@ limitations under the License.
 -->
 <dom-module id="tf-scalar-chart">
   <template>
-    <tf-card-heading title="[[tag]]"></tf-card-heading>
+    <tf-card-heading tag="[[tag]]"></tf-card-heading>
     <div id="chart-and-spinner-container">
       <vz-line-chart
         x-type="[[xType]]"

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
@@ -30,8 +30,7 @@ tf-text-loader displays markdown text data from the Text plugin.
 
 <dom-module id="tf-text-loader">
   <template>
-    <tf-card-heading title="[[tag]]" color="[[_runColor]]">
-      [[run]]
+    <tf-card-heading run="[[run]]" tag="[[tag]]" color="[[_runColor]]">
     </tf-card-heading>
     <paper-material
       elevation="1"


### PR DESCRIPTION
Summary:
This commit retrofits `tf-card-heading` to display the new metadata
associated with summaries.

![Example screenshot](https://user-images.githubusercontent.com/4317806/28694545-1acb19e8-72df-11e7-913d-18ec0356cdb2.png)

Test Plan:
Re-run the histogram demo to generate test data with summaries. Then,
check that all dashboards behave properly, and that the histogram
dashboard has an option to show descriptions.

wchargin-branch: show-display-name-and-description