### PR TITLE
Sort charts by (tag, run) not just (tag,)

### DIFF
--- a/tensorboard/components/tf_categorization_utils/BUILD
+++ b/tensorboard/components/tf_categorization_utils/BUILD
@@ -19,6 +19,7 @@ ts_web_library(
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/vz_sorting",
         "@org_polymer_iron_collapse",
     ],
 )

--- a/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
+++ b/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {compareTagNames} from '../vz-sorting/sorting.js';
 import {getTags} from '../tf-backend/backend.js';
 
 /**
@@ -130,6 +131,14 @@ export function categorizeTags(
   }));
 }
 
+function compareTagRun(a, b: {tag: string, run: string}): number {
+  const c = compareTagNames(a.tag, b.tag);
+  if (c != 0) {
+    return c;
+  }
+  return compareTagNames(a.run, b.run);
+}
+
 export function categorizeRunTagCombinations(
     runToTag: RunToTag,
     selectedRuns: string[],
@@ -139,6 +148,7 @@ export function categorizeRunTagCombinations(
   function explodeCategory(tagCategory: TagCategory): RunTagCategory {
     const items = _.flatten(tagCategory.items.map(
       ({tag, runs}) => runs.map(run => ({tag, run}))));
+    items.sort(compareTagRun);
     return {
       name: tagCategory.name,
       metadata: tagCategory.metadata,


### PR DESCRIPTION
Previously the ordering of tags with the same name was undefined. This change
causes the dashboards to look pretty much the same, except without the subtle
sorting issue.