### PR TITLE
Introduce `data_compat`, legacy summary converter

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -97,6 +97,30 @@ filegroup(
 )
 
 py_library(
+    name = "data_compat",
+    srcs = ["data_compat.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/plugins/histogram:metadata",
+    ],
+)
+
+py_test(
+    name = "data_compat_test",
+    size = "small",
+    srcs = ["data_compat_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":data_compat",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/plugins/histogram:metadata",
+        "//tensorboard/plugins/histogram:summary",
+    ],
+)
+
+py_library(
     name = "db",
     srcs = ["db.py"],
     srcs_version = "PY2AND3",

--- a/tensorboard/data_compat.py
+++ b/tensorboard/data_compat.py
@@ -1,0 +1,67 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Utilities to migrate legacy protos to their modern equivalents."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+
+from tensorboard.plugins.histogram import metadata as histogram_metadata
+
+
+def migrate_value(value):
+  """Convert `value` to a new-style value, if necessary and possible.
+
+  An "old-style" value is a value that uses any `value` field other than
+  the `tensor` field. A "new-style" value is a value that uses the
+  `tensor` field. TensorBoard continues to support old-style values on
+  disk; this method converts them to new-style values so that further
+  code need only deal with one data format.
+
+  Arguments:
+    value: A `tf.Summary.Value` object. This argument is not modified.
+
+  Returns:
+    If the `value` is an old-style value for which there is a new-style
+    equivalent, the result is the new-style value. Otherwise---if the
+    value is already new-style or does not yet have a new-style
+    equivalent---the value will be returned unchanged.
+
+  :type value: tf.Summary.Value
+  :rtype: tf.Summary.Value
+  """
+  handler = {
+      'histo': _migrate_histogram_value,
+  }.get(value.WhichOneof('value'))
+  return handler(value) if handler else value
+
+
+def _migrate_histogram_value(value):
+  histogram_value = value.histo
+  bucket_lefts = [histogram_value.min] + histogram_value.bucket_limit[:-1]
+  bucket_rights = histogram_value.bucket_limit[:-1] + [histogram_value.max]
+  bucket_counts = histogram_value.bucket
+  buckets = np.array([bucket_lefts, bucket_rights, bucket_counts]).transpose()
+
+  tensor_proto = tf.make_tensor_proto(buckets)
+  summary_metadata = histogram_metadata.create_summary_metadata(
+      display_name=value.metadata.display_name or value.tag,
+      description=value.metadata.summary_description)
+  return tf.Summary.Value(tag=value.tag,
+                          metadata=summary_metadata,
+                          tensor=tensor_proto)

--- a/tensorboard/data_compat_test.py
+++ b/tensorboard/data_compat_test.py
@@ -1,0 +1,124 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from tensorboard import data_compat
+from tensorboard.plugins.histogram import summary as histogram_summary
+from tensorboard.plugins.histogram import metadata as histogram_metadata
+
+
+class MigrateValueTest(tf.test.TestCase):
+  """Tests for `migrate_value`.
+
+  These tests should ensure that all first-party new-style values are
+  passed through unchanged, that all supported old-style values are
+  converted to new-style values, and that other old-style values are
+  passed through unchanged.
+  """
+
+  def _value_from_op(self, op):
+    with tf.Session() as sess:
+      summary_pbtxt = sess.run(op)
+    summary = tf.Summary()
+    summary.ParseFromString(summary_pbtxt)
+    # There may be multiple values (e.g., for an image summary that emits
+    # multiple images in one batch). That's fine; we'll choose any
+    # representative value, assuming that they're homogeneous.
+    assert summary.value
+    return summary.value[0]
+
+  def _assert_noop(self, value):
+    original_pbtxt = value.SerializeToString()
+    result = data_compat.migrate_value(value)
+    self.assertEqual(value, result)
+    self.assertEqual(original_pbtxt, value.SerializeToString())
+
+  def test_scalar(self):
+    op = tf.summary.scalar('important_constants', tf.constant(0x5f3759df))
+    value = self._value_from_op(op)
+    assert value.HasField('simple_value'), value
+    self._assert_noop(value)
+
+  def test_image(self):
+    op = tf.summary.image('mona_lisa',
+                          tf.random_normal(shape=[1, 400, 200, 3]))
+    value = self._value_from_op(op)
+    assert value.HasField('image'), value
+    self._assert_noop(value)
+
+  def test_audio(self):
+    op = tf.summary.audio('white_noise',
+                          tf.random_uniform(shape=[1, 44100],
+                                            minval=-1.0,
+                                            maxval=1.0),
+                          sample_rate=44100)
+    value = self._value_from_op(op)
+    assert value.HasField('audio'), value
+    self._assert_noop(value)
+
+  def test_text(self):
+    op = tf.summary.text('lorem_ipsum', tf.constant('dolor sit amet'))
+    value = self._value_from_op(op)
+    assert value.HasField('tensor'), value
+    self._assert_noop(value)
+
+  def test_fully_populated_tensor(self):
+    metadata = tf.SummaryMetadata()
+    metadata.plugin_data.add(plugin_name='font_of_wisdom',
+                             content='adobe_garamond')
+    op = tf.summary.tensor_summary(
+        name='tensorpocalypse',
+        tensor=tf.constant([[0.0, 2.0], [float('inf'), float('nan')]]),
+        display_name='TENSORPOCALYPSE',
+        summary_description='look on my works ye mighty and despair',
+        summary_metadata=metadata)
+    value = self._value_from_op(op)
+    assert value.HasField('tensor'), value
+    self._assert_noop(value)
+
+  def test_histogram(self):
+    old_op = tf.summary.histogram('important_data',
+                                  tf.random_normal(shape=[23, 45]))
+    old_value = self._value_from_op(old_op)
+    assert old_value.HasField('histo'), old_value
+    new_value = data_compat.migrate_value(old_value)
+
+    self.assertEqual('important_data', new_value.tag)
+    expected_metadata = histogram_metadata.create_summary_metadata(
+        display_name='important_data', description='')
+    self.assertEqual(expected_metadata, new_value.metadata)
+    self.assertTrue(new_value.HasField('tensor'))
+    buckets = tf.make_ndarray(new_value.tensor)
+    self.assertEqual(old_value.histo.min, buckets[0][0])
+    self.assertEqual(old_value.histo.max, buckets[-1][1])
+    self.assertEqual(23 * 45, buckets[:, 2].astype(int).sum())
+
+  def test_new_style_histogram(self):
+    op = histogram_summary.op('important_data',
+                              tf.random_normal(shape=[10, 10]),
+                              bucket_count=100,
+                              display_name='Important data',
+                              description='secrets of the universe')
+    value = self._value_from_op(op)
+    assert value.HasField('tensor'), value
+    self._assert_noop(value)
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
Summary:
As we move from using old-style summaries to using only tensor
summaries, we need to continue supporting the old formats. The only
plugin that has been converted so far is the histogram plugin, and that
plugin manages the compatibility itself. But it would be nicer to have a
unified Event Translation Layer where we convert all the old-style
events to new-style events. Once we do this, plugin code will only have
to deal with new-style events---which is especially attractive because
it makes the plugins more copy-pastable.

This commit introduces `data_compat`, a module that will perform such
conversions. This module will intercept events before the event
accumulator processes them. This is forward-compatible with SQL mode:
we can simply call out to this module from the SQL loader instead of the
event accumulator. For now, `data_compat` converts histogram values and
leaves everything else alone.

I haven't connected this layer to the event accumulator because it has
breaking behavior for the distributions plugin, which depends on
special-casing behavior in the accumulator. The plan to deal with that
is to move the histogram compression logic out of the event accumulator
and into the distributions plugin itself (so that compression is
performed on the fly instead of being precomputed).

Test Plan:
Run the included unit tests, which are comprehensive.

Also, apply the following patch:
```diff
diff --git a/tensorboard/backend/event_processing/BUILD b/tensorboard/backend/event_processing/BUILD
index 3ae126f..4043ca2 100644
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -82,6 +82,7 @@ py_library(
         ":event_file_loader",
         ":plugin_asset_util",
         ":reservoir",
+        "//tensorboard:data_compat",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins/distribution:compressor",
     ],
diff --git a/tensorboard/backend/event_processing/event_accumulator.py b/tensorboard/backend/event_processing/event_accumulator.py
index 65acc30..c588579 100644
--- a/tensorboard/backend/event_processing/event_accumulator.py
+++ b/tensorboard/backend/event_processing/event_accumulator.py
@@ -23,6 +23,7 @@ import threading

 import tensorflow as tf

+from tensorboard import data_compat
 from tensorboard.backend.event_processing import directory_watcher
 from tensorboard.backend.event_processing import event_file_loader
 from tensorboard.backend.event_processing import plugin_asset_util
@@ -383,6 +384,8 @@ class EventAccumulator(object):
       self._tagged_metadata[tag] = event.tagged_run_metadata.run_metadata
     elif event.HasField('summary'):
       for value in event.summary.value:
+        value = data_compat.translate_value(value)
+
         if value.HasField('metadata'):
           tag = value.tag
           # We only store the first instance of the metadata. This check
```
Verify that the resulting TensorBoard instance has working histograms
from both old- and new-style sources. (You can tell that the old-style
histograms have been converted because the reservoir sampling will be
more aggressive.) Note also that the distributions plugin is marked as
inactive, and that the event accumulator tests fail.

wchargin-branch: data-compat