### PR TITLE
Remove explicitly set language mode in Vulcanize

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -375,7 +375,6 @@ public final class Vulcanize {
     // Nice options.
     options.setColorizeErrorOutput(true);
     options.setContinueAfterErrors(true);
-    options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT_2016);
     options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT5);
     options.setGenerateExports(true);
     options.setStrictModeInput(false);
@@ -528,7 +527,6 @@ public final class Vulcanize {
   private static String minify(Webpath path, String script) {
     CompilerOptions options = new CompilerOptions();
     options.skipAllCompilerPasses();
-    options.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT_2016);
     options.setLanguageOut(CompilerOptions.LanguageMode.ECMASCRIPT5);
     options.setContinueAfterErrors(true);
     CompilationLevel.SIMPLE_OPTIMIZATIONS.setOptionsForCompilationLevel(options);


### PR DESCRIPTION
*Imported from cl/174861943*

The default is now ECMASCRIPT_2017 (aka ECMAScript 8) and the language versions
will be advancing much more quickly in coming years.