### PR TITLE
Prevent computing unit norm of vectors of 0s

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -236,7 +236,11 @@ export class DataSet {
     for (let id = 0; id < this.points.length; ++id) {
       let dataPoint = this.points[id];
       dataPoint.vector = vector.sub(dataPoint.vector, centroid);
-      vector.unit(dataPoint.vector);
+      if (vector.norm2(dataPoint.vector) > 0) {
+        // If we take the unit norm of a vector of all 0s, we get a vector of
+        // all NaNs. We prevent that with a guard.
+        vector.unit(dataPoint.vector);
+      }
     }
   }
 


### PR DESCRIPTION
Previously, the embedding projector would take the norm of vectors of all 0s, resulting in vectors of all NaN values being used as part of PCA calculations. This change adds a guard to prevent that.

Fixes #450.