### PR TITLE
Convert the simplest cases of <content> to <slot>

### DIFF
--- a/tensorboard/components/tf_card_heading/tf-card-heading.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading.html
@@ -66,7 +66,7 @@ limitations under the License.
             </div>
           </div>
         </template>
-        <content></content>
+        <slot></slot>
       </figcaption>
       <template is="dom-if" if="[[description]]">
         <paper-icon-button

--- a/tensorboard/components/tf_categorization_utils/tf-category-pane.html
+++ b/tensorboard/components/tf_categorization_utils/tf-category-pane.html
@@ -45,7 +45,7 @@ limitations under the License.
       <iron-collapse opened="[[_opened]]">
         <div class="content">
           <template is="dom-if" if="[[_opened]]" restamp="[[restamp]]">
-            <content></content>
+            <slot></slot>
           </template>
         </div>
       </iron-collapse>

--- a/tensorboard/components/tf_dashboard_common/tf-option-selector.html
+++ b/tensorboard/components/tf_dashboard_common/tf-option-selector.html
@@ -26,7 +26,7 @@ provides a "selectedId" property that is one of the IDs of the buttons inside it
   <template>
     <div id="wrap">
       <h3>[[name]]</h3>
-      <div class="content-wrapper"><content></content></div>
+      <div class="content-wrapper"><slot></slot></div>
     </div>
     <style>
       .content-wrapper ::content > * {

--- a/tensorboard/components/tf_option_selector/tf-option-selector.html
+++ b/tensorboard/components/tf_option_selector/tf-option-selector.html
@@ -26,7 +26,7 @@ provides a "selectedId" property that is one of the IDs of the buttons inside it
   <template>
     <div id="wrap">
       <h3>[[name]]</h3>
-      <div class="content-wrapper"><content></content></div>
+      <div class="content-wrapper"><slot></slot></div>
     </div>
     <style>
       .content-wrapper ::content > * {

--- a/tensorboard/components/tf_paginated_view/tf-paginated-view.html
+++ b/tensorboard/components/tf_paginated_view/tf-paginated-view.html
@@ -67,7 +67,7 @@ limitations under the License.
         >Next page</paper-button>
       </div>
     </template>
-    <div><content></content></div>
+    <div><slot></slot></div>
     <template is="dom-if" if="[[_multiplePagesExist]]">
       <div id="controls-container">
         <div style="display: inline-block; padding: 0 5px">

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -138,7 +138,7 @@ limitations under the License.
       </paper-toolbar>
 
       <div id="content" class="fit">
-        <content id="injected-overview"></content>
+        <slot id="injected-overview"></slot>
         <template is="dom-if" if="[[_activeDashboardsFailedToLoad]]">
           <div class="warning-message">
             <h3>Failed to load the set of active dashboards.</h3>


### PR DESCRIPTION
*Imported from cl/174107529 and cl/174588409*

The `<content>` element is deprecated, part of the Shadow DOM v0 API which has
been supplanted by Shadow DOM v1's `<slot>` element. For very simple uses – like
those in this CL – this change should be safe and will not require changes to
the usage sites of your element. Therefor, these changes are
backwards-compatible with Polymer 1.0 applications.

As `<content>` is the more powerful API, Polymer 1.0 supports both `<content>` and
`<slot>` by converting `<slot>` back into `<content>` at runtime. Polymer 2.0 only
supports `<slot>`. There will likely never be cross-browser native support for
`<content>`, while Safari and Chrome already support `<slot>` natively.