### PR TITLE
Do not install futures for python3

### DIFF
--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -25,7 +25,6 @@ import tensorboard.version
 
 
 REQUIRED_PACKAGES = [
-    'futures >= 3.1.1',
     'numpy >= 1.12.0',
     'six >= 1.10.0',
     'protobuf >= 3.3.0',
@@ -40,6 +39,10 @@ if sys.version_info.major == 3:
   REQUIRED_PACKAGES.append('wheel >= 0.26')
 else:
   REQUIRED_PACKAGES.append('wheel')
+
+# futures is a backport of python3's concurrent.futures module
+if sys.version_info.major < 3:
+  REQUIRED_PACKAGES.append('futures >= 3.1.1')
 
 CONSOLE_SCRIPTS = [
     'tensorboard = tensorboard.main:main',


### PR DESCRIPTION
The `futures` package is a backport of python3's `concurrent.futures` package. The former does not exist for python3.

This would fix #650.