### PR TITLE
Force reinstallation of TensorFlow deps on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     rm -f install.sh
     case "${TF}" in
       RELEASE)
-        pip install tensorflow
+        pip install -I tensorflow
         ;;
       NIGHTLY)
         if [[ "${TRAVIS_PYTHON_VERSION}" == 2* ]]; then
@@ -34,10 +34,10 @@ before_install:
         else
         NIGHTLY_URL='https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-1.head-cp34-cp34m-linux_x86_64.whl'
         fi
-        pip install "${NIGHTLY_URL}"
+        pip install -I "${NIGHTLY_URL}"
         ;;
       *)
-        pip install tensorflow=="${TF}"
+        pip install -I tensorflow=="${TF}"
         ;;
     esac
 


### PR DESCRIPTION
Summary:
We were recently encountering the following error on Travis on any
attempt to import `tensorflow` in the Python 3 environment:
```
RuntimeError: module compiled against API version 0xb but this version of numpy is 0xa
```
This exception ultimately manifests with the following message:
```
SystemError: initialization of _pywrap_tensorflow_internal raised unreported exception
```
The Travis logs include the following line during the TensorFlow
installation:
```
Requirement already satisfied: numpy>=1.11.0 in /home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages (from tensorflow==1.head)
```
This indicates that the Travis system already has a conflicting numpy
version installed. Because we’re not using a virtualenv, this conflict
prevents TensorFlow from being imported.

You can reproduce this in a virtualenv as follows:
```
$ virtualenv test -p python3
$ source test/bin/activate
$ pip install numpy==1.11.0  # critical line
$ pip install "${NIGHTLY_URL}"  # Python 3 nightly wheel (in .travis.yml)
$ python -c 'import tensorflow'
```
The presence of the critical line causes the import to fail.

By passing the `-I` flag to `pip install`, we ask `pip` to ignore
existing versions of dependencies, instead reinstalling the latest
versions.

We might want to switch to a virtualenv, anyway.

Test Plan:
Deploy to Travis. We expect tests to still fail, but they should be
actual failures due to recent changes in TensorFlow nightly. (We have a
PR out to fix them, but it needs this PR to run the Python 3 tests.)

wchargin-branch: force-travis-deps-reinstallation