### PR TITLE
Support new-style audio summaries

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -103,6 +103,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/plugins/audio:metadata",
         "//tensorboard/plugins/histogram:metadata",
         "//tensorboard/plugins/image:metadata",
     ],
@@ -116,6 +117,8 @@ py_test(
     deps = [
         ":data_compat",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/plugins/audio:metadata",
+        "//tensorboard/plugins/audio:summary",
         "//tensorboard/plugins/histogram:metadata",
         "//tensorboard/plugins/histogram:summary",
         "//tensorboard/plugins/image:metadata",

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -40,13 +40,13 @@ from tensorboard.backend import http_util
 from tensorboard.backend.event_processing import event_accumulator
 from tensorboard.backend.event_processing import event_multiplexer
 from tensorboard.plugins import base_plugin
+from tensorboard.plugins.audio import metadata as audio_metadata
 from tensorboard.plugins.core import core_plugin
 from tensorboard.plugins.histogram import metadata as histogram_metadata
 from tensorboard.plugins.image import metadata as image_metadata
 
 
 DEFAULT_SIZE_GUIDANCE = {
-    event_accumulator.AUDIO: 10,
     event_accumulator.SCALARS: 1000,
     event_accumulator.TENSORS: 10,
 }
@@ -55,6 +55,7 @@ DEFAULT_SIZE_GUIDANCE = {
 # alternative that does not privilege first-party plugins.
 DEFAULT_TENSOR_SIZE_GUIDANCE = {
     image_metadata.PLUGIN_NAME: 10,
+    audio_metadata.PLUGIN_NAME: 10,
     histogram_metadata.PLUGIN_NAME: 500,
 }
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -96,6 +96,7 @@ py_test(
     deps = [
         ":event_accumulator",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/plugins/audio:summary",
         "//tensorboard/plugins/distribution:compressor",
         "//tensorboard/plugins/image:summary",
     ],

--- a/tensorboard/backend/event_processing/event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/event_multiplexer_test.py
@@ -60,8 +60,7 @@ class _FakeAccumulator(object):
     }
 
   def Tags(self):
-    return {event_accumulator.AUDIO: ['snd1', 'snd2'],
-            event_accumulator.SCALARS: ['sv1', 'sv2']}
+    return {event_accumulator.SCALARS: ['sv1', 'sv2']}
 
   def FirstEventTimestamp(self):
     return 0
@@ -73,9 +72,6 @@ class _FakeAccumulator(object):
 
   def Scalars(self, tag_name):
     return self._TagHelper(tag_name, event_accumulator.SCALARS)
-
-  def Audio(self, tag_name):
-    return self._TagHelper(tag_name, event_accumulator.AUDIO)
 
   def Tensors(self, tag_name):
     return self._TagHelper(tag_name, event_accumulator.TENSORS)

--- a/tensorboard/data_compat_test.py
+++ b/tensorboard/data_compat_test.py
@@ -19,10 +19,12 @@ from __future__ import print_function
 import tensorflow as tf
 
 from tensorboard import data_compat
-from tensorboard.plugins.image import summary as image_summary
-from tensorboard.plugins.image import metadata as image_metadata
+from tensorboard.plugins.audio import summary as audio_summary
+from tensorboard.plugins.audio import metadata as audio_metadata
 from tensorboard.plugins.histogram import summary as histogram_summary
 from tensorboard.plugins.histogram import metadata as histogram_metadata
+from tensorboard.plugins.image import summary as image_summary
+from tensorboard.plugins.image import metadata as image_metadata
 
 
 class MigrateValueTest(tf.test.TestCase):
@@ -58,14 +60,24 @@ class MigrateValueTest(tf.test.TestCase):
     self._assert_noop(value)
 
   def test_audio(self):
-    op = tf.summary.audio('white_noise',
-                          tf.random_uniform(shape=[1, 44100],
-                                            minval=-1.0,
-                                            maxval=1.0),
-                          sample_rate=44100)
-    value = self._value_from_op(op)
-    assert value.HasField('audio'), value
-    self._assert_noop(value)
+    audio = tf.reshape(tf.linspace(0.0, 100.0, 4 * 10 * 2), (4, 10, 2))
+    old_op = tf.summary.audio('k488', audio, 44100)
+    old_value = self._value_from_op(old_op)
+    assert old_value.HasField('audio'), old_value
+    new_value = data_compat.migrate_value(old_value)
+
+    self.assertEqual('k488/audio/0', new_value.tag)
+    expected_metadata = audio_metadata.create_summary_metadata(
+        display_name='k488/audio/0',
+        description='',
+        encoding=audio_metadata.Encoding.Value('WAV'))
+    self.assertEqual(expected_metadata, new_value.metadata)
+    self.assertTrue(new_value.HasField('tensor'))
+    data = tf.make_ndarray(new_value.tensor)
+    self.assertEqual((1, 2), data.shape)
+    self.assertEqual(tf.compat.as_bytes(old_value.audio.encoded_audio_string),
+                     data[0][0])
+    self.assertEqual(b'', data[0][1])  # empty label
 
   def test_text(self):
     op = tf.summary.text('lorem_ipsum', tf.constant('dolor sit amet'))
@@ -140,6 +152,17 @@ class MigrateValueTest(tf.test.TestCase):
                                   tf.uint8),
                           display_name='The Mona Lisa',
                           description='A renowned portrait by da Vinci.')
+    value = self._value_from_op(op)
+    assert value.HasField('tensor'), value
+    self._assert_noop(value)
+
+  def test_new_style_audio(self):
+    audio = tf.reshape(tf.linspace(0.0, 100.0, 4 * 10 * 2), (4, 10, 2))
+    op = audio_summary.op('k488',
+                          tf.cast(audio, tf.float32),
+                          sample_rate=44100,
+                          display_name='Piano Concerto No.23',
+                          description='In **A major**.')
     value = self._value_from_op(op)
     assert value.HasField('tensor'), value
     self._assert_noop(value)

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -16,6 +16,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",
@@ -31,6 +32,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":audio_plugin",
+        ":summary",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
@@ -73,6 +75,7 @@ py_binary(
     srcs = ["audio_demo.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":summary",
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/audio/audio_plugin_test.py
+++ b/tensorboard/plugins/audio/audio_plugin_test.py
@@ -34,6 +34,7 @@ from werkzeug import wrappers
 from tensorboard.backend import application
 from tensorboard.backend.event_processing import event_multiplexer
 from tensorboard.plugins import base_plugin
+from tensorboard.plugins.audio import summary
 from tensorboard.plugins.audio import audio_plugin
 
 
@@ -46,7 +47,7 @@ class AudioPluginTest(tf.test.TestCase):
     # in this test.
     numpy.random.seed(42)
 
-    # Create audio summaries for run foo.
+    # Create old-style audio summaries for run "foo".
     tf.reset_default_graph()
     sess = tf.Session()
     placeholder = tf.placeholder(tf.float32)
@@ -62,11 +63,14 @@ class AudioPluginTest(tf.test.TestCase):
       }), global_step=step)
     writer.close()
 
-    # Create audio summaries for run bar.
+    # Create new-style audio summaries for run "bar".
     tf.reset_default_graph()
     sess = tf.Session()
-    placeholder = tf.placeholder(tf.float32)
-    tf.summary.audio(name="quux", tensor=placeholder, sample_rate=44100)
+    audio_placeholder = tf.placeholder(tf.float32)
+    labels_placeholder = tf.placeholder(tf.string)
+    summary.op("quux", audio_placeholder, sample_rate=44100,
+               labels=labels_placeholder,
+               description="how do you pronounce that, anyway?")
     merged_summary_op = tf.summary.merge_all()
     bar_directory = os.path.join(self.log_dir, "bar")
     writer = tf.summary.FileWriter(bar_directory)
@@ -74,7 +78,11 @@ class AudioPluginTest(tf.test.TestCase):
     for step in xrange(2):
       # The floats (sample data) range from -1 to 1.
       writer.add_summary(sess.run(merged_summary_op, feed_dict={
-          placeholder: numpy.random.rand(42, 11025) * 2 - 1
+          audio_placeholder: numpy.random.rand(42, 11025, 1) * 2 - 1,
+          labels_placeholder: [
+              tf.compat.as_bytes('step **%s**, sample %s' % (step, sample))
+              for sample in xrange(42)
+          ],
       }), global_step=step)
     writer.close()
 
@@ -111,10 +119,10 @@ class AudioPluginTest(tf.test.TestCase):
     self.assertIsInstance(routes["/individualAudio"], collections.Callable)
     self.assertIsInstance(routes["/tags"], collections.Callable)
 
-  def testAudioRoute(self):
-    """Tests that the /audio routes returns with the correct data."""
+  def testOldStyleAudioRoute(self):
+    """Tests that the /audio routes returns correct old-style data."""
     response = self.server.get(
-        "/data/plugin/audio/audio?run=foo&tag=baz/audio/0")
+        "/data/plugin/audio/audio?run=foo&tag=baz/audio/0&sample=0")
     self.assertEqual(200, response.status_code)
 
     # Verify that the correct entries are returned.
@@ -123,37 +131,108 @@ class AudioPluginTest(tf.test.TestCase):
 
     # Verify that the 1st entry is correct.
     entry = entries[0]
+    self.assertEqual("audio/wav", entry["contentType"])
+    self.assertEqual("", entry["label"])
     self.assertEqual(0, entry["step"])
     parsed_query = urllib.parse.parse_qs(entry["query"])
-    self.assertListEqual(["0"], parsed_query["index"])
     self.assertListEqual(["foo"], parsed_query["run"])
     self.assertListEqual(["baz/audio/0"], parsed_query["tag"])
+    self.assertListEqual(["0"], parsed_query["sample"])
+    self.assertListEqual(["0"], parsed_query["index"])
 
     # Verify that the 2nd entry is correct.
     entry = entries[1]
+    self.assertEqual("audio/wav", entry["contentType"])
+    self.assertEqual("", entry["label"])
     self.assertEqual(1, entry["step"])
     parsed_query = urllib.parse.parse_qs(entry["query"])
-    self.assertListEqual(["1"], parsed_query["index"])
     self.assertListEqual(["foo"], parsed_query["run"])
     self.assertListEqual(["baz/audio/0"], parsed_query["tag"])
+    self.assertListEqual(["0"], parsed_query["sample"])
+    self.assertListEqual(["1"], parsed_query["index"])
 
-  def testIndividualAudioRoute(self):
-    """Tests fetching an individual audio."""
+  def testNewStyleAudioRoute(self):
+    """Tests that the /audio routes returns correct new-style data."""
     response = self.server.get(
-        "/data/plugin/audio/individualAudio?run=bar&tag=quux/audio/0&index=0")
+        "/data/plugin/audio/audio?run=bar&tag=quux/audio_summary&sample=0")
+    self.assertEqual(200, response.status_code)
+
+    # Verify that the correct entries are returned.
+    entries = self._DeserializeResponse(response.get_data())
+    self.assertEqual(2, len(entries))
+
+    # Verify that the 1st entry is correct.
+    entry = entries[0]
+    self.assertEqual("audio/wav", entry["contentType"])
+    self.assertEqual(
+        "<p>step <strong>%s</strong>, sample 0</p>" % entry["step"],
+        entry["label"])
+    self.assertEqual(0, entry["step"])
+    parsed_query = urllib.parse.parse_qs(entry["query"])
+    self.assertListEqual(["bar"], parsed_query["run"])
+    self.assertListEqual(["quux/audio_summary"], parsed_query["tag"])
+    self.assertListEqual(["0"], parsed_query["sample"])
+    self.assertListEqual(["0"], parsed_query["index"])
+
+    # Verify that the 2nd entry is correct.
+    entry = entries[1]
+    self.assertEqual("audio/wav", entry["contentType"])
+    self.assertEqual(
+        "<p>step <strong>%s</strong>, sample 0</p>" % entry["step"],
+        entry["label"])
+    self.assertEqual(1, entry["step"])
+    parsed_query = urllib.parse.parse_qs(entry["query"])
+    self.assertListEqual(["bar"], parsed_query["run"])
+    self.assertListEqual(["quux/audio_summary"], parsed_query["tag"])
+    self.assertListEqual(["0"], parsed_query["sample"])
+    self.assertListEqual(["1"], parsed_query["index"])
+
+  def testOldStyleIndividualAudioRoute(self):
+    """Tests fetching an individual audio clip from an old-style summary."""
+    response = self.server.get(
+        "/data/plugin/audio/individualAudio"
+        "?run=foo&tag=baz/audio/0&sample=0&index=0")
     self.assertEqual(200, response.status_code)
     self.assertEqual("audio/wav", response.headers.get("content-type"))
 
-  def testRunsRoute(self):
-    """Tests that the /runs route offers the correct run to tag mapping."""
+  def testNewStyleIndividualAudioRoute(self):
+    """Tests fetching an individual audio clip from an old-style summary."""
+    response = self.server.get(
+        "/data/plugin/audio/individualAudio"
+        "?run=bar&tag=quux/audio_summary&sample=0&index=0")
+    self.assertEqual(200, response.status_code)
+    self.assertEqual("audio/wav", response.headers.get("content-type"))
+
+  def testTagsRoute(self):
+    """Tests that the /tags route offers the correct run to tag mapping."""
     response = self.server.get("/data/plugin/audio/tags")
     self.assertEqual(200, response.status_code)
-    run_to_tags = self._DeserializeResponse(response.get_data())
-    self.assertItemsEqual(("foo", "bar"), run_to_tags.keys())
-    self.assertItemsEqual(
-        ["baz/audio/0", "baz/audio/1", "baz/audio/2"], run_to_tags["foo"])
-    self.assertItemsEqual(
-        ["quux/audio/0", "quux/audio/1", "quux/audio/2"], run_to_tags["bar"])
+    self.assertDictEqual({
+        "foo": {
+            "baz/audio/0": {
+                "displayName": "baz/audio/0",
+                "description": "",
+                "samples": 1,
+            },
+            "baz/audio/1": {
+                "displayName": "baz/audio/1",
+                "description": "",
+                "samples": 1,
+            },
+            "baz/audio/2": {
+                "displayName": "baz/audio/2",
+                "description": "",
+                "samples": 1,
+            },
+        },
+        "bar": {
+            "quux/audio_summary": {
+                "displayName": "quux",
+                "description": "<p>how do you pronounce that, anyway?</p>",
+                "samples": 3,  # 42 inputs, but max_outputs=3
+            },
+        },
+    }, self._DeserializeResponse(response.get_data()))
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/audio/tf_audio_dashboard/BUILD
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/BUILD
@@ -22,6 +22,7 @@ ts_web_library(
         "//tensorboard/components/tf_imports:d3",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_markdown_view",
         "//tensorboard/components/tf_paginated_view",
         "//tensorboard/components/tf_runs_selector",
         "@org_polymer_iron_icon",

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
@@ -83,8 +83,10 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
                         <tf-audio-loader
                           run="[[item.run]]"
                           tag="[[item.tag]]"
+                          sample="[[item.sample]]"
+                          total-samples="[[item.totalSamples]]"
+                          tag-metadata="[[_tagMetadata(_runToTagInfo, item.run, item.tag)]]"
                           request-manager="[[_requestManager]]"
-                          show-actual-size="[[_showActualSize]]"
                         ></tf-audio-loader>
                     </div>
                   </template>
@@ -115,7 +117,7 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
       is: 'tf-audio-dashboard',
       properties: {
         _selectedRuns: Array,
-        _runToTag: Object,  // map<run: string, tags: string[]>
+        _runToTagInfo: Object,
         _dataNotFound: Boolean,
 
         _tagFilter: {
@@ -125,7 +127,7 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
         _categories: {
           type: Array,
           computed:
-            '_makeCategories(_runToTag, _selectedRuns, _tagFilter)',
+            '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter)',
         },
 
         _requestManager: {
@@ -144,14 +146,15 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
       },
       _fetchTags() {
         const url = getRouter().pluginRoute('audio', '/tags');
-        return this._requestManager.request(url).then(runToTag => {
-          if (_.isEqual(runToTag, this._runToTag)) {
+        return this._requestManager.request(url).then(runToTagInfo => {
+          if (_.isEqual(runToTagInfo, this._runToTagInfo)) {
             // No need to update anything if there are no changes.
             return;
           }
+          const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
           const tags = getTags(runToTag);
           this.set('_dataNotFound', tags.length === 0);
-          this.set('_runToTag', runToTag);
+          this.set('_runToTagInfo', runToTagInfo);
         });
       },
       _reloadAudio() {
@@ -160,8 +163,25 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
         });
       },
 
-      _makeCategories(runToTag, selectedRuns, tagFilter) {
-        return categorizeRunTagCombinations(runToTag, selectedRuns, tagFilter);
+      _makeCategories(runToTagInfo, selectedRuns, tagFilter) {
+        const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
+        const baseCategories =
+          categorizeRunTagCombinations(runToTag, selectedRuns, tagFilter);
+        function explodeItem(item) {
+          const samples = runToTagInfo[item.run][item.tag].samples;
+          return _.range(samples).map(i => Object.assign({}, item, {
+            sample: i,
+            totalSamples: samples,
+          }));
+        }
+        const withSamples = baseCategories.map(category =>
+          Object.assign({}, category, {
+            items: [].concat.apply([], category.items.map(explodeItem)),
+          }));
+        return withSamples;
+      },
+      _tagMetadata(runToTagInfo, run, tag) {
+        return runToTagInfo[run][tag];
       },
     });
   </script>

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
@@ -23,6 +23,7 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
 <link rel="import" href="../tf-imports/d3.html">
 <link rel="import" href="../tf-imports/lodash.html">
+<link rel="import" href="../tf-markdown-view/tf-markdown-view.html">
 
 <!--
 tf-audio-loader loads an individual audio clip from the TensorBoard
@@ -30,7 +31,16 @@ backend.
 -->
 <dom-module id="tf-audio-loader">
   <template>
-    <tf-card-heading run="[[run]]" tag="[[tag]]" color="[[_runColor]]">
+    <tf-card-heading
+      tag="[[tag]]"
+      run="[[run]]"
+      display-name="[[tagMetadata.displayName]]"
+      description="[[tagMetadata.description]]"
+      color="[[_runColor]]"
+    >
+      <template is="dom-if" if="[[_hasMultipleSamples]]">
+        <div>sample: [[_sampleText]] of [[totalSamples]]</div>
+      </template>
       <template is="dom-if" if="[[_hasAtLeastOneStep]]">
         step
         <span style="font-weight: bold">[[_currentDatum.step]]</span>
@@ -55,8 +65,9 @@ backend.
         controls
         loop="loop"
         src$="[[_currentDatum.url]]"
-        type="[[_currentDatum.content_type]]"
+        type$="[[_currentDatum.contentType]]"
       ></audio>
+      <tf-markdown-view html="[[_currentDatum.label]]"></tf-markdown-view>
     </template>
     <div id="main-audio-container">
     </div>
@@ -64,7 +75,7 @@ backend.
     <style>
       :host {
         display: block;
-        width: 330px;
+        width: 350px;
         height: auto;
         position: relative;
         --step-slider-knob-color: #424242;
@@ -100,6 +111,10 @@ backend.
       properties: {
         run: String,
         tag: String,
+        sample: Number,
+        totalSamples: Number,  // how many samples in this run--tag combination?
+        /** @type {{description: string, displayName: string}} */
+        tagMetadata: Object,
 
         _runColor: {
           type: String,
@@ -112,10 +127,11 @@ backend.
           value: () => new Canceller(),
         },
 
-        // steps: {
+        // _steps: {
         //   wall_time: string,
         //   step: number,
-        //   content_type: string,
+        //   label: string,
+        //   contentType: string,
         //   url: string,
         // }[]
         _steps: {
@@ -131,17 +147,21 @@ backend.
           type: Boolean,
           computed: "_computeHasMultipleSteps(_steps)",
         },
-        _stepValue: {
-          type: Number,
-          computed: "_computeStepValue(_stepIndex)",
-        },
         _currentDatum: {
-          type: Object,  // {wall_time, step, content_type, url}
+          type: Object,  // {wall_time, step, label, url}
           computed: "_computeCurrentDatum(_steps, _stepIndex)",
         },
         _maxStepIndex: {
           type: Number,
           computed: "_computeMaxStepIndex(_steps)",
+        },
+        _sampleText: {
+          type: String,
+          computed: "_computeSampleText(sample)",
+        },
+        _hasMultipleSamples: {
+          type: Boolean,
+          computed: "_computeHasMultipleSamples(totalSamples)",
         },
       },
       observers: ['reload(run, tag)'],
@@ -154,14 +174,17 @@ backend.
       _computeHasMultipleSteps(steps) {
         return !!steps && steps.length > 1;
       },
-      _computeStepValue(stepIndex) {
-        return this._steps[stepIndex].step;
-      },
       _computeMaxStepIndex(steps) {
         return steps.length - 1;
       },
       _computeCurrentDatum(steps, stepIndex) {
         return steps[stepIndex];
+      },
+      _computeSampleText(sample) {
+        return `${sample + 1}`;
+      },
+      _computeHasMultipleSamples(totalSamples) {
+        return totalSamples > 1;
       },
 
       attached() {
@@ -174,8 +197,9 @@ backend.
         }
         this._metadataCanceller.cancelAll();
         const router = getRouter();
-        const url =
-          router.pluginRunTagRoute("audio", "/audio")(this.tag, this.run);
+        const baseURL = router.pluginRoute("audio", "/audio");
+        const query = `run=${this.run}&tag=${this.tag}&sample=${this.sample}`;
+        const url = baseURL + (baseURL.indexOf('?') !== -1 ? '&' : '?') + query;
         const updateSteps = this._metadataCanceller.cancellable(result => {
           if (result.cancelled) {
             return;
@@ -213,7 +237,8 @@ backend.
         return {
           wall_time: new Date(audioMetadata.wall_time * 1000).toString(),
           step: audioMetadata.step,
-          content_type: audioMetadata.content_type,
+          label: audioMetadata.label,
+          contentType: audioMetadata.contentType,
           url: individualAudioURL,
         };
       },


### PR DESCRIPTION
Summary:
This commit adds support for new-style audio summaries to the plugin
frontend and backend.

Here is a screenshot of the resulting dashboard:
![Screenshot](https://user-images.githubusercontent.com/4317806/29231118-d1ce0a44-7e9a-11e7-8029-0ffff6ab44de.png)

This change is fully compatible with the old data format.

Test Plan:
Run `bazel run //tensorboard/plugins/audio:audio_demo` to get data
using new-style audio summaries. Also grab some old-style audio
summaries, perhaps by running the version of that target that appeared
before this commit (and changing the logdir to avoid writing into the
same directory). Launch a TensorBoard with a logdir enclosing all of
this data, and verify that it all renders correctly.

When running `bazel test //tensorboard/...`, be aware that this diff
contains a particularly large number of uses of `tf.compat.as_bytes` and
friends. Thus, it is wise to run this test command in both py2 and py3
virtualenvs.

wchargin-branch: new-style-audio-frontend