### PR TITLE
Add "in beta" warnings to new summary modules

### DIFF
--- a/tensorboard/plugins/audio/summary.py
+++ b/tensorboard/plugins/audio/summary.py
@@ -19,6 +19,9 @@ An audio summary stores a rank-2 string tensor of shape `[k, 2]`, where
 the tensor is a pair `[encoded_audio, label]`, where `encoded_audio` is
 a binary string whose encoding is specified in the summary metadata, and
 `label` is a UTF-8 encoded Markdown string describing the audio clip.
+
+NOTE: This module is in beta, and its API is subject to change, but the
+data that it stores to disk will be supported forever.
 """
 
 from __future__ import absolute_import

--- a/tensorboard/plugins/histogram/summary.py
+++ b/tensorboard/plugins/histogram/summary.py
@@ -23,6 +23,9 @@ like 30. There are two edge cases: if there is no data, then there are
 no buckets (the shape is `[0, 3]`); and if there is data but all points
 have the same value, then there is one bucket whose left and right
 endpoints are the same (the shape is `[1, 3]`).
+
+NOTE: This module is in beta, and its API is subject to change, but the
+data that it stores to disk will be supported forever.
 """
 
 from __future__ import absolute_import

--- a/tensorboard/plugins/image/summary.py
+++ b/tensorboard/plugins/image/summary.py
@@ -16,6 +16,9 @@
 
 An image summary stores the width, height, and PNG-encoded data for zero
 or more images in a rank-1 string array: `[w, h, png0, png1, ...]`.
+
+NOTE: This module is in beta, and its API is subject to change, but the
+data that it stores to disk will be supported forever.
 """
 
 from __future__ import absolute_import

--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+"""Precision--recall curves and TensorFlow operations to create them.
+
+NOTE: This module is in beta, and its API is subject to change, but the
+data that it stores to disk will be supported forever.
+"""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tensorboard/plugins/scalar/summary.py
+++ b/tensorboard/plugins/scalar/summary.py
@@ -15,6 +15,9 @@
 """Scalar summaries and TensorFlow operations to create them.
 
 A scalar summary stores a single floating-point value, as a rank-0 tensor.
+
+NOTE: This module is in beta, and its API is subject to change, but the
+data that it stores to disk will be supported forever.
 """
 
 from __future__ import absolute_import


### PR DESCRIPTION
Summary:
We’d like to push a new pip package, but we also recognize that the new
summary modules are still somewhat in development, and we want to retain
the flexibility to change either the Python APIs or the format of the
data stored on disk. As these APIs are additions to existing
functionality, it should be sufficient to clearly indicate their status
in the module docstrings.

A follow-up commit will explicitly version the metadata protos for each
summary.

wchargin-branch: summary-modules-in-beta