### PR TITLE
Use `displayName` and `description` for PR curves

### DIFF
--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/BUILD
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/BUILD
@@ -36,6 +36,7 @@ ts_web_library(
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_runs_selector",
+        "//tensorboard/components/tf_utils",
         "//tensorboard/components/vz_line_chart",
         "@org_polymer_iron_icon",
         "@org_polymer_paper_button",

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -29,11 +29,11 @@ limitations under the License.
 -->
 <dom-module id="tf-pr-curve-card">
   <template>
-    <!-- TODO(chihuahua): Pass display-name and description. This
-         requires generalizing the logic for dimensionality reduction
-         from the scalar chart. -->
-    <tf-card-heading tag="[[tag]]">
-    </tf-card-heading>
+    <tf-card-heading
+      tag="[[tag]]"
+      display-name="[[tagMetadata.displayName]]"
+      description="[[tagMetadata.description]]"
+    ></tf-card-heading>
 
     <div id="chart-and-spinner-container">
       <vz-line-chart
@@ -164,6 +164,9 @@ limitations under the License.
       properties: {
         runs: Array,
         tag: String,
+        /** @type {{displayName: string, description: string}} */
+        tagMetadata: Object,
+
         // For each run, the card will display the PR curve at this step or the
         // one closest to it, but less than it.
         runToStepCap: Object,

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
@@ -24,6 +24,7 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
+<link rel="import" href="../tf-utils/tf-utils.html">
 <link rel="import" href="tf-pr-curve-card.html">
 <link rel="import" href="tf-pr-curve-steps-selector.html">
 
@@ -108,6 +109,7 @@ limitations under the License.
                         <tf-pr-curve-card
                           runs="[[item.runs]]"
                           tag="[[item.tag]]"
+                          tag-metadata="[[_tagMetadata(_runToTagInfo, item.runs, item.tag)]]"
                           request-manager="[[_requestManager]]"
                           run-to-step-cap="[[_runToStep]]"
                         ></tf-pr-curve-card>
@@ -137,10 +139,11 @@ limitations under the License.
   </template>
 
   <script>
-  import {RequestManager} from '../tf-backend/requestManager.js';
-  import {getTags} from '../tf-backend/backend.js';
-  import {getRouter} from '../tf-backend/router.js';
+  import {aggregateTagInfo} from '../tf-utils/utils.js';
   import {categorizeTags} from '../tf-categorization-utils/categorizationUtils.js';
+  import {getRouter} from '../tf-backend/router.js';
+  import {getTags} from '../tf-backend/backend.js';
+  import {RequestManager} from '../tf-backend/requestManager.js';
   import {runsColorScale} from "../tf-color-scale/colorScale.js";
 
   Polymer({
@@ -153,7 +156,7 @@ limitations under the License.
         value: 'step',
       },
       _selectedRuns: Array,
-      _runToTag: Object,  // map<run: string, tags: string[]>
+      _runToTagInfo: Object,
       // The steps that the step slider for each run should use.
       _runToAvailableTimeEntries: {
         type: Object, // map<run: string, steps: number[]>
@@ -162,7 +165,7 @@ limitations under the License.
       // A list of runs that are both selected and have PR curve data.
       _relevantSelectedRuns: {
         type: Array,
-        computed: "_computeRelevantSelectedRuns(_selectedRuns, _runToTag)",
+        computed: "_computeRelevantSelectedRuns(_selectedRuns, _runToTagInfo)",
       },
       _runsWithPrCurveData: Array,  // string[]
       // The desired step value that each run should use. If a run + tag lacks a
@@ -179,7 +182,7 @@ limitations under the License.
       },
       _categories: {
         type: Array,
-        computed: '_makeCategories(_runToTag, _selectedRuns, _tagFilter)',
+        computed: '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter)',
       },
       _requestManager: {
         type: Object,
@@ -202,15 +205,15 @@ limitations under the License.
     },
     _fetchTags() {
       const url = getRouter().pluginRoute('pr_curves', '/tags');
-      return this._requestManager.request(url).then(runToTagToContent => {
-        const runToTag = _.mapValues(runToTagToContent, o => _.keys(o));
-        if (_.isEqual(runToTag, this._runToTag)) {
+      return this._requestManager.request(url).then(runToTagInfo => {
+        if (_.isEqual(runToTagInfo, this._runToTagInfo)) {
           // No need to update anything if there are no changes.
           return;
         }
+        const runToTag = _.mapValues(runToTagInfo, o => _.keys(o));
         const tags = getTags(runToTag);
         this.set('_dataNotFound', tags.length === 0);
-        this.set('_runToTag', runToTag);
+        this.set('_runToTagInfo', runToTagInfo);
       });
     },
     _fetchTimeEntriesPerRun() {
@@ -238,14 +241,25 @@ limitations under the License.
         card.reload();
       });
     },
-    _makeCategories(runToTag, selectedRuns, tagFilter) {
+    _makeCategories(runToTagInfo, selectedRuns, tagFilter) {
+      const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
       return categorizeTags(runToTag, selectedRuns, tagFilter);
     },
     _computeColorForRun(run) {
       return runsColorScale(run);
     },
-    _computeRelevantSelectedRuns(selectedRuns, runToTag) {
-      return _.filter(selectedRuns, run => runToTag[run]);
+    _computeRelevantSelectedRuns(selectedRuns, runToTagInfo) {
+      return selectedRuns.filter(run => runToTagInfo[run]);
+    },
+    _tagMetadata(runToTagsInfo, runs, tag) {
+      const runToTagInfo = {};
+      runs.forEach(run => {
+          runToTagInfo[run] = runToTagsInfo[run][tag];
+      });
+      // All PR curve tags include the `/pr_curves` suffix. We can trim
+      // that from the display name.
+      const defaultDisplayName = tag.replace(/\/pr_curves$/, '');
+      return aggregateTagInfo(runToTagInfo, defaultDisplayName);
     },
   });
   </script>


### PR DESCRIPTION
Summary:
Fixes #446.

The UI is the same as the existing UI as seen in the scalar dashboard
(including the existing display bug discussed in #430), but here’s a
screenshot, anyway:
![Screenshot.](https://user-images.githubusercontent.com/4317806/29992053-c10b61f8-8f60-11e7-95f2-36eef6058dd9.png)

Test Plan:
Load the PR curve dashboard, and ensure that you’re able to replicate
the screenshot above.

wchargin-branch: pr-curve-display-name-description