### PR TITLE
Remove add/remove button for library function nodes

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
@@ -357,11 +357,14 @@ limitations under the License.
           </div>
         </template>
 
-        <div class="toggle-include-group">
-          <paper-button raised class="toggle-include" on-click="_toggleInclude">
-            <span>[[_auxButtonText]]</span>
-          </paper-button>
-        </div>
+        <template is="dom-if" if="[[!_isLibraryFunction(_node)]]">
+          <div class="toggle-include-group">
+            <paper-button raised class="toggle-include" on-click="_toggleInclude">
+              <span>[[_auxButtonText]]</span>
+            </paper-button>
+          </div>
+        </template>
+
         <template is="dom-if" if="{{_isInSeries(_node)}}">
           <div class="toggle-include-group">
             <paper-button raised class="toggle-include" on-click="_toggleGroup">
@@ -670,6 +673,14 @@ limitations under the License.
           var graphElem = document.querySelector("#graph");
           var seriesName = tf.graph.scene.node.getSeriesName(this._node);
           graphElem.fire("node-toggle-seriesgroup", { name: seriesName });
+        },
+        _isLibraryFunction(node) {
+          // If the node name starts with this string, the node is either a
+          // library function or a node within it. Those nodes should never be
+          // extracted into the auxiliary scene group because they represent
+          // templates for function call nodes, not ops in the graph themselves.
+          return node &&
+                 node.name.startsWith(tf.graph.FUNCTION_LIBRARY_NODE_PREFIX);
         },
         _isInSeries: function(node) {
           return tf.graph.scene.node.canBeInSeries(node);


### PR DESCRIPTION
Library functions are not part of the TensorFlow graph - they serve as templates for creating other ops. The graph explorer should thus not allow library functions to be extracted.

<img width="385" alt="add to main button" src="https://user-images.githubusercontent.com/4221553/30942851-1df3542a-a3a2-11e7-9cde-4ab4545da3e9.png">

This change hides the 'Add/remove to/from the main graph' button from the info card when a library function is selected.

<img width="649" alt="no button for extraction" src="https://user-images.githubusercontent.com/4221553/30942862-30d20294-a3a2-11e7-9907-1ccf04ffa87f.png">

This relates to fixing #574.

Test plan: Start TensorBoard pointed at the attached events file. Note that the button for adding/removing a node is hidden if the node is a library function. Also not that the button still appears for other ops in the graph.

[events.out.tfevents.functions.txt](https://github.com/tensorflow/tensorboard/files/1339011/events.out.tfevents.functions.txt)
