### PR TITLE
Explicitly version plugin data protos

### DIFF
--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -5,6 +5,8 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 exports_files(["LICENSE"])
 
 ## Histograms Plugin ##
@@ -50,6 +52,7 @@ py_library(
         "//tensorboard:internal",
     ],
     deps = [
+        ":protos_all_py_pb2",
         "//tensorboard:expect_tensorflow_installed",
     ],
 )
@@ -89,4 +92,10 @@ py_binary(
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],
+)
+
+tb_proto_library(
+    name = "protos_all",
+    srcs = ["plugin_data.proto"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorboard/plugins/histogram/plugin_data.proto
+++ b/tensorboard/plugins/histogram/plugin_data.proto
@@ -17,11 +17,11 @@ syntax = "proto3";
 
 package tensorboard;
 
-// Scalar summaries created by the `tensorboard.plugins.scalar.summary`
+// Histogram summaries created by the `tensorboard.plugins.histogram.summary`
 // module will include `SummaryMetadata` whose `plugin_data` field has
-// as `content` a binary string that is the encoding of an
-// `ScalarPluginData` proto.
-message ScalarPluginData {
+// as `content` a binary string that is the encoding of a
+// `HistogramPluginData` proto.
+message HistogramPluginData {
   // Version `0` is the only supported version.
   int32 version = 1;
 }

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -80,7 +80,8 @@ class SummaryTest(tf.test.TestCase):
     self.assertEqual(summary_metadata.summary_description, '')
     plugin_data = summary_metadata.plugin_data
     self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
-    self.assertEqual(summary_metadata.plugin_data.content, '{}')
+    parsed = metadata.parse_plugin_metadata(plugin_data.content)
+    self.assertEqual(metadata.PROTO_VERSION, parsed.version)
 
   def test_explicit_display_name_and_description(self):
     display_name = 'Widget metrics'
@@ -93,7 +94,8 @@ class SummaryTest(tf.test.TestCase):
     self.assertEqual(summary_metadata.summary_description, description)
     plugin_data = summary_metadata.plugin_data
     self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
-    self.assertEqual(plugin_data.content, '{}')
+    parsed = metadata.parse_plugin_metadata(plugin_data.content)
+    self.assertEqual(metadata.PROTO_VERSION, parsed.version)
 
   def test_empty_input(self):
     pb = self.compute_and_check_summary_pb('nothing_to_see_here', [])

--- a/tensorboard/plugins/image/metadata.py
+++ b/tensorboard/plugins/image/metadata.py
@@ -24,6 +24,10 @@ from tensorboard.plugins.image import plugin_data_pb2
 
 PLUGIN_NAME = 'images'
 
+# The most recent value for the `version` field of the `ImagePluginData`
+# proto.
+PROTO_VERSION = 0
+
 
 def create_summary_metadata(display_name, description):
   """Create a `tf.SummaryMetadata` proto for image plugin data.
@@ -31,12 +35,13 @@ def create_summary_metadata(display_name, description):
   Returns:
     A `tf.SummaryMetadata` protobuf object.
   """
-  content = plugin_data_pb2.ImagePluginData()
-  metadata = tf.SummaryMetadata(display_name=display_name,
-                                summary_description=description,
-                                plugin_data=tf.SummaryMetadata.PluginData(
-                                    plugin_name=PLUGIN_NAME,
-                                    content=content.SerializeToString()))
+  content = plugin_data_pb2.ImagePluginData(version=PROTO_VERSION)
+  metadata = tf.SummaryMetadata(
+      display_name=display_name,
+      summary_description=description,
+      plugin_data=tf.SummaryMetadata.PluginData(
+          plugin_name=PLUGIN_NAME,
+          content=content.SerializeToString()))
   return metadata
 
 
@@ -51,5 +56,16 @@ def parse_plugin_metadata(content):
     An `ImagePluginData` protobuf object.
   """
   result = plugin_data_pb2.ImagePluginData()
-  result.ParseFromString(content)
-  return result
+  # TODO(@jart): Instead of converting to bytes, assert that the input
+  # is a bytestring, and raise a ValueError otherwise...but only after
+  # converting `PluginData`'s `content` field to have type `bytes`
+  # instead of `string`.
+  result.ParseFromString(tf.compat.as_bytes(content))
+  if result.version == 0:
+    return result
+  else:
+    tf.logging.warn(
+        'Unknown metadata version: %s. The latest version known to '
+        'this build of TensorBoard is %s; perhaps a newer build is '
+        'available?', result.version, PROTO_VERSION)
+    return result

--- a/tensorboard/plugins/image/plugin_data.proto
+++ b/tensorboard/plugins/image/plugin_data.proto
@@ -21,8 +21,7 @@ package tensorboard;
 // module will include `SummaryMetadata` whose `plugin_data` field has
 // as `content` a binary string that is the encoding of an
 // `ImagePluginData` proto.
-//
-// We don't currently need to store any static metadata with image
-// summaries, so this message is empty.
 message ImagePluginData {
+  // Version `0` is the only supported version.
+  int32 version = 1;
 }

--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -38,7 +38,7 @@ py_test(
 
 tb_proto_library(
     name = "protos_all",
-    srcs = ["pr_curve.proto"],
+    srcs = ["plugin_data.proto"],
     visibility = ["//visibility:public"],
 )
 

--- a/tensorboard/plugins/pr_curve/plugin_data.proto
+++ b/tensorboard/plugins/pr_curve/plugin_data.proto
@@ -18,5 +18,8 @@ syntax = "proto3";
 package tensorboard;
 
 message PrCurvePluginData {
-  uint32 num_thresholds = 1;
+  // Version `0` is the only supported version.
+  int32 version = 1;
+
+  uint32 num_thresholds = 2;
 }

--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 import tensorflow as tf
 
 from google.protobuf import json_format
-from tensorboard.plugins.pr_curve import pr_curve_pb2
+from tensorboard.plugins.pr_curve import plugin_data_pb2
 
 # A tiny value. Used to prevent division by 0 as well as to make precision 1
 # when the threshold is 0.
@@ -149,7 +149,7 @@ def op(
 
     # Store the number of thresholds within the summary metadata because
     # that value is constant for all pr curve summaries with the same tag.
-    pr_curve_plugin_data = pr_curve_pb2.PrCurvePluginData(
+    pr_curve_plugin_data = plugin_data_pb2.PrCurvePluginData(
         num_thresholds=num_thresholds)
     content = json_format.MessageToJson(pr_curve_plugin_data)
     summary_metadata = tf.SummaryMetadata(

--- a/tensorboard/plugins/pr_curve/summary_test.py
+++ b/tensorboard/plugins/pr_curve/summary_test.py
@@ -27,8 +27,8 @@ import tensorflow as tf
 
 from google.protobuf import json_format
 from tensorboard.backend.event_processing import event_multiplexer
+from tensorboard.plugins.pr_curve import plugin_data_pb2
 from tensorboard.plugins.pr_curve import pr_curve_demo
-from tensorboard.plugins.pr_curve import pr_curve_pb2
 from tensorboard.plugins.pr_curve import summary
 
 
@@ -78,7 +78,7 @@ class PrCurveTest(tf.test.TestCase):
 
     for tag in expected_tags:
       # Parse the data within the JSON string and set the proto's fields.
-      plugin_data = pr_curve_pb2.PrCurvePluginData()
+      plugin_data = plugin_data_pb2.PrCurvePluginData()
       json_format.Parse(tag_content_dict[tag], plugin_data)
       self.assertEqual(5, plugin_data.num_thresholds)
 
@@ -180,7 +180,7 @@ class PrCurveTest(tf.test.TestCase):
 
     for tag in expected_tags:
       # Parse the data within the JSON string and set the proto's fields.
-      plugin_data = pr_curve_pb2.PrCurvePluginData()
+      plugin_data = plugin_data_pb2.PrCurvePluginData()
       json_format.Parse(tag_content_dict[tag], plugin_data)
       self.assertEqual(5, plugin_data.num_thresholds)
 

--- a/tensorboard/plugins/scalar/metadata.py
+++ b/tensorboard/plugins/scalar/metadata.py
@@ -24,6 +24,11 @@ from tensorboard.plugins.scalar import plugin_data_pb2
 
 PLUGIN_NAME = 'scalars'
 
+# The most recent value for the `version` field of the
+# `ScalarPluginData` proto.
+PROTO_VERSION = 0
+
+
 
 def create_summary_metadata(display_name, description):
   """Create a `tf.SummaryMetadata` proto for scalar plugin data.
@@ -31,12 +36,13 @@ def create_summary_metadata(display_name, description):
   Returns:
     A `tf.SummaryMetadata` protobuf object.
   """
-  content = plugin_data_pb2.ScalarPluginData()
-  metadata = tf.SummaryMetadata(display_name=display_name,
-                                summary_description=description,
-                                plugin_data=tf.SummaryMetadata.PluginData(
-                                    plugin_name=PLUGIN_NAME,
-                                    content=content.SerializeToString()))
+  content = plugin_data_pb2.ScalarPluginData(version=PROTO_VERSION)
+  metadata = tf.SummaryMetadata(
+      display_name=display_name,
+      summary_description=description,
+      plugin_data=tf.SummaryMetadata.PluginData(
+          plugin_name=PLUGIN_NAME,
+          content=content.SerializeToString()))
   return metadata
 
 
@@ -51,5 +57,16 @@ def parse_plugin_metadata(content):
     A `ScalarPluginData` protobuf object.
   """
   result = plugin_data_pb2.ScalarPluginData()
+  # TODO(@jart): Instead of converting to bytes, assert that the input
+  # is a bytestring, and raise a ValueError otherwise...but only after
+  # converting `PluginData`'s `content` field to have type `bytes`
+  # instead of `string`.
   result.ParseFromString(tf.compat.as_bytes(content))
-  return result
+  if result.version == 0:
+    return result
+  else:
+    tf.logging.warn(
+        'Unknown metadata version: %s. The latest version known to '
+        'this build of TensorBoard is %s; perhaps a newer build is '
+        'available?', result.version, PROTO_VERSION)
+    return result


### PR DESCRIPTION
Summary:
This commit ensures that the plugin data proto defined by each plugin
has an `int32 version = 1` field, where the only value currently
supported is `version = 0`. Plugins that have a `metadata` module have
had such modules updated to populate the field appropriately when
generating protos, and check it when deserializing, emitting a warning
if the version is not recognized (and, presumably, performing some
transformations if the data is from an older version).

While we’re at it, we rename `pr_curve.proto` to `plugin_data.proto` so
that it can fit in with all the rest of the plugins.

Test Plan:
Run all unit tests. Then, launch TensorBoard with data from all plugins
that have frontends, and verify that everything is still displayed
properly.

wchargin-branch: explicitly-version-plugin-data-protos