### PR TITLE
Make webdriver test manual-only

### DIFF
--- a/tensorboard/functionaltests/BUILD
+++ b/tensorboard/functionaltests/BUILD
@@ -11,8 +11,10 @@ py_web_test_suite(
     data = [
         "//tensorboard",
     ],
+    # TODO(@jart): Make this fast and not flaky.
     flaky = True,
     srcs_version = "PY2AND3",
+    tags = ["manual"],
     deps = [
         "//tensorboard/plugins/audio:audio_demo",
         "//tensorboard/plugins/scalar:scalars_demo",


### PR DESCRIPTION
Summary:
This test takes over 100 seconds to run and often fails multiple times.
It has never discovered any regressions, and causes far more trouble
than it is worth. @caisq reports that it sometimes hits hard timeout
limits. We should run it manually only.

Test Plan:
To verify that this commit does in fact prevent the test from running
automatically, invoke `bazel test //tensorboard/...` and note that it
completes within a reasonable amount of time, and in particular that
this test is not included in the list of passing tests.

wchargin-branch: disable-webdriver-test

