### PR TITLE
Tidy up the tensorboard.main API

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -22,13 +22,38 @@ py_binary(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        ":default",
+        ":program",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_library(
+    name = "program",
+    srcs = ["program.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
         ":util",
         ":version",
+        "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_file_inspector",
+        "@org_pocoo_werkzeug",
+    ],
+)
+
+py_library(
+    name = "default",
+    srcs = ["default.py"],
+    data = ["webfiles.zip"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins/audio:audio_plugin",
         "//tensorboard/plugins/core:core_plugin",
-        "//tensorboard/plugins/debugger:debugger_plugin",
+        "//tensorboard/plugins/debugger:debugger_plugin_loader",
         "//tensorboard/plugins/distribution:distributions_plugin",
         "//tensorboard/plugins/graph:graphs_plugin",
         "//tensorboard/plugins/histogram:histograms_plugin",
@@ -38,8 +63,6 @@ py_binary(
         "//tensorboard/plugins/projector:projector_plugin",
         "//tensorboard/plugins/scalar:scalars_plugin",
         "//tensorboard/plugins/text:text_plugin",
-        "@org_pocoo_werkzeug",
-        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -57,7 +57,6 @@ py_test(
 py_library(
     name = "application",
     srcs = ["application.py"],
-    data = ["//tensorboard:webfiles.zip"],
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -1,0 +1,90 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Collection of first-party plugins.
+
+This module exists to isolate tensorboard.server from the potentially
+heavyweight build dependencies for first-party plugins. This way people
+doing custom builds of TensorBoard have the option to only pay for the
+dependencies they want.
+
+This module also grants the flexibility to those doing custom builds, to
+automatically inherit the centrally-maintained list of standard plugins,
+for less repetition.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+import tensorflow as tf
+
+from tensorboard.plugins.audio import audio_plugin
+from tensorboard.plugins.core import core_plugin
+from tensorboard.plugins.distribution import distributions_plugin
+from tensorboard.plugins.graph import graphs_plugin
+from tensorboard.plugins.debugger import debugger_plugin_loader
+from tensorboard.plugins.histogram import histograms_plugin
+from tensorboard.plugins.image import images_plugin
+from tensorboard.plugins.pr_curve import pr_curves_plugin
+from tensorboard.plugins.profile import profile_plugin
+from tensorboard.plugins.projector import projector_plugin
+from tensorboard.plugins.scalar import scalars_plugin
+from tensorboard.plugins.text import text_plugin
+
+
+def get_plugins():
+  """Returns list of TensorBoard's first-party TBPlugin classes.
+
+  This list can then be passed to functions in `tensorboard.server` or
+  `tensorboard.backend.application`.
+
+  :rtype: list[:class:`base_plugin.TBPlugin`]
+  """
+  plugins = [
+      core_plugin.CorePlugin,
+      scalars_plugin.ScalarsPlugin,
+      images_plugin.ImagesPlugin,
+      audio_plugin.AudioPlugin,
+      graphs_plugin.GraphsPlugin,
+      distributions_plugin.DistributionsPlugin,
+      histograms_plugin.HistogramsPlugin,
+      pr_curves_plugin.PrCurvesPlugin,
+      projector_plugin.ProjectorPlugin,
+      text_plugin.TextPlugin,
+      profile_plugin.ProfilePlugin,
+  ]
+  # The debugger plugin is only activated if its flag is set.
+  debugger = debugger_plugin_loader.get_debugger_plugin()
+  if debugger is not None:
+    plugins.append(debugger)
+  return plugins
+
+
+def get_assets_zip_provider():
+  """Opens stock TensorBoard web assets collection.
+
+  Returns:
+    Returns function that returns a newly opened file handle to zip file
+    containing static assets for stock TensorBoard, or None if webfiles.zip
+    could not be found. The value the callback returns must be closed. The
+    paths inside the zip file are considered absolute paths on the web server.
+  """
+  path = os.path.join(tf.resource_loader.get_data_files_path(), 'webfiles.zip')
+  if not os.path.exists(path):
+    tf.logging.warning('webfiles.zip static assets not found: %s', path)
+    return None
+  return lambda: open(path, 'rb')

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -12,300 +12,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Serve TensorFlow summary data to a web frontend.
+"""TensorBoard main module.
 
-This is a simple web server to proxy data from the event_loader to the web, and
-serve static web files.
+This module ties together `tensorboard.program` and
+`tensorboard.default_plugins` to provide standard TensorBoard. It's
+meant to be tiny and act as little other than a config file. Those
+wishing to customize the set of plugins or static assets that
+TensorBoard uses can swap out this file with their own.
 """
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import errno
-import os
-import socket
-import sys
-
-import six
 import tensorflow as tf
-from werkzeug import serving
 
-from tensorboard import util
-from tensorboard import version
-from tensorboard.backend import application
-from tensorboard.backend.event_processing import event_file_inspector as efi
-from tensorboard.plugins.audio import audio_plugin
-from tensorboard.plugins.core import core_plugin
-from tensorboard.plugins.distribution import distributions_plugin
-from tensorboard.plugins.graph import graphs_plugin
-from tensorboard.plugins.histogram import histograms_plugin
-from tensorboard.plugins.image import images_plugin
-from tensorboard.plugins.pr_curve import pr_curves_plugin
-from tensorboard.plugins.profile import profile_plugin
-from tensorboard.plugins.projector import projector_plugin
-from tensorboard.plugins.scalar import scalars_plugin
-from tensorboard.plugins.text import text_plugin
-
-# TensorBoard flags
-
-tf.flags.DEFINE_string('logdir', '', """logdir specifies the directory where
-TensorBoard will look to find TensorFlow event files that it can display.
-TensorBoard will recursively walk the directory structure rooted at logdir,
-looking for .*tfevents.* files.
-
-You may also pass a comma separated list of log directories, and TensorBoard
-will watch each directory. You can also assign names to individual log
-directories by putting a colon between the name and the path, as in
-
-tensorboard --logdir name1:/path/to/logs/1,name2:/path/to/logs/2
-""")
-
-tf.flags.DEFINE_string(
-    'host', '', 'What host to listen to. Defaults to '
-    'serving on all interfaces, set to 127.0.0.1 (localhost) to'
-    'disable remote access (also quiets security warnings).')
-
-tf.flags.DEFINE_integer('port', 6006, 'What port to serve TensorBoard on.')
-
-tf.flags.DEFINE_boolean(
-    'purge_orphaned_data', True, 'Whether to purge data that '
-    'may have been orphaned due to TensorBoard restarts. '
-    'Disabling purge_orphaned_data can be used to debug data '
-    'disappearance.')
-
-tf.flags.DEFINE_integer('reload_interval', 5,
-                        'How often the backend should load '
-                        'more data.')
-
-tf.flags.DEFINE_string('db', "", """\
-[Experimental] Sets SQL database URI.
-
-This mode causes TensorBoard to persist experiments to a SQL database. The
-following databases are supported:
-
-- sqlite: Use SQLite built in to Python. URI must specify the path of the
-  database file, which will be created if it doesn't exist. For example:
-  --db sqlite3:~/.tensorboard.db
-
-Warning: This feature is a work in progress and only has limited support.
-""")
-
-# Inspect Mode flags
-
-tf.flags.DEFINE_boolean('inspect', False, """Use this flag to print out a digest
-of your event files to the command line, when no data is shown on TensorBoard or
-the data shown looks weird.
-
-Example usages:
-tensorboard --inspect --event_file myevents.out
-tensorboard --inspect --event_file myevents.out --tag loss
-tensorboard --inspect --logdir mylogdir
-tensorboard --inspect --logdir mylogdir --tag loss
-
-See tensorflow/python/summary/event_file_inspector.py for more info and
-detailed usage.
-""")
-
-tf.flags.DEFINE_string(
-    'tag', '',
-    'The particular tag to query for. Only used if --inspect is present')
-
-tf.flags.DEFINE_string(
-    'event_file', '',
-    'The particular event file to query for. Only used if --inspect is present '
-    'and --logdir is not specified.')
-tf.flags.DEFINE_string(
-    'path_prefix', '',
-    'An optional, relative prefix to the path, e.g. "/path/to/tensorboard". '
-    'resulting in the new base url being located at '
-    'localhost:6006/path/to/tensorboard under default settings. A leading '
-    'slash is required when specifying the path_prefix, however trailing '
-    'slashes can be omitted. The path_prefix can be leveraged for path '
-    'based routing of an elb when the website base_url is not available '
-    'e.g. "example.site.com/path/to/tensorboard/"')
-
-tf.flags.DEFINE_integer(
-    'debugger_data_server_grpc_port', None,
-    'The port at which the debugger data server (to be started by the debugger '
-    'plugin) should receive debugging data via gRPC from one or more '
-    'debugger-enabled TensorFlow runtimes. No debugger plugin or debugger data '
-    'server will be started if this flag is not provided.')
-
-FLAGS = tf.flags.FLAGS
-
-
-def create_tb_app(plugins, assets_zip_provider=None):
-  """Read the flags, and create a TensorBoard WSGI application.
-
-  Args:
-    plugins: A list of constructor functions for TBPlugin subclasses.
-    assets_zip_provider: Delegates to TBContext or uses default if None.
-
-  Raises:
-    ValueError: if a logdir is not specified.
-
-  Returns:
-    A new TensorBoard WSGI application.
-  """
-  if not FLAGS.db and not FLAGS.logdir:
-    raise ValueError('A logdir must be specified when db is not specified. '
-                     'Run `tensorboard --help` for details and examples.')
-  return application.standard_tensorboard_wsgi(
-      assets_zip_provider=assets_zip_provider,
-      db_uri=FLAGS.db,
-      logdir=os.path.expanduser(FLAGS.logdir),
-      purge_orphaned_data=FLAGS.purge_orphaned_data,
-      reload_interval=FLAGS.reload_interval,
-      plugins=plugins,
-      path_prefix=FLAGS.path_prefix)
-
-
-def make_simple_server(tb_app, host=None, port=None, path_prefix=None):
-  """Create an HTTP server for TensorBoard.
-
-  Args:
-    tb_app: The TensorBoard WSGI application to create a server for.
-    host: Indicates the interfaces to bind to ('::' or '0.0.0.0' for all
-        interfaces, '::1' or '127.0.0.1' for localhost). A blank value ('')
-        indicates protocol-agnostic all interfaces. If not specified, will
-        default to the flag value.
-    port: The port to bind to (0 indicates an unused port selected by the
-        operating system). If not specified, will default to the flag value.
-    path_prefix: Optional relative prefix to the path, e.g. "/service/tf"
-
-  Returns:
-    A tuple of (server, url):
-      server: An HTTP server object configured to host TensorBoard.
-      url: A best guess at a URL where TensorBoard will be accessible once the
-        server has been started.
-
-  Raises:
-    socket.error: If a server could not be constructed with the host and port
-      specified. Also logs an error message.
-  """
-  if host is None:
-    host = FLAGS.host
-  if port is None:
-    port = FLAGS.port
-  if path_prefix is None:
-    path_prefix = FLAGS.path_prefix
-  try:
-    if host:
-      # The user gave us an explicit host
-      server = serving.make_server(host, port, tb_app, threaded=True)
-      if ':' in host and not host.startswith('['):
-        # Display IPv6 addresses as [::1]:80 rather than ::1:80
-        final_host = '[{}]'.format(host)
-      else:
-        final_host = host
-    else:
-      # We've promised to bind to all interfaces on this host. However, we're
-      # not sure whether that means IPv4 or IPv6 interfaces.
-      try:
-        # First try passing in a blank host (meaning all interfaces). This,
-        # unfortunately, defaults to IPv4 even if no IPv4 interface is available
-        # (yielding a socket.error).
-        server = serving.make_server(host, port, tb_app, threaded=True)
-      except socket.error:
-        # If a blank host didn't work, we explicitly request IPv6 interfaces.
-        server = serving.make_server('::', port, tb_app, threaded=True)
-      final_host = socket.gethostname()
-    server.daemon_threads = True
-  except socket.error as socket_error:
-    if port == 0:
-      msg = 'TensorBoard unable to find any open port'
-    else:
-      msg = (
-          'TensorBoard attempted to bind to port %d, but it was already in use'
-          % port)
-    tf.logging.error(msg)
-    print(msg)
-    raise socket_error
-  server.handle_error = _handle_error
-  final_port = server.socket.getsockname()[1]
-  tensorboard_url = 'http://%s:%d%s' % (final_host, final_port, path_prefix)
-  return server, tensorboard_url
-
-
-def run_simple_server(tb_app):
-  """Run a TensorBoard HTTP server, and print some messages to the console."""
-  try:
-    server, url = make_simple_server(tb_app)
-  except socket.error:
-    # An error message was already logged
-    # TODO(@jart): Remove log and throw anti-pattern.
-    sys.exit(-1)
-  sys.stderr.write('TensorBoard %s at %s (Press CTRL+C to quit)\n' %
-                   (version.VERSION, url))
-  sys.stderr.flush()
-  server.serve_forever()
-
-
-# Kludge to override a SocketServer.py method so we can get rid of noisy
-# EPIPE errors. They're kind of a red herring as far as errors go. For
-# example, `curl -N http://localhost:6006/ | head` will cause an EPIPE.
-def _handle_error(unused_request, client_address):
-  exc_info = sys.exc_info()
-  e = exc_info[1]
-  if isinstance(e, IOError) and e.errno == errno.EPIPE:
-    tf.logging.warn('EPIPE caused by %s:%d in HTTP serving' % client_address)
-  else:
-    tf.logging.error('HTTP serving error', exc_info=exc_info)
+from tensorboard import default
+from tensorboard import program
 
 
 def main(unused_argv=None):
-  util.setup_logging()
-  if FLAGS.inspect:
-    tf.logging.info('Not bringing up TensorBoard, but inspecting event files.')
-    event_file = os.path.expanduser(FLAGS.event_file)
-    efi.inspect(FLAGS.logdir, event_file, FLAGS.tag)
-    return 0
-  else:
+  """Standard TensorBoard program CLI.
 
-    # The default is HTTP/1.0 for some strange reason. If we don't use
-    # HTTP/1.1 then a new TCP socket and Python thread is created for
-    # each HTTP request. The tradeoff is we must always specify the
-    # Content-Length header, or do chunked encoding for streaming.
-    serving.WSGIRequestHandler.protocol_version = 'HTTP/1.1'
+  See `tensorboard.program.main` for further documentation.
+  """
+  return program.main(default.get_plugins(),
+                      default.get_assets_zip_provider())
 
-    plugins = [
-        core_plugin.CorePlugin,
-        scalars_plugin.ScalarsPlugin,
-        images_plugin.ImagesPlugin,
-        audio_plugin.AudioPlugin,
-        graphs_plugin.GraphsPlugin,
-        distributions_plugin.DistributionsPlugin,
-        histograms_plugin.HistogramsPlugin,
-        pr_curves_plugin.PrCurvesPlugin,
-        projector_plugin.ProjectorPlugin,
-        text_plugin.TextPlugin,
-        profile_plugin.ProfilePlugin,
-    ]
 
-    def ConstructDebuggerPluginWithGrpcPort(context):
-      try:
-        # pylint: disable=line-too-long,g-import-not-at-top
-        from tensorboard.plugins.debugger import debugger_plugin as debugger_plugin_lib
-        # pylint: enable=line-too-long,g-import-not-at-top
-      except ImportError as err:
-        (unused_type, unused_value, traceback) = sys.exc_info()
-        six.reraise(
-            ImportError,
-            ImportError(
-                err.message +
-                "\n\nTo use the debugger plugin, you need to have "
-                "gRPC installed:\n  pip install grpcio"),
-            traceback)
-      tf.logging.info("Starting Debugger Plugin at gRPC port %d",
-                      FLAGS.debugger_data_server_grpc_port)
-      debugger_plugin = debugger_plugin_lib.DebuggerPlugin(context)
-      debugger_plugin.listen(FLAGS.debugger_data_server_grpc_port)
-      return debugger_plugin
-    if FLAGS.debugger_data_server_grpc_port is not None:
-      plugins.append(ConstructDebuggerPluginWithGrpcPort)
+def create_tb_app(*args, **kwargs):
+  tf.logging.warning('DEPRECATED API: create_tb_app() should now be accessed '
+                     'via the `tensorboard.program` module')
+  return program.create_tb_app(*args, **kwargs)
 
-    tb = create_tb_app(plugins)
-    run_simple_server(tb)
+
+def make_simple_server(*args, **kwargs):
+  tf.logging.warning('DEPRECATED API: make_simple_server() should now be '
+                     'accessed via the `tensorboard.program` module')
+  return program.make_simple_server(*args, **kwargs)
+
+
+def run_simple_server(*args, **kwargs):
+  tf.logging.warning('DEPRECATED API: run_simple_server() should now be '
+                     'accessed via the `tensorboard.program` module')
+  return program.run_simple_server(*args, **kwargs)
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/core/BUILD
+++ b/tensorboard/plugins/core/BUILD
@@ -3,6 +3,9 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
+load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:zipper.bzl", "tensorboard_zip_file")
+
 licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
@@ -25,6 +28,7 @@ py_test(
     name = "core_plugin_test",
     size = "small",
     srcs = ["core_plugin_test.py"],
+    data = ["test_webfiles.zip"],
     srcs_version = "PY2AND3",
     deps = [
         ":core_plugin",
@@ -35,4 +39,17 @@ py_test(
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],
+)
+
+ts_web_library(
+    name = "test_assets",
+    testonly = 1,
+    srcs = ["index.html"],
+    path = "/",
+)
+
+tensorboard_zip_file(
+    name = "test_webfiles",
+    testonly = 1,
+    deps = [":test_assets"],
 )

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -44,7 +44,7 @@ class CorePluginTest(tf.test.TestCase):
         size_guidance=application.DEFAULT_SIZE_GUIDANCE,
         purge_orphaned_data=True)
     self._context = base_plugin.TBContext(
-        assets_zip_provider=application.get_default_assets_zip_provider(),
+        assets_zip_provider=get_test_assets_zip_provider(),
         logdir=self.logdir,
         multiplexer=self.multiplexer)
     self.plugin = core_plugin.CorePlugin(self._context)
@@ -187,6 +187,15 @@ class CorePluginTest(tf.test.TestCase):
 class CorePluginUsingMetagraphOnlyTest(CorePluginTest):
   # Tests new ability to use only the MetaGraphDef
   _only_use_meta_graph = True  # Server data contains only a MetaGraphDef
+
+
+def get_test_assets_zip_provider():
+  path = os.path.join(tf.resource_loader.get_data_files_path(),
+                      'test_webfiles.zip')
+  if not os.path.exists(path):
+    tf.logging.warning('test_webfiles.zip static assets not found: %s', path)
+    return None
+  return lambda: open(path, 'rb')
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/core/index.html
+++ b/tensorboard/plugins/core/index.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<p>This is a fake TensorBoard index page.

--- a/tensorboard/plugins/debugger/BUILD
+++ b/tensorboard/plugins/debugger/BUILD
@@ -129,6 +129,7 @@ py_library(
     name = "debugger_plugin",
     srcs = ["debugger_plugin.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":constants",
         ":debugger_server_lib",
@@ -138,6 +139,18 @@ py_library(
         "//tensorboard/backend/event_processing:event_file_loader",
         "//tensorboard/plugins:base_plugin",
         "@org_pocoo_werkzeug",
+    ],
+)
+
+py_library(
+    name = "debugger_plugin_loader",
+    srcs = ["debugger_plugin_loader.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":debugger_plugin",
+        "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -1,0 +1,69 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Wrapper around debugger plugin to conditionally enable it."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
+
+import six
+import tensorflow as tf
+
+tf.flags.DEFINE_integer(
+    'debugger_data_server_grpc_port', None,
+    'The port at which the debugger data server (to be started by the debugger '
+    'plugin) should receive debugging data via gRPC from one or more '
+    'debugger-enabled TensorFlow runtimes. No debugger plugin or debugger data '
+    'server will be started if this flag is not provided.')
+
+FLAGS = tf.flags.FLAGS
+
+
+def get_debugger_plugin():
+  """Returns the debugger plugin, if possible.
+
+  This function can be passed along to the functions in
+  `tensorboard.program`.
+
+  Returns:
+    The TBPlugin constructor for the debugger plugin, or None if
+    the necessary flag was not set.
+  """
+  if FLAGS.debugger_data_server_grpc_port is None:
+    return None
+  return _ConstructDebuggerPluginWithGrpcPort
+
+
+def _ConstructDebuggerPluginWithGrpcPort(context):
+  try:
+    # pylint: disable=line-too-long,g-import-not-at-top
+    from tensorboard.plugins.debugger import debugger_plugin as debugger_plugin_lib
+    # pylint: enable=line-too-long,g-import-not-at-top
+  except ImportError as err:
+    (unused_type, unused_value, traceback) = sys.exc_info()
+    six.reraise(
+        ImportError,
+        ImportError(
+            err.message +
+            "\n\nTo use the debugger plugin, you need to have "
+            "gRPC installed:\n  pip install grpcio"),
+        traceback)
+  tf.logging.info("Starting Debugger Plugin at gRPC port %d",
+                  FLAGS.debugger_data_server_grpc_port)
+  debugger_plugin = debugger_plugin_lib.DebuggerPlugin(context)
+  debugger_plugin.listen(FLAGS.debugger_data_server_grpc_port)
+  return debugger_plugin

--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -21,6 +21,7 @@ py_library(
     name = "pr_curves_plugin",
     srcs = ["pr_curves_plugin.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":metadata",
         "//tensorboard:expect_tensorflow_installed",
@@ -40,8 +41,8 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":metadata",
-        ":pr_curves_plugin",
         ":pr_curve_demo",
+        ":pr_curves_plugin",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
@@ -55,9 +56,7 @@ py_library(
     name = "summary",
     srcs = ["summary.py"],
     srcs_version = "PY2AND3",
-    visibility = [
-        "//visibility:public",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         ":metadata",
         "//tensorboard:expect_tensorflow_installed",

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -1,0 +1,287 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Utilities for TensorBoard command line program.
+
+This is a lightweight module for bringing up a TensorBoard HTTP server
+or emulating the `tensorboard` shell command.
+
+Those wishing to create custom builds of TensorBoard can use this module
+by swapping out `tensorboard.main` with the custom definition that
+modifies the set of plugins and static assets.
+
+This module does not depend on first-party plugins or the default web
+server assets. Those are defined in `tensorboard.default_plugins`.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import errno
+import os
+import socket
+import sys
+import types  # pylint: disable=unused-import
+
+import tensorflow as tf
+from werkzeug import serving
+
+from tensorboard import util
+from tensorboard import version
+from tensorboard.backend import application
+from tensorboard.backend.event_processing import event_file_inspector as efi
+
+tf.flags.DEFINE_string('logdir', '', """logdir specifies the directory where
+TensorBoard will look to find TensorFlow event files that it can display.
+TensorBoard will recursively walk the directory structure rooted at logdir,
+looking for .*tfevents.* files.
+
+You may also pass a comma separated list of log directories, and TensorBoard
+will watch each directory. You can also assign names to individual log
+directories by putting a colon between the name and the path, as in
+
+tensorboard --logdir name1:/path/to/logs/1,name2:/path/to/logs/2
+""")
+
+tf.flags.DEFINE_string(
+    'host', '', 'What host to listen to. Defaults to '
+    'serving on all interfaces, set to 127.0.0.1 (localhost) to'
+    'disable remote access (also quiets security warnings).')
+
+tf.flags.DEFINE_integer('port', 6006, 'What port to serve TensorBoard on.')
+
+tf.flags.DEFINE_boolean(
+    'purge_orphaned_data', True, 'Whether to purge data that '
+    'may have been orphaned due to TensorBoard restarts. '
+    'Disabling purge_orphaned_data can be used to debug data '
+    'disappearance.')
+
+tf.flags.DEFINE_integer('reload_interval', 5,
+                        'How often the backend should load '
+                        'more data.')
+
+tf.flags.DEFINE_string('db', "", """\
+[Experimental] Sets SQL database URI.
+
+This mode causes TensorBoard to persist experiments to a SQL database. The
+following databases are supported:
+
+- sqlite: Use SQLite built in to Python. URI must specify the path of the
+  database file, which will be created if it doesn't exist. For example:
+  --db sqlite3:~/.tensorboard.db
+
+Warning: This feature is a work in progress and only has limited support.
+""")
+
+tf.flags.DEFINE_boolean('inspect', False, """Use this flag to print out a digest
+of your event files to the command line, when no data is shown on TensorBoard or
+the data shown looks weird.
+
+Example usages:
+tensorboard --inspect --event_file myevents.out
+tensorboard --inspect --event_file myevents.out --tag loss
+tensorboard --inspect --logdir mylogdir
+tensorboard --inspect --logdir mylogdir --tag loss
+
+See tensorflow/python/summary/event_file_inspector.py for more info and
+detailed usage.
+""")
+
+tf.flags.DEFINE_string(
+    'tag', '',
+    'The particular tag to query for. Only used if --inspect is present')
+
+tf.flags.DEFINE_string(
+    'event_file', '',
+    'The particular event file to query for. Only used if --inspect is present '
+    'and --logdir is not specified.')
+
+tf.flags.DEFINE_string(
+    'path_prefix', '',
+    'An optional, relative prefix to the path, e.g. "/path/to/tensorboard". '
+    'resulting in the new base url being located at '
+    'localhost:6006/path/to/tensorboard under default settings. A leading '
+    'slash is required when specifying the path_prefix, however trailing '
+    'slashes can be omitted. The path_prefix can be leveraged for path '
+    'based routing of an elb when the website base_url is not available '
+    'e.g. "example.site.com/path/to/tensorboard/"')
+
+FLAGS = tf.flags.FLAGS
+
+
+def main(plugins, assets_zip_provider=None):
+  """Main function for TensorBoard.
+
+  This function makes some global changes to the Python environment and
+  then delegates to other functions in this module.
+
+  Since this function will generally run forever, it should only be
+  called if the Python process is only meant to be a TensorBoard
+  server.
+
+  Args:
+    plugins: A list of constructor functions for TBPlugin subclasses.
+    assets_zip_provider: Delegates to TBContext or uses default if None.
+
+  Returns:
+    Process exit code, i.e. 0 if successful or non-zero on failure. In
+    practice, an exception will most likely be raised instead of
+    returning non-zero.
+
+  :type plugins: list[:class:`base_plugin.TBPlugin`]
+  :type assets_zip_provider: () -> file
+  :rtype: int
+  """
+  util.setup_logging()
+
+  if FLAGS.inspect:
+    tf.logging.info('Not bringing up TensorBoard, but inspecting event files.')
+    event_file = os.path.expanduser(FLAGS.event_file)
+    efi.inspect(FLAGS.logdir, event_file, FLAGS.tag)
+    return 0
+
+  # The default is HTTP/1.0 for some strange reason. If we don't use
+  # HTTP/1.1 then a new TCP socket and Python thread is created for
+  # each HTTP request. The tradeoff is we must always specify the
+  # Content-Length header, or do chunked encoding for streaming.
+  serving.WSGIRequestHandler.protocol_version = 'HTTP/1.1'
+
+  tb = create_tb_app(plugins, assets_zip_provider)
+  run_simple_server(tb)
+
+  return 0
+
+
+def create_tb_app(plugins, assets_zip_provider=None):
+  """Read the flags, and create a TensorBoard WSGI application.
+
+  Args:
+    plugins: A list of constructor functions for TBPlugin subclasses.
+    assets_zip_provider: Delegates to TBContext or uses default if None.
+
+  Raises:
+    ValueError: if a logdir is not specified.
+
+  Returns:
+    A new TensorBoard WSGI application.
+
+  :type plugins: list[:class:`base_plugin.TBPlugin`]
+  :type assets_zip_provider: () -> file
+  :rtype: types.FunctionType
+  """
+  if not FLAGS.db and not FLAGS.logdir:
+    raise ValueError('A logdir must be specified when db is not specified. '
+                     'Run `tensorboard --help` for details and examples.')
+  return application.standard_tensorboard_wsgi(
+      assets_zip_provider=assets_zip_provider,
+      db_uri=FLAGS.db,
+      logdir=os.path.expanduser(FLAGS.logdir),
+      purge_orphaned_data=FLAGS.purge_orphaned_data,
+      reload_interval=FLAGS.reload_interval,
+      plugins=plugins,
+      path_prefix=FLAGS.path_prefix)
+
+
+def make_simple_server(tb_app, host=None, port=None, path_prefix=None):
+  """Create an HTTP server for TensorBoard.
+
+  Args:
+    tb_app: The TensorBoard WSGI application to create a server for.
+    host: Indicates the interfaces to bind to ('::' or '0.0.0.0' for all
+        interfaces, '::1' or '127.0.0.1' for localhost). A blank value ('')
+        indicates protocol-agnostic all interfaces. If not specified, will
+        default to the flag value.
+    port: The port to bind to (0 indicates an unused port selected by the
+        operating system). If not specified, will default to the flag value.
+    path_prefix: Optional relative prefix to the path, e.g. "/service/tf"
+
+  Returns:
+    A tuple of (server, url):
+      server: An HTTP server object configured to host TensorBoard.
+      url: A best guess at a URL where TensorBoard will be accessible once the
+        server has been started.
+
+  Raises:
+    socket.error: If a server could not be constructed with the host and port
+      specified. Also logs an error message.
+  """
+  if host is None:
+    host = FLAGS.host
+  if port is None:
+    port = FLAGS.port
+  if path_prefix is None:
+    path_prefix = FLAGS.path_prefix
+  try:
+    if host:
+      # The user gave us an explicit host
+      server = serving.make_server(host, port, tb_app, threaded=True)
+      if ':' in host and not host.startswith('['):
+        # Display IPv6 addresses as [::1]:80 rather than ::1:80
+        final_host = '[{}]'.format(host)
+      else:
+        final_host = host
+    else:
+      # We've promised to bind to all interfaces on this host. However, we're
+      # not sure whether that means IPv4 or IPv6 interfaces.
+      try:
+        # First try passing in a blank host (meaning all interfaces). This,
+        # unfortunately, defaults to IPv4 even if no IPv4 interface is available
+        # (yielding a socket.error).
+        server = serving.make_server(host, port, tb_app, threaded=True)
+      except socket.error:
+        # If a blank host didn't work, we explicitly request IPv6 interfaces.
+        server = serving.make_server('::', port, tb_app, threaded=True)
+      final_host = socket.gethostname()
+    server.daemon_threads = True
+  except socket.error as socket_error:
+    if port == 0:
+      msg = 'TensorBoard unable to find any open port'
+    else:
+      msg = (
+          'TensorBoard attempted to bind to port %d, but it was already in use'
+          % port)
+    tf.logging.error(msg)
+    print(msg)
+    raise socket_error
+  server.handle_error = _handle_error
+  final_port = server.socket.getsockname()[1]
+  tensorboard_url = 'http://%s:%d%s' % (final_host, final_port, path_prefix)
+  return server, tensorboard_url
+
+
+def run_simple_server(tb_app):
+  """Run a TensorBoard HTTP server, and print some messages to the console."""
+  try:
+    server, url = make_simple_server(tb_app)
+  except socket.error:
+    # An error message was already logged
+    # TODO(@jart): Remove log and throw anti-pattern.
+    sys.exit(-1)
+  sys.stderr.write('TensorBoard %s at %s (Press CTRL+C to quit)\n' %
+                   (version.VERSION, url))
+  sys.stderr.flush()
+  server.serve_forever()
+
+
+# Kludge to override a SocketServer.py method so we can get rid of noisy
+# EPIPE errors. They're kind of a red herring as far as errors go. For
+# example, `curl -N http://localhost:6006/ | head` will cause an EPIPE.
+def _handle_error(unused_request, client_address):
+  exc_info = sys.exc_info()
+  e = exc_info[1]
+  if isinstance(e, IOError) and e.errno == errno.EPIPE:
+    tf.logging.warn('EPIPE caused by %s:%d in HTTP serving' % client_address)
+  else:
+    tf.logging.error('HTTP serving error', exc_info=exc_info)


### PR DESCRIPTION
This change will make it easier to write plugins with custom builds of
TensorBoard. The plugin author will no longer be required to explicitly list
all the first-party plugins, as they can now be inherited via the
`tensorboard.default` module.

The `tensorboard.program` module has also been introduced. This module gives a
permanent home to all the APIs that crept into `tensorboard.main` over the
years. After this change, the `tensorboard.main` module is nothing more than
glue between the `program` and `default` modules.

The special-case code in main.py that the debugger plugin was using, has now
been relocated into the debugger plugin's directory.

This change is backwards-compatible. Delegates have been added for relocated
functions that will log a deprecation warning if used.

## Proof that this is good

This change, along with #611 which was recently submitted, have allowed me to write https://github.com/tensorflow/tensorboard-plugin-example/pull/18 which removed about a hundred lines of boilerplate the custom tensorboard building process.