### PR TITLE
Format image-loader step counts with commas

### DIFF
--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -49,7 +49,7 @@ future for loading older images.
       <template is="dom-if" if="[[_hasAtLeastOneStep]]">
         <div class="heading-row">
           <div class="heading-label">
-            step <span style="font-weight: bold">[[_stepValue]]</span>
+            step <span style="font-weight: bold">[[_toLocaleString(_stepValue)]]</span>
           </div>
           <div class="heading-label heading-right">
             <template is="dom-if" if="[[_currentWallTime]]">
@@ -366,6 +366,10 @@ future for loading older images.
       },
       _handleTap(e) {
         this.set('actualSize', !this.actualSize);
+      },
+      _toLocaleString(number) {
+        // Shows commas (or locale-appropriate punctuation) for large numbers.
+        return number.toLocaleString();
       },
     });
   </script>


### PR DESCRIPTION
Tweak to make the images plugin step counts more readable when they exceed 1000.

Before:

![image](https://user-images.githubusercontent.com/710113/31205241-1b62332e-a925-11e7-8ddf-0d678d2b4f87.png)

After:

![image](https://user-images.githubusercontent.com/710113/31205244-246fc486-a925-11e7-898f-6b718d4a24cb.png)

