### PR TITLE
Modify dashboard mapping to take object values

### DIFF
--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -35,7 +35,10 @@ ts_web_library(
 
 ts_web_library(
     name = "default_plugins",
-    srcs = ["default-plugins.html"],
+    srcs = [
+        "default-plugins.html",
+        "default-plugins.ts",
+    ],
     path = "/tf-tensorboard",
     visibility = ["//visibility:public"],
     deps = [

--- a/tensorboard/components/tf_tensorboard/default-plugins.html
+++ b/tensorboard/components/tf_tensorboard/default-plugins.html
@@ -28,17 +28,4 @@ limitations under the License.
 <link rel="import" href="../vz-projector/vz-projector-dashboard.html">
 
 <!-- Tell tf-tensorboard what plugins exist. -->
-<script>
-  const TENSORBOARD_PLUGINS = {
-    'scalars': 'tf-scalar-dashboard',
-    'images': 'tf-image-dashboard',
-    'audio': 'tf-audio-dashboard',
-    'graphs': 'tf-graph-dashboard',
-    'distributions': 'tf-distribution-dashboard',
-    'histograms': 'tf-histogram-dashboard',
-    'projector': 'vz-projector-dashboard',
-    'text': 'tf-text-dashboard',
-    'pr_curves': 'tf-pr-curve-dashboard',
-    'profile': 'tf-profile-dashboard',
-  };
-</script>
+<script src="default-plugins.js"></script>

--- a/tensorboard/components/tf_tensorboard/default-plugins.ts
+++ b/tensorboard/components/tf_tensorboard/default-plugins.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-export interface DashboardInformation {
+export interface DashboardData {
   // The name of the element for the dashboard (excluding the angle brackets on
   // either side). For instance, tf-scalar-dashboard. Used to select the correct
   // dashboard when a user enters it.
@@ -31,9 +31,8 @@ export interface DashboardInformation {
   tabName: string;
 }
 
-// Maps plugin name (must match the backend) to DashboardInformation.
-const PLUGIN_TO_DASHBOARD_INFORMATION
-    : {[key: string]: DashboardInformation} = {
+// Maps plugin name (must match the backend) to DashboardData.
+const PLUGIN_TO_DASHBOARD_DATA : {[key: string]: DashboardData} = {
   'scalars': {
     elementName: 'tf-scalar-dashboard',
     plugin: 'scalars',
@@ -85,3 +84,11 @@ const PLUGIN_TO_DASHBOARD_INFORMATION
     tabName: 'Profile',
   },
 };
+
+// The key for each entry in the mapping above must match the corresponding
+// plugin string property.
+_.forOwn(PLUGIN_TO_DASHBOARD_DATA, (data, plugin) => {
+  if (data.plugin !== plugin) {
+    throw new Error(`Plugin name mismatch for key: ${plugin}`);
+  }
+});

--- a/tensorboard/components/tf_tensorboard/default-plugins.ts
+++ b/tensorboard/components/tf_tensorboard/default-plugins.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-export interface DashboardData {
+export interface DashboardDatum {
   // The name of the element for the dashboard (excluding the angle brackets on
   // either side). For instance, tf-scalar-dashboard. Used to select the correct
   // dashboard when a user enters it.
@@ -31,8 +31,8 @@ export interface DashboardData {
   tabName: string;
 }
 
-// Maps plugin name (must match the backend) to DashboardData.
-const PLUGIN_TO_DASHBOARD_DATA : {[key: string]: DashboardData} = {
+// Maps plugin name (must match the backend) to DashboardDatum.
+const PLUGIN_TO_DASHBOARD_DATUM : {[key: string]: DashboardDatum} = {
   'scalars': {
     elementName: 'tf-scalar-dashboard',
     plugin: 'scalars',
@@ -87,7 +87,7 @@ const PLUGIN_TO_DASHBOARD_DATA : {[key: string]: DashboardData} = {
 
 // The key for each entry in the mapping above must match the corresponding
 // plugin string property.
-_.forOwn(PLUGIN_TO_DASHBOARD_DATA, (data, plugin) => {
+_.forOwn(PLUGIN_TO_DASHBOARD_DATUM, (data, plugin) => {
   if (data.plugin !== plugin) {
     throw new Error(`Plugin name mismatch for key: ${plugin}`);
   }

--- a/tensorboard/components/tf_tensorboard/default-plugins.ts
+++ b/tensorboard/components/tf_tensorboard/default-plugins.ts
@@ -1,0 +1,87 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export interface DashboardInformation {
+  // The name of the element for the dashboard (excluding the angle brackets on
+  // either side). For instance, tf-scalar-dashboard. Used to select the correct
+  // dashboard when a user enters it.
+  elementName: string;
+
+  // The name of the plugin associated with this dashboard. This string must
+  // match the PLUGIN_NAME specified by the backend of the plugin. Each plugin
+  // can be associated with no more than 1 plugin - this also means that each
+  // dashboard has a unique plugin field.
+  plugin: string;
+
+  // The string to show in the menu item for this dashboard within the
+  // navigation bar. That tab name may differ from the plugin name. For
+  // instance, the tab name should not use underscores to separate words.
+  tabName: string;
+}
+
+// Maps plugin name (must match the backend) to DashboardInformation.
+const PLUGIN_TO_DASHBOARD_INFORMATION
+    : {[key: string]: DashboardInformation} = {
+  'scalars': {
+    elementName: 'tf-scalar-dashboard',
+    plugin: 'scalars',
+    tabName: 'Scalars',
+  },
+  'images': {
+    elementName: 'tf-image-dashboard',
+    plugin: 'images',
+    tabName: 'Images',
+  },
+  'audio': {
+    elementName: 'tf-audio-dashboard',
+    plugin: 'audio',
+    tabName: 'Audio',
+  },
+  'graphs': {
+    elementName: 'tf-graph-dashboard',
+    plugin: 'graphs',
+    tabName: 'Graphs',
+  },
+  'distributions': {
+    elementName: 'tf-distribution-dashboard',
+    plugin: 'distributions',
+    tabName: 'Distributions',
+  },
+  'histograms': {
+    elementName: 'tf-histogram-dashboard',
+    plugin: 'histograms',
+    tabName: 'Histograms',
+  },
+  'projector': {
+    elementName: 'vz-projector-dashboard',
+    plugin: 'projector',
+    tabName: 'Projector',
+  },
+  'text': {
+    elementName: 'tf-text-dashboard',
+    plugin: 'text',
+    tabName: 'Text',
+  },
+  'pr_curves': {
+    elementName: 'tf-pr-curve-dashboard',
+    plugin: 'pr_curves',
+    tabName: 'PR Curves',
+  },
+  'profile': {
+    elementName: 'tf-profile-dashboard',
+    plugin: 'profile',
+    tabName: 'Profile',
+  },
+};

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -381,19 +381,19 @@ limitations under the License.
 
         /**
          * The set of all dashboards. Each object within this array is a
-         * dashboardData object.
+         * DashboardDatum object.
          *
          * @type {Array<Object>}
          */
         _dashboardData: {
           type: Array,
           readOnly: true,
-          value: Object.values(PLUGIN_TO_DASHBOARD_DATA),
+          value: Object.values(PLUGIN_TO_DASHBOARD_DATUM),
         },
 
         /**
          * The set of currently active dashboards.
-         * `null` if not yet fetched. Each item is a dashboardData
+         * `null` if not yet fetched. Each item is a DashboardDatum
          * object.
          *
          * TODO(@wchargin): Consider templating in an initial value for
@@ -494,17 +494,17 @@ limitations under the License.
       /**
        * @param {string?} disabledDashboards comma-separated
        * @param {Array<string>?} activeDashboards if null, nothing is active
-       * @param {Object} dashboardData
+       * @param {Object} dashboardDatum
        * @return {boolean}
        */
       _isDashboardActive(
-          disabledDashboards, activeDashboards, dashboardData) {
+          disabledDashboards, activeDashboards, dashboardDatum) {
         if ((disabledDashboards || '').split(',').indexOf(
-            dashboardData.plugin) >= 0) {
+            dashboardDatum.plugin) >= 0) {
           // Explicitly disabled.
           return false;
         }
-        if (!(activeDashboards || []).includes(dashboardData.plugin)) {
+        if (!(activeDashboards || []).includes(dashboardDatum.plugin)) {
           // Inactive.
           return false;
         }
@@ -516,18 +516,18 @@ limitations under the License.
        *
        * @param {string?} disabledDashboards comma-separated
        * @param {Array<string>?} activeDashboards if null, nothing is active
-       * @param {Object} dashboardData
+       * @param {Object} dashboardDatum
        * @return {boolean}
        */
       _isDashboardInactive(
-          disabledDashboards, activeDashboards, dashboardData) {
+          disabledDashboards, activeDashboards, dashboardDatum) {
         if ((disabledDashboards || '').split(',').indexOf(
-            dashboardData.plugin) >= 0) {
+            dashboardDatum.plugin) >= 0) {
           // Disabled dashboards don't appear at all; they're not just
           // inactive.
           return false;
         }
-        if (!(activeDashboards || []).includes(dashboardData.plugin)) {
+        if (!(activeDashboards || []).includes(dashboardDatum.plugin)) {
           // Inactive.
           return true;
         }
@@ -613,7 +613,7 @@ limitations under the License.
         }
         if (container.childNodes.length === 0) {
           const component = document.createElement(
-              PLUGIN_TO_DASHBOARD_DATA[selectedDashboard].elementName);
+              PLUGIN_TO_DASHBOARD_DATUM[selectedDashboard].elementName);
           component.id = 'dashboard';  // used in `_selectedDashboardComponent`
           container.appendChild(component);
         }

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -60,18 +60,23 @@ limitations under the License.
               noink
               id="tabs"
             >
-              <template is="dom-repeat" items="[[_dashboards]]" as="dashboard">
+              <template
+                is="dom-repeat"
+                items="[[_dashboardInformationObjects]]"
+                as="dashboardInformation">
                 <template
                   is="dom-if"
-                  if="[[_isDashboardActive(disabledDashboards, _activeDashboards, dashboard)]]"
+                  if="[[_isDashboardActive(disabledDashboards, _activeDashboards, dashboardInformation)]]"
                 >
-                  <paper-tab data-dashboard$="[[dashboard]]">[[dashboard]]</paper-tab>
+                  <paper-tab data-dashboard$="[[dashboardInformation.plugin]]">
+                    [[dashboardInformation.tabName]]
+                  </paper-tab>
                 </template>
               </template>
             </paper-tabs>
             <template
               is="dom-if"
-              if="[[_inactiveDashboardsExist(_dashboards, disabledDashboards, _activeDashboards)]]"
+              if="[[_inactiveDashboardsExist(_dashboardInformationObjects, disabledDashboards, _activeDashboards)]]"
             >
               <paper-dropdown-menu
                 label="Inactive"
@@ -85,15 +90,17 @@ limitations under the License.
                   selected="{{_selectedDashboard}}"
                   attr-for-selected="data-dashboard"
                 >
-                  <template is="dom-repeat" items="[[_dashboards]]" as="dashboard">
+                  <template is="dom-repeat"
+                            items="[[_dashboardInformationObjects]]"
+                            as="dashboardInformation">
                     <template
                       is="dom-if"
-                      if="[[_isDashboardInactive(disabledDashboards, _activeDashboards, dashboard)]]"
+                      if="[[_isDashboardInactive(disabledDashboards, _activeDashboards, dashboardInformation)]]"
                       restamp
                     >
                       <paper-item
-                        data-dashboard$="[[dashboard]]"
-                      >[[dashboard]]</paper-item>
+                        data-dashboard$="[[dashboardInformation.plugin]]"
+                      >[[dashboardInformation.tabName]]</paper-item>
                     </template>
                   </template>
                 </paper-menu>
@@ -176,13 +183,13 @@ limitations under the License.
         <template
           is="dom-repeat"
           id="dashboards-template"
-          items="[[_dashboards]]"
-          as="dashboard"
+          items="[[_dashboardInformationObjects]]"
+          as="dashboardInformation"
         >
           <div
             class="dashboard-container"
-            data-dashboard$="[[dashboard]]"
-            style="display: [[_displayStyle(_selectedDashboard, dashboard)]]"
+            data-dashboard$="[[dashboardInformation.plugin]]"
+            style="display: [[_displayStyle(_selectedDashboard, dashboardInformation.plugin)]]"
           ><!-- Dashboards will be injected here dynamically. --></div>
         </template>
       </div>
@@ -373,19 +380,21 @@ limitations under the License.
         },
 
         /**
-         * The set of all possible dashboard names.
+         * The set of all dashboards. Each object within this array is a
+         * DashboardInformation object.
          *
-         * @type {!Array<string>}
+         * @type {!Array<Object>}
          */
-        _dashboards: {
-          type: Array,
+        _dashboardInformationObjects: {
+          type: Object,
           readOnly: true,
-          value: Object.keys(TENSORBOARD_PLUGINS),
+          value: Object.values(PLUGIN_TO_DASHBOARD_INFORMATION),
         },
 
         /**
          * The set of currently active dashboards.
-         * `null` if not yet fetched.
+         * `null` if not yet fetched. Each item is a DashboardInformation
+         * object.
          *
          * TODO(@wchargin): Consider templating in an initial value for
          * this property.
@@ -425,11 +434,11 @@ limitations under the License.
         _showNoSuchDashboardMessage: {
           type: Boolean,
           computed:
-            '_computeShowNoSuchDashboardMessage(_dashboards, _selectedDashboard)',
+            '_computeShowNoSuchDashboardMessage(_dashboardInformationObjects, _selectedDashboard)',
         },
 
         /**
-         * The name of the currently selected dashboard, or `null` if no
+         * The plugin name of the currently selected dashboard, or `null` if no
          * dashboard is selected. A `null` value here is represented by
          * an empty string in the hash, and vice versa.
          */
@@ -485,15 +494,17 @@ limitations under the License.
       /**
        * @param {string?} disabledDashboards comma-separated
        * @param {Array<string>?} activeDashboards if null, nothing is active
-       * @param {string} dashboard
+       * @param {Object} dashboardInformation
        * @return {boolean}
        */
-      _isDashboardActive(disabledDashboards, activeDashboards, dashboard) {
-        if ((disabledDashboards || '').split(',').indexOf(dashboard) >= 0) {
+      _isDashboardActive(
+          disabledDashboards, activeDashboards, dashboardInformation) {
+        if ((disabledDashboards || '').split(',').indexOf(
+            dashboardInformation.plugin) >= 0) {
           // Explicitly disabled.
           return false;
         }
-        if (!(activeDashboards || []).includes(dashboard)) {
+        if (!(activeDashboards || []).includes(dashboardInformation.plugin)) {
           // Inactive.
           return false;
         }
@@ -505,16 +516,18 @@ limitations under the License.
        *
        * @param {string?} disabledDashboards comma-separated
        * @param {Array<string>?} activeDashboards if null, nothing is active
-       * @param {string} dashboard
+       * @param {Object} dashboardInformation
        * @return {boolean}
        */
-      _isDashboardInactive(disabledDashboards, activeDashboards, dashboard) {
-        if ((disabledDashboards || '').split(',').indexOf(dashboard) >= 0) {
+      _isDashboardInactive(
+          disabledDashboards, activeDashboards, dashboardInformation) {
+        if ((disabledDashboards || '').split(',').indexOf(
+            dashboardInformation.plugin) >= 0) {
           // Disabled dashboards don't appear at all; they're not just
           // inactive.
           return false;
         }
-        if (!(activeDashboards || []).includes(dashboard)) {
+        if (!(activeDashboards || []).includes(dashboardInformation.plugin)) {
           // Inactive.
           return true;
         }
@@ -528,13 +541,13 @@ limitations under the License.
         }
         const workingSet = new Set();
         dashboards.forEach(d => {
-          workingSet.add(d);
+          workingSet.add(d.plugin);
         });
         (disabledDashboards || '').split(',').forEach(d => {
-          workingSet.delete(d);
+          workingSet.delete(d.plugin);
         });
         activeDashboards.forEach(d => {
-          workingSet.delete(d);
+          workingSet.delete(d.plugin);
         });
         return workingSet.size > 0;
       },
@@ -588,18 +601,20 @@ limitations under the License.
        * this does nothing.
        */
       _ensureSelectedDashboardStamped(containersStamped, activeDashboards,
-                                      dashboard) {
-        if (!containersStamped || !activeDashboards || !dashboard) {
+                                      selectedDashboard) {
+        if (!containersStamped || !activeDashboards || !selectedDashboard) {
           return;
         }
         const container = this.$$(
-          `.dashboard-container[data-dashboard=${dashboard}]`);
+            `.dashboard-container[data-dashboard=${selectedDashboard}]`);
         if (!container) {
           // This dashboard doesn't exist. Nothing to do here.
+          console.log(`no exist - ${selectedDashboard}`);
           return;
         }
         if (container.childNodes.length === 0) {
-          const component = document.createElement(TENSORBOARD_PLUGINS[dashboard]);
+          const component = document.createElement(
+              PLUGIN_TO_DASHBOARD_INFORMATION[selectedDashboard].elementName);
           component.id = 'dashboard';  // used in `_selectedDashboardComponent`
           container.appendChild(component);
         }
@@ -664,7 +679,10 @@ limitations under the License.
             return;
           }
           const activePlugins = result.value;
-          this._activeDashboards = this._dashboards.filter(d => activePlugins[d]);
+          this._activeDashboards = _.map(
+              this._dashboardInformationObjects.filter(
+                  d => activePlugins[d.plugin]),
+              d => d.plugin);
           this._activeDashboardsLoadState = ActiveDashboardsLoadState.LOADED;
         });
         const onFailure = () => {
@@ -696,7 +714,9 @@ limitations under the License.
           && selectedDashboard == null);
       },
       _computeShowNoSuchDashboardMessage(dashboards, selectedDashboard) {
-        return !!selectedDashboard && !dashboards.includes(selectedDashboard);
+        return !!selectedDashboard &&
+               _.isUndefined(
+                   _.find(dashboards, d => d.plugin === selectedDashboard))
       },
 
       _updateRouter(router) {

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -62,21 +62,21 @@ limitations under the License.
             >
               <template
                 is="dom-repeat"
-                items="[[_dashboardInformationObjects]]"
-                as="dashboardInformation">
+                items="[[_dashboardDataObjects]]"
+                as="dashboardData">
                 <template
                   is="dom-if"
-                  if="[[_isDashboardActive(disabledDashboards, _activeDashboards, dashboardInformation)]]"
+                  if="[[_isDashboardActive(disabledDashboards, _activeDashboards, dashboardData)]]"
                 >
-                  <paper-tab data-dashboard$="[[dashboardInformation.plugin]]">
-                    [[dashboardInformation.tabName]]
+                  <paper-tab data-dashboard$="[[dashboardData.plugin]]">
+                    [[dashboardData.tabName]]
                   </paper-tab>
                 </template>
               </template>
             </paper-tabs>
             <template
               is="dom-if"
-              if="[[_inactiveDashboardsExist(_dashboardInformationObjects, disabledDashboards, _activeDashboards)]]"
+              if="[[_inactiveDashboardsExist(_dashboardDataObjects, disabledDashboards, _activeDashboards)]]"
             >
               <paper-dropdown-menu
                 label="Inactive"
@@ -91,16 +91,16 @@ limitations under the License.
                   attr-for-selected="data-dashboard"
                 >
                   <template is="dom-repeat"
-                            items="[[_dashboardInformationObjects]]"
-                            as="dashboardInformation">
+                            items="[[_dashboardDataObjects]]"
+                            as="dashboardData">
                     <template
                       is="dom-if"
-                      if="[[_isDashboardInactive(disabledDashboards, _activeDashboards, dashboardInformation)]]"
+                      if="[[_isDashboardInactive(disabledDashboards, _activeDashboards, dashboardData)]]"
                       restamp
                     >
                       <paper-item
-                        data-dashboard$="[[dashboardInformation.plugin]]"
-                      >[[dashboardInformation.tabName]]</paper-item>
+                        data-dashboard$="[[dashboardData.plugin]]"
+                      >[[dashboardData.tabName]]</paper-item>
                     </template>
                   </template>
                 </paper-menu>
@@ -183,13 +183,13 @@ limitations under the License.
         <template
           is="dom-repeat"
           id="dashboards-template"
-          items="[[_dashboardInformationObjects]]"
-          as="dashboardInformation"
+          items="[[_dashboardDataObjects]]"
+          as="dashboardData"
         >
           <div
             class="dashboard-container"
-            data-dashboard$="[[dashboardInformation.plugin]]"
-            style="display: [[_displayStyle(_selectedDashboard, dashboardInformation.plugin)]]"
+            data-dashboard$="[[dashboardData.plugin]]"
+            style="display: [[_displayStyle(_selectedDashboard, dashboardData.plugin)]]"
           ><!-- Dashboards will be injected here dynamically. --></div>
         </template>
       </div>
@@ -381,19 +381,19 @@ limitations under the License.
 
         /**
          * The set of all dashboards. Each object within this array is a
-         * DashboardInformation object.
+         * dashboardData object.
          *
          * @type {!Array<Object>}
          */
-        _dashboardInformationObjects: {
+        _dashboardDataObjects: {
           type: Object,
           readOnly: true,
-          value: Object.values(PLUGIN_TO_DASHBOARD_INFORMATION),
+          value: Object.values(PLUGIN_TO_DASHBOARD_DATA),
         },
 
         /**
          * The set of currently active dashboards.
-         * `null` if not yet fetched. Each item is a DashboardInformation
+         * `null` if not yet fetched. Each item is a dashboardData
          * object.
          *
          * TODO(@wchargin): Consider templating in an initial value for
@@ -434,7 +434,7 @@ limitations under the License.
         _showNoSuchDashboardMessage: {
           type: Boolean,
           computed:
-            '_computeShowNoSuchDashboardMessage(_dashboardInformationObjects, _selectedDashboard)',
+            '_computeShowNoSuchDashboardMessage(_dashboardDataObjects, _selectedDashboard)',
         },
 
         /**
@@ -494,17 +494,17 @@ limitations under the License.
       /**
        * @param {string?} disabledDashboards comma-separated
        * @param {Array<string>?} activeDashboards if null, nothing is active
-       * @param {Object} dashboardInformation
+       * @param {Object} dashboardData
        * @return {boolean}
        */
       _isDashboardActive(
-          disabledDashboards, activeDashboards, dashboardInformation) {
+          disabledDashboards, activeDashboards, dashboardData) {
         if ((disabledDashboards || '').split(',').indexOf(
-            dashboardInformation.plugin) >= 0) {
+            dashboardData.plugin) >= 0) {
           // Explicitly disabled.
           return false;
         }
-        if (!(activeDashboards || []).includes(dashboardInformation.plugin)) {
+        if (!(activeDashboards || []).includes(dashboardData.plugin)) {
           // Inactive.
           return false;
         }
@@ -516,18 +516,18 @@ limitations under the License.
        *
        * @param {string?} disabledDashboards comma-separated
        * @param {Array<string>?} activeDashboards if null, nothing is active
-       * @param {Object} dashboardInformation
+       * @param {Object} dashboardData
        * @return {boolean}
        */
       _isDashboardInactive(
-          disabledDashboards, activeDashboards, dashboardInformation) {
+          disabledDashboards, activeDashboards, dashboardData) {
         if ((disabledDashboards || '').split(',').indexOf(
-            dashboardInformation.plugin) >= 0) {
+            dashboardData.plugin) >= 0) {
           // Disabled dashboards don't appear at all; they're not just
           // inactive.
           return false;
         }
-        if (!(activeDashboards || []).includes(dashboardInformation.plugin)) {
+        if (!(activeDashboards || []).includes(dashboardData.plugin)) {
           // Inactive.
           return true;
         }
@@ -609,12 +609,11 @@ limitations under the License.
             `.dashboard-container[data-dashboard=${selectedDashboard}]`);
         if (!container) {
           // This dashboard doesn't exist. Nothing to do here.
-          console.log(`no exist - ${selectedDashboard}`);
           return;
         }
         if (container.childNodes.length === 0) {
           const component = document.createElement(
-              PLUGIN_TO_DASHBOARD_INFORMATION[selectedDashboard].elementName);
+              PLUGIN_TO_DASHBOARD_DATA[selectedDashboard].elementName);
           component.id = 'dashboard';  // used in `_selectedDashboardComponent`
           container.appendChild(component);
         }
@@ -680,9 +679,11 @@ limitations under the License.
           }
           const activePlugins = result.value;
           this._activeDashboards = _.map(
-              this._dashboardInformationObjects.filter(
+              this._dashboardDataObjects .filter(
                   d => activePlugins[d.plugin]),
               d => d.plugin);
+          this._activeDashboards = this._dashboardDataObjects.map(
+              d => d.plugin).filter(p => activePlugins[p]);
           this._activeDashboardsLoadState = ActiveDashboardsLoadState.LOADED;
         });
         const onFailure = () => {
@@ -715,8 +716,7 @@ limitations under the License.
       },
       _computeShowNoSuchDashboardMessage(dashboards, selectedDashboard) {
         return !!selectedDashboard &&
-               _.isUndefined(
-                   _.find(dashboards, d => d.plugin === selectedDashboard))
+               !dashboards.some(d => d.plugin === selectedDashboard);
       },
 
       _updateRouter(router) {

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -62,21 +62,21 @@ limitations under the License.
             >
               <template
                 is="dom-repeat"
-                items="[[_dashboardDataObjects]]"
-                as="dashboardData">
+                items="[[_dashboardData]]"
+                as="dashboardDatum">
                 <template
                   is="dom-if"
-                  if="[[_isDashboardActive(disabledDashboards, _activeDashboards, dashboardData)]]"
+                  if="[[_isDashboardActive(disabledDashboards, _activeDashboards, dashboardDatum)]]"
                 >
-                  <paper-tab data-dashboard$="[[dashboardData.plugin]]">
-                    [[dashboardData.tabName]]
+                  <paper-tab data-dashboard$="[[dashboardDatum.plugin]]">
+                    [[dashboardDatum.tabName]]
                   </paper-tab>
                 </template>
               </template>
             </paper-tabs>
             <template
               is="dom-if"
-              if="[[_inactiveDashboardsExist(_dashboardDataObjects, disabledDashboards, _activeDashboards)]]"
+              if="[[_inactiveDashboardsExist(_dashboardData, disabledDashboards, _activeDashboards)]]"
             >
               <paper-dropdown-menu
                 label="Inactive"
@@ -91,16 +91,16 @@ limitations under the License.
                   attr-for-selected="data-dashboard"
                 >
                   <template is="dom-repeat"
-                            items="[[_dashboardDataObjects]]"
-                            as="dashboardData">
+                            items="[[_dashboardData]]"
+                            as="dashboardDatum">
                     <template
                       is="dom-if"
-                      if="[[_isDashboardInactive(disabledDashboards, _activeDashboards, dashboardData)]]"
+                      if="[[_isDashboardInactive(disabledDashboards, _activeDashboards, dashboardDatum)]]"
                       restamp
                     >
                       <paper-item
-                        data-dashboard$="[[dashboardData.plugin]]"
-                      >[[dashboardData.tabName]]</paper-item>
+                        data-dashboard$="[[dashboardDatum.plugin]]"
+                      >[[dashboardDatum.tabName]]</paper-item>
                     </template>
                   </template>
                 </paper-menu>
@@ -183,7 +183,7 @@ limitations under the License.
         <template
           is="dom-repeat"
           id="dashboards-template"
-          items="[[_dashboardDataObjects]]"
+          items="[[_dashboardData]]"
           as="dashboardData"
         >
           <div
@@ -383,10 +383,10 @@ limitations under the License.
          * The set of all dashboards. Each object within this array is a
          * dashboardData object.
          *
-         * @type {!Array<Object>}
+         * @type {Array<Object>}
          */
-        _dashboardDataObjects: {
-          type: Object,
+        _dashboardData: {
+          type: Array,
           readOnly: true,
           value: Object.values(PLUGIN_TO_DASHBOARD_DATA),
         },
@@ -434,7 +434,7 @@ limitations under the License.
         _showNoSuchDashboardMessage: {
           type: Boolean,
           computed:
-            '_computeShowNoSuchDashboardMessage(_dashboardDataObjects, _selectedDashboard)',
+            '_computeShowNoSuchDashboardMessage(_dashboardData, _selectedDashboard)',
         },
 
         /**
@@ -678,11 +678,7 @@ limitations under the License.
             return;
           }
           const activePlugins = result.value;
-          this._activeDashboards = _.map(
-              this._dashboardDataObjects .filter(
-                  d => activePlugins[d.plugin]),
-              d => d.plugin);
-          this._activeDashboards = this._dashboardDataObjects.map(
+          this._activeDashboards = this._dashboardData.map(
               d => d.plugin).filter(p => activePlugins[p]);
           this._activeDashboardsLoadState = ActiveDashboardsLoadState.LOADED;
         });

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -184,12 +184,12 @@ limitations under the License.
           is="dom-repeat"
           id="dashboards-template"
           items="[[_dashboardData]]"
-          as="dashboardData"
+          as="dashboardDatum"
         >
           <div
             class="dashboard-container"
-            data-dashboard$="[[dashboardData.plugin]]"
-            style="display: [[_displayStyle(_selectedDashboard, dashboardData.plugin)]]"
+            data-dashboard$="[[dashboardDatum.plugin]]"
+            style="display: [[_displayStyle(_selectedDashboard, dashboardDatum.plugin)]]"
           ><!-- Dashboards will be injected here dynamically. --></div>
         </template>
       </div>

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -392,9 +392,7 @@ limitations under the License.
         },
 
         /**
-         * The set of currently active dashboards.
-         * `null` if not yet fetched. Each item is a DashboardDatum
-         * object.
+         * The set of currently active dashboards. `null` if not yet fetched.
          *
          * TODO(@wchargin): Consider templating in an initial value for
          * this property.


### PR DESCRIPTION
Previously, logic related to dashboards would reference
TENSORBOARD_PLUGINS, a mapping between plugin name to dashboard element
name. Logic would also use the name of the plugin (the key of that
mapping) as the tab name displayed in TensorBoard.

This is suboptimal for several reasons - the plugin name is not
necessarily optimized for display purposes. For instance, take the
plugin name pr_curves. We would ideally remove the underscore from it.

We thus introduce the concept of `DashboardData`, which encapsulates data on a dashboard - the name of the element for the dashboard component (`elementName`), the name of the associated plugin (`plugin`), and the name to show within the navigation menu (`tabName`).

Renamed the _dashboards array within the tf-tensorboard component to
_dashboardInformationObjects to emphasize how that array is not a string
array, but rather contains objects.

Note that the underscore is now gone from the tab name of the PR curves dashboard.
![pr curves](https://user-images.githubusercontent.com/4221553/29991234-919d4c56-8f38-11e7-991f-f46c8f9daf3b.png)

![xuvg4au1yp8](https://user-images.githubusercontent.com/4221553/29991244-b253ba2a-8f38-11e7-814f-1837206ecb77.png)

