### PR TITLE
Log exceptions during processing in the modal

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/data-provider.ts
+++ b/tensorboard/plugins/projector/vz_projector/data-provider.ts
@@ -436,7 +436,7 @@ export function retrieveSpriteAndMetadataInfo(metadataPath: string,
       try {
         callback(metadata);
       } catch (e) {
-        logging.setModalMessage(`Error: ${e}`);
+        logging.setModalMessage(String(e));
       }
     }
   });

--- a/tensorboard/plugins/projector/vz_projector/data-provider.ts
+++ b/tensorboard/plugins/projector/vz_projector/data-provider.ts
@@ -433,7 +433,11 @@ export function retrieveSpriteAndMetadataInfo(metadataPath: string,
     } else {
       metadata.spriteImage = spriteImage;
       metadata.spriteMetadata = spriteMetadata;
-      callback(metadata);
+      try {
+        callback(metadata);
+      } catch (e) {
+        logging.setModalMessage(`Error: ${e}`);
+      }
     }
   });
 }


### PR DESCRIPTION
Previously, when an error occurred while the projector was processing data (creating data sets and vectors, normalizing data points, computing PCA, etc), it would be logged to the console.

<img width="1371" alt="screen shot 2017-09-04 at 12 42 26 am" src="https://user-images.githubusercontent.com/4221553/30017102-add6e8d4-910c-11e7-9991-70cab86f78cd.png">

This change uses a try ... catch block to make those exceptions appear as errors in the modal.

![c9vwa6xnw6k](https://user-images.githubusercontent.com/4221553/30017115-b958f3aa-910c-11e7-9340-1ac1cb8f1b85.png)

This change unfortunately hurts performance a bit because Chrome's V8 engine bypasses an optimized path for JS within a try ... catch block. However, so many people have taken issue with the lack of clarity surrounding projector bugs that I deem this change worth it.