### PR TITLE
Ensure that the list of function usages updates

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
@@ -341,7 +341,7 @@ limitations under the License.
           <div class="sub-list-group predecessors">
             Usages of the Function
             (<span>[[_functionUsages.length]]</span>)
-            <iron-list class="sub-list" id="inputsList" items="[[_functionUsages]]">
+            <iron-list class="sub-list" id="functionUsagesList" items="[[_functionUsages]]">
               <template>
                 <tf-node-list-item
                     class="non-control-list-item"
@@ -436,6 +436,12 @@ limitations under the License.
             type: Object,
             computed: '_getPredecessors(_node, graphHierarchy)'
           },
+          // Only relevant if this is a library function. A list of nodes that
+          // represent where the function is used.
+          _functionUsages: {
+            type: Array,
+            computed: '_getFunctionUsages(_node, graphHierarchy)',
+          },
           _subnodes: {
             type: Array,
             computed: '_getSubnodes(_node)'
@@ -462,12 +468,6 @@ limitations under the License.
           },
           _auxButtonText: String,
           _groupButtonText: String,
-          // Only relevant if this is a library function. A list of nodes that
-          // represent where the function is used.
-          _functionUsages: {
-            type: Array,
-            computed: '_computeFunctionUsages(nodeName, graphHierarchy)',
-          },
         },
         expandNode: function() {
           this.fire('_node.expand', this.node);
@@ -552,21 +552,43 @@ limitations under the License.
         _getDevice: function(node) {
           return node ? node.device : null;
         },
-        _getSuccessors: function(node, hierarchy) {
-          this.async(this._resizeList.bind(this, "#inputsList"));
+        _getSuccessors(node, hierarchy) {
+          this._refreshNodeItemList("inputsList");
           if (!node) {
             return {regular: [], control: []}
           }
           return this._convertEdgeListToEdgeInfoList(
             hierarchy.getSuccessors(node.name), false, node.isGroupNode);
         },
-        _getPredecessors: function(node, hierarchy) {
-          this.async(this._resizeList.bind(this, "#outputsList"));
+        _getPredecessors(node, hierarchy) {
+          this._refreshNodeItemList("outputsList");
           if (!node) {
             return {regular: [], control: []}
           }
           return this._convertEdgeListToEdgeInfoList(
             hierarchy.getPredecessors(node.name), true, node.isGroupNode);
+        },
+        _getFunctionUsages(node, hierarchy) {
+          this._refreshNodeItemList("functionUsagesList");
+          if (!node || node.type !== tf.graph.NodeType.META) {
+            // Functions must be represented by metanodes.
+            return [];
+          }
+
+          const libraryFunctionData = hierarchy.libraryFunctions[
+              node.associatedFunction];
+          if (!libraryFunctionData) {
+            // This is no function.
+            return [];
+          }
+
+          // Return where the function is used.
+          return libraryFunctionData.usages;
+        },
+        // The iron lists that enumerate ops must be asynchronously updated when
+        // the data they render changes. This function triggers that update.
+        _refreshNodeItemList(nodeListId) {
+          this.async(this._resizeList.bind(this, `#${nodeListId}`));
         },
         _convertEdgeListToEdgeInfoList: function(list, isPredecessor, isGroupNode) {
 
@@ -673,23 +695,6 @@ limitations under the License.
         },
         _isInSeries: function(node) {
           return tf.graph.scene.node.canBeInSeries(node);
-        },
-        _computeFunctionUsages(nodeName, graphHierarchy) {
-          const node = this._getNode(nodeName, graphHierarchy);
-          if (!node || node.type !== tf.graph.NodeType.META) {
-            // Functions must be represented by metanodes.
-            return [];
-          }
-
-          const libraryFunctionData = graphHierarchy.libraryFunctions[
-              node.associatedFunction];
-          if (!libraryFunctionData) {
-            // This is no function.
-            return [];
-          }
-
-          // Return where the function is used.
-          return libraryFunctionData.usages;
         },
       });
     })();


### PR DESCRIPTION
Previously, when a user selected a node that represents a function, the list of function usages in the info card might not update. In response, this change

1. makes the info card asynchronously update that iron-list when the list of function usages changes. The logic for asynchronously updating node list items is now moved into a helper method also used by the logic for rendering lists of inputs and outputs.
2. makes `_functionUsages` depend on `_node` instead of `nodeName` like the other lists of nodes do. This prevents duplicating a little code and also ensure that `_resetState` is called when `_functionUsages` updates.
3. Renamed the 3 methods that obtain lists of nodes (`_getSuccessors`, `_getPredecessors`, and `_getFunctionUsages`) to be consistent. Moved them closer together so that future developers will hopefully see a pattern between them and not forget to asynchronously update the UI.

Test plan:
Start TensorBoard with the attached events file. In the graph dashboard, select an op node such as `y_`. Then select a function call node such as `MnistLoss` in the core graph. Notice that usages of the function are listed in the info card. Notice that the info card still lists inputs and successors for various ops throughout the graph as expected.

Fixes #577.

<img width="1001" alt="there are function usages now" src="https://user-images.githubusercontent.com/4221553/30942702-4f27074a-a3a1-11e7-9f75-ecbf4cc7bef4.png">

[events.out.tfevents.functions.txt](https://github.com/tensorflow/tensorboard/files/1338991/events.out.tfevents.functions.txt)
