### PR TITLE
Change TextPlugin to compute index_impl() asynchronously

### DIFF
--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -279,13 +279,15 @@ class ProjectorPlugin(base_plugin.TBPlugin):
     # The plugin is currently not active. The frontend might check again later.
     # For now, spin off a separate thread to determine whether the plugin is
     # active.
-    new_thread = threading.Thread(target=self._determine_is_active)
+    new_thread = threading.Thread(
+        target=self._determine_is_active,
+        name='ProjectorPluginIsActiveThread')
     self._thread_for_determining_is_active = new_thread
     new_thread.start()
     return False
 
   def _determine_is_active(self):
-    """Determines whether the thread is active.
+    """Determines whether the plugin is active.
 
     This method is run in a separate thread so that the plugin can offer an
     immediate response to whether it is active and determine whether it should

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -21,6 +21,8 @@ from __future__ import print_function
 import collections
 import json
 import textwrap
+import threading
+import time
 
 # pylint: disable=g-bad-import-order
 # Necessary for an internal test with special behavior for numpy.
@@ -203,6 +205,66 @@ class TextPlugin(base_plugin.TBPlugin):
     """
     self._multiplexer = context.multiplexer
 
+    # Cache the last result of index_impl() so that methods that depend on it
+    # can return without blocking (while kicking off a background thread to
+    # recompute the current index).
+    self._index_cached = None
+
+    # Lock that ensures that only one thread attempts to compute index_impl()
+    # at a given time, since it's expensive.
+    self._index_impl_lock = threading.Lock()
+
+    # Pointer to the current thread computing index_impl(), if any.  This is
+    # stored on TextPlugin only to facilitate testing.
+    self._index_impl_thread = None
+
+  def is_active(self):
+    """Determines whether this plugin is active.
+
+    This plugin is only active if TensorBoard sampled any text summaries.
+
+    Returns:
+      Whether this plugin is active.
+    """
+    if not self._multiplexer:
+      return False
+
+    if self._index_cached is not None:
+      # If we already have computed the index, use it to determine whether
+      # the plugin should be active, and if so, return immediately.
+      if any(self._index_cached.values()):
+        return True
+
+    # We haven't conclusively determined if the plugin should be active. Launch
+    # a thread to compute index_impl() and return False to avoid blocking.
+    self._maybe_launch_index_impl_thread()
+    return False
+
+  def _maybe_launch_index_impl_thread(self):
+    """Attempts to launch a thread to compute index_impl().
+
+    This may not launch a new thread if one is already running to compute
+    index_impl(); in that case, this function is a no-op.
+    """
+    # Try to acquire the lock for computing index_impl(), without blocking.
+    if self._index_impl_lock.acquire(False):
+      # We got the lock. Start the thread, which will unlock the lock when done.
+      self._index_impl_thread = threading.Thread(
+          target=self._async_index_impl,
+          name='TextPluginIndexImplThread')
+      self._index_impl_thread.start()
+
+  def _async_index_impl(self):
+    """Computes index_impl() asynchronously on a separate thread."""
+    start = time.time()
+    tf.logging.info('TextPlugin computing index_impl() in a new thread')
+    self._index_cached = self.index_impl()
+    self._index_impl_lock.release()
+    self._index_impl_thread = None
+    elapsed = time.time() - start
+    tf.logging.info(
+        'TextPlugin index_impl() thread ending after %0.3f sec', elapsed)
+
   def index_impl(self):
     # A previous system of collecting and serving text summaries involved
     # storing the tags of text summaries within tensors.json files. See if we
@@ -231,13 +293,19 @@ class TextPlugin(base_plugin.TBPlugin):
       run_to_series[run] += tags.keys()
     return run_to_series
 
+  def tags_impl(self):
+    # Recompute the index on demand whenever tags are requested, but do it
+    # in a separate thread to avoid blocking.
+    self._maybe_launch_index_impl_thread()
+
+    # Use the cached index if present; if it's not, this route shouldn't have
+    # been reached anyway (since the plugin should be saying it's inactive)
+    # so just return an empty response.
+    return self._index_cached if self._index_cached else {}
+
   @wrappers.Request.application
   def tags_route(self, request):
-    # Map from run to a list of tags.
-    response = {
-        run: tag_listing
-        for (run, tag_listing) in self.index_impl().items()
-    }
+    response = self.tags_impl()
     return http_util.Respond(request, response, 'application/json')
 
   def text_impl(self, run, tag):
@@ -260,13 +328,3 @@ class TextPlugin(base_plugin.TBPlugin):
         TAGS_ROUTE: self.tags_route,
         TEXT_ROUTE: self.text_route,
     }
-
-  def is_active(self):
-    """Determines whether this plugin is active.
-
-    This plugin is only active if TensorBoard sampled any text summaries.
-
-    Returns:
-      Whether this plugin is active.
-    """
-    return bool(self._multiplexer and any(self.index_impl().values()))

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -259,8 +259,8 @@ class TextPlugin(base_plugin.TBPlugin):
     start = time.time()
     tf.logging.info('TextPlugin computing index_impl() in a new thread')
     self._index_cached = self.index_impl()
-    self._index_impl_lock.release()
     self._index_impl_thread = None
+    self._index_impl_lock.release()
     elapsed = time.time() - start
     tf.logging.info(
         'TextPlugin index_impl() thread ending after %0.3f sec', elapsed)

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -88,10 +88,7 @@ class TextPluginTest(tf.test.TestCase):
   def testIndex(self):
     index = self.plugin.index_impl()
     self.assertItemsEqual(['fry', 'leela'], index.keys())
-    # The summary made via plugin assets (the old method being phased out) is
-    # only available for run 'fry'.
-    self.assertItemsEqual(['message', 'vector'],
-                          index['fry'])
+    self.assertItemsEqual(['message', 'vector'], index['fry'])
     self.assertItemsEqual(['message', 'vector'], index['leela'])
 
   def testText(self):
@@ -322,12 +319,41 @@ class TextPluginTest(tf.test.TestCase):
       </table>""")
     self.assertEqual(convert(d3), d3_expected)
 
+  def assertIsActive(self, plugin, expected_is_active):
+    """Helper to simulate threading for asserting on is_active()."""
+    patcher = tf.test.mock.patch('threading.Thread.start', autospec=True)
+    mock = patcher.start()
+    self.addCleanup(patcher.stop)
+
+    # Initial response from is_active() is always False.
+    self.assertFalse(plugin.is_active())
+    thread = plugin._index_impl_thread
+    mock.assert_called_once_with(thread)
+
+    # The thread hasn't run yet, so is_active() should still be False, and we
+    # should not have tried to launch a second thread.
+    self.assertFalse(plugin.is_active())
+    mock.assert_called_once_with(thread)
+
+    # Run the thread; it should clean up after itself.
+    thread.run()
+    self.assertIsNone(plugin._index_impl_thread)
+
+    if expected_is_active:
+      self.assertTrue(plugin.is_active())
+      # The call above shouldn't have launched a new thread.
+      mock.assert_called_once_with(thread)
+    else:
+      self.assertFalse(plugin.is_active())
+      # The call above should have launched a second thread to check again.
+      self.assertEqual(2, mock.call_count)
+
   def testPluginIsActiveWhenNoRuns(self):
     """The plugin should be inactive when there are no runs."""
     multiplexer = event_multiplexer.EventMultiplexer()
     context = base_plugin.TBContext(logdir=None, multiplexer=multiplexer)
     plugin = text_plugin.TextPlugin(context)
-    self.assertFalse(plugin.is_active())
+    self.assertIsActive(plugin, False)
 
   def testPluginIsActiveWhenTextRuns(self):
     """The plugin should be active when there are runs with text."""
@@ -336,7 +362,7 @@ class TextPluginTest(tf.test.TestCase):
     plugin = text_plugin.TextPlugin(context)
     multiplexer.AddRunsFromDirectory(self.logdir)
     multiplexer.Reload()
-    self.assertTrue(plugin.is_active())
+    self.assertIsActive(plugin, True)
 
   def testPluginIsActiveWhenRunsButNoText(self):
     """The plugin should be inactive when there are runs but none has text."""
@@ -347,7 +373,31 @@ class TextPluginTest(tf.test.TestCase):
     self.generate_testdata(include_text=False, logdir=logdir)
     multiplexer.AddRunsFromDirectory(logdir)
     multiplexer.Reload()
-    self.assertFalse(plugin.is_active())
+    self.assertIsActive(plugin, False)
+
+  def testPluginTagsImpl(self):
+    patcher = tf.test.mock.patch('threading.Thread.start', autospec=True)
+    mock = patcher.start()
+    self.addCleanup(patcher.stop)
+
+    # Initially we have not computed index_impl() so we'll get the placeholder.
+    self.assertEqual({}, self.plugin.tags_impl())
+    thread = self.plugin._index_impl_thread
+    mock.assert_called_once_with(thread)
+
+    # The thread hasn't run yet, so no change in response, and we should not
+    # have tried to launch a second thread.
+    self.assertEqual({}, self.plugin.tags_impl())
+    mock.assert_called_once_with(thread)
+
+    # Run the thread; it should clean up after itself.
+    thread.run()
+    self.assertIsNone(self.plugin._index_impl_thread)
+
+    # Expect response to be identical to calling index_impl() directly.
+    self.assertEqual(self.plugin.index_impl(), self.plugin.tags_impl())
+    # The call above should have launched a second thread to check again.
+    self.assertEqual(2, mock.call_count)
 
 
 class TextPluginBackwardsCompatibilityTest(tf.test.TestCase):


### PR DESCRIPTION
Addresses tensorflow/tensorboard#625 by changing TextPlugin to avoid blocking its `is_active()` method on reading from the filesystem.  Note that "reading from the filesystem" is not only reading once, but reading in all plugin assets from all runs, which could be dozens of reads per run, potentially over the network if using a remote filesystem.  In my testing this could easily cause `is_active()` to take 30+ seconds that kind of scenario, which in turn blocks the `/plugins_listing` response for the whole of TensorBoard.

Since the TextPlugin's `is_active()` is based on its `index_impl()` (which backs its `/tags` route) and the expensive filesystem-checking logic is shared, this change puts the entirety of `index_impl()` on a background thread.  This way the `/tags` route can also benefit from not blocking.

The semantics are now that `is_active()` will return False and `index_impl()` will return a placeholder empty response when first invoked, but they'll kick off at most one background thread at a time to do the computation and store the resulting index response.  Once the plugin is detected to be active, `is_active()` will no longer kick off new background threads when invoked, but `index_impl()` will still kick off a new background thread when called (if one is not running already) so that refreshes will pick up new data as it gets written to the logdir.

