### PR TITLE
Projector: Add t-SNE pause/resume button (replaced Stop button)

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -130,6 +130,7 @@ export class DataSet {
   nearest: knn.NearestEntry[][];
   nearestK: number;
   tSNEIteration: number = 0;
+  tSNEShouldPause = false;
   tSNEShouldStop = true;
   dim: [number, number] = [0, 0];
   hasTSNERun: boolean = false;
@@ -312,6 +313,7 @@ export class DataSet {
     let k = Math.floor(3 * perplexity);
     let opt = {epsilon: learningRate, perplexity: perplexity, dim: tsneDim};
     this.tsne = new TSNE(opt);
+    this.tSNEShouldPause = false;
     this.tSNEShouldStop = false;
     this.tSNEIteration = 0;
 
@@ -322,19 +324,21 @@ export class DataSet {
         this.tsne = null;
         return;
       }
-      this.tsne.step();
-      let result = this.tsne.getSolution();
-      sampledIndices.forEach((index, i) => {
-        let dataPoint = this.points[index];
+      if (!this.tSNEShouldPause) {
+        this.tsne.step();
+        let result = this.tsne.getSolution();
+        sampledIndices.forEach((index, i) => {
+          let dataPoint = this.points[index];
 
-        dataPoint.projections['tsne-0'] = result[i * tsneDim + 0];
-        dataPoint.projections['tsne-1'] = result[i * tsneDim + 1];
-        if (tsneDim === 3) {
-          dataPoint.projections['tsne-2'] = result[i * tsneDim + 2];
-        }
-      });
-      this.tSNEIteration++;
-      stepCallback(this.tSNEIteration);
+          dataPoint.projections['tsne-0'] = result[i * tsneDim + 0];
+          dataPoint.projections['tsne-1'] = result[i * tsneDim + 1];
+          if (tsneDim === 3) {
+            dataPoint.projections['tsne-2'] = result[i * tsneDim + 2];
+          }
+        });
+        this.tSNEIteration++;
+        stepCallback(this.tSNEIteration);
+      }
       requestAnimationFrame(step);
     };
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
@@ -214,7 +214,7 @@ limitations under the License.
       </div>
       <p>
         <button class="run-tsne ink-button" title="Re-run t-SNE">Re-run</button>
-        <button class="stop-tsne ink-button" title="Stop t-SNE">Stop</button>
+        <button class="pause-tsne ink-button" title="Pause t-SNE">Pause</button>
       </p>
       <p>Iteration: <span class="run-tsne-iter">0</span></p>
       <p id="tsne-sampling" class="notice">

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -94,7 +94,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
 
   /** Polymer elements. */
   private runTsneButton: HTMLButtonElement;
-  private stopTsneButton: HTMLButtonElement;
+  private pauseTsneButton: HTMLButtonElement;
   private perplexitySlider: HTMLInputElement;
   private learningRateInput: HTMLInputElement;
   private zDropdown: HTMLElement;
@@ -123,7 +123,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   ready() {
     this.zDropdown = this.querySelector('#z-dropdown') as HTMLElement;
     this.runTsneButton = this.querySelector('.run-tsne') as HTMLButtonElement;
-    this.stopTsneButton = this.querySelector('.stop-tsne') as HTMLButtonElement;
+    this.pauseTsneButton = this.querySelector('.pause-tsne') as HTMLButtonElement;
     this.perplexitySlider =
         this.querySelector('#perplexity-slider') as HTMLInputElement;
     this.learningRateInput =
@@ -168,8 +168,15 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
     }
 
     this.runTsneButton.addEventListener('click', () => this.runTSNE());
-    this.stopTsneButton.addEventListener(
-        'click', () => this.dataSet.stopTSNE());
+    this.pauseTsneButton.addEventListener('click', () => {
+      if (this.dataSet.tSNEShouldPause) {
+        this.dataSet.tSNEShouldPause = false;
+        this.pauseTsneButton.innerText = 'Pause';
+      } else {
+        this.dataSet.tSNEShouldPause = true;
+        this.pauseTsneButton.innerText = 'Resume';
+      }
+    });
 
     this.perplexitySlider.value = this.perplexity.toString();
     this.perplexitySlider.addEventListener(
@@ -420,7 +427,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
 
   private runTSNE() {
     this.runTsneButton.disabled = true;
-    this.stopTsneButton.disabled = null;
+    this.pauseTsneButton.disabled = null;
     this.dataSet.projectTSNE(
         this.perplexity, this.learningRate, this.tSNEis3d ? 3 : 2,
         (iteration: number) => {
@@ -429,7 +436,8 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
             this.projector.notifyProjectionPositionsUpdated();
           } else {
             this.runTsneButton.disabled = null;
-            this.stopTsneButton.disabled = true;
+            this.pauseTsneButton.disabled = true;
+            this.pauseTsneButton.innerText = 'Pause';
           }
         });
   }


### PR DESCRIPTION
Projector: Replaced t-SNE Stop button (which terminates t-SNE) with a Pause/Resume button and functionality, while retaining t-SNE auto-termination upon projection-type switch (from t-SNE to PCA or Custom).

Demo here: http://tensorserve.com:6010
```bash
git clone https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout a6a61e902234b48ee9429f4657dea5dc0dddc300
bazel run tensorboard -- --logdir /home/$USER/emnist-2000 --host 0.0.0.0 --port 6010
```
Supersedes [#672](https://github.com/tensorflow/tensorboard/pull/672): Projector improvements: Pause/resume T-SNE, and 2D sprite element zoom