### PR TITLE
Fix dimensions of card heading’s colored run label

### DIFF
--- a/tensorboard/components/tf_card_heading/tf-card-heading.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading.html
@@ -48,11 +48,15 @@ limitations under the License.
             </div>
           </template>
           <template is="dom-if" if="[[run]]">
-            <div itemprop="run"
-                 class="heading-label heading-right run"
-                 style="background: [[_runBackground]]; color: [[_runColor]]">
-              [[run]]
-            </div>
+            <!-- Extra wrapping span needed to avoid flexbox blockification. -->
+            <!-- (see flexbox spec, section 4 "Flex Items") -->
+            <span>
+              <span
+                itemprop="run"
+                class="heading-label heading-right run"
+                style="background: [[_runBackground]]; color: [[_runColor]]"
+              >[[run]]</span>
+            </span>
           </template>
         </div>
         <template is="dom-if" if="[[_tagLabel]]">


### PR DESCRIPTION
Summary:
In the case where a run label appears on the same line as the tag name
(i.e., is not wrapped to the next line), the label is too tall. This is
because the label was a direct flex item and so was being blockified.
It should have been a `<span>`, and it also needs to be wrapped in a
second `<span>` to avoid blockification.

Before:
![“Before” screenshot. A run label wrapped to the next line looks fine, while a run label on the same line as the tag is too tall and the text is not vertically centered.](https://user-images.githubusercontent.com/4317806/30505732-8f635d92-9a44-11e7-81a4-13f01ce77914.png)

After:
![“After” screenshot. Run labels are fine whether they wrap to the next line or not.](https://user-images.githubusercontent.com/4317806/30505731-8f5c9232-9a44-11e7-9b5e-950864d98709.png)

Test Plan:
Load a dataset with both short tag names and long tag names, so that
some of the run labels are wrapped while others are not. (The standard
histogram demo suffices.) Ensure that the height of each run label is
the same.

wchargin-branch: fix-run-label-height