### PR TITLE
Fix downloaded graph PNGs to make them not tiny

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/minimap.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/minimap.ts
@@ -222,10 +222,11 @@ export class Minimap {
 
     // Download canvas width and height are multiples of the style width and
     // height in order to increase pixel density of the PNG for clarity.
-    d3.select(this.downloadCanvas).style(
-      <any>{ width: sceneSize.width, height: sceneSize.height });
-    d3.select(this.downloadCanvas).attr(
-      <any>{ width: sceneSize.width * 3, height: sceneSize.height * 3 });
+    const downloadCanvasSelection = d3.select(this.downloadCanvas);
+    downloadCanvasSelection.style('width', sceneSize.width);
+    downloadCanvasSelection.style('height', sceneSize.height);
+    downloadCanvasSelection.attr('width', 3 * sceneSize.width);
+    downloadCanvasSelection.attr('height', 3 * sceneSize.height);
 
     if (this.translate != null && this.zoom != null) {
       // Update the viewpoint rectangle shape since the aspect ratio of the


### PR DESCRIPTION
Summary:
In the graph dashboard, we attempt to set the size of the download
canvas according to the scene size. However, the syntax that we use to
do this is no longer supported by d3v4 ([source]), and so this ends up
doing nothing. Simply changing the syntax fixes the bug.

Fixes #88.

[source]: https://github.com/d3/d3/issues/2793

Test Plan:
Launch the graph explorer, and click "Download PNG" at left. Before this
patch, this always resulted in a 300×150 px image. Now, it results in an
image whose size is properly determined by the contents of the graph.

wchargin-branch: fix-graph-png-size