### PR TITLE
Prevent library functions from being in/out extracted

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -1747,7 +1747,11 @@ function extractSpecifiedNodes(renderNode: RenderGroupNodeInfo) {
   let graph = renderNode.coreGraph;
   _.each(graph.nodes(), n => {
     let renderInfo = graph.node(n);
-    if (renderInfo.node.include === InclusionType.EXCLUDE) {
+    if (renderInfo.node.include === InclusionType.EXCLUDE &&
+        !n.startsWith(tf.graph.FUNCTION_LIBRARY_NODE_PREFIX)) {
+      // Move the node if the node is excluded and not part of the library
+      // function scene group, which contains nodes that do not represent ops in
+      // the graph and should thus never have its nodes added to the core graph.
       if (renderNode.coreGraph.outEdges(n).length >
           renderNode.coreGraph.inEdges(n).length) {
         makeOutExtract(renderNode, n, true);


### PR DESCRIPTION
Previously, the graph explorer would iterate through all nodes and deem nodes that lack any inputs or outputs to be in or out extracts. Library functions are isolated nodes within a special scene group, so they got lumped into the in and out extracts. This change adds a guard to prevent that.

Test Plan: Start TensorBoard with the attached events file. Add the init op to the main graph. Note that the library functions are no longer replicated, which had been a bug.

Fixes #574. The library functions are no longer extracted into auxiliary when a node such as init is added or removed:

<img width="1032" alt="init node successfully added to graph" src="https://user-images.githubusercontent.com/4221553/30942467-459b94a8-a3a0-11e7-9633-67fbccb3f131.png">

[events.out.tfevents.functions.txt](https://github.com/tensorflow/tensorboard/files/1338982/events.out.tfevents.functions.txt)

