### PR TITLE
Create a tensor scalar summary

### DIFF
--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -5,6 +5,8 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 exports_files(["LICENSE"])
 
 ## Scalars Plugin ##
@@ -48,4 +50,50 @@ py_binary(
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],
+)
+
+py_library(
+    name = "summary",
+    srcs = ["summary.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":metadata",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:util",
+    ],
+)
+
+py_test(
+    name = "summary_test",
+    size = "small",
+    srcs = ["summary_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":metadata",
+        ":summary",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_library(
+    name = "metadata",
+    srcs = ["metadata.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//tensorboard:internal",
+    ],
+    deps = [
+        ":protos_all_py_pb2",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+tb_proto_library(
+    name = "protos_all",
+    srcs = ["plugin_data.proto"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorboard/plugins/scalar/metadata.py
+++ b/tensorboard/plugins/scalar/metadata.py
@@ -1,0 +1,55 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Internal information about the scalar plugin."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+from tensorboard.plugins.scalar import plugin_data_pb2
+
+
+PLUGIN_NAME = 'scalars'
+
+
+def create_summary_metadata(display_name, description):
+  """Create a `tf.SummaryMetadata` proto for scalar plugin data.
+
+  Returns:
+    A `tf.SummaryMetadata` protobuf object.
+  """
+  content = plugin_data_pb2.ScalarPluginData()
+  metadata = tf.SummaryMetadata(display_name=display_name,
+                                summary_description=description,
+                                plugin_data=tf.SummaryMetadata.PluginData(
+                                    plugin_name=PLUGIN_NAME,
+                                    content=content.SerializeToString()))
+  return metadata
+
+
+def parse_plugin_metadata(content):
+  """Parse summary metadata to a Python object.
+
+  Arguments:
+    content: The `content` field of a `SummaryMetadata` proto
+      corresponding to the scalar plugin.
+
+  Returns:
+    A `ScalarPluginData` protobuf object.
+  """
+  result = plugin_data_pb2.ScalarPluginData()
+  result.ParseFromString(tf.compat.as_bytes(content))
+  return result

--- a/tensorboard/plugins/scalar/plugin_data.proto
+++ b/tensorboard/plugins/scalar/plugin_data.proto
@@ -1,0 +1,28 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+syntax = "proto3";
+
+package tensorboard;
+
+// Scalar summaries created by the `tensorboard.plugins.scalar.summary`
+// module will include `SummaryMetadata` whose `plugin_data` field has
+// as `content` a binary string that is the encoding of an
+// `ScalarPluginData` proto.
+//
+// We don't currently need to store any static metadata with scalar
+// summaries, so this message is empty.
+message ScalarPluginData {
+}

--- a/tensorboard/plugins/scalar/summary.py
+++ b/tensorboard/plugins/scalar/summary.py
@@ -1,0 +1,96 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Scalar summaries and TensorFlow operations to create them.
+
+A scalar summary stores a single floating-point value, as a rank-0 tensor.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+import numpy as np
+
+from tensorboard.plugins.scalar import metadata
+
+
+def op(name,
+       data,
+       display_name=None,
+       description=None,
+       collections=None):
+  """Create a scalar summary op.
+
+  Arguments:
+    name: A unique name for the generated summary node.
+    data: A real numeric rank-0 `Tensor`. Must have `dtype` compatible
+      with `float32`.
+    display_name: Optional name for this summary in TensorBoard, as a
+      constant `str`. Defaults to `name`.
+    description: Optional long-form description for this summary, as a
+      constant `str`. Markdown is supported. Defaults to empty.
+    collections: Optional list of graph collections keys. The new
+      summary op is added to these collections. Defaults to
+      `[Graph Keys.SUMMARIES]`.
+
+  Returns:
+    A TensorFlow summary op.
+  """
+  if display_name is None:
+    display_name = name
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=display_name, description=description)
+  with tf.name_scope(name):
+    with tf.control_dependencies([tf.assert_scalar(data)]):
+      return tf.summary.tensor_summary(name='scalar_summary',
+                                       tensor=tf.cast(data, tf.float32),
+                                       collections=collections,
+                                       summary_metadata=summary_metadata)
+
+
+def pb(name, data, display_name=None, description=None):
+  """Create a scalar summary protobuf.
+
+  Arguments:
+    name: A unique name for the generated summary, including any desired
+      name scopes.
+    data: A rank-0 `np.array` or array-like form (so raw `int`s and
+      `float`s are fine, too).
+    display_name: Optional name for this summary in TensorBoard, as a
+      `str`. Defaults to `name`.
+    description: Optional long-form description for this summary, as a
+      `str`. Markdown is supported. Defaults to empty.
+
+  Returns:
+    A `tf.Summary` protobuf object.
+  """
+  data = np.array(data)
+  if data.shape != ():
+    raise ValueError('Expected scalar shape for data, saw shape: %s.'
+                     % data.shape)
+  if data.dtype.kind not in ('b', 'i', 'u', 'f'):  # bool, int, uint, float
+    raise ValueError('Cast %s to float is not supported' % data.dtype.name)
+  tensor = tf.make_tensor_proto(data.astype(np.float32))
+
+  if display_name is None:
+    display_name = name
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=display_name, description=description)
+  summary = tf.Summary()
+  summary.value.add(tag='%s/scalar_summary' % name,
+                    metadata=summary_metadata,
+                    tensor=tensor)
+  return summary

--- a/tensorboard/plugins/scalar/summary_test.py
+++ b/tensorboard/plugins/scalar/summary_test.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the scalar plugin summary generation functions."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import six
+import tensorflow as tf
+
+from tensorboard.plugins.scalar import metadata
+from tensorboard.plugins.scalar import summary
+
+
+class SummaryTest(tf.test.TestCase):
+
+  def pb_via_op(self, summary_op, feed_dict=None):
+    with tf.Session() as sess:
+      actual_pbtxt = sess.run(summary_op, feed_dict=feed_dict or {})
+    actual_proto = tf.Summary()
+    actual_proto.ParseFromString(actual_pbtxt)
+    return actual_proto
+
+  def normalize_summary_pb(self, pb):
+    """Pass `pb`'s `TensorProto` through a marshalling roundtrip.
+
+    `TensorProto`s can be equal in value even if they are not identical
+    in representation, because data can be stored in either the
+    `tensor_content` field or the `${dtype}_value` field. This
+    normalization ensures a canonical form, and should be used before
+    comparing two `Summary`s for equality.
+    """
+    result = tf.Summary()
+    result.MergeFrom(pb)
+    for value in result.value:
+      if value.HasField('tensor'):
+        new_tensor = tf.make_tensor_proto(tf.make_ndarray(value.tensor))
+        value.ClearField('tensor')
+        value.tensor.MergeFrom(new_tensor)
+    return result
+
+  def compute_and_check_summary_pb(self, name, data,
+                                   display_name=None, description=None,
+                                   data_tensor=None, feed_dict=None):
+    """Use both `op` and `pb` to get a summary, asserting equality.
+
+    Returns:
+      a `Summary` protocol buffer
+    """
+    if data_tensor is None:
+      data_tensor = tf.constant(data)
+    op = summary.op(
+        name, data, display_name=display_name, description=description)
+    pb = self.normalize_summary_pb(summary.pb(
+        name, data, display_name=display_name, description=description))
+    pb_via_op = self.normalize_summary_pb(
+        self.pb_via_op(op, feed_dict=feed_dict))
+    self.assertProtoEquals(pb, pb_via_op)
+    return pb
+
+  def test_metadata(self):
+    pb = self.compute_and_check_summary_pb('a', 1.13)
+    summary_metadata = pb.value[0].metadata
+    plugin_data = summary_metadata.plugin_data
+    self.assertEqual(summary_metadata.display_name, 'a')
+    self.assertEqual(summary_metadata.summary_description, '')
+    self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
+    content = summary_metadata.plugin_data.content
+    # There's no content, so successfully parsing is fine.
+    metadata.parse_plugin_metadata(content)
+
+  def test_explicit_display_name_and_description(self):
+    display_name = '"A"'
+    description = 'The first letter of the alphabet.'
+    pb = self.compute_and_check_summary_pb('a', 1.13,
+                                           display_name=display_name,
+                                           description=description)
+    summary_metadata = pb.value[0].metadata
+    self.assertEqual(summary_metadata.display_name, display_name)
+    self.assertEqual(summary_metadata.summary_description, description)
+    plugin_data = summary_metadata.plugin_data
+    self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
+    content = summary_metadata.plugin_data.content
+    # There's no content, so successfully parsing is fine.
+    metadata.parse_plugin_metadata(content)
+
+  def test_float_value(self):
+    pb = self.compute_and_check_summary_pb('a', 1.13)
+    value = tf.make_ndarray(pb.value[0].tensor).item()
+    self.assertEqual(float, type(value))
+    self.assertNear(1.13, value, 1e-6)
+
+  def test_int_value(self):
+    # ints should be valid, but converted to floats.
+    pb = self.compute_and_check_summary_pb('a', 113)
+    value = tf.make_ndarray(pb.value[0].tensor).item()
+    self.assertEqual(float, type(value))
+    self.assertNear(113.0, value, 1e-6)
+
+  def test_bool_value(self):
+    # bools should be valid, but converted to floats.
+    pb = self.compute_and_check_summary_pb('a', True)
+    value = tf.make_ndarray(pb.value[0].tensor).item()
+    self.assertEqual(float, type(value))
+    self.assertEqual(1.0, value)
+
+  def test_string_value_in_op(self):
+    with six.assertRaisesRegex(self, Exception, r'Cast str.*float'):
+      with tf.Session() as sess:
+        sess.run(summary.op('a', tf.constant("113")))
+
+  def test_string_value_in_pb(self):
+    with six.assertRaisesRegex(self, ValueError, r'Cast str.*float'):
+      summary.pb('a', np.array("113"))
+
+  def test_requires_rank_0_in_op(self):
+    with six.assertRaisesRegex(self, Exception, r'Expected scalar shape'):
+      with tf.Session() as sess:
+        sess.run(summary.op('a', tf.constant([1, 1, 3])))
+
+  def test_requires_rank_0_in_pb(self):
+    with six.assertRaisesRegex(self, ValueError, r'Expected scalar shape'):
+      summary.pb('a', np.array([1, 1, 3]))
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
Summary:
It's the last one! This commit introduces a new-style summary for
scalars, which new code should prefer over `tf.summary.scalar`. The new
summary is not privileged and is built on top of `tensor_summary`.

The backend and data_compat layers have not yet been updated, so there
is no user-visible effect. The next PR will incorporate the remaining
changes.

Test Plan:
The new code is completely self-contained (nothing references it), so
the additional unit tests suffice: `bazel test ...`.

wchargin-branch: tensor-scalar-summary