### PR TITLE
Make PR curves backend serve more information

### DIFF
--- a/tensorboard/plugins/pr_curve/metadata.py
+++ b/tensorboard/plugins/pr_curve/metadata.py
@@ -24,8 +24,11 @@ from tensorboard.plugins.pr_curve import plugin_data_pb2
 
 PLUGIN_NAME = 'pr_curves'
 
-# Indices for obtaining precision and recall values from the tensor
-# stored in a summary.
+# Indices for obtaining various values from the tensor stored in a summary.
+TRUE_POSITIVES_INDEX = 0
+FALSE_POSITIVES_INDEX = 1
+TRUE_NEGATIVES_INDEX = 2
+FALSE_NEGATIVES_INDEX = 3
 PRECISION_INDEX = 4
 RECALL_INDEX = 5
 

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
@@ -30,6 +30,12 @@ from tensorboard.plugins import base_plugin
 from tensorboard.plugins.pr_curve import pr_curve_demo
 from tensorboard.plugins.pr_curve import pr_curves_plugin
 
+# We use an absolute error instead of a relative one because the expected values
+# are small. The default relative error (rtol) of 1e-7 yields many undesired
+# test failures.
+assert_allclose = functools.partial(
+    np.testing.assert_allclose, rtol=0, atol=1e-7)
+
 
 class PrCurvesPluginTest(tf.test.TestCase):
 
@@ -77,14 +83,8 @@ class PrCurvesPluginTest(tf.test.TestCase):
       pr_curve_entry: The PR curve entry to evaluate.
     """
     self.assertEqual(expected_step, pr_curve_entry['step'])
-    # We use an absolute error instead of a relative one because the expected
-    # values are small. The default relative error (rtol) of 1e-7 yields many
-    # undesired test failures.
-    atol = 1e-7
-    np.testing.assert_allclose(
-        expected_precision, pr_curve_entry['precision'], rtol=0, atol=atol)
-    np.testing.assert_allclose(
-        expected_recall, pr_curve_entry['recall'], rtol=0, atol=atol)
+    assert_allclose(expected_precision, pr_curve_entry['precision'])
+    assert_allclose(expected_recall, pr_curve_entry['recall'])
     self.assertListEqual(
         expected_true_positives, pr_curve_entry['true_positives'])
     self.assertListEqual(
@@ -93,9 +93,7 @@ class PrCurvesPluginTest(tf.test.TestCase):
         expected_true_negatives, pr_curve_entry['true_negatives'])
     self.assertListEqual(
         expected_false_negatives, pr_curve_entry['false_negatives'])
-    np.testing.assert_allclose(
-        expected_thresholds,
-        pr_curve_entry['thresholds'], rtol=0, atol=atol)
+    assert_allclose(expected_thresholds, pr_curve_entry['thresholds'])
 
   def computeCorrectDescription(self, standard_deviation):
     """Generates a correct description.

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import functools
 import os.path
 
 import numpy as np

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
@@ -57,23 +57,45 @@ class PrCurvesPluginTest(tf.test.TestCase):
       expected_step,
       expected_precision,
       expected_recall,
+      expected_true_positives,
+      expected_false_positives,
+      expected_true_negatives,
+      expected_false_negatives,
+      expected_thresholds,
       pr_curve_entry):
     """Checks that the values stored within a tensor are correct.
 
     Args:
       expected_step: The expected step.
-      expected_precision: A list of float precision values.
-      expected_recall: A list of float recall values.
+      expected_precision: A list of float values.
+      expected_recall: A list of float values.
+      expected_true_positives: A list of int values.
+      expected_false_positives: A list of int values.
+      expected_true_negatives: A list of int values.
+      expected_false_negatives: A list of int values.
+      expected_thresholds: A list of floats ranging from 0 to 1.
       pr_curve_entry: The PR curve entry to evaluate.
     """
     self.assertEqual(expected_step, pr_curve_entry['step'])
     # We use an absolute error instead of a relative one because the expected
     # values are small. The default relative error (rtol) of 1e-7 yields many
     # undesired test failures.
+    atol = 1e-7
     np.testing.assert_allclose(
-        expected_precision, pr_curve_entry['precision'], rtol=0, atol=1e-7)
+        expected_precision, pr_curve_entry['precision'], rtol=0, atol=atol)
     np.testing.assert_allclose(
-        expected_recall, pr_curve_entry['recall'], rtol=0, atol=1e-7)
+        expected_recall, pr_curve_entry['recall'], rtol=0, atol=atol)
+    self.assertListEqual(
+        expected_true_positives, pr_curve_entry['true_positives'])
+    self.assertListEqual(
+        expected_false_positives, pr_curve_entry['false_positives'])
+    self.assertListEqual(
+        expected_true_negatives, pr_curve_entry['true_negatives'])
+    self.assertListEqual(
+        expected_false_negatives, pr_curve_entry['false_negatives'])
+    np.testing.assert_allclose(
+        expected_thresholds,
+        pr_curve_entry['thresholds'], rtol=0, atol=atol)
 
   def computeCorrectDescription(self, standard_deviation):
     """Generates a correct description.
@@ -188,16 +210,31 @@ class PrCurvesPluginTest(tf.test.TestCase):
         expected_step=0,
         expected_precision=[0.3333333, 0.3853211, 0.5421687, 0.75, 0.0],
         expected_recall=[1.0, 0.84, 0.3, 0.04, 0.0],
+        expected_true_positives=[150, 126, 45, 6, 0],
+        expected_false_positives=[300, 201, 38, 2, 0],
+        expected_true_negatives=[0, 99, 262, 298, 300],
+        expected_false_negatives=[0, 24, 105, 144, 150],
+        expected_thresholds=[0.2, 0.4, 0.6, 0.8, 1.0],
         pr_curve_entry=entries[0])
     self.validatePrCurveEntry(
         expected_step=1,
         expected_precision=[0.3333333, 0.3855422, 0.5357143, 0.4, 0.0],
         expected_recall=[1.0, 0.8533334, 0.3, 0.0266667, 0.0],
+        expected_true_positives=[150, 128, 45, 4, 0],
+        expected_false_positives=[300, 204, 39, 6, 0],
+        expected_true_negatives=[0, 96, 261, 294, 300],
+        expected_false_negatives=[0, 22, 105, 146, 150],
+        expected_thresholds=[0.2, 0.4, 0.6, 0.8, 1.0],
         pr_curve_entry=entries[1])
     self.validatePrCurveEntry(
         expected_step=2,
         expected_precision=[0.3333333, 0.3934426, 0.5064935, 0.6666667, 0.0],
         expected_recall=[1.0, 0.8, 0.26, 0.0266667, 0.0],
+        expected_true_positives=[150, 120, 39, 4, 0],
+        expected_false_positives=[300, 185, 38, 2, 0],
+        expected_true_negatives=[0, 115, 262, 298, 300],
+        expected_false_negatives=[0, 30, 111, 146, 150],
+        expected_thresholds=[0.2, 0.4, 0.6, 0.8, 1.0],
         pr_curve_entry=entries[2])
 
     # Assert that PR curve data is correct for the mask_every_other_prediction
@@ -208,16 +245,31 @@ class PrCurvesPluginTest(tf.test.TestCase):
         expected_step=0,
         expected_precision=[0.3333333, 0.3786982, 0.5384616, 1.0, 0.0],
         expected_recall=[1.0, 0.8533334, 0.28, 0.0666667, 0.0],
+        expected_true_positives=[75, 64, 21, 5, 0],
+        expected_false_positives=[150, 105, 18, 0, 0],
+        expected_true_negatives=[0, 45, 132, 150, 150],
+        expected_false_negatives=[0, 11, 54, 70, 75],
+        expected_thresholds=[0.2, 0.4, 0.6, 0.8, 1.0],
         pr_curve_entry=entries[0])
     self.validatePrCurveEntry(
         expected_step=1,
         expected_precision=[0.3333333, 0.3850932, 0.5, 0.25, 0.0],
         expected_recall=[1.0, 0.8266667, 0.28, 0.0133333, 0.0],
+        expected_true_positives=[75, 62, 21, 1, 0],
+        expected_false_positives=[150, 99, 21, 3, 0],
+        expected_true_negatives=[0, 51, 129, 147, 150],
+        expected_false_negatives=[0, 13, 54, 74, 75],
+        expected_thresholds=[0.2, 0.4, 0.6, 0.8, 1.0],
         pr_curve_entry=entries[1])
     self.validatePrCurveEntry(
         expected_step=2,
         expected_precision=[0.3333333, 0.3986928, 0.4444444, 0.6666667, 0.0],
         expected_recall=[1.0, 0.8133333, 0.2133333, 0.0266667, 0.0],
+        expected_true_positives=[75, 61, 16, 2, 0],
+        expected_false_positives=[150, 92, 20, 1, 0],
+        expected_true_negatives=[0, 58, 130, 149, 150],
+        expected_false_negatives=[0, 14, 59, 73, 75],
+        expected_thresholds=[0.2, 0.4, 0.6, 0.8, 1.0],
         pr_curve_entry=entries[2])
 
   def testPrCurvesRaisesValueErrorWhenNoData(self):


### PR DESCRIPTION
We make the PR curves plugin backend serve more information so that PR curves can later display them in tooltips. Specifically, the backend's /pr_curves route now additionally serves the counts of true positives, false positives, true negatives, and false negatives. The backend also serves the thresholds for a PR curve.

This additional information helps users gain visibility into the precision and recall values. For instance, they might wonder about #444.

The thresholds are actually the same for each run--tag combination (and do not change per step), so we could actually serve them through another endpoint that is requested once per TensorBoard refresh. However, serving the thresholds via the /pr_curves route does make the frontend design more straightforward because we do not have compute a mapping from tag to run to the thresholds to use.

This PR is part of #463.