### PR TITLE
Stylize the newly selected node after expansion

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
@@ -1076,9 +1076,6 @@ Polymer({
       return;
     }
 
-    if (selectedNode) {
-      this._updateNodeState(selectedNode);
-    }
     if (oldSelectedNode) {
       this._updateNodeState(oldSelectedNode);
     }
@@ -1117,6 +1114,10 @@ Polymer({
     if (topParentNodeToBeExpanded) {
       this.setNodeExpanded(topParentNodeToBeExpanded);
       this._zoomed = true;
+    }
+
+    if (selectedNode) {
+      this._updateNodeState(selectedNode);
     }
 
     if (tf.graph.scene.panToNode(selectedNode, this.$.svg, this.$.root,


### PR DESCRIPTION
Previously, when the user performs some functionality to expand the
graph and then select a node (such as navigating to a node after
observing TPU compatibility or clicking an op in the debugger plugin),
the graph would select a node before expanding its parent nodes.

This can cause an error because the selected node is not yet present in
the graph hierarchy:

```
(index):7546 Uncaught (in promise) TypeError: Cannot read property
'node' of undefined
   at HTMLElement._updateNodeState ((index):7546)
         at HTMLElement._selectedNodeChanged ((index):7547)
```

This change makes the scene only stylize the selected node
after expansion of necessary nodes finishes. I don't think I can repro
the issue after this change.

FYI, @caisq 