### PR TITLE
Implement DB transaction logic

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -128,7 +128,10 @@ py_library(
     srcs = ["db.py"],
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
-    deps = ["//tensorboard:expect_sqlite3_installed"],
+    deps = [
+        ":util",
+        "//tensorboard:expect_sqlite3_installed",
+    ],
 )
 
 py_test(
@@ -140,6 +143,7 @@ py_test(
     deps = [
         ":db",
         ":test_util",
+        ":util",
         "//tensorboard:expect_sqlite3_installed",
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -393,7 +393,7 @@ def create_sqlite_connection_provider(db_uri):
   path = os.path.expanduser(uri.path)
   params = _get_connect_params(uri.query)
   # TODO(@jart): Add thread-local pooling.
-  return lambda: sqlite3.connect(path, **params)
+  return lambda: db.Connection(sqlite3.connect(path, **params))
 
 
 def _get_connect_params(query):

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -97,10 +97,9 @@ def standard_tensorboard_wsgi(
   db_module, db_connection_provider = get_database_info(db_uri)
   if db_connection_provider is not None:
     with contextlib.closing(db_connection_provider()) as db_conn:
-      with db_conn:
-        schema = db.Schema(db_conn)
-        schema.create_tables()
-        schema.create_indexes()
+      schema = db.Schema(db_conn)
+      schema.create_tables()
+      schema.create_indexes()
   context = base_plugin.TBContext(
       db_module=db_module,
       db_connection_provider=db_connection_provider,

--- a/tensorboard/db.py
+++ b/tensorboard/db.py
@@ -721,12 +721,14 @@ class _TransactionConnection(Connection):
 class _TransactionCursor(Cursor):
   """PEP 249 Cursor object when inside TensorBoard transactions."""
 
-  FORBIDDEN_PATTERN = re.compile(r'^\s*(ALTER|CREATE|DROP|VACUUM)\b', re.I)
-  WRITE_QUERY_PATTERN = re.compile(r'^\s*(DELETE|INSERT|REPLACE|UPDATE) ', re.I)
+  FORBIDDEN_PATTERN = re.compile(
+      r'^\s*(?:ALTER|CREATE|DROP|VACUUM)\b', re.I)
+  WRITE_QUERY_PATTERN = re.compile(
+      r'^\s*(?:DELETE|INSERT|REPLACE|UPDATE)\b', re.I)
 
   def __init__(self, connection):
     super(_TransactionCursor, self).__init__(connection)
-    self.connection = connection  # assign again for type inference
+    self.connection = connection  # assign again for IDE type inference
 
   def execute(self, sql, parameters=()):
     _check_sql_allowed_in_transaction(sql)

--- a/tensorboard/db_test.py
+++ b/tensorboard/db_test.py
@@ -45,8 +45,8 @@ class DbTestCase(test_util.TestCase):
   def setUp(self):
     super(DbTestCase, self).setUp()
     db_path = os.path.join(self.get_temp_dir(), 'DbTestCase.sqlite')
-    self._db_connection_provider = \
-        lambda: sqlite3.connect(db_path, isolation_level=None)
+    self._db_connection_provider = (
+        lambda: db.Connection(sqlite3.connect(db_path, isolation_level=None)))
     with contextlib.closing(self.connect()) as db_conn:
       schema = db.Schema(db_conn)
       schema.create_tables()
@@ -126,6 +126,10 @@ class TransactionTest(DbTestCase):
     with self.assertRaises(Exception):
       self.tbase.run_transaction(second)
     self.tbase.run_transaction(third)
+
+  def testTransactionalVacuum_isForbidden(self):
+    with self.assertRaises(ValueError):
+      self.tbase.run_transaction(lambda c: c.execute('vacuum'))
 
 
 class IdTest(test_util.TestCase):

--- a/tensorboard/db_test.py
+++ b/tensorboard/db_test.py
@@ -17,6 +17,7 @@ from __future__ import division
 from __future__ import print_function
 
 import contextlib
+import functools
 import itertools
 import os
 import sqlite3
@@ -24,7 +25,10 @@ import sqlite3
 import tensorflow as tf
 
 from tensorboard import db
+from tensorboard import util
 from tensorboard import test_util
+
+db.TESTING_MODE = True
 
 
 class DbTestCase(test_util.TestCase):
@@ -32,26 +36,96 @@ class DbTestCase(test_util.TestCase):
   def __init__(self, *args, **kwargs):
     super(DbTestCase, self).__init__(*args, **kwargs)
     self._db_connection_provider = None
+    self.clock = test_util.FakeClock()
+    self.sleep = test_util.FakeSleep(self.clock)
+    self.Retrier = functools.partial(util.Retrier, sleep=self.sleep)
+    self.tbase = db.TensorBase(db_connection_provider=self.connect,
+                               retrier_factory=self.Retrier)
 
   def setUp(self):
     super(DbTestCase, self).setUp()
     db_path = os.path.join(self.get_temp_dir(), 'DbTestCase.sqlite')
-    self._db_connection_provider = lambda: sqlite3.connect(db_path)
-    with contextlib.closing(self._db_connection_provider()) as conn:
-      with conn:
-        schema = db.Schema(conn)
-        schema.create_tables()
-        schema.create_indexes()
+    self._db_connection_provider = \
+        lambda: sqlite3.connect(db_path, isolation_level=None)
+    with contextlib.closing(self.connect()) as db_conn:
+      schema = db.Schema(db_conn)
+      schema.create_tables()
+      schema.create_indexes()
+
+  def connect(self):
+    return self._db_connection_provider()
 
 
-class PluginTest(DbTestCase):
+class PluginsTest(DbTestCase):
 
   def testGetPluginIds(self):
-    tbase = db.TensorBase(self._db_connection_provider)
-    self.assertEqual({'b': 1}, tbase.get_plugin_ids(['b']))
-    self.assertEqual({'a': 2}, tbase.get_plugin_ids(['a']))
-    self.assertEqual({'b': 1}, tbase.get_plugin_ids(['b']))
-    self.assertEqual({'b': 1, 'c': 3}, tbase.get_plugin_ids(['c', 'b']))
+    self.assertEqual({'b': 1}, self.tbase.get_plugin_ids(['b']))
+    self.assertEqual({'a': 2}, self.tbase.get_plugin_ids(['a']))
+    self.assertEqual({'b': 1}, self.tbase.get_plugin_ids(['b']))
+    self.assertEqual({'b': 1, 'c': 3}, self.tbase.get_plugin_ids(['c', 'b']))
+
+
+class TransactionTest(DbTestCase):
+
+  def setUp(self):
+    super(TransactionTest, self).setUp()
+    with contextlib.closing(self.connect()) as db_conn:
+      with contextlib.closing(db_conn.cursor()) as c:
+        c.execute('CREATE TABLE IF NOT EXISTS Numbers (a INTEGER, b INTEGER)')
+
+  def testWritesNotVisibleUntilNextTransaction(self):
+
+    def first(db_conn):
+      db_conn.execute('INSERT INTO Numbers (a, b) VALUES (7, 23)')
+
+    def second(db_conn):
+      with contextlib.closing(db_conn.cursor()) as c:
+        c.execute('SELECT b FROM Numbers WHERE a = 7')
+        self.assertEqual(23, c.fetchone()[0])
+        c.execute('UPDATE Numbers SET b = 24 WHERE a = 7')
+      with contextlib.closing(db_conn.cursor()) as c:
+        c.execute('SELECT b FROM Numbers WHERE a = 7')
+        self.assertEqual(23, c.fetchone()[0])
+
+    def third(db_conn):
+      c = db_conn.execute('SELECT b FROM Numbers WHERE a = 7')
+      self.assertEqual(24, c.fetchone()[0])
+
+    self.tbase.run_transaction(first)
+    self.tbase.run_transaction(second)
+    self.tbase.run_transaction(third)
+
+  def testWritesAreOrdered(self):
+
+    def first(db_conn):
+      db_conn.execute('INSERT INTO Numbers (a, b) VALUES (7, 23)')
+      db_conn.execute('UPDATE Numbers SET b = 24 WHERE a = 7')
+      db_conn.execute('UPDATE Numbers SET b = 25 WHERE a = 7')
+
+    def second(db_conn):
+      c = db_conn.execute('SELECT b FROM Numbers WHERE a = 7')
+      self.assertEqual(25, c.fetchone()[0])
+
+    self.tbase.run_transaction(first)
+    self.tbase.run_transaction(second)
+
+  def testRollback(self):
+
+    def first(db_conn):
+      db_conn.execute('INSERT INTO Numbers (a, b) VALUES (7, 23)')
+
+    def second(db_conn):
+      db_conn.execute('UPDATE Numbers SET b = 24 WHERE a = 7')
+      raise Exception()
+
+    def third(db_conn):
+      c = db_conn.execute('SELECT b FROM Numbers WHERE a = 7')
+      self.assertEqual(23, c.fetchone()[0])
+
+    self.tbase.run_transaction(first)
+    with self.assertRaises(Exception):
+      self.tbase.run_transaction(second)
+    self.tbase.run_transaction(third)
 
 
 class IdTest(test_util.TestCase):

--- a/tensorboard/test_util.py
+++ b/tensorboard/test_util.py
@@ -70,6 +70,13 @@ class FakeClock(object):
     self._lock = threading.Lock()
 
   def __call__(self):
+    """Delegates to get_time().
+
+    :rtype: float
+    """
+    return self.get_time()
+
+  def get_time(self):
     """Returns current fake time.
 
     Returns:


### PR DESCRIPTION
These helpers allow us to do optimistic write-deferred transactions retried
with exponential back-off. This is necessary because we're planning to compute
primary keys randomly, in order to get good sharding behavior, and collisions
might occur. Writes are deferred to minimize the amount of time that SQLite
needs a RESERVED lock, which blocks both transactional reads and writes.

This was implemented by composing the PEP 249 API, which was burdensome,
but will pay dividends as we support more databases.