### PR TITLE
Add stripes to the background of function metanodes

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
@@ -48,42 +48,53 @@ limitations under the License.
 
 /* --- Node and annotation-node for Metanode --- */
 
-::content .meta > .nodeshape > rect,
-::content .meta > .annotation-node > rect {
-  cursor: pointer;
+::content .meta > .nodeshape > rect.nodecolortarget,
+::content .meta > .annotation-node > rect.nodecolortarget {
   fill: hsl(0, 0%, 70%);
 }
 
-::content .node.meta.highlighted > .nodeshape > rect,
-::content .node.meta.highlighted > .annotation-node > rect {
+::content .meta > .nodeshape > rect.function-indicator-layer,
+::content .meta > .annotation-node > rect.function-indicator-layer {
+  fill: url(#stripe-pattern);
+  fill-opacity: 0.07;
+}
+
+::content .node.meta > .nodeshape > rect.event-handling-layer,
+::content .node.meta > .annotation-node > rect.event-handling-layer {
+  cursor: pointer;
+  fill-opacity: 0;
+}
+
+::content .node.meta.highlighted > .nodeshape > rect.event-handling-layer,
+::content .node.meta.highlighted > .annotation-node > rect.event-handling-layer {
   stroke-width: 2;
 }
 
-::content .annotation.meta.highlighted > .nodeshape > rect,
-::content .annotation.meta.highlighted > .annotation-node > rect {
+::content .annotation.meta.highlighted > .nodeshape > rect.event-handling-layer,
+::content .annotation.meta.highlighted > .annotation-node > rect.event-handling-layer {
   stroke-width: 1;
 }
 
-::content .meta.selected > .nodeshape > rect,
-::content .meta.selected > .annotation-node > rect {
+::content .meta.selected > .nodeshape > rect.event-handling-layer,
+::content .meta.selected > .annotation-node > rect.event-handling-layer {
   stroke: red;
   stroke-width: 2;
 }
 
-::content .node.meta.selected.expanded > .nodeshape > rect,
-::content .node.meta.selected.expanded > .annotation-node > rect {
+::content .node.meta.selected.expanded > .nodeshape > rect.event-handling-layer,
+::content .node.meta.selected.expanded > .annotation-node > rect.event-handling-layer {
   stroke: red;
   stroke-width: 3;
 }
 
-::content .annotation.meta.selected > .nodeshape > rect,
-::content .annotation.meta.selected > .annotation-node > rect {
+::content .annotation.meta.selected > .nodeshape > rect.event-handling-layer,
+::content .annotation.meta.selected > .annotation-node > rect.event-handling-layer {
   stroke: red;
   stroke-width: 2;
 }
 
-::content .node.meta.selected.expanded.highlighted > .nodeshape > rect,
-::content .node.meta.selected.expanded.highlighted > .annotation-node > rect {
+::content .node.meta.selected.expanded.highlighted > .nodeshape > rect.event-handling-layer,
+::content .node.meta.selected.expanded.highlighted > .annotation-node > rect.event-handling-layer {
   stroke: red;
   stroke-width: 4;
 }
@@ -630,6 +641,15 @@ limitations under the License.
         <feMergeNode in="SourceGraphic"/>
       </feMerge>
     </filter>
+
+    <!-- A striped background pattern. -->
+    <pattern id="stripe-pattern"
+             width="6"
+             height="6"
+             patternTransform="rotate(45)"
+             patternUnits="userSpaceOnUse">
+      <rect width="3" height="6" fill="#000"></rect>
+    </pattern>
   </defs>
   <!-- Make a large rectangle that fills the svg space so that
   zoom events get captured on safari -->

--- a/tensorboard/plugins/graph/tf_graph_common/scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/scene.ts
@@ -26,6 +26,10 @@ module tf.graph.scene {
       SHAPE: 'nodeshape',
       // <*> element(s) under SHAPE that should receive color updates.
       COLOR_TARGET: 'nodecolortarget',
+      // The layer (or shape in the stack) that handles events (clicks, etc).
+      EVENT_HANDLING_LAYER: 'event-handling-layer',
+      // The layer that visually distinguishes a shape as a TensorFlow function.
+      FUNCTION_INDICATOR_LAYER: 'function-indicator-layer',
       // <text> element showing the node's label.
       LABEL: 'nodelabel',
       // <g> element that contains all visuals for the expand/collapse
@@ -506,7 +510,7 @@ export function translate(selection, x0: number, y0: number) {
 
 /**
  * Helper for setting position of a svg rect
- * @param rect rect to set position of.
+ * @param rect A d3 selection of rect(s) to set position of.
  * @param cx Center x.
  * @param cy Center x.
  * @param width Width to set.


### PR DESCRIPTION
We use a striped background to differentiate metanodes that represent functions. This is accomplished via an SVG pattern, which requires no special background image.

We use 3 rects all overlaid atop each other to render the metanode. The first one renders the color (for structure, device, etc). The second one renders the striped pattern (and is semi-transparent). The last one (on top of the other 2) handles mouse events.