### PR TITLE
Rename tf-tensorboard title attribute to brand

### DIFF
--- a/tensorboard/components/tensorboard.html
+++ b/tensorboard/components/tensorboard.html
@@ -25,4 +25,4 @@ limitations under the License.
 <link rel="import" href="tf-tensorboard/tf-tensorboard.html">
 <link rel="import" href="analytics.html">
 <body>
-<tf-tensorboard use-hash title="TensorBoard"></tf-tensorboard>
+<tf-tensorboard use-hash brand="TensorBoard"></tf-tensorboard>

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -47,7 +47,7 @@ limitations under the License.
     <paper-header-panel>
       <paper-toolbar id="toolbar" slot="header">
         <div id="toolbar-content" slot="top">
-          <div class="toolbar-title">[[title]]</div>
+          <div class="toolbar-title">[[brand]]</div>
           <template is="dom-if" if="[[_activeDashboardsNotLoaded]]">
             <span class="toolbar-message">
               Loading active dashboards&hellip;
@@ -323,9 +323,17 @@ limitations under the License.
          * This defaults to TensorBoard-X because we recommend against custom
          * builds being branded as TensorBoard.
          */
-        title: {
+        brand: {
           type: String,
           value: 'TensorBoard-X',
+        },
+
+        /**
+         * Deprecated: Equivalent to 'brand' attribute.
+         */
+        title: {
+          type: String,
+          observer: '_updateTitle',
         },
 
         /**
@@ -693,6 +701,12 @@ limitations under the License.
 
       _updateRouter(router) {
         setRouter(router);
+      },
+
+      _updateTitle(title) {
+        if (title) {
+          this.set('brand', title);
+        }
       },
 
       reload() {


### PR DESCRIPTION
This way we don't have a global HTML tooltip that says "TensorBoard".