### PR TITLE
Projector: 2D sprite element zoom

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerSprites.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerSprites.ts
@@ -60,6 +60,18 @@ const VERTEX_SHADER = `
     float outputPointSize = pointSize;
     if (sizeAttenuation) {
       outputPointSize = -pointSize / cameraSpacePos.z;
+    } else {  // Create size attenuation (if we're in 2D mode)
+      const float PI = 3.1415926535897932384626433832795;
+      const float minScale = 0.1;  // minimum scaling factor
+      const float outSpeed = 2.0;  // shrink speed when zooming out
+      const float outNorm = (1. - minScale) / atan(outSpeed);
+      const float maxScale = 15.0;  // maximum scaling factor
+      const float inSpeed = 0.02;  // enlarge speed when zooming in
+      const float zoomOffset = 0.3;  // offset zoom pivot
+      float zoom = projectionMatrix[0][0] + zoomOffset;  // zoom pivot
+      float scale = zoom < 1. ? 1. + outNorm * atan(outSpeed * (zoom - 1.)) :
+                    1. + 2. / PI * (maxScale - 1.) * atan(inSpeed * (zoom - 1.));
+      outputPointSize = pointSize * scale;
     }
 
     gl_PointSize =


### PR DESCRIPTION
The Projector can now enlarge/shrink the actual sprite images/placeholders during zooming, which is useful for closer inspection of samples when zooming, or for reducing sprite occlusion when zooming far out.

Demo here: http://tensorserve.com:6011
```bash
git clone -b projector-2d-spritezoom https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout 9a71c652944672826671a6ff32c6d022e0d9cd01
bazel run tensorboard -- --logdir /home/emnist-2000 --host 0.0.0.0 --port 6011
```
Supersedes [#672](https://github.com/tensorflow/tensorboard/pull/672): Projector improvements: Pause/resume T-SNE, and 2D sprite element zoom

### Sprite shrink and enlarge sizes
Smallest sprite size, and reset zoom size:
<img width="290" alt="smallest sprite size" src="https://user-images.githubusercontent.com/10847676/32365950-badd36d0-c084-11e7-9a05-b72fdef8ffa3.png"><img width="290" alt="reset zoom" src="https://user-images.githubusercontent.com/10847676/32365951-bb27e02c-c084-11e7-91c8-d5dd8f1072a8.png">
Medium enlarge size, and maximum sprite size:
<img width="290" alt="medium enlarge" src="https://user-images.githubusercontent.com/10847676/32365953-bb7d5728-c084-11e7-883a-4a15738c3b8f.png"><img width="290" alt="maximum sprite size" src="https://user-images.githubusercontent.com/10847676/32365954-bc059ff2-c084-11e7-8c18-d32fabb5d3cf.png">

### Zoom pivot and offset
The 2D zoom is set according to the **projectionMatrix** and an offset value, since the default/reset zoom seems to be less than 1 so an offset is needed to ensure 2D sprite sizes are about the same as they were before. 
```cpp
const float zoomOffset = 0.3;  // offset zoom pivot
float zoom = projectionMatrix[0][0] + zoomOffset;  // zoom pivot
```
A zoom less than the zoom pivot should produce stronger shrinkage gradient to reduce occlusion when zooming out, and a zoom greater than the pivot should have a weaker enlarging gradient when zooming in to also reduce occlusion, this assumes that the level of sprite occlusion at the zoom pivot is already agreeable. 

The arc tangent function displays the desired gradients around the origin as pivot, and one can define an arbitrary sizing speed by using a specific width of the function:
![image](https://user-images.githubusercontent.com/10847676/32363898-4d92b37a-c07a-11e7-8b6b-d59bf0824d17.png)
![image](https://user-images.githubusercontent.com/10847676/32363891-40772478-c07a-11e7-84aa-d0c1315c5391.png)

### Less than zoom pivot
Lets use the negative domain of the arc tangent to promote faster sizing when zooming out to reduce occlusion, here _m_ is the minimum scaling factor, _s_ the sizing speed, and _z_ the zoom:
![image](https://user-images.githubusercontent.com/10847676/32363920-73e952d6-c07a-11e7-9ea2-861865575346.png)
![image](https://user-images.githubusercontent.com/10847676/32363929-80669406-c07a-11e7-921f-ba67deee3ea2.png)
Set the minimum scaling factor to 10% and the speed at 2.0, then we calculate the scale accordingly:
```cpp
const float minScale = 0.1;  // minimum scaling factor
const float outSpeed = 2.0;  // shrink speed when zooming out
const float outNorm = (1. - minScale) / atan(outSpeed);
float scale = zoom < 1. ? 1. + outNorm * atan(outSpeed * (zoom - 1.)) :
                     1. + 2. / PI * (maxScale - 1.) * atan(inSpeed * (zoom - 1.));
```
When the sizing speed is increased the function responds with an increased gradient around the pivot:
<img width="300" src="https://user-images.githubusercontent.com/10847676/32363915-63497ae6-c07a-11e7-9a53-8efbbd29e28a.png"><img width="300" src="https://user-images.githubusercontent.com/10847676/32364002-01444370-c07b-11e7-93f2-c2c2a4ca2d56.png">
![image](https://user-images.githubusercontent.com/10847676/32363918-6ab078ac-c07a-11e7-9e5d-777e32ce06f7.png)![image](https://user-images.githubusercontent.com/10847676/32364009-0d2cbe38-c07b-11e7-86f2-d190b62b6391.png)

### Greater than zoom pivot
Now for a zoom greater than the pivot lets use the positive domain of the arc tangent to promote slower sizing when zooming in to reduce occlusion, here _m_ is the maximum scaling factor, _s_ the sizing speed, and _z_ the zoom:
![image](https://user-images.githubusercontent.com/10847676/32364171-045cecdc-c07c-11e7-937b-eeedf9809e46.png)
![image](https://user-images.githubusercontent.com/10847676/32364174-0f6b34b2-c07c-11e7-977c-ef5be7acca02.png)
A maximum size scaling factor of 15x and a slow sizing speed of 0.02 is chosen as it produces an agreeable sizing dynamic:
```cpp
const float maxScale = 15.0;  // maximum scaling factor
const float inSpeed = 0.02;  // enlarge speed when zooming in
float scale = zoom < 1. ? 1. + outNorm * atan(outSpeed * (zoom - 1.)) :
                     1. + 2. / PI * (maxScale - 1.) * atan(inSpeed * (zoom - 1.));
```
<img width="300" src="https://user-images.githubusercontent.com/10847676/32364615-7da1412c-c07e-11e7-96a5-2e8b81c1aa55.png">
<img src="https://user-images.githubusercontent.com/10847676/32364586-59483eca-c07e-11e7-993c-7c125776b87d.png">

The sizing speed can also be adjusted here to change the sizing gradient:

<img width="300" src="https://user-images.githubusercontent.com/10847676/32364505-e8238b82-c07d-11e7-936b-047bba61263f.png"><img width="300" src="https://user-images.githubusercontent.com/10847676/32364538-1c0be6ce-c07e-11e7-8e3b-11556cec08dd.png">
<img src="https://user-images.githubusercontent.com/10847676/32364536-17dc778a-c07e-11e7-9e50-ff3fa7bab1e9.png"><img src="https://user-images.githubusercontent.com/10847676/32364540-20455806-c07e-11e7-9134-2ab78c663281.png">


