### PR TITLE
Allow configuring pagination limit in settings

### DIFF
--- a/tensorboard/components/tf_paginated_view/BUILD
+++ b/tensorboard/components/tf_paginated_view/BUILD
@@ -6,12 +6,17 @@ licenses(["notice"])  # Apache 2.0
 
 ts_web_library(
     name = "tf_paginated_view",
-    srcs = ["tf-paginated-view.html"],
+    srcs = [
+        "paginatedViewStore.ts",
+        "tf-paginated-view.html",
+        "tf-paginated-view-store.html",
+    ],
     path = "/tf-paginated-view",
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_storage",
         "@org_polymer_paper_button",
         "@org_polymer_paper_input",
         "@org_polymer_paper_styles",

--- a/tensorboard/components/tf_paginated_view/paginatedViewStore.ts
+++ b/tensorboard/components/tf_paginated_view/paginatedViewStore.ts
@@ -1,0 +1,67 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {getNumber, setNumber} from '../tf-storage/storage.js';
+
+const LIMIT_LOCAL_STORAGE_KEY = 'TF.TensorBoard.PaginatedView.limit';
+const DEFAULT_LIMIT = 12;  // reasonably small and has lots of factors
+
+let _limit: number = null;  // cached localStorage value
+
+export type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+/**
+ * Register a listener (nullary function) to be called when the page
+ * limit changes.
+ */
+export function addLimitListener(listener: Listener): void {
+  listeners.add(listener);
+}
+
+/**
+ * Remove a listener registered with `addLimitListener`.
+ */
+export function removeLimitListener(listener: Listener): void {
+  listeners.delete(listener);
+}
+
+export function getLimit() {
+  if (_limit == null) {
+    _limit = getNumber(LIMIT_LOCAL_STORAGE_KEY, /*useLocalStorage=*/true);
+    if (_limit == null || !isFinite(_limit) || _limit <= 0) {
+      _limit = DEFAULT_LIMIT;
+    }
+  }
+  return _limit;
+}
+
+export function setLimit(limit: number) {
+  if (limit !== Math.floor(limit)) {
+    throw new Error(`limit must be an integer, but got: ${limit}`);
+  }
+  if (limit <= 0) {
+    throw new Error(`limit must be positive, but got: ${limit}`);
+  }
+  if (limit === _limit) {
+    return;
+  }
+  _limit = limit;
+  setNumber(LIMIT_LOCAL_STORAGE_KEY, _limit, /*useLocalStorage=*/true);
+  listeners.forEach(listener => {
+    listener();
+  });
+}

--- a/tensorboard/components/tf_paginated_view/tf-paginated-view-store.html
+++ b/tensorboard/components/tf_paginated_view/tf-paginated-view-store.html
@@ -1,0 +1,20 @@
+<!--
+@license
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../tf-storage/tf-storage.html">
+
+<script src="paginatedViewStore.js"></script>

--- a/tensorboard/components/tf_paginated_view/tf-paginated-view.html
+++ b/tensorboard/components/tf_paginated_view/tf-paginated-view.html
@@ -19,6 +19,7 @@ limitations under the License.
 <link rel="import" href="../paper-input/paper-input.html">
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
+<link rel="import" href="tf-paginated-view-store.html">
 
 <!--
   tf-paginated-view takes an input list and outputs the input broken
@@ -33,8 +34,6 @@ limitations under the License.
 
   Properties in:
     - `items`: a list of elements, treated opaquely.
-    - `limit` [optional]: maximum number of items to emit at a time.
-      Must be a positive integer.
   Properties out:
     - `pages`: an array of pages, each with a property `items` (a
       sublist of the input items) and `active` (a boolean indicating
@@ -134,6 +133,8 @@ limitations under the License.
     </style>
   </template>
   <script>
+  import * as store from './paginatedViewStore.js';
+
   Polymer({
     is: "tf-paginated-view",
     properties: {
@@ -147,15 +148,6 @@ limitations under the License.
       },
 
       /**
-       * The maximum number of items to include on each page.
-       */
-      limit: {
-        type: Number,
-        value: 12,  // reasonably small and has lots of factors
-        observer: '_validateLimit',  // must be a positive integer
-      },
-
-      /**
        * A list of all pages, exactly one of which will be active
        * (unless the list of pages is empty). We guarantee that if
        *
@@ -165,24 +157,32 @@ limitations under the License.
        * `contents.length === items.length` and for each index `i` we
        * have `Object.is(contents[i], items[i])`.
        *
-       * Every page except for the last will include exactly `limit`
-       * items. Every page will include at most `limit` items.
+       * Every page except for the last will include exactly `_limit`
+       * items. Every page will include at most `_limit` items.
        *
        * @type {Array<{active: boolean, items: Array<Object>}>}
        */
       pages: {
         type: Array,
         notify: true,
-        computed: '_computePages(items, limit, _activeIndex, _pageCount)',
+        computed: '_computePages(items, _limit, _activeIndex, _pageCount)',
+      },
+
+      /**
+       * The maximum number of items to include on each page.
+       */
+      _limit: {
+        type: Number,
+        value: 12,  // reasonably small and has lots of factors
       },
 
       // At any time we'll mark one particular item('s index) as
       // "active," and we'll always render the page containing that
       // item. Clicking the next/previous page buttons will adjust this
-      // index by `limit`.
+      // index by `_limit`.
       //
       // We track an active index instead of an active page so that any
-      // changes to the `limit` will keep roughly the same set of items
+      // changes to the `_limit` will keep roughly the same set of items
       // displayed. (Cf.: in a browser, when you zoom to adjust the text
       // size, your reading position stays in about the same place.)
       // (This decision incurs hardly any additional complexity, which
@@ -198,11 +198,11 @@ limitations under the License.
 
       _currentPage: {
         type: Number,  // 1-indexed
-        computed: '_computeCurrentPage(limit, _activeIndex)',
+        computed: '_computeCurrentPage(_limit, _activeIndex)',
       },
       _pageCount: {
         type: Number,
-        computed: '_computePageCount(items, limit)',
+        computed: '_computePageCount(items, _limit)',
       },
       _multiplePagesExist: {
         type: Boolean,
@@ -237,13 +237,16 @@ limitations under the License.
     },
     observers: ['_clampActiveIndex(items)'],
 
-    _validateLimit(limit) {
-      if (limit !== Math.floor(limit)) {
-        throw new Error(`limit must be an integer, but got: ${limit}`);
-      }
-      if (limit <= 0) {
-        throw new Error(`limit must be positive, but got: ${limit}`);
-      }
+    attached() {
+      this._limitListener = () => {
+        this.set('_limit', store.getLimit());
+      };
+      store.addLimitListener(this._limitListener);
+      this._limitListener();
+    },
+
+    detached() {
+      store.removeLimitListener(this._limitListener);
     },
 
     _computePages(items, limit, activeIndex, pageCount) {
@@ -292,10 +295,10 @@ limitations under the License.
       this._setActiveIndex(this._activeIndex);
     },
     _performPreviousPage() {
-      this._setActiveIndex(this._activeIndex - this.limit);
+      this._setActiveIndex(this._activeIndex - this._limit);
     },
     _performNextPage() {
-      this._setActiveIndex(this._activeIndex + this.limit);
+      this._setActiveIndex(this._activeIndex + this._limit);
     },
     _performNextPageAndJumpToTop() {
       const topMarker = this.$$('#top-of-container');
@@ -326,7 +329,7 @@ limitations under the License.
       }
       const page =
         Math.max(1, Math.min(oneIndexedPage, this._pageCount)) - 1;
-      this._setActiveIndex(this.limit * page);
+      this._setActiveIndex(this._limit * page);
     },
     _handlePageChangeEvent() {
       // Occurs on Enter, etc. Commit the true state.

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -20,6 +20,7 @@ ts_web_library(
         "//tensorboard/components/tf_globals",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_paginated_view",
         "//tensorboard/components/tf_storage",
         "@org_polymer_font_roboto",
         "@org_polymer_iron_icons",

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -28,6 +28,7 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
 <link rel="import" href="../tf-globals/tf-globals.html">
 <link rel="import" href="../tf-imports/lodash.html">
+<link rel="import" href="../tf-paginated-view/tf-paginated-view-store.html">
 <link rel="import" href="../tf-storage/tf-storage.html">
 
 <!--
@@ -43,6 +44,15 @@ limitations under the License.
       <paper-checkbox id="auto-reload-checkbox" checked="{{autoReloadEnabled}}">
         Reload data every <span>[[autoReloadIntervalSecs]]</span>s.
       </paper-checkbox>
+      <paper-input
+        id="paginationLimitInput"
+        label="Pagination limit"
+        always-float-label
+        type="number"
+        min="1"
+        step="1"
+        on-change="_paginationLimitChanged"
+      ></paper-input>
     </paper-dialog>
     <paper-header-panel>
       <paper-toolbar id="toolbar" slot="header">
@@ -312,6 +322,7 @@ limitations under the License.
     import {RequestManager} from "../tf-backend/requestManager.js";
     import {getRouter, setRouter, createRouter} from "../tf-backend/router.js";
     import {fetchRuns} from "../tf-backend/runsStore.js";
+    import * as paginatedViewStore from "../tf-paginated-view/paginatedViewStore.js";
 
     /** @enum {string} */ const ActiveDashboardsLoadState = {
       NOT_LOADED: 'NOT_LOADED',
@@ -739,6 +750,15 @@ limitations under the License.
 
       openSettings() {
         this.$.settings.open();
+        this.$.paginationLimitInput.value = paginatedViewStore.getLimit();
+      },
+      _paginationLimitChanged(e) {
+        const value = e.target.valueAsNumber;
+        // We set type="number" and min="1" on the input, but Polymer
+        // doesn't actually enforce those, so we have to check manually.
+        if (value === +value && value > 0) {
+          paginatedViewStore.setLimit(e.target.valueAsNumber);
+        }
       },
     });
   </script>


### PR DESCRIPTION
Summary:
In accordance with #483, this patch adds a configuration option to allow
changing the number of visualizations per page to a value other than 12.

Closes #483.

Test Plan:
Load the histogram dashboard with the histogram demo, which has seven
visualizations. Open the settings menu, and note that the default
pagination limit value is 12. Change the value to 1, close the dialog,
and move to page 6. Then, reopen the dialog and change the pagination
limit to 2; note that you are now on page 3 of 4. (This tests that the
existing-but-never-before-used behavior of `tf-pagination-view` that
attempts to retain approximately the same view across pagination limit
changes still works.)

Try to change the value to 0 or a negative value; note that this fails
without any console errors.

wchargin-branch: configurable-pagination-limit