### PR TITLE
Use entire string as node label if no match

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -1589,7 +1589,18 @@ export class RenderNodeInfo {
       // to see that in the graph, as the node would already be within
       // the functions scene group.
       const match = this.displayName.match(nodeDisplayNameRegex);
-      this.displayName = match[1];
+      if (match) {
+        // The display name had been successfully extracted. This is the most
+        // common scenario.
+        this.displayName = match[1];
+      } else if (_.startsWith(
+          this.displayName, tf.graph.FUNCTION_LIBRARY_NODE_PREFIX)) {
+        // The string does not match the usual pattern for how functions are
+        // named. Just use the entire second portion of the string as the name
+        // if we can successfully remove the prefix.
+        this.displayName = this.displayName.substring(
+            tf.graph.FUNCTION_LIBRARY_NODE_PREFIX.length);
+      }
     }
   }
 


### PR DESCRIPTION
Previously, the graph explorer attempted to extract a label from a
string to use as the display name for a node representing a function.
Apparently, that regex does not always match a function. Certain graphs
found within Google directly use the entire string as the name of the
function. That caused the graph explorer to be blank due to an error.

This change makes it so that we just use the entire string as the
display name if no display name can be extracted from the string.

Test Plan: Start TensorBoard pointed at the attached events file. The
graph loads correctly as before. Also load the newly discovered internal
pbtxt. It also loads successfully.

[events.out.tfevents.1506397086.functions.txt](https://github.com/tensorflow/tensorboard/files/1357970/events.out.tfevents.1506397086.functions.txt)


