### PR TITLE
Make is_active for projector return quickly

### DIFF
--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -22,9 +22,10 @@ import collections
 import imghdr
 import math
 import os
+import threading
+
 import numpy as np
 import tensorflow as tf
-import threading
 from werkzeug import wrappers
 
 from google.protobuf import json_format
@@ -228,7 +229,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
     self.old_num_run_paths = None
     self.config_fpaths = None
     self.tensor_cache = LRUCache(_TENSOR_CACHE_CAPACITY)
-    
+
     # Whether the plugin is active (has meaningful data to process and serve).
     # Once the plugin is deemed active, we no longer re-compute the value
     # because doing so is potentially expensive.
@@ -237,7 +238,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
     # The running thread that is currently determining whether the plugin is
     # active. If such a thread exists, do not start a duplicate thread.
     self._thread_for_determining_is_active = None
-    
+
     if self.multiplexer:
       self.run_paths = self.multiplexer.RunPaths()
 

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -294,17 +294,6 @@ class ProjectorPlugin(base_plugin.TBPlugin):
       self._is_active = True
     self._thread_for_determining_is_active = None
 
-  def _get_thread_for_determining_is_active(self):
-    """Gets the currently running thread for determining is_active.
-
-    This method is useful for testing.
-
-    Returns:
-      The thread that is currently determining whether the plugin is active.
-      This is None if no such thread is running.
-    """
-    return self._thread_for_determining_is_active
-
   @property
   def configs(self):
     """Returns a map of run paths to `ProjectorConfig` protos."""

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -259,7 +259,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
     This plugin is only active if any run has an embedding.
 
     Returns:
-      A boolean. Whether this plugin is active.
+      Whether any run has embedding data to show in the projector.
     """
     if not self.multiplexer:
       return False

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -200,21 +200,23 @@ class ProjectorAppTest(tf.test.TestCase):
     # The projector plugin has not yet determined whether it is active, but it
     # should now start a thread to determine that.
     self.assertFalse(self.plugin.is_active())
-    mock.assert_called_once_with(self.plugin._thread_for_determining_is_active)
+    thread = self.plugin._thread_for_determining_is_active
+    mock.assert_called_once_with(thread)
 
     # The logic has not finished running yet, so the plugin should still not
     # have deemed itself to be active.
     self.assertFalse(self.plugin.is_active())
-    mock.assert_called_once_with(self.plugin._thread_for_determining_is_active)
+    mock.assert_called_once_with(thread)
 
     self.plugin._thread_for_determining_is_active.run()
 
     # The plugin later finds that embedding data is available.
     self.assertTrue(self.plugin.is_active())
 
-    # Subsequent calls to is_active should not start a new thread.
+    # Subsequent calls to is_active should not start a new thread. The mock
+    # should only have been called once throughout this test.
     self.assertTrue(self.plugin.is_active())
-    mock.assert_called_once_with(self.plugin._thread_for_determining_is_active)
+    mock.assert_called_once_with(thread)
 
   def testPluginIsNotActive(self):
     self._SetupWSGIApp()

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -197,7 +197,7 @@ class ProjectorAppTest(tf.test.TestCase):
     mock = patcher.start()
     self.addCleanup(patcher.stop)
 
-    mock.assert_not_called()
+    self.assertEqual(0, mock.call_count)
     # The projector plugin has not yet determined whether it is active, but it
     # should now start a thread to determine that.
     self.assertFalse(self.plugin.is_active())

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -253,7 +253,7 @@ class ProjectorAppTest(tf.test.TestCase):
     tf.test.mock.patch('threading.Thread', FakeThread).start()
 
     # The projector plugin has not yet determined whether it is active, but it
-    # should have started a thread to determine that.
+    # should now start a thread to determine that.
     self.assertFalse(self.plugin.is_active())
 
     # We simulate the logic of the thread executing.

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -240,7 +240,7 @@ class ProjectorAppTest(tf.test.TestCase):
     self.assertFalse(self.plugin.is_active())
 
     # We simulate the logic of the thread executing.
-    self.plugin._get_thread_for_determining_is_active().actually_run()
+    self.plugin._thread_for_determining_is_active.actually_run()
 
     # The plugin later finds that embedding data is available.
     self.assertTrue(self.plugin.is_active())
@@ -257,7 +257,7 @@ class ProjectorAppTest(tf.test.TestCase):
     self.assertFalse(self.plugin.is_active())
 
     # We simulate the logic of the thread executing.
-    self.plugin._get_thread_for_determining_is_active().actually_run()
+    self.plugin._thread_for_determining_is_active.actually_run()
 
     # The plugin later finds that embedding data is not available.
     self.assertFalse(self.plugin.is_active())

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -38,37 +38,6 @@ from tensorboard.plugins.projector import projector_config_pb2
 from tensorboard.plugins.projector import projector_plugin
 
 
-class FakeThread(object):
-  """Fakes threading behavior so that threads can be effectively tested."""
-
-  def __init__(self, target):
-    """A 'thread' that lets a test run its logic at any time.
-  
-    Specifically, a test makes the logic run by calling actually_run.
-
-    Args:
-      target: The function to call.
-    """
-    self._started = False
-    self._target = target
-
-  def start(self):  # pylint: disable=invalid-name
-    """Starts the thread. Part of the API for python threads."""
-    self._started = True
-
-  def actually_run(self):
-    """Actually runs the target.
-
-    Called within tests to simulate the logic of the thread being executed.
-
-    Raises:
-      RuntimeError: If this method is called before the thread is started.
-    """
-    if not self._started:
-      raise RuntimeError('Attempted to run a FakeThread before it started')
-    self._target()
-
-
 class ProjectorAppTest(tf.test.TestCase):
 
   def __init__(self, *args, **kwargs):
@@ -79,9 +48,6 @@ class ProjectorAppTest(tf.test.TestCase):
 
   def setUp(self):
     self.log_dir = self.get_temp_dir()
-    
-  def tearDown(self):
-    tf.test.mock.patch.stopall()
 
   def testRunsWithValidCheckpoint(self):
     self._GenerateProjectorTestData()
@@ -227,20 +193,22 @@ class ProjectorAppTest(tf.test.TestCase):
     self._GenerateProjectorTestData()
     self._SetupWSGIApp()
 
-    # The is_active method makes use of a separate thread, so we mock threading
-    # behavior to make this test deterministic.
-    tf.test.mock.patch('threading.Thread', FakeThread).start()
+    patcher = tf.test.mock.patch('threading.Thread.start', autospec=True)
+    mock = patcher.start()
+    self.addCleanup(patcher.stop)
 
+    mock.assert_not_called()
     # The projector plugin has not yet determined whether it is active, but it
     # should now start a thread to determine that.
     self.assertFalse(self.plugin.is_active())
+    mock.assert_called_once_with(self.plugin._thread_for_determining_is_active)
 
     # The logic has not finished running yet, so the plugin should still not
     # have deemed itself to be active.
     self.assertFalse(self.plugin.is_active())
+    mock.assert_called_once_with(self.plugin._thread_for_determining_is_active)
 
-    # We simulate the logic of the thread executing.
-    self.plugin._thread_for_determining_is_active.actually_run()
+    self.plugin._thread_for_determining_is_active.run()
 
     # The plugin later finds that embedding data is available.
     self.assertTrue(self.plugin.is_active())
@@ -250,14 +218,16 @@ class ProjectorAppTest(tf.test.TestCase):
 
     # The is_active method makes use of a separate thread, so we mock threading
     # behavior to make this test deterministic.
-    tf.test.mock.patch('threading.Thread', FakeThread).start()
+    patcher = tf.test.mock.patch('threading.Thread.start', autospec=True)
+    mock = patcher.start()
+    self.addCleanup(patcher.stop)
 
     # The projector plugin has not yet determined whether it is active, but it
     # should now start a thread to determine that.
     self.assertFalse(self.plugin.is_active())
+    mock.assert_called_once_with(self.plugin._thread_for_determining_is_active)
 
-    # We simulate the logic of the thread executing.
-    self.plugin._thread_for_determining_is_active.actually_run()
+    self.plugin._thread_for_determining_is_active.run()
 
     # The plugin later finds that embedding data is not available.
     self.assertFalse(self.plugin.is_active())

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -232,7 +232,7 @@ class ProjectorAppTest(tf.test.TestCase):
     tf.test.mock.patch('threading.Thread', FakeThread).start()
 
     # The projector plugin has not yet determined whether it is active, but it
-    # should have started a thread to determine that.
+    # should now start a thread to determine that.
     self.assertFalse(self.plugin.is_active())
 
     # The logic has not finished running yet, so the plugin should still not

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -42,7 +42,9 @@ class FakeThread(object):
   """Fakes threading behavior so that threads can be effectively tested."""
 
   def __init__(self, target):
-    """A 'thread' that just synchronously calls a method.
+    """A 'thread' that lets a test run its logic at any time.
+  
+    Specifically, a test makes the logic run by calling actually_run.
 
     Args:
       target: The function to call.

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -212,6 +212,10 @@ class ProjectorAppTest(tf.test.TestCase):
     # The plugin later finds that embedding data is available.
     self.assertTrue(self.plugin.is_active())
 
+    # Subsequent calls to is_active should not start a new thread.
+    self.assertTrue(self.plugin.is_active())
+    mock.assert_called_once_with(self.plugin._thread_for_determining_is_active)
+
   def testPluginIsNotActive(self):
     self._SetupWSGIApp()
 
@@ -230,6 +234,11 @@ class ProjectorAppTest(tf.test.TestCase):
 
     # The plugin later finds that embedding data is not available.
     self.assertFalse(self.plugin.is_active())
+
+    # Furthermore, the plugin should have spawned a new thread to check whether
+    # it is active (because it might now be active even though it had not been
+    # beforehand), so the mock should now be called twice.
+    self.assertEqual(2, mock.call_count)
 
   def _SetupWSGIApp(self):
     multiplexer = event_multiplexer.EventMultiplexer(

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -197,7 +197,6 @@ class ProjectorAppTest(tf.test.TestCase):
     mock = patcher.start()
     self.addCleanup(patcher.stop)
 
-    self.assertEqual(0, mock.call_count)
     # The projector plugin has not yet determined whether it is active, but it
     # should now start a thread to determine that.
     self.assertFalse(self.plugin.is_active())


### PR DESCRIPTION
This change makes the projector plugin start a separate thread to compute whether it is active. This allows the `is_active` method to return immediately. Otherwise, it may take a long time to return, which could cause issues. See #301.

We can actually compute the `_is_active` property in less time by halting the other thread when we know we have 1 entry in the config object (instead of computing all the values of the object), but computing the config object should usually not take severely long anyway so the added complexity and duplicated logic does not seem worth it.