### PR TITLE
Redesign the `tf-storage` module

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.ts
@@ -27,7 +27,7 @@ Polymer({
     },  // All the runs in consideration
     regexInput: {
       type: String,
-      value: storage.getStringInitializer('regexInput', ''),
+      value: storage.getStringInitializer('regexInput', {defaultValue: ''}),
       observer: '_regexInputObserver',
     },  // Regex for filtering the runs
     regex: {type: Object, computed: '_makeRegex(regexInput)'},
@@ -39,7 +39,8 @@ Polymer({
       // if a run is explicitly enabled, True, if explicitly disabled, False.
       // if undefined, default value (enable for first k runs, disable after).
       type: Object,
-      value: storage.getObjectInitializer('runSelectionState', {}),
+      value: storage.getObjectInitializer(
+          'runSelectionState', {defaultValue: {}}),
       observer: '_storeRunToIsCheckedMapping',
     },
     // (Allows state to persist across regex filtering)
@@ -87,7 +88,7 @@ Polymer({
     '_setIsolatorIcon(runSelectionState, names)',
   ],
   _storeRunToIsCheckedMapping:
-      storage.getObjectObserver('runSelectionState', {}),
+      storage.getObjectObserver('runSelectionState', {defaultValue: {}}),
   _makeRegex: function(regex) {
     try {
       return new RegExp(regex)
@@ -166,7 +167,7 @@ Polymer({
   _isChecked: function(item, outSelectedChange) {
     return this.outSelected.indexOf(item) != -1;
   },
-  _regexInputObserver: storage.getStringObserver('regexInput', ''),
+  _regexInputObserver: storage.getStringObserver('regexInput', {defaultValue: ''}),
   toggleAll: function() {
     var _this = this;
     var anyToggledOn = this.namesMatchingRegex.some(function(n) {

--- a/tensorboard/components/tf_dashboard_common/tf-regex-group.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-regex-group.ts
@@ -21,7 +21,8 @@ Polymer({
     rawRegexes: {
       type: Array,
       value: storage.getObjectInitializer(
-          'rawRegexes', [{regex: '', valid: true}]),
+          'rawRegexes',
+          {defaultValue: [{regex: '', valid: true}]}),
     },
     regexes:
         {type: Array, computed: 'usableRegexes(rawRegexes.*)', notify: true},
@@ -31,8 +32,9 @@ Polymer({
     'checkValidity(rawRegexes.*)',
     '_uriStoreRegexes(rawRegexes.*)',
   ],
-  _uriStoreRegexes:
-      storage.getObjectObserver('rawRegexes', [{regex: '', valid: true}]),
+  _uriStoreRegexes: storage.getObjectObserver(
+      'rawRegexes',
+      {defaultValue: [{regex: '', valid: true}]}),
   checkValidity: function(x) {
     var match = x.path.match(/rawRegexes\.(\d+)\.regex/);
     if (match) {

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -33,7 +33,7 @@ type StringDict = {[key: string]: string};
  * A key that users cannot use, since TensorBoard uses this to store info
  * about the active tab.
  */
-export let TAB = '__tab__';
+export const TAB = '__tab__';
 
 /**
  * The name of the property for users to set on a Polymer component
@@ -51,82 +51,155 @@ export let TAB = '__tab__';
  * it is NOT safe to change the disambiguator string without find+replace
  * across the codebase.
  */
-export let DISAMBIGUATOR = 'disambiguator';
+export const DISAMBIGUATOR = 'disambiguator';
 
-/**
- * Return a string stored in URI or localStorage.
- * Undefined if not found.
- */
-export function getString(key: string, useLocalStorage: boolean): string {
-  if (useLocalStorage) {
-    return window.localStorage.getItem(key);
-  } else {
-    return _componentToDict(_readComponent())[key];
+export const {
+  get: getString,
+  set: setString,
+  getInitializer: getStringInitializer,
+  getObserver: getStringObserver,
+} = makeBindings(x => x, x => x);
+
+export const {
+  get: getBoolean,
+  set: setBoolean,
+  getInitializer: getBooleanInitializer,
+  getObserver: getBooleanObserver,
+} = makeBindings(
+  s => (s === 'true' ? true: s === 'false' ? false : undefined),
+  b => b.toString());
+
+export const {
+  get: getNumber,
+  set: setNumber,
+  getInitializer: getNumberInitializer,
+  getObserver: getNumberObserver,
+} = makeBindings(
+  s => +s,
+  n => n.toString());
+
+export const {
+  get: getObject,
+  set: setObject,
+  getInitializer: getObjectInitializer,
+  getObserver: getObjectObserver,
+} = makeBindings(
+  s => JSON.parse(atob(s)),
+  o => btoa(JSON.stringify(o)));
+
+export interface StorageOptions<T> {
+  defaultValue: T;
+  polymerProperty?: string;
+  useLocalStorage?: boolean;
+}
+
+function makeBindings<T>(fromString: (string) => T, toString: (T) => string): {
+    get: (key: string, useLocalStorage?: boolean) => T,
+    set: (key: string, value: T, useLocalStorage?: boolean) => void,
+    getInitializer: (key: string, options: StorageOptions<T>) => Function,
+    getObserver: (key: string, options: StorageOptions<T>) => Function,
+} {
+  function get(key: string, useLocalStorage = false): T {
+    const value = useLocalStorage ?
+      window.localStorage.getItem(key) :
+      componentToDict(readComponent())[key];
+    return value === undefined ? undefined : fromString(value);
   }
-}
 
-/**
- * Set a string in URI or localStorage.
- */
-export function setString(
-    key: string, value: string, useLocalStorage: boolean) {
-  if (useLocalStorage) {
-    window.localStorage.setItem(key, value);
-  } else {
-    const items = _componentToDict(_readComponent());
-    items[key] = value;
-    _writeComponent(_dictToComponent(items));
+  function set(key: string, value: T, useLocalStorage = false): void {
+    const stringValue = toString(value);
+    if (useLocalStorage) {
+      window.localStorage.setItem(key, stringValue);
+    } else {
+      const items = componentToDict(readComponent());
+      items[key] = stringValue;
+      writeComponent(dictToComponent(items));
+    }
   }
-}
 
-/**
- * Return a boolean stored in stored in URI or localStorage.
- * Undefined if not found.
- */
-export function getBoolean(key: string, useLocalStorage: boolean): boolean {
-  const item = getString(key, useLocalStorage);
-  return item === 'true' ? true : item === 'false' ? false : undefined;
-}
+  function getInitializer(key: string, options: StorageOptions<T>): Function {
+    const fullOptions = {
+      defaultValue: options.defaultValue,
+      polymerProperty: key,
+      useLocalStorage: false,
+      ...options,
+    };
+    return function() {
+      const uriStorageName = getURIStorageName(this, key);
+      // setComponentValue will be called every time the hash changes,
+      // and is responsible for ensuring that new state in the hash will
+      // be propagated to the component with that property. It is
+      // important that this function does not re-assign needlessly,
+      // to avoid Polymer observer churn.
+      const setComponentValue = () => {
+        const uriValue = get(uriStorageName, false);
+        const currentValue = this[fullOptions.polymerProperty];
+        // if uriValue is undefined, we will ensure that the property has the
+        // default value
+        if (uriValue === undefined) {
+          let valueToSet: T;
+          // if we are using localStorage, we will set the value to the value
+          // from localStorage. Then, the corresponding observer will proxy
+          // the localStorage value into URI storage.
+          // in this way, localStorage takes precedence over the default val
+          // but not over the URI value.
+          if (fullOptions.useLocalStorage) {
+            const useLocalStorageValue = get(uriStorageName, true);
+            valueToSet = useLocalStorageValue === undefined ?
+              fullOptions.defaultValue :
+              useLocalStorageValue;
+          } else {
+            valueToSet = fullOptions.defaultValue;
+          }
+          if (!_.isEqual(currentValue, valueToSet)) {
+            // If we don't have an explicit URI value, then we need to ensure
+            // the property value is equal to the default value.
+            // We will assign a clone rather than the canonical default, because
+            // the component receiving this property may mutate it, and we need
+            // to keep a pristine copy of the default.
+            this[fullOptions.polymerProperty] = _.cloneDeep(valueToSet);
+          }
+          // In this case, we have an explicit URI value, so we will ensure that
+          // the component has an equivalent value.
+        } else {
+          if (!_.isEqual(uriValue, currentValue)) {
+            this[fullOptions.polymerProperty] = uriValue;
+          }
+        }
+      };
+      // Set the value on the property.
+      setComponentValue();
+      // Update it when the hashchanges.
+      window.addEventListener('hashchange', setComponentValue);
+    };
+  }
 
-/**
- * Store a boolean in URI or localStorage.
- */
-export function setBoolean(
-    key: string, value: boolean, useLocalStorage = false) {
-  setString(key, value.toString(), useLocalStorage);
-}
+  function getObserver(key: string, options: StorageOptions<T>): Function {
+    const fullOptions = {
+      defaultValue: options.defaultValue,
+      polymerProperty: key,
+      useLocalStorage: false,
+      ...options,
+    };
+    return function() {
+      const uriStorageName = getURIStorageName(this, key);
+      const newVal = this[fullOptions.polymerProperty];
+      // if this is a localStorage property, we always synchronize the value
+      // in localStorage to match the one currently in the URI.
+      if (fullOptions.useLocalStorage) {
+        set(uriStorageName, newVal, true);
+      }
+      if (!_.isEqual(newVal, get(uriStorageName, false))) {
+        if (_.isEqual(newVal, fullOptions.defaultValue)) {
+          unsetFromURI(uriStorageName);
+        } else {
+          set(uriStorageName, newVal, false);
+        }
+      }
+    };
+  }
 
-/**
- * Return a number stored in stored in URI or localStorage.
- * Undefined if not found.
- */
-export function getNumber(key: string, useLocalStorage: boolean): number {
-  const item = getString(key, useLocalStorage);
-  return item === undefined ? undefined : +item;
-}
-
-/**
- * Store a number in URI or localStorage.
- */
-export function setNumber(
-    key: string, value: number, useLocalStorage: boolean) {
-  setString(key, '' + value, useLocalStorage);
-}
-
-/**
- * Return an object stored in stored in URI or localStorage.
- * Undefined if not found.
- */
-export function getObject(key: string, useLocalStorage: boolean): {} {
-  const item = getString(key, useLocalStorage);
-  return item === undefined ? undefined : JSON.parse(atob(item));
-}
-
-/**
- * Store an object in URI or localStorage.
- */
-export function setObject(key: string, value: {}, useLocalStorage: boolean) {
-  setString(key, btoa(JSON.stringify(value)), useLocalStorage);
+  return {get, set, getInitializer, getObserver};
 }
 
 /**
@@ -135,134 +208,25 @@ export function setObject(key: string, value: {}, useLocalStorage: boolean) {
  * DISAMBIGUATOR must be set on the component, if other components use the
  * same propertyName.
  */
-export function getURIStorageName(
+function getURIStorageName(
     component: {}, propertyName: string): string {
   const d = component[DISAMBIGUATOR];
   const components = d == null ? [propertyName] : [d, propertyName];
   return components.join('.');
 }
 
-/**
- * Return a function that:
- * (1) Initializes a Polymer boolean property with a default value, if its
- *     value is not already set
- * (2) Sets up listener that updates Polymer property on hash change.
- *
- * @param {boolean=} useLocalStorage
- */
-export function getBooleanInitializer(
-    propertyName: string, defaultVal: boolean,
-    useLocalStorage = false): Function {
-  return _getInitializer(
-      getBoolean, propertyName, defaultVal, useLocalStorage);
-}
-
-/**
- * Return a function that:
- * (1) Initializes a Polymer string property with a default value, if its
- *     value is not already set
- * (2) Sets up listener that updates Polymer property on hash change.
- *
- * @param {boolean=} useLocalStorage
- */
-export function getStringInitializer(
-    propertyName: string, defaultVal: string,
-    useLocalStorage = false): Function {
-  return _getInitializer(
-      getString, propertyName, defaultVal, useLocalStorage);
-}
-
-/**
- * Return a function that:
- * (1) Initializes a Polymer number property with a default value, if its
- *     value is not already set
- * (2) Sets up listener that updates Polymer property on hash change.
- *
- * @param {boolean=} useLocalStorage
- */
-export function getNumberInitializer(
-    propertyName: string, defaultVal: number,
-    useLocalStorage = false): Function {
-  return _getInitializer(
-      getNumber, propertyName, defaultVal, useLocalStorage);
-}
-
-/**
- * Return a function that:
- * (1) Initializes a Polymer Object property with a default value, if its
- *     value is not already set
- * (2) Sets up listener that updates Polymer property on hash change.
- *
- * Generates a deep clone of the defaultVal to avoid mutation issues.
- *
- * @param {boolean=} useLocalStorage
- */
-export function getObjectInitializer(
-    propertyName: string, defaultVal: {}, useLocalStorage = false): Function {
-  return _getInitializer(
-      getObject, propertyName, defaultVal, useLocalStorage);
-}
-
-/**
- * Return a function that updates URIStorage when a string property changes.
- *
- * @param {boolean=} useLocalStorage
- */
-export function getBooleanObserver(
-    propertyName: string, defaultVal: boolean,
-    useLocalStorage = false): Function {
-  return _getObserver(
-      getBoolean, setBoolean, propertyName, defaultVal, useLocalStorage);
-}
-
-/**
- * Return a function that updates URIStorage when a string property changes.
- *
- * @param {boolean=} useLocalStorage
- */
-export function getStringObserver(
-    propertyName: string, defaultVal: string,
-    useLocalStorage = false): Function {
-  return _getObserver(
-      getString, setString, propertyName, defaultVal, useLocalStorage);
-}
-
-/**
- * Return a function that updates URIStorage when a number property changes.
- *
- * @param {boolean=} useLocalStorage
- */
-export function getNumberObserver(
-    propertyName: string, defaultVal: number,
-    useLocalStorage = false): Function {
-  return _getObserver(
-      getNumber, setNumber, propertyName, defaultVal, useLocalStorage);
-}
-
-/**
- * Return a function that updates URIStorage when an object property changes.
- * Generates a deep clone of the defaultVal to avoid mutation issues.
- *
- * @param {boolean=} useLocalStorage
- */
-export function getObjectObserver(
-    propertyName: string, defaultVal: {}, useLocalStorage = false): Function {
-  const clone = _.cloneDeep(defaultVal);
-  return _getObserver(
-      getObject, setObject, propertyName, clone, useLocalStorage);
-}
 
 /**
  * Read component from URI (e.g. returns "events&runPrefix=train*").
  */
-function _readComponent(): string {
+function readComponent(): string {
   return useHash() ? window.location.hash.slice(1) : getFakeHash();
 }
 
 /**
  * Write component to URI.
  */
-function _writeComponent(component: string) {
+function writeComponent(component: string) {
   if (useHash()) {
     window.location.hash = component;
   } else {
@@ -277,7 +241,7 @@ function _writeComponent(component: string) {
  * gets prepended to the URI Component string for backwards compatibility
  * reasons.
  */
-function _dictToComponent(items: StringDict): string {
+function dictToComponent(items: StringDict): string {
   let component = '';
 
   // Add the tab name e.g. 'events', 'images', 'histograms' as a prefix
@@ -305,7 +269,7 @@ function _dictToComponent(items: StringDict): string {
  * Returns dict consisting of all key-value pairs and
  * dict[TAB] = tabName
  */
-function _componentToDict(component: string): StringDict {
+function componentToDict(component: string): StringDict {
   const items = {} as StringDict;
 
   const tokens = component.split('&');
@@ -322,95 +286,10 @@ function _componentToDict(component: string): StringDict {
 }
 
 /**
- * Return a function that:
- * (1) Initializes a Polymer property with a default value, if its
- *     value is not already set
- * (2) Sets up listener that updates Polymer property on hash change.
- */
-function _getInitializer<T>(
-    get: (name: string, useLocalStorage: boolean) => T, propertyName: string,
-    defaultVal: T, useLocalStorage): Function {
-  return function() {
-    const URIStorageName = getURIStorageName(this, propertyName);
-    // setComponentValue will be called every time the hash changes, and is
-    // responsible for ensuring that new state in the hash will be propagated
-    // to the component with that property.
-    // It is important that this function does not re-assign needlessly,
-    // to avoid Polymer observer churn.
-    const setComponentValue = () => {
-      const uriValue = get(URIStorageName, false);
-      const currentValue = this[propertyName];
-      // if uriValue is undefined, we will ensure that the property has the
-      // default value
-      if (uriValue === undefined) {
-        let valueToSet: T;
-        // if we are using localStorage, we will set the value to the value
-        // from localStorage. Then, the corresponding observer will proxy
-        // the localStorage value into URI storage.
-        // in this way, localStorage takes precedence over the default val
-        // but not over the URI value.
-        if (useLocalStorage) {
-          const useLocalStorageValue = get(URIStorageName, true);
-          valueToSet = useLocalStorageValue === undefined ?
-              defaultVal :
-              useLocalStorageValue;
-        } else {
-          valueToSet = defaultVal;
-        }
-        if (!_.isEqual(currentValue, valueToSet)) {
-          // If we don't have an explicit URI value, then we need to ensure
-          // the property value is equal to the default value.
-          // We will assign a clone rather than the canonical default, because
-          // the component receiving this property may mutate it, and we need
-          // to keep a pristine copy of the default.
-          this[propertyName] = _.clone(valueToSet);
-        }
-        // In this case, we have an explicit URI value, so we will ensure that
-        // the component has an equivalent value.
-      } else {
-        if (!_.isEqual(uriValue, currentValue)) {
-          this[propertyName] = uriValue;
-        }
-      }
-    };
-    // Set the value on the property.
-    setComponentValue();
-    // Update it when the hashchanges.
-    window.addEventListener('hashchange', setComponentValue);
-  };
-}
-
-/**
- * Return a function that updates URIStorage when a property changes.
- */
-function _getObserver<T>(
-    get: (name: string, useLocalStorage: boolean) => T,
-    set: (name: string, newVal: T, useLocalStorage: boolean) => void,
-    propertyName: string, defaultVal: T, useLocalStorage: boolean): Function {
-  return function() {
-    const URIStorageName = getURIStorageName(this, propertyName);
-    const newVal = this[propertyName];
-    // if this is a localStorage property, we always synchronize the value
-    // in localStorage to match the one currently in the URI.
-    if (useLocalStorage) {
-      set(URIStorageName, newVal, true);
-    }
-    if (!_.isEqual(newVal, get(URIStorageName, false))) {
-      if (_.isEqual(newVal, defaultVal)) {
-        _unsetFromURI(URIStorageName);
-      } else {
-        set(URIStorageName, newVal, false);
-      }
-    }
-  };
-}
-
-/**
  * Delete a key from the URI.
  */
-function _unsetFromURI(key) {
-  const items = _componentToDict(_readComponent());
+function unsetFromURI(key) {
+  const items = componentToDict(readComponent());
   delete items[key];
-  _writeComponent(_dictToComponent(items));
+  writeComponent(dictToComponent(items));
 }
-

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -209,13 +209,14 @@ limitations under the License.
         _showDownloadLinks: {
           type: Boolean,
           notify: true,
-          value: storage.getBooleanInitializer('_showDownloadLinks', false, true),
+          value: storage.getBooleanInitializer('_showDownloadLinks',
+              {defaultValue: false, useLocalStorage: true}),
           observer: '_showDownloadLinksObserver',
         },
         _smoothingWeight: {
           type: Number,
           notify: true,
-          value: storage.getNumberInitializer('_smoothingWeight', 0.6),
+          value: storage.getNumberInitializer('_smoothingWeight', {defaultValue: 0.6}),
           observer: '_smoothingWeightObserver',
         },
         _smoothingEnabled: {
@@ -224,7 +225,8 @@ limitations under the License.
         },
         _ignoreYOutliers: {
           type: Boolean,
-          value: storage.getBooleanInitializer('_ignoreYOutliers', true, true),
+          value: storage.getBooleanInitializer('_ignoreYOutliers',
+              {defaultValue: true, useLocalStorage: true}),
           observer: '_ignoreYOutliersObserver',
         },
         /** @type {X_TYPE} */
@@ -253,11 +255,11 @@ limitations under the License.
         },
       },
       _showDownloadLinksObserver: storage.getBooleanObserver(
-          '_showDownloadLinks', /*default=*/ false, /*useLocalStorage=*/ true),
+          '_showDownloadLinks', {defaultValue: false, useLocalStorage: true}),
       _smoothingWeightObserver: storage.getNumberObserver(
-          '_smoothingWeight', 0.6),
+          '_smoothingWeight', {defaultValue: 0.6}),
       _ignoreYOutliersObserver: storage.getBooleanObserver(
-          '_ignoreYOutliers', /*default=*/ true, /*useLocalStorage=*/true),
+          '_ignoreYOutliers', {defaultValue: true, useLocalStorage: true}),
       _computeSmoothingEnabled(_smoothingWeight) {
         return _smoothingWeight > 0;
       },


### PR DESCRIPTION
Summary:
This commit improves the API of the `tf-storage` module, and also
simplifies its internal implementation (hence the negative delta).
There are two API changes:

  - It is now possible to have a `polymerProperty` different from the
    `key` used in the storage layer.

  - Arguments other than the `key` are now accepted in an `options`
    object, so that they are effectively named arguments instead of
    positional arguments. This is especially useful for the boolean
    observer and initializer functions, which used to take two
    consecutive boolean parameters: one was the default value, and one
    indicated whether to use local storage. (Which was which?)

Internally, each object type’s bindings are now generated and exported
from a single function call. This removes a bunch of boilerplate code
(120 lines of it, to be precise).

Test Plan:
  - Verified that values are persisted both to the fragment and to local
    storage.
  - Verified that `window.localStorage` has the correct value.
  - Verified that changes to the hash cause Polymer properties to
    update.
  - Applied the patch listed below to verify that two-way binding still
    works when the `polymerProperty` differs from the `key`.

```diff
diff --git a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
index 21be17e..75a6177 100644
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -216,7 +216,7 @@ limitations under the License.
         _smoothingWeight: {
           type: Number,
           notify: true,
-          value: storage.getNumberInitializer('_smoothingWeight', {defaultValue: 0.6}),
+          value: storage.getNumberInitializer('wait', {defaultValue: 0.6, polymerProperty: '_smoothingWeight'}),
           observer: '_smoothingWeightObserver',
         },
         _smoothingEnabled: {
@@ -257,7 +257,7 @@ limitations under the License.
       _showDownloadLinksObserver: storage.getBooleanObserver(
           '_showDownloadLinks', {defaultValue: false, useLocalStorage: true}),
       _smoothingWeightObserver: storage.getNumberObserver(
-          '_smoothingWeight', {defaultValue: 0.6}),
+          'wait', {defaultValue: 0.6, polymerProperty: '_smoothingWeight'}),
       _ignoreYOutliersObserver: storage.getBooleanObserver(
           '_ignoreYOutliers', {defaultValue: true, useLocalStorage: true}),
       _computeSmoothingEnabled(_smoothingWeight) {
```

wchargin-branch: redesign-storage