### PR TITLE
Make info card list usages of a function

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -33,7 +33,7 @@ export interface LibraryFunctionData {
   // The metanode representing this function in the library scene group.
   node: Metanode; 
 
-  // A list of metanodes that represent calls to this library function.
+  // A list of nodes that represent calls to this library function.
   usages: Node[];
 }
 

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -679,9 +679,9 @@ export class RenderGraphInfo {
       _.each(metagraph.nodes(), childName => {
         // Why is this so often undefined?
         const originalNode = metagraph.node(childName) as OpNode;
-        const libraryMetanode =
+        const libraryFunctionData =
             this.hierarchy.libraryFunctions[originalNode.op];
-        if (!libraryMetanode) {
+        if (!libraryFunctionData) {
           // This node is not a function call.
           return;
         }
@@ -698,8 +698,8 @@ export class RenderGraphInfo {
         const clonedMetanode = this.cloneFunctionLibraryMetanode(
             metagraph,
             originalNode,
-            libraryMetanode,
-            libraryMetanode.name,
+            libraryFunctionData.node,
+            libraryFunctionData.node.name,
             originalNode.name);
         nodesThatGotCloned.push(originalNode);
         functionCallMetanodesToAdd.push(clonedMetanode);
@@ -761,7 +761,10 @@ export class RenderGraphInfo {
     if (nodeName === tf.graph.ROOT_NAME) {
       // Add all metanodes representing library function templates into the
       // library function scene group for the root node.
-      _.forOwn(this.hierarchy.libraryFunctions, (node, functionName) => {
+      _.forOwn(
+          this.hierarchy.libraryFunctions,
+          (libraryFunctionData, functionName) => {
+        const node = libraryFunctionData.node;
         const childRenderInfo = this.getOrCreateRenderNodeByName(node.name);
         renderGroupNodeInfo.libraryFunctionsExtract.push(childRenderInfo);
 

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
@@ -341,8 +341,7 @@ limitations under the License.
           <div class="sub-list-group predecessors">
             Usages of the Function
             (<span>[[_functionUsages.length]]</span>)
-            <iron-list class="sub-list" id ="inputsList"
-                      items="[[_functionUsages]]">
+            <iron-list class="sub-list" id ="inputsList" items="[[_functionUsages]]">
               <template>
                 <tf-node-list-item
                     class="non-control-list-item"

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
@@ -211,7 +211,7 @@ limitations under the License.
         <div class="sub-list-group predecessors">
           Inputs
           (<span>[[_totalPredecessors]]</span>)
-          <iron-list class="sub-list" id ="inputsList"
+          <iron-list class="sub-list" id="inputsList"
                     items="[[_predecessors.regular]]">
             <template>
               <tf-node-list-item
@@ -341,7 +341,7 @@ limitations under the License.
           <div class="sub-list-group predecessors">
             Usages of the Function
             (<span>[[_functionUsages.length]]</span>)
-            <iron-list class="sub-list" id ="inputsList" items="[[_functionUsages]]">
+            <iron-list class="sub-list" id="inputsList" items="[[_functionUsages]]">
               <template>
                 <tf-node-list-item
                     class="non-control-list-item"

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
@@ -336,6 +336,28 @@ limitations under the License.
             </div>
           </div>
         </template>
+
+        <template is="dom-if" if="[[_functionUsages.length]]">
+          <div class="sub-list-group predecessors">
+            Usages of the Function
+            (<span>[[_functionUsages.length]]</span>)
+            <iron-list class="sub-list" id ="inputsList"
+                      items="[[_functionUsages]]">
+              <template>
+                <tf-node-list-item
+                    class="non-control-list-item"
+                    card-node="[[_node]]"
+                    item-node="[[item]]"
+                    name="[[item.name]]"
+                    item-type="functionUsages"
+                    color-by="[[colorBy]]"
+                    template-index="[[_templateIndex]]">
+                </tf-node-list-item>
+              </template>
+            </iron-list>
+          </div>
+        </template>
+
         <div class="toggle-include-group">
           <paper-button raised class="toggle-include" on-click="_toggleInclude">
             <span>[[_auxButtonText]]</span>
@@ -440,7 +462,13 @@ limitations under the License.
             value: false
           },
           _auxButtonText: String,
-          _groupButtonText: String
+          _groupButtonText: String,
+          // Only relevant if this is a library function. A list of nodes that
+          // represent where the function is used.
+          _functionUsages: {
+            type: Array,
+            computed: '_computeFunctionUsages(nodeName, graphHierarchy)',
+          },
         },
         expandNode: function() {
           this.fire('_node.expand', this.node);
@@ -646,7 +674,25 @@ limitations under the License.
         },
         _isInSeries: function(node) {
           return tf.graph.scene.node.canBeInSeries(node);
-        }
+        },
+        _computeFunctionUsages(nodeName, graphHierarchy) {
+          const node = this._getNode(nodeName, graphHierarchy);
+          console.log('_computeFunctionUsages', nodeName, graphHierarchy, node);
+          if (!node || node.type !== tf.graph.NodeType.META) {
+            // Functions must be represented by metanodes.
+            return [];
+          }
+
+          const libraryFunctionData = graphHierarchy.libraryFunctions[
+              node.associatedFunction];
+          if (!libraryFunctionData) {
+            // This is no function.
+            return [];
+          }
+
+          // Return where the function is used.
+          return libraryFunctionData.usages;
+        },
       });
     })();
   </script>

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
@@ -677,7 +677,6 @@ limitations under the License.
         },
         _computeFunctionUsages(nodeName, graphHierarchy) {
           const node = this._getNode(nodeName, graphHierarchy);
-          console.log('_computeFunctionUsages', nodeName, graphHierarchy, node);
           if (!node || node.type !== tf.graph.NodeType.META) {
             // Functions must be represented by metanodes.
             return [];


### PR DESCRIPTION
This change makes it so that the info card lists where a function is
called when the highlighted node represents a library function. Clicking
on one of the function calls makes the graph select the node that
represents the call.

This change involves introducing a new data container
`LibraryFunctionData` that encapsulates the name of a function as well
as instances in which the function is called.

![2tn8ofz10ea](https://user-images.githubusercontent.com/4221553/30675918-4260120e-9e38-11e7-8b73-4ef0eab65adb.png)

Test plan:
1. Create a log directory containing the attached events file. The only reason that the binary file ends in txt is because GitHub forbids users from uploading binary files.
2. Start TensorBoard pointed at it.
3. Click on a node representing a library function.
4. Click on one of the node list items representing the function call. The graph should select it.

[events.out.tfevents.1502484134.agent007.txt](https://github.com/tensorflow/tensorboard/files/1319763/events.out.tfevents.1502484134.agent007.txt)
