### PR TITLE
Expose the tag-info aggregation logic

### DIFF
--- a/tensorboard/components/tf_utils/BUILD
+++ b/tensorboard/components/tf_utils/BUILD
@@ -1,0 +1,15 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "ts_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+ts_web_library(
+    name = "tf_utils",
+    srcs = [
+        "utils.ts",
+        "tf-utils.html",
+    ],
+    path = "/tf-utils",
+    visibility = ["//visibility:public"],
+)

--- a/tensorboard/components/tf_utils/tf-utils.html
+++ b/tensorboard/components/tf_utils/tf-utils.html
@@ -1,0 +1,18 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script src="utils.js"></script>

--- a/tensorboard/components/tf_utils/utils.ts
+++ b/tensorboard/components/tf_utils/utils.ts
@@ -1,0 +1,101 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/*
+ * Miscellaneous utilities that may be useful to plugin frontends.
+ */
+
+export interface TagInfo {
+    displayName: string;
+    description: string;
+}
+
+/**
+ * Given many occurrences of tag info for a particular tag across
+ * multiple runs, create a representative info object. This is useful
+ * for plugins that display just one visualization per tag, instead of
+ * one per run--tag combination: each run--tag combination can have its
+ * own display name or description, so there is a dimension mismatch. We
+ * reconcile this as follows:
+ *
+ *   - We only show a display name if all runs agree. Otherwise, or if
+ *     there are no runs, we use the provided `defaultDisplayName`.
+ *
+ *   - If all runs agree on a description, we use it. Otherwise,
+ *     we concatenate all descriptions, annotating which ones
+ *     came from which run, and display them in a list.
+ *
+ * NOTE: Per TensorBoard convention, we assume that the provided
+ * `description`s have sanitized HTML and are safe to render into the
+ * DOM, while the `displayName` may be an arbitrary string. The output
+ * of this function respects this convention as well.
+ */
+export function aggregateTagInfo(
+    runToTagInfo: {[run: string]: TagInfo}, defaultDisplayName: string): TagInfo {
+  let unanimousDisplayName: string | null | undefined = undefined;
+  const descriptionToRuns: {[description: string]: string[]} = {};
+  Object.keys(runToTagInfo).forEach(run => {
+    const info = runToTagInfo[run];
+    if (unanimousDisplayName === undefined) {
+      unanimousDisplayName = info.displayName;
+    }
+    if (unanimousDisplayName !== info.displayName) {
+      unanimousDisplayName = null;
+    }
+    if (descriptionToRuns[info.description] === undefined) {
+      descriptionToRuns[info.description] = [];
+    }
+    descriptionToRuns[info.description].push(run);
+  });
+  const displayName =
+    unanimousDisplayName != null ?
+    unanimousDisplayName :
+    defaultDisplayName;
+  const description = (() => {
+    const descriptions = Object.keys(descriptionToRuns);
+    if (descriptions.length === 0) {
+      return '';
+    } else if (descriptions.length === 1) {
+      return descriptions[0];
+    } else {
+      const items = descriptions.map(description => {
+        const runs = descriptionToRuns[description].map(run => {
+          // We're splicing potentially unsafe display names into
+          // sanitized descriptions, so we need to sanitize them.
+          const safeRun = run
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')  // for symmetry :-)
+            .replace(/&/g, '&amp;');
+          return `<code>${safeRun}</code>`;
+        });
+        const joined = runs.length > 2 ?
+          (runs.slice(0, runs.length - 1).join(', ')
+            + ', and ' + runs[runs.length - 1]) :
+          runs.join(' and ');
+        const runNoun = ngettext(runs.length, 'run', 'runs');
+        return `<li><p>For ${runNoun} ${joined}:</p>${description}</li>`;
+      });
+      const prefix = '<p><strong>Multiple descriptions:</strong></p>';
+      return `${prefix}<ul>${items.join('')}</ul>`;
+    }
+  })();
+  return {displayName, description};
+}
+
+function ngettext(k: number, enSingular: string, enPlural: string): string {
+  // Potential extension point for proper i18n infrastructure, if we
+  // ever implement it.
+  return k === 1 ? enSingular : enPlural;
+}

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -24,6 +24,7 @@ ts_web_library(
         "//tensorboard/components/tf_paginated_view",
         "//tensorboard/components/tf_runs_selector",
         "//tensorboard/components/tf_storage",
+        "//tensorboard/components/tf_utils",
         "//tensorboard/components/vz_line_chart",
         "@org_polymer_iron_collapse",
         "@org_polymer_iron_icon",

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -33,6 +33,7 @@ limitations under the License.
 <link rel="import" href="../tf-paginated-view/tf-paginated-view.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 <link rel="import" href="../tf-storage/tf-storage.html">
+<link rel="import" href="../tf-utils/tf-utils.html">
 <link rel="import" href="tf-scalar-chart.html">
 <link rel="import" href="tf-smoothing-input.html">
 
@@ -189,10 +190,11 @@ limitations under the License.
   </template>
 
   <script>
-    import {RequestManager} from '../tf-backend/requestManager.js';
-    import {getTags} from '../tf-backend/backend.js';
-    import {getRouter} from '../tf-backend/router.js';
+    import {aggregateTagInfo} from '../tf-utils/utils.js';
     import {categorizeTags} from '../tf-categorization-utils/categorizationUtils.js';
+    import {getRouter} from '../tf-backend/router.js';
+    import {getTags} from '../tf-backend/backend.js';
+    import {RequestManager} from '../tf-backend/requestManager.js';
     import * as storage from '../tf-storage/storage.js';
 
     /** @enum {string} */ const X_TYPE = {
@@ -292,65 +294,15 @@ limitations under the License.
         const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
         return categorizeTags(runToTag, selectedRuns, tagFilter);
       },
-      _tagMetadata(runToTagInfo, runs, tag) {
-        /*
-         * Each run--tag combination may have its own display name and
-         * description, but we display just one chart per tag: this is a
-         * dimension mismatch. We reconcile this as follows:
-         *
-         *   - We only show a display name if all runs agree. Otherwise,
-         *     we use the tag name without the "/scalar_summary" suffix.
-         *
-         *   - If all runs agree on a description, we use it. Otherwise,
-         *     we concatenate all descriptions, annotating which ones
-         *     came from which run, and display them in a list.
-         */
-        let unanimousDisplayName = undefined;
-        const descriptionToRuns = {};  // from description to runs it appears in
+      _tagMetadata(runToTagsInfo, runs, tag) {
+        const runToTagInfo = {};
         runs.forEach(run => {
-          const info = runToTagInfo[run][tag];
-          if (unanimousDisplayName === undefined) {
-            unanimousDisplayName = info.displayName;
-          }
-          if (unanimousDisplayName !== info.displayName) {
-            unanimousDisplayName = null;
-          }
-          if (descriptionToRuns[info.description] === undefined) {
-            descriptionToRuns[info.description] = [];
-          }
-          descriptionToRuns[info.description].push(run);
+            runToTagInfo[run] = runToTagsInfo[run][tag];
         });
-        const displayName =
-          unanimousDisplayName !== null ?
-          unanimousDisplayName :
-          tag.replace(/\/scalar_summary$/, '');
-        const description = (() => {
-          const descriptions = Object.keys(descriptionToRuns);
-          if (descriptions.length === 0) {
-            return '';
-          } else if (descriptions.length === 1) {
-            return descriptions[0];
-          } else {
-            const items = descriptions.map(description => {
-              const runs = descriptionToRuns[description].map(run => {
-                const safeRun = run
-                  .replace(/</g, '&lt;')
-                  .replace(/>/g, '&gt;')  // for symmetry :-)
-                  .replace(/&/g, '&amp;');
-                return `<code>${safeRun}</code>`;
-              });
-              const joined = runs.length > 2 ?
-                (runs.slice(0, runs.length - 1).join(', ')
-                  + ', and ' + runs[runs.length - 1]) :
-                runs.join(' and ');
-              const runNoun = runs.length === 1 ? 'run' : 'runs';
-              return `<li><p>For ${runNoun} ${joined}:</p>${description}</li>`;
-            });
-            const prefix = '<p><strong>Multiple descriptions:</strong></p>';
-            return `${prefix}<ul>${items.join('')}</ul>`;
-          }
-        })();
-        return {displayName, description};
+        // All new-style scalar tags include the `/scalar_summary`
+        // suffix. We can trim that from the display name.
+        const defaultDisplayName = tag.replace(/\/scalar_summary$/, '');
+        return aggregateTagInfo(runToTagInfo, defaultDisplayName);
       },
     });
   </script>


### PR DESCRIPTION
Summary:
Plugins that render one visualization per tag may need to aggregate
information across multiple runs. This commit generalizes that logic
from the scalar plugin to a `tf-utils` module, so that it can be used in
other similar plugins. This is particularly worthwhile because it
contains some security-sensitive code (HTML sanitization).

Test Plan:
Verified that the current behavior of the scalar dashboard is maintained
in the following cases:
  - A tag with a display name.
  - A tag with no display name.
  - A tag with no selected runs, and so no descriptions.
  - A tag with one or multiple selected runs that all have identical
    descriptions.
  - A tag with differing descriptions.

wchargin-branch: expose-tag-info-aggregation