### PR TITLE
Add handleNodeSelected property to tf-graph

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.html
@@ -128,10 +128,15 @@ Polymer({
     nodeNamesToHealthPills: Object,
     // The step of health pills to show throughout the graph.
     healthPillStepIndex: Number,
+    // An optional function that takes a node selected event (whose `detail`
+    // property is the selected node ... which could be null if a node is
+    // deselected). Called whenever a node is selected or deselected.
+    handleNodeSelected: Object,
   },
   observers: [
     '_statsChanged(stats, devicesForStats)',
-    '_buildRenderHierarchy(graphHierarchy)'
+    '_buildRenderHierarchy(graphHierarchy)',
+    '_selectedNodeChanged(selectedNode)',
   ],
   _statsChanged: function(stats, devicesForStats) {
     if (this.graphHierarchy) {
@@ -242,6 +247,15 @@ Polymer({
   _enableClick: function(event) {
     this._allowGraphSelect = true;
   },
+  // Called when the selected node changes, ie there is a new selected node or
+  // the current one is unselected.
+  _selectedNodeChanged(selectedNode) {
+    if (this.handleNodeSelected) {
+      // A higher-level component provided a callback. Run it.
+      this.handleNodeSelected(selectedNode);
+    }
+  },
+  // Called only when a new (non-null) node is selected.
   _nodeSelected: function(event) {
     if (this._allowGraphSelect) {
       this.set('selectedNode', event.detail.name);

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
@@ -145,6 +145,7 @@ paper-progress {
               progress="{{progress}}"
               node-names-to-health-pills="[[nodeNamesToHealthPills]]"
               health-pill-step-index="[[healthPillStepIndex]]"
+              handle-node-selected="[[handleNodeSelected]]"
     ></tf-graph>
   </div>
   <div id="info">
@@ -231,7 +232,11 @@ Polymer({
     },
     // The enum value of the include property of the selected node.
     _selectedNodeInclude: Number,
-    _highlightedNode: String
+    _highlightedNode: String,
+    // An optional function that takes a node selected event (whose `detail`
+    // property is the selected node ... which could be null if a node is
+    // deselected). Called whenever a node is selected or deselected.
+    handleNodeSelected: Object,
   },
   listeners: {
     'node-toggle-extract': '_nodeToggleExtract'


### PR DESCRIPTION
This change adds a `handleNodeSelected` property to the `tf-graph` and
`tf-graph-board` components. This property is a function that is called
every time the selected node changes (a new node is selected or the
current node is unselected).

This change is part of an effort to make the graph explorer
generalizable to various use cases.

Test plan: Modify the graph dashboard to pass a `handleNodeSelected`
callback to the `tf-graph-board` that console.logs selected nodes. After
starting TensorBoard, note that both node selection and deselection are
logged correctly.