### PR TITLE
Improve card header UI

### DIFF
--- a/tensorboard/components/tf_card_heading/BUILD
+++ b/tensorboard/components/tf_card_heading/BUILD
@@ -8,6 +8,9 @@ ts_web_library(
     name = "tf_card_heading",
     srcs = [
         "tf-card-heading.html",
+        "tf-card-heading-style.html",
+        "util.html",
+        "util.js",
     ],
     path = "/tf-card-heading",
     visibility = ["//visibility:public"],

--- a/tensorboard/components/tf_card_heading/tf-card-heading-style.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading-style.html
@@ -1,0 +1,47 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+  Shared stylesheet for figure captions.
+-->
+<dom-module id="tf-card-heading-style">
+  <template>
+    <style>
+
+      /** Horizontal line of labels. */
+      .row {
+        margin-top: -4px;
+        clear: both;
+      }
+
+      /** Piece of text in the figure caption. */
+      .label {
+        float: left;
+        margin-top: 4px;
+        /* TODO(@jart): Use proper width so overflow works. */
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
+
+      /** Makes label show on the right. */
+      .right {
+        float: right;
+        margin-left: 0.5em;
+      }
+    </style>
+  </template>
+</dom-module>

--- a/tensorboard/components/tf_card_heading/tf-card-heading-style.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading-style.html
@@ -23,13 +23,13 @@ limitations under the License.
     <style>
 
       /** Horizontal line of labels. */
-      tf-card-heading .row {
+      .heading-row {
         margin-top: -4px;
         clear: both;
       }
 
       /** Piece of text in the figure caption. */
-      tf-card-heading .label {
+      .heading-label {
         float: left;
         margin-top: 4px;
         /* TODO(@jart): Use proper width so overflow works. */
@@ -38,7 +38,7 @@ limitations under the License.
       }
 
       /** Makes label show on the right. */
-      tf-card-heading .right {
+      .heading-right {
         float: right;
         margin-left: 0.5em;
       }

--- a/tensorboard/components/tf_card_heading/tf-card-heading-style.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading-style.html
@@ -23,13 +23,13 @@ limitations under the License.
     <style>
 
       /** Horizontal line of labels. */
-      .row {
+      tf-card-heading .row {
         margin-top: -4px;
         clear: both;
       }
 
       /** Piece of text in the figure caption. */
-      .label {
+      tf-card-heading .label {
         float: left;
         margin-top: 4px;
         /* TODO(@jart): Use proper width so overflow works. */
@@ -38,7 +38,7 @@ limitations under the License.
       }
 
       /** Makes label show on the right. */
-      .right {
+      tf-card-heading .right {
         float: right;
         margin-left: 0.5em;
       }

--- a/tensorboard/components/tf_card_heading/tf-card-heading.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading.html
@@ -20,6 +20,8 @@ limitations under the License.
 <link rel="import" href="../paper-dialog-scrollable/paper-dialog-scrollable.html">
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-markdown-view/tf-markdown-view.html">
+<link rel="import" href="tf-card-heading-style.html">
+<link rel="import" href="util.html">
 
 <!--
   A compact heading to appear above a single visualization, summarizing
@@ -37,13 +39,31 @@ limitations under the License.
 -->
 <dom-module id="tf-card-heading">
   <template>
-    <div class="container" style="border-color: [[_borderColor]]">
-      <div class="content">
-        <template is="dom-repeat" items="[[_labels]]">
-          <span class="label">[[item]]</span>
+    <div class="container">
+      <figcaption class="content">
+        <div class="row">
+          <template is="dom-if" if="[[_nameLabel]]">
+            <div itemprop="name" class="label name">
+              [[_nameLabel]]
+            </div>
+          </template>
+          <template is="dom-if" if="[[run]]">
+            <div itemprop="run"
+                 class="label right run"
+                 style="background: [[_runBackground]]; color: [[_runColor]]">
+              [[run]]
+            </div>
+          </template>
+        </div>
+        <template is="dom-if" if="[[_tagLabel]]">
+          <div class="row">
+            <div class="label">
+              tag: <span itemprop="tag">[[_tagLabel]]</span>
+            </div>
+          </div>
         </template>
         <content></content>
-      </div>
+      </figcaption>
       <template is="dom-if" if="[[description]]">
         <paper-icon-button
           icon="info"
@@ -62,24 +82,24 @@ limitations under the License.
         </paper-dialog-scrollable>
       </paper-dialog>
     </div>
-    <style>
+    <style include="tf-card-heading-style">
       .container {
-        border-left: 4px solid;  /* border-color set as inline style */
-        padding-left: 5px;
-        margin-bottom: 10px;
         display: flex;
       }
       .content {
         font-size: 12px;
         flex-grow: 1;
       }
-      .label {
-        display: block;
-        text-overflow: ellipsis;
-        overflow: hidden;
-      }
-      .label:first-child {
+      .name {
         font-size: 14px;
+      }
+      .run {
+        font-size: 11px;
+        width: auto;
+        border-radius: 3px;
+        text-shadow: 0 -1px 0 rgba(0,0,0,0.25);
+        font-weight: bold;
+        padding: 1px 4px 2px;
       }
       paper-icon-button {
         flex-grow: 0;
@@ -90,6 +110,8 @@ limitations under the License.
     </style>
   </template>
   <script>
+    import {pickTextColor} from './util.js';
+
     Polymer({
       is: "tf-card-heading",
 
@@ -100,34 +122,45 @@ limitations under the License.
         description: {type: String, value: null},
         color: {type: String, value: null},  // a CSS color (e.g., '#abcdef')
 
-        _borderColor: {
+        _runBackground: {
           type: String,
-          computed: '_computeBorderColor(color)',
+          computed: '_computeRunBackground(color)',
           readOnly: true,
         },
-        /** @type {!Array<!string>} */
-        _labels: {
-          type: Array,
-          computed: '_computeLabels(displayName, tag, run)',
+
+        _runColor: {
+          type: String,
+          computed: '_computeRunColor(color)',
+          readOnly: true,
+        },
+
+        _nameLabel: {
+          type: String,
+          computed: '_computeNameLabel(displayName, tag)',
+        },
+
+        _tagLabel: {
+          type: String,
+          computed: '_computeTagLabel(displayName, tag)',
         },
       },
 
-      _computeBorderColor(color) {
-        return color || 'rgba(255, 255, 255, 0.0)';  // 100% transparent white
+      _computeRunBackground(color) {
+        return color || 'none';
       },
-      _computeLabels(displayName, tag, run) {
-        const results = [];
-        if (displayName) {
-          results.push(displayName);
-        }
-        if (tag && tag !== displayName) {
-          results.push(results.length ? `tag: ${tag}` : tag);
-        }
-        if (run) {
-          results.push(results.length ? `run: ${run}` : run);
-        }
-        return results;
+
+      _computeRunColor(color) {
+        return pickTextColor(color);
       },
+
+      _computeNameLabel(displayName, tag) {
+        return displayName || tag || '';
+      },
+
+      _computeTagLabel(displayName, tag) {
+        return tag && tag !== displayName ? tag : '';
+      },
+
       _toggleDescriptionDialog(e) {
         this.$.descriptionDialog.positionTarget = e.target;
         this.$.descriptionDialog.toggle();

--- a/tensorboard/components/tf_card_heading/tf-card-heading.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading.html
@@ -43,13 +43,13 @@ limitations under the License.
       <figcaption class="content">
         <div class="row">
           <template is="dom-if" if="[[_nameLabel]]">
-            <div itemprop="name" class="label name">
+            <div itemprop="name" class="heading-label name">
               [[_nameLabel]]
             </div>
           </template>
           <template is="dom-if" if="[[run]]">
             <div itemprop="run"
-                 class="label right run"
+                 class="heading-label heading-right run"
                  style="background: [[_runBackground]]; color: [[_runColor]]">
               [[run]]
             </div>
@@ -57,7 +57,7 @@ limitations under the License.
         </div>
         <template is="dom-if" if="[[_tagLabel]]">
           <div class="row">
-            <div class="label">
+            <div class="heading-label">
               tag: <span itemprop="tag">[[_tagLabel]]</span>
             </div>
           </div>
@@ -97,7 +97,6 @@ limitations under the License.
         font-size: 11px;
         width: auto;
         border-radius: 3px;
-        text-shadow: 0 -1px 0 rgba(0,0,0,0.25);
         font-weight: bold;
         padding: 1px 4px 2px;
       }

--- a/tensorboard/components/tf_card_heading/util.html
+++ b/tensorboard/components/tf_card_heading/util.html
@@ -1,0 +1,18 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script src="util.js"></script>

--- a/tensorboard/components/tf_card_heading/util.js
+++ b/tensorboard/components/tf_card_heading/util.js
@@ -1,0 +1,69 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/**
+ * Formats timestamp for the card header.
+ * @param {Date} date
+ * @return {string}
+ */
+export function formatDate(date) {
+  if (!date) {
+    return '';
+  }
+  // Turn things like "GMT-0700 (PDT)" into just "PDT".
+  return date.toString().replace(/GMT-\d+ \(([^)]+)\)/, '$1');
+}
+
+
+/**
+ * Returns CSS color that will contrast against background.
+ * @param {?string} background
+ * @return {string}
+ */
+export function pickTextColor(background) {
+  const rgb = convertHexToRgb(background);
+  if (!rgb) {
+    return 'inherit';
+  }
+  // See: http://www.w3.org/TR/AERT#color-contrast
+  const brightness = Math.round((rgb[0] * 299 +
+                                 rgb[1] * 587 +
+                                 rgb[2] * 114) / 1000);
+  return brightness > 125 ? 'inherit' : '#eee';
+}
+
+
+/**
+ * Turns a hex string into an RGB array.
+ * @param {?string} color
+ * @return {Array<number>}
+ */
+function convertHexToRgb(color) {
+  if (!color) {
+    return null;
+  }
+  let m = color.match(/^#([0-9a-f]{1,2})([0-9a-f]{1,2})([0-9a-f]{1,2})$/);
+  if (!m) {
+    return null;
+  }
+  if (color.length == 4) {
+    for (var i = 1; i <= 3; i++) {
+      m[i] = m[i] + m[i];
+    }
+  }
+  return [parseInt(m[1], 16),
+          parseInt(m[2], 16),
+          parseInt(m[3], 16)];
+}

--- a/tensorboard/components/tf_card_heading/util.js
+++ b/tensorboard/components/tf_card_heading/util.js
@@ -29,7 +29,7 @@ export function formatDate(date) {
 
 /**
  * Returns CSS color that will contrast against background.
- * @param {?string} background
+ * @param {?string} background RGB hex color code, e.g. #eee, #eeeeee.
  * @return {string}
  */
 export function pickTextColor(background) {
@@ -47,7 +47,7 @@ export function pickTextColor(background) {
 
 /**
  * Turns a hex string into an RGB array.
- * @param {?string} color
+ * @param {?string} color RGB hex color code, e.g. #eee, #eeeeee.
  * @return {Array<number>}
  */
 function convertHexToRgb(color) {

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
@@ -19,6 +19,8 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-card-heading/tf-card-heading.html">
+<link rel="import" href="../tf-card-heading/tf-card-heading-style.html">
+<link rel="import" href="../tf-card-heading/util.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
 <link rel="import" href="../tf-imports/d3.html">
@@ -39,25 +41,36 @@ backend.
       color="[[_runColor]]"
     >
       <template is="dom-if" if="[[_hasMultipleSamples]]">
-        <div>sample: [[_sampleText]] of [[totalSamples]]</div>
+        <div class="row">
+          <div class="label">
+            sample: [[_sampleText]] of [[totalSamples]]
+          </div>
+        </div>
       </template>
       <template is="dom-if" if="[[_hasAtLeastOneStep]]">
-        step
-        <span style="font-weight: bold">[[_currentDatum.step]]</span>
-        <template is="dom-if" if="[[_currentDatum.wall_time]]">
-          ([[_currentDatum.wall_time]])
-        </template>
+        <div class="row">
+          <div class="label">
+            step <strong>[[_currentDatum.step]]</strong>
+          </div>
+          <template is="dom-if" if="[[_currentDatum.wall_time]]">
+            <div class="label right">
+              [[_currentDatum.wall_time]]
+            </div>
+          </template>
+        </div>
       </template>
       <template is="dom-if" if="[[_hasMultipleSteps]]">
-        <paper-slider
-          id="steps"
-          immediate-value="{{_stepIndex}}"
-          max="[[_maxStepIndex]]"
-          max-markers="[[_maxStepIndex]]"
-          snaps
-          step="1"
-          value="{{_stepIndex}}"
-        ></paper-slider>
+        <div class="row">
+          <paper-slider
+              id="steps"
+              immediate-value="{{_stepIndex}}"
+              max="[[_maxStepIndex]]"
+              max-markers="[[_maxStepIndex]]"
+              snaps
+              step="1"
+              value="{{_stepIndex}}"
+          ></paper-slider>
+        </div>
       </template>
     </tf-card-heading>
     <template is="dom-if" if="[[_hasAtLeastOneStep]]">
@@ -72,7 +85,7 @@ backend.
     <div id="main-audio-container">
     </div>
 
-    <style>
+    <style include="tf-card-heading-style">
       :host {
         display: block;
         width: 350px;
@@ -103,6 +116,7 @@ backend.
     "use strict";
     import {Canceller} from "../tf-backend/canceller.js";
     import {getRouter} from "../tf-backend/router.js";
+    import {formatDate} from '../tf-card-heading/util.js';
     import {runsColorScale} from "../tf-color-scale/colorScale.js";
     import * as urlPathHelpers from "../tf-backend/urlPathHelpers.js";
 
@@ -235,7 +249,7 @@ backend.
           individualAudioURL += `&ts=${audioMetadata.wall_time}`;
         }
         return {
-          wall_time: new Date(audioMetadata.wall_time * 1000).toString(),
+          wall_time: formatDate(new Date(audioMetadata.wall_time * 1000)),
           step: audioMetadata.step,
           label: audioMetadata.label,
           contentType: audioMetadata.contentType,

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
@@ -41,26 +41,26 @@ backend.
       color="[[_runColor]]"
     >
       <template is="dom-if" if="[[_hasMultipleSamples]]">
-        <div class="row">
-          <div class="label">
+        <div class="heading-row">
+          <div class="heading-label">
             sample: [[_sampleText]] of [[totalSamples]]
           </div>
         </div>
       </template>
       <template is="dom-if" if="[[_hasAtLeastOneStep]]">
-        <div class="row">
-          <div class="label">
+        <div class="heading-row">
+          <div class="heading-label">
             step <strong>[[_currentDatum.step]]</strong>
           </div>
           <template is="dom-if" if="[[_currentDatum.wall_time]]">
-            <div class="label right">
+            <div class="heading-label heading-right">
               [[_currentDatum.wall_time]]
             </div>
           </template>
         </div>
       </template>
       <template is="dom-if" if="[[_hasMultipleSteps]]">
-        <div class="row">
+        <div class="heading-row">
           <paper-slider
               id="steps"
               immediate-value="{{_stepIndex}}"

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-loader.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-loader.html
@@ -79,6 +79,10 @@ limitations under the License.
       paper-icon-button[selected] {
         background: var(--tb-ui-light-accent);
       }
+
+      tf-card-heading {
+        margin-bottom: 10px;
+      }
     </style>
   </template>
   <script>

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
@@ -79,8 +79,14 @@ limitations under the License.
         height: 32px;
         padding: 4px;
       }
+
       paper-icon-button[selected] {
         background: var(--tb-ui-light-accent);
+      }
+
+      tf-card-heading {
+        margin-bottom: 10px;
+        width: 90%;
       }
     </style>
   </template>

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -21,6 +21,8 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-card-heading/tf-card-heading.html">
+<link rel="import" href="../tf-card-heading/tf-card-heading-style.html">
+<link rel="import" href="../tf-card-heading/util.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
 <link rel="import" href="../tf-imports/d3.html">
@@ -45,14 +47,19 @@ future for loading older images.
         <div>sample: [[_sampleText]] of [[ofSamples]]</div>
       </template>
       <template is="dom-if" if="[[_hasAtLeastOneStep]]">
-        <div>
-          step
-          <span style="font-weight: bold">[[_stepValue]]</span>
-          <template is="dom-if" if="[[_currentWallTime]]">
-            ([[_currentWallTime]])
-          </template>
-          <paper-spinner-lite active hidden$=[[!_isImageLoading]]>
-          </paper-spinner-lite>
+        <div class="row">
+          <div class="label">
+            step <span style="font-weight: bold">[[_stepValue]]</span>
+          </div>
+          <div class="label right">
+            <template is="dom-if" if="[[_currentWallTime]]">
+              [[_currentWallTime]]
+            </template>
+          </div>
+          <div class="label right">
+            <paper-spinner-lite active hidden$=[[!_isImageLoading]]>
+            </paper-spinner-lite>
+          </div>
         </div>
       </template>
       <template is="dom-if" if="[[_hasMultipleSteps]]">
@@ -74,7 +81,7 @@ future for loading older images.
             id="main-image-container"
             on-tap="_handleTap"></button>
 
-    <style>
+    <style include="tf-card-heading-style">
       /** Make button a div. */
       button {
         width: 100%;
@@ -176,6 +183,7 @@ future for loading older images.
     "use strict";
     import {Canceller} from "../tf-backend/canceller.js";
     import {getRouter} from "../tf-backend/router.js";
+    import {formatDate} from '../tf-card-heading/util.js';
     import {runsColorScale} from "../tf-color-scale/colorScale.js";
     import * as urlPathHelpers from "../tf-backend/urlPathHelpers.js";
 
@@ -276,7 +284,7 @@ future for loading older images.
         return this._steps[stepIndex].step;
       },
       _computeCurrentWallTime(stepIndex) {
-        return this._steps[stepIndex].wall_time.toString();
+        return formatDate(this._steps[stepIndex].wall_time);
       },
       _computeMaxStepIndex(steps) {
         return steps.length - 1;

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -47,11 +47,11 @@ future for loading older images.
         <div>sample: [[_sampleText]] of [[ofSamples]]</div>
       </template>
       <template is="dom-if" if="[[_hasAtLeastOneStep]]">
-        <div class="row">
-          <div class="label">
+        <div class="heading-row">
+          <div class="heading-label">
             step <span style="font-weight: bold">[[_stepValue]]</span>
           </div>
-          <div class="label right">
+          <div class="heading-label heading-right">
             <template is="dom-if" if="[[_currentWallTime]]">
               [[_currentWallTime]]
             </template>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
@@ -146,6 +146,10 @@ limitations under the License.
         background: var(--tb-ui-light-accent);
       }
 
+      tf-card-heading {
+        margin-bottom: 10px;
+      }
+
       .download-links {
         display: flex;
         height: 32px;

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
@@ -85,6 +85,10 @@ tf-text-loader displays markdown text data from the Text plugin.
       .step-container:not(:first-child) {
         margin-top: 15px;
       }
+
+      tf-card-heading {
+        margin-bottom: 10px;
+      }
     </style>
   </template>
   <script>


### PR DESCRIPTION
This change improves the aesthetics of figure captions. It makes the information seem less crowded, while also freeing up vertical space. The improvement looks the best on the image dashboard.

Before:

![image](https://user-images.githubusercontent.com/49262/29755290-c5bea4a4-8b4a-11e7-8b27-5c0d2ffb1933.png)

After:

![image](https://user-images.githubusercontent.com/49262/29755282-adc99b42-8b4a-11e7-86b6-20779c33bef9.png)
