### PR TITLE
Prototype the custom-scalars plugin.

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -53,6 +53,7 @@ py_library(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins/audio:audio_plugin",
         "//tensorboard/plugins/core:core_plugin",
+        "//tensorboard/plugins/custom_scalar:custom_scalars_plugin",
         "//tensorboard/plugins/debugger:debugger_plugin_loader",
         "//tensorboard/plugins/distribution:distributions_plugin",
         "//tensorboard/plugins/graph:graphs_plugin",
@@ -292,6 +293,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/plugins/audio:summary",
+        "//tensorboard/plugins/custom_scalar:summary",
         "//tensorboard/plugins/histogram:summary",
         "//tensorboard/plugins/image:summary",
         "//tensorboard/plugins/pr_curve:summary",

--- a/tensorboard/components/tf_categorization_utils/tf-category-pane.html
+++ b/tensorboard/components/tf_categorization_utils/tf-category-pane.html
@@ -130,6 +130,7 @@ limitations under the License.
         opened: {
           type: Boolean,
           value: true,
+          notify: true,
         },
 
         /**

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -41,6 +41,7 @@ limitations under the License.
         default-x-range="[[defaultXRange]]"
         default-y-range="[[defaultYRange]]"
         fill-area="[[fillArea]]"
+        symbol-function="[[symbolFunction]]"
       ></vz-line-chart>
       <template is="dom-if" if="[[_loading]]">
         <div id="loading-spinner-container">
@@ -135,6 +136,8 @@ limitations under the License.
 
         defaultXRange: Array,
         defaultYRange: Array,
+
+        symbolFunction: Object,
 
         /**
          * A function that takes as inputs:

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -52,6 +52,7 @@ ts_web_library(
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/plugins/audio/tf_audio_dashboard",
+        "//tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard",
         "//tensorboard/plugins/distribution/tf_distribution_dashboard",
         "//tensorboard/plugins/graph/tf_graph_dashboard",
         "//tensorboard/plugins/histogram/tf_histogram_dashboard",

--- a/tensorboard/components/tf_tensorboard/default-plugins.html
+++ b/tensorboard/components/tf_tensorboard/default-plugins.html
@@ -26,6 +26,7 @@ limitations under the License.
   ordering of tabs in TensorBoard's GUI.
 -->
 <link rel="import" href="../tf-scalar-dashboard/tf-scalar-dashboard.html">
+<link rel="import" href="../tf-custom-scalar-dashboard/tf-custom-scalar-dashboard.html">
 <link rel="import" href="../tf-image-dashboard/tf-image-dashboard.html">
 <link rel="import" href="../tf-audio-dashboard/tf-audio-dashboard.html">
 <link rel="import" href="../tf-graph-dashboard/tf-graph-dashboard.html">

--- a/tensorboard/components/vz_line_chart/vz-chart-helpers.ts
+++ b/tensorboard/components/vz_line_chart/vz-chart-helpers.ts
@@ -27,6 +27,42 @@ export type ScalarDatum = Datum & Scalar;
 
 export type DataFn = (run: string, tag: string) => Promise<Array<Datum>>;
 
+export interface LineChartSymbol {
+  // A single unicode character string representing the symbol. Maybe a diamond
+  // unicode character for instance. 
+  character: string;
+  // A special method used by Plottable to draw the symbol in the line chart.
+  method: (() => Plottable.SymbolFactories.SymbolFactory);
+}
+
+/**
+ * A list of symbols that line charts can cycle through per data series.
+ */
+export const SYMBOLS_LIST: LineChartSymbol[] = [
+  {
+    character: '\u25FC',
+    method: Plottable.SymbolFactories.square,
+  },
+  {
+    character: '\u25c6',
+    method: Plottable.SymbolFactories.diamond,
+  },
+  {
+    character: '\u25B2',
+    method: Plottable.SymbolFactories.triangle,
+  },
+  {
+    character: '\u2605',
+    method: Plottable.SymbolFactories.star,
+  },
+  {
+    character: '\u271a',
+    method: Plottable.SymbolFactories.cross,
+  },
+];
+
+export type SymbolFn = (series: string) => Plottable.SymbolFactory;
+
 export let Y_TOOLTIP_FORMATTER_PRECISION = 4;
 export let STEP_FORMATTER_PRECISION = 4;
 export let Y_AXIS_FORMATTER_PRECISION = 3;

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -34,6 +34,7 @@ import tensorflow as tf
 
 from tensorboard.plugins.audio import audio_plugin
 from tensorboard.plugins.core import core_plugin
+from tensorboard.plugins.custom_scalar import custom_scalars_plugin
 from tensorboard.plugins.distribution import distributions_plugin
 from tensorboard.plugins.graph import graphs_plugin
 from tensorboard.plugins.debugger import debugger_plugin_loader
@@ -57,6 +58,7 @@ def get_plugins():
   plugins = [
       core_plugin.CorePlugin,
       scalars_plugin.ScalarsPlugin,
+      custom_scalars_plugin.CustomScalarsPlugin,
       images_plugin.ImagesPlugin,
       audio_plugin.AudioPlugin,
       graphs_plugin.GraphsPlugin,

--- a/tensorboard/plugins/custom_scalar/BUILD
+++ b/tensorboard/plugins/custom_scalar/BUILD
@@ -1,0 +1,87 @@
+# Description:
+# TensorBoard plugin for custom scalars plots
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])  # Apache 2.0
+
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
+exports_files(["LICENSE"])
+
+## Custom Scalars Plugin ##
+py_library(
+    name = "custom_scalars_plugin",
+    srcs = ["custom_scalars_plugin.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":metadata",
+        ":protos_all_py_pb2",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:plugin_util",
+        "//tensorboard/backend:http_util",
+        "//tensorboard/plugins:base_plugin",
+        "//tensorboard/plugins/scalar:metadata",
+        "//tensorboard/plugins/scalar:scalars_plugin",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
+    ],
+)
+
+py_library(
+    name = "metadata",
+    srcs = ["metadata.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "summary",
+    srcs = ["summary.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":metadata",
+        ":protos_all_py_pb2",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_test(
+    name = "summary_test",
+    size = "small",
+    srcs = ["summary_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":summary",
+        ":metadata",
+        ":protos_all_py_pb2",
+        "//tensorboard/backend:application",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_test(
+    name = "custom_scalars_plugin_test",
+    size = "small",
+    srcs = ["custom_scalars_plugin_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":custom_scalars_plugin",
+        ":summary",
+        ":protos_all_py_pb2",
+        "//tensorboard/backend:application",
+        "//tensorboard/plugins:base_plugin",
+        "//tensorboard/plugins/scalar:scalars_plugin",
+        "//tensorboard/plugins/scalar:summary",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+tb_proto_library(
+    name = "protos_all",
+    srcs = ["layout.proto"],
+    visibility = ["//visibility:public"],
+)

--- a/tensorboard/plugins/custom_scalar/__init__.py
+++ b/tensorboard/plugins/custom_scalar/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
@@ -1,0 +1,327 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""The TensorBoard Custom Scalars plugin.
+
+This plugin lets the user create scalars plots with custom run-tag combinations
+by specifying regular expressions.
+
+See `http_api.md` in this directory for specifications of the routes for
+this plugin.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import re
+
+from google.protobuf import json_format
+import numpy as np
+import tensorflow as tf
+from werkzeug import wrappers
+
+from tensorboard.backend import http_util
+from tensorboard.plugins import base_plugin
+from tensorboard.plugins.custom_scalar import layout_pb2
+from tensorboard.plugins.custom_scalar import metadata
+from tensorboard.plugins.scalar import metadata as scalars_metadata
+from tensorboard.plugins.scalar import scalars_plugin
+
+# The name of the property in the response for whether the regex is valid.
+_REGEX_VALID_PROPERTY = 'regex_valid'
+
+# The name of the property in the response for the payload (tag to ScalarEvents
+# mapping).
+_TAG_TO_EVENTS_PROPERTY = 'tag_to_events'
+
+# The number of seconds to wait in between checks for the config file specifying
+# layout.
+_CONFIG_FILE_CHECK_THROTTLE = 60
+
+
+class CustomScalarsPlugin(base_plugin.TBPlugin):
+  """CustomScalars Plugin for TensorBoard."""
+
+  plugin_name = metadata.PLUGIN_NAME
+
+  def __init__(self, context):
+    """Instantiates ScalarsPlugin via TensorBoard core.
+
+    Args:
+      context: A base_plugin.TBContext instance.
+    """
+    self._logdir = context.logdir
+    self._multiplexer = context.multiplexer
+    self._plugin_name_to_instance = context.plugin_name_to_instance
+
+  def _get_scalars_plugin(self):
+    """Tries to get the scalars plugin.
+
+    Returns:
+      The scalars plugin. Or None if it is not yet registered.
+    """
+    if scalars_metadata.PLUGIN_NAME in self._plugin_name_to_instance:
+      # The plugin is registered.
+      return self._plugin_name_to_instance[scalars_metadata.PLUGIN_NAME]
+    # The plugin is not yet registered.
+    return None
+
+  def get_plugin_apps(self):
+    return {
+        '/download_data': self.download_data_route,
+        '/layout': self.layout_route,
+        '/scalars': self.scalars_route,
+    }
+
+  def is_active(self):
+    """This plugin is active if 2 conditions hold.
+
+    1. The scalars plugin is registered and active.
+    2. There is a custom layout for the dashboard.
+    """
+    scalars_plugin_instance = self._get_scalars_plugin()
+    if not (scalars_plugin_instance and
+            scalars_plugin_instance.is_active()):
+      return False
+
+    for run in self._multiplexer.Runs():
+      try:
+        self._multiplexer.Tensors(run, metadata.CONFIG_SUMMARY_TAG)
+      except KeyError:
+        continue
+      return True
+
+    return False
+
+  @wrappers.Request.application
+  def download_data_route(self, request):
+    run = request.args.get('run')
+    tag = request.args.get('tag')
+    response_format = request.args.get('format')
+    try:
+      body, mime_type = self.download_data_impl(run, tag, response_format)
+    except ValueError as e:
+      return http_util.Respond(
+          request=request,
+          content=str(e),
+          content_type='text/plain',
+          code=500)
+    return http_util.Respond(request, body, mime_type)
+
+  def download_data_impl(self, run, tag, response_format):
+    """Provides a response for downloading scalars data for a data series.
+
+    Args:
+      run: The run.
+      tag: The specific tag.
+      response_format: A string. One of the values of the OutputFormat enum of
+        the scalar plugin.
+
+    Raises:
+      ValueError: If the scalars plugin is not registered.
+
+    Returns:
+      2 entities:
+        - A JSON object response body.
+        - A mime type (string) for the response.
+    """
+    scalars_plugin_instance = self._get_scalars_plugin()
+    if not scalars_plugin_instance:
+      raise ValueError(('Failed to respond to request for /download_data. '
+                        'The scalars plugin is oddly not registered.'))
+
+    body, mime_type = scalars_plugin_instance.scalars_impl(
+        tag, run, response_format)
+    return body, mime_type
+
+  @wrappers.Request.application
+  def scalars_route(self, request):
+    """Given a tag regex and single run, return ScalarEvents.
+
+    This route takes 2 GET params:
+    run: A run string to find tags for.
+    tag: A string that is a regex used to find matching tags.
+    The response is a JSON object:
+    {
+      // Whether the regular expression is valid. Also false if empty.
+      regexValid: boolean,
+
+      // An object mapping tag name to a list of ScalarEvents.
+      payload: Object<string, ScalarEvent[]>,
+    }
+    """
+    # TODO: return HTTP status code for malformed requests
+    tag_regex_string = request.args.get('tag')
+    run = request.args.get('run')
+    mime_type = 'application/json'
+
+    try:
+      body = self.scalars_impl(run, tag_regex_string)
+    except ValueError as e:
+      return http_util.Respond(
+          request=request,
+          content=str(e),
+          content_type='text/plain',
+          code=500)
+
+    # Produce the response.
+    return http_util.Respond(request, body, mime_type)
+
+  def scalars_impl(self, run, tag_regex_string):
+    """Given a tag regex and single run, return ScalarEvents.
+
+    Args:
+      run: A run string.
+      tag_regex_string: A regular expression that captures portions of tags.
+
+    Raises:
+      ValueError: if the scalars plugin is not registered.
+
+    Returns:
+      A dictionary that is the JSON-able response.
+    """
+    if not tag_regex_string:
+      # The user provided no regex.
+      return {
+          _REGEX_VALID_PROPERTY: False,
+          _TAG_TO_EVENTS_PROPERTY: {},
+      }
+
+    # Construct the regex.
+    try:
+      regex = re.compile(tag_regex_string)
+    except re.error:
+      return {
+          _REGEX_VALID_PROPERTY: False,
+          _TAG_TO_EVENTS_PROPERTY: {},
+      }
+
+    # Fetch the tags for the run. Filter for tags that match the regex.
+    run_to_data = self._multiplexer.PluginRunToTagToContent(
+        scalars_metadata.PLUGIN_NAME)
+
+    tag_to_data = None
+    try:
+      tag_to_data = run_to_data[run]
+    except KeyError:
+      # The run could not be found. Perhaps a configuration specified a run that
+      # TensorBoard has not read from disk yet.
+      payload = {}
+
+    if tag_to_data:
+      scalars_plugin_instance = self._get_scalars_plugin()
+      if not scalars_plugin_instance:
+        raise ValueError(('Failed to respond to request for /scalars. '
+                          'The scalars plugin is oddly not registered.'))
+
+      form = scalars_plugin.OutputFormat.JSON
+      payload = {tag: scalars_plugin_instance.scalars_impl(tag, run, form)[0]
+                 for tag in tag_to_data.keys()
+                 if regex.match(tag)}
+
+    return {
+        _REGEX_VALID_PROPERTY: True,
+        _TAG_TO_EVENTS_PROPERTY: payload,
+    }
+
+  @wrappers.Request.application
+  def layout_route(self, request):
+    r"""Fetches the custom layout specified by the config file in the logdir.
+
+    If more than 1 run contains a layout, this method merges the layouts by
+    merging charts within individual categories. If 2 categories with the same
+    name are found, the charts within are merged. The merging is based on the
+    order of the runs to which the layouts are written.
+
+    The response is a JSON object mirroring properties of the Layout proto if a
+    layout for any run is found:
+
+    {
+      categories: [
+        {
+          title: 'Biases',
+          chart: [
+            {
+              title: 'biases',
+              tag: 'foo/layer\d+/biases'
+            },
+            {
+              title: 'biases',
+              tag: 'foo/logits/biases'
+            },
+          ],
+        },
+        {
+          title: 'Activations',
+          chart: [
+            {
+              title: 'activations',
+              tag: 'foo/layer0/activations',
+            },
+          ],
+        },
+      ],
+    }
+
+    The response is an empty object if no layout could be found.
+    """
+    body = self.layout_impl()
+    return http_util.Respond(request, body, 'application/json')
+
+  def layout_impl(self):
+    # Keep a mapping between and category so we do not create duplicate
+    # categories.
+    title_to_category = {}
+
+    merged_layout = None
+    runs = list(self._multiplexer.Runs())
+    runs.sort()
+    for run in runs:
+      try:
+        tensor_events = self._multiplexer.Tensors(
+            run, metadata.CONFIG_SUMMARY_TAG)
+      except KeyError:
+        # This run lacks a layout.
+        continue
+
+      # This run has a layout. Merge it with the ones currently found.
+      string_array = tf.make_ndarray(tensor_events[0].tensor_proto)
+      content = np.asscalar(string_array)
+      layout_proto = layout_pb2.Layout()
+      layout_proto.ParseFromString(tf.compat.as_bytes(content))
+
+      if merged_layout:
+        # Append the categories within this layout to the merged layout.
+        for category in layout_proto.category:
+          if category.title in title_to_category:
+            # A category with this name has been seen before. Do not create a
+            # new one. Merge their charts.
+            title_to_category[category.title].chart.extend(category.chart)
+          else:
+            # This category has not been seen before.
+            merged_layout.category.add().MergeFrom(category)
+            title_to_category[category.title] = category
+      else:
+        # This is the first layout encountered.
+        merged_layout = layout_proto
+        for category in layout_proto.category:
+          title_to_category[category.title] = category
+
+    if merged_layout:
+      return json_format.MessageToJson(
+          merged_layout, including_default_value_fields=True)
+    else:
+      # No layout was found.
+      return {}

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Integration tests for the Custom Scalars Plugin."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+import numpy as np
+import tensorflow as tf
+
+from google.protobuf import json_format
+from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
+from tensorboard.plugins import base_plugin
+from tensorboard.plugins.custom_scalar import custom_scalars_plugin
+from tensorboard.plugins.custom_scalar import layout_pb2
+from tensorboard.plugins.custom_scalar import summary
+from tensorboard.plugins.scalar import scalars_plugin
+from tensorboard.plugins.scalar import summary as scalar_summary
+
+
+class CustomScalarsPluginTest(tf.test.TestCase):
+
+  def __init__(self, *args, **kwargs):
+    super(CustomScalarsPluginTest, self).__init__(*args, **kwargs)
+    self.logdir = os.path.join(self.get_temp_dir(), 'logdir')
+    os.makedirs(self.logdir)
+
+    self.logdir_layout = layout_pb2.Layout(
+        category=[
+            layout_pb2.Category(
+                title='cross entropy',
+                chart=[
+                    layout_pb2.Chart(
+                        title='cross entropy',
+                        tag=[r'cross entropy']),
+                ],
+                closed=True)
+            ]
+    )
+    self.foo_layout = layout_pb2.Layout(
+        category=[
+            layout_pb2.Category(
+                title='mean biases',
+                chart=[
+                    layout_pb2.Chart(
+                        title='mean layer biases',
+                        tag=[r'mean/layer0/biases', r'mean/layer1/biases'])
+                ]),
+            layout_pb2.Category(
+                title='std weights',
+                chart=[
+                    layout_pb2.Chart(
+                        title='stddev layer weights',
+                        tag=[r'stddev/layer\d+/weights'])
+                    ]),
+            # A category with this name is also present in a layout for a
+            # different run (the logdir run)
+            layout_pb2.Category(
+                title='cross entropy',
+                chart=[
+                    layout_pb2.Chart(
+                        title='cross entropy 2',
+                        tag=[r'cross entropy 2']),
+                ])
+            ]
+    )
+
+    # Generate test data.
+    with tf.summary.FileWriter(os.path.join(self.logdir, 'foo')) as writer:
+      writer.add_summary(summary.pb(self.foo_layout))
+      for step in range(4):
+        writer.add_summary(scalar_summary.pb('squares', step * step), step)
+
+    with tf.summary.FileWriter(os.path.join(self.logdir, 'bar')) as writer:
+      for step in range(3):
+        writer.add_summary(scalar_summary.pb('increments', step + 1), step)
+
+    # The '.' run lacks scalar data but has a layout.
+    with tf.summary.FileWriter(self.logdir) as writer:
+      writer.add_summary(summary.pb(self.logdir_layout))
+
+    self.plugin = self.createPlugin(self.logdir)
+
+  def createPlugin(self, logdir):
+    multiplexer = event_multiplexer.EventMultiplexer()
+    multiplexer.AddRunsFromDirectory(logdir)
+    multiplexer.Reload()
+    plugin_name_to_instance = {}
+    context = base_plugin.TBContext(
+        logdir=logdir,
+        multiplexer=multiplexer,
+        plugin_name_to_instance=plugin_name_to_instance)
+    scalars_plugin_instance = scalars_plugin.ScalarsPlugin(context)
+    custom_scalars_plugin_instance = custom_scalars_plugin.CustomScalarsPlugin(
+        context)
+    plugin_instances = [scalars_plugin_instance, custom_scalars_plugin_instance]
+    for plugin_instance in plugin_instances:
+      plugin_name_to_instance[plugin_instance.plugin_name] = plugin_instance
+    return custom_scalars_plugin_instance
+
+  def testDownloadData(self):
+    body, mime_type = self.plugin.download_data_impl(
+        'foo', 'squares/scalar_summary', 'json')
+    self.assertEqual('application/json', mime_type)
+    self.assertEqual(4, len(body))
+    for step, entry in enumerate(body):
+      # The time stamp should be reasonable.
+      self.assertGreater(entry[0], 0)
+      self.assertEqual(step, entry[1])
+      np.testing.assert_allclose(step * step, entry[2])
+
+  def testScalars(self):
+    body = self.plugin.scalars_impl('bar', 'increments')
+    self.assertTrue(body['regex_valid'])
+    self.assertItemsEqual(
+        ['increments/scalar_summary'], list(body['tag_to_events'].keys()))
+    data = body['tag_to_events']['increments/scalar_summary']
+    for step, entry in enumerate(data):
+      # The time stamp should be reasonable.
+      self.assertGreater(entry[0], 0)
+      self.assertEqual(step, entry[1])
+      np.testing.assert_allclose(step + 1, entry[2])
+
+  def testMergedLayout(self):
+    parsed_layout = layout_pb2.Layout()
+    json_format.Parse(self.plugin.layout_impl(), parsed_layout)
+    correct_layout = layout_pb2.Layout(
+        category=[
+            layout_pb2.Category(
+                title='cross entropy',
+                chart=[
+                    # Note that the "cross entropy 2" chart from layout for run
+                    # foo is now merged within the existing "cross entropy"
+                    # category because the categories have the same names.
+                    layout_pb2.Chart(
+                        title='cross entropy',
+                        tag=[r'cross entropy']),
+                    layout_pb2.Chart(
+                        title='cross entropy 2',
+                        tag=[r'cross entropy 2']),
+                ],
+                closed=True),
+            layout_pb2.Category(
+                title='mean biases',
+                chart=[
+                    layout_pb2.Chart(
+                        title='mean layer biases',
+                        tag=[r'mean/layer0/biases', r'mean/layer1/biases'])
+                ]),
+            layout_pb2.Category(
+                title='std weights',
+                chart=[
+                    layout_pb2.Chart(
+                        title='stddev layer weights',
+                        tag=[r'stddev/layer\d+/weights'])
+                    ]),
+            ]
+    )
+    self.assertProtoEquals(correct_layout, parsed_layout)
+
+  def testLayoutFromSingleRun(self):
+    # The foo directory contains 1 single layout.
+    local_plugin = self.createPlugin(os.path.join(self.logdir, 'foo'))
+    parsed_layout = layout_pb2.Layout()
+    json_format.Parse(local_plugin.layout_impl(), parsed_layout)
+    self.assertProtoEquals(self.foo_layout, parsed_layout)
+
+  def testNoLayoutFound(self):
+    # The bar directory contains no layout.
+    local_plugin = self.createPlugin(os.path.join(self.logdir, 'bar'))
+    self.assertDictEqual({}, local_plugin.layout_impl())
+
+  def testIsActive(self):
+    self.assertTrue(self.plugin.is_active())
+
+  def testIsNotActiveDueToNoLayout(self):
+    # The bar directory contains scalar data but no layout.
+    local_plugin = self.createPlugin(os.path.join(self.logdir, 'bar'))
+    self.assertFalse(local_plugin.is_active())
+
+  def testIsNotActiveDueToNoScalarsData(self):
+    # Generate a directory with a layout but no scalars data.
+    directory = os.path.join(self.logdir, 'no_scalars')
+    with tf.summary.FileWriter(directory) as writer:
+      writer.add_summary(summary.pb(self.logdir_layout))
+
+    local_plugin = self.createPlugin(directory)
+    self.assertFalse(local_plugin.is_active())
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/tensorboard/plugins/custom_scalar/layout.proto
+++ b/tensorboard/plugins/custom_scalar/layout.proto
@@ -1,0 +1,59 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+syntax = "proto3";
+
+package tensorboard;
+
+
+/**
+ * Encapsulates information on a single chart. Many charts appear in a category.
+ */
+message Chart {
+  // The title shown atop this chart. This field is optional and defaults to a
+  // comma-separated list of tag regular expressions.
+  string title = 1;
+
+  // A list of regular expressions for tags that should appear in this chart.
+  // Tags are matched based from beginning to end.
+  repeated string tag = 2;
+}
+
+/**
+ * A category contains a group of charts. Each category maps to a collapsible
+ * within the dashboard.
+ */
+message Category {
+  // This string appears atop each grouping of charts within the dashboard.
+  string title = 1;
+
+  // Encapsulates data on charts to be shown in the category.
+  repeated Chart chart = 2;
+
+  // Whether this category should be initially closed. False by default.
+  bool closed = 3;
+}
+
+/**
+ * A layout encapsulates how charts are laid out within the custom scalars
+ * dashboard.
+ */
+message Layout {
+  // Version `0` is the only supported version.
+  int32 version = 1;
+
+  // The categories here are rendered from top to bottom.
+  repeated Category category = 2;
+}

--- a/tensorboard/plugins/custom_scalar/metadata.py
+++ b/tensorboard/plugins/custom_scalar/metadata.py
@@ -1,0 +1,24 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Information on the custom scalars plugin."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# A special tag named used for the summary that stores the layout.
+CONFIG_SUMMARY_TAG = 'custom_scalars__config__'
+
+PLUGIN_NAME = 'custom_scalars'

--- a/tensorboard/plugins/custom_scalar/summary.py
+++ b/tensorboard/plugins/custom_scalar/summary.py
@@ -1,0 +1,77 @@
+
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Contains summaries related to laying out the custom scalars dashboard.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from tensorboard.plugins.custom_scalar import layout_pb2
+from tensorboard.plugins.custom_scalar import metadata
+
+def op(scalars_layout, collections=None):
+  """Creates a summary that contains a layout.
+
+  When users navigate to the custom scalars dashboard, they will see a layout
+  based on the proto provided to this function.
+
+  Args:
+    scalars_layout: The scalars_layout_pb2.Layout proto that specifies the
+        layout.
+    collections: Optional list of graph collections keys. The new
+        summary op is added to these collections. Defaults to
+        `[Graph Keys.SUMMARIES]`.
+
+  Returns:
+    A tensor summary op that writes the layout to disk.
+  """
+  assert isinstance(scalars_layout, layout_pb2.Layout)
+  return tf.summary.tensor_summary(name=metadata.CONFIG_SUMMARY_TAG,
+                                   tensor=tf.constant(
+                                       scalars_layout.SerializeToString(),
+                                       dtype=tf.string),
+                                   collections=collections,
+                                   summary_metadata=_create_summary_metadata())
+
+def pb(scalars_layout):
+  """Creates a summary that contains a layout.
+
+  When users navigate to the custom scalars dashboard, they will see a layout
+  based on the proto provided to this function.
+
+  Args:
+    scalars_layout: The scalars_layout_pb2.Layout proto that specifies the
+        layout.
+
+  Returns:
+    A summary proto containing the layout.
+  """
+  assert isinstance(scalars_layout, layout_pb2.Layout)
+  tensor = tf.make_tensor_proto(
+      scalars_layout.SerializeToString(), dtype=tf.string)
+  summary = tf.Summary()
+  summary.value.add(tag=metadata.CONFIG_SUMMARY_TAG,
+                    metadata=_create_summary_metadata(),
+                    tensor=tensor)
+  return summary
+
+def _create_summary_metadata():
+  return tf.SummaryMetadata(
+      plugin_data=tf.SummaryMetadata.PluginData(
+          plugin_name=metadata.PLUGIN_NAME))

--- a/tensorboard/plugins/custom_scalar/summary_test.py
+++ b/tensorboard/plugins/custom_scalar/summary_test.py
@@ -1,0 +1,92 @@
+
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the layout module."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+
+from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
+from tensorboard.plugins.custom_scalar import summary
+from tensorboard.plugins.custom_scalar import metadata
+from tensorboard.plugins.custom_scalar import layout_pb2
+
+
+class LayoutTest(tf.test.TestCase):
+
+  def setUp(self):
+    super(LayoutTest, self).setUp()
+    self.logdir = self.get_temp_dir()
+
+  def testSetLayout(self):
+    layout_proto_to_write = layout_pb2.Layout(
+        category=[
+            layout_pb2.Category(
+                title='mean biases',
+                chart=[
+                    layout_pb2.Chart(
+                        title='mean layer biases',
+                        tag=[r'mean/layer\d+/biases'])
+                ]),
+            layout_pb2.Category(
+                title='std weights',
+                chart=[
+                    layout_pb2.Chart(
+                        title='stddev layer weights',
+                        tag=[r'stddev/layer\d+/weights'])
+                    ]),
+            layout_pb2.Category(
+                title='cross entropy ... and maybe some other values',
+                chart=[
+                    layout_pb2.Chart(
+                        title='cross entropy',
+                        tag=[r'cross entropy']),
+                    layout_pb2.Chart(
+                        title='accuracy',
+                        tag=[r'accuracy']),
+                    layout_pb2.Chart(
+                        title='max layer weights',
+                        tag=[r'max/layer1/.*', r'max/layer2/.*'])
+                ],
+                closed=True)
+        ])
+
+    # Write the data as a summary for the '.' run.
+    with tf.Session() as s, tf.summary.FileWriter(self.logdir) as writer:
+      writer.add_summary(s.run(summary.op(layout_proto_to_write)))
+
+    # Read the data from disk.
+    multiplexer = event_multiplexer.EventMultiplexer()
+    multiplexer.AddRunsFromDirectory(self.logdir)
+    multiplexer.Reload()
+    tensor_events = multiplexer.Tensors('.', metadata.CONFIG_SUMMARY_TAG)
+    self.assertEqual(1, len(tensor_events))
+
+    # Parse the data.
+    string_array = tf.make_ndarray(tensor_events[0].tensor_proto)
+    content = np.asscalar(string_array)
+    layout_proto_from_disk = layout_pb2.Layout()
+    layout_proto_from_disk.ParseFromString(tf.compat.as_bytes(content))
+
+    # Verify the content.
+    self.assertProtoEquals(layout_proto_to_write, layout_proto_from_disk)
+
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/BUILD
@@ -1,0 +1,44 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "ts_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+ts_web_library(
+    name = "tf_custom_scalar_dashboard",
+    srcs = [
+        "tf-custom-scalar-card.html",
+        "tf-custom-scalar-dashboard.html",
+        "tf-custom-scalar-helpers.ts",
+    ],
+    path = "/tf-custom-scalar-dashboard",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_card_heading",
+        "//tensorboard/components/tf_categorization_utils",
+        "//tensorboard/components/tf_color_scale",
+        "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_imports:lodash",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_line_chart_data_loader",
+        "//tensorboard/components/tf_paginated_view",
+        "//tensorboard/components/tf_runs_selector",
+        "//tensorboard/components/tf_storage",
+        "//tensorboard/components/tf_tensorboard:registry",
+        "//tensorboard/components/tf_utils",
+        "//tensorboard/components/vz_line_chart",
+        "//tensorboard/plugins/scalar/tf_scalar_dashboard",
+        "@org_polymer_iron_collapse",
+        "@org_polymer_iron_icon",
+        "@org_polymer_paper_button",
+        "@org_polymer_paper_checkbox",
+        "@org_polymer_paper_dropdown_menu",
+        "@org_polymer_paper_icon_button",
+        "@org_polymer_paper_input",
+        "@org_polymer_paper_item",
+        "@org_polymer_paper_menu",
+        "@org_polymer_paper_slider",
+        "@org_polymer_paper_styles",
+    ],
+)

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-card.html
@@ -1,0 +1,500 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../iron-collapse/iron-collapse.html">
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../paper-item/paper-item.html">
+<link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="../paper-menu/paper-menu.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
+<link rel="import" href="../tf-line-chart-data-loader/tf-line-chart-data-loader.html">
+<link rel="import" href="../tf-card-heading/tf-card-heading.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
+
+<!--
+  A card that handles loading data (at the right times), rendering a scalar
+  chart, and providing UI affordances (such as buttons) for scalar data.
+-->
+<dom-module id="tf-custom-scalar-card">
+<template>
+  <h1>[[_titleDisplayString]]</h1>
+  <div id="tf-line-chart-data-loader-container">
+    <tf-line-chart-data-loader
+      x-type="[[xType]]"
+      x-components-creation-method="[[_xComponentsCreationMethod]]"
+      smoothing-enabled="[[smoothingEnabled]]"
+      smoothing-weight="[[smoothingWeight]]"
+      tooltip-sorting-method="[[tooltipSortingMethod]]"
+      ignore-y-outliers="[[ignoreYOutliers]]"
+      request-manager="[[requestManager]]"
+      runs="[[runs]]"
+      tag="[[_tagFilter]]"
+      active="[[active]]"
+      data-url="[[_dataUrl]]"
+      log-scale-active="[[_logScaleActive]]"
+      process-data="[[_createProcessDataFunction()]]"
+      color-scale="[[_colorScale]]"
+      data-series="[[_dataSeriesStrings]]"
+      symbol-function="[[_createSymbolFunction()]]"
+    >
+    </tf-line-chart-data-loader>
+  </div>
+  <div id="buttons">
+    <paper-icon-button
+      selected$="[[_expanded]]"
+      icon="fullscreen"
+      on-tap="_toggleExpanded"
+    ></paper-icon-button>
+    <paper-icon-button
+      selected$="[[_logScaleActive]]"
+      icon="line-weight"
+      on-tap="_toggleLogScale"
+      title="Toggle y-axis log scale"
+    ></paper-icon-button>
+    <paper-icon-button
+      icon="settings-overscan"
+      on-tap="_resetDomain"
+      title="Fit domain to data"
+    ></paper-icon-button>
+    <span style="flex-grow: 1"></span>
+    <template is="dom-if" if="[[showDownloadLinks]]">
+      <div class="download-links">
+        <paper-dropdown-menu
+          no-label-float="true"
+          label="series to download"
+          selected-item-label="{{_dataSeriesNameToDownload}}"
+        >
+          <paper-menu class="dropdown-content" slot="dropdown-content">
+            <template is="dom-repeat" items="[[_dataSeriesStrings]]" as="dataSeriesName">
+              <paper-item no-label-float=true>[[dataSeriesName]]</paper-item>
+            </template>
+          </paper-menu>
+        </paper-dropdown-menu>
+        <a
+          download="[[_dataSeriesNameToDownload]].csv"
+          href="[[_csvUrl(_nameToDataSeries, _dataSeriesNameToDownload)]]"
+        >CSV</a> <a
+          download="[[_dataSeriesNameToDownload]].json"
+          href="[[_jsonUrl(_nameToDataSeries, _dataSeriesNameToDownload)]]"
+        >JSON</a>
+      </div>
+    </template>
+  </div>
+  <div id="matches-container">
+    <div id="matches-list-title">
+      <template is="dom-if" if="[[_dataSeriesStrings.length]]">
+        <paper-icon-button
+          icon="[[_getToggleMatchesIcon(_matchesListOpened)]]"
+          on-click="_toggleMatchesOpen"
+          class="toggle-matches-button">
+        </paper-icon-button>
+      </template>
+
+      <span class="matches-text">
+        Matches ([[_dataSeriesStrings.length]])
+      </span>
+    </div>
+    <template is="dom-if" if="[[_dataSeriesStrings.length]]">
+      <iron-collapse opened="[[_matchesListOpened]]">
+        <div id="matches-list">
+          <template is="dom-repeat"
+                    items="[[_dataSeriesStrings]]"
+                    as="seriesName">
+              <div class="match-list-entry"
+                   style="color: [[_determineColor(_colorScale, seriesName)]];">
+                <span class="match-entry-symbol">
+                  [[_determineSymbol(_nameToDataSeries, seriesName)]]
+                </span>
+                [[seriesName]]
+              </div>
+          </template>
+        </div>
+      </iron-collapse>
+    </template>
+  </div>
+
+  </div>
+  <style>
+    :host {
+      margin: 5px 10px;
+      display: inline-block;
+      width: 330px;
+      vertical-align: text-top;
+    }
+
+    :host[_expanded] {
+      width: 100%;
+    }
+
+    :host[_expanded] #tf-line-chart-data-loader-container {
+      height: 400px;
+    }
+
+    h1 {
+      font-size: 19px;
+      font-weight: normal;
+    }
+
+    #tf-line-chart-data-loader-container {
+      height: 200px;
+      width: 100%;
+    }
+
+    #buttons {
+      display: flex;
+      flex-direction: row;
+    }
+
+    paper-icon-button {
+      color: #2196F3;
+      border-radius: 100%;
+      width: 32px;
+      height: 32px;
+      padding: 4px;
+    }
+
+    paper-icon-button[selected] {
+      background: var(--tb-ui-light-accent);
+    }
+
+    .download-links {
+      display: flex;
+      height: 32px;
+    }
+
+    .download-links a {
+      font-size: 10px;
+      align-self: center;
+      margin: 2px;
+    }
+
+    .download-links paper-dropdown-menu {
+      width: 100px;
+      --paper-input-container-label: {
+        font-size: 10px;
+      }
+      --paper-input-container-input: {
+        font-size: 10px;
+      }
+    }
+
+    #matches-list-title {
+      margin: 10px 0 5px 0;
+    }
+
+    #matches-list {
+      font-size: 0.8em;
+      max-height: 200px;
+      overflow-y: auto;
+    }
+
+    .match-list-entry {
+      margin: 0 0 5px 0;
+    }
+
+    .match-entry-symbol {
+      font-family: arial, sans-serif;
+      display: inline-block;
+      width: 10px;
+    }
+
+    .matches-text {
+      vertical-align: middle;
+    }
+  </style>
+</template>
+<script src='tf-custom-scalar-helpers.js'></script>
+<script>
+  import * as CustomScalarCardHelpers from './tf-custom-scalar-helpers.js';
+  import {addParams} from '../tf-backend/urlPathHelpers.js';
+  import {getRouter} from '../tf-backend/router.js';
+  import {runsColorScale} from '../tf-color-scale/colorScale.js';
+  import * as storage from '../tf-storage/storage.js';
+  import * as ChartHelpers from '../vz-line-chart/vz-chart-helpers.js';
+
+  /**
+   * Allows:
+   * - "step" - Linear scale using the "step" property of the datum.
+   * - "wall_time" - Temporal scale using the "wall_time" property of the
+   * datum.
+   * - "relative" - Temporal scale using the "relative" property of the
+   * datum if it is present or calculating from "wall_time" if it isn't.
+   * @enum {string}
+   */
+  const X_TYPE = {
+    STEP: 'step',
+    RELATIVE: 'relative',
+    WALL_TIME: 'wall_time',
+  };
+
+  Polymer({
+      is: 'tf-custom-scalar-card',
+      properties: {
+        runs: Array,  // of String
+
+        /**
+         * TODO: Add type.
+         */
+        xType: String,
+
+        active: {
+          type: Boolean,
+          value: true,
+          readOnly: true,
+        },
+        title: String,
+        tagRegexes: Array,
+        ignoreYOutliers: Boolean,
+        requestManager: Object,
+        showDownloadLinks: Boolean,
+        smoothingEnabled: Boolean,
+        smoothingWeight: Number,
+        tagMetadata: Object,
+        tooltipSortingMethod: String,
+
+        // We use a special color scale that wraps the run-based one.
+        _colorScale: {
+          type: Object,
+          value: new CustomScalarCardHelpers.DataSeriesColorScale({scale: runsColorScale}),
+          readOnly: true,
+        },
+
+        /**
+         * A regular expression to use for matching tags.
+         */
+        _tagFilter: {
+          type: String,
+          computed: '_computeTagFilter(tagRegexes)',
+        },
+
+        /**
+         * Maps from the name of the data series to the DataSeries object.
+         */
+        _nameToDataSeries: {
+          type: Object,
+          value: {},
+        },
+
+        /**
+         * A mapping between selected runs (strings) to the value 1. This is
+         * effectively a set of strings.
+         */
+        _selectedRunsSet: {
+          type: Object,
+          computed: '_computeSelectedRunsSet(runs)',
+        },
+        _dataSeriesStrings: {
+          type: Array,
+          computed: '_computeDataSeriesStrings(_selectedRunsSet, _nameToDataSeries)',
+        },
+        _dataSeriesObjects: {
+          type: Array,
+          computed: '_computeDataSeriesObjects(_nameToDataSeries, _dataSeriesStrings)',
+        },
+        _expanded: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,  // for CSS
+        },
+        _logScaleActive: Boolean,
+        _dataUrl: {
+          type: Function,
+          value: () => (tag, run) => addParams(
+              getRouter().pluginRoute(
+                  'custom_scalars', '/scalars'), {tag, run}),
+        },
+        _xComponentsCreationMethod: {
+          type: Object,
+          computed: '_computeXComponentsCreationMethod(xType)',
+        },
+        /**
+         * A mapping from run to the next available symbol for that run. We use
+         * symbols to differentiate data series within the same run.
+         */
+        _runToNextAvailableSymbolIndex: {
+          type: Object,
+          value: {},
+        },
+        _matchesListOpened: {
+          type: Boolean,
+          value: false,
+        },
+        _titleDisplayString: {
+          type: String,
+          computed: '_computeTitleDisplayString(title, _tagFilter)',
+        },
+      },
+      observers: [
+        '_updateChart(_nameToDataSeries)',
+        // Clear the data series when the tag filter changes.
+        '_refreshDataSeries(_tagFilter)',
+      ],
+      reload() {
+        this.$$('tf-line-chart-data-loader').reload();
+      },
+      redraw() {
+        this.$$('tf-line-chart-data-loader').redraw();
+      },
+      _toggleExpanded(e) {
+        this.set('_expanded', !this._expanded);
+        this.redraw();
+      },
+      _toggleLogScale() {
+        this.set('_logScaleActive', !this._logScaleActive);
+      },
+      _resetDomain() {
+        const chart = this.$$('tf-line-chart-data-loader');
+        if (chart) {
+          chart.resetDomain();
+        }
+      },
+      _csvUrl(nameToDataSeries, dataSeriesName) {
+        const baseUrl = this._downloadDataUrl(nameToDataSeries, dataSeriesName);
+        return addParams(baseUrl, {format: 'csv'});
+      },
+      _jsonUrl(nameToDataSeries, dataSeriesName) {
+        const baseUrl = this._downloadDataUrl(nameToDataSeries, dataSeriesName);
+        return addParams(baseUrl, {format: 'json'});
+      },
+      _downloadDataUrl(nameToDataSeries, dataSeriesName) {
+        const dataSeries = nameToDataSeries[dataSeriesName];
+        const getVars = {
+            tag: dataSeries.getTag(),
+            run: dataSeries.getRun(),
+        };
+        return addParams(
+              getRouter().pluginRoute(
+                  'custom_scalars', '/download_data'), getVars);
+      },
+      _computeXComponentsCreationMethod(xType) {
+        return () => ChartHelpers.getXComponents(xType);
+      },
+      _createProcessDataFunction() {
+        // This function is called when data is received from the backend.
+        return ((scalarChart, run, data) => {
+          if (data.regex_valid) {
+            // The user's regular expression was valid.
+            // Incorporate these newly loaded values.
+            const newMapping = _.clone(this._nameToDataSeries);
+            _.forOwn(data.tag_to_events, (scalarEvents, tag) => {
+              const data = scalarEvents.map(datum => ({
+                wall_time: new Date(datum[0] * 1000),
+                step: datum[1],
+                scalar: datum[2],
+              }));
+
+              const seriesName = CustomScalarCardHelpers.generateDataSeriesName(
+                  run, tag);
+              let series = newMapping[seriesName];
+
+              if (series) {
+                // This series already exists.
+                series.setData(data);
+              } else {
+                if (_.isUndefined(this._runToNextAvailableSymbolIndex[run])) {
+                  // The run has not been seen before. Define the next available
+                  // marker index.
+                  this._runToNextAvailableSymbolIndex[run] = 0;
+                }
+
+                // Every data series within a run has a unique symbol.
+                const lineChartSymbol = ChartHelpers.SYMBOLS_LIST[
+                    this._runToNextAvailableSymbolIndex[run]];
+
+                // Create a series with this name.
+                series = new CustomScalarCardHelpers.DataSeries(
+                    run,
+                    tag,
+                    seriesName,
+                    data,
+                    lineChartSymbol);
+                newMapping[seriesName] = series;
+
+                // Loop back to the beginning if we are out of symbols.
+                const numSymbols = ChartHelpers.SYMBOLS_LIST.length;
+                this._runToNextAvailableSymbolIndex[run] =
+                    (this._runToNextAvailableSymbolIndex[run] + 1) % numSymbols;
+              }
+            });
+
+            this.set('_nameToDataSeries', newMapping);
+          } else {
+            // The user's regular expression was invalid.
+            // TODO(chihuahua): Handle this.
+          }
+        });
+      },
+      _updateChart(nameToDataSeries) {
+        // Add new data series.
+        _.forOwn(nameToDataSeries, dataSeries => {
+          this.$$('tf-line-chart-data-loader').setSeriesData(
+              dataSeries.getName(), dataSeries.getData());
+        });
+      },
+      _computeSelectedRunsSet(runs) {
+        const mapping = {};
+        _.forEach(runs, run => {
+          mapping[run] = 1;
+        });
+        return mapping;
+      },
+      _computeDataSeriesStrings(selectedRunsSet, nameToDataSeries) {
+        return _.values(nameToDataSeries)
+            .filter(series => selectedRunsSet[series.getRun()])
+            .map(series => series.getName());
+      },
+      _computeDataSeriesObjects(nameToDataSeries, dataSeriesStrings) {
+        return dataSeriesStrings.map(
+            seriesName => nameToDataSeries[seriesName]);
+      },
+      _determineColor(colorScale, seriesName) {
+        return colorScale.scale(seriesName);
+      },
+      _refreshDataSeries(_tagFilter) {
+        this.set('_nameToDataSeries', {});
+      },
+      _createSymbolFunction() {
+        return seriesName => (
+            this._nameToDataSeries[seriesName].getSymbol().method());
+      },
+      _determineSymbol(nameToDataSeries, seriesName) {
+        return nameToDataSeries[seriesName].getSymbol().character;
+      },
+      _computeTagFilter(tagRegexes) {
+        if (tagRegexes.length === 1) {
+          return tagRegexes[0];
+        }
+        // Combine the different regexes into a single regex.
+        return tagRegexes.map(r => '(' + r + ')').join('|');
+      },
+      _getToggleMatchesIcon(matchesListOpened) {
+        return matchesListOpened ? 'expand-less' : 'expand-more';
+      },
+      _toggleMatchesOpen() {
+        this.set('_matchesListOpened', !this._matchesListOpened);
+      },
+      _computeTitleDisplayString(title, tagFilter) {
+        // If no title is provided, use the tag filter.
+        return title || tagFilter;
+      },
+  });
+</script>
+</dom-module>

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
@@ -1,0 +1,368 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../paper-button/paper-button.html">
+<link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
+<link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
+<link rel="import" href="../tf-categorization-utils/tf-category-pane.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
+<link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
+<link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
+<link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
+<link rel="import" href="../tf-scalar-dashboard/tf-smoothing-input.html">
+<link rel="import" href="../tf-tensorboard/registry.html">
+<link rel="import" href="../tf-utils/tf-utils.html">
+<link rel="import" href="tf-custom-scalar-card.html">
+
+<!--
+  A frontend that displays a custom set of line charts.
+-->
+<dom-module id="tf-custom-scalar-dashboard">
+  <template>
+    <tf-dashboard-layout>
+      <div class="sidebar">
+        <div class="sidebar-section">
+          <div class="line-item">
+            <paper-checkbox
+              checked="{{_showDownloadLinks}}"
+            >Show data download links</paper-checkbox>
+          </div>
+          <div class="line-item">
+            <paper-checkbox
+              checked="{{_ignoreYOutliers}}"
+            >Ignore outliers in chart scaling</paper-checkbox>
+          </div>
+          <div id="tooltip-sorting">
+            <div id="tooltip-sorting-label">Tooltip sorting method:</div>
+            <paper-dropdown-menu
+              no-label-float
+              selected-item-label="{{_tooltipSortingMethod}}"
+            >
+              <paper-menu class="dropdown-content" selected="0" slot="dropdown-content">
+                <paper-item>default</paper-item>
+                <paper-item>descending</paper-item>
+                <paper-item>ascending</paper-item>
+                <paper-item>nearest</paper-item>
+              </paper-menu>
+            </paper-dropdown-menu>
+          </div>
+        </div>
+        <div class="sidebar-section">
+          <tf-smoothing-input
+            weight="{{_smoothingWeight}}"
+            step="0.001"
+            min="0"
+            max="1"
+          ></tf-smoothing-input>
+        </div>
+        <div class="sidebar-section">
+          <tf-option-selector
+            id="x-type-selector"
+            name="Horizontal Axis"
+            selected-id="{{_xType}}"
+          >
+            <paper-button id="step">step</paper-button><!--
+            --><paper-button id="relative">relative</paper-button><!--
+            --><paper-button id="wall_time">wall</paper-button>
+          </tf-option-selector>
+        </div>
+        <div class="sidebar-section">
+          <tf-runs-selector selected-runs="{{_selectedRuns}}">
+          </tf-runs-selector>
+        </div>
+      </div>
+      <div class="center" id="categories-container">
+        <template is="dom-if" if="[[_dataNotFound]]">
+          <div class="no-data-warning">
+            <h3>The custom scalars dashboard is inactive.</h3>
+            <p>Probable causes:</p>
+            <ol>
+              <li>You haven't laid out the dashboard.
+              <li>You haven’t written any scalar data to your event files.
+            </ol>
+            <p>
+              To lay out the dashboard, pass a <code>Layout</code> protobuffer
+              to the <code>set_layout</code> method. For example,
+            </p>
+<pre>
+from tensorboard import summary
+from tensorboard.plugins.custom_scalar import layout_pb2
+...
+# This action does not have to be performed at every step, so the action is not
+# taken care of by an op in the graph. We only need to specify the layout once. 
+summary_writer.add_summary(
+    summary.custom_scalars_pb(
+        layout_pb2.Layout(category=[
+            layout_pb2.Category(
+                title='mean biases',
+                chart=[
+                    layout_pb2.Chart(
+                        title='mean layer biases',
+                        tag=[r'mean/layer\d+/biases'])
+                ],
+                closed=True),
+            layout_pb2.Category(
+                title='std weights',
+                chart=[
+                    layout_pb2.Chart(
+                        title='stddev layer weights',
+                        tag=[r'stddev/layer\d+/weights'])
+                    ])))
+)
+</pre>
+        <p>
+        If you’re new to using TensorBoard, and want to find out how
+        to add data and set up your event files, check out the
+        <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md">README</a>
+        and perhaps the <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard">TensorBoard tutorial</a>.
+        </p>
+         </div>
+        </template>
+        <template is="dom-if" if="[[!_dataNotFound]]">
+          <template is="dom-repeat" items="[[_categories]]" as="category">
+            <tf-category-pane
+                category="[[category]]"
+                opened="[[category.metadata.opened]]"
+                on-opened-changed="_categoryOpenedToggled"
+              >
+              <template is="dom-repeat" items="[[category.items]]" as="chart">
+                <tf-custom-scalar-card
+                  active="[[_active]]"
+                  request-manager="[[_requestManager]]"
+                  runs="[[_selectedRuns]]"
+                  title="[[chart.title]]"
+                  x-type="[[_xType]]"
+                  smoothing-enabled="[[_smoothingEnabled]]"
+                  smoothing-weight="[[_smoothingWeight]]"
+                  tooltip-sorting-method="[[tooltipSortingMethod]]"
+                  ignore-y-outliers="[[ignoreYOutliers]]"
+                  show-download-links="[[_showDownloadLinks]]"
+                  tag-regexes="[[chart.tag]]"
+                ></tf-custom-scalar-card>
+              </template>
+            </tf-category-pane>
+          </template>
+        </template>
+      </div>
+    </tf-dashboard-layout>
+
+    <style include="dashboard-style"></style>
+    <style>
+      .center {
+        height: 100%;
+        padding: 10px 20px;
+        box-sizing: border-box;
+      }
+      #tooltip-sorting {
+        display: flex;
+        font-size: 14px;
+        margin-top: 5px;
+      }
+      #tooltip-sorting-label {
+        margin-top: 13px;
+      }
+      #tooltip-sorting paper-dropdown-menu {
+        margin-left: 10px;
+        --paper-input-container-focus-color: var(--tb-orange-strong);
+        width: 105px;
+      }
+      #x-type-selector paper-button {
+        margin: 5px 3px;
+      }
+      .line-item {
+        display: block;
+        padding-top: 5px;
+      }
+      .no-data-warning {
+        max-width: 540px;
+        margin: 80px auto 0 auto;
+      }
+    </style>
+  </template>
+
+  <script>
+    "use strict";
+
+    import {Canceller} from "../tf-backend/canceller.js";
+    import {RequestManager} from '../tf-backend/requestManager.js';
+    import {getRouter} from '../tf-backend/router.js';
+    import * as storage from '../tf-storage/storage.js';
+    import {registerDashboard} from '../tf-tensorboard/registry.js';
+
+    Polymer({
+      is: 'tf-custom-scalar-dashboard',
+      properties: {
+        _requestManager: {
+          type: Object,
+          value: () => new RequestManager(50),
+        },
+        _canceller: {
+          type: Object,
+          value: () => new Canceller(),
+        },
+        _selectedRuns: Array,
+        _showDownloadLinks: {
+          type: Boolean,
+          notify: true,
+          value: storage.getBooleanInitializer('_showDownloadLinks',
+              {defaultValue: false, useLocalStorage: true}),
+          observer: '_showDownloadLinksObserver',
+        },
+        _smoothingWeight: {
+          type: Number,
+          notify: true,
+          value: storage.getNumberInitializer('_smoothingWeight', {defaultValue: 0.6}),
+          observer: '_smoothingWeightObserver',
+        },
+        _smoothingEnabled: {
+          type: Boolean,
+          computed: '_computeSmoothingEnabled(_smoothingWeight)',
+        },
+        _ignoreYOutliers: {
+          type: Boolean,
+          value: storage.getBooleanInitializer('_ignoreYOutliers',
+              {defaultValue: true, useLocalStorage: true}),
+          observer: '_ignoreYOutliersObserver',
+        },
+        _xType: {
+          type: String,
+          value: 'step',
+        },
+        /**
+         * The layout object has type CustomScalarCardHelpers.Layout.
+         */
+        _layout: Object,
+        _dataNotFound: Boolean,
+        /**
+         * This is array of Category<string> objects. Category is an interface
+         * defined within categorizationUtils. The items for each category are
+         * regexes. Each regex is associated with a custom chart.
+         */
+        _categories: {
+          type: Array,
+          computed: '_makeCategories(_layout)',
+        },
+        /**
+         * A mapping between opened categories to 1. When the dashboard reloads,
+         * the category panes are redrawn. We then re-open the categories that
+         * had previously been open.
+         */
+        _openedCategories: {
+          type: Object,
+        },
+        _active: {
+          type: Boolean,
+          value: true,
+          readOnly: true,
+        },
+      },
+      ready() {
+        this.reload();
+      },
+      reload() {
+        const url = getRouter().pluginsListing();
+        const handlePluginsListingResponse = this._canceller.cancellable(
+            result => {
+          if (result.cancelled) {
+            return;
+          }
+
+          this.set('_dataNotFound', !result.value['custom_scalars']);
+          if (this._dataNotFound) {
+            return;
+          }
+          this._retrieveLayoutAndData();
+        });
+        this._requestManager.request(url).then(handlePluginsListingResponse);
+      },
+      _reloadCharts() {
+        this.querySelectorAll('tf-custom-scalar-card').forEach(chart => {
+          chart.reload();
+        });
+      },
+      _retrieveLayoutAndData() {
+        const url = getRouter().pluginRoute('custom_scalars', '/layout');
+        const update = this._canceller.cancellable(result => {
+          if (result.cancelled) {
+            return;
+          }
+
+          // This plugin is only active if data is available.
+          this.set('_layout', result.value);
+          if (!this._dataNotFound) {
+            this._reloadCharts();
+          }
+        });
+        this._requestManager.request(url).then(update);
+      },
+      _showDownloadLinksObserver: storage.getBooleanObserver(
+          '_showDownloadLinks', {defaultValue: false, useLocalStorage: true}),
+      _smoothingWeightObserver: storage.getNumberObserver(
+          '_smoothingWeight', {defaultValue: 0.6}),
+      _ignoreYOutliersObserver: storage.getBooleanObserver(
+          '_ignoreYOutliers', {defaultValue: true, useLocalStorage: true}),
+      _computeSmoothingEnabled(_smoothingWeight) {
+        return _smoothingWeight > 0;
+      },
+      _makeCategories(layout) {
+        if (!layout.category) {
+          return [];
+        }
+        let firstTimeLoad = false;
+        if (!this._openedCategories) {
+          // This is the first time the user loads the categories. Start storing
+          // which categories are open.
+          firstTimeLoad = true;
+          this._openedCategories = {};
+        }
+
+        const categories = layout.category.map(category => {
+          if (firstTimeLoad && !category.closed) {
+            // Remember whether this category is currently open.
+            this._openedCategories[category.title] = true;
+          }
+          return {
+            name: category.title,
+            items: category.chart,
+            metadata: {
+              opened: !!this._openedCategories[category.title],
+            },
+          };
+        });
+        return categories;
+      },
+      _categoryOpenedToggled(event) {
+        const pane = event.target;
+        if (pane.opened) {
+          this._openedCategories[pane.category.name] = true;
+        } else {
+          delete this._openedCategories[pane.category.name];
+        }
+      },
+    });
+
+    registerDashboard({
+      plugin: 'custom_scalars',
+      elementName: 'tf-custom-scalar-dashboard',
+      tabName: 'Custom Scalars',
+    });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-helpers.ts
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-helpers.ts
@@ -1,0 +1,139 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import * as ChartHelpers from '../vz-line-chart/vz-chart-helpers.js';
+
+export interface CustomScalarResponse {
+  regex_valid: boolean;
+
+  // Maps tag name to a list of scalar data.
+  tag_to_events: {[key: string]: ChartHelpers.ScalarDatum[]};
+}
+
+/**
+ * A chart encapsulates data on a single chart.
+ */
+export interface Chart {
+  // A title for the chart. If not provided, a comma-separated list of tags is
+  // used.
+  title: string,
+
+  // A list of regexes for tags that should be long in this chart.
+  tag: string[],
+}
+
+/**
+ * A category specifies charts within a single collapsible.
+ */
+export interface Category {
+  title: string,
+
+  // A list of charts to show in this category.
+  chart: Chart[],
+}
+
+/**
+ * A layout specifies how the various categories and charts should be laid out
+ * within the dashboard.
+ */
+export interface Layout {
+  category: Category[],
+}
+
+/**
+ * A class that represents a data series for a custom scalars chart.
+ */
+export class DataSeries {
+  private run: string;
+  private tag: string;
+  private name: string;
+  private scalarData: ChartHelpers.ScalarDatum[];
+  private symbol: ChartHelpers.LineChartSymbol;
+
+  constructor(run: string,
+              tag: string,
+              name: string,
+              scalarData: ChartHelpers.ScalarDatum[],
+              symbol: ChartHelpers.LineChartSymbol) {
+    this.run = run;
+    this.tag = tag;
+    this.name = name;
+    this.scalarData = scalarData;
+    this.symbol = symbol;
+  }
+
+  getName(): string {
+    return this.name;
+  }
+
+  setData(scalarData: ChartHelpers.ScalarDatum[]) {
+    this.scalarData = scalarData;
+  }
+
+  getData(): ChartHelpers.ScalarDatum[] {
+    return this.scalarData;
+  }
+
+  getRun(): string {
+    return this.run;
+  }
+
+  getTag(): string {
+    return this.tag;
+  }
+
+  getSymbol(): ChartHelpers.LineChartSymbol {
+    return this.symbol;
+  }
+}
+
+export function generateDataSeriesName(run: string, tag: string): string {
+  return `${tag} (${run})`;
+}
+
+/**
+ * A color scale that wraps the usual color scale that relies on runs. This
+ * particular color scale parses the run from a series name and defers to that
+ * former color scale.
+ */
+export class DataSeriesColorScale {
+  private runBasedColorScale: Plottable.Scales.Color;
+
+  constructor(runBasedColorScale: Plottable.Scales.Color) {
+    this.runBasedColorScale = runBasedColorScale;
+  }
+
+  /**
+   * Obtains the correct color based on the run.
+   * @param {string} dataSeries
+   * @return {string} The color.
+   */
+  scale(dataSeries: string): string {
+    return this.runBasedColorScale.scale(this.parseRunName(dataSeries));
+  }
+
+  /**
+   * Parses the run name from a data series string. Returns the empty string if
+   * parsing fails.
+   */
+  private parseRunName(dataSeries: string): string {
+    const match = dataSeries.match(/\((.*)\)$/);
+    if (!match) {
+      // No match found.
+      return '';
+    }
+    return match[1];
+  }
+}

--- a/tensorboard/summary.py
+++ b/tensorboard/summary.py
@@ -22,6 +22,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorboard.plugins.audio import summary as _audio_summary
+from tensorboard.plugins.custom_scalar import summary as _custom_scalar_summary
 from tensorboard.plugins.histogram import summary as _histogram_summary
 from tensorboard.plugins.image import summary as _image_summary
 from tensorboard.plugins.pr_curve import summary as _pr_curve_summary
@@ -31,6 +32,9 @@ from tensorboard.plugins.text import summary as _text_summary
 
 audio = _audio_summary.op
 audio_pb = _audio_summary.pb
+
+custom_scalars = _custom_scalar_summary.op
+custom_scalars_pb = _custom_scalar_summary.pb
 
 histogram = _histogram_summary.op
 histogram_pb = _histogram_summary.pb

--- a/tensorboard/summary_test.py
+++ b/tensorboard/summary_test.py
@@ -30,6 +30,7 @@ from tensorboard import summary
 
 STANDARD_PLUGINS = frozenset([
     'audio',
+    'custom_scalars',
     'histogram',
     'image',
     'pr_curve',


### PR DESCRIPTION
This plugin makes custom line charts based on regex filtering of tags. Input appreciated! I want to port a prototype into google ASAP so we can test it out.

At a glance, here's how it works. The user sets the dashboard layout via a proto. For instance,

```python
from tensorboard import summary
from tensorboard.plugins.custom_scalar import layout_pb2
...
layout = layout_pb2.Layout(
    category=[
        layout_pb2.Category(
            title='mean biases',
            chart=[
                layout_pb2.Chart(
                    title='mean layer biases',
                    tag=[r'mean/layer\d+/biases'])
            ]),
        layout_pb2.Category(
            title='std weights',
            chart=[
                layout_pb2.Chart(
                    title='stddev layer weights',
                    tag=[r'stddev/layer\d+/weights'])
                ]),
        layout_pb2.Category(
            title='cross entropy ... and maybe some other values',
            chart=[
                layout_pb2.Chart(
                    title='cross entropy',
                    tag=[r'cross entropy']),
                layout_pb2.Chart(
                    title='accuracy',
                    tag=[r'accuracy']),
                layout_pb2.Chart(
                    title='max layer weights',
                    tag=[r'max/layer1/.*', r'max/layer2/.*'])
            ],
            closed=True)
    ])

# Write the Layout proto to disk. This only has to be done once, so we do this outside
# of the TensorFlow graph. `custom_scalars_pb` returns a Summary proto, not an op.
writer.add_summary(self.logdir, summary.custom_scalars_pb(layout))
```

The `set` method writes a pbtxt into `$LOG_DIR/custom_scalars_config.pbtxt`, which the plugin uses to organize the dashboard:

![image](https://user-images.githubusercontent.com/4221553/31806682-67418a10-b51e-11e7-939a-d61e49454a2f.png)

Different tags within the same runs are differentiated by markers. The user can opt for certain categories to be opened by default.

Again, I really want to know everyone's feedback on this. This prototype deviates a bit from the discussion on the thread, but I think makes sense and addresses @georgedahl's needs.

I was wavering between whether to pass the dashboard organization via a flag or via a programmatic API ... and opted for the latter because 

1. The user can more straightforwardly specify the dashboard layout via creating a proto.
2. A programmatic API lets a script change the layout over time.
3. Adding a flag for custom line charts introduces some dilemmas. For instance, what if both a flag value is specified and the pbtxt is written to disk? Which one should be the source of truth?