### PR TITLE
Preload and precompress static assets in CorePlugin

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -123,7 +123,6 @@ def Respond(request,
       request.headers.get('Accept-Encoding', ''))
   # Automatically gzip uncompressed text data if accepted.
   if textual and not content_encoding and gzip_accepted:
-    orig_len = len(content)
     out = six.BytesIO()
     # Set mtime to zero to make payload for a given input deterministic.
     with gzip.GzipFile(fileobj=out, mode='wb', compresslevel=3, mtime=0) as f:

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -139,17 +139,17 @@ class RespondTest(tf.test.TestCase):
         r.response, [fall_of_hyperion_canto1_stanza1.encode('utf-8')])
 
   def testAcceptGzip_alreadyCompressed_sendsPrecompressedResponse(self):
-    gzipped_text = _gzip('hello hello hello world')
+    gzip_text = _gzip(b'hello hello hello world')
     e = wtest.EnvironBuilder(headers={'Accept-Encoding': 'gzip'}).get_environ()
     q = wrappers.Request(e)
-    r = http_util.Respond(q, gzipped_text, 'text/plain', content_encoding='gzip')
-    self.assertEqual(r.response, [gzipped_text])  # Still singly zipped
+    r = http_util.Respond(q, gzip_text, 'text/plain', content_encoding='gzip')
+    self.assertEqual(r.response, [gzip_text])  # Still singly zipped
 
   def testPrecompressedResponse_noAcceptGzip_decompressesResponse(self):
-    orig_text = 'hello hello hello world'
-    gzipped_text = _gzip(orig_text)
+    orig_text = b'hello hello hello world'
+    gzip_text = _gzip(orig_text)
     q = wrappers.Request(wtest.EnvironBuilder().get_environ())
-    r = http_util.Respond(q, gzipped_text, 'text/plain', content_encoding='gzip')
+    r = http_util.Respond(q, gzip_text, 'text/plain', content_encoding='gzip')
     self.assertEqual(r.response, [orig_text])
 
   def testJson_getsAutoSerialized(self):

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -19,9 +19,11 @@ from __future__ import division
 from __future__ import print_function
 
 import functools
+import gzip
 import mimetypes
 import zipfile
 
+import six
 import tensorflow as tf
 from werkzeug import utils
 from werkzeug import wrappers
@@ -65,12 +67,13 @@ class CorePlugin(base_plugin.TBPlugin):
         '/images': self._redirect_to_index,
     }
     if self._assets_zip_provider:
-      apps['/'] = functools.partial(self._serve_asset, 'index.html')
       with self._assets_zip_provider() as fp:
         with zipfile.ZipFile(fp) as zip_:
-          for info in zip_.infolist():
-            path = info.filename
-            apps['/' + path] = functools.partial(self._serve_asset, path)
+          for path in zip_.namelist():
+            gzipped_asset_bytes = _gzip(zip_.read(path))
+            apps['/' + path] = functools.partial(
+                self._serve_asset, path, gzipped_asset_bytes)
+      apps['/'] = apps['/index.html']
     return apps
 
   @wrappers.Request.application
@@ -82,14 +85,11 @@ class CorePlugin(base_plugin.TBPlugin):
     return utils.redirect('/')
 
   @wrappers.Request.application
-  def _serve_asset(self, path, request):
-    """Serves a static asset from the zip file."""
+  def _serve_asset(self, path, gzipped_asset_bytes, request):
+    """Serves a pre-gzipped static asset from the zip file."""
     mimetype = mimetypes.guess_type(path)[0] or 'application/octet-stream'
-    with self._assets_zip_provider() as fp:
-      with zipfile.ZipFile(fp) as zip_:
-        with zip_.open(path) as file_:
-          html = file_.read()
-    return http_util.Respond(request, html, mimetype)
+    return http_util.Respond(
+        request, gzipped_asset_bytes, mimetype, content_encoding='gzip')
 
   @wrappers.Request.application
   def _serve_logdir(self, request):
@@ -129,3 +129,11 @@ class CorePlugin(base_plugin.TBPlugin):
     }
     run_names.sort(key=first_event_timestamps.get)
     return http_util.Respond(request, run_names, 'application/json')
+
+
+def _gzip(bytestring):
+  out = six.BytesIO()
+  # Set mtime to zero for deterministic results across TensorBoard launches.
+  with gzip.GzipFile(fileobj=out, mode='wb', compresslevel=3, mtime=0) as f:
+    f.write(bytestring)
+  return out.getvalue()


### PR DESCRIPTION
This changes CorePlugin to load its static assets into memory at startup and precompress them with gzip.  The two static assets in this case are "index.html" (the main vulcanized TensorBoard HTML blob) and "trace_viewer_index.html".  Since "index.html" at a minimum is always served when using TensorBoard, this spends roughly 1 MB of extra RAM to move the cost of preparing it to startup-time so that it can be served directly from memory.

Prior to this change, a typical request for those assets would involve 1) a disk read to open the assets_zip_provider webfiles.zip file, 2) unzipping that zip file, 3) extracting the index.html file from the zip archive, and 4) recompressing the file using gzip (about 40ms to compress 2.6MB down to 0.7ish) to send it back to the client.

Now it's just served as precompressed gzip data directly from memory.  From some basic testing on my workstation with a local TensorBoard, this changes the TTFB (Time To First Byte [1]) for index.html from about 100ms average to less than 5ms, and the average delay to DOMContentLoaded firing correspondingly drops from about 1000ms to 900ms.

Modern browsers pretty much all send `Accept-Encoding: gzip` but in case the user doesn't send that header, this change also adds support for decompressing precompressed data before responding.  In theory we could avoid the decompression delay as well by also storing uncompressed assets in memory, but I opted not to because it complicates the Respond() API and the argument in favor is much weaker since decompression is typically faster than compression (in testing it took about 20ms for index.html) and we expect gzip supporting requests to be the vast majority, so it'd be spending more memory to save less time less often.

[1] https://developers.google.com/web/tools/chrome-devtools/network-performance/reference#timing-explanation