### PR TITLE
Remove `pluginRunTagRoute`

### DIFF
--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -15,15 +15,12 @@ limitations under the License.
 
 import {addParams} from './urlPathHelpers.js';
 
-export type RunTagUrlFn = (tag: string, run: string) => string;
-
 export interface Router {
   logdir: () => string;
   runs: () => string;
   pluginsListing: () => string;
   isDemoMode: () => boolean;
   pluginRoute: (pluginName: string, route: string) => string;
-  pluginRunTagRoute: (pluginName: string, route: string) => RunTagUrlFn;
 }
 ;
 
@@ -47,18 +44,12 @@ export function createRouter(dataDir = 'data', demoMode = false): Router {
   function pluginRoute(pluginName: string, route: string): string {
     return `${dataDir}/plugin/${pluginName}${route}`;
   }
-  function pluginRunTagRoute(pluginName: string, route: string):
-      ((tag: string, run: string) => string) {
-    const base = pluginRoute(pluginName, route);
-    return (tag, run) => addParams(base, {tag, run});
-  }
   return {
     logdir: () => dataDir + '/logdir',
     runs: () => dataDir + '/runs' + (demoMode ? '.json' : ''),
     pluginsListing: () => dataDir + '/plugins_listing',
     isDemoMode: () => demoMode,
     pluginRoute,
-    pluginRunTagRoute,
   };
 };
 

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-loader.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-loader.html
@@ -86,6 +86,7 @@ limitations under the License.
     </style>
   </template>
   <script>
+    import {addParams} from "../tf-backend/urlPathHelpers.js";
     import {Canceller} from "../tf-backend/canceller.js";
     import {getRouter} from "../tf-backend/router.js";
     import {runsColorScale} from "../tf-color-scale/colorScale.js";
@@ -142,8 +143,9 @@ limitations under the License.
         }
         this._canceller.cancelAll();
         const router = getRouter();
-        const url = router.pluginRunTagRoute("distributions", "/distributions")(
-          this.tag, this.run);
+        const url = addParams(
+          router.pluginRoute("distributions", "/distributions"),
+          {tag: this.tag, run: this.run});
         const updateData = this._canceller.cancellable(result => {
           if (result.cancelled) {
             return;

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -338,8 +338,9 @@ Polymer({
             (runToMetadata[runName] || []).sort(compareTagNames),
             tag => ({
               tag: tag,
-              path: getRouter().pluginRunTagRoute(
-                'graphs', '/run_metadata')(tag, runName),
+              path: addParams(
+                getRouter().pluginRoute('graphs', '/run_metadata'),
+                {tag: tag, run: runName}),
             })),
         }));
         this.set('_datasets', datasets);

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
@@ -93,7 +93,7 @@ limitations under the License.
   <script src="histogramCore.js"></script>
   <script>
     "use strict";
-
+    import {addParams} from "../tf-backend/urlPathHelpers.js";
     import {Canceller} from "../tf-backend/canceller.js";
     import {getRouter} from "../tf-backend/router.js";
     import {runsColorScale} from "../tf-color-scale/colorScale.js";
@@ -147,8 +147,10 @@ limitations under the License.
         }
         this._canceller.cancelAll();
         const router = getRouter();
-        const url = router.pluginRunTagRoute("histograms", "/histograms")(
-          this.tag, this.run);
+        const url = addParams(router.pluginRoute("histograms", "/histograms"), {
+          tag: this.tag,
+          run: this.run,
+        });
         const updateData = this._canceller.cancellable(result => {
           if (result.cancelled) {
             return;

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
@@ -73,6 +73,7 @@ tf-op-details {
   </template>
 
   <script>
+import {addParams} from "../tf-backend/urlPathHelpers.js";
 import {RequestManager} from '../tf-backend/requestManager.js';
 import {getRouter} from '../tf-backend/router.js';
 import {flameColor, utilization, percent} from './utils.js';
@@ -109,9 +110,8 @@ Polymer({
     },
   },
   _load: function(run) {
-    this._requestManager.request(
-        getRouter().
-            pluginRunTagRoute('profile', '/data')('op_profile', run)
+    this._requestManager.request(addParams(
+        getRouter().pluginRoute('profile', '/data'), {tag: 'op_profile', run})
     ).then((data) => {
       this._data = data;
     });

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -105,6 +105,7 @@ profile run can have multiple tools that present the performance profile as diff
 <script>
   "use strict";
 
+  import {addParams} from "../tf-backend/urlPathHelpers.js";
   import {RequestManager} from '../tf-backend/requestManager.js';
   import {compareTagNames} from "../vz-sorting/sorting.js";
   import {getRouter} from '../tf-backend/router.js';
@@ -199,8 +200,9 @@ profile run can have multiple tools that present the performance profile as diff
     },
     _maybeUpdateTool: function(datasets, selectedDataset, currentTool) {
       if (currentTool == "trace_viewer") {
-        var trace_data_url = (getRouter().pluginRunTagRoute('profile', '/data')(
-            'trace_viewer', datasets[selectedDataset].name));
+        var trace_data_url = addParams(
+            getRouter().pluginRoute('profile', '/data'),
+            {tag: 'trace_viewer', run: datasets[selectedDataset].name});
         // Make the trace data url relative to the root.
         if (trace_data_url[0] != '/') {
           trace_data_url = '/' + trace_data_url;

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
@@ -324,7 +324,8 @@ limitations under the License.
         // scalar data for the appropriate run and tag.
         _scalarUrl: {
           type: Function,
-          value: () => getRouter().pluginRunTagRoute('scalars', '/scalars'),
+          value: () => (tag, run) => addParams(
+              getRouter().pluginRoute('scalars', '/scalars'), {tag, run}),
         },
 
         /*

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
@@ -92,6 +92,7 @@ tf-text-loader displays markdown text data from the Text plugin.
     </style>
   </template>
   <script>
+    import {addParams} from "../tf-backend/urlPathHelpers.js";
     import {Canceller} from "../tf-backend/canceller.js";
     import {getRouter} from "../tf-backend/router.js";
     import {runsColorScale} from "../tf-color-scale/colorScale.js";
@@ -136,8 +137,10 @@ tf-text-loader displays markdown text data from the Text plugin.
         }
         this._canceller.cancelAll();
         const router = getRouter();
-        const url = router.pluginRunTagRoute("text", "/text")(
-          this.tag, this.run);
+        const url = addParams(router.pluginRoute("text", "/text"), {
+          tag: this.tag,
+          run: this.run,
+        });
         const updateTexts = this._canceller.cancellable(result => {
           if (result.cancelled) {
             return;


### PR DESCRIPTION
Summary:
A long, long time ago, we had one module `backend.ts` that had lots of
functions like `scalarTags()` and `scalar(run, tag)`. While
decentralizing these, I introduced `pluginRunTagRoute` as an immediate
compatibility layer for these functions.

But `pluginRunTagRoute` is not a good long-term solution. There’s no
reason that our backend core should assume the format of plugins’
routes. Plugins that need to extend this—say, with run, tag, and sample
parameters—use

    pluginRunTagRoute('foo', '/bar')(tag, run) + '&sample=sample',

which is bizarre because it requires the arguments in heterogeneous
form. Every route can easily just use `pluginRoute` and the `addParams`
function to specify exactly what it needs.

Test Plan:
I verified that all plugins work as intended.

wchargin-branch: remove-plugin-run-tag-route