### PR TITLE
Add a "Functions" scene group

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
@@ -504,11 +504,7 @@ limitations under the License.
   top: 20px;
 }
 
-.title {
-  position: absolute;
-}
-
-.auxTitle {
+.title, .auxTitle, .functionLibraryTitle {
   position: absolute;
 }
 
@@ -521,6 +517,7 @@ limitations under the License.
 <div class="titleContainer">
   <div id="title" class="title">Main Graph</div>
   <div id="auxTitle" class="auxTitle">Auxiliary Nodes</div>
+  <div id="functionLibraryTitle" class="functionLibraryTitle">Functions</div>
 </div>
 <svg id="svg">
   <defs>
@@ -899,7 +896,10 @@ Polymer({
   _updateLabels: function(showLabels) {
     var mainGraphTitleElement = this.getElementsByClassName('title')[0];
     var titleStyle = mainGraphTitleElement.style;
-    var auxTitleStyle = this.getElementsByClassName('auxTitle')[0].style;
+    var auxTitleElement = this.getElementsByClassName('auxTitle')[0];
+    var auxTitleStyle = auxTitleElement.style;
+    var functionLibraryTitleStyle =
+        this.getElementsByClassName('functionLibraryTitle')[0].style;
     var core = d3.select("." + tf.graph.scene.Class.Scene.GROUP + ">." +
       tf.graph.scene.Class.Scene.CORE).node();
     // Only show labels if the graph is fully loaded.
@@ -925,9 +925,29 @@ Polymer({
       } else {
         auxTitleStyle.display = 'none';
       }
+
+      let functionLibrary = d3.select(
+          "." + tf.graph.scene.Class.Scene.GROUP + ">." +
+              tf.graph.scene.Class.Scene.FUNCTION_LIBRARY).node();
+      let functionLibraryX =
+          functionLibrary ? functionLibrary.getCTM().e : null;
+      if (functionLibraryX !== null && functionLibraryX !== auxX) {
+        functionLibraryTitleStyle.display = 'inline';
+
+        // Make sure that the function library title is positioned rightwards
+        // enough so as to prevent overlap with other content.
+        functionLibraryX = Math.max(
+            auxX + auxTitleElement.getBoundingClientRect().width,
+            functionLibraryX);
+
+        functionLibraryTitleStyle.left = functionLibraryX + 'px';
+      } else {
+        functionLibraryTitleStyle.display = 'none';
+      }
     } else {
-      titleStyle.display='none';
+      titleStyle.display = 'none';
       auxTitleStyle.display = 'none';
+      functionLibraryTitleStyle.display = 'none';
     }
   },
   /**

--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -17,7 +17,7 @@ module tf.graph {
 /** Delimiter used in node names to denote namespaces. */
 export const NAMESPACE_DELIM = '/';
 export const ROOT_NAME = '__root__';
-export const FUNCTION_LIBRARY_NODE = '__function_library__';
+export const FUNCTION_LIBRARY_NODE_PREFIX = '__function_library__';
 
 /** Attribute key used for storing attributes that are too large. */
 export const LARGE_ATTRS_KEY = '_too_large_attrs';
@@ -313,6 +313,10 @@ export interface Metanode extends GroupNode {
   depth: number;
   templateId: string;
   opHistogram: {[op: string]: number};
+
+  // The name of the function this metanode is associated with if any.
+  associatedFunction: string;
+  
   getFirstChild(): GroupNode|OpNode;
   getRootOp(): OpNode;
   /** Return name of all leaves inside a metanode. */
@@ -596,6 +600,7 @@ export class MetanodeImpl implements Metanode {
   hasNonControlEdges: boolean;
   include: InclusionType;
   nodeAttributes: {[key: string]: any;};
+  associatedFunction: string;
 
   /** A label object for meta-nodes in the graph hierarchy */
   constructor(name: string, opt = {}) {
@@ -626,6 +631,7 @@ export class MetanodeImpl implements Metanode {
     this.parentNode = null;
     this.hasNonControlEdges = false;
     this.include = InclusionType.UNSPECIFIED;
+    this.associatedFunction = '';
   }
 
   getFirstChild(): GroupNode|OpNode {
@@ -1059,7 +1065,7 @@ export function build(
             const processFunction = (func: tf.graph.proto.FunctionDef) => {
               // Give the function itself a node.
               const functionNodeName =
-                  FUNCTION_LIBRARY_NODE + NAMESPACE_DELIM + func.signature.name;
+                  FUNCTION_LIBRARY_NODE_PREFIX + func.signature.name;
               // Create an op node for the function. Mark it as part of a
               // function library.
               processRawNode({

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -592,9 +592,24 @@ function addNodes(h: Hierarchy, graph: SlimGraph) {
         child.parentNode = parent;
         h.setNode(name, child);
         parent.metagraph.setNode(name, child);
+
+        if (name.indexOf(tf.graph.FUNCTION_LIBRARY_NODE_PREFIX) === 0 &&
+            parent.name === tf.graph.ROOT_NAME) {
+          // This metanode represents a function in the Library. We later copy
+          // its contents to dynamically inject function data into the graph
+          // when the subhierarchy of a metanode is built (upon its expansion).
+          const functionName = name.substring(
+              tf.graph.FUNCTION_LIBRARY_NODE_PREFIX.length);
+
+          // For now, remember the metanode that represents the function with
+          // this name.
+          h.libraryFunctions[functionName] = child;
+          child.associatedFunction = functionName;
+        }
       }
       parent = child;
     }
+
     // Assuming node name is 'a/b/c', assign the OpNode as a child of the
     // metanode 'a/b'.
     h.setNode(node.name, node);
@@ -611,30 +626,6 @@ function addNodes(h: Hierarchy, graph: SlimGraph) {
       embedding.parentNode = node;
     });
   });
-
-  const libraryFunctionNode =
-      h.node(tf.graph.FUNCTION_LIBRARY_NODE) as Metanode;
-  if (libraryFunctionNode) {
-    // This graph has a function library. Remove the library from the root node
-    // itself. We later dynamically add copies of functions into metanodes that
-    // are actually function calls.
-    const rootNode = libraryFunctionNode.parentNode as Metanode;
-    rootNode.metagraph.removeNode(libraryFunctionNode.name);
-
-    // Add all of the library function node's children to a mapping. All of the
-    // nodes within this special node for library functions are themselves
-    // metanodes for library functions.
-    _.each(libraryFunctionNode.metagraph.nodes(), functionNodeName => {
-      const childNode =
-          libraryFunctionNode.metagraph.node(functionNodeName) as Metanode;
-      if (childNode.type === tf.graph.NodeType.META) {
-        const functionName = functionNodeName.substring(
-            tf.graph.FUNCTION_LIBRARY_NODE.length +
-                tf.graph.NAMESPACE_DELIM.length);
-        h.libraryFunctions[functionName] = childNode;
-      }
-    });
-  }
 };
 
 /**

--- a/tensorboard/plugins/graph/tf_graph_common/layout.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/layout.ts
@@ -237,8 +237,7 @@ function updateTotalWidthOfNode(renderInfo: render.RenderNodeInfo): void {
   renderInfo.coreBox.width = renderInfo.width;
   renderInfo.coreBox.height = renderInfo.height;
   // TODO: Account for font width rather than using a magic number.
-  let labelLength = renderInfo.node.name.length -
-      renderInfo.node.name.lastIndexOf(NAMESPACE_DELIM) - 1;
+  let labelLength = renderInfo.displayName.length;
   let charWidth = 3; // 3 pixels per character.
   // Compute the total width of the node.
   renderInfo.width = Math.max(renderInfo.coreBox.width +

--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -339,8 +339,7 @@ export function getGroupSettingLabel(node: Node) {
  */
 function labelBuild(nodeGroup, renderNodeInfo: render.RenderNodeInfo,
     sceneElement) {
-  let namePath = renderNodeInfo.node.name.split('/');
-  let text = namePath[namePath.length - 1];
+  let text = renderNodeInfo.displayName;
 
   // Truncate long labels for unexpanded Metanodes.
   let useFontScale = renderNodeInfo.node.type === NodeType.META &&

--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -714,7 +714,9 @@ export function stylize(nodeGroup, renderInfo: render.RenderNodeInfo,
   nodeClass = nodeClass || Class.Node.SHAPE;
   let isHighlighted = sceneElement.isNodeHighlighted(renderInfo.node.name);
   let isSelected = sceneElement.isNodeSelected(renderInfo.node.name);
-  let isExtract = renderInfo.isInExtract || renderInfo.isOutExtract;
+  let isExtract = renderInfo.isInExtract ||
+                  renderInfo.isOutExtract ||
+                  renderInfo.isLibraryFunction;
   let isExpanded = renderInfo.expanded && nodeClass !== Class.Annotation.NODE;
   let isFadedOut = renderInfo.isFadedOut;
   nodeGroup.classed('highlighted', isHighlighted);

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -158,7 +158,9 @@ const PARAMS = {
  * The regular expression to use when parsing for the string that is
  * used to label a function node in the graph. We strip away a prefix
  * indicating that the node represents a function definition. We also
- * remove an arbitrary hexadecimal suffix and its 
+ * remove an arbitrary hexadecimal suffix and the number following it
+ * if it is present. To be clear, we extract foo from
+ * __function__library_foo_deadb00f_42.
  */
 const nodeDisplayNameRegex = new RegExp(
     '^(?:' + tf.graph.FUNCTION_LIBRARY_NODE_PREFIX +

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -160,7 +160,7 @@ const PARAMS = {
  * indicating that the node represents a function definition. We also
  * remove an arbitrary hexadecimal suffix and the number following it
  * if it is present. To be clear, we extract foo from
- * __function__library_foo_deadb00f_42.
+ * __function_library__foo_deadb00f_42.
  */
 const nodeDisplayNameRegex = new RegExp(
     '^(?:' + tf.graph.FUNCTION_LIBRARY_NODE_PREFIX +

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -768,7 +768,6 @@ export class RenderGraphInfo {
         // Do not render function definitions in the core graph.
         childRenderInfo.node.include = InclusionType.EXCLUDE;
         coreGraph.removeNode(node.name);
-        console.log('removing ' + node.name);
       });
     }
 

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -1455,9 +1455,8 @@ export class RenderNodeInfo {
     this.displayName = node.name.substring(
         node.name.lastIndexOf(tf.graph.NAMESPACE_DELIM) + 1);
 
-    const functionNode = node as Metanode;
-    if (functionNode.type === NodeType.META &&
-        functionNode.associatedFunction) {
+    if (node.type === NodeType.META &&
+        (node as Metanode).associatedFunction) {
       // Function names are suffixed with a length-8 hexadecimal string
       // followed by an optional number. We remove that suffix because
       // the user did not generate that suffix. That suffix merely

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -1449,20 +1449,14 @@ export class RenderNodeInfo {
     // By default, we don't fade nodes out. Default to false for safety.
     this.isFadedOut = false;
 
-    this.displayName = node.name;
+    // Only use the portion beyond the last delimiter as the display
+    // name.
+    this.displayName = node.name.substring(
+        node.name.lastIndexOf(tf.graph.NAMESPACE_DELIM) + 1);
+
     const functionNode = node as Metanode;
     if (functionNode.type === NodeType.META &&
         functionNode.associatedFunction) {
-      // Strip the random hexadecimal suffix as well as the numeric
-      // count (marking the index for this function call).
-      const delimiterIndex = functionNode.name.lastIndexOf(
-          tf.graph.NAMESPACE_DELIM);
-      if (delimiterIndex > -1) {
-        // Only use the last portion as the display name.
-        this.displayName = this.displayName.substring(
-            delimiterIndex + 1);
-      }
-
       // Function names are suffixed with a length-8 hexadecimal string
       // followed by an optional number. We remove that suffix because
       // the user did not generate that suffix. That suffix merely

--- a/tensorboard/plugins/graph/tf_graph_common/scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/scene.ts
@@ -59,6 +59,7 @@ module tf.graph.scene {
     Scene: {
       GROUP: 'scene',
       CORE: 'core',
+      FUNCTION_LIBRARY: 'function-library',
       INEXTRACT: 'in-extract',
       OUTEXTRACT: 'out-extract'
     },
@@ -389,6 +390,16 @@ export function buildGroup(container,
     selectChild(sceneGroup, 'g', Class.Scene.OUTEXTRACT).remove();
   }
 
+  // Library functions
+  if (renderNode.libraryFunctionsExtract.length > 0) {
+    let outExtractGroup =
+        selectOrCreateChild(sceneGroup, 'g', Class.Scene.FUNCTION_LIBRARY);
+    node.buildGroup(outExtractGroup, renderNode.libraryFunctionsExtract,
+        sceneElement);
+  } else {
+    selectChild(sceneGroup, 'g', Class.Scene.FUNCTION_LIBRARY).remove();
+  }
+
   position(sceneGroup, renderNode);
 
   // Fade in the scene group if it didn't already exist.
@@ -420,12 +431,31 @@ function position(sceneGroup, renderNode: render.RenderGroupNodeInfo) {
   // in-extract
   let hasInExtract = renderNode.isolatedInExtract.length > 0;
   let hasOutExtract = renderNode.isolatedOutExtract.length > 0;
+  let hasLibraryFunctions = renderNode.libraryFunctionsExtract.length > 0;
+
+  let offset = layout.PARAMS.subscene.meta.extractXOffset;
+
+  let auxWidth = 0;
+  if (hasInExtract) {
+    auxWidth += renderNode.outExtractBox.width;
+  }
+  if (hasOutExtract) {
+    auxWidth += renderNode.outExtractBox.width;
+  }
 
   if (hasInExtract) {
-    let offset = layout.PARAMS.subscene.meta.extractXOffset;
-    let inExtractX = renderNode.coreBox.width -
-      renderNode.inExtractBox.width / 2 - renderNode.outExtractBox.width -
+    let inExtractX = renderNode.coreBox.width;
+    if (auxWidth < layout.MIN_AUX_WIDTH) {
+      inExtractX = inExtractX - layout.MIN_AUX_WIDTH +
+          renderNode.inExtractBox.width / 2;
+    } else {
+      inExtractX = inExtractX -
+          renderNode.inExtractBox.width / 2 - renderNode.outExtractBox.width -
           (hasOutExtract ? offset : 0);
+    }
+    inExtractX = inExtractX -
+        renderNode.libraryFunctionsBox.width -
+        (hasLibraryFunctions ? offset : 0);
     translate(
         selectChild(sceneGroup, 'g', Class.Scene.INEXTRACT), inExtractX,
         yTranslate);
@@ -433,10 +463,27 @@ function position(sceneGroup, renderNode: render.RenderGroupNodeInfo) {
 
   // out-extract
   if (hasOutExtract) {
-    let outExtractX = renderNode.coreBox.width -
-      renderNode.outExtractBox.width / 2;
+    let outExtractX = renderNode.coreBox.width;
+    if (auxWidth < layout.MIN_AUX_WIDTH) {
+      outExtractX = outExtractX - layout.MIN_AUX_WIDTH +
+          renderNode.outExtractBox.width / 2;
+    } else {
+      outExtractX -= renderNode.outExtractBox.width / 2;
+    }
+    outExtractX = outExtractX -
+      renderNode.libraryFunctionsBox.width -
+      (hasLibraryFunctions ? offset : 0);
     translate(
         selectChild(sceneGroup, 'g', Class.Scene.OUTEXTRACT), outExtractX,
+        yTranslate);
+  }
+
+  if (hasLibraryFunctions) {
+    let libraryFunctionsExtractX = renderNode.coreBox.width -
+        renderNode.libraryFunctionsBox.width / 2;
+    translate(
+        selectChild(sceneGroup, 'g', Class.Scene.FUNCTION_LIBRARY),
+        libraryFunctionsExtractX,
         yTranslate);
   }
 };


### PR DESCRIPTION
This change adds a "Functions" scene group if the graph being visualized has a function library, which contains definitions for functions (templates for subgraphs) used in the TensorFlow graph.

As part of that effort, this change also strips the arbitrary hexadecimal suffix from names of functions in the graph. That suffix is not user-generated - it merely serves to distinguish between functions with the same name but different signatures.

This refactors the implementation to prefix metanodes representing functions with `FUNCTION_LIBRARY_NODE_PREFIX` instead of lumping them under a metanode named `FUNCTION_LIBRARY_NODE`. We now also remove the function metanodes from the core graph later when building the sub-hierarchy instead of excluding them in the first place from the `__root__` metagraph. That lets us use existing paths to render the metanodes for functions in the scene group.

The metanodes in the scene group (which represent function definitions) are not yet linked to individual calls throughout the graph - that will happen in a later change.

This change is complex and will be tested via internal Selenium-based integration tests.

Screenshot:

![zyn4vsdjbv4](https://user-images.githubusercontent.com/4221553/29508308-ee22d402-8608-11e7-8468-d10c4f05101f.png)
