### PR TITLE
Expose the `PersistentOpEvaluator` class

### DIFF
--- a/tensorboard/util.py
+++ b/tensorboard/util.py
@@ -340,7 +340,7 @@ def _hack_the_main_frame():
   return frame
 
 
-class _PersistentOpEvaluator(object):
+class PersistentOpEvaluator(object):
   """Evaluate a fixed TensorFlow graph repeatedly, safely, efficiently.
 
   Extend this class to create a particular kind of op evaluator, like an
@@ -355,7 +355,7 @@ class _PersistentOpEvaluator(object):
 
   Example usage:
 
-      class FluxCapacitanceEvaluator(_PersistentOpEvaluator):
+      class FluxCapacitanceEvaluator(PersistentOpEvaluator):
         \"\"\"Compute the flux capacitance required for a system.
 
         Arguments:
@@ -379,7 +379,7 @@ class _PersistentOpEvaluator(object):
   """
 
   def __init__(self):
-    super(_PersistentOpEvaluator, self).__init__()
+    super(PersistentOpEvaluator, self).__init__()
     self._session = None
     self._initialization_lock = threading.Lock()
 
@@ -417,7 +417,7 @@ class _PersistentOpEvaluator(object):
       return self.run(*args, **kwargs)
 
 
-class _TensorFlowPngEncoder(_PersistentOpEvaluator):
+class _TensorFlowPngEncoder(PersistentOpEvaluator):
   """Encode an image to PNG.
 
   This function is thread-safe, and has high performance when run in
@@ -452,7 +452,7 @@ class _TensorFlowPngEncoder(_PersistentOpEvaluator):
 encode_png = _TensorFlowPngEncoder()
 
 
-class _TensorFlowWavEncoder(_PersistentOpEvaluator):
+class _TensorFlowWavEncoder(PersistentOpEvaluator):
   """Encode an audio clip to WAV.
 
   This function is thread-safe and exhibits good parallel performance.

--- a/tensorboard/util_test.py
+++ b/tensorboard/util_test.py
@@ -228,21 +228,70 @@ def TerminalStringIO():
   return stream
 
 
-class TensorFlowPngEncoderTest(tf.test.TestCase):
-  """Tests for the private `_TensorFlowPngEncoder` class.
-
-  The functionality of this class is tested via the `SummaryTest` (via
-  the `summary.pb` function). This class tests how it interacts with
-  other graphs and sessions---namely, not at all!
-  """
+class PersistentOpEvaluatorTest(tf.test.TestCase):
 
   def setUp(self):
-    super(TensorFlowPngEncoderTest, self).setUp()
+    super(PersistentOpEvaluatorTest, self).setUp()
 
     patch = tf.test.mock.patch('tensorflow.Session', wraps=tf.Session)
     patch.start()
     self.addCleanup(patch.stop)
 
+    class Squarer(util.PersistentOpEvaluator):
+
+      def __init__(self):
+        super(Squarer, self).__init__()
+        self._input = None
+        self._squarer = None
+
+      def initialize_graph(self):
+        self._input = tf.placeholder(tf.int32)
+        self._squarer = tf.square(self._input)
+
+      def run(self, xs):  # pylint: disable=arguments-differ
+        return self._squarer.eval(feed_dict={self._input: xs})
+
+    self._square = Squarer()
+
+  def test_preserves_existing_graph(self):
+    tf.constant(1) + tf.constant(2)  # pylint: disable=expression-not-assigned
+    original_graph = tf.get_default_graph()
+    original_proto = original_graph.as_graph_def().SerializeToString()
+    assert len(original_proto) > 10, original_graph
+
+    result = self._square(123)
+    self.assertEqual(123 * 123, result)
+
+    self.assertIs(original_graph, tf.get_default_graph())
+    self.assertEqual(original_proto,
+                     tf.get_default_graph().as_graph_def().SerializeToString())
+
+  def test_preserves_existing_session(self):
+    with tf.Session() as sess:
+      op = tf.reduce_sum([2, 2])
+      self.assertIs(sess, tf.get_default_session())
+
+      result = self._square(123)
+      self.assertEqual(123 * 123, result)
+
+      self.assertIs(sess, tf.get_default_session())
+      number_of_lights = sess.run(op)
+      self.assertEqual(number_of_lights, 4)
+
+  def test_lazily_initializes_sessions(self):
+    self.assertEqual(tf.Session.call_count, 0)
+
+  def test_reuses_sessions(self):
+    self._square(123)
+    self.assertEqual(tf.Session.call_count, 1)
+    self._square(234)
+    self.assertEqual(tf.Session.call_count, 1)
+
+
+class TensorFlowPngEncoderTest(tf.test.TestCase):
+
+  def setUp(self):
+    super(TensorFlowPngEncoderTest, self).setUp()
     self._encode = util._TensorFlowPngEncoder()
     self._rgb = np.arange(12 * 34 * 3).reshape((12, 34, 3)).astype(np.uint8)
     self._rgba = np.arange(21 * 43 * 4).reshape((21, 43, 4)).astype(np.uint8)
@@ -270,42 +319,12 @@ class TensorFlowPngEncoderTest(tf.test.TestCase):
     data = self._encode(self._rgba)
     self._check_png(data)
 
-  def test_preserves_existing_graph(self):
-    tf.constant(1) + tf.constant(2)  # pylint: disable=expression-not-assigned
-    original_graph = tf.get_default_graph()
-    original_proto = original_graph.as_graph_def().SerializeToString()
-    assert len(original_proto) > 10, original_graph
-    self._encode(self._rgb)
-    self.assertIs(original_graph, tf.get_default_graph())
-    self.assertEqual(original_proto,
-                     tf.get_default_graph().as_graph_def().SerializeToString())
-
-  def test_preserves_existing_session(self):
-    with tf.Session() as sess:
-      op = tf.reduce_sum([2, 2])
-      self.assertIs(sess, tf.get_default_session())
-      data = self._encode(self._rgb)
-      self._check_png(data)
-      self.assertIs(sess, tf.get_default_session())
-      number_of_lights = sess.run(op)
-      self.assertEqual(number_of_lights, 4)
-
-  def test_lazily_initializes_sessions(self):
-    self.assertEqual(tf.Session.call_count, 0)
-
-  def test_reuses_sessions(self):
-    self._encode(self._rgb)
-    self.assertEqual(tf.Session.call_count, 1)
-    self._encode(self._rgb)
-    self.assertEqual(tf.Session.call_count, 1)
-
 
 class TensorFlowWavEncoderTest(tf.test.TestCase):
 
   def setUp(self):
     super(TensorFlowWavEncoderTest, self).setUp()
     self._encode = util._TensorFlowWavEncoder()
-
     space = np.linspace(0.0, 100.0, 44100)
     self._stereo = np.array([np.sin(space), np.cos(space)]).transpose()
     self._mono = self._stereo.mean(axis=1, keepdims=True)


### PR DESCRIPTION
Summary:
We’ve used this class three times now (encoding PNGs, encoding WAVs, and
[performing nearest-neighbor resizing][1]). The API has proven to be
sufficiently permissive to be widely useful, so we should expose this
publicly.

[1]: https://github.com/chrisranderson/beholder/issues/48#issuecomment-322533474

Test Plan:
There are no changes in functionality. All unit tests pass.

wchargin-branch: expose-persistentopevaluator