### PR TITLE
Allow for data series that are not runs

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -113,8 +113,9 @@ limitations under the License.
         runs: Array,
         tag: String,
 
-        // A list of data series. Defaults to the list of runs. Each data series
-        // is a string that corresponds to a line in the chart.
+        // An optional list of data series. Each data series is a string that
+        // corresponds to a line in the chart. If this property is not provided,
+        // the list of data series consists of the list of runs.
         dataSeries: Array,
 
         xComponentsCreationMethod: Object,
@@ -207,7 +208,6 @@ limitations under the License.
       },
       observers: [
         '_tagChanged(_attached, tag)',
-        '_initializeDataSeries(runs)',
         '_dataChanged(_attached, dataSeries, runs.*)'
       ],
       created() {
@@ -239,20 +239,13 @@ limitations under the License.
         this._resetDomainOnNextLoad = true;
         this._loadData();
       },
-      _initializeDataSeries(runs) {
-        // If the user provided no data series, default to the list of runs.
-        if (this.dataSeries) {
-          // The user has provided data series.
-          return;
-        }
-        this.set('dataSeries', runs);
-      },
       _dataChanged(attached, dataSeries, runsUpdateRecord) {
         if (!attached) {
           return;
         }
 
-        this.$$('vz-line-chart').setVisibleSeries(dataSeries);
+        this.$$('vz-line-chart').setVisibleSeries(
+            dataSeries || runsUpdateRecord.base);
         this._loadData();
       },
       _loadData() {
@@ -312,7 +305,7 @@ limitations under the License.
         });
       },
       _changeSeries() {
-        this.$$('vz-line-chart').setVisibleSeries(this.dataSeries);
+        this.$$('vz-line-chart').setVisibleSeries(this.dataSeries || this.runs);
         this._loadData();
       },
       _logScaleChanged(logScaleActive) {

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -31,7 +31,7 @@ limitations under the License.
       <vz-line-chart
         x-components-creation-method="[[xComponentsCreationMethod]]"
         y-value-accessor="[[yValueAccessor]]"
-        color-scale="[[_runsColorScale]]"
+        color-scale="[[colorScale]]"
         tooltip-columns="[[tooltipColumns]]"
         smoothing-enabled="[[smoothingEnabled]]"
         smoothing-weight="[[smoothingWeight]]"
@@ -113,6 +113,10 @@ limitations under the License.
         runs: Array,
         tag: String,
 
+        // A list of data series. Defaults to the list of runs. Each data series
+        // is a string that corresponds to a line in the chart.
+        dataSeries: Array,
+
         xComponentsCreationMethod: Object,
         xType: String,
         yValueAccessor: Object,
@@ -153,7 +157,10 @@ limitations under the License.
           observer: '_logScaleChanged',
         },
 
-        _runsColorScale: {
+        /**
+         * An object with a scale method that maps from data series to color.
+         */
+        colorScale: {
           type: Object,
           value: () => ({scale: runsColorScale}),
         },
@@ -200,7 +207,8 @@ limitations under the License.
       },
       observers: [
         '_tagChanged(_attached, tag)',
-        '_runsChanged(_attached, runs.*)'
+        '_initializeDataSeries(runs)',
+        '_dataChanged(_attached, dataSeries, runs.*)'
       ],
       created() {
         this._loadData = _.debounce(
@@ -231,11 +239,20 @@ limitations under the License.
         this._resetDomainOnNextLoad = true;
         this._loadData();
       },
-      _runsChanged(attached, runsUpdateRecord) {
+      _initializeDataSeries(runs) {
+        // If the user provided no data series, default to the list of runs.
+        if (this.dataSeries) {
+          // The user has provided data series.
+          return;
+        }
+        this.set('dataSeries', runs);
+      },
+      _dataChanged(attached, dataSeries, runsUpdateRecord) {
         if (!attached) {
           return;
         }
-        this.$$('vz-line-chart').setVisibleSeries(this.runs);
+
+        this.$$('vz-line-chart').setVisibleSeries(dataSeries);
         this._loadData();
       },
       _loadData() {
@@ -295,7 +312,7 @@ limitations under the License.
         });
       },
       _changeSeries() {
-        this.$$('vz-line-chart').setVisibleSeries(this.runs);
+        this.$$('vz-line-chart').setVisibleSeries(this.dataSeries);
         this._loadData();
       },
       _logScaleChanged(logScaleActive) {


### PR DESCRIPTION
Some plugins (such as the `custom-scalar` and `debugger` plugins) make use of the `vz_line_chart` component but plot data series that are not runs (such as custom run-tag combos or tensor values).

This change makes the `tf-line-chart-data-loader` component accept a data series property that defaults to the list of runs.

Test plan: Note that the custom scalars plugin works (allows for custom run-tag combos within `vz_line_chart`) after this change: #664 
I plan to rebase #664 after this change goes in. Furthermore, it seems like the scalars dashboard still WAI.

FYI, @caisq 