### PR TITLE
Remove some unneeded styles

### DIFF
--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-loader.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-loader.html
@@ -72,7 +72,6 @@ limitations under the License.
       paper-icon-button {
         color: #2196F3;
         border-radius: 100%;
-        pointer-events: auto;  /* TODO(@wchargin): why? */
         width: 32px;
         height: 32px;
         padding: 4px;

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
@@ -75,7 +75,6 @@ limitations under the License.
       paper-icon-button {
         color: #2196F3;
         border-radius: 100%;
-        pointer-events: auto;  /* TODO(@wchargin): why? */
         width: 32px;
         height: 32px;
         padding: 4px;

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
@@ -136,7 +136,6 @@ limitations under the License.
       paper-icon-button {
         color: #2196F3;
         border-radius: 100%;
-        pointer-events: auto;  /* TODO(@wchargin): why? */
         width: 32px;
         height: 32px;
         padding: 4px;


### PR DESCRIPTION
Summary:
We used to have a blanket `pointer-events: none` provided by
`tf-chart-scaffold`. We no longer have such a construction, so these
exemptions are no longer required.

Test Plan:
Note that you can still click on all the buttons.

wchargin-branch: remove-unneeded-styles