### PR TITLE
Use corebox dimensions to render triangles

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -555,7 +555,8 @@ function position(nodeGroup, d: render.RenderNodeInfo) {
         // This shape represents the input into or output out of a TensorFlow
         // function.
         let shape = scene.selectChild(shapeGroup, 'polygon');
-        scene.positionTriangle(shape, d.x, d.y, d.width, d.height);
+        scene.positionTriangle(
+            shape, d.x, d.y, d.coreBox.width, d.coreBox.height);
       } else {
         let shape = scene.selectChild(shapeGroup, 'ellipse');
         scene.positionEllipse(


### PR DESCRIPTION
Previously, triangles within function nodes that represented inputs and outputs ops had relied on the wrong width and height, resulting in stretched triangles.

![image](https://user-images.githubusercontent.com/4221553/31221491-b27b3320-a978-11e7-872c-25a0c5cd00ab.png)

Now, the triangles use the dimensions of their core box, as was already the case with ellipses representing normal ops.

![image](https://user-images.githubusercontent.com/4221553/31221475-a69034c0-a978-11e7-9147-19d25c5224cb.png)

Test Plan: Load the attached events file and view the graph dashboard. Confirm the behavior above after expanding the `MnistForward` function.

[events.out.tfevents.functions.txt](https://github.com/tensorflow/tensorboard/files/1358841/events.out.tfevents.functions.txt)
