### PR TITLE
Projector: Inspector-panel neighbors slider editable

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
@@ -165,7 +165,14 @@ limitations under the License.
 }
 
 #nn-slider {
-  margin: 0 -12px 0 10px;
+  margin: 0 -12px 0 0px;
+  --paper-slider-input: {
+    width: 66px
+  };
+  --paper-input-container-input-webkit-spinner: {
+    -webkit-appearance: none;
+    margin: 0;
+  };
 }
 
 .euclidean {
@@ -220,8 +227,7 @@ limitations under the License.
           <paper-tooltip position="bottom" animation-delay="0" fit-to-visible-bounds>
             The number of neighbors (in the original space) to show when clicking on a point.
           </paper-tooltip>
-          <paper-slider id="nn-slider" pin min="5" max="1000" value="100"></paper-slider>
-          <span class="nn-count"></span>
+          <paper-slider id="nn-slider" pin min="5" max="999" value="100" editable></paper-slider>
         </div>
       </div>
       <div class="distance">

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
@@ -303,8 +303,6 @@ export class InspectorPanel extends PolymerClass {
     const numNNInput = this.$$('#nn-slider') as HTMLInputElement;
     const updateNumNN = () => {
       this.numNN = +numNNInput.value;
-      (this.querySelector('.num-nn .nn-count') as HTMLSpanElement).innerText =
-          '' + this.numNN;
       if (this.selectedPointIndices != null) {
         this.projectorEventContext.notifySelectionChanged(
             [this.selectedPointIndices[0]]);


### PR DESCRIPTION
Make the neighbors slider editable in the inspector panel of the projector. This allows for finer-grained control on neighborhood size when selecting groups, which becomes important during interactive supervision.

Demo here: http://tensorserve.com:6021
```bash
git clone https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout  de640f6fb3a4dd1822dafca928055e8f0476ddac
bazel run tensorboard -- --logdir /home/$USER/emnist-2000 --host 0.0.0.0 --port 6021
```
### Design and behavior
1. Lowered maximum from 1000 to 999 to fit into slider edit box.
2. Requires [Enter] to set the new neighborhood size.
3. Edit box arrows auto-hide when unfocused.

### Neighbors slider before
<img width="281" src="https://user-images.githubusercontent.com/10847676/32785387-140ce4a2-c95a-11e7-8e33-d9a3223f6173.png">

### Neighbors slider with edit box
<img width="281" src="https://user-images.githubusercontent.com/10847676/32785391-15e917d2-c95a-11e7-9028-5db86e2b849b.png">
<img width="281" src="https://user-images.githubusercontent.com/10847676/32785444-399ac14e-c95a-11e7-8302-20f7b03cd0ba.png">
<img width="281" src="https://user-images.githubusercontent.com/10847676/32785480-568142e2-c95a-11e7-8c8c-12bdb9e34d63.png">
