### PR TITLE
[profile] Make profile_plugin load json trace.

### DIFF
--- a/tensorboard/plugins/profile/BUILD
+++ b/tensorboard/plugins/profile/BUILD
@@ -32,9 +32,9 @@ py_library(
 
 py_test(
     name = "profile_plugin_test",
+    size = "small",
     srcs = ["profile_plugin_test.py"],
     srcs_version = "PY2AND3",
-    size="small",
     deps = [
         ":profile_plugin",
         "//tensorboard:expect_tensorflow_installed",

--- a/tensorboard/plugins/profile/BUILD
+++ b/tensorboard/plugins/profile/BUILD
@@ -22,8 +22,6 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
-        ":protos_all_py_pb2",
-        ":trace_events_json",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:plugin_asset_util",
@@ -45,6 +43,8 @@ py_test(
     ],
 )
 
+# TODO(ioeric): this is only used by test and demo at this point. Clean it up
+# when we are sure that we will not convert JSON in the plugin anymore.
 py_library(
     name = "trace_events_json",
     srcs = ["trace_events_json.py"],
@@ -77,6 +77,7 @@ py_binary(
     deps = [
         ":profile_plugin",
         ":protos_all_py_pb2",
+        ":trace_events_json",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend/event_processing:plugin_asset_util",
     ],

--- a/tensorboard/plugins/profile/BUILD
+++ b/tensorboard/plugins/profile/BUILD
@@ -34,9 +34,9 @@ py_test(
     name = "profile_plugin_test",
     srcs = ["profile_plugin_test.py"],
     srcs_version = "PY2AND3",
+    size="small",
     deps = [
         ":profile_plugin",
-        ":protos_all_py_pb2",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend/event_processing:plugin_asset_util",
         "//tensorboard/plugins:base_plugin",

--- a/tensorboard/plugins/profile/profile_demo.py
+++ b/tensorboard/plugins/profile/profile_demo.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import gzip
 import os
 import tensorflow as tf
 
@@ -56,7 +57,7 @@ def dump_data(logdir):
     run_dir = os.path.join(plugin_logdir, run)
     _maybe_create_directory(run_dir)
     if run in profile_demo_data.TRACES:
-      with open(os.path.join(run_dir, 'trace.json'), 'w') as f:
+      with gzip.open(os.path.join(run_dir, 'trace.json.gz'), 'wb') as f:
         proto = trace_events_pb2.Trace()
         text_format.Merge(profile_demo_data.TRACES[run], proto)
         f.write(''.join(trace_events_json.TraceEventsJsonStream(proto)))

--- a/tensorboard/plugins/profile/profile_demo.py
+++ b/tensorboard/plugins/profile/profile_demo.py
@@ -32,6 +32,7 @@ from google.protobuf import text_format
 from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.plugins.profile import profile_demo_data
 from tensorboard.plugins.profile import profile_plugin
+from tensorboard.plugins.profile import trace_events_json
 from tensorboard.plugins.profile import trace_events_pb2
 
 # Directory into which to write tensorboard data.
@@ -55,10 +56,10 @@ def dump_data(logdir):
     run_dir = os.path.join(plugin_logdir, run)
     _maybe_create_directory(run_dir)
     if run in profile_demo_data.TRACES:
-      with open(os.path.join(run_dir, 'trace'), 'w') as f:
+      with open(os.path.join(run_dir, 'trace.json'), 'w') as f:
         proto = trace_events_pb2.Trace()
         text_format.Merge(profile_demo_data.TRACES[run], proto)
-        f.write(proto.SerializeToString())
+        f.write(''.join(trace_events_json.TraceEventsJsonStream(proto)))
 
   # Unsupported tool data should not be displayed.
   run_dir = os.path.join(plugin_logdir, 'empty')

--- a/tensorboard/plugins/profile/profile_demo_data.py
+++ b/tensorboard/plugins/profile/profile_demo_data.py
@@ -46,15 +46,15 @@ trace_events {
   device_id: 1
   resource_id: 2
   name: "E1.2.1"
-  timestamp_ns: 100
-  duration_ns: 10
+  timestamp_ps: 100
+  duration_ps: 10
 }
 trace_events {
   device_id: 2
   resource_id: 2
   name: "E2.2.1"
-  timestamp_ns: 90
-  duration_ns: 40
+  timestamp_ps: 90
+  duration_ps: 40
 }
 """
 
@@ -81,13 +81,13 @@ trace_events {
   device_id: 1
   resource_id: 2
   name: "E1.2.1"
-  timestamp_ns: 10
-  duration_ns: 1000
+  timestamp_ps: 10
+  duration_ps: 1000
 }
 trace_events {
   device_id: 2
   resource_id: 2
   name: "E2.2.1"
-  timestamp_ns: 105
+  timestamp_ps: 105
 }
 """

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -139,10 +139,10 @@ class ProfilePlugin(base_plugin.TBPlugin):
       # TODO(ioeric): Switch to use plugin_asset_util.RetieveAsset when the API
       # supports reading bytes data in python 3. We might add tools with binary
       # data soon.
-      with tf.gfile.Open(asset_path, "r") as f:
+      with tf.gfile.Open(asset_path, 'r') as f:
         raw_data = f.read()
     except tf.errors.NotFoundError:
-      logging.warning("Asset path %s not found", asset_path)
+      logging.warning('Asset path %s not found', asset_path)
     except tf.errors.OpError as e:
       logging.warning("Couldn't read asset path: %s, OpError %s", asset_path, e)
 

--- a/tensorboard/plugins/profile/profile_plugin_test.py
+++ b/tensorboard/plugins/profile/profile_plugin_test.py
@@ -51,12 +51,10 @@ class ProfilePluginTest(tf.test.TestCase):
           continue
         tool_file = os.path.join(run_dir, profile_plugin.TOOLS[tool])
         if tool == 'trace_viewer':
-          trace = trace_events_pb2.Trace()
-          trace.devices[0].name = run
-          data = trace.SerializeToString()
+          data = json.dumps(dict(run=run))
         else:
           data = tool
-        with open(tool_file, 'wb') as f:
+        with open(tool_file, 'w') as f:
           f.write(data)
     with open(os.path.join(plugin_logdir, 'noise'), 'w') as f:
       f.write('Not a dir, not a run.')
@@ -78,22 +76,7 @@ class ProfilePluginTest(tf.test.TestCase):
 
   def testData(self):
     trace = json.loads(self.plugin.data_impl('foo', 'trace_viewer'))
-    self.assertEqual(trace,
-                     dict(
-                         displayTimeUnit='ns',
-                         metadata={'highres-ticks': True},
-                         traceEvents=[
-                             dict(
-                                 ph='M',
-                                 pid=0,
-                                 name='process_name',
-                                 args=dict(name='foo')),
-                             dict(
-                                 ph='M',
-                                 pid=0,
-                                 name='process_sort_index',
-                                 args=dict(sort_index=0)), {}
-                         ]))
+    self.assertEqual(trace, dict(run='foo'))
 
     # Invalid tool/run.
     self.assertEqual(None, self.plugin.data_impl('foo', 'nonono'))

--- a/tensorboard/plugins/profile/profile_plugin_test.py
+++ b/tensorboard/plugins/profile/profile_plugin_test.py
@@ -26,7 +26,6 @@ import tensorflow as tf
 from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.profile import profile_plugin
-from tensorboard.plugins.profile import trace_events_pb2
 
 
 class ProfilePluginTest(tf.test.TestCase):


### PR DESCRIPTION
Instead of converting trace events to json traces on the fly, which
could be very slow for large traces, we now dump converted json traces into
the log directory.

The json traces should be ready to be displayed in TraceViewer.

TESTED: bazel test tensorboard/plugins/profile:all