### PR TITLE
Remove max op from numerator of precision

### DIFF
--- a/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
@@ -186,18 +186,18 @@ class PrCurvesPluginTest(tf.test.TestCase):
     self.assertEqual(3, len(entries))
     self.validatePrCurveEntry(
         expected_step=0,
-        expected_precision=[0.3333333, 0.3853211, 0.5421686, 0.75, 1.0],
-        expected_recall=[1.0, 0.8400000, 0.3000000, 0.0400000, 0.0],
+        expected_precision=[0.3333333, 0.3853211, 0.5421687, 0.75, 0.0],
+        expected_recall=[1.0, 0.84, 0.3, 0.04, 0.0],
         pr_curve_entry=entries[0])
     self.validatePrCurveEntry(
         expected_step=1,
-        expected_precision=[0.3333333, 0.3855421, 0.5357142, 0.4000000, 1.0],
-        expected_recall=[1.0, 0.8533333, 0.3000000, 0.0266666, 0.0],
+        expected_precision=[0.3333333, 0.3855422, 0.5357143, 0.4, 0.0],
+        expected_recall=[1.0, 0.8533334, 0.3, 0.0266667, 0.0],
         pr_curve_entry=entries[1])
     self.validatePrCurveEntry(
         expected_step=2,
-        expected_precision=[0.3333333, 0.3934426, 0.5064935, 0.6666666, 1.0],
-        expected_recall=[1.0, 0.8000000, 0.2599999, 0.0266666, 0.0],
+        expected_precision=[0.3333333, 0.3934426, 0.5064935, 0.6666667, 0.0],
+        expected_recall=[1.0, 0.8, 0.26, 0.0266667, 0.0],
         pr_curve_entry=entries[2])
 
     # Assert that PR curve data is correct for the mask_every_other_prediction
@@ -206,18 +206,18 @@ class PrCurvesPluginTest(tf.test.TestCase):
     self.assertEqual(3, len(entries))
     self.validatePrCurveEntry(
         expected_step=0,
-        expected_precision=[0.3333333, 0.3786982, 0.5384616, 1.0, 1.0],
+        expected_precision=[0.3333333, 0.3786982, 0.5384616, 1.0, 0.0],
         expected_recall=[1.0, 0.8533334, 0.28, 0.0666667, 0.0],
         pr_curve_entry=entries[0])
     self.validatePrCurveEntry(
         expected_step=1,
-        expected_precision=[0.3333333, 0.3850932, 0.5, 0.25, 1.0],
+        expected_precision=[0.3333333, 0.3850932, 0.5, 0.25, 0.0],
         expected_recall=[1.0, 0.8266667, 0.28, 0.0133333, 0.0],
         pr_curve_entry=entries[1])
     self.validatePrCurveEntry(
         expected_step=2,
-        expected_precision=[0.3333333, 0.3986928, 0.4444444, 0.6666667, 1.0],
-        expected_recall=[1.0, 0.8133333, 0.2133333, 0.0266666, 0.0],
+        expected_precision=[0.3333333, 0.3986928, 0.4444444, 0.6666667, 0.0],
+        expected_recall=[1.0, 0.8133333, 0.2133333, 0.0266667, 0.0],
         pr_curve_entry=entries[2])
 
   def testPrCurvesRaisesValueErrorWhenNoData(self):

--- a/tensorboard/plugins/pr_curve/summary_test.py
+++ b/tensorboard/plugins/pr_curve/summary_test.py
@@ -88,24 +88,24 @@ class PrCurveTest(tf.test.TestCase):
         [350.0, 50.0, 11.0, 2.0, 0.0],  # False positives.
         [0.0, 300.0, 339.0, 348.0, 350.0],  # True negatives.
         [0.0, 55.0, 89.0, 98.0, 100.0],  # False negatives.
-        [0.2222222, 0.4736842, 0.5, 0.5, 1.0],  # Precision.
-        [1.0, 0.4499999, 0.1100000, 0.0199999, 0.0],  # Recall.
+        [0.2222222, 0.4736842, 0.5, 0.5, 0.0],  # Precision.
+        [1.0, 0.45, 0.11, 0.02, 0.0],  # Recall.
     ], tensor_events[0])
     self.validateTensorEvent(1, [
         [100.0, 41.0, 11.0, 1.0, 0.0],  # True positives.
         [350.0, 48.0, 7.0, 1.0, 0.0],  # False positives.
         [0.0, 302.0, 343.0, 349.0, 350.0],  # True negatives.
         [0.0, 59.0, 89.0, 99.0, 100.0],  # False negatives.
-        [0.2222222, 0.4606741, 0.6111111, 0.5, 1.0],  # Precision.
-        [1.0, 0.4100000, 0.1100000, 0.0099999, 0.0],  # Recall.
+        [0.2222222, 0.4606742, 0.6111111, 0.5, 0.0],  # Precision.
+        [1.0, 0.41, 0.11, 0.01, 0.0],  # Recall.
     ], tensor_events[1])
     self.validateTensorEvent(2, [
         [100.0, 39.0, 11.0, 2.0, 0.0],  # True positives.
         [350.0, 54.0, 13.0, 1.0, 0.0],  # False positives.
         [0.0, 296.0, 337.0, 349.0, 350.0],  # True negatives.
         [0.0, 61.0, 89.0, 98.0, 100.0],  # False negatives.
-        [0.2222222, 0.4193548, 0.4583333, 0.6666666, 1.0],  # Precision.
-        [1.0, 0.3899999, 0.1100000, 0.0199999, 0.0],  # Recall.
+        [0.2222222, 0.4193548, 0.4583333, 0.6666667, 0.0],  # Precision.
+        [1.0, 0.39, 0.11, 0.02, 0.0],  # Recall.
     ], tensor_events[2])
 
     # Test the output for the green classifier.
@@ -115,24 +115,24 @@ class PrCurveTest(tf.test.TestCase):
         [250.0, 100.0, 13.0, 2.0, 0.0],  # False positives.
         [0.0, 150.0, 237.0, 248.0, 250.0],  # True negatives.
         [0.0, 75.0, 152.0, 193.0, 200.0],  # False negatives.
-        [0.4444444, 0.5555555, 0.7868852, 0.7777777, 1.0],  # Precision.
-        [1.0, 0.625, 0.2400000, 0.0350000, 0.0],  # Recall.
+        [0.4444444, 0.5555556, 0.7868853, 0.7777778, 0.0],  # Precision.
+        [1.0, 0.625, 0.24, 0.035, 0.0],  # Recall.
     ], tensor_events[0])
     self.validateTensorEvent(1, [
         [200.0, 123.0, 36.0, 7.0, 0.0],  # True positives.
         [250.0, 91.0, 18.0, 2.0, 0.0],  # False positives.
         [0.0, 159.0, 232.0, 248.0, 250.0],  # True negatives.
         [0.0, 77.0, 164.0, 193.0, 200.0],  # False negatives.
-        [0.4444444, 0.5747663, 0.6666666, 0.7777777, 1.0],  # Precision.
-        [1.0, 0.6150000, 0.1800000, 0.0350000, 0.0],  # Recall.
+        [0.4444444, 0.5747663, 0.6666667, 0.7777778, 0.0],  # Precision.
+        [1.0, 0.615, 0.18, 0.035, 0.0],  # Recall.
     ], tensor_events[1])
     self.validateTensorEvent(2, [
         [200.0, 116.0, 40.0, 5.0, 0.0],  # True positives.
         [250.0, 87.0, 18.0, 1.0, 0.0],  # False positives.
         [0.0, 163.0, 232.0, 249.0, 250.0],  # True negatives.
         [0.0, 84.0, 160.0, 195.0, 200.0],  # False negatives.
-        [0.4444444, 0.5714285, 0.6896551, 0.8333333, 1.0],  # Precision.
-        [1.0, 0.5800000, 0.1999999, 0.0249999, 0.0],  # Recall.
+        [0.4444444, 0.5714286, 0.6896552, 0.8333333, 0.0],  # Precision.
+        [1.0, 0.58, 0.2, 0.025, 0.0],  # Recall.
     ], tensor_events[2])
 
     # Test the output for the blue classifier. The normal distribution that is
@@ -143,24 +143,24 @@ class PrCurveTest(tf.test.TestCase):
         [300.0, 201.0, 38.0, 2.0, 0.0],  # False positives.
         [0.0, 99.0, 262.0, 298.0, 300.0],  # True negatives.
         [0.0, 24.0, 105.0, 144.0, 150.0],  # False negatives.
-        [0.3333333, 0.3853211, 0.5421686, 0.75, 1.0],  # Precision.
-        [1.0, 0.8400000, 0.3000000, 0.0400000, 0.0],  # Recall.
+        [0.3333333, 0.3853211, 0.5421687, 0.75, 0.0],  # Precision.
+        [1.0, 0.84, 0.3, 0.04, 0.0],  # Recall.
     ], tensor_events[0])
     self.validateTensorEvent(1, [
         [150.0, 128.0, 45.0, 4.0, 0.0],  # True positives.
         [300.0, 204.0, 39.0, 6.0, 0.0],  # False positives.
         [0.0, 96.0, 261.0, 294.0, 300.0],  # True negatives.
         [0.0, 22.0, 105.0, 146.0, 150.0],  # False negatives.
-        [0.3333333, 0.3855421, 0.5357142, 0.4000000, 1.0],  # Precision.
-        [1.0, 0.8533333, 0.3000000, 0.0266666, 0.0],  # Recall.
+        [0.3333333, 0.3855422, 0.5357143, 0.4, 0.0],  # Precision.
+        [1.0, 0.8533334, 0.3, 0.0266667, 0.0],  # Recall.
     ], tensor_events[1])
     self.validateTensorEvent(2, [
         [150.0, 120.0, 39.0, 4.0, 0.0],  # True positives.
         [300.0, 185.0, 38.0, 2.0, 0.0],  # False positives.
         [0.0, 115.0, 262.0, 298.0, 300.0],  # True negatives.
         [0.0, 30.0, 111.0, 146.0, 150.0],  # False negatives.
-        [0.3333333, 0.3934426, 0.5064935, 0.6666666, 1.0],  # Precision.
-        [1.0, 0.8000000, 0.2599999, 0.0266666, 0.0],  # Recall.
+        [0.3333333, 0.3934426, 0.5064935, 0.6666667, 0.0],  # Precision.
+        [1.0, 0.8, 0.26, 0.0266667, 0.0],  # Recall.
     ], tensor_events[2])
 
   def testExplicitWeights(self):
@@ -189,87 +189,79 @@ class PrCurveTest(tf.test.TestCase):
         [175.0, 22.0, 6.0, 1.0, 0.0],  # False positives.
         [0.0, 153.0, 169.0, 174.0, 175.0],  # True negatives.
         [0.0, 28.0, 46.0, 50.0, 50.0],  # False negatives.
-        [0.2222222, 0.5, 0.4, 1e-07, 1.0],  # Precision.
+        [0.2222222, 0.5, 0.4, 0.0, 0.0],  # Precision.
         [1.0, 0.44, 0.08, 0.0, 0.0],  # Recall.
     ], tensor_events[0])
-
     self.validateTensorEvent(1, [
         [50.0, 17.0, 5.0, 1.0, 0.0],  # True positives.
         [175.0, 28.0, 1.0, 0.0, 0.0],  # False positives.
         [0.0, 147.0, 174.0, 175.0, 175.0],  # True negatives.
         [0.0, 33.0, 45.0, 49.0, 50.0],  # False negatives.
-        [0.2222222, 0.3777778, 0.8333333, 1.0, 1.0],  # Precision.
+        [0.2222222, 0.3777778, 0.8333333, 1.0, 0.0],  # Precision.
         [1.0, 0.34, 0.1, 0.02, 0.0],  # Recall.
     ], tensor_events[1])
-
     self.validateTensorEvent(2, [
         [50.0, 18.0, 6.0, 1.0, 0.0],  # True positives.
         [175.0, 27.0, 6.0, 0.0, 0.0],  # False positives.
         [0.0, 148.0, 169.0, 175.0, 175.0],  # True negatives.
         [0.0, 32.0, 44.0, 49.0, 50.0],  # False negatives.
-        [0.2222222, 0.4, 0.5, 1.0, 1.0],  # Precision.
+        [0.2222222, 0.4, 0.5, 1.0, 0.0],  # Precision.
         [1.0, 0.36, 0.12, 0.02, 0.0],  # Recall.
     ], tensor_events[2])
 
     # Test the output for the green classifier.
     tensor_events = accumulator.Tensors('green/pr_curves')
-
     self.validateTensorEvent(0, [
         [100.0, 71.0, 24.0, 2.0, 0.0],  # True positives.
         [125.0, 51.0, 5.0, 2.0, 0.0],  # False positives.
         [0.0, 74.0, 120.0, 123.0, 125.0],  # True negatives.
         [0.0, 29.0, 76.0, 98.0, 100.0],  # False negatives.
-        [0.4444444, 0.5819672, 0.8275862, 0.5, 1.0],  # Precision.
+        [0.4444444, 0.5819672, 0.8275862, 0.5, 0.0],  # Precision.
         [1.0, 0.71, 0.24, 0.02, 0.0],  # Recall.
     ], tensor_events[0])
-
     self.validateTensorEvent(1, [
         [100.0, 63.0, 20.0, 5.0, 0.0],  # True positives.
         [125.0, 42.0, 7.0, 1.0, 0.0],  # False positives.
         [0.0, 83.0, 118.0, 124.0, 125.0],  # True negatives.
         [0.0, 37.0, 80.0, 95.0, 100.0],  # False negatives.
-        [0.4444444, 0.6, 0.7407407, 0.8333333, 1.0],  # Precision.
+        [0.4444444, 0.6, 0.7407407, 0.8333333, 0.0],  # Precision.
         [1.0, 0.63, 0.2, 0.05, 0.0],  # Recall.
     ], tensor_events[1])
-
     self.validateTensorEvent(2, [
         [100.0, 58.0, 19.0, 2.0, 0.0],  # True positives.
         [125.0, 40.0, 7.0, 0.0, 0.0],  # False positives.
         [0.0, 85.0, 118.0, 125.0, 125.0],  # True negatives.
         [0.0, 42.0, 81.0, 98.0, 100.0],  # False negatives.
-        [0.4444444, 0.5918368, 0.7307692, 1.0, 1.0],  # Precision.
+        [0.4444444, 0.5918368, 0.7307692, 1.0, 0.0],  # Precision.
         [1.0, 0.58, 0.19, 0.02, 0.0],  # Recall.
     ], tensor_events[2])
 
     # Test the output for the blue classifier. The normal distribution that is
     # the blue classifier has the widest standard deviation.
     tensor_events = accumulator.Tensors('blue/pr_curves')
-
     self.validateTensorEvent(0, [
         [75.0, 64.0, 21.0, 5.0, 0.0],  # True positives.
         [150.0, 105.0, 18.0, 0.0, 0.0],  # False positives.
         [0.0, 45.0, 132.0, 150.0, 150.0],  # True negatives.
         [0.0, 11.0, 54.0, 70.0, 75.0],  # False negatives.
-        [0.3333333, 0.3786982, 0.5384616, 1.0, 1.0],  # Precision.
+        [0.3333333, 0.3786982, 0.5384616, 1.0, 0.0],  # Precision.
         [1.0, 0.8533334, 0.28, 0.0666667, 0.0],  # Recall.
     ], tensor_events[0])
-
     self.validateTensorEvent(1, [
         [75.0, 62.0, 21.0, 1.0, 0.0],  # True positives.
         [150.0, 99.0, 21.0, 3.0, 0.0],  # False positives.
         [0.0, 51.0, 129.0, 147.0, 150.0],  # True negatives.
         [0.0, 13.0, 54.0, 74.0, 75.0],  # False negatives.
-        [0.3333333, 0.3850932, 0.5, 0.25, 1.0],  # Precision.
+        [0.3333333, 0.3850932, 0.5, 0.25, 0.0],  # Precision.
         [1.0, 0.8266667, 0.28, 0.0133333, 0.0],  # Recall.
     ], tensor_events[1])
-
     self.validateTensorEvent(2, [
         [75.0, 61.0, 16.0, 2.0, 0.0],  # True positives.
         [150.0, 92.0, 20.0, 1.0, 0.0],  # False positives.
         [0.0, 58.0, 130.0, 149.0, 150.0],  # True negatives.
         [0.0, 14.0, 59.0, 73.0, 75.0],  # False negatives.
-        [0.3333333, 0.3986928, 0.4444444, 0.6666667, 1.0],  # Precision.
-        [1.0, 0.8133333, 0.2133333, 0.0266666, 0.0],  # Recall.
+        [0.3333333, 0.3986928, 0.4444444, 0.6666667, 0.0],  # Precision.
+        [1.0, 0.8133333, 0.2133333, 0.0266667, 0.0],  # Recall.
     ], tensor_events[2])
 
 


### PR DESCRIPTION
When the threshold is high enough so that the predictor makes no
positive predictions, precision is undefined because its denominator is
fp + tp. Hence, we remove the max operation from the numerator of the
precision calculation, so that precision is 0 (and not 1) when the thresold is 1.
1 might be misleading because that implies there is area under the curve.

Screenshot with this change:

![wwmchckyjar](https://user-images.githubusercontent.com/4221553/29999975-0ea6932e-9010-11e7-9336-5ac91f67b197.png)

Notice that the curve does not drop from 1 to some tiny value and then
go back up again as recall increases (as before).

A subsequent effort will make the frontend just not show data points for
which fp + tp = 0. For now, we get rid of that max op so that the user
does not see precision as equal to 1e-07, which can be confusing.

Also computed recall simply as

```python
recall = tp / tf.maximum(_MINIMUM_COUNT, tp + fn)
```

We already compute false positive counts via fn = tp[0] - tp. That seems
more straightforward.

Renamed the variable containing the epsilon value to `_MINIMUM_COUNT`
and set it to 1. This value is the minimum for counts, which should never be
less than 1.

