### PR TITLE
[Fix] Projector: MetadataCard toggle icon

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-metadata-card.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-metadata-card.html
@@ -27,7 +27,7 @@ limitations under the License.
   background-color: rgba(255,255,255,0.9);
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),
       0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
-  width: 280px;
+  width: 270px;
 }
 
 #header {
@@ -71,13 +71,9 @@ limitations under the License.
 <template is="dom-if" if="[[hasMetadata]]">
   <div id="metadata-card">
     <div id="icon-container">
-      <paper-icon-button id="expand-more"
-          style="display: none"
-          icon="expand-more"
-          on-tap="_expandMore"></paper-icon-button>
-      <paper-icon-button id="expand-less"
-          on-tap="_expandLess"
-          icon="expand-less"></paper-icon-button>
+      <paper-icon-button icon="[[collapseIcon]]"
+          on-tap="_toggleMetadataContainer">
+      </paper-icon-button>
     </div>
     <div id="header">
       <div id="metadata-label">[[label]]</div>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-metadata-card.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-metadata-card.ts
@@ -19,6 +19,8 @@ export let MetadataCardPolymer = PolymerElement({
   is: 'vz-projector-metadata-card',
   properties: {
     hasMetadata: {type: Boolean, value: false},
+    isCollapsed: {type: Boolean, value: false},
+    collapseIcon: {type: String, value: 'expand-less'},
     metadata: {type: Array},
     label: String
   }
@@ -26,34 +28,19 @@ export let MetadataCardPolymer = PolymerElement({
 
 export class MetadataCard extends MetadataCardPolymer {
   hasMetadata: boolean;
+  isCollapsed: boolean;
+  collapseIcon: string;
   metadata: Array<{key: string, value: string}>;
   label: string;
 
   private labelOption: string;
   private pointMetadata: PointMetadata;
 
-  private expandLessButton: HTMLButtonElement;
-  private expandMoreButton: HTMLButtonElement;
-
-  ready() {
-    this.expandLessButton =
-        this.querySelector('#expand-less') as HTMLButtonElement;
-    this.expandMoreButton =
-        this.querySelector('#expand-more') as HTMLButtonElement;
-  }
-  /** Handles a click on the expand more icon. */
-  _expandMore() {
+  /** Handles toggle of metadata-container. */
+  _toggleMetadataContainer() {
     (this.$$('#metadata-container') as any).toggle();
-
-    this.expandMoreButton.style.display = 'none';
-    this.expandLessButton.style.display = '';
-  }
-
-  /** Handles a click on the expand less icon. */
-  _expandLess() {
-    (this.$$('#metadata-container') as any).toggle();
-    this.expandMoreButton.style.display = '';
-    this.expandLessButton.style.display = 'none';
+    this.isCollapsed = !this.isCollapsed;
+    this.set('collapseIcon', this.isCollapsed ? 'expand-more' : 'expand-less');
   }
 
   updateMetadata(pointMetadata?: PointMetadata) {


### PR DESCRIPTION
Paper-icon-button in metadata-card eventually becomes null, which throws an error when trying to set style. Rewrote metadata-card toggling to use Polymer property to dynamically change icon based on collapse state. Also reduced the width of the metadata-card slightly as it often occludes part of the projection slightly.

Demo here: http://tensorserve.com:6023
```bash
git clone https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout 8e266291011e3dc693d69cc1130ac5d014cee4a9
bazel run tensorboard -- --logdir /home/$USER/emnist-2000 --host 0.0.0.0 --port 6023
```

### Chrome error upon toggle of metadata-card
```javascript
Uncaught TypeError: Cannot read property 'style' of null
    at HTMLElement.MetadataCard._expandLess ((index):142485)
    at handler ((index):8238)
    at HTMLElement.decorated ((index):12199)
    at HTMLElement.fire ((index):9015)
    at Object.fire ((index):8587)
    at Object.forward ((index):8884)
    at Object.click ((index):8869)
    at HTMLElement.handleNative ((index):8477)
```