### PR TITLE
Declare dependency on TensorFlow >= 1.3.0

### DIFF
--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -32,7 +32,7 @@ REQUIRED_PACKAGES = [
     'html5lib == 0.9999999',  # identical to 1.0b8
     'markdown >= 2.6.8',
     'bleach == 1.5.0',
-    'tensorflow >= 1.2.0',
+    'tensorflow >= 1.3.0',
 ]
 
 # python3 requires wheel 0.26


### PR DESCRIPTION
Summary:
We need this for changes to `SummaryMetadata`. Trying to run TensorBoard
on TensorFlow 1.2.0 yields the error
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/local/google/home/wchargin/tensorboard-0.1.4-on-tensorflow-1.2/local/lib/python2.7/site-packages/tensorboard/backend/application.py", line 327, in _reload_forever
    reload_multiplexer(multiplexer, path_to_run)
  File "/usr/local/google/home/wchargin/tensorboard-0.1.4-on-tensorflow-1.2/local/lib/python2.7/site-packages/tensorboard/backend/application.py", line 301, in reload_multiplexer
    multiplexer.Reload()
  File "/usr/local/google/home/wchargin/tensorboard-0.1.4-on-tensorflow-1.2/local/lib/python2.7/site-packages/tensorboard/backend/event_processing/event_multiplexer.py", line 195, in Reload
    accumulator.Reload()
  File "/usr/local/google/home/wchargin/tensorboard-0.1.4-on-tensorflow-1.2/local/lib/python2.7/site-packages/tensorboard/backend/event_processing/event_accumulator.py", line 189, in Reload
    self._ProcessEvent(event)
  File "/usr/local/google/home/wchargin/tensorboard-0.1.4-on-tensorflow-1.2/local/lib/python2.7/site-packages/tensorboard/backend/event_processing/event_accumulator.py", line 337, in _ProcessEvent
    if value.HasField('metadata'):
ValueError: Unknown field metadata.
```

Users can easily get into this state if they had TensorFlow 1.2.0
installed and then ran `pip install tensorflow-tensorboard==0.1.4`.

Test Plan:
None.

wchargin-branch: depend-on-tf-1.3.0