### PR TITLE
Close the FileWriter in summary_test

### DIFF
--- a/tensorboard/plugins/pr_curve/summary_test.py
+++ b/tensorboard/plugins/pr_curve/summary_test.py
@@ -275,8 +275,7 @@ class PrCurveTest(tf.test.TestCase):
     ], tensor_events[2])
 
   def testRawMetricsOp(self):
-    writer = tf.summary.FileWriter(self.logdir)
-    with tf.Session() as sess:
+    with tf.summary.FileWriter(self.logdir) as writer, tf.Session() as sess:
       # We pass raw counts and precision/recall values.
       writer.add_summary(sess.run(summary.raw_metrics_op(
           tag='foo',


### PR DESCRIPTION
A FileWriter within the summary_test for the PR curves plugin had
previously been unclosed before the multiplexer read from it, which
potentially could have been causing flaky behavior.