### PR TITLE
Add the frontend for the PR curves plugin

### DIFF
--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -44,6 +44,7 @@ ts_web_library(
         "//tensorboard/plugins/graph/tf_graph_dashboard",
         "//tensorboard/plugins/histogram/tf_histogram_dashboard",
         "//tensorboard/plugins/image/tf_image_dashboard",
+        "//tensorboard/plugins/pr_curve/tf_pr_curve_dashboard",
         "//tensorboard/plugins/profile/tf_profile_dashboard",
         "//tensorboard/plugins/projector/vz_projector",
         "//tensorboard/plugins/scalar/tf_scalar_dashboard",

--- a/tensorboard/components/tf_tensorboard/default-plugins.html
+++ b/tensorboard/components/tf_tensorboard/default-plugins.html
@@ -21,6 +21,7 @@ limitations under the License.
 <link rel="import" href="../tf-graph-dashboard/tf-graph-dashboard.html">
 <link rel="import" href="../tf-histogram-dashboard/tf-histogram-dashboard.html">
 <link rel="import" href="../tf-image-dashboard/tf-image-dashboard.html">
+<link rel="import" href="../tf-pr-curve-dashboard/tf-pr-curve-dashboard.html">
 <link rel="import" href="../tf-profile-dashboard/tf-profile-dashboard.html">
 <link rel="import" href="../tf-scalar-dashboard/tf-scalar-dashboard.html">
 <link rel="import" href="../tf-text-dashboard/tf-text-dashboard.html">
@@ -37,6 +38,7 @@ limitations under the License.
     'histograms': 'tf-histogram-dashboard',
     'projector': 'vz-projector-dashboard',
     'text': 'tf-text-dashboard',
+    'pr_curves': 'tf-pr-curve-dashboard',
     'profile': 'tf-profile-dashboard',
   };
 </script>

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/BUILD
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/BUILD
@@ -1,0 +1,47 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "ts_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+ts_web_library(
+    name = "tf_pr_curve_dashboard",
+    srcs = [
+        "tf-pr-curve-card.html",
+        "tf-pr-curve-dashboard.html",
+        "tf-pr-curve-steps-selector.html",
+    ],
+    path = "/tf-pr-curve-dashboard",
+    deps = [
+        "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_color_scale",
+        "//tensorboard/components/tf_card_heading",
+        "//tensorboard/components/tf_paginated_view",
+        "//tensorboard/components/tf_categorization_utils",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_imports:lodash",
+        "//tensorboard/components/tf_runs_selector",
+        "//tensorboard/components/vz_line_chart",
+        "@org_polymer_iron_icon//:org_polymer_iron_icon",
+        "@org_polymer_paper_button//:org_polymer_paper_button",
+        "@org_polymer_paper_icon_button//:org_polymer_paper_icon_button",
+        "@org_polymer_paper_input//:org_polymer_paper_input",
+        "@org_polymer_paper_slider//:org_polymer_paper_slider",
+        "@org_polymer_paper_spinner//:org_polymer_paper_spinner",
+    ],
+)

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -175,7 +175,7 @@ limitations under the License.
         // plot. The entry is based on which step the user currently selects.
         _runToPrCurveEntry: {
           type: Object,
-          value: {},
+          value: () => ({}),
         },
         // We also cache the previous run to entry mapping in order to prevent
         // redrawing PR curves for runs that did not change. Ideally, we would
@@ -183,7 +183,7 @@ limitations under the License.
         // does not work for run names that contain periods.
         _previousRunToPrCurveEntry: {
           type: Object,
-          value: {},
+          value: () => ({}),
         },
         // A list of runs with an available step. Used to populate the table of
         // steps per run.
@@ -245,7 +245,7 @@ limitations under the License.
                 (x) => isNaN(x) ? 'NaN' : valueFormatter(x);
             return [
               {
-                title: 'Name',
+                title: 'Run',
                 evaluate: (d) => d.dataset.metadata().name,
               },
               {
@@ -324,15 +324,15 @@ limitations under the License.
           this._updateSeriesDataForRun(run, entry);
         });
       },
-      _updateSeriesDataForRun(run, entryFor1Step) {
+      _updateSeriesDataForRun(run, entryForOneStep) {
         // Reverse the values so they are plotted in order. The logic within
         // the line chart for associating information to show in the tooltip
         // with points in the chart assumes that the series data is ordered
         // by the variable on the X axis. If the values are not in order,
         // tooltips will not work because the tooltip will always be stuck on
         // one side of the chart.
-        const precision = entryFor1Step.precision.slice().reverse();
-        const recall = entryFor1Step.recall.slice().reverse();
+        const precision = entryForOneStep.precision.slice().reverse();
+        const recall = entryForOneStep.recall.slice().reverse();
         const seriesData = _.zipWith(
             precision, recall, (precision, recall) => ({
               precision: precision,

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -287,10 +287,12 @@ limitations under the License.
 
         this._canceller.cancelAll();
         const router = getRouter();
+
         let url = router.pluginRoute('pr_curves', '/pr_curves');
         url += url.indexOf('?') > -1 ? '&' : '?';
-        const urlRunsPortion = this.runs.map(r => `&run=${r}`).join('');
-        url += `tag=${this.tag}${urlRunsPortion}`;
+        url += `tag=${this.tag}`;
+        url += this.runs.map(r => `&run=${r}`).join('');
+
         const updateData = this._canceller.cancellable(result => {
           if (result.cancelled) {
             return;
@@ -378,7 +380,7 @@ limitations under the License.
       _computeSetOfRelevantRuns(runsWithStepAvailable) {
         const setOfRelevantRuns = {};
         _.forEach(runsWithStepAvailable, run => {
-          setOfRelevantRuns[run] = 1;
+          setOfRelevantRuns[run] = true;
         });
         return setOfRelevantRuns;
       },
@@ -395,7 +397,7 @@ limitations under the License.
         if (!entry) {
           return null;
         }
-        return new Date(runToPrCurveEntry[run].wall_time * 1000).toString();
+        return new Date(entry.wall_time * 1000).toString();
       },
       _toggleExpanded(e) {
         this.set('_expanded', !this._expanded);

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -1,0 +1,409 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../paper-spinner/paper-spinner-lite.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
+<link rel="import" href="../tf-card-heading/tf-card-heading.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../tf-imports/lodash.html">
+<link rel="import" href="../vz-line-chart/vz-line-chart.html">
+
+<!--
+  Renders precision–recall curves.
+-->
+<dom-module id="tf-pr-curve-card">
+  <template>
+    <!-- TODO(chihuahua): Pass display-name and description. This
+         requires generalizing the logic for dimensionality reduction
+         from the scalar chart. -->
+    <tf-card-heading tag="[[tag]]">
+    </tf-card-heading>
+
+    <div id="chart-and-spinner-container">
+      <vz-line-chart
+        x-components-creation-method="[[_xComponentsCreationMethod]]"
+        y-value-accessor="[[_yValueAccessor]]"
+        tooltip-columns="[[_tooltipColumns]]"
+        color-scale="[[_colorScaleFunction]]"
+      ></vz-line-chart>
+      <template is="dom-if" if="[[loading]]">
+        <div id="loading-spinner-container">
+          <paper-spinner-lite active></paper-spinner-lite>
+        </div>
+      </template>
+    </div>
+
+    <div id="buttons-row">
+      <paper-icon-button
+        selected$="[[_expanded]]"
+        icon="fullscreen"
+        on-tap="_toggleExpanded"
+      ></paper-icon-button>
+    </div>
+
+    <div id="step-legend">
+      <template is="dom-repeat" items="[[_runsWithStepAvailable]]" as="run">
+        <div class="legend-row">
+          <div class="color-box"
+               style="background: [[_computeRunColor(run)]];">
+          </div>
+          [[run]] is at
+          <span class="step-label-text">
+            step [[_computeCurrentStepForRun(_runToPrCurveEntry, run)]]
+          </span><br>
+          <span class="wall-time-label-text">
+            ([[_computeCurrentWallTimeForRun(_runToPrCurveEntry, run)]])
+          </span>
+        </div>
+      </template>
+    </div>
+
+    <style>
+      :host {
+        display: flex;
+        flex-direction: column;
+        width: 500px;
+        margin-right: 10px;
+        margin-bottom: 25px;
+      }
+      :host[_expanded] {
+        width: 100%;
+      }
+      #chart-and-spinner-container {
+        display: flex;
+        height: 300px;
+        position: relative;
+      }
+      :host[_expanded] #chart-and-spinner-container {
+        height: 600px;
+      }
+      #line-chart-container {
+        width: 100%;
+        height: 100%;
+      }
+      #loading-spinner-container {
+        align-items: center;
+        bottom: 0;
+        display: flex;
+        display: flex;
+        justify-content: center;
+        left: 0;
+        pointer-events: none;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+      vz-line-chart {
+        -webkit-user-select: none;
+        -moz-user-select: none;
+      }
+      #buttons-row {
+        display: flex;
+        flex-direction: row;
+      }
+      #buttons-row paper-icon-button {
+        color: #2196F3;
+        border-radius: 100%;
+        width: 32px;
+        height: 32px;
+        padding: 4px;
+      }
+      #buttons-row paper-icon-button[selected] {
+        background: var(--tb-ui-light-accent);
+      }
+      #step-legend {
+        box-sizing: border-box;
+        font-size: 0.8em;
+        max-height: 200px;
+        overflow-y: auto;
+        padding: 0 0 0 10px;
+        width: 100%;
+      }
+      .legend-row {
+        margin: 5px 0 5px 0;
+        width: 100%;
+      }
+      .color-box {
+        display: inline-block;
+        border-radius: 1px;
+        width: 10px;
+        height: 10px;
+      }
+      .step-label-text {
+        font-weight: bold;
+      }
+      .wall-time-label-text {
+        color: #888;
+        font-size: 0.8em;
+      }
+    </style>
+  </template>
+  <script>
+    import {Canceller} from "../tf-backend/canceller.js";
+    import {getRouter} from "../tf-backend/router.js";
+    import {runsColorScale} from "../tf-color-scale/colorScale.js";
+    import * as ChartHelpers from '../vz-line-chart/vz-chart-helpers.js';
+
+    Polymer({
+      is: "tf-pr-curve-card",
+      properties: {
+        runs: Array,
+        tag: String,
+        // For each run, the card will display the PR curve at this step or the
+        // one closest to it, but less than it.
+        runToStepCap: Object,
+        requestManager: Object,
+        _expanded: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,  // for CSS
+        },
+        // This maps run to the PR curve entry that contains the PR data to
+        // plot. The entry is based on which step the user currently selects.
+        _runToPrCurveEntry: {
+          type: Object,
+          value: {},
+        },
+        // We also cache the previous run to entry mapping in order to prevent
+        // redrawing PR curves for runs that did not change. Ideally, we would
+        // use polymer property observers to implement this behavior, but that
+        // does not work for run names that contain periods.
+        _previousRunToPrCurveEntry: {
+          type: Object,
+          value: {},
+        },
+        // A list of runs with an available step. Used to populate the table of
+        // steps per run.
+        _runsWithStepAvailable: {
+          type: Array,
+          computed: "_computeRunsWithStepAvailable(runs, _runToPrCurveEntry)",
+        },
+        // An object whose keys are the list of runs that both are selected and
+        // have data loaded. We use this mapping (which is really a set in
+        // practice) to determine whether or not to clear a data series.
+        _setOfRelevantRuns: {
+          type: Object,
+          computed: "_computeSetOfRelevantRuns(_runsWithStepAvailable)",
+        },
+        // This property is set after PR curve data from the backend is
+        // received. We index into this object after determining which step to
+        // draw PR curves for.
+        _runToDataOverTime: Object,
+        _colorScaleFunction: {
+          type: Object,  // function: string => string
+          value: () => ({scale: runsColorScale}),
+        },
+        _canceller: {
+          type: Object,
+          value: () => new Canceller(),
+        },
+        _attached: Boolean,
+        // The value field is a function that returns a function because Polymer
+        // will actually call the value field if the field is a function.
+        // However, we actually want the value itself to be a function.
+        _xComponentsCreationMethod: {
+          type: Object,
+          readOnly: true,
+          value: () => (() => {
+            const scale = new Plottable.Scales.Linear();
+            return {
+              scale: scale,
+              axis: new Plottable.Axes.Numeric(scale, 'bottom'),
+              accessor: d => d.recall,
+            };
+          }),
+        },
+        _yValueAccessor: {
+          type: Object,
+          readOnly: true,
+          // This function returns a function because polymer calls the outer
+          // function to compute the value. We actually want the value of this
+          // property to be the inner function.
+          value: () => (d => d.precision),
+        },
+        loading: Boolean,
+        _tooltipColumns: {
+          type: Array,
+          readOnly: true,
+          value: () => {
+            const valueFormatter = ChartHelpers.multiscaleFormatter(
+                ChartHelpers.Y_TOOLTIP_FORMATTER_PRECISION);
+            const formatValueOrNaN =
+                (x) => isNaN(x) ? 'NaN' : valueFormatter(x);
+            return [
+              {
+                title: 'Name',
+                evaluate: (d) => d.dataset.metadata().name,
+              },
+              {
+                title: 'Precision',
+                evaluate: (d) => formatValueOrNaN(d.datum.precision),
+              },
+              {
+                title: 'Recall',
+                evaluate: (d) => formatValueOrNaN(d.datum.recall),
+              }];
+          },
+        }
+      },
+      observers: [
+        'reload(runs, tag)',
+        '_runsChanged(_attached, runs)',
+        '_setChartData(_runToPrCurveEntry, _previousRunToPrCurveEntry, _setOfRelevantRuns)',
+        '_updateRunToPrCurveEntry(_runToDataOverTime, runToStepCap)',
+      ],
+      _computeRunColor(run) {
+        return this._colorScaleFunction.scale(run);
+      },
+      attached() {
+        // Defer reloading until after we're attached, because that ensures that
+        // the requestManager has been set from above. (Polymer is tricky
+        // sometimes)
+        this._attached = true;
+        this.reload();
+      },
+      reload() {
+        if (!this._attached) {
+          return;
+        }
+        if (this.runs.length === 0) {
+          // There are no selected runs.
+          this.set('_runToDataOverTime', {});
+          return;
+        }
+
+        this._canceller.cancelAll();
+        const router = getRouter();
+        let url = router.pluginRoute('pr_curves', '/pr_curves');
+        url += url.indexOf('?') > -1 ? '&' : '?';
+        const urlRunsPortion = this.runs.map(r => `&run=${r}`).join('');
+        url += `tag=${this.tag}${urlRunsPortion}`;
+        const updateData = this._canceller.cancellable(result => {
+          if (result.cancelled) {
+            return;
+          }
+
+          const runToDataOverTime = result.value;
+          this.set('_runToDataOverTime', runToDataOverTime);
+          this.set('loading', false);
+        });
+        this.set('loading', true);
+        this.requestManager.request(url).then(updateData);
+      },
+      _setChartData(
+          runToPrCurveEntry, previousRunToPrCurveEntry, setOfRelevantRuns) {
+        _.forOwn(runToPrCurveEntry, (entry, run) => {
+          const previousEntry = previousRunToPrCurveEntry[run];
+          if (previousEntry &&
+              runToPrCurveEntry[run].step === previousEntry.step) {
+            // The PR curve for this run does not need to be updated.
+            return;
+          }
+
+          if (!setOfRelevantRuns[run]) {
+            // Clear this dataset - the user has unselected it.
+            this._clearSeriesData(run);
+            return;
+          }
+
+          this._updateSeriesDataForRun(run, entry);
+        });
+      },
+      _updateSeriesDataForRun(run, entryFor1Step) {
+        // Reverse the values so they are plotted in order. The logic within
+        // the line chart for associating information to show in the tooltip
+        // with points in the chart assumes that the series data is ordered
+        // by the variable on the X axis. If the values are not in order,
+        // tooltips will not work because the tooltip will always be stuck on
+        // one side of the chart.
+        const precision = entryFor1Step.precision.slice().reverse();
+        const recall = entryFor1Step.recall.slice().reverse();
+        const seriesData = _.zipWith(
+            precision, recall, (precision, recall) => ({
+              precision: precision,
+              recall: recall,
+            }));
+        this.$$('vz-line-chart').setSeriesData(run, seriesData);
+      },
+      _clearSeriesData(run) {
+        // Clears data for a run in the chart.
+        this.$$('vz-line-chart').setSeriesData(run, []);
+      },
+      _runsChanged(attached, runs) {
+        if (!attached) {
+          return;
+        }
+        this.$$('vz-line-chart').setVisibleSeries(this.runs);
+        this.reload();
+      },
+      _updateRunToPrCurveEntry(runToDataOverTime, runToStepCap) {
+        const runToEntry = {};
+        _.forOwn(runToDataOverTime, (entries, run) => {
+          if (!entries || !entries.length) {
+            return;
+          }
+
+          runToEntry[run] = this._computeEntryClosestOrEqualToStepCap(
+              runToStepCap[run], entries);
+        });
+
+        // Set the previous PR curve entry so we can later compare and only
+        // redraw for runs that changed in step.
+        this.set('_previousRunToPrCurveEntry', this._runToPrCurveEntry);
+
+        this.set('_runToPrCurveEntry', runToEntry);
+      },
+      _computeEntryClosestOrEqualToStepCap(stepCap, entries) {
+        const entryIndex = Math.min(
+            _.sortedIndex(entries.map(entry => entry.step), stepCap),
+            entries.length - 1);
+        return entries[entryIndex];
+      },
+      _computeRunsWithStepAvailable(runs, actualPrCurveEntryPerRun) {
+        return _.filter(runs, run => actualPrCurveEntryPerRun[run]).sort();
+      },
+      _computeSetOfRelevantRuns(runsWithStepAvailable) {
+        const setOfRelevantRuns = {};
+        _.forEach(runsWithStepAvailable, run => {
+          setOfRelevantRuns[run] = 1;
+        });
+        return setOfRelevantRuns;
+      },
+      _computeCurrentStepForRun(runToPrCurveEntry, run) {
+        // If there is no data for the run, then the run is not being shown, so
+        // the return value is not used. We return null as a reasonable value.
+        const entry = runToPrCurveEntry[run];
+        return entry ? entry.step : null;
+      },
+      _computeCurrentWallTimeForRun(runToPrCurveEntry, run) {
+        const entry = runToPrCurveEntry[run];
+        // If there is no data for the run, then the run is not being shown, so
+        // the return value is not used. We return null as a reasonable value.
+        if (!entry) {
+          return null;
+        }
+        return new Date(runToPrCurveEntry[run].wall_time * 1000).toString();
+      },
+      _toggleExpanded(e) {
+        this.set('_expanded', !this._expanded);
+        this.redraw();
+      },
+      redraw() {
+        this.$$('vz-line-chart').redraw();
+      },
+    });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -1,10 +1,13 @@
 <!--
 @license
 Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -97,7 +100,6 @@ limitations under the License.
       #loading-spinner-container {
         align-items: center;
         bottom: 0;
-        display: flex;
         display: flex;
         justify-content: center;
         left: 0;

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
@@ -128,7 +128,7 @@ limitations under the License.
         max-width: 540px;
         margin: 80px auto 0 auto;
       }
-      /** Not not let the steps selector occlude the run selector. */
+      /** Do not let the steps selector occlude the run selector. */
       #steps-selector-container {
         max-height: 40%;
         overflow-y: auto;
@@ -165,7 +165,7 @@ limitations under the License.
         computed: "_computeRelevantSelectedRuns(_selectedRuns, _runToTag)",
       },
       _runsWithPrCurveData: Array,  // string[]
-      // The actual step value that each run should use. If a run + tag lacks a
+      // The desired step value that each run should use. If a run + tag lacks a
       // PR curve at this exact step value, the greatest step value less than
       // this value will be used.
       _runToStep: {
@@ -220,10 +220,6 @@ limitations under the License.
         // Compute the relative field for each time entry. For each step, the
         // relative field is the number of seconds (float) since the first step.
         _.forOwn(timeEntriesPerRun, (entries, run) => {
-          if (!entries.length) {
-            return;
-          }
-
           _.forEach(entries, entry => {
             entry['relative'] = entry.wall_time - entries[0].wall_time;
           });
@@ -231,7 +227,7 @@ limitations under the License.
 
         this.set('_runToAvailableTimeEntries', timeEntriesPerRun);
 
-        const listOfRuns = _.keys(timeEntriesPerRun).sort();
+        const listOfRuns = _.keys(timeEntriesPerRun).slice().sort();
         if (!_.isEqual(listOfRuns, this._runsWithPrCurveData)) {
           this.set('_runsWithPrCurveData', listOfRuns);
         }

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
@@ -1,0 +1,265 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../paper-button/paper-button.html">
+<link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
+<link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
+<link rel="import" href="../tf-categorization-utils/tf-category-pane.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
+<link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
+<link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
+<link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
+<link rel="import" href="tf-pr-curve-card.html">
+<link rel="import" href="tf-pr-curve-steps-selector.html">
+
+<!--
+  A frontend that displays a set of precision–recall curves. Each PR curve is
+  associated with a tag (which is in turn associated with 1 class).
+-->
+<dom-module id="tf-pr-curve-dashboard">
+  <template>
+    <tf-dashboard-layout>
+      <div class="sidebar">
+        <div class="sidebar-section">
+          <tf-option-selector
+            id="time-type-selector"
+            name="Time Display Type"
+            selected-id="{{_timeDisplayType}}"
+          >
+            <paper-button id="step">step</paper-button><!--
+            --><paper-button id="relative">relative</paper-button><!--
+            --><paper-button id="wall_time">wall</paper-button>
+          </tf-option-selector>
+        </div>
+        <template is="dom-if" if="[[_runToAvailableTimeEntries]]">
+          <div class="sidebar-section" id="steps-selector-container">
+            <tf-pr-curve-steps-selector
+                  runs="[[_relevantSelectedRuns]]"
+                  run-to-step="{{_runToStep}}"
+                  run-to-available-time-entries="[[_runToAvailableTimeEntries]]"
+                  time-display-type="[[_timeDisplayType]]"></tf-pr-curve-steps-selector>
+          </div>
+        </template>
+        <div class="sidebar-section">
+          <tf-runs-selector selected-runs="{{_selectedRuns}}">
+          </tf-runs-selector>
+        </div>
+       </div>
+      </div>
+      <div class="center">
+        <template is="dom-if" if="[[_dataNotFound]]">
+          <div class="no-data-warning">
+            <h3>No precision–recall curve data was found.</h3>
+            <p>Probable causes:</p>
+            <ul>
+              <li>
+                You haven’t written any precision–recall data to your event
+                files.
+              </li>
+              <li>
+                TensorBoard can’t find your event files.
+              </li>
+            </ul>
+            <p>
+            If you’re new to using TensorBoard, and want to find out how
+            to add data and set up your event files, check out the
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md">README</a>
+            and perhaps the <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard">TensorBoard tutorial</a>.
+            <p>
+            If you think TensorBoard is configured properly, please see
+            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong">the section of the README devoted to missing data problems</a>
+            and consider filing an issue on GitHub.
+          </div>
+        </template>
+        <template is="dom-if" if="[[!_dataNotFound]]">
+          <paper-input
+            no-label-float
+            label="Filter tags (regular expressions supported)"
+            value="{{_tagFilter}}"
+            class="search-input"
+          >
+            <iron-icon prefix icon="search"></iron-icon>
+          </paper-input>
+          <template is="dom-repeat" items="[[_categories]]" as="category">
+            <tf-category-pane category="[[category]]">
+              <tf-paginated-view
+                items="[[category.items]]"
+                pages="{{category._pages}}"
+              >
+                <template is="dom-repeat" items="[[category._pages]]" as="page">
+                  <template is="dom-if" if="[[page.active]]">
+                    <div class="layout horizontal wrap">
+                      <template is="dom-repeat" items="[[page.items]]">
+                        <tf-pr-curve-card
+                          runs="[[item.runs]]"
+                          tag="[[item.tag]]"
+                          request-manager="[[_requestManager]]"
+                          run-to-step-cap="[[_runToStep]]"
+                        ></tf-pr-curve-card>
+                      </template>
+                    </div>
+                  </template>
+                </template>
+              </tf-paginated-view>
+            </tf-category-pane>
+          </template>
+        </template>
+      </div>
+    </tf-dashboard-layout>
+
+    <style include="dashboard-style"></style>
+    <style>
+      #instructions {
+        width: 300px;
+      }
+      .tooltip-block-container {
+        display: inline-block;
+      }
+      .no-data-warning {
+        max-width: 540px;
+        margin: 80px auto 0 auto;
+      }
+      .run-step-combo .run-text {
+        margin: 10px 0 0 0;
+      }
+      /** Not not let the steps selector occlude the run selector. */
+      #steps-selector-container {
+        max-height: 40%;
+        overflow-y: auto;
+      }
+    </style>
+  </template>
+
+  <script>
+  import {RequestManager} from '../tf-backend/requestManager.js';
+  import {getTags} from '../tf-backend/backend.js';
+  import {getRouter} from '../tf-backend/router.js';
+  import {categorizeTags} from '../tf-categorization-utils/categorizationUtils.js';
+  import {runsColorScale} from "../tf-color-scale/colorScale.js";
+
+  Polymer({
+    is: 'tf-pr-curve-dashboard',
+    properties: {
+      // Determines how the time entry is shown. One of step, relative, or
+      // wall_time.
+      _timeDisplayType : {
+        type: String,
+        value: 'step',
+      },
+      _selectedRuns: Array,
+      _runToTag: Object,  // map<run: string, tags: string[]>
+      // The steps that the step slider for each run should use.
+      _runToAvailableTimeEntries: {
+        type: Object, // map<run: string, steps: number[]>
+        value: {},
+      },
+      // A list of runs that are both selected and have PR curve data.
+      _relevantSelectedRuns: {
+        type: Array,
+        computed: "_computeRelevantSelectedRuns(_selectedRuns, _runToTag)",
+      },
+      _runsWithPrCurveData: Array,  // string[]
+      // The actual step value that each run should use. If a run + tag lacks a
+      // PR curve at this exact step value, the greatest step value less than
+      // this value will be used.
+      _runToStep: {
+        type: Object,  // map<run: string, step: number>
+        notify: true,
+      },
+      _dataNotFound: Boolean,
+      _tagFilter: {
+        type: String,  // upward bound from paper-input
+        value: '.*',
+      },
+      _categories: {
+        type: Array,
+        computed: '_makeCategories(_runToTag, _selectedRuns, _tagFilter)',
+      },
+      _requestManager: {
+        type: Object,
+        value: () => new RequestManager(),
+      },
+      _step: {
+        type: Number,
+        value: 0,
+        notify: true,
+      },
+    },
+    ready() {
+      this.reload();
+    },
+    reload() {
+      Promise.all(
+          [this._fetchTags(), this._fetchTimeEntriesPerRun()]).then(() => {
+        this._reloadCards();
+      });
+    },
+    _fetchTags() {
+      const url = getRouter().pluginRoute('pr_curves', '/tags');
+      return this._requestManager.request(url).then(runToTagToContent => {
+        const runToTag = _.mapValues(runToTagToContent, o => _.keys(o));
+        if (_.isEqual(runToTag, this._runToTag)) {
+          // No need to update anything if there are no changes.
+          return;
+        }
+        const tags = getTags(runToTag);
+        this.set('_dataNotFound', tags.length === 0);
+        this.set('_runToTag', runToTag);
+      });
+    },
+    _fetchTimeEntriesPerRun() {
+      const url = getRouter().pluginRoute(
+          'pr_curves', '/available_time_entries');
+      return this._requestManager.request(url).then(timeEntriesPerRun => {
+        // Compute the relative field for each time entry. For each step, the
+        // relative field is the number of seconds (float) since the first step.
+        _.forOwn(timeEntriesPerRun, (entries, run) => {
+          if (!entries.length) {
+            return;
+          }
+
+          _.forEach(entries, entry => {
+            entry['relative'] = entry.wall_time - entries[0].wall_time;
+          });
+        });
+
+        this.set('_runToAvailableTimeEntries', timeEntriesPerRun);
+
+        const listOfRuns = _.keys(timeEntriesPerRun).sort();
+        if (!_.isEqual(listOfRuns, this._runsWithPrCurveData)) {
+          this.set('_runsWithPrCurveData', listOfRuns);
+        }
+      });
+    },
+    _reloadCards() {
+      _.forEach(this.querySelectorAll('tf-pr-curve-card'), card => {
+        card.reload();
+      });
+    },
+    _makeCategories(runToTag, selectedRuns, tagFilter) {
+      return categorizeTags(runToTag, selectedRuns, tagFilter);
+    },
+    _computeColorForRun(run) {
+      return runsColorScale(run);
+    },
+    _computeRelevantSelectedRuns(selectedRuns, runToTag) {
+      return _.filter(selectedRuns, run => runToTag[run]);
+    },
+  });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
@@ -124,18 +124,9 @@ limitations under the License.
 
     <style include="dashboard-style"></style>
     <style>
-      #instructions {
-        width: 300px;
-      }
-      .tooltip-block-container {
-        display: inline-block;
-      }
       .no-data-warning {
         max-width: 540px;
         margin: 80px auto 0 auto;
-      }
-      .run-step-combo .run-text {
-        margin: 10px 0 0 0;
       }
       /** Not not let the steps selector occlude the run selector. */
       #steps-selector-container {

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
@@ -108,7 +108,7 @@ limitations under the License.
       // do not make this handler run when _runToStepIndex is updated because
       // asynchronously changing _runToStepIndex could create a rendering loop
       // and jittery sliders.
-      setTimeout(() => {
+      this.async(() => {
         this._updateSliders(this._runToStepIndex);
       }, 0);
     },
@@ -141,7 +141,7 @@ limitations under the License.
       } else if (timeDisplayType === 'wall_time') {
         return new Date(value * 1000).toString();
       }
-      console.error(
+      throw new Error(
           `The display type of ${timeDisplayType} is not recognized.`);
     },
     _sliderValueChanged(event) {
@@ -155,14 +155,26 @@ limitations under the License.
       return entries && entries.length ? entries.length - 1 : 0;
     },
     _runToAvailableTimeEntriesChanged(runToAvailableTimeEntries) {
-      // The step for each run just refreshed. Change every slider to point to
-      // the last available step.
+      // The mapping from run to available time entries just changed.
       const newRunToStepIndex = {};
+      let runAdded = false;
       _.forOwn(runToAvailableTimeEntries, (entries, run) => {
-        if (entries.length) {
+        if (!this._runToStepIndex ||
+            !_.isNumber(this._runToStepIndex[run])) {
+          // This run had previously lacked a slider. Initially set the slider
+          // for the run to point to the last step. This method directly uses
+          // this._runToStepIndex instead of accepting it as a parameter because
+          // this method later directly modifies _runToStepIndex.
           newRunToStepIndex[run] = entries.length - 1;
+          runAdded = true;
         }
       });
+
+      if (!runAdded) {
+        // Do not update sliders if no new runs had been added.
+        return;
+      }
+
       this.set('_runToStepIndex', newRunToStepIndex);
 
       // Set the values of all the sliders. They are not 2-way bound, so we must
@@ -170,12 +182,9 @@ limitations under the License.
       this._updateSliders(newRunToStepIndex);
     },
     _updateSliders(runToStepIndex) {
-      const sliders = this.querySelectorAll("paper-slider");
-      if (sliders) {
-        for (let i = 0; i < sliders.length; i++) {
-          const run = sliders[i].dataset.run;
-          sliders[i].value = runToStepIndex[run];
-        }
+      const sliders = this.querySelectorAll('paper-slider');
+      for (let i = 0; i < sliders.length; i++) {
+        sliders[i].value = sliders[i].dataset.run;
       }
     },
     _computeRunToStep(runToAvailableTimeEntries, runToStepIndex) {
@@ -183,7 +192,7 @@ limitations under the License.
       _.forOwn(runToStepIndex, (index, run) => {
         const entries = runToAvailableTimeEntries[run];
         if (!entries) {
-          return
+          return;
         }
         runToStep[run] = entries[index].step;
       });

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
@@ -1,0 +1,194 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../paper-slider/paper-slider.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-card-heading/tf-card-heading.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../tf-imports/lodash.html">
+
+<!--
+  Renders a UI for selecting a step.
+-->
+<dom-module id="tf-pr-curve-steps-selector">
+  <template>
+    <template is="dom-repeat" items="[[runs]]" as="run">
+      <div class="run-widget">
+        <div class="run-display-container">
+          <div class="run-color-box" style="background:[[_computeColorForRun(run)]];"></div>
+          <div class="run-text">
+            [[run]]
+          </div>
+        </div>
+        <div class="step-display-container">
+          [[_computeTimeTextForRun(runToAvailableTimeEntries, _runToStepIndex, run, timeDisplayType)]]
+        </div>
+        <paper-slider
+            data-run$="[[run]]"
+            step="1"
+            type="number"
+            min=0
+            max="[[_computeMaxStepIndexForRun(runToAvailableTimeEntries, run)]]"
+            ></paper-slider>
+      </div>
+    </template>
+    <style>
+      .run-widget {
+        margin: 10px 0 0 0;
+      }
+      paper-slider {
+        margin: -8px 0 0 -15px;
+        width: 100%;
+      }
+      .step-display-container {
+        font-size: 0.9em;
+        margin: 0 15px 0 0;
+      }
+      .run-text {
+        display: inline-block;
+      }
+      .run-color-box {
+        width: 12px;
+        height: 12px;
+        border-radius: 3px;
+        display: inline-block;
+      }
+    </style>
+  </template>
+  <script>
+  import {runsColorScale} from "../tf-color-scale/colorScale.js";
+
+  Polymer({
+    is: "tf-pr-curve-steps-selector",
+    properties: {
+      // A list of runs to create sliders for.
+      runs: Array,
+      // A mapping between run and list of steps to use for the slider for that
+      // run. This component indexes into this object to retrieve the steps.
+      runToAvailableTimeEntries: Object,
+      // The object mapping run to step. This object is updated by this
+      // component when the selected step for the run changes, so this property
+      // should be upward bound.
+      runToStep: {
+        type: Object,
+        notify: true,
+        computed: "_computeRunToStep(runToAvailableTimeEntries, _runToStepIndex)",
+      },
+      timeDisplayType: String,
+      // A mapping between run and slider index.
+      _runToStepIndex: Object,
+    },
+    listeners: {
+      "value-change": "_sliderValueChanged",
+      "immediate-value-change": "_sliderValueChanged",
+    },
+    observers: [
+      "_runsChanged(runs, _runToStepIndex)",
+      "_runToAvailableTimeEntriesChanged(runToAvailableTimeEntries)",
+    ],
+    ready() {
+      // Initialize the sliders so they point to the most recent value.
+      this._updateSliders(this._runToStepIndex);
+    },
+    _runsChanged(runs) {
+      // When selected runs change, make sure any new sliders point to the
+      // correct step. We use a setTimeout to add this operation to the end of
+      // the JS event queue so that it happens after the dom-repeat renders. We
+      // do not make this handler run when _runToStepIndex is updated because
+      // asynchronously changing _runToStepIndex could create a rendering loop
+      // and jittery sliders.
+      setTimeout(() => {
+        this._updateSliders(this._runToStepIndex);
+      }, 0);
+    },
+    _computeColorForRun(run) {
+      return runsColorScale(run);
+    },
+    _computeTimeTextForRun(
+        runToAvailableTimeEntries, runToStepIndex, run, timeDisplayType) {
+      const stepIndex = runToStepIndex[run];
+      if (!_.isNumber(stepIndex)) {
+        // The step is not known yet.
+        return '';
+      }
+
+      const entries = runToAvailableTimeEntries[run];
+      if (!entries) {
+        // No PR curve data has been received from the server yet.
+        return '';
+      }
+
+      const value = entries[stepIndex][timeDisplayType];
+      if (timeDisplayType === 'step') {
+        return `step ${value}`;
+      } else if (timeDisplayType === 'relative') {
+        // Return the time using the units that are most apt.
+        if (value < 1) {
+          return `${(value * 1000).toFixed(2)} ms`;
+        }
+        return `${value.toFixed(2)} s`;
+      } else if (timeDisplayType === 'wall_time') {
+        return new Date(value * 1000).toString();
+      }
+      console.error(
+          `The display type of ${timeDisplayType} is not recognized.`);
+    },
+    _sliderValueChanged(event) {
+      const run = event.target.dataset.run;
+      const newRunToStepIndex = _.clone(this._runToStepIndex);
+      newRunToStepIndex[run] = event.target.immediateValue;
+      this.set('_runToStepIndex', newRunToStepIndex);
+    },
+    _computeMaxStepIndexForRun(runToAvailableTimeEntries, run) {
+      const entries = runToAvailableTimeEntries[run];
+      return entries && entries.length ? entries.length - 1 : 0;
+    },
+    _runToAvailableTimeEntriesChanged(runToAvailableTimeEntries) {
+      // The step for each run just refreshed. Change every slider to point to
+      // the last available step.
+      const newRunToStepIndex = {};
+      _.forOwn(runToAvailableTimeEntries, (entries, run) => {
+        if (entries.length) {
+          newRunToStepIndex[run] = entries.length - 1;
+        }
+      });
+      this.set('_runToStepIndex', newRunToStepIndex);
+
+      // Set the values of all the sliders. They are not 2-way bound, so we must
+      // actually set them.
+      this._updateSliders(newRunToStepIndex);
+    },
+    _updateSliders(runToStepIndex) {
+      const sliders = this.querySelectorAll("paper-slider");
+      if (sliders) {
+        for (let i = 0; i < sliders.length; i++) {
+          const run = sliders[i].dataset.run;
+          sliders[i].value = runToStepIndex[run];
+        }
+      }
+    },
+    _computeRunToStep(runToAvailableTimeEntries, runToStepIndex) {
+      const runToStep = {};
+      _.forOwn(runToStepIndex, (index, run) => {
+        const entries = runToAvailableTimeEntries[run];
+        if (!entries) {
+          return
+        }
+        runToStep[run] = entries[index].step;
+      });
+      return runToStep;
+    },
+  });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
@@ -156,22 +156,22 @@ limitations under the License.
     },
     _runToAvailableTimeEntriesChanged(runToAvailableTimeEntries) {
       // The mapping from run to available time entries just changed.
-      const newRunToStepIndex = {};
-      let runAdded = false;
+      // This method directly uses this._runToStepIndex instead of
+      // accepting it as a parameter because this method later directly
+      // modifies _runToStepIndex.
+      const newRunToStepIndex = _.clone(this._runToStepIndex || {});
+      const runAdded = false;
       _.forOwn(runToAvailableTimeEntries, (entries, run) => {
-        if (!this._runToStepIndex ||
-            !_.isNumber(this._runToStepIndex[run])) {
+        if (!_.isNumber(newRunToStepIndex[run])) {
           // This run had previously lacked a slider. Initially set the slider
-          // for the run to point to the last step. This method directly uses
-          // this._runToStepIndex instead of accepting it as a parameter because
-          // this method later directly modifies _runToStepIndex.
+          // for the run to point to the last step.
           newRunToStepIndex[run] = entries.length - 1;
           runAdded = true;
         }
       });
 
       if (!runAdded) {
-        // Do not update sliders if no new runs had been added.
+        // No new runs added. Do not update sliders.
         return;
       }
 

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
@@ -94,20 +94,8 @@ limitations under the License.
       "immediate-value-change": "_sliderValueChanged",
     },
     observers: [
-      "_runsChanged(runs, _runToStepIndex)",
       "_runToAvailableTimeEntriesChanged(runToAvailableTimeEntries)",
     ],
-    _runsChanged(runs) {
-      // When selected runs change, make sure any new sliders point to the
-      // correct step. We use a setTimeout to add this operation to the end of
-      // the JS event queue so that it happens after the dom-repeat renders. We
-      // do not make this handler run when _runToStepIndex is updated because
-      // asynchronously changing _runToStepIndex could create a rendering loop
-      // and jittery sliders.
-      this.async(() => {
-        this._updateSliders(this._runToStepIndex);
-      }, 0);
-    },
     _computeColorForRun(run) {
       return runsColorScale(run);
     },
@@ -152,24 +140,17 @@ limitations under the License.
     },
     _runToAvailableTimeEntriesChanged(runToAvailableTimeEntries) {
       // The mapping from run to available time entries just changed.
-      // This method directly uses this._runToStepIndex instead of
-      // accepting it as a parameter because this method later directly
-      // modifies _runToStepIndex.
-      const newRunToStepIndex = _.clone(this._runToStepIndex || {});
-      let runAdded = false;
+      const newRunToStepIndex = {};
       _.forOwn(runToAvailableTimeEntries, (entries, run) => {
-        if (!_.isNumber(newRunToStepIndex[run])) {
+        if (!_.isNumber(this._runToStepIndex[run])) {
           // This run had previously lacked a slider. Initially set the slider
           // for the run to point to the last step.
           newRunToStepIndex[run] = entries.length - 1;
-          runAdded = true;
+        } else {
+          // The step for this run did not change.
+          newRunToStepIndex[run] = this._runToStepIndex[run];
         }
       });
-
-      if (!runAdded) {
-        // No new runs added. Do not update sliders.
-        return;
-      }
 
       this.set('_runToStepIndex', newRunToStepIndex);
 
@@ -178,9 +159,11 @@ limitations under the License.
       this._updateSliders(newRunToStepIndex);
     },
     _updateSliders(runToStepIndex) {
+      // When selected runs change, make sure any new sliders point to the
+      // correct step.
       const sliders = this.querySelectorAll('paper-slider');
       for (let i = 0; i < sliders.length; i++) {
-        sliders[i].value = sliders[i].dataset.run;
+        sliders[i].value = runToStepIndex[sliders[i].dataset.run];
       }
     },
     _computeRunToStep(runToAvailableTimeEntries, runToStepIndex) {

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
@@ -97,10 +97,6 @@ limitations under the License.
       "_runsChanged(runs, _runToStepIndex)",
       "_runToAvailableTimeEntriesChanged(runToAvailableTimeEntries)",
     ],
-    ready() {
-      // Initialize the sliders so they point to the most recent value.
-      this._updateSliders(this._runToStepIndex);
-    },
     _runsChanged(runs) {
       // When selected runs change, make sure any new sliders point to the
       // correct step. We use a setTimeout to add this operation to the end of

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
@@ -160,7 +160,7 @@ limitations under the License.
       // accepting it as a parameter because this method later directly
       // modifies _runToStepIndex.
       const newRunToStepIndex = _.clone(this._runToStepIndex || {});
-      const runAdded = false;
+      let runAdded = false;
       _.forOwn(runToAvailableTimeEntries, (entries, run) => {
         if (!_.isNumber(newRunToStepIndex[run])) {
           // This run had previously lacked a slider. Initially set the slider


### PR DESCRIPTION
This frontend for the PR curves plugin makes use of the `vz-line-chart` component that had been generalized in #388. Each `tf-pr-curve-card` contains 1 PR curve. The `tf-pr-curve-steps-selector` creates 1 slider per run and lets the user select steps.

This PR is a part of dividing #334 (which contains resourceful input from @wchargin) into smaller PRs.