### PR TITLE
Pass skipLibCheck to tsc in ts_web_library

### DIFF
--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -159,6 +159,7 @@ def _ts_web_library(ctx):
                 inlineSources=True,
                 module="es6",
                 moduleResolution="node",
+                skipLibCheck=True,
                 noResolve=True,
                 target="es5",
             ),


### PR DESCRIPTION
skipLibCheck means that the TypeScript compiler will not check `.d.ts` files for
internal correctness. It will only check their use in `.ts` files.

This works around two issues:
- With certain inputs, Clutz will produce inconsistent `.d.ts` files. The
  problems are cosmetic insofar as using the APIs generated works and checks
  correctly, just the `.d.ts` doesn't check out internally. As no user wrote
  that code, it doesn't make sense to check it.
- TypeScript initially reads large declaration files such as `lib.d.ts`. That
  takes a lot of time, so this change will speed up compilation.

This change unblocks an upgrade of Clutz in google3.