### PR TITLE
Change markdown_to_safe_html() to avoid tf.logging dep

### DIFF
--- a/tensorboard/plugin_util.py
+++ b/tensorboard/plugin_util.py
@@ -24,8 +24,6 @@ import bleach
 import markdown
 import six
 
-import tensorflow as tf
-
 _ALLOWED_ATTRIBUTES = {
     'a': ['href', 'title'],
     'img': ['src', 'title', 'alt'],
@@ -70,6 +68,7 @@ def markdown_to_safe_html(markdown_string):
   Returns:
     A string containing safe HTML.
   """
+  warning = ''
   # Convert to utf-8 whenever we have a binary input.
   if isinstance(markdown_string, six.binary_type):
     markdown_string_decoded = markdown_string.decode('utf-8')
@@ -78,11 +77,11 @@ def markdown_to_safe_html(markdown_string):
     markdown_string = markdown_string_decoded.replace(u'\x00', u'')
     num_null_bytes = len(markdown_string_decoded) - len(markdown_string)
     if num_null_bytes:
-      tf.logging.warning('Found %d null bytes when decoding markdown as UTF-8',
-                         num_null_bytes)
+      warning = ('<!-- WARNING: discarded %d null bytes in markdown string '
+                 'after UTF-8 decoding -->\n') % num_null_bytes
 
   string_html = markdown.markdown(
       markdown_string, extensions=['markdown.extensions.tables'])
   string_sanitized = bleach.clean(
       string_html, tags=_ALLOWED_TAGS, attributes=_ALLOWED_ATTRIBUTES)
-  return string_sanitized
+  return warning + string_sanitized

--- a/tensorboard/plugin_util_test.py
+++ b/tensorboard/plugin_util_test.py
@@ -112,9 +112,15 @@ class MarkdownToSafeHTMLTest(tf.test.TestCase):
     # If this function is mistakenly called with UTF-16 or UTF-32 encoded text,
     # there will probably be a bunch of null bytes. These would be stripped by
     # the sanitizer no matter what, but make sure we remove them before markdown
-    # interpretation to avoid affecting output (e.g. "_with_" gets italicized).
-    s = u'word_with_underscores'.encode('utf-32-le')
-    self._test(s, u'<p>word_with_underscores</p>')
+    # interpretation to avoid affecting output (e.g. middle-word underscores
+    # would generate erroneous <em> tags like "un<em>der</em>score") and add an
+    # HTML comment with a warning.
+    s = u'un_der_score'.encode('utf-32-le')
+    # UTF-32 encoding of ASCII will have 3 null bytes per char. 36 = 3 * 12.
+    self._test(s,
+               u'<!-- WARNING: discarded 36 null bytes in markdown string '
+               'after UTF-8 decoding -->\n'
+               '<p>un_der_score</p>')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead of logging, it will now insert an HTML comment warning about the null bytes being stripped, per suggestion from @000drax.