### PR TITLE
Projector: Add inspector-panel distance space selection

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -22,6 +22,7 @@ import * as util from './util.js';
 import * as vector from './vector.js';
 
 export type DistanceFunction = (a: number[], b: number[]) => number;
+export type DistanceSpace = (_: DataPoint) => Float32Array;
 export type ProjectionComponents3D = [string, string, string];
 
 export interface PointMetadata { [key: string]: number|string; }
@@ -410,11 +411,11 @@ export class DataSet {
    * Finds the nearest neighbors of the query point using a
    * user-specified distance metric.
    */
-  findNeighbors(pointIndex: number, distFunc: DistanceFunction, numNN: number):
-      knn.NearestEntry[] {
+  findNeighbors(pointIndex: number, distFunc: DistanceFunction,
+      distSpace: DistanceSpace, numNN: number): knn.NearestEntry[] {
     // Find the nearest neighbors of a particular point.
     let neighbors = knn.findKNNofPoint(
-        this.points, pointIndex, numNN, (d => d.vector), distFunc);
+        this.points, pointIndex, numNN, distSpace, distFunc);
     // TODO(@dsmilkov): Figure out why we slice.
     let result = neighbors.slice(0, numNN);
     return result;

--- a/tensorboard/plugins/projector/vz_projector/projectorEventContext.ts
+++ b/tensorboard/plugins/projector/vz_projector/projectorEventContext.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DistanceFunction, Projection} from './data.js';
+import {DistanceFunction, DistanceSpace, Projection} from './data.js';
 import {NearestEntry} from './knn.js';
 
 export type HoverListener = (index: number) => void;
@@ -23,6 +23,8 @@ export type SelectionChangedListener =
 export type ProjectionChangedListener = (projection: Projection) => void;
 export type DistanceMetricChangedListener =
     (distanceMetric: DistanceFunction) => void;
+export type DistanceSpaceChangedListener =
+    (distanceSpace: DistanceSpace) => void;
 export interface ProjectorEventContext {
   /** Register a callback to be invoked when the mouse hovers over a point. */
   registerHoverListener(listener: HoverListener);
@@ -42,4 +44,7 @@ export interface ProjectorEventContext {
   registerDistanceMetricChangedListener(listener:
                                             DistanceMetricChangedListener);
   notifyDistanceMetricChanged(distMetric: DistanceFunction);
+  registerDistanceSpaceChangedListener(listener:
+                                            DistanceSpaceChangedListener);
+  notifyDistanceSpaceChanged(distSpace: DistanceSpace);
 }

--- a/tensorboard/plugins/projector/vz_projector/projectorScatterPlotAdapter.ts
+++ b/tensorboard/plugins/projector/vz_projector/projectorScatterPlotAdapter.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DataSet, DistanceFunction, Projection, ProjectionComponents3D, State} from './data.js';
+import {DataSet, DistanceFunction, DistanceSpace, Projection, ProjectionComponents3D, State} from './data.js';
 import {NearestEntry} from './knn.js';
 import {ProjectorEventContext} from './projectorEventContext.js';
 import {LabelRenderParams} from './renderContext.js';
@@ -84,6 +84,7 @@ export class ProjectorScatterPlotAdapter {
   private labelPointAccessor: string;
   private legendPointColorer: (ds: DataSet, index: number) => string;
   private distanceMetric: DistanceFunction;
+  private distanceSpace: DistanceSpace;
 
   private spriteVisualizer: ScatterPlotVisualizerSprites;
   private labels3DVisualizer: ScatterPlotVisualizer3DLabels;
@@ -115,6 +116,12 @@ export class ProjectorScatterPlotAdapter {
     projectorEventContext.registerDistanceMetricChangedListener(
         distanceMetric => {
           this.distanceMetric = distanceMetric;
+          this.updateScatterPlotAttributes();
+          this.scatterPlot.render();
+        });
+    projectorEventContext.registerDistanceSpaceChangedListener(
+        distanceSpace => {
+          this.distanceSpace = distanceSpace;
           this.updateScatterPlotAttributes();
           this.scatterPlot.render();
         });

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
@@ -131,7 +131,7 @@ limitations under the License.
   width: 100px;
 }
 
-.distance .options {
+.distance .options, .distance-space .options {
   float: right;
 }
 
@@ -147,14 +147,14 @@ limitations under the License.
 }
 
 .neighbors {
-  margin-bottom: 30px;
+  margin-bottom: 10px;
 }
 
-.neighbors-options {
+.neighbors-options, .distance, .distance-space {
   margin-top: 6px;
 }
 
-.neighbors-options .option-label, .distance .option-label {
+.neighbors-options .option-label, .distance .option-label, .distance-space .option-label {
   color: #727272;
   margin-right: 2px;
   width: auto;
@@ -168,7 +168,7 @@ limitations under the License.
   margin: 0 -12px 0 10px;
 }
 
-.euclidean {
+.euclidean, .tsne-space {
   margin-right: 10px;
 }
 
@@ -229,6 +229,14 @@ limitations under the License.
         <div class="options">
           <a class="selected cosine" href="javascript:void(0);">COSINE</a>
           <a class="euclidean" href="javascript:void(0);">EUCLIDEAN</a>
+        </div>
+      </div>
+      <div class="distance-space">
+        <span class="option-label">dist. space</span>
+        <div class="options">
+          <a class="selected original-space" href="javascript:void(0);">ORIGINAL</a>
+          <a class="pca-space" href="javascript:void(0);">PCA</a>
+          <a class="tsne-space" href="javascript:void(0);">T-SNE</a>
         </div>
       </div>
     </div>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -15,14 +15,14 @@ limitations under the License.
 
 import {AnalyticsLogger} from './analyticsLogger.js';
 import * as data from './data.js';
-import {ColorOption, ColumnStats, DataPoint, DataProto, DataSet, DistanceFunction, PointMetadata, Projection, SpriteAndMetadataInfo, State, stateGetAccessorDimensions} from './data.js';
+import {ColorOption, ColumnStats, DataPoint, DataProto, DataSet, DistanceFunction, DistanceSpace, PointMetadata, Projection, SpriteAndMetadataInfo, State, stateGetAccessorDimensions} from './data.js';
 import {DataProvider, EmbeddingInfo, ServingMode} from './data-provider.js';
 import {DemoDataProvider} from './data-provider-demo.js';
 import {ProtoDataProvider} from './data-provider-proto.js';
 import {ServerDataProvider} from './data-provider-server.js';
 import * as knn from './knn.js';
 import * as logging from './logging.js';
-import {DistanceMetricChangedListener, HoverListener, ProjectionChangedListener, ProjectorEventContext, SelectionChangedListener} from './projectorEventContext.js';
+import {DistanceMetricChangedListener, DistanceSpaceChangedListener, HoverListener, ProjectionChangedListener, ProjectorEventContext, SelectionChangedListener} from './projectorEventContext.js';
 import {ProjectorScatterPlotAdapter} from './projectorScatterPlotAdapter.js';
 import {MouseMode} from './scatterPlot.js';
 import * as util from './util.js';
@@ -67,6 +67,7 @@ export class Projector extends ProjectorPolymer implements
   private hoverListeners: HoverListener[];
   private projectionChangedListeners: ProjectionChangedListener[];
   private distanceMetricChangedListeners: DistanceMetricChangedListener[];
+  private distanceSpaceChangedListeners: DistanceSpaceChangedListener[];
 
   private originalDataSet: DataSet;
   private dataSetBeforeFilter: DataSet;
@@ -117,6 +118,7 @@ export class Projector extends ProjectorPolymer implements
     this.hoverListeners = [];
     this.projectionChangedListeners = [];
     this.distanceMetricChangedListeners = [];
+    this.distanceSpaceChangedListeners = [];
     this.selectedPointIndices = [];
     this.neighborsOfFirstPoint = [];
 
@@ -247,7 +249,7 @@ export class Projector extends ProjectorPolymer implements
     if (newSelectedPointIndices.length === 1) {
       neighbors = this.dataSet.findNeighbors(
           newSelectedPointIndices[0], this.inspectorPanel.distFunc,
-          this.inspectorPanel.numNN);
+          this.inspectorPanel.distSpace, this.inspectorPanel.numNN);
       this.metadataCard.updateMetadata(
           this.dataSet.points[newSelectedPointIndices[0]].metadata);
     } else {
@@ -286,6 +288,14 @@ export class Projector extends ProjectorPolymer implements
 
   notifyDistanceMetricChanged(distMetric: DistanceFunction) {
     this.distanceMetricChangedListeners.forEach(l => l(distMetric));
+  }
+
+  registerDistanceSpaceChangedListener(l: DistanceSpaceChangedListener) {
+    this.distanceSpaceChangedListeners.push(l);
+  }
+
+  notifyDistanceSpaceChanged(distSpace: DistanceSpace) {
+    this.distanceSpaceChangedListeners.forEach(l => l(distSpace));
   }
 
   _dataProtoChanged(dataProtoString: string) {


### PR DESCRIPTION
Add a distance space selection in the projector inspector-panel, choosing from 'original', 'pca' or 't-sne' spaces in which the distance function is calculated. This selection may be desired when neighbors according to the original, typically high-dimensional space are not as useful as neighbors in the projected space.

Demo here: http://tensorserve.com:6013
```bash
git clone -b projector-inspector-distspace https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout a63c3301862a1ee75559bb50adcd7e4dd966635b
bazel run tensorboard -- --logdir /home/emnist-2000 --host 0.0.0.0 --port 6013
```
### Design and behavior
1. Original distance space is the default selection and gives exactly the same behavior as before, with the exception that now a change in distance function selection updates the projector display (bug fix - since Cosine and Euclidean distance functions likely gives same neighborhood in high dimensional original space, the lack of projector display update after distance function change was never noticed).
2. t-SNE distance space selection is disabled until the t-SNE projection is activated.
3. Can use any distance space in any projection, given t-SNE has been activated, e.g. can show t-SNE neighbors in PCA projection, or PCA neighbors in t-SNE projection.
4. Types and placeholders are used so that other distance spaces can be defined in future.

### Inspector panel before
<img width="283" src="https://user-images.githubusercontent.com/10847676/32408492-4d28dbb2-c1a1-11e7-884f-708313e79443.png">

### Inspector panel with distance space selection
<img width="283" src="https://user-images.githubusercontent.com/10847676/32408493-4d636aa2-c1a1-11e7-9463-15c1abc32241.png">
