### PR TITLE
Properly express data dependency in tf-downloader

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-downloader.html
+++ b/tensorboard/components/tf_dashboard_common/tf-downloader.html
@@ -36,12 +36,12 @@ limitations under the License.
     <div class="center">
       <span>
         <a
-          download="[[_csvName(_run)]]"
-          href="[[_csvUrl(_run, urlFn)]]"
+          download="[[_csvName(tag, _run)]]"
+          href="[[_csvUrl(tag, _run, urlFn)]]"
           >CSV</a>
         <a
-          download="[[_jsonName(_run)]]"
-          href="[[_jsonUrl(_run, urlFn)]]"
+          download="[[_jsonName(tag, _run)]]"
+          href="[[_jsonUrl(tag, _run, urlFn)]]"
           >JSON</a>
       </span>
     </div>
@@ -83,17 +83,17 @@ limitations under the License.
         tag: String,
         urlFn: Function,
       },
-      _csvUrl: function(_run, urlFn) {
-        return addParams(urlFn(this.tag, _run), {format: "csv"});
+      _csvUrl(tag, run, urlFn) {
+        return addParams(urlFn(tag, run), {format: "csv"});
       },
-      _jsonUrl: function(_run, urlFn) {
-        return urlFn(this.tag, _run);
+      _jsonUrl(tag, run, urlFn) {
+        return urlFn(tag, run);
       },
-      _csvName: function(_run) {
-        return "run_" + _run + ",tag_" + this.tag + ".csv";
+      _csvName(tag, run) {
+        return `run_${run},tag_${tag}.csv`;
       },
-      _jsonName: function(_run) {
-        return "run-" + _run + "-tag-" + this.tag + ".json";
+      _jsonName(tag, run) {
+        return `run_${run},tag_${tag}.json`;
       },
     });
   </script>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-chart.html
@@ -88,10 +88,10 @@ limitations under the License.
           </paper-dropdown-menu>
           <a
             download="run_[[_runToDownload]]-tag-[[tag]].csv"
-            href="[[_csvUrl(_runToDownload)]]"
+            href="[[_csvUrl(tag, _runToDownload)]]"
           >CSV</a> <a
             download="run_[[_runToDownload]]-tag-[[tag]].json"
-            href="[[_jsonUrl(_runToDownload)]]"
+            href="[[_jsonUrl(tag, _runToDownload)]]"
           >JSON</a>
           </div>
         </div>
@@ -487,11 +487,11 @@ limitations under the License.
         }
       },
 
-      _csvUrl(run) {
-        return addParams(this._scalarUrl(this.tag, run), {format: 'csv'});
+      _csvUrl(tag, run) {
+        return addParams(this._scalarUrl(tag, run), {format: 'csv'});
       },
-      _jsonUrl(run) {
-        return this._scalarUrl(this.tag, run);
+      _jsonUrl(tag, run) {
+        return this._scalarUrl(tag, run);
       },
       _computeXComponentsCreationMethod(xType) {
         return () => ChartHelpers.getXComponents(xType);


### PR DESCRIPTION
Summary and Test Plan:
Steps to reproduce bug fixed by this commit:
 1. Load the scalar sample dataset and enable one run.
 2. Check “Show data download links”.
 3. Select the run in the dropdown for the first tag, `delta`.
 4. _Paste_ into the search box: `temperature/current`. The first view
    now represents `temperature/current` instead of `delta`.
 5. Right-click the CSV download link, and copy the link location.

Before this commit: The link in the clipboard corresponds to `delta`.
After this commit: It corresponds to `temperature/current`.

Note: `tf-downloader` is never actually used. We can delete it if we
want. (I don’t think it carries its own weight: the implementation in
the scalar chart is cleaner than it would be using `tf-downloader`.)

wchargin-branch: fix-tf-downloader-data-dependency