### PR TITLE
Use `encode_png` in the image plugin

### DIFF
--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -65,6 +65,7 @@ py_library(
     deps = [
         ":metadata",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:util",
     ],
 )
 

--- a/tensorboard/plugins/image/summary.py
+++ b/tensorboard/plugins/image/summary.py
@@ -25,6 +25,7 @@ from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
+from tensorboard import util
 from tensorboard.plugins.image import metadata
 
 
@@ -112,7 +113,7 @@ def pb(name, images, max_outputs=3, display_name=None, description=None):
     raise ValueError('Shape %r must have rank 4' % (images.shape, ))
 
   limited_images = images[:max_outputs]
-  encoded_images = [_encode_png(image) for image in limited_images]
+  encoded_images = [util.encode_png(image) for image in limited_images]
   (width, height) = (images.shape[1], images.shape[2])
   content = [str(width), str(height)] + encoded_images
   tensor = tf.make_tensor_proto(content, dtype=tf.string)
@@ -127,9 +128,3 @@ def pb(name, images, max_outputs=3, display_name=None, description=None):
                     metadata=summary_metadata,
                     tensor=tensor)
   return summary
-
-
-def _encode_png(image):
-  # TODO(@wchargin): Pick a third-party PNG backend and implement this.
-  del image
-  raise NotImplementedError('Encoding PNGs in Python is not yet supported.')

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -19,8 +19,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import hashlib
-
 import numpy as np
 import six
 import tensorflow as tf
@@ -34,9 +32,6 @@ class SummaryTest(tf.test.TestCase):
   def setUp(self):
     super(SummaryTest, self).setUp()
     tf.reset_default_graph()
-    self.stubs = tf.test.StubOutForTesting()
-    self.stubs.Set(summary, '_encode_png', self.stub_for_encode_png)
-    self.stubs.Set(tf.image, 'encode_png', self.stub_for_tf_encode_png)
 
     self.image_width = 300
     self.image_height = 75
@@ -45,34 +40,9 @@ class SummaryTest(tf.test.TestCase):
     self.images = self._generate_images(channels=3)
     self.images_with_alpha = self._generate_images(channels=4)
 
-  def tearDown(self):
-    self.stubs.CleanUp()
-    super(SummaryTest, self).tearDown()
-
   def _generate_images(self, channels):
     size = [self.image_count, self.image_width, self.image_height, channels]
     return np.random.uniform(low=0, high=255, size=size).astype(np.uint8)
-
-  def stub_for_encode_png(self, data_array):
-    data_str = str(data_array)  # numpy will truncate this value
-    data_bytes = data_array.tobytes()  # this is not truncated
-    hashed = hashlib.sha256(data_bytes).hexdigest()
-    prefix = data_str[:64]
-    suffix = data_str[-64:]
-    digest = '%r...[%s]...%r' % (prefix, hashed, suffix)
-    return tf.compat.as_bytes('shape:%r;length:%s;digest:%s'
-                              % (data_array.shape, len(data_bytes), digest))
-
-  def stub_for_tf_encode_png(self, data_tensor):
-    f = tf.py_func(self.stub_for_encode_png,
-                   [data_tensor],
-                   Tout=tf.string,
-                   stateful=False)
-    # The shape needs to be statically known. In the real code, it's
-    # correctly inferred, but we have to set it manually here because we
-    # use a `py_func`.
-    f.set_shape([])  # PNG text is a string scalar (rank-0)
-    return f
 
   def pb_via_op(self, summary_op, feed_dict=None):
     with tf.Session() as sess:
@@ -161,16 +131,15 @@ class SummaryTest(tf.test.TestCase):
     self.assertEqual(tf.compat.as_bytes(str(self.image_width)), result[0])
     self.assertEqual(tf.compat.as_bytes(str(self.image_height)), result[1])
 
-    # Check fake PNG data (verifying that the image was passed to the
-    # encoder correctly).
+    # Check actual image dimensions.
     images = result[2:]
-    shape = (self.image_width, self.image_height, channel_count)
-    shape_tag = tf.compat.as_bytes('shape:%r;' % (shape, ))
-    for image in images:
-      self.assertTrue(
-          image.startswith(shape_tag),
-          'expected fake image data to start with %r, but found: %r'
-          % (shape_tag, image[:len(shape_tag) * 2]))
+    with tf.Session() as sess:
+      placeholder = tf.placeholder(tf.string)
+      decoder = tf.image.decode_png(placeholder)
+      for image in images:
+        decoded = sess.run(decoder, feed_dict={placeholder: image})
+        self.assertEqual((self.image_width, self.image_height, channel_count),
+                         decoded.shape)
 
   def test_dimensions(self):
     self._test_dimensions(alpha=False)


### PR DESCRIPTION
Summary:
This commit completes the implementation of the image summary's `pb`
function by using `tensorboard.util.encode_png` for PNG encoding.
In doing so, we can remove the stubs for the PNG encoding from the test.

Interestingly, this change makes the Python 3 tests take significantly
longer, without a corresponding increase in the Python 2 test timing.
Tests take 2.2s on Python 2 and 10.3s on Python 3. These results are
consistent within 0.2s across multiple runs. The previous times were
1.6s for Python 2 and 1.9s for Python 3, consistent within 0.1s.
I haven't investigated the discrepancy.

Test Plan:
Unit tests suffice. Run `bazel test //tensorboard/plugins/image:all`.

wchargin-branch: use-encode-png-in-image-plugin