### PR TITLE
Show layout analysis for convolution ops

### DIFF
--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-details.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-details.html
@@ -84,6 +84,31 @@ tf-op-bar {
   font-style: italic;
   color: #666;
 }
+
+.layout {
+  display: table;
+  width: 50%;
+  border-spacing: 1em 0.3em;
+}
+.layout > * { display: table-row; }
+.layout > * > * { display: table-cell; }
+.layout .size, .layout .size-x { text-align: center; }
+.layout .size-x { font-weight: bold; color: #888; }
+.layout .semantics {
+  font-size: smaller;
+  font-weight: bold;
+  color: #48c;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+.layout .alignment {
+  /* Make the background extend outside the box */
+  position: absolute;
+  padding: 0.5em;
+  margin-top: -0.5em;
+  width: 50%;
+  box-sizing: border-box;
+}
   </style>
   <template>
     <paper-card id="card" heading="[[node.name]]" elevation="2">
@@ -102,6 +127,19 @@ tf-op-bar {
         </div>
         <div class="unavailable" hidden="[[!node.category]]">
           Select items within this category for performace details.
+        </div>
+        <div hidden="[[!node.xla.layout]]">
+          <b>Layout: </b>
+          <div class="layout" hidden="[[!node.xla.layout]]">
+            <template is="dom-repeat" items="[[node.xla.layout.dimensions]]">
+              <div hidden="[[!index]]"><span class="size-x">×</span></div>
+              <div>
+                <span class="size">[[item.size]]</span>
+                <span class="semantics">[[item.semantics]]</span>
+                <span class="alignment" style$="background-color:[[_dimensionColor(item)]]">[[_dimensionHint(item)]]</span>
+              </div>
+            </template>
+          </div>
         </div>
       </div>
     </paper-card>
@@ -133,6 +171,20 @@ Polymer({
     return "Unknown";
   },
   _fused: function(node){ return node && node.xla && !node.metrics; },
+  _dimensionColor: function(dim) {
+    if (!dim || !dim.alignment) return null;
+    var ratio = dim.size / dim.alignment;
+    // Colors should grade harshly: 50% in a dimension is already very bad.
+    var harshCurve = (x) => 1 - Math.sqrt(1 - x);
+    return flameColor(ratio / Math.ceil(ratio), 1, 0.25, harshCurve);
+  },
+  _dimensionHint: function(dim) {
+    if (!dim || !dim.alignment) return null;
+    var mul = Math.ceil(dim.size / dim.alignment);
+    var mulSuffix = (mul == 1) ? "" : ": " + mul + " × " + dim.alignment;
+    if (dim.size % dim.alignment == 0) return "Exact fit" + mulSuffix;
+    return "Pad to " + (mul * dim.alignment) + mulSuffix;
+  },
 });
   </script>
 </dom-module>

--- a/tensorboard/plugins/profile/tf_op_profile/utils.ts
+++ b/tensorboard/plugins/profile/tf_op_profile/utils.ts
@@ -23,11 +23,13 @@ function rgba(red: number, green: number, blue: number, alpha: number) {
  * @param {number} fraction
  * @param {number=} brightness
  * @param {number=} opacity
+ * @param {Function=} curve mapping [0-1] to [0-1]
  * @return {string} An RGBA color.
  */
-export function flameColor(fraction: number, brightness = 1, opacity = 1) {
+export function flameColor(
+    fraction: number, brightness = 1, opacity = 1, curve = Math.sqrt) {
   if (isNaN(fraction)) return rgba(brightness, brightness, brightness, opacity);
-  fraction = Math.sqrt(fraction);  // Or everything is depressing and red.
+  fraction = curve(fraction); // Or everything is depressing and red.
   return (fraction < 0.5) ?
     rgba(brightness, 2 * fraction * brightness, 0, opacity) :
     rgba(2 * (1 - fraction) * brightness, brightness, 0, opacity);


### PR DESCRIPTION
This is designed to show how well your data fits the TPU. It looks like this:

![image](https://user-images.githubusercontent.com/548993/30108061-11f6be02-9301-11e7-9488-eee8ec9dabb3.png)

The new data is described in a change to `tensorflow/contrib/tpu/profiler/op_profile.proto` that hasn't made it to github yet. This is what's added to XLA instruction info:

    // Describes the physical memory layout of the instruction's primary input.
    // e.g. for a convolution, this analyzes the image and ignores the kernel.
    LayoutAnalysis layout = 5;
    message LayoutAnalysis {
      // The physical data layout, from most-minor to most-major dimensions.
      repeated Dimension dimensions = 1;
      message Dimension {
        int32 size = 1;       // Size of the data in this dimension.
        int32 alignment = 2;  // Data must be padded to a multiple of alignment.
        string semantics = 3;  // What the dimension represents, e.g. "spatial".
      }
    }