### PR TITLE
Ensure flags get initialized

### DIFF
--- a/tensorboard/__main__.py
+++ b/tensorboard/__main__.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+"""Module that allows the user to run `python -m tensorboard`."""
 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import sys
+from tensorboard import main as _main
 
-from tensorboard.main import main
+run_main = _main.run_main
+
+del _main
 
 if __name__ == '__main__':
-  sys.exit(main())
+  run_main()

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -31,6 +31,11 @@ from tensorboard import default
 from tensorboard import program
 
 
+def run_main():
+  """Initializes flags and calls main()."""
+  tf.app.run(main)
+
+
 def main(unused_argv=None):
   """Standard TensorBoard program CLI.
 
@@ -59,4 +64,4 @@ def run_simple_server(*args, **kwargs):
 
 
 if __name__ == '__main__':
-  tf.app.run()
+  run_main()

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -41,7 +41,7 @@ REQUIRED_PACKAGES = [
 ]
 
 CONSOLE_SCRIPTS = [
-    'tensorboard = tensorboard.main:main',
+    'tensorboard = tensorboard.main:run_main',
 ]
 
 def get_readme():


### PR DESCRIPTION
The open source entry-point might not have been invoking tf.app.run() which
a user reports might have caused errors like this to happen:

```
  absl.flags._exceptions.UnparsedFlagAccessError: Trying to access flag
  --debugger_data_server_grpc_port before flags were parsed.
```

I wasn't actually able to reproduce this error, but this change might fix things.