### PR TITLE
Add demo data for op_profile view

### DIFF
--- a/tensorboard/plugins/profile/BUILD
+++ b/tensorboard/plugins/profile/BUILD
@@ -73,6 +73,7 @@ py_binary(
         "profile_demo.py",
         "profile_demo_data.py",
     ],
+    data = ["profile_demo.op_profile.json"],
     srcs_version = "PY2AND3",
     deps = [
         ":profile_plugin",

--- a/tensorboard/plugins/profile/profile_demo.op_profile.json
+++ b/tensorboard/plugins/profile/profile_demo.op_profile.json
@@ -52,22 +52,22 @@
         },
         "children": [{
           "name": "%dot.1",
-          "children": [],
           "xla": {
             "op": "dot",
             "expression": "%dot.1 = something",
             "provenance": "TfOpForFusedDot",
             "category": "Good ops"
-          }
+          },
+          "children": []
         }, {
           "name": "%dot.2",
-          "children": [],
           "xla": {
             "op": "dot",
             "expression": "%dot.2 = something",
             "provenance": "",
             "category": "Good ops"
-          }
+          },
+          "children": []
         }]
       }]
     }, {
@@ -88,7 +88,8 @@
           "expression": "%infeed = something",
           "provenance": "",
           "category": "Overhead"
-        }
+        },
+        "children": []
       }]
     }]
   }

--- a/tensorboard/plugins/profile/profile_demo.op_profile.json
+++ b/tensorboard/plugins/profile/profile_demo.op_profile.json
@@ -1,0 +1,95 @@
+{
+  "byCategory": {
+    "name": "byCategory",
+    "metrics": {
+      "time": 1,
+      "flops": 0.4
+    },
+    "children": [{
+      "name": "Good ops",
+      "metrics": {
+        "time": 0.6,
+        "flops": 0.4
+      },
+      "category": {},
+      "children": [{
+        "name": "%convolution",
+        "metrics": {
+          "time": 0.2,
+          "flops": 0.18
+        },
+        "xla": {
+          "op": "convolution",
+          "expression": "%convolution = something",
+          "provenance": "Convolution2D",
+          "category": "Good ops",
+          "layout": {"dimensions":[{
+            "size": 200,
+            "alignment": 128,
+            "semantics": "feature"
+          }, {
+            "size": 8,
+            "alignment": 8,
+            "semantics": "batch"
+          }, {
+            "size": 256,
+            "alignment": 0,
+            "semantics": "spatial"
+          }]}
+        },
+        "children": []
+      }, {
+        "name": "%fusion",
+        "metrics": {
+          "time": 0.4,
+          "flops": 0.22
+        },
+        "xla": {
+          "op": "fusion:kOutput",
+          "expression": "%fusion = something",
+          "provenance": "",
+          "category": "Good ops"
+        },
+        "children": [{
+          "name": "%dot.1",
+          "children": [],
+          "xla": {
+            "op": "dot",
+            "expression": "%dot.1 = something",
+            "provenance": "TfOpForFusedDot",
+            "category": "Good ops"
+          }
+        }, {
+          "name": "%dot.2",
+          "children": [],
+          "xla": {
+            "op": "dot",
+            "expression": "%dot.2 = something",
+            "provenance": "",
+            "category": "Good ops"
+          }
+        }]
+      }]
+    }, {
+      "name": "Overhead",
+      "metrics": {
+        "time": 0.4,
+        "flops": 0
+      },
+      "category": {},
+      "children": [{
+        "name": "%infeed",
+        "metrics": {
+          "time": 0.4,
+          "flops": 0
+        },
+        "xla": {
+          "op": "infeed",
+          "expression": "%infeed = something",
+          "provenance": "",
+          "category": "Overhead"
+        }
+      }]
+    }]
+  }
+}

--- a/tensorboard/plugins/profile/profile_demo.py
+++ b/tensorboard/plugins/profile/profile_demo.py
@@ -33,6 +33,7 @@ from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.plugins.profile import profile_demo_data
 from tensorboard.plugins.profile import profile_plugin
 from tensorboard.plugins.profile import trace_events_pb2
+from shutil import copyfile
 
 # Directory into which to write tensorboard data.
 LOGDIR = '/tmp/profile_demo'
@@ -59,6 +60,8 @@ def dump_data(logdir):
         proto = trace_events_pb2.Trace()
         text_format.Merge(profile_demo_data.TRACES[run], proto)
         f.write(proto.SerializeToString())
+    copyfile('tensorboard/plugins/profile/profile_demo.op_profile.json',
+             os.path.join(run_dir, 'op_profile.json'))
 
   # Unsupported tool data should not be displayed.
   run_dir = os.path.join(plugin_logdir, 'empty')

--- a/tensorboard/plugins/profile/profile_demo.py
+++ b/tensorboard/plugins/profile/profile_demo.py
@@ -26,6 +26,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import shutil
 import tensorflow as tf
 
 from google.protobuf import text_format
@@ -33,7 +34,6 @@ from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.plugins.profile import profile_demo_data
 from tensorboard.plugins.profile import profile_plugin
 from tensorboard.plugins.profile import trace_events_pb2
-from shutil import copyfile
 
 # Directory into which to write tensorboard data.
 LOGDIR = '/tmp/profile_demo'
@@ -60,8 +60,8 @@ def dump_data(logdir):
         proto = trace_events_pb2.Trace()
         text_format.Merge(profile_demo_data.TRACES[run], proto)
         f.write(proto.SerializeToString())
-    copyfile('tensorboard/plugins/profile/profile_demo.op_profile.json',
-             os.path.join(run_dir, 'op_profile.json'))
+    shutil.copyfile('tensorboard/plugins/profile/profile_demo.op_profile.json',
+                    os.path.join(run_dir, 'op_profile.json'))
 
   # Unsupported tool data should not be displayed.
   run_dir = os.path.join(plugin_logdir, 'empty')


### PR DESCRIPTION
The data is about the minimal set that exercises all current features (and #484)

For brevity, it omits some "required" stuff we don't currently use, like the byProgramStructure tree, and the raw{Time,Flops} metrics.

@ioeric 