### PR TITLE
Rename internal histogram metadata parser function

### DIFF
--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -74,7 +74,7 @@ class HistogramsPlugin(base_plugin.TBPlugin):
     mapping = self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME)
     for (run, tag_to_content) in six.iteritems(mapping):
       for (tag, content) in six.iteritems(tag_to_content):
-        content = metadata.parse_summary_metadata(content)
+        content = metadata.parse_plugin_metadata(content)
         summary_metadata = self._multiplexer.SummaryMetadata(run, tag)
         result[run][tag] = {'displayName': summary_metadata.display_name,
                             'description': plugin_util.markdown_to_safe_html(

--- a/tensorboard/plugins/histogram/metadata.py
+++ b/tensorboard/plugins/histogram/metadata.py
@@ -45,7 +45,7 @@ def create_summary_metadata(display_name, description):
           content=content))
 
 
-def parse_summary_metadata(content):
+def parse_plugin_metadata(content):
   """Parse summary metadata to a Python object.
 
   Arguments:


### PR DESCRIPTION
Summary:
For consistency with the rest of plugins, we should pick one of
`parse_{plugin,summary}_metadata` and stick to it. I opine that the
former is better, because the latter could be confused as parsing an
entire `SummaryMetadata` proto, while really all that we're doing is
parsing the plugin-specific data.

Test Plan:
The `metadata` module is private, so there are no external API changes.
Lint and tests suffice.

wchargin-branch: rename-histogram-metadata-parser