### PR TITLE
Projector: t-SNE perturb v2

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -125,8 +125,6 @@ export class DataSet {
   tSNEIteration: number = 0;
   tSNEShouldPause = false;
   tSNEShouldStop = true;
-  tSNEShouldPerturb = false;
-  perturbFactor: number = 0.4;
   dim: [number, number] = [0, 0];
   hasTSNERun: boolean = false;
   spriteAndMetadataInfo: SpriteAndMetadataInfo;
@@ -310,7 +308,6 @@ export class DataSet {
     this.tsne = new TSNE(opt);
     this.tSNEShouldPause = false;
     this.tSNEShouldStop = false;
-    this.tSNEShouldPerturb = false;
     this.tSNEIteration = 0;
 
     let sampledIndices = this.shuffledDataIndices.slice(0, TSNE_SAMPLE_SIZE);
@@ -323,8 +320,7 @@ export class DataSet {
       }
 
       if (!this.tSNEShouldPause) {
-        this.tsne.step(this.tSNEShouldPerturb ? this.perturbFactor : 0.0);
-        this.tSNEShouldPerturb = false;
+        this.tsne.step();
         let result = this.tsne.getSolution();
         sampledIndices.forEach((index, i) => {
           let dataPoint = this.points[index];
@@ -362,6 +358,26 @@ export class DataSet {
             this.tsne.initDataDist(this.nearest);
           }).then(step);
     });
+  }
+
+  /* Perturb TSNE and update dataset point coordinates. */
+  perturbTsne() {
+    if (this.hasTSNERun && this.tsne) {
+      this.tsne.perturb();
+      let tsneDim = this.tsne.getDim();
+      let result = this.tsne.getSolution();
+      let sampledIndices = this.shuffledDataIndices.slice(0, TSNE_SAMPLE_SIZE);
+
+      sampledIndices.forEach((index, i) => {
+        let dataPoint = this.points[index];
+
+        dataPoint.projections['tsne-0'] = result[i * tsneDim + 0];
+        dataPoint.projections['tsne-1'] = result[i * tsneDim + 1];
+        if (tsneDim === 3) {
+          dataPoint.projections['tsne-2'] = result[i * tsneDim + 2];
+        }
+      });
+    }
   }
 
   /**

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
@@ -212,20 +212,6 @@ limitations under the License.
         </paper-slider>
         <span></span>
       </div>
-      <div class="slider tsne-perturb-factor">
-        <label>
-          Perturb factor
-          <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
-          <paper-tooltip position="right" animation-delay="0" fit-to-visible-bounds>
-            The multiplicative factor that determines the extent of the perturb offset, 
-            which is applied to positions independently per point and dimension.
-          </paper-tooltip>
-        </label>
-        <paper-slider id="perturb-factor-slider" snaps min="0.1" max="0.8" step="0.1"
-            value="0.4" max-markers="8">
-        </paper-slider>
-        <span></span>
-      </div>
       <p>
         <button class="run-tsne ink-button" title="Re-run t-SNE">Run</button>
         <button class="pause-tsne ink-button" title="Pause t-SNE">Pause</button>


### PR DESCRIPTION
_Please merge this via #763 otherwise this will create blocking conflicts. This #762 kept open to allow for easier review of isolated code and to document feature._

Now t-SNE perturb works only with mousedown, firing every 0.1 sec randomly offsetting points within their 5% hyperspheres while remaining within the t-SNE hypersphere. This has the effect of producing an even more homogenized spherical uniform distribution upon successive perturbation, with points doing random walks. Now mousedown duration is used to choose the extent of perturbation, and the perturb slider can thus be removed.

Demo here: http://tensorserve.com:6014
```bash
git clone https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout 1cc807e4797bb230e839582e2b9fbad0e974fc90
bazel run tensorboard -- --logdir /home/$USER/emnist-2000 --host 0.0.0.0 --port 6014
```

### Design and behavior:
1. Behavior remains exactly the same when the perturb button is never clicked.
2. Perturbation of point locations are now performed as a random walk within the bounds of the assumed t-SNE plotting space modeled as a hypersphere.
3. A perturbation step is done uniformly within a small hypersphere, set at 5% of the t-SNE hypersphere size, centered around each point.
4. A randomly chosen perturbation has to place the perturbed point inside the t-SNE hypersphere, so sampling is performed until this condition is met, which should happen at least with probability equal to the inverse proportion of a small 5% hypersphere to its intersection with the t-SNE hypersphere centered on the hypersphere surface. For most points well inside the t-SNE hypersphere the first random perturbation sampling will very likely be valid.
5. The perturb slider is no longer required, as the perturb button alone is enough to apply a random walk of all points as long as it is pressed with visual feedback via the updated projection after every perturbation.
6. The perturbation can happen while t-SNE is running or when it is paused, as long as it hasTSNERun.
7. The perturbation fires immediately on mousedown, then it fires approximately every 0.1 seconds as a new perturbation calculation.
8. The t-SNE embedding may have slight asymmetry to begin with, but it is assumed that its dimensions are approximately normalized with respect to one another, otherwise the hypersphere assumption will not hold.
9. Perturbation keeps points within the approximate hypersphere and the random walks produce a more uniform distribution of the points and make the t-SNE more spherical.

### Random walk of some points
![projector-tsne-perturb-v2-vid1-red1](https://user-images.githubusercontent.com/10847676/33084629-1b75d078-ceeb-11e7-8b5e-be95f1e8c01a.gif)


### t-SNE panel before:
<img width="313" alt="screen shot 2017-11-21 at 6 26 21 pm" src="https://user-images.githubusercontent.com/10847676/33084643-2042c5ac-ceeb-11e7-9599-75b07f4a370a.png">

### t-SNE panel after:
<img width="313" alt="screen shot 2017-11-21 at 6 26 42 pm" src="https://user-images.githubusercontent.com/10847676/33084646-23a4a59e-ceeb-11e7-8945-c4e7dbe2de35.png">

