### PR TITLE
[Debugger Plugin]: Initial commit

### DIFF
--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -53,6 +53,7 @@ ts_web_library(
     deps = [
         "//tensorboard/plugins/audio/tf_audio_dashboard",
         "//tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard",
+        "//tensorboard/plugins/debugger/tf_debugger_dashboard",
         "//tensorboard/plugins/distribution/tf_distribution_dashboard",
         "//tensorboard/plugins/graph/tf_graph_dashboard",
         "//tensorboard/plugins/histogram/tf_histogram_dashboard",

--- a/tensorboard/components/tf_tensorboard/default-plugins.html
+++ b/tensorboard/components/tf_tensorboard/default-plugins.html
@@ -29,6 +29,7 @@ limitations under the License.
 <link rel="import" href="../tf-custom-scalar-dashboard/tf-custom-scalar-dashboard.html">
 <link rel="import" href="../tf-image-dashboard/tf-image-dashboard.html">
 <link rel="import" href="../tf-audio-dashboard/tf-audio-dashboard.html">
+<link rel="import" href="../tf-debugger-dashboard/tf-debugger-dashboard.html">
 <link rel="import" href="../tf-graph-dashboard/tf-graph-dashboard.html">
 <link rel="import" href="../tf-distribution-dashboard/tf-distribution-dashboard.html">
 <link rel="import" href="../tf-histogram-dashboard/tf-histogram-dashboard.html">

--- a/tensorboard/plugins/debugger/BUILD
+++ b/tensorboard/plugins/debugger/BUILD
@@ -33,6 +33,7 @@ py_test(
     deps = [
         ":debug_graphs_helper",
         "//tensorboard:expect_tensorflow_installed",
+        "@org_python_pypi_portpicker",
     ],
 )
 
@@ -87,6 +88,9 @@ py_library(
     name = "comm_channel",
     srcs = ["comm_channel.py"],
     srcs_version = "PY2AND3",
+    deps = [
+        "@org_pythonhosted_six",
+    ],
 )
 
 py_test(

--- a/tensorboard/plugins/debugger/BUILD
+++ b/tensorboard/plugins/debugger/BUILD
@@ -20,6 +20,90 @@ py_library(
 )
 
 py_library(
+    name = "debug_graphs_helper",
+    srcs = ["debug_graphs_helper.py"],
+    srcs_version = "PY2AND3",
+)
+
+py_test(
+    name = "debug_graphs_helper_test",
+    size = "small",
+    srcs = ["debug_graphs_helper_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":debug_graphs_helper",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_library(
+    name = "tensor_helper",
+    srcs = ["tensor_helper.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        "//tensorboard:util",
+        "//tensorboard:expect_numpy_installed"
+    ],
+)
+
+py_test(
+    name = "tensor_helper_test",
+    size = "small",
+    srcs = ["tensor_helper_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":tensor_helper",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/plugins/beholder:im_util",
+    ],
+)
+
+py_library(
+    name = "tensor_store",
+    srcs = ["tensor_store.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":tensor_helper",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_test(
+    name = "tensor_store_test",
+    size = "small",
+    srcs = ["tensor_store_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":tensor_store",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/plugins/beholder:im_util",
+    ],
+)
+
+py_library(
+    name = "comm_channel",
+    srcs = ["comm_channel.py"],
+    srcs_version = "PY2AND3",
+)
+
+py_test(
+    name = "comm_channel_test",
+    size = "small",
+    srcs = ["comm_channel_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":comm_channel",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+# TODO(cais): Incorporate debug_graphs_helper into debug_data.py in tensorflow.
+# TODO(cais): Add unit tests for code in debug_graphs_helper.py.
+
+py_library(
     name = "events_writer_manager",
     srcs = ["events_writer_manager.py"],
     srcs_version = "PY2AND3",
@@ -94,6 +178,21 @@ py_library(
     ],
 )
 
+py_library(
+    name = "interactive_debugger_server_lib",
+    srcs = ["interactive_debugger_server_lib.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":comm_channel",
+        ":debug_graphs_helper",
+        ":events_writer_manager",
+        ":numerics_alert",
+        ":tensor_helper",
+        ":tensor_store",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
 py_test(
     name = "debugger_server_test",
     size = "small",
@@ -105,6 +204,7 @@ py_test(
         ":constants",
         ":debugger_server_lib",
         ":numerics_alert",
+        ":tensor_store",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
     ],
@@ -124,7 +224,25 @@ py_test(
     ],
 )
 
-## TensorFlow Debugger Plugin ##
+py_test(
+    name = "interactive_debugger_plugin_test",
+    size = "medium",
+    srcs = ["interactive_debugger_plugin_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":interactive_debugger_plugin",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:application",
+        "//tensorboard/backend/event_processing:event_multiplexer",
+        "//tensorboard/plugins:base_plugin",
+        "@org_pocoo_werkzeug",
+        "@org_python_pypi_portpicker",
+        "@org_pythonhosted_six",
+    ],
+)
+
+## Debugger Plugin: Non-interactive, for Health Pills in Graph Dashboard. ##
 py_library(
     name = "debugger_plugin",
     srcs = ["debugger_plugin.py"],
@@ -142,6 +260,25 @@ py_library(
     ],
 )
 
+## Debugger Plugin: for the interactive Debugger Dashboard. ##
+py_library(
+    name = "interactive_debugger_plugin",
+    srcs = ["interactive_debugger_plugin.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":constants",
+        ":debug_graphs_helper",
+        ":interactive_debugger_server_lib",
+        "//tensorboard:expect_futures_installed",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:http_util",
+        "//tensorboard/backend:process_graph",
+        "//tensorboard/plugins:base_plugin",
+        "@org_pocoo_werkzeug",
+    ],
+)
+
 py_library(
     name = "debugger_plugin_loader",
     srcs = ["debugger_plugin_loader.py"],
@@ -149,6 +286,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":debugger_plugin",
+        ":interactive_debugger_plugin",
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/debugger/BUILD
+++ b/tensorboard/plugins/debugger/BUILD
@@ -194,6 +194,7 @@ py_library(
         ":tensor_helper",
         ":tensor_store",
         "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/plugins/debugger/comm_channel.py
+++ b/tensorboard/plugins/debugger/comm_channel.py
@@ -1,0 +1,73 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Communication channel used by the TensorBoard Debugger Plugin."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import Queue
+import threading
+import time
+
+
+class CommChannel(object):
+  """A class that handles the queueing of outgoing and incoming messages."""
+
+  def __init__(self):
+    self._outgoing = []
+    self._outgoing_counter = 0
+    self._outgoing_lock = threading.Lock()
+
+    self._incoming = Queue.Queue()
+
+  def put_outgoing(self, message):
+    """Put a message into the outgoing message stack.
+
+    Outgoing message will be stored indefinitely to support multi-users.
+    """
+    with self._outgoing_lock:
+      self._outgoing.append(message)
+      self._outgoing_counter += 1
+
+  def get_outgoing(self, pos):
+    """Get message(s) from the outgoing message stack.
+
+    Blocks until an item at stack position pos becomes available.
+
+    Args:
+       pos: An int specifying the top position of the message stack to access.
+         For example, if the stack counter is at 3 and pos == 2, then the 2nd
+         item on the stack will be returned, together with an int that indicates
+         the current stack heigh (3 in this case).
+
+    Returns:
+      1. The item at stack position pos.
+      2. The height of the stack when the retun values are generated.
+    """
+    assert pos > 0, "Invalid pos %d: pos must be > 0" % pos
+    self._wait_till_stack_height(pos)
+    with self._outgoing_lock:
+      return self._outgoing[pos - 1], self._outgoing_counter
+
+  def _wait_till_stack_height(self, pos, polling_period=0.01):
+    while self._outgoing_counter < pos:
+      time.sleep(polling_period)
+
+  def put_incoming(self, message):
+    self._incoming.put(message)
+
+  def get_incoming(self):
+    return self._incoming.get()

--- a/tensorboard/plugins/debugger/comm_channel.py
+++ b/tensorboard/plugins/debugger/comm_channel.py
@@ -18,9 +18,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import Queue
 import threading
 import time
+
+from six.moves import queue as Queue  # pylint: disable=redefined-builtin
 
 
 class CommChannel(object):

--- a/tensorboard/plugins/debugger/comm_channel.py
+++ b/tensorboard/plugins/debugger/comm_channel.py
@@ -24,7 +24,26 @@ from six.moves import queue
 
 
 class CommChannel(object):
-  """A class that handles the queueing of outgoing and incoming messages."""
+  """A class that handles the queueing of outgoing and incoming messages.
+
+  A CommChannel instance has an incoming channel and an outgoing channel.
+
+  The incoming channel is a simple FIFO queue.  The put_incoming() method
+  performs enqueuing; the get_incoming() method performs dequeuing.
+
+  CommChannel's outgoing channel is a multi-consumer interface that serves the
+  following purposes:
+  1) Keeps track of all the messages that it has received from the caller of
+     put_outgoing(). In the case of TDP, these are messages about the start of
+     Session.runs() and the pausing events at tensor breakpoints. These messages
+     are kept in the order they are received.
+  2) Allows the callers of get_outgoing() to retrieve any message by a position
+     index at anytime. Notice that we want to support multiple callers because
+     more than once browser sessions may need to connect to the backend
+     simultaneously. If a caller of get_outgoing() requests a position that has
+     not been received from put_going() yet, the get_ougoing() call will block
+     until a message is received at that position.
+  """
 
   def __init__(self):
     self._outgoing = []

--- a/tensorboard/plugins/debugger/comm_channel_test.py
+++ b/tensorboard/plugins/debugger/comm_channel_test.py
@@ -30,36 +30,36 @@ class CommChannelTest(tf.test.TestCase):
   def testGetOutgoingWithInvalidPosLeadsToAssertionError(self):
     channel = comm_channel.CommChannel()
     with self.assertRaises(ValueError):
-      channel.get_outgoing(0)
+      channel.get(0)
     with self.assertRaises(ValueError):
-      channel.get_outgoing(-1)
+      channel.get(-1)
 
   def testOutgoingSerialPutOneAndGetOne(self):
     channel = comm_channel.CommChannel()
-    channel.put_outgoing('A')
-    self.assertEqual(('A', 1), channel.get_outgoing(1))
+    channel.put('A')
+    self.assertEqual(('A', 1), channel.get(1))
 
   def testOutgoingSerialPutTwoGetOne(self):
     channel = comm_channel.CommChannel()
-    channel.put_outgoing('A')
-    channel.put_outgoing('B')
-    channel.put_outgoing('C')
-    self.assertEqual(('A', 3), channel.get_outgoing(1))
-    self.assertEqual(('B', 3), channel.get_outgoing(2))
-    self.assertEqual(('C', 3), channel.get_outgoing(3))
+    channel.put('A')
+    channel.put('B')
+    channel.put('C')
+    self.assertEqual(('A', 3), channel.get(1))
+    self.assertEqual(('B', 3), channel.get(2))
+    self.assertEqual(('C', 3), channel.get(3))
 
   def testOutgoingConcurrentPutAndOneGetter(self):
     channel = comm_channel.CommChannel()
 
     result = {'outgoing': []}
     def get_two():
-      result['outgoing'].append(channel.get_outgoing(1))
-      result['outgoing'].append(channel.get_outgoing(2))
+      result['outgoing'].append(channel.get(1))
+      result['outgoing'].append(channel.get(2))
 
     t = threading.Thread(target=get_two)
     t.start()
-    channel.put_outgoing('A')
-    channel.put_outgoing('B')
+    channel.put('A')
+    channel.put('B')
     t.join()
     self.assertEqual('A', result['outgoing'][0][0])
     self.assertIn(result['outgoing'][0][1], [1, 2])
@@ -71,19 +71,19 @@ class CommChannelTest(tf.test.TestCase):
     result1 = {'outgoing': []}
     result2 = {'outgoing': []}
     def getter1():
-      result1['outgoing'].append(channel.get_outgoing(1))
-      result1['outgoing'].append(channel.get_outgoing(2))
+      result1['outgoing'].append(channel.get(1))
+      result1['outgoing'].append(channel.get(2))
     def getter2():
-      result2['outgoing'].append(channel.get_outgoing(1))
-      result2['outgoing'].append(channel.get_outgoing(2))
+      result2['outgoing'].append(channel.get(1))
+      result2['outgoing'].append(channel.get(2))
 
     t1 = threading.Thread(target=getter1)
     t1.start()
     t2 = threading.Thread(target=getter2)
     t2.start()
 
-    channel.put_outgoing('A')
-    channel.put_outgoing('B')
+    channel.put('A')
+    channel.put('B')
     t1.join()
     t2.join()
 
@@ -93,19 +93,6 @@ class CommChannelTest(tf.test.TestCase):
     self.assertEqual('A', result2['outgoing'][0][0])
     self.assertIn(result2['outgoing'][0][1], [1, 2])
     self.assertEqual(('B', 2), result2['outgoing'][1])
-
-  def testIncomingQueue(self):
-    channel = comm_channel.CommChannel()
-
-    result = {'incoming': None}
-    def get_one():
-      result['incoming'] = channel.get_incoming()
-
-    t = threading.Thread(target=get_one)
-    t.start()
-    channel.put_incoming('Z')
-    t.join()
-    self.assertEqual('Z', result['incoming'])
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/debugger/comm_channel_test.py
+++ b/tensorboard/plugins/debugger/comm_channel_test.py
@@ -1,0 +1,81 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for CommChannel."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import threading
+import time
+
+import tensorflow as tf
+
+from tensorboard.plugins.debugger import comm_channel
+
+
+class CommChannelTest(tf.test.TestCase):
+
+  def testGetOutgoingWithInvalidPosLeadsToAssertionError(self):
+    channel = comm_channel.CommChannel()
+    with self.assertRaises(AssertionError):
+      channel.get_outgoing(0)
+
+  def testOutgoingSerialPutOneAndGetOne(self):
+    channel = comm_channel.CommChannel()
+    channel.put_outgoing("A")
+    self.assertEqual(("A", 1), channel.get_outgoing(1))
+
+  def testOutgoingSerialPutTwoGetOne(self):
+    channel = comm_channel.CommChannel()
+    channel.put_outgoing("A")
+    channel.put_outgoing("B")
+    channel.put_outgoing("C")
+    self.assertEqual(("A", 3), channel.get_outgoing(1))
+    self.assertEqual(("B", 3), channel.get_outgoing(2))
+    self.assertEqual(("C", 3), channel.get_outgoing(3))
+
+  def testOutgoingConcurrentPutAndGet(self):
+    channel = comm_channel.CommChannel()
+
+    result = {"outgoing": []}
+    def get_two():
+      result["outgoing"].append(channel.get_outgoing(1))
+      result["outgoing"].append(channel.get_outgoing(2))
+
+    t = threading.Thread(target=get_two)
+    t.start()
+    channel.put_outgoing("A")
+    time.sleep(0.025)  # Greater than the default polling interval (0.01).
+    channel.put_outgoing("B")
+    t.join()
+    self.assertEqual([("A", 1), ("B", 2)], result["outgoing"])
+
+  def testIncomingQueue(self):
+    channel = comm_channel.CommChannel()
+
+    result = {"incoming": None}
+    def get_one():
+      result["incoming"] = channel.get_incoming()
+
+    t = threading.Thread(target=get_one)
+    t.start()
+    channel.put_incoming("Z")
+    t.join()
+    self.assertEqual("Z", result["incoming"])
+
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/tensorboard/plugins/debugger/comm_channel_test.py
+++ b/tensorboard/plugins/debugger/comm_channel_test.py
@@ -19,7 +19,6 @@ from __future__ import division
 from __future__ import print_function
 
 import threading
-import time
 
 import tensorflow as tf
 
@@ -60,10 +59,11 @@ class CommChannelTest(tf.test.TestCase):
     t = threading.Thread(target=get_two)
     t.start()
     channel.put_outgoing('A')
-    time.sleep(0.025)  # Greater than the default polling interval (0.01).
     channel.put_outgoing('B')
     t.join()
-    self.assertEqual([('A', 1), ('B', 2)], result['outgoing'])
+    self.assertEqual('A', result['outgoing'][0][0])
+    self.assertIn(result['outgoing'][0][1], [1, 2])
+    self.assertEqual(('B', 2), result['outgoing'][1])
 
   def testOutgoingConcurrentPutAndTwoGetters(self):
     channel = comm_channel.CommChannel()
@@ -83,13 +83,16 @@ class CommChannelTest(tf.test.TestCase):
     t2.start()
 
     channel.put_outgoing('A')
-    time.sleep(0.025)  # Greater than the default polling interval (0.01).
     channel.put_outgoing('B')
     t1.join()
     t2.join()
 
-    self.assertEqual([('A', 1), ('B', 2)], result1['outgoing'])
-    self.assertEqual([('A', 1), ('B', 2)], result2['outgoing'])
+    self.assertEqual('A', result1['outgoing'][0][0])
+    self.assertIn(result1['outgoing'][0][1], [1, 2])
+    self.assertEqual(('B', 2), result1['outgoing'][1])
+    self.assertEqual('A', result2['outgoing'][0][0])
+    self.assertIn(result2['outgoing'][0][1], [1, 2])
+    self.assertEqual(('B', 2), result2['outgoing'][1])
 
   def testIncomingQueue(self):
     channel = comm_channel.CommChannel()

--- a/tensorboard/plugins/debugger/debug_graphs_helper.py
+++ b/tensorboard/plugins/debugger/debug_graphs_helper.py
@@ -49,7 +49,7 @@ def extract_gated_grpc_tensors(graph_def, match_debug_op=None):
       continue
 
     for attr_key in node.attr:
-      if attr_key == "gated_grpc" and node.attr[attr_key].b:
+      if attr_key == 'gated_grpc' and node.attr[attr_key].b:
 
         node_name, output_slot, _, debug_op = (
             debug_graphs.parse_debug_node_name(node.name))
@@ -75,6 +75,6 @@ def maybe_base_expanded_node_name(node_name, graph_def):
     Possibly base-expanded node name.
   """
   for node in graph_def.node:
-    if node.name.startswith(node_name + "/"):
-      return node_name + "/(" + node_name.split("/")[-1] + ")"
+    if node.name.startswith(node_name + '/'):
+      return node_name + '/(' + node_name.split('/')[-1] + ')'
   return node_name

--- a/tensorboard/plugins/debugger/debug_graphs_helper.py
+++ b/tensorboard/plugins/debugger/debug_graphs_helper.py
@@ -66,7 +66,7 @@ class DebugGraphWrapper(object):
                     debug_graphs.parse_debug_node_name(node.name))
                 gated.append(
                     (node_name, node_name_to_op_type[node_name], output_slot,
-                    debug_op))
+                     debug_op))
                 break
         self._grpc_gated_tensors[matching_debug_op] = gated
 

--- a/tensorboard/plugins/debugger/debug_graphs_helper.py
+++ b/tensorboard/plugins/debugger/debug_graphs_helper.py
@@ -18,63 +18,94 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import threading
+
 from tensorflow.python.debug.lib import debug_graphs
 
 
-def extract_gated_grpc_tensors(graph_def, match_debug_op=None):
-  """Extract all nodes with gated-gRPC debug ops attached.
+class DebugGraphWrapper(object):
+  """A wrapper for potentially debugger-decorated GraphDef."""
 
-  Args:
-    graph_def: A tf.GraphDef proto.
-    match_debug_op: Return tensors and nodes with only matching the specified
-      debug op name (optional). If `None`, will extract only `DebugIdentity`
-      debug ops.
+  def __init__(self, graph_def):
+    self._graph_def = graph_def
+    # A map from debug op to list of debug-op-attached tensors.
+    self._grpc_gated_tensors = dict()
+    self._grpc_gated_lock = threading.Lock()
+    self._maybe_base_expanded_node_names = None
+    self._node_name_lock = threading.Lock()
 
-  Returns:
-    A list of (node_name, op_type, output_slot, debug_op) tuples.
-  """
-  if match_debug_op is None:
-    match_debug_op = 'DebugIdentity'
+  def get_gated_grpc_tensors(self, matching_debug_op=None):
+    """Extract all nodes with gated-gRPC debug ops attached.
 
-  node_name_to_op_type = {}
+    Uses cached values if available.
+    This method is thread-safe.
 
-  # First, construct a map from node name to op type.
-  for node in graph_def.node:
-    node_name_to_op_type[node.name] = node.op
+    Args:
+      graph_def: A tf.GraphDef proto.
+      matching_debug_op: Return tensors and nodes with only matching the
+        specified debug op name (optional). If `None`, will extract only
+        `DebugIdentity` debug ops.
 
-  # Second, populate the output list.
-  gated = []
-  for node in graph_def.node:
-    if node.op != match_debug_op:
-      continue
+    Returns:
+      A list of (node_name, op_type, output_slot, debug_op) tuples.
+    """
+    with self._grpc_gated_lock:
+      matching_debug_op = matching_debug_op or 'DebugIdentity'
+      if matching_debug_op not in self._grpc_gated_tensors:
+        # First, construct a map from node name to op type.
+        node_name_to_op_type = dict(
+            (node.name, node.op) for node in self._graph_def.node)
 
-    for attr_key in node.attr:
-      if attr_key == 'gated_grpc' and node.attr[attr_key].b:
+        # Second, populate the output list.
+        gated = []
+        for node in self._graph_def.node:
+          if node.op == matching_debug_op:
+            for attr_key in node.attr:
+              if attr_key == 'gated_grpc' and node.attr[attr_key].b:
+                node_name, output_slot, _, debug_op = (
+                    debug_graphs.parse_debug_node_name(node.name))
+                gated.append(
+                    (node_name, node_name_to_op_type[node_name], output_slot,
+                    debug_op))
+                break
+        self._grpc_gated_tensors[matching_debug_op] = gated
 
-        node_name, output_slot, _, debug_op = (
-            debug_graphs.parse_debug_node_name(node.name))
-        gated.append(
-            (node_name, node_name_to_op_type[node_name], output_slot, debug_op))
-  return gated
+      return self._grpc_gated_tensors[matching_debug_op]
 
+  def maybe_base_expanded_node_name(self, node_name):
+    """Expand the base name if there are node names nested under the node.
 
-def maybe_base_expanded_node_name(node_name, graph_def):
-  """Expand the base name if there are node names nested under the node.
+    For example, if there are two nodes in the graph, "a" and "a/read", then
+    calling this function on "a" will give "a/(a)", a form that points at
+    a leaf node in the nested TensorBoard graph. Calling this function on
+    "a/read" will just return "a/read", because there is no node nested under
+    it.
 
-  For example, if there are two nodes in the graph, "a" and "a/read", then
-  calling this function on "a" will give "a/(a)", a form that points at
-  a leaf node in the nested TensorBoard graph. Calling this function on
-  "a/read" will just return "a/read", because there is no node nested under
-  it.
+    This method is thread-safe.
 
-  Args:
-    node_name: Name of the node.
-    graph_def: The `GraphDef` that the node is a part of.
+    Args:
+      node_name: Name of the node.
+      graph_def: The `GraphDef` that the node is a part of.
 
-  Return:
-    Possibly base-expanded node name.
-  """
-  for node in graph_def.node:
-    if node.name.startswith(node_name + '/'):
-      return node_name + '/(' + node_name.split('/')[-1] + ')'
-  return node_name
+    Returns:
+      Possibly base-expanded node name.
+    """
+    with self._node_name_lock:
+      # Lazily populate the map from original node name to base-expanded ones.
+      if self._maybe_base_expanded_node_names is None:
+        self._maybe_base_expanded_node_names = dict()
+        # Sort all the node names.
+        sorted_names = sorted(node.name for node in self._graph_def.node)
+        for i, name in enumerate(sorted_names):
+          j = i + 1
+          while j < len(sorted_names) and sorted_names[j].startswith(name):
+            if sorted_names[j].startswith(name + '/'):
+              self._maybe_base_expanded_node_names[name] = (
+                  name + '/(' + name.split('/')[-1] + ')')
+              break
+            j += 1
+      return self._maybe_base_expanded_node_names.get(node_name, node_name)
+
+  @property
+  def graph_def(self):
+    return self._graph_def

--- a/tensorboard/plugins/debugger/debug_graphs_helper.py
+++ b/tensorboard/plugins/debugger/debug_graphs_helper.py
@@ -1,0 +1,80 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Helper methods and classes for tfdbg-decorated graphs."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.debug.lib import debug_graphs
+
+
+def extract_gated_grpc_tensors(graph_def, match_debug_op=None):
+  """Extract all nodes with gated-gRPC debug ops attached.
+
+  Args:
+    graph_def: A tf.GraphDef proto.
+    match_debug_op: Return tensors and nodes with only matching the specified
+      debug op name (optional). If `None`, will extract only `DebugIdentity`
+      debug ops.
+
+  Returns:
+    A list of (node_name, op_type, output_slot, debug_op) tuples.
+  """
+  if match_debug_op is None:
+    match_debug_op = 'DebugIdentity'
+
+  node_name_to_op_type = {}
+
+  # First, construct a map from node name to op type.
+  for node in graph_def.node:
+    node_name_to_op_type[node.name] = node.op
+
+  # Second, populate the output list.
+  gated = []
+  for node in graph_def.node:
+    if node.op != match_debug_op:
+      continue
+
+    for attr_key in node.attr:
+      if attr_key == "gated_grpc" and node.attr[attr_key].b:
+
+        node_name, output_slot, _, debug_op = (
+            debug_graphs.parse_debug_node_name(node.name))
+        gated.append(
+            (node_name, node_name_to_op_type[node_name], output_slot, debug_op))
+  return gated
+
+
+def maybe_base_expanded_node_name(node_name, graph_def):
+  """Expand the base name if there are node names nested under the node.
+
+  For example, if there are two nodes in the graph, "a" and "a/read", then
+  calling this function on "a" will give "a/(a)", a form that points at
+  a leaf node in the nested TensorBoard graph. Calling this function on
+  "a/read" will just return "a/read", because there is no node nested under
+  it.
+
+  Args:
+    node_name: Name of the node.
+    graph_def: The `GraphDef` that the node is a part of.
+
+  Return:
+    Possibly base-expanded node name.
+  """
+  for node in graph_def.node:
+    if node.name.startswith(node_name + "/"):
+      return node_name + "/(" + node_name.split("/")[-1] + ")"
+  return node_name

--- a/tensorboard/plugins/debugger/debug_graphs_helper_test.py
+++ b/tensorboard/plugins/debugger/debug_graphs_helper_test.py
@@ -1,0 +1,146 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests the debug_graphs_helper module."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+from tensorflow.python import debug as tf_debug
+from tensorflow.python.debug.lib import grpc_debug_test_server
+
+from tensorboard.plugins.debugger import debug_graphs_helper
+
+
+class ExtractGatedGrpcDebugOpsTes(tf.test.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    (cls.debug_server_port, cls.debug_server_url, _, cls.debug_server_thread,
+     cls.debug_server
+    ) = grpc_debug_test_server.start_server_on_separate_thread(
+        dump_to_filesystem=False)
+    tf.logging.info("debug server url: %s", cls.debug_server_url)
+
+  @classmethod
+  def tearDownClass(cls):
+    cls.debug_server.stop_server().wait()
+    cls.debug_server_thread.join()
+
+  def tearDown(self):
+    tf.reset_default_graph()
+    self.debug_server.clear_data()
+
+  def _createTestGraphAndRunOptions(self, sess, gated_grpc=True):
+    a = tf.Variable([1.0], name="a")
+    b = tf.Variable([2.0], name="b")
+    c = tf.Variable([3.0], name="c")
+    d = tf.Variable([4.0], name="d")
+    x = tf.add(a, b, name="x")
+    y = tf.add(c, d, name="y")
+    z = tf.add(x, y, name="z")
+
+    run_options = tf.RunOptions(output_partition_graphs=True)
+    debug_op = "DebugIdentity"
+    if gated_grpc:
+      debug_op += "(gated_grpc=True)"
+    tf_debug.watch_graph(run_options,
+                         sess.graph,
+                         debug_ops=debug_op,
+                         debug_urls=self.debug_server_url)
+    return z, run_options
+
+  def testExtractGatedGrpcTensorsFoundGatedGrpcOps(self):
+    with tf.Session() as sess:
+      z, run_options = self._createTestGraphAndRunOptions(sess, gated_grpc=True)
+
+      sess.run(tf.global_variables_initializer())
+      run_metadata = tf.RunMetadata()
+      self.assertAllClose(
+          [10.0], sess.run(z, options=run_options, run_metadata=run_metadata))
+
+      gated_debug_ops = debug_graphs_helper.extract_gated_grpc_tensors(
+          run_metadata.partition_graphs[0])
+      self.assertEqual(11, len(gated_debug_ops))
+
+      # Verify that the op types are available.
+      for item in gated_debug_ops:
+        self.assertTrue(item[1])
+
+      # Strip out the op types before further checks, because op type names can
+      # change in the future (e.g., "VariableV2" --> "VariableV3").
+      gated_debug_ops = [
+          (item[0], item[2], item[3]) for item in gated_debug_ops]
+
+      self.assertIn(("a", 0, "DebugIdentity"), gated_debug_ops)
+      self.assertIn(("a/read", 0, "DebugIdentity"), gated_debug_ops)
+      self.assertIn(("b", 0, "DebugIdentity"), gated_debug_ops)
+      self.assertIn(("b/read", 0, "DebugIdentity"), gated_debug_ops)
+      self.assertIn(("c", 0, "DebugIdentity"), gated_debug_ops)
+      self.assertIn(("c/read", 0, "DebugIdentity"), gated_debug_ops)
+      self.assertIn(("d", 0, "DebugIdentity"), gated_debug_ops)
+      self.assertIn(("d/read", 0, "DebugIdentity"), gated_debug_ops)
+      self.assertIn(("x", 0, "DebugIdentity"), gated_debug_ops)
+      self.assertIn(("y", 0, "DebugIdentity"), gated_debug_ops)
+      self.assertIn(("z", 0, "DebugIdentity"), gated_debug_ops)
+
+  def testExtractGatedGrpcTensorsFoundNoGatedGrpcOps(self):
+    with tf.Session() as sess:
+      z, run_options = self._createTestGraphAndRunOptions(sess,
+                                                          gated_grpc=False)
+
+      sess.run(tf.global_variables_initializer())
+      run_metadata = tf.RunMetadata()
+      self.assertAllClose(
+          [10.0], sess.run(z, options=run_options, run_metadata=run_metadata))
+
+      gated_debug_ops = debug_graphs_helper.extract_gated_grpc_tensors(
+          run_metadata.partition_graphs[0])
+      self.assertEqual([], gated_debug_ops)
+
+
+class BaseExpandedNodeNameTest(tf.test.TestCase):
+
+  def testMaybeBaseExpandedNodeName(self):
+    with tf.Session() as sess:
+      a = tf.Variable([1.0], name="foo/a")
+      b = tf.Variable([2.0], name="bar/b")
+      _ = tf.add(a, b, name="baz/c")
+
+      self.assertEqual(
+          "foo/a/(a)",
+          debug_graphs_helper.maybe_base_expanded_node_name(
+              "foo/a", sess.graph_def))
+      self.assertEqual(
+          "bar/b/(b)",
+          debug_graphs_helper.maybe_base_expanded_node_name(
+              "bar/b", sess.graph_def))
+      self.assertEqual(
+          "foo/a/read",
+          debug_graphs_helper.maybe_base_expanded_node_name(
+              "foo/a/read", sess.graph_def))
+      self.assertEqual(
+          "bar/b/read",
+          debug_graphs_helper.maybe_base_expanded_node_name(
+              "bar/b/read", sess.graph_def))
+      self.assertEqual(
+          "baz/c",
+          debug_graphs_helper.maybe_base_expanded_node_name(
+              "baz/c", sess.graph_def))
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -65,8 +65,8 @@ def get_debugger_plugin():
   # Check that not both grpc port flags are specified.
   if FLAGS.debugger_data_server_grpc_port > 0 and FLAGS.debugger_port > 0:
     raise ValueError(
-      '--debugger_data_server_grpc_port and --debugger_port are mutually'
-      ' exclusive. Do not use both of them at the same time.')
+        '--debugger_data_server_grpc_port and --debugger_port are mutually '
+        'exclusive. Do not use both of them at the same time.')
 
   if FLAGS.debugger_data_server_grpc_port > 0 or FLAGS.debugger_port > 0:
     return _ConstructDebuggerPluginWithGrpcPort

--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -63,9 +63,10 @@ def get_debugger_plugin():
       flags are specified as >= 0.
   """
   # Check that not both grpc port flags are specified.
-  if FLAGS.debugger_data_server_grpc_port > 0 and FLAGS.debugger_port <= 0:
-    raise ValueError('--debugger_data_server_grpc_port and --debugger_port are '
-                     'mutually exclusive. Do not use more than one of them.')
+  if FLAGS.debugger_data_server_grpc_port > 0 and FLAGS.debugger_port > 0:
+    raise ValueError(
+      '--debugger_data_server_grpc_port and --debugger_port are mutually'
+      ' exclusive. Do not use both of them at the same time.')
 
   if FLAGS.debugger_data_server_grpc_port > 0 or FLAGS.debugger_port > 0:
     return _ConstructDebuggerPluginWithGrpcPort

--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -57,12 +57,15 @@ def get_debugger_plugin():
   Returns:
     The TBPlugin constructor for the debugger plugin, or None if
     the necessary flag was not set.
+
+  Raises:
+    ValueError: If both the `debugger_data_server_grpc_port` and `debugger_port`
+      flags are specified as >= 0.
   """
   # Check that not both grpc port flags are specified.
-  error_msg = ('--debugger_data_server_grpc_port and --debugger_port are '
-               'mutually exclusive. Do not use more than one of them.')
-  assert (FLAGS.debugger_data_server_grpc_port <= 0 or
-          FLAGS.debugger_port <= 0), error_msg
+  if FLAGS.debugger_data_server_grpc_port > 0 and FLAGS.debugger_port <= 0:
+    raise ValueError('--debugger_data_server_grpc_port and --debugger_port are '
+                     'mutually exclusive. Do not use more than one of them.')
 
   if FLAGS.debugger_data_server_grpc_port > 0 or FLAGS.debugger_port > 0:
     return _ConstructDebuggerPluginWithGrpcPort

--- a/tensorboard/plugins/debugger/debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/debugger_server_lib.py
@@ -53,9 +53,7 @@ class DebuggerDataStreamHandler(
     3) receives tensor value Event proto(s) through its on_value_event method.
   """
 
-  # TODO(@caisq): Call superclass __init__ once it doesn't raise
-  # NotImplementedError anymore.
-  def __init__(self,  # pylint: disable=super-init-not-called
+  def __init__(self,
                events_writer_manager,
                numerics_alert_callback=None):
     """Constructor of DebuggerDataStreamHandler.
@@ -66,6 +64,7 @@ class DebuggerDataStreamHandler(
         event with bad values (Nan, -Inf, or +Inf) is received. The callback
         takes the event as a parameter.
     """
+    super(DebuggerDataStreamHandler, self).__init__()
     self._events_writer_manager = events_writer_manager
     self._numerics_alert_callback = numerics_alert_callback
 

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin.py
@@ -1,0 +1,252 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""The plugin for the interactive Debugger Dashboard."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import json
+import platform
+import threading
+
+import tensorflow as tf
+from werkzeug import wrappers
+
+from tensorboard.backend import http_util
+from tensorboard.plugins import base_plugin
+from tensorboard.plugins.debugger import constants
+from tensorboard.plugins.debugger import debug_graphs_helper
+from tensorboard.plugins.debugger import interactive_debugger_server_lib
+
+# HTTP routes.
+_ACK_ROUTE = '/ack'
+_COMM_ROUTE = '/comm'
+_DEBUGGER_GRAPH_ROUTE = '/debugger_graph'
+_DEBUGGER_GRPC_HOST_PORT_ROUTE = '/debugger_grpc_host_port'
+_GATED_GRPC_ROUTE = '/gated_grpc'
+_TENSOR_DATA_ROUTE = '/tensor_data'
+
+
+class InteractiveDebuggerPlugin(base_plugin.TBPlugin):
+  """Interactive TensorFlow Debugger plugin.
+
+  This underlies the interactive Debugger Dashboard.
+
+  This is different from the non-interactive `DebuggerPlugin` in module
+  `debugger_plugin`. The latter is for the "health pills" feature in the Graph
+  Dashboard.
+  """
+
+  # This string field is used by TensorBoard to generate the paths for routes
+  # provided by this plugin. It must thus be URL-friendly. This field is also
+  # used to uniquely identify this plugin throughout TensorBoard. See BasePlugin
+  # for details.
+  plugin_name = constants.DEBUGGER_PLUGIN_NAME
+
+  def __init__(self, context):
+    """Constructs a debugger plugin for TensorBoard.
+
+    This plugin adds handlers for retrieving debugger-related data. The plugin
+    also starts a debugger data server once the log directory is passed to the
+    plugin via the call to get_plugin_apps.
+
+    Args:
+      context: A base_plugin.TBContext instance.
+    """
+    del context  # Unused.
+    self._debugger_data_server = None
+    self._grpc_port = None
+
+  def listen(self, grpc_port):
+    """Start listening on the given gRPC port.
+
+    This method of an instance of InteractiveDebuggerPlugin can be invoked at
+    most once. This method is not thread safe.
+
+    Args:
+      grpc_port: port number to listen at.
+
+    Raises:
+      ValueError: If this instance is already listening at a gRPC port.
+    """
+    if self._grpc_port:
+      raise ValueError(
+          'This InteractiveDebuggerPlugin instance is already listening at '
+          'gRPC port %d' % self._grpc_port)
+    self._grpc_port = grpc_port
+
+    tf.logging.info('Creating InteractiveDebuggerPlugin at port %d',
+                    self._grpc_port)
+    self._debugger_data_server = (
+        interactive_debugger_server_lib.InteractiveDebuggerDataServer(
+            self._grpc_port))
+
+    threading.Thread(target=self._debugger_data_server.
+                     start_the_debugger_data_receiving_server).start()
+
+  def get_plugin_apps(self):
+    """Obtains a mapping between routes and handlers.
+
+    This function also starts a debugger data server on separate thread if the
+    plugin has not started one yet.
+
+    Returns:
+      A mapping between routes and handlers (functions that respond to
+      requests).
+    """
+    return {
+        _ACK_ROUTE: self._serve_ack,
+        _COMM_ROUTE: self._serve_comm,
+        _DEBUGGER_GRPC_HOST_PORT_ROUTE: self._serve_debugger_grpc_host_port,
+        _DEBUGGER_GRAPH_ROUTE: self._serve_debugger_graph,
+        _GATED_GRPC_ROUTE: self._serve_gated_grpc,
+        _TENSOR_DATA_ROUTE: self._serve_tensor_data,
+    }
+
+  def is_active(self):
+    """Determines whether this plugin is active.
+
+    This plugin is active if any health pills information is present for any
+    run.
+
+    Returns:
+      A boolean. Whether this plugin is active.
+    """
+    return self._grpc_port is not None
+
+  @wrappers.Request.application
+  def _serve_ack(self, request):
+    # Send client acknowledgement. `True` is just used as a dummy value.
+    self._debugger_data_server.put_incoming_message(True)
+    return http_util.Respond(request, {}, 'application/json')
+
+  @wrappers.Request.application
+  def _serve_comm(self, request):
+    # comm_channel.get() blocks until an item is put into the queue (by
+    # self._debugger_data_server). This is how the HTTP long polling ends.
+    pos = int(request.args.get("pos"))
+    comm_data = self._debugger_data_server.get_outgoing_message(pos)
+    return http_util.Respond(request, comm_data, 'application/json')
+
+  @wrappers.Request.application
+  def _serve_debugger_graph(self, request):
+    device_name = request.args.get('device_name')
+    tf.logging.info('_serve_debugger_graph: device_name = %s', device_name)
+    if not device_name or device_name == 'null':
+      return http_util.Respond(request, str(None), 'text/x-protobuf')
+
+    run_key = interactive_debugger_server_lib.RunKey(
+        *json.loads(request.args.get('run_key')))
+    tf.logging.info('_serve_debugger_graph(): run_key = %s', run_key)
+    graph_def = self._debugger_data_server.get_graph(run_key, device_name)
+    tf.logging.info('_serve_debugger_graph(): type(graph_def) = %s',
+                    type(graph_def))
+    return http_util.Respond(request, str(graph_def), 'text/x-protobuf')
+
+  @wrappers.Request.application
+  def _serve_gated_grpc(self, request):
+    mode = request.args.get('mode')
+    if mode == 'retrieve_all' or mode == 'retrieve_device_names':
+      # Retrieve all gated-gRPC debug tensors and currently enabled breakpoints.
+      run_key = interactive_debugger_server_lib.RunKey(
+          *json.loads(request.args.get('run_key')))
+      # debug_graph_defs is a map from device_name to GraphDef.
+      debug_graph_defs = self._debugger_data_server.get_graphs(run_key,
+                                                               debug=True)
+      if mode == 'retrieve_device_names':
+        return http_util.Respond(request, {
+            'device_names': debug_graph_defs.keys(),
+        }, 'application/json')
+
+      gated = {}
+      for device_name in debug_graph_defs:
+        gated[device_name] = debug_graphs_helper.extract_gated_grpc_tensors(
+            debug_graph_defs[device_name])
+
+      # Both gated and self._debugger_data_server.breakpoints are lists whose
+      # items are (node_name, output_slot, debug_op_name).
+      return http_util.Respond(request, {
+          'gated_grpc_tensors': gated,
+          'breakpoints': self._debugger_data_server.breakpoints,
+          'device_names': debug_graph_defs.keys(),
+      }, 'application/json')
+    elif mode == 'breakpoints':
+      # Retrieve currently enabled breakpoints.
+      return http_util.Respond(
+          request, self._debugger_data_server.breakpoints, 'application/json')
+    elif mode == 'set_state':
+      # Set the state of gated-gRPC debug tensors, e.g., disable, enable
+      # breakpoint.
+      node_name = request.args.get('node_name')
+      output_slot = int(request.args.get('output_slot'))
+      debug_op = request.args.get('debug_op')
+      state = request.args.get('state')
+      tf.logging.info('Setting state of %s:%d:%s to: %s' %
+                      (node_name, output_slot, debug_op, state))
+      if state == 'disable':
+        self._debugger_data_server.request_unwatch(
+            node_name, output_slot, debug_op)
+      elif state == 'watch':
+        self._debugger_data_server.request_watch(
+            node_name, output_slot, debug_op, breakpoint=False)
+      elif state == 'break':
+        self._debugger_data_server.request_watch(
+            node_name, output_slot, debug_op, breakpoint=True)
+      else:
+        tf.logging.error('Unrecognized new state for %s:%d:%s: %s' %
+                         (node_name, output_slot, debug_op, state))
+      return http_util.Respond(
+          request,
+          {'node_name': node_name,
+           'output_slot': output_slot,
+           'debug_op': debug_op,
+           'state': state},
+          'application/json')
+    else:
+      tf.logging.error('Unrecognized mode for the gated_grpc route: %s' % mode)
+
+  @wrappers.Request.application
+  def _serve_debugger_grpc_host_port(self, request):
+    return http_util.Respond(
+        request,
+        {'host': platform.node(), 'port': self._grpc_port}, 'application/json')
+
+  @wrappers.Request.application
+  def _serve_tensor_data(self, request):
+    response_encoding = 'application/json'
+    watch_key = request.args.get('watch_key')
+    time_indices = request.args.get('time_indices')
+    mapping = request.args.get('mapping')
+    slicing = request.args.get('slicing')
+
+    try:
+      sliced_tensor_data = self._debugger_data_server.query_tensor_store(
+          watch_key, time_indices=time_indices, slicing=slicing,
+          mapping=mapping)
+      response = {
+          'tensor_data': sliced_tensor_data,
+          'error': None
+      }
+      return http_util.Respond(request, response, response_encoding)
+    except (IndexError, ValueError) as e:
+      response = {
+          'tensor_data': None,
+          'error': {
+              'type': type(e).__name__,
+              'message': str(e),
+          },
+      }
+      return http_util.Respond(request, response, response_encoding)

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin.py
@@ -28,7 +28,6 @@ from werkzeug import wrappers
 from tensorboard.backend import http_util
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.debugger import constants
-from tensorboard.plugins.debugger import debug_graphs_helper
 from tensorboard.plugins.debugger import interactive_debugger_server_lib
 
 # HTTP routes.

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin.py
@@ -168,7 +168,7 @@ class InteractiveDebuggerPlugin(base_plugin.TBPlugin):
                                                                debug=True)
       if mode == 'retrieve_device_names':
         return http_util.Respond(request, {
-            'device_names': debug_graph_defs.keys(),
+            'device_names': list(debug_graph_defs.keys()),
         }, 'application/json')
 
       gated = {}
@@ -181,7 +181,7 @@ class InteractiveDebuggerPlugin(base_plugin.TBPlugin):
       return http_util.Respond(request, {
           'gated_grpc_tensors': gated,
           'breakpoints': self._debugger_data_server.breakpoints,
-          'device_names': debug_graph_defs.keys(),
+          'device_names': list(debug_graph_defs.keys()),
       }, 'application/json')
     elif mode == 'breakpoints':
       # Retrieve currently enabled breakpoints.

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
@@ -1,0 +1,580 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests end-to-end debugger interactive data server behavior.
+
+This test launches an instance InteractiveDebuggerPlugin as a separate thread.
+The test then calls Session.run() using RunOptions pointing to the grpc:// debug
+URL of the debugger data server. It then sends HTTP requests to the TensorBoard
+backend endpoints to query and control the state of the Sessoin.run().
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import json
+import shutil
+import tempfile
+import threading
+
+import portpicker  # pylint: disable=import-error
+from six.moves import urllib
+import tensorflow as tf
+from tensorflow.python import debug as tf_debug
+
+from werkzeug import test as werkzeug_test
+from werkzeug import wrappers
+
+from tensorboard.backend import application
+from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
+from tensorboard.plugins import base_plugin
+from tensorboard.plugins.debugger import interactive_debugger_plugin
+
+_SERVER_URL_PREFIX = '/data/plugin/debugger/'
+
+
+class InteractiveDebuggerPluginTest(tf.test.TestCase):
+
+  def setUp(self):
+    super(InteractiveDebuggerPluginTest, self).setUp()
+
+    self._dummy_logdir = tempfile.mkdtemp()
+    self._dummy_multiplexer = event_multiplexer.EventMultiplexer({})
+    self._debugger_port = portpicker.pick_unused_port()
+    self._debugger_url = 'grpc://localhost:%d' % self._debugger_port
+    context = base_plugin.TBContext(logdir=self._dummy_logdir,
+                                    multiplexer=self._dummy_multiplexer)
+    self._debugger_plugin = (
+        interactive_debugger_plugin.InteractiveDebuggerPlugin(context))
+    self._debugger_plugin.listen(self._debugger_port)
+
+    wsgi_app = application.TensorBoardWSGIApp(
+        self._dummy_logdir,
+        [self._debugger_plugin],
+        self._dummy_multiplexer,
+        reload_interval=0,
+        path_prefix='')
+    self._server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+
+  def tearDown(self):
+    self._debugger_plugin._debugger_data_server.stop_server()
+    shutil.rmtree(self._dummy_logdir, ignore_errors=True)
+    super(InteractiveDebuggerPluginTest, self).tearDown()
+
+  def _serverGet(self, path, params=None):
+    """Send the serve a GET request and obtain the response.
+
+    Args:
+      path: URL path (excluding the prefix), without parameters encoded.
+      params: Query parameters to be encoded in the URL, as a dict.
+
+    Returns:
+      Response from server.
+    """
+    url = _SERVER_URL_PREFIX + path
+    if params:
+      url += '?' + urllib.parse.urlencode(params)
+    response = self._server.get(url)
+    self.assertEqual(200, response.status_code)
+    return response
+
+  def _deserializeResponse(self, response):
+    """Deserializes byte content that is a JSON encoding.
+
+    Args:
+      response: A response object.
+
+    Returns:
+      The deserialized python object decoded from JSON.
+    """
+    return json.loads(response.get_data().decode("utf-8"))
+
+  def _runSimpleAddMultiplyGraph(self, variable_size=1):
+    session_run_results = []
+    def session_run_job():
+      with tf.Session() as sess:
+        a = tf.Variable([10.0] * variable_size, name='a')
+        b = tf.Variable([20.0] * variable_size, name='b')
+        c = tf.Variable([30.0] * variable_size, name='c')
+        x = tf.multiply(a, b, name="x")
+        y = tf.add(x, c, name="y")
+
+        sess.run(tf.global_variables_initializer())
+
+        run_options = tf.RunOptions()
+        tf_debug.watch_graph(run_options,
+                             sess.graph,
+                             debug_ops="DebugIdentity(gated_grpc=True)",
+                             debug_urls=self._debugger_url)
+        session_run_results.append(sess.run(y, options=run_options))
+    session_run_thread = threading.Thread(target=session_run_job)
+    session_run_thread.start()
+    return session_run_thread, session_run_results
+
+  def _runMultiStepAssignAddGraph(self, steps):
+    session_run_results = []
+    def session_run_job():
+      with tf.Session() as sess:
+        a = tf.Variable(10, dtype=tf.int32, name='a')
+        b = tf.Variable(1, dtype=tf.int32, name='b')
+        inc_a = tf.assign_add(a, b, name='inc_a')
+
+        sess.run(tf.global_variables_initializer())
+
+        run_options = tf.RunOptions()
+        tf_debug.watch_graph(run_options,
+                             sess.graph,
+                             debug_ops="DebugIdentity(gated_grpc=True)",
+                             debug_urls=self._debugger_url)
+
+        for _ in range(steps):
+          session_run_results.append(sess.run(inc_a, options=run_options))
+    session_run_thread = threading.Thread(target=session_run_job)
+    session_run_thread.start()
+    return session_run_thread, session_run_results
+
+  def _runTfGroupGraph(self):
+    session_run_results = []
+    def session_run_job():
+      with tf.Session() as sess:
+        a = tf.Variable(10, dtype=tf.int32, name='a')
+        b = tf.Variable(20, dtype=tf.int32, name='b')
+        d = tf.constant(1, dtype=tf.int32, name='d')
+        inc_a = tf.assign_add(a, d, name='inc_a')
+        inc_b = tf.assign_add(b, d, name='inc_b')
+        inc_ab = tf.group([inc_a, inc_b], name="inc_ab")
+
+        sess.run(tf.global_variables_initializer())
+        run_options = tf.RunOptions()
+        tf_debug.watch_graph(run_options,
+                             sess.graph,
+                             debug_ops="DebugIdentity(gated_grpc=True)",
+                             debug_urls=self._debugger_url)
+        session_run_results.append(sess.run(inc_ab, options=run_options))
+    session_run_thread = threading.Thread(target=session_run_job)
+    session_run_thread.start()
+    return session_run_thread, session_run_results
+
+  def testCommAndAckWithoutBreakpoints(self):
+    session_run_thread, session_run_results = self._runSimpleAddMultiplyGraph()
+
+    comm_response = self._serverGet('comm', {'pos': 1})
+    response_data = self._deserializeResponse(comm_response)
+    self.assertGreater(response_data['timestamp'], 0)
+    self.assertEqual('meta', response_data['type'])
+    self.assertEqual({'run_key': ['', 'y:0', '']}, response_data['data'])
+
+    self._serverGet('ack')
+
+    session_run_thread.join()
+    self.assertAllClose([[230.0]], session_run_results)
+
+  def testGetDeviceNamesAndDebuggerGraph(self):
+    session_run_thread, session_run_results = self._runSimpleAddMultiplyGraph()
+
+    comm_response = self._serverGet('comm', {'pos': 1})
+    response_data = self._deserializeResponse(comm_response)
+    run_key = json.dumps(response_data['data']['run_key'])
+
+    device_names_response = self._serverGet(
+        'gated_grpc', {'mode': 'retrieve_device_names', 'run_key': run_key})
+    device_names_data = self._deserializeResponse(device_names_response)
+    self.assertEqual(1, len(device_names_data['device_names']))
+    device_name = device_names_data['device_names'][0]
+
+    graph_response = self._serverGet(
+        'debugger_graph', {'run_key': run_key, 'device_name': device_name})
+    self.assertTrue(graph_response.get_data())
+
+    self._serverGet('ack')
+
+    session_run_thread.join()
+    self.assertAllClose([[230.0]], session_run_results)
+
+  def testActivateOneBreakpoint(self):
+    session_run_thread, session_run_results = self._runSimpleAddMultiplyGraph()
+
+    comm_response = self._serverGet('comm', {'pos': 1})
+
+    # Activate breakpoint for x:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'x', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+
+    # Proceed to breakpoint x:0.
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 2})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertGreater(comm_data['timestamp'], 0)
+    self.assertEqual('tensor', comm_data['type'])
+    self.assertEqual('float32', comm_data['data']['dtype'])
+    self.assertEqual([1], comm_data['data']['shape'])
+    self.assertEqual('x', comm_data['data']['node_name'])
+    self.assertEqual(0, comm_data['data']['output_slot'])
+    self.assertEqual('DebugIdentity', comm_data['data']['debug_op'])
+    self.assertAllClose([200.0], comm_data['data']['values'])
+
+    # Proceed to the end of the Session.run().
+    self._serverGet('ack')
+
+    session_run_thread.join()
+    self.assertAllClose([[230.0]], session_run_results)
+
+    # Verify that the activated breakpoint is remembered.
+    breakpoints_response = self._serverGet(
+        'gated_grpc', {'mode': 'breakpoints'})
+    breakpoints_data = self._deserializeResponse(breakpoints_response)
+    self.assertEqual([['x', 0, 'DebugIdentity']], breakpoints_data)
+
+  def testActivateAndDeactivateOneBreakpoint(self):
+    session_run_thread, session_run_results = self._runSimpleAddMultiplyGraph()
+
+    self._serverGet('comm', {'pos': 1})
+
+    # Activate breakpoint for x:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'x', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+
+    # Deactivate the breakpoint right away.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'x', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'disable'})
+
+    # Proceed to the end of the Session.run().
+    self._serverGet('ack')
+
+    session_run_thread.join()
+    self.assertAllClose([[230.0]], session_run_results)
+
+    # Verify that there is no breakpoint activated.
+    breakpoints_response = self._serverGet(
+        'gated_grpc', {'mode': 'breakpoints'})
+    breakpoints_data = self._deserializeResponse(breakpoints_response)
+    self.assertEqual([], breakpoints_data)
+
+  def testActivateTwoBreakpoints(self):
+    session_run_thread, session_run_results = self._runSimpleAddMultiplyGraph()
+
+    comm_response = self._serverGet('comm', {'pos': 1})
+
+    # Activate breakpoint for x:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'x', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+    # Activate breakpoint for y:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'y', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+
+    # Proceed to breakpoint x:0.
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 2})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertGreater(comm_data['timestamp'], 0)
+    self.assertEqual('tensor', comm_data['type'])
+    self.assertEqual('float32', comm_data['data']['dtype'])
+    self.assertEqual([1], comm_data['data']['shape'])
+    self.assertEqual('x', comm_data['data']['node_name'])
+    self.assertEqual(0, comm_data['data']['output_slot'])
+    self.assertEqual('DebugIdentity', comm_data['data']['debug_op'])
+    self.assertAllClose([200.0], comm_data['data']['values'])
+
+    # Proceed to breakpoint y:0.
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 3})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertGreater(comm_data['timestamp'], 0)
+    self.assertEqual('tensor', comm_data['type'])
+    self.assertEqual('float32', comm_data['data']['dtype'])
+    self.assertEqual([1], comm_data['data']['shape'])
+    self.assertEqual('y', comm_data['data']['node_name'])
+    self.assertEqual(0, comm_data['data']['output_slot'])
+    self.assertEqual('DebugIdentity', comm_data['data']['debug_op'])
+    self.assertAllClose([230.0], comm_data['data']['values'])
+
+    # Proceed to the end of the Session.run().
+    self._serverGet('ack')
+
+    session_run_thread.join()
+    self.assertAllClose([[230.0]], session_run_results)
+
+    # Verify that the activated breakpoints are remembered.
+    breakpoints_response = self._serverGet(
+        'gated_grpc', {'mode': 'breakpoints'})
+    breakpoints_data = self._deserializeResponse(breakpoints_response)
+    self.assertItemsEqual(
+        [['x', 0, 'DebugIdentity'], ['y', 0, 'DebugIdentity']],
+        breakpoints_data)
+
+  def testCommResponseOmitsLargeSizedTensorValues(self):
+    session_run_thread, session_run_results = (
+        self._runSimpleAddMultiplyGraph(10))
+
+    comm_response = self._serverGet('comm', {'pos': 1})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertGreater(comm_data['timestamp'], 0)
+    self.assertEqual('meta', comm_data['type'])
+    self.assertEqual({'run_key': ['', 'y:0', '']}, comm_data['data'])
+
+    # Activate breakpoint for inc_a:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'x', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+
+    # Continue to the breakpiont at x:0.
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 2})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertEqual('tensor', comm_data['type'])
+    self.assertEqual('float32', comm_data['data']['dtype'])
+    self.assertEqual([10], comm_data['data']['shape'])
+    self.assertEqual('x', comm_data['data']['node_name'])
+    self.assertEqual(0, comm_data['data']['output_slot'])
+    self.assertEqual('DebugIdentity', comm_data['data']['debug_op'])
+    # Verify that the large-sized tensor gets omitted in the comm response.
+    self.assertEqual(None, comm_data['data']['values'])
+
+    # Use the /tensor_data endpoint to obtain the full value of x:0.
+    tensor_response = self._serverGet(
+        'tensor_data',
+        {'watch_key': 'x:0:DebugIdentity',
+         'time_indices': '-1',
+         'mapping': '',
+         'slicing': ''})
+    tensor_data = self._deserializeResponse(tensor_response)
+    self.assertEqual(None, tensor_data['error'])
+    self.assertAllClose([[200.0] * 10], tensor_data['tensor_data'])
+
+    # Use the /tensor_data endpoint to obtain the sliced value of x:0.
+    tensor_response = self._serverGet(
+        'tensor_data',
+        {'watch_key': 'x:0:DebugIdentity',
+         'time_indices': '-1',
+         'mapping': '',
+         'slicing': '[:5]'})
+    tensor_data = self._deserializeResponse(tensor_response)
+    self.assertEqual(None, tensor_data['error'])
+    self.assertAllClose([[200.0] * 5], tensor_data['tensor_data'])
+
+    # Continue to the end.
+    self._serverGet('ack')
+
+    session_run_thread.join()
+    self.assertAllClose([[230.0] * 10], session_run_results)
+
+  def testMultipleSessionRunsTensorValueFullHistory(self):
+    session_run_thread, session_run_results = (
+        self._runMultiStepAssignAddGraph(2))
+
+    comm_response = self._serverGet('comm', {'pos': 1})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertGreater(comm_data['timestamp'], 0)
+    self.assertEqual('meta', comm_data['type'])
+    self.assertEqual({'run_key': ['', 'inc_a:0', '']}, comm_data['data'])
+
+    # Activate breakpoint for inc_a:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'inc_a', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+
+    # Continue to inc_a:0 for the 1st time.
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 2})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertEqual('tensor', comm_data['type'])
+    self.assertEqual('int32', comm_data['data']['dtype'])
+    self.assertEqual([], comm_data['data']['shape'])
+    self.assertEqual('inc_a', comm_data['data']['node_name'])
+    self.assertEqual(0, comm_data['data']['output_slot'])
+    self.assertEqual('DebugIdentity', comm_data['data']['debug_op'])
+    self.assertAllClose(11.0, comm_data['data']['values'])
+
+    # Call /tensor_data to get the full history of the inc_a tensor (so far).
+    tensor_response = self._serverGet(
+        'tensor_data',
+        {'watch_key': 'inc_a:0:DebugIdentity',
+         'time_indices': ':',
+         'mapping': '',
+         'slicing': ''})
+    tensor_data = self._deserializeResponse(tensor_response)
+    self.assertEqual({'tensor_data': [11], 'error': None}, tensor_data)
+
+    # Continue to the beginning of the 2nd session.run.
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 3})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertGreater(comm_data['timestamp'], 0)
+    self.assertEqual('meta', comm_data['type'])
+    self.assertEqual({'run_key': ['', 'inc_a:0', '']}, comm_data['data'])
+
+    # Continue to inc_a:0 for the 2nd time.
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 4})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertEqual('tensor', comm_data['type'])
+    self.assertEqual('int32', comm_data['data']['dtype'])
+    self.assertEqual([], comm_data['data']['shape'])
+    self.assertEqual('inc_a', comm_data['data']['node_name'])
+    self.assertEqual(0, comm_data['data']['output_slot'])
+    self.assertEqual('DebugIdentity', comm_data['data']['debug_op'])
+    self.assertAllClose(12.0, comm_data['data']['values'])
+
+    # Call /tensor_data to get the full history of the inc_a tensor.
+    tensor_response = self._serverGet(
+        'tensor_data',
+        {'watch_key': 'inc_a:0:DebugIdentity',
+         'time_indices': ':',
+         'mapping': '',
+         'slicing': ''})
+    tensor_data = self._deserializeResponse(tensor_response)
+    self.assertEqual({'tensor_data': [11, 12], 'error': None}, tensor_data)
+
+    # Call /tensor_data to get the latst time index of the inc_a tensor.
+    tensor_response = self._serverGet(
+        'tensor_data',
+        {'watch_key': 'inc_a:0:DebugIdentity',
+         'time_indices': '-1',
+         'mapping': '',
+         'slicing': ''})
+    tensor_data = self._deserializeResponse(tensor_response)
+    self.assertEqual({'tensor_data': [12], 'error': None}, tensor_data)
+
+    # Continue to the end.
+    self._serverGet('ack')
+
+    session_run_thread.join()
+    self.assertAllClose([11.0, 12.0], session_run_results)
+
+  def testSetBreakpointOnNoTensorOp(self):
+    session_run_thread, session_run_results = self._runTfGroupGraph()
+
+    comm_response = self._serverGet('comm', {'pos': 1})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertGreater(comm_data['timestamp'], 0)
+    self.assertEqual('meta', comm_data['type'])
+    self.assertEqual({'run_key': ['', '', 'inc_ab']}, comm_data['data'])
+
+    # Activate breakpoint for inc_a:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'inc_a', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+
+    # Activate breakpoint for inc_ab.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'inc_ab', 'output_slot': -1,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+
+    # Continue to inc_a:0.
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 2})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertEqual('tensor', comm_data['type'])
+    self.assertEqual('int32', comm_data['data']['dtype'])
+    self.assertEqual([], comm_data['data']['shape'])
+    self.assertEqual('inc_a', comm_data['data']['node_name'])
+    self.assertEqual(0, comm_data['data']['output_slot'])
+    self.assertEqual('DebugIdentity', comm_data['data']['debug_op'])
+    self.assertAllClose(11.0, comm_data['data']['values'])
+
+    # Continue to the end. The breakpoint at inc_ab should not have blocked
+    # the execution, due to the fact that inc_ab is a tf.group op that produces
+    # no output.
+    self._serverGet('ack')
+    session_run_thread.join()
+    self.assertEqual([None], session_run_results)
+
+    breakpoints_response = self._serverGet(
+        'gated_grpc', {'mode': 'breakpoints'})
+    breakpoints_data = self._deserializeResponse(breakpoints_response)
+    self.assertItemsEqual(
+        [['inc_a', 0, 'DebugIdentity'], ['inc_ab', -1, 'DebugIdentity']],
+        breakpoints_data)
+
+  def testCommDataCanBeServedToMultipleClients(self):
+    session_run_thread, session_run_results = self._runSimpleAddMultiplyGraph()
+
+    comm_response = self._serverGet('comm', {'pos': 1})
+    comm_data_1 = self._deserializeResponse(comm_response)
+
+    # Activate breakpoint for x:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'x', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+    # Activate breakpoint for y:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'y', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+
+    # Proceed to breakpoint x:0.
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 2})
+    comm_data_2 = self._deserializeResponse(comm_response)
+    self.assertGreater(comm_data_2['timestamp'], 0)
+    self.assertEqual('tensor', comm_data_2['type'])
+    self.assertEqual('float32', comm_data_2['data']['dtype'])
+    self.assertEqual([1], comm_data_2['data']['shape'])
+    self.assertEqual('x', comm_data_2['data']['node_name'])
+    self.assertEqual(0, comm_data_2['data']['output_slot'])
+    self.assertEqual('DebugIdentity', comm_data_2['data']['debug_op'])
+    self.assertAllClose([200.0], comm_data_2['data']['values'])
+
+    # Proceed to breakpoint y:0.
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 3})
+    comm_data_3 = self._deserializeResponse(comm_response)
+    self.assertGreater(comm_data_3['timestamp'], 0)
+    self.assertEqual('tensor', comm_data_3['type'])
+    self.assertEqual('float32', comm_data_3['data']['dtype'])
+    self.assertEqual([1], comm_data_3['data']['shape'])
+    self.assertEqual('y', comm_data_3['data']['node_name'])
+    self.assertEqual(0, comm_data_3['data']['output_slot'])
+    self.assertEqual('DebugIdentity', comm_data_3['data']['debug_op'])
+    self.assertAllClose([230.0], comm_data_3['data']['values'])
+
+    # Proceed to the end of the Session.run().
+    self._serverGet('ack')
+
+    session_run_thread.join()
+    self.assertAllClose([[230.0]], session_run_results)
+
+    # A 2nd client requests for comm data at positions 1, 2 and 3 again.
+    comm_response = self._serverGet('comm', {'pos': 1})
+    self.assertEqual(comm_data_1, self._deserializeResponse(comm_response))
+    comm_response = self._serverGet('comm', {'pos': 2})
+    self.assertEqual(comm_data_2, self._deserializeResponse(comm_response))
+    comm_response = self._serverGet('comm', {'pos': 3})
+    self.assertEqual(comm_data_3, self._deserializeResponse(comm_response))
+
+  def testDebuggerHostAndGrpcPortEndpoint(self):
+    response = self._serverGet('debugger_grpc_host_port')
+    response_data = self._deserializeResponse(response)
+    self.assertTrue(response_data['host'])
+    self.assertEqual(self._debugger_port, response_data['port'])
+
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
@@ -1,0 +1,434 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Receives data from a TensorFlow debugger. Writes event summaries.
+
+This listener server writes debugging-related events into a logdir directory,
+from which a TensorBoard instance can read.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+import functools
+import json
+
+import tensorflow as tf
+from tensorflow.python import debug as tf_debug
+from tensorflow.core.debug import debug_service_pb2
+from tensorflow.python.debug.lib import grpc_debug_server
+
+from tensorboard.plugins.debugger import comm_channel as comm_channel_lib
+from tensorboard.plugins.debugger import debug_graphs_helper
+from tensorboard.plugins.debugger import tensor_helper
+from tensorboard.plugins.debugger import tensor_store as tensor_store_lib
+
+
+RunKey = collections.namedtuple(
+    'RunKey', ['input_names', 'output_names', 'target_nodes'])
+
+
+def _extract_device_name_from_event(event):
+  """Extract device name from a tf.Event proto carrying tensor value."""
+  plugin_data_content = json.loads(
+      event.summary.value[0].metadata.plugin_data.content)
+  return plugin_data_content['device']
+
+
+def _comm_metadata(run_key, timestamp):
+  return {
+      'type': 'meta',
+      'timestamp': timestamp,
+      'data': {
+          'run_key': run_key,
+      }
+  }
+
+
+def _comm_tensor_data(device_name,
+                      node_name,
+                      maybe_base_expanded_node_name,
+                      output_slot,
+                      debug_op,
+                      tensor_value,
+                      wall_time):
+  """Create a dict() as the outgoing data in the tensor data comm route.
+
+  Args:
+    device_name: Name of the device that the tensor is on.
+    node_name: (Original) name of the node that produces the tensor.
+    maybe_base_expanded_node_name: Possbily base-expanded node name.
+    output_slot: Output slot number.
+    debug_op: Name of the debug op.
+    tensor_value: Value of the tensor, as a numpy.ndarray.
+    wall_time: Wall timestamp for the tensor.
+
+  Returns:
+    A dict representing the tensor data.
+  """
+  output_slot = int(output_slot)
+  tf.logging.info(
+      'Recording tensor value: %s, %d, %s', node_name, output_slot, debug_op)
+  tensor_dtype = str(tensor_value.dtype)
+  tensor_shape = tensor_value.shape
+  # The /comm endpoint should respond with tensor values only if the tensor is
+  # small enough. Otherwise, the detailed values sould be queried through a
+  # dedicated tensor_data that supports slicing.
+  if tensor_helper.numel(tensor_shape) < 5:
+    _, _, tensor_values = tensor_helper.array_view(tensor_value)
+  else:
+    tensor_values = None
+  return {
+      'type': 'tensor',
+      'timestamp': wall_time,
+      'data': {
+          'device_name': device_name,
+          'node_name': node_name,
+          'maybe_base_expanded_node_name': maybe_base_expanded_node_name,
+          'output_slot': output_slot,
+          'debug_op': debug_op,
+          'dtype': tensor_dtype,
+          'shape': tensor_shape,
+          'values': tensor_values,
+      },
+  }
+
+
+class RunStates(object):
+  """A class that keeps track of state of debugged Session.run() calls."""
+
+  def __init__(self, breakpoints_func=None):
+    """Constructor of RunStates.
+
+    Args:
+      breakpoint_func: A callable of the signatuer:
+        def breakpoint_func():
+        which returns all the currently activated breakpoints.
+    """
+    self._run_key_to_original_graphs = dict()
+    self._run_key_to_debug_graphs = dict()
+    self._maybe_expanded_node_names = dict()
+
+    if breakpoints_func:
+      assert callable(breakpoints_func)
+      self._breakpoints_func = breakpoints_func
+
+  def add_graph(self, run_key, device_name, graph_def, debug=False):
+    """Add a GraphDef.
+
+    Args:
+      run_key: A key for the run, containing information about the feeds,
+        fetches, and targets.
+      device_name: The name of the device that the `GraphDef` is for.
+      graph_def: An instance of the `GraphDef` proto.
+      debug: Whether `graph_def` consists of the debug ops.
+    """
+    graph_dict = (self._run_key_to_debug_graphs if debug else
+                  self._run_key_to_original_graphs)
+    if not run_key in graph_dict:
+      graph_dict[run_key] = dict()  # Mapping device_name to GraphDef.
+    graph_dict[run_key][device_name] = graph_def
+
+  def get_graphs(self, run_key, debug=False):
+    """Get the runtime graphs associated with a run key.
+
+    Args:
+      run_key: A Session.run kay.
+      debug: Whether the debugger-decoratedgraph is to be retrieved.
+
+    Returns:
+      A `dict` mapping device name to `GraphDef` protos.
+    """
+    graph_dict = (self._run_key_to_debug_graphs if debug else
+                  self._run_key_to_original_graphs)
+    return graph_dict.get(run_key, {})
+
+  def get_graph(self, run_key, device_name, debug=False):
+    """Get the runtime graphs associated with a run key and a device.
+
+    Args:
+      run_key: A Session.run kay.
+      device_name: Name of the device in question.
+      debug: Whether the debugger-decoratedgraph is to be retrieved.
+
+    Returns:
+      A `GraphDef`.
+    """
+    return self.get_graphs(run_key, debug=debug).get(device_name, None)
+
+  def get_breakpoints(self):
+    """Obtain all the currently activated breakpoints."""
+    return self._breakpoints_func()
+
+  def get_maybe_base_expanded_node_name(self, node_name, run_key, device_name):
+    """Obtain possibly base-expanded node name.
+
+    Base-expansion is the transformation of a node name which happens to be the
+    name scope of other nodes in the same graph. For example, if two nodes,
+    called 'a/b' and 'a/b/read' in a graph, the name of the first node will
+    be base-expanded to 'a/b/(b)'.
+
+    This method uses caching to avoid unnecessary recomputation.
+
+    Args:
+      node_name: Name of the node.
+      run_key: The run key to which the node belongs.
+      graph_def: GraphDef to which the node belongs.
+    """
+    if (run_key in self._maybe_expanded_node_names and
+        device_name in self._maybe_expanded_node_names[run_key] and
+        node_name in self._maybe_expanded_node_names[run_key][device_name]):
+      return self._maybe_expanded_node_names[run_key][device_name][node_name]
+
+    if run_key not in self._run_key_to_original_graphs:
+      raise ValueError('Unknown run_key: %s' % run_key)
+    if device_name not in self._run_key_to_original_graphs[run_key]:
+      raise ValueError(
+          'Unknown device for run key "%s": %s' % (run_key, device_name))
+    graph_def = self._run_key_to_original_graphs[run_key][device_name]
+    base_expanded = debug_graphs_helper.maybe_base_expanded_node_name(
+        node_name, graph_def)
+    if run_key not in self._maybe_expanded_node_names:
+      self._maybe_expanded_node_names[run_key] = dict()
+    if device_name not in self._maybe_expanded_node_names[run_key]:
+      self._maybe_expanded_node_names[run_key][device_name] = dict()
+    self._maybe_expanded_node_names[
+        run_key][device_name][node_name] = base_expanded
+    return base_expanded
+
+
+class InteractiveDebuggerDataStreamHandler(
+    grpc_debug_server.EventListenerBaseStreamHandler):
+  """Implementation of stream handler for debugger data.
+
+  Each instance of this class is created by a InteractiveDebuggerDataServer
+  upon a gRPC stream established between the debugged Session::Run() invocation
+  in TensorFlow core runtime and the InteractiveDebuggerDataServer instance.
+
+  Each instance of this class does the following:
+    1) receives a core metadata Event proto during its constructor call.
+    2) receives GraphDef Event proto(s) through its on_graph_def method.
+    3) receives tensor value Event proto(s) through its on_value_event method.
+  """
+
+  def __init__(self, comm_channel, run_states, tensor_store):
+    """Constructor of InteractiveDebuggerDataStreamHandler.
+
+    Args:
+      comm_channel: An instance of `CommChannel`, which manages
+        the incoming commands and outgoing data.
+      run_states: An instance of `RunStates`, which keeps track of the states
+        (graphs and breakpoints) of debugged Session.run() calls.
+      tensor_store: An instance of `TensorStore`, which stores Tensor values
+        from debugged Session.run() calls.
+    """
+    super(InteractiveDebuggerDataStreamHandler, self).__init__()
+
+    self._comm_channel = comm_channel
+    self._run_states = run_states
+    self._tensor_store = tensor_store
+
+    self._run_key = None
+    self._graph_defs = dict()  # A dict mapping device name to GraphDef.
+    self._graph_defs_arrive_first = True
+
+  def on_core_metadata_event(self, event):
+    """Implementation of the core metadata-carrying Event proto callback.
+
+    Args:
+      event: An Event proto that contains core metadata about the debugged
+        Session::Run() in its log_message.message field, as a JSON string.
+        See the doc string of debug_data.DebugDumpDir.core_metadata for details.
+    """
+    core_metadata = json.loads(event.log_message.message)
+    input_names = ','.join(core_metadata['input_names'])
+    output_names = ','.join(core_metadata['output_names'])
+    target_nodes = ','.join(core_metadata['target_nodes'])
+
+    self._run_key = RunKey(input_names, output_names, target_nodes)
+    if not self._graph_defs:
+      self._graph_defs_arrive_first = False
+    else:
+      for device_name in self._graph_defs:
+        self._add_graph_def(device_name, self._graph_defs[device_name])
+
+    self._comm_channel.put_outgoing(
+        _comm_metadata(self._run_key, event.wall_time))
+
+    # Wait for acknowledgement from client. Blocks until an item is got.
+    tf.logging.info('on_core_metadata_event() waiting for client ack (meta)...')
+    self._comm_channel.get_incoming()
+    tf.logging.info('on_core_metadata_event() client ack received (meta).')
+
+  def _add_graph_def(self, device_name, graph_def):
+    self._run_states.add_graph(
+        self._run_key, device_name,
+        tf_debug.reconstruct_non_debug_graph_def(graph_def))
+    self._run_states.add_graph(
+        self._run_key, device_name, graph_def, debug=True)
+
+  def on_graph_def(self, graph_def, device_name, wall_time):
+    """Implementation of the GraphDef-carrying Event proto callback.
+
+    Args:
+      graph_def: A GraphDef proto. N.B.: The GraphDef is from
+        the core runtime of a debugged Session::Run() call, after graph
+        partition. Therefore it may differ from the GraphDef available to
+        the general TensorBoard. For example, the GraphDef in general
+        TensorBoard may get partitioned for multiple devices (CPUs and GPUs),
+        each of which will generate a GraphDef event proto sent to this
+        method.
+      device_name: Name of the device on which the graph was created.
+      wall_time: An epoch timestamp (in microseconds) for the graph.
+    """
+    # For now, we do nothing with the graph def. However, we must define this
+    # method to satisfy the handler's interface. Furthermore, we may use the
+    # graph in the future (for instance to provide a graph if there is no graph
+    # provided otherwise).
+    del wall_time
+    self._graph_defs[device_name] = graph_def
+
+    if not self._graph_defs_arrive_first:
+      self._add_graph_def(device_name, graph_def)
+      self._comm_channel.get_incoming()
+
+  def on_value_event(self, event):
+    """Records the summary values based on an updated message from the debugger.
+
+    Logs an error message if writing the event to disk fails.
+
+    Args:
+      event: The Event proto to be processed.
+    """
+    if not event.summary.value:
+      tf.logging.info('The summary of the event lacks a value.')
+      return
+
+    # The node name property in the event proto is actually a watch key, which
+    # is a concatenation of several pieces of data.
+    watch_key = event.summary.value[0].node_name
+    tensor_value = tf.make_ndarray(event.summary.value[0].tensor)
+    device_name = _extract_device_name_from_event(event)
+    node_name, output_slot, debug_op = (
+        event.summary.value[0].node_name.split(':'))
+    maybe_base_expanded_node_name = (
+        self._run_states.get_maybe_base_expanded_node_name(node_name,
+                                                           self._run_key,
+                                                           device_name))
+    self._comm_channel.put_outgoing(_comm_tensor_data(
+        device_name, node_name, maybe_base_expanded_node_name, output_slot,
+        debug_op, tensor_value, event.wall_time))
+    self._tensor_store.add(watch_key, tensor_value)
+
+    tf.logging.info('on_value_event(): waiting for client ack (tensors)...')
+    self._comm_channel.get_incoming()
+    tf.logging.info('on_value_event(): client ack received (tensor).')
+
+    # Determine if the particular debug watch key is in the current list of
+    # breakpoints. If it is, send an EventReply() to unblock the debug op.
+    if self._is_debug_node_in_breakpoints(event.summary.value[0].node_name):
+      tf.logging.info('Sending empty EventReply for breakpoint: %s',
+                      event.summary.value[0].node_name)
+      # TODO(cais): Support receiving and sending tensor value from front-end.
+      return debug_service_pb2.EventReply()
+
+  def _is_debug_node_in_breakpoints(self, debug_node_key):
+    node_name, output_slot, debug_op = debug_node_key.split(':')
+    output_slot = int(output_slot)
+    return (node_name, output_slot,
+            debug_op) in self._run_states.get_breakpoints()
+
+
+
+class InteractiveDebuggerDataServer(
+    grpc_debug_server.EventListenerBaseServicer):
+  """A service that receives and writes debugger data such as health pills.
+  """
+
+  def __init__(self, receive_port):
+    """Receives health pills from a debugger and writes them to disk.
+
+    Args:
+      receive_port: The port at which to receive health pills from the
+        TensorFlow debugger.
+      always_flush: A boolean indicating whether the EventsWriter will be
+        flushed after every write. Can be used for testing.
+    """
+    super(InteractiveDebuggerDataServer, self).__init__(
+        receive_port, InteractiveDebuggerDataStreamHandler)
+
+    self._comm_channel = comm_channel_lib.CommChannel()
+    self._run_states = RunStates(breakpoints_func=lambda: self.breakpoints)
+    self._tensor_store = tensor_store_lib.TensorStore()
+
+    curried_handler_constructor = functools.partial(
+        InteractiveDebuggerDataStreamHandler,
+        self._comm_channel, self._run_states, self._tensor_store,)
+    grpc_debug_server.EventListenerBaseServicer.__init__(
+        self, receive_port, curried_handler_constructor)
+
+  def start_the_debugger_data_receiving_server(self):
+    """Starts the HTTP server for receiving health pills at `receive_port`.
+
+    After this method is called, health pills issued to host:receive_port
+    will be stored by this object. Calling this method also creates a file
+    within the log directory for storing health pill summary events.
+    """
+    self.run_server()
+
+  def get_graphs(self, run_key, debug=False):
+    return self._run_states.get_graphs(run_key, debug=debug)
+
+  def get_graph(self, run_key, device_name, debug=False):
+    return self._run_states.get_graph(run_key, device_name, debug=debug)
+
+  def get_outgoing_message(self, pos):
+    msg, _ = self._comm_channel.get_outgoing(pos)
+    return msg
+
+  def put_incoming_message(self, message):
+    return self._comm_channel.put_incoming(message)
+
+  def query_tensor_store(self,
+                         watch_key,
+                         time_indices=None,
+                         slicing=None,
+                         mapping=None):
+    """Query tensor store for a given debugged tensor value.
+
+    Args:
+      watch_key: The watch key of the debugged tensor being sought. Format:
+        <node_name>:<output_slot>:<debug_op>
+        E.g., Dense_1/MatMul:0:DebugIdentity.
+      time_indices: Optional time indices string By default, the lastest time
+        index ('-1') is returned.
+      slicing: Optional slicing string.
+      mapping: Optional mapping string, e.g., 'image/png'.
+
+    Returns:
+      If mapping is `None`, the possibly sliced values as a nested list of
+        values or its mapped format. A `list` of nested `list` of values,
+      If mapping is not `None`, the format of the return value will depend on
+        the mapping.
+    """
+    return self._tensor_store.query(watch_key,
+                                    time_indices=time_indices,
+                                    slicing=slicing,
+                                    mapping=mapping)
+
+  def dispose(self):
+    """Disposes of this object. Call only after this is done being used."""
+    self._tensor_store.dispose()

--- a/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
@@ -44,7 +44,7 @@ RunKey = collections.namedtuple(
 def _extract_device_name_from_event(event):
   """Extract device name from a tf.Event proto carrying tensor value."""
   plugin_data_content = json.loads(
-      event.summary.value[0].metadata.plugin_data.content)
+      tf.compat.as_str(event.summary.value[0].metadata.plugin_data.content))
   return plugin_data_content['device']
 
 
@@ -140,7 +140,7 @@ class RunStates(object):
                   self._run_key_to_original_graphs)
     if not run_key in graph_dict:
       graph_dict[run_key] = dict()  # Mapping device_name to GraphDef.
-    graph_dict[run_key][device_name] = graph_def
+    graph_dict[run_key][tf.compat.as_str(device_name)] = graph_def
 
   def get_graphs(self, run_key, debug=False):
     """Get the runtime graphs associated with a run key.
@@ -188,6 +188,7 @@ class RunStates(object):
       run_key: The run key to which the node belongs.
       graph_def: GraphDef to which the node belongs.
     """
+    device_name = tf.compat.as_str(device_name)
     if (run_key in self._maybe_expanded_node_names and
         device_name in self._maybe_expanded_node_names[run_key] and
         node_name in self._maybe_expanded_node_names[run_key][device_name]):

--- a/tensorboard/plugins/debugger/session_debug_test.py
+++ b/tensorboard/plugins/debugger/session_debug_test.py
@@ -205,15 +205,13 @@ class SessionDebugTestBase(tf.test.TestCase):
 
     report = self._debug_data_server.numerics_alert_report()
     self.assertEqual(2, len(report))
-    self.assertEqual("/job:localhost/replica:0/task:0/device:CPU:0",
-                     report[0].device_name)
+    self.assertTrue(report[0].device_name.lower().endswith("cpu:0"))
     self.assertEqual("u:0", report[0].tensor_name)
     self.assertGreater(report[0].first_timestamp, 0)
     self.assertEqual(0, report[0].nan_event_count)
     self.assertEqual(0, report[0].neg_inf_event_count)
     self.assertEqual(1, report[0].pos_inf_event_count)
-    self.assertEqual("/job:localhost/replica:0/task:0/device:CPU:0",
-                     report[1].device_name)
+    self.assertTrue(report[1].device_name.lower().endswith("cpu:0"))
     self.assertEqual("u:0", report[0].tensor_name)
     self.assertGreaterEqual(report[1].first_timestamp,
                             report[0].first_timestamp)
@@ -299,7 +297,7 @@ class SessionDebugTestBase(tf.test.TestCase):
 
       def run_v(thread_id):
         for _ in range(num_runs_per_thread):
-          sess.run(v, options=run_options_list[thread_id])  # DEBUG
+          sess.run(v, options=run_options_list[thread_id])
 
       run_threads = []
       for thread_id in range(num_threads):
@@ -312,15 +310,13 @@ class SessionDebugTestBase(tf.test.TestCase):
 
     report = self._debug_data_server.numerics_alert_report()
     self.assertEqual(2, len(report))
-    self.assertEqual("/job:localhost/replica:0/task:0/device:CPU:0",
-                     report[0].device_name)
+    self.assertTrue(report[0].device_name.lower().endswith("cpu:0"))
     self.assertEqual("u:0", report[0].tensor_name)
     self.assertGreater(report[0].first_timestamp, 0)
     self.assertEqual(0, report[0].nan_event_count)
     self.assertEqual(0, report[0].neg_inf_event_count)
     self.assertEqual(total_num_runs, report[0].pos_inf_event_count)
-    self.assertEqual("/job:localhost/replica:0/task:0/device:CPU:0",
-                     report[1].device_name)
+    self.assertTrue(report[1].device_name.lower().endswith("cpu:0"))
     self.assertEqual("u:0", report[0].tensor_name)
     self.assertGreaterEqual(report[1].first_timestamp,
                             report[0].first_timestamp)

--- a/tensorboard/plugins/debugger/tensor_helper.py
+++ b/tensorboard/plugins/debugger/tensor_helper.py
@@ -26,10 +26,6 @@ from tensorflow.python.debug.cli import command_parser
 from tensorboard import util
 
 
-class TimeIndexingError(Exception):
-  pass
-
-
 def numel(shape):
   """Obtain total number of elements from a tensor (ndarray) shape.
 
@@ -46,16 +42,19 @@ def parse_time_indices(s):
   """Parse a string as time indices.
 
   Args:
-    s: A valid string for time indices. E.g., '-1', '[:]', ':', '2:10'
+    s: A valid slicing string for time indices. E.g., '-1', '[:]', ':', '2:10'
 
   Returns:
     A slice object.
+
+  Raises:
+    ValueError: If `s` does not represent valid time indices.
   """
   if not s.startswith('['):
     s = '[' + s + ']'
   parsed = command_parser._parse_slices(s)
   if len(parsed) != 1:
-    raise TimeIndexingError(
+    raise ValueError(
         'Invalid number of slicing objects in time indices (%d)' % len(parsed))
   else:
     return parsed[0]

--- a/tensorboard/plugins/debugger/tensor_helper.py
+++ b/tensorboard/plugins/debugger/tensor_helper.py
@@ -1,0 +1,129 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Helper methods for tensor data."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import base64
+
+import numpy as np
+from tensorflow.python.debug.cli import command_parser
+
+from tensorboard import util
+
+
+class TimeIndexingError(Exception):
+
+  def __init__(self, msg):
+    super(TimeIndexingError, self).__init__(msg)
+
+
+def numel(shape):
+  """Obtain total number of elements from a tensor (ndarray) shape.
+
+  Args:
+    shape: A list or tuple represenitng a tensor (ndarray) shape.
+  """
+  output = 1
+  for dim in shape:
+    output *= dim
+  return output
+
+
+def parse_time_indices(s):
+  """Parse a string as time indices.
+
+  Args:
+    s: A valid string for time indices. E.g., '-1', '[:]', ':', '2:10'
+
+  Returns:
+    A slice object.
+  """
+  if not s.startswith('['):
+    s = '[' + s + ']'
+  parsed = command_parser._parse_slices(s)
+  if len(parsed) != 1:
+    raise TimeIndexingError(
+        'Invalid number of slicing objects in time indices (%d)' % len(parsed))
+  else:
+    return parsed[0]
+
+
+def array_view(array, slicing=None, mapping=None):
+  """View a slice or the entirety of an ndarray.
+
+  Args:
+    array: The input array, as an numpy.ndarray.
+    slicing: Optional slicing string, e.g., "[:, 1:3, :]".
+    mapping: Optional mapping string. Supported mappings:
+      `None` or case-insensitive `'None'`: Unmapped nested list.
+      `'image/png'`: Image encoding of a 2D sliced array or 3D sliced array
+        with 3 as the last dimension. If the sliced array is not 2D or 3D with
+        3 as the last dimension, a `ValueError` will be thrown.
+
+  Returns:
+    1. dtype as a `str`.
+    2. shape of the sliced array, as a tuple of `int`s.
+    3. the potentially sliced values, as a nested `list`.
+  """
+
+  dtype = str(array.dtype)
+  sliced_array = (array[command_parser._parse_slices(slicing)] if slicing
+                  else array)
+  shape = sliced_array.shape
+  if mapping == "image/png":
+    if len(sliced_array.shape) == 2:
+      return dtype, shape, array_to_base64_png(sliced_array)
+    elif len(sliced_array.shape) == 3:
+      raise NotImplementedError(
+          "image/png mapping for 3D array has not been implemented")
+    else:
+      raise ValueError("Invalid rank for image/png mapping: %d" %
+                       len(sliced_array.shape))
+  elif mapping is None or mapping == '' or  mapping.lower() == 'none':
+    return dtype, shape, sliced_array.tolist()
+  else:
+    raise ValueError("Invalid mapping: %s" % mapping)
+
+
+def array_to_base64_png(array):
+  """Convert an array into base64-enoded PNG image.
+
+  Args:
+    array: A 2D np.ndarray or nested list of items.
+
+  Returns:
+    A base64-encoded string the image. The image is grayscale if the array is
+    2D. The image is RGB color if the image is 3D with lsat dimension equal to
+    3.
+  """
+  # TODO(cais): Deal with 3D case.
+  # TODO(cais): If there are None values in here, replace them with all NaNs.
+  array = np.array(array, dtype=np.float32)
+  assert len(array.shape) == 2
+
+  healthy_indices = np.where(np.logical_and(np.logical_not(np.isnan(array)),
+                                            np.logical_not(np.isinf(array))))
+  # TODO(cais): Deal with case in which there is no health elements, i.e., all
+  # elements are NaN of Inf.
+  minval = np.min(array[healthy_indices])
+  maxval = np.max(array[healthy_indices])
+  # TODO(cais): Deal with the case in which minval == maxval.
+  scaled = np.array((array - minval) / (maxval - minval) * 255, dtype=np.uint8)
+  rgb = np.repeat(np.expand_dims(scaled, -1), 3, axis=-1)
+  image_encoded = base64.b64encode(util.encode_png(rgb))
+  return image_encoded

--- a/tensorboard/plugins/debugger/tensor_helper.py
+++ b/tensorboard/plugins/debugger/tensor_helper.py
@@ -27,9 +27,7 @@ from tensorboard import util
 
 
 class TimeIndexingError(Exception):
-
-  def __init__(self, msg):
-    super(TimeIndexingError, self).__init__(msg)
+  pass
 
 
 def numel(shape):

--- a/tensorboard/plugins/debugger/tensor_helper_test.py
+++ b/tensorboard/plugins/debugger/tensor_helper_test.py
@@ -1,0 +1,147 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests the Tensorboard debugger data plugin."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import base64
+
+import numpy as np
+import tensorflow as tf
+
+from tensorboard.plugins.beholder import im_util
+from tensorboard.plugins.debugger import tensor_helper
+
+
+class TensorHelperTest(tf.test.TestCase):
+
+  def testArrayViewFloat2DNoSlicing(self):
+    float_array = np.ones([3, 3], dtype=np.float32)
+    dtype, shape, values = tensor_helper.array_view(float_array)
+    self.assertEqual("float32", dtype)
+    self.assertEqual((3, 3), shape)
+    self.assertEqual(float_array.tolist(), values)
+
+  def testArrayViewFloat2DWithSlicing(self):
+    x = np.ones([4, 4], dtype=np.float64)
+    y = np.zeros([4, 4], dtype=np.float64)
+    float_array = np.concatenate((x, y), axis=1)
+
+    dtype, shape, values = tensor_helper.array_view(
+        float_array, slicing="[2:, :]")
+    self.assertEqual("float64", dtype)
+    self.assertEqual((2, 8), shape)
+    self.assertAllClose(
+        [[1, 1, 1, 1, 0, 0, 0, 0],
+         [1, 1, 1, 1, 0, 0, 0, 0]], values)
+
+  def testArrayViewInt3DWithSlicing(self):
+    x = np.ones([4, 4], dtype=np.int32)
+    int_array = np.zeros([3, 4, 4], dtype=np.int32)
+    int_array[0, ...] = x
+    int_array[1, ...] = 2 * x
+    int_array[2, ...] = 3 * x
+
+    dtype, shape, values = tensor_helper.array_view(
+        int_array, slicing="[:, :, 2]")
+    self.assertEqual("int32", dtype)
+    self.assertEqual((3, 4), shape)
+    self.assertEqual([[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3]], values)
+
+  def testArrayView2DWithSlicingAndImagePngMapping(self):
+    x = np.ones([15, 16], dtype=np.int32)
+    dtype, shape, data = tensor_helper.array_view(
+        x, slicing="[:15:3, :16:2]", mapping="image/png")
+    self.assertEqual("int32", dtype)
+    self.assertEqual((5, 8), shape)
+    decoded_x = im_util.decode_png(base64.b64decode(data))
+    self.assertEqual((5, 8, 3), decoded_x.shape)
+
+class ArrayToBase64PNGTest(tf.test.TestCase):
+
+  def testConvertHealthy2DArray(self):
+    x = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    encoded_x = tensor_helper.array_to_base64_png(x)
+    decoded_x = im_util.decode_png(base64.b64decode(encoded_x))
+    self.assertEqual((3, 3, 3), decoded_x.shape)
+    decoded_flat = decoded_x.flatten()
+    self.assertEqual(0, np.min(decoded_flat))
+    self.assertEqual(255, np.max(decoded_flat))
+
+  def testConvertHealthy2DNestedList(self):
+    x = [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]
+    encoded_x = tensor_helper.array_to_base64_png(x)
+    decoded_x = im_util.decode_png(base64.b64decode(encoded_x))
+    self.assertEqual((4, 4, 3), decoded_x.shape)
+    decoded_flat = decoded_x.flatten()
+    self.assertEqual(0, np.min(decoded_flat))
+    self.assertEqual(255, np.max(decoded_flat))
+
+
+class ParseTimeIndicesTest(tf.test.TestCase):
+
+  def testParseSingleIntegerMinusOne(self):
+    slicing = tensor_helper.parse_time_indices('-1')
+    self.assertEqual(-1, slicing)
+
+  def testParseSingleIntegerMinusOneWithBrackets(self):
+    slicing = tensor_helper.parse_time_indices('[-1]')
+    self.assertEqual(-1, slicing)
+
+  def testParseSlicingWithStartAndStop(self):
+    slicing = tensor_helper.parse_time_indices('[0:3]')
+    self.assertEqual(slice(0, 3, None), slicing)
+    slicing = tensor_helper.parse_time_indices('0:3')
+    self.assertEqual(slice(0, 3, None), slicing)
+
+  def testParseSlicingWithStep(self):
+    slicing = tensor_helper.parse_time_indices('[::2]')
+    self.assertEqual(slice(None, None, 2), slicing)
+    slicing = tensor_helper.parse_time_indices('::2')
+    self.assertEqual(slice(None, None, 2), slicing)
+
+  def testParseSlicingWithOnlyStart(self):
+    slicing = tensor_helper.parse_time_indices('[3:]')
+    self.assertEqual(slice(3, None, None), slicing)
+    slicing = tensor_helper.parse_time_indices('3:')
+    self.assertEqual(slice(3, None, None), slicing)
+
+  def testParseSlicingWithMinusOneStop(self):
+    slicing = tensor_helper.parse_time_indices('[3:-1]')
+    self.assertEqual(slice(3, -1, None), slicing)
+    slicing = tensor_helper.parse_time_indices('3:-1')
+    self.assertEqual(slice(3, -1, None), slicing)
+
+  def testParseSlicingWithOnlyStop(self):
+    slicing = tensor_helper.parse_time_indices('[:-2]')
+    self.assertEqual(slice(None, -2, None), slicing)
+    slicing = tensor_helper.parse_time_indices(':-2')
+    self.assertEqual(slice(None, -2, None), slicing)
+
+  def test2DSlicingLeadsToError(self):
+    with self.assertRaisesRegexp(
+        tensor_helper.TimeIndexingError,
+        r'Invalid number of slicing objects in time indices \(2\)'):
+      tensor_helper.parse_time_indices('[1:2, 3:4]')
+    with self.assertRaisesRegexp(
+        tensor_helper.TimeIndexingError,
+        r'Invalid number of slicing objects in time indices \(2\)'):
+      tensor_helper.parse_time_indices('1:2,3:4')
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorboard/plugins/debugger/tensor_helper_test.py
+++ b/tensorboard/plugins/debugger/tensor_helper_test.py
@@ -133,13 +133,9 @@ class ParseTimeIndicesTest(tf.test.TestCase):
     self.assertEqual(slice(None, -2, None), slicing)
 
   def test2DSlicingLeadsToError(self):
-    with self.assertRaisesRegexp(
-        tensor_helper.TimeIndexingError,
-        r'Invalid number of slicing objects in time indices \(2\)'):
+    with self.assertRaises(tensor_helper.TimeIndexingError):
       tensor_helper.parse_time_indices('[1:2, 3:4]')
-    with self.assertRaisesRegexp(
-        tensor_helper.TimeIndexingError,
-        r'Invalid number of slicing objects in time indices \(2\)'):
+    with self.assertRaises(tensor_helper.TimeIndexingError):
       tensor_helper.parse_time_indices('1:2,3:4')
 
 

--- a/tensorboard/plugins/debugger/tensor_helper_test.py
+++ b/tensorboard/plugins/debugger/tensor_helper_test.py
@@ -133,9 +133,9 @@ class ParseTimeIndicesTest(tf.test.TestCase):
     self.assertEqual(slice(None, -2, None), slicing)
 
   def test2DSlicingLeadsToError(self):
-    with self.assertRaises(tensor_helper.TimeIndexingError):
+    with self.assertRaises(ValueError):
       tensor_helper.parse_time_indices('[1:2, 3:4]')
-    with self.assertRaises(tensor_helper.TimeIndexingError):
+    with self.assertRaises(ValueError):
       tensor_helper.parse_time_indices('1:2,3:4')
 
 

--- a/tensorboard/plugins/debugger/tensor_store.py
+++ b/tensorboard/plugins/debugger/tensor_store.py
@@ -17,51 +17,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
-import shutil
-import tempfile
-
-import numpy as np
 import tensorflow as tf
 
 from tensorboard.plugins.debugger import tensor_helper
 
 
-class _TensorValueDeferredToDisk(object):
-
-  def __init__(self, watch_key, time_index, value, root_dir):
-    self._watch_key = watch_key
-    self._time_index = time_index
-    self._nbytes = value.nbytes
-    path_items = watch_key.split('/')
-    path_items = path_items[:-1] + path_items[-1].split(':')
-    self._dir = os.path.join(*([root_dir] + os.path.join(path_items)))
-    if not tf.gfile.IsDirectory(self._dir):
-      tf.gfile.MakeDirs(self._dir)
-    self._file_path = os.path.join(self._dir, '%.5d.npy' % time_index)
-    np.save(self._file_path, value)
-    self._disposed = False
-
-  def get_value(self):
-    if self._disposed:
-      raise ValueError('Cannot read value: already disposed')
-    return np.load(self._file_path)
-
-  def dispose(self):
-    self._disposed = True
-    tf.gfile.Remove(self._file_path)
-
-  @property
-  def watch_key(self):
-    return self._watch_key
-
-  @property
-  def time_index(self):
-    return self._time_index
-
-  @property
-  def nbytes(self):
-    return self._nbytes
+# TODO(cais): Defer some tensor values to TensorBase, within a bytes limit,
+#   before discarding them.
 
 
 class _TensorValueDiscarded(object):
@@ -86,40 +48,30 @@ class _TensorValueDiscarded(object):
 class _WatchStore(object):
   """The store for a single debug tensor watch.
 
-  Defers values to disk and/or discard them according to pre-set byte limits.
+  Discards data according to pre-set byte limit.
   """
 
   def __init__(self,
                watch_key,
-               root_dir,
-               mem_bytes_limit=10e6,
-               disk_bytes_limit=100e6):
+               mem_bytes_limit=10e6):
     """Constructor of _WatchStore.
 
     The overflowing works as follows:
     The most recent tensor values are stored in memory, up to `mem_bytes_limit`
     bytes. But at least one (the most recent) value is always stored in memory.
-    For older tensors exceeding that limit, they are written to the disk, at
-    the directory `root_dir`. The disk amount up to `mem_bytes_limit` bytes are
-    used. But at least one value is always stored on disk. Older tensors that
-    exceed that limit are discarded. When a tensor is discarded at a given time
-    index, queries for the value at that time index will return `None`.
+    For older tensors exceeding that limit, they are discarded.
 
     Args:
       watch_key: A string representing the debugger tensor watch, with th
         format:
-          NODE_NAME:OUTPUT_SLOT:DEBUG_OP_NAME
+          <NODE_NAME>:<OUTPUT_SLOT>:<DEBUG_OP_NAME>
         e.g.,
           'Dense_1/BiasAdd:0:DebugIdentity'.
-      root_dir: Root directory on the file system for storing overflow data.
       mem_bytes_limit: Limit on number of bytes to store in memory.
-      disk_bytes_limit: Limit on number of bytes to store in file system.
     """
 
     self._watch_key = watch_key
-    self._root_dir = root_dir
     self._mem_bytes_limit = mem_bytes_limit
-    self._disk_bytes_limit = disk_bytes_limit
     self._in_mem_bytes = 0
     self._disposed = False
     self._data = []  # A map from index to tensor value.
@@ -146,30 +98,11 @@ class _WatchStore(object):
         # Always keep at least one time index in the memory.
         break
       i -= 1
-    # i is now the last time index to defer to disk.
-
-    j = i
-    cum_disk_size = 0
-    while j >= 0:
-      cum_disk_size += self._data[j].nbytes
-      if j < i and cum_disk_size > self._disk_bytes_limit:
-        break
-      j -= 1
-    # j is now the last time index to discard (due to limit).
-
-    # Defer some tensors to disk.
-    while i > j:
-      if not isinstance(self._data[i], _TensorValueDeferredToDisk):
-        deferred = _TensorValueDeferredToDisk(
-            self._watch_key, i, self._data[i], self._root_dir)
-        self._data[i] = deferred
-      i -= 1
+    # i is now the last time index to discard.
 
     # Mark remaining ones as discarded.
     while i >= 0:
       if not isinstance(self._data[i], _TensorValueDiscarded):
-        if isinstance(self._data[i], _TensorValueDeferredToDisk):
-          self._data[i].dispose()
         self._data[i] = _TensorValueDiscarded(self._watch_key, i)
       i -= 1
 
@@ -181,16 +114,10 @@ class _WatchStore(object):
     """Get number of values in memory."""
     n = len(self._data) - 1
     while n >= 0:
-      if isinstance(
-          self._data[n],
-          (_TensorValueDeferredToDisk, _TensorValueDiscarded)):
+      if isinstance(self._data[n], _TensorValueDiscarded):
         break
       n -= 1
     return len(self._data) - 1 - n
-
-  def num_on_disk(self):
-    """Get the number of values currently stored on disk."""
-    return len(self._data) - self.num_in_memory() - self.num_discarded()
 
   def num_discarded(self):
     """Get the number of values discarded due to exceeding both limits."""
@@ -210,8 +137,8 @@ class _WatchStore(object):
       time_indices: 0-based time indices to query, as a `list` of `int`.
 
     Returns:
-      Values as a list of `numpy.ndarray` (for time indices in memory or on
-      disk) or `None` (for time indices discarded).
+      Values as a list of `numpy.ndarray` (for time indices in memory) or
+      `None` (for time indices discarded).
     """
     if self._disposed:
       raise ValueError(
@@ -222,37 +149,24 @@ class _WatchStore(object):
     for time_index in time_indices:
       if isinstance(self._data[time_index], _TensorValueDiscarded):
         output.append(None)
-      elif isinstance(self._data[time_index], _TensorValueDeferredToDisk):
-        output.append(self._data[time_index].get_value())
       else:
         output.append(self._data[time_index])
     return output
 
   def dispose(self):
-    for datum in self._data:
-      if isinstance(datum, _TensorValueDeferredToDisk):
-        datum.dispose()
     self._disposed = True
 
 
 class TensorStore(object):
 
-  def __init__(self,
-               root_dir=None,
-               watch_mem_bytes_limit=10e6,
-               watch_disk_bytes_limit=100e6):
+  def __init__(self, watch_mem_bytes_limit=10e6):
     """Constructor of TensorStore.
 
     Args:
-      root_dir: Root directory on the file system for storing overflow data.
       watch_mem_bytes_limit: Limit on number of bytes to store in memory for
         each watch key.
-      watch_disk_bytes_limit: Limit on number of bytes to store in file system
-        each watch key.
     """
-    self._root_dir = root_dir or tempfile.mkdtemp(prefix="tdp_")
     self._watch_mem_bytes_limit = watch_mem_bytes_limit
-    self._watch_disk_bytes_limit = watch_disk_bytes_limit
     self._tensor_data = dict()  # A map from watch key to _WatchStore instances.
 
   def add(self, watch_key, tensor_value):
@@ -266,9 +180,7 @@ class TensorStore(object):
     if watch_key not in self._tensor_data:
       self._tensor_data[watch_key] = _WatchStore(
           watch_key,
-          self._root_dir,
-          mem_bytes_limit=self._watch_mem_bytes_limit,
-          disk_bytes_limit=self._watch_disk_bytes_limit)
+          mem_bytes_limit=self._watch_mem_bytes_limit)
     self._tensor_data[watch_key].add(tensor_value)
 
   def query(self, watch_key, time_indices=None, slicing=None, mapping=None):
@@ -319,7 +231,7 @@ class TensorStore(object):
     if recombine_and_map:
       if mapping == 'image/png':
         output = tensor_helper.array_to_base64_png(output)
-      else:
+      elif mapping and mapping != 'none':
         tf.logging.warn(
             'Unsupported mapping mode after recomining time steps: %s',
             mapping)
@@ -328,4 +240,3 @@ class TensorStore(object):
   def dispose(self):
     for watch_key in self._tensor_data:
       self._tensor_data[watch_key].dispose()
-    shutil.rmtree(self._root_dir)

--- a/tensorboard/plugins/debugger/tensor_store.py
+++ b/tensorboard/plugins/debugger/tensor_store.py
@@ -1,0 +1,331 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import shutil
+import tempfile
+
+import numpy as np
+import tensorflow as tf
+
+from tensorboard.plugins.debugger import tensor_helper
+
+
+class _TensorValueDeferredToDisk(object):
+
+  def __init__(self, watch_key, time_index, value, root_dir):
+    self._watch_key = watch_key
+    self._time_index = time_index
+    self._nbytes = value.nbytes
+    path_items = watch_key.split('/')
+    path_items = path_items[:-1] + path_items[-1].split(':')
+    self._dir = os.path.join(*([root_dir] + os.path.join(path_items)))
+    if not tf.gfile.IsDirectory(self._dir):
+      tf.gfile.MakeDirs(self._dir)
+    self._file_path = os.path.join(self._dir, '%.5d.npy' % time_index)
+    np.save(self._file_path, value)
+    self._disposed = False
+
+  def get_value(self):
+    if self._disposed:
+      raise ValueError('Cannot read value: already disposed')
+    return np.load(self._file_path)
+
+  def dispose(self):
+    self._disposed = True
+    tf.gfile.Remove(self._file_path)
+
+  @property
+  def watch_key(self):
+    return self._watch_key
+
+  @property
+  def time_index(self):
+    return self._time_index
+
+  @property
+  def nbytes(self):
+    return self._nbytes
+
+
+class _TensorValueDiscarded(object):
+
+  def __init__(self, watch_key, time_index):
+    self._watch_key = watch_key
+    self._time_index = time_index
+
+  @property
+  def watch_key(self):
+    return self._watch_key
+
+  @property
+  def time_index(self):
+    return self._time_index
+
+  @property
+  def nbytes(self):
+    return 0
+
+
+class _WatchStore(object):
+  """The store for a single debug tensor watch.
+
+  Defers values to disk and/or discard them according to pre-set byte limits.
+  """
+
+  def __init__(self,
+               watch_key,
+               root_dir,
+               mem_bytes_limit=10e6,
+               disk_bytes_limit=100e6):
+    """Constructor of _WatchStore.
+
+    The overflowing works as follows:
+    The most recent tensor values are stored in memory, up to `mem_bytes_limit`
+    bytes. But at least one (the most recent) value is always stored in memory.
+    For older tensors exceeding that limit, they are written to the disk, at
+    the directory `root_dir`. The disk amount up to `mem_bytes_limit` bytes are
+    used. But at least one value is always stored on disk. Older tensors that
+    exceed that limit are discarded. When a tensor is discarded at a given time
+    index, queries for the value at that time index will return `None`.
+
+    Args:
+      watch_key: A string representing the debugger tensor watch, with th
+        format:
+          NODE_NAME:OUTPUT_SLOT:DEBUG_OP_NAME
+        e.g.,
+          'Dense_1/BiasAdd:0:DebugIdentity'.
+      root_dir: Root directory on the file system for storing overflow data.
+      mem_bytes_limit: Limit on number of bytes to store in memory.
+      disk_bytes_limit: Limit on number of bytes to store in file system.
+    """
+
+    self._watch_key = watch_key
+    self._root_dir = root_dir
+    self._mem_bytes_limit = mem_bytes_limit
+    self._disk_bytes_limit = disk_bytes_limit
+    self._in_mem_bytes = 0
+    self._disposed = False
+    self._data = []  # A map from index to tensor value.
+
+  def add(self, value):
+    """Add a tensor the watch store."""
+    if self._disposed:
+      raise ValueError(
+          'Cannot add value: this _WatchStore instance is already disposed')
+    self._data.append(value)
+    self._in_mem_bytes += value.nbytes
+    self._ensure_bytes_limits()
+
+  def _ensure_bytes_limits(self):
+    # TODO(cais): Thread safety?
+    if self._in_mem_bytes <= self._mem_bytes_limit:
+      return
+
+    i = len(self._data) - 1
+    cum_mem_size = 0
+    while i >= 0:
+      cum_mem_size += self._data[i].nbytes
+      if i < len(self._data) - 1 and cum_mem_size > self._mem_bytes_limit:
+        # Always keep at least one time index in the memory.
+        break
+      i -= 1
+    # i is now the last time index to defer to disk.
+
+    j = i
+    cum_disk_size = 0
+    while j >= 0:
+      cum_disk_size += self._data[j].nbytes
+      if j < i and cum_disk_size > self._disk_bytes_limit:
+        break
+      j -= 1
+    # j is now the last time index to discard (due to limit).
+
+    # Defer some tensors to disk.
+    while i > j:
+      if not isinstance(self._data[i], _TensorValueDeferredToDisk):
+        deferred = _TensorValueDeferredToDisk(
+            self._watch_key, i, self._data[i], self._root_dir)
+        self._data[i] = deferred
+      i -= 1
+
+    # Mark remaining ones as discarded.
+    while i >= 0:
+      if not isinstance(self._data[i], _TensorValueDiscarded):
+        if isinstance(self._data[i], _TensorValueDeferredToDisk):
+          self._data[i].dispose()
+        self._data[i] = _TensorValueDiscarded(self._watch_key, i)
+      i -= 1
+
+  def num_total(self):
+    """Get the total number of values."""
+    return len(self._data)
+
+  def num_in_memory(self):
+    """Get number of values in memory."""
+    n = len(self._data) - 1
+    while n >= 0:
+      if isinstance(
+          self._data[n],
+          (_TensorValueDeferredToDisk, _TensorValueDiscarded)):
+        break
+      n -= 1
+    return len(self._data) - 1 - n
+
+  def num_on_disk(self):
+    """Get the number of values currently stored on disk."""
+    return len(self._data) - self.num_in_memory() - self.num_discarded()
+
+  def num_discarded(self):
+    """Get the number of values discarded due to exceeding both limits."""
+    if not self._data:
+      return 0
+    n = 0
+    while n < len(self._data):
+      if not isinstance(self._data[n], _TensorValueDiscarded):
+        break
+      n += 1
+    return n
+
+  def query(self, time_indices):
+    """Query the values at given time indices.
+
+    Args:
+      time_indices: 0-based time indices to query, as a `list` of `int`.
+
+    Returns:
+      Values as a list of `numpy.ndarray` (for time indices in memory or on
+      disk) or `None` (for time indices discarded).
+    """
+    if self._disposed:
+      raise ValueError(
+          'Cannot query: this _WatchStore instance is already disposed')
+    if not isinstance(time_indices, (tuple, list)):
+      time_indices = [time_indices]
+    output = []
+    for time_index in time_indices:
+      if isinstance(self._data[time_index], _TensorValueDiscarded):
+        output.append(None)
+      elif isinstance(self._data[time_index], _TensorValueDeferredToDisk):
+        output.append(self._data[time_index].get_value())
+      else:
+        output.append(self._data[time_index])
+    return output
+
+  def dispose(self):
+    for datum in self._data:
+      if isinstance(datum, _TensorValueDeferredToDisk):
+        datum.dispose()
+    self._disposed = True
+
+
+class TensorStore(object):
+
+  def __init__(self,
+               root_dir=None,
+               watch_mem_bytes_limit=10e6,
+               watch_disk_bytes_limit=100e6):
+    """Constructor of TensorStore.
+
+    Args:
+      root_dir: Root directory on the file system for storing overflow data.
+      watch_mem_bytes_limit: Limit on number of bytes to store in memory for
+        each watch key.
+      watch_disk_bytes_limit: Limit on number of bytes to store in file system
+        each watch key.
+    """
+    self._root_dir = root_dir or tempfile.mkdtemp(prefix="tdp_")
+    self._watch_mem_bytes_limit = watch_mem_bytes_limit
+    self._watch_disk_bytes_limit = watch_disk_bytes_limit
+    self._tensor_data = dict()  # A map from watch key to _WatchStore instances.
+
+  def add(self, watch_key, tensor_value):
+    """Add a tensor value.
+
+    Args:
+      watch_key: A string representing the debugger tensor watch, e.g.,
+        'Dense_1/BiasAdd:0:DebugIdentity'.
+      tensor_value: The value of the tensor as a numpy.ndarray.
+    """
+    if watch_key not in self._tensor_data:
+      self._tensor_data[watch_key] = _WatchStore(
+          watch_key,
+          self._root_dir,
+          mem_bytes_limit=self._watch_mem_bytes_limit,
+          disk_bytes_limit=self._watch_disk_bytes_limit)
+    self._tensor_data[watch_key].add(tensor_value)
+
+  def query(self, watch_key, time_indices=None, slicing=None, mapping=None):
+    """Query tensor store for a given watch_key.
+
+    Args:
+      watch_key: The watch key to query.
+      time_indices: A numpy-style slicing string for time indices. E.g.,
+        `-1`, `:-2`, `[::2]`. If not provided (`None`), will use -1.
+      slicing: A numpy-style slicing string for individual time steps.
+      mapping: An mapping string or a list of them. Supported mappings:
+        `{None, 'image/png'}`.
+
+    Returns:
+      The potentially sliced values as a nested list of values or its mapped
+        format. A `list` of nested `list` of values.
+
+    Raises:
+      ValueError: If the shape of the sliced array is incompatible with mapping
+        mode. Or if the mapping type is invalid.
+    """
+    if watch_key not in self._tensor_data:
+      raise KeyError("watch_key not found: %s" % watch_key)
+
+    if time_indices is None:
+      time_indices = '-1'
+    time_slicing = tensor_helper.parse_time_indices(time_indices)
+    all_time_indices = list(range(self._tensor_data[watch_key].num_total()))
+    sliced_time_indices = all_time_indices[time_slicing]
+    if not isinstance(sliced_time_indices, list):
+      sliced_time_indices = [sliced_time_indices]
+
+    recombine_and_map = False
+    step_mapping = mapping
+    if len(sliced_time_indices) > 1 and mapping not in (None, ):
+      recombine_and_map = True
+      step_mapping = None
+
+    output = []
+    for index in sliced_time_indices:
+      value = self._tensor_data[watch_key].query(index)[0]
+      if value is not None:
+        output.append(tensor_helper.array_view(
+            value, slicing=slicing, mapping=step_mapping)[2])
+      else:
+        output.append(None)
+
+    if recombine_and_map:
+      if mapping == 'image/png':
+        output = tensor_helper.array_to_base64_png(output)
+      else:
+        tf.logging.warn(
+            'Unsupported mapping mode after recomining time steps: %s',
+            mapping)
+    return output
+
+  def dispose(self):
+    for watch_key in self._tensor_data:
+      self._tensor_data[watch_key].dispose()
+    shutil.rmtree(self._root_dir)

--- a/tensorboard/plugins/debugger/tensor_store_test.py
+++ b/tensorboard/plugins/debugger/tensor_store_test.py
@@ -1,0 +1,362 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests the TensorBoard Debugger Plugin Tensor Store Module."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import base64
+import glob
+import os
+import shutil
+import tempfile
+
+import numpy as np
+import tensorflow as tf
+
+from tensorboard.plugins.beholder import im_util
+from tensorboard.plugins.debugger import tensor_store
+
+
+class TensorValueDeferredToDiskTest(tf.test.TestCase):
+
+  def setUp(self):
+    super(TensorValueDeferredToDiskTest, self).setUp()
+    self._temp_root_dir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    shutil.rmtree(self._temp_root_dir)
+    super(TensorValueDeferredToDiskTest, self).tearDown()
+
+  def testConstructorAndGetValue(self):
+    watch_key = 'Dense/BiasAdd:0:DebugIdentity'
+    time_index = 10
+    value = np.eye(3)
+    disk_value = tensor_store._TensorValueDeferredToDisk(
+        watch_key, time_index, value, self._temp_root_dir)
+
+    self.assertEqual(watch_key, disk_value.watch_key)
+    self.assertEqual(time_index, disk_value.time_index)
+    self.assertEqual(value.nbytes, disk_value.nbytes)
+    self.assertAllEqual(value, disk_value.get_value())
+
+  def testDispose(self):
+    watch_key = 'Dense/BiasAdd:0:DebugIdentity'
+    time_index = 10
+    value = np.eye(3)
+    disk_value = tensor_store._TensorValueDeferredToDisk(
+        watch_key, time_index, value, self._temp_root_dir)
+
+    self.assertTrue(tf.gfile.Exists(os.path.join(
+        self._temp_root_dir, 'Dense', 'BiasAdd', '0', 'DebugIdentity',
+        '00010.npy')))
+    self.assertAllEqual(value, disk_value.get_value())
+    disk_value.dispose()
+    self.assertFalse(tf.gfile.Exists(os.path.join(
+        self._temp_root_dir, 'Dense', 'BiasAdd', '0', 'DebugIdentity',
+        '00010.npy')))
+    with self.assertRaises(ValueError):
+      disk_value.get_value()
+
+
+class WatchStoreTest(tf.test.TestCase):
+
+  def setUp(self):
+    super(WatchStoreTest, self).setUp()
+    self._temp_root_dir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    shutil.rmtree(self._temp_root_dir)
+    super(WatchStoreTest, self).tearDown()
+
+  def testDeferToDisk(self):
+    watch_key = 'Dense/BiasAdd:0:DebugIdentity'
+    watch_store = tensor_store._WatchStore(watch_key,
+                                           self._temp_root_dir,
+                                           mem_bytes_limit=100,
+                                           disk_bytes_limit=10e6)
+
+    value = np.eye(3, dtype=np.float64)
+    self.assertEqual(72, value.nbytes)
+    self.assertEqual(0, watch_store.num_total())
+    self.assertEqual(0, watch_store.num_in_memory())
+    self.assertEqual(0, watch_store.num_on_disk())
+    self.assertEqual(0, watch_store.num_discarded())
+    self.assertEqual(0, watch_store.num_on_disk())
+
+    watch_store.add(value)
+    self.assertEqual(1, watch_store.num_total())
+    self.assertEqual(1, watch_store.num_in_memory())
+    self.assertEqual(0, watch_store.num_on_disk())
+    self.assertEqual(0, watch_store.num_discarded())
+    self.assertAllEqual([value], watch_store.query(0))
+    self.assertAllEqual([value], watch_store.query([0]))
+    with self.assertRaises(IndexError):
+      watch_store.query([1])
+
+    watch_store.add(value * 2)
+    self.assertEqual(2, watch_store.num_total())
+    self.assertEqual(1, watch_store.num_in_memory())
+    self.assertEqual(1, watch_store.num_on_disk())
+    self.assertEqual(0, watch_store.num_discarded())
+    self.assertAllEqual([value], watch_store.query([0]))
+    self.assertAllEqual([value, value * 2], watch_store.query([0, 1]))
+    with self.assertRaises(IndexError):
+      watch_store.query(2)
+
+    watch_store.add(value * 3)
+    self.assertEqual(3, watch_store.num_total())
+    self.assertEqual(1, watch_store.num_in_memory())
+    self.assertEqual(2, watch_store.num_on_disk())
+    self.assertEqual(0, watch_store.num_discarded())
+    self.assertAllEqual([value], watch_store.query([0]))
+    self.assertAllEqual([value, value * 2], watch_store.query([0, 1]))
+    self.assertAllEqual([value, value * 2, value * 3],
+                        watch_store.query([0, 1, 2]))
+    with self.assertRaises(IndexError):
+      watch_store.query(3)
+
+  def testAlwaysKeepsOneValueInMemory(self):
+    watch_key = 'Dense/BiasAdd:0:DebugIdentity'
+    watch_store = tensor_store._WatchStore(watch_key,
+                                           self._temp_root_dir,
+                                           mem_bytes_limit=50,
+                                           disk_bytes_limit=10e6)
+
+    value = np.eye(3, dtype=np.float64)
+    self.assertEqual(72, value.nbytes)
+    self.assertEqual(0, watch_store.num_total())
+    self.assertEqual(0, watch_store.num_in_memory())
+    self.assertEqual(0, watch_store.num_on_disk())
+    self.assertEqual(0, watch_store.num_discarded())
+    self.assertEqual(0, watch_store.num_on_disk())
+
+    watch_store.add(value)
+    self.assertEqual(1, watch_store.num_total())
+    self.assertEqual(1, watch_store.num_in_memory())
+    self.assertEqual(0, watch_store.num_on_disk())
+    self.assertEqual(0, watch_store.num_discarded())
+    self.assertAllEqual([value], watch_store.query(0))
+    self.assertAllEqual([value], watch_store.query([0]))
+    with self.assertRaises(IndexError):
+      watch_store.query([1])
+
+    watch_store.add(value * 2)
+    self.assertEqual(2, watch_store.num_total())
+    self.assertEqual(1, watch_store.num_in_memory())
+    self.assertEqual(1, watch_store.num_on_disk())
+    self.assertEqual(0, watch_store.num_discarded())
+    self.assertAllEqual([value], watch_store.query([0]))
+    self.assertAllEqual([value, value * 2], watch_store.query([0, 1]))
+    with self.assertRaises(IndexError):
+      watch_store.query(2)
+
+  def testDiscarding(self):
+    watch_key = 'Dense/BiasAdd:0:DebugIdentity'
+    watch_store = tensor_store._WatchStore(watch_key,
+                                           self._temp_root_dir,
+                                           mem_bytes_limit=100,
+                                           disk_bytes_limit=100)
+
+    value = np.eye(3, dtype=np.float64)
+
+    watch_store.add(value)
+    watch_store.add(value * 2)
+    self.assertEqual(2, watch_store.num_total())
+    self.assertEqual(1, watch_store.num_in_memory())
+    self.assertEqual(1, watch_store.num_on_disk())
+    self.assertEqual(0, watch_store.num_discarded())
+    self.assertAllEqual([value], watch_store.query([0]))
+    self.assertAllEqual([value, value * 2], watch_store.query([0, 1]))
+    with self.assertRaises(IndexError):
+      watch_store.query(2)
+
+    watch_store.add(value * 3)
+    self.assertEqual(3, watch_store.num_total())
+    self.assertEqual(1, watch_store.num_in_memory())
+    self.assertEqual(1, watch_store.num_on_disk())
+    self.assertEqual(1, watch_store.num_discarded())
+    self.assertEqual([None], watch_store.query([0]))
+    result = watch_store.query([0, 1])
+    self.assertIsNone(result[0])
+    self.assertAllEqual(value * 2, result[1])
+    result = watch_store.query([0, 1, 2])
+    self.assertIsNone(result[0])
+    self.assertAllEqual([value * 2, value * 3], result[1:])
+    with self.assertRaises(IndexError):
+      watch_store.query(3)
+
+    watch_store.add(value * 4)
+    self.assertEqual(4, watch_store.num_total())
+    self.assertEqual(1, watch_store.num_in_memory())
+    self.assertEqual(1, watch_store.num_on_disk())
+    self.assertEqual(2, watch_store.num_discarded())
+    self.assertEqual([None], watch_store.query([0]))
+    result = watch_store.query([0, 1])
+    self.assertIsNone(result[0])
+    self.assertIsNone(result[1])
+    result = watch_store.query([0, 1, 2])
+    self.assertIsNone(result[0])
+    self.assertIsNone(result[1])
+    self.assertAllEqual(value * 3, result[2])
+    result = watch_store.query([0, 1, 2, 3])
+    self.assertIsNone(result[0])
+    self.assertIsNone(result[1])
+    self.assertAllEqual(value * 3, result[2])
+    self.assertAllEqual(value * 4, result[3])
+    with self.assertRaises(IndexError):
+      watch_store.query(4)
+
+
+class TensorHelperTest(tf.test.TestCase):
+
+  def testAddAndQuerySingleTensor(self):
+    store = tensor_store.TensorStore()
+    watch_key = "A:0:DebugIdentity"
+    data = np.array([[1, 2], [3, 4]])
+    store.add(watch_key, data)
+    self.assertAllClose([data], store.query(watch_key))
+
+  def testAddAndQuerySingleTensorWithSlicing(self):
+    store = tensor_store.TensorStore()
+    watch_key = "A:0:DebugIdentity"
+    data = np.array([[1, 2], [3, 4]])
+    store.add(watch_key, data)
+    self.assertAllClose([[2, 4]], store.query(watch_key, slicing="[:, 1]"))
+
+  def testAddAndQueryMultipleTensorForSameWatchKey(self):
+    store = tensor_store.TensorStore()
+    watch_key = "A:0:DebugIdentity"
+    data1 = np.array([[1, 2], [3, 4]])
+    data2 = np.array([[-1, -2], [-3, -4]])
+    store.add(watch_key, data1)
+    store.add(watch_key, data2)
+
+    self.assertAllClose([data2], store.query(watch_key))
+    self.assertAllClose([data1], store.query(watch_key, time_indices='0'))
+    self.assertAllClose([data2], store.query(watch_key, time_indices='1'))
+    self.assertAllClose([data2], store.query(watch_key, time_indices='-1'))
+
+  def testAddAndQueryMultipleTensorForSameWatchKeyWithSlicing(self):
+    store = tensor_store.TensorStore()
+    watch_key = "A:0:DebugIdentity"
+    data1 = np.array([[1, 2], [3, 4]])
+    data2 = np.array([[-1, -2], [-3, -4]])
+    store.add(watch_key, data1)
+    store.add(watch_key, data2)
+
+    self.assertAllClose(
+        [[2, 4], [-2, -4]],
+        store.query(watch_key, time_indices='0:2', slicing="[:,1]"))
+
+  def testQueryMultipleTensorsAtOnce(self):
+    store = tensor_store.TensorStore()
+    watch_key = "A:0:DebugIdentity"
+    data1 = np.array([[1, 2], [3, 4]])
+    data2 = np.array([[-1, -2], [-3, -4]])
+    store.add(watch_key, data1)
+    store.add(watch_key, data2)
+
+    self.assertAllClose(
+        [[[1, 2], [3, 4]], [[-1, -2], [-3, -4]]],
+        store.query(watch_key, time_indices='[0:2]'))
+
+  def testQueryNonexistentWatchKey(self):
+    store = tensor_store.TensorStore()
+    watch_key = "A:0:DebugIdentity"
+    data = np.array([[1, 2], [3, 4]])
+    store.add(watch_key, data)
+    with self.assertRaises(KeyError):
+      store.query("B:0:DebugIdentity")
+
+  def testQueryInvalidTimeIndex(self):
+    store = tensor_store.TensorStore()
+    watch_key = "A:0:DebugIdentity"
+    data = np.array([[1, 2], [3, 4]])
+    store.add(watch_key, data)
+    with self.assertRaises(IndexError):
+      store.query("A:0:DebugIdentity", time_indices='10')
+
+  def testQeuryWithTimeIndicesStop(self):
+    store = tensor_store.TensorStore()
+    watch_key = "A:0:DebugIdentity"
+    store.add(watch_key, np.array(1))
+    store.add(watch_key, np.array(3))
+    store.add(watch_key, np.array(3))
+    store.add(watch_key, np.array(7))
+    self.assertAllClose([1, 3, 3], store.query(watch_key, time_indices=':3:'))
+
+  def testQeuryWithTimeIndicesStopAndStep(self):
+    store = tensor_store.TensorStore()
+    watch_key = "A:0:DebugIdentity"
+    store.add(watch_key, np.array(1))
+    store.add(watch_key, np.array(3))
+    store.add(watch_key, np.array(3))
+    store.add(watch_key, np.array(7))
+    self.assertAllClose([3, 7], store.query(watch_key, time_indices='1::2'))
+
+  def testQeuryWithTimeIndicesAllRange(self):
+    store = tensor_store.TensorStore()
+    watch_key = "A:0:DebugIdentity"
+    store.add(watch_key, np.array(1))
+    store.add(watch_key, np.array(3))
+    store.add(watch_key, np.array(3))
+    store.add(watch_key, np.array(7))
+    self.assertAllClose([1, 3, 3, 7], store.query(watch_key, time_indices=':'))
+
+  def testQuery1DTensorHistoryWithImagePngMapping(self):
+    store = tensor_store.TensorStore()
+    watch_key = "A:0:DebugIdentity"
+    store.add(watch_key, np.array([0, 2, 4, 6, 8]))
+    store.add(watch_key, np.array([1, 3, 5, 7, 9]))
+    output = store.query(watch_key, time_indices=':', mapping='image/png')
+    decoded = im_util.decode_png(base64.b64decode(output))
+    self.assertEqual((2, 5, 3), decoded.shape)
+
+  def testTensorValuesExceedingDiskBytesLimitAreDiscarded(self):
+    store = tensor_store.TensorStore(
+        watch_mem_bytes_limit=100, watch_disk_bytes_limit=100)
+    watch_key = "A:0:DebugIdentity"
+    value = np.eye(3, dtype=np.float64)
+    self.assertEqual(72, value.nbytes)
+    store.add(watch_key, value)
+    self.assertAllEqual([value], store.query(watch_key, time_indices=':'))
+
+    store.add(watch_key, value * 2)
+    self.assertAllEqual([value, value * 2],
+                        store.query(watch_key, time_indices=':'))
+
+    store.add(watch_key, value * 3)
+    result = store.query(watch_key, time_indices=':')
+    self.assertIsNone(result[0])
+    self.assertAllEqual([value * 2, value * 3], result[1:])
+
+  def testDisposingTensorStoreErasesDataFiles(self):
+    store = tensor_store.TensorStore(
+        watch_mem_bytes_limit=10, watch_disk_bytes_limit=1000)
+    watch_key = "A:0:DebugIdentity"
+    value = np.eye(3, dtype=np.float64)
+    for _ in range(10):
+      store.add(watch_key, value)
+
+    self.assertTrue(
+        glob.glob(os.path.join(
+            store._root_dir, "A", "0", "DebugIdentity", "*")))
+    store.dispose()
+    self.assertFalse(glob.glob(os.path.join(store._root_dir)))
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
@@ -1,0 +1,54 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "ts_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+ts_web_library(
+    name = "tf_debugger_dashboard",
+    srcs = [
+        "selection-tree-node.ts",
+        "tensor-shape-helper.ts",
+        "tf-debugger-dashboard.html",
+        "tf-debugger-initial-dialog.html",
+        "tf-debugger-line-chart.html",
+        "tf-op-selector.html",
+        "tf-session-runs-view.html",
+        "tf-tensor-data-summary.html",
+        "tf-tensor-value-multi-view.html",
+        "tf-tensor-value-view.html",
+    ],
+    path = "/tf-debugger-dashboard",
+    visibility = ["//visibility:public"],
+    deps = [
+        # ":tf_tensor_shape_helper",
+        "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_card_heading",
+        "//tensorboard/components/tf_categorization_utils",
+        "//tensorboard/components/tf_color_scale",
+        "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_imports:lodash",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_paginated_view",
+        "//tensorboard/components/tf_runs_selector",
+        "//tensorboard/components/tf_storage",
+        "//tensorboard/components/tf_tensorboard:registry",
+        "//tensorboard/components/vz_line_chart",
+        "//tensorboard/plugins/graph/tf_graph",
+        "//tensorboard/plugins/graph/tf_graph_loader",
+        "//tensorboard/plugins/histogram/vz_histogram_timeseries",
+        "@org_polymer_iron_collapse",
+        "@org_polymer_iron_icon",
+        "@org_polymer_paper_button",
+        "@org_polymer_paper_checkbox",
+        "@org_polymer_paper_dropdown_menu",
+        "@org_polymer_paper_icon_button",
+        "@org_polymer_paper_input",
+        "@org_polymer_paper_item",
+        "@org_polymer_paper_menu",
+        "@org_polymer_paper_slider",
+        "@org_polymer_paper_spinner",
+        "@org_polymer_paper_styles",
+        "@org_polymer_paper_toast",
+    ],
+)

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
@@ -21,7 +21,6 @@ ts_web_library(
     path = "/tf-debugger-dashboard",
     visibility = ["//visibility:public"],
     deps = [
-        # ":tf_tensor_shape_helper",
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_card_heading",
         "//tensorboard/components/tf_categorization_utils",

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/selection-tree-node.ts
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/selection-tree-node.ts
@@ -1,0 +1,336 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace tf_debugger_dashboard {
+
+/**
+ * A string used to separate parts of a node name. Should be kept consistent
+ * with the graph component.
+ */
+export const NODE_NAME_SEPARATOR = '/';
+export const DEVICE_NAME_PATTERN =
+    /^\/job:[A-Za-z0-9_]+\/replica:[0-9_]+\/task:[0-9]+\/device:[A-Za-z0-9_]+:[0-9]+/;
+
+// A checkbox is partially checked if it is a checkbox for a non-leaf node and
+// some (but not all) of its children are checked.
+export enum CheckboxState {EMPTY, CHECKED, PARTIAL};
+
+export interface DebugWatch {
+  node_name: string;
+  op_type: string;
+  output_slot: number;
+  debug_op: string;
+}
+
+/** Function that takes action based on item clicked in the context menu. */
+export interface DebugWatchChange {
+  (debugWatch: DebugWatch, checked: boolean): void;
+}
+
+/**
+ * Split a node name, potentially with a device name prefix.
+ * @param string: Input node name, potentially with a device name prefix, e.g.,
+ *   '/job:localhost/replica:0/task:0/device:CPU:0/Dense/BiasAdd'
+ * @return Split items. The device name, if present, will be the first item.
+ */
+export function splitNodeName(name: string): string[] {
+  let items = [];
+  const deviceNameMatches = name.match(DEVICE_NAME_PATTERN);
+  let nodeName = name;
+  if (deviceNameMatches != null) {
+    items.push(deviceNameMatches[0]);
+    // Expect there to be a slash after the device name. Skip it.
+    if (nodeName[deviceNameMatches[0].length] !== '/') {
+      console.error('No slash ("/") after device name in node name:', nodeName);
+    }
+    nodeName = nodeName.slice(deviceNameMatches[0].length + 1);
+  }
+  items = items.concat(nodeName.split(NODE_NAME_SEPARATOR));
+  return items;
+}
+
+/**
+ * Get a node name without device name prefix or base-expansion suffix.
+ * @param name The node name, possibly with a device name prefix, e.g.,
+ *   '/job:localhost/replica:0/task:0/device:CPU:0/Dense/BiasAdd'
+ * @return The node name without any device name prefixes or '/' at the front.
+ *   E.g., 'Dense/BiasAdd'
+ */
+export function getCleanNodeName(name: string): string {
+  let cleanName = name;
+  const deviceNameMatches = name.match(DEVICE_NAME_PATTERN);
+  if (deviceNameMatches != null) {
+    if (cleanName.length > deviceNameMatches[0].length &&
+        cleanName[deviceNameMatches[0].length] != '/') {
+      console.error('No slash ("/") after device name in node name:', name);
+    }
+    cleanName = cleanName.slice(deviceNameMatches[0].length + 1);
+  } else {
+    if (cleanName[0] === '/') {
+      cleanName = cleanName.slice(1);
+    }
+  }
+  // Remove any base-expansion suffix.
+  if (cleanName.indexOf(')') === cleanName.length - 1) {
+    cleanName = cleanName.slice(0, cleanName.indexOf('/('));
+  }
+  return cleanName;
+}
+
+/**
+ * Sort and base-expand an `Array` of `DebugWatch`es in place.
+ * "Base-expand" means adding a '/(baseName)' suffix to nodes whose names are
+ * the name scope of some other node's name.
+ * @param debugWatches
+ */
+export function sortAndBaseExpandDebugWatches(debugWatches: DebugWatch[]) {
+  // Sort the debug watches.
+  debugWatches.sort((watch1, watch2) => {
+    if (watch1.node_name < watch2.node_name) {
+      return -1;
+    } else if (watch1.node_name > watch2.node_name) {
+      return 1;
+    } else {
+      return watch1.output_slot - watch2.output_slot;
+    }
+  });
+
+  // Find leaf nodes that need to be base-expanded due to their names being a
+  // prefix of other nodes.
+  for (let i = 0; i < debugWatches.length; ++i) {
+    const withSlashSuffix = debugWatches[i].node_name + '/';
+    let toBaseExpandLeaf = false;
+    for (let j = i + 1; j < debugWatches.length; ++j) {
+      if (debugWatches[j].node_name.indexOf(withSlashSuffix) === 0) {
+        toBaseExpandLeaf = true;
+        break;
+      }
+    }
+    if (toBaseExpandLeaf) {
+      const items = debugWatches[i].node_name.split('/');
+      debugWatches[i].node_name += '/(' + items[items.length - 1] + ')';
+    }
+  }
+}
+
+export function assembleDeviceAndNodeNames(nameItems: string[]): string[] {
+  const deviceAndNodeNames: string[] = [null, null];
+  if (nameItems[0].match(DEVICE_NAME_PATTERN)) {
+    let deviceName = nameItems[0];
+    if (deviceName[deviceName.length - 1] === '/') {
+      deviceName = deviceName.slice(0, deviceName.length - 1);
+    }
+    deviceAndNodeNames[0] = deviceName;
+    deviceAndNodeNames[1] = nameItems.slice(1).join('/');
+  } else {
+    deviceAndNodeNames[1] = nameItems.join('/');
+  }
+  return deviceAndNodeNames;
+}
+
+/**
+ * Filter debug watches according to given filter mode and filter input.
+ * @param debugWatches An array of `DebugWatch` instances.
+ * @param filterMode Filter mode, e.g., 'Node Name', 'Op Type'.
+ * @param filterInput Filter input, as a regular expression, e.g., for
+ *   filterMode === 'Op Type': 'Variable.'.
+ * @returns An array of `DebugWatch` instances from the input `debugWatches`
+ *   that pass the filter.
+ */
+export function filterDebugWatches(
+    debugWatches: DebugWatch[],
+    filterMode: string,
+    filterInput: string): DebugWatch[] {
+  const filterRegex = new RegExp(filterInput, 'g');
+  return debugWatches.filter((debugWatch) => {
+    if (filterMode === 'Node Name') {
+      return debugWatch.node_name.match(filterRegex) != null;
+    } else if (filterMode === 'Op Type') {
+      return debugWatch.op_type.match(filterRegex) != null;
+    } else {
+      throw new Error(`Invalid filterMode: ${filterMode}`);
+    }
+  });
+}
+
+export class SelectionTreeNode {
+  name: string;
+  parent: SelectionTreeNode;
+
+  // Maps from the name at the current level to the tree node.
+  children: {[key: string]: SelectionTreeNode};
+
+  // Onlt leaf nodes have debug watches.
+  isRoot: boolean;
+
+  checkboxState: CheckboxState;
+  checkbox: Element;
+
+  // If this is set, toggling the checkbox won't prompt ancestor or children
+  // nodes to update. Used for updating various checkboxes so that invariants
+  // are held, ie, if a metanode is checked, all nodes under it are checked.
+  private avoidPropagation: boolean;
+
+  constructor(
+      name: string,
+      readonly debugWatchChange: DebugWatchChange,
+      parent?: SelectionTreeNode,
+      readonly debugWatch?: DebugWatch) {
+    this.name = name;
+    this.debugWatch = debugWatch;
+
+    // We start out empty.
+    this.checkboxState = CheckboxState.EMPTY;
+    this.parent = parent;
+    this.children = {};
+
+    this.checkbox = document.createElement('paper-checkbox');
+    this.checkbox.addEventListener('change', () => {
+      this._handleChange();
+    }, false);
+  }
+
+  _handleChange() {
+    if (this.avoidPropagation) {
+      // Do not propagate.
+      if (this.debugWatch) {
+        this.debugWatchChange(this.debugWatch, this.isCheckboxChecked());
+      }
+      return;
+    }
+
+    if (this.debugWatch) {
+      // This is a leaf node.
+      this.setCheckboxState(
+          this.isCheckboxChecked() ?
+              CheckboxState.CHECKED : CheckboxState.EMPTY,
+          true);
+      if (this.isCheckboxChecked()) {
+        // A checkbox just got checked. All nodes above this one are either
+        // partial or complete. Go up the tree and check.
+        this.setNodesAboveToChecked();
+      } else {
+        // A checkbox got unchecked. All nodes above this are either empty or
+        // partial now.
+        this.setNodesAboveToEmpty();
+      }
+      // Run the callback.
+      this.debugWatchChange(this.debugWatch, this.isCheckboxChecked());
+    } else {
+      // This is a meta node.
+      this.setCheckboxState(
+          this.isCheckboxChecked() ?
+              CheckboxState.CHECKED : CheckboxState.EMPTY,
+          true);
+      if (this.isCheckboxChecked()) {
+        // Check all the nodes under it.
+        const descendants = _.values(this.children) as SelectionTreeNode[];
+        while (descendants.length) {
+          let node = descendants.pop();
+          _.forEach(node.children, child => descendants.push(child));
+          node.setCheckboxState(CheckboxState.CHECKED, true);
+        }
+
+        // Reconcile nodes above.
+        this.setNodesAboveToChecked();
+      } else {
+        // Uncheck all the nodes under it.
+        const descendants = _.values(this.children) as SelectionTreeNode[];
+        while (descendants.length) {
+          let node = descendants.pop();
+          _.forEach(node.children, child => descendants.push(child));
+          node.setCheckboxState(CheckboxState.EMPTY, true);
+        }
+
+        // Reconcile nodes above.
+        this.setNodesAboveToEmpty();
+      }
+    }
+  }
+
+  isLeaf(): boolean {
+    return !!this.debugWatch;
+  }
+
+  setToAllCheckedExternally() {
+    this.setCheckboxState(CheckboxState.CHECKED);
+    this._handleChange();
+  }
+
+  setCheckboxState(state: CheckboxState, avoidPropagation?: boolean) {
+    this.avoidPropagation = avoidPropagation;
+    this.checkboxState = state;
+
+    this.checkbox.classList.toggle(
+        'partial-checkbox', state === CheckboxState.PARTIAL);
+
+    if (state === CheckboxState.CHECKED) {
+      this.checkbox.setAttribute('checked', 'checked');
+    } else {
+      this.checkbox.removeAttribute('checked');
+    }
+
+    this.avoidPropagation = false;
+  }
+
+  private isCheckboxChecked(): boolean {
+    return this.checkbox.hasAttribute('checked');
+  }
+
+  setNodesAboveToChecked() {
+    let currentNode = this.parent;
+    let partialFound = false;
+    while (currentNode) {
+      if (partialFound) {
+        // We found a PARTIAL checkbox lower in the tree. Higher up ones
+        // must also be partial (and can't be complete any more).
+        currentNode.setCheckboxState(CheckboxState.PARTIAL, true);
+      } else {
+        const index = _.findIndex(
+            _.values(currentNode.children) as SelectionTreeNode[],
+            child => (child.checkboxState !== CheckboxState.CHECKED));
+        // Either all or only some of the children were checked.
+        partialFound = index !== -1;
+        currentNode.setCheckboxState(
+            partialFound ? CheckboxState.PARTIAL : CheckboxState.CHECKED, true);
+      }
+      // Move up the tree.
+      currentNode = currentNode.parent;
+    }
+  }
+
+  setNodesAboveToEmpty() {
+    let currentNode = this.parent;
+    let partialFound = false;
+    while (currentNode) {
+      if (partialFound) {
+        // We found a PARTIAL checkbox lower in the tree. Higher up ones
+        // must also be partial (and can't be complete any more).
+        currentNode.setCheckboxState(CheckboxState.PARTIAL, true);
+      } else {
+        const index = _.findIndex(
+            _.values(currentNode.children) as SelectionTreeNode[],
+            child => (child.checkboxState !== CheckboxState.EMPTY));
+        // Either all or only some of the children were empty.
+        partialFound = index !== -1;
+        currentNode.setCheckboxState(
+            partialFound ? CheckboxState.PARTIAL : CheckboxState.EMPTY, true);
+      }
+      // Move up the tree.
+      currentNode = currentNode.parent;
+    }
+  }
+}
+
+}  // namespace tf_debugger_dashboard

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tensor-shape-helper.ts
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tensor-shape-helper.ts
@@ -86,7 +86,7 @@ export function rankFromSlicing(slicing: string): number {
   } else {
     const slicingElements: string[] = slicing.split(',');
     let rank = slicingElements.length;
-    // Examinehow many of the slicing elements are single numbers, which leads
+    // Examine how many of the slicing elements are single numbers, which leads
     // to a decrement in rank.
     for (const element of slicingElements) {
       if (!isNaN(Number(element))) {

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tensor-shape-helper.ts
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tensor-shape-helper.ts
@@ -1,0 +1,100 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace tf_debugger_dashboard {
+
+const maxElements1D = 1000;
+const maxElements2D = 250;
+
+/**
+ * Get a Python-style slicing string representing strided slicing.
+ * @param size Total size along the dimension being sliced.
+ * @param maxElements Maximum number of elements allowed in the slicing result.
+ * @returns A Python-style slicing string beginning with two colons, without
+ *   surrounding brackets.
+ */
+function getStridedSlicing(size: number, maxElements: number): string {
+  if (size <= maxElements) {
+    return '::';
+  } else {
+    return '::' + Math.ceil(size / maxElements);
+  }
+}
+
+/**
+ * Get the default slicing given a tensor shape.
+ * @param shape: The tensor shape, represented as an Array of number.
+ * @return: Numpy-style slicing string, with the surrounding brackets, e.g.,
+ *   '[::2, 0:10]'.
+ */
+export function getDefaultSlicing(shape: number[]): string {
+  if (shape.length === 0) {
+    // Scalar: no slicing.
+    return '';
+  } else if (shape.length === 1) {
+    return '[' + getStridedSlicing(shape[0], maxElements1D) + ']';
+  } else if (shape.length === 2) {
+    return '[' + getStridedSlicing(shape[0], maxElements2D) + ', '  +
+        getStridedSlicing(shape[1], maxElements2D) + ']';
+  } else if (shape.length === 3) {
+    return '[0, ' + getStridedSlicing(shape[1], maxElements2D) + ', '  +
+        getStridedSlicing(shape[2], maxElements2D) + ']';
+  } else if (shape.length === 4) {
+    // Assume NHWC as the default.
+    return '[0, ' + getStridedSlicing(shape[1], maxElements2D) + ', '  +
+        getStridedSlicing(shape[2], maxElements2D) + ', 0]';
+  } else {
+    let slicing = '[';
+    for (let i = 0; i < shape.length; ++i) {
+      if (i < shape.length - 2) {
+        slicing += '0';
+      } else {
+        slicing += getStridedSlicing(shape[i], maxElements2D);
+      }
+      if (i < shape.length - 1) {
+        slicing += ', ';
+      }
+    }
+    slicing += ']';
+    return slicing;
+  }
+}
+
+/**
+ * Determine rank of a slicing string.
+ * @param slicing The slicing string.
+ * @return The rank.
+ */
+export function rankFromSlicing(slicing: string): number {
+  if (slicing.startsWith('[')) {
+    slicing = slicing.slice(1, slicing.length - 1);
+  }
+  if (slicing.length === 0) {
+    // Scalar: no slicing.
+    return 0;
+  } else {
+    const slicingElements: string[] = slicing.split(',');
+    let rank = slicingElements.length;
+    // Examinehow many of the slicing elements are single numbers, which leads
+    // to a decrement in rank.
+    for (const element of slicingElements) {
+      if (!isNaN(Number(element))) {
+        rank--;
+      }
+    }
+    return rank;
+  }
+}
+
+}  // namespace tf_debugger_dashboard

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -841,7 +841,6 @@ limitations under the License.
     tf_tensorboard.registerDashboard({
       plugin: 'debugger',
       elementName: 'tf-debugger-dashboard',
-      tabName: 'Debugger',   // TODO(cais): Confirm necessary.
     });
 
   </script>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -1,0 +1,848 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../paper-button/paper-button.html">
+<link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
+<link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="../paper-input/paper-textarea.html">
+<link rel="import" href="../paper-item/paper-item.html">
+<link rel="import" href="../paper-menu/paper-menu.html">
+<link rel="import" href="../paper-toast/paper-toast.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
+<link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
+<link rel="import" href="../tf-graph/tf-graph.html">
+<link rel="import" href="../tf-graph-loader/tf-graph-loader.html">
+<link rel="import" href="../tf-imports/lodash.html">
+<link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
+<link rel="import" href="../tf-tensorboard/registry.html">
+<link rel="import" href="tf-debugger-initial-dialog.html">
+<link rel="import" href="tf-op-selector.html">
+<link rel="import" href="tf-session-runs-view.html">
+<link rel="import" href="tf-tensor-data-summary.html">
+<link rel="import" href="tf-tensor-value-multi-view.html">
+
+<dom-module id="tf-debugger-dashboard">
+  <template>
+    <paper-toast id="toast" text="" always-on-top></paper-toast>
+    <paper-dialog with-backdrop id="continueDialog" width="320">
+      <h2>Continue...</h2>
+      <paper-input
+        id="continueNum"
+        label="Number of times (including current one):"
+        always-float-label
+        type="number"
+        min="1"
+        step="1"
+        value="[[_continueNum]]"
+        on-change="_continueNumChanged"
+      ></paper-input>
+      <paper-button raised class="continue-go-button" on-click="_continueGo">
+        <span>Go</span>
+      </paper-button>
+    </paper-dialog>
+    <tf-debugger-initial-dialog
+      id="initialDialog"
+    >
+    </tf-debugger-initial-dialog>
+    <!-- TODO(caisq, chihuahua): This shouldn't be a dialog. It should be a prettier
+      widget that supports showing both text, curves and images. -->
+    <tf-dashboard-layout>
+      <div class="sidebar">
+        <div id="node-entries" class="node-entries">
+          <div class="debugger-section-title">Node List</div>
+          <tf-op-selector
+              debug-watches=[[_debugWatches]]
+              debug-watch-change="[[_createDebugWatchChangeHandler()]]"
+              node-clicked="[[_createListNodeClickedHandler()]]"
+              force-expansion-node-name="[[_forceExpansionNodeName]]">
+          </tf-op-selector>
+        </div>
+        <div class="sidebar-section">
+          <tf-session-runs-view
+            id="sessionRunsView"
+            latest-session-run="[[_latestSessionRun]]"
+            session-run-key-to-device-names="[[_sessionRunKey2DeviceNames]]"
+            sole-active="[[_sessionRunSoleActive]]">
+          </tf-session-runs-view>
+          <br/>
+          <div>
+              <paper-button raised class="continue-button" on-click="_step">
+                  <span>[[_stepButtonText]]</span>
+              </paper-button>
+              <paper-button
+                  raised
+                  class="continue-button"
+                  on-click="_openContinueDialog">
+                  <span>[[_continueButtonText]]</span>
+              </paper-button>
+          </div>
+        </div>
+        <div class="container">
+          <tf-graph-loader id="loader"
+              out-graph-hierarchy="{{graphHierarchy}}"
+              out-graph="{{graph}}"
+              out-stats="{{stats}}"
+              progress="{{_progress}}"
+          ></tf-graph-loader>
+        </div>
+      </div>
+      <div class="center">
+        <div id="top-right-content-container">
+          <paper-tabs selected="0" selected="{{_topRightSelected}}">
+            <template is="dom-repeat" items="[[_topRightTabs]]">
+              <paper-tab id="[[item.id]]">[[item.name]]</paper-tab>
+            </template>
+          </paper-tabs>
+          <span id="runtime-graph-device-name">
+          </span>
+          <paper-dropdown-menu
+            id="active-runtime-graph-device-name"
+            no-label-float="true"
+            label="Device name"
+            selected-item-label="{{_activeRuntimeGraphDeviceName}}"
+          >
+            <paper-menu class="dropdown-content" slot="dropdown-content">
+              <template is="dom-repeat" items="[[_activeSessionRunDevices]]">
+                <paper-item no-label-float=true>[[item]]</paper-item>
+              </template>
+            </paper-menu>
+          </paper-dropdown-menu>
+          <template is="dom-if" if="[[_isTopRightRuntimeGraphsActive]]">
+            <div id="graph-header">
+              <span id="runtime-graph-label">
+                Runtime Graphs
+              </span>
+            </div>
+            <div id="graph-container">
+              <tf-graph id="graph"
+                  graph-hierarchy="[[graphHierarchy]]"
+                  basic-graph="[[graph]]"
+                  stats="[[stats]]"
+                  progress="[[_progress]]"
+                  color-by="structure"
+                  color-by-params="{{colorByParams}}"
+                  render-hierarchy="{{_renderHierarchy}}"
+                  node-context-menu-items="[[_createNodeContextMenuItems()]]"
+              ></tf-graph>
+              <div class="context-menu"></div>
+            </div>
+          </template>
+          <template is="dom-if" if="[[_isTopRightTensorValuesActive]]">
+            <tf-tensor-value-multi-view
+              id="tensorValueMultiView">
+            </tf-tensor-value-multi-view>
+          </template>
+        </div>
+
+        <div id="tensor-data" class="tensor-data">
+          <div class="debugger-section-title">Tensor Value Summary</div>
+          <tf-tensor-data-summary
+            latest-tensor-data="[[_latestTensorData]]"
+            expand-handler="[[_createTensorDataExpandHandler()]]">
+          </tf-tensor-data-summary>
+        </div>
+      </div>
+    </tf-dashboard-layout>
+
+    <style include="dashboard-style"></style>
+    <style>
+      .debugger-section-title {
+        font-size: 110%;
+        font-weight: bold;
+      }
+      paper-tabs {
+        color: #555;
+        font-weight: normal;
+      }
+      paper-tab.iron-selected {
+        color: black;
+        font-weight: bold;
+      }
+      #graph-container {
+        position: relative;
+      }
+      #graph {
+        display: block;
+        width: 100%;
+        height: 400px;
+      }
+      #tooltip-sorting {
+        display: flex;
+        font-size: 14px;
+        margin-top: 5px;
+      }
+      #tooltip-sorting-label {
+        margin-top: 13px;
+      }
+      #tooltip-sorting paper-dropdown-menu {
+        margin-left: 10px;
+        --paper-input-container-focus-color: var(--tb-orange-strong);
+        width: 105px;
+      }
+      #x-type-selector paper-button {
+        margin: 5px 3px;
+      }
+      #runtime-graph-device-name {
+        font-size: 85%;
+        word-break: break-all;
+        display: inline-block;
+      }
+      #active-runtime-graph-device-name {
+        font-size: 85%;
+        width: 350px;
+        display: inline-block;
+      }
+      .line-item {
+        display: block;
+        padding-top: 5px;
+      }
+      .no-data-warning {
+        max-width: 540px;
+        margin: 80px auto 0 auto;
+      }
+      .center {
+        position: relative;
+        height: 100%;
+      }
+      .context-menu {
+        position: absolute;
+        display: none;
+        background-color: #e2e2e2;
+        border-radius: 2px;
+        font-size: 14px;
+        min-width: 150px;
+        border: 1px solid #d4d4d4;
+      }
+      .node-entries {
+        height: 66%;
+        overflow: auto;
+        padding-top: 3px;
+        padding-left: 3px;
+        padding-right: 3px;
+        box-shadow: 3px 3px #ddd;
+      }
+      .tensor-data {
+        height: 34%;
+        overflow: auto;
+      }
+      #top-right-content-container {
+        height: 66%;
+        overflow: auto;
+      }
+      /deep/ .context-menu ul {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+        cursor: default;
+      }
+      /deep/ .context-menu ul li {
+        padding: 4px 16px;
+      }
+      /deep/ .context-menu ul li:hover {
+        background-color: #f3913e;
+        color: white;
+      }
+
+      paper-input {
+        width: 200px;
+      }
+      .inline, paper-item {
+        display: inline;
+      }
+
+      vz-line-chart {
+        height: 300px;
+        position: relative;
+      }
+    </style>
+  </template>
+  <script src="tensor-shape-helper.js"></script>
+  <script>
+
+    Polymer({
+      is: 'tf-debugger-dashboard',
+      properties: {
+        _topRightTabs: {
+          type: Array,
+          value: [
+            {id: 'tab-runtime-graphs', name: 'Runtime Graphs'},
+            {id: 'tab-tensor-values', name: 'Tensor Values'},
+            {id: 'tab-python-source', name: 'Python Source'}
+          ],
+          readonly: true,
+        },
+        _isTopRightRuntimeGraphsActive: {
+          type: Boolean,
+          value: true,
+        },
+        _isTopRightTensorValuesActive: {
+          type: Boolean,
+          value: false,
+        },
+        _isTopRightPythonSourceActive: {
+          type: Boolean,
+          value: false,
+        },
+        _topRightSelected: {
+          type: String,
+          value: "0",
+          observer: '_topRightSelectedChanged',
+        },
+
+        _longPollCount: {
+            type: Number,
+            value: 0,
+        },
+        _stepButtonText: {
+            type: String,
+            value: 'Step',
+        },
+        _continueButtonText: {
+            type: String,
+            value: 'Continue...',
+        },
+        _continueNum: {  // How many times to continue over, e.g., Session.Runs.
+            type: Number,
+            value: 5,
+        },
+
+        _tensorViewIdCounter: {
+            type: Number,
+            value: 0,
+        },
+
+        isReloadDisabled: {
+          type: Boolean,
+          value: true,
+          readOnly: true,
+        },
+        alreadyStarted: {
+          type: Boolean,
+          value: false,
+        },
+        _currentSessionRunInfo: {
+          type: String,
+          value: null,
+        },
+        _sessionRunCounters: {
+          type: Object,
+          value: {},
+        },
+        // A map from Session.run key to names of devices involved..
+        _sessionRunKey2DeviceNames: {
+          type: Object,
+          value: {},
+        },
+        _activeSessionRunKey: {   // TODO(cais): Maybe deduplicate with below.
+          type: String,
+          value: null,
+        },
+        _activeSessionRunDevices: {
+          type: Array,
+          value: [],
+        },
+        _activeSessionRunNumDevices: {
+          type: Number,
+          value: -1,
+        },
+        _activeRuntimeGraphDeviceName: {
+          type: String,
+          value: null,
+          notify: true,
+        },
+
+        // What kind of entity to continue over. Possibilities:
+        // {'', 'SessionRun', 'tensor'}. TODO(cais): Implement tensor logic.
+        // '' is the default state, i.e., a state where the UI is not continuing
+        // over anything.
+        _continueToType: {
+          type: String,
+          value: '',
+        },
+        // The target of the continue-to action. For example, for _continueToType ==
+        // 'SessionRun', this can be the session run string. For _continueToType ==
+        // 'tensor', this can be a debug tensor name.
+        _continueToTarget: {
+          type: String,
+          value: '',
+        },
+        // A counter target for the continue-to action. This can be a Session.Run index
+        // if _continueToType == 'SessionRun'.
+        _continueToCounterTarget: {
+          type: Number,
+          value: -1,
+        },
+
+        _requestManager: {
+           type: Object,
+           value: () => new tf_backend.RequestManager(50),
+        },
+      },
+
+      observers: [
+        "_onActiveRuntimeGraphDeviceNameChange(_activeRuntimeGraphDeviceName)",
+      ],
+
+      ready() {
+        this.reload();
+      },
+
+      long_poll() {
+        const parameters = {
+          'pos': ++this._longPollCount,
+        };
+        let path = tf_backend.getRouter().pluginRoute('debugger', '/comm');
+        path = tf_backend.addParams(path, parameters);
+        console.log('Sending long-polling request to: ', path);
+        this._requestManager.request(path).then(response => {
+          const responseType = response['type'];
+          const responseData = response['data'];
+          if (responseType == 'meta') {
+            const runKey = responseData['run_key'];
+            const feedNames = runKey[0].split(',');
+            const fetchNames = runKey[1].split(',');
+            const targetNames = runKey[2].split(',');
+            this.set('_activeSessionRunKey', runKey);
+            this.set('_latestSessionRun', {
+              'feeds': feedNames,
+              'fetches': fetchNames,
+              'targets': targetNames,
+            });
+            this.set('_sessionRunSoleActive', true);
+            if (this._sessionRunKey2DeviceNames[runKey] === undefined) {
+              this._sessionRunKey2DeviceNames[runKey] = [];
+              this.set('_activeSessionRunDevices', []);
+            } else {
+              this.set('_activeSessionRunDevices',
+                       this._sessionRunKey2DeviceNames[runKey]);
+            }
+
+            const runInfo = 'Feeds: ' + feedNames + '; Fetches: ' +
+                fetchNames + '; Targets: ' + targetNames;
+            this._currentSessionRunInfo = runInfo;
+            if (this._sessionRunCounters.hasOwnProperty(runInfo)) {
+              this._sessionRunCounters[runInfo] += 1;
+            } else {
+              this._sessionRunCounters[runInfo] = 1;
+            }
+            this.$.initialDialog.closeDialog();
+
+            if (!this._continueToType) {
+              // Do not refresh node list if we are in continue model.
+              this._processGatedGrpcDebugOps(runKey, false);
+              this._showToast('A new Session.run() has begun.');
+            }
+          } else if (responseType == 'tensor') {
+            const deviceName = responseData['device_name'];
+            const nodeName = responseData['node_name'];
+            const maybeBaseExpandedNodeName = responseData[
+                'maybe_base_expanded_node_name'];
+
+            if (this._activeRuntimeGraphDeviceName != deviceName) {
+              // The logic here is a workaround. When the device name needs to
+              // be changed, the graph rendering often finishes so late that
+              // the set selectedNode call will error out.
+              // TODO(cais): Find a way to change the graph and change the
+              // selectedNode in the same tensor value event.
+              this.set('_activeRuntimeGraphDeviceName', deviceName);
+            } else {
+              if (!this._continueToType) {
+                // Do not refresh graph to focus on the current node if we are
+                // in continue mode.
+                if (this._isTopRightRuntimeGraphsActive) {
+                  this.$$('#graph').set('selectedNode', maybeBaseExpandedNodeName);
+                }
+              }
+            }
+
+            this.set('_sessionRunSoleActive', false);
+            const tensorName = nodeName + ':' + responseData['output_slot'];
+            this.set('_latestTensorData', {
+              tensorName: tensorName,
+              debugOp: responseData['debug_op'],
+              dtype: responseData['dtype'],
+              shape: responseData['shape'],
+              value: responseData['values'],
+            });
+
+            this._maybeUpdateTensorValueViews(
+                tensorName, responseData['debug_op']);
+          } else {
+            console.error(
+                'Invalid long-polling response type: ', responseType);
+          }
+
+          if (this._continueToType === 'SessionRun') {
+            if (this._sessionRunCounters[this._currentSessionRunInfo] <
+                this._continueToCounterTarget) {
+              this._step();
+            } else {
+              this._clearContinueTo();
+            }
+          }
+
+          // Long polling loop: initialite the next long polling.
+          this.long_poll();
+        });
+      },
+
+      _maybeUpdateTensorValueViews(tensorName, debugOp) {
+        const multiView = this.$$('#tensorValueMultiView');
+        if (multiView == null) {
+          return;
+        }
+        let anyTensorMatch = false;
+        _.forEach(multiView.getViews(), valueView => {
+          if (valueView.tensorName === tensorName &&
+              valueView.debugOp === debugOp) {
+            anyTensorMatch = true;
+            return false;  // lodash break.
+          }
+        });
+        if (anyTensorMatch) {
+          multiView.renderTensorValues();
+        }
+      },
+
+      reload() {
+        if (this.alreadyStarted) {
+          return;
+        }
+
+        const url = tf_backend.getRouter().pluginRoute(
+            'debugger', '/debugger_grpc_host_port');
+        this._requestManager.request(url).then(response => {
+          // TODO(cais): If the TDP backend is not activated, display message
+          // informing the user of that.
+          this.$.initialDialog.openDialog(response.host, response.port);
+        }).catch(error => {
+          this.$.initialDialog.renderDebuggerNotEnabledMessage();
+        });
+
+        // Initiate long-polling.
+        this.long_poll();
+
+        this.set('alreadyStarted', true);
+      },
+
+      _openContinueDialog() {
+        this.$.continueDialog.open();
+      },
+
+      _showToast(text) {  // TODO(cais): Move to Scrolling Message View.
+        this.$.toast.setAttribute('text', text);
+        this.$.toast.open();
+      },
+
+      _displayGraph(runKey, deviceName) {
+        const parameters = {
+          'run_key': JSON.stringify(runKey),
+          'device_name': deviceName,
+        };
+        const baseUrl = '/data/plugin/debugger/debugger_graph';
+        const url = tf_backend.addParams(baseUrl, parameters);
+        this.$.loader.datasets = [{
+          "name": "/debugger_graph",
+          "path": url,
+        }];
+        this.$.loader.set("selectedDataset", 0);
+        this.$$('.container').style.width = '600px';
+        this.$$('.container').style.width = '450px';
+      },
+
+      _processGatedGrpcDebugOps(runKey, pollingForFirstGraph) {
+        if (pollingForFirstGraph) {
+          console.log('Polling for first GraphDef for run key:', runKey);
+        } else {
+          this.set('_activeRuntimeGraphDeviceName', null);
+        }
+
+        const parameters = {
+          'mode': 'retrieve_all',
+          'run_key': JSON.stringify(runKey),
+        };
+        const baseUrl = tf_backend.getRouter().pluginRoute('debugger', '/gated_grpc');
+        const url = tf_backend.addParams(baseUrl, parameters);
+        let debugWatches = [];
+        this._requestManager.request(url).then(response => {
+          if (response['device_names'].length == 0) {
+            if (!pollingForFirstGraph) {
+              // Not even a single device / runtime GraphDef has been received
+              // when the Session.run starts. This is likely a Session.run
+              // controlling in-graph-distributed devices.
+              // Will send a step() ACK response to unblock the first graph send.
+              this._step();
+              this._processGatedGrpcDebugOps(runKey, true);
+            } else {
+              // GraphDef still hasn't arrived. Poll again.
+              this._processGatedGrpcDebugOps(runKey, true);
+            }
+            return;
+          }
+
+          let lastDeviceName = null;
+          for (const deviceName in response['gated_grpc_tensors']) {
+            if (response['gated_grpc_tensors'].hasOwnProperty(deviceName)) {
+              if (this._sessionRunKey2DeviceNames[runKey].indexOf(deviceName) === -1) {
+                this._sessionRunKey2DeviceNames[runKey].push(deviceName);
+                this.$.sessionRunsView.updateNumDevices(
+                    this._sessionRunKey2DeviceNames[runKey].length);
+              }
+              this.set('_activeSessionRunDevices',
+                       this._sessionRunKey2DeviceNames[runKey].slice());
+              lastDeviceName =
+                  this._activeSessionRunDevices[this._activeSessionRunDevices.length - 1];
+
+              const gatedGrpcTensors = response['gated_grpc_tensors'][deviceName];
+              for (let i = 0; i < gatedGrpcTensors.length; ++i) {
+                debugWatches.push(
+                    {'node_name': deviceName + '/' + gatedGrpcTensors[i][0],
+                     'op_type': gatedGrpcTensors[i][1],
+                     'output_slot': gatedGrpcTensors[i][2],
+                     'debug_op': gatedGrpcTensors[i][3]});
+              }
+            }
+          }
+
+          if (lastDeviceName != null) {
+            this.set('_activeRuntimeGraphDeviceName', lastDeviceName);
+            // TODO(cais): Make automatic updating of the selected device name work?
+            const dropdownMenu = Polymer.dom(this.$$('#active-runtime-graph-device-name'));
+            if (dropdownMenu != null) {
+              dropdownMenu.setAttribute('selected', lastDeviceName);
+            }
+          }
+
+          // Sort the debug watches and maybe base-expand the leaf nodes.
+          tf_debugger_dashboard.sortAndBaseExpandDebugWatches(debugWatches);
+          this.set('_debugWatches', debugWatches);
+        });
+      },
+      _createDebugWatchChangeHandler() {
+        // This method returns a handler instead of having this method being
+        // directly passed to the property binding. This is because the handler
+        // references other properties of this component, and so the execution
+        // context of the function (this) must be bound to the dashboard.
+        return ((debugObject, checked) => {
+          const state = checked ? 'break' : 'disable';
+          // TODO(cais): Investigate why this is fired twice sometimes.
+          this._requestBreakpointStateChange(
+              tf_debugger_dashboard.getCleanNodeName(debugObject.node_name),
+              debugObject.output_slot, debugObject.debug_op, state);
+        });
+      },
+      _createListNodeClickedHandler() {
+        return((deviceName, nodeName) => {
+          if (deviceName != null &&
+              this._activeRuntimeGraphDeviceName !== deviceName) {
+            this.set('_activeRuntimeGraphDeviceName', deviceName);
+          }
+          this._setTopRightRuntimeGraphsToActive();
+          this.$$('#graph').set('selectedNode', nodeName);
+        });
+      },
+
+      _createTensorDataExpandHandler() {
+        const self = this;
+        function handleTensorDataExpand(tensorData) {
+          const multiView = self.$$('#tensorValueMultiView');
+          if (multiView == null) {
+            self._setTopRightTensorValuesToActive();
+            self._showToast('Switching to Tensor Values View! Click me again!');
+            return;
+          }
+          multiView.addView({
+            viewId: self._createTensorViewId(),
+            tensorName: tensorData.tensorName,
+            debugOp: tensorData.debugOp,
+            slicing: tf_debugger_dashboard.getDefaultSlicing(tensorData.shape),
+            timeIndices: '-1',
+          });
+        };
+        return handleTensorDataExpand;
+      },
+
+      _createTensorViewId() {
+        const id = "debugger-tensor-view-" + this._tensorViewIdCounter;
+        this._tensorViewIdCounter++;
+        return id;
+      },
+
+      // Create menu title and callback for the node context menus in the graph
+      // visualizer.
+      _createNodeContextMenuItems() {
+        return [
+          {
+            title: (data) => {
+              // TODO(cais): Make this 'Toggle breakpoint'.
+              return 'Add breakpoint';
+            },
+            action: (elem, d, i) => {
+              const nodeName =
+                  tf_debugger_dashboard.getCleanNodeName(elem.node.name);
+              this.set('_forceExpansionNodeName',
+                       this._activeRuntimeGraphDeviceName + '/' + elem.node.name);
+            },
+          },
+        ];
+      },
+
+      _onActiveRuntimeGraphDeviceNameChange(deviceName) {
+        const deviceNameElement = Polymer.dom(this.$$('#runtime-graph-device-name'));
+        if (this._activeSessionRunDevices.length > 0) {
+          let deviceGraphLabel = deviceName;
+          deviceGraphLabel +=
+               ' (device ' + (this._activeSessionRunDevices.indexOf(deviceName) + 1) +
+               ' of ' + this._activeSessionRunDevices.length + ')';
+          if (this._isTopRightRuntimeGraphsActive) {
+            if (deviceNameElement != null ) {
+              deviceNameElement.textContent = deviceGraphLabel;
+            }
+          }
+        } else {
+          if (this._isTopRightRuntimeGraphsActive) {
+            if (deviceNameElement != null) {
+              deviceNameElement.textContent = 'Waiting for device...';
+            }
+          }
+        }
+        if (!this._continueToType) {
+          // Do not refresh graph if we are in continue mode.
+          this._displayGraph(this._activeSessionRunKey, deviceName);
+        }
+      },
+
+      _step() {
+        // Do nothing if we are currently not in a Session.run.
+        if (this._activeSessionRunKey == null) {
+          return;
+        }
+
+        // First, check to see if any new device GraphDef(s) have arrived and if
+        // so, retrieve them.
+        const parameters = {
+          'mode': 'retrieve_device_names',
+          'run_key': JSON.stringify(this._activeSessionRunKey),
+        };
+        const baseUrl = tf_backend.getRouter().pluginRoute('debugger', '/gated_grpc');
+        const url = tf_backend.addParams(baseUrl, parameters);
+        let debugWatches = [];
+        this._requestManager.request(url).then(response => {
+          let anyNewDevices = false;
+          for (let i = 0; i < response['device_names'].length; ++i) {
+            const deviceName = response['device_names'][i];
+            if (this._activeSessionRunDevices.indexOf(deviceName) === -1) {
+              anyNewDevices = true;
+              break;
+            }
+          }
+          const url = tf_backend.getRouter().pluginRoute('debugger', '/ack');
+          this._requestManager.request(url).then(response => {
+            if (anyNewDevices) {
+              // If there are new device(s), display them in the graph
+              // visualizer and the node list, to allow user to select
+              // breakpoints.
+              this._processGatedGrpcDebugOps(this._activeSessionRunKey, false);
+            }
+          });
+        });
+      },
+
+      _continueGo() {
+        if (this._continueNum > 0) {
+          this._setContinueTo('SessionRun', this._currentSessionRunInfo,
+              this._sessionRunCounters[this._currentSessionRunInfo] +
+              this._continueNum);
+          this._step();
+          this.$.continueDialog.close();
+        } else {
+          this._continueNum = 1;
+        }
+      },
+      _continueNumChanged(e) {
+        this._continueNum = e.target.valueAsNumber;
+      },
+      _setContinueTo(type, target, counter_target) {
+        this._continueToType = type;
+        this._continueToTarget = target;
+        this._continueToCounterTarget = counter_target;
+      },
+      _clearContinueTo() {
+        this._continueToType = '';
+        this._continueToTarget = '';
+        this._continueToCounterTarget = -1;
+      },
+
+      _topRightSelectedChanged(topRightSelected) {
+        const selectedId = this._topRightTabs[topRightSelected].id;
+        this.set('_isTopRightRuntimeGraphsActive',
+                 selectedId === 'tab-runtime-graphs');
+        this.set('_isTopRightTensorValuesActive',
+                 selectedId === 'tab-tensor-values');
+        this.set('_isTopRightPythonSourceActive',
+                 selectedId === 'tab-python-source');
+      },
+      _setTopRightRuntimeGraphsToActive() {
+        this.set('_topRightSelected', '0');
+        this.set('_isTopRightRuntimeGraphsActive', true);
+        this.set('_isTopRightTensorValuesActive', false);
+        this.set('_isTopRightPythonSourceActive', false);
+      },
+      _setTopRightTensorValuesToActive() {
+        this.set('_topRightSelected', '1');
+        this.set('_isTopRightRuntimeGraphsActive', false);
+        this.set('_isTopRightTensorValuesActive', true);
+        this.set('_isTopRightPythonSourceActive', false);
+      },
+
+      /**
+       * Request a state change for a breakpoint associated with a debugged tensor.
+       * @param nodeName Name of the node that produces the tensor.
+       * @param outputSlot Output slot of the tensor on the node.
+       * @param debugOp Name of the debug op attached to the debugged tensor, e.g.,
+       *   'DebugIdentity'.
+       * @param newState New state, e.g., 'disable', 'break'.
+       */
+      _requestBreakpointStateChange(nodeName, outputSlot, debugOp, newState) {
+        // TODO(cais): Add deviceName to args, to handle cases in which there are
+        // duplicate node names across devices (rare).
+        const parameters = {
+          'mode': 'set_state',
+          'node_name': nodeName,
+          'output_slot': outputSlot,
+          'debug_op': debugOp,
+          'state': newState,
+        };
+        const baseUrl = tf_backend.getRouter().pluginRoute('debugger', '/gated_grpc');
+        const url = tf_backend.addParams(baseUrl, parameters);
+        this._requestManager.request(url).then(response => {
+          console.log('Breakpoint set_state response: ', response);
+        });
+      },
+    });
+
+    tf_tensorboard.registerDashboard({
+      plugin: 'debugger',
+      elementName: 'tf-debugger-dashboard',
+      tabName: 'Debugger',   // TODO(cais): Confirm necessary.
+    });
+
+  </script>
+</dom-module>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
@@ -24,8 +24,24 @@ limitations under the License.
     <paper-dialog with-backdrop id="dialog" width="320" modal>
       <h2 id='dialog-title'>Waiting for first Session.run() to connect...</h2>
       <div class='code-example'>
-        <span id='session-run-code-example' ></span>
-        <span id='hook-code-example'></span>
+        <!-- TODO(cais): Rename id. -->
+        <pre id="session-run-code-example">
+# To connect to the debugger from your tf.Session:
+from tensorflow.python import debug as tf_debug
+sess = tf.Session()
+def watch_fn(fetches, feeds):
+  return tf_debug.WatchOptions(debug_ops=["DebugIdentity(gated_grpc=true)"])
+sess = tf_debug.GrpcDebugWrapperSession(sess, "[[_host]]:[[_port]]", watch_fn=watch_fn)
+sess.run(my_fetches)
+        </pre>
+        <pre id="hook-code-example">
+# To connect to the debugger using hooks, e.g., from tf.Estimator:
+from tensorflow.python import debug as tf_debug
+def watch_fn(fetches, feeds):
+  return tf_debug.WatchOptions(debug_ops=["DebugIdentity(gated_grpc=true)"])
+hook = tf_debug.GrpcDebugHook("[[_host]]:[[_port]]", watch_fn=watch_fn)
+my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
+        </pre>
       </div>
     </paper-dialog>
   </template>
@@ -40,14 +56,22 @@ limitations under the License.
   Polymer({
     is: "tf-debugger-initial-dialog",
     properties: {
+      _host: {
+        type: String,
+        value: null,
+      },
+      _port: {
+        type: String,
+        value: null,
+      },
     },
 
     openDialog(host, port) {
       this.$.dialog.open();
       if (host != null && port != null) {
         // TODO(cais): Use markdown; syntax highlight Python code.
-        this._renderSessionRunCodeExample(host, port);
-        this._renderHookCodeExample(host, port);
+        this.set('_host', host);
+        this.set('_port', port);
       }
     },
     closeDialog() {
@@ -56,36 +80,11 @@ limitations under the License.
     renderDebuggerNotEnabledMessage() {
       this.$.dialog.open();
       Polymer.dom(this.$$('#dialog-title')).textContent =
-          'ERROR: debugger is not enabled in this TensorBoard instance';
-      let ex = '<br/># To enable the debugger in tensorboard, use the flag:<br/>'
-      ex += '&nbsp&nbsp--debugger_data_server_grpc_port port_number<br/>'
-      Polymer.dom(this.$$('#hook-code-example')).innerHTML = ex;
-    },
-
-    _renderSessionRunCodeExample(host, port) {
-      let ex = '<br/># To connect to the debugger from your tf.Session:<br/>';
-      ex += 'from tensorflow.python import debug as tf_debug<br/>';
-      ex += 'sess = tf.Session()<br/>';
-      ex += 'def watch_fn(fetches, feeds):<br/>';
-      ex += '&nbsp&nbspreturn tf_debug.WatchOptions(debug_ops=["DebugIdentity(gated_grpc=true)"])<br/>';
-      // TODO(cais): GrpcDebugWrapperSession should provide a gated option to
-      // avoid the tedious watch_fn.
-      ex += 'sess = tf_debug.GrpcDebugWrapperSession(sess, "' +
-            host + ':' + port + '", watch_fn=watch_fn)<br/>';
-      ex += 'sess.run(my_fetches)<br/>';
-      Polymer.dom(this.$$('#session-run-code-example')).innerHTML = ex;
-    },
-    _renderHookCodeExample(host, port) {
-      let ex = '<br/># To connect to the debugger using hooks, e.g., from tf.Estimator:<br/>';
-      ex += 'from tensorflow.python import debug as tf_debug<br/>';
-      ex += 'def watch_fn(fetches, feeds):<br/>';
-      ex += '&nbsp&nbspreturn tf_debug.WatchOptions(debug_ops=["DebugIdentity(gated_grpc=true)"])<br/>';
-      ex += 'hook = tf_debug.GrpcDebugHook("' +
-            host + ':' + port + '", watch_fn=watch_fn)<br/>';
-      // TODO(cais): GrpcDebugWrapperSession should provide a gated option to
-      // avoid the tedious watch_fn.
-      ex += 'my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])<br/>';
-      Polymer.dom(this.$$('#hook-code-example')).innerHTML = ex;
+          'ERROR: debugger is not enabled in this TensorBoard instance.';
+      let ex = 'To enable the debugger in tensorboard, use the flag: ' +
+               '--debugger_port <port_number>'
+      Polymer.dom(this.$$('#session-run-code-example')).textContent = ex;
+      Polymer.dom(this.$$('#hook-code-example')).textContent = '';
     },
   });
   </script>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
@@ -1,0 +1,92 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/lodash.html">
+
+
+<dom-module id="tf-debugger-initial-dialog">
+  <template>
+    <paper-dialog with-backdrop id="dialog" width="320" modal>
+      <h2 id='dialog-title'>Waiting for first Session.run() to connect...</h2>
+      <div class='code-example'>
+        <span id='session-run-code-example' ></span>
+        <span id='hook-code-example'></span>
+      </div>
+    </paper-dialog>
+  </template>
+  <style>
+      .code-example {
+        margin: 10px;
+        font-family: monospace;
+      }
+  </style>
+  <script>
+
+  Polymer({
+    is: "tf-debugger-initial-dialog",
+    properties: {
+    },
+
+    openDialog(host, port) {
+      this.$.dialog.open();
+      if (host != null && port != null) {
+        // TODO(cais): Use markdown; syntax highlight Python code.
+        this._renderSessionRunCodeExample(host, port);
+        this._renderHookCodeExample(host, port);
+      }
+    },
+    closeDialog() {
+      this.$.dialog.close();
+    },
+    renderDebuggerNotEnabledMessage() {
+      this.$.dialog.open();
+      Polymer.dom(this.$$('#dialog-title')).textContent =
+          'ERROR: debugger is not enabled in this TensorBoard instance';
+      let ex = '<br/># To enable the debugger in tensorboard, use the flag:<br/>'
+      ex += '&nbsp&nbsp--debugger_data_server_grpc_port port_number<br/>'
+      Polymer.dom(this.$$('#hook-code-example')).innerHTML = ex;
+    },
+
+    _renderSessionRunCodeExample(host, port) {
+      let ex = '<br/># To connect to the debugger from your tf.Session:<br/>';
+      ex += 'from tensorflow.python import debug as tf_debug<br/>';
+      ex += 'sess = tf.Session()<br/>';
+      ex += 'def watch_fn(fetches, feeds):<br/>';
+      ex += '&nbsp&nbspreturn tf_debug.WatchOptions(debug_ops=["DebugIdentity(gated_grpc=true)"])<br/>';
+      // TODO(cais): GrpcDebugWrapperSession should provide a gated option to
+      // avoid the tedious watch_fn.
+      ex += 'sess = tf_debug.GrpcDebugWrapperSession(sess, "' +
+            host + ':' + port + '", watch_fn=watch_fn)<br/>';
+      ex += 'sess.run(my_fetches)<br/>';
+      Polymer.dom(this.$$('#session-run-code-example')).innerHTML = ex;
+    },
+    _renderHookCodeExample(host, port) {
+      let ex = '<br/># To connect to the debugger using hooks, e.g., from tf.Estimator:<br/>';
+      ex += 'from tensorflow.python import debug as tf_debug<br/>';
+      ex += 'def watch_fn(fetches, feeds):<br/>';
+      ex += '&nbsp&nbspreturn tf_debug.WatchOptions(debug_ops=["DebugIdentity(gated_grpc=true)"])<br/>';
+      ex += 'hook = tf_debug.GrpcDebugHook("' +
+            host + ':' + port + '", watch_fn=watch_fn)<br/>';
+      // TODO(cais): GrpcDebugWrapperSession should provide a gated option to
+      // avoid the tedious watch_fn.
+      ex += 'my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])<br/>';
+      Polymer.dom(this.$$('#hook-code-example')).innerHTML = ex;
+    },
+  });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-line-chart.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-line-chart.html
@@ -1,0 +1,115 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../vz-line-chart/vz-line-chart.html">
+
+<dom-module id="tf-debugger-line-chart">
+  <template>
+    <vz-line-chart
+      x-components-creation-method="[[_lineChartXComponentsCreationMethod]]"
+      y-value-accessor="[[_lineChartYValueAccessor]]"
+      color-scale="[[_lineChartColorScaleFunction]]"
+      tooltip-columns="[[_lineChartTooltipColumns]]"
+      smoothing-enabled="[[_lineChartSmoothingEnabled]]"
+    ></vz-line-chart>
+    <style>
+      vz-line-chart {
+        height: 300px;
+        position: relative;
+      }
+    </style>
+  </template>
+
+  <script>
+    Polymer({
+      is: "tf-debugger-line-chart",
+      properties: {
+        xData: {
+          type: Array,
+          value: [],
+        },
+        yData: {
+          type: Array,
+          value: [],
+        },
+
+        _lineChartXComponentsCreationMethod: {
+          type: Object,
+          readOnly: true,
+          value: () => (() => {
+            const scale = new Plottable.Scales.Linear();
+            return {
+              scale: scale,
+              axis: new Plottable.Axes.Numeric(scale, 'bottom'),
+              accessor: d => d.step,
+            };
+          }),
+        },
+        _lineChartYValueAccessor: {
+          type: Object,
+          readOnly: true,
+          // This function returns a function because polymer calls the outer
+          // function to compute the value. We actually want the value of this
+          // property to be the inner function.
+          value: () => (d => d.scalar),
+        },
+        _lineChartColorScaleFunction: {
+          type: Object,  // function: string => string
+          value: () => ({scale: tf_color_scale.runsColorScale}),
+        },
+        _lineChartTooltipColumns: {
+          type: Array,
+          readOnly: true,
+          value: () => {
+            return [
+              {
+                title: 'Name',
+                evaluate: (d) => {
+                  return 'step=' + d.datum.step + '; scalar= ' + d.datum.scalar;
+                },
+              },
+            ];
+          },
+        },
+        _lineChartSmoothingEnabled: {
+          type: Boolean,
+          value: false,
+          readOnly: true,
+        },
+
+      },
+
+      observers: [
+        "render(xData, yData)",
+        // TODO(cais): Add additional data such as yAxis and title.
+      ],
+
+      render(xData, yData) {
+        this.$$('vz-line-chart').setVisibleSeries(['__debugger_data__']);
+        // TODO(cais): Do not hardcode series name.
+        let seriesData = [];
+        for (let i = 0; i < this.xData.length; ++i) {
+          seriesData.push({'step': xData[i], 'scalar': yData[i]});
+        }
+        this.$$('vz-line-chart').setSeriesData('__debugger_data__', seriesData);
+      },
+    });
+  </script>
+
+</dom-module>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-op-selector.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-op-selector.html
@@ -1,0 +1,473 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../iron-collapse/iron-collapse.html">
+<link rel="import" href="../paper-checkbox/paper-checkbox.html">
+<link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/lodash.html">
+
+<!--
+  Offers a hierarchical UI for selecting ops.
+-->
+<dom-module id="tf-op-selector">
+  <template>
+    <div>
+      <paper-dropdown-menu
+        id="f-mode"
+        no-label-float="true"
+        label="Filter Mode"
+        selected-item-label="{{_filterMode}}"
+      >
+        <paper-menu class="dropdown-content" slot="dropdown-content">
+          <paper-item no-label-float=true>Node Name</paper-item>
+          <paper-item no-label-float=true>Op Type</paper-item>
+        </paper-menu>
+      </paper-dropdown-menu>
+      <paper-input
+        id="filter-input"
+        label="Filter Regex"
+        always-float-label
+        value="{{_filterInput}}"
+      ></paper-input>
+    </div>
+    <div id="selector-hierarchy">
+    </div>
+    <style>
+      :host .indented-level-container .content-container {
+        margin: 0 0 0 20px;
+      }
+
+      :host .level-container iron-collapse {
+        padding: 0 0 0 20px;
+      }
+
+      :host paper-checkbox {
+        display: inline-block;
+        width: 18px;
+        height: 18px;
+        margin: 0 8px 0 0;
+      }
+
+      :host .op-type {
+        padding-right: 10px;
+        color: #444;
+      }
+
+      :host .op-title-leaf {
+        text-decoration: underline;
+        cursor: pointer;
+      }
+
+      :host .partial-checkbox {
+        background: #f57c00;
+      }
+
+      :host .node-expand-button {
+        margin: 0 0 0 -13px;
+      }
+
+      :host .level-title-text {
+        display: inline-block;
+        font-weight: 800;
+        margin: 0 0 0 -1px;
+      }
+
+      :host .op-description {
+        font-weight: 300;
+        margin: 0 0 0 27px;
+        padding: 10px 0;
+      }
+
+      :host #filter-mode {
+        width: 100px;
+        display: inline-block;
+      }
+
+      :host #filter-input {
+        width: 250px;
+        display: inline-block;
+      }
+    </style>
+  </template>
+  <script src="selection-tree-node.js"></script>
+  <script>
+
+  Polymer({
+    is: "tf-op-selector",
+    properties: {
+      // A list of debug watches. A debug watch object has 3 properties:
+      // node_name (string), output_slot (number), and debug_op (string).
+      debugWatches: Array,
+      // A function called when a debug watch is toggled. This function takes
+      // the click event.
+      debugWatchChange: Object,
+      // A function called when a node in the list (not the state checkbox or
+      // the expand button) is clicked,
+      nodeClicked: Function,
+
+      // Name of the node externally forced to expand to.
+      forceExpansionNodeName: {
+        type: String,
+        value: null,
+      },
+
+      // A mapping between node name and debug watch. Only nodes that are
+      // currently selected reside within this mapping. A node that is
+      // deselected will be removed from this mapping.
+      _selectedDebugWatchMapping: {
+        type: Object,
+        value: () => ({}),
+      },
+
+      // A map from non-leaf node name to containers. Used during externally
+      // forced expansion.
+      _levelName2Container: {
+        type: Object,
+        value: null,
+      },
+      // A map from node/level names to checkboxes. Used during externally
+      // triggered click events.
+      _levelName2Node: {
+        type: Object,
+        value: null,
+      },
+
+      // This is the SelectionTreeNode.SelectionTreeNode object that is the root
+      // of the tree for node selection.
+      _watchHierarchy: {
+        type: Object,
+        computed: "_computeWatchHierarchy(debugWatches, debugWatchChange, _filterMode, _filterInput)",
+      },
+
+      _filterMode: {
+        type: String,
+        value: 'Node Name',
+        notify: true,
+      },
+
+      _filterInput: {
+        type: String,
+        value: '',
+        notify: true,
+      },
+    },
+    observers: [
+      "_renderHierarchy(_watchHierarchy, debugWatchChange)",
+      "_handleForceNodeExpansion(forceExpansionNodeName)",
+    ],
+    _computeWatchHierarchy(debugWatches, debugWatchChange, filterMode, filterInput) {
+      filterInput = filterInput.trim();
+      let filteredDebugWatches = debugWatches;
+      if (filterMode != null && filterInput.length > 0) {
+        filteredDebugWatches = tf_debugger_dashboard.filterDebugWatches(
+            debugWatches, filterMode, filterInput);
+      }
+
+      const hierarchy = new tf_debugger_dashboard.SelectionTreeNode('', debugWatchChange);
+      hierarchy.isRoot = true;
+
+      _.forEach(filteredDebugWatches, debugWatch => {
+        const portions = tf_debugger_dashboard.splitNodeName(debugWatch.node_name);
+        // Start at the highest level.
+        let currentNode = hierarchy;
+        _.forEach(portions, (portion, i) => {
+          if (i === portions.length - 1) {
+            // This is the last portion. Map it to the original debug watch.
+            const newNode = new tf_debugger_dashboard.SelectionTreeNode(
+                portion, debugWatchChange, currentNode, debugWatch);
+            currentNode.children[portion] = newNode;
+            return;
+          }
+
+          // Create a new level if it does not already exist.
+          if (!currentNode.children[portion]) {
+            currentNode.children[portion] =
+                new tf_debugger_dashboard.SelectionTreeNode(
+                    portion, debugWatchChange, currentNode);
+          }
+          currentNode = currentNode.children[portion];
+        });
+      });
+
+      return hierarchy;
+    },
+
+    _renderHierarchy(watchHierarchy, debugWatchChange, filterMode, filterInput) {
+      this.set('_levelName2Container', {});
+      this.set('_levelName2Node', {});
+      this.$$('#selector-hierarchy').innerHTML = '';
+      const dom = this._renderLevel(null, null, watchHierarchy, debugWatchChange);
+
+      // After rendering the hierarchy, check the boxes that correspond to
+      // breakpoints. Otherwise, breakpoints will be initially unselected.
+      _.forOwn(this._selectedDebugWatchMapping, (debugWatch, nodeName) => {
+        // Traverse to the leaf node that is a break point.
+        const portions = tf_debugger_dashboard.splitNodeName(nodeName);
+        let currentNode = this._watchHierarchy;
+        for (let i = 0; i < portions.length; i++) {
+          currentNode = currentNode.children[portions[i]];
+          if (!currentNode) {
+            // This node no longer exists. Perhaps the model changed.
+            break;
+          }
+        }
+
+        if (!currentNode) {
+          return;
+        }
+
+        // Select the node.
+        currentNode.setCheckboxState(tf_debugger_dashboard.CheckboxState['CHECKED']);
+
+        // Possibly change metanodes above it to be checked or partial. This
+        // has to be manually called because the checkbox has not been rendered
+        // in the DOM yet. Therefore, checkbox event handlers (which take care
+        // of this logic) are not called.
+        currentNode.setNodesAboveToChecked();
+      });
+
+      // Append the hierarchy to the DOM.
+      Polymer.dom(this.$$('#selector-hierarchy')).appendChild(dom);
+    },
+
+    _renderLevel(levelName, parentLevelName, levelObject, debugWatchChange) {
+      const levelContainer = document.createElement('div');
+      if (levelName != null) {
+        levelContainer.setAttribute('level-name', levelName);
+      }
+      let fullLevelName;
+      if (parentLevelName == null) {
+        fullLevelName = levelName;
+      } else {
+        fullLevelName = parentLevelName + '/' + levelName;
+      }
+
+      Polymer.dom(levelContainer).classList.add('level-container');
+      const contentContainer = document.createElement('iron-collapse');
+      if (levelName) {
+        // This level is an expandable.
+        this._levelName2Container[fullLevelName] = contentContainer;
+
+        // Close this entry of nodes. Let the user expand later if necessary.
+        contentContainer.removeAttribute('opened');
+
+        Polymer.dom(levelContainer).classList.add('indented-level-container');
+        const levelTitle = document.createElement('div');
+        Polymer.dom(levelTitle).classList.add('level-title');
+
+        // Add a little button for expanding or collapsing the section.
+        const expandButton = document.createElement('paper-icon-button');
+        Polymer.dom(expandButton).classList.add('node-expand-button');
+        const setExpandButtonIcon = () => {
+          expandButton.setAttribute(
+              'icon',
+              contentContainer.hasAttribute('opened') ? 'expand-less' : 'expand-more');
+        };
+        // When the user clicks the expand button, toggle expansion.
+        expandButton.addEventListener('click', () => {
+          if (contentContainer.hasAttribute('opened')) {
+            // Close the section.
+            contentContainer.removeAttribute('opened');
+          } else {
+            // Open the section.
+            contentContainer.setAttribute('opened', true);
+          }
+          setExpandButtonIcon();
+        }, false);
+        setExpandButtonIcon();
+        Polymer.dom(levelTitle).appendChild(expandButton);
+
+        // Give the title a checkbox.
+        Polymer.dom(levelTitle).appendChild(levelObject.checkbox);
+
+        // Title the expandable.
+        const titleText = document.createElement('span');
+        Polymer.dom(titleText).classList.add('level-title-text');
+        titleText.textContent = levelName;
+        Polymer.dom(levelTitle).appendChild(titleText);
+
+        Polymer.dom(levelContainer).appendChild(levelTitle);
+
+        // If this is a device name level, fire its click event to expand it
+        // immediately.
+        if (levelName.match(tf_debugger_dashboard.DEVICE_NAME_PATTERN)) {
+          contentContainer.setAttribute('opened', true);
+        }
+      } else {
+        // This entry should be opened by default.
+        contentContainer.setAttribute('opened', true);
+      }
+
+      const levelContainers = [];
+      const ops = [];
+
+      Polymer.dom(contentContainer).classList.add('content-container');
+      _.forEach(levelObject.children, (objectToRender, childLevelName) => {
+        const debugWatch = objectToRender.debugWatch;
+        let childFullLevelName = fullLevelName;
+        if (fullLevelName == null) {
+          childFullLevelName = '';
+        }
+        childFullLevelName += '/' + childLevelName;
+        this._levelName2Node[childFullLevelName] = objectToRender;
+
+        if (debugWatch) {
+          // The debug watch exists, so this is a leaf node.
+          const opDescription = document.createElement('div');
+          Polymer.dom(opDescription).classList.add('op-description');
+
+          objectToRender.checkbox.addEventListener('change', (event) => {
+            this._handleLeafNodeSelected(
+                debugWatchChange, debugWatch, event.target.checked);
+          }, false);
+          Polymer.dom(opDescription).appendChild(objectToRender.checkbox);
+
+          const opType = document.createElement('span');
+          opType.textContent = '[' + debugWatch.op_type + ']';
+          opType.setAttribute('class', 'op-type');
+          Polymer.dom(opDescription).appendChild(opType);
+
+          const opTitle = document.createElement('span');
+          opTitle.textContent = childLevelName;
+          opTitle.setAttribute('class', 'op-title-leaf');
+          opTitle.addEventListener('click', () => {
+            const deviceAndNodeNames = this._getDeviceAndNodeNames(
+                childLevelName, levelContainer);
+            this.nodeClicked(deviceAndNodeNames[0], deviceAndNodeNames[1]);
+          }, false);
+          Polymer.dom(opDescription).appendChild(opTitle);
+
+          ops.push(opDescription);
+        } else {
+          objectToRender.checkbox.addEventListener('change', (event) => {
+            this._handleMetaNodeChange(
+                objectToRender, debugWatchChange, event.target.checked);
+          });
+
+          // Based on duck-typing, this is another level. Add the level.
+          levelContainers.push(
+              this._renderLevel(childLevelName, fullLevelName,
+                                objectToRender, debugWatchChange));
+        }
+      });
+
+      // Append checkboxes for ops before other level containers.
+      const appendToContainer = element => {
+        Polymer.dom(contentContainer).appendChild(element);
+      };
+      _.forEach(ops, appendToContainer);
+      _.forEach(levelContainers, appendToContainer);
+      Polymer.dom(levelContainer).appendChild(contentContainer);
+
+      return levelContainer;
+    },
+
+    _getLeafDebugWatches(node, leafDebugWatches) {
+      if (node.debugWatch) {
+        leafDebugWatches.push(node.debugWatch);
+      } else {
+        _.forEach(node.children, (child, key, object) => {
+          // Recursive call.
+          this._getLeafDebugWatches(child, leafDebugWatches);
+        });
+      }
+    },
+
+    /* Determine the device name and full node name from level name and level
+     * container */
+    _getDeviceAndNodeNames(levelName, levelContainer) {
+      let levelNameItems = [levelName];
+      let parentNode = levelContainer;
+      // Figure out the full name of the node (including device name, if any),
+      // by going up the hierarchy.
+      while (true) {
+        const currLevelName = parentNode.getAttribute('level-name');
+        if (currLevelName == null) {
+          break;
+        } else {
+          levelNameItems.push(currLevelName);
+        }
+        parentNode = Polymer.dom(parentNode).parentNode.parentNode;
+      }
+      levelNameItems.reverse();
+      return tf_debugger_dashboard.assembleDeviceAndNodeNames(levelNameItems);
+    },
+
+    _handleMetaNodeChange(levelObject, debugWatchChangeMethod, isChecked) {
+      // Get all leaf nodes.
+      let leafDebugWatches = [];
+      this._getLeafDebugWatches(levelObject, leafDebugWatches);
+      _.forEach(leafDebugWatches, (debugWatch) => {
+        this._handleLeafNodeSelected(
+            debugWatchChangeMethod, debugWatch, isChecked);
+      });
+    },
+
+    _handleLeafNodeSelected(debugWatchChangeMethod, debugWatch, isChecked) {
+      if (isChecked) {
+        this._selectedDebugWatchMapping[debugWatch.node_name] = debugWatch;
+      } else {
+        delete this._selectedDebugWatchMapping[debugWatch.node_name];
+      }
+      debugWatchChangeMethod(debugWatch, isChecked);
+    },
+
+    _handleForceNodeExpansion(forceExpansionNodeName) {
+      this.set('_filterInput', '');
+
+      if (forceExpansionNodeName == null) {
+        return;
+      }
+      if (this._levelName2Container == null) {
+        return;  // No node tree has been rendered yet.
+      }
+      const levelItems = tf_debugger_dashboard.splitNodeName(forceExpansionNodeName);
+      for (let i = 1; i <= levelItems.length; ++i) {
+        let currLevelName = levelItems.slice(0, i).join('/');
+        const currTreeNode = this._levelName2Node[currLevelName];
+
+        if (i < levelItems.length) {
+          // At non-lowest level.
+          if (this._levelName2Container[currLevelName] != null) {
+            // It is possible that the node is not present in the tree, e.g.,
+            // due to node-name filtering or other types of filtering.
+            this._levelName2Container[currLevelName].setAttribute('opened', true);
+          }
+        } else {
+          // At lowest level.
+          // If the lowest level is a meta node, send enable-breakpoint request
+          // for all its children.
+          if (!currTreeNode.debugWatch) {
+            this._handleMetaNodeChange(currTreeNode, currTreeNode.debugWatchChange, true);
+          }
+
+          currTreeNode.setToAllCheckedExternally();
+          const debugWatch = currTreeNode.debugWatch;
+          if (debugWatch) {
+            if (this._selectedDebugWatchMapping[debugWatch.node_name] == null) {
+              this._selectedDebugWatchMapping[debugWatch.node_name] = debugWatch;
+            }
+          }
+        }
+      }
+    },
+  });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-op-selector.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-op-selector.html
@@ -177,7 +177,9 @@ limitations under the License.
       let filteredDebugWatches = debugWatches;
       if (filterMode != null && filterInput.length > 0) {
         filteredDebugWatches = tf_debugger_dashboard.filterDebugWatches(
-            debugWatches, filterMode, filterInput);
+            debugWatches,
+            tf_debugger_dashboard.DebugWatchFilterMode[filterMode.replace(/\s/g, '')],
+            new RegExp(filterInput));
       }
 
       const hierarchy = new tf_debugger_dashboard.SelectionTreeNode('', debugWatchChange);
@@ -209,10 +211,18 @@ limitations under the License.
       return hierarchy;
     },
 
+    _clearSelectorHierarchy() {
+      const selectorHierarchy = this.$$('#selector-hierarchy');
+      while (selectorHierarchy.firstChild) {
+        selectorHierarchy.removeChild(selectorHierarchy.firstChild);
+      }
+    },
+
     _renderHierarchy(watchHierarchy, debugWatchChange, filterMode, filterInput) {
       this.set('_levelName2Container', {});
       this.set('_levelName2Node', {});
-      this.$$('#selector-hierarchy').innerHTML = '';
+      this._clearSelectorHierarchy();
+
       const dom = this._renderLevel(null, null, watchHierarchy, debugWatchChange);
 
       // After rendering the hierarchy, check the boxes that correspond to

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
@@ -134,7 +134,7 @@ limitations under the License.
     },
 
     _renderSessionRunTable() {
-      this.$$('#session-runs-table').innerHTML = '';
+      this._clearTable();
       // TODO(cais): Support sorting.
       this._renderHeader();
       for (const runKey in this._runKey2Count) {
@@ -145,6 +145,13 @@ limitations under the License.
           const numDevices = this._runKey2NumDevices[runKey];
           this._renderRow(sessionRun, numDevices, count, isActive, this.soleActive);
         }
+      }
+    },
+
+    _clearTable() {
+      const table = this.$$('#session-runs-table');
+      while (table.firstChild) {
+        table.removeChild(table.firstChild);
       }
     },
 

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
@@ -1,0 +1,209 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/lodash.html">
+
+<!--
+  Offers a UI for summarizing and displaying tensor data.
+-->
+<dom-module id="tf-session-runs-view">
+  <template>
+    <div id="tensor-data-div" class="tensor-data-div">
+      <div class="section-title">Session Runs</div>
+      <table id="session-runs-table" align="left" class="session-runs-table">
+        <tr align="left">
+          <th>Feeds</th>
+          <th>Fetches</th>
+          <th>Targets</th>
+          <th>#(Devices)</th>
+          <th>Count</th>
+        </tr>
+      </table>
+    </div>
+    <style>
+      .section-title {
+        font-size: 110%;
+        font-weight: bold;
+      }
+      :host .indented-level-container .content-container {
+        margin: 0 0 0 10px;
+      }
+      /* TODO(cais): This needs work: the table shouldn't get too wide when
+         there are many feeds/fetches/targte names. */
+      .session-runs-table {
+        align-content: left;
+        align-items: left;
+        text-align: left;
+        border-style: solid 1px black;
+        width: 400px;
+        table-layout: fixed;
+        word-break: break-all;
+        padding-top: 3px;
+        padding-left: 3px;
+        padding-right: 3px;
+        box-shadow: 3px 3px #ddd;
+      }
+      .active-session-run {
+        background-color: #FFFFE0;
+        font-weight: bold;
+      }
+      .sole-active-session-run {
+        background-color: rgb(172, 232, 188);
+        font-weight: bold;
+      }
+    </style>
+  </template>
+  <script>
+
+  Polymer({
+    is: "tf-session-runs-view",
+    properties: {
+      // latestSessionRun is an object with the following fields:
+      // {
+      //   feeds:   // String[], names of the feed tensors.
+      //   fetches:  // String[], names of the fetched tensors.
+      //   targets:  // String[], names of the target ops.
+      // }
+      latestSessionRun: Object,
+      sessionRunKeyToDeviceNames: Object,
+
+      // A flag indicating whether the debugger plugin is currently focused
+      // on the beginning of a Session.run(), i.e., without any specific tensor
+      // breakpoint being active.
+      soleActive: Boolean,
+
+      // A map from session.run key to count of how many the session.run's
+      // execution has started.
+      _runKey2Count: {
+        type: Object,
+        value: {},
+      },
+      // A map from session.run key to the number of devices involved in the
+      // session.run.
+      _runKey2NumDevices: {
+        type: Object,
+        value: {},
+      },
+      // Stores the current active session run object.
+      _activeRunKey: Object,
+    },
+    observers: [
+      "renderLatest(latestSessionRun)",
+      "setSoleActiveStatus(soleActive)",
+    ],
+
+    renderLatest(latestSessionRun) {
+      const runKey = JSON.stringify(latestSessionRun);
+      if (this._runKey2Count[runKey] === undefined) {
+        this._runKey2Count[runKey] = 1;
+      } else {
+        this._runKey2Count[runKey] += 1;
+      }
+      if (this._runKey2NumDevices[runKey] === undefined) {
+        this._runKey2NumDevices[runKey] = 0;
+      }
+      this.set('_activeRunKey', runKey);
+      this._renderSessionRunTable();
+    },
+
+    updateNumDevices(numDevices) {
+      if (this._activeRunKey == null) {
+        return;
+      }
+      this._runKey2NumDevices[this._activeRunKey] = numDevices;
+      this._renderSessionRunTable();
+    },
+
+    setSoleActiveStatus(soleActive) {
+      this._renderSessionRunTable();
+    },
+
+    _renderSessionRunTable() {
+      this.$$('#session-runs-table').innerHTML = '';
+      // TODO(cais): Support sorting.
+      this._renderHeader();
+      for (const runKey in this._runKey2Count) {
+        if (this._runKey2Count.hasOwnProperty(runKey)) {
+          const sessionRun = JSON.parse(runKey);
+          const count = this._runKey2Count[runKey];
+          const isActive = this._activeRunKey === runKey;
+          const numDevices = this._runKey2NumDevices[runKey];
+          this._renderRow(sessionRun, numDevices, count, isActive, this.soleActive);
+        }
+      }
+    },
+
+    _renderHeader() {
+      const headerRow = document.createElement('tr');
+      const feedsCell = document.createElement('th');
+      feedsCell.textContent = 'Feeds';
+      const fetchesCell = document.createElement('th');
+      fetchesCell.textContent = 'Fetches';
+      const targetsCell = document.createElement('th');
+      targetsCell.textContent = 'Targets';
+      const numDevicesCell = document.createElement('th');
+      numDevicesCell.textContent = '#(Devices)';
+      const countCell = document.createElement('th');
+      countCell.textContent = 'Count';
+
+      headerRow.appendChild(feedsCell);
+      headerRow.appendChild(fetchesCell);
+      headerRow.appendChild(targetsCell);
+      headerRow.appendChild(numDevicesCell);
+      headerRow.appendChild(countCell);
+
+      Polymer.dom(this.$$('#session-runs-table')).appendChild(headerRow);
+    },
+
+    _renderRow(sessionRun, numDevices, count, isActive, soleActive) {
+      const sessionRunRow = document.createElement('tr');
+
+      // TOOD(cais): All feeds, and fetches and targets should be made into
+      // clickable links, which when clicked, will focus on the corresponding
+      // node in the Graph View and/or highlight corresponding tensors in the
+      // Tensor Summary View and the Tensor Value View.
+      const feedsCell = document.createElement('td');
+      feedsCell.textContent = JSON.stringify(sessionRun.feeds);
+      const fetchesCell = document.createElement('td');
+      fetchesCell.textContent = JSON.stringify(sessionRun.fetches);
+      const targetsCell = document.createElement('td');
+      targetsCell.textContent = JSON.stringify(sessionRun.targets);
+      const numDevicesCell = document.createElement('td');
+      numDevicesCell.textContent = numDevices;
+      const countCell = document.createElement('td');
+      countCell.textContent = count;
+
+      sessionRunRow.appendChild(feedsCell);
+      sessionRunRow.appendChild(fetchesCell);
+      sessionRunRow.appendChild(targetsCell);
+      sessionRunRow.appendChild(numDevicesCell);
+      sessionRunRow.appendChild(countCell);
+
+      if (isActive) {
+        if (soleActive) {
+          sessionRunRow.setAttribute('class', 'sole-active-session-run');
+        } else {
+          sessionRunRow.setAttribute('class', 'active-session-run');
+        }
+      }
+
+      Polymer.dom(this.$$('#session-runs-table')).appendChild(sessionRunRow);
+    },
+  });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
@@ -1,0 +1,228 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/lodash.html">
+
+<!--
+  Offers a UI for summarizing and displaying tensor data.
+-->
+<dom-module id="tf-tensor-data-summary">
+  <template>
+    <div id="tensor-data-div" class="tensor-data-div">
+      <table id="tensor-data-table" align="left" class="tensor-data-table">
+        <tr align="left">
+          <th>Tensor</th>
+          <th>Count</th>
+          <th>DType</th>
+          <th>Shape</th>
+          <th width="30%">Value</th>
+        </tr>
+      </table>
+    </div>
+    <style>
+      .section-title {
+        font-size: 110%;
+        font-weight: bold;
+      }
+      :host .indented-level-container .content-container {
+        margin: 0 0 0 10px;
+      }
+      :host .tensor-data-table {
+        align-content: left;
+        align-items: left;
+        text-align: left;
+        border-style: solid 1px black;
+        width: 100%;
+        padding-top: 3px;
+        padding-left: 3px;
+        padding-right: 3px;
+        box-shadow: 3px 3px #ddd;
+      }
+      .active-tensor {
+        background-color: #FFFFE0;
+      }
+      .value-expansion-link {
+        text-decoration: underline;
+        cursor: pointer;
+      }
+      .value-expansion-link :hover {
+        color: blue;
+      }
+    </style>
+  </template>
+  <script>
+
+  Polymer({
+    is: "tf-tensor-data-summary",
+    properties: {
+      // latestTensorData is an object with the following fields:
+      // {
+      //   tensorName: // String, name of the tensor, e.g., 'MatMul:0'
+      //   debugOp:  // String, debug op name, e.g., 'DebugIdenitty'
+      //   dtype:  // String, dtype, e.g., 'float32'
+      //   shape:  // Number[], shape of the tensor, e.g., [16, 28, 28]
+      //   value,  // An optional nested list of values.
+      // }
+      latestTensorData: Object,
+
+      // Callback for clicking of the expand button.
+      expandHandler: Object,
+
+      _watchKeys: {
+        type: Array,
+        value: [],
+      },
+      _watchKey2Count: {
+        type: Object,
+        value: {},
+      },
+      _watchKey2DType: {
+        type: Object,
+        value: {},
+      },
+      _watchKey2Shape: {
+        type: Object,
+        value: {},
+      },
+      _watchKey2ExpandHandler: {
+        type: Object,
+        value: {},
+      },
+      _watchKey2ValueShort: {
+        type: Object,
+        value: {},
+      },
+      _activeWatchKey: String,
+    },
+    observers: [
+      "renderLatest(latestTensorData, expandHandler)",
+    ],
+
+    renderLatest(latestTensorData, expandHandler) {
+      // TODO(cais): May need to include device name for GPU and distributed, in
+      // case there are duplicate node names between devices (which is rare).
+      const watchKey = latestTensorData.tensorName + ':' +
+                       latestTensorData.debugOp;
+      const dtype = latestTensorData.dtype;
+      const shape = latestTensorData.shape;
+      const instanceExpandHandler = () => {
+        expandHandler(latestTensorData);
+      };
+
+      let valueShort;
+      if (latestTensorData.value !== null) {
+        valueShort = JSON.stringify(latestTensorData.value,
+            (key, val) => {
+              return val.toFixed ? Number(val.toFixed(3)) : val;
+            });
+      } else {
+        valueShort = "(Click to view)";
+      }
+
+      if (this._watchKeys.indexOf(watchKey) === -1) {
+        this._watchKeys.push(watchKey);
+        this._watchKey2Count[watchKey] = 1;
+        this._watchKey2DType[watchKey] = dtype;
+        this._watchKey2Shape[watchKey] = shape;
+        this._watchKey2ExpandHandler[watchKey] = instanceExpandHandler;
+      } else {
+        this._watchKey2Count[watchKey] += 1;
+      }
+      this._watchKey2ValueShort[watchKey] = valueShort;
+      this._activeWatchKey = watchKey;
+
+      this.$$('#tensor-data-table').innerHTML = '';
+      // TODO(cais): Support sorting by clicking headers.
+      this._renderHeader();
+      for (let i = 0; i < this._watchKeys.length; ++i) {
+        this._renderRow(this._watchKeys[i]);
+      }
+    },
+
+    _renderHeader() {
+      const headerRow = document.createElement('tr');
+      const nameCell = document.createElement('th');
+      nameCell.textContent = 'Name';
+      const countCell = document.createElement('th');
+      countCell.textContent = 'Count';
+      const dtypeCell = document.createElement('th');
+      dtypeCell.textContent = 'DType';
+      const shapeCell = document.createElement('th');
+      shapeCell.textContent = 'Shape';
+      const valueShortCell = document.createElement('th');
+      valueShortCell.textContent = 'Value';
+
+      headerRow.appendChild(nameCell);
+      headerRow.appendChild(countCell);
+      headerRow.appendChild(dtypeCell);
+      headerRow.appendChild(shapeCell);
+      headerRow.appendChild(valueShortCell);
+
+      Polymer.dom(this.$$('#tensor-data-table')).appendChild(headerRow);
+    },
+
+    _renderRow(watchKey) {
+      const items = watchKey.split(':');
+      const tensorName = items[0] + ':' + items[1];
+      const count = this._watchKey2Count[watchKey];
+      const debugOp = items[2];
+      const dtype = this._watchKey2DType[watchKey];
+      const shape = this._watchKey2Shape[watchKey];
+      const valueShort = this._watchKey2ValueShort[watchKey];
+      const expandHandler = this._watchKey2ExpandHandler[watchKey];
+      const isActive = (watchKey === this._activeWatchKey);
+
+      const tensorDataRow = document.createElement('tr');
+      const tensorNameCell = document.createElement('td');
+      tensorNameCell.textContent = tensorName;
+      const countCell = document.createElement('td');
+      countCell.textContent = count;
+      if (isActive) {
+        countCell.style.fontWeight = 'bold';
+      }
+      // TODO(cais): Display debug op only if it is not the default
+      // (DebugIdentity). The following commented-out lines of code may be
+      // useful for that purpose.
+      // const debugOpCell = document.createElement('td');
+      // debugOpCell.textContent = (debugOp === 'DebugIdentity') ? '' : debugOp;
+      const dtypeCell = document.createElement('td');
+      dtypeCell.textContent = dtype;
+      const shapeCell = document.createElement('td');
+      shapeCell.textContent = JSON.stringify(shape);
+      const valueCell = document.createElement('td');
+      valueCell.textContent = valueShort;
+      valueCell.setAttribute('class', 'value-expansion-link');
+
+      valueCell.addEventListener('click', expandHandler, false);
+
+      tensorDataRow.appendChild(tensorNameCell);
+      // tensorDataRow.appendChild(debugOpCell);
+      tensorDataRow.appendChild(countCell);
+      tensorDataRow.appendChild(dtypeCell);
+      tensorDataRow.appendChild(shapeCell);
+      tensorDataRow.appendChild(valueCell);
+
+      if (isActive) {
+        tensorDataRow.setAttribute('class', 'active-tensor');
+      }
+
+      Polymer.dom(this.$$('#tensor-data-table')).appendChild(tensorDataRow);
+    },
+  });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
@@ -146,11 +146,18 @@ limitations under the License.
       this._watchKey2ValueShort[watchKey] = valueShort;
       this._activeWatchKey = watchKey;
 
-      this.$$('#tensor-data-table').innerHTML = '';
+      this._clearTensorDataTable();
       // TODO(cais): Support sorting by clicking headers.
       this._renderHeader();
       for (let i = 0; i < this._watchKeys.length; ++i) {
         this._renderRow(this._watchKeys[i]);
+      }
+    },
+
+    _clearTensorDataTable() {
+      const tensorDataTable = this.$$('#tensor-data-table');
+      while (tensorDataTable.firstChild) {
+        tensorDataTable.removeChild(tensorDataTable.firstChild);
       }
     },
 

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-multi-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-multi-view.html
@@ -1,0 +1,123 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="tf-tensor-value-view.html">
+
+<dom-module id="tf-tensor-value-multi-view">
+  <template>
+    <div id="multiView">
+      <div class="section-title">Tensor Values</div>
+      <div id="multi-tensor-view-container">
+      </div>
+    </div>
+  </template>
+  <style>
+    .section-title {
+      font-size: 110%;
+      font-weight: bold;
+    }
+    #multiView{
+      background-color: #fff;
+      padding-top: 3px;
+      padding-left: 3px;
+      padding-right: 3px;
+      box-shadow: 3px 3px #eee;
+    }
+  </style>
+  <script>
+    Polymer({
+      is: 'tf-tensor-value-multi-view',
+      properties: {
+        _tensorViewCounter: {
+          type: Number,
+          value: 0
+        },
+      },
+
+      addView(view) {
+        const multiViewContainer = this.$$('#multi-tensor-view-container');
+        const viewCard = document.createElement('tf-tensor-value-view');
+        viewCard.setAttribute('class', 'debugger-tensor-view');
+        viewCard.viewId = view.viewId;
+        viewCard.tensorName = view.tensorName;
+        viewCard.debugOp = view.debugOp;
+        viewCard.slicing = view.slicing;
+        viewCard.timeIndices = view.timeIndices;
+        viewCard.closeButtonCallback = this._createCloseButtonCallback(view.viewId);
+        multiViewContainer.appendChild(viewCard);
+        viewCard.refresh();
+      },
+
+      getViews() {
+        const viewCards = this.querySelectorAll('.debugger-tensor-view');
+        const views = [];
+        _.forEach(viewCards, viewCard => {
+          views.push({
+            viewId: viewCard.viewId,
+            tensorName: viewCard.tensorName,
+            debugOp: viewCard.debugOp,
+            slicing: viewCard.slicing,
+            timeIndices: viewCard.timeIndices,
+          });
+        });
+        return views;
+      },
+
+      renderTensorValues() {
+        const tensorViews = this.querySelectorAll('.debugger-tensor-view');
+        _.forEach(tensorViews, tensorView => {
+          tensorView.renderTensorValue();
+        });
+      },
+
+      _redrawViews(views) {
+        const multiViewContainer = this.$$('#multi-tensor-view-container');
+
+        // First, clear all current views.
+        const tensorViews = this.querySelectorAll('.debugger-tensor-view');
+        _.forEach(tensorViews, tensorView => {
+          multiViewContainer.removeChild(tensorView);
+        });
+
+        _.forEach(views, view => {
+          this.addView(view);
+        });
+      },
+
+      _createCloseButtonCallback(viewId) {
+        return () => {
+          const newViews = [];
+          const tensorViews = this.querySelectorAll('.debugger-tensor-view');
+          for (let i = 0; i < tensorViews.length; ++i) {
+            const tensorView = tensorViews[i];
+            if (tensorView.viewId !== viewId) {
+              newViews.push({
+                viewId: tensorView.viewId,
+                tensorName: tensorView.tensorName,
+                debugOp: tensorView.debugOp,
+                slicing: tensorView.slicing,
+                timeIndices: tensorView.timeIndices,
+              });
+            }
+          };
+          this._redrawViews(newViews);
+        };
+      },
+    });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
@@ -37,12 +37,11 @@ limitations under the License.
               value="[[tensorName]]"
               readOnly="true">
             </paper-input>
-            <span
+            <paper-icon-button
+              icon="close"
               class="value-view-close-button"
               id="value-view-close-button"
-              on-click="closeButtonCallback">
-              X
-            </span>
+              on-tap="closeButtonCallback">X</paper-icon-button>
           </div>
         </td>
       </tr>
@@ -53,25 +52,22 @@ limitations under the License.
               class="inline"
               label="Debug Op"
               id="debug-op"
-              width="200px"
               value="[[debugOp]]"
               readOnly="true"></paper-input>
           </div>
           <div>
             <paper-input
-              class="inline"
+              class="inline value-card-input"
               label="Slicing"
               id="slicing"
-              width="200px",
               value="{{slicing}}">
             </paper-input>
           </div>
           <div>
             <paper-input
-              class="inline"
+              class="inline value-card-input"
               label="Time Indices"
               id="time-indices"
-              width="200px"
               value="{{timeIndices}}">
             </paper-input>
             <paper-button raised
@@ -129,6 +125,9 @@ limitations under the License.
     }
     .tensor-value-view-td {
       width: 350px;
+    }
+    .value-card-input {
+      width: 150px;
     }
     #tensor-name {
       display: inline-block;
@@ -196,7 +195,7 @@ limitations under the License.
 
       _requestManager: {
           type: Object,
-          value: () => new tf_backend.RequestManager(20),
+          value: () => new tf_backend.RequestManager(10),
       },
     },
     observers: [
@@ -283,8 +282,8 @@ limitations under the License.
       } else {
         const slicingElements = slicing.split(',');
         let rank = slicingElements.length;
-        // Examinehow many of the slicing elements are single numbers, which leads
-        // to a decrement in rank.
+        // Examine how many of the slicing elements are single numbers, which
+        // leads to a decrement in rank.
         for (const element of slicingElements) {
           if (!isNaN(Number(element))) {
             rank--;

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
@@ -1,0 +1,348 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../paper-toast/paper-toast.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
+<link rel="import" href="../tf-imports/lodash.html">
+<link rel="import" href="tf-debugger-line-chart.html">
+
+<!--
+  Offers a UI for displaying the value of a single tensor.
+-->
+<dom-module id="tf-tensor-value-view">
+  <template>
+    <paper-toast id="tensorValueToast" text="" always-on-top></paper-toast>
+    <table class="tensor-value-view-table">
+      <tr>
+        <td colspan="2">
+          <div>
+            <paper-input
+              class="inline"
+              id="tensor-name"
+              value="[[tensorName]]"
+              readOnly="true">
+            </paper-input>
+            <span
+              class="value-view-close-button"
+              id="value-view-close-button"
+              on-click="closeButtonCallback">
+              X
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <div>
+            <paper-input
+              class="inline"
+              label="Debug Op"
+              id="debug-op"
+              width="200px"
+              value="[[debugOp]]"
+              readOnly="true"></paper-input>
+          </div>
+          <div>
+            <paper-input
+              class="inline"
+              label="Slicing"
+              id="slicing"
+              width="200px",
+              value="{{slicing}}">
+            </paper-input>
+          </div>
+          <div>
+            <paper-input
+              class="inline"
+              label="Time Indices"
+              id="time-indices"
+              width="200px"
+              value="{{timeIndices}}">
+            </paper-input>
+            <paper-button raised
+              id='time-indices-toggle-button'
+              class='tensor-value-buttons'
+              on-click='_timeIndicesToggleButtonCallback'
+            >Full History</paper-button>
+            <paper-button raised
+              class="tensor-value-buttons"
+              on-click="refresh"
+            >Refresh</paper-button>
+          </div>
+        </td>
+        <td class="tensor-value-view-td">
+          <template is="dom-if" if="[[_isValueScalar]]">
+            <paper-input
+              class="inline"
+              label="Scalar Value"
+              id="value-scalar"
+              value="[[_dataScalar]]">
+            </paper-input>
+          </template>
+          <template is="dom-if" if="[[_isValueLineChart]]">
+            <tf-debugger-line-chart
+              x-data="[[_dataLineChartX]]"
+              y-data="[[_dataLineChartY]]"
+            ></tf-debugger-line-chart>
+          </template>
+          <template is="dom-if" if="[[_isValueImage]]">
+            <img
+              class="value-image"
+              height="250px"
+              width="250px"
+              src="[[_dataImageSrc]]"></img>
+          </template>
+        </td>
+      </tr>
+    </table>
+  </template>
+  <style>
+    .tensor-value-buttons {
+      height: 75%;
+      font-size: 10px;
+    }
+    .tensor-value-view-table {
+      width: 500px;
+      display: inline-table;
+      border-spacing: 5px;
+      padding-top: 3px;
+      padding-bottom: 3px;
+      padding-left: 3px;
+      padding-right: 3px;
+      background-color: #f8f8f8;
+      box-shadow: 3px 3px 1px 1px #d8d8d8;
+    }
+    .tensor-value-view-td {
+      width: 350px;
+    }
+    #tensor-name {
+      display: inline-block;
+      width: 80%;
+    }
+    .value-image {
+      image-rendering: pixelated;
+    }
+    .value-view-close-button {
+      display: inline-block;
+      float: right;
+      text-align: right;
+      width: 20%;
+      text-decoration: underline;
+      cursor: pointer;
+      font-size: 90%;
+      color: blue;
+    }
+  </style>
+  <script>
+
+  Polymer({
+    is: 'tf-tensor-value-view',
+    properties: {
+      // A unique identifier for this tensor value view. "Unique" within the
+      // lifetime of a TDP frontend session.
+      viewId: String,
+
+      tensorName: String,
+      debugOp: String,
+      slicing: String,
+      timeIndices: String,
+
+      closeButtonCallback: Object,
+
+      _isTensorValueScalar: {
+        type: Boolean,
+        value: false,
+      },
+      _isTensorValueLineChart: {
+        type: Boolean,
+        value: false,
+      },
+      _isTensorValueImage: {
+        type: Boolean,
+        value: false,
+      },
+
+      _dataScalar: {
+        type: Number,
+        value: null,
+      },
+      _dataLineChartX: {
+        type: Array,
+        value: [],
+      },
+      _dataLineChartY: {
+        type: Array,
+        value: [],
+      },
+      _dataImageSrc: {
+        type: String,
+        value: null,
+      },
+
+      _requestManager: {
+          type: Object,
+          value: () => new tf_backend.RequestManager(20),
+      },
+    },
+    observers: [
+      "_updateTimeIndicesToggle(timeIndices)",
+    ],
+
+    ready() {
+      this.renderTensorValue();
+    },
+
+    renderTensorValue() {
+      if (!this.tensorName) {
+        return;
+      }
+      const tensorRank = this._rankFromSlicing(this.slicing.trim());
+      const isSingleTimeStep = this._isTimeIndicesSingleStep(this.timeIndices);
+      let tensorRankWithTime = tensorRank;
+      if (!isSingleTimeStep) {
+        if (tensorRank > 1) {
+          this._showToast('History for tensors > 1D is not yet supported.');
+          return;
+        } else {
+          tensorRankWithTime += 1;
+        }
+      }
+
+      let mapping = tensorRankWithTime >= 2 ? 'image/png' : 'none';
+      const parameters = {
+        'watch_key': this.tensorName + ':' + this.debugOp,
+        'slicing': this.slicing,
+        'time_indices': this.timeIndices,
+        'mapping': mapping,
+      };
+      const baseUrl = tf_backend.getRouter().pluginRoute('debugger', '/tensor_data');
+      const url = tf_backend.addParams(baseUrl, parameters);
+      this._requestManager.request(url).then(response => {
+        if (response.error != null) {
+          this._showToast(
+              response.error.type + ': ' + response.error.message);
+          return;
+        }
+
+        const tensorData =
+            isSingleTimeStep ? response.tensor_data[0] : response.tensor_data;
+        if (tensorRankWithTime === 0) {
+          // Scalar.
+          this._setVisualizationType('scalar');
+          this.set('_dataScalar', tensorData);
+        } else if (tensorRankWithTime === 1) {
+          this._setVisualizationType('lineChart');
+          let xData = [];
+          // TODO(cais): For history mode, this should be time steps.
+          for (let i = 0; i < tensorData.length; ++i) {
+            xData.push(i + 1);
+          }
+          this.set('_dataLineChartX', xData);
+          this.set('_dataLineChartY', tensorData);
+        } else if (tensorRankWithTime >= 2) {
+          this._setVisualizationType('image');
+          this.set('_dataImageSrc', 'data:image/png;base64,' + tensorData);
+        } else {
+          this._showToast(
+              'Visualization of rank-' + tensorRankWithTime  + ' tensors ' +
+              'is not yet supported.');
+        }
+      });
+    },
+
+    refresh() {
+      if (!this.tensorName.trim()) {
+        return;
+      }
+      this.renderTensorValue();
+    },
+
+    // TODO(cais): Deduplicate with .ts
+    _rankFromSlicing(slicing) {
+      if (slicing.startsWith('[')) {
+        slicing = slicing.slice(1, slicing.length - 1);
+      }
+      if (slicing.length === 0) {
+        // Scalar: no slicing.
+        return 0;
+      } else {
+        const slicingElements = slicing.split(',');
+        let rank = slicingElements.length;
+        // Examinehow many of the slicing elements are single numbers, which leads
+        // to a decrement in rank.
+        for (const element of slicingElements) {
+          if (!isNaN(Number(element))) {
+            rank--;
+          }
+        }
+        return rank;
+      }
+    },
+
+    _setVisualizationType(visualizationType) {
+      if (visualizationType === 'scalar') {
+        this.set('_isValueScalar', true);
+        this.set('_isValueLineChart', false);
+        this.set('_isValueImage', false);
+      } else if (visualizationType === 'lineChart') {
+        this.set('_isValueScalar', false);
+        this.set('_isValueLineChart', true);
+        this.set('_isValueImage', false);
+      } else if (visualizationType === 'image') {
+        this.set('_isValueScalar', false);
+        this.set('_isValueLineChart', false);
+        this.set('_isValueImage', true);
+      } else {
+        console.error('Invalid visualizationType:', visualizationType);
+      }
+    },
+
+    _timeIndicesToggleButtonCallback() {
+      const buttonText = Polymer.dom(this.$$('#time-indices-toggle-button')).textContent;
+      if (buttonText.toLowerCase() === 'full history') {
+        this.set('timeIndices', ':');
+      } else {
+        this.set('timeIndices', '-1');
+      }
+      this.renderTensorValue();
+    },
+
+    _updateTimeIndicesToggle(timeIndices) {
+      if (this._isTimeIndicesSingleStep(timeIndices)) {
+        Polymer.dom(this.$$('#time-indices-toggle-button')).textContent = 'Full History';
+      } else {
+        Polymer.dom(this.$$('#time-indices-toggle-button')).textContent = 'Latest Time Point';
+      }
+    },
+
+    // Determine whether a timing indices string represents a single time step.
+    _isTimeIndicesSingleStep(timeIndices) {
+      let s = timeIndices;
+      if (s.startsWith('[')) {
+        s = s.slice(1, s.length - 1);
+      }
+      return !isNaN(Number(s));
+    },
+
+    _showToast(text) {  // TODO(cais): Move to Scrolling Message View.
+      this.$.tensorValueToast.setAttribute('text', text);
+      this.$.tensorValueToast.open();
+    },
+  });
+  </script>
+</dom-module>


### PR DESCRIPTION
This large change list fleshes out the overall architecture of the
TensorBoard Debugger Plugin (TDP), including the backend and frontend.

The basic functionalities of the TDP are working, despite many rough
edges and TODO items. The basic functionalities include:

* Control Session.run() state with the Step and Continu... buttons:
  breakpoints at the level of intra-graph nodes, possibly inside
  tensorflow control-flow structures such as `tf.while_loop`s.
* Inspection of device-partitioned, runtime graphs, in conjuction with
  the node list.
* Ability to filter nodes by node-name and op-type regular expressions,
  which facilitates the searching and activation of node breakpints.
* Viewing a summary of runtime tensor shape, dtype and values for the
  node breakpoints that have been activated.
* Viewing detailed tensor values, represented as curves (1D) or images
  (2D), with optional slicing and full-history mode. The view
  automatically refreshes during "continuing" through multiple
  Session.run() calls, giving a real-time animation of the tensor
  values.