### PR TITLE
Make TensorBoard logic assume 1 plugin_data

### DIFF
--- a/tensorboard/data_compat_test.py
+++ b/tensorboard/data_compat_test.py
@@ -74,9 +74,10 @@ class MigrateValueTest(tf.test.TestCase):
     self._assert_noop(value)
 
   def test_fully_populated_tensor(self):
-    metadata = tf.SummaryMetadata()
-    metadata.plugin_data.add(plugin_name='font_of_wisdom',
-                             content='adobe_garamond')
+    metadata = tf.SummaryMetadata(
+        plugin_data=tf.SummaryMetadata.PluginData(
+            plugin_name='font_of_wisdom',
+            content='adobe_garamond'))
     op = tf.summary.tensor_summary(
         name='tensorpocalypse',
         tensor=tf.constant([[0.0, 2.0], [float('inf'), float('nan')]]),

--- a/tensorboard/plugins/histogram/metadata.py
+++ b/tensorboard/plugins/histogram/metadata.py
@@ -36,12 +36,13 @@ def create_summary_metadata(display_name, description):
   Returns:
     A `tf.SummaryMetadata` protobuf object.
   """
-  content = HistogramMetadata()
-  metadata = tf.SummaryMetadata(display_name=display_name,
-                                summary_description=description)
-  metadata.plugin_data.add(plugin_name=PLUGIN_NAME,
-                           content=json.dumps(content._asdict()))  # pylint: disable=protected-access
-  return metadata
+  content = json.dumps(HistogramMetadata()._asdict())  # pylint: disable=protected-access
+  return tf.SummaryMetadata(
+      display_name=display_name,
+      summary_description=description,
+      plugin_data=tf.SummaryMetadata.PluginData(
+          plugin_name=PLUGIN_NAME,
+          content=content))
 
 
 def parse_summary_metadata(content):

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -78,9 +78,9 @@ class SummaryTest(tf.test.TestCase):
     summary_metadata = pb.value[0].metadata
     self.assertEqual(summary_metadata.display_name, 'widgets')
     self.assertEqual(summary_metadata.summary_description, '')
-    plugin_data = summary_metadata.plugin_data[0]
+    plugin_data = summary_metadata.plugin_data
     self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
-    self.assertEqual(summary_metadata.plugin_data[0].content, '{}')
+    self.assertEqual(summary_metadata.plugin_data.content, '{}')
 
   def test_explicit_display_name_and_description(self):
     display_name = 'Widget metrics'
@@ -91,7 +91,7 @@ class SummaryTest(tf.test.TestCase):
     summary_metadata = pb.value[0].metadata
     self.assertEqual(summary_metadata.display_name, display_name)
     self.assertEqual(summary_metadata.summary_description, description)
-    plugin_data = summary_metadata.plugin_data[0]
+    plugin_data = summary_metadata.plugin_data
     self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
     self.assertEqual(plugin_data.content, '{}')
 

--- a/tensorboard/plugins/image/metadata.py
+++ b/tensorboard/plugins/image/metadata.py
@@ -33,9 +33,10 @@ def create_summary_metadata(display_name, description):
   """
   content = plugin_data_pb2.ImagePluginData()
   metadata = tf.SummaryMetadata(display_name=display_name,
-                                summary_description=description)
-  metadata.plugin_data.add(plugin_name=PLUGIN_NAME,
-                           content=content.SerializeToString())
+                                summary_description=description,
+                                plugin_data=tf.SummaryMetadata.PluginData(
+                                    plugin_name=PLUGIN_NAME,
+                                    content=content.SerializeToString()))
   return metadata
 
 

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -70,9 +70,9 @@ class SummaryTest(tf.test.TestCase):
   def test_metadata(self):
     pb = self.compute_and_check_summary_pb('mona_lisa', self.images)
     summary_metadata = pb.value[0].metadata
-    plugin_data = summary_metadata.plugin_data[0]
+    plugin_data = summary_metadata.plugin_data
     self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
-    content = summary_metadata.plugin_data[0].content
+    content = summary_metadata.plugin_data.content
     # There's no content, so successfully parsing is fine.
     metadata.parse_plugin_metadata(content)
 

--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -148,14 +148,14 @@ def op(
 
     # Store the number of thresholds within the summary metadata because
     # that value is constant for all pr curve summaries with the same tag.
-    summary_metadata = tf.SummaryMetadata(
-        display_name=display_name if display_name is not None else tag,
-        summary_description=description or '')
     pr_curve_plugin_data = pr_curve_pb2.PrCurvePluginData(
         num_thresholds=num_thresholds)
-    summary_metadata.plugin_data.add(
-        plugin_name='pr_curve',
-        content=json_format.MessageToJson(pr_curve_plugin_data))
+    content = json_format.MessageToJson(pr_curve_plugin_data)
+    summary_metadata = tf.SummaryMetadata(
+        display_name=display_name if display_name is not None else tag,
+        summary_description=description or '',
+        plugin_data=tf.SummaryMetadata.PluginData(plugin_name='pr_curve',
+                                                  content=content))
 
     precision = tf.maximum(_TINY_EPISILON, tp) / tf.maximum(
         _TINY_EPISILON, tp + fp)


### PR DESCRIPTION
We had just modified the plugin_data field of SummaryMetadata to be
optional instead of repeated. TensorBoard code must now jive with that
because that change is now in TensorFlow nightly.

This change makes tests pass again.