### PR TITLE
Generalize tf-scalar-chart.html

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2.0
 ts_web_library(
     name = "tf_scalar_dashboard",
     srcs = [
+        "tf-scalar-card.html",
         "tf-scalar-chart.html",
         "tf-scalar-dashboard.html",
         "tf-smoothing-input.html",

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -1,0 +1,308 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../paper-item/paper-item.html">
+<link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../paper-menu/paper-menu.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
+<link rel="import" href="../tf-card-heading/tf-card-heading.html">
+<link rel="import" href="../vz-line-chart/vz-line-chart.html">
+<link rel="import" href="tf-scalar-chart.html">
+
+<!--
+  A card that handles loading data (at the right times), rendering a scalar
+  chart, and providing UI affordances (such as buttons) for scalar data.
+-->
+<dom-module id="tf-scalar-card">
+<template>
+  <tf-card-heading
+    tag="[[tag]]"
+    display-name="[[tagMetadata.displayName]]"
+    description="[[tagMetadata.description]]"
+  ></tf-card-heading>
+  <tf-scalar-chart
+    x-type="[[xType]]"
+    x-components-creation-method="[[_xComponentsCreationMethod]]"
+    y-value-accessor="[[_yValueAccessor]]"
+    tooltip-columns="[[_tooltipColumns]]"
+    smoothing-enabled="[[smoothingEnabled]]"
+    smoothing-weight="[[smoothingWeight]]"
+    tooltip-sorting-method="[[tooltipSortingMethod]]"
+    ignore-y-outliers="[[ignoreYOutliers]]"
+    request-manager="[[requestManager]]"
+    runs="[[runs]]"
+    tag="[[tag]]"
+    tag-metadata="[[tagMetadata]]"
+    active="[[active]]"
+    data-url="[[_dataUrl]]"
+    log-scale-active="[[_logScaleActive]]"
+    process-data="[[_processData]]"
+  >
+  <div id="buttons">
+    <paper-icon-button
+      selected$="[[_expanded]]"
+      icon="fullscreen"
+      on-tap="_toggleExpanded"
+    ></paper-icon-button>
+    <paper-icon-button
+      selected$="[[_logScaleActive]]"
+      icon="line-weight"
+      on-tap="_toggleLogScale"
+      title="Toggle y-axis log scale"
+    ></paper-icon-button>
+    <paper-icon-button
+      icon="settings-overscan"
+      on-tap="_resetDomain"
+      title="Fit domain to data"
+    ></paper-icon-button>
+    <span style="flex-grow: 1"></span>
+    <template is="dom-if" if="[[showDownloadLinks]]">
+      <div class="download-links">
+        <paper-dropdown-menu
+          no-label-float="true"
+          label="run to download"
+          selected-item-label="{{_runToDownload}}"
+        >
+          <paper-menu class="dropdown-content" slot="dropdown-content">
+            <template is="dom-repeat" items="[[runs]]">
+              <paper-item no-label-float=true>[[item]]</paper-item>
+            </template>
+          </paper-menu>
+        </paper-dropdown-menu>
+        <a
+          download="run_[[_runToDownload]]-tag-[[tag]].csv"
+          href="[[_csvUrl(tag, _runToDownload)]]"
+        >CSV</a> <a
+          download="run_[[_runToDownload]]-tag-[[tag]].json"
+          href="[[_jsonUrl(tag, _runToDownload)]]"
+        >JSON</a>
+        </div>
+      </div>
+    </template>
+  </div>
+  </tf-scalar-chart>
+  <style>
+    :host {
+      height: 235px;
+      width: 330px;
+      margin: 5px;
+      display: block;
+    }
+
+    :host[_expanded] {
+      height: 400px;
+      width: 100%;
+    }
+
+    tf-card-heading {
+      margin-bottom: 10px;
+    }
+
+    #buttons {
+      display: flex;
+      flex-direction: row;
+    }
+
+    paper-icon-button {
+      color: #2196F3;
+      border-radius: 100%;
+      width: 32px;
+      height: 32px;
+      padding: 4px;
+    }
+
+    paper-icon-button[selected] {
+      background: var(--tb-ui-light-accent);
+    }
+
+    .download-links {
+      display: flex;
+      height: 32px;
+    }
+
+    .download-links a {
+      font-size: 10px;
+      align-self: center;
+      margin: 2px;
+    }
+
+    .download-links paper-dropdown-menu {
+      width: 100px;
+      --paper-input-container-label: {
+        font-size: 10px;
+      }
+      --paper-input-container-input: {
+        font-size: 10px;
+      }
+    }
+  </style>
+</template>
+<script>
+  import {addParams} from '../tf-backend/urlPathHelpers.js';
+  import * as ChartHelpers from '../vz-line-chart/vz-chart-helpers.js';
+  import {getRouter} from '../tf-backend/router.js';
+
+  /** 
+   * Allows:
+   * - "step" - Linear scale using the "step" property of the datum.
+   * - "wall_time" - Temporal scale using the "wall_time" property of the
+   * datum.
+   * - "relative" - Temporal scale using the "relative" property of the
+   * datum if it is present or calculating from "wall_time" if it isn't.
+   * @enum {string}
+   */
+  const X_TYPE = {
+    STEP: 'step',
+    RELATIVE: 'relative',
+    WALL_TIME: 'wall_time',
+  };
+
+  Polymer({
+      is: 'tf-scalar-card',
+      properties: {
+        runs: Array,  // of String
+        tag: String,
+
+        /**
+         * @type {X_TYPE}
+         */
+        xType: String,
+
+        active: Boolean,
+        ignoreYOutliers: Boolean,
+        requestManager: Object,
+        showDownloadLinks: Boolean,
+        smoothingEnabled: Boolean,
+        smoothingWeight: Number,
+        tagMetadata: Object,
+        tooltipSortingMethod: String,
+
+        // This function is called when data is received from the backend.
+        _processData: {
+          type: Object,
+          value: () => ((scalarChart, run, data) => {
+            const formattedData = data.map(datum => ({
+              wall_time: new Date(datum[0] * 1000),
+              step: datum[1],
+              scalar: datum[2],
+            }));
+            scalarChart.setSeriesData(run, formattedData);
+          }),
+          readOnly: true,
+        },
+
+        _expanded: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,  // for CSS
+        },
+
+        _logScaleActive: Boolean,
+
+        _dataUrl: {
+          type: Function,
+          value: () => (tag, run) => addParams(
+              getRouter().pluginRoute('scalars', '/scalars'), {tag, run}),
+        },
+
+        _xComponentsCreationMethod: {
+          type: Object,
+          computed: '_computeXComponentsCreationMethod(xType)',
+        },
+
+        _yValueAccessor: {
+          type: Object,
+          readOnly: true,
+          value: () => {
+            return d => d.scalar;
+          },
+        },
+
+        _tooltipColumns: {
+          type: Array,
+          readOnly: true,
+          value: () => {
+            const valueFormatter = ChartHelpers.multiscaleFormatter(
+                ChartHelpers.Y_TOOLTIP_FORMATTER_PRECISION);
+            const formatValueOrNaN =
+                (x) => isNaN(x) ? 'NaN' : valueFormatter(x);
+            return [
+              {
+                title: 'Name',
+                evaluate: (d) => d.dataset.metadata().name,
+              },
+              {
+                title: 'Smoothed',
+                evaluate: (d, statusObject) => formatValueOrNaN(
+                    statusObject.smoothingEnabled ?
+                        d.datum.smoothed : d.datum.scalar),
+              },
+              {
+                title: 'Value',
+                evaluate: (d) => formatValueOrNaN(d.datum.scalar),
+              },
+              {
+                title: 'Step',
+                evaluate: (d) => ChartHelpers.stepFormatter(d.datum.step),
+              },
+              {
+                title: 'Time',
+                evaluate: (d) => ChartHelpers.timeFormatter(d.datum.wall_time),
+              },
+              {
+                title: 'Relative',
+                evaluate:
+                    (d) => ChartHelpers.relativeFormatter(
+                        ChartHelpers.relativeAccessor(d.datum, -1, d.dataset)),
+              },
+            ]
+          },
+        },
+      },
+      reload() {
+        this.$$('tf-scalar-chart').reload();
+      },
+      redraw() {
+        this.$$('tf-scalar-chart').redraw();
+      },
+      _toggleExpanded(e) {
+        this.set('_expanded', !this._expanded);
+        this.redraw();
+      },
+      _toggleLogScale() {
+        this.set('_logScaleActive', !this._logScaleActive);
+      },
+      _resetDomain() {
+        const chart = this.$$('vz-line-chart');
+        if (chart) {
+          chart.resetDomain();
+        }
+      },
+      _csvUrl(tag, run) {
+        return addParams(this._dataUrl(tag, run), {format: 'csv'});
+      },
+      _jsonUrl(tag, run) {
+        return this._dataUrl(tag, run);
+      },
+      _computeXComponentsCreationMethod(xType) {
+        return () => ChartHelpers.getXComponents(xType);
+      },
+  });
+</script>
+</dom-module>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
@@ -15,34 +15,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
-<link rel="import" href="../paper-icon-button/paper-icon-button.html">
-<link rel="import" href="../paper-item/paper-item.html">
-<link rel="import" href="../paper-menu/paper-menu.html">
 <link rel="import" href="../paper-spinner/paper-spinner-lite.html">
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
-<link rel="import" href="../tf-card-heading/tf-card-heading.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../vz-line-chart/vz-line-chart.html">
 
 <!--
-  A component that fetches scalar data from the TensorBoard server and
-  renders it into a vz-line-chart.
+  A component that fetches data from the TensorBoard server and renders it into
+  a vz-line-chart.
 -->
 <dom-module id="tf-scalar-chart">
   <template>
-    <tf-card-heading
-      tag="[[tag]]"
-      display-name="[[tagMetadata.displayName]]"
-      description="[[tagMetadata.description]]"
-    ></tf-card-heading>
     <div id="chart-and-spinner-container">
       <vz-line-chart
-        x-components-creation-method="[[_xComponentsCreationMethod]]"
-        y-value-accessor="[[_yValueAccessor]]"
+        x-components-creation-method="[[xComponentsCreationMethod]]"
+        y-value-accessor="[[yValueAccessor]]"
         color-scale="[[_runsColorScale]]"
-        tooltip-columns="[[_tooltipColumns]]"
+        tooltip-columns="[[tooltipColumns]]"
         smoothing-enabled="[[smoothingEnabled]]"
         smoothing-weight="[[smoothingWeight]]"
         tooltip-sorting-method="[[tooltipSortingMethod]]"
@@ -55,59 +45,12 @@ limitations under the License.
         </div>
       </template>
     </div>
-    <div style="display: flex; flex-direction: row;">
-      <paper-icon-button
-        selected$="[[_expanded]]"
-        icon="fullscreen"
-        on-tap="_toggleExpanded"
-      ></paper-icon-button>
-      <paper-icon-button
-        selected$="[[_logScaleActive]]"
-        icon="line-weight"
-        on-tap="_toggleLogScale"
-        title="Toggle y-axis log scale"
-      ></paper-icon-button>
-      <paper-icon-button
-        icon="settings-overscan"
-        on-tap="_resetDomain"
-        title="Fit domain to data"
-      ></paper-icon-button>
-      <span style="flex-grow: 1"></span>
-      <template is="dom-if" if="[[showDownloadLinks]]">
-        <div class="download-links">
-          <paper-dropdown-menu
-            no-label-float="true"
-            label="run to download"
-            selected-item-label="{{_runToDownload}}"
-          >
-            <paper-menu class="dropdown-content" slot="dropdown-content">
-              <template is="dom-repeat" items="[[runs]]">
-                <paper-item no-label-float=true>[[item]]</paper-item>
-              </template>
-            </paper-menu>
-          </paper-dropdown-menu>
-          <a
-            download="run_[[_runToDownload]]-tag-[[tag]].csv"
-            href="[[_csvUrl(tag, _runToDownload)]]"
-          >CSV</a> <a
-            download="run_[[_runToDownload]]-tag-[[tag]].json"
-            href="[[_jsonUrl(tag, _runToDownload)]]"
-          >JSON</a>
-          </div>
-        </div>
-      </template>
-    </div>
     <style>
       :host {
-        height: 235px;
-        width: 330px;
-        margin: 5px;
+        height: 100%;
+        width: 100%;
         display: flex;
         flex-direction: column;
-      }
-      :host[_expanded] {
-        height: 400px;
-        width: 100%;
       }
 
       :host[_maybe-rendered-in-bad-state] vz-line-chart {
@@ -119,6 +62,7 @@ limitations under the License.
         flex-grow: 1;
         position: relative;
       }
+
       #loading-spinner-container {
         align-items: center;
         bottom: 0;
@@ -131,51 +75,16 @@ limitations under the License.
         right: 0;
         top: 0;
       }
+
       vz-line-chart {
         -webkit-user-select: none;
         -moz-user-select: none;
       }
-      paper-icon-button {
-        color: #2196F3;
-        border-radius: 100%;
-        width: 32px;
-        height: 32px;
-        padding: 4px;
-      }
-      paper-icon-button[selected] {
-        background: var(--tb-ui-light-accent);
-      }
-
-      tf-card-heading {
-        margin-bottom: 10px;
-      }
-
-      .download-links {
-        display: flex;
-        height: 32px;
-      }
-      .download-links a {
-        font-size: 10px;
-        align-self: center;
-        margin: 2px;
-      }
-      .download-links paper-dropdown-menu {
-        width: 100px;
-        --paper-input-container-label: {
-          font-size: 10px;
-        }
-        --paper-input-container-input: {
-          font-size: 10px;
-        }
-      }
     </style>
   </template>
   <script>
-    import {addParams} from '../tf-backend/urlPathHelpers.js';
     import {Canceller} from '../tf-backend/canceller.js';
-    import {getRouter} from '../tf-backend/router.js';
     import {runsColorScale} from '../tf-color-scale/colorScale.js';
-    import * as ChartHelpers from '../vz-line-chart/vz-chart-helpers.js';
 
     // The chart can sometimes get in a bad state, when it redraws while
     // it is display: none due to the user having switched to a different
@@ -195,92 +104,33 @@ limitations under the License.
       }
     }, 100);
 
-    /** 
-     * Allows:
-     * - "step" - Linear scale using the "step" property of the datum.
-     * - "wall_time" - Temporal scale using the "wall_time" property of the
-     * datum.
-     * - "relative" - Temporal scale using the "relative" property of the
-     * datum if it is present or calculating from "wall_time" if it isn't.
-     * @enum {string}
-     * */
-    
-    const X_TYPE = {
-      STEP: 'step',
-      RELATIVE: 'relative',
-      WALL: 'wall',
-    };
-
     Polymer({
       is: 'tf-scalar-chart',
       properties: {
-        runs: Array,  // of String
+        // An array of selected runs (strings).
+        runs: Array,
         tag: String,
 
-        /**
-         * @type {X_TYPE}
-         */
+        xComponentsCreationMethod: Object,
         xType: String,
-
-        _xComponentsCreationMethod: {
-          type: Object,
-          computed: '_computeXComponentsCreationMethod(xType)',
-        },
-
-        _yValueAccessor: {
-          type: Object,
-          readOnly: true,
-          value: () => {
-            return d => d.scalar;
-          },
-        },
-
-        _tooltipColumns: {
-          type: Array,
-          readOnly: true,
-          value: () => {
-            const valueFormatter = ChartHelpers.multiscaleFormatter(
-                ChartHelpers.Y_TOOLTIP_FORMATTER_PRECISION);
-            const formatValueOrNaN =
-                (x) => isNaN(x) ? 'NaN' : valueFormatter(x);
-            return [
-              {
-                title: 'Name',
-                evaluate: (d) => d.dataset.metadata().name,
-              },
-              {
-                title: 'Smoothed',
-                evaluate: (d, statusObject) => formatValueOrNaN(
-                    statusObject.smoothingEnabled ?
-                        d.datum.smoothed : d.datum.scalar),
-              },
-              {
-                title: 'Value',
-                evaluate: (d) => formatValueOrNaN(d.datum.scalar),
-              },
-              {
-                title: 'Step',
-                evaluate: (d) => ChartHelpers.stepFormatter(d.datum.step),
-              },
-              {
-                title: 'Time',
-                evaluate: (d) => ChartHelpers.timeFormatter(d.datum.wall_time),
-              },
-              {
-                title: 'Relative',
-                evaluate:
-                    (d) => ChartHelpers.relativeFormatter(
-                        ChartHelpers.relativeAccessor(d.datum, -1, d.dataset)),
-              },
-            ]
-          },
-        },
+        yValueAccessor: Object,
+        tooltipColumns: Array,
 
         smoothingEnabled: Boolean,
         smoothingWeight: Number,
         tooltipSortingMethod: String,
         ignoreYOutliers: Boolean,
-        showDownloadLinks: Boolean,
+
+        /**
+         * A function that takes as inputs:
+         * 1. This tf-scalar-chart component.
+         * 2. The run (string) the response is relevant to.
+         * 3. The response received from the data URL.
+         * This function will be called when a response from a request to that
+         * data URL is successfully received.
+         * @type {Function}
+         */
+        processData: Object,
 
         active: {
           type: Boolean,
@@ -289,15 +139,13 @@ limitations under the License.
 
         requestManager: Object,
 
-        _logScaleActive: {
+        // A function that takes 2 string arguments (tag and run) and returns a
+        // string URL for fetching data.
+        dataUrl: Function,
+
+        logScaleActive: {
           type: Boolean,
           observer: '_logScaleChanged',
-        },
-
-        _expanded: {
-          type: Boolean,
-          value: false,
-          reflectToAttribute: true,  // for CSS
         },
 
         _runsColorScale: {
@@ -318,14 +166,6 @@ limitations under the License.
         _canceller: {
           type: Object,
           value: () => new Canceller(),
-        },
-
-        // Usage: this._scalarUrl('tag', 'run') yields the URL to the
-        // scalar data for the appropriate run and tag.
-        _scalarUrl: {
-          type: Function,
-          value: () => (tag, run) => addParams(
-              getRouter().pluginRoute('scalars', '/scalars'), {tag, run}),
         },
 
         /*
@@ -369,6 +209,18 @@ limitations under the License.
         this._loadedRuns = {};
         this._loadData();
       },
+      resetDomain() {
+        const chart = this.$$('vz-line-chart');
+        if (chart) {
+          chart.resetDomain();
+        }
+      },
+      setSeriesData(run, data) {
+        this.$$('vz-line-chart').setSeriesData(run, data);
+      },
+      redraw() {
+        this.$$('vz-line-chart').redraw();
+      },
       _tagChanged(attached, tagUpdateRecord) {
         this._loadedRuns = {};
         this._resetDomainOnNextLoad = true;
@@ -396,17 +248,11 @@ limitations under the License.
             if (this._loadedRuns[run]) {
               return Promise.resolve();
             }
-            const url = this._scalarUrl(tag, run);
+            const url = this.dataUrl(tag, run);
             const updateSeries = this._canceller.cancellable(result => {
               if (result.cancelled) {
                 return;
               }
-              const data = result.value;
-              const formattedData = data.map(datum => ({
-                wall_time: new Date(datum[0] * 1000),
-                step: datum[1],
-                scalar: datum[2],
-              }));
               if (tag === this.tag) {
                 // Only update the runs cache for the current tag. If we
                 // load data for Tag A, then the tag changes to Tag B
@@ -414,7 +260,7 @@ limitations under the License.
                 // should not poison the cache.
                 this._loadedRuns[run] = true;
               }
-              this.$$('vz-line-chart').setSeriesData(run, formattedData);
+              this.processData(this, run, result.value);
             });
             return this.requestManager.request(url).then(updateSeries);
           });
@@ -447,24 +293,11 @@ limitations under the License.
         this.$$('vz-line-chart').setVisibleSeries(this.runs);
         this._loadData();
       },
-      redraw() {
-        this.$$('vz-line-chart').redraw();
-      },
-
-      _toggleLogScale() {
-        this.set('_logScaleActive', !this._logScaleActive);
-      },
       _logScaleChanged(logScaleActive) {
         var chart = this.$$('vz-line-chart');
         chart.yScaleType = logScaleActive ? 'log' : 'linear';
         this.redraw();
       },
-
-      _toggleExpanded(e) {
-        this.set('_expanded', !this._expanded);
-        this.redraw();
-      },
-
       _computeLineChartStyle(loading) {
         return loading ? 'opacity: 0.3;' : '';
       },
@@ -478,23 +311,6 @@ limitations under the License.
           redrawQueue.push(this);
           cascadingRedraw();
         }
-      },
-
-      _resetDomain() {
-        const chart = this.$$('vz-line-chart');
-        if (chart) {
-          chart.resetDomain();
-        }
-      },
-
-      _csvUrl(tag, run) {
-        return addParams(this._scalarUrl(tag, run), {format: 'csv'});
-      },
-      _jsonUrl(tag, run) {
-        return this._scalarUrl(tag, run);
-      },
-      _computeXComponentsCreationMethod(xType) {
-        return () => ChartHelpers.getXComponents(xType);
       },
     });
   </script>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -34,7 +34,7 @@ limitations under the License.
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 <link rel="import" href="../tf-storage/tf-storage.html">
 <link rel="import" href="../tf-utils/tf-utils.html">
-<link rel="import" href="tf-scalar-chart.html">
+<link rel="import" href="tf-scalar-card.html">
 <link rel="import" href="tf-smoothing-input.html">
 
 <!--
@@ -136,7 +136,7 @@ limitations under the License.
                   <template is="dom-if" if="[[page.active]]">
                     <div class="layout horizontal wrap">
                       <template is="dom-repeat" items="[[page.items]]">
-                        <tf-scalar-chart
+                        <tf-scalar-card
                           x-type="[[_xType]]"
                           smoothing-enabled="[[_smoothingEnabled]]"
                           smoothing-weight="[[_smoothingWeight]]"
@@ -148,7 +148,7 @@ limitations under the License.
                           tag="[[item.tag]]"
                           tag-metadata="[[_tagMetadata(_runToTagInfo, item.runs, item.tag)]]"
                           active="[[page.active]]"
-                        ></tf-scalar-chart>
+                        ></tf-scalar-card>
                       </template>
                     </div>
                   </template>


### PR DESCRIPTION
Before this change, tf-scalar-chart.html contains much logic specific to
the scalars plugin. We extract that scalars-specific logic into a new
component called tf-scalar-card. Some of the logic extracted includes
properties that allow for setting X and Y axes, the buttons under the
chart, and the callback that is run when data is received from the
server.

This change is a step towards allowing any plugin to make use of the
tf-scalar-chart component (albeit a subsequent change will move and
rename this component to clarify that it is generally applicable). That
goal is desirable because tf-scalar-chart contains a lot of fixes that
correct for bugs in the vz-line-chart component and Plottable. Those fixes
include #163, #189, and #204. 

Screenshot (The scalars dashboard WAI):

![anf0v4j2pqa](https://user-images.githubusercontent.com/4221553/30008237-33395bfa-90d2-11e7-90d1-04ae72b66ccf.png)
