### PR TITLE
Add property nodeContextMenuItems to tf-graph

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
@@ -762,6 +762,9 @@ Polymer({
       value: 18
     },
     progress: Object,
+    // An array of ContextMenuItem objects. Items that appear in the context
+    // menu for a node.
+    nodeContextMenuItems: Array,
     // A mapping between node name to the tf.graph.scene.HealthPill to render.
     nodeNamesToHealthPills: Object,
     // The step of health pills to show throughout the graph.

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.html
@@ -64,6 +64,7 @@ paper-button {
           selected-node="{{selectedNode}}"
           color-by="[[colorBy]]"
           progress="[[progress]]"
+          node-context-menu-items="[[nodeContextMenuItems]]"
           node-names-to-health-pills="[[nodeNamesToHealthPills]]"
           health-pill-step-index="{{healthPillStepIndex}}"
     ></tf-graph-scene>
@@ -112,6 +113,9 @@ Polymer({
       readOnly: true,
       notify: true,
     },
+    // An array of ContextMenuItem objects. Items that appear in the context
+    // menu for a node.
+    nodeContextMenuItems: Array,
     _renderDepth: {
       type: Number,
       value: 1

--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -269,6 +269,10 @@ export function getContextMenu(node: Node, sceneElement) {
       sceneElement.fire('node-toggle-extract', {name: node.name});
     }
   }];
+  if (sceneElement.nodeContextMenuItems) {
+    // Add these additional context menu items.
+    menu = menu.concat(sceneElement.nodeContextMenuItems);
+  }
   if (canBeInSeries(node)) {
     menu.push({
       title: d => { return getGroupSettingLabel(node); },


### PR DESCRIPTION
Added a property nodeContextMenuItems to the tf-graph and tf-graph-scene components. This optional property is an array of `contextmenu.ContextMenuItem`s. This property offers an API for developers to extend the context menu by adding custom items, each with a title and a callback.

See `getContextMenu` for an example array:

```ts
  let menu = [{
    title: (d): string => {
      return getIncludeNodeButtonString(node.include);
    },
    action: (elm, d, i) => {
      sceneElement.fire('node-toggle-extract', {name: node.name});
    }
  }];
```

Screenshot (Here, we add a "Foo" context menu item):

![wtfio66dqk6](https://user-images.githubusercontent.com/4221553/30001394-87e9090c-9041-11e7-833d-b5bce2c1b7f5.png)

FYI, @caisq 