### PR TITLE
Add icon for resetting PR curves

### DIFF
--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -55,6 +55,11 @@ limitations under the License.
         icon="fullscreen"
         on-tap="_toggleExpanded"
       ></paper-icon-button>
+      <paper-icon-button
+        icon="settings-overscan"
+        on-tap="_resetDomain"
+        title="Reset axes to [0, 1]."
+      ></paper-icon-button>
     </div>
 
     <div id="step-legend">
@@ -453,6 +458,9 @@ limitations under the License.
       _toggleExpanded(e) {
         this.set('_expanded', !this._expanded);
         this.redraw();
+      },
+      _resetDomain() {
+        this.$$('vz-line-chart').resetDomain();
       },
       redraw() {
         this.$$('vz-line-chart').redraw();


### PR DESCRIPTION
This change adds an icon beneath each PR curve that lets the user reset
the ranges of the chart axes. The icon mirrors that under scalar charts.

Test plan: Run the PR curves demo. Start TensorBoard. Zoom in to a
PR curve, and click the icon.

![wqzsfqctq2x](https://user-images.githubusercontent.com/4221553/30571882-4a45dec6-9c9f-11e7-8b22-1611246c3f35.png)

This change should merge only after https://github.com/tensorflow/tensorboard/pull/541 is merged.