### PR TITLE
Link function nodes with library

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
@@ -1018,6 +1018,21 @@ Polymer({
     if (nodeGroup) {
       tf.graph.scene.node.stylize(nodeGroup, node, this);
     }
+    
+    if (node.node.type === tf.graph.NodeType.META &&
+        node.node.associatedFunction &&
+        !node.isLibraryFunction) {
+      // The node is that of a function call. Also link the node within the
+      // function library. This clarifies to the user that the library function
+      // is being used.
+      var libraryFunctionNodeName = tf.graph.FUNCTION_LIBRARY_NODE_PREFIX +
+          node.node.associatedFunction;
+      var functionGroup = d3.select(
+          '.' + tf.graph.scene.Class.Scene.GROUP + '>.' +
+          tf.graph.scene.Class.Scene.FUNCTION_LIBRARY + ' g[data-name="' +
+          libraryFunctionNodeName + '"]');
+      tf.graph.scene.node.stylize(functionGroup, node, this);
+    }
 
     var annotationGroupIndex = this.getAnnotationGroupsIndex(n);
     _.each(annotationGroupIndex, function(aGroup, hostName) {


### PR DESCRIPTION
Make it so that when users highlight or select a node that is a call to
a function, the corresponding node within the function library is also
styled. This linking further clarifies that the nodes are related.

![ic2oezymn5m](https://user-images.githubusercontent.com/4221553/30145267-14fbc928-9345-11e7-8b4d-a7baec4841b5.png)
