### PR TITLE
Fix non-existent localStorage lookup behavior

### DIFF
--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -103,7 +103,7 @@ function makeBindings<T>(fromString: (string) => T, toString: (T) => string): {
     const value = useLocalStorage ?
       window.localStorage.getItem(key) :
       componentToDict(readComponent())[key];
-    return value === undefined ? undefined : fromString(value);
+    return value == undefined ? undefined : fromString(value);
   }
 
   function set(key: string, value: T, useLocalStorage = false): void {


### PR DESCRIPTION
Summary:
When we use the `tf-storage` module’s APIs to look up a key that does
not exist, it is supposed to return `undefined`. However, calling
`getNumber("nonexistent")` before this patch would return `0` instead.
This is because `localStorage.getItem("nonexistent")` evaluates to
`null`, and `undefined !== null`. Using weak equality fixes the issue.

(Despite the timing, this error was not introduced by the recent
refactor to `tf-storage`; it was present previously.)

Test Plan:
Add `console.log(getNumber("nonexistent"), /*useLocalStorage=*/true)` in
some module. Note that it prints `0` before this patch, and `undefined`
after.

wchargin-branch: fix-nonexistent-localstorage-lookup