### PR TITLE
Set defaults for weight and num_thresholds to None

### DIFF
--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -30,8 +30,8 @@ def op(
     tag,
     labels,
     predictions,
-    num_thresholds=200,
-    weight=1.0,
+    num_thresholds=None,
+    weight=None,
     display_name=None,
     description=None,
     collections=None):
@@ -78,6 +78,12 @@ def op(
     false positives, true negatives, false negatives, precision, recall.
 
   """
+  if num_thresholds is None:
+    num_thresholds = 200
+
+  if weight is None:
+    weight = 1.0
+
   dtype = predictions.dtype
 
   with tf.name_scope(tag, values=[labels, predictions, weight]):


### PR DESCRIPTION
Set the default parameter value for `weight` as well as `num_thresholds` to be `None`. That had slipped through a previous PR.