### PR TITLE
Let user select edges if handleEdgeSelected set

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
@@ -429,6 +429,19 @@ limitations under the License.
   stroke-width: 0.75;
 }
 
+::content .edge .selectableedge {
+  cursor: pointer;
+}
+
+::content .selectededge > path.edgeline {
+  cursor: default;
+  stroke: #f00;
+}
+
+::content .edge.selectededge text {
+  fill: #000;
+}
+
 /* Labels showing tensor shapes on edges */
 ::content .edge > text {
   font-size: 3.5px;
@@ -441,6 +454,10 @@ limitations under the License.
 
 ::content .reference-arrowhead {
   fill: #FFB74D;
+}
+
+::content .selected-arrowhead {
+  fill: #f00;
 }
 
 ::content .edge .control-dep {
@@ -660,6 +677,9 @@ Polymer({
       type: String,
       observer: '_selectedNodeChanged'
     },
+    // An optional callback that implements the tf.graph.edge.EdgeSelectionCallback signature. If
+    // provided, edges are selectable, and this callback is run when an edge is selected.
+    handleEdgeSelected: Object,
     /** Keeps track of if the graph has been zoomed/panned since loading */
     _zoomed: {
       type: Boolean,

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.html
@@ -140,15 +140,25 @@ Polymer({
     nodeNamesToHealthPills: Object,
     // The step of health pills to show throughout the graph.
     healthPillStepIndex: Number,
-    // An optional function that takes a node selected event (whose `detail`
-    // property is the selected node ... which could be null if a node is
-    // deselected). Called whenever a node is selected or deselected.
+    /**
+     * An optional function that takes a node selected event (whose `detail`
+     * property is the selected node ... which could be null if a node is
+     * deselected). Called whenever a node is selected or deselected.
+     * @type {Function}
+     */
     handleNodeSelected: Object,
-    // An optional function that computes the label for an edge. Should
-    // implement the EdgeLabelFunction signature.
+    /**
+     * An optional function that computes the label for an edge. Should
+     * implement the EdgeLabelFunction signature.
+     * @type {Function}
+     */
     edgeLabelFunction: Object,
-    // An optional callback that implements the tf.graph.edge.EdgeSelectionCallback signature. If
-    // provided, edges are selectable, and this callback is run when an edge is selected.
+    /**
+     * An optional callback that implements the
+     * tf.graph.edge.EdgeSelectionCallback signature. If provided, edges are
+     * selectable, and this callback is run when an edge is selected.
+     * @type {Function}
+     */
     handleEdgeSelected: Object,
   },
   observers: [

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.html
@@ -62,11 +62,13 @@ paper-button {
           render-hierarchy="[[renderHierarchy]]"
           highlighted-node="[[_getVisible(highlightedNode)]]"
           selected-node="{{selectedNode}}"
+          selected-edge="{{selectedEdge}}"
           color-by="[[colorBy]]"
           progress="[[progress]]"
           node-context-menu-items="[[nodeContextMenuItems]]"
           node-names-to-health-pills="[[nodeNamesToHealthPills]]"
           health-pill-step-index="{{healthPillStepIndex}}"
+          handle-edge-selected="[[handleEdgeSelected]]"
     ></tf-graph-scene>
   </div>
 </div>
@@ -97,6 +99,13 @@ Polymer({
       type: String,
       notify: true,
     },
+    // An EdgeData object if an edge is selected. Otherwise, null.
+    selectedEdge: {
+      type: Object,
+      notify: true,
+    },
+    // The <g> element of the last selected edge. Used to mark the edge as selected.
+    _lastSelectedEdgeGroup: Object,
     highlightedNode: {
       type: String,
       notify: true
@@ -138,11 +147,15 @@ Polymer({
     // An optional function that computes the label for an edge. Should
     // implement the EdgeLabelFunction signature.
     edgeLabelFunction: Object,
+    // An optional callback that implements the tf.graph.edge.EdgeSelectionCallback signature. If
+    // provided, edges are selectable, and this callback is run when an edge is selected.
+    handleEdgeSelected: Object,
   },
   observers: [
     '_statsChanged(stats, devicesForStats)',
     '_buildRenderHierarchy(graphHierarchy)',
     '_selectedNodeChanged(selectedNode)',
+    '_selectedEdgeChanged(selectedEdge)',
   ],
   _statsChanged: function(stats, devicesForStats) {
     if (this.graphHierarchy) {
@@ -221,6 +234,8 @@ Polymer({
     'node-unhighlight': '_nodeUnhighlighted',
     'node-toggle-extract': '_nodeToggleExtract',
     'node-toggle-seriesgroup': '_nodeToggleSeriesGroup',
+    // Edges
+    'edge-select': '_edgeSelected',
 
     // Annotations
 
@@ -244,6 +259,7 @@ Polymer({
     // indicate a user desire to click on a specific section of the graph.
     if (this._allowGraphSelect) {
       this.set('selectedNode', null);
+      this.set('selectedEdge', null);
     }
     // Reset this variable as a bug in d3 zoom behavior can cause zoomend
     // callback not to be called if a right-click happens during a zoom event.
@@ -263,10 +279,38 @@ Polymer({
       this.handleNodeSelected(selectedNode);
     }
   },
+  // Called when the selected edge changes, ie there is a new selected edge or
+  // the current one is unselected.
+  _selectedEdgeChanged(selectedEdge) {
+    this._deselectPreviousEdge();
+
+    // Visually mark this new edge as selected.
+    if (selectedEdge) {
+      this._lastSelectedEdgeGroup.classed(
+          tf.graph.scene.Class.Edge.SELECTED, true);
+
+      // Update the color of the marker too if the edge has one.
+      this._updateMarkerOfSelectedEdge(selectedEdge);
+    }
+
+    if (this.handleEdgeSelected) {
+      // A higher-level component provided a callback. Run it.
+      this.handleEdgeSelected(selectedEdge);
+    }
+  },
   // Called only when a new (non-null) node is selected.
   _nodeSelected: function(event) {
     if (this._allowGraphSelect) {
       this.set('selectedNode', event.detail.name);
+    }
+    // Reset this variable as a bug in d3 zoom behavior can cause zoomend
+    // callback not to be called if a right-click happens during a zoom event.
+    this._allowGraphSelect = true;
+  },
+  _edgeSelected(event) {
+    if (this._allowGraphSelect) {
+      this.set('_lastSelectedEdgeGroup', event.detail.edgeGroup);
+      this.set('selectedEdge', event.detail.edgeData);
     }
     // Reset this variable as a bug in d3 zoom behavior can cause zoomend
     // callback not to be called if a right-click happens during a zoom event.
@@ -334,6 +378,49 @@ Polymer({
       this.set('graphHierarchy', graphHierarchy);
       this._buildRenderHierarchy(this.graphHierarchy);
     }.bind(this));
+  },
+  _deselectPreviousEdge() {
+    const selectedSelector = '.' + tf.graph.scene.Class.Edge.SELECTED;
+    // Visually mark the previously selected edge (if any) as deselected.
+    d3.select(selectedSelector)
+        .classed(tf.graph.scene.Class.Edge.SELECTED, false)
+        .each((d, i) => {
+          // Reset its marker.
+          if (d.label) {
+            const paths = d3.select(this).selectAll('path.edgeline');
+            if (d.label.startMarkerId) {
+              paths.style('marker-start', `url(#${d.label.startMarkerId})`);
+            }
+            if (d.label.endMarkerId) {
+              paths.style('marker-end', `url(#${d.label.endMarkerId})`);
+            }
+          }
+        });
+  },
+  _updateMarkerOfSelectedEdge(selectedEdge) {
+    if (selectedEdge.label) {
+      // The marker will vary based on the direction of the edge.
+      const markerId = selectedEdge.label.startMarkerId || selectedEdge.label.endMarkerId;
+      if (markerId) {
+        // Find the corresponding marker for a selected edge.
+        const selectedMarkerId = markerId.replace('dataflow-', 'selected-');
+        let selectedMarker = this.$$('#' + selectedMarkerId);
+
+        if (!selectedMarker) {
+          // The marker for a selected edge of this size does not exist yet. Create it.
+          const originalMarker = this.$$('tf-graph-scene').querySelector('#' + markerId);
+          selectedMarker = originalMarker.cloneNode(true);
+          selectedMarker.setAttribute('id', selectedMarkerId);
+          selectedMarker.classList.add('selected-arrowhead');
+          originalMarker.parentNode.appendChild(selectedMarker);
+        }
+
+        // Make the path use this new marker while it is selected.
+        const markerAttribute = selectedEdge.label.startMarkerId ? 'marker-start' : 'marker-end';
+        this._lastSelectedEdgeGroup.selectAll('path.edgeline').style(
+            markerAttribute, `url(#${selectedMarkerId})`);
+      }
+    }
   },
   not: function(x) {
     return !x;

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
@@ -148,6 +148,7 @@ paper-progress {
               node-names-to-health-pills="[[nodeNamesToHealthPills]]"
               health-pill-step-index="[[healthPillStepIndex]]"
               handle-node-selected="[[handleNodeSelected]]"
+              handle-edge-selected="[[handleEdgeSelected]]"
     ></tf-graph>
   </div>
   <div id="info">
@@ -245,6 +246,9 @@ Polymer({
     // An optional function that computes the label for an edge. Should
     // implement the EdgeLabelFunction signature.
     edgeLabelFunction: Object,
+    // An optional callback that implements the tf.graph.edge.EdgeSelectionCallback signature. If
+    // provided, edges are selectable, and this callback is run when an edge is selected.
+    handleEdgeSelected: Object,
   },
   listeners: {
     'node-toggle-extract': '_nodeToggleExtract'

--- a/tensorboard/plugins/graph/tf_graph_common/scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/scene.ts
@@ -44,6 +44,8 @@ module tf.graph.scene {
       LINE: 'edgeline',
       REFERENCE_EDGE: 'referenceedge',
       REF_LINE: 'refline',
+      SELECTABLE: 'selectableedge',
+      SELECTED: 'selectededge',
       STRUCTURAL: 'structural'
     },
     Annotation: {


### PR DESCRIPTION
Added a new property to `tf-graph` and `tf-graph-board` called
`handleEdgeSelected`. If this property is set, the user can select edges
by clicking on them. That same property is a callback run when an edge
is selected, allowing developers to handle edge selection.

Stylized selected edges so that they are red.

This change is part of an effort to generalize the graph explorer. The info
card does not respond yet, but that is fine because I believe developers
who use this new API functionality can handle edge selection.

Test Plan: Pass a handleSelectedEdge property from `tf-graph-dashboard`
to `tf-graph-board`. Load a graph such as via the attached events file.
Note that edges are now selectable and turn red upon selection. Clicking
on the graph deselects edges.

![yubit38pohp](https://user-images.githubusercontent.com/4221553/31061506-1020b972-a6d7-11e7-92c3-c64b64a512c8.png)

Also, try removing the `handleEdgeSelected` and restarting TensorBoard.
Note that edges are now not selectable.

[events.out.tfevents.1506397086.functions.txt](https://github.com/tensorflow/tensorboard/files/1347720/events.out.tfevents.1506397086.functions.txt)

