### PR TITLE
Make scalars is_active short circuit if apt

### DIFF
--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -65,8 +65,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
     if not self._multiplexer:
       return False
 
-    mapping = self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME)
-    return any(mapping.values())
+    return bool(self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME))
 
   def index_impl(self):
     """Return {runName: {tagName: {displayName: ..., description: ...}}}."""

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -62,7 +62,11 @@ class ScalarsPlugin(base_plugin.TBPlugin):
 
   def is_active(self):
     """The scalars plugin is active iff any run has at least one scalar tag."""
-    return bool(self._multiplexer) and any(self.index_impl().values())
+    if not self._multiplexer:
+      return False
+
+    mapping = self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME)
+    return any(mapping.values())
 
   def index_impl(self):
     """Return {runName: {tagName: {displayName: ..., description: ...}}}."""


### PR DESCRIPTION
This change makes the `is_active` method of the scalars plugin
short-circuit if it discovers that any run has at least 1 relevant tag.

This change preserves existing behavior, so there are no changes to
tests (which check for the preservation of behavior).

Test plan: Start TensorBoard pointed at the scalars demo data. Note that
the scalars plugin loads. Start TensorBoard pointed at the PR curves
demo data. The scalars plugin is inactive.

Use `time.time()` to log the time it takes for some internal events file
(with over 30K tags in one specific run) with and without this change.

With this change, the is_active method takes 0.0s to complete. Without this
change, it takes 12.0s. Sometimes, the frontend won't load because
`is_active` takes too long to respond.

Granted, one might reason that a user should not have 30K tags ... but
even so, that should not block the rest of TensorBoard from loading.