### PR TITLE
Support new-style image summaries

### DIFF
--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -69,6 +69,7 @@ py_library(
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins/core:core_plugin",
         "//tensorboard/plugins/histogram:metadata",
+        "//tensorboard/plugins/image:metadata",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -42,10 +42,10 @@ from tensorboard.backend.event_processing import event_multiplexer
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.core import core_plugin
 from tensorboard.plugins.histogram import metadata as histogram_metadata
+from tensorboard.plugins.image import metadata as image_metadata
 
 
 DEFAULT_SIZE_GUIDANCE = {
-    event_accumulator.IMAGES: 10,
     event_accumulator.AUDIO: 10,
     event_accumulator.SCALARS: 1000,
     event_accumulator.TENSORS: 10,
@@ -54,6 +54,7 @@ DEFAULT_SIZE_GUIDANCE = {
 # TODO(@wchargin): Once SQL mode is in play, replace this with an
 # alternative that does not privilege first-party plugins.
 DEFAULT_TENSOR_SIZE_GUIDANCE = {
+    image_metadata.PLUGIN_NAME: 10,
     histogram_metadata.PLUGIN_NAME: 500,
 }
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -97,6 +97,7 @@ py_test(
         ":event_accumulator",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins/distribution:compressor",
+        "//tensorboard/plugins/image:summary",
     ],
 )
 

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -324,23 +324,6 @@ class EventMultiplexer(object):
     accumulator = self.GetAccumulator(run)
     return accumulator.RunMetadata(tag)
 
-  def Images(self, run, tag):
-    """Retrieve the image events associated with a run and tag.
-
-    Args:
-      run: A string name of the run for which values are retrieved.
-      tag: A string name of the tag for which values are retrieved.
-
-    Raises:
-      KeyError: If the run is not found, or the tag is not available for
-        the given run.
-
-    Returns:
-      An array of `event_accumulator.ImageEvents`.
-    """
-    accumulator = self.GetAccumulator(run)
-    return accumulator.Images(tag)
-
   def Audio(self, run, tag):
     """Retrieve the audio events associated with a run and tag.
 
@@ -422,8 +405,7 @@ class EventMultiplexer(object):
 
     Returns:
     ```
-      {runName: { images: [tag1, tag2, tag3],
-                  scalarValues: [tagA, tagB, tagC],
+      {runName: { scalarValues: [tagA, tagB, tagC],
                   graph: true, meta_graph: true}}
     ```
     """

--- a/tensorboard/backend/event_processing/event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/event_multiplexer_test.py
@@ -60,8 +60,7 @@ class _FakeAccumulator(object):
     }
 
   def Tags(self):
-    return {event_accumulator.IMAGES: ['im1', 'im2'],
-            event_accumulator.AUDIO: ['snd1', 'snd2'],
+    return {event_accumulator.AUDIO: ['snd1', 'snd2'],
             event_accumulator.SCALARS: ['sv1', 'sv2']}
 
   def FirstEventTimestamp(self):
@@ -74,9 +73,6 @@ class _FakeAccumulator(object):
 
   def Scalars(self, tag_name):
     return self._TagHelper(tag_name, event_accumulator.SCALARS)
-
-  def Images(self, tag_name):
-    return self._TagHelper(tag_name, event_accumulator.IMAGES)
 
   def Audio(self, tag_name):
     return self._TagHelper(tag_name, event_accumulator.AUDIO)

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -17,6 +17,7 @@ py_library(
     deps = [
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",
@@ -43,6 +44,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":images_plugin",
+        ":summary",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
@@ -92,6 +92,9 @@ TensorFlow run.
                         <tf-image-loader
                           run="[[item.run]]"
                           tag="[[item.tag]]"
+                          sample="[[item.sample]]"
+                          of-samples="[[item.ofSamples]]"
+                          tag-metadata="[[_tagMetadata(_runToTagInfo, item.run, item.tag)]]"
                           request-manager="[[_requestManager]]"
                           actual-size="[[_actualSize]]"
                         ></tf-image-loader>
@@ -125,7 +128,7 @@ TensorFlow run.
       is: 'tf-image-dashboard',
       properties: {
         _selectedRuns: Array,
-        _runToTag: Object,  // map<run: string, tags: string[]>
+        _runToTagInfo: Object,
         _dataNotFound: Boolean,
         _actualSize: Boolean,
 
@@ -136,7 +139,7 @@ TensorFlow run.
         _categories: {
           type: Array,
           computed:
-            '_makeCategories(_runToTag, _selectedRuns, _tagFilter)',
+            '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter)',
         },
 
         _requestManager: {
@@ -155,14 +158,15 @@ TensorFlow run.
       },
       _fetchTags() {
         const url = getRouter().pluginRoute('images', '/tags');
-        return this._requestManager.request(url).then(runToTag => {
-          if (_.isEqual(runToTag, this._runToTag)) {
+        return this._requestManager.request(url).then(runToTagInfo => {
+          if (_.isEqual(runToTagInfo, this._runToTagInfo)) {
             // No need to update anything if there are no changes.
             return;
           }
+          const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
           const tags = getTags(runToTag);
           this.set('_dataNotFound', tags.length === 0);
-          this.set('_runToTag', runToTag);
+          this.set('_runToTagInfo', runToTagInfo);
         });
       },
       _reloadImages() {
@@ -171,8 +175,25 @@ TensorFlow run.
         });
       },
 
-      _makeCategories(runToTag, selectedRuns, tagFilter) {
-        return categorizeRunTagCombinations(runToTag, selectedRuns, tagFilter);
+      _makeCategories(runToTagInfo, selectedRuns, tagFilter) {
+        const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
+        const baseCategories =
+          categorizeRunTagCombinations(runToTag, selectedRuns, tagFilter);
+        function explodeItem(item) {
+          const samples = runToTagInfo[item.run][item.tag].samples;
+          return _.range(samples).map(i => Object.assign({}, item, {
+            sample: i,
+            ofSamples: samples,
+          }));
+        }
+        const withSamples = baseCategories.map(category =>
+          Object.assign({}, category, {
+            items: [].concat.apply([], category.items.map(explodeItem)),
+          }));
+        return withSamples;
+      },
+      _tagMetadata(runToTagInfo, run, tag) {
+        return runToTagInfo[run][tag];
       },
     });
   </script>

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -34,26 +34,39 @@ future for loading older images.
 -->
 <dom-module id="tf-image-loader">
   <template>
-    <tf-card-heading tag="[[tag]]" run="[[run]]" color="[[_runColor]]">
+    <tf-card-heading
+      tag="[[tag]]"
+      run="[[run]]"
+      display-name="[[tagMetadata.displayName]]"
+      description="[[tagMetadata.description]]"
+      color="[[_runColor]]"
+    >
+      <template is="dom-if" if="[[_hasMultipleSamples]]">
+        <div>sample: [[_sampleText]] of [[ofSamples]]</div>
+      </template>
       <template is="dom-if" if="[[_hasAtLeastOneStep]]">
-        step
-        <span style="font-weight: bold">[[_stepValue]]</span>
-        <template is="dom-if" if="[[_currentWallTime]]">
-          ([[_currentWallTime]])
-        </template>
-        <paper-spinner-lite active hidden$=[[!_isImageLoading]]>
-        </paper-spinner-lite>
+        <div>
+          step
+          <span style="font-weight: bold">[[_stepValue]]</span>
+          <template is="dom-if" if="[[_currentWallTime]]">
+            ([[_currentWallTime]])
+          </template>
+          <paper-spinner-lite active hidden$=[[!_isImageLoading]]>
+          </paper-spinner-lite>
+        </div>
       </template>
       <template is="dom-if" if="[[_hasMultipleSteps]]">
-        <paper-slider
-          id="steps"
-          immediate-value="{{_stepIndex}}"
-          max="[[_maxStepIndex]]"
-          max-markers="[[_maxStepIndex]]"
-          snaps
-          step="1"
-          value="{{_stepIndex}}"
-        ></paper-slider>
+        <div>
+          <paper-slider
+            id="steps"
+            immediate-value="{{_stepIndex}}"
+            max="[[_maxStepIndex]]"
+            max-markers="[[_maxStepIndex]]"
+            snaps
+            step="1"
+            value="{{_stepIndex}}"
+          ></paper-slider>
+        </div>
       </template>
     </tf-card-heading>
     <div id="main-image-container"></div>
@@ -61,7 +74,7 @@ future for loading older images.
     <style>
       :host {
         display: block;
-        width: 330px;
+        width: 350px;
         height: auto;
         position: relative;
         margin: 0 15px 40px 0;
@@ -145,6 +158,10 @@ future for loading older images.
       properties: {
         run: String,
         tag: String,
+        sample: Number,
+        ofSamples: Number,
+        /** @type {{description: string, displayName: string}} */
+        tagMetadata: Object,
 
         _runColor: {
           type: String,
@@ -202,6 +219,14 @@ future for loading older images.
           type: Number,
           computed: "_computeMaxStepIndex(_steps)",
         },
+        _sampleText: {
+          type: String,
+          computed: "_computeSampleText(sample)",
+        },
+        _hasMultipleSamples: {
+          type: Boolean,
+          computed: "_computeHasMultipleSamples(ofSamples)",
+        },
         _isImageLoading: {
           type: Boolean,
           value: false,
@@ -230,6 +255,12 @@ future for loading older images.
       _computeMaxStepIndex(steps) {
         return steps.length - 1;
       },
+      _computeSampleText(sample) {
+        return `${sample + 1}`;
+      },
+      _computeHasMultipleSamples(ofSamples) {
+        return ofSamples > 1;
+      },
 
       attached() {
         this._attached = true;
@@ -241,8 +272,9 @@ future for loading older images.
         }
         this._metadataCanceller.cancelAll();
         const router = getRouter();
-        const url =
-          router.pluginRunTagRoute("images", "/images")(this.tag, this.run);
+        const baseURL = router.pluginRoute("images", "/images");
+        const query = `run=${this.run}&tag=${this.tag}&sample=${this.sample}`;
+        const url = baseURL + (baseURL.indexOf('?') !== -1 ? '&' : '?') + query;
         const updateSteps = this._metadataCanceller.cancellable(result => {
           if (result.cancelled) {
             return;


### PR DESCRIPTION
Summary:
This commit adds support for new-style image summaries to the plugin
frontend and backend.

From the previous PR (#314), here's a screenshot of the resulting
dashboard:
![Screenshot](https://user-images.githubusercontent.com/4317806/28850780-7e246538-76d3-11e7-956b-674ca58123ee.png)

Old-style and new-style image summaries handle larger-than-unit batch
sizes in different ways. Old-style summaries create multiple tags, and
may emit multiple summaries per step. New-style summaries can't do this
(they have to emit a single tensor at every step), so they emit a tensor
containing all the images at once. The new-style format gives us more
flexibility as to how we display the result (see #296 for some ideas),
but for now we preserve the form of the UI used for the old-style
summaries.

This change is fully compatible with the old data format.

Test Plan:
Run `bazel run //tensorboard/plugins/image:images_demo` to get data
using new-style image summaries. Then, run some standard MNIST model to
get data using old-style image summaries. Launch a TensorBoard with
a logdir enclosing all of this data, and verify that it all renders
correctly.

Here is a video of the above test plan:
https://drive.google.com/file/d/0B6hO3pg41pf9Y1VmeGJJVGtncWc/view
(May not be accessible to non-Googlers.)

When running `bazel test //tensorboard/...`, be aware that this diff
contains a particularly large number of uses of `tf.compat.as_bytes` and
friends. Thus, it is wise to run this test command in both py2 and py3
virtualenvs.

wchargin-branch: new-style-image-frontend