### PR TITLE
Revert "Update required version of html5lib to 1.0b10 (#589)"

### DIFF
--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -31,7 +31,7 @@ REQUIRED_PACKAGES = [
     'six >= 1.10.0',
     'protobuf >= 3.2.0',
     'werkzeug >= 0.11.10',
-    'html5lib == 0.999999999',  # identical to 1.0b10
+    'html5lib == 0.9999999',  # identical to 1.0b8
     'markdown >= 2.6.8',
     'bleach == 1.5.0',
 ]


### PR DESCRIPTION
This reverts commit 46c153f993b126f0ba9e599229ecfee440c8393c and unfixes #588. A regression was caused where the following happens:

```
(tf)html5lib-rollback jart@compy:~/code/tensorboard$ tensorboard --logdir=~/tb/fast
Traceback (most recent call last):
  File "/usr/local/google/home/jart/tf/bin/tensorboard", line 7, in <module>
    from tensorboard.main import main
  File "/usr/local/google/home/jart/tf/local/lib/python2.7/site-packages/tensorboard/main.py", line 36, in <module>
    from tensorboard.plugins.audio import audio_plugin
  File "/usr/local/google/home/jart/tf/local/lib/python2.7/site-packages/tensorboard/plugins/audio/audio_plugin.py", line 27, in <module>
    from tensorboard import plugin_util
  File "/usr/local/google/home/jart/tf/local/lib/python2.7/site-packages/tensorboard/plugin_util.py", line 21, in <module>
    import bleach
  File "/usr/local/google/home/jart/tf/local/lib/python2.7/site-packages/bleach/__init__.py", line 14, in <module>
    from html5lib.sanitizer import HTMLSanitizer
ImportError: No module named sanitizer
```

Since html5lib 0.999999999 totally breaks the API of 0.9999999, we would probably need to upgrade to bleach 2.0 (see #427) in order to use the latest html5lib. Please note that upgrading past the breakage would require upgrading everyone at Google. 