### PR TITLE
 [Fix] Projector: Terminate t-SNE properly on re-run

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -311,10 +311,10 @@ export class DataSet {
   projectTSNE(
       perplexity: number, learningRate: number, tsneDim: number,
       stepCallback: (iter: number) => void) {
-    this.hasTSNERun = true;
     let k = Math.floor(3 * perplexity);
     let opt = {epsilon: learningRate, perplexity: perplexity, dim: tsneDim};
     this.tsne = new TSNE(opt);
+    this.hasTSNERun = true;
     this.tSNEShouldPause = false;
     this.tSNEShouldStop = false;
     this.tSNEShouldPerturb = false;
@@ -323,8 +323,9 @@ export class DataSet {
     let sampledIndices = this.shuffledDataIndices.slice(0, TSNE_SAMPLE_SIZE);
     let step = () => {
       if (this.tSNEShouldStop) {
-        stepCallback(null);
         this.tsne = null;
+        this.hasTSNERun = false;
+        stepCallback(null);
         return;
       }
 

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -311,10 +311,10 @@ export class DataSet {
   projectTSNE(
       perplexity: number, learningRate: number, tsneDim: number,
       stepCallback: (iter: number) => void) {
+    this.hasTSNERun = true;
     let k = Math.floor(3 * perplexity);
     let opt = {epsilon: learningRate, perplexity: perplexity, dim: tsneDim};
     this.tsne = new TSNE(opt);
-    this.hasTSNERun = true;
     this.tSNEShouldPause = false;
     this.tSNEShouldStop = false;
     this.tSNEShouldPerturb = false;

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -323,9 +323,9 @@ export class DataSet {
     let sampledIndices = this.shuffledDataIndices.slice(0, TSNE_SAMPLE_SIZE);
     let step = () => {
       if (this.tSNEShouldStop) {
+        stepCallback(null);
         this.tsne = null;
         this.hasTSNERun = false;
-        stepCallback(null);
         return;
       }
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
@@ -227,7 +227,7 @@ limitations under the License.
         <span></span>
       </div>
       <p>
-        <button class="run-tsne ink-button" title="Re-run t-SNE">Re-run</button>
+        <button class="run-tsne ink-button" title="Re-run t-SNE">Run</button>
         <button class="pause-tsne ink-button" title="Pause t-SNE">Pause</button>
         <button class="perturb-tsne ink-button" title="Perturb t-SNE">Perturb</button>
       </p>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -180,7 +180,15 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
       }
     }
 
-    this.runTsneButton.addEventListener('click', () => this.runTSNE());
+    this.runTsneButton.addEventListener('click', () => {
+      if (this.dataSet.hasTSNERun) {
+        this.dataSet.stopTSNE();
+      }
+      else {
+        this.runTSNE();
+      }
+    });
+
     this.pauseTsneButton.addEventListener('click', () => {
       if (this.dataSet.tSNEShouldPause) {
         this.dataSet.tSNEShouldPause = false;
@@ -450,24 +458,28 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   }
 
   private runTSNE() {
+    this.runTsneButton.innerText = 'Stop';
     this.runTsneButton.disabled = true;
-    this.perturbTsneButton.disabled = true;
-    this.pauseTsneButton.disabled = true;
     this.pauseTsneButton.innerText = 'Pause';
+    this.pauseTsneButton.disabled = true;
+    this.perturbTsneButton.disabled = true;
+
     this.dataSet.projectTSNE(
         this.perplexity, this.learningRate, this.tSNEis3d ? 3 : 2,
         (iteration: number) => {
           if (iteration != null) {
             this.runTsneButton.disabled = false;
-            this.perturbTsneButton.disabled = false;
             this.pauseTsneButton.disabled = false;
+            this.perturbTsneButton.disabled = false;
             this.iterationLabel.innerText = '' + iteration;
             this.projector.notifyProjectionPositionsUpdated();
-          } else {
-            this.runTsneButton.disabled = null;
-            this.perturbTsneButton.disabled = true;
-            this.pauseTsneButton.disabled = true;
+          }
+          else {
+            this.runTsneButton.innerText = 'Re-run';
+            this.runTsneButton.disabled = false;
             this.pauseTsneButton.innerText = 'Pause';
+            this.pauseTsneButton.disabled = true;
+            this.perturbTsneButton.disabled = true;
           }
         });
   }


### PR DESCRIPTION
t-SNE now first terminates upon press of Stop/Re-run button, then a second button click re-runs t-SNE. Otherwise existing requestAnimationFrame(step) process does not terminate.

Demo here: http://tensorserve.com:6010
```bash
git clone https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout a7f1672f29875dde29f2a0080a61f105606a85dc
bazel run tensorboard -- --logdir /home/$USER/emnist-2000 --host 0.0.0.0 --port 6010
```

Referencing https://github.com/tensorflow/tensorboard/pull/691 Projector: Add t-SNE pause/resume button (replaced Stop button).

@dsmilkov please consider merging this important fix.

### Design and behavior
1. Re-run button now becomes a Stop or Re-Run button, depending on _dataSet.hasTSNERun_.
2. Stop/Re-run button press checks _dataSet.hasTSNERun_ to determine whether a t-SNE process already exists.
3. Sends _tSNEShouldStop_ termination signal to requestAnimationFrame(step) if _dataSet.hasTSNERun_ is true and sets button label to Re-run, otherwise starts t-SNE process and sets button label to Stop.
4. _dataSet.hasTSNERun_ is only turned off right before requestAnimationFrame(step) terminates, and it has to be off for the Re-run button to restart t-SNE, so there are no race conditions I can currently think of.

### Revised t-SNE projections panel
<img width="374" src="https://user-images.githubusercontent.com/10847676/32881089-a869de34-cab8-11e7-9cd9-2f1c9f6eb35b.png">
<img width="318" src="https://user-images.githubusercontent.com/10847676/32881106-b921f39c-cab8-11e7-9a86-0dba7bdcc2a6.png">
<img width="319" src="https://user-images.githubusercontent.com/10847676/32881108-bae84064-cab8-11e7-8b53-df80cc57b596.png">
<img width="329" src="https://user-images.githubusercontent.com/10847676/32881112-bed28d6a-cab8-11e7-8b32-99cd19af8566.png">
<img width="323" src="https://user-images.githubusercontent.com/10847676/32881117-c2f20600-cab8-11e7-9c9e-aeb4b2251d2e.png">
