### PR TITLE
Add optional fillArea prop to vz-line-chart

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -40,7 +40,7 @@ limitations under the License.
         style="[[_computeLineChartStyle(_loading)]]"
         default-x-range="[[defaultXRange]]"
         default-y-range="[[defaultYRange]]"
-        margin-specification="[[marginSpecification]]"
+        margin-fill-area="[[marginFillArea]]"
       ></vz-line-chart>
       <template is="dom-if" if="[[_loading]]">
         <div id="loading-spinner-container">
@@ -118,7 +118,7 @@ limitations under the License.
         xType: String,
         yValueAccessor: Object,
         tooltipColumns: Array,
-        marginSpecification: Object,
+        marginFillArea: Object,
 
         smoothingEnabled: Boolean,
         smoothingWeight: Number,

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -40,6 +40,7 @@ limitations under the License.
         style="[[_computeLineChartStyle(_loading)]]"
         default-x-range="[[defaultXRange]]"
         default-y-range="[[defaultYRange]]"
+        margin-specification="[[marginSpecification]]"
       ></vz-line-chart>
       <template is="dom-if" if="[[_loading]]">
         <div id="loading-spinner-container">
@@ -117,6 +118,7 @@ limitations under the License.
         xType: String,
         yValueAccessor: Object,
         tooltipColumns: Array,
+        marginSpecification: Object,
 
         smoothingEnabled: Boolean,
         smoothingWeight: Number,

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -40,7 +40,7 @@ limitations under the License.
         style="[[_computeLineChartStyle(_loading)]]"
         default-x-range="[[defaultXRange]]"
         default-y-range="[[defaultYRange]]"
-        margin-fill-area="[[marginFillArea]]"
+        fill-area="[[fillArea]]"
       ></vz-line-chart>
       <template is="dom-if" if="[[_loading]]">
         <div id="loading-spinner-container">
@@ -118,7 +118,7 @@ limitations under the License.
         xType: String,
         yValueAccessor: Object,
         tooltipColumns: Array,
-        marginFillArea: Object,
+        fillArea: Object,
 
         smoothingEnabled: Boolean,
         smoothingWeight: Number,

--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -690,8 +690,11 @@ class LineChart {
     } else {
       // Generate a reasonable range.
       const accessors = this.getAccessorsForComputingYRange();
-      const vals = _.flatMap(d, d => _.flatMap(accessors, accessor =>
-          d.data().map(accessor(x, -1, d)).filter(isFinite)));
+      let datasetToValues: (d: Plottable.Dataset) => number[][] = (d) => {
+        return accessors.map(accessor => d.data().map(x => accessor(x, -1, d)));
+      };		
+      const vals = _.flattenDeep<number>(this.datasets.map(datasetToValues))
+          .filter(isFinite);
       yDomain = ChartHelpers.computeDomain(vals, this._ignoreYOutliers);
     }
     this.yScale.domain(yDomain);

--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -417,13 +417,13 @@ class LineChart {
 
   private linePlot: Plottable.Plots.Line<number|Date>;
   private smoothLinePlot: Plottable.Plots.Line<number|Date>;
-  private marginAreaPlot: Plottable.Plots.Area<number|Date>?;
+  private marginAreaPlot?: Plottable.Plots.Area<number|Date>;
   private scatterPlot: Plottable.Plots.Scatter<number|Date, Number>;
   private nanDisplay: Plottable.Plots.Scatter<number|Date, Number>;
   private yValueAccessor: Plottable.IAccessor<number>;
   private smoothedAccessor: Plottable.IAccessor<number>;
   private lastPointsDataset: Plottable.Dataset;
-  private fillArea: FillArea?;
+  private fillArea?: FillArea;
   private datasets: Plottable.Dataset[];
   private onDatasetChanged: (dataset: Plottable.Dataset) => void;
   private nanDataset: Plottable.Dataset;

--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -692,7 +692,7 @@ class LineChart {
       const accessors = this.getAccessorsForComputingYRange();
       let datasetToValues: (d: Plottable.Dataset) => number[][] = (d) => {
         return accessors.map(accessor => d.data().map(x => accessor(x, -1, d)));
-      };		
+      };
       const vals = _.flattenDeep<number>(this.datasets.map(datasetToValues))
           .filter(isFinite);
       yDomain = ChartHelpers.computeDomain(vals, this._ignoreYOutliers);

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -51,7 +51,6 @@ limitations under the License.
       data-url="[[_dataUrl]]"
       log-scale-active="[[_logScaleActive]]"
       process-data="[[_processData]]"
-      margin-specification="[[_marginSpecification]]"
     >
     </tf-line-chart-data-loader>
   </div>
@@ -213,15 +212,6 @@ limitations under the License.
             scalarChart.setSeriesData(run, formattedData);
           }),
           readOnly: true,
-        },
-
-        _marginSpecification: {
-          type: Object,
-          readOnly: true,
-          value: {
-            lowerAccessor: d => d.scalar - Math.abs(Math.cos(d.scalar)) * 0.05 - 0.03,
-            higherAccessor: d => d.scalar + Math.abs(Math.cos(d.scalar)) * 0.05 + 0.03,
-          },
         },
 
         _expanded: {

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -219,8 +219,8 @@ limitations under the License.
           type: Object,
           readOnly: true,
           value: {
-            lowerAccessor: d => d.scalar - Math.random() * 0.05 - 0.03,
-            higherAccessor: d => d.scalar + Math.random() * 0.05 + 0.03,
+            lowerAccessor: d => d.scalar - Math.abs(Math.cos(d.scalar)) * 0.05 - 0.03,
+            higherAccessor: d => d.scalar + Math.abs(Math.cos(d.scalar)) * 0.05 + 0.03,
           },
         },
 

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -51,6 +51,7 @@ limitations under the License.
       data-url="[[_dataUrl]]"
       log-scale-active="[[_logScaleActive]]"
       process-data="[[_processData]]"
+      margin-specification="[[_marginSpecification]]"
     >
     </tf-line-chart-data-loader>
   </div>
@@ -212,6 +213,15 @@ limitations under the License.
             scalarChart.setSeriesData(run, formattedData);
           }),
           readOnly: true,
+        },
+
+        _marginSpecification: {
+          type: Object,
+          readOnly: true,
+          value: {
+            lowerAccessor: d => d.scalar - Math.random() * 0.05 - 0.03,
+            higherAccessor: d => d.scalar + Math.random() * 0.05 + 0.03,
+          },
         },
 
         _expanded: {


### PR DESCRIPTION
This change adds an optional `fillArea` property to
`vz-line-chart` and `tf-line-chart-data-loader`. This property takes on
a `FillArea` object. If provided, line charts visualize fill areas for
each data series. See screenshot.

A developer is making a plugin to address #545 and would like this
feature within line charts.

Test Plan: Add a `_fillArea` property to `tf-scalar-dashboard` that
contains some stock accessors, like these ones that generate random
bounds:

```ts
// Specify a fill area by setting accessors for its bounds.
fillArea: {
  type: Object,
  readOnly: true,
  value: {
      lowerAccessor: d => d.scalar + Math.random() * 0.05 + 0.03,
      higherAccessor: d => d.scalar - Math.random() * 0.05 - 0.03,
  },
},
```

Pass the property into `tf-line-chart-data-loader`. Line charts should
visualize fill areas per the screenshot.

![image](https://user-images.githubusercontent.com/4221553/32265572-cdac2400-bea0-11e7-9fa9-5d3b291c0ba9.png)

