### PR TITLE
Add property edgeWidthFunction to tf-graph

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.html
@@ -116,6 +116,9 @@ Polymer({
     // An array of ContextMenuItem objects. Items that appear in the context
     // menu for a node.
     nodeContextMenuItems: Array,
+    // A function with signature EdgeThicknessFunction that computes the
+    // thickness of a given edge.
+    edgeWidthFunction: Object,
     _renderDepth: {
       type: Number,
       value: 1
@@ -158,11 +161,12 @@ Polymer({
       }
       var renderGraph = new tf.graph.render.RenderGraphInfo(
           graphHierarchy, !!this.stats /** displayingStats */);
+      renderGraph.edgeWidthFunction = this.edgeWidthFunction;
+
       // Producing the 'color by' parameters to be consumed
       // by the tf-graph-controls panel. It contains information about the
       // min and max values and their respective colors, as well as list
       // of devices with their respective colors.
-
       function getColorParamsFromScale(scale) {
         return {
           minValue: scale.domain()[0],

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
@@ -143,6 +143,7 @@ paper-progress {
               color-by="[[colorBy]]"
               color-by-params="{{colorByParams}}"
               progress="{{progress}}"
+              edge-width-function="[[edgeWidthFunction]]"
               node-names-to-health-pills="[[nodeNamesToHealthPills]]"
               health-pill-step-index="[[healthPillStepIndex]]"
               handle-node-selected="[[handleNodeSelected]]"
@@ -230,6 +231,9 @@ Polymer({
       type: String,
       notify: true,
     },
+    // A function with signature EdgeThicknessFunction that computes the
+    // thickness of a given edge.
+    edgeWidthFunction: Object,
     // The enum value of the include property of the selected node.
     _selectedNodeInclude: Number,
     _highlightedNode: String,

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -75,6 +75,14 @@ export let SeriesNodeColors = {
   DEFAULT_STROKE: '#b2b2b2'
 };
 
+
+/**
+ * Function that computes edge thickness in pixels.
+ */
+export interface EdgeThicknessFunction {
+  (edgeData: scene.edge.EdgeData, edgeClass: string): number;
+}
+
 /**
  * Parameters that affect how the graph is rendered on the screen.
  */
@@ -180,7 +188,7 @@ export class RenderGraphInfo {
   private memoryUsageScale: d3.ScaleLinear<string, string>;
   private computeTimeScale: d3.ScaleLinear<string, string>;
   /** Scale for the thickness of edges when there is no shape information. */
-  edgeWidthScale:
+  edgeWidthSizedBasedScale:
       d3.ScaleLinear<number, number> | d3.ScalePower<number, number>;
   // Since the rendering information for each node is constructed lazily,
   // upon node's expansion by the user, we keep a map between the node's name
@@ -189,6 +197,9 @@ export class RenderGraphInfo {
   private hasSubhierarchy: {[nodeName: string]: boolean};
   root: RenderGroupNodeInfo;
   traceInputs: Boolean;
+  // An optional function that computes the thickness of an edge given edge
+  // data. If not provided, defaults to encoding tensor size in thickness.
+  edgeWidthFunction: EdgeThicknessFunction;
 
   constructor(hierarchy: hierarchy.Hierarchy, displayingStats: boolean) {
     this.hierarchy = hierarchy;
@@ -248,8 +259,8 @@ export class RenderGraphInfo {
         .domain([0, maxComputeTime])
         .range(PARAMS.minMaxColors);
 
-    this.edgeWidthScale = this.hierarchy.hasShapeInfo ?
-      scene.edge.EDGE_WIDTH_SCALE :
+    this.edgeWidthSizedBasedScale = this.hierarchy.hasShapeInfo ?
+      scene.edge.EDGE_WIDTH_SIZE_BASED_SCALE :
       d3.scaleLinear()
         .domain([1, this.hierarchy.maxMetaEdgeSize])
         .range([scene.edge.MIN_EDGE_WIDTH, scene.edge.MAX_EDGE_WIDTH]);


### PR DESCRIPTION
This change adds a `edgeWidthFunction` property to tf-graph and
tf-graph-board. This is a method that a user can specify to compute the
thickenss (in pixels) of individual edges in the graph. If specified,
edge thickness is no longer based on tensor size but rather on
`edgeWidthFunction`.

Renamed `EDGE_WIDTH_SCALE` to
`EDGE_WIDTH_SIZE_BASED_SCALE` in order to clarify that the
scale is relevant to default behavior.

This change is part of making the graph generalizable to other
applications.

Test plan: Make `tf-graph-dashboard` pass some arbitrary
`edgeWidthFunction` to `tf-graph-board` such as this one.

```ts
_edgeWidthFunction: {
  type: Object,
  value: () => {
    return (edgeData, edgeClass) => {
      if (edgeClass.indexOf('edgeline') == -1) {
        // Other edges such as annotation edges continue to have width 1.
        return 1;
      }
      // Here's the info available to the computation.
      console.log(edgeData, edgeClass);
      // Just make the edge thickness PI lol.
      return Math.PI;
    };
  },
  readOnly: true,
},
```

Start TensorBoard with a graph that normally varies in edge thickness
such as the attached pbtxt. Note that the edge thicknesses vary based
on the provided function instead of tensor size.

![m1fjco5ukch](https://user-images.githubusercontent.com/4221553/31050273-7352db98-a5fa-11e7-8972-58f08668bac0.png)

Also, start a version of TensorBoard for which `edgeWidthFunction` is left
empty. Note that edge thickness scales based on tensor size as expected.
