### PR TITLE
Simplify debugger_plugin_testlib test skipping

### DIFF
--- a/tensorboard/plugins/debugger/debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_test.py
@@ -31,17 +31,6 @@ from tensorboard.plugins.debugger import numerics_alert
 
 class DebuggerPluginTest(debugger_plugin_testlib.DebuggerPluginTestBase):
 
-  def setUp(self):
-    # Importing the debugger_plugin can sometimes unfortunately produce errors.
-    try:
-      # pylint: disable=g-import-not-at-top
-      from tensorboard.plugins.debugger import debugger_plugin
-      # pylint: enable=g-import-not-at-top
-    except Exception as e:  # pylint: disable=broad-except
-      self.skipTest(
-          'Skipping test because importing debugger_plugin failed: %r' % e)
-    self.debugger_plugin_module = debugger_plugin
-
   def testHealthPillsRouteProvided(self):
     """Tests that the plugin offers the route for requesting health pills."""
     apps = self.plugin.get_plugin_apps()

--- a/tensorboard/plugins/debugger/debugger_plugin_testlib.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_testlib.py
@@ -39,7 +39,12 @@ from tensorflow.core.debug import debugger_event_metadata_pb2
 
 class DebuggerPluginTestBase(tf.test.TestCase):
 
+  def __init__(self, *args, **kwargs):
+    super(DebuggerPluginTestBase, self).__init__(*args, **kwargs)
+    self.debugger_plugin_module = None
+
   def setUp(self):
+    super(DebuggerPluginTestBase, self).setUp()
     # Importing the debugger_plugin can sometimes unfortunately produce errors.
     try:
       # pylint: disable=g-import-not-at-top
@@ -47,8 +52,9 @@ class DebuggerPluginTestBase(tf.test.TestCase):
       from tensorboard.plugins.debugger import debugger_server_lib
       # pylint: enable=g-import-not-at-top
     except Exception as e:  # pylint: disable=broad-except
-      self.skipTest(
+      raise self.skipTest(
           'Skipping test because importing some modules failed: %r' % e)
+    self.debugger_plugin_module = debugger_plugin
 
     # Populate the log directory with debugger event for run '.'.
     self.log_dir = self.get_temp_dir()

--- a/tensorboard/plugins/debugger/events_writer_manager_test.py
+++ b/tensorboard/plugins/debugger/events_writer_manager_test.py
@@ -31,17 +31,6 @@ from tensorboard.plugins.debugger import numerics_alert
 
 class DebuggerPluginTest(debugger_plugin_testlib.DebuggerPluginTestBase):
 
-  def setUp(self):
-    # Importing the debugger_plugin can sometimes unfortunately produce errors.
-    try:
-      # pylint: disable=g-import-not-at-top
-      from tensorboard.plugins.debugger import debugger_plugin
-      # pylint: enable=g-import-not-at-top
-    except Exception as e:  # pylint: disable=broad-except
-      self.skipTest(
-          'Skipping test because importing debugger_plugin failed: %r' % e)
-    self.debugger_plugin_module = debugger_plugin
-
   def testHealthPillsRouteProvided(self):
     """Tests that the plugin offers the route for requesting health pills."""
     apps = self.plugin.get_plugin_apps()


### PR DESCRIPTION
Overriding the setUp() method without calling super caused the test to fail
when it isn't being skipped.