### PR TITLE
Create TensorBoard 0.4.0-rc1

### DIFF
--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '0.4.0a0'
+VERSION = '0.4.0rc1'


### PR DESCRIPTION
This PR starts the TensorBoard 0.4 minor series, which maps to TensorFlow 1.4.

The `0.4` branch has been cut from `HEAD` today for this series. The true name of this release will be `0.4.0-rc1`, to conform to semver. However, in `tensorboard.version` and on PyPi it will be known as `0.4.0rc1` to conform to PEP 440. @gunan has informed me there are benefits to semver conformance, as we introduce more languages into the repository.

As soon as this change is merged, this release candidate will be published to PyPi. I've confirmed that `pip install tensorflow-tensorboard` will *not* choose by default to install an RC.

Then, I will send a PR to TensorFlow updating their setup.py to say `tensorflow-tensorboard >= 0.4.0rc1, < 0.5.0`, so they can create their release candidate. I'm confident this will work.

```pycon
>>> from packaging import version
>>> version.parse('0.4.0rc0') >= version.parse('0.4.0')
False
>>> version.parse('0.4.0rc0') >= version.parse('0.4.0rc0')
True
>>> version.parse('0.4.0rc1') >= version.parse('0.4.0rc0')
True
>>> version.parse('0.4.1') >= version.parse('0.4.0rc0')
True
>>> version.parse('0.4.1rc1') < version.parse('0.5.0')
True
```