### PR TITLE
Fix pageview hit counting to avoid dupes

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -454,12 +454,13 @@ limitations under the License.
 
         /**
          * The plugin name of the currently selected dashboard, or `null` if no
-         * dashboard is selected. A `null` value here is represented by
-         * an empty string in the hash, and vice versa.
+         * dashboard is selected, which corresponds to an empty hash. Defaults
+         * to the value stored in the hash.
          */
         _selectedDashboard: {
           type: String,
-          value: null,
+          value: getString(TAB, /*useLocalStorage=*/false) || null,
+          observer: '_selectedDashboardChanged'
         },
 
         /*
@@ -497,7 +498,8 @@ limitations under the License.
         },
       },
       observers: [
-        '_updateSelectedDashboard(_selectedDashboard, _activeDashboards)',
+        ('_updateSelectedDashboardFromActive(' +
+         '_selectedDashboard, _activeDashboards)'),
         ('_ensureSelectedDashboardStamped(' +
          '_dashboardContainersStamped, _activeDashboards, ' +
          '_selectedDashboard)'),
@@ -571,31 +573,36 @@ limitations under the License.
         return dashboards[index];
       },
 
-      _displayStyle(currentDashboard, candidateDashboard) {
+      _displayStyle(selectedDashboard, candidateDashboard) {
          // Display only the selected dashboard.
-        return currentDashboard === candidateDashboard ? 'inherit' : 'none';
+        return selectedDashboard === candidateDashboard ? 'inherit' : 'none';
+      },
+
+      /**
+       * Handle a change in the selected dashboard by persisting the current
+       * selection to the hash and logging a pageview if analytics are enabled.
+       */
+      _selectedDashboardChanged(selectedDashboard) {
+        const pluginString = selectedDashboard || '';
+        setString(TAB, pluginString, /*useLocalStorage=*/false);
+        // Record this dashboard selection as a page view.
+        ga('set', 'page', '/' + pluginString);
+        ga('send', 'pageview');
       },
 
       /**
        * If no dashboard is selected but dashboards are available,
-       * select the first active dashboard. In any case, synchronize the
-       * state to the hash.
+       * set the selected dashboard to the first active one.
        */
-      _updateSelectedDashboard(selectedDashboard, activeDashboards) {
+      _updateSelectedDashboardFromActive(selectedDashboard, activeDashboards) {
         if (activeDashboards && selectedDashboard == null) {
           selectedDashboard = activeDashboards[0] || null;
           if (selectedDashboard != null) {
+            // Note: the following line will re-trigger this handler, but it
+            // will be a no-op since selectedDashboard is no longer null.
             this._selectedDashboard = selectedDashboard;
-            return;  // we just triggered that handler; don't need another
           }
         }
-
-        const pluginString = selectedDashboard || '';
-        setString(TAB, pluginString, /*useLocalStorage=*/false);
-
-        // Record this dashboard selection as a page view.
-        ga('set', 'page', '/' + pluginString);
-        ga('send', 'pageview');
       },
 
       _updateSelectedDashboardFromHash() {

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -316,9 +316,6 @@ Polymer({
       // Either this dashboard is already initialized ... or we are not yet ready to initialize.
       return;
     }
-    if (typeof ga !== 'undefined' && ga != null) {
-      ga('send', {hitType: 'pageview', page: '/v/graph'});
-    }
     // Set this to true so we only initialize once.
     this._initialized = true;
     Promise.all([this._fetchGraphRuns(), this._fetchRunMetadataTags()])


### PR DESCRIPTION
This PR fixes some duplication issues in pageview counting for Google Analytics.  Note that currently analytics is only enabled for internal Google users.

Specifically, sending pageview hits from _updateSelectedDashboard() was not really correct because that Polymer observer is invoked on any change to either observed property - the selected dashboard or the list of active dashboards.  That means that as the active dashboards are loaded, every change to _activeDashboards will result in a duplicate page hit being logged for the currently selected dashboard.

As a special case of this, observers are also invoked a single time once their default values are all initialized to handle the default values (as a new change from "undefined").  So this also meant that on every page load we would send a pageview hit right away for the "/" page corresponding to the "null" default value of _selectedDashboard, even if loading e.g. http://tb/#scalars directly.

This fixes the first issue by changing _updateSelectedDashboard() to exclusively focus on setting the selected dashboard to the first active dashboard (if appropriate), and moving the pageview and hash updating into a separate observer _selectedDashboardChanged() that only observes _selectedDashboard.  It fixes the second issue by making _selectedDashboard default to the value from the hash, so that loading http://tb/#scalars generates only a single pageview hit for "/scalars" rather than "/" followed by "/scalars".

Note that the way I have it now, loading http://tb/ will still always generate that first hit for "/" even if the active dashboards result in immediately "redirecting" to e.g. http://tb/#scalars which then gets recorded as a second hit.  I think this is reasonable since the user did still type in "/" and that way we can distinguish visitors to the TensorBoard "home" page who get redirected to the first active dashboard from visitors who go immediately to a preselected dashboard.

Lastly, this removes the extra pageview hit for "/v/graph" sent by tf-graph-dashboard; it was introduced before the automatic hash-based plugin pageview hits were added to tf-tensorboard, and it's pretty much just redundant with the hit for "/graphs" that the latter would generate.