### PR TITLE
Note how we develop on TF nightly

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,19 @@
-# How to Develop TensorBoard
+# Development Guidelines
+
+## Contributor License Agreements
+
+We highly encourage contributions from the community. First, please fill out either the individual or corporate Contributor License Agreement (CLA).
+
+* If you are an individual writing original source code and you're sure you own the intellectual property, then you'll need to sign an individual CLA.
+* If you work for a company that wants to allow you to contribute your work, then you'll need to sign a corporate CLA.
+
+Only original source code from you and other people that have signed the CLA can be accepted into the main repository.
+
+## Setup
+
+TensorBoard at HEAD relies on the nightly installation of TensorFlow, so please install TensorFlow nighly for development. To install TensorFlow nightly, `pip install` the link to the [appropriate whl file listed at the TensorFlow repository](https://github.com/tensorflow/tensorflow).
+
+Our decision to develop on TensorFlow nightly has pros and cons. A main advantage is that plugin authors can use the latest features of TensorFlow. A disadvantage is that the previous release of TensorFlow does not suffice for development.
 
 Running TensorBoard automatically asks Bazel to create a vulcanized HTML binary:
 
@@ -6,10 +21,8 @@ Running TensorBoard automatically asks Bazel to create a vulcanized HTML binary:
 bazel run //tensorboard -- --logdir /path/to/logs
 ```
 
-If you need to generate fake data, run:
+To generate filler data for a plugin, run its demo script. For instance, this command generates fake scalar data in `/tmp/scalars_demo`:
 
 ```sh
 bazel run //tensorboard/plugins/scalar:scalars_demo
 ```
-
-This will generate some fake scalar data in `/tmp/scalars_demo`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # How to Develop TensorBoard
 
-TensorBoard at HEAD relies on the nightly installation of TensorFlow, so please install TensorFlow nighly for development. To install TensorFlow nightly, `pip install` the link to the [appropriate whl file listed at the TensorFlow repository](https://github.com/tensorflow/tensorflow).
+TensorBoard at HEAD relies on the nightly installation of TensorFlow, so please install TensorFlow nightly for development. To install TensorFlow nightly, `pip install` the link to the [appropriate whl file listed at the TensorFlow repository](https://github.com/tensorflow/tensorflow).
 
 Our decision to develop on TensorFlow nightly has pros and cons. A main advantage is that plugin authors can use the latest features of TensorFlow. A disadvantage is that the previous release of TensorFlow does not suffice for development.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,15 +1,4 @@
-# Development Guidelines
-
-## Contributor License Agreements
-
-We highly encourage contributions from the community. First, please fill out either the individual or corporate Contributor License Agreement (CLA).
-
-* If you are an individual writing original source code and you're sure you own the intellectual property, then you'll need to sign an individual CLA.
-* If you work for a company that wants to allow you to contribute your work, then you'll need to sign a corporate CLA.
-
-Only original source code from you and other people that have signed the CLA can be accepted into the main repository.
-
-## Setup
+# How to Develop TensorBoard
 
 TensorBoard at HEAD relies on the nightly installation of TensorFlow, so please install TensorFlow nighly for development. To install TensorFlow nightly, `pip install` the link to the [appropriate whl file listed at the TensorFlow repository](https://github.com/tensorflow/tensorflow).
 
@@ -21,7 +10,7 @@ Running TensorBoard automatically asks Bazel to create a vulcanized HTML binary:
 bazel run //tensorboard -- --logdir /path/to/logs
 ```
 
-To generate filler data for a plugin, run its demo script. For instance, this command generates fake scalar data in `/tmp/scalars_demo`:
+To generate fake data for a plugin, run its demo script. For instance, this command generates fake scalar data in `/tmp/scalars_demo`:
 
 ```sh
 bazel run //tensorboard/plugins/scalar:scalars_demo


### PR DESCRIPTION
Within DEVELOPMENT.md, we note how TensorBoard at HEAD relies on TF nightly - that seems important to developers and has been the root of various issues such as #431.