### PR TITLE
Figure out types of node properties

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -1015,7 +1015,18 @@ export function build(
   let isInEmbeddedPred = getEmbedPredicate(params.inEmbeddingTypes);
   let isOutEmbeddedPred = getEmbedPredicate(params.outEmbeddingTypes);
   let embeddingNodeNames: string[] = [];
-  let rawNodes = graphDef.node;
+
+  let unknownTypeRawNodes = graphDef.node;
+  if (unknownTypeRawNodes && !_.isArray((unknownTypeRawNodes))) {
+    // The node property is not actually an array. It is a single node. The
+    // pbtxt syntax is unfortunately not flexible enough to communicate whether
+    // a property is an array or a single value, so we have to figure out the
+    // actual type.
+    unknownTypeRawNodes = [
+        (unknownTypeRawNodes as tf.graph.proto.NodeDef)];
+  }
+  let rawNodes = unknownTypeRawNodes as tf.graph.proto.NodeDef[];
+
   /**
    * A list of all the non-embedding node names which appear in the processed
    * list of raw nodes. Here we pre-allocate enough room for all the rawNodes,
@@ -1135,7 +1146,18 @@ export function build(
                 }
               }
 
-              _.each(func.node_def, rawNode => {
+              let unknownTypeNodes = func.node_def;
+              if (unknownTypeNodes && !_.isArray(unknownTypeNodes)) {
+                // The node_def property is not actually an array. It is a
+                // single node. The pbtxt syntax is unfortunately not flexible
+                // enough to communicate whether a property is an array or a
+                // single value, so we have to figure out the actual type.
+                unknownTypeNodes = [
+                    (unknownTypeNodes as tf.graph.proto.NodeDef)];
+              }
+              let nodeDefs = unknownTypeNodes as tf.graph.proto.NodeDef[];
+
+              _.each(nodeDefs, rawNode => {
                 // Prefix with the name of the function so that the graph
                 // correctly computes the hierarchy (and makes metanodes).
                 rawNode.name = functionNodeName + '/' + rawNode.name;

--- a/tensorboard/plugins/graph/tf_graph_common/proto.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/proto.ts
@@ -67,8 +67,8 @@ module tf.graph.proto {
    */
   export interface OpDef {
     name: string;
-    input_arg: ArgDef[];
-    output_arg: ArgDef[];
+    input_arg: ArgDef | ArgDef[];
+    output_arg: ArgDef | ArgDef[];
   };
 
   /**
@@ -99,7 +99,7 @@ module tf.graph.proto {
     node: NodeDef | NodeDef[];
 
     // Compatibility versions of the graph.
-    versions: VersionDef[];
+    versions: VersionDef | VersionDef[];
 
     // Contains a library of functions that may composed through the graph.
     library: FunctionDefLibraryDef;

--- a/tensorboard/plugins/graph/tf_graph_common/proto.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/proto.ts
@@ -80,7 +80,7 @@ module tf.graph.proto {
     signature: OpDef;
 
     // A list of nodes in the function.
-    node_def: NodeDef[];
+    node_def: NodeDef | NodeDef[];
   };
 
   /**
@@ -96,7 +96,7 @@ module tf.graph.proto {
    */
   export interface GraphDef {
     // A list of nodes in the graph.
-    node: NodeDef[];
+    node: NodeDef | NodeDef[];
 
     // Compatibility versions of the graph.
     versions: VersionDef[];


### PR DESCRIPTION
The pbtxt syntax is unfortunately not flexible enough to communicate whether a property is an array or a single value. For instance,

```
node_def {
  ...
}
```

could indicate that node_def is an array with 1 NodeDef, or the snippet could indicate that node_def is a property that has type NodeDef.

The meaning is clear when there are multiple instances of a property in the pbtxt file (then, the property must clearly be an array), but the situation is ambiguous when there is 1 instance of a property.

We hence need to manually figure out the types of values parsed from the pbtxt file. Fixes #418. This change also marks some other definitions within proto.js as potentially being either a list or 1 entity.

Without this change, some graphs (such as the one attached in #418) fail to load because some metanodes or functions contain 1 single node.