### PR TITLE
Clarify DEVELOPMENT.md from a new dev perspective

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,10 +1,17 @@
 # How to Develop TensorBoard
 
-TensorBoard at HEAD relies on the nightly installation of TensorFlow: this allows plugin authors to use the latest features of TensorFlow, but it means release versions of TensorFlow may not suffice for development. We recommend installing TensorFlow nightly in a [Python virtualenv](https://virtualenv.pypa.io), and then running your modified development copy of TensorBoard within that virtualenv. To install TensorFlow nightly within the virtualenv, you can simply run `pip install tf-nightly`.
+TensorBoard at HEAD relies on the nightly installation of TensorFlow: this allows plugin authors to use the latest features of TensorFlow, but it means release versions of TensorFlow may not suffice for development. We recommend installing TensorFlow nightly in a [Python virtualenv](https://virtualenv.pypa.io), and then running your modified development copy of TensorBoard within that virtualenv. To install TensorFlow nightly within the virtualenv, you can simply run
 
-TensorBoard builds are done with [Bazel](https://bazel.build), so you may need to [install Bazel](https://docs.bazel.build/versions/master/install.html).
+```sh
+virtualenv tf
+source tf/bin/activate
+pip install --upgrade pip
+pip install tf-nightly
+```
 
-Running TensorBoard via Bazel will automatically create a vulcanized HTML python binary:
+TensorBoard builds are done with [Bazel](https://bazel.build), so you may need to [install Bazel](https://docs.bazel.build/versions/master/install.html). The Bazel build will automatically "vulcanize" all the HTML files and generate a "binary" launcher script. When HTML is vulcanized, it means all the script tags and HTML imports are inlined into one big HTML file. Then the Bazel build puts that index.html file inside a static assets zip. The python HTTP server then reads static assets from that zip while serving.
+
+You can run a locally built TensorBoard via Bazel as follows:
 
 ```sh
 bazel run //tensorboard -- --logdir /path/to/logs

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,10 +1,10 @@
 # How to Develop TensorBoard
 
-TensorBoard at HEAD relies on the nightly installation of TensorFlow, so please install TensorFlow nightly for development. To install TensorFlow nightly, `pip install` the link to the [appropriate whl file listed at the TensorFlow repository](https://github.com/tensorflow/tensorflow).
+TensorBoard at HEAD relies on the nightly installation of TensorFlow: this allows plugin authors to use the latest features of TensorFlow, but it means release versions of TensorFlow may not suffice for development. We recommend installing TensorFlow nightly in a [Python virtualenv](https://virtualenv.pypa.io), and then running your modified development copy of TensorBoard within that virtualenv. To install TensorFlow nightly within the virtualenv, you can simply run `pip install tf-nightly`.
 
-Our decision to develop on TensorFlow nightly has pros and cons. A main advantage is that plugin authors can use the latest features of TensorFlow. A disadvantage is that the previous release of TensorFlow does not suffice for development.
+TensorBoard builds are done with [Bazel](https://bazel.build), so you may need to [install Bazel](https://docs.bazel.build/versions/master/install.html).
 
-Running TensorBoard automatically asks Bazel to create a vulcanized HTML binary:
+Running TensorBoard via Bazel will automatically create a vulcanized HTML python binary:
 
 ```sh
 bazel run //tensorboard -- --logdir /path/to/logs

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,22 +3,25 @@
 TensorBoard at HEAD relies on the nightly installation of TensorFlow: this allows plugin authors to use the latest features of TensorFlow, but it means release versions of TensorFlow may not suffice for development. We recommend installing TensorFlow nightly in a [Python virtualenv](https://virtualenv.pypa.io), and then running your modified development copy of TensorBoard within that virtualenv. To install TensorFlow nightly within the virtualenv, you can simply run
 
 ```sh
-virtualenv tf
-source tf/bin/activate
-pip install --upgrade pip
-pip install tf-nightly
+$ virtualenv tf
+$ source tf/bin/activate
+(tf)$ pip install --upgrade pip
+(tf)$ pip install tf-nightly
 ```
 
 TensorBoard builds are done with [Bazel](https://bazel.build), so you may need to [install Bazel](https://docs.bazel.build/versions/master/install.html). The Bazel build will automatically "vulcanize" all the HTML files and generate a "binary" launcher script. When HTML is vulcanized, it means all the script tags and HTML imports are inlined into one big HTML file. Then the Bazel build puts that index.html file inside a static assets zip. The python HTTP server then reads static assets from that zip while serving.
 
-You can run a locally built TensorBoard via Bazel as follows:
+You can build and run TensorBoard via Bazel (from within the TensorFlow nightly virtualenv) as follows:
 
 ```sh
-bazel run //tensorboard -- --logdir /path/to/logs
+(tf)$ bazel build tensorboard
+(tf)$ ./bazel-bin/tensorboard/tensorboard --logdir path/to/logs
+# Or combine the above steps as:
+(tf)$ bazel run //tensorboard -- --logdir /path/to/logs
 ```
 
-To generate fake data for a plugin, run its demo script. For instance, this command generates fake scalar data in `/tmp/scalars_demo`:
+To generate fake log data for a plugin, run its demo script. For instance, this command generates fake scalar data in `/tmp/scalars_demo`:
 
 ```sh
-bazel run //tensorboard/plugins/scalar:scalars_demo
+(tf)$ bazel run //tensorboard/plugins/scalar:scalars_demo
 ```


### PR DESCRIPTION
This clarifies some things that I encountered - in particular, it specifies that you'll probably want TensorFlow installed in a virtualenv, and it updates the advice about getting the nightly build now that tf-nightly is on pypi (https://pypi.python.org/pypi/tf-nightly).  It also links to Bazel installation instructions just for the sake of being explicit.