### PR TITLE
Rename tf-scalar-chart to tf-line-chart-data-loader

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/BUILD
+++ b/tensorboard/components/tf_line_chart_data_loader/BUILD
@@ -1,0 +1,23 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
+load("//tensorboard/defs:web.bzl", "ts_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+ts_web_library(
+    name = "tf_line_chart_data_loader",
+    srcs = [
+        "tf-line-chart-data-loader.html",
+    ],
+    path = "/tf-line-chart-data-loader",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_color_scale",
+        "//tensorboard/components/tf_imports:lodash",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/vz_line_chart",
+        "@org_polymer_paper_spinner",
+    ],
+)

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -25,7 +25,7 @@ limitations under the License.
   A component that fetches data from the TensorBoard server and renders it into
   a vz-line-chart.
 -->
-<dom-module id="tf-scalar-chart">
+<dom-module id="tf-line-chart-data-loader">
   <template>
     <div id="chart-and-spinner-container">
       <vz-line-chart
@@ -105,7 +105,7 @@ limitations under the License.
     }, 100);
 
     Polymer({
-      is: 'tf-scalar-chart',
+      is: 'tf-line-chart-data-loader',
       properties: {
         // An array of selected runs (strings).
         runs: Array,
@@ -123,7 +123,7 @@ limitations under the License.
 
         /**
          * A function that takes as inputs:
-         * 1. This tf-scalar-chart component.
+         * 1. This tf-line-chart-data-loader component.
          * 2. The run (string) the response is relevant to.
          * 3. The response received from the data URL.
          * This function will be called when a response from a request to that

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -8,7 +8,6 @@ ts_web_library(
     name = "tf_scalar_dashboard",
     srcs = [
         "tf-scalar-card.html",
-        "tf-scalar-chart.html",
         "tf-scalar-dashboard.html",
         "tf-smoothing-input.html",
     ],
@@ -22,11 +21,11 @@ ts_web_library(
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_line_chart_data_loader",
         "//tensorboard/components/tf_paginated_view",
         "//tensorboard/components/tf_runs_selector",
         "//tensorboard/components/tf_storage",
         "//tensorboard/components/tf_utils",
-        "//tensorboard/components/vz_line_chart",
         "@org_polymer_iron_collapse",
         "@org_polymer_iron_icon",
         "@org_polymer_paper_button",
@@ -37,7 +36,6 @@ ts_web_library(
         "@org_polymer_paper_item",
         "@org_polymer_paper_menu",
         "@org_polymer_paper_slider",
-        "@org_polymer_paper_spinner",
         "@org_polymer_paper_styles",
     ],
 )

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -21,9 +21,8 @@ limitations under the License.
 <link rel="import" href="../paper-menu/paper-menu.html">
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
+<link rel="import" href="../tf-line-chart-data-loader/tf-line-chart-data-loader.html">
 <link rel="import" href="../tf-card-heading/tf-card-heading.html">
-<link rel="import" href="../vz-line-chart/vz-line-chart.html">
-<link rel="import" href="tf-scalar-chart.html">
 
 <!--
   A card that handles loading data (at the right times), rendering a scalar
@@ -36,8 +35,8 @@ limitations under the License.
     display-name="[[tagMetadata.displayName]]"
     description="[[tagMetadata.description]]"
   ></tf-card-heading>
-  <div id="tf-scalar-chart-container">
-    <tf-scalar-chart
+  <div id="tf-line-chart-data-loader-container">
+    <tf-line-chart-data-loader
       x-type="[[xType]]"
       x-components-creation-method="[[_xComponentsCreationMethod]]"
       y-value-accessor="[[_yValueAccessor]]"
@@ -55,7 +54,7 @@ limitations under the License.
       log-scale-active="[[_logScaleActive]]"
       process-data="[[_processData]]"
     >
-    </tf-scalar-chart>
+    </tf-line-chart-data-loader>
   </div>
   <div id="buttons">
     <paper-icon-button
@@ -110,11 +109,11 @@ limitations under the License.
       width: 100%;
     }
 
-    :host[_expanded] #tf-scalar-chart-container {
+    :host[_expanded] #tf-line-chart-data-loader-container {
       height: 400px;
     }
 
-    #tf-scalar-chart-container {
+    #tf-line-chart-data-loader-container {
       height: 200px;
       width: 100%;
     }
@@ -286,10 +285,10 @@ limitations under the License.
         },
       },
       reload() {
-        this.$$('tf-scalar-chart').reload();
+        this.$$('tf-line-chart-data-loader').reload();
       },
       redraw() {
-        this.$$('tf-scalar-chart').redraw();
+        this.$$('tf-line-chart-data-loader').redraw();
       },
       _toggleExpanded(e) {
         this.set('_expanded', !this._expanded);
@@ -299,7 +298,7 @@ limitations under the License.
         this.set('_logScaleActive', !this._logScaleActive);
       },
       _resetDomain() {
-        const chart = this.$$('tf-scalar-chart');
+        const chart = this.$$('tf-line-chart-data-loader');
         if (chart) {
           chart.resetDomain();
         }

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -287,7 +287,7 @@ limitations under the License.
         });
       },
       _reloadCharts() {
-        this.querySelectorAll('tf-scalar-chart').forEach(chart => {
+        this.querySelectorAll('tf-scalar-card').forEach(chart => {
           chart.reload();
         });
       },


### PR DESCRIPTION
Also moved that component into the components directory. Modified the scalars dashboard to use `tf-line-chart-data-loader`.

At a higher level, the scalars dashboard had been reloading the `tf-scalar-chart` component, which was unexpected - this change sets it to reload `tf-scalar-card` components.

The scalars dashboard WAI.

![zermde9zzwd](https://user-images.githubusercontent.com/4221553/30515218-b962c274-9ad8-11e7-8936-d5aadca3d65a.png)

A subsequent change will make the PR curves component use `tf-line-chart-data-loader`.