### PR TITLE
Create raw_metrics_op for creating PR curves

### DIFF
--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -71,6 +71,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":pr_curve_demo",
+        ":summary",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",

--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -217,7 +217,7 @@ def raw_metrics_op(
       true_negative_counts,
       false_negative_counts,
       precision,
-      recall
+      recall,
   ]):
     return _create_tensor_summary(
         tag,
@@ -250,15 +250,7 @@ def _create_tensor_summary(
   to prevent the scope of `raw_metrics_op` from being embedded within `op`.
 
   Args:
-    tag: See docs for `raw_metrics_op`.
-    true_positive_counts: See docs for `raw_metrics_op`.
-    false_positive_counts: See docs for `raw_metrics_op`.
-    true_negative_counts: See docs for `raw_metrics_op`.
-    false_negative_counts: See docs for `raw_metrics_op`.
-    num_thresholds: See docs for `raw_metrics_op`.
-    display_name: See docs for `raw_metrics_op`.
-    description: See docs for `raw_metrics_op`.
-    collections: See docs for `raw_metrics_op`.
+    Arguments are the same as for raw_metrics_op
 
   Returns:
     A tensor summary that collects data for PR curves.

--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -249,8 +249,7 @@ def _create_tensor_summary(
   We use a helper method instead of having `op` directly call `raw_metrics_op`
   to prevent the scope of `raw_metrics_op` from being embedded within `op`.
 
-  Args:
-    Arguments are the same as for raw_metrics_op
+  Arguments are the same as for raw_metrics_op
 
   Returns:
     A tensor summary that collects data for PR curves.

--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -249,7 +249,7 @@ def _create_tensor_summary(
   We use a helper method instead of having `op` directly call `raw_metrics_op`
   to prevent the scope of `raw_metrics_op` from being embedded within `op`.
 
-  Arguments are the same as for raw_metrics_op
+  Arguments are the same as for raw_metrics_op.
 
   Returns:
     A tensor summary that collects data for PR curves.


### PR DESCRIPTION
This change introduces a `raw_metrics_op` for collecting data for generating PR curves. Fixes #515. See #515 for the motivation behind `raw_metrics_op`. 