### PR TITLE
Improve card header word breaks

### DIFF
--- a/tensorboard/components/tf_card_heading/tf-card-heading.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading.html
@@ -62,7 +62,10 @@ limitations under the License.
         <template is="dom-if" if="[[_tagLabel]]">
           <div class="heading-row">
             <div class="heading-label">
-              tag: <span itemprop="tag">[[_tagLabel]]</span>
+              tag: <div
+                     itemprop="tag"
+                     inner-h-t-m-l="[[_breakString(_tagLabel)]]"
+                   ></div>
             </div>
           </div>
         </template>
@@ -167,6 +170,11 @@ limitations under the License.
       _toggleDescriptionDialog(e) {
         this.$.descriptionDialog.positionTarget = e.target;
         this.$.descriptionDialog.toggle();
+      },
+
+      // Break the string at natural points, including commas, equals, and slashes
+      _breakString: function(originalString) {
+        return originalString.replace(/([\/=\-_,])/g, "$1<wbr>");
       },
     });
   </script>


### PR DESCRIPTION
Insert <wbr> tags into the tag names used in card headers, so that in the case of long tag names, they will break more gracefully at word boundaries.

Before:

![image](https://user-images.githubusercontent.com/710113/31255404-81165774-a9e1-11e7-8189-edcabea1b961.png)

After:

![image](https://user-images.githubusercontent.com/710113/31255409-89e8db60-a9e1-11e7-957d-8eaca96eb209.png)

Note that incidentally this also seems to address a bug where the long unbroken tag name pushed the containing div out too far, and bumped the "show description" circled-i icon out of view, making it inaccessible.  The bug is not 100% fixed because in the case of a tag name which has an unbreakable component that exceeds the card width (e.g. "someVeryLongUnbrokenRunNameWithNoHyphensSlashesOrUnderscores/loss/scalar_summary") we would still have the problem.  But that seems much less likely with this change in place.