### PR TITLE
Move TPU profile tf-op-details into the tool controls area on the left

### DIFF
--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
@@ -31,13 +31,13 @@ You may obtain a copy of the License at
     <style>
 tf-op-details {
   position: fixed;
-  top: 80px;
-  right: 16px;
+  top: 270px;
+  left: 16px;
   width: 330px;
 }
 :host {
   display: block;
-  margin-right: 360px;
+  margin-right: 1.5em;
 }
     </style>
     <div class="tf-op-profile">

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
@@ -29,9 +29,11 @@ You may obtain a copy of the License at
 <dom-module id="tf-op-profile">
   <template>
     <style>
+/* The detail box lives in the left navigation column.
+ * This is weird, but makes good use of our horizontal space. */
 tf-op-details {
   position: fixed;
-  top: 270px;
+  /* don't set top, so it ends up next to tf-op-table */
   left: 16px;
   width: 330px;
 }
@@ -41,7 +43,6 @@ tf-op-details {
 }
     </style>
     <div class="tf-op-profile">
-      <tf-op-details hidden="[[!_active]]" node="[[_active]]"></tf-op-details>
       <h4>Overall TPU utilization is
         <span style$="color:[[_textColor(_root)]]">[[_utilizationPercent(_root)]]</span>
       </h4>
@@ -68,6 +69,7 @@ tf-op-details {
         </span>
       </p>
       </div>
+      <tf-op-details hidden="[[!_active]]" node="[[_active]]"></tf-op-details>
       <tf-op-table root-node="[[_root]]" active={{_active}}></tf-op-table>
     </div>
   </template>


### PR DESCRIPTION
Move TPU profile tf-op-details into the tool controls area on the left.

This is pretty weird, but we're currently extremely wasteful of horizontal space, and adding any more data to the table will break layout on 1200px monitors. This column is exactly the width we need, and basically empty.

It looks like this:

![image](https://user-images.githubusercontent.com/548993/30384058-8d29a1c8-98a3-11e7-88d4-a2e5d1df65ea.png)
