### PR TITLE
Encode run and tag names

### DIFF
--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
@@ -211,9 +211,10 @@ backend.
         }
         this._metadataCanceller.cancelAll();
         const router = getRouter();
-        const baseURL = router.pluginRoute("audio", "/audio");
-        const query = `run=${this.run}&tag=${this.tag}&sample=${this.sample}`;
-        const url = baseURL + (baseURL.indexOf('?') !== -1 ? '&' : '?') + query;
+        const route = router.pluginRunTagRoute("audio", "/audio")(
+            this.tag, this.run);
+        const query = `sample=${this.sample}`;
+        const url = route + (route.indexOf('?') !== -1 ? '&' : '?') + query;
         const updateSteps = this._metadataCanceller.cancellable(result => {
           if (result.cancelled) {
             return;

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
@@ -213,8 +213,7 @@ backend.
         const router = getRouter();
         const route = router.pluginRunTagRoute("audio", "/audio")(
             this.tag, this.run);
-        const query = `sample=${this.sample}`;
-        const url = route + (route.indexOf('?') !== -1 ? '&' : '?') + query;
+        const url = `${route}&sample=${this.sample}`;
         const updateSteps = this._metadataCanceller.cancellable(result => {
           if (result.cancelled) {
             return;

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -308,8 +308,7 @@ future for loading older images.
         const router = getRouter();
         const route = router.pluginRunTagRoute("images", "/images")(
             this.tag, this.run);
-        const query = `sample=${this.sample}`;
-        const url = route + (route.indexOf('?') !== -1 ? '&' : '?') + query;
+        const url = `${route}&sample=${this.sample}`;
         const updateSteps = this._metadataCanceller.cancellable(result => {
           if (result.cancelled) {
             return;

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -306,9 +306,10 @@ future for loading older images.
         }
         this._metadataCanceller.cancelAll();
         const router = getRouter();
-        const baseURL = router.pluginRoute("images", "/images");
-        const query = `run=${this.run}&tag=${this.tag}&sample=${this.sample}`;
-        const url = baseURL + (baseURL.indexOf('?') !== -1 ? '&' : '?') + query;
+        const route = router.pluginRunTagRoute("images", "/images")(
+            this.tag, this.run);
+        const query = `sample=${this.sample}`;
+        const url = route + (route.indexOf('?') !== -1 ? '&' : '?') + query;
         const updateSteps = this._metadataCanceller.cancellable(result => {
           if (result.cancelled) {
             return;

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -295,8 +295,8 @@ limitations under the License.
 
         let url = router.pluginRoute('pr_curves', '/pr_curves');
         url += url.indexOf('?') > -1 ? '&' : '?';
-        url += `tag=${this.tag}`;
-        url += this.runs.map(r => `&run=${r}`).join('');
+        url += `tag=${encodeURIComponent(this.tag)}`;
+        url += this.runs.map(r => `&run=${encodeURIComponent(r)}`).join('');
 
         const updateData = this._canceller.cancellable(result => {
           if (result.cancelled) {


### PR DESCRIPTION
This change encodes the names of runs and tags included within the GET
parameters of URIs for the audio, image, and pr_curve plugins. We pass
those run and tag names into `encodeURIComponent`.

For the audio and image plugins, we simply needed to use
`pluginRunTagRoute` while constructing URLs. `pluginRunTagRoute` calls
`queryEncoder` from `urlPathHelpers`, which in turn calls
`encodeURIComponent`. The pr_curves plugin lacks that luxury because
its URLs contain multiple run GET property-value pairs, and
`pluginRunTagRoute` only supports 1 run argument. The scalars plugin
might seem analogous, but the scalars plugin actually requests data for
each run--tag combination separately.

Fixes #477. I verified that the audio, image, and PR curve plugins WAI.