### PR TITLE
Use compat to pre-empt how content is now bytes

### DIFF
--- a/tensorboard/backend/event_processing/event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/event_accumulator_test.py
@@ -873,7 +873,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
         display_name='current tagee',
         summary_description='no',
         plugin_data=tf.SummaryMetadata.PluginData(plugin_name='outlet',
-                                                  content='120v'))
+                                                  content=b'120v'))
     self._writeMetadata(logdir, summary_metadata_1, nonce='1')
     acc = ea.EventAccumulator(logdir)
     acc.Reload()
@@ -881,7 +881,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
         display_name='tagee of the future',
         summary_description='definitely not',
         plugin_data=tf.SummaryMetadata.PluginData(plugin_name='plug',
-                                                  content='110v'))
+                                                  content=b'110v'))
     self._writeMetadata(logdir, summary_metadata_2, nonce='2')
     acc.Reload()
 
@@ -897,7 +897,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
         display_name='current tagee',
         summary_description='no',
         plugin_data=tf.SummaryMetadata.PluginData(plugin_name='outlet',
-                                                  content='120v'))
+                                                  content=b'120v'))
     self._writeMetadata(logdir, summary_metadata_1, nonce='1')
     acc = ea.EventAccumulator(logdir)
     acc.Reload()
@@ -905,12 +905,12 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
         display_name='tagee of the future',
         summary_description='definitely not',
         plugin_data=tf.SummaryMetadata.PluginData(plugin_name='plug',
-                                                  content='110v'))
+                                                  content=b'110v'))
     self._writeMetadata(logdir, summary_metadata_2, nonce='2')
     acc.Reload()
 
     self.assertEqual(acc.PluginTagToContent('outlet'),
-                     {'you_are_it': '120v'})
+                     {'you_are_it': b'120v'})
     with six.assertRaisesRegex(self, KeyError, 'plug'):
       acc.PluginTagToContent('plug')
 

--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -475,7 +475,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
     with self.test_session() as sess:
       summary_metadata = tf.SummaryMetadata(
           plugin_data=tf.SummaryMetadata.PluginData(plugin_name=plugin_name,
-                                                    content='{}'))
+                                                    content=b'{}'))
       tf.summary.tensor_summary('scalar', tf.constant(1.0),
                                 summary_metadata=summary_metadata)
       merged = tf.summary.merge_all()
@@ -673,7 +673,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
         display_name='current tagee',
         summary_description='no',
         plugin_data=tf.SummaryMetadata.PluginData(plugin_name='outlet',
-                                                  content='120v'))
+                                                  content=b'120v'))
     self._writeMetadata(logdir, summary_metadata_1, nonce='1')
     acc = ea.EventAccumulator(logdir)
     acc.Reload()
@@ -681,7 +681,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
         display_name='tagee of the future',
         summary_description='definitely not',
         plugin_data=tf.SummaryMetadata.PluginData(plugin_name='plug',
-                                                  content='110v'))
+                                                  content=b'110v'))
     self._writeMetadata(logdir, summary_metadata_2, nonce='2')
     acc.Reload()
 
@@ -697,7 +697,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
         display_name='current tagee',
         summary_description='no',
         plugin_data=tf.SummaryMetadata.PluginData(plugin_name='outlet',
-                                                  content='120v'))
+                                                  content=b'120v'))
     self._writeMetadata(logdir, summary_metadata_1, nonce='1')
     acc = ea.EventAccumulator(logdir)
     acc.Reload()
@@ -705,12 +705,12 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
         display_name='tagee of the future',
         summary_description='definitely not',
         plugin_data=tf.SummaryMetadata.PluginData(plugin_name='plug',
-                                                  content='110v'))
+                                                  content=b'110v'))
     self._writeMetadata(logdir, summary_metadata_2, nonce='2')
     acc.Reload()
 
     self.assertEqual(acc.PluginTagToContent('outlet'),
-                     {'you_are_it': '120v'})
+                     {'you_are_it': b'120v'})
     with six.assertRaisesRegex(self, KeyError, 'plug'):
       acc.PluginTagToContent('plug')
 

--- a/tensorboard/data_compat_test.py
+++ b/tensorboard/data_compat_test.py
@@ -103,7 +103,7 @@ class MigrateValueTest(tf.test.TestCase):
     metadata = tf.SummaryMetadata(
         plugin_data=tf.SummaryMetadata.PluginData(
             plugin_name='font_of_wisdom',
-            content='adobe_garamond'))
+            content=b'adobe_garamond'))
     op = tf.summary.tensor_summary(
         name='tensorpocalypse',
         tensor=tf.constant([[0.0, 2.0], [float('inf'), float('nan')]]),

--- a/tensorboard/plugins/debugger/debugger_plugin.py
+++ b/tensorboard/plugins/debugger/debugger_plugin.py
@@ -398,7 +398,8 @@ class DebuggerPlugin(base_plugin.TBPlugin):
         plugin_data = summary_metadata.plugin_data
         if plugin_data.plugin_name == constants.DEBUGGER_PLUGIN_NAME:
           try:
-            content = json.loads(summary_metadata.plugin_data.content)
+            content = json.loads(
+                tf.compat.as_text(summary_metadata.plugin_data.content))
           except ValueError as err:
             tf.logging.warning(
                 'Could not parse the JSON string containing data for '

--- a/tensorboard/plugins/debugger/debugger_plugin.py
+++ b/tensorboard/plugins/debugger/debugger_plugin.py
@@ -201,7 +201,7 @@ class DebuggerPlugin(base_plugin.TBPlugin):
 
     jsonified_node_names = request.form[_NODE_NAMES_POST_KEY]
     try:
-      node_names = json.loads(jsonified_node_names)
+      node_names = json.loads(tf.compat.as_text(jsonified_node_names))
     except Exception as e:  # pylint: disable=broad-except
       # Different JSON libs raise different exceptions, so we just do a
       # catch-all here. This problem is complicated by how Tensorboard might be
@@ -281,7 +281,7 @@ class DebuggerPlugin(base_plugin.TBPlugin):
       for tensor_event in self._event_multiplexer.Tensors(run, node_name):
         json_string = tags_to_content[node_name]
         try:
-          content_object = json.loads(json_string)
+          content_object = json.loads(tf.compat.as_text(json_string))
           device_name = content_object['device']
           output_slot = content_object['outputSlot']
           health_pills.append(

--- a/tensorboard/plugins/debugger/debugger_plugin_testlib.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_testlib.py
@@ -139,7 +139,7 @@ class DebuggerPluginTestBase(tf.test.TestCase):
 
     mock_debugger_data_server = self.mock_debugger_data_server
     start = mock_debugger_data_server.start_the_debugger_data_receiving_server
-    start.assert_called_once()
+    self.assertEqual(1, start.call_count)
 
   def tearDown(self):
     # Remove the directory with debugger-related events files.

--- a/tensorboard/plugins/debugger/debugger_plugin_testlib.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_testlib.py
@@ -169,8 +169,9 @@ class DebuggerPluginTestBase(tf.test.TestCase):
     content_proto = debugger_event_metadata_pb2.DebuggerEventMetadata(
         device=device_name, output_slot=output_slot)
     value.metadata.plugin_data.plugin_name = constants.DEBUGGER_PLUGIN_NAME
-    value.metadata.plugin_data.content = json_format.MessageToJson(
-        content_proto, including_default_value_fields=True)
+    value.metadata.plugin_data.content = tf.compat.as_bytes(
+        json_format.MessageToJson(
+            content_proto, including_default_value_fields=True))
     return event
 
   def _DeserializeResponse(self, byte_content):

--- a/tensorboard/plugins/debugger/debugger_server_test.py
+++ b/tensorboard/plugins/debugger/debugger_server_test.py
@@ -98,7 +98,7 @@ class DebuggerDataServerTest(tf.test.TestCase):
     plugin_content = debugger_event_metadata_pb2.DebuggerEventMetadata(
         device="/job:localhost/replica:0/task:0/cpu:0", output_slot=output_slot)
     value.metadata.plugin_data.plugin_name = constants.DEBUGGER_PLUGIN_NAME
-    value.metadata.plugin_data.content = tf.compat.to_bytes(
+    value.metadata.plugin_data.content = tf.compat.as_bytes(
         json_format.MessageToJson(
             plugin_content, including_default_value_fields=True))
     return event

--- a/tensorboard/plugins/debugger/debugger_server_test.py
+++ b/tensorboard/plugins/debugger/debugger_server_test.py
@@ -98,8 +98,9 @@ class DebuggerDataServerTest(tf.test.TestCase):
     plugin_content = debugger_event_metadata_pb2.DebuggerEventMetadata(
         device="/job:localhost/replica:0/task:0/cpu:0", output_slot=output_slot)
     value.metadata.plugin_data.plugin_name = constants.DEBUGGER_PLUGIN_NAME
-    value.metadata.plugin_data.content = json_format.MessageToJson(
-        plugin_content, including_default_value_fields=True)
+    value.metadata.plugin_data.content = tf.compat.to_bytes(
+        json_format.MessageToJson(
+            plugin_content, including_default_value_fields=True))
     return event
 
   def _verify_event_lists_have_same_tensor_values(self, expected, gotten):

--- a/tensorboard/plugins/debugger/numerics_alert.py
+++ b/tensorboard/plugins/debugger/numerics_alert.py
@@ -313,6 +313,8 @@ def extract_numerics_alert(event):
   if not debugger_plugin_metadata_content:
     raise ValueError("Event proto input lacks debugger plugin SummaryMetadata.")
 
+  debugger_plugin_metadata_content = tf.compat.as_text(
+      debugger_plugin_metadata_content)
   try:
     content_object = json.loads(debugger_plugin_metadata_content)
     device_name = content_object["device"]

--- a/tensorboard/plugins/debugger/numerics_alert.py
+++ b/tensorboard/plugins/debugger/numerics_alert.py
@@ -26,6 +26,8 @@ import collections
 import json
 import re
 
+import tensorflow as tf
+
 from tensorflow.python import debug as tf_debug
 from tensorboard.plugins.debugger import constants
 


### PR DESCRIPTION
A proto change will soon make the type of the content field of
PluginData 'bytes' instead of 'string'. This PR pre-empts that
change by using the compat module to convert to bytes or text as
necessary within the debugger plugin.

Without this change, the script could fail because strings must
consist of UTF-8 characters, but bytes fields are not restricted by
that rule.

FYI @caisq 

Ideally, we would also use protos instead of JSON
serialization/deserialization, but can make that change in a
separate PR.