### PR TITLE
Fix TextPlugin scalar string decoding errors in py3

### DIFF
--- a/tensorboard/plugin_util.py
+++ b/tensorboard/plugin_util.py
@@ -24,6 +24,7 @@ import bleach
 import markdown
 import six
 
+import tensorflow as tf
 
 _ALLOWED_ATTRIBUTES = {
     'a': ['href', 'title'],
@@ -71,7 +72,14 @@ def markdown_to_safe_html(markdown_string):
   """
   # Convert to utf-8 whenever we have a binary input.
   if isinstance(markdown_string, six.binary_type):
-    markdown_string = markdown_string.decode('utf-8')
+    markdown_string_decoded = markdown_string.decode('utf-8')
+    # Remove null bytes and warn if there were any, since it probably means
+    # we were given a bad encoding.
+    markdown_string = markdown_string_decoded.replace(u'\x00', u'')
+    num_null_bytes = len(markdown_string_decoded) - len(markdown_string)
+    if num_null_bytes:
+      tf.logging.warning('Found %d null bytes when decoding markdown as UTF-8',
+                         num_null_bytes)
 
   string_html = markdown.markdown(
       markdown_string, extensions=['markdown.extensions.tables'])

--- a/tensorboard/plugin_util_test.py
+++ b/tensorboard/plugin_util_test.py
@@ -113,7 +113,7 @@ class MarkdownToSafeHTMLTest(tf.test.TestCase):
     # there will probably be a bunch of null bytes. These would be stripped by
     # the sanitizer no matter what, but make sure we remove them before markdown
     # interpretation to avoid affecting output (e.g. "_with_" gets italicized).
-    s = u'word_with_underscores'.encode('utf-16')[2:]  # Strip byte-order mark
+    s = u'word_with_underscores'.encode('utf-32-le')
     self._test(s, u'<p>word_with_underscores</p>')
 
 

--- a/tensorboard/plugin_util_test.py
+++ b/tensorboard/plugin_util_test.py
@@ -108,6 +108,14 @@ class MarkdownToSafeHTMLTest(tf.test.TestCase):
     self._test(s,
                u'<blockquote>\n<p>Look\u2014some UTF-8!</p>\n</blockquote>')
 
+  def test_null_bytes_stripped_before_markdown_processing(self):
+    # If this function is mistakenly called with UTF-16 or UTF-32 encoded text,
+    # there will probably be a bunch of null bytes. These would be stripped by
+    # the sanitizer no matter what, but make sure we remove them before markdown
+    # interpretation to avoid affecting output (e.g. "_with_" gets italicized).
+    s = u'word_with_underscores'.encode('utf-16')[2:]  # Strip byte-order mark
+    self._test(s, u'<p>word_with_underscores</p>')
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -166,8 +166,7 @@ def text_array_to_html(text_arr):
   """
   if not text_arr.shape:
     # It is a scalar. No need to put it in a table, just apply markdown
-    return plugin_util.markdown_to_safe_html(
-        text_arr.astype(np.dtype(str)).tostring())
+    return plugin_util.markdown_to_safe_html(np.asscalar(text_arr))
   warning = ''
   if len(text_arr.shape) > 2:
     warning = plugin_util.markdown_to_safe_html(WARNING_TEMPLATE

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -263,11 +263,18 @@ class TextPluginTest(tf.test.TestCase):
       np.testing.assert_array_equal(actual, expected)
 
   def test_text_array_to_html(self):
-
     convert = text_plugin.text_array_to_html
     scalar = np.array('foo')
     scalar_expected = '<p>foo</p>'
     self.assertEqual(convert(scalar), scalar_expected)
+
+    # Check that underscores are preserved correctly; this detects erroneous
+    # use of UTF-16 or UTF-32 encoding when calling markdown_to_safe_html(),
+    # which would introduce spurious null bytes and cause undesired <em> tags
+    # around the underscores.
+    scalar_underscores = np.array('word_with_underscores')
+    scalar_underscores_expected = '<p>word_with_underscores</p>'
+    self.assertEqual(convert(scalar_underscores), scalar_underscores_expected)
 
     vector = np.array(['foo', 'bar'])
     vector_expected = textwrap.dedent("""\


### PR DESCRIPTION
This fixes tensorflow/tensorboard#647 in which TextPlugin incorrectly decodes scalar string values as their raw numpy byte representation before passing them to `markdown_to_safe_html()`.  When running python 2 this happens to work because numpy and Python use the same raw byte representation for string data, but in python 3 this is not the case, and the result is a string with spurious null bytes, leading the markdown processor to interpret certain patterns incorrectly.  See the issue for details.

This both fixes the TextPlugin decoding logic itself, and also fixes `markdown_to_safe_html()` so that it will discard null bytes and log a warning about them before doing markdown interpretation.

Tested under python 2 and 3 via `bazel test --python_path=...`.