### PR TITLE
Create a tensor image summary

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -104,6 +104,7 @@ py_library(
     deps = [
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins/histogram:metadata",
+        "//tensorboard/plugins/image:metadata",
     ],
 )
 
@@ -117,6 +118,8 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins/histogram:metadata",
         "//tensorboard/plugins/histogram:summary",
+        "//tensorboard/plugins/image:metadata",
+        "//tensorboard/plugins/image:summary",
     ],
 )
 

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -5,6 +5,8 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 exports_files(["LICENSE"])
 
 py_library(
@@ -13,6 +15,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:event_accumulator",
@@ -37,4 +40,49 @@ py_test(
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],
+)
+
+py_library(
+    name = "summary",
+    srcs = ["summary.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":metadata",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_test(
+    name = "summary_test",
+    size = "small",
+    srcs = ["summary_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":metadata",
+        ":summary",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_library(
+    name = "metadata",
+    srcs = ["metadata.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//tensorboard:internal",
+    ],
+    deps = [
+        ":protos_all_py_pb2",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+tb_proto_library(
+    name = "protos_all",
+    srcs = ["plugin_data.proto"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorboard/plugins/image/metadata.py
+++ b/tensorboard/plugins/image/metadata.py
@@ -1,0 +1,54 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Internal information about the images plugin."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+from tensorboard.plugins.image import plugin_data_pb2
+
+
+PLUGIN_NAME = 'images'
+
+
+def create_summary_metadata(display_name, description):
+  """Create a `tf.SummaryMetadata` proto for image plugin data.
+
+  Returns:
+    A `tf.SummaryMetadata` protobuf object.
+  """
+  content = plugin_data_pb2.ImagePluginData()
+  metadata = tf.SummaryMetadata(display_name=display_name,
+                                summary_description=description)
+  metadata.plugin_data.add(plugin_name=PLUGIN_NAME,
+                           content=content.SerializeToString())
+  return metadata
+
+
+def parse_plugin_metadata(content):
+  """Parse summary metadata to a Python object.
+
+  Arguments:
+    content: The `content` field of a `SummaryMetadata` proto
+      corresponding to the image plugin.
+
+  Returns:
+    An `ImagePluginData` protobuf object.
+  """
+  result = plugin_data_pb2.ImagePluginData()
+  result.ParseFromString(content)
+  return result

--- a/tensorboard/plugins/image/plugin_data.proto
+++ b/tensorboard/plugins/image/plugin_data.proto
@@ -1,0 +1,28 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+syntax = "proto3";
+
+package tensorboard;
+
+// Image summaries created by the `tensorboard.plugins.image.summary`
+// module will include `SummaryMetadata` whose `plugin_data` field has
+// as `content` a binary string that is the encoding of an
+// `ImagePluginData` proto.
+//
+// We don't currently need to store any static metadata with image
+// summaries, so this message is empty.
+message ImagePluginData {
+}

--- a/tensorboard/plugins/image/summary.py
+++ b/tensorboard/plugins/image/summary.py
@@ -1,0 +1,135 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Image summaries and TensorFlow operations to create them.
+
+An image summary stores the width, height, and PNG-encoded data for zero
+or more images in a rank-1 string array: `[w, h, png0, png1, ...]`.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+
+from tensorboard.plugins.image import metadata
+
+
+def op(name,
+       images,
+       max_outputs=3,
+       display_name=None,
+       description=None,
+       collections=None):
+  """Create an image summary op for use in a TensorFlow graph.
+
+  Arguments:
+    name: A unique name for the generated summary node.
+    images: A `Tensor` representing pixel data with shape `[k, w, h, c]`,
+      where `k` is the number of images, `w` and `h` are the width and
+      height of the images, and `c` is the number of channels, which
+      should be 1, 3, or 4. Any of the dimensions may be statically
+      unknown (i.e., `None`).
+    max_outputs: Optional `int` or rank-0 integer `Tensor`. At most this
+      many images will be emitted at each step. When more than
+      `max_outputs` many images are provided, the first `max_outputs` many
+      images will be used and the rest silently discarded.
+    display_name: Optional name for this summary in TensorBoard, as a
+      constant `str`. Defaults to `name`.
+    description: Optional long-form description for this summary, as a
+      constant `str`. Markdown is supported. Defaults to empty.
+    collections: Optional list of graph collections keys. The new
+      summary op is added to these collections. Defaults to
+      `[Graph Keys.SUMMARIES]`.
+
+  Returns:
+    A TensorFlow summary op.
+  """
+  if display_name is None:
+    display_name = name
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=display_name, description=description)
+  with tf.name_scope(name), \
+       tf.control_dependencies([tf.assert_rank(images, 4),
+                                tf.assert_type(images, tf.uint8),
+                                tf.assert_non_negative(max_outputs)]):
+    limited_images = images[:max_outputs]
+    encoded_images = tf.map_fn(tf.image.encode_png, limited_images,
+                               dtype=tf.string,
+                               name='encode_each_image')
+    image_shape = tf.shape(images)
+    dimensions = tf.stack([tf.as_string(image_shape[1], name='width'),
+                           tf.as_string(image_shape[2], name='height')],
+                          name='dimensions')
+    tensor = tf.concat([dimensions, encoded_images], axis=0)
+    return tf.summary.tensor_summary(name='image_summary',
+                                     tensor=tensor,
+                                     collections=collections,
+                                     summary_metadata=summary_metadata)
+
+
+def pb(name, images, max_outputs=3, display_name=None, description=None):
+  """Create an image summary protobuf.
+
+  This behaves as if you were to create an `op` with the same arguments
+  (wrapped with constant tensors where appropriate) and then execute
+  that summary op in a TensorFlow session.
+
+  Arguments:
+    name: A unique name for the generated summary, including any desired
+      name scopes.
+    images: An `np.array` representing pixel data with shape
+      `[k, w, h, c]`, where `k` is the number of images, `w` and `h` are
+      the width and height of the images, and `c` is the number of
+      channels, which should be 1, 3, or 4.
+    max_outputs: Optional `int`. At most this many images will be
+      emitted. If more than this many images are provided, the first
+      `max_outputs` many images will be used and the rest silently
+      discarded.
+    display_name: Optional name for this summary in TensorBoard, as a
+      `str`. Defaults to `name`.
+    description: Optional long-form description for this summary, as a
+      `str`. Markdown is supported. Defaults to empty.
+
+  Returns:
+    A `tf.Summary` protobuf object.
+  """
+  images = np.array(images).astype(np.uint8)
+  if images.ndim != 4:
+    raise ValueError('Shape %r must have rank 4' % (images.shape, ))
+
+  limited_images = images[:max_outputs]
+  encoded_images = [_encode_png(image) for image in limited_images]
+  (width, height) = (images.shape[1], images.shape[2])
+  content = [str(width), str(height)] + encoded_images
+  tensor = tf.make_tensor_proto(content, dtype=tf.string)
+
+  if display_name is None:
+    display_name = name
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=display_name, description=description)
+
+  summary = tf.Summary()
+  summary.value.add(tag='%s/image_summary' % name,
+                    metadata=summary_metadata,
+                    tensor=tensor)
+  return summary
+
+
+def _encode_png(image):
+  # TODO(@wchargin): Pick a third-party PNG backend and implement this.
+  del image
+  raise NotImplementedError('Encoding PNGs in Python is not yet supported.')

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the image plugin summary generation functions."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import hashlib
+
+import numpy as np
+import six
+import tensorflow as tf
+
+from tensorboard.plugins.image import metadata
+from tensorboard.plugins.image import summary
+
+
+class SummaryTest(tf.test.TestCase):
+
+  def setUp(self):
+    super(SummaryTest, self).setUp()
+    tf.reset_default_graph()
+    self.stubs = tf.test.StubOutForTesting()
+    self.stubs.Set(summary, '_encode_png', self.stub_for_encode_png)
+    self.stubs.Set(tf.image, 'encode_png', self.stub_for_tf_encode_png)
+
+    self.image_width = 300
+    self.image_height = 75
+    self.image_count = 8
+    np.random.seed(0)
+    self.images = self._generate_images(channels=3)
+    self.images_with_alpha = self._generate_images(channels=4)
+
+  def tearDown(self):
+    self.stubs.CleanUp()
+    super(SummaryTest, self).tearDown()
+
+  def _generate_images(self, channels):
+    size = [self.image_count, self.image_width, self.image_height, channels]
+    return np.random.uniform(low=0, high=255, size=size).astype(np.uint8)
+
+  def stub_for_encode_png(self, data_array):
+    data_str = str(data_array)  # numpy will truncate this value
+    data_bytes = data_array.tobytes()  # this is not truncated
+    hashed = hashlib.sha256(data_bytes).hexdigest()
+    prefix = data_str[:64]
+    suffix = data_str[-64:]
+    digest = '%r...[%s]...%r' % (prefix, hashed, suffix)
+    return tf.compat.as_bytes('shape:%r;length:%s;digest:%s'
+                              % (data_array.shape, len(data_bytes), digest))
+
+  def stub_for_tf_encode_png(self, data_tensor):
+    f = tf.py_func(self.stub_for_encode_png,
+                   [data_tensor],
+                   Tout=tf.string,
+                   stateful=False)
+    # The shape needs to be statically known. In the real code, it's
+    # correctly inferred, but we have to set it manually here because we
+    # use a `py_func`.
+    f.set_shape([])  # PNG text is a string scalar (rank-0)
+    return f
+
+  def pb_via_op(self, summary_op, feed_dict=None):
+    with tf.Session() as sess:
+      actual_pbtxt = sess.run(summary_op, feed_dict=feed_dict or {})
+    actual_proto = tf.Summary()
+    actual_proto.ParseFromString(actual_pbtxt)
+    return actual_proto
+
+
+  def compute_and_check_summary_pb(self, name, images, max_outputs=3,
+                                   images_tensor=None, feed_dict=None):
+    """Use both `op` and `pb` to get a summary, asserting equality.
+
+    Returns:
+      a `Summary` protocol buffer
+    """
+    if images_tensor is None:
+      images_tensor = tf.cast(tf.constant(images), tf.uint8)
+    op = summary.op(name, images_tensor, max_outputs=max_outputs)
+    pb = summary.pb(name, images, max_outputs=max_outputs)
+    pb_via_op = self.pb_via_op(op, feed_dict=feed_dict)
+    self.assertProtoEquals(pb, pb_via_op)
+    return pb
+
+  def test_metadata(self):
+    pb = self.compute_and_check_summary_pb('mona_lisa', self.images)
+    summary_metadata = pb.value[0].metadata
+    plugin_data = summary_metadata.plugin_data[0]
+    self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
+    content = summary_metadata.plugin_data[0].content
+    # There's no content, so successfully parsing is fine.
+    metadata.parse_plugin_metadata(content)
+
+  def test_correctly_handles_no_images(self):
+    shape = (0, self.image_width, self.image_height, 3)
+    images = np.array([]).reshape(shape)
+    pb = self.compute_and_check_summary_pb('mona_lisa', images, max_outputs=3)
+    self.assertEqual(1, len(pb.value))
+    result = pb.value[0].tensor.string_val
+    self.assertEqual(tf.compat.as_bytes(str(self.image_width)), result[0])
+    self.assertEqual(tf.compat.as_bytes(str(self.image_height)), result[1])
+    image_results = result[2:]
+    self.assertEqual(len(image_results), 0)
+
+  def test_image_count_when_fewer_than_max(self):
+    max_outputs = len(self.images) - 3
+    assert max_outputs > 0, max_outputs
+    pb = self.compute_and_check_summary_pb('mona_lisa', self.images,
+                                           max_outputs=max_outputs)
+    self.assertEqual(1, len(pb.value))
+    result = pb.value[0].tensor.string_val
+    image_results = result[2:]  # skip width, height
+    self.assertEqual(len(image_results), max_outputs)
+
+  def test_image_count_when_more_than_max(self):
+    max_outputs = len(self.images) + 3
+    pb = self.compute_and_check_summary_pb('mona_lisa', self.images,
+                                           max_outputs=max_outputs)
+    self.assertEqual(1, len(pb.value))
+    result = pb.value[0].tensor.string_val
+    image_results = result[2:]  # skip width, height
+    self.assertEqual(len(image_results), len(self.images))
+
+  def _test_dimensions(self, alpha=False, static_dimensions=True):
+    if not alpha:
+      images = self.images
+      channel_count = 3
+    else:
+      images = self.images_with_alpha
+      channel_count = 4
+
+    if static_dimensions:
+      images_tensor = tf.constant(images, dtype=tf.uint8)
+      feed_dict = {}
+    else:
+      images_tensor = tf.placeholder(tf.uint8)
+      feed_dict = {images_tensor: images}
+
+    pb = self.compute_and_check_summary_pb('mona_lisa', images,
+                                           images_tensor=images_tensor,
+                                           feed_dict=feed_dict)
+    self.assertEqual(1, len(pb.value))
+    result = pb.value[0].tensor.string_val
+
+    # Check annotated dimensions.
+    self.assertEqual(tf.compat.as_bytes(str(self.image_width)), result[0])
+    self.assertEqual(tf.compat.as_bytes(str(self.image_height)), result[1])
+
+    # Check fake PNG data (verifying that the image was passed to the
+    # encoder correctly).
+    images = result[2:]
+    shape = (self.image_width, self.image_height, channel_count)
+    shape_tag = tf.compat.as_bytes('shape:%r;' % (shape, ))
+    for image in images:
+      self.assertTrue(
+          image.startswith(shape_tag),
+          'expected fake image data to start with %r, but found: %r'
+          % (shape_tag, image[:len(shape_tag) * 2]))
+
+  def test_dimensions(self):
+    self._test_dimensions(alpha=False)
+
+  def test_dimensions_with_alpha(self):
+    self._test_dimensions(alpha=True)
+
+  def test_dimensions_when_not_statically_known(self):
+    self._test_dimensions(alpha=False, static_dimensions=False)
+
+  def test_dimensions_with_alpha_when_not_statically_known(self):
+    self._test_dimensions(alpha=True, static_dimensions=False)
+
+  def test_requires_rank_4_in_op(self):
+    with six.assertRaisesRegex(self, ValueError, 'must have rank 4'):
+      summary.op('mona_lisa', tf.constant([[1, 2, 3], [4, 5, 6]]))
+
+  def test_requires_rank_4_in_pb(self):
+    with six.assertRaisesRegex(self, ValueError, 'must have rank 4'):
+      summary.pb('mona_lisa', np.array([[1, 2, 3], [4, 5, 6]]))
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
Summary:
This commit introduces a new-style summary for images, which new code
should prefer over `tf.summary.image`. The new summary is not privileged
and is built on top of `tensor_summary`.

The backend has not yet been updated, so there is no user-visible
effect. The next PR will contain a demo (including screenshots), and the
one after that will contain the backend and frontend changes.

The `pb` function is not yet supported because we don't have a
PNG-encoding library that is not TensorFlow, and we try to implement the
`pb` functions without using TensorFlow kernels (i.e., stuff like
`tf.make_tensor_proto` is of course fine, but `tf.Session.run()` is
not).

Test Plan:
Run `bazel test //tensorboard/plugins/image:summary_test`.

wchargin-branch: tensor-image-summary