### PR TITLE
Introduce the selected_dataset GET parameter

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_dashboard/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/BUILD
@@ -14,6 +14,7 @@ ts_web_library(
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_storage",
         "//tensorboard/components/vz_sorting",
         "//tensorboard/plugins/graph/tf_graph",
         "//tensorboard/plugins/graph/tf_graph_board",

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -35,6 +35,7 @@ by default. The user can select a different run from a dropdown menu.
 -->
 <dom-module id="tf-graph-dashboard">
 <template>
+<paper-dialog id="error-dialog" with-backdrop></paper-dialog>
 <template is="dom-if" if="[[_datasetsEmpty(_datasets)]]">
   <div style="max-width: 540px; margin: 80px auto 0 auto;">
     <h3>No graph definition files were found.</h3>
@@ -120,6 +121,10 @@ by default. The user can select a different run from a dropdown menu.
   height: 100%;
 }
 
+paper-dialog {
+  padding: 20px;
+}
+
 </style>
 </template>
 </dom-module>
@@ -130,11 +135,18 @@ import {Canceller} from "../tf-backend/canceller.js";
 import {compareTagNames} from "../vz-sorting/sorting.js";
 import {getRouter} from "../tf-backend/router.js";
 import {addParams} from "../tf-backend/urlPathHelpers.js";
+import {queryEncoder} from "../tf-backend/urlPathHelpers.js";
+import * as storage from '../tf-storage/storage.js';
+
+/**
+ * The (string) name for the run of the selected dataset in the graph dashboard.
+ */
+const RUN_STORAGE_KEY = 'run';
 
 Polymer({
   is: 'tf-graph-dashboard',
   properties: {
-    _datasets: Object,
+    _datasets: Array,
     _renderHierarchy: {type: Object, observer: '_renderHierarchyChanged'},
     _requestManager: {
       type: Object,
@@ -193,6 +205,20 @@ Polymer({
       value: true,  // TODO(@chihuahua): Reconcile this setting with Health Pills.
       readOnly: true,
     },
+    run: {
+      type: String,
+      notify: true,
+      value: storage.getStringInitializer(
+          RUN_STORAGE_KEY, {
+            defaultValue: '',
+            useLocalStorage: false,
+          }),
+      observer: '_runObserver',
+    },
+    _selectedDataset: {
+      type: Number,
+      notify: true,
+    },
   },
   listeners: {
     'node-toggle-expand': '_handleNodeToggleExpand',
@@ -201,6 +227,8 @@ Polymer({
     '_maybeFetchHealthPills(_debuggerDataEnabled, allStepsModeEnabled, ' +
         'specificHealthPillStep, _selectedNode)',
     '_maybeInitializeDashboard(_isAttached)',
+    '_determineSelectedDataset(_datasets, run)',
+    '_updateSelectedDatasetName(_datasets, _selectedDataset)',
   ],
   attached: function() {
     this.set('_isAttached', true);
@@ -230,6 +258,12 @@ Polymer({
 
     this._maybeFetchHealthPills();
   },
+  _runObserver: storage.getStringObserver(
+      RUN_STORAGE_KEY, {
+        defaultValue: '',
+        polymerProperty: 'run',
+        useLocalStorage: false,
+      }),
   _fetchGraphRuns() {
     return this._requestManager.request(
         getRouter().pluginRoute('graphs', '/runs'));
@@ -310,6 +344,31 @@ Polymer({
         }));
         this.set('_datasets', datasets);
       });
+  },
+  _determineSelectedDataset(datasets, run) {
+    // By default, load the first dataset.
+    if (!run) {
+      // By default, load the first dataset. 
+      this.set('_selectedDataset', 0);
+      return;
+    }
+    
+    // If the URL specifies a dataset, load it.
+    const dataset = datasets.findIndex(d => d.name === run);
+    if (dataset === -1) {
+      // Tell the user if the dataset cannot be found to avoid misleading
+      // the user.
+      const dialog = this.$$('#error-dialog');
+      dialog.textContent =
+          `No dataset named "${run}" could be found.`;
+      dialog.open();
+      return;
+    }
+
+    this.set('_selectedDataset', dataset);
+  },
+  _updateSelectedDatasetName(datasets, selectedDataset) {
+    this.set('run', datasets[selectedDataset].name);
   },
   _requestHealthPills: function() {
     this.set('_areHealthPillsLoading', true);


### PR DESCRIPTION
Introduced a selected_dataset GET parameter for the graph dashboard. The
value of this parameter is the name of the dataset (run) to load. This
parameter lets users send links to other users of the graph dashboard
that load specific datasets. Fixes #306.

When the user changes the dataset in the graph dashboard UI, the URL
parameter correspondingly changes. I tested this behavior out using the
various runs of the scalars demo. The correct dataset loads given the
selected_dataset parameter, and the URL changes when the dataset is
changed in the UI.

For instance, http://localhost:6006/#graphs&selected_dataset=temperature%3At0%3D270%2CtA%3D270%2CkH%3D0.001 makes the dashboard load the correct dataset.

If no dataset with the specified name can be found, we show a dialog
that notifies the user. This avoids misleading the user.

![download](https://user-images.githubusercontent.com/4221553/30196233-e7c250ce-9413-11e7-8a59-edb96577d2ce.png)

Set the type of the graph dashboard's `_datasets` property to Array. It had
previously been Object (incorrect).
