### PR TITLE
Make PR curve summary visible to public

### DIFF
--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -55,6 +55,9 @@ py_library(
     name = "summary",
     srcs = ["summary.py"],
     srcs_version = "PY2AND3",
+    visibility = [
+        "//visibility:public",
+    ],
     deps = [
         ":metadata",
         "//tensorboard:expect_tensorflow_installed",


### PR DESCRIPTION
Made the BUILD target for the PR curve summary op visible to other packages. Otherwise, no code outside of TensorBoard can use it.