### PR TITLE
Fix X and Y ranges of PR curves to [-0.05, 1.05]

### DIFF
--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -279,8 +279,6 @@ Polymer({
       var div = d3.select(this.$.chartdiv);
       chart.renderTo(div);
       this._chart = chart;
-
-      this.dispatchEvent(new CustomEvent('chart-rendered'));
     }, 350);
   },
   _reloadFromCache: function() {
@@ -572,9 +570,9 @@ class LineChart {
 
   private resetXDomain() {
     let xDomain;
-    if (this._defaultXRange) {
+    if (this._defaultXRange != null) {
       // Use the range specified by the caller.
-      xDomain = d3.scaleLinear().domain(this._defaultXRange).domain();
+      xDomain = this._defaultXRange;
     } else {
       // (Copied from DragZoomLayer.unzoom.)
       const xScale = this.xScale as any;
@@ -587,9 +585,9 @@ class LineChart {
 
   private resetYDomain() {
     let yDomain;
-    if (this._defaultYRange) {
+    if (this._defaultYRange != null) {
       // Use the range specified by the caller.
-      yDomain = d3.scaleLinear().domain(this._defaultYRange).domain();
+      yDomain = this._defaultYRange;
     } else {
       // Generate a reasonable range.
       const accessor = this.getAccessor();
@@ -905,6 +903,18 @@ class LineChart {
   public renderTo(targetSVG: d3.Selection<any, any, any, any>) {
     this.targetSVG = targetSVG;
     this.outer.renderTo(targetSVG);
+
+    if (this._defaultXRange != null) {
+      // A higher-level component provided a default range for the X axis.
+      // Start with that range.
+      this.resetXDomain();
+    }
+
+    if (this._defaultYRange != null) {
+      // A higher-level component provided a default range for the Y axis.
+      // Start with that range.
+      this.resetYDomain();
+    }
   }
 
   public redraw() {

--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -93,6 +93,22 @@ Polymer({
     tooltipColumns: Array,
 
     /**
+     * An optional array of 2 numbers for the min and max of the default range
+     * of the Y axis. If not provided, a reasonable range will be generated.
+     * This property is a list instead of 2 individual properties to emphasize
+     * that both the min and the max must be specified (or neither at all).
+     */
+    defaultXRange: Array,
+
+    /**
+     * An optional array of 2 numbers for the min and max of the default range
+     * of the Y axis. If not provided, a reasonable range will be generated.
+     * This property is a list instead of 2 individual properties to emphasize
+     * that both the min and the max must be specified (or neither at all).
+     */
+    defaultYRange: Array,
+
+    /**
      * Tooltip header innerHTML text. We cannot use a dom-repeat inside of a
      * table element because Polymer does not support that. This seems like
      * a bug in Polymer. Hence, we manually generate the HTML for creating a row
@@ -194,7 +210,8 @@ Polymer({
   },
 
   /**
-   * Reset the chart domain to fit its data.
+   * Reset the chart domain. If the chart has not rendered yet, a call to this
+   * method no-ops.
    */
   resetDomain: function() {
     if (this._chart) {
@@ -220,6 +237,11 @@ Polymer({
     this.scopeSubtree(this.$.tooltip, true);
     this.scopeSubtree(this.$.chartdiv, true);
   },
+
+  /**
+   * Creates a chart, and asynchronously renders it. Fires a chart-rendered
+   * event after the chart is rendered.
+   */
   _makeChart: function(
       xComponentsCreationMethod,
       yValueAccessor,
@@ -251,10 +273,14 @@ Polymer({
           yScaleType,
           colorScale,
           tooltip,
-          this.tooltipColumns);
+          this.tooltipColumns,
+          this.defaultXRange,
+          this.defaultYRange);
       var div = d3.select(this.$.chartdiv);
       chart.renderTo(div);
       this._chart = chart;
+
+      this.dispatchEvent(new CustomEvent('chart-rendered'));
     }, 350);
   },
   _reloadFromCache: function() {
@@ -335,6 +361,11 @@ class LineChart {
   private tooltipPosition: string;
   private _ignoreYOutliers: boolean;
 
+  // An optional list of 2 numbers.
+  private _defaultXRange: number[];
+  // An optional list of 2 numbers.
+  private _defaultYRange: number[];
+
   private targetSVG: d3.Selection<any, any, any, any>;
 
   constructor(
@@ -343,7 +374,9 @@ class LineChart {
       yScaleType: string,
       colorScale: Plottable.Scales.Color,
       tooltip: d3.Selection<any, any, any, any>,
-      tooltipColumns: ChartHelpers.TooltipColumn[]) {
+      tooltipColumns: ChartHelpers.TooltipColumn[],
+      defaultXRange?: number[],
+      defaultYRange?: number[]) {
     this.seriesNames = [];
     this.name2datasets = {};
     this.colorScale = colorScale;
@@ -358,6 +391,10 @@ class LineChart {
     // need to do a single bind, so we can deregister the callback from
     // old Plottable.Datasets. (Deregistration is done by identity checks.)
     this.onDatasetChanged = this._onDatasetChanged.bind(this);
+
+    this._defaultXRange = defaultXRange;
+    this._defaultYRange = defaultYRange;
+
     this.buildChart(
         xComponentsCreationMethod, yValueAccessor, yScaleType, tooltipColumns);
   }
@@ -534,23 +571,36 @@ class LineChart {
   }
 
   private resetXDomain() {
-    // (Copied from DragZoomLayer.unzoom.)
-    const xScale = this.xScale as any;
-    xScale._domainMin = null;
-    xScale._domainMax = null;
-    const xDomain = xScale._getExtent();
+    let xDomain;
+    if (this._defaultXRange) {
+      // Use the range specified by the caller.
+      xDomain = d3.scaleLinear().domain(this._defaultXRange).domain();
+    } else {
+      // (Copied from DragZoomLayer.unzoom.)
+      const xScale = this.xScale as any;
+      xScale._domainMin = null;
+      xScale._domainMax = null;
+      xDomain = xScale._getExtent();
+    }
     this.xScale.domain(xDomain);
   }
 
   private resetYDomain() {
-    const accessor = this.getAccessor();
-    let datasetToValues: (d: Plottable.Dataset) => number[] = (d) => {
-      return d.data().map((x) => accessor(x, -1, d));
-    };
-    let vals = _.flatten(this.datasets.map(datasetToValues));
-    vals = vals.filter((x) => x === x && x !== Infinity && x !== -Infinity);
-    let domain = ChartHelpers.computeDomain(vals, this._ignoreYOutliers);
-    this.yScale.domain(domain);
+    let yDomain;
+    if (this._defaultYRange) {
+      // Use the range specified by the caller.
+      yDomain = d3.scaleLinear().domain(this._defaultYRange).domain();
+    } else {
+      // Generate a reasonable range.
+      const accessor = this.getAccessor();
+      let datasetToValues: (d: Plottable.Dataset) => number[] = (d) => {
+        return d.data().map((x) => accessor(x, -1, d));
+      };
+      let vals = _.flatten(this.datasets.map(datasetToValues));
+      vals = vals.filter((x) => x === x && x !== Infinity && x !== -Infinity);
+      yDomain = ChartHelpers.computeDomain(vals, this._ignoreYOutliers);
+    }
+    this.yScale.domain(yDomain);
   }
 
   private getAccessor(): Plottable.IAccessor<number> {

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -41,6 +41,8 @@ limitations under the License.
         y-value-accessor="[[_yValueAccessor]]"
         tooltip-columns="[[_tooltipColumns]]"
         color-scale="[[_colorScaleFunction]]"
+        default-x-range="[[_defaultXRange]]"
+        default-y-range="[[_defaultYRange]]"
       ></vz-line-chart>
       <template is="dom-if" if="[[loading]]">
         <div id="loading-spinner-container">
@@ -300,6 +302,16 @@ limitations under the License.
           ],
           readOnly: true,
         },
+        _defaultXRange: {
+          type: Array,
+          value: [0, 1],
+          readOnly: true,
+        },
+        _defaultYRange: {
+          type: Array,
+          value: [0, 1],
+          readOnly: true,
+        },
       },
       observers: [
         'reload(runs, tag)',
@@ -316,6 +328,13 @@ limitations under the License.
         // sometimes)
         this._attached = true;
         this.reload();
+      },
+      ready() {
+        this.$$('vz-line-chart').addEventListener('chart-rendered', () => {
+          // Reset the chart's X and Y domains to [0, 1] only after the chart is
+          // rendered. Otherwise, the call to resetDomain no-ops. 
+          this.$$('vz-line-chart').resetDomain();
+        }, false);
       },
       reload() {
         if (!this._attached) {

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -304,12 +304,12 @@ limitations under the License.
         },
         _defaultXRange: {
           type: Array,
-          value: [0, 1],
+          value: [-0.05, 1.05],
           readOnly: true,
         },
         _defaultYRange: {
           type: Array,
-          value: [0, 1],
+          value: [-0.05, 1.05],
           readOnly: true,
         },
       },
@@ -328,13 +328,6 @@ limitations under the License.
         // sometimes)
         this._attached = true;
         this.reload();
-      },
-      ready() {
-        this.$$('vz-line-chart').addEventListener('chart-rendered', () => {
-          // Reset the chart's X and Y domains to [0, 1] only after the chart is
-          // rendered. Otherwise, the call to resetDomain no-ops. 
-          this.$$('vz-line-chart').resetDomain();
-        }, false);
       },
       reload() {
         if (!this._attached) {


### PR DESCRIPTION
Beforehand, the `vz-line-chart` component would set reasonable X and Y
ranges for all plots. This was problematic because as the user slides
across steps in the PR curves dashboard, the Y axis would change,
leading to difficulty in comparing across steps.

This change adds `defaultXRange` and `defaultYRange` properties to
`vz-line-chart` so that dashboards can manually set default ranges for
the X and Y axes if the need arises. It also makes PR curves start out
with those default ranges.

Test plan:
Run the PR curves demo, and start TensorBoard. Note that all PR curves
exhibit the new X and Y ranges. Also, run the scalars demo, and start
TensorBoard. Note that it loads and behaves as expected.

Before:
![pr80qwbyrdb](https://user-images.githubusercontent.com/4221553/30568034-f5b80fc6-9c87-11e7-93bd-b602cff9038b.png)

After:
![nhtu4egyvh2](https://user-images.githubusercontent.com/4221553/30568047-0d182dd6-9c88-11e7-8c30-ebc9166cd176.png)


