### PR TITLE
Projector: Add selection editor

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -21,7 +21,7 @@ import * as scatterPlot from './scatterPlot.js';
 import * as util from './util.js';
 import * as vector from './vector.js';
 
-export type DistanceFunction = (a: number[], b: number[]) => number;
+export type DistanceFunction = (a: vector.Vector, b: vector.Vector) => number;
 export type ProjectionComponents3D = [string, string, string];
 
 export interface PointMetadata { [key: string]: number|string; }

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.html
@@ -292,6 +292,9 @@ limitations under the License.
       <paper-icon-button id="selectMode" alt="Bounding box selection" toggles icon="image:photo-size-select-small"></paper-icon-button>
       <paper-tooltip for="selectMode" position="bottom" animation-delay="0" fit-to-visible-bounds>Bounding box selection</paper-tooltip>
 
+      <paper-icon-button id="editMode" alt="Edit current selection" toggles icon="image:exposure"></paper-icon-button>
+      <paper-tooltip for="editMode" position="bottom" animation-delay="0" fit-to-visible-bounds>Edit current selection</paper-tooltip>
+
       <paper-icon-button id="nightDayMode" alt="Enable/disable night mode" toggles icon="image:brightness-2"></paper-icon-button>
       <paper-tooltip for="nightDayMode" position="bottom" animation-delay="0" fit-to-visible-bounds>Enable/disable night mode</paper-tooltip>
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -77,6 +77,7 @@ export class Projector extends ProjectorPolymer implements
   private selectedPointIndices: number[];
   private neighborsOfFirstPoint: knn.NearestEntry[];
   private hoverPointIndex: number;
+  private editMode: boolean;
 
   private dataProvider: DataProvider;
   private inspectorPanel: InspectorPanel;
@@ -119,6 +120,7 @@ export class Projector extends ProjectorPolymer implements
     this.distanceMetricChangedListeners = [];
     this.selectedPointIndices = [];
     this.neighborsOfFirstPoint = [];
+    this.editMode = false;
 
     this.dataPanel = this.$['data-panel'] as DataPanel;
     this.inspectorPanel = this.$['inspector-panel'] as InspectorPanel;
@@ -241,19 +243,58 @@ export class Projector extends ProjectorPolymer implements
    * Used by clients to indicate that a selection has occurred.
    */
   notifySelectionChanged(newSelectedPointIndices: number[]) {
-    this.selectedPointIndices = newSelectedPointIndices;
     let neighbors: knn.NearestEntry[] = [];
 
-    if (newSelectedPointIndices.length === 1) {
-      neighbors = this.dataSet.findNeighbors(
-          newSelectedPointIndices[0], this.inspectorPanel.distFunc,
-          this.inspectorPanel.numNN);
-      this.metadataCard.updateMetadata(
-          this.dataSet.points[newSelectedPointIndices[0]].metadata);
-    } else {
-      this.metadataCard.updateMetadata(null);
-    }
+    if (this.editMode  // point selection toggle in existing selection
+        && newSelectedPointIndices.length > 0) {  // selection required
+      if (this.selectedPointIndices.length === 1) {  // main point with neighbors
+        let main_point_vector = this.dataSet.points[
+            this.selectedPointIndices[0]].vector;
+        neighbors = this.neighborsOfFirstPoint.filter(n =>  // deselect
+            newSelectedPointIndices.filter(p => p == n.index).length == 0);
+        newSelectedPointIndices.forEach(p => {  // add additional neighbors
+          if (p != this.selectedPointIndices[0]  // not main point
+              && this.neighborsOfFirstPoint.filter(n => n.index == p).length == 0) {
+            let p_vector = this.dataSet.points[p].vector;
+            let n_dist = this.inspectorPanel.distFunc(main_point_vector, p_vector);
+            let pos = 0;  // insertion position into dist ordered neighbors
+            while (pos < neighbors.length && neighbors[pos].dist < n_dist)  // find pos
+              pos = pos + 1;  // move up the sorted neighbors list according to dist
+            neighbors.splice(pos, 0, {index: p, dist: n_dist});  // add new neighbor
+          }
+        });
+      }
+      else {  // multiple selections
+        let updatedSelectedPointIndices = this.selectedPointIndices.filter(n =>
+            newSelectedPointIndices.filter(p => p == n).length == 0);  // deselect
+        newSelectedPointIndices.forEach(p => {  // add additional selections
+          if (this.selectedPointIndices.filter(s => s == p).length == 0)  // unselected
+            updatedSelectedPointIndices.push(p);
+        });
+        this.selectedPointIndices = updatedSelectedPointIndices;  // update selection
 
+        if (this.selectedPointIndices.length > 0) {  // at least one selected point
+          this.metadataCard.updateMetadata(  // show metadata for first selected point
+              this.dataSet.points[this.selectedPointIndices[0]].metadata);
+        } else {  // no points selected
+          this.metadataCard.updateMetadata(null);  // clear metadata
+        }
+      }
+    }
+    else {  // normal selection mode
+      this.selectedPointIndices = newSelectedPointIndices;
+
+      if (newSelectedPointIndices.length === 1) {
+        neighbors = this.dataSet.findNeighbors(
+            newSelectedPointIndices[0], this.inspectorPanel.distFunc,
+            this.inspectorPanel.numNN);
+        this.metadataCard.updateMetadata(
+            this.dataSet.points[newSelectedPointIndices[0]].metadata);
+      } else {
+        this.metadataCard.updateMetadata(null);
+      }
+    }
+    
     this.selectionChangedListeners.forEach(
         l => l(this.selectedPointIndices, neighbors));
   }
@@ -416,6 +457,11 @@ export class Projector extends ProjectorPolymer implements
     nightModeButton.addEventListener('click', () => {
       this.projectorScatterPlotAdapter.scatterPlot.setDayNightMode(
           (nightModeButton as any).active);
+    });
+
+    let editModeButton = this.querySelector('#editMode');
+      editModeButton.addEventListener('click', (event) => {
+        this.editMode = (editModeButton as any).active;
     });
 
     const labels3DModeButton = this.get3DLabelModeButton();


### PR DESCRIPTION
In the Projector any point selections can be modified by toggling selection/deselection, which can be done for single points or a collection.

Demo here: http://tensorserve.com:6012
```bash
git clone -b projector-selection-editor https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout 9d9a9658fa8ffbe29e55ed375f2abd97019f4591
bazel run tensorboard -- --logdir /home/emnist-2000 --host 0.0.0.0 --port 6012
```

### Design and behavior
1. Uses toggle button for edit mode, like "Bounding box selection".
2. When edit mode is off Projector works exactly as before.
3. When edit mode is on, any existing point selection will toggle selection/deselection for any chosen points, even for multiple points now selected with bounding box.
4. Inspector panel neighbors list gets updated with appropriate distance calculated for any newly selected/added points, which are inserted correctly to keep distance sorting of neighbors list.
5. The main point, i.e. an initial point for which a neighborhood is calculated, cannot be deselected in edit mode.
6. Checks are in place to ensure no points are duplicated in the selection arrays.

### Projector toolbar before:
<img width="538" src="https://user-images.githubusercontent.com/10847676/32377715-34ae0738-c0b1-11e7-87d9-9d72bfd1d96e.png">

### Projector toolbar after:
<img width="540" src="https://user-images.githubusercontent.com/10847676/32377646-0aabe8b0-c0b1-11e7-958a-726398a177e6.png">
<img width="538" src="https://user-images.githubusercontent.com/10847676/32377645-0a671992-c0b1-11e7-9bce-b72c74da0ada.png">

