### PR TITLE
Remove tests relating to ffmpeg change

### DIFF
--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -57,19 +57,6 @@ py_library(
     ],
 )
 
-py_test(
-    name = "summary_test",
-    size = "small",
-    srcs = ["summary_test.py"],
-    srcs_version = "PY2AND3",
-    deps = [
-        ":metadata",
-        ":summary",
-        "//tensorboard:expect_numpy_installed",
-        "//tensorboard:expect_tensorflow_installed",
-    ],
-)
-
 py_binary(
     name = "audio_demo",
     srcs = ["audio_demo.py"],

--- a/tensorboard/util_test.py
+++ b/tensorboard/util_test.py
@@ -320,28 +320,5 @@ class TensorFlowPngEncoderTest(tf.test.TestCase):
     self._check_png(data)
 
 
-class TensorFlowWavEncoderTest(tf.test.TestCase):
-
-  def setUp(self):
-    super(TensorFlowWavEncoderTest, self).setUp()
-    self._encode = util._TensorFlowWavEncoder()
-    space = np.linspace(0.0, 100.0, 44100)
-    self._stereo = np.array([np.sin(space), np.cos(space)]).transpose()
-    self._mono = self._stereo.mean(axis=1, keepdims=True)
-
-  def _check_wav(self, data):
-    # If it has a valid WAV/RIFF header and is of a reasonable size, we
-    # can assume it did the right thing. We trust the underlying
-    # `encode_audio` op.
-    self.assertEqual(b'RIFF', data[:4])
-    self.assertGreater(len(data), 128)
-
-  def test_encodes_mono_wav(self):
-    self._check_wav(self._encode(self._mono, samples_per_second=44100))
-
-  def test_encodes_stereo_wav(self):
-    self._check_wav(self._encode(self._stereo, samples_per_second=44100))
-
-
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
This is a known issue documented in the release notes. A contrib.ffmpeg
change didn't make it into TF 1.3. This new API for audio summaries
will work if the user installs the nightly pip package for TensorFlow.