### PR TITLE
Introduce loader.EventLog helper class

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -213,6 +213,7 @@ py_test(
         ":test_util",
         ":util",
         "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/loader.py
+++ b/tensorboard/loader.py
@@ -677,10 +677,10 @@ class Progress(object):
 @util.closeable
 @functools.total_ordering
 @six.python_2_unicode_compatible
-class EventLog(object):
+class EventLogReader(object):
   """Helper class for reading from event log files.
 
-  This class is wrapper around BufferedRecordReader that operates on
+  This class is a wrapper around BufferedRecordReader that operates on
   record files containing tf.Event protocol buffers.
 
   Fields:
@@ -813,13 +813,13 @@ def get_event_logs(directory):
     List of EventLog objects, ordered by directory name and timestamp.
 
   :type directory: str
-  :rtype: list[EventLog]
+  :rtype: list[EventLogReader]
   """
   logs = []
   for dirname, _, filenames in tf.gfile.Walk(directory):
     for filename in filenames:
       if is_event_log_file(filename):
-        logs.append(EventLog(os.path.join(dirname, filename)))
+        logs.append(EventLogReader(os.path.join(dirname, filename)))
   logs.sort()
   return logs
 

--- a/tensorboard/loader.py
+++ b/tensorboard/loader.py
@@ -19,8 +19,10 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import functools
 import locale
 import logging
+import os
 import re
 import sys
 import time
@@ -670,6 +672,169 @@ class Progress(object):
             (util.Ansi.FLIP if self._offset % 2 == 0 else u'') +
             text +
             util.Ansi.RESET)
+
+
+@util.closeable
+@functools.total_ordering
+@six.python_2_unicode_compatible
+class EventLog(object):
+  """Helper class for reading from event log files.
+
+  This class is wrapper around BufferedRecordReader that operates on
+  record files containing tf.Event protocol buffers.
+
+  Fields:
+    path: A string with the path of the event log on the local or
+        remote file system.
+    timestamp: An integer of the number of seconds since the UNIX epoch
+        in UTC according to hostname at the time when the event log
+        file was created.
+    hostname: A string with the FQDN of the machine that wrote this
+        event log file.
+  """
+
+  def __init__(self, path,
+               start_offset=0,
+               record_reader_factory=BufferedRecordReader):
+    """Creates new instance.
+
+    Args:
+      path: Path of event log file.
+      start_offset: Byte offset to seek in file once it's opened.
+      record_reader_factory: A reference to the constructor of a class
+          that implements the same interface as RecordReader.
+
+    :type path: str
+    :type record_reader_factory: (str, int) -> RecordReader
+    """
+    self.path = tf.compat.as_text(path)
+    m = _EVENT_LOG_PATH_PATTERN.search(self.path)
+    if not m:
+      raise ValueError('Bad event log path: ' + self.path)
+    self.timestamp = int(m.group('timestamp'))
+    self.hostname = m.group('hostname')
+    self._mark = -1
+    self._offset = start_offset
+    self._reader = record_reader_factory(self.path, start_offset)
+    self._key = (os.path.dirname(self.path), self.timestamp, self.hostname)
+    self._saved_events = \
+        collections.deque()  # type: collections.deque[tf.Event]
+    self._prepended_events = \
+        collections.deque()  # type: collections.deque[tf.Event]
+
+  def get_next_event(self):
+    """Reads an event proto from the file.
+
+    Returns:
+      A tf.Event or None if no more records exist in the file. Please
+      note that the file remains open for subsequent reads in case more
+      are appended later.
+
+    :rtype: tf.Event
+    """
+    if self._prepended_events:
+      event = self._prepended_events.popleft()
+    else:
+      record = self._reader.get_next_record()
+      if record is None:
+        return None
+      event = tf.Event()
+      event.ParseFromString(record.record)
+      self._offset = record.offset
+    if self._mark != -1:
+      self._saved_events.append(event)
+    return event
+
+  def get_offset(self):
+    """Returns current byte offset in file.
+
+    If mark() was called, then this returns the marked position.
+
+    :rtype: int
+    """
+    if self._mark != -1:
+      return self._mark
+    return self._offset
+
+  def get_size(self):
+    """Returns byte length of file.
+
+    :rtype: int
+    """
+    return self._reader.get_size()
+
+  def mark(self):
+    """Marks current position in file so reset() can be called."""
+    if self._prepended_events:
+      raise ValueError('mark() offsets must be monotonic')
+    self._mark = self._offset
+    self._saved_events.clear()
+
+  def reset(self):
+    """Resets read state to where mark() was called."""
+    if self._mark == -1:
+      raise ValueError('mark() was not called')
+    self._prepended_events.extend(self._saved_events)
+    self._saved_events.clear()
+
+  def close(self):
+    """Closes event log reader if open.
+
+    Further i/o is not permitted after this method is called.
+    """
+    if self._reader is not None:
+      self._reader.close()
+      self._reader = None
+
+  def __hash__(self):
+    return hash(self._key)
+
+  def __eq__(self, other):
+    return self._key == other._key
+
+  def __lt__(self, other):
+    return self._key < other._key
+
+  def __str__(self):
+    offset = self.get_offset()
+    if offset:
+      return u'EventLog{path=%s, offset=%d}' % (self.path, offset)
+    else:
+      return u'EventLog{%s}' % self.path
+
+
+def get_event_logs(directory):
+  """Walks directory tree for EventLog files.
+
+  Args:
+    directory: Path of directory.
+
+  Returns:
+    List of EventLog objects, ordered by directory name and timestamp.
+
+  :type directory: str
+  :rtype: list[EventLog]
+  """
+  logs = []
+  for dirname, _, filenames in tf.gfile.Walk(directory):
+    for filename in filenames:
+      if is_event_log_file(filename):
+        logs.append(EventLog(os.path.join(dirname, filename)))
+  logs.sort()
+  return logs
+
+
+_EVENT_LOG_PATH_PATTERN = re.compile(
+    r'\.tfevents\.(?P<timestamp>\d+).(?P<hostname>[-.0-9A-Za-z]+)$')
+
+
+def is_event_log_file(path):
+  """Returns True if path appears to be an event log file.
+
+  :type path: str
+  :rtype: bool
+  """
+  return bool(_EVENT_LOG_PATH_PATTERN.search(path))
 
 
 _SHORTEN_EVENT_LOG_PATH_PATTERN = re.compile(r'(?:[^/\\]+[/\\])?(?:[^/\\]+)$')

--- a/tensorboard/loader_test.py
+++ b/tensorboard/loader_test.py
@@ -20,6 +20,7 @@ import functools
 import locale
 import os
 
+import six
 import tensorflow as tf
 
 from tensorboard import loader
@@ -246,8 +247,8 @@ class ProgressTest(LoaderTestCase):
     self.bars.append(format_ % args)
 
 
-class EventLogTest(LoaderTestCase):
-  EventLog = functools.partial(loader.EventLog,
+class EventLogReaderTest(LoaderTestCase):
+  EventLog = functools.partial(loader.EventLogReader,
                                record_reader_factory=loader.RecordReader)
 
   def testInvalidFilename_throwsException(self):
@@ -288,8 +289,7 @@ class EventLogTest(LoaderTestCase):
       self.assertIsNone(log.get_next_event())
 
   def testReadOneEvent(self):
-    event = tf.Event()
-    event.step = 123
+    event = tf.Event(step=123)
     path = self._save_records('events.out.tfevents.0.localhost',
                               [event.SerializeToString()])
     with self.EventLog(path) as log:
@@ -297,22 +297,22 @@ class EventLogTest(LoaderTestCase):
       self.assertIsNone(log.get_next_event())
 
   def testMarkReset(self):
-    event = tf.Event()
-    event.step = 123
+    event1 = tf.Event(step=123)
+    event2 = tf.Event(step=456)
     path = self._save_records('events.out.tfevents.0.localhost',
-                              [event.SerializeToString()])
+                              [event1.SerializeToString(),
+                               event2.SerializeToString()])
     with self.EventLog(path) as log:
       log.mark()
-      self.assertEqual(event, log.get_next_event())
+      self.assertEqual(event1, log.get_next_event())
       log.reset()
-      self.assertEqual(event, log.get_next_event())
+      self.assertEqual(event1, log.get_next_event())
+      self.assertEqual(event2, log.get_next_event())
       self.assertIsNone(log.get_next_event())
 
   def testMarkWithShrinkingBatchSize_raisesValueError(self):
-    event1 = tf.Event()
-    event1.step = 123
-    event2 = tf.Event()
-    event2.step = 456
+    event1 = tf.Event(step=123)
+    event2 = tf.Event(step=456)
     path = self._save_records('events.out.tfevents.0.localhost',
                               [event1.SerializeToString(),
                                event2.SerializeToString()])
@@ -322,7 +322,7 @@ class EventLogTest(LoaderTestCase):
       self.assertEqual(event2, log.get_next_event())
       log.reset()
       self.assertEqual(event1, log.get_next_event())
-      with self.assertRaisesRegexp(ValueError, 'monotonic'):
+      with six.assertRaisesRegex(self, ValueError, r'monotonic'):
         log.mark()
 
 


### PR DESCRIPTION
This class delegates to RecordReader and decodes the individual protos. It
supports marking which is going to be needed when transactions have transient
failures. Instances are sortable, which assists with reading them in order.