### PR TITLE
graph] Use 0 as the minimum memory/time in the color scale.

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -235,17 +235,26 @@ export class RenderGraphInfo {
         .domain(memoryExtent)
         .range(PARAMS.minMaxColors);
 
-    // Find also the minimum and maximum compute time.
-    let computeTimeExtent = d3.extent(topLevelGraph.nodes(),
-        (nodeName, index) => {
-      let node = topLevelGraph.node(nodeName);
+    // Find the maximum and minimum compute time in the whole graph.
+    let minMicros = null;
+    let maxMicros = null;
+    _.each(this.hierarchy.getNodeMap(), (node, nodeName) => {
       // Some ops don't have stats at all.
       if (node.stats != null) {
-        return node.stats.getTotalMicros();
+        let m = node.stats.getTotalMicros();
+        if (m == null) {
+          return;
+        }
+        if (minMicros == null || minMicros > m) {
+          minMicros = m;
+        }
+        if (maxMicros == null || maxMicros < m) {
+          maxMicros = m;
+        }
       }
     });
     this.computeTimeScale = d3.scaleLinear<string, string>()
-        .domain(computeTimeExtent)
+        .domain([minMicros, maxMicros])
         .range(PARAMS.minMaxColors);
 
     this.edgeWidthScale = this.hierarchy.hasShapeInfo ?

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -222,8 +222,8 @@ export class RenderGraphInfo {
                 MetanodeColors.XLA_CLUSTER_PALETTE));
 
     let topLevelGraph = this.hierarchy.root.metagraph;
-    // Find the maximum and minimum memory usage.
-    let memoryExtent = d3.extent(topLevelGraph.nodes(),
+    // Find the maximum memory usage. Use 0 as the minimum.
+    let maxMemory = d3.max(topLevelGraph.nodes(),
         (nodeName, index) => {
       let node = topLevelGraph.node(nodeName);
       // Some ops don't have stats at all.
@@ -232,29 +232,20 @@ export class RenderGraphInfo {
       }
     });
     this.memoryUsageScale = d3.scaleLinear<string, string>()
-        .domain(memoryExtent)
+        .domain([0, maxMemory])
         .range(PARAMS.minMaxColors);
 
-    // Find the maximum and minimum compute time in the whole graph.
-    let minMicros = null;
-    let maxMicros = null;
-    _.each(this.hierarchy.getNodeMap(), (node, nodeName) => {
+    // Find the maximum compute time. Use 0 as the minimum.
+    let maxComputeTime = d3.max(topLevelGraph.nodes(),
+        (nodeName, index) => {
+      let node = topLevelGraph.node(nodeName);
       // Some ops don't have stats at all.
       if (node.stats != null) {
-        let m = node.stats.getTotalMicros();
-        if (m == null) {
-          return;
-        }
-        if (minMicros == null || minMicros > m) {
-          minMicros = m;
-        }
-        if (maxMicros == null || maxMicros < m) {
-          maxMicros = m;
-        }
+        return node.stats.getTotalMicros();
       }
     });
     this.computeTimeScale = d3.scaleLinear<string, string>()
-        .domain([minMicros, maxMicros])
+        .domain([0, maxComputeTime])
         .range(PARAMS.minMaxColors);
 
     this.edgeWidthScale = this.hierarchy.hasShapeInfo ?


### PR DESCRIPTION
When calculating the color scale for the compute time, consider all nodes in the graph instead of just the nodes in the top-level graph. 

I have a graph with one single sub-graph, which consumes all the compute time (say X ms), in the top-level graph, so the color scale becomes "X ms -> X ms". 

Not sure about the original intention of the top-level graph; let me know if this is the right fix.

(I don't really know typescript. Please let me know if there is more efficient way to get  the extent of a map :)