### PR TITLE
Reword “compatible with” → “castable to” in docs

### DIFF
--- a/tensorboard/plugins/histogram/summary.py
+++ b/tensorboard/plugins/histogram/summary.py
@@ -42,7 +42,7 @@ def _buckets(data, bucket_count=None):
   """Create a TensorFlow op to group data into histogram buckets.
 
   Arguments:
-    data: A `Tensor` of any shape. Must be compatible with `float64`.
+    data: A `Tensor` of any shape. Must be castable to `float64`.
     bucket_count: Optional positive `int` or scalar `int32` `Tensor`.
   Returns:
     A `Tensor` of shape `[k, 3]` and type `float64`. The `i`th row is
@@ -105,7 +105,7 @@ def op(name,
 
   Arguments:
     name: A unique name for the generated summary node.
-    data: A `Tensor` of any shape. Must be compatible with `float64`.
+    data: A `Tensor` of any shape. Must be castable to `float64`.
     bucket_count: Optional positive `int`. The output will have this
       many buckets, except in two edge cases. If there is no data, then
       there are no buckets. If there is data but all points have the
@@ -141,7 +141,7 @@ def pb(name, data, bucket_count=None, display_name=None, description=None):
     name: A unique name for the generated summary, including any desired
       name scopes.
     data: A `np.array` or array-like form of any shape. Must have type
-      compatible with `float`.
+      castable to `float`.
     bucket_count: Optional positive `int`. The output will have this
       many buckets, except in two edge cases. If there is no data, then
       there are no buckets. If there is data but all points have the

--- a/tensorboard/plugins/scalar/summary.py
+++ b/tensorboard/plugins/scalar/summary.py
@@ -36,8 +36,8 @@ def op(name,
 
   Arguments:
     name: A unique name for the generated summary node.
-    data: A real numeric rank-0 `Tensor`. Must have `dtype` compatible
-      with `float32`.
+    data: A real numeric rank-0 `Tensor`. Must have `dtype` castable
+      to `float32`.
     display_name: Optional name for this summary in TensorBoard, as a
       constant `str`. Defaults to `name`.
     description: Optional long-form description for this summary, as a


### PR DESCRIPTION
Summary:
I’d been using the implicit definition that “dtype *x* is **compatible
with** dtype *y* if `tf.cast(op, y)` is valid when `op` has dtype *x*”.
However, it appears that [TensorFlow uses the term “compatible” to mean
something different][1]. To avoid confusion, I’m switching to “castable
to,” which is a bit less of a real word but just as clear.

[1]: https://www.tensorflow.org/api_docs/python/tf/DType#is_compatible_with

wchargin-branch: reword-compatible-with