### PR TITLE
Perform legacy event conversion with `data_compat`

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -47,7 +47,6 @@ DEFAULT_SIZE_GUIDANCE = {
     event_accumulator.IMAGES: 10,
     event_accumulator.AUDIO: 10,
     event_accumulator.SCALARS: 1000,
-    event_accumulator.HISTOGRAMS: 500,
     event_accumulator.TENSORS: 500,
 }
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -82,6 +82,7 @@ py_library(
         ":event_file_loader",
         ":plugin_asset_util",
         ":reservoir",
+        "//tensorboard:data_compat",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins/distribution:compressor",
     ],

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -318,23 +318,6 @@ class EventMultiplexer(object):
     accumulator = self.GetAccumulator(run)
     return accumulator.RunMetadata(tag)
 
-  def Histograms(self, run, tag):
-    """Retrieve the histogram events associated with a run and tag.
-
-    Args:
-      run: A string name of the run for which values are retrieved.
-      tag: A string name of the tag for which values are retrieved.
-
-    Raises:
-      KeyError: If the run is not found, or the tag is not available for
-        the given run.
-
-    Returns:
-      An array of `event_accumulator.HistogramEvents`.
-    """
-    accumulator = self.GetAccumulator(run)
-    return accumulator.Histograms(tag)
-
   def Images(self, run, tag):
     """Retrieve the image events associated with a run and tag.
 
@@ -435,7 +418,6 @@ class EventMultiplexer(object):
     ```
       {runName: { images: [tag1, tag2, tag3],
                   scalarValues: [tagA, tagB, tagC],
-                  histograms: [tagX, tagY, tagZ],
                   graph: true, meta_graph: true}}
     ```
     """

--- a/tensorboard/backend/event_processing/event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/event_multiplexer_test.py
@@ -62,7 +62,6 @@ class _FakeAccumulator(object):
   def Tags(self):
     return {event_accumulator.IMAGES: ['im1', 'im2'],
             event_accumulator.AUDIO: ['snd1', 'snd2'],
-            event_accumulator.HISTOGRAMS: ['hst1', 'hst2'],
             event_accumulator.SCALARS: ['sv1', 'sv2']}
 
   def FirstEventTimestamp(self):
@@ -75,9 +74,6 @@ class _FakeAccumulator(object):
 
   def Scalars(self, tag_name):
     return self._TagHelper(tag_name, event_accumulator.SCALARS)
-
-  def Histograms(self, tag_name):
-    return self._TagHelper(tag_name, event_accumulator.HISTOGRAMS)
 
   def Images(self, tag_name):
     return self._TagHelper(tag_name, event_accumulator.IMAGES)

--- a/tensorboard/http_api.md
+++ b/tensorboard/http_api.md
@@ -111,9 +111,9 @@ value the empty array.
 
 ## `/data/plugin/histograms/histograms?run=foo&tag=bar`
 
-Returns an array of event_accumulator.HistogramEvents ([wall_time, step,
-HistogramValue]) for the given run and tag. A HistogramValue is [min, max, num,
-sum, sum_squares, bucket_limit, bucket]. wall_time is seconds since epoch.
+Returns an array of [wall_time, step, HistogramValue] for the given run
+and tag. A HistogramValue is a list of buckets, where each bucket is of
+the form [min, max, count]. wall_time is seconds since epoch.
 
 Annotated Example: (note - real data is higher precision)
 
@@ -122,16 +122,9 @@ Annotated Example: (note - real data is higher precision)
         1443871386.185149, # wall_time
         235166,            # step
         [
-          -0.66,           # minimum value
-          0.44,            # maximum value
-          8.0,             # number of items in the histogram
-          -0.80,           # sum of items in the histogram
-          0.73,            # sum of squares of items in the histogram
-          [-0.68, -0.62, -0.292, -0.26, -0.11, -0.10, -0.08, -0.07, -0.05,
-          -0.0525, -0.0434, -0.039, -0.029, -0.026, 0.42, 0.47, 1.8e+308],
-                          # the right edge of each bucket
-        [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0,
-          1.0, 0.0]        # the number of elements within each bucket
+          [0.0, 1.0, 123.0],
+          [1.0, 2.0, 234.0],
+          [2.0, 3.0, 188.0]
         ]
       ]
     ]
@@ -152,8 +145,8 @@ value the empty array.
 
 ## `/data/plugin/distributions/distributions?run=foo&tag=bar`
 
-Returns an array of event_accumulator.CompressedHistogramEvents ([wall_time,
-step, CompressedHistogramValues]) for the given run and tag.
+Returns an array of [wall_time, step, CompressedHistogramValues] for the
+given run and tag.
 
 CompressedHistogramValues is a list of namedtuples with each tuple specifying
 a basis point (bps) as well as an interpolated value of the histogram value

--- a/tensorboard/plugins/distribution/distributions_plugin_test.py
+++ b/tensorboard/plugins/distribution/distributions_plugin_test.py
@@ -61,7 +61,6 @@ class DistributionsPluginTest(tf.test.TestCase):
       self.generate_run(run_name)
     multiplexer = event_multiplexer.EventMultiplexer(size_guidance={
         # don't truncate my test data, please
-        event_accumulator.HISTOGRAMS: self._STEPS,
         event_accumulator.TENSORS: self._STEPS,
     })
     multiplexer.AddRunsFromDirectory(self.logdir)

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -17,7 +17,6 @@ py_library(
         ":metadata",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
-        "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",

--- a/tensorboard/plugins/histogram/histograms_plugin_test.py
+++ b/tensorboard/plugins/histogram/histograms_plugin_test.py
@@ -60,7 +60,6 @@ class HistogramsPluginTest(tf.test.TestCase):
       self.generate_run(run_name)
     multiplexer = event_multiplexer.EventMultiplexer(size_guidance={
         # don't truncate my test data, please
-        event_accumulator.HISTOGRAMS: self._STEPS,
         event_accumulator.TENSORS: self._STEPS,
     })
     multiplexer.AddRunsFromDirectory(self.logdir)


### PR DESCRIPTION
Summary:
This commit simply hooks up the existing `data_compat` module to the
event accumulator. This is possible now that the distributions dashboard
does not rely on the existence of old-style histogram events.

In doing so, we remove the logic for old-style histograms from the event
accumulator and multiplexer. (Ideally, I'd prefer to do this in a
separate commit, but the tests depend heavily on this behavior, so it's
far easier to just knock 'em all out in one go. This is why this commit
is not only a few lines. But the delta is all red!)

Test Plan:
Take TensorBoard for a test drive (paying closest attention to the
histograms and distributions dashboards), and run all tests.

wchargin-branch: use-data-compat