### PR TITLE
Remove histogram compression from TensorBoard core

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -44,11 +44,11 @@ from tensorboard.plugins.core import core_plugin
 
 
 DEFAULT_SIZE_GUIDANCE = {
-    event_accumulator.COMPRESSED_HISTOGRAMS: 500,
     event_accumulator.IMAGES: 10,
     event_accumulator.AUDIO: 10,
     event_accumulator.SCALARS: 1000,
-    event_accumulator.HISTOGRAMS: 50,
+    event_accumulator.HISTOGRAMS: 500,
+    event_accumulator.TENSORS: 500,
 }
 
 DATA_PREFIX = '/data'

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -335,23 +335,6 @@ class EventMultiplexer(object):
     accumulator = self.GetAccumulator(run)
     return accumulator.Histograms(tag)
 
-  def CompressedHistograms(self, run, tag):
-    """Retrieve the compressed histogram events associated with a run and tag.
-
-    Args:
-      run: A string name of the run for which values are retrieved.
-      tag: A string name of the tag for which values are retrieved.
-
-    Raises:
-      KeyError: If the run is not found, or the tag is not available for
-        the given run.
-
-    Returns:
-      An array of `event_accumulator.CompressedHistogramEvents`.
-    """
-    accumulator = self.GetAccumulator(run)
-    return accumulator.CompressedHistograms(tag)
-
   def Images(self, run, tag):
     """Retrieve the image events associated with a run and tag.
 
@@ -453,7 +436,6 @@ class EventMultiplexer(object):
       {runName: { images: [tag1, tag2, tag3],
                   scalarValues: [tagA, tagB, tagC],
                   histograms: [tagX, tagY, tagZ],
-                  compressedHistograms: [tagX, tagY, tagZ],
                   graph: true, meta_graph: true}}
     ```
     """

--- a/tensorboard/backend/event_processing/event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/event_multiplexer_test.py
@@ -63,7 +63,6 @@ class _FakeAccumulator(object):
     return {event_accumulator.IMAGES: ['im1', 'im2'],
             event_accumulator.AUDIO: ['snd1', 'snd2'],
             event_accumulator.HISTOGRAMS: ['hst1', 'hst2'],
-            event_accumulator.COMPRESSED_HISTOGRAMS: ['cmphst1', 'cmphst2'],
             event_accumulator.SCALARS: ['sv1', 'sv2']}
 
   def FirstEventTimestamp(self):
@@ -79,9 +78,6 @@ class _FakeAccumulator(object):
 
   def Histograms(self, tag_name):
     return self._TagHelper(tag_name, event_accumulator.HISTOGRAMS)
-
-  def CompressedHistograms(self, tag_name):
-    return self._TagHelper(tag_name, event_accumulator.COMPRESSED_HISTOGRAMS)
 
   def Images(self, tag_name):
     return self._TagHelper(tag_name, event_accumulator.IMAGES)
@@ -107,9 +103,8 @@ class _FakeAccumulator(object):
 
 def _GetFakeAccumulator(path,
                         size_guidance=None,
-                        compression_bps=None,
                         purge_orphaned_data=None):
-  del size_guidance, compression_bps, purge_orphaned_data  # Unused.
+  del size_guidance, purge_orphaned_data  # Unused.
   return _FakeAccumulator(path)
 
 

--- a/tensorboard/plugins/distribution/BUILD
+++ b/tensorboard/plugins/distribution/BUILD
@@ -14,11 +14,11 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        ":compressor",
         "//tensorboard/backend:http_util",
-        "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/plugins/histogram:histograms_plugin",
         "@org_pocoo_werkzeug",
-        "@org_pythonhosted_six",
     ],
 )
 
@@ -29,12 +29,14 @@ py_test(
     main = "distributions_plugin_test.py",
     srcs_version = "PY2AND3",
     deps = [
+        ":compressor",
         ":distributions_plugin",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/plugins/histogram:summary",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/distribution/compressor_test.py
+++ b/tensorboard/plugins/distribution/compressor_test.py
@@ -26,87 +26,70 @@ def _make_expected_value(*values):
   return [compressor.CompressedHistogramValue(bp, val) for bp, val in values]
 
 
-class HistcompTest(tf.test.TestCase):
+class CompressorTest(tf.test.TestCase):
 
-  def testExample(self):
+  def test_example(self):
     bps = (0, 2500, 5000, 7500, 10000)
-    proto = tf.HistogramProto(
-        min=1,
-        max=2,
-        num=3,
-        sum=4,
-        sum_squares=5,
-        bucket_limit=[1, 2, 3],
-        bucket=[0, 3, 0])
+    buckets = [[0, 1, 0], [1, 2, 3], [2, 3, 0]]
+    self.assertEqual(
+        _make_expected_value(
+            (0, 0.0),
+            (2500, 0.5),
+            (5000, 1.0),
+            (7500, 1.5),
+            (10000, 3.0),
+        ),
+        compressor.compress_histogram(buckets, bps))
+
+  def test_another_example(self):
+    bps = (0, 2500, 5000, 7500, 10000)
+    buckets = [[1, 2, 1], [2, 3, 3], [3, 4, 0]]
     self.assertEqual(
         _make_expected_value(
             (0, 1.0),
-            (2500, 1.25),
-            (5000, 1.5),
-            (7500, 1.75),
-            (10000, 2.0)),
-        compressor.CompressHistogram(proto, bps))
+            (2500, 2.0),
+            (5000, 2.0 + 1/3),
+            (7500, 2.0 + 2/3),
+            (10000, 4.0)
+        ),
+        compressor.compress_histogram(buckets, bps))
 
-  def testAnotherExample(self):
+  def test_empty(self):
     bps = (0, 2500, 5000, 7500, 10000)
-    proto = tf.HistogramProto(
-        min=-2,
-        max=3,
-        num=4,
-        sum=5,
-        sum_squares=6,
-        bucket_limit=[2, 3, 4],
-        bucket=[1, 3, 0])
+    buckets = [[0, 1, 0], [1, 2, 0], [2, 3, 0]]
     self.assertEqual(
         _make_expected_value(
-            (0, -2),
-            (2500, 2),
-            (5000, 2 + 1 / 3),
-            (7500, 2 + 2 / 3),
-            (10000, 3)),
-        compressor.CompressHistogram(proto, bps))
+            (0, 3.0),
+            (2500, 3.0),
+            (5000, 3.0),
+            (7500, 3.0),
+            (10000, 3.0),
+        ),
+        compressor.compress_histogram(buckets, bps))
 
-  def testEmpty(self):
-    bps = (0, 2500, 5000, 7500, 10000)
-    proto = tf.HistogramProto(
-        min=None,
-        max=None,
-        num=0,
-        sum=0,
-        sum_squares=0,
-        bucket_limit=[1, 2, 3],
-        bucket=[0, 0, 0])
-    self.assertEqual(
-        _make_expected_value(
-            (0, 0),
-            (2500, 0),
-            (5000, 0),
-            (7500, 0),
-            (10000, 0)),
-        compressor.CompressHistogram(proto, bps))
-
-  def testUgly(self):
+  def test_ugly(self):
     bps = (0, 668, 1587, 3085, 5000, 6915, 8413, 9332, 10000)
-    proto = tf.HistogramProto(
-        min=0.0,
-        max=1.0,
-        num=960.0,
-        sum=64.0,
-        sum_squares=64.0,
-        bucket_limit=[0.0, 1e-12, 0.917246389039776, 1.0089710279437536,
-                      1.7976931348623157e+308],
-        bucket=[0.0, 896.0, 0.0, 64.0, 0.0])
-    vals = compressor.CompressHistogram(proto, bps)
+    bucket_limits = [-1.0,
+                     0.0,
+                     0.917246389039776,
+                     1.0089710279437536,
+                     1.7976931348623157e+308]
+    bucket_counts = [0.0, 896.0, 0.0, 64.0]
+    assert len(bucket_counts) == len(bucket_limits) - 1
+    buckets = list(zip(*[bucket_limits[:-1],
+                         bucket_limits[1:],
+                         bucket_counts]))
+    vals = compressor.compress_histogram(buckets, bps)
     self.assertEqual(tuple(v.basis_point for v in vals), bps)
-    self.assertAlmostEqual(vals[0].value, 0.0)
-    self.assertAlmostEqual(vals[1].value, 7.157142857142856e-14)
-    self.assertAlmostEqual(vals[2].value, 1.7003571428571426e-13)
-    self.assertAlmostEqual(vals[3].value, 3.305357142857143e-13)
-    self.assertAlmostEqual(vals[4].value, 5.357142857142857e-13)
-    self.assertAlmostEqual(vals[5].value, 7.408928571428571e-13)
-    self.assertAlmostEqual(vals[6].value, 9.013928571428571e-13)
-    self.assertAlmostEqual(vals[7].value, 9.998571428571429e-13)
-    self.assertAlmostEqual(vals[8].value, 1.0)
+    self.assertAlmostEqual(vals[0].value, -1.0)
+    self.assertAlmostEqual(vals[1].value, -0.86277993701301037)
+    self.assertAlmostEqual(vals[2].value, -0.67399964077791519)
+    self.assertAlmostEqual(vals[3].value, -0.36628159533703131)
+    self.assertAlmostEqual(vals[4].value, 0.027096279842737214)
+    self.assertAlmostEqual(vals[5].value, 0.42047415502250551)
+    self.assertAlmostEqual(vals[6].value, 0.72819220046338917)
+    self.assertAlmostEqual(vals[7].value, 0.91697249669848446)
+    self.assertAlmostEqual(vals[8].value, 1.7976931348623157e+308)
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/distribution/distributions_plugin.py
+++ b/tensorboard/plugins/distribution/distributions_plugin.py
@@ -12,7 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""The TensorBoard Distributions (a.k.a. compressed histograms) plugin."""
+"""The TensorBoard Distributions (a.k.a. compressed histograms) plugin.
+
+This plugin provides a different view for the same data that is used for
+the histograms plugin. Its `/distributions` route returns a result of
+the form
+
+    [[wall_time, step, [[bp_1, icdf_1], ..., [bp_k, icdf_k]]], ...],
+
+where each `icdf_i` is the value of the inverse CDF of the probability
+distribution provided by the data evaluated at `bp_i / 10000`. That is,
+each `icdf_i` is the lowest value such that `bp_i / 10000` of the values
+in the original data fall below `icdf_i`.
+
+The `bp_i` are the fixed values of `NORMAL_HISTOGRAM_BPS` in the
+`compressor` module of this package; `k` is `len(NORMAL_HISTOGRAM_BPS)`.
+"""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -21,16 +36,21 @@ from __future__ import print_function
 from werkzeug import wrappers
 
 from tensorboard.backend import http_util
-from tensorboard.backend.event_processing import event_accumulator
 from tensorboard.plugins import base_plugin
-
-_PLUGIN_PREFIX_ROUTE = event_accumulator.COMPRESSED_HISTOGRAMS
+from tensorboard.plugins.distribution import compressor
+from tensorboard.plugins.histogram import histograms_plugin
 
 
 class DistributionsPlugin(base_plugin.TBPlugin):
-  """Distributions Plugin for TensorBoard."""
+  """Distributions Plugin for TensorBoard.
 
-  plugin_name = _PLUGIN_PREFIX_ROUTE
+  This supports both old-style summaries (created with TensorFlow ops
+  that output directly to the `histo` field of the proto) and new-style
+  summaries (as created by the `tensorboard.plugins.histogram.summary`
+  module).
+  """
+
+  plugin_name = 'distributions'
 
   def __init__(self, context):
     """Instantiates DistributionsPlugin via TensorBoard core.
@@ -38,6 +58,7 @@ class DistributionsPlugin(base_plugin.TBPlugin):
     Args:
       context: A base_plugin.TBContext instance.
     """
+    self._histograms_plugin = histograms_plugin.HistogramsPlugin(context)
     self._multiplexer = context.multiplexer
 
   def get_plugin_apps(self):
@@ -47,20 +68,27 @@ class DistributionsPlugin(base_plugin.TBPlugin):
     }
 
   def is_active(self):
-    """This plugin is active iff any run has at least one relevant tag."""
-    return bool(self._multiplexer) and any(self.index_impl().values())
+    """This plugin is active iff any run has at least one histogram tag.
 
-  def index_impl(self):
-    return {
-        run_name: run_data[event_accumulator.COMPRESSED_HISTOGRAMS]
-        for (run_name, run_data) in self._multiplexer.Runs().items()
-        if event_accumulator.COMPRESSED_HISTOGRAMS in run_data
-    }
+    (The distributions plugin uses the same data source as the histogram
+    plugin.)
+    """
+    return self._histograms_plugin.is_active()
 
   def distributions_impl(self, tag, run):
-    """Result of the form `(body, mime_type)`."""
-    values = self._multiplexer.CompressedHistograms(run, tag)
-    return (values, 'application/json')
+    """Result of the form `(body, mime_type)`, or `ValueError`."""
+    (histograms, mime_type) = self._histograms_plugin.histograms_impl(
+        tag, run, downsample_to=None)
+    return ([self._compress(histogram) for histogram in histograms],
+            mime_type)
+
+  def _compress(self, histogram):
+    (wall_time, step, buckets) = histogram
+    converted_buckets = compressor.compress_histogram(buckets)
+    return [wall_time, step, converted_buckets]
+
+  def index_impl(self):
+    return self._histograms_plugin.index_impl()
 
   @wrappers.Request.application
   def tags_route(self, request):
@@ -69,8 +97,13 @@ class DistributionsPlugin(base_plugin.TBPlugin):
 
   @wrappers.Request.application
   def distributions_route(self, request):
-    """Given a tag and single run, return array of compressed histograms."""
+    """Given a tag and single run, return an array of compressed histograms."""
     tag = request.args.get('tag')
     run = request.args.get('run')
-    (body, mime_type) = self.distributions_impl(tag, run)
-    return http_util.Respond(request, body, mime_type)
+    try:
+      (body, mime_type) = self.distributions_impl(tag, run)
+      code = 200
+    except ValueError as e:
+      (body, mime_type) = (str(e), 'text/plain')
+      code = 400
+    return http_util.Respond(request, body, mime_type, code=code)

--- a/tensorboard/plugins/distribution/distributions_plugin_test.py
+++ b/tensorboard/plugins/distribution/distributions_plugin_test.py
@@ -22,22 +22,31 @@ from __future__ import print_function
 import collections
 import os.path
 
+import six
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
 from tensorboard.backend.event_processing import event_accumulator
 from tensorboard.backend.event_processing import event_multiplexer
 from tensorboard.plugins import base_plugin
+from tensorboard.plugins.distribution import compressor
 from tensorboard.plugins.distribution import distributions_plugin
+from tensorboard.plugins.histogram import summary
 
 
 class DistributionsPluginTest(tf.test.TestCase):
 
   _STEPS = 99
 
+  _LEGACY_DISTRIBUTION_TAG = 'my-ancient-distribution'
   _DISTRIBUTION_TAG = 'my-favorite-distribution'
   _SCALAR_TAG = 'my-boring-scalars'
 
+  _DISPLAY_NAME = 'Very important production statistics'
+  _DESCRIPTION = 'quod *erat* dispertiendum'
+  _HTML_DESCRIPTION = '<p>quod <em>erat</em> dispertiendum</p>'
+
+  _RUN_WITH_LEGACY_DISTRIBUTION = '_RUN_WITH_LEGACY_DISTRIBUTION'
   _RUN_WITH_DISTRIBUTION = '_RUN_WITH_DISTRIBUTION'
   _RUN_WITH_SCALARS = '_RUN_WITH_SCALARS'
 
@@ -52,35 +61,29 @@ class DistributionsPluginTest(tf.test.TestCase):
       self.generate_run(run_name)
     multiplexer = event_multiplexer.EventMultiplexer(size_guidance={
         # don't truncate my test data, please
-        event_accumulator.COMPRESSED_HISTOGRAMS:
-            self._STEPS,
+        event_accumulator.HISTOGRAMS: self._STEPS,
+        event_accumulator.TENSORS: self._STEPS,
     })
     multiplexer.AddRunsFromDirectory(self.logdir)
     multiplexer.Reload()
     context = base_plugin.TBContext(logdir=self.logdir, multiplexer=multiplexer)
     self.plugin = distributions_plugin.DistributionsPlugin(context)
 
-  def testRoutesProvided(self):
-    """Tests that the plugin offers the correct routes."""
-    self.set_up_with_runs([self._RUN_WITH_SCALARS])
-    routes = self.plugin.get_plugin_apps()
-    self.assertIsInstance(routes['/distributions'], collections.Callable)
-    self.assertIsInstance(routes['/tags'], collections.Callable)
-
   def generate_run(self, run_name):
-    if run_name == self._RUN_WITH_DISTRIBUTION:
-      (use_distributions, use_scalars) = (True, False)
-    elif run_name == self._RUN_WITH_SCALARS:
-      (use_distributions, use_scalars) = (False, True)
-    else:
-      assert False, 'Invalid run name: %r' % run_name
     tf.reset_default_graph()
     sess = tf.Session()
     placeholder = tf.placeholder(tf.float32, shape=[3])
-    if use_distributions:
-      tf.summary.histogram(self._DISTRIBUTION_TAG, placeholder)
-    if use_scalars:
+
+    if run_name == self._RUN_WITH_LEGACY_DISTRIBUTION:
+      tf.summary.histogram(self._LEGACY_DISTRIBUTION_TAG, placeholder)
+    elif run_name == self._RUN_WITH_DISTRIBUTION:
+      summary.op(self._DISTRIBUTION_TAG, placeholder,
+                 display_name=self._DISPLAY_NAME,
+                 description=self._DESCRIPTION)
+    elif run_name == self._RUN_WITH_SCALARS:
       tf.summary.scalar(self._SCALAR_TAG, tf.reduce_mean(placeholder))
+    else:
+      assert False, 'Invalid run name: %r' % run_name
     summ = tf.summary.merge_all()
 
     subdir = os.path.join(self.logdir, run_name)
@@ -92,34 +95,61 @@ class DistributionsPluginTest(tf.test.TestCase):
       writer.add_summary(s, global_step=step)
     writer.close()
 
+  def test_routes_provided(self):
+    """Tests that the plugin offers the correct routes."""
+    self.set_up_with_runs([self._RUN_WITH_SCALARS])
+    routes = self.plugin.get_plugin_apps()
+    self.assertIsInstance(routes['/distributions'], collections.Callable)
+    self.assertIsInstance(routes['/tags'], collections.Callable)
+
   def test_index(self):
-    self.set_up_with_runs([self._RUN_WITH_DISTRIBUTION,
-                           self._RUN_WITH_SCALARS])
+    self.set_up_with_runs([self._RUN_WITH_SCALARS,
+                           self._RUN_WITH_LEGACY_DISTRIBUTION,
+                           self._RUN_WITH_DISTRIBUTION])
     self.assertEqual({
-        self._RUN_WITH_DISTRIBUTION: [self._DISTRIBUTION_TAG],
-        self._RUN_WITH_SCALARS: [],
+        self._RUN_WITH_SCALARS: {},
+        self._RUN_WITH_LEGACY_DISTRIBUTION: {
+            self._LEGACY_DISTRIBUTION_TAG: {
+                'displayName': self._LEGACY_DISTRIBUTION_TAG,
+                'description': '',
+            },
+        },
+        self._RUN_WITH_DISTRIBUTION: {
+            '%s/histogram_summary' % self._DISTRIBUTION_TAG: {
+                'displayName': self._DISPLAY_NAME,
+                'description': self._HTML_DESCRIPTION,
+            },
+        },
     }, self.plugin.index_impl())
 
-  def _test_distributions_json(self, run_name, should_have_distributions):
-    self.set_up_with_runs([self._RUN_WITH_DISTRIBUTION,
-                           self._RUN_WITH_SCALARS])
-    if should_have_distributions:
-      (data, mime_type) = self.plugin.distributions_impl(
-          self._DISTRIBUTION_TAG, run_name)
+  def _test_distributions(self, run_name, tag_name, should_work=True):
+    self.set_up_with_runs([self._RUN_WITH_SCALARS,
+                           self._RUN_WITH_LEGACY_DISTRIBUTION,
+                           self._RUN_WITH_DISTRIBUTION])
+    if should_work:
+      (data, mime_type) = self.plugin.distributions_impl(tag_name, run_name)
       self.assertEqual('application/json', mime_type)
       self.assertEqual(len(data), self._STEPS)
       for i in xrange(self._STEPS):
-        self.assertEqual(i, data[i].step)
+        [_unused_wall_time, step, bps_and_icdfs] = data[i]
+        self.assertEqual(i, step)
+        (bps, _unused_icdfs) = zip(*bps_and_icdfs)
+        self.assertEqual(bps, compressor.NORMAL_HISTOGRAM_BPS)
     else:
-      with self.assertRaises(KeyError):
-        self.plugin.distributions_impl(
-            self._DISTRIBUTION_TAG, run_name)
+      with six.assertRaisesRegex(self, ValueError, 'No histogram tag'):
+        self.plugin.distributions_impl(self._DISTRIBUTION_TAG, run_name)
 
-  def test_distributions_json_with_scalars(self):
-    self._test_distributions_json(self._RUN_WITH_DISTRIBUTION, True)
+  def test_distributions_with_scalars(self):
+    self._test_distributions(self._RUN_WITH_SCALARS, self._DISTRIBUTION_TAG,
+                             should_work=False)
 
-  def test_distributions_json_with_histogram(self):
-    self._test_distributions_json(self._RUN_WITH_SCALARS, False)
+  def test_distributions_with_legacy_distribution(self):
+    self._test_distributions(self._RUN_WITH_LEGACY_DISTRIBUTION,
+                             self._LEGACY_DISTRIBUTION_TAG)
+
+  def test_distributions_with_distribution(self):
+    self._test_distributions(self._RUN_WITH_DISTRIBUTION,
+                             '%s/histogram_summary' % self._DISTRIBUTION_TAG)
 
   def test_active_with_distribution(self):
     self.set_up_with_runs([self._RUN_WITH_DISTRIBUTION])

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
@@ -101,6 +101,7 @@ limitations under the License.
                         <tf-distribution-loader
                           run="[[item.run]]"
                           tag="[[item.tag]]"
+                          tag-metadata="[[_tagMetadata(_runToTagInfo, item.run, item.tag)]]"
                           x-type="[[_xType]]"
                           request-manager="[[_requestManager]]"
                         ></tf-distribution-loader>
@@ -142,6 +143,7 @@ limitations under the License.
 
         _selectedRuns: Array,
         _runToTag: Object,  // map<run: string, tags: string[]>
+        _runToTagInfo: Object,
         _dataNotFound: Boolean,
 
         _tagFilter: {
@@ -169,14 +171,16 @@ limitations under the License.
       },
       _fetchTags() {
         const url = getRouter().pluginRoute('distributions', '/tags');
-        return this._requestManager.request(url).then(runToTag => {
-          if (_.isEqual(runToTag, this._runToTag)) {
+        return this._requestManager.request(url).then(runToTagInfo => {
+          if (_.isEqual(runToTagInfo, this._runToTagInfo)) {
             // No need to update anything if there are no changes.
             return;
           }
+          const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
           const tags = getTags(runToTag);
           this.set('_dataNotFound', tags.length === 0);
           this.set('_runToTag', runToTag);
+          this.set('_runToTagInfo', runToTagInfo);
         });
       },
       _reloadDistributions() {
@@ -187,6 +191,9 @@ limitations under the License.
 
       _makeCategories(runToTag, selectedRuns, tagFilter) {
         return categorizeRunTagCombinations(runToTag, selectedRuns, tagFilter);
+      },
+      _tagMetadata(runToTagInfo, run, tag) {
+        return runToTagInfo[run][tag];
       },
     });
   </script>

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-loader.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-loader.html
@@ -28,8 +28,13 @@ limitations under the License.
 -->
 <dom-module id="tf-distribution-loader">
   <template>
-    <tf-card-heading run="[[run]]" tag="[[tag]]" color="[[_runColor]]">
-    </tf-card-heading>
+    <tf-card-heading
+      tag="[[tag]]"
+      run="[[run]]"
+      display-name="[[tagMetadata.displayName]]"
+      description="[[tagMetadata.description]]"
+      color="[[_runColor]]"
+    ></tf-card-heading>
     <!--
       The main distribution that we render. Data is set directly with
       `setSeriesData`, not with a bound property.
@@ -87,6 +92,8 @@ limitations under the License.
       properties: {
         run: String,
         tag: String,
+        /** @type {{description: string, displayName: string}} */
+        tagMetadata: Object,
         xType: String,
 
         _colorScale: {


### PR DESCRIPTION
Summary:
This commit moves histogram compression from the event accumulator to
the distributions plugin. That is, instead of compressing histograms at
event processing time, we compress them at serving time (when the
`/distributions` route is requested). This should have no performance
impact, as the number of buckets in the histograms being compressed is
at most 30 (unless the user overrides the default), and the compression
algorithm is already very efficient.

Here is one subtle effect of this change: because the histograms and
compressed histograms had different reservoir sizes, naively applying
the change as described above would result in the time granularity of
the rendered distributions becoming significantly more coarse. (See
screenshots below.) To resolve this effect, we raise the histogram
downsampling threshold to that of the distributions, but perform
additional downsampling in the histograms plugin (and not the
distributions plugin). As a result, the amount of data sent over the
network in any given request is unchanged. It's true that more
histograms than before are stored in TensorBoard's memory, but the
increase should not be too great. Indeed, instead of thinking of the
change as increasing the amount of histograms stored, think of the
change as "uncompressing" all the already-compressed histograms and then
deleting all the original histograms. Because the uncompression factor
is not too large (in turn because we're always compressing from 30 bins
to 9 basis points), there shouldn't be any performance problems.

Here are three screenshots. The first is the original dashboard. The
second is the dashboard with this commit but without the dynamic
downsampling logic; this exhibits the coarse granularity issue described
above. The third is the dashboard after this commit, whose data is only
imperceptibly different from the original data.
![The distributions dashboard on master, before this commit](https://user-images.githubusercontent.com/4317806/28701498-730a2898-730b-11e7-9c16-201ba02cebd0.png)
![The distributions dashboard with a version of this commit that did not include dynamic downsampling](https://user-images.githubusercontent.com/4317806/28701494-7088b544-730b-11e7-9ac4-72bef442b8c9.png)
![The distributions dashboard after this commit](https://user-images.githubusercontent.com/4317806/28702387-7855821a-7311-11e7-8443-6c458f034c39.png)

Note that the distributions dashboard now supports new-style histograms.
In fact, we get this for free, because the distributions dashboard now
wraps the histogram dashboard plugin and post-processes its results!
This implementation change reflects the implicit dependency that the
distributions plugin has always had on the histograms plugin, making it
an explicit dependency in the code.

Full disclosure: the test data in `compressor_test.py` didn't make any
sense. The histogram protos had `min` and `max` values that were
disjoint with the data, had bogus `sum` and `sum_squares` values, etc.
I simply created reasonable test data and copied the results from
"actual" to "expected," so these tests trivially pass currently and from
now on can serve as regression tests. My test that the behavior is
actually reasonable is to compare the first and third screenshots above
and note that everything appears well-behaved: I cannot perceive a
single difference in the output. (Also, the only changes that I made to
the algorithm were to redirect the appropriate inputs for the new
format.)

Test Plan:
As described above, view the dashboard before and after this change, and
note that the distributions qualitatively appear very similar (though
the underlying data will of course not be exactly the same), while the
histograms dashboard is unchanged. Also, `bazel test //tensorboard/...`
passes with flying colors.

wchargin-branch: encapsulate-histogram-compression