### PR TITLE
Write op and pb methods for text summaries

### DIFF
--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -67,6 +67,7 @@ py_library(
         ":metadata",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:util",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -76,6 +77,7 @@ py_test(
     srcs = ["summary_test.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":metadata",
         ":summary",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -67,7 +67,6 @@ py_library(
         ":metadata",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:util",
-        "@org_pythonhosted_six",
     ],
 )
 
@@ -81,6 +80,7 @@ py_test(
         ":summary",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -5,6 +5,8 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 exports_files(["LICENSE"])
 
 ## Text Plugin ##
@@ -14,6 +16,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        ":metadata",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
@@ -51,4 +54,49 @@ py_binary(
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],
+)
+
+py_library(
+    name = "summary",
+    srcs = ["summary.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":metadata",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:util",
+    ],
+)
+
+py_test(
+    name = "summary_test",
+    size = "small",
+    srcs = ["summary_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":summary",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_library(
+    name = "metadata",
+    srcs = ["metadata.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//tensorboard:internal",
+    ],
+    deps = [
+        ":protos_all_py_pb2",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+tb_proto_library(
+    name = "protos_all",
+    srcs = ["plugin_data.proto"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorboard/plugins/text/metadata.py
+++ b/tensorboard/plugins/text/metadata.py
@@ -1,0 +1,64 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Internal information about the text plugin."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+from tensorboard.plugins.text import plugin_data_pb2
+
+
+PLUGIN_NAME = 'text'
+
+# The most recent value for the `version` field of the
+# `TextPluginData` proto.
+PROTO_VERSION = 0
+
+
+def create_summary_metadata(display_name, description):
+  """Create a `tf.SummaryMetadata` proto for text plugin data.
+  Returns:
+    A `tf.SummaryMetadata` protobuf object.
+  """
+  content = plugin_data_pb2.TextPluginData(version=PROTO_VERSION)
+  metadata = tf.SummaryMetadata(
+      display_name=display_name,
+      summary_description=description,
+      plugin_data=tf.SummaryMetadata.PluginData(
+          plugin_name=PLUGIN_NAME,
+          content=content.SerializeToString()))
+  return metadata
+
+
+def parse_plugin_metadata(content):
+  """Parse summary metadata to a Python object.
+  Arguments:
+    content: The `content` field of a `SummaryMetadata` proto corresponding to
+      the text plugin.
+  Returns:
+    A `TextPluginData` protobuf object.
+  """
+  result = plugin_data_pb2.TextPluginData()
+  result.ParseFromString(tf.compat.as_bytes(content))
+  if result.version == 0:
+    return result
+  else:
+    tf.logging.warn(
+        'Unknown metadata version: %s. The latest version known to '
+        'this build of TensorBoard is %s; perhaps a newer build is '
+        'available?', result.version, PROTO_VERSION)
+    return result

--- a/tensorboard/plugins/text/plugin_data.proto
+++ b/tensorboard/plugins/text/plugin_data.proto
@@ -1,0 +1,27 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+syntax = "proto3";
+
+package tensorboard;
+
+// Text summaries created by the `tensorboard.plugins.text.summary`
+// module will include `SummaryMetadata` whose `plugin_data` field has
+// as `content` a binary string that is the encoding of an
+// `TextPluginData` proto.
+message TextPluginData {
+  // Version `0` is the only supported version.
+  int32 version = 1;
+}

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -95,7 +95,7 @@ def pb(name, data, display_name=None, description=None):
   if isinstance(data, six.binary_type):
     if isinstance(data, six.text_type):
       raise ValueError(
-        'Unicode text (%r) is not supported. Only byte strings are.' % data)
+          'Unicode text (%r) is not supported. Only byte strings are.' % data)
     data = np.array(data)
   if data.dtype.kind != 'S':
     raise ValueError(

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -97,7 +97,7 @@ def pb(name, data, display_name=None, description=None):
       # This is a unicode string.
       data = tf.compat.as_bytes(data)
     data = np.array(data)
-  if data.dtype.kind != 'S':
+  if data.dtype.kind not in ('S', 'U'):
     raise ValueError(
         'Type %r is not supported. Only strings are.' % data.dtype.name)
   tensor = tf.make_tensor_proto(data, dtype=tf.string)

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -92,7 +92,7 @@ def pb(name, data, display_name=None, description=None):
   Returns:
     A `tf.Summary` protobuf object.
   """
-  if isinstance(data, six.binary_type) or isinstance(command, six.string_types):
+  if isinstance(data, six.binary_type) or isinstance(data, six.string_types):
     # Check if data is of type bytes or string. For python3, binary_type checks
     # for bytes instead of string, so we also check for six.string_types.
     if isinstance(data, six.text_type):

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -79,8 +79,8 @@ def pb(name, data, display_name=None, description=None):
   Arguments:
     name: A name for the generated node. Will also serve as a series name in
       TensorBoard.
-    data: A python bytes string (str), a unicode string, or a numpy array
-      containing string data (of type numpy.string_).
+    data: A Python bytestring (of type bytes), or Unicode string, or numpy array
+      of one of these types.
     display_name: Optional name for this summary in TensorBoard, as a
       `str`. Defaults to `name`.
     description: Optional long-form description for this summary, as a

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -20,8 +20,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
 import numpy as np
+import tensorflow as tf
 import six
 
 from tensorboard.plugins.text import metadata
@@ -79,27 +79,21 @@ def pb(name, data, display_name=None, description=None):
   Arguments:
     name: A name for the generated node. Will also serve as a series name in
       TensorBoard.
-    data: A Python bytestring (of type bytes), or Unicode string, or numpy array
-      of one of these types.
+    data: A Python bytestring (of type bytes), or Unicode string. Or a numpy
+      data array of those types.
     display_name: Optional name for this summary in TensorBoard, as a
       `str`. Defaults to `name`.
     description: Optional long-form description for this summary, as a
       `str`. Markdown is supported. Defaults to empty.
 
   Raises:
-    ValueError: If the data is of the wrong type.
+    TypeError: If the type of the data is unsupported.
 
   Returns:
     A `tf.Summary` protobuf object.
   """
-  if isinstance(data, (six.binary_type, six.string_types)):
-    if isinstance(data, six.text_type):
-      # This is a unicode string.
-      data = tf.compat.as_bytes(data)
+  if not isinstance(data, np.ndarray):
     data = np.array(data)
-  if data.dtype.kind not in ('S', 'U'):
-    raise ValueError(
-        'Type %r is not supported. Only strings are.' % data.dtype.name)
   tensor = tf.make_tensor_proto(data, dtype=tf.string)
 
   if display_name is None:

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -92,7 +92,7 @@ def pb(name, data, display_name=None, description=None):
   Returns:
     A `tf.Summary` protobuf object.
   """
-  if isinstance(data, six.binary_type) or isinstance(data, six.string_types):
+  if isinstance(data, six.binary_type, six.string_types):
     # Check if data is of type bytes or string. For python3, binary_type checks
     # for bytes instead of string, so we also check for six.string_types.
     if isinstance(data, six.text_type):

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -31,7 +31,7 @@ def op(name,
        display_name=None,
        description=None,
        collections=None):
-  """Summarizes textual data.
+  """Create a text summary op.
 
   Text data summarized via this plugin will be visible in the Text Dashboard
   in TensorBoard. The standard TensorBoard Text Dashboard will render markdown
@@ -44,7 +44,7 @@ def op(name,
   Args:
     name: A name for the generated node. Will also serve as a series name in
       TensorBoard.
-    data: a string-type Tensor to summarize. The text should be UTF-encoded.
+    data: A string-type Tensor to summarize. The text must be encoded in UTF-8.
     display_name: Optional name for this summary in TensorBoard, as a
       constant `str`. Defaults to `name`.
     description: Optional long-form description for this summary, as a
@@ -91,9 +91,6 @@ def pb(name, data, display_name=None, description=None):
   Returns:
     A `tf.Summary` protobuf object.
   """
-  if not isinstance(data, np.ndarray):
-    data = np.array(data)
-
   try:
     tensor = tf.make_tensor_proto(data, dtype=tf.string)
   except TypeError as e:

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 
 import numpy as np
 import tensorflow as tf
-import six
 
 from tensorboard.plugins.text import metadata
 
@@ -36,10 +35,10 @@ def op(name,
 
   Text data summarized via this plugin will be visible in the Text Dashboard
   in TensorBoard. The standard TensorBoard Text Dashboard will render markdown
-  in the strings, and will automatically organize 1d and 2d tensors into tables.
-  If a tensor with more than 2 dimensions is provided, a 2d subarray will be
+  in the strings, and will automatically organize 1D and 2D tensors into tables.
+  If a tensor with more than 2 dimensions is provided, a 2D subarray will be
   displayed along with a warning message. (Note that this behavior is not
-  intrinsic to the text summary api, but rather to the default TensorBoard text
+  intrinsic to the text summary API, but rather to the default TensorBoard text
   plugin.)
 
   Args:
@@ -50,8 +49,8 @@ def op(name,
       constant `str`. Defaults to `name`.
     description: Optional long-form description for this summary, as a
       constant `str`. Markdown is supported. Defaults to empty.
-    collections: Optional list of ops.GraphKeys.  The collections to add the
-      summary to.  Defaults to [_ops.GraphKeys.SUMMARIES]
+    collections: Optional list of ops.GraphKeys. The collections to which to add
+      the summary. Defaults to [Graph Keys.SUMMARIES].
 
   Returns:
     A TensorSummary op that is configured so that TensorBoard will recognize

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import numpy as np
 import tensorflow as tf
 
 from tensorboard.plugins.text import metadata

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -79,8 +79,8 @@ def pb(name, data, display_name=None, description=None):
   Arguments:
     name: A name for the generated node. Will also serve as a series name in
       TensorBoard.
-    data: A python bytes string (str). Or a numpy array containing string data
-      (of type numpy.string_).
+    data: A python bytes string (str), a unicode string, or a numpy array
+      containing string data (of type numpy.string_).
     display_name: Optional name for this summary in TensorBoard, as a
       `str`. Defaults to `name`.
     description: Optional long-form description for this summary, as a
@@ -93,11 +93,9 @@ def pb(name, data, display_name=None, description=None):
     A `tf.Summary` protobuf object.
   """
   if isinstance(data, (six.binary_type, six.string_types)):
-    # Check if data is of type bytes or string. For python3, binary_type checks
-    # for bytes instead of string, so we also check for six.string_types.
     if isinstance(data, six.text_type):
-      raise ValueError(
-          'Unicode text (%r) is not supported. Only byte strings are.' % data)
+      # This is a unicode string.
+      data = tf.compat.as_bytes(data)
     data = np.array(data)
   if data.dtype.kind != 'S':
     raise ValueError(

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -87,14 +87,18 @@ def pb(name, data, display_name=None, description=None):
       `str`. Markdown is supported. Defaults to empty.
 
   Raises:
-    TypeError: If the type of the data is unsupported.
+    ValueError: If the type of the data is unsupported.
 
   Returns:
     A `tf.Summary` protobuf object.
   """
   if not isinstance(data, np.ndarray):
     data = np.array(data)
-  tensor = tf.make_tensor_proto(data, dtype=tf.string)
+
+  try:
+    tensor = tf.make_tensor_proto(data, dtype=tf.string)
+  except TypeError as e:
+    raise ValueError(e)
 
   if display_name is None:
     display_name = name

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -80,7 +80,7 @@ def pb(name, data, display_name=None, description=None):
     name: A name for the generated node. Will also serve as a series name in
       TensorBoard.
     data: A python bytes string (str). Or a numpy array containing string data
-      (of type numpy.string_). 
+      (of type numpy.string_).
     display_name: Optional name for this summary in TensorBoard, as a
       `str`. Defaults to `name`.
     description: Optional long-form description for this summary, as a

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -92,7 +92,9 @@ def pb(name, data, display_name=None, description=None):
   Returns:
     A `tf.Summary` protobuf object.
   """
-  if isinstance(data, six.binary_type):
+  if isinstance(data, six.binary_type) or isinstance(command, six.string_types):
+    # Check if data is of type bytes or string. For python3, binary_type checks
+    # for bytes instead of string, so we also check for six.string_types.
     if isinstance(data, six.text_type):
       raise ValueError(
           'Unicode text (%r) is not supported. Only byte strings are.' % data)

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -92,7 +92,7 @@ def pb(name, data, display_name=None, description=None):
   Returns:
     A `tf.Summary` protobuf object.
   """
-  if isinstance(data, six.binary_type, six.string_types):
+  if isinstance(data, (six.binary_type, six.string_types)):
     # Check if data is of type bytes or string. For python3, binary_type checks
     # for bytes instead of string, so we also check for six.string_types.
     if isinstance(data, six.text_type):

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -1,0 +1,91 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Text summaries and TensorFlow operations to create them.
+A text summary stores a single string value.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+import numpy as np
+
+from tensorboard.plugins.text import metadata
+
+
+def op(name,
+       data,
+       display_name=None,
+       description=None,
+       collections=None):
+  """Create a string summary op.
+  Arguments:
+    name: A unique name for the generated summary node.
+    data: A rank-0 `Tensor`. Must have `dtype` of string.
+    display_name: Optional name for this summary in TensorBoard, as a
+      constant `str`. Defaults to `name`.
+    description: Optional long-form description for this summary, as a
+      constant `str`. Markdown is supported. Defaults to empty.
+    collections: Optional list of graph collections keys. The new
+      summary op is added to these collections. Defaults to
+      `[Graph Keys.SUMMARIES]`.
+  Returns:
+    A TensorFlow summary op.
+  """
+  if display_name is None:
+    display_name = name
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=display_name, description=description)
+  with tf.name_scope(name):
+    with tf.control_dependencies([tf.assert_type(data, tf.string)]):
+      return tf.summary.tensor_summary(name='text_summary',
+                                       tensor=data,
+                                       collections=collections,
+                                       summary_metadata=summary_metadata)
+
+
+def pb(name, data, display_name=None, description=None):
+  """Create a scalar summary protobuf.
+  Arguments:
+    name: A unique name for the generated summary, including any desired
+      name scopes.
+    data: A python string. Or a rank-0 numpy array containing string data (of
+      type numpy.string_). 
+    display_name: Optional name for this summary in TensorBoard, as a
+      `str`. Defaults to `name`.
+    description: Optional long-form description for this summary, as a
+      `str`. Markdown is supported. Defaults to empty.
+  Returns:
+    A `tf.Summary` protobuf object.
+  """
+  if isinstance(data, str):
+    data = np.array(data)
+  if data.shape != ():
+    raise ValueError('Expected rank of 0 for data, saw shape: %s.' % data.shape)
+  if data.dtype.kind != 'S':
+    raise ValueError(
+        'Type %s is not supported. Only strings are.' % data.dtype.name)
+  tensor = tf.make_tensor_proto(data, dtype=tf.string)
+
+  if display_name is None:
+    display_name = name
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=display_name, description=description)
+  summary = tf.Summary()
+  summary.value.add(tag='%s/text_summary' % name,
+                    metadata=summary_metadata,
+                    tensor=tensor)
+  return summary

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -111,7 +111,7 @@ class SummaryTest(tf.test.TestCase):
     self.assertIsInstance(value, six.binary_type)
     self.assertEqual(b'A name I call myself.', value)
 
-  def test_np_array_string_value(self):
+  def test_np_array_bytes_value(self):
     pb = self.compute_and_check_summary_pb(
         'fa', np.array([[b'A', b'long', b'long'], [b'way', b'to', b'run']]))
     values = tf.make_ndarray(pb.value[0].tensor).tolist()

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -105,8 +105,14 @@ class SummaryTest(tf.test.TestCase):
     self.assertIsInstance(value, six.binary_type)
     self.assertEqual('A name I call myself.', value)
 
-  def test_np_array_value(self):
+  def test_np_array_string_value(self):
     pb = self.compute_and_check_summary_pb('fa', 'A long, long way to run.')
+    value = tf.make_ndarray(pb.value[0].tensor).item()
+    self.assertIsInstance(value, six.binary_type)
+    self.assertEqual('A long, long way to run.', value)
+
+  def test_np_array_unicode_value(self):
+    pb = self.compute_and_check_summary_pb('fa', u'A long, long way to run.')
     value = tf.make_ndarray(pb.value[0].tensor).item()
     self.assertIsInstance(value, six.binary_type)
     self.assertEqual('A long, long way to run.', value)

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -102,13 +102,13 @@ class SummaryTest(tf.test.TestCase):
   def test_string_value(self):
     pb = self.compute_and_check_summary_pb('mi', 'A name I call myself.')
     value = tf.make_ndarray(pb.value[0].tensor).item()
-    self.assertEqual(str, type(value))
+    self.assertIsInstance(value, six.binary_type)
     self.assertEqual('A name I call myself.', value)
 
   def test_np_array_value(self):
     pb = self.compute_and_check_summary_pb('fa', 'A long, long way to run.')
     value = tf.make_ndarray(pb.value[0].tensor).item()
-    self.assertEqual(str, type(value))
+    self.assertIsInstance(value, six.binary_type)
     self.assertEqual('A long, long way to run.', value)
 
   def test_non_string_value_in_op(self):
@@ -130,7 +130,7 @@ class SummaryTest(tf.test.TestCase):
     pb = self.compute_and_check_summary_pb(
         'ti', u'A drink with jam and bread.')
     value = tf.make_ndarray(pb.value[0].tensor).item()
-    self.assertEqual(str, type(value))
+    self.assertIsInstance(value, six.binary_type)
     self.assertEqual('A drink with jam and bread.', value)
 
 

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the text plugin summary generation functions."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import six
+import tensorflow as tf
+
+from tensorboard.plugins.text import summary
+
+
+class SummaryTest(tf.test.TestCase):
+
+  def test_op(self):
+    with tf.Session() as sess:
+      pbtxt = sess.run(summary.op('foo', tf.constant('forty-two')))
+      summary_pb = tf.Summary()
+      summary_pb.ParseFromString(pbtxt)
+
+    self.assertEqual(1, len(summary_pb.value))
+    value = summary_pb.value[0]
+    self.assertEqual('foo/text_summary', value.tag)
+    self.assertEqual('foo', value.metadata.display_name)
+    self.assertEqual('', value.metadata.summary_description)
+    string_content = tf.make_ndarray(value.tensor).astype(np.dtype(str))
+    self.assertEqual('forty-two', string_content)
+
+  def test_op_with_custom_display_name_and_description(self):
+    with tf.Session() as sess:
+      op = summary.op(
+          name='foo',
+          data=tf.constant('forty-two'),
+          display_name='42',
+          description='It succeeds 41 and precedes 43.')
+      pbtxt = sess.run(op)
+      summary_pb = tf.Summary()
+      summary_pb.ParseFromString(pbtxt)
+
+    self.assertEqual(1, len(summary_pb.value))
+    value = summary_pb.value[0]
+    self.assertEqual('42', value.metadata.display_name)
+    self.assertEqual(
+        'It succeeds 41 and precedes 43.', value.metadata.summary_description)
+
+  def test_pb_with_python_string(self):
+    summary_pb = summary.pb('foo', 'forty-two')
+    self.assertEqual(1, len(summary_pb.value))
+    value = summary_pb.value[0]
+    self.assertEqual('foo/text_summary', value.tag)
+    self.assertEqual('foo', value.metadata.display_name)
+    self.assertEqual('', value.metadata.summary_description)
+    string_content = tf.make_ndarray(value.tensor).astype(np.dtype(str))
+    self.assertEqual('forty-two', string_content)
+
+  def test_pb_with_numpy_array(self):
+    summary_pb = summary.pb('foo', np.array('forty-two'))
+    self.assertEqual(1, len(summary_pb.value))
+    value = summary_pb.value[0]
+    self.assertEqual('foo/text_summary', value.tag)
+    self.assertEqual('foo', value.metadata.display_name)
+    self.assertEqual('', value.metadata.summary_description)
+    string_content = tf.make_ndarray(value.tensor).astype(np.dtype(str))
+    self.assertEqual('forty-two', string_content)
+
+  def test_pb_with_custom_display_name_and_description(self):
+    summary_pb = summary.pb(
+        name='foo',
+        data='forty-two',
+        display_name='42',
+        description='It succeeds 41 and precedes 43.')
+    self.assertEqual(1, len(summary_pb.value))
+    value = summary_pb.value[0]
+    self.assertEqual('42', value.metadata.display_name)
+    self.assertEqual(
+        'It succeeds 41 and precedes 43.', value.metadata.summary_description)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -103,19 +103,19 @@ class SummaryTest(tf.test.TestCase):
     pb = self.compute_and_check_summary_pb('mi', 'A name I call myself.')
     value = tf.make_ndarray(pb.value[0].tensor).item()
     self.assertIsInstance(value, six.binary_type)
-    self.assertEqual('A name I call myself.', value)
+    self.assertEqual(b'A name I call myself.', value)
 
   def test_np_array_string_value(self):
     pb = self.compute_and_check_summary_pb('fa', 'A long, long way to run.')
     value = tf.make_ndarray(pb.value[0].tensor).item()
     self.assertIsInstance(value, six.binary_type)
-    self.assertEqual('A long, long way to run.', value)
+    self.assertEqual(b'A long, long way to run.', value)
 
   def test_np_array_unicode_value(self):
     pb = self.compute_and_check_summary_pb('fa', u'A long, long way to run.')
     value = tf.make_ndarray(pb.value[0].tensor).item()
     self.assertIsInstance(value, six.binary_type)
-    self.assertEqual('A long, long way to run.', value)
+    self.assertEqual(b'A long, long way to run.', value)
 
   def test_non_string_value_in_op(self):
     with six.assertRaisesRegex(
@@ -137,7 +137,7 @@ class SummaryTest(tf.test.TestCase):
         'ti', u'A drink with jam and bread.')
     value = tf.make_ndarray(pb.value[0].tensor).item()
     self.assertIsInstance(value, six.binary_type)
-    self.assertEqual('A drink with jam and bread.', value)
+    self.assertEqual(b'A drink with jam and bread.', value)
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -100,23 +100,27 @@ class SummaryTest(tf.test.TestCase):
     metadata.parse_plugin_metadata(content)
 
   def test_bytes_value(self):
-    pb = self.compute_and_check_summary_pb('mi', b'A name I call myself.')
+    pb = self.compute_and_check_summary_pb(
+        'mi', b'A name\xe2\x80\xa6I call myself')
     value = tf.make_ndarray(pb.value[0].tensor).item()
     self.assertIsInstance(value, six.binary_type)
-    self.assertEqual(b'A name I call myself.', value)
+    self.assertEqual(b'A name\xe2\x80\xa6I call myself', value)
 
   def test_unicode_value(self):
-    pb = self.compute_and_check_summary_pb('mi', u'A name I call myself.')
+    pb = self.compute_and_check_summary_pb('mi', u'A name\u2026I call myself')
     value = tf.make_ndarray(pb.value[0].tensor).item()
     self.assertIsInstance(value, six.binary_type)
-    self.assertEqual(b'A name I call myself.', value)
+    self.assertEqual(b'A name\xe2\x80\xa6I call myself', value)
 
   def test_np_array_bytes_value(self):
     pb = self.compute_and_check_summary_pb(
-        'fa', np.array([[b'A', b'long', b'long'], [b'way', b'to', b'run']]))
+        'fa',
+        np.array(
+            [[b'A', b'long', b'long'], [b'way', b'to', b'run \xe2\x80\xbc']]))
     values = tf.make_ndarray(pb.value[0].tensor).tolist()
     self.assertEqual(
-        [[b'A', b'long', b'long'], [b'way', b'to', b'run']], values)
+        [[b'A', b'long', b'long'], [b'way', b'to', b'run \xe2\x80\xbc']],
+        values)
     # Check that all entries are byte strings.
     for vectors in values:
       for value in vectors:
@@ -124,10 +128,13 @@ class SummaryTest(tf.test.TestCase):
 
   def test_np_array_unicode_value(self):
     pb = self.compute_and_check_summary_pb(
-        'fa', np.array([[u'A', u'long', u'long'], [u'way', u'to', u'run']]))
+        'fa',
+        np.array(
+            [[u'A', u'long', u'long'], [u'way', u'to', u'run \u203C']]))
     values = tf.make_ndarray(pb.value[0].tensor).tolist()
     self.assertEqual(
-        [[b'A', b'long', b'long'], [b'way', b'to', b'run']], values)
+        [[b'A', b'long', b'long'], [b'way', b'to', b'run \xe2\x80\xbc']],
+        values)
     # Check that all entries are byte strings.
     for vectors in values:
       for value in vectors:

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -127,11 +127,11 @@ class SummaryTest(tf.test.TestCase):
       summary.pb('la', np.array(range(42)))
 
   def test_unicode_numpy_array_value_in_pb(self):
-    with six.assertRaisesRegex(
-        self,
-        ValueError,
-        r'Type \'unicode\d+\' is not supported. Only strings are.'):
-      summary.pb('ti', np.array(u'A drink with jam and bread.'))
+    pb = self.compute_and_check_summary_pb(
+        'ti', u'A drink with jam and bread.')
+    value = tf.make_ndarray(pb.value[0].tensor).item()
+    self.assertEqual(str, type(value))
+    self.assertEqual('A drink with jam and bread.', value)
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -100,22 +100,38 @@ class SummaryTest(tf.test.TestCase):
     metadata.parse_plugin_metadata(content)
 
   def test_string_value(self):
-    pb = self.compute_and_check_summary_pb('mi', 'A name I call myself.')
+    pb = self.compute_and_check_summary_pb('mi', b'A name I call myself.')
+    value = tf.make_ndarray(pb.value[0].tensor).item()
+    self.assertIsInstance(value, six.binary_type)
+    self.assertEqual(b'A name I call myself.', value)
+
+  def test_unicode_value(self):
+    pb = self.compute_and_check_summary_pb('mi', u'A name I call myself.')
     value = tf.make_ndarray(pb.value[0].tensor).item()
     self.assertIsInstance(value, six.binary_type)
     self.assertEqual(b'A name I call myself.', value)
 
   def test_np_array_string_value(self):
-    pb = self.compute_and_check_summary_pb('fa', 'A long, long way to run.')
-    value = tf.make_ndarray(pb.value[0].tensor).item()
-    self.assertIsInstance(value, six.binary_type)
-    self.assertEqual(b'A long, long way to run.', value)
+    pb = self.compute_and_check_summary_pb(
+        'fa', np.array([[b'A', b'long', b'long'], [b'way', b'to', b'run']]))
+    values = tf.make_ndarray(pb.value[0].tensor).tolist()
+    self.assertEqual(
+        [[b'A', b'long', b'long'], [b'way', b'to', b'run']], values)
+    # Check that all entries are byte strings.
+    for vectors in values:
+      for value in vectors:
+        self.assertIsInstance(value, six.binary_type)
 
   def test_np_array_unicode_value(self):
-    pb = self.compute_and_check_summary_pb('fa', u'A long, long way to run.')
-    value = tf.make_ndarray(pb.value[0].tensor).item()
-    self.assertIsInstance(value, six.binary_type)
-    self.assertEqual(b'A long, long way to run.', value)
+    pb = self.compute_and_check_summary_pb(
+        'fa', np.array([[u'A', u'long', u'long'], [u'way', u'to', u'run']]))
+    values = tf.make_ndarray(pb.value[0].tensor).tolist()
+    self.assertEqual(
+        [[b'A', b'long', b'long'], [b'way', b'to', b'run']], values)
+    # Check that all entries are byte strings.
+    for vectors in values:
+      for value in vectors:
+        self.assertIsInstance(value, six.binary_type)
 
   def test_non_string_value_in_op(self):
     with six.assertRaisesRegex(
@@ -128,16 +144,9 @@ class SummaryTest(tf.test.TestCase):
   def test_non_string_value_in_pb(self):
     with six.assertRaisesRegex(
         self,
-        ValueError,
-        r'Type \'int\d+\' is not supported. Only strings are.'):
+        TypeError,
+        r'Expected binary or unicode string, got 0'):
       summary.pb('la', np.array(range(42)))
-
-  def test_unicode_numpy_array_value_in_pb(self):
-    pb = self.compute_and_check_summary_pb(
-        'ti', u'A drink with jam and bread.')
-    value = tf.make_ndarray(pb.value[0].tensor).item()
-    self.assertIsInstance(value, six.binary_type)
-    self.assertEqual(b'A drink with jam and bread.', value)
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -144,7 +144,7 @@ class SummaryTest(tf.test.TestCase):
   def test_non_string_value_in_pb(self):
     with six.assertRaisesRegex(
         self,
-        TypeError,
+        ValueError,
         r'Expected binary or unicode string, got 0'):
       summary.pb('la', np.array(range(42)))
 

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -99,7 +99,7 @@ class SummaryTest(tf.test.TestCase):
     # There's no content, so successfully parsing is fine.
     metadata.parse_plugin_metadata(content)
 
-  def test_string_value(self):
+  def test_bytes_value(self):
     pb = self.compute_and_check_summary_pb('mi', b'A name I call myself.')
     value = tf.make_ndarray(pb.value[0].tensor).item()
     self.assertIsInstance(value, six.binary_type)

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -35,9 +35,6 @@ from tensorboard.backend import http_util
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.text import metadata
 
-# The prefix of routes provided by this plugin.
-_PLUGIN_PREFIX_ROUTE = metadata.PLUGIN_NAME
-
 # HTTP routes
 TAGS_ROUTE = '/tags'
 TEXT_ROUTE = '/text'
@@ -225,7 +222,7 @@ class TextPlugin(base_plugin.TBPlugin):
 
     # TensorBoard is obtaining summaries related to the text plugin based on
     # SummaryMetadata stored within Value protos.
-    mapping = self._multiplexer.PluginRunToTagToContent(_PLUGIN_PREFIX_ROUTE)
+    mapping = self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME)
 
     # Augment the summaries created via the deprecated (plugin asset based)
     # method with these summaries created with the new method. When they

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -33,9 +33,10 @@ from werkzeug import wrappers
 from tensorboard import plugin_util
 from tensorboard.backend import http_util
 from tensorboard.plugins import base_plugin
+from tensorboard.plugins.text import metadata
 
 # The prefix of routes provided by this plugin.
-_PLUGIN_PREFIX_ROUTE = 'text'
+_PLUGIN_PREFIX_ROUTE = metadata.PLUGIN_NAME
 
 # HTTP routes
 TAGS_ROUTE = '/tags'
@@ -195,7 +196,7 @@ def process_string_tensor_event(event):
 class TextPlugin(base_plugin.TBPlugin):
   """Text Plugin for TensorBoard."""
 
-  plugin_name = _PLUGIN_PREFIX_ROUTE
+  plugin_name = metadata.PLUGIN_NAME
 
   def __init__(self, context):
     """Instantiates TextPlugin via TensorBoard core.


### PR DESCRIPTION
Fixes #481. As part of this effort, introduced a metadata.py file for
text plugin which currently provides the name of the plugin as well as
some functionality for creating and parsing (currently unused)
TextPluginData protos.

Looping in @dandelionmane as the plugin author. :)