### PR TITLE
Projector: Interactive supervised t-SNE

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -130,6 +130,7 @@ export class DataSet {
   nearest: knn.NearestEntry[][];
   nearestK: number;
   tSNEIteration: number = 0;
+  tSNEShouldPause = false;
   tSNEShouldStop = true;
   dim: [number, number] = [0, 0];
   hasTSNERun: boolean = false;
@@ -312,6 +313,7 @@ export class DataSet {
     let k = Math.floor(3 * perplexity);
     let opt = {epsilon: learningRate, perplexity: perplexity, dim: tsneDim};
     this.tsne = new TSNE(opt);
+    this.tSNEShouldPause = false;
     this.tSNEShouldStop = false;
     this.tSNEIteration = 0;
 
@@ -322,19 +324,21 @@ export class DataSet {
         this.tsne = null;
         return;
       }
-      this.tsne.step();
-      let result = this.tsne.getSolution();
-      sampledIndices.forEach((index, i) => {
-        let dataPoint = this.points[index];
+      if (!this.tSNEShouldPause) {
+        this.tsne.step();
+        let result = this.tsne.getSolution();
+        sampledIndices.forEach((index, i) => {
+          let dataPoint = this.points[index];
 
-        dataPoint.projections['tsne-0'] = result[i * tsneDim + 0];
-        dataPoint.projections['tsne-1'] = result[i * tsneDim + 1];
-        if (tsneDim === 3) {
-          dataPoint.projections['tsne-2'] = result[i * tsneDim + 2];
-        }
-      });
-      this.tSNEIteration++;
-      stepCallback(this.tSNEIteration);
+          dataPoint.projections['tsne-0'] = result[i * tsneDim + 0];
+          dataPoint.projections['tsne-1'] = result[i * tsneDim + 1];
+          if (tsneDim === 3) {
+            dataPoint.projections['tsne-2'] = result[i * tsneDim + 2];
+          }
+        });
+        this.tSNEIteration++;
+        stepCallback(this.tSNEIteration);
+      }
       requestAnimationFrame(step);
     };
 

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -368,13 +368,14 @@ export class DataSet {
     });
   }
 
-  setTSNESupervision(labelsChanged: boolean, superviseColumn: string,
-      superviseFactor?: number, unlabeledClass?: string) {
+  setTSNESupervision(superviseFactor: number, superviseColumn?: string,
+      unlabeledClass?: string) {
     if (this.tsne) {
-      if (labelsChanged || this.tsne.superviseColumn != superviseColumn) {
+      if (superviseFactor != null) {
+        this.tsne.superviseFactor = superviseFactor;
+      }
+      if (superviseColumn) {
         this.tsne.superviseColumn = superviseColumn;
-        console.log(this.tsne.superviseColumn);
-
         let labelCounts = {};
         this.spriteAndMetadataInfo.stats
             .find(s => s.name == superviseColumn).uniqueEntries
@@ -386,9 +387,6 @@ export class DataSet {
         sampledIndices.forEach((index, i) => 
           labels[i] = this.points[index].metadata[superviseColumn].toString());
         this.tsne.labels = labels;
-      }
-      if (superviseFactor != null) {
-        this.tsne.superviseFactor = superviseFactor;
       }
       if (unlabeledClass != null) {
         this.tsne.unlabeledClass = unlabeledClass;

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -368,10 +368,10 @@ export class DataSet {
     });
   }
 
-  setTSNESupervision(superviseColumn: string, superviseFactor?: number,
-      unlabeledClass?: string) {
+  setTSNESupervision(labelsChanged: boolean, superviseColumn: string,
+      superviseFactor?: number, unlabeledClass?: string) {
     if (this.tsne) {
-      if (this.tsne.superviseColumn != superviseColumn) {
+      if (labelsChanged || this.tsne.superviseColumn != superviseColumn) {
         this.tsne.superviseColumn = superviseColumn;
         console.log(this.tsne.superviseColumn);
 

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -365,6 +365,34 @@ export class DataSet {
     });
   }
 
+  setTSNESupervision(superviseColumn: string, superviseFactor?: number,
+      unlabeledClass?: string) {
+    if (this.tsne) {
+      if (this.tsne.superviseColumn != superviseColumn) {
+        this.tsne.superviseColumn = superviseColumn;
+        console.log(this.tsne.superviseColumn);
+
+        let labelCounts = {};
+        this.spriteAndMetadataInfo.stats
+            .find(s => s.name == superviseColumn).uniqueEntries
+            .forEach(e => labelCounts[e.label] = e.count);
+        this.tsne.labelCounts = labelCounts;
+
+        let sampledIndices = this.shuffledDataIndices.slice(0, TSNE_SAMPLE_SIZE);
+        let labels = new Array(sampledIndices.length);
+        sampledIndices.forEach((index, i) => 
+          labels[i] = this.points[index].metadata[superviseColumn].toString());
+        this.tsne.labels = labels;
+      }
+      if (superviseFactor != null) {
+        this.tsne.superviseFactor = superviseFactor;
+      }
+      if (unlabeledClass != null) {
+        this.tsne.unlabeledClass = unlabeledClass;
+      }
+    }
+  }
+
   /**
    * Merges metadata to the dataset and returns whether it succeeded.
    */

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -22,7 +22,9 @@ import * as util from './util.js';
 import * as vector from './vector.js';
 
 export type DistanceFunction = (a: vector.Vector, b: vector.Vector) => number;
+
 export type DistanceSpace = (_: DataPoint) => Float32Array;
+
 export type ProjectionComponents3D = [string, string, string];
 
 export interface PointMetadata { [key: string]: number|string; }

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -21,7 +21,8 @@ import * as scatterPlot from './scatterPlot.js';
 import * as util from './util.js';
 import * as vector from './vector.js';
 
-export type DistanceFunction = (a: number[], b: number[]) => number;
+export type DistanceFunction = (a: vector.Vector, b: vector.Vector) => number;
+export type DistanceSpace = (_: DataPoint) => Float32Array;
 export type ProjectionComponents3D = [string, string, string];
 
 export interface PointMetadata { [key: string]: number|string; }
@@ -442,11 +443,54 @@ export class DataSet {
    * Finds the nearest neighbors of the query point using a
    * user-specified distance metric.
    */
-  findNeighbors(pointIndex: number, distFunc: DistanceFunction, numNN: number):
-      knn.NearestEntry[] {
+  findNeighbors(pointIndex: number, distFunc: DistanceFunction, distGeo: boolean,
+      distSpace: DistanceSpace, numNN: number): knn.NearestEntry[] {
     // Find the nearest neighbors of a particular point.
     let neighbors = knn.findKNNofPoint(
-        this.points, pointIndex, numNN, (d => d.vector), distFunc);
+        this.points, pointIndex, numNN, distSpace, distFunc);
+
+    if (distGeo) {  // Use approximate geodesic distance to grow neighborhood over manifold
+      let K = 5;  // number of nearest neighbors
+      let neighborhood = neighbors.map(n => n.index);  // use direct neighborhood
+      let manifold = neighbors.slice(0, K);  // growing manifold to select from
+      let dist_sum = manifold.reduce((sum, n) => sum + n.dist, 0);  // sum of edge distances traversed
+      let dist_count = manifold.length;
+      neighbors = [];  // neighbor selection to return after populating
+
+      while (neighbors.length < numNN && manifold.length > 0) {  // grow to max numNN points
+        let knn = [];  // store list of dist ordered neighbors
+        let neighbor = manifold.shift();  // get next candidate, referred to as 'candidate'
+
+        if (neighbor.dist <= 2.0 * dist_sum / dist_count  // within 2x avg edge distance
+            && neighbors.filter(f => f.index == neighbor.index).length == 0) {  // previously unchosen
+          neighbors.push({index: neighbor.index, dist: neighbor.dist});  // add suitable candidate
+          dist_sum = dist_sum + neighbor.dist;  // update dist_sum
+          dist_count = dist_count + 1;  // increment number of manifold
+          let point = distSpace(this.points[neighbor.index]);  // find point vector representation
+          
+          neighborhood.forEach(n => {  // choose only from initial neighborhood points
+            let n_dist = distFunc(point, distSpace(this.points[n]));  // distance from candidate to n
+            let k = K;  // start checking ordered list at larger distance end
+
+            if (knn.length < K+1)  // add up to K neighbors of candidate
+              knn.push({index: n, dist: n_dist});  // add n as neighbor
+            else {  // already have K neighbors
+              while (k >= 0 && n_dist < knn[k].dist)  // find sorted insertion position
+                k = k - 1;  // move down the dist list
+
+              if (k < K)  // n is closer than existing knn
+                knn.splice(k + 1, 0, {index: n, dist: n_dist});  // insert n into list to grow list
+            }
+          });
+
+          knn.slice(0, K).forEach(n => {  // add up to K new points to manifold
+            if (manifold.filter(f => f.index == n.index).length == 0)  // not already in manifold
+              manifold.push(n);  // add new point to manifold, allow reconsideration of earlier points
+          });
+          neighborhood = neighborhood.filter(n => n != neighbor.index);  // don't reuse successful candidate
+        }
+      }
+    }
     // TODO(@dsmilkov): Figure out why we slice.
     let result = neighbors.slice(0, numNN);
     return result;

--- a/tensorboard/plugins/projector/vz_projector/projectorEventContext.ts
+++ b/tensorboard/plugins/projector/vz_projector/projectorEventContext.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DistanceFunction, Projection} from './data.js';
+import {DistanceFunction, DistanceSpace, Projection} from './data.js';
 import {NearestEntry} from './knn.js';
 
 export type HoverListener = (index: number) => void;
@@ -23,6 +23,8 @@ export type SelectionChangedListener =
 export type ProjectionChangedListener = (projection: Projection) => void;
 export type DistanceMetricChangedListener =
     (distanceMetric: DistanceFunction) => void;
+export type DistanceSpaceChangedListener =
+    (distanceSpace: DistanceSpace) => void;
 export interface ProjectorEventContext {
   /** Register a callback to be invoked when the mouse hovers over a point. */
   registerHoverListener(listener: HoverListener);
@@ -42,4 +44,7 @@ export interface ProjectorEventContext {
   registerDistanceMetricChangedListener(listener:
                                             DistanceMetricChangedListener);
   notifyDistanceMetricChanged(distMetric: DistanceFunction);
+  registerDistanceSpaceChangedListener(listener:
+                                            DistanceSpaceChangedListener);
+  notifyDistanceSpaceChanged(distSpace: DistanceSpace);
 }

--- a/tensorboard/plugins/projector/vz_projector/projectorScatterPlotAdapter.ts
+++ b/tensorboard/plugins/projector/vz_projector/projectorScatterPlotAdapter.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DataSet, DistanceFunction, Projection, ProjectionComponents3D, State} from './data.js';
+import {DataSet, DistanceFunction, DistanceSpace, Projection, ProjectionComponents3D, State} from './data.js';
 import {NearestEntry} from './knn.js';
 import {ProjectorEventContext} from './projectorEventContext.js';
 import {LabelRenderParams} from './renderContext.js';
@@ -84,6 +84,7 @@ export class ProjectorScatterPlotAdapter {
   private labelPointAccessor: string;
   private legendPointColorer: (ds: DataSet, index: number) => string;
   private distanceMetric: DistanceFunction;
+  private distanceSpace: DistanceSpace;
 
   private spriteVisualizer: ScatterPlotVisualizerSprites;
   private labels3DVisualizer: ScatterPlotVisualizer3DLabels;
@@ -115,6 +116,12 @@ export class ProjectorScatterPlotAdapter {
     projectorEventContext.registerDistanceMetricChangedListener(
         distanceMetric => {
           this.distanceMetric = distanceMetric;
+          this.updateScatterPlotAttributes();
+          this.scatterPlot.render();
+        });
+    projectorEventContext.registerDistanceSpaceChangedListener(
+        distanceSpace => {
+          this.distanceSpace = distanceSpace;
           this.updateScatterPlotAttributes();
           this.scatterPlot.render();
         });

--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerSprites.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerSprites.ts
@@ -60,6 +60,18 @@ const VERTEX_SHADER = `
     float outputPointSize = pointSize;
     if (sizeAttenuation) {
       outputPointSize = -pointSize / cameraSpacePos.z;
+    } else {  // Create size attenuation (if we're in 2D mode)
+      const float PI = 3.1415926535897932384626433832795;
+      const float minScale = 0.1;  // minimum scaling factor
+      const float outSpeed = 2.0;  // shrink speed when zooming out
+      const float outNorm = (1. - minScale) / atan(outSpeed);
+      const float maxScale = 15.0;  // maximum scaling factor
+      const float inSpeed = 0.02;  // enlarge speed when zooming in
+      const float zoomOffset = 0.3;  // offset zoom pivot
+      float zoom = projectionMatrix[0][0] + zoomOffset;  // zoom pivot
+      float scale = zoom < 1. ? 1. + outNorm * atan(outSpeed * (zoom - 1.)) :
+                    1. + 2. / PI * (maxScale - 1.) * atan(inSpeed * (zoom - 1.));
+      outputPointSize = pointSize * scale;
     }
 
     gl_PointSize =

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
@@ -116,6 +116,28 @@ paper-dropdown-menu paper-item {
   margin: 10px 0;
 }
 
+.metadata-editor {
+  display: flex;
+}
+
+.metadata-editor paper-input {
+  width: calc(100%-150px);
+}
+
+.metadata-editor paper-dropdown-menu {
+  margin-left: 10px;
+  width: 100px;
+}
+
+#metadata-edit-button {
+  margin-left: 10px;
+  margin-right: 0px;
+  margin-top: 20px;
+  min-width: 40px;
+  height: 36px;
+  vertical-align: bottom;
+}
+
 .config-checkbox {
   display: inline-block;
   font-size: 11px;
@@ -190,7 +212,7 @@ paper-dropdown-menu paper-item {
 }
 
 .colorby-container {
-  margin-bottom: 10px;
+  margin-bottom: 0px;
 }
 </style>
 <div class="title">DATA</div>
@@ -262,6 +284,26 @@ paper-dropdown-menu paper-item {
       <vz-projector-legend render-info="[[colorLegendRenderInfo]]"></vz-projector-legend>
     </template>
   </div>
+
+  <!-- Tag selection as -->
+  <div class="metadata-editor">
+    <paper-input value="{{editLabelInput}}" label="{{editLabelInputLabel}}"
+    on-input="editLabelInputChange"></paper-input>
+    <paper-dropdown-menu no-animations label="in">
+      <paper-listbox attr-for-selected="value" class="dropdown-content" slot="dropdown-content"
+          selected="{{editLabelColumn}}" on-selected-item-changed="editLabelColumnChange">
+        <template is="dom-repeat" items="[[metadataFields]]">
+          <paper-item value="[[item]]" label="[[item]]">
+            [[item]]
+          </paper-item>
+        </template>
+      </paper-listbox>
+    </paper-dropdown-menu>
+    <paper-button id="metadata-edit-button" class="ink-button"
+    on-click="metadataEditButtonClicked"
+    disabled="[[metadataEditButtonDisabled]]">Label</paper-button>
+  </div>
+
   <paper-checkbox id="normalize-data-checkbox" checked="{{normalizeData}}">
     Sphereize data
     <paper-icon-button icon="help" class="help-icon"></paper-icon-button>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
@@ -131,7 +131,7 @@ limitations under the License.
   width: 100px;
 }
 
-.distance .options {
+.distance .options, .distance-space .options {
   float: right;
 }
 
@@ -146,15 +146,19 @@ limitations under the License.
   color: #009EFE;
 }
 
-.neighbors {
-  margin-bottom: 30px;
+.options a.selected-geo {
+  color: #F57C00;
 }
 
-.neighbors-options {
+.neighbors {
+  margin-bottom: 10px;
+}
+
+.neighbors-options, .distance, .distance-space {
   margin-top: 6px;
 }
 
-.neighbors-options .option-label, .distance .option-label {
+.neighbors-options .option-label, .distance .option-label, .distance-space .option-label {
   color: #727272;
   margin-right: 2px;
   width: auto;
@@ -175,7 +179,7 @@ limitations under the License.
   };
 }
 
-.euclidean {
+.geodesic, .tsne-space {
   margin-right: 10px;
 }
 
@@ -225,7 +229,7 @@ limitations under the License.
           <span class="option-label">neighbors</span>
           <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
           <paper-tooltip position="bottom" animation-delay="0" fit-to-visible-bounds>
-            The number of neighbors (in the original space) to show when clicking on a point.
+            The number of neighbors (in the selected space) to show when clicking on a point.
           </paper-tooltip>
           <paper-slider id="nn-slider" pin min="5" max="999" value="100" editable></paper-slider>
         </div>
@@ -233,12 +237,21 @@ limitations under the License.
       <div class="distance">
         <span class="option-label">distance</span>
         <div class="options">
-          <a class="selected cosine" href="javascript:void(0);">COSINE</a>
-          <a class="euclidean" href="javascript:void(0);">EUCLIDEAN</a>
+          <a class="selected cosine" href="javascript:void(0);">COS</a>
+          <a class="euclidean" href="javascript:void(0);">EUCLID</a>
+          <a class="geodesic" href="javascript:void(0);">GEODESIC</a>
+        </div>
+      </div>
+      <div class="distance-space">
+        <span class="option-label">dist. space</span>
+        <div class="options">
+          <a class="selected original-space" href="javascript:void(0);">ORIGINAL</a>
+          <a class="pca-space" href="javascript:void(0);">PCA</a>
+          <a class="tsne-space" href="javascript:void(0);">T-SNE</a>
         </div>
       </div>
     </div>
-    <p>Nearest points in the original space:
+    <p>Nearest points in the selected space:
     <div class="nn-list"></div>
   </div>
   <div class="matches-list" style="display: none">

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
@@ -165,7 +165,14 @@ limitations under the License.
 }
 
 #nn-slider {
-  margin: 0 -12px 0 10px;
+  margin: 0 -12px 0 0px;
+  --paper-slider-input: {
+    width: 66px
+  };
+  --paper-input-container-input-webkit-spinner: {
+    -webkit-appearance: none;
+    margin: 0;
+  };
 }
 
 .euclidean {
@@ -220,8 +227,7 @@ limitations under the License.
           <paper-tooltip position="bottom" animation-delay="0" fit-to-visible-bounds>
             The number of neighbors (in the original space) to show when clicking on a point.
           </paper-tooltip>
-          <paper-slider id="nn-slider" pin min="5" max="1000" value="100"></paper-slider>
-          <span class="nn-count"></span>
+          <paper-slider id="nn-slider" pin min="5" max="999" value="100" editable></paper-slider>
         </div>
       </div>
       <div class="distance">

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {DistanceFunction, SpriteAndMetadataInfo, State} from './data.js';
+import {DistanceFunction, DistanceSpace, DataPoint, SpriteAndMetadataInfo, State} from './data.js';
 import * as knn from './knn.js';
 import {ProjectorEventContext} from './projectorEventContext.js';
 import * as adapter from './projectorScatterPlotAdapter.js';
@@ -35,6 +35,8 @@ export let PolymerClass = PolymerElement({
 
 export class InspectorPanel extends PolymerClass {
   distFunc: DistanceFunction;
+  distSpace: DistanceSpace;
+  distGeo: boolean;
   numNN: number;
 
   private projectorEventContext: ProjectorEventContext;
@@ -253,6 +255,8 @@ export class InspectorPanel extends PolymerClass {
 
   private setupUI(projector: Projector) {
     this.distFunc = vector.cosDist;
+    this.distSpace = d => d.vector;
+    this.distGeo = false;
     const eucDist =
         this.querySelector('.distance a.euclidean') as HTMLLinkElement;
     eucDist.onclick = () => {
@@ -264,8 +268,9 @@ export class InspectorPanel extends PolymerClass {
 
       this.distFunc = vector.dist;
       this.projectorEventContext.notifyDistanceMetricChanged(this.distFunc);
+      this.projectorEventContext.notifySelectionChanged(this.selectedPointIndices);
       const neighbors = projector.dataSet.findNeighbors(
-          this.selectedPointIndices[0], this.distFunc, this.numNN);
+          this.selectedPointIndices[0], this.distFunc, this.distGeo, this.distSpace, this.numNN);
       this.updateNeighborsList(neighbors);
     };
 
@@ -279,9 +284,87 @@ export class InspectorPanel extends PolymerClass {
 
       this.distFunc = vector.cosDist;
       this.projectorEventContext.notifyDistanceMetricChanged(this.distFunc);
+      this.projectorEventContext.notifySelectionChanged(this.selectedPointIndices);
       const neighbors = projector.dataSet.findNeighbors(
-          this.selectedPointIndices[0], this.distFunc, this.numNN);
+          this.selectedPointIndices[0], this.distFunc, this.distGeo, this.distSpace, this.numNN);
       this.updateNeighborsList(neighbors);
+    };
+
+    const geoDist = this.querySelector('.distance a.geodesic') as HTMLLinkElement;
+    geoDist.onclick = () => {
+      if (this.distGeo) {
+        this.distGeo = false;
+        util.classed(geoDist, 'selected-geo', false);
+      }
+      else {
+        this.distGeo = true;
+        util.classed(geoDist, 'selected-geo', true);
+      }
+
+      this.projectorEventContext.notifySelectionChanged(this.selectedPointIndices);
+      const neighbors = projector.dataSet.findNeighbors(
+          this.selectedPointIndices[0], this.distFunc, this.distGeo, this.distSpace, this.numNN);
+      this.updateNeighborsList(neighbors);
+    };
+
+    const originalSpace = this.querySelector('.distance-space a.original-space') as HTMLLinkElement;
+    originalSpace.onclick = () => {
+      const links = this.querySelectorAll('.distance-space a');
+      for (let i = 0; i < links.length; i++) {
+        util.classed(links[i] as HTMLElement, 'selected', false);
+      }
+      util.classed(originalSpace, 'selected', true);
+
+      this.distSpace = d => d.vector;
+      this.projectorEventContext.notifyDistanceSpaceChanged(this.distSpace);
+      this.projectorEventContext.notifySelectionChanged(this.selectedPointIndices);
+      const neighbors = projector.dataSet.findNeighbors(
+          this.selectedPointIndices[0], this.distFunc, this.distGeo, this.distSpace, this.numNN);
+      this.updateNeighborsList(neighbors);
+    };
+
+    const pcaSpace = this.querySelector('.distance-space a.pca-space') as HTMLLinkElement;
+    pcaSpace.onclick = () => {
+      const links = this.querySelectorAll('.distance-space a');
+      for (let i = 0; i < links.length; i++) {
+        util.classed(links[i] as HTMLElement, 'selected', false);
+      }
+      util.classed(pcaSpace, 'selected', true);
+
+      this.distSpace = d => new Float32Array(
+        ('pca-2' in d.projections)?
+        [d.projections['pca-0'], d.projections['pca-1'], d.projections['pca-2']]:
+        ('pca-1' in d.projections)?
+        [d.projections['pca-0'], d.projections['pca-1']]:
+        d.vector);
+      this.projectorEventContext.notifyDistanceSpaceChanged(this.distSpace);
+      this.projectorEventContext.notifySelectionChanged(this.selectedPointIndices);
+      const neighbors = projector.dataSet.findNeighbors(
+          this.selectedPointIndices[0], this.distFunc, this.distGeo, this.distSpace, this.numNN);
+      this.updateNeighborsList(neighbors);
+    };
+
+    const tsneSpace = this.querySelector('.distance-space a.tsne-space') as HTMLLinkElement;
+    tsneSpace.onclick = () => {
+      if (projector.dataSet.hasTSNERun) {
+        const links = this.querySelectorAll('.distance-space a');
+        for (let i = 0; i < links.length; i++) {
+          util.classed(links[i] as HTMLElement, 'selected', false);
+        }
+        util.classed(tsneSpace, 'selected', true);
+
+        this.distSpace = d => new Float32Array(
+          ('tsne-2' in d.projections)?
+          [d.projections['tsne-0'], d.projections['tsne-1'], d.projections['tsne-2']]:
+          ('tsne-1' in d.projections)?
+          [d.projections['tsne-0'], d.projections['tsne-1']]:
+          d.vector);
+        this.projectorEventContext.notifyDistanceSpaceChanged(this.distSpace);
+        this.projectorEventContext.notifySelectionChanged(this.selectedPointIndices);
+        const neighbors = projector.dataSet.findNeighbors(
+            this.selectedPointIndices[0], this.distFunc, this.distGeo, this.distSpace, this.numNN);
+        this.updateNeighborsList(neighbors);
+      }
     };
 
     // Called whenever the search text input changes.

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
@@ -105,9 +105,14 @@ export class InspectorPanel extends PolymerClass {
       }
       return stats.name;
     });
-    labelIndex = Math.max(0, labelIndex);
-    // Make the default label the first non-numeric column.
-    this.selectedMetadataField = spriteAndMetadata.stats[labelIndex].name;
+
+    if (this.selectedMetadataField == null || this.metadataFields.filter(name =>
+        name == this.selectedMetadataField).length == 0) {
+      // Make the default label the first non-numeric column.
+      this.selectedMetadataField = this.metadataFields[Math.max(0, labelIndex)];
+    }
+    this.updateInspectorPane(this.selectedPointIndices, 
+        this.neighborsOfFirstPoint);
   }
 
   datasetChanged() {

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
@@ -303,8 +303,6 @@ export class InspectorPanel extends PolymerClass {
     const numNNInput = this.$$('#nn-slider') as HTMLInputElement;
     const updateNumNN = () => {
       this.numNN = +numNNInput.value;
-      (this.querySelector('.num-nn .nn-count') as HTMLSpanElement).innerText =
-          '' + this.numNN;
       if (this.selectedPointIndices != null) {
         this.projectorEventContext.notifySelectionChanged(
             [this.selectedPointIndices[0]]);

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
@@ -101,6 +101,24 @@ limitations under the License.
   min-height: 35px;
 }
 
+.tsne-supervise-factor {
+  margin-bottom: -8px;
+}
+
+.tsne-supervise-by {
+  display: flex;
+  padding-top: 0px;
+}
+
+.tsne-supervise-by paper-input {
+  width: 100%;
+}
+
+.tsne-supervise-by paper-dropdown-menu {
+  margin-left: 10px;
+  width: 130px;
+}
+
 #z-container {
   display: flex;
   align-items: center;
@@ -211,6 +229,33 @@ limitations under the License.
             value="1" max-markers="6">
         </paper-slider>
         <span></span>
+      </div>
+      <div class="slider tsne-supervise-factor">
+        <label>
+          Supervise
+          <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
+          <paper-tooltip position="right" animation-delay="0" fit-to-visible-bounds>
+            The label importance used for supervision, from 0 (disabled) to 100
+            (full importance) on a logarithmic slider.
+          </paper-tooltip>
+        </label>
+        <paper-slider id="supervise-factor-slider" min="0" max="100" value="0">
+        </paper-slider>
+        <span></span>
+      </div>
+      <div class="tsne-supervise-by">
+        <paper-input value="{{unlabeledClassInput}}" label="{{unlabeledClassInputLabel}}"
+        on-input="unlabeledClassInputChange"></paper-input>
+        <paper-dropdown-menu no-animations label="Supervise with">
+          <paper-listbox attr-for-selected="value" class="dropdown-content"
+              selected="{{superviseColumn}}" slot="dropdown-content">
+            <template is="dom-repeat" items="[[metadataFields]]">
+              <paper-item value="[[item]]" label="[[item]]">
+                [[item]]
+              </paper-item>
+            </template>
+          </paper-listbox>
+        </paper-dropdown-menu>
       </div>
       <p>
         <button class="run-tsne ink-button" title="Re-run t-SNE">Re-run</button>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
@@ -214,7 +214,7 @@ limitations under the License.
       </div>
       <p>
         <button class="run-tsne ink-button" title="Re-run t-SNE">Re-run</button>
-        <button class="stop-tsne ink-button" title="Stop t-SNE">Stop</button>
+        <button class="pause-tsne ink-button" title="Pause t-SNE">Pause</button>
       </p>
       <p>Iteration: <span class="run-tsne-iter">0</span></p>
       <p id="tsne-sampling" class="notice">

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -94,7 +94,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
 
   /** Polymer elements. */
   private runTsneButton: HTMLButtonElement;
-  private stopTsneButton: HTMLButtonElement;
+  private pauseTsneButton: HTMLButtonElement;
   private perplexitySlider: HTMLInputElement;
   private learningRateInput: HTMLInputElement;
   private zDropdown: HTMLElement;
@@ -123,7 +123,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   ready() {
     this.zDropdown = this.querySelector('#z-dropdown') as HTMLElement;
     this.runTsneButton = this.querySelector('.run-tsne') as HTMLButtonElement;
-    this.stopTsneButton = this.querySelector('.stop-tsne') as HTMLButtonElement;
+    this.pauseTsneButton = this.querySelector('.pause-tsne') as HTMLButtonElement;
     this.perplexitySlider =
         this.querySelector('#perplexity-slider') as HTMLInputElement;
     this.learningRateInput =
@@ -168,8 +168,15 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
     }
 
     this.runTsneButton.addEventListener('click', () => this.runTSNE());
-    this.stopTsneButton.addEventListener(
-        'click', () => this.dataSet.stopTSNE());
+    this.pauseTsneButton.addEventListener('click', () => {
+      if (this.dataSet.tSNEShouldPause) {
+        this.dataSet.tSNEShouldPause = false;
+        this.pauseTsneButton.innerText = 'Pause';
+      } else {
+        this.dataSet.tSNEShouldPause = true;
+        this.pauseTsneButton.innerText = 'Resume';
+      }
+    });
 
     this.perplexitySlider.value = this.perplexity.toString();
     this.perplexitySlider.addEventListener(
@@ -420,7 +427,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
 
   private runTSNE() {
     this.runTsneButton.disabled = true;
-    this.stopTsneButton.disabled = null;
+    this.pauseTsneButton.disabled = null;
     this.dataSet.projectTSNE(
         this.perplexity, this.learningRate, this.tSNEis3d ? 3 : 2,
         (iteration: number) => {
@@ -429,7 +436,8 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
             this.projector.notifyProjectionPositionsUpdated();
           } else {
             this.runTsneButton.disabled = null;
-            this.stopTsneButton.disabled = true;
+            this.pauseTsneButton.disabled = true;
+            this.pauseTsneButton.innerText = 'Pause';
           }
         });
   }

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -505,11 +505,14 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
 
   private runTSNE() {
     this.runTsneButton.disabled = true;
-    this.pauseTsneButton.disabled = null;
+    this.pauseTsneButton.disabled = true;
+    this.pauseTsneButton.innerText = 'Pause';
     this.dataSet.projectTSNE(
         this.perplexity, this.learningRate, this.tSNEis3d ? 3 : 2,
         (iteration: number) => {
           if (iteration != null) {
+            this.runTsneButton.disabled = false;
+            this.pauseTsneButton.disabled = false;
             this.iterationLabel.innerText = '' + iteration;
             this.projector.notifyProjectionPositionsUpdated();
           } else {

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -185,7 +185,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
       }
       (this.querySelector('.tsne-supervise-factor span') as HTMLSpanElement)
       .innerText = ('' + (100 * superviseFactor).toFixed(0));
-      this.dataSet.setTSNESupervision(this.superviseColumn, superviseFactor);
+      this.dataSet.setTSNESupervision(false, this.superviseColumn, superviseFactor);
     }
   }
 
@@ -198,7 +198,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
 
       if (value == null || value.trim() === '') {
         this.unlabeledClassInputLabel = 'Unlabeled class';
-        this.dataSet.setTSNESupervision(this.superviseColumn, 0, '');
+        this.dataSet.setTSNESupervision(false, this.superviseColumn, 0, '');
         return;
       }
       let numMatches = this.dataSet.points.filter(p =>
@@ -206,10 +206,10 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
       
       if (numMatches === 0) {
         this.unlabeledClassInputLabel = 'Unlabeled class [0 matches]';
-        this.dataSet.setTSNESupervision(this.superviseColumn, 0, '');
+        this.dataSet.setTSNESupervision(false, this.superviseColumn, 0, '');
       } else {
         this.unlabeledClassInputLabel = `Unlabeled class [${numMatches} matches]`;
-        this.dataSet.setTSNESupervision(this.superviseColumn, 0, value);
+        this.dataSet.setTSNESupervision(false, this.superviseColumn, 0, value);
       }
     }
   }
@@ -415,6 +415,9 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
       this.unlabeledClassInput = '';
       this.unlabeledClassInputChange();
     }
+
+    if (this.dataSet)  // Handle possible metadata change in supervision
+      this.dataSet.setTSNESupervision(true, this.superviseColumn);
 
     // Project by options for custom projections.
     let searchByMetadataIndex = -1;

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.html
@@ -292,6 +292,9 @@ limitations under the License.
       <paper-icon-button id="selectMode" alt="Bounding box selection" toggles icon="image:photo-size-select-small"></paper-icon-button>
       <paper-tooltip for="selectMode" position="bottom" animation-delay="0" fit-to-visible-bounds>Bounding box selection</paper-tooltip>
 
+      <paper-icon-button id="editMode" alt="Edit current selection" toggles icon="image:exposure"></paper-icon-button>
+      <paper-tooltip for="editMode" position="bottom" animation-delay="0" fit-to-visible-bounds>Edit current selection</paper-tooltip>
+
       <paper-icon-button id="nightDayMode" alt="Enable/disable night mode" toggles icon="image:brightness-2"></paper-icon-button>
       <paper-tooltip for="nightDayMode" position="bottom" animation-delay="0" fit-to-visible-bounds>Enable/disable night mode</paper-tooltip>
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -200,6 +200,23 @@ export class Projector extends ProjectorPolymer implements
     }
   }
 
+  metadataChanged(spriteAndMetadata: SpriteAndMetadataInfo,
+      metadataFile: string) {
+    this.dataSet.spriteAndMetadataInfo = spriteAndMetadata;
+    this.projectionsPanel.metadataChanged(spriteAndMetadata);
+    this.inspectorPanel.metadataChanged(spriteAndMetadata);
+    this.dataPanel.metadataChanged(spriteAndMetadata, metadataFile);
+    
+    if (this.selectedPointIndices.length > 0) {  // at least one selected point
+      this.metadataCard.updateMetadata(  // show metadata for first selected point
+          this.dataSet.points[this.selectedPointIndices[0]].metadata);
+    }
+    else {  // no points selected
+      this.metadataCard.updateMetadata(null);  // clear metadata
+    }
+    this.setSelectedLabelOption(this.selectedLabelOption);
+  }
+
   setSelectedTensor(run: string, tensorInfo: EmbeddingInfo) {
     this.bookmarkPanel.setSelectedTensor(run, tensorInfo, this.dataProvider);
   }
@@ -474,6 +491,8 @@ export class Projector extends ProjectorPolymer implements
       neighborsOfFirstPoint: knn.NearestEntry[]) {
     this.selectedPointIndices = selectedPointIndices;
     this.neighborsOfFirstPoint = neighborsOfFirstPoint;
+    this.dataPanel.onProjectorSelectionChanged(selectedPointIndices, 
+        neighborsOfFirstPoint);
     let totalNumPoints =
         this.selectedPointIndices.length + neighborsOfFirstPoint.length;
     this.statusBar.innerText = `Selected ${totalNumPoints} points`;

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -15,14 +15,14 @@ limitations under the License.
 
 import {AnalyticsLogger} from './analyticsLogger.js';
 import * as data from './data.js';
-import {ColorOption, ColumnStats, DataPoint, DataProto, DataSet, DistanceFunction, PointMetadata, Projection, SpriteAndMetadataInfo, State, stateGetAccessorDimensions} from './data.js';
+import {ColorOption, ColumnStats, DataPoint, DataProto, DataSet, DistanceFunction, DistanceSpace, PointMetadata, Projection, SpriteAndMetadataInfo, State, stateGetAccessorDimensions} from './data.js';
 import {DataProvider, EmbeddingInfo, ServingMode} from './data-provider.js';
 import {DemoDataProvider} from './data-provider-demo.js';
 import {ProtoDataProvider} from './data-provider-proto.js';
 import {ServerDataProvider} from './data-provider-server.js';
 import * as knn from './knn.js';
 import * as logging from './logging.js';
-import {DistanceMetricChangedListener, HoverListener, ProjectionChangedListener, ProjectorEventContext, SelectionChangedListener} from './projectorEventContext.js';
+import {DistanceMetricChangedListener, DistanceSpaceChangedListener, HoverListener, ProjectionChangedListener, ProjectorEventContext, SelectionChangedListener} from './projectorEventContext.js';
 import {ProjectorScatterPlotAdapter} from './projectorScatterPlotAdapter.js';
 import {MouseMode} from './scatterPlot.js';
 import * as util from './util.js';
@@ -67,6 +67,7 @@ export class Projector extends ProjectorPolymer implements
   private hoverListeners: HoverListener[];
   private projectionChangedListeners: ProjectionChangedListener[];
   private distanceMetricChangedListeners: DistanceMetricChangedListener[];
+  private distanceSpaceChangedListeners: DistanceSpaceChangedListener[];
 
   private originalDataSet: DataSet;
   private dataSetBeforeFilter: DataSet;
@@ -117,6 +118,7 @@ export class Projector extends ProjectorPolymer implements
     this.hoverListeners = [];
     this.projectionChangedListeners = [];
     this.distanceMetricChangedListeners = [];
+    this.distanceSpaceChangedListeners = [];
     this.selectedPointIndices = [];
     this.neighborsOfFirstPoint = [];
 
@@ -264,6 +266,7 @@ export class Projector extends ProjectorPolymer implements
     if (newSelectedPointIndices.length === 1) {
       neighbors = this.dataSet.findNeighbors(
           newSelectedPointIndices[0], this.inspectorPanel.distFunc,
+          this.inspectorPanel.distGeo, this.inspectorPanel.distSpace, 
           this.inspectorPanel.numNN);
       this.metadataCard.updateMetadata(
           this.dataSet.points[newSelectedPointIndices[0]].metadata);
@@ -303,6 +306,14 @@ export class Projector extends ProjectorPolymer implements
 
   notifyDistanceMetricChanged(distMetric: DistanceFunction) {
     this.distanceMetricChangedListeners.forEach(l => l(distMetric));
+  }
+
+  registerDistanceSpaceChangedListener(l: DistanceSpaceChangedListener) {
+    this.distanceSpaceChangedListeners.push(l);
+  }
+
+  notifyDistanceSpaceChanged(distSpace: DistanceSpace) {
+    this.distanceSpaceChangedListeners.forEach(l => l(distSpace));
   }
 
   _dataProtoChanged(dataProtoString: string) {


### PR DESCRIPTION
Interactive supervision is enabled in the t-SNE projector by incorporating the following new main components previously proposed as separate independent pull requests:
1. **Selection space choice**: Allow for selection of t-SNE clusters.
2. **Geodesic neighborhood selection**: Allow for improved cluster selection.
4. **Metadata editor**: Allow for the modification of labels to effectively impose supervision.
5. **Semi-supervised t-SNE**: Incorporate label information into t-SNE embedding.

Demo here: http://tensorserve.com:6020
```bash
git clone https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout  0dffc08aa9fe90c97784c889e57ac3b72210c4ab
bazel run tensorboard -- --logdir /home/$USER/emnist-2000 --host 0.0.0.0 --port 6020
```

### Merging process followed
1. Merge https://github.com/tensorflow/tensorboard/pull/696 Projector: 2D sprite element zoom
2. Merge https://github.com/tensorflow/tensorboard/pull/733 Projector: Inspector-panel neighbors slider editable 
3. Merge https://github.com/tensorflow/tensorboard/pull/691 Projector: Add t-SNE pause/resume button (replaced Stop button) 
4. Merge https://github.com/tensorflow/tensorboard/pull/709 Projector: Metadata editor (projector-metadata-editor-v2)
5. Merge https://github.com/tensorflow/tensorboard/pull/724 Projector: Semi-supervised t-SNE
6. Merge https://github.com/tensorflow/tensorboard/pull/732 Projector: Geodesic neighborhood selection
7. Manual merge https://github.com/tensorflow/tensorboard/pull/697 Projector: Add selection editor

### Demonstration
[In process of generating some imagery that illustrate the use of interactive supervision]