### PR TITLE
Add chevron scrolling to toolbar tabs

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -65,12 +65,10 @@ limitations under the License.
             </span>
           </template>
           <template is="dom-if" if="[[_activeDashboardsLoaded]]">
-            <paper-tabs
-              selected="{{_selectedDashboard}}"
-              attr-for-selected="data-dashboard"
-              noink
-              id="tabs"
-            >
+            <paper-tabs noink
+                        scrollable
+                        selected="{{_selectedDashboard}}"
+                        attr-for-selected="data-dashboard">
               <template
                 is="dom-repeat"
                 items="[[_dashboardData]]"
@@ -79,7 +77,8 @@ limitations under the License.
                   is="dom-if"
                   if="[[_isDashboardActive(disabledDashboards, _activeDashboards, dashboardDatum)]]"
                 >
-                  <paper-tab data-dashboard$="[[dashboardDatum.plugin]]">
+                  <paper-tab data-dashboard$="[[dashboardDatum.plugin]]"
+                             title="[[dashboardDatum.tabName]]">
                     [[dashboardDatum.tabName]]
                   </paper-tab>
                 </template>
@@ -224,7 +223,6 @@ limitations under the License.
         text-rendering: optimizeLegibility;
         letter-spacing: -0.025em;
         font-weight: 500;
-        flex-grow: 1;
         display: var(--tb-toolbar-title-display, block);
       }
 
@@ -235,14 +233,15 @@ limitations under the License.
         font-weight: 500;
       }
 
-      #tabs {
-        flex-grow: 1;
-        text-transform: uppercase;
-        height: 100%;
-      }
-
       paper-tabs {
+        flex-grow: 1;
+        width: 100%;
+        height: 100%;
         --paper-tabs-selection-bar-color: white;
+        --paper-tabs-content: {
+          -webkit-font-smoothing: antialiased;
+          text-transform: uppercase;
+        }
       }
 
       paper-dropdown-menu {
@@ -275,7 +274,6 @@ limitations under the License.
       }
 
       .global-actions {
-        flex-grow: 1;
         display: inline-flex; /* Ensure that icons stay aligned */
         justify-content: flex-end;
         text-align: right;


### PR DESCRIPTION
This change makes it possible to render the UI on desktops when there's a large
number of active plugins, which might have long names. While it may not be the
optimal solution, it represents a significant improvement.

### Crunched appearance

#### Before

![image](https://user-images.githubusercontent.com/49262/32755308-72e6d306-c889-11e7-9a97-024447d81fa1.png)

#### After

![image](https://user-images.githubusercontent.com/49262/32755345-9f8a6c06-c889-11e7-934b-91402e5dfd49.png)

### Normal appearance

#### Before

![image](https://user-images.githubusercontent.com/49262/32755268-494fe424-c889-11e7-822d-ae39d2b02734.png)

#### After

![image](https://user-images.githubusercontent.com/49262/32755200-02956180-c889-11e7-8a2d-63c21e70abe2.png)
