### PR TITLE
Projector: Metadata editor

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
@@ -116,6 +116,28 @@ paper-dropdown-menu paper-item {
   margin: 10px 0;
 }
 
+.metadata-edit {
+  display: flex;
+}
+
+.metadata-edit vz-projector-input {
+  width: calc(100%-150px);
+}
+
+.metadata-edit paper-dropdown-menu {
+  margin-left: 10px;
+  width: 100px;
+}
+
+#apply-label {
+  margin-left: 10px;
+  margin-right: 0px;
+  margin-top: 20px;
+  min-width: 40px;
+  height: 36px;
+  vertical-align: bottom;
+}
+
 .config-checkbox {
   display: inline-block;
   font-size: 11px;
@@ -190,7 +212,7 @@ paper-dropdown-menu paper-item {
 }
 
 .colorby-container {
-  margin-bottom: 10px;
+  margin-bottom: 0px;
 }
 </style>
 <div class="title">DATA</div>
@@ -262,6 +284,21 @@ paper-dropdown-menu paper-item {
       <vz-projector-legend render-info="[[colorLegendRenderInfo]]"></vz-projector-legend>
     </template>
   </div>
+
+  <div class="metadata-edit">
+    <vz-projector-input id="labeling-box" label="Tag selection as"></vz-projector-input>
+    <paper-dropdown-menu no-animations label="in">
+      <paper-listbox attr-for-selected="value" class="dropdown-content" selected="{{selectedMetadataField}}" slot="dropdown-content">
+        <template is="dom-repeat" items="[[metadataFields]]">
+          <paper-item value="[[item]]" label="[[item]]">
+            [[item]]
+          </paper-item>
+        </template>
+      </paper-listbox>
+    </paper-dropdown-menu>
+    <paper-button id="apply-label" class="ink-button">Label</paper-button>
+  </div>
+
   <paper-checkbox id="normalize-data-checkbox" checked="{{normalizeData}}">
     Sphereize data
     <paper-icon-button icon="help" class="help-icon"></paper-icon-button>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-input.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-input.ts
@@ -103,6 +103,10 @@ export class ProjectorInput extends PolymerClass {
     return this.inRegexMode;
   }
 
+  toggleRegexVisibility() {
+    this.inRegexModeButton.hidden = !this.inRegexModeButton.hidden;
+  }
+
   set(value: string, inRegexMode: boolean) {
     (this.inRegexModeButton as any).active = inRegexMode;
     this.paperInput.value = value;

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
@@ -105,9 +105,14 @@ export class InspectorPanel extends PolymerClass {
       }
       return stats.name;
     });
-    labelIndex = Math.max(0, labelIndex);
-    // Make the default label the first non-numeric column.
-    this.selectedMetadataField = spriteAndMetadata.stats[labelIndex].name;
+    
+    if (this.selectedMetadataField == null || this.metadataFields.filter(name =>
+        name == this.selectedMetadataField).length == 0) {
+      // Make the default label the first non-numeric column.
+      this.selectedMetadataField = this.metadataFields[Math.max(0, labelIndex)];
+    }
+    this.updateInspectorPane(this.selectedPointIndices, 
+        this.neighborsOfFirstPoint);
   }
 
   datasetChanged() {

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -200,6 +200,22 @@ export class Projector extends ProjectorPolymer implements
     }
   }
 
+  metadataChanged(spriteAndMetadata: SpriteAndMetadataInfo,
+      metadataFile: string) {
+    this.dataSet.spriteAndMetadataInfo = spriteAndMetadata;
+    this.projectionsPanel.metadataChanged(spriteAndMetadata);
+    this.inspectorPanel.metadataChanged(spriteAndMetadata);
+    this.dataPanel.metadataChanged(spriteAndMetadata, metadataFile);
+    
+    if (this.selectedPointIndices.length > 0)  // at least one selected point
+      this.metadataCard.updateMetadata(  // show metadata for first selected point
+          this.dataSet.points[this.selectedPointIndices[0]].metadata);
+    else {  // no points selected
+      this.metadataCard.updateMetadata(null);  // clear metadata
+    }
+    this.setSelectedLabelOption(this.selectedLabelOption);
+  }
+
   setSelectedTensor(run: string, tensorInfo: EmbeddingInfo) {
     this.bookmarkPanel.setSelectedTensor(run, tensorInfo, this.dataProvider);
   }
@@ -474,6 +490,8 @@ export class Projector extends ProjectorPolymer implements
       neighborsOfFirstPoint: knn.NearestEntry[]) {
     this.selectedPointIndices = selectedPointIndices;
     this.neighborsOfFirstPoint = neighborsOfFirstPoint;
+    this.dataPanel.onProjectorSelectionChanged(selectedPointIndices, 
+        neighborsOfFirstPoint);
     let totalNumPoints =
         this.selectedPointIndices.length + neighborsOfFirstPoint.length;
     this.statusBar.innerText = `Selected ${totalNumPoints} points`;


### PR DESCRIPTION
Add a metadata editor to the Projector, which gives the option to modify attributes of selected points. This is very helpful to make alterations and corrections to an existing labeling, although changes are only made in the browser session and do not persist to the metadata file. 

Demo here: http://tensorserve.com:6015
```bash
git clone -b projector-metadata-editor https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout 5c08357d3300f11d0a1776f4d7f76391e3edbad0
bazel run tensorboard -- --logdir /home/emnist-2000 --host 0.0.0.0 --port 6015
```

### Design and behavior
1. The metadata editor only requires one extra row in the data panel.
2. The label button is disabled if no selection has been made, or if no label has been specified.
3. An attribute search is done to find the number of existing samples with the specified label.
4. Projector components related to metadata display are refreshed after attribute changes, which also expands the color palette for the modified attribute when a new class is added.
5. _metadataChanged()_ is invoked in the projector after a metadata edit, which normally resets the attribute choices in the data panel and inspector panel. It is proposed that if there is an existing selection it should be retained if it is valid choice, which means that if another metadata file is loaded and it contains the selection it would be preferred.


### Data panel before
<img width="306" src="https://user-images.githubusercontent.com/10847676/32536492-5f6b8bee-c467-11e7-9699-3c554bf3777f.png">

### Data panel with metadata editor
<img width="292" src="https://user-images.githubusercontent.com/10847676/32536491-5f1c9408-c467-11e7-8ec8-7089b6843353.png">

### Label entered into metadata editor
<img width="292" src="https://user-images.githubusercontent.com/10847676/32536493-5fb2676c-c467-11e7-89cc-61b634ee4674.png">
