### PR TITLE
Mark certain fields as repeated

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -1157,17 +1157,7 @@ export function build(
 
             if (graphDef.library && graphDef.library.function) {
               // This graph contains functions.
-              if (graphDef.library.function['length'] >= 0) {
-                // The graph has several functions.
-                _.each(
-                  graphDef.library.function as tf.graph.proto.FunctionDef[],
-                  processFunction);
-              } else {
-                // The graph has 1 function. In that case, the function property
-                // is a single function (not an array).
-                processFunction(
-                  graphDef.library.function as tf.graph.proto.FunctionDef);
-              }
+              _.each(graphDef.library.function, processFunction);
             }
 
             opNodes.splice(index);

--- a/tensorboard/plugins/graph/tf_graph_common/parser.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/parser.ts
@@ -164,6 +164,11 @@ export function streamParse(
  * object.
  */
 const GRAPH_REPEATED_FIELDS: {[attrPath: string]: boolean} = {
+  'library.function': true,
+  'library.function.node_def': true,
+  'library.function.signature.input_arg': true,
+  'library.function.signature.output_arg': true,
+  'library.versions': true,
   'node': true,
   'node.input': true,
   'node.attr': true,

--- a/tensorboard/plugins/graph/tf_graph_common/proto.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/proto.ts
@@ -21,7 +21,7 @@ limitations under the License.
  * These should stay in sync.
  * 
  * When adding a repeated field to this file, make sure to update the
- * GRAPH_REPEATED_FIELDS and METADATA_REPEATED_FIELDS within parser.ts.
+ * GRAPH_REPEATED_FIELDS and METADATA_REPEATED_FIELDS lists within parser.ts.
  * Otherwise, the parser has no way of differentiating between a field with a
  * certain value and a repeated field that has only 1 occurence, resulting in
  * subtle bugs.

--- a/tensorboard/plugins/graph/tf_graph_common/proto.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/proto.ts
@@ -19,6 +19,12 @@ limitations under the License.
  *     graph.proto
  *     step_stats.proto
  * These should stay in sync.
+ * 
+ * When adding a repeated field to this file, make sure to update the
+ * GRAPH_REPEATED_FIELDS and METADATA_REPEATED_FIELDS within parser.ts.
+ * Otherwise, the parser has no way of differentiating between a field with a
+ * certain value and a repeated field that has only 1 occurence, resulting in
+ * subtle bugs.
  */
 module tf.graph.proto {
   /**
@@ -88,7 +94,7 @@ module tf.graph.proto {
    */
   export interface FunctionDefLibraryDef {
     // A list of functions.
-    function: FunctionDef | FunctionDef[];
+    function: FunctionDef[];
   };
 
   /**


### PR DESCRIPTION
This allows the graph explorer to successfully parse repeated fields.
Without this change, the parser cannot differentiate between a
non-repeated field vs. a repeated field with a single value.

That results in some subtle bugs. For instance, logic might iterate over
the characters of a string instead of across strings.