### PR TITLE
fix type annotation for typescript 2.4

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/parser.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/parser.ts
@@ -211,7 +211,7 @@ export function parseStatsPbTxt(input: ArrayBuffer):
  */
 function parsePbtxtFile(
     input: ArrayBuffer,
-    repeatedFields: {[attrPath: string]: boolean}): Promise<Object> {
+    repeatedFields: {[attrPath: string]: boolean}): Promise<any> {
   let output: { [name: string]: any; } = {};
   let stack = [];
   let path: string[] = [];


### PR DESCRIPTION
TypeScript 2.4 has more strict type checking around Promises;
the current code fails with:

.../tf-graph-common/parser.ts(192,3): error TS2322: Type 'Promise<Object>' is not assignable to type 'Promise<NodeDef[]>'.
  Type 'Object' is not assignable to type 'NodeDef[]'.
    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
      Property 'length' is missing in type 'Object'.

This function is declaring that it returns an arbitrary object, which in TypeScript
is written "any".