### PR TITLE
Hide "Show health pills" when debugger is inactive

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -320,22 +320,16 @@ table.tf-graph-controls td.input-element-table-data {
       </div>
     </div>
   </template>
-  <table class="control-holder">
-    <tr>
-      <td class="title">Trace inputs</td>
-      <td class="input-element-table-data">
-        <paper-toggle-button id="trace-inputs"></paper-toggle-button>
-      </td>
-    </tr>
-    <template is="dom-if" if="[[healthPillsFeatureEnabled]]">
-      <tr>
-        <td class="title">Show health pills</td>
-        <td class="input-element-table-data">
-          <paper-toggle-button checked="{{healthPillsToggledOn}}"></paper-toggle-button>
-        </td>
-      </tr>
-    </template>
-  </table>
+  <div class="control-holder">
+    <paper-toggle-button id="trace-inputs"></paper-toggle-button>
+    <div class="title">Trace inputs</div>
+  </div>
+  <template is="dom-if" if="[[healthPillsFeatureEnabled]]">
+    <div class="control-holder">
+      <paper-toggle-button checked="{{healthPillsToggledOn}}"></paper-toggle-button>
+      <div class="title">Show health pills</div>
+    </div>
+  </template>
   <div class="control-holder">
     <div class="title">Color</div>
     <paper-radio-group id="color-by-radio-group" selected="{{colorBy}}">
@@ -619,7 +613,7 @@ table.tf-graph-controls td.input-element-table-data {
               </defs>
               <path marker-end="url(#dataflow-arrowhead-legend)"
                     stroke="#bbb" d="M2 9 l 29 0"
-                    stroke-linecap="round" />
+                    stroke-linecap="round" />showUploadButton
             </svg>
           </td>
           <td>

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -613,7 +613,7 @@ table.tf-graph-controls td.input-element-table-data {
               </defs>
               <path marker-end="url(#dataflow-arrowhead-legend)"
                     stroke="#bbb" d="M2 9 l 29 0"
-                    stroke-linecap="round" />showUploadButton
+                    stroke-linecap="round" />
             </svg>
           </td>
           <td>


### PR DESCRIPTION
We now hide the "Show health pills" toggle within the graph dashboard
when the debugger plugin is inactive.

When the debugger is active:
![download](https://user-images.githubusercontent.com/4221553/28890227-49e0d42a-777b-11e7-8818-4159ee3a25eb.png)

vs inactive:
![qxdnr7judre](https://user-images.githubusercontent.com/4221553/28890341-980d8486-777b-11e7-94ac-c84b64cb255f.png)

Previously, the problem had been that a dom-if block had been used as a
direct child of a `<table>` element. Apparently, polymer ignores the
dom-if condition in that case. I also formatted the toggles using divs
instead of tables and positioned labels to the right of their respective
toggle widgets for alignment.

Fixes #318.