### PR TITLE
Introduce a raw_data_pb method for PR curve summaries

### DIFF
--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -223,19 +223,16 @@ def pb(name,
   precision = tp / np.maximum(_MINIMUM_COUNT, tp + fp)
   recall = tp / np.maximum(_MINIMUM_COUNT, tp + fn)
 
-  if display_name is None:
-    display_name = name
-  summary_metadata = metadata.create_summary_metadata(
-      display_name=display_name if display_name is not None else name,
-      description=description or '',
-      num_thresholds=num_thresholds)
-  summary = tf.Summary()
-  data = np.stack((tp, fp, tn, fn, precision, recall))
-  tensor = tf.make_tensor_proto(data, dtype=tf.float32)
-  summary.value.add(tag='%s/pr_curves' % name,
-                    metadata=summary_metadata,
-                    tensor=tensor)
-  return summary
+  return raw_data_pb(name,
+                     true_positive_counts=tp,
+                     false_positive_counts=fp,
+                     true_negative_counts=tn,
+                     false_negative_counts=fn,
+                     precision=precision,
+                     recall=recall,
+                     num_thresholds=num_thresholds,
+                     display_name=display_name,
+                     description=description)
 
 def streaming_op(name,
                  labels,
@@ -336,7 +333,6 @@ def streaming_op(name,
 
     return pr_curve, update_op
 
-
 def raw_data_op(
     name,
     true_positive_counts,
@@ -404,6 +400,64 @@ def raw_data_op(
         display_name,
         description,
         collections)
+
+def raw_data_pb(
+    name,
+    true_positive_counts,
+    false_positive_counts,
+    true_negative_counts,
+    false_negative_counts,
+    precision,
+    recall,
+    num_thresholds=None,
+    display_name=None,
+    description=None):
+  """Create a PR curves summary protobuf from raw data values.
+
+  Args:
+    name: A tag attached to the summary. Used by TensorBoard for organization.
+    true_positive_counts: A rank-1 numpy array of true positive counts. Must
+        contain `num_thresholds` elements and be castable to float32.
+    false_positive_counts: A rank-1 numpy array of false positive counts. Must
+        contain `num_thresholds` elements and be castable to float32.
+    true_negative_counts: A rank-1 numpy array of true negative counts. Must
+        contain `num_thresholds` elements and be castable to float32.
+    false_negative_counts: A rank-1 numpy array of false negative counts. Must
+        contain `num_thresholds` elements and be castable to float32.
+    precision: A rank-1 numpy array of precision values. Must contain
+        `num_thresholds` elements and be castable to float32.
+    recall: A rank-1 numpy array of recall values. Must contain `num_thresholds`
+        elements and be castable to float32.
+    num_thresholds: Number of thresholds, evenly distributed in `[0, 1]`, to
+        compute PR metrics for. Should be an int `>= 2`.
+    display_name: Optional name for this summary in TensorBoard, as a `str`.
+        Defaults to `name`.
+    description: Optional long-form description for this summary, as a `str`.
+        Markdown is supported. Defaults to empty.
+
+  Returns:
+    A summary operation for use in a TensorFlow graph. See docs for the `op`
+    method for details on the float32 tensor produced by this summary.
+  """
+  if display_name is None:
+    display_name = name
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=display_name if display_name is not None else name,
+      description=description or '',
+      num_thresholds=num_thresholds)
+  summary = tf.Summary()
+  data = np.stack(
+      (true_positive_counts,
+       false_positive_counts,
+       true_negative_counts,
+       false_negative_counts,
+       precision,
+       recall))
+  tensor = tf.make_tensor_proto(np.float32(data), dtype=tf.float32)
+  summary.value.add(tag='%s/pr_curves' % name,
+                    metadata=summary_metadata,
+                    tensor=tensor)
+  return summary
 
 def _create_tensor_summary(
     name,

--- a/tensorboard/summary.py
+++ b/tensorboard/summary.py
@@ -41,7 +41,8 @@ image_pb = _image_summary.pb
 pr_curve = _pr_curve_summary.op
 pr_curve_pb = _pr_curve_summary.pb
 pr_curve_streaming_op = _pr_curve_summary.streaming_op
-pr_curve_raw_data = _pr_curve_summary.raw_data_op
+pr_curve_raw_data_op = _pr_curve_summary.raw_data_op
+pr_curve_raw_data_pb = _pr_curve_summary.raw_data_pb
 
 scalar = _scalar_summary.op
 scalar_pb = _scalar_summary.pb


### PR DESCRIPTION
This method lets users generate PR curve summaries from raw TP, FP, TN, FN, precision, recall values without the use of TensorFlow.

Added `pr_curve_raw_data_pb` to TensorBoard's main summary module. Renamed `pr_curve_raw_data` to `pr_curve_raw_data_op` to be parallel.