### PR TITLE
Projector: Semi-supervised t-SNE

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -361,6 +361,34 @@ export class DataSet {
     });
   }
 
+  setTSNESupervision(superviseColumn: string, superviseFactor?: number,
+      unlabeledClass?: string) {
+    if (this.tsne) {
+      if (this.tsne.superviseColumn != superviseColumn) {
+        this.tsne.superviseColumn = superviseColumn;
+        console.log(this.tsne.superviseColumn);
+
+        let labelCounts = {};
+        this.spriteAndMetadataInfo.stats
+            .find(s => s.name == superviseColumn).uniqueEntries
+            .forEach(e => labelCounts[e.label] = e.count);
+        this.tsne.labelCounts = labelCounts;
+
+        let sampledIndices = this.shuffledDataIndices.slice(0, TSNE_SAMPLE_SIZE);
+        let labels = new Array(sampledIndices.length);
+        sampledIndices.forEach((index, i) => 
+          labels[i] = this.points[index].metadata[superviseColumn].toString());
+        this.tsne.labels = labels;
+      }
+      if (superviseFactor != null) {
+        this.tsne.superviseFactor = superviseFactor;
+      }
+      if (unlabeledClass != null) {
+        this.tsne.unlabeledClass = unlabeledClass;
+      }
+    }
+  }
+
   /**
    * Merges metadata to the dataset and returns whether it succeeded.
    */

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -134,6 +134,9 @@ export class DataSet {
   tSNEShouldStop = true;
   tSNEShouldPerturb = false;
   perturbFactor: number = 0.4;
+  superviseFactor: number = 0;
+  superviseColumn: string = '';
+  unlabeledClass: string = '';
   dim: [number, number] = [0, 0];
   hasTSNERun: boolean = false;
   spriteAndMetadataInfo: SpriteAndMetadataInfo;
@@ -315,6 +318,8 @@ export class DataSet {
     let k = Math.floor(3 * perplexity);
     let opt = {epsilon: learningRate, perplexity: perplexity, dim: tsneDim};
     this.tsne = new TSNE(opt);
+    this.setTSNESupervision(this.superviseFactor, this.superviseColumn,
+        this.unlabeledClass);
     this.tSNEShouldPause = false;
     this.tSNEShouldStop = false;
     this.tSNEShouldPerturb = false;
@@ -325,6 +330,7 @@ export class DataSet {
       if (this.tSNEShouldStop) {
         stepCallback(null);
         this.tsne = null;
+        this.hasTSNERun = false;
         return;
       }
 
@@ -370,12 +376,32 @@ export class DataSet {
     });
   }
 
-  setTSNESupervision(superviseColumn: string, superviseFactor?: number,
+  setSupervision(superviseFactor: number, superviseColumn?: string,
+      unlabeledClass?: string) {
+    this.setTSNESupervision(superviseFactor, superviseColumn, unlabeledClass);
+
+    if (superviseFactor != null) {
+      this.superviseFactor = superviseFactor;
+    }
+
+    if (superviseColumn != null) {
+      this.superviseColumn = superviseColumn;
+    }
+
+    if (unlabeledClass != null) {
+      this.unlabeledClass = unlabeledClass;
+    }
+  }
+
+  setTSNESupervision(superviseFactor: number, superviseColumn?: string,
       unlabeledClass?: string) {
     if (this.tsne) {
-      if (this.tsne.superviseColumn != superviseColumn) {
+      if (superviseFactor != null) {
+        this.tsne.superviseFactor = superviseFactor;
+      }
+
+      if (superviseColumn != null) {
         this.tsne.superviseColumn = superviseColumn;
-        console.log(this.tsne.superviseColumn);
 
         let labelCounts = {};
         this.spriteAndMetadataInfo.stats
@@ -383,15 +409,14 @@ export class DataSet {
             .forEach(e => labelCounts[e.label] = e.count);
         this.tsne.labelCounts = labelCounts;
 
-        let sampledIndices = this.shuffledDataIndices.slice(0, TSNE_SAMPLE_SIZE);
+        let sampledIndices =
+            this.shuffledDataIndices.slice(0, TSNE_SAMPLE_SIZE);
         let labels = new Array(sampledIndices.length);
         sampledIndices.forEach((index, i) => 
           labels[i] = this.points[index].metadata[superviseColumn].toString());
         this.tsne.labels = labels;
       }
-      if (superviseFactor != null) {
-        this.tsne.superviseFactor = superviseFactor;
-      }
+
       if (unlabeledClass != null) {
         this.tsne.unlabeledClass = unlabeledClass;
       }

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
@@ -112,11 +112,18 @@ limitations under the License.
 
 .tsne-supervise-by paper-input {
   width: 100%;
+  --paper-input-container-label-floating: {
+    white-space: normal;
+    line-height: normal;
+  };
 }
 
 .tsne-supervise-by paper-dropdown-menu {
   margin-left: 10px;
   width: 130px;
+  --paper-input-container-label-floating: {
+    line-height: normal;
+  };
 }
 
 #z-container {
@@ -250,18 +257,21 @@ limitations under the License.
           <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
           <paper-tooltip position="right" animation-delay="0" fit-to-visible-bounds>
             The label importance used for supervision, from 0 (disabled) to 100
-            (full importance) on a logarithmic slider.
+            (full importance).
           </paper-tooltip>
         </label>
-        <paper-slider id="supervise-factor-slider" min="0" max="100" value="0">
+        <paper-slider id="supervise-factor-slider" min="0" max="100" pin
+            value="{{superviseFactor}}">
         </paper-slider>
         <span></span>
       </div>
       <div class="tsne-supervise-by">
-        <paper-input value="{{unlabeledClassInput}}" label="{{unlabeledClassInputLabel}}"
-        on-input="unlabeledClassInputChange"></paper-input>
+        <paper-input value="{{unlabeledClass}}" label="{{unlabeledClassLabel}}"
+            on-change="unlabeledClassChange" on-input="unlabeledClassTyping">
+        </paper-input>
         <paper-dropdown-menu no-animations label="Supervise with">
           <paper-listbox attr-for-selected="value" class="dropdown-content"
+              on-selected-item-changed="superviseColumnChanged"
               selected="{{superviseColumn}}" slot="dropdown-content">
             <template is="dom-repeat" items="[[metadataFields]]">
               <paper-item value="[[item]]" label="[[item]]">
@@ -272,7 +282,7 @@ limitations under the License.
         </paper-dropdown-menu>
       </div>
       <p>
-        <button class="run-tsne ink-button" title="Re-run t-SNE">Re-run</button>
+        <button class="run-tsne ink-button" title="Re-run t-SNE">Run</button>
         <button class="pause-tsne ink-button" title="Pause t-SNE">Pause</button>
         <button class="perturb-tsne ink-button" title="Perturb t-SNE">Perturb</button>
       </p>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
@@ -101,6 +101,24 @@ limitations under the License.
   min-height: 35px;
 }
 
+.tsne-supervise-factor {
+  margin-bottom: -8px;
+}
+
+.tsne-supervise-by {
+  display: flex;
+  padding-top: 0px;
+}
+
+.tsne-supervise-by paper-input {
+  width: 100%;
+}
+
+.tsne-supervise-by paper-dropdown-menu {
+  margin-left: 10px;
+  width: 130px;
+}
+
 #z-container {
   display: flex;
   align-items: center;
@@ -211,6 +229,33 @@ limitations under the License.
             value="1" max-markers="6">
         </paper-slider>
         <span></span>
+      </div>
+      <div class="slider tsne-supervise-factor">
+        <label>
+          Supervise
+          <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
+          <paper-tooltip position="right" animation-delay="0" fit-to-visible-bounds>
+            The label importance used for supervision, from 0 (disabled) to 100
+            (full importance) on a logarithmic slider.
+          </paper-tooltip>
+        </label>
+        <paper-slider id="supervise-factor-slider" min="0" max="100" value="0">
+        </paper-slider>
+        <span></span>
+      </div>
+      <div class="tsne-supervise-by">
+        <paper-input value="{{unlabeledClassInput}}" label="{{unlabeledClassInputLabel}}"
+        on-input="unlabeledClassInputChange"></paper-input>
+        <paper-dropdown-menu no-animations label="Supervise with">
+          <paper-listbox attr-for-selected="value" class="dropdown-content"
+              selected="{{superviseColumn}}" slot="dropdown-content">
+            <template is="dom-repeat" items="[[metadataFields]]">
+              <paper-item value="[[item]]" label="[[item]]">
+                [[item]]
+              </paper-item>
+            </template>
+          </paper-listbox>
+        </paper-dropdown-menu>
       </div>
       <p>
         <button class="run-tsne ink-button" title="Re-run t-SNE">Re-run</button>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -205,7 +205,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
       }
       else {
         this.unlabeledClassLabel =
-            `Supervising with '${this.unlabeledClassSelected}'`;
+            `Supervising without '${this.unlabeledClassSelected}'`;
       }
       return;
     }
@@ -240,7 +240,11 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
       let numMatches = this.dataSet.points.filter(p =>
           p.metadata[this.superviseColumn].toString().trim() == value).length;
       
-      if (numMatches > 0) {
+      if (numMatches === 0) {
+        this.unlabeledClassLabel = 
+            `Supervising without '${this.unlabeledClassSelected}'`;
+      }
+      else {
         this.unlabeledClassSelected = value;
         this.unlabeledClassLabel = 
             `Supervising without '${value}' [${numMatches} points]`;

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -43,6 +43,20 @@ export let ProjectionsPanelPolymer = PolymerElement({
       type: String,
       observer: '_customSelectedSearchByMetadataOptionChanged'
     },
+    unlabeledClassInput: {
+      type: String
+    },
+    unlabeledClassInputLabel: {
+      type: String,
+      value: 'Unlabeled class'
+    },
+    unlabeledClassInputChange: {
+      type: Object
+    },
+    superviseColumn: {
+      type: String,
+      observer: '_superviseColumnOptionChanged'
+    }
   }
 });
 
@@ -91,12 +105,17 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   public pcaY: number;
   public pcaZ: number;
   public customSelectedSearchByMetadataOption: string;
+  private unlabeledClassInput: string;
+  private unlabeledClassInputLabel: string;
+  private superviseColumn: string;
+  private metadataFields: string[];
 
   /** Polymer elements. */
   private runTsneButton: HTMLButtonElement;
   private stopTsneButton: HTMLButtonElement;
   private perplexitySlider: HTMLInputElement;
   private learningRateInput: HTMLInputElement;
+  private superviseFactorInput: HTMLInputElement;
   private zDropdown: HTMLElement;
   private iterationLabel: HTMLElement;
 
@@ -128,6 +147,8 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
         this.querySelector('#perplexity-slider') as HTMLInputElement;
     this.learningRateInput =
         this.querySelector('#learning-rate-slider') as HTMLInputElement;
+    this.superviseFactorInput =
+        this.querySelector('#supervise-factor-slider') as HTMLInputElement;
     this.iterationLabel = this.querySelector('.run-tsne-iter') as HTMLElement;
   }
 
@@ -155,6 +176,44 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
         .innerText = '' + this.learningRate;
   }
 
+  private updateTSNESuperviseFactorFromUIChange() {
+    if (this.dataSet) {
+      let superviseFactor = 0;
+      if (+this.superviseFactorInput.value > 0) {
+        superviseFactor = Math.exp(Math.log(1./100) * 
+            (1. - +this.superviseFactorInput.value / 100));
+      }
+      (this.querySelector('.tsne-supervise-factor span') as HTMLSpanElement)
+      .innerText = ('' + (100 * superviseFactor).toFixed(0));
+      this.dataSet.setTSNESupervision(this.superviseColumn, superviseFactor);
+    }
+  }
+
+  private unlabeledClassInputChange() {
+    if (this.dataSet) {
+      let value = this.unlabeledClassInput;
+      this.superviseFactorInput.value = "0";
+      (this.querySelector('.tsne-supervise-factor span') as HTMLSpanElement)
+      .innerText = "0";
+
+      if (value == null || value.trim() === '') {
+        this.unlabeledClassInputLabel = 'Unlabeled class';
+        this.dataSet.setTSNESupervision(this.superviseColumn, 0, '');
+        return;
+      }
+      let numMatches = this.dataSet.points.filter(p =>
+          p.metadata[this.superviseColumn] == value).length;
+      
+      if (numMatches === 0) {
+        this.unlabeledClassInputLabel = 'Unlabeled class [0 matches]';
+        this.dataSet.setTSNESupervision(this.superviseColumn, 0, '');
+      } else {
+        this.unlabeledClassInputLabel = `Unlabeled class [${numMatches} matches]`;
+        this.dataSet.setTSNESupervision(this.superviseColumn, 0, value);
+      }
+    }
+  }
+
   private setupUIControls() {
     {
       const self = this;
@@ -179,6 +238,10 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
     this.learningRateInput.addEventListener(
         'change', () => this.updateTSNELearningRateFromUIChange());
     this.updateTSNELearningRateFromUIChange();
+
+    this.superviseFactorInput.addEventListener(
+        'change', () => this.updateTSNESuperviseFactorFromUIChange());
+    this.updateTSNESuperviseFactorFromUIChange();
 
     this.setupCustomProjectionInputFields();
     // TODO: figure out why `--paper-input-container-input` css mixin didn't
@@ -331,6 +394,21 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   }
 
   metadataChanged(spriteAndMetadata: SpriteAndMetadataInfo) {
+    let labelIndex = -1;
+    this.metadataFields = spriteAndMetadata.stats.map((stats, i) => {
+      if (!stats.isNumeric && labelIndex === -1)
+        labelIndex = i;
+      return stats.name;
+    });
+    
+    if (this.superviseColumn == null || this.metadataFields.filter(name =>
+        name == this.superviseColumn).length == 0) {
+      // Make the default supervise class the first non-numeric column.
+      this.superviseColumn = this.metadataFields[Math.max(0, labelIndex)];
+      this.unlabeledClassInput = '';
+      this.unlabeledClassInputChange();
+    }
+
     // Project by options for custom projections.
     let searchByMetadataIndex = -1;
     this.searchByMetadataOptions = spriteAndMetadata.stats.map((stats, i) => {
@@ -507,6 +585,14 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
     if (this.currentProjection === 'custom') {
       this.computeAllCentroids();
       this.reprojectCustom();
+    }
+  }
+
+  _superviseColumnOptionChanged(newVal: string, oldVal: string) {
+    if (this.dataSet) {
+      this.superviseColumn = newVal;
+      this.unlabeledClassInput = '';
+      this.unlabeledClassInputChange();
     }
   }
 


### PR DESCRIPTION
Add to the projections-panel a supervise factor slider, an unlabeled class specifier and a supervise column specifier. Capture the events and update the dataset t-SNE variables that will be used to alter the projections. Add a supervision clause to t-SNE to incorporate pairwise prior probabilities based on label differences and similarities.

~Demo here: http://tensorserve.com:6016~
```bash
git clone https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout  4b726e0a69e2fbd1e671a26ba19eea2d928e0eaf
bazel run tensorboard -- --logdir /home/$USER/emnist-2000 --host 0.0.0.0 --port 6016
```
### Pairwise label similarity priors
Notice the repeating contraction in the below image, relating to repetitively turning supervision on and off, which incorporates the prior probabilities based on pairwise label similarity/dissimilarity when supervision is turned on.
![projector-tsne-supervise-vid1-red2-size2](https://user-images.githubusercontent.com/10847676/32723572-a0202ef2-c876-11e7-808d-86c154e30c44.gif)
### Design and behavior
1. When the supervision slider is set to 0, t-SNE functions exactly as before as the supervision clause is not entered.
2. The supervision slider sets the label importance value in range [0, 1], where 0 turns off supervision and 1 sets full label importance. The concept of label importance is used from McInnes et al. [1] and welcoming comments from @lmcinnes .
3. The supervision slider changes a visible percentage value from 0 to 100, corresponding to label importance values of 0 to 1.
4. An unlabeled class label, also known as an ignored label can be specified, which would consider corresponding points as unlabeled points that receive a default pairwise prior probability.
5. A supervise column specifier gets the metadata column to use to determine which labels the supervision is conducted with.
6. t-SNE does cause some unexpected behavior when choosing a metadata column with many hundreds of classes, then a re-run is required.
7. Changes in the supervision settings are updated first in the dataset class, and then propageted to the TSNE class itself to use in the gradient step function, where a snapshot is made to prevent supervision changes during the step (not 100% sure if deep copy actually happens).
8. The supervision settings may change from step to step, e.g. such that one step may include supervision while the next step is without supervision, i.e. if the user slides the supervision factor from a non-zero value to zero.

### Semi-supervised t-SNE
1. The pairwise prior probabilities are set according to McInnes et al. [1], where neighbors are used and where current labeling is not representative of class prior probabilities.
2. However, the normalization is computed over all pairwise prior probabilities according to Yang et al. [2], and not only within neighborhoods as in [1].
3. The naive pairwise prior probability is 1/N, which is used for interactions with unlabeled class samples.
4. For different label pairs we subtract superviseFactor/otherCount from the naive prior, where otherCount is the number of samples with a different label, so if superviseFactor is sufficiently large the attractive force between two samples with different labels will be set to epsilon. Attractive force is easily zeroed between different labeled samples.
5. For same-label pairs we add superviseFactor/sameCount to the naive prior, and the maximum sum is limited close to 1. Attractive force scales up more gradually between same-label pairs.

### t-SNE projections panel before
<img width="320" src="https://user-images.githubusercontent.com/10847676/32908723-1683ffae-cb0d-11e7-802f-c54f9364a011.png">


### t-SNE projections panel with supervision
<img width="322" src="https://user-images.githubusercontent.com/10847676/32908726-1b6fc728-cb0d-11e7-9abe-dd27f38a4c78.png">
<img width="318" src="https://user-images.githubusercontent.com/10847676/32908728-1fad4202-cb0d-11e7-80b6-e687407d8174.png">

### Status messaging in unlabeled class / ignored label
<img width="321" src="https://user-images.githubusercontent.com/10847676/32908730-2188f666-cb0d-11e7-9d82-8bb768348641.png">
<img width="319" src="https://user-images.githubusercontent.com/10847676/32908733-2415a8b6-cb0d-11e7-96a6-4c839a3a3898.png">
<img width="320" src="https://user-images.githubusercontent.com/10847676/32909170-8c44c5f6-cb0e-11e7-87dd-123dcd49fc34.png">
<img width="324" src="https://user-images.githubusercontent.com/10847676/32909152-7bb04c1a-cb0e-11e7-99fa-18ca1202b6ea.png">
<img width="324" src="https://user-images.githubusercontent.com/10847676/32910530-2f7f5418-cb12-11e7-94e8-5f1f725a45f0.png">
<img width="318" src="https://user-images.githubusercontent.com/10847676/32908809-5bace582-cb0d-11e7-952d-23e48ecc6dd3.png">


### Semi-Supervised t-SNE of McInnes et al. [1]

From https://github.com/lmcinnes/sstsne/blob/master/sstsne/_utils.pyx :
```python
for i in range(n_samples):
    sum_Pi = 0
    if using_neighbors:
        for k in range(K):
            j = neighbors[i, k]
            n_same_label = label_sizes[labels[i] + 1]
            n_other_label = n_samples - n_same_label - n_unlabelled
            if rep_samples:
                ...
            else:
                if labels[i] == -1 or labels[j] == -1:
                    prior_prob = 1.0 / n_samples
                elif labels[j] == labels[i]:
                    prior_prob = min((1.0 / n_samples) + (label_importance / n_same_label), 1.0 - EPSILON_DBL)
                else:
                    prior_prob = max((1.0 / n_samples) - (label_importance / n_other_label), EPSILON_DBL)
            P[i, j] *= prior_prob
            sum_Pi += P[i, j]
        for k in range(K):
            j = neighbors[i, k]
            P[i, j] /= sum_Pi
```

### Attraction normalization of Yang et al. [2]

From Yang et al. [1] the attractive and repulsive forces in weighted t-SNE are balanced with a connection scalar:

<img src="https://latex.codecogs.com/svg.latex?%5Cfrac%7B%5Cpartial%20D_%7B%5Ctext%7Bws-SNE%7D%7D%28Y%29%7D%7B%5Cpartial%20y_i%7D%3D%5Csum_jp_%7Bij%7Dq_%7Bij%7D%5E%7B%5Ctheta%7D%28y_i-y_j%29-cd_id_jq_%7Bij%7D%5E%7B1&plus;%5Ctheta%7D%28y_i-y_j%29">
where the connection scalar is given as <img src="https://latex.codecogs.com/svg.latex?%5Cinline%20c%3D%5Csum_%7Bij%7Dp_%7Bij%7D%5Cleft/%5Cleft%28%5Csum_%7Bij%7Dd_id_jq_%7Bij%7D%20%5Cright%20%29%5Cright.">
The issue here is that if the sum of the prior probabilities are small, then the effective gradient gets scaled down accordingly, which is the case here with a nominal prior of 1/N. So we normalize the gradient size by dividing with the sum of prior probabilities and leaving the repulsion normalization unaffected:

<img src="https://latex.codecogs.com/svg.latex?%5Cfrac%7B1%7D%7B%5Csum_%7Bij%7Dp_%7Bij%7D%7D%5Cfrac%7B%5Cpartial%20D_%7B%5Ctext%7Bws-SNE%7D%7D%28Y%29%7D%7B%5Cpartial%20y_i%7D%3D%5Cfrac%7B%5Csum_jp_%7Bij%7Dq_%7Bij%7D%5E%7B%5Ctheta%7D%28y_i-y_j%29%7D%7B%5Csum_%7Bij%7Dp_%7Bij%7D%7D-%5Cfrac%7Bd_id_jq_%7Bij%7D%5E%7B1&plus;%5Ctheta%7D%28y_i-y_j%29%7D%7B%5Csum_%7Bij%7Dd_id_jq_%7Bij%7D%7D">

Note that the result here is shown for weighted t-SNE, but it holds for normal t-SNE and its Barnes-Hut implementation.

```typescript
    let sum_pij = 0;
    let forces: [number[], number[]][] = new Array(N);
    for (let i = 0; i < N; ++i) {
      let pointI = points[i];
      if (supervise) {
        var sameCount = labelCounts[labels[i]];
        var otherCount = N - sameCount - unlabeledCount;
      }
      // Compute the positive forces for the i-th node.
      let Fpos = this.dim === 3 ? [0, 0, 0] : [0, 0];
      let neighbors = this.nearest[i];
      for (let k = 0; k < neighbors.length; ++k) {
        let j = neighbors[k].index;
        let pij = P[i * N + j];
        if (supervise) {  // apply semi-supervised prior probabilities
          if (labels[i] == unlabeledClass || labels[j] == unlabeledClass) {
            pij *= 1. / N;
          }
          else if (labels[i] != labels[j]) {
            pij *= Math.max(1. / N - superviseFactor / otherCount, 1E-7);
          }
          else if (labels[i] == labels[j]) {
            pij *= Math.min(1. / N + superviseFactor / sameCount, 1. - 1E-7);
          }
          sum_pij += pij;
        }
    
    ...
    
    let A = 4 * alpha;
    if (supervise)
      A /= sum_pij;
    const B = 4 / Z;
```

### References
[1] Leland McInnes, Alexander Fabisch, Christopher Moody, Nick Travers, "Semi-Supervised t-SNE using a Bayesian prior based on partial labelling", https://github.com/lmcinnes/sstsne. 2016.

[2] Yang, Zhirong, Jaakko Peltonen, and Samuel Kaski. ["Optimization equivalence of divergences improves neighbor embedding"](http://proceedings.mlr.press/v32/yange14.pdf). International Conference on Machine Learning. 2014.




