### PR TITLE
Make version at HEAD 0.4.0

### DIFF
--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '0.1.3'
+VERSION = '0.2.0'

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '0.2.0'
+VERSION = '0.4.0'

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '0.4.0'
+VERSION = '0.4.0a0'


### PR DESCRIPTION
This will correspond with the TensorFlow 1.4.x release.

Cherry-picks for TensorBoard 0.1.x (TF 1.3.x) will go in our `0.1` branch.