### PR TITLE
Only show sliders for runs with steps

### DIFF
--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
@@ -23,7 +23,7 @@ limitations under the License.
 -->
 <dom-module id="tf-pr-curve-steps-selector">
   <template>
-    <template is="dom-repeat" items="[[runs]]" as="run">
+    <template is="dom-repeat" items="[[_runsWithSliders]]" as="run">
       <div class="run-widget">
         <div class="run-display-container">
           <div class="run-color-box" style="background:[[_computeColorForRun(run)]];"></div>
@@ -72,7 +72,7 @@ limitations under the License.
   Polymer({
     is: "tf-pr-curve-steps-selector",
     properties: {
-      // A list of runs to create sliders for.
+      // A list of selected runs.
       runs: Array,
       // A mapping between run and list of steps to use for the slider for that
       // run. This component indexes into this object to retrieve the steps.
@@ -90,6 +90,10 @@ limitations under the License.
       _runToStepIndex: {
         type: Object,
         value: () => ({}),
+      },
+      _runsWithSliders: {
+        type: Array,
+        computed: "_computeRunsWithSliders(runs, runToAvailableTimeEntries)",
       },
     },
     listeners: {
@@ -190,6 +194,10 @@ limitations under the License.
         runToStep[run] = entries[index].step;
       });
       return runToStep;
+    },
+    _computeRunsWithSliders(runs, runToAvailableTimeEntries) {
+      // Only create sliders for selected runs with steps available.
+      return runs.filter(r => runToAvailableTimeEntries[r]);
     },
   });
   </script>


### PR DESCRIPTION
The PR curves dashboard used to show a slider for each selected run.
A dysfunctional slider is still shown even if a run lacks PR curve data.
That dysfunctional slider also causes a console error.

![0mqmynr2dur](https://user-images.githubusercontent.com/4221553/30529727-621ef8c0-9bf5-11e7-8bbe-8079493c6b32.png)

This change makes it so that only sliders for selected runs with PR
curve data are rendered.

The alternative of using a `dom-if` within the `dom-repeat` that guards
whether there is data for a run does not work - the sliders in those cases
render after `updateSliders` is called.

Test plan:
Create a logdir containing some runs with PR curve data and some without. For instance, first run the PR curves demo, then run the scalars demo ... then move subdirectories generated by the scalars demo into the PR curves demo directory. Load the PR curves dashboard. Toggle some runs. Try 10 times
to check for flakiness.

![oezpbpmhgho](https://user-images.githubusercontent.com/4221553/30529729-67433af0-9bf5-11e7-8033-59c72d32c0c7.png)