### PR TITLE
Make addition of Debugger Plugin conditional on FLAG

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -39,6 +39,7 @@ py_binary(
         "//tensorboard/plugins/scalar:scalars_plugin",
         "//tensorboard/plugins/text:text_plugin",
         "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 


### PR DESCRIPTION
The import also becomes conditional, which should get rid of
ImportErrors related to futures and grpcio when the user
hasn't explicitly specified the --debugger_data_server_grpc_port
flag.