### PR TITLE
Declare required packages that vary by python version

### DIFF
--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -32,17 +32,15 @@ REQUIRED_PACKAGES = [
     'html5lib == 0.9999999',  # identical to 1.0b8
     'markdown >= 2.6.8',
     'bleach == 1.5.0',
+
+    # futures is a backport of the concurrent.futures module added in
+    # python 3.2
+    'futures >= 3.1.1;python_version < "3.2"',
+
+    # python3 specifically requires wheel 0.26
+    'wheel;python_version < "3"',
+    'wheel >= 0.26;python_version >= "3"',
 ]
-
-# python3 requires wheel 0.26
-if sys.version_info.major == 3:
-  REQUIRED_PACKAGES.append('wheel >= 0.26')
-else:
-  REQUIRED_PACKAGES.append('wheel')
-
-# futures is a backport of python3's concurrent.futures module
-if sys.version_info.major < 3:
-  REQUIRED_PACKAGES.append('futures >= 3.1.1')
 
 CONSOLE_SCRIPTS = [
     'tensorboard = tensorboard.main:main',

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -17,8 +17,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import sys
-
 from setuptools import find_packages, setup
 
 import tensorboard.version


### PR DESCRIPTION
Previously, we had used `sys.version_info.major` to determine the
python version within setup.py and the conditionally installed
certain modules.

We now directly state those conditions while declaring required
packages. This solution is more robust. See discussion in #667.

We also now only install the `futures` package if the python
version is less than 3.2 (not just 3).