### PR TITLE
Use flex positioning for card headings

### DIFF
--- a/tensorboard/components/tf_card_heading/tf-card-heading-style.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading-style.html
@@ -38,8 +38,6 @@ limitations under the License.
       .heading-label {
         flex-grow: 1;
         margin-top: 4px;
-        /* TODO(@jart): Use proper width so overflow works. */
-        text-overflow: ellipsis;
         max-width: 100%;
         word-wrap: break-word;
       }

--- a/tensorboard/components/tf_card_heading/tf-card-heading-style.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading-style.html
@@ -22,11 +22,16 @@ limitations under the License.
   <template>
     <style>
 
+      figcaption {
+        width: 100%;
+      }
+
       /** Horizontal line of labels. */
       .heading-row {
         margin-top: -4px;
         display: flex;
         flex-direction: row;
+        flex-wrap: wrap;
       }
 
       /** Piece of text in the figure caption. */
@@ -35,13 +40,13 @@ limitations under the License.
         margin-top: 4px;
         /* TODO(@jart): Use proper width so overflow works. */
         text-overflow: ellipsis;
-        overflow: hidden;
+        max-width: 100%;
+        word-wrap: break-word;
       }
 
       /** Makes label show on the right. */
       .heading-right {
         flex-grow: 0;
-        margin-left: 0.5em;
       }
     </style>
   </template>

--- a/tensorboard/components/tf_card_heading/tf-card-heading-style.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading-style.html
@@ -25,12 +25,13 @@ limitations under the License.
       /** Horizontal line of labels. */
       .heading-row {
         margin-top: -4px;
-        clear: both;
+        display: flex;
+        flex-direction: row;
       }
 
       /** Piece of text in the figure caption. */
       .heading-label {
-        float: left;
+        flex-grow: 1;
         margin-top: 4px;
         /* TODO(@jart): Use proper width so overflow works. */
         text-overflow: ellipsis;
@@ -39,7 +40,7 @@ limitations under the License.
 
       /** Makes label show on the right. */
       .heading-right {
-        float: right;
+        flex-grow: 0;
         margin-left: 0.5em;
       }
     </style>

--- a/tensorboard/components/tf_card_heading/tf-card-heading.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading.html
@@ -41,7 +41,7 @@ limitations under the License.
   <template>
     <div class="container">
       <figcaption class="content">
-        <div class="row">
+        <div class="heading-row">
           <template is="dom-if" if="[[_nameLabel]]">
             <div itemprop="name" class="heading-label name">
               [[_nameLabel]]
@@ -56,7 +56,7 @@ limitations under the License.
           </template>
         </div>
         <template is="dom-if" if="[[_tagLabel]]">
-          <div class="row">
+          <div class="heading-row">
             <div class="heading-label">
               tag: <span itemprop="tag">[[_tagLabel]]</span>
             </div>


### PR DESCRIPTION
In comments within #430, @wchargin proposed that we use flex positioning
to position elements within the header. That seems like a robust idea.

This PR thus uses @wchargin's proposed method to implement @jart's
original, space-efficient design that makes use of both the left and
right sides of headings (if space is available).

![wdyssdns5d1](https://user-images.githubusercontent.com/4221553/30080044-1c4e9a66-9237-11e7-8cbc-8bb7e9d6f12d.png)

Having that idea lingering at the end of a closed PR seemed a bit precipitous, so I just went ahead and implemented.

This PR fixes the layout issues brought up in #430. This change also fixes #421.