### PR TITLE
Set dataSeries to default to empty list

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -117,7 +117,10 @@ limitations under the License.
         // An optional list of data series. Each data series is a string that
         // corresponds to a line in the chart. If this property is not provided,
         // the list of data series consists of the list of runs.
-        dataSeries: Array,
+        dataSeries: {
+          type: Array,
+          value: [],
+        },
 
         xComponentsCreationMethod: Object,
         xType: String,
@@ -246,8 +249,12 @@ limitations under the License.
           return;
         }
 
-        this.$$('vz-line-chart').setVisibleSeries(
-            dataSeries || runsUpdateRecord.base);
+        let visibleSeries = dataSeries;
+        if (visibleSeries.length === 0) {
+          // The data series is not explicitly set. Default to using runs.
+          visibleSeries = runsUpdateRecord.base;
+        }
+        this.$$('vz-line-chart').setVisibleSeries(visibleSeries);
         this._loadData();
       },
       _loadData() {
@@ -307,7 +314,13 @@ limitations under the License.
         });
       },
       _changeSeries() {
-        this.$$('vz-line-chart').setVisibleSeries(this.dataSeries || this.runs);
+        let visibleSeries = this.dataSeries;
+        if (this.dataSeries.length === 0) {
+          // The data series is not explicitly set. Default to using runs.
+          visibleSeries = this.runs;
+        }
+
+        this.$$('vz-line-chart').setVisibleSeries(visibleSeries);
         this._loadData();
       },
       _logScaleChanged(logScaleActive) {


### PR DESCRIPTION
Make the default value for the dataSeries property an empty list.
Previously, PR #679 had set no default value for the property, which
meant that polymer would not trigger observers that depend on the
property, which meant that changing runs via the run selector did
nothing for dashboards that had not set the dataSeries property to a
non-falsy value (such as the scalars and PR curves dashboards).