### PR TITLE
Projector: Metadata editor

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
@@ -122,20 +122,27 @@ paper-dropdown-menu paper-item {
 
 .metadata-editor paper-input {
   width: calc(100%-150px);
+  --paper-input-container-label-floating: {
+    white-space: normal;
+    line-height: normal;
+  };
 }
 
-.metadata-editor paper-dropdown-menu {
-  margin-left: 10px;
-  width: 100px;
-}
-
-#metadata-edit-button {
+.metadata-editor paper-button {
   margin-left: 10px;
   margin-right: 0px;
   margin-top: 20px;
   min-width: 40px;
   height: 36px;
   vertical-align: bottom;
+}
+
+.metadata-editor paper-dropdown-menu {
+  margin-left: 10px;
+  width: 100px;
+  --paper-input-container-label-floating: {
+    line-height: normal;
+  };
 }
 
 .config-checkbox {
@@ -286,12 +293,13 @@ paper-dropdown-menu paper-item {
   </div>
 
   <!-- Tag selection as -->
-  <div class="metadata-editor">
-    <paper-input value="{{editLabelInput}}" label="{{editLabelInputLabel}}"
-    on-input="editLabelInputChange"></paper-input>
+  <div hidden$="[[!_hasChoice(labelOptions)]]" class="metadata-editor">
+    <paper-input value="{{metadataEditorInput}}" label="{{metadataEditorInputLabel}}"
+    on-input="metadataEditorInputChange"></paper-input>
     <paper-dropdown-menu no-animations label="in">
       <paper-listbox attr-for-selected="value" class="dropdown-content" slot="dropdown-content"
-          selected="{{editLabelColumn}}" on-selected-item-changed="editLabelColumnChange">
+          on-selected-item-changed="metadataEditorColumnChange"
+          selected="{{metadataEditorColumn}}" >
         <template is="dom-repeat" items="[[metadataFields]]">
           <paper-item value="[[item]]" label="[[item]]">
             [[item]]
@@ -299,9 +307,8 @@ paper-dropdown-menu paper-item {
         </template>
       </paper-listbox>
     </paper-dropdown-menu>
-    <paper-button id="metadata-edit-button" class="ink-button"
-    on-click="metadataEditButtonClicked"
-    disabled="[[metadataEditButtonDisabled]]">Label</paper-button>
+    <paper-button class="ink-button" on-click="metadataEditorButtonClicked"
+        disabled="[[metadataEditorButtonDisabled]]">Label</paper-button>
   </div>
 
   <paper-checkbox id="normalize-data-checkbox" checked="{{normalizeData}}">

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
@@ -116,6 +116,28 @@ paper-dropdown-menu paper-item {
   margin: 10px 0;
 }
 
+.metadata-editor {
+  display: flex;
+}
+
+.metadata-editor paper-input {
+  width: calc(100%-150px);
+}
+
+.metadata-editor paper-dropdown-menu {
+  margin-left: 10px;
+  width: 100px;
+}
+
+#metadata-edit-button {
+  margin-left: 10px;
+  margin-right: 0px;
+  margin-top: 20px;
+  min-width: 40px;
+  height: 36px;
+  vertical-align: bottom;
+}
+
 .config-checkbox {
   display: inline-block;
   font-size: 11px;
@@ -190,7 +212,7 @@ paper-dropdown-menu paper-item {
 }
 
 .colorby-container {
-  margin-bottom: 10px;
+  margin-bottom: 0px;
 }
 </style>
 <div class="title">DATA</div>
@@ -262,6 +284,26 @@ paper-dropdown-menu paper-item {
       <vz-projector-legend render-info="[[colorLegendRenderInfo]]"></vz-projector-legend>
     </template>
   </div>
+
+  <!-- Tag selection as -->
+  <div class="metadata-editor">
+    <paper-input value="{{editLabelInput}}" label="{{editLabelInputLabel}}"
+    on-input="editLabelInputChange"></paper-input>
+    <paper-dropdown-menu no-animations label="in">
+      <paper-listbox attr-for-selected="value" class="dropdown-content" slot="dropdown-content"
+          selected="{{editLabelColumn}}" on-selected-item-changed="editLabelColumnChange">
+        <template is="dom-repeat" items="[[metadataFields]]">
+          <paper-item value="[[item]]" label="[[item]]">
+            [[item]]
+          </paper-item>
+        </template>
+      </paper-listbox>
+    </paper-dropdown-menu>
+    <paper-button id="metadata-edit-button" class="ink-button"
+    on-click="metadataEditButtonClicked"
+    disabled="[[metadataEditButtonDisabled]]">Label</paper-button>
+  </div>
+
   <paper-checkbox id="normalize-data-checkbox" checked="{{normalizeData}}">
     Sphereize data
     <paper-icon-button icon="help" class="help-icon"></paper-icon-button>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
@@ -36,26 +36,26 @@ export let DataPanelPolymer = PolymerElement({
         {type: String, notify: true, observer: '_selectedLabelOptionChanged'},
     normalizeData: Boolean,
     showForceCategoricalColorsCheckbox: Boolean,
-    editLabelInput: {
+    metadataEditorInput: {
       type: String
     },
-    editLabelInputLabel: {
+    metadataEditorInputLabel: {
       type: String,
       value: 'Tag selection as'
     },
-    editLabelInputChange: {
+    metadataEditorInputChange: {
       type: Object
     },
-    editLabelColumn: {
+    metadataEditorColumn: {
       type: String,
     },
-    editLabelColumnChange: {
+    metadataEditorColumnChange: {
       type: Object
     },
-    metadataEditButtonClicked: {
+    metadataEditorButtonClicked: {
       type: Object
     },
-    metadataEditButtonDisabled: {
+    metadataEditorButtonDisabled: {
       type: Boolean
     }
   },
@@ -73,9 +73,9 @@ export class DataPanel extends DataPanelPolymer {
   private labelOptions: string[];
   private colorOptions: ColorOption[];
   forceCategoricalColoring: boolean = false;
-  private editLabelInput: string;
-  private editLabelInputLabel: string;
-  private metadataEditButtonDisabled: boolean;
+  private metadataEditorInput: string;
+  private metadataEditorInputLabel: string;
+  private metadataEditorButtonDisabled: boolean;
 
   private selectedPointIndices: number[];
   private neighborsOfFirstPoint: knn.NearestEntry[];
@@ -169,10 +169,10 @@ export class DataPanel extends DataPanelPolymer {
       return stats.name;
     });
 
-    if (this.editLabelColumn == null || this.metadataFields.filter(name =>
-        name == this.editLabelColumn).length == 0) {
+    if (this.metadataEditorColumn == null || this.metadataFields.filter(name =>
+        name == this.metadataEditorColumn).length == 0) {
       // Make the default label the first non-numeric column.
-      this.editLabelColumn = this.metadataFields[Math.max(0, labelIndex)];
+      this.metadataEditorColumn = this.metadataFields[Math.max(0, labelIndex)];
     }
   }
 
@@ -181,7 +181,7 @@ export class DataPanel extends DataPanelPolymer {
       neighborsOfFirstPoint: knn.NearestEntry[]) {
     this.selectedPointIndices = selectedPointIndices;
     this.neighborsOfFirstPoint = neighborsOfFirstPoint;
-    this.editLabelInputChange();
+    this.metadataEditorInputChange();
   }
 
   private addWordBreaks(longString: string): string {
@@ -272,56 +272,60 @@ export class DataPanel extends DataPanelPolymer {
     this.colorOptions = standardColorOption.concat(metadataColorOption);
   }
 
-  private editLabelInputChange() {
-    let value = this.editLabelInput;
+  private metadataEditorInputChange() {
+    let value = this.metadataEditorInput;
     let selectionSize = this.selectedPointIndices.length + 
         this.neighborsOfFirstPoint.length;
     
     if (selectionSize > 0) {
       if (value != null && value.trim() != '') {
         let numMatches = this.projector.dataSet.points.filter(p =>
-            p.metadata[this.editLabelColumn].toString() == value).length;
+            p.metadata[this.metadataEditorColumn].toString() == value).length;
 
         if (numMatches === 0) {
-          this.editLabelInputLabel = `Tag ${selectionSize} with new label`;
+          this.metadataEditorInputLabel = `Tag ${selectionSize} with new label`;
         }
         else {
-          this.editLabelInputLabel = 
-              `Add ${selectionSize} to ${numMatches} found`;
+          this.metadataEditorInputLabel = 
+              `Tag ${selectionSize} points as`;
         }
-        this.metadataEditButtonDisabled = false;
+        this.metadataEditorButtonDisabled = false;
       }
       else {
-        this.editLabelInputLabel = 'Tag selection as';
-        this.metadataEditButtonDisabled = true;
+        this.metadataEditorInputLabel = 'Tag selection as';
+        this.metadataEditorButtonDisabled = true;
       }
     }
     else {
-      this.metadataEditButtonDisabled = true;
+      this.metadataEditorButtonDisabled = true;
+
       if (value != null && value.trim() != '') {
-        this.editLabelInputLabel = 'Select points to tag';
+        this.metadataEditorInputLabel = 'Select points to tag';
       }
       else {
-        this.editLabelInputLabel = 'Tag selection as';
+        this.metadataEditorInputLabel = 'Tag selection as';
       }
     }
   }
 
-  private editLabelColumnChange() {
-    this.editLabelInputChange();
+  private metadataEditorColumnChange() {
+    this.metadataEditorInputChange();
   }
 
-  private metadataEditButtonClicked() {
-    this.metadataEditButtonDisabled = true;
+  private metadataEditorButtonClicked() {
     let selectionSize = this.selectedPointIndices.length + 
         this.neighborsOfFirstPoint.length;
-    this.editLabelInputLabel = `${selectionSize} labeled as '${this.editLabelInput}'`;
+    this.metadataEditorButtonDisabled = true;
+    this.metadataEditorInputLabel = `${selectionSize} labeled as '${this.metadataEditorInput}'`;
+
     this.selectedPointIndices.forEach(i =>
-        this.projector.dataSet.points[i].metadata[this.editLabelColumn] =
-        this.editLabelInput);
+        this.projector.dataSet.points[i].metadata[this.metadataEditorColumn] =
+        this.metadataEditorInput);
+    
     this.neighborsOfFirstPoint.forEach(p =>
-        this.projector.dataSet.points[p.index].metadata[this.editLabelColumn] =
-        this.editLabelInput);
+        this.projector.dataSet.points[p.index].metadata[this.metadataEditorColumn] =
+        this.metadataEditorInput);
+    
     this.spriteAndMetadata.stats = analyzeMetadata(
         this.spriteAndMetadata.stats.map(s => s.name),
         this.projector.dataSet.points.map(p => p.metadata));
@@ -611,6 +615,10 @@ export class DataPanel extends DataPanelPolymer {
   _getNumRunsLabel(): string {
     return this.runNames.length === 1 ? '1 run' :
                                         this.runNames.length + ' runs';
+  }
+
+  _hasChoice(choices: any[]): boolean {
+    return choices.length > 0;
   }
 
   _hasChoices(choices: any[]): boolean {

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
@@ -36,28 +36,13 @@ export let DataPanelPolymer = PolymerElement({
         {type: String, notify: true, observer: '_selectedLabelOptionChanged'},
     normalizeData: Boolean,
     showForceCategoricalColorsCheckbox: Boolean,
-    metadataEditorInput: {
-      type: String
-    },
-    metadataEditorInputLabel: {
-      type: String,
-      value: 'Tag selection as'
-    },
-    metadataEditorInputChange: {
-      type: Object
-    },
-    metadataEditorColumn: {
-      type: String,
-    },
-    metadataEditorColumnChange: {
-      type: Object
-    },
-    metadataEditorButtonClicked: {
-      type: Object
-    },
-    metadataEditorButtonDisabled: {
-      type: Boolean
-    }
+    metadataEditorInput: {type: String},
+    metadataEditorInputLabel: {type: String, value: 'Tag selection as'},
+    metadataEditorInputChange: {type: Object},
+    metadataEditorColumn: {type: String},
+    metadataEditorColumnChange: {type: Object},
+    metadataEditorButtonClicked: {type: Object},
+    metadataEditorButtonDisabled: {type: Boolean}
   },
   observers: [
     '_generateUiForNewCheckpointForRun(selectedRun)',
@@ -316,15 +301,16 @@ export class DataPanel extends DataPanelPolymer {
     let selectionSize = this.selectedPointIndices.length + 
         this.neighborsOfFirstPoint.length;
     this.metadataEditorButtonDisabled = true;
-    this.metadataEditorInputLabel = `${selectionSize} labeled as '${this.metadataEditorInput}'`;
+    this.metadataEditorInputLabel =
+        `${selectionSize} labeled as '${this.metadataEditorInput}'`;
 
     this.selectedPointIndices.forEach(i =>
         this.projector.dataSet.points[i].metadata[this.metadataEditorColumn] =
         this.metadataEditorInput);
     
     this.neighborsOfFirstPoint.forEach(p =>
-        this.projector.dataSet.points[p.index].metadata[this.metadataEditorColumn] =
-        this.metadataEditorInput);
+        this.projector.dataSet.points[p.index]
+            .metadata[this.metadataEditorColumn] = this.metadataEditorInput);
     
     this.spriteAndMetadata.stats = analyzeMetadata(
         this.spriteAndMetadata.stats.map(s => s.name),

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
@@ -105,9 +105,14 @@ export class InspectorPanel extends PolymerClass {
       }
       return stats.name;
     });
-    labelIndex = Math.max(0, labelIndex);
-    // Make the default label the first non-numeric column.
-    this.selectedMetadataField = spriteAndMetadata.stats[labelIndex].name;
+
+    if (this.selectedMetadataField == null || this.metadataFields.filter(name =>
+        name == this.selectedMetadataField).length == 0) {
+      // Make the default label the first non-numeric column.
+      this.selectedMetadataField = this.metadataFields[Math.max(0, labelIndex)];
+    }
+    this.updateInspectorPane(this.selectedPointIndices, 
+        this.neighborsOfFirstPoint);
   }
 
   datasetChanged() {

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -200,6 +200,23 @@ export class Projector extends ProjectorPolymer implements
     }
   }
 
+  metadataChanged(spriteAndMetadata: SpriteAndMetadataInfo,
+      metadataFile: string) {
+    this.dataSet.spriteAndMetadataInfo = spriteAndMetadata;
+    this.projectionsPanel.metadataChanged(spriteAndMetadata);
+    this.inspectorPanel.metadataChanged(spriteAndMetadata);
+    this.dataPanel.metadataChanged(spriteAndMetadata, metadataFile);
+    
+    if (this.selectedPointIndices.length > 0) {  // at least one selected point
+      this.metadataCard.updateMetadata(  // show metadata for first selected point
+          this.dataSet.points[this.selectedPointIndices[0]].metadata);
+    }
+    else {  // no points selected
+      this.metadataCard.updateMetadata(null);  // clear metadata
+    }
+    this.setSelectedLabelOption(this.selectedLabelOption);
+  }
+
   setSelectedTensor(run: string, tensorInfo: EmbeddingInfo) {
     this.bookmarkPanel.setSelectedTensor(run, tensorInfo, this.dataProvider);
   }
@@ -474,6 +491,8 @@ export class Projector extends ProjectorPolymer implements
       neighborsOfFirstPoint: knn.NearestEntry[]) {
     this.selectedPointIndices = selectedPointIndices;
     this.neighborsOfFirstPoint = neighborsOfFirstPoint;
+    this.dataPanel.onProjectorSelectionChanged(selectedPointIndices, 
+        neighborsOfFirstPoint);
     let totalNumPoints =
         this.selectedPointIndices.length + neighborsOfFirstPoint.length;
     this.statusBar.innerText = `Selected ${totalNumPoints} points`;


### PR DESCRIPTION
Add a metadata editor to the Projector, which gives the option to modify metadata attributes of selected points. This is very helpful to make alterations and corrections to an existing labeling, although changes are only made in the browser session and do not persist to the metadata file. 

~Demo here: http://tensorserve.com:6018~
```bash
git clone https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout d86fb52a41e5a4e47c3484054b00ea13a2e40538
bazel run tensorboard -- --logdir /home/$USER/emnist-2000 --host 0.0.0.0 --port 6018
```
Supersedes https://github.com/tensorflow/tensorboard/pull/709 Projector: Metadata editor

@dsmilkov - Simplified the metadata editor status messaging, but we could consider using existing sample sizes of applied labels in future.

### Design and behavior
1. The metadata editor only requires one extra row in the data panel.
2. The metadata editor hides when no metadata is available.
3. The label button is disabled if no selection has been made, or if no label has been specified.
4. Multiline floating label is set for the metadata label paper-input to accommodate status messaging for longer labels.
5. An metadata search is done to find the number of existing samples with the specified label.
6. Projector components related to metadata display are refreshed after attribute changes, which also expands the color palette for the modified attribute when a new class is added.
7. _metadataChanged()_ is invoked in the projector after a metadata edit, which normally resets the attribute choices in the data panel and inspector panel. It is proposed that if there is an existing selection it should be retained if it is valid choice, which means that if another metadata file is loaded and it contains the selection it would be preferred.

### Data panel before
<img width="306" src="https://user-images.githubusercontent.com/10847676/32536492-5f6b8bee-c467-11e7-9699-3c554bf3777f.png">

### Data panel with metadata editor
<img width="284" alt="screen shot 2017-11-15 at 7 30 56 pm" src="https://user-images.githubusercontent.com/10847676/32850708-94aa4e10-ca3b-11e7-905b-d1d9e6229e44.png">

### Status updates in metadata editor
<img width="262" src="https://user-images.githubusercontent.com/10847676/32850330-8023d57a-ca3a-11e7-917f-86490172dd21.png">
<img width="262" src="https://user-images.githubusercontent.com/10847676/32850339-85b96978-ca3a-11e7-83e7-1d5981fe3aac.png">
<img width="262" src="https://user-images.githubusercontent.com/10847676/32850351-8ed0d564-ca3a-11e7-925d-f2814540fcff.png">
<img width="262" src="https://user-images.githubusercontent.com/10847676/32850355-919db64a-ca3a-11e7-8a2c-a3cb437b45da.png">
<img width="262" src="https://user-images.githubusercontent.com/10847676/32850375-9a04a3ac-ca3a-11e7-9652-fd1793f6b8eb.png">
<img width="262" src="https://user-images.githubusercontent.com/10847676/32850435-cd93420a-ca3a-11e7-84d3-b0ab2ed521ca.png">







