### PR TITLE
Make step text depend on steps array

### DIFF
--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -243,11 +243,11 @@ future for loading older images.
         },
         _stepValue: {
           type: Number,
-          computed: "_computeStepValue(_stepIndex)",
+          computed: "_computeStepValue(_steps, _stepIndex)",
         },
         _currentWallTime: {
           type: Number,
-          computed: "_computeCurrentWallTime(_stepIndex)",
+          computed: "_computeCurrentWallTime(_steps, _stepIndex)",
         },
         _maxStepIndex: {
           type: Number,
@@ -280,11 +280,11 @@ future for loading older images.
       _computeHasMultipleSteps(steps) {
         return !!steps && steps.length > 1;
       },
-      _computeStepValue(stepIndex) {
-        return this._steps[stepIndex].step;
+      _computeStepValue(steps, stepIndex) {
+        return steps[stepIndex].step;
       },
-      _computeCurrentWallTime(stepIndex) {
-        return formatDate(this._steps[stepIndex].wall_time);
+      _computeCurrentWallTime(steps, stepIndex) {
+        return formatDate(steps[stepIndex].wall_time);
       },
       _computeMaxStepIndex(steps) {
         return steps.length - 1;


### PR DESCRIPTION
Previously, the text atop image loaders (displaying step and wall time)
would only depend on the step index. This was problematic because during
reloads, the array of steps changes, but the number of sampled steps
remains the same, so the text above individual images would not update.

Fixes #550.

Test plan: Run mnist_with_summaries.py:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py

Start TensorBoard pointed at
/tmp/tensorflow/mnist/logs/mnist_with_summaries, and navigate to the
image dashboard. Notice that the step updates now when TensorBoard
reloads, both during the periodic reload and during manually triggered
reloads.

![d1anzjtecav](https://user-images.githubusercontent.com/4221553/30677533-0621b30c-9e41-11e7-8ddb-c5b2dc54a2aa.png)
