### PR TITLE
Make tensor_summary accept 'pr_curves' as a name

### DIFF
--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -176,7 +176,7 @@ def op(
     combined_data = tf.stack([tp, fp, tn, fn, precision, recall])
 
     return tf.summary.tensor_summary(
-        name=tag,
+        name='pr_curves',
         tensor=combined_data,
         collections=collections,
         summary_metadata=summary_metadata)

--- a/tensorboard/plugins/pr_curve/summary_test.py
+++ b/tensorboard/plugins/pr_curve/summary_test.py
@@ -60,15 +60,15 @@ class PrCurveTest(tf.test.TestCase):
     # Verify that the metadata was correctly written.
     accumulator = multiplexer.GetAccumulator('foo')
     tag_content_dict = accumulator.PluginTagToContent('pr_curve')
-    self.assertListEqual(['tag_bar/tag_bar'], list(tag_content_dict.keys()))
+    self.assertListEqual(['tag_bar/pr_curves'], list(tag_content_dict.keys()))
 
     # Parse the data within the JSON string and set the proto's fields.
     plugin_data = pr_curve_pb2.PrCurvePluginData()
-    json_format.Parse(tag_content_dict['tag_bar/tag_bar'], plugin_data)
+    json_format.Parse(tag_content_dict['tag_bar/pr_curves'], plugin_data)
     self.assertEqual(10, plugin_data.num_thresholds)
 
     # Test the summary contents.
-    tensor_events = accumulator.Tensors('tag_bar/tag_bar')
+    tensor_events = accumulator.Tensors('tag_bar/pr_curves')
     self.assertEqual(1, len(tensor_events))
     tensor_event = tensor_events[0]
     self.assertEqual(1, tensor_event.step)


### PR DESCRIPTION
Previously, the call to tensor_summary within the PR Curve summary op accepted the tag as the name parameter. This should be the name of the plugin instead. The pattern followed by existing ops is to create a name-scope of tag specified by the user and then create a summary with the name of the plugin.