### PR TITLE
Upgrade protobuf version in workspace.bzl and setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
 
     pip install pylint
     pip install futures==3.1.1
-    pip install grpcio==1.4.0
+    pip install grpcio==1.6.3
 
 script:
   - |

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -28,7 +28,7 @@ REQUIRED_PACKAGES = [
     'futures >= 3.1.1',
     'numpy >= 1.12.0',
     'six >= 1.10.0',
-    'protobuf >= 3.3.0',
+    'protobuf >= 3.4.0',
     'werkzeug >= 0.11.10',
     'html5lib == 0.9999999',  # identical to 1.0b8
     'markdown >= 2.6.8',

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -30,9 +30,12 @@ def tensorboard_workspace():
 
   native.http_archive(
       name = "protobuf",
-      urls = ["http://mirror.bazel.build/github.com/google/protobuf/archive/0b059a3d8a8f8aa40dde7bea55edca4ec5dfea66.tar.gz"],
-      sha256 = "6d43b9d223ce09e5d4ce8b0060cb8a7513577a35a64c7e3dad10f0703bf3ad93",
-      strip_prefix = "protobuf-0b059a3d8a8f8aa40dde7bea55edca4ec5dfea66",
+      urls = [
+          "http://mirror.bazel.build/github.com/google/protobuf/archive/v3.4.1.tar.gz",
+          "https://github.com/google/protobuf/archive/v3.4.1.tar.gz",
+      ],
+      sha256 = "8e0236242106e680b4f9f576cc44b8cd711e948b20a9fc07769b0a20ceab9cc4",
+      strip_prefix = "protobuf-3.4.1",
       # TODO: remove patching when tensorflow stops linking same protos into
       #       multiple shared libraries loaded in runtime by python.
       #       This patch fixes a runtime crash when tensorflow is compiled


### PR DESCRIPTION
The previous version was very old (3.0.0), which may caused the
following error to occur when the --debugger_data_server_grpc_port
flag is used when launching the tensorboard binary from bazel run.
The version was also inconsistent with the protobuf dependency
version specified in pip_package/setup.py.

This change fixes those inconsistencies.
It also makes the protobuf version consistent with tensorboard.

Also in this change:
* Update grpcio version used by Travis CI.