### PR TITLE
Switch to a more accessible color scale

### DIFF
--- a/tensorboard/components/tf_color_scale/colorScale.ts
+++ b/tensorboard/components/tf_color_scale/colorScale.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import * as RunsStore from '../tf-backend/runsStore.js';
-import {palettes} from './palettes.js';
+import {standard as standardPalette} from './palettes.js';
 
 // Example usage:
 // runs = ["train", "test", "test1", "test2"]
@@ -28,11 +28,11 @@ export class ColorScale {
 
   /**
    * Creates a color scale with optional custom palette.
-   * @param {Array<string>} [palette=palettes.googleColorBlind] - The color
-   *     palette you want as an Array of hex strings.
+   * @param {Array<string>} palette The color palette to use, as an
+   *   Array of hex strings. Defaults to the standard palette.
    */
   constructor(
-      private readonly palette: string[] = palettes.googleColorBlindAssist) {}
+      private readonly palette: string[] = standardPalette) {}
 
   /**
    * Set the domain of strings.

--- a/tensorboard/components/tf_color_scale/palettes.ts
+++ b/tensorboard/components/tf_color_scale/palettes.ts
@@ -44,15 +44,28 @@ export const palettes = {
     '#f4b400'   // google yellow 700
   ],
   googleColorBlindAssist: [
+    //'#ff7043',  // orange
+    //'#00ACC1',  // dark cyan
+    //'#AB47BC',  // bright purple
+    //'#2A56C6',  // dark blue
+    '#0b8043',  // green
+    '#f7cb4d',  // yellow
+    '#c0ca33',  // lime
+    //'#5e35b1',  // purple
+    '#A52714',  // red
+  ],
+  // A palette based on `googleColorBlindAssist` that is more accessible
+  // to deuteranopes (anecdotally).
+  tensorboardColorBlindAssist: [
     '#ff7043',  // orange
     '#00ACC1',  // dark cyan
     '#AB47BC',  // bright purple
     '#2A56C6',  // dark blue
-    '#0b8043',  // green
-    '#F7CB4D',  // yellow
-    '#c0ca33',  // lime
+    '#14894c',  // green (modified from Google standard)
+    '#f7d336',  // yellow (modified from Google standard)
+    '#9bca11',  // lime (modified from Google standard)
     '#5e35b1',  // purple
-    '#A52714',  // red
+    '#b92714',  // red (modified from Google standard)
   ],
   // These palettes try to be better for color differentiation.
   // https://personal.sron.nl/~pault/
@@ -66,11 +79,16 @@ export const palettes = {
     '#332288', '#6699cc', '#88ccee', '#44aa99', '#117733', '#999933', '#ddcc77',
     '#cc6677', '#aa4466', '#882255', '#661100', '#aa4499'
   ],
-  // based on this palette: http://mkweb.bcgsc.ca/biovis2012/
   colorBlindAssist4: [
+    '#4477aa', '#66ccee', '#228833', '#ccbb44', '#ee6677', '#aa3377', '#bbbbbb',
+  ],
+  // based on this palette: http://mkweb.bcgsc.ca/biovis2012/
+  colorBlindAssist5: [
     '#FF6DB6', '#920000', '#924900', '#DBD100', '#24FF24', '#006DDB', '#490092'
   ],
   mldash: [
     '#E47EAD', '#F4640D', '#FAA300', '#F5E636', '#00A077', '#0077B8', '#00B7ED'
   ]
 };
+
+export const standard = palettes.colorBlindAssist4;


### PR DESCRIPTION
Summary:
Per @jart's request, I've been looking into color schemes that are more
accessible to people with deuteranomaly/deuteranopia (like me). Our
previous color scheme had three particularly bad color pairs:
yellow/lime, green/red (duh), and, to a lesser extent, blue/purple. [1]
I adjusted the first two of these pairs such that I could more
comfortably tell them apart at the scales at which they're used, but
the resulting scheme is still not great: the colors are just too
similar.

So I switched to the palette preferred by Paul Tol for
categorical data. (We already have several palettes of his and
modifications thereof in our `palettes.ts`, but not the best one!)

This image compares the three stages:
![Results of my comparison](https://user-images.githubusercontent.com/4317806/28694991-6d9e7d98-72e1-11e7-9fe3-581b7e32a1d2.png)

[1]: This pair is still pretty bad, just not as bad as the other two.

Here's what the resulting TensorBoard looks like:
![The histogram dashboard with the new color palette](https://user-images.githubusercontent.com/4317806/28695189-9f6df168-72e2-11e7-92e7-6fef5578d102.png)
![The scalar dashboard with the new color palette](https://user-images.githubusercontent.com/4317806/28695191-a053ad2a-72e2-11e7-987e-ab2554baa8a8.png)

The colors aren't always as vibrant as before on the scalar dashboard,
but I still think that they're attractive, especially when used at
larger scales (e.g., the histogram dashboard is quite pretty).
More importantly---they're more functional.

Test Plan:
Ask a colorblind person what they think!

In particular, the following is an interesting heuristic: look at the
list of checkboxes in the runs selector. Move from top to bottom, and
stop when you think you've gotten to a color that you've already seen.
If you have a false positive, the color palette is bad; this is very
much the case with all three bad pairs in the original palette, and also
(for me) with the blue/purple pair in the Mark II palette, but Tol's
palette has clearly distinct colors with no such false positives.

wchargin-branch: improve-color-a11y