### PR TITLE
Fix the PR curve plugin backend JSON serialization

### DIFF
--- a/tensorboard/plugins/pr_curve/pr_curves_plugin.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin.py
@@ -242,8 +242,8 @@ class PrCurvesPlugin(base_plugin.TBPlugin):
     return {
         'wall_time': event.wall_time,
         'step': event.step,
-        'precision': data_array[metadata.PRECISION_INDEX][:end_index],
-        'recall': data_array[metadata.RECALL_INDEX][:end_index],
+        'precision': data_array[metadata.PRECISION_INDEX, :end_index].tolist(),
+        'recall': data_array[metadata.RECALL_INDEX, :end_index].tolist(),
         'true_positives': true_positives[:end_index],
         'false_positives': false_positives[:end_index],
         'true_negatives':


### PR DESCRIPTION
Summary:
The PR curve data route was returning numpy arrays, which are not
JSON-serializable. This caused `/data/plugin/pr_curves/pr_curves`
requests to fail with status 500, which in turn caused the PR curve
dashboard to not display any data.

Test Plan:
Load the PR curve dashboard with some demo data. Before this patch,
you’ll see only perpetual loading spinners, plus some console failures
indicating the status-500 request. After this patch, the PR curves will
load and there won’t be any console failures.

wchargin-branch: fix-pr-curve-serialization