### PR TITLE
Add a mapping from plugin name to instance

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -110,16 +110,17 @@ def standard_tensorboard_wsgi(
       schema = db.Schema(db_conn)
       schema.create_tables()
       schema.create_indexes()
+  plugin_name_to_instance = {}
   context = base_plugin.TBContext(
       db_module=db_module,
       db_connection_provider=db_connection_provider,
       logdir=logdir,
       multiplexer=multiplexer,
-      assets_zip_provider=assets_zip_provider)
+      assets_zip_provider=assets_zip_provider,
+      plugin_name_to_instance=plugin_name_to_instance)
   plugin_instances = [constructor(context) for constructor in plugins]
-  context.plugin_name_to_instance = {
-      plugin_instance.plugin_name: plugin_instance
-      for plugin_instance in plugin_instances}
+  for plugin_instance in plugin_instances:
+    plugin_name_to_instance[plugin_instance.plugin_name] = plugin_instance
   return TensorBoardWSGIApp(
       logdir, plugin_instances, multiplexer, reload_interval, path_prefix)
 

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -116,9 +116,12 @@ def standard_tensorboard_wsgi(
       logdir=logdir,
       multiplexer=multiplexer,
       assets_zip_provider=assets_zip_provider)
-  plugins = [constructor(context) for constructor in plugins]
-  return TensorBoardWSGIApp(logdir, plugins, multiplexer, reload_interval,
-                            path_prefix)
+  plugin_instances = [constructor(context) for constructor in plugins]
+  context.plugin_name_to_instance = {
+      plugin_instance.plugin_name: plugin_instance
+      for plugin_instance in plugin_instances}
+  return TensorBoardWSGIApp(
+      logdir, plugin_instances, multiplexer, reload_interval, path_prefix)
 
 
 def TensorBoardWSGIApp(logdir, plugins, multiplexer, reload_interval,

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -340,6 +340,7 @@ class ParseEventFilesSpecTest(tf.test.TestCase):
 class TensorBoardPluginsTest(tf.test.TestCase):
 
   def setUp(self):
+    self.context = None
     plugins = [
         functools.partial(
             FakePlugin,

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -119,3 +119,10 @@ class TBContext(object):
     self.db_module = db_module
     self.logdir = logdir
     self.multiplexer = multiplexer
+
+    # A mapping between plugin name to instance. Plugins may use this property
+    # to access other plugins. The context object is passed to plugins during
+    # their construction, so a given plugin may be absent from this mapping
+    # until it is registered. Plugin logic should handle cases in which a plugin
+    # is absent from this mapping, lest a KeyError is raised.
+    self.plugin_name_to_instance = {}

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -87,7 +87,8 @@ class TBContext(object):
       db_connection_provider=None,
       db_module=None,
       logdir=None,
-      multiplexer=None):
+      multiplexer=None,
+      plugin_name_to_instance=None):
     """Instantiates magic container.
 
     The argument list is sorted and may be extended in the future; therefore,
@@ -113,16 +114,16 @@ class TBContext(object):
       logdir: The string logging directory TensorBoard was started with.
       multiplexer: An EventMultiplexer with underlying TB data. Plugins should
           copy this data over to the database when the db fields are set.
+      plugin_name_to_instance: A mapping between plugin name to instance.
+          Plugins may use this property to access other plugins. The context
+          object is passed to plugins during their construction, so a given
+          plugin may be absent from this mapping until it is registered. Plugin
+          logic should handle cases in which a plugin is absent from this
+          mapping, lest a KeyError is raised.
     """
     self.assets_zip_provider = assets_zip_provider
     self.db_connection_provider = db_connection_provider
     self.db_module = db_module
     self.logdir = logdir
     self.multiplexer = multiplexer
-
-    # A mapping between plugin name to instance. Plugins may use this property
-    # to access other plugins. The context object is passed to plugins during
-    # their construction, so a given plugin may be absent from this mapping
-    # until it is registered. Plugin logic should handle cases in which a plugin
-    # is absent from this mapping, lest a KeyError is raised.
-    self.plugin_name_to_instance = {}
+    self.plugin_name_to_instance = plugin_name_to_instance


### PR DESCRIPTION
Specifically, we add a `plugin_name_to_instance` dictionary property to
the context magic container passed to all plugins during construction.

Fixes #658.