### PR TITLE
Visualize function inputs and outputs as triangles.

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
@@ -194,21 +194,21 @@ limitations under the License.
 
 /* --- Op Node --- */
 
-::content .op > .nodeshape > ellipse,
-::content .op > .annotation-node > ellipse {
+::content .op > .nodeshape > .nodecolortarget,
+::content .op > .annotation-node > .nodecolortarget {
   cursor: pointer;
   fill: #fff;
   stroke: #ccc;
 }
 
-::content .op.selected > .nodeshape > ellipse,
-::content .op.selected > .annotation-node > ellipse {
+::content .op.selected > .nodeshape > .nodecolortarget,
+::content .op.selected > .annotation-node > .nodecolortarget {
   stroke: red;
   stroke-width: 2;
 }
 
-::content .op.highlighted > .nodeshape > ellipse,
-::content .op.highlighted > .annotation-node > ellipse {
+::content .op.highlighted > .nodeshape > .nodecolortarget,
+::content .op.highlighted > .annotation-node > .nodecolortarget {
   stroke-width: 2;
 }
 

--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -487,13 +487,7 @@ export function buildShape(nodeGroup, d, nodeClass: string): d3.Selection<any, a
         // This is input or output arg for a TensorFlow function. Use a special
         // shape (a triangle) for them.
         scene.selectOrCreateChild(
-            shapeGroup,
-            'polygon',
-            [
-              Class.Node.COLOR_TARGET,
-              _.isNumber(opNode.functionInputIndex) ?
-                  Class.Node.INPUT_ARG : Class.Node.OUTPUT_ARG
-            ]);
+            shapeGroup, 'polygon', Class.Node.COLOR_TARGET);
         break;
       }
       scene.selectOrCreateChild(shapeGroup, 'ellipse', Class.Node.COLOR_TARGET);

--- a/tensorboard/plugins/graph/tf_graph_common/scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/scene.ts
@@ -26,10 +26,6 @@ module tf.graph.scene {
       SHAPE: 'nodeshape',
       // <*> element(s) under SHAPE that should receive color updates.
       COLOR_TARGET: 'nodecolortarget',
-      // Input argument of a TensorFlow function.
-      INPUT_ARG: 'input-arg',
-      // Output argument of a TensorFlow function.
-      OUTPUT_ARG: 'output-arg',
       // <text> element showing the node's label.
       LABEL: 'nodelabel',
       // <g> element that contains all visuals for the expand/collapse

--- a/tensorboard/plugins/graph/tf_graph_common/scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/scene.ts
@@ -26,6 +26,10 @@ module tf.graph.scene {
       SHAPE: 'nodeshape',
       // <*> element(s) under SHAPE that should receive color updates.
       COLOR_TARGET: 'nodecolortarget',
+      // Input argument of a TensorFlow function.
+      INPUT_ARG: 'input-arg',
+      // Output argument of a TensorFlow function.
+      OUTPUT_ARG: 'output-arg',
       // <text> element showing the node's label.
       LABEL: 'nodelabel',
       // <g> element that contains all visuals for the expand/collapse
@@ -472,6 +476,26 @@ export function positionRect(rect, cx: number, cy: number, width: number,
     .attr('y', cy - height / 2)
     .attr('width', width)
     .attr('height', height);
+};
+
+/**
+ * Positions a triangle and sizes it.
+ * @param polygon polygon to set position of.
+ * @param cx Center x.
+ * @param cy Center y.
+ * @param width Width of bounding box for triangle.
+ * @param height Height of bounding box for triangle.
+ */
+export function positionTriangle(polygon, cx, cy, width, height) {
+  const halfHeight = height / 2;
+  const halfWidth = width / 2;
+  const points = [
+    [cx, cy - halfHeight],
+    [cx + halfWidth, cy + halfHeight],
+    [cx - halfWidth, cy + halfHeight]
+  ];
+  polygon.transition().attr(
+      'points', points.map(point => point.join(',')).join(' '));
 };
 
 /**


### PR DESCRIPTION
Rendered `input_arg`s of TensorFlow functions as brown triangles. Rendered `output_args` of TensorFlow functions as teal triangles.

Triangles nicely convey a sense of direction and seem starky different from other nodes.

Screenshot:

![l5fker8o6s0](https://user-images.githubusercontent.com/4221553/29508677-3d1ee46e-860a-11e7-8bd0-2c1574c89583.png)
 