### PR TITLE
Projector: Supervision and metadata editor (semi-supervised t-SNE)

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/bh_tsne.ts
+++ b/tensorboard/plugins/projector/vz_projector/bh_tsne.ts
@@ -271,6 +271,12 @@ export class TSNE {
   private computeForce:
       (force: number[], mult: number, pointA: number[],
        pointB: number[]) => void;
+  
+  superviseFactor: number;
+  unlabeledClass: string;
+  superviseColumn: string;
+  labels: string[];
+  labelCounts: {[key: string]: number};
 
   constructor(opt: TSNEOptions) {
     opt = opt || {dim: 2};
@@ -365,6 +371,15 @@ export class TSNE {
     // Trick that helps with local optima.
     let alpha = this.iter < 100 ? 4 : 1;
 
+    let superviseFactor = this.superviseFactor / 100.;  // set in range [0, 1]
+    let unlabeledClass = this.unlabeledClass;
+    let labels = this.labels;
+    let labelCounts = this.labelCounts;
+    let supervised = superviseFactor != null && superviseFactor > 0 &&
+        labels != null && labelCounts != null;
+    let unlabeledCount = supervised && unlabeledClass != null &&
+        unlabeledClass != '' ? labelCounts[unlabeledClass] : 0;
+
     // Make data for the SP tree.
     let points: number[][] = new Array(N);  // (x, y)[]
     for (let i = 0; i < N; ++i) {
@@ -418,15 +433,33 @@ export class TSNE {
     // compute current Q distribution, unnormalized first
     let grad: number[][] = [];
     let Z = 0;
+    let sum_pij = 0;
     let forces: [number[], number[]][] = new Array(N);
     for (let i = 0; i < N; ++i) {
       let pointI = points[i];
+      if (supervised) {
+        var sameCount = labelCounts[labels[i]];
+        var otherCount = N - sameCount - unlabeledCount;
+      }
       // Compute the positive forces for the i-th node.
       let Fpos = this.dim === 3 ? [0, 0, 0] : [0, 0];
       let neighbors = this.nearest[i];
       for (let k = 0; k < neighbors.length; ++k) {
         let j = neighbors[k].index;
         let pij = P[i * N + j];
+        // apply semi-supervised prior probabilities
+        if (supervised) {
+          if (labels[i] == unlabeledClass || labels[j] == unlabeledClass) {
+            pij *= 1. / N;
+          }
+          else if (labels[i] != labels[j]) {
+            pij *= Math.max(1. / N - superviseFactor / otherCount, 1E-7);
+          }
+          else if (labels[i] == labels[j]) {
+            pij *= Math.min(1. / N + superviseFactor / sameCount, 1. - 1E-7);
+          }
+          sum_pij += pij;
+        }
         let pointJ = points[j];
         let squaredDistItoJ = this.dist2(pointI, pointJ);
         let premult = pij / (1 + squaredDistItoJ);
@@ -458,7 +491,10 @@ export class TSNE {
       forces[i] = [Fpos, FnegZ];
     }
     // Normalize the negative forces and compute the gradient.
-    const A = 4 * alpha;
+    let A = 4 * alpha;
+    if (supervised) {
+      A /= sum_pij;
+    }
     const B = 4 / Z;
     for (let i = 0; i < N; ++i) {
       let [FPos, FNegZ] = forces[i];

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
@@ -79,6 +79,13 @@ paper-item {
 
 paper-dropdown-menu {
   width: 100%;
+  --paper-input-container-input: {
+    font-size: 15px;
+  };
+  --paper-input-container-label-floating: {
+    white-space: normal;
+    line-height: normal;
+  };
 }
 
 paper-dropdown-menu paper-item {
@@ -114,6 +121,34 @@ paper-dropdown-menu paper-item {
 
 #projector-share-button-container {
   margin: 10px 0;
+}
+
+.metadata-editor {
+  display: flex;
+}
+
+.metadata-editor paper-input {
+  width: calc(100%-150px);
+  --paper-input-container-label-floating: {
+    white-space: normal;
+    line-height: normal;
+  };
+}
+
+.metadata-editor paper-button {
+  margin-left: 10px;
+  margin-right: 0px;
+  margin-top: 20px;
+  padding-left: 8px;
+  padding-right: 8px;
+  min-width: 35px;
+  height: 36px;
+  vertical-align: bottom;
+}
+
+.metadata-editor paper-dropdown-menu {
+  margin-right: 10px;
+  width: 120px;
 }
 
 .config-checkbox {
@@ -190,7 +225,7 @@ paper-dropdown-menu paper-item {
 }
 
 .colorby-container {
-  margin-bottom: 10px;
+  margin-bottom: 0px;
 }
 </style>
 <div class="title">DATA</div>
@@ -223,19 +258,6 @@ paper-dropdown-menu paper-item {
       </paper-listbox>
     </paper-dropdown-menu>
   </template>
-  <!-- Label by -->
-  <template is="dom-if" if="[[_hasChoices(labelOptions)]]">
-    <paper-dropdown-menu no-animations label="Label by">
-      <paper-listbox attr-for-selected="value" class="dropdown-content" selected="{{selectedLabelOption}}" slot="dropdown-content">
-        <template is="dom-repeat" items="[[labelOptions]]">
-          <paper-item value="[[item]]" label="[[item]]">
-            [[item]]
-          </paper-item>
-        </template>
-      </paper-listbox>
-    </paper-dropdown-menu>
-  </template>
-
   <!-- Color by -->
   <div hidden$="[[!_hasChoices(colorOptions)]]" class="colorby-container">
     <paper-dropdown-menu id="colorby" no-animations label="Color by">
@@ -262,6 +284,25 @@ paper-dropdown-menu paper-item {
       <vz-projector-legend render-info="[[colorLegendRenderInfo]]"></vz-projector-legend>
     </template>
   </div>
+  <template is="dom-if" if="[[_hasChoice(labelOptions)]]">
+    <div class="metadata-editor">
+      <paper-dropdown-menu no-animations label="Label by">
+        <paper-listbox attr-for-selected="value" class="dropdown-content" slot="dropdown-content"
+            on-selected-item-changed="metadataEditorColumnChange"
+            selected="{{metadataEditorColumn}}" >
+          <template is="dom-repeat" items="[[metadataFields]]">
+            <paper-item value="[[item]]" label="[[item]]">
+              [[item]]
+            </paper-item>
+          </template>
+        </paper-listbox>
+      </paper-dropdown-menu>
+      <paper-input value="{{metadataEditorInput}}" label="{{metadataEditorInputLabel}}"
+      on-input="metadataEditorInputChange"></paper-input>
+      <paper-button class="ink-button" on-click="metadataEditorButtonClicked"
+          disabled="[[metadataEditorButtonDisabled]]">Label</paper-button>
+    </div>
+  </template>
   <paper-checkbox id="normalize-data-checkbox" checked="{{normalizeData}}">
     Sphereize data
     <paper-icon-button icon="help" class="help-icon"></paper-icon-button>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
@@ -37,7 +37,7 @@ limitations under the License.
 <style include="vz-projector-styles"></style>
 <style>
 .container {
-  padding: 10px 20px 20px 20px;
+  padding: 5px 20px 20px 20px;
 }
 
 input[type=file] {
@@ -77,8 +77,22 @@ paper-item {
   font-size: 12px;
 }
 
+paper-input {
+  font-size: 15px;
+  --paper-input-container: {
+    padding: 5px 0;
+  };
+  --paper-input-container-label-floating: {
+    white-space: normal;
+    line-height: normal;
+  };
+}
+
 paper-dropdown-menu {
   width: 100%;
+  --paper-input-container: {
+    padding: 5px 0;
+  };
   --paper-input-container-input: {
     font-size: 15px;
   };
@@ -123,32 +137,26 @@ paper-dropdown-menu paper-item {
   margin: 10px 0;
 }
 
-.metadata-editor {
+.metadata-editor, .supervise-settings {
   display: flex;
 }
 
-.metadata-editor paper-input {
-  width: calc(100%-150px);
-  --paper-input-container-label-floating: {
-    white-space: normal;
-    line-height: normal;
-  };
+.supervise-settings paper-dropdown-menu {
+  width: 100px;
+  margin-right: 10px;
 }
 
-.metadata-editor paper-button {
-  margin-left: 10px;
-  margin-right: 0px;
-  margin-top: 20px;
-  padding-left: 8px;
-  padding-right: 8px;
-  min-width: 35px;
-  height: 36px;
-  vertical-align: bottom;
+.supervise-settings paper-input {
+  width: calc(100% - 110px);
 }
 
 .metadata-editor paper-dropdown-menu {
+  width: 100px;
   margin-right: 10px;
-  width: 120px;
+}
+
+.metadata-editor paper-input {
+  width: calc(100% - 110px);
 }
 
 .config-checkbox {
@@ -175,6 +183,20 @@ paper-dropdown-menu paper-item {
 
 .delimiter {
   color: #B71C1C;
+}
+
+.button-container {
+  flex: 1 100%;
+  margin-right: 5px;
+}
+
+.button-container paper-button {
+  min-width: 50px;
+  width: 100%;
+}
+
+#label-button {
+  margin-right: 0px;
 }
 
 .upload-step {
@@ -222,10 +244,7 @@ paper-dropdown-menu paper-item {
 
 #demo-data-buttons-container {
   display: none;
-}
-
-.colorby-container {
-  margin-bottom: 0px;
+  margin-top: 10px;
 }
 </style>
 <div class="title">DATA</div>
@@ -285,6 +304,22 @@ paper-dropdown-menu paper-item {
     </template>
   </div>
   <template is="dom-if" if="[[_hasChoice(labelOptions)]]">
+    <div hidden$="[[!showSuperviseSettings]]" class="supervise-settings">
+      <paper-dropdown-menu no-animations label="Supervise with">
+        <paper-listbox attr-for-selected="value" class="dropdown-content"
+            on-selected-item-changed="superviseColumnChanged"
+            selected="{{superviseColumn}}" slot="dropdown-content">
+          <template is="dom-repeat" items="[[metadataFields]]">
+            <paper-item value="[[item]]" label="[[item]]">
+              [[item]]
+            </paper-item>
+          </template>
+        </paper-listbox>
+      </paper-dropdown-menu>
+      <paper-input value="{{superviseInput}}" label="{{superviseInputLabel}}"
+          on-change="superviseInputChange" on-input="superviseInputTyping">
+      </paper-input>
+    </div>
     <div class="metadata-editor">
       <paper-dropdown-menu no-animations label="Label by">
         <paper-listbox attr-for-selected="value" class="dropdown-content" slot="dropdown-content"
@@ -299,32 +334,29 @@ paper-dropdown-menu paper-item {
       </paper-dropdown-menu>
       <paper-input value="{{metadataEditorInput}}" label="{{metadataEditorInputLabel}}"
       on-input="metadataEditorInputChange"></paper-input>
-      <paper-button class="ink-button" on-click="metadataEditorButtonClicked"
-          disabled="[[metadataEditorButtonDisabled]]">Label</paper-button>
     </div>
   </template>
-  <paper-checkbox id="normalize-data-checkbox" checked="{{normalizeData}}">
-    Sphereize data
-    <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
-    <paper-tooltip position="bottom" animation-delay="0" fit-to-visible-bounds>
-      The data is normalized by shifting each point by the centroid and making
-      it unit norm.
-    </paper-tooltip>
-  </paper-checkbox>
-  <p id="demo-data-buttons-container">
-    <span>
+  <div id="demo-data-buttons-container">
+    <span class="button-container">
       <paper-tooltip position="bottom" animation-delay="0" fit-to-visible-bounds>
         Load data from your computer
       </paper-tooltip>
-      <paper-button id="upload" class="ink-button" onclick="dataDialog.open()">Load data</paper-button>
+      <paper-button id="upload" class="ink-button" onclick="dataDialog.open()">Load</paper-button>
     </span>
-    <span id="publish-container">
+    <span id="publish-container" class="button-container">
       <paper-tooltip position="bottom" animation-delay="0" fit-to-visible-bounds>
         Publish your embedding visualization and data
       </paper-tooltip>
       <paper-button id="host-embedding" class="ink-button" onclick="projectorConfigDialog.open()">Publish</paper-button>
     </span>
-  </p>
+    <span id="label-button" class="button-container">
+      <paper-tooltip position="bottom" animation-delay="0" fit-to-visible-bounds>
+        Label selected metadata
+      </paper-tooltip>
+      <paper-button class="ink-button" on-click="metadataEditorButtonClicked"
+          disabled="[[metadataEditorButtonDisabled]]">Label</paper-button>
+    </span>
+  </div>
   <div>
     <paper-dialog id="dataDialog" with-backdrop>
       <h2>Load data from your computer</h2>
@@ -424,6 +456,14 @@ paper-dropdown-menu paper-item {
       <div class="dismiss-dialog-note">Click outside to dismiss.</div>
     </paper-dialog>
   </div>
+  <paper-checkbox id="normalize-data-checkbox" checked="{{normalizeData}}">
+    Sphereize data
+    <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
+    <paper-tooltip position="bottom" animation-delay="0" fit-to-visible-bounds>
+      The data is normalized by shifting each point by the centroid and making
+      it unit norm.
+    </paper-tooltip>
+  </paper-checkbox>
   <div class="dirs">
     <table>
       <tr>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
@@ -32,7 +32,14 @@ export let DataPanelPolymer = PolymerElement({
     metadataEditorColumn: {type: String},
     metadataEditorColumnChange: {type: Object},
     metadataEditorButtonClicked: {type: Object},
-    metadataEditorButtonDisabled: {type: Boolean}
+    metadataEditorButtonDisabled: {type: Boolean},
+    superviseInput: {type: String},
+    superviseInputTyping: {type: Object},
+    superviseInputChange: {type: Object},
+    superviseInputLabel: {type: String, value: 'Ignored label'},
+    superviseColumn: {type: String},
+    superviseColumnChanged: {type: Object},
+    showSuperviseSettings: {type: Boolean, value: false}
   },
   observers: [
     '_generateUiForNewCheckpointForRun(selectedRun)',
@@ -42,6 +49,7 @@ export let DataPanelPolymer = PolymerElement({
 export class DataPanel extends DataPanelPolymer {
   selectedColorOptionName: string;
   showForceCategoricalColorsCheckbox: boolean;
+  showSuperviseSettings: boolean;
 
   private normalizeData: boolean;
   private labelOptions: string[];
@@ -51,6 +59,10 @@ export class DataPanel extends DataPanelPolymer {
   private metadataEditorInput: string;
   private metadataEditorInputLabel: string;
   private metadataEditorButtonDisabled: boolean;
+  private superviseInput: string;
+  private superviseInputLabel: string;
+  private superviseInputSelected: string;
+  private superviseColumn: string;
 
   private selectedPointIndices: number[];
   private neighborsOfFirstPoint: knn.NearestEntry[];
@@ -67,6 +79,7 @@ export class DataPanel extends DataPanelPolymer {
 
   ready() {
     this.normalizeData = true;
+    this.superviseInputSelected = '';
   }
 
   initialize(projector: Projector, dp: DataProvider) {
@@ -141,13 +154,35 @@ export class DataPanel extends DataPanelPolymer {
       if (!stats.isNumeric && labelIndex === -1) {
         labelIndex = i;
       }
-      return stats.name;
+      return stats.name.trim();
     });
 
     if (this.metadataEditorColumn == null || this.metadataFields.filter(name =>
         name == this.metadataEditorColumn).length == 0) {
       // Make the default label the first non-numeric column.
       this.metadataEditorColumn = this.metadataFields[Math.max(0, labelIndex)];
+    }
+    
+    if (this.superviseColumn == null || this.metadataFields.filter(name =>
+        name == this.superviseColumn).length == 0) {
+      // Make the default supervise class the first non-numeric column.
+      this.superviseColumn = this.metadataFields[Math.max(0, labelIndex)];
+      this.superviseInput = '';
+    }
+
+    this.superviseInputChange();
+  }
+
+  projectionChanged(projection: Projection) {
+    if (projection) {
+      switch (projection.projectionType) {
+        case 'tsne':
+          this.set('showSuperviseSettings', true);
+          break;
+
+        default:
+          this.set('showSuperviseSettings', false);
+      }
     }
   }
 
@@ -307,6 +342,74 @@ export class DataPanel extends DataPanelPolymer {
         this.spriteAndMetadata.stats.map(s => s.name),
         this.projector.dataSet.points.map(p => p.metadata));
     this.projector.metadataChanged(this.spriteAndMetadata, this.metadataFile);
+  }
+
+  private superviseInputTyping() {
+    let value = this.superviseInput.trim();
+
+    if (value == null || value.trim() === '') {
+      if (this.superviseInputSelected == '') {
+        this.superviseInputLabel = 'No ignored label';
+      }
+      else {
+        this.superviseInputLabel =
+            `Supervising without '${this.superviseInputSelected}'`;
+      }
+      return;
+    }
+
+    if (this.projector && this.projector.dataSet) {
+      let numMatches = this.projector.dataSet.points.filter(p =>
+          p.metadata[this.superviseColumn].toString().trim() == value).length;
+      
+      if (numMatches === 0) {
+        this.superviseInputLabel = 'Label not found';
+      }
+      else {
+        if (this.projector.dataSet.superviseInput != value) {
+          this.superviseInputLabel =
+              `Supervise without '${value}' [${numMatches} points]`;
+        }
+      }
+    }
+  }
+
+  private superviseInputChange() {
+    let value = this.superviseInput.trim();
+
+    if (value == null || value.trim() === '') {
+      this.superviseInputSelected = '';
+      this.superviseInputLabel = 'No ignored label';
+      this.setSupervision(this.superviseColumn, '');
+      return;
+    }
+
+    if (this.projector && this.projector.dataSet) {
+      let numMatches = this.projector.dataSet.points.filter(p =>
+          p.metadata[this.superviseColumn].toString().trim() == value).length;
+      
+      if (numMatches === 0) {
+        this.superviseInputLabel = 
+            `Supervising without '${this.superviseInputSelected}'`;
+      }
+      else {
+        this.superviseInputSelected = value;
+        this.superviseInputLabel = 
+            `Supervising without '${value}' [${numMatches} points]`;
+        this.setSupervision(this.superviseColumn, value);
+      }
+    }
+  }
+
+  private superviseColumnChanged() {
+    this.superviseInput = '';
+    this.superviseInputChange();
+  }
+
+  private setSupervision(superviseColumn: string, superviseInput: string) {
+    if (this.projector && this.projector.dataSet) {
+      this.projector.dataSet.setSupervision(superviseColumn, superviseInput);
+    }
   }
 
   setNormalizeData(normalizeData: boolean) {
@@ -501,7 +604,7 @@ export class DataPanel extends DataPanelPolymer {
     }
 
     (this.$$('#demo-data-buttons-container') as HTMLElement).style.display =
-        'block';
+        'flex';
 
     // Fill out the projector config.
     const projectorConfigTemplate =
@@ -592,6 +695,10 @@ export class DataPanel extends DataPanelPolymer {
 
   _hasChoice(choices: any[]): boolean {
     return choices.length > 0;
+  }
+
+  _hasChoices(choices: any[]): boolean {
+    return choices.length > 1;
   }
 }
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
@@ -109,6 +109,9 @@ export class InspectorPanel extends InspectorPanelPolymer {
     this.enableResetFilterButton(false);
   }
 
+  projectionChanged() {
+  }
+
   private updateSearchResults(indices: number[]) {
     const container = this.querySelector('.matches-list') as HTMLDivElement;
     container.style.display = indices.length ? null : 'none';

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
@@ -95,9 +95,14 @@ export class InspectorPanel extends InspectorPanelPolymer {
       }
       return stats.name;
     });
-    labelIndex = Math.max(0, labelIndex);
-    // Make the default label the first non-numeric column.
-    this.selectedMetadataField = spriteAndMetadata.stats[labelIndex].name;
+
+    if (this.selectedMetadataField == null || this.metadataFields.filter(name =>
+        name == this.selectedMetadataField).length == 0) {
+      // Make the default label the first non-numeric column.
+      this.selectedMetadataField = this.metadataFields[Math.max(0, labelIndex)];
+    }
+    this.updateInspectorPane(this.selectedPointIndices, 
+        this.neighborsOfFirstPoint);
   }
 
   datasetChanged() {

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
@@ -101,6 +101,10 @@ limitations under the License.
   min-height: 35px;
 }
 
+.tsne-supervise-factor {
+  margin-bottom: -8px;
+}
+
 #z-container {
   display: flex;
   align-items: center;
@@ -223,6 +227,20 @@ limitations under the License.
         </label>
         <paper-slider id="perturb-factor-slider" snaps min="0.1" max="0.8" step="0.1"
             value="0.4" max-markers="8">
+        </paper-slider>
+        <span></span>
+      </div>
+      <div class="slider tsne-supervise-factor">
+        <label>
+          Supervise
+          <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
+          <paper-tooltip position="right" animation-delay="0" fit-to-visible-bounds>
+            The label importance used for supervision, from 0 (disabled) to 100
+            (full importance).
+          </paper-tooltip>
+        </label>
+        <paper-slider id="supervise-factor-slider" min="0" max="100" pin
+            value="{{superviseFactor}}">
         </paper-slider>
         <span></span>
       </div>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -24,6 +24,7 @@ export let ProjectionsPanelPolymer = PolymerElement({
         {type: Boolean, value: true, observer: '_pcaDimensionToggleObserver'},
     tSNEis3d:
         {type: Boolean, value: true, observer: '_tsneDimensionToggleObserver'},
+    superviseFactor: {type: Number, value: 0},
     // PCA projection.
     pcaComponents: Array,
     pcaX: {type: Number, value: 0, observer: 'showPCAIfEnabled'},
@@ -68,6 +69,8 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   private perplexity: number;
   /** T-SNE learning rate. */
   private learningRate: number;
+  /** T-SNE supervise factor. */
+  private superviseFactor: number;
 
   private searchByMetadataOptions: string[];
 
@@ -93,6 +96,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   private perplexitySlider: HTMLInputElement;
   private learningRateInput: HTMLInputElement;
   private perturbFactorInput: HTMLInputElement;
+  private superviseFactorInput: HTMLInputElement;
   private zDropdown: HTMLElement;
   private iterationLabel: HTMLElement;
 
@@ -119,14 +123,18 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   ready() {
     this.zDropdown = this.querySelector('#z-dropdown') as HTMLElement;
     this.runTsneButton = this.querySelector('.run-tsne') as HTMLButtonElement;
-    this.pauseTsneButton = this.querySelector('.pause-tsne') as HTMLButtonElement;
-    this.perturbTsneButton = this.querySelector('.perturb-tsne') as HTMLButtonElement;
+    this.pauseTsneButton =
+        this.querySelector('.pause-tsne') as HTMLButtonElement;
+    this.perturbTsneButton =
+        this.querySelector('.perturb-tsne') as HTMLButtonElement;
     this.perplexitySlider =
         this.querySelector('#perplexity-slider') as HTMLInputElement;
     this.learningRateInput =
         this.querySelector('#learning-rate-slider') as HTMLInputElement;
     this.perturbFactorInput =
         this.querySelector('#perturb-factor-slider') as HTMLInputElement;
+    this.superviseFactorInput =
+        this.querySelector('#supervise-factor-slider') as HTMLInputElement;
     this.iterationLabel = this.querySelector('.run-tsne-iter') as HTMLElement;
   }
 
@@ -160,6 +168,15 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
     }
     (this.querySelector('.tsne-perturb-factor span') as HTMLSpanElement)
         .innerText = '' + this.perturbFactorInput.value;
+  }
+
+  private updateTSNESuperviseFactorFromUIChange() {
+    (this.querySelector('.tsne-supervise-factor span') as HTMLSpanElement)
+        .innerText = ('' + this.superviseFactor);
+    
+    if (this.dataSet) {
+      this.dataSet.setSuperviseFactor(this.superviseFactor);
+    }
   }
 
   private setupUIControls() {
@@ -211,6 +228,10 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
     this.perturbFactorInput.addEventListener(
         'change', () => this.updateTSNEPerturbFactorFromUIChange());
     this.updateTSNEPerturbFactorFromUIChange();
+
+    this.superviseFactorInput.addEventListener(
+        'change', () => this.updateTSNESuperviseFactorFromUIChange());
+    this.updateTSNESuperviseFactorFromUIChange();
 
     this.setupCustomProjectionInputFields();
     // TODO: figure out why `--paper-input-container-input` css mixin didn't

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -182,6 +182,23 @@ export class Projector extends ProjectorPolymer implements
     }
   }
 
+  metadataChanged(spriteAndMetadata: SpriteAndMetadataInfo,
+      metadataFile: string) {
+    this.dataSet.spriteAndMetadataInfo = spriteAndMetadata;
+    this.projectionsPanel.metadataChanged(spriteAndMetadata);
+    this.inspectorPanel.metadataChanged(spriteAndMetadata);
+    this.dataPanel.metadataChanged(spriteAndMetadata, metadataFile);
+    
+    if (this.selectedPointIndices.length > 0) {  // at least one selected point
+      this.metadataCard.updateMetadata(  // show metadata for first selected point
+          this.dataSet.points[this.selectedPointIndices[0]].metadata);
+    }
+    else {  // no points selected
+      this.metadataCard.updateMetadata(null);  // clear metadata
+    }
+    this.setSelectedLabelOption(this.selectedLabelOption);
+  }
+
   setSelectedTensor(run: string, tensorInfo: EmbeddingInfo) {
     this.bookmarkPanel.setSelectedTensor(run, tensorInfo, this.dataProvider);
   }
@@ -500,6 +517,8 @@ export class Projector extends ProjectorPolymer implements
       neighborsOfFirstPoint: knn.NearestEntry[]) {
     this.selectedPointIndices = selectedPointIndices;
     this.neighborsOfFirstPoint = neighborsOfFirstPoint;
+    this.dataPanel.onProjectorSelectionChanged(selectedPointIndices, 
+        neighborsOfFirstPoint);
     let totalNumPoints =
         this.selectedPointIndices.length + neighborsOfFirstPoint.length;
     this.statusBar.innerText = `Selected ${totalNumPoints} points`;

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -486,6 +486,9 @@ export class Projector extends ProjectorPolymer implements
     this.registerHoverListener(
         (hoverIndex: number) => this.onHover(hoverIndex));
 
+    this.registerProjectionChangedListener((projection: Projection) =>
+        this.onProjectionChanged(projection));
+
     this.registerSelectionChangedListener(
         (selectedPointIndices: number[],
          neighborsOfFirstPoint: knn.NearestEntry[]) =>
@@ -523,6 +526,11 @@ export class Projector extends ProjectorPolymer implements
         this.selectedPointIndices.length + neighborsOfFirstPoint.length;
     this.statusBar.innerText = `Selected ${totalNumPoints} points`;
     this.statusBar.style.display = totalNumPoints > 0 ? null : 'none';
+  }
+
+  onProjectionChanged(projection?: Projection) {
+    this.dataPanel.projectionChanged(projection);
+    this.inspectorPanel.projectionChanged();
   }
 
   setProjection(projection: Projection) {


### PR DESCRIPTION
Combines an updated metadata editor layout with supervision settings in the data panel, as well as a supervision factor slider in t-SNE projection panel that sets semi-supervised use of specified metadata. The data panel is revised for improved usability of the metadata editor and supervision. Capture the events and update the dataset t-SNE variables that will be used to alter the projections. Add a supervision clause to t-SNE to incorporate pairwise prior probabilities based on label differences and similarities.

~Demo here: http://tensorserve.com:6016~
```bash
git clone https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout 2cf6535a2de180557367f505b1f938de2af173d4
bazel run tensorboard -- --logdir /home/$USER/emnist-2000 --host 0.0.0.0 --port 6016
```

Supersedes:
1. https://github.com/tensorflow/tensorboard/pull/724 Projector: Semi-supervised t-SNE
2. https://github.com/tensorflow/tensorboard/pull/753 Projector: Metadata editor [#753 could be merged first though, then this one, there likely shouldn't be conflicts]

### Pairwise label similarity priors
Notice the repeating contraction in the below image, relating to repetitively turning supervision on and off, which incorporates the prior probabilities based on pairwise label similarity/dissimilarity when supervision is turned on.
![projector-tsne-supervise-vid1-red2-size2](https://user-images.githubusercontent.com/10847676/32723572-a0202ef2-c876-11e7-808d-86c154e30c44.gif)

### Design and behavior
1. When the supervision slider is set to 0, t-SNE functions exactly as before as the supervision clause is not entered.
2. The supervision slider sets the label importance value in range [0, 1], where 0 turns off supervision and 1 sets full label importance. The concept of label importance is used from McInnes et al. [1].
3. The supervision slider changes a visible percentage value from 0 to 100, corresponding to label importance values of 0 to 1.
4. An unlabeled class label, also known as an ignored label can be specified, which would consider corresponding points as unlabeled points that receive a default pairwise prior probability. The supervision settings in the data panel names this field superviseInput to generalize and allow for other uses of the text field in future, e.g. for other types of supervision.
5. A supervise column specifier gets the metadata column to use to determine which labels the supervision is conducted with.
6. t-SNE does cause some unexpected behavior when choosing a metadata column with many hundreds of classes, then a re-run is required.
7. Changes in the supervision settings are updated first in the dataset class, and then propagated to the TSNE class itself to use in the gradient step function, where a snapshot is made to prevent supervision changes during the step (not 100% sure if deep copy actually happens).
8. The supervision settings may change from step to step, e.g. such that one step may include supervision while the next step is without supervision, i.e. if the user slides the supervision factor from a non-zero value to zero.
9. The metadata editor and 'Label by' dropdown-menu is moved below the supervision settings, so that the metadata label field and status messages are paired with the 'Label' button in the row below.
10. The supervision settings only appear for specified projections, such as t-SNE in this case, otherwise it is hidden. The supervision settings are moved to the data panel as it may be a common element for multiple supervised projections.
11. Other projections could be added, like the t-SNE successor umap, and its semi-supervised version where the supervision settings elements in the data panel can then be reused with only a supervision slider required for the corresponding projections panel.
12. Now only one button row is required to load, publish, save and label data, with auto-sizing if some buttons are dynamically hidden. Save button is desired to download metadata when changes have been made, and this feature will be presented soon.

### Semi-supervised t-SNE
1. The pairwise prior probabilities are set according to McInnes et al. [1], where neighbors are used and where current labeling is not representative of class prior probabilities.
2. However, the normalization is computed over all pairwise prior probabilities according to Yang et al. [2], and not only within neighborhoods as in [1].
3. The naive pairwise prior probability is 1/N, which is used for interactions with unlabeled class samples.
4. For different label pairs we subtract superviseFactor/otherCount from the naive prior, where otherCount is the number of samples with a different label, so if superviseFactor is sufficiently large the attractive force between two samples with different labels will be set to epsilon. Attractive force is easily zeroed between different labeled samples.
5. For same-label pairs we add superviseFactor/sameCount to the naive prior, and the maximum sum is limited close to 1. Attractive force scales up more gradually between same-label pairs.

### Data and projection panel before & after
<img width="298" alt="screen shot 2017-11-20 at 6 23 35 pm" src="https://user-images.githubusercontent.com/10847676/33028999-0d41b56a-ce20-11e7-8abb-5f7917effb94.png"> <img width="298" alt="screen shot 2017-11-20 at 6 36 57 pm" src="https://user-images.githubusercontent.com/10847676/33029661-dfe58f36-ce21-11e7-89af-e286470397b8.png">

### Data panel with PCA & t-SNE
<img width="313" alt="screen shot 2017-11-20 at 6 40 54 pm" src="https://user-images.githubusercontent.com/10847676/33029879-6b6b2764-ce22-11e7-897a-e710fd9f6f47.png"> <img width="298" alt="screen shot 2017-11-20 at 6 29 51 pm" src="https://user-images.githubusercontent.com/10847676/33029748-159759ac-ce22-11e7-928b-c041b0d24255.png">

### Data panel with flex button fitting already implemented (illustrative)
<img width="320" alt="screen shot 2017-11-20 at 5 39 49 pm" src="https://user-images.githubusercontent.com/10847676/33030640-7f24c7d6-ce24-11e7-8402-b515ab806ecc.png">

### Supervision settings status messages
<img width="298" alt="screen shot 2017-11-20 at 6 31 06 pm" src="https://user-images.githubusercontent.com/10847676/33029762-1e638c90-ce22-11e7-8da2-a79d3130a92b.png">
<img width="298" alt="screen shot 2017-11-20 at 6 30 49 pm" src="https://user-images.githubusercontent.com/10847676/33029764-2088e3e4-ce22-11e7-8b8d-0452bf760660.png">
<img width="298" alt="screen shot 2017-11-20 at 6 31 22 pm" src="https://user-images.githubusercontent.com/10847676/33029771-232134b2-ce22-11e7-813c-cdec9995bb1e.png">
<img width="298" alt="screen shot 2017-11-20 at 6 31 33 pm" src="https://user-images.githubusercontent.com/10847676/33029774-25131308-ce22-11e7-9c93-e02000ce7609.png">
<img width="298" alt="screen shot 2017-11-20 at 6 31 57 pm" src="https://user-images.githubusercontent.com/10847676/33029778-26bb20d8-ce22-11e7-93ba-89b54872cc6f.png">
<img width="298" alt="screen shot 2017-11-20 at 6 32 18 pm" src="https://user-images.githubusercontent.com/10847676/33029787-29f5a7c8-ce22-11e7-8f10-ad071958f2a8.png">
<img width="298" alt="screen shot 2017-11-20 at 6 32 59 pm" src="https://user-images.githubusercontent.com/10847676/33029790-2bca4e50-ce22-11e7-9715-5ebd12ab2c9d.png">

### Metadata editor status messages
<img width="298" alt="screen shot 2017-11-20 at 6 33 56 pm" src="https://user-images.githubusercontent.com/10847676/33029795-2f9533f6-ce22-11e7-8d1d-c09f62a63366.png">
<img width="298" alt="screen shot 2017-11-20 at 6 34 12 pm" src="https://user-images.githubusercontent.com/10847676/33029797-311650ca-ce22-11e7-83f8-2fa405415bab.png">
<img width="298" alt="screen shot 2017-11-20 at 6 34 27 pm" src="https://user-images.githubusercontent.com/10847676/33029801-335cc120-ce22-11e7-88b6-cbd1e7dc9dea.png">
<img width="298" alt="screen shot 2017-11-20 at 6 34 39 pm" src="https://user-images.githubusercontent.com/10847676/33029806-35ebe04c-ce22-11e7-857b-d1b3b606fd56.png">
<img width="298" alt="screen shot 2017-11-20 at 6 34 59 pm" src="https://user-images.githubusercontent.com/10847676/33029807-377fda08-ce22-11e7-8db4-31f939ce2dc8.png">
<img width="298" alt="screen shot 2017-11-20 at 6 35 09 pm" src="https://user-images.githubusercontent.com/10847676/33029811-3a656d1e-ce22-11e7-9aed-5af98625bf47.png">



### Semi-Supervised t-SNE of McInnes et al. [1]

From https://github.com/lmcinnes/sstsne/blob/master/sstsne/_utils.pyx :
```python
for i in range(n_samples):
    sum_Pi = 0
    if using_neighbors:
        for k in range(K):
            j = neighbors[i, k]
            n_same_label = label_sizes[labels[i] + 1]
            n_other_label = n_samples - n_same_label - n_unlabelled
            if rep_samples:
                ...
            else:
                if labels[i] == -1 or labels[j] == -1:
                    prior_prob = 1.0 / n_samples
                elif labels[j] == labels[i]:
                    prior_prob = min((1.0 / n_samples) + (label_importance / n_same_label), 1.0 - EPSILON_DBL)
                else:
                    prior_prob = max((1.0 / n_samples) - (label_importance / n_other_label), EPSILON_DBL)
            P[i, j] *= prior_prob
            sum_Pi += P[i, j]
        for k in range(K):
            j = neighbors[i, k]
            P[i, j] /= sum_Pi
```

### Attraction normalization of Yang et al. [2]

From Yang et al. [1] the attractive and repulsive forces in weighted t-SNE are balanced with a connection scalar:

<img src="https://latex.codecogs.com/svg.latex?%5Cfrac%7B%5Cpartial%20D_%7B%5Ctext%7Bws-SNE%7D%7D%28Y%29%7D%7B%5Cpartial%20y_i%7D%3D%5Csum_jp_%7Bij%7Dq_%7Bij%7D%5E%7B%5Ctheta%7D%28y_i-y_j%29-cd_id_jq_%7Bij%7D%5E%7B1&plus;%5Ctheta%7D%28y_i-y_j%29">
where the connection scalar is given as <img src="https://latex.codecogs.com/svg.latex?%5Cinline%20c%3D%5Csum_%7Bij%7Dp_%7Bij%7D%5Cleft/%5Cleft%28%5Csum_%7Bij%7Dd_id_jq_%7Bij%7D%20%5Cright%20%29%5Cright.">
The issue here is that if the sum of the prior probabilities are small, then the effective gradient gets scaled down accordingly, which is the case here with a nominal prior of 1/N. So we normalize the gradient size by dividing with the sum of prior probabilities and leaving the repulsion normalization unaffected:

<img src="https://latex.codecogs.com/svg.latex?%5Cfrac%7B1%7D%7B%5Csum_%7Bij%7Dp_%7Bij%7D%7D%5Cfrac%7B%5Cpartial%20D_%7B%5Ctext%7Bws-SNE%7D%7D%28Y%29%7D%7B%5Cpartial%20y_i%7D%3D%5Cfrac%7B%5Csum_jp_%7Bij%7Dq_%7Bij%7D%5E%7B%5Ctheta%7D%28y_i-y_j%29%7D%7B%5Csum_%7Bij%7Dp_%7Bij%7D%7D-%5Cfrac%7Bd_id_jq_%7Bij%7D%5E%7B1&plus;%5Ctheta%7D%28y_i-y_j%29%7D%7B%5Csum_%7Bij%7Dd_id_jq_%7Bij%7D%7D">

Note that the result here is shown for weighted t-SNE, but it holds for normal t-SNE and its Barnes-Hut implementation.

```typescript
    let sum_pij = 0;
    let forces: [number[], number[]][] = new Array(N);
    for (let i = 0; i < N; ++i) {
      let pointI = points[i];
      if (supervise) {
        var sameCount = labelCounts[labels[i]];
        var otherCount = N - sameCount - unlabeledCount;
      }
      // Compute the positive forces for the i-th node.
      let Fpos = this.dim === 3 ? [0, 0, 0] : [0, 0];
      let neighbors = this.nearest[i];
      for (let k = 0; k < neighbors.length; ++k) {
        let j = neighbors[k].index;
        let pij = P[i * N + j];
        // apply semi-supervised prior probabilities
        if (supervised) {
          if (labels[i] == unlabeledClass || labels[j] == unlabeledClass) {
            pij *= 1. / N;
          }
          else if (labels[i] != labels[j]) {
            pij *= Math.max(1. / N - superviseFactor / otherCount, 1E-7);
          }
          else if (labels[i] == labels[j]) {
            pij *= Math.min(1. / N + superviseFactor / sameCount, 1. - 1E-7);
          }
          sum_pij += pij;
        }
    
    ...
    
    let A = 4 * alpha;
    if (supervised) {
      A /= sum_pij;
    }
    const B = 4 / Z;
```

### References
[1] Leland McInnes, Alexander Fabisch, Christopher Moody, Nick Travers, "Semi-Supervised t-SNE using a Bayesian prior based on partial labelling", https://github.com/lmcinnes/sstsne. 2016.

[2] Yang, Zhirong, Jaakko Peltonen, and Samuel Kaski. ["Optimization equivalence of divergences improves neighbor embedding"](http://proceedings.mlr.press/v32/yange14.pdf). International Conference on Machine Learning. 2014.