### PR TITLE
Make graph explorer work for functions that output to metanodes

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -763,24 +763,20 @@ export class RenderGraphInfo {
     // added later. Construct the hierarchies for nodes that are predecessors to
     // nodes in the current hierarchy so that edges are drawn correctly.
     if (!_.isEmpty(this.hierarchy.libraryFunctions)) {
-      console.log('buildSubhierarchy', nodeName, metagraph.edges());
       _.each(metagraph.edges(), edgeObj => {
         let metaedge = metagraph.edge(edgeObj);
         let renderMetaedgeInfo = new RenderMetaedgeInfo(metaedge);
         _.forEach(renderMetaedgeInfo.metaedge.baseEdgeList,
             baseEdge => {
           const sourcePathList = baseEdge.v.split(tf.graph.NAMESPACE_DELIM);
-          console.log('baseedge', baseEdge, baseEdge.v);
 
           for (let i = sourcePathList.length; i >= 0; i--) {
             const fromBeginningPathList = sourcePathList.slice(0, i);
             const node = this.hierarchy.node(
                 fromBeginningPathList.join(tf.graph.NAMESPACE_DELIM));
-            console.log('observing', fromBeginningPathList, node);
             if (node) {
               if (node.type === NodeType.OP &&
                   this.hierarchy.libraryFunctions[(node as OpNode).op]) {
-                console.log('library function found', node, fromBeginningPathList);
                 for (let j = 1; j < fromBeginningPathList.length; j++) {
                   // Expand all hierarchies including the parent.
                   const currentNodeName = fromBeginningPathList
@@ -789,7 +785,6 @@ export class RenderGraphInfo {
                     continue;
                   }
 
-                  console.log('try buildSubhierarchy', currentNodeName, this.index, this.index[currentNodeName]);
                   this.buildSubhierarchy(currentNodeName);
                 }
               }


### PR DESCRIPTION
Previously, if the output for a function was the input into an op within a metanode, the graph explorer would fail to visualize the graph and produce an error upon rendering the hierarchy for the metanode:

    Uncaught TypeError: Cannot read property 'inputs' of undefined

This PR takes 2 actions to fix that.

1. We scan the base edges of the destination op, which have to have OpNodes as destinations (instead of scanning the inputs of the destination op, which could be MetaNodes).
2. If a node at the current hierarchy has an input that is within a function call, we render the hierarchy of the function call's parent so that edges are generated correctly (because the source nodes are now available).

Test plan:
Load the attached pbtxt file into the graph explorer. Beforehand, the error would appear when the user expands the `scope_foo` metanode (because rendering an output op would fail). Now, the metanode correctly renders.

![rmaznjynmat](https://user-images.githubusercontent.com/4221553/30845606-2ec3c9ce-a262-11e7-9011-c38ca14da1f2.png)

[mnist_with_functions.pbtxt.txt](https://github.com/tensorflow/tensorboard/files/1332002/mnist_with_functions.pbtxt.txt)

The function call expands correctly too.

![obpe8w0ovxo](https://user-images.githubusercontent.com/4221553/30845710-accbcff6-a262-11e7-8175-5a4b94d081da.png)
