### PR TITLE
Add RunReader class to loader module

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -199,6 +199,7 @@ py_library(
     deps = [
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/loader.py
+++ b/tensorboard/loader.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""TensorBoard data ingestion module."""
+"""TensorBoard data ingestion module.
+
+WARNING: This module is currently EXPERIMENTAL.
+"""
 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
 import collections
+import contextlib
 import functools
 import locale
 import logging
@@ -32,6 +36,7 @@ import types  # pylint: disable=unused-import
 import six
 import tensorflow as tf
 
+from tensorboard import db
 from tensorboard import util
 
 
@@ -684,6 +689,7 @@ class EventLogReader(object):
   record files containing tf.Event protocol buffers.
 
   Fields:
+    rowid: An integer primary key in EventLogs table, or 0 if unknown.
     path: A string with the path of the event log on the local or
         remote file system.
     timestamp: An integer of the number of seconds since the UNIX epoch
@@ -692,6 +698,8 @@ class EventLogReader(object):
     hostname: A string with the FQDN of the machine that wrote this
         event log file.
   """
+
+  FIRST_STEP_PEEKS = 5
 
   def __init__(self, path,
                start_offset=0,
@@ -707,20 +715,20 @@ class EventLogReader(object):
     :type path: str
     :type record_reader_factory: (str, int) -> RecordReader
     """
+    self.rowid = 0
     self.path = tf.compat.as_text(path)
     m = _EVENT_LOG_PATH_PATTERN.search(self.path)
     if not m:
       raise ValueError('Bad event log path: ' + self.path)
     self.timestamp = int(m.group('timestamp'))
     self.hostname = m.group('hostname')
-    self._mark = -1
     self._offset = start_offset
-    self._reader = record_reader_factory(self.path, start_offset)
+    self._reader_factory = record_reader_factory
+    self._reader = self._reader_factory(self.path, start_offset)
     self._key = (os.path.dirname(self.path), self.timestamp, self.hostname)
-    self._saved_events = \
-        collections.deque()  # type: collections.deque[tf.Event]
-    self._prepended_events = \
-        collections.deque()  # type: collections.deque[tf.Event]
+    self._first_step = None  # type: int
+    self._observed_zero_step = False
+    self._update_first_step_invocations = 0
 
   def get_next_event(self):
     """Reads an event proto from the file.
@@ -732,28 +740,31 @@ class EventLogReader(object):
 
     :rtype: tf.Event
     """
-    if self._prepended_events:
-      event = self._prepended_events.popleft()
-    else:
-      record = self._reader.get_next_record()
-      if record is None:
-        return None
-      event = tf.Event()
-      event.ParseFromString(record.record)
-      self._offset = record.offset
-    if self._mark != -1:
-      self._saved_events.append(event)
+    record = self._reader.get_next_record()
+    if record is None:
+      return None
+    event = tf.Event()
+    event.ParseFromString(record.record)
+    self._offset = record.offset
+    self._update_first_step(event)
     return event
+
+  def set_offset(self, offset):
+    """Sets byte offset in file.
+
+    :type offset: int
+    """
+    if offset == self._offset:
+      return
+    self._reader.close()
+    self._reader = self._reader_factory(self.path, offset)
+    self._offset = offset
 
   def get_offset(self):
     """Returns current byte offset in file.
 
-    If mark() was called, then this returns the marked position.
-
     :rtype: int
     """
-    if self._mark != -1:
-      return self._mark
     return self._offset
 
   def get_size(self):
@@ -763,19 +774,33 @@ class EventLogReader(object):
     """
     return self._reader.get_size()
 
-  def mark(self):
-    """Marks current position in file so reset() can be called."""
-    if self._prepended_events:
-      raise ValueError('mark() offsets must be monotonic')
-    self._mark = self._offset
-    self._saved_events.clear()
+  def get_first_step(self):
+    """Determines step count of first summary event.
 
-  def reset(self):
-    """Resets read state to where mark() was called."""
-    if self._mark == -1:
-      raise ValueError('mark() was not called')
-    self._prepended_events.extend(self._saved_events)
-    self._saved_events.clear()
+    This method requires an open/read/close but memoizes the result. If
+    the answer was already inferred from previous calls to
+    get_next_event, then no i/o should be necessary.
+
+    Returns:
+      The step count of the first summary event, or None if there
+      didn't appear to be any summary events, or the user isn't logging
+      step counts.
+
+    :rtype: int
+    """
+    if self._first_step is not None:
+      return self._first_step
+    if self._update_first_step_invocations >= EventLogReader.FIRST_STEP_PEEKS:
+      return None
+    with RecordReader(self.path) as reader:
+      for _ in range(EventLogReader.FIRST_STEP_PEEKS):
+        record = reader.get_next_record()
+        if record is None:
+          break
+        event = tf.Event()
+        event.ParseFromString(record.record)
+        self._update_first_step(event)
+    return self._first_step
 
   def close(self):
     """Closes event log reader if open.
@@ -785,6 +810,16 @@ class EventLogReader(object):
     if self._reader is not None:
       self._reader.close()
       self._reader = None
+
+  def _update_first_step(self, event):
+    self._update_first_step_invocations += 1
+    # proto3 doesn't let us distinguish between absent and 0.
+    if event.step:
+      step = 0 if self._observed_zero_step else event.step
+      if self._first_step is None or step < self._first_step:
+        self._first_step = step
+    elif event.summary:
+      self._observed_zero_step = True
 
   def __hash__(self):
     return hash(self._key)
@@ -798,19 +833,274 @@ class EventLogReader(object):
   def __str__(self):
     offset = self.get_offset()
     if offset:
-      return u'EventLog{path=%s, offset=%d}' % (self.path, offset)
+      return u'EventLogReader{path=%s, offset=%d}' % (self.path, offset)
     else:
-      return u'EventLog{%s}' % self.path
+      return u'EventLogReader{%s}' % self.path
+
+
+@util.closeable
+@functools.total_ordering
+@six.python_2_unicode_compatible
+class RunReader(object):
+  """Utility for loading event logs into the DB.
+
+  This class merges the chain of event log files into one meaningful
+  stream of events, ordered by step or timestamp.
+
+  Fields:
+    rowid: The primary key of the corresponding row in Runs.
+    name: Display name of this run.
+  """
+
+  def __init__(self, db_conn, rowid, name):
+    """Creates new instance.
+
+    Args:
+      db_conn: A PEP 249 Connection object.
+      rowid: Primary key of run in `Runs` table, which should already
+          be inserted. This is a bit-packed int made by db.RUN_ROWID.
+      run_id: The run_id column which is encoded in the rowid bits.
+      name: Display name of run.
+
+    :type db_conn: db.Connection
+    :type rowid: int
+    :type name: str
+    """
+    self._db_conn = db_conn
+    self.rowid = db.RUN_ROWID.check(rowid)
+    self.run_id = db.RUN_ROWID.parse(rowid)[1]
+    self.name = tf.compat.as_text(name)
+    self._mark = -1
+    self._logs = []  # type: list[EventLogReader]
+    self._i = 0
+    self._entombed_progress = 0
+    self._has_new_stuff = False
+    self._saved_events = \
+        collections.deque()  # type: collections.deque[tf.Event]
+    self._prepended_events = \
+        collections.deque()  # type: collections.deque[tf.Event]
+
+  def add_event_log(self, log):
+    """Adds event log to run loader.
+
+    Event logs must be added monotonically, based on the timestamp in
+    the filename. Please note that calling this method could cause a
+    current batch of reads to fast forward.
+
+    Args:
+      log: An EventLogReader instance.
+
+    Returns:
+      True if log was actually added.
+
+    :type log: EventLogReader
+    :rtype: bool
+    """
+    if self._logs and log <= self._logs[-1]:
+      return False
+    with contextlib.closing(self._db_conn.cursor()) as c:
+      c.execute(
+          'SELECT rowid, offset FROM EventLogs WHERE run_id = ? AND path = ?',
+          (self.run_id, log.path))
+      row = c.fetchone()
+      if row:
+        log.rowid = row[0]
+        log.set_offset(row[1])
+      else:
+        event_log_id = db.EVENT_LOG_ID.generate()
+        log.rowid = db.EVENT_LOG_ROWID.create(self.run_id, event_log_id)
+        c.execute(
+            ('INSERT INTO EventLogs (rowid, run_id, path, offset)'
+             ' VALUES (?, ?, ?, 0)'),
+            (log.rowid, self.run_id, log.path))
+    self._logs.append(log)
+    self._has_new_stuff = True
+    tf.logging.debug('Adding %s', log)
+    return True
+
+  def get_next_event(self):
+    """Returns next tf.Event from event logs or None if stalled.
+
+    :rtype: tf.Event
+    """
+    if self._has_new_stuff:
+      self._fast_forward_over_things_we_have_read()
+      self._fast_forward_over_restarted_runs()
+      self._cleanup()
+      self._has_new_stuff = False
+    event = None
+    if self._prepended_events:
+      event = self._prepended_events.popleft()
+    elif self._i < len(self._logs):
+      while True:
+        log = self._logs[self._i]
+        event = log.get_next_event()
+        if event is not None:
+          break
+        if self._i == len(self._logs) - 1:
+          break
+        self._i += 1
+        self._cleanup()
+    if event is not None and self._mark != -1:
+      self._saved_events.append(event)
+    return event
+
+  def mark_peek_reset(self):
+    """Returns next event without advancing.
+
+    Note: This method sets the mark to the current position.
+
+    :rtype: tf.Event
+    """
+    self.mark()
+    result = self.get_next_event()
+    self.reset()
+    return result
+
+  def get_offset(self):
+    """Returns number of bytes read across all event log files.
+
+    :rtype: int
+    """
+    if self._mark != -1:
+      return self._mark
+    return self._get_offset()
+
+  def _get_offset(self):
+    return sum(el.get_offset() for el in self._logs) + self._entombed_progress
+
+  def get_size(self):
+    """Returns sum of byte lengths of event log files.
+
+    :rtype: int
+    """
+    return sum(el.get_size() for el in self._logs) + self._entombed_progress
+
+  def save_progress(self):
+    """Saves current offsets of all open event logs to DB.
+
+    This should be called after the mark has been advanced.
+    """
+    with contextlib.closing(self._db_conn.cursor()) as c:
+      n = 0
+      while self._i >= n < len(self._logs):
+        log = self._logs[n]
+        n += 1
+        offset = log.get_offset()
+        c.execute(
+            'UPDATE EventLogs SET offset = ? WHERE rowid = ? AND offset < ?',
+            (offset, log.rowid, offset))
+
+  def mark(self):
+    """Marks current position in file so reset() can be called."""
+    if self._prepended_events:
+      raise ValueError('mark() offsets must be monotonic')
+    self._mark = self._get_offset()
+    self._saved_events.clear()
+
+  def reset(self):
+    """Resets read state to where mark() was called."""
+    if self._mark == -1:
+      return
+    self._prepended_events.extend(self._saved_events)
+    self._saved_events.clear()
+
+  def close(self):
+    """Closes all event log readers.
+
+    This method may be called multiple times, but further operations
+    are not permitted.
+
+    Raises:
+      Exception: To propagate the most recent exception thrown by the
+          EventLogReader close method. Suppressed exceptions are
+          logged.
+    """
+    util.close_all(self._logs)
+    self._i = len(self._logs)
+    self._mark = -1
+    self._prepended_events.clear()
+    self._saved_events.clear()
+
+  def _cleanup(self):
+    # Last event log has to be preserved so we can continue enforcing
+    # monotonicity. We entomb offset because that also has to be
+    # monotonic, but the size does not.
+    if 0 < self._i < len(self._logs):
+      deleted = self._logs[:self._i]
+      self._logs = self._logs[self._i:]
+      self._i = 0
+      self._entombed_progress += sum(l.get_offset() for l in deleted)
+      util.close_all(deleted)
+
+  def _fast_forward_over_things_we_have_read(self):
+    for i in range(len(self._logs) - 1, self._i + 1, -1):
+      if self._logs[i].get_offset():
+        self._skip_to_event_log(i)
+        break
+
+  def _fast_forward_over_restarted_runs(self):
+    skip_to = self._i
+    for i in range(len(self._logs) - 2, self._i - 1, -1):
+      a = self._logs[i].get_first_step()
+      b = self._logs[i + 1].get_first_step()
+      if b is not None and (a is None or b <= a):
+        skip_to = i + 1
+        break
+    for i in range(self._i, skip_to):
+      tf.logging.warning('Skipping %s because %s reset the step counter',
+                         self._logs[i], self._logs[skip_to])
+    self._skip_to_event_log(skip_to)
+
+  def _skip_to_event_log(self, i):
+    should_mark = self._mark != -1 and i > self._i
+    self._i = i
+    if should_mark:
+      self._prepended_events.clear()
+      self.mark()
+
+  def __hash__(self):
+    return hash(self.rowid)
+
+  def __eq__(self, other):
+    return self.rowid == other.rowid
+
+  def __lt__(self, other):
+    return self.rowid < other.rowid
+
+  def __str__(self):
+    offset = self.get_offset()
+    if offset:
+      return u'RunReader{name=%s, offset=%d}' % (self.name, offset)
+    else:
+      return u'RunReader{%s}' % self.name
+
+
+def _get_basename(path):
+  """Gets base name of path.
+
+  This is the same as os.path.basename, however it may potentially do
+  i/o to handle a few edge cases, which would otherwise cause the
+  result to be less meaningful, e.g. "." and "..".
+
+  :type path: str
+  :rtype: str
+  """
+  result = os.path.basename(os.path.normpath(path))
+  if result in ('', '.', '..'):
+    result = os.path.basename(os.path.realpath(path))
+  return result
 
 
 def get_event_logs(directory):
-  """Walks directory tree for EventLog files.
+  """Walks directory tree for EventLogReader files.
 
   Args:
     directory: Path of directory.
 
   Returns:
-    List of EventLog objects, ordered by directory name and timestamp.
+    List of EventLogReader objects, ordered by directory name and
+    timestamp.
 
   :type directory: str
   :rtype: list[EventLogReader]

--- a/tensorboard/loader.py
+++ b/tensorboard/loader.py
@@ -1027,7 +1027,18 @@ def _get_basename(path):
   :type path: str
   :rtype: str
   """
-  return os.path.basename(os.path.normpath(os.path.join(os.getcwd(), path)))
+  return os.path.basename(os.path.normpath(os.path.join(_get_cwd(), path)))
+
+
+def _get_cwd():
+  """Returns current directory and try not to expand symlinks.
+
+  :rtype: str
+  """
+  result = os.environ.get('PWD')
+  if not result:
+    result = os.getcwd()
+  return result
 
 
 def get_event_logs(directory):

--- a/tensorboard/loader_test.py
+++ b/tensorboard/loader_test.py
@@ -304,10 +304,10 @@ class RunReaderTest(LoaderTestCase):
 
   def testBadRowId_throwsValueError(self):
     with self.assertRaises(ValueError):
-      loader.RunReader(self.connect(), 0, 'doodle')
+      loader.RunReader(self.connect_db(), 0, 'doodle')
 
   def testEqualAndSortsByRowId(self):
-    conn = self.connect()
+    conn = self.connect_db()
     a = loader.RunReader(conn, db.RUN_ROWID.create(1, 1), 'doodle')
     b = loader.RunReader(conn, db.RUN_ROWID.create(1, 2), 'doodle')
     c = loader.RunReader(conn, db.RUN_ROWID.create(2, 1), 'doodle')
@@ -315,7 +315,7 @@ class RunReaderTest(LoaderTestCase):
 
   def testFields(self):
     id_ = db.RUN_ROWID.create(1, 1)
-    with loader.RunReader(self.connect(), id_, 'doodle') as run:
+    with loader.RunReader(self.connect_db(), id_, 'doodle') as run:
       self.assertEqual('doodle', run.name)
       self.assertEqual(id_, run.rowid)
 
@@ -323,14 +323,14 @@ class RunReaderTest(LoaderTestCase):
     id_ = db.RUN_ROWID.create(1, 1)
     path = self._save_records('events.out.tfevents.0.localhost', [])
     with self.EventLog(path) as log:
-      run = loader.RunReader(self.connect(), id_, 'doodle')
+      run = loader.RunReader(self.connect_db(), id_, 'doodle')
       run.add_event_log(log)
       run.close()
       run.close()
 
   def testNoEventLogs_returnsNone(self):
     id_ = db.RUN_ROWID.create(1, 1)
-    with loader.RunReader(self.connect(), id_, 'doodle') as run:
+    with loader.RunReader(self.connect_db(), id_, 'doodle') as run:
       self.assertIsNone(run.get_next_event())
 
   def testReadOneEvent(self):
@@ -339,7 +339,7 @@ class RunReaderTest(LoaderTestCase):
     path = self._save_records('events.out.tfevents.0.localhost',
                               [event.SerializeToString()])
     with self.EventLog(path) as log:
-      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+      with loader.RunReader(self.connect_db(), id_, 'doodle') as run:
         run.add_event_log(log)
         self.assertEqual(event, run.get_next_event())
         self.assertIsNone(run.get_next_event())
@@ -350,7 +350,7 @@ class RunReaderTest(LoaderTestCase):
     path = self._save_records('events.out.tfevents.0.localhost',
                               [event.SerializeToString()])
     with self.EventLog(path) as log:
-      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+      with loader.RunReader(self.connect_db(), id_, 'doodle') as run:
         run.add_event_log(log)
         self.assertEqual(0, run.get_offset())
         self.assertGreater(run.get_size(), 0)
@@ -367,7 +367,7 @@ class RunReaderTest(LoaderTestCase):
     path2 = self._save_records('events.out.tfevents.2.localhost',
                                [event2.SerializeToString()])
     with self.EventLog(path1) as log1, self.EventLog(path2) as log2:
-      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+      with loader.RunReader(self.connect_db(), id_, 'doodle') as run:
         run.add_event_log(log1)
         run.add_event_log(log2)
         self.assertIsNotNone(run.mark_peek_reset())
@@ -389,7 +389,7 @@ class RunReaderTest(LoaderTestCase):
     path2 = self._save_records('events.out.tfevents.2.localhost',
                                [event2.SerializeToString()])
     with self.EventLog(path1) as log1, self.EventLog(path2) as log2:
-      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+      with loader.RunReader(self.connect_db(), id_, 'doodle') as run:
         run.add_event_log(log1)
         run.add_event_log(log2)
         run.mark()
@@ -411,7 +411,7 @@ class RunReaderTest(LoaderTestCase):
     path2 = self._save_records('events.out.tfevents.2.localhost',
                                [event2.SerializeToString()])
     with self.EventLog(path1) as log1, self.EventLog(path2) as log2:
-      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+      with loader.RunReader(self.connect_db(), id_, 'doodle') as run:
         run.add_event_log(log1)
         run.add_event_log(log2)
         run.mark()
@@ -431,12 +431,12 @@ class RunReaderTest(LoaderTestCase):
                                [event1.SerializeToString(),
                                 event2.SerializeToString()])
     with self.EventLog(path) as log:
-      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+      with loader.RunReader(self.connect_db(), id_, 'doodle') as run:
         run.add_event_log(log)
         self.assertEqual(event1, run.get_next_event())
         run.save_progress()
     with self.EventLog(path) as log:
-      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+      with loader.RunReader(self.connect_db(), id_, 'doodle') as run:
         run.add_event_log(log)
         self.assertEqual(event2, run.get_next_event())
 

--- a/tensorboard/loader_test.py
+++ b/tensorboard/loader_test.py
@@ -432,8 +432,8 @@ class RunReaderTest(LoaderTestCase):
     event1 = tf.Event(step=123)
     event2 = tf.Event(step=456)
     path = self._save_records('events.out.tfevents.1.localhost',
-                               [event1.SerializeToString(),
-                                event2.SerializeToString()])
+                              [event1.SerializeToString(),
+                               event2.SerializeToString()])
     with self.connect_db() as db_conn:
       with self.EventLog(path) as log:
         with loader.RunReader(id_, 'doodle') as run:

--- a/tensorboard/loader_test.py
+++ b/tensorboard/loader_test.py
@@ -440,21 +440,6 @@ class RunReaderTest(LoaderTestCase):
         run.add_event_log(log)
         self.assertEqual(event2, run.get_next_event())
 
-  def testRunWasRestarted_doesntBotherReadingOldEventLog(self):
-    id_ = db.RUN_ROWID.create(1, 1)
-    event1 = tf.Event(step=1, wall_time=666)
-    event2 = tf.Event(step=1, wall_time=777)
-    path1 = self._save_records('events.out.tfevents.1.localhost',
-                               [event1.SerializeToString()])
-    path2 = self._save_records('events.out.tfevents.2.localhost',
-                               [event2.SerializeToString()])
-    with self.EventLog(path1) as log1, self.EventLog(path2) as log2:
-      with loader.RunReader(self.connect(), id_, 'doodle') as run:
-        run.add_event_log(log1)
-        run.add_event_log(log2)
-        self.assertEqual(event2, run.get_next_event())
-        self.assertIsNone(run.mark_peek_reset())
-
 
 @util.closeable
 class RecordWriter(object):

--- a/tensorboard/loader_test.py
+++ b/tensorboard/loader_test.py
@@ -23,6 +23,7 @@ import os
 import six
 import tensorflow as tf
 
+from tensorboard import db
 from tensorboard import loader
 from tensorboard import test_util
 from tensorboard import util
@@ -296,34 +297,163 @@ class EventLogReaderTest(LoaderTestCase):
       self.assertEqual(event, log.get_next_event())
       self.assertIsNone(log.get_next_event())
 
+
+class RunReaderTest(LoaderTestCase):
+  EventLog = functools.partial(loader.EventLogReader,
+                               record_reader_factory=loader.RecordReader)
+
+  def testBadRowId_throwsValueError(self):
+    with self.assertRaises(ValueError):
+      loader.RunReader(self.connect(), 0, 'doodle')
+
+  def testEqualAndSortsByRowId(self):
+    conn = self.connect()
+    a = loader.RunReader(conn, db.RUN_ROWID.create(1, 1), 'doodle')
+    b = loader.RunReader(conn, db.RUN_ROWID.create(1, 2), 'doodle')
+    c = loader.RunReader(conn, db.RUN_ROWID.create(2, 1), 'doodle')
+    self.assertEqual([a, b, c], sorted([c, b, a]))
+
+  def testFields(self):
+    id_ = db.RUN_ROWID.create(1, 1)
+    with loader.RunReader(self.connect(), id_, 'doodle') as run:
+      self.assertEqual('doodle', run.name)
+      self.assertEqual(id_, run.rowid)
+
+  def testClose_canBeCalledMultipleTimes(self):
+    id_ = db.RUN_ROWID.create(1, 1)
+    path = self._save_records('events.out.tfevents.0.localhost', [])
+    with self.EventLog(path) as log:
+      run = loader.RunReader(self.connect(), id_, 'doodle')
+      run.add_event_log(log)
+      run.close()
+      run.close()
+
+  def testNoEventLogs_returnsNone(self):
+    id_ = db.RUN_ROWID.create(1, 1)
+    with loader.RunReader(self.connect(), id_, 'doodle') as run:
+      self.assertIsNone(run.get_next_event())
+
+  def testReadOneEvent(self):
+    id_ = db.RUN_ROWID.create(1, 1)
+    event = tf.Event(step=123)
+    path = self._save_records('events.out.tfevents.0.localhost',
+                              [event.SerializeToString()])
+    with self.EventLog(path) as log:
+      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+        run.add_event_log(log)
+        self.assertEqual(event, run.get_next_event())
+        self.assertIsNone(run.get_next_event())
+
+  def testProgress(self):
+    id_ = db.RUN_ROWID.create(1, 1)
+    event = tf.Event(step=123)
+    path = self._save_records('events.out.tfevents.0.localhost',
+                              [event.SerializeToString()])
+    with self.EventLog(path) as log:
+      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+        run.add_event_log(log)
+        self.assertEqual(0, run.get_offset())
+        self.assertGreater(run.get_size(), 0)
+        self.assertEqual(event, run.get_next_event())
+        self.assertIsNone(run.get_next_event())
+        self.assertEqual(run.get_offset(), run.get_size())
+
   def testMarkReset(self):
+    id_ = db.RUN_ROWID.create(1, 1)
     event1 = tf.Event(step=123)
     event2 = tf.Event(step=456)
-    path = self._save_records('events.out.tfevents.0.localhost',
-                              [event1.SerializeToString(),
-                               event2.SerializeToString()])
-    with self.EventLog(path) as log:
-      log.mark()
-      self.assertEqual(event1, log.get_next_event())
-      log.reset()
-      self.assertEqual(event1, log.get_next_event())
-      self.assertEqual(event2, log.get_next_event())
-      self.assertIsNone(log.get_next_event())
+    path1 = self._save_records('events.out.tfevents.1.localhost',
+                               [event1.SerializeToString()])
+    path2 = self._save_records('events.out.tfevents.2.localhost',
+                               [event2.SerializeToString()])
+    with self.EventLog(path1) as log1, self.EventLog(path2) as log2:
+      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+        run.add_event_log(log1)
+        run.add_event_log(log2)
+        self.assertIsNotNone(run.mark_peek_reset())
+        self.assertEqual(event1, run.get_next_event())
+        run.reset()
+        self.assertEqual(event1, run.get_next_event())
+        run.mark()
+        self.assertEqual(event2, run.get_next_event())
+        run.mark()
+        self.assertIsNone(run.get_next_event())
+        self.assertIsNone(run.mark_peek_reset())
+
+  def testMarkReset_acrossFiles(self):
+    id_ = db.RUN_ROWID.create(1, 1)
+    event1 = tf.Event(step=123)
+    event2 = tf.Event(step=456)
+    path1 = self._save_records('events.out.tfevents.1.localhost',
+                               [event1.SerializeToString()])
+    path2 = self._save_records('events.out.tfevents.2.localhost',
+                               [event2.SerializeToString()])
+    with self.EventLog(path1) as log1, self.EventLog(path2) as log2:
+      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+        run.add_event_log(log1)
+        run.add_event_log(log2)
+        run.mark()
+        self.assertEqual(event1, run.get_next_event())
+        self.assertEqual(event2, run.get_next_event())
+        self.assertIsNone(run.get_next_event())
+        run.reset()
+        self.assertEqual(event1, run.get_next_event())
+        self.assertEqual(event2, run.get_next_event())
+        self.assertIsNone(run.get_next_event())
+        run.mark()
 
   def testMarkWithShrinkingBatchSize_raisesValueError(self):
+    id_ = db.RUN_ROWID.create(1, 1)
     event1 = tf.Event(step=123)
     event2 = tf.Event(step=456)
-    path = self._save_records('events.out.tfevents.0.localhost',
-                              [event1.SerializeToString(),
-                               event2.SerializeToString()])
+    path1 = self._save_records('events.out.tfevents.1.localhost',
+                               [event1.SerializeToString()])
+    path2 = self._save_records('events.out.tfevents.2.localhost',
+                               [event2.SerializeToString()])
+    with self.EventLog(path1) as log1, self.EventLog(path2) as log2:
+      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+        run.add_event_log(log1)
+        run.add_event_log(log2)
+        run.mark()
+        self.assertEqual(event1, run.get_next_event())
+        self.assertEqual(event2, run.get_next_event())
+        self.assertIsNone(run.get_next_event())
+        run.reset()
+        self.assertEqual(event1, run.get_next_event())
+        with six.assertRaisesRegex(self, ValueError, r'monotonic'):
+          run.mark()
+
+  def testRestartProgram_resumesThings(self):
+    id_ = db.RUN_ROWID.create(1, 1)
+    event1 = tf.Event(step=123)
+    event2 = tf.Event(step=456)
+    path = self._save_records('events.out.tfevents.1.localhost',
+                               [event1.SerializeToString(),
+                                event2.SerializeToString()])
     with self.EventLog(path) as log:
-      log.mark()
-      self.assertEqual(event1, log.get_next_event())
-      self.assertEqual(event2, log.get_next_event())
-      log.reset()
-      self.assertEqual(event1, log.get_next_event())
-      with six.assertRaisesRegex(self, ValueError, r'monotonic'):
-        log.mark()
+      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+        run.add_event_log(log)
+        self.assertEqual(event1, run.get_next_event())
+        run.save_progress()
+    with self.EventLog(path) as log:
+      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+        run.add_event_log(log)
+        self.assertEqual(event2, run.get_next_event())
+
+  def testRunWasRestarted_doesntBotherReadingOldEventLog(self):
+    id_ = db.RUN_ROWID.create(1, 1)
+    event1 = tf.Event(step=1, wall_time=666)
+    event2 = tf.Event(step=1, wall_time=777)
+    path1 = self._save_records('events.out.tfevents.1.localhost',
+                               [event1.SerializeToString()])
+    path2 = self._save_records('events.out.tfevents.2.localhost',
+                               [event2.SerializeToString()])
+    with self.EventLog(path1) as log1, self.EventLog(path2) as log2:
+      with loader.RunReader(self.connect(), id_, 'doodle') as run:
+        run.add_event_log(log1)
+        run.add_event_log(log2)
+        self.assertEqual(event2, run.get_next_event())
+        self.assertIsNone(run.mark_peek_reset())
 
 
 @util.closeable

--- a/tensorboard/test_util.py
+++ b/tensorboard/test_util.py
@@ -34,6 +34,8 @@ import tensorflow as tf
 from tensorboard import db
 from tensorboard import util
 
+db.TESTING_MODE = True
+
 
 class TestCase(tf.test.TestCase):
   """TensorBoard base test class.

--- a/tensorboard/test_util.py
+++ b/tensorboard/test_util.py
@@ -34,8 +34,6 @@ import tensorflow as tf
 from tensorboard import db
 from tensorboard import util
 
-db.TESTING_MODE = True
-
 
 class TestCase(tf.test.TestCase):
   """TensorBoard base test class.

--- a/tensorboard/util.py
+++ b/tensorboard/util.py
@@ -106,7 +106,8 @@ def close_all(resources):
       resource.close()
     except Exception as e:  # pylint: disable=broad-except
       if exc_info is not None:
-        tf.logging.error('Suppressing close(%s) failure: %s', resource, e)
+        tf.logging.error('Suppressing close(%s) failure: %s', resource, e,
+                         exc_info=exc_info)
       exc_info = sys.exc_info()
   if exc_info is not None:
     six.reraise(*exc_info)

--- a/tensorboard/util.py
+++ b/tensorboard/util.py
@@ -85,6 +85,32 @@ def closeable(class_):
   return class_
 
 
+def close_all(resources):
+  """Safely closes multiple resources.
+
+  The close method on all resources is guaranteed to be called. If
+  multiple close methods throw exceptions, then the least recent ones
+  will be logged via tf.logging.error.
+
+  Args:
+    resources: An iterable of object instances whose classes implement
+        the close method.
+
+  Raises:
+    Exception: To rethrow the last exception raised by a close method.
+  """
+  badness = None
+  for resource in resources:
+    try:
+      resource.close()
+    except Exception as e:  # pylint: disable=broad-except
+      if badness is not None:
+        tf.logging.error('Suppressing close(%s) failure: %s', resource, e)
+      badness = e
+  if badness is not None:
+    raise badness  # pylint: disable=raising-bad-type
+
+
 def guarded_by(field):
   """Indicates method should be called from within a lock.
 


### PR DESCRIPTION
The `RunReader` weaves `EventLogReader` handles together into one continuous stream of events.

It's able to store the file offset in the database so we don't import the same data twice. This allows the loader to be re-run on the same experiment directory, over and over again, as new contents are added, without suffering the penalty of doing everything from scratch. This is helpful since SQL will introduce some overhead.

It also has functionality for our cool progress bar.

The mark and reset functionality is being moved into this class. It's not needed in the other one. The purpose of this functionality is so we can retry aborted transactions.