### PR TITLE
Remove Closure annotations for non-native types in HTML files

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
@@ -659,7 +659,7 @@ Polymer({
     /** Whether this scene element is currently attached to a parent element. */
     _isAttached: Boolean,
 
-    /** @type {d3_zoom} d3 zoom object */
+    /** This property is a d3_zoom object. */
     _zoom: Object,
     highlightedNode: {
       type: String,
@@ -699,15 +699,15 @@ Polymer({
       value: 20
     },
     /**
-     * @type {d3.scale.ordinal}
      * Scale mapping from template name to a number between 0 and N-1
      * where N is the number of different template names. Used by
      * tf.graph.scene.node when computing node color by structure.
+     * This property is a d3.scale.ordinal object.
      */
     templateIndex: Function,
     /**
-     * @type {tf.scene.Minimap}
      * A minimap object to notify for zoom events.
+     * This property is a tf.scene.Minimap object.
      */
     minimap: Object,
     /*

--- a/tensorboard/plugins/graph/tf_graph_info/tf-graph-icon.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-graph-icon.html
@@ -107,7 +107,7 @@ limitations under the License.
            * Node to represent with an icon. Optional, but if specified, its
            * properties override those defined in the type, vertical, const and
            * summary properties.
-           * @type {tf.graph.Node}
+           * This property is a tf.graph.Node.
            */
           node: {
             type: Object,
@@ -118,7 +118,7 @@ limitations under the License.
            * Render node information associated with this node. Optional. If
            * specified, this is only used when computing the fill of the icon
            * element.
-           * @type {tf.graph.render.RenderNodeInfo}
+           * This property is a tf.graph.render.RenderNodeInfo.
            */
           renderInfo: {
             type: Object,

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-list-item.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-list-item.html
@@ -87,12 +87,12 @@ limitations under the License.
         properties: {
           /**
            * The Node for the card itself, on which this item is being drawn.
-           * @type {tf.graph.Node}
+           * This property is a tf.graph.Node.
            */
           cardNode: Object,
           /**
            * The Node for the item within the card, somehow related to cardNode.
-           * @type {tf.graph.Node}
+           * This property is a tf.graph.Node.
            */
           itemNode: Object,
           /** The edge label associated with this item. */

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-list-item.html
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-list-item.html
@@ -89,12 +89,12 @@ limitations under the License.
     properties: {
       /**
        * The Node for the card itself, on which this item is being drawn.
-       * @type {tf.graph.Node}
+       * This property is a tf.graph.Node.
        */
       cardNode: Object,
       /**
        * The Node for the item within the card, somehow related to cardNode.
-       * @type {tf.graph.Node}
+       * This property is a tf.graph.Node.
        */
       itemNode: Object,
       /** The edge label associated with this item. */


### PR DESCRIPTION
Previously, Closure type annotations with non-native types (such as those within the `tf.*` or `d3` namespace) triggered compile-time warnings noting that the types were not known.

If the types were not known, then the Closure compiler had not been using the annotations to enforce type safety anyway. Therefore, this change removes those annotations in favor of explicitly mentioning the type in a comment. 

I am not sure how to make those types available to HTML files at the Closure level. Maybe we could dynamically generate an extern? Anyways, that seems like it might not be worth it because the HTML files are mostly un-annotated with types.

This fixes #355.

