### PR TITLE
Update pip dependencies in preparation for 0.4

### DIFF
--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -286,8 +286,8 @@ def main(unused_argv=None):
             ImportError,
             ImportError(
                 err.message +
-                "\n\nTo use the debugger plugin, you need to have futures and "
-                "grpcio installed:\n  pip install futures grpcio"),
+                "\n\nTo use the debugger plugin, you need to have "
+                "gRPC installed:\n  pip install grpcio"),
             traceback)
       tf.logging.info("Starting Debugger Plugin at gRPC port %d",
                       FLAGS.debugger_data_server_grpc_port)

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -26,10 +26,9 @@ import tensorboard.version
 
 REQUIRED_PACKAGES = [
     'futures >= 3.1.1',
-    'grpcio >= 1.4.0',
-    'numpy >= 1.11.0',
+    'numpy >= 1.12.0',
     'six >= 1.10.0',
-    'protobuf >= 3.2.0',
+    'protobuf >= 3.3.0',
     'werkzeug >= 0.11.10',
     'html5lib == 0.9999999',  # identical to 1.0b8
     'markdown >= 2.6.8',

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -30,12 +30,9 @@ def tensorboard_workspace():
 
   native.http_archive(
       name = "protobuf",
-      urls = [
-          "http://mirror.bazel.build/github.com/google/protobuf/archive/2b7430d96aeff2bb624c8d52182ff5e4b9f7f18a.tar.gz",
-          "https://github.com/google/protobuf/archive/2b7430d96aeff2bb624c8d52182ff5e4b9f7f18a.tar.gz",
-      ],
-      sha256 = "e5d3d4e227a0f7afb8745df049bbd4d55474b158ca5aaa2a0e31099af24be1d0",
-      strip_prefix = "protobuf-2b7430d96aeff2bb624c8d52182ff5e4b9f7f18a",
+      urls = ["http://mirror.bazel.build/github.com/google/protobuf/archive/0b059a3d8a8f8aa40dde7bea55edca4ec5dfea66.tar.gz"],
+      sha256 = "6d43b9d223ce09e5d4ce8b0060cb8a7513577a35a64c7e3dad10f0703bf3ad93",
+      strip_prefix = "protobuf-0b059a3d8a8f8aa40dde7bea55edca4ec5dfea66",
       # TODO: remove patching when tensorflow stops linking same protos into
       #       multiple shared libraries loaded in runtime by python.
       #       This patch fixes a runtime crash when tensorflow is compiled
@@ -48,12 +45,9 @@ def tensorboard_workspace():
   # Unfortunately there is no way to alias http_archives at the moment.
   native.http_archive(
       name = "com_google_protobuf",
-      urls = [
-          "http://mirror.bazel.build/github.com/google/protobuf/archive/2b7430d96aeff2bb624c8d52182ff5e4b9f7f18a.tar.gz",
-          "https://github.com/google/protobuf/archive/2b7430d96aeff2bb624c8d52182ff5e4b9f7f18a.tar.gz",
-      ],
-      sha256 = "e5d3d4e227a0f7afb8745df049bbd4d55474b158ca5aaa2a0e31099af24be1d0",
-      strip_prefix = "protobuf-2b7430d96aeff2bb624c8d52182ff5e4b9f7f18a",
+      urls = ["http://mirror.bazel.build/github.com/google/protobuf/archive/0b059a3d8a8f8aa40dde7bea55edca4ec5dfea66.tar.gz"],
+      sha256 = "6d43b9d223ce09e5d4ce8b0060cb8a7513577a35a64c7e3dad10f0703bf3ad93",
+      strip_prefix = "protobuf-0b059a3d8a8f8aa40dde7bea55edca4ec5dfea66",
   )
 
   # Protobuf's BUILD file depends on //external:six.


### PR DESCRIPTION
grpcio is now an optional dependency, thanks to 939fcb3e6c998e0444fee162048b79232dc999a0.

NumPy and Protobuf were updated to be the same as what's in TensorFlow's setup.py file at HEAD.

Once this change is merged, I'll cut a 0.4 branch off HEAD and publish TensorBoard 0.4.0-rc1 in preparation for TensorFlow 1.4-rc1 which is expected in the next few days.