### PR TITLE
Have click toggle actualSize of image

### DIFF
--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -69,9 +69,30 @@ future for loading older images.
         </div>
       </template>
     </tf-card-heading>
-    <div id="main-image-container" on-tap="_handleTap"></div>
+    <button id="main-image-container" on-tap="_handleTap"></button>
 
     <style>
+      /** Make button a div. */
+      button {
+        width: 100%;
+        display: block;
+        background: none;
+        border: 0;
+        padding: 0;
+      }
+
+      /** Firefox: Get rid of dotted line inside button. */
+      button::-moz-focus-inner {
+        border: 0;
+        padding: 0;
+      }
+
+      /** Firefox: Simulate Chrome's outer glow on button when focused. */
+      button:-moz-focusring {
+        outline: none;
+        box-shadow: 0px 0px 1px 2px Highlight;
+      }
+
       :host {
         display: block;
         width: 350px;
@@ -89,6 +110,7 @@ future for loading older images.
 
       :host[actual-size] #main-image-container {
         max-height: none;
+        width: auto;
       }
 
       :host[actual-size] #main-image-container img {

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -69,7 +69,10 @@ future for loading older images.
         </div>
       </template>
     </tf-card-heading>
-    <button id="main-image-container" on-tap="_handleTap"></button>
+
+    <button aria-label="Toggle actual size"
+            id="main-image-container"
+            on-tap="_handleTap"></button>
 
     <style>
       /** Make button a div. */

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -69,7 +69,7 @@ future for loading older images.
         </div>
       </template>
     </tf-card-heading>
-    <div id="main-image-container"></div>
+    <div id="main-image-container" on-tap="_handleTap"></div>
 
     <style>
       :host {
@@ -342,6 +342,9 @@ future for loading older images.
         // Load the new image.
         this.set("_isImageLoading", true);
         img.src = steps[stepIndex].url;
+      },
+      _handleTap(e) {
+        this.set('actualSize', !this.actualSize);
       },
     });
   </script>

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -127,9 +127,10 @@ future for loading older images.
       }
 
       #main-image-container img {
+        cursor: pointer;
+        display: block;
         image-rendering: -moz-crisp-edges;
         image-rendering: pixelated;
-        display: block;
         width: 100%;
         height: auto;
       }


### PR DESCRIPTION
#261 recently removed the expand button from the image dashboard, which freed up whitespace. However the checkbox in the top left isn't conspicuous enough. With this change, clicking on an individual image, will toggle its actual size state, for only that image. This seems intuitive to me.