### PR TITLE
Define audio/summary_test as medium size

### DIFF
--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -60,7 +60,7 @@ py_library(
 
 py_test(
     name = "summary_test",
-    size = "small",
+    size = "medium",
     srcs = ["summary_test.py"],
     srcs_version = "PY2AND3",
     deps = [


### PR DESCRIPTION
This broke the internal CI by taking longer than sixty seconds.
A test that spawns subprocesses also probably can't be called
small, according to the go/testsizes definitions.