### PR TITLE
Fix timestamps in the audio dashboard

### DIFF
--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
@@ -211,7 +211,7 @@ backend.
           individualAudioURL += `&ts=${audioMetadata.wall_time}`;
         }
         return {
-          wall_time: new Date(audioMetadata.wall_time).toString(),
+          wall_time: new Date(audioMetadata.wall_time * 1000).toString(),
           step: audioMetadata.step,
           content_type: audioMetadata.content_type,
           url: individualAudioURL,


### PR DESCRIPTION
Summary:
Same as #226, but for audio summaries.

Test Plan:
Before:
!["Before" screenshot. Timestamp reads, "Sun Jan 18 1970 01:09:56 GMT-0800 (PST)"](https://user-images.githubusercontent.com/4317806/29227245-0891b0d2-7e8a-11e7-9446-91536154a744.png)
After:
!["After" screenshot. Timestamp reads, "Thu Aug 03 2017 14:48:50 GMT-0700 (PDT)"](https://user-images.githubusercontent.com/4317806/29227252-0e95eca0-7e8a-11e7-8321-106643ce20b8.png)

wchargin-branch: fix-audio-timestamps