### PR TITLE
Rename raw_metrics_op to raw_data_op

### DIFF
--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -164,7 +164,7 @@ def op(
         description,
         collections)
 
-def raw_metrics_op(
+def raw_data_op(
     tag,
     true_positive_counts,
     false_positive_counts,
@@ -246,10 +246,10 @@ def _create_tensor_summary(
     collections=None):
   """A private helper method for generating a tensor summary.
 
-  We use a helper method instead of having `op` directly call `raw_metrics_op`
-  to prevent the scope of `raw_metrics_op` from being embedded within `op`.
+  We use a helper method instead of having `op` directly call `raw_data_op`
+  to prevent the scope of `raw_data_op` from being embedded within `op`.
 
-  Arguments are the same as for raw_metrics_op.
+  Arguments are the same as for raw_data_op.
 
   Returns:
     A tensor summary that collects data for PR curves.

--- a/tensorboard/plugins/pr_curve/summary_test.py
+++ b/tensorboard/plugins/pr_curve/summary_test.py
@@ -274,10 +274,10 @@ class PrCurveTest(tf.test.TestCase):
         [1.0, 0.8133333, 0.2133333, 0.0266667, 0.0],  # Recall.
     ], tensor_events[2])
 
-  def testRawMetricsOp(self):
+  def testRawDataOp(self):
     with tf.summary.FileWriter(self.logdir) as writer, tf.Session() as sess:
       # We pass raw counts and precision/recall values.
-      writer.add_summary(sess.run(summary.raw_metrics_op(
+      writer.add_summary(sess.run(summary.raw_data_op(
           tag='foo',
           true_positive_counts=tf.constant([75, 64, 21, 5, 0]),
           false_positive_counts=tf.constant([150, 105, 18, 0, 0]),


### PR DESCRIPTION
Per internal feedback, 'metric op' has a specific meaning:
https://www.tensorflow.org/versions/r0.12/api_docs/python/contrib.metrics/metric_ops

and the op is not a metric op. This renaming avoids confusion.