### PR TITLE
Allow tensor reservoir size to depend on plugin

### DIFF
--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -68,6 +68,7 @@ py_library(
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins/core:core_plugin",
+        "//tensorboard/plugins/histogram:metadata",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -41,13 +41,20 @@ from tensorboard.backend.event_processing import event_accumulator
 from tensorboard.backend.event_processing import event_multiplexer
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.core import core_plugin
+from tensorboard.plugins.histogram import metadata as histogram_metadata
 
 
 DEFAULT_SIZE_GUIDANCE = {
     event_accumulator.IMAGES: 10,
     event_accumulator.AUDIO: 10,
     event_accumulator.SCALARS: 1000,
-    event_accumulator.TENSORS: 500,
+    event_accumulator.TENSORS: 10,
+}
+
+# TODO(@wchargin): Once SQL mode is in play, replace this with an
+# alternative that does not privilege first-party plugins.
+DEFAULT_TENSOR_SIZE_GUIDANCE = {
+    histogram_metadata.PLUGIN_NAME: 500,
 }
 
 DATA_PREFIX = '/data'
@@ -84,6 +91,7 @@ def standard_tensorboard_wsgi(
   """
   multiplexer = event_multiplexer.EventMultiplexer(
       size_guidance=DEFAULT_SIZE_GUIDANCE,
+      tensor_size_guidance=DEFAULT_TENSOR_SIZE_GUIDANCE,
       purge_orphaned_data=purge_orphaned_data)
   db_module, db_connection_provider = get_database_info(db_uri)
   if db_connection_provider is not None:

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -70,6 +70,7 @@ class EventMultiplexer(object):
   def __init__(self,
                run_path_map=None,
                size_guidance=None,
+               tensor_size_guidance=None,
                purge_orphaned_data=True):
     """Constructor for the `EventMultiplexer`.
 
@@ -79,6 +80,9 @@ class EventMultiplexer(object):
         None, then the EventMultiplexer initializes without any runs.
       size_guidance: A dictionary mapping from `tagType` to the number of items
         to store for each tag of that type. See
+        `event_accumulator.EventAccumulator` for details.
+      tensor_size_guidance: A dictionary mapping from `plugin_name` to
+        the number of items to store for each tag of that type. See
         `event_accumulator.EventAccumulator` for details.
       purge_orphaned_data: Whether to discard any events that were "orphaned" by
         a TensorFlow restart.
@@ -90,6 +94,7 @@ class EventMultiplexer(object):
     self._reload_called = False
     self._size_guidance = (size_guidance or
                            event_accumulator.DEFAULT_SIZE_GUIDANCE)
+    self._tensor_size_guidance = tensor_size_guidance
     self.purge_orphaned_data = purge_orphaned_data
     if run_path_map is not None:
       tf.logging.info('Event Multplexer doing initialization load for %s',
@@ -130,6 +135,7 @@ class EventMultiplexer(object):
         accumulator = event_accumulator.EventAccumulator(
             path,
             size_guidance=self._size_guidance,
+            tensor_size_guidance=self._tensor_size_guidance,
             purge_orphaned_data=self.purge_orphaned_data)
         self._accumulators[name] = accumulator
         self._paths[name] = path

--- a/tensorboard/backend/event_processing/event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/event_multiplexer_test.py
@@ -99,8 +99,9 @@ class _FakeAccumulator(object):
 
 def _GetFakeAccumulator(path,
                         size_guidance=None,
+                        tensor_size_guidance=None,
                         purge_orphaned_data=None):
-  del size_guidance, purge_orphaned_data  # Unused.
+  del size_guidance, tensor_size_guidance, purge_orphaned_data  # Unused.
   return _FakeAccumulator(path)
 
 


### PR DESCRIPTION
Summary:
In the current model, we determine reservoir size solely by which
`oneof value` is relevant to a given summary (e.g., `image` summaries
and `simple_value` scalar summaries have different values). But once
everything becomes a tensor, we lose this ability to differentiate.

This patch introduces a short-term solution, wherein we dispatch on the
`plugin_name` from the plugin metadata. It is short-term because it
preserves the current privileging of first-party plugins instead of
reducing it. However, it is a necessary step for porting our first-party
plugins to use tensor summaries.

Test Plan:
Note that before this change text summaries would have 500 samples due
to #291, while after this change they are back down to 10 while
distributions remain at 500 and histograms at 50 (by manual
downsampling; see #291 for more details). Also, note that all the unit
tests pass.

wchargin-branch: dependent-tensor-reservoirs