### PR TITLE
Log dashboard selection if Analytics is enabled

### DIFF
--- a/tensorboard/components/analytics.html
+++ b/tensorboard/components/analytics.html
@@ -16,3 +16,9 @@ limitations under the License.
 -->
 
 <!-- TODO(@jart): Give users the ability to opt-in to analytics. -->
+<script>
+  // We fake the global 'ga' object, so the object is a noop. The
+  // google.analytics typing gives the object a type of UniversalAnalytics.ga.
+  // We do not track open source users.
+  window['ga'] = function() {};
+</script>

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -583,7 +583,13 @@ limitations under the License.
             return;  // we just triggered that handler; don't need another
           }
         }
-        setString(TAB, selectedDashboard || '', /*useLocalStorage=*/false);
+
+        const pluginString = selectedDashboard || '';
+        setString(TAB, pluginString, /*useLocalStorage=*/false);
+
+        // Record this dashboard selection as a page view.
+        ga('set', 'page', '/' + pluginString);
+        ga('send', 'pageview');
       },
 
       _updateSelectedDashboardFromHash() {

--- a/third_party/typings.bzl
+++ b/third_party/typings.bzl
@@ -25,6 +25,10 @@ def tensorboard_typings_workspace():
               "http://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/chai/chai.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/chai/chai.d.ts",
           ],
+          "a285ca43837c03640134d31fb64a52625f65f4a2890194414d695fbc050b289e": [
+              "http://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/5d0f2126c8dac8fce0ff020218aea06607213b0d/google.analytics/ga.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/5d0f2126c8dac8fce0ff020218aea06607213b0d/google.analytics/ga.d.ts",
+          ],
           "e4cd3d5de0eb3bc7b1063b50d336764a0ac82a658b39b5cf90511f489ffdee60": [
               "http://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/efd40e67ff323f7147651bdbef03c03ead7b1675/lodash/lodash.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/efd40e67ff323f7147651bdbef03c03ead7b1675/lodash/lodash.d.ts",


### PR DESCRIPTION
Added a tf-logging component that contains a logEvent function. This function takes an Analytics event and logs it if Analytics is enabled (as detected by whether the global 'ga' object is defined). Used that method to log dashboard selection.

The vz-projector-app is for now unaffected because that app is a standalone app not used within TensorBoard.

Fixes #524.

Test Plan:
1. Start TensorBoard externally. Note the requests in the Network tab - none are triggered by the `logEvent` method. Also `console.log`ging shows that the `logEvent` method is not called.
2. Start TensorBoard within Google. Note that requests are issued, and `console.log`ing reveals that `logEvent` is called. I think we'll have to wait a few days for the events to show up in the Analytics UI. We can iterate then if we see things that are awry.