### PR TITLE
Create a tensor audio summary

### DIFF
--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -5,6 +5,8 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 exports_files(["LICENSE"])
 
 py_library(
@@ -39,6 +41,33 @@ py_test(
     ],
 )
 
+py_library(
+    name = "summary",
+    srcs = ["summary.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":metadata",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:util",
+    ],
+)
+
+py_test(
+    name = "summary_test",
+    size = "small",
+    srcs = ["summary_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":metadata",
+        ":summary",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
 py_binary(
     name = "audio_demo",
     srcs = ["audio_demo.py"],
@@ -47,4 +76,23 @@ py_binary(
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],
+)
+
+py_library(
+    name = "metadata",
+    srcs = ["metadata.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//tensorboard:internal",
+    ],
+    deps = [
+        ":protos_all_py_pb2",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+tb_proto_library(
+    name = "protos_all",
+    srcs = ["plugin_data.proto"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorboard/plugins/audio/metadata.py
+++ b/tensorboard/plugins/audio/metadata.py
@@ -1,0 +1,58 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Internal information about the audio plugin."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+from tensorboard.plugins.audio import plugin_data_pb2
+
+
+PLUGIN_NAME = 'audio'
+
+# Expose the `Encoding` enum constants.
+Encoding = plugin_data_pb2.AudioPluginData.Encoding
+
+
+def create_summary_metadata(display_name, description, encoding):
+  """Create a `tf.SummaryMetadata` proto for audio plugin data.
+
+  Returns:
+    A `tf.SummaryMetadata` protobuf object.
+  """
+  content = plugin_data_pb2.AudioPluginData(encoding=encoding)
+  metadata = tf.SummaryMetadata(display_name=display_name,
+                                summary_description=description,
+                                plugin_data=tf.SummaryMetadata.PluginData(
+                                    plugin_name=PLUGIN_NAME,
+                                    content=content.SerializeToString()))
+  return metadata
+
+
+def parse_plugin_metadata(content):
+  """Parse summary metadata to a Python object.
+
+  Arguments:
+    content: The `content` field of a `SummaryMetadata` proto
+      corresponding to the audio plugin.
+
+  Returns:
+    An `AudioPluginData` protobuf object.
+  """
+  result = plugin_data_pb2.AudioPluginData()
+  result.ParseFromString(tf.compat.as_bytes(content))
+  return result

--- a/tensorboard/plugins/audio/plugin_data.proto
+++ b/tensorboard/plugins/audio/plugin_data.proto
@@ -1,0 +1,35 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+syntax = "proto3";
+
+package tensorboard;
+
+// Audio summaries created by the `tensorboard.plugins.audio.summary`
+// module will include `SummaryMetadata` whose `plugin_data` field has
+// as `content` a binary string that is the encoding of an
+// `AudioPluginData` proto.
+message AudioPluginData {
+  enum Encoding {
+    // Do not use `UNKNOWN`; it is only present because it must be.
+    UNKNOWN = 0;
+    WAV = 11;
+  }
+
+  // Version `0` is the only supported version.
+  int32 version = 1;
+
+  Encoding encoding = 2;
+}

--- a/tensorboard/plugins/audio/summary.py
+++ b/tensorboard/plugins/audio/summary.py
@@ -1,0 +1,204 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Audio summaries and TensorFlow operations to create them.
+
+An audio summary stores a rank-2 string tensor of shape `[k, 2]`, where
+`k` is the number of audio clips recorded in the summary. Each row of
+the tensor is a pair `[encoded_audio, label]`, where `encoded_audio` is
+a binary string whose encoding is specified in the summary metadata, and
+`label` is a UTF-8 encoded Markdown string describing the audio clip.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import functools
+
+import numpy as np
+import tensorflow as tf
+
+from tensorboard import util
+from tensorboard.plugins.audio import metadata
+
+
+def op(name,
+       audio,
+       sample_rate,
+       labels=None,
+       max_outputs=3,
+       encoding=None,
+       display_name=None,
+       description=None,
+       collections=None):
+  """Create an audio summary op for use in a TensorFlow graph.
+
+  Arguments:
+    name: A unique name for the generated summary node.
+    audio: A `Tensor` representing audio data with shape `[k, t, c]`,
+      where `k` is the number of audio clips, `t` is the number of
+      frames, and `c` is the number of channels. Elements should be
+      floating-point values in `[-1.0, 1.0]`. Any of the dimensions may
+      be statically unknown (i.e., `None`).
+    sample_rate: An `int` or rank-0 `int32` `Tensor` that represents the
+      sample rate, in Hz. Must be positive.
+    labels: Optional `string` `Tensor`, a vector whose length is the
+      first dimension of `audio`, where `labels[i]` contains arbitrary
+      textual information about `audio[i]`. (For instance, this could be
+      some text that a TTS system was supposed to produce.) Markdown is
+      supported. Contents should be UTF-8.
+    max_outputs: Optional `int` or rank-0 integer `Tensor`. At most this
+      many audio clips will be emitted at each step. When more than
+      `max_outputs` many clips are provided, the first `max_outputs`
+      many clips will be used and the rest silently discarded.
+    encoding: A constant `str` (not string tensor) indicating the
+      desired encoding. You can choose any format you like, as long as
+      it's "wav". Please see the "API compatibility note" below.
+    display_name: Optional name for this summary in TensorBoard, as a
+      constant `str`. Defaults to `name`.
+    description: Optional long-form description for this summary, as a
+      constant `str`. Markdown is supported. Defaults to empty.
+    collections: Optional list of graph collections keys. The new
+      summary op is added to these collections. Defaults to
+      `[Graph Keys.SUMMARIES]`.
+
+  Returns:
+    A TensorFlow summary op.
+
+  API compatibility note: The default value of the `encoding`
+  argument is _not_ guaranteed to remain unchanged across TensorBoard
+  versions. In the future, we will by default encode as FLAC instead of
+  as WAV. If the specific format is important to you, please provide a
+  file format explicitly.
+  """
+
+  if display_name is None:
+    display_name = name
+  if encoding is None:
+    encoding = 'wav'
+
+  if encoding == 'wav':
+    encoding = metadata.Encoding.Value('WAV')
+    encoder = functools.partial(tf.contrib.ffmpeg.encode_audio,
+                                samples_per_second=sample_rate,
+                                file_format='wav')
+  else:
+    raise ValueError('Unknown encoding: %r' % encoding)
+
+  with tf.name_scope(name), \
+       tf.control_dependencies([tf.assert_rank(audio, 3)]):
+    limited_audio = audio[:max_outputs]
+    encoded_audio = tf.map_fn(encoder, limited_audio,
+                              dtype=tf.string,
+                              name='encode_each_audio')
+    if labels is None:
+      limited_labels = tf.tile([''], tf.shape(limited_audio)[:1])
+    else:
+      limited_labels = labels[:max_outputs]
+    tensor = tf.transpose(tf.stack([encoded_audio, limited_labels]))
+    summary_metadata = metadata.create_summary_metadata(
+        display_name=display_name,
+        description=description,
+        encoding=encoding)
+    return tf.summary.tensor_summary(name='audio_summary',
+                                     tensor=tensor,
+                                     collections=collections,
+                                     summary_metadata=summary_metadata)
+
+
+def pb(name,
+       audio,
+       sample_rate,
+       labels=None,
+       max_outputs=3,
+       encoding=None,
+       display_name=None,
+       description=None):
+  """Create an audio summary protobuf.
+
+  This behaves as if you were to create an `op` with the same arguments
+  (wrapped with constant tensors where appropriate) and then execute
+  that summary op in a TensorFlow session.
+
+  Arguments:
+    name: A unique name for the generated summary node.
+    audio: An `np.array` representing audio data with shape `[k, t, c]`,
+      where `k` is the number of audio clips, `t` is the number of
+      frames, and `c` is the number of channels. Elements should be
+      floating-point values in `[-1.0, 1.0]`.
+    sample_rate: An `int` that represents the sample rate, in Hz.
+      Must be positive.
+    labels: Optional list (or rank-1 `np.array`) of textstrings or UTF-8
+      bytestrings whose length is the first dimension of `audio`, where
+      `labels[i]` contains arbitrary textual information about
+      `audio[i]`. (For instance, this could be some text that a TTS
+      system was supposed to produce.) Markdown is supported.
+    max_outputs: Optional `int`. At most this many audio clips will be
+      emitted. When more than `max_outputs` many clips are provided, the
+      first `max_outputs` many clips will be used and the rest silently
+      discarded.
+    encoding: A constant `str` indicating the desired encoding. You
+      can choose any format you like, as long as it's "wav". Please see
+      the "API compatibility note" below.
+    display_name: Optional name for this summary in TensorBoard, as a
+      `str`. Defaults to `name`.
+    description: Optional long-form description for this summary, as a
+      `str`. Markdown is supported. Defaults to empty.
+
+  Returns:
+    A `tf.Summary` protobuf object.
+
+  API compatibility note: The default value of the `encoding`
+  argument is _not_ guaranteed to remain unchanged across TensorBoard
+  versions. In the future, we will by default encode as FLAC instead of
+  as WAV. If the specific format is important to you, please provide a
+  file format explicitly.
+  """
+  audio = np.array(audio)
+  if audio.ndim != 3:
+    raise ValueError('Shape %r must have rank 3' % (audio.shape,))
+  if encoding is None:
+    encoding = 'wav'
+
+  if encoding == 'wav':
+    encoding = metadata.Encoding.Value('WAV')
+    encoder = functools.partial(util.encode_wav,
+                                samples_per_second=sample_rate)
+  else:
+    raise ValueError('Unknown encoding: %r' % encoding)
+
+  limited_audio = audio[:max_outputs]
+  if labels is None:
+    limited_labels = [b''] * len(limited_audio)
+  else:
+    limited_labels = [tf.compat.as_bytes(label)
+                      for label in labels[:max_outputs]]
+
+  encoded_audio = [encoder(a) for a in limited_audio]
+  content = np.array([encoded_audio, limited_labels]).transpose()
+  tensor = tf.make_tensor_proto(content, dtype=tf.string)
+
+  if display_name is None:
+    display_name = name
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=display_name,
+      description=description,
+      encoding=encoding)
+
+  summary = tf.Summary()
+  summary.value.add(tag='%s/audio_summary' % name,
+                    metadata=summary_metadata,
+                    tensor=tensor)
+  return summary

--- a/tensorboard/plugins/audio/summary_test.py
+++ b/tensorboard/plugins/audio/summary_test.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the audio plugin summary generation functions."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import six
+import tensorflow as tf
+
+from tensorboard.plugins.audio import metadata
+from tensorboard.plugins.audio import summary
+
+
+class SummaryTest(tf.test.TestCase):
+
+  def setUp(self):
+    super(SummaryTest, self).setUp()
+    tf.reset_default_graph()
+
+    self.samples_per_second = 44100
+    self.audio_count = 6
+    stereo_shape = (self.audio_count, -1, 2)
+    space = (np.linspace(0.0, 100.0, self.samples_per_second)
+             .astype(np.float32).reshape(stereo_shape))
+    self.audio_length = space.shape[1]
+    self.stereo = np.sin(space)
+    self.mono = self.stereo.mean(axis=2, keepdims=True)
+
+  def pb_via_op(self, summary_op, feed_dict=None):
+    with tf.Session() as sess:
+      actual_pbtxt = sess.run(summary_op, feed_dict=feed_dict or {})
+    actual_proto = tf.Summary()
+    actual_proto.ParseFromString(actual_pbtxt)
+    return actual_proto
+
+  def compute_and_check_summary_pb(self,
+                                   name,
+                                   audio,
+                                   max_outputs=3,
+                                   display_name=None,
+                                   description=None,
+                                   audio_tensor=None,
+                                   feed_dict=None):
+    """Use both `op` and `pb` to get a summary, asserting validity.
+
+    "Validity" means that the `op` and `pb` functions must return the
+    same protobufs, and also that each encoded audio value appears to be
+    a valid WAV file. If either of these conditions fails, the test will
+    immediately fail. Otherwise, the valid protobuf will be returned.
+
+    Returns:
+      A `Summary` protocol buffer.
+    """
+    if audio_tensor is None:
+      audio_tensor = tf.constant(audio)
+    op = summary.op(name, audio_tensor, self.samples_per_second,
+                    max_outputs=max_outputs,
+                    display_name=display_name, description=description)
+    pb = summary.pb(name, audio, self.samples_per_second,
+                    max_outputs=max_outputs,
+                    display_name=display_name, description=description)
+    pb_via_op = self.pb_via_op(op, feed_dict=feed_dict)
+    self.assertProtoEquals(pb, pb_via_op)
+    audios = tf.make_ndarray(pb.value[0].tensor)[:, 0].tolist()
+    invalid_audios = [x for x in audios
+                      if not x.startswith(b'RIFF')]
+    self.assertFalse(invalid_audios)
+    return pb
+
+  def test_metadata(self):
+    pb = self.compute_and_check_summary_pb('k488', self.stereo)
+    self.assertEqual(len(pb.value), 1)
+    self.assertEqual(pb.value[0].tag, 'k488/audio_summary')
+    summary_metadata = pb.value[0].metadata
+    self.assertEqual(summary_metadata.display_name, 'k488')
+    self.assertEqual(summary_metadata.summary_description, '')
+    plugin_data = summary_metadata.plugin_data
+    self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
+    content = summary_metadata.plugin_data.content
+    parsed = metadata.parse_plugin_metadata(content)
+    self.assertEqual(parsed.encoding, metadata.Encoding.Value('WAV'))
+
+  def test_metadata_with_explicit_name_and_description(self):
+    display_name = 'Piano Concerto No. 23 (K488)'
+    description = 'In **A major.**'
+    pb = self.compute_and_check_summary_pb(
+        'k488', self.stereo, display_name=display_name, description=description)
+    self.assertEqual(len(pb.value), 1)
+    self.assertEqual(pb.value[0].tag, 'k488/audio_summary')
+    summary_metadata = pb.value[0].metadata
+    self.assertEqual(summary_metadata.display_name, display_name)
+    self.assertEqual(summary_metadata.summary_description, description)
+    plugin_data = summary_metadata.plugin_data
+    self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
+    content = summary_metadata.plugin_data.content
+    parsed = metadata.parse_plugin_metadata(content)
+    self.assertEqual(parsed.encoding, metadata.Encoding.Value('WAV'))
+
+  def test_correctly_handles_no_audio(self):
+    shape = (0, self.audio_length, 2)
+    audio = np.array([]).reshape(shape).astype(np.float32)
+    pb = self.compute_and_check_summary_pb('k488', audio, max_outputs=3)
+    self.assertEqual(1, len(pb.value))
+    results = tf.make_ndarray(pb.value[0].tensor)
+    self.assertEqual(results.shape, (0, 2))
+
+  def test_audio_count_when_fewer_than_max(self):
+    max_outputs = len(self.stereo) - 2
+    assert max_outputs > 0, max_outputs
+    pb = self.compute_and_check_summary_pb('k488', self.stereo,
+                                           max_outputs=max_outputs)
+    self.assertEqual(1, len(pb.value))
+    results = tf.make_ndarray(pb.value[0].tensor)
+    self.assertEqual(results.shape, (max_outputs, 2))
+
+  def test_audio_count_when_more_than_max(self):
+    max_outputs = len(self.stereo) + 2
+    pb = self.compute_and_check_summary_pb('k488', self.stereo,
+                                           max_outputs=max_outputs)
+    self.assertEqual(1, len(pb.value))
+    results = tf.make_ndarray(pb.value[0].tensor)
+    self.assertEqual(results.shape, (len(self.stereo), 2))
+
+  def test_processes_mono_audio(self):
+    pb = self.compute_and_check_summary_pb('k488', self.mono)
+    self.assertGreater(len(pb.value[0].tensor.string_val), 0)
+
+  def test_requires_rank_3_in_op(self):
+    with six.assertRaisesRegex(self, ValueError, 'must have rank 3'):
+      summary.op('k488', tf.constant([[1, 2, 3], [4, 5, 6]]), 44100)
+
+  def test_requires_rank_3_in_pb(self):
+    with six.assertRaisesRegex(self, ValueError, 'must have rank 3'):
+      summary.pb('k488', np.array([[1, 2, 3], [4, 5, 6]]), 44100)
+
+  def test_requires_wav_in_op(self):
+    with six.assertRaisesRegex(self, ValueError, 'Unknown encoding'):
+      summary.op('k488', self.stereo, 44100, encoding='pptx')
+
+  def test_requires_wav_in_pb(self):
+    with six.assertRaisesRegex(self, ValueError, 'Unknown encoding'):
+      summary.pb('k488', self.stereo, 44100, encoding='pptx')
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorboard/util_test.py
+++ b/tensorboard/util_test.py
@@ -300,5 +300,29 @@ class TensorFlowPngEncoderTest(tf.test.TestCase):
     self.assertEqual(tf.Session.call_count, 1)
 
 
+class TensorFlowWavEncoderTest(tf.test.TestCase):
+
+  def setUp(self):
+    super(TensorFlowWavEncoderTest, self).setUp()
+    self._encode = util._TensorFlowWavEncoder()
+
+    space = np.linspace(0.0, 100.0, 44100)
+    self._stereo = np.array([np.sin(space), np.cos(space)]).transpose()
+    self._mono = self._stereo.mean(axis=1, keepdims=True)
+
+  def _check_wav(self, data):
+    # If it has a valid WAV/RIFF header and is of a reasonable size, we
+    # can assume it did the right thing. We trust the underlying
+    # `encode_audio` op.
+    self.assertEqual(b'RIFF', data[:4])
+    self.assertGreater(len(data), 128)
+
+  def test_encodes_mono_wav(self):
+    self._check_wav(self._encode(self._mono, samples_per_second=44100))
+
+  def test_encodes_stereo_wav(self):
+    self._check_wav(self._encode(self._stereo, samples_per_second=44100))
+
+
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
Summary:
This commit introduces a new-style summary for audio, which new code
should prefer over `tf.summary.audio`. The new summary is not privileged
and is built on top of `tensor_summary`.

The backend and `data_compat` layers have not yet been updated, so there
is no user-visible effect. The next PR will incorporate the remaining
changes.

NOTE: This change requires a TensorFlow build from 2017-08-11 nightly or
later. (Specifically, we need 22730fd4c633a74e59c03ff76dc92e6ae2d5d020.)

Test Plan:
The new code is completely self-contained (nothing references it), so
the additional unit tests suffice: `bazel test ...`.

wchargin-branch: tensor-audio-summary