### PR TITLE
Add property edgeLabelFunction to tf-graph

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.html
@@ -132,6 +132,9 @@ Polymer({
     // property is the selected node ... which could be null if a node is
     // deselected). Called whenever a node is selected or deselected.
     handleNodeSelected: Object,
+    // An optional function that computes the label for an edge. Should
+    // implement the EdgeLabelFunction signature.
+    edgeLabelFunction: Object,
   },
   observers: [
     '_statsChanged(stats, devicesForStats)',
@@ -158,6 +161,7 @@ Polymer({
       }
       var renderGraph = new tf.graph.render.RenderGraphInfo(
           graphHierarchy, !!this.stats /** displayingStats */);
+      renderGraph.edgeLabelFunction = this.edgeLabelFunction;
       // Producing the 'color by' parameters to be consumed
       // by the tf-graph-controls panel. It contains information about the
       // min and max values and their respective colors, as well as list

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
@@ -143,6 +143,7 @@ paper-progress {
               color-by="[[colorBy]]"
               color-by-params="{{colorByParams}}"
               progress="{{progress}}"
+              edge-label-function="[[edgeLabelFunction]]"
               node-names-to-health-pills="[[nodeNamesToHealthPills]]"
               health-pill-step-index="[[healthPillStepIndex]]"
               handle-node-selected="[[handleNodeSelected]]"
@@ -237,6 +238,9 @@ Polymer({
     // property is the selected node ... which could be null if a node is
     // deselected). Called whenever a node is selected or deselected.
     handleNodeSelected: Object,
+    // An optional function that computes the label for an edge. Should
+    // implement the EdgeLabelFunction signature.
+    edgeLabelFunction: Object,
   },
   listeners: {
     'node-toggle-extract': '_nodeToggleExtract'

--- a/tensorboard/plugins/graph/tf_graph_common/edge.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/edge.ts
@@ -146,6 +146,12 @@ export function getLabelForBaseEdge(
  */
 export function getLabelForEdge(metaedge: Metaedge,
     renderInfo: render.RenderGraphInfo): string {
+  if (renderInfo.edgeLabelFunction) {
+    // The user has specified a means of computing the label.
+    return renderInfo.edgeLabelFunction(metaedge, renderInfo);
+  }
+
+  // Compute the label based on either tensor count or size.
   let isMultiEdge = metaedge.baseEdgeList.length > 1;
   return isMultiEdge ?
       metaedge.baseEdgeList.length + ' tensors' :

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -76,6 +76,18 @@ export let SeriesNodeColors = {
 };
 
 /**
+ * Function that computes edge label strings. This function accepts a Metaedge,
+ * which could actually encapsulate several base edges. For instance, several
+ * base edges may merge into a single metaedge.
+ *
+ * To determine whether a metaedge represents several edges, check the length of
+ * its baseEdgeList property.
+ */
+export interface EdgeLabelFunction {
+  (metaedge: Metaedge, renderInfo: render.RenderGraphInfo): string;
+}
+
+/**
  * Parameters that affect how the graph is rendered on the screen.
  */
 const PARAMS = {
@@ -189,6 +201,7 @@ export class RenderGraphInfo {
   private hasSubhierarchy: {[nodeName: string]: boolean};
   root: RenderGroupNodeInfo;
   traceInputs: Boolean;
+  edgeLabelFunction: EdgeLabelFunction;
 
   constructor(hierarchy: hierarchy.Hierarchy, displayingStats: boolean) {
     this.hierarchy = hierarchy;


### PR DESCRIPTION
This new property lets users override the default graph behavior of
labelling edges based on tensor size.

Test plan: Make `tf-graph-dashboard` use a custom edge label function
such as this one.

```ts
_edgeLabelFunction: {
  type: Object,
  value: () => ((metaedge, renderInfo) => {
    if (metaedge.baseEdgeList.length > 1) {
      return 'multiedge';
    }
    const baseEdge = metaedge.baseEdgeList[0];
    console.log(baseEdge, renderInfo);
    return 'edge from ' + baseEdge.w + ' to ' + baseEdge.v;
  }),
  readOnly: true,
},
```

Note that it is reflected within the graph.

![screenshot from 2017-09-30 18 32 51](https://user-images.githubusercontent.com/4221553/31050903-92770274-a60e-11e7-802d-15aeb1c9e73c.png)
