### PR TITLE
Projector: Perturb t-SNE solution

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/bh_tsne.ts
+++ b/tensorboard/plugins/projector/vz_projector/bh_tsne.ts
@@ -315,7 +315,7 @@ export class TSNE {
   getSolution() { return this.Y; }
 
   // perform a single step of optimization to improve the embedding
-  step() {
+  step(perturb: number) {
     this.iter += 1;
     let N = this.N;
 
@@ -344,6 +344,7 @@ export class TSNE {
         // step!
         let i_d = i * this.dim + d;
         this.Y[i_d] += newsid;
+        this.Y[i_d] *= 1.0 + perturb * (Math.random() - 1.0);
         ymean[d] += this.Y[i_d];  // accumulate mean so that we
                                   // can center later
       }

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -131,6 +131,8 @@ export class DataSet {
   nearestK: number;
   tSNEIteration: number = 0;
   tSNEShouldStop = true;
+  tSNEShouldPerturb = false;
+  perturbFactor: number = 0.4;
   dim: [number, number] = [0, 0];
   hasTSNERun: boolean = false;
   spriteAndMetadataInfo: SpriteAndMetadataInfo;
@@ -313,6 +315,7 @@ export class DataSet {
     let opt = {epsilon: learningRate, perplexity: perplexity, dim: tsneDim};
     this.tsne = new TSNE(opt);
     this.tSNEShouldStop = false;
+    this.tSNEShouldPerturb = false;
     this.tSNEIteration = 0;
 
     let sampledIndices = this.shuffledDataIndices.slice(0, TSNE_SAMPLE_SIZE);
@@ -322,7 +325,8 @@ export class DataSet {
         this.tsne = null;
         return;
       }
-      this.tsne.step();
+      this.tsne.step(this.tSNEShouldPerturb ? this.perturbFactor : 0.0);
+      this.tSNEShouldPerturb = false;
       let result = this.tsne.getSolution();
       sampledIndices.forEach((index, i) => {
         let dataPoint = this.points[index];

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
@@ -46,7 +46,7 @@ limitations under the License.
   border-radius: 2px;
   font-size: 13px;
   padding: 10px;
-  min-width: 100px;
+  min-width: 88px;
   flex-shrink: 0;
   background: #e3e3e3;
 }
@@ -212,9 +212,24 @@ limitations under the License.
         </paper-slider>
         <span></span>
       </div>
+      <div class="slider tsne-perturb-factor">
+        <label>
+          Perturb factor
+          <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
+          <paper-tooltip position="right" animation-delay="0" fit-to-visible-bounds>
+            The multiplicative factor that determines the extent of the perturb offset, 
+            which is applied to positions independently per point and dimension.
+          </paper-tooltip>
+        </label>
+        <paper-slider id="perturb-factor-slider" snaps min="0.1" max="0.8" step="0.1"
+            value="0.4" max-markers="8">
+        </paper-slider>
+        <span></span>
+      </div>
       <p>
         <button class="run-tsne ink-button" title="Re-run t-SNE">Re-run</button>
         <button class="stop-tsne ink-button" title="Stop t-SNE">Stop</button>
+        <button class="perturb-tsne ink-button" title="Perturb t-SNE">Perturb</button>
       </p>
       <p>Iteration: <span class="run-tsne-iter">0</span></p>
       <p id="tsne-sampling" class="notice">

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -95,8 +95,10 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   /** Polymer elements. */
   private runTsneButton: HTMLButtonElement;
   private stopTsneButton: HTMLButtonElement;
+  private perturbTsneButton: HTMLButtonElement;
   private perplexitySlider: HTMLInputElement;
   private learningRateInput: HTMLInputElement;
+  private perturbFactorInput: HTMLInputElement;
   private zDropdown: HTMLElement;
   private iterationLabel: HTMLElement;
 
@@ -124,10 +126,13 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
     this.zDropdown = this.querySelector('#z-dropdown') as HTMLElement;
     this.runTsneButton = this.querySelector('.run-tsne') as HTMLButtonElement;
     this.stopTsneButton = this.querySelector('.stop-tsne') as HTMLButtonElement;
+    this.perturbTsneButton = this.querySelector('.perturb-tsne') as HTMLButtonElement;
     this.perplexitySlider =
         this.querySelector('#perplexity-slider') as HTMLInputElement;
     this.learningRateInput =
         this.querySelector('#learning-rate-slider') as HTMLInputElement;
+    this.perturbFactorInput =
+        this.querySelector('#perturb-factor-slider') as HTMLInputElement;
     this.iterationLabel = this.querySelector('.run-tsne-iter') as HTMLElement;
   }
 
@@ -155,6 +160,14 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
         .innerText = '' + this.learningRate;
   }
 
+  private updateTSNEPerturbFactorFromUIChange() {
+    if (this.perturbFactorInput && this.dataSet) {
+      this.dataSet.perturbFactor = +this.perturbFactorInput.value;
+    }
+    (this.querySelector('.tsne-perturb-factor span') as HTMLSpanElement)
+        .innerText = '' + this.perturbFactorInput.value;
+  }
+
   private setupUIControls() {
     {
       const self = this;
@@ -171,6 +184,10 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
     this.stopTsneButton.addEventListener(
         'click', () => this.dataSet.stopTSNE());
 
+    this.perturbTsneButton.addEventListener('click', () => {
+      this.dataSet.tSNEShouldPerturb = !this.dataSet.tSNEShouldPerturb;
+    });
+
     this.perplexitySlider.value = this.perplexity.toString();
     this.perplexitySlider.addEventListener(
         'change', () => this.updateTSNEPerplexityFromSliderChange());
@@ -179,6 +196,10 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
     this.learningRateInput.addEventListener(
         'change', () => this.updateTSNELearningRateFromUIChange());
     this.updateTSNELearningRateFromUIChange();
+
+    this.perturbFactorInput.addEventListener(
+        'change', () => this.updateTSNEPerturbFactorFromUIChange());
+    this.updateTSNEPerturbFactorFromUIChange();
 
     this.setupCustomProjectionInputFields();
     // TODO: figure out why `--paper-input-container-input` css mixin didn't
@@ -234,6 +255,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
     this.setZDropdownEnabled(this.pcaIs3d);
     this.updateTSNEPerplexityFromSliderChange();
     this.updateTSNELearningRateFromUIChange();
+    this.updateTSNEPerturbFactorFromUIChange();
     if (this.iterationLabel) {
       this.iterationLabel.innerText = bookmark.tSNEIteration.toString();
     }
@@ -421,6 +443,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   private runTSNE() {
     this.runTsneButton.disabled = true;
     this.stopTsneButton.disabled = null;
+    this.perturbTsneButton.disabled = false;
     this.dataSet.projectTSNE(
         this.perplexity, this.learningRate, this.tSNEis3d ? 3 : 2,
         (iteration: number) => {
@@ -430,6 +453,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
           } else {
             this.runTsneButton.disabled = null;
             this.stopTsneButton.disabled = true;
+            this.perturbTsneButton.disabled = true;
           }
         });
   }


### PR DESCRIPTION
A user-defined perturb factor determines the extent of random position shifts upon pressing of Perturb button, which is useful to move out of a local optimum or to alter the solution for a fresh perspective. Perturb T-SNE by independently scaling point positions when Perturb button is clicked, which is useful to move out of a local optima.

Demo here: http://tensorserve.com:6014
```bash
git clone -b projector-tsne-perturb https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout 5b6a71b30f8f5b68896bef4354c90fd4d8bd73e1
bazel run tensorboard -- --logdir /home/emnist-2000 --host 0.0.0.0 --port 6014
```
### Design and behavior:
1. Behavior remains exactly the same when the perturb button is never clicked.
2. Only one change is made in the t-SNE step() function, with a random independent downscaling of point coordinates of which the scaling magnitude is influenced by the perturb factor.
3. A small perturb factor of 0.1 scales a coordinate randomly in range [0.9, 1], and a large perturb factor of 0.8 scales in range [0.2, 1].
4. A coordinate scaling larger than 1 appears to cause unwanted effects where points on the extrema can be pushed out further, which squeezes the majority of the points in as the embedding is normally scaled to fit in the extrema. So we only randomly scale down coordinates, which appears to render the desired effect.
5. The perturb button can be pressed, when activated, at any time and repetitively to produce an even greater cumulative perturbation.

### t-SNE panel before:
<img width="313" src="https://user-images.githubusercontent.com/10847676/32413724-5a7f4628-c220-11e7-8327-f8b34ca1459c.png">

### t-SNE panel with Perturb slider/button:
<img width="313" src="https://user-images.githubusercontent.com/10847676/32413723-5a4834b2-c220-11e7-9786-18d59a8a47a1.png">

