### PR TITLE
Rename ts_web_library -> tf_web_library

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = [":internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:zipper.bzl", "tensorboard_zip_file")
 
 licenses(["notice"])  # Apache 2.0
@@ -79,7 +79,7 @@ tensorboard_zip_file(
     deps = [":assets"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "assets",
     srcs = [
         "//tensorboard/components:index.html",
@@ -129,7 +129,7 @@ py_library(
 )
 
 filegroup(
-    name = "ts_web_library_default_typings",
+    name = "tf_web_library_default_typings",
     srcs = [
         # Ordering probably matters.
         "@com_microsoft_typescript//:lib.es6.d.ts",

--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tensorboard",
     srcs = [
         "analytics.html",
@@ -26,7 +26,7 @@ tensorboard_html_binary(
     deps = [":tensorboard"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "trace_viewer",
     srcs = ["trace_viewer.html"],
     path = "/",

--- a/tensorboard/components/tf_backend/BUILD
+++ b/tensorboard/components/tf_backend/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_backend",
     srcs = [
         "backend.ts",

--- a/tensorboard/components/tf_backend/test/BUILD
+++ b/tensorboard/components/tf_backend/test/BUILD
@@ -3,11 +3,11 @@ package(
     default_visibility = ["//tensorboard:internal"],
 )
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "test",
     srcs = [
         "tests.html",

--- a/tensorboard/components/tf_card_heading/BUILD
+++ b/tensorboard/components/tf_card_heading/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_card_heading",
     srcs = [
         "tf-card-heading.html",

--- a/tensorboard/components/tf_categorization_utils/BUILD
+++ b/tensorboard/components/tf_categorization_utils/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_categorization_utils",
     srcs = [
         "categorizationUtils.ts",

--- a/tensorboard/components/tf_categorization_utils/test/BUILD
+++ b/tensorboard/components/tf_categorization_utils/test/BUILD
@@ -3,11 +3,11 @@ package(
     default_visibility = ["//tensorboard:internal"],
 )
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "test",
     srcs = [
         "tests.html",

--- a/tensorboard/components/tf_color_scale/BUILD
+++ b/tensorboard/components/tf_color_scale/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_color_scale",
     srcs = [
         "colorScale.ts",

--- a/tensorboard/components/tf_color_scale/test/BUILD
+++ b/tensorboard/components/tf_color_scale/test/BUILD
@@ -3,11 +3,11 @@ package(
     default_visibility = ["//tensorboard:internal"],
 )
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "test",
     srcs = [
         "colorScaleTests.ts",

--- a/tensorboard/components/tf_dashboard_common/BUILD
+++ b/tensorboard/components/tf_dashboard_common/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_dashboard_common",
     srcs = [
         "dashboard-style.html",
@@ -49,7 +49,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = [
         "tf-multi-checkbox-demo.html",

--- a/tensorboard/components/tf_globals/BUILD
+++ b/tensorboard/components/tf_globals/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_globals",
     srcs = [
         "globals.ts",

--- a/tensorboard/components/tf_imports/BUILD
+++ b/tensorboard/components/tf_imports/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:hacks.bzl", "tensorboard_typescript_bundle")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "webcomponentsjs",
     srcs = ["@org_definitelytyped//:webcomponents.js.d.ts"],
     path = "/webcomponentsjs",
@@ -13,7 +13,7 @@ ts_web_library(
     exports = ["@org_polymer_webcomponentsjs"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "polymer",
     srcs = ["@org_definitelytyped//:polymer.d.ts"],
     path = "/polymer",
@@ -22,7 +22,7 @@ ts_web_library(
     deps = [":webcomponentsjs"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "lodash",
     srcs = [
         "lodash.html",
@@ -33,7 +33,7 @@ ts_web_library(
     deps = ["@com_lodash"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "threejs",
     srcs = [
         "threejs.html",
@@ -45,7 +45,7 @@ ts_web_library(
     visibility = ["//visibility:public"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "numericjs",
     srcs = [
         "numericjs.html",
@@ -55,7 +55,7 @@ ts_web_library(
     visibility = ["//visibility:public"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "weblas",
     srcs = [
         "weblas.html",
@@ -65,7 +65,7 @@ ts_web_library(
     visibility = ["//visibility:public"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "graphlib",
     srcs = [
         "graphlib.html",
@@ -76,7 +76,7 @@ ts_web_library(
     deps = [":lodash"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "dagre",
     srcs = [
         "dagre.html",
@@ -90,7 +90,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "d3",
     srcs = [
         "d3.d.ts",
@@ -101,7 +101,7 @@ ts_web_library(
     visibility = ["//visibility:public"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "plottable",
     srcs = [
         "plottable.d.ts",
@@ -115,7 +115,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "plottable_js_css",
     srcs = [
         "@com_palantir_plottable//:package/plottable.css",
@@ -126,7 +126,7 @@ ts_web_library(
     visibility = ["//visibility:private"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "web_component_tester",
     testonly = 1,
     visibility = ["//visibility:public"],
@@ -138,7 +138,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "chai_typings",
     testonly = 1,
     srcs = ["@org_definitelytyped//:chai.d.ts"],
@@ -146,7 +146,7 @@ ts_web_library(
     visibility = ["//visibility:private"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "mocha_typings",
     testonly = 1,
     srcs = ["@org_definitelytyped//:mocha.d.ts"],
@@ -154,7 +154,7 @@ ts_web_library(
     visibility = ["//visibility:private"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "sinon_typings",
     testonly = 1,
     srcs = ["@org_definitelytyped//:sinon.d.ts"],

--- a/tensorboard/components/tf_line_chart_data_loader/BUILD
+++ b/tensorboard/components/tf_line_chart_data_loader/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_line_chart_data_loader",
     srcs = [
         "tf-line-chart-data-loader.html",

--- a/tensorboard/components/tf_markdown_view/BUILD
+++ b/tensorboard/components/tf_markdown_view/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_markdown_view",
     srcs = ["tf-markdown-view.html"],
     path = "/tf-markdown-view",

--- a/tensorboard/components/tf_option_selector/BUILD
+++ b/tensorboard/components/tf_option_selector/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_option_selector",
     srcs = ["tf-option-selector.html"],
     path = "/tf-option-selector",

--- a/tensorboard/components/tf_paginated_view/BUILD
+++ b/tensorboard/components/tf_paginated_view/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_paginated_view",
     srcs = [
         "paginatedViewStore.ts",

--- a/tensorboard/components/tf_runs_selector/BUILD
+++ b/tensorboard/components/tf_runs_selector/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_runs_selector",
     srcs = ["tf-runs-selector.html"],
     path = "/tf-runs-selector",

--- a/tensorboard/components/tf_storage/BUILD
+++ b/tensorboard/components/tf_storage/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_storage",
     srcs = [
         "storage.ts",

--- a/tensorboard/components/tf_storage/test/BUILD
+++ b/tensorboard/components/tf_storage/test/BUILD
@@ -3,11 +3,11 @@ package(
     default_visibility = ["//tensorboard:internal"],
 )
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "test",
     srcs = [
         "storageTests.ts",

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_tensorboard",
     srcs = [
         "autoReloadBehavior.ts",
@@ -35,7 +35,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "registry",
     srcs = [
         "registry.html",
@@ -45,7 +45,7 @@ ts_web_library(
     visibility = ["//visibility:public"],
 )
 
-ts_web_library(
+tf_web_library(
     name = "default_plugins",
     srcs = ["default-plugins.html"],
     path = "/tf-tensorboard",
@@ -65,7 +65,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["demo.html"],
     path = "/tf-tensorboard",

--- a/tensorboard/components/tf_trace_viewer/BUILD
+++ b/tensorboard/components/tf_trace_viewer/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_trace_viewer",
     srcs = [
         "tf-trace-viewer.html",
@@ -13,7 +13,7 @@ ts_web_library(
     path = "/tf-trace-viewer",
 )
 
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["demo.html"],
     path = "/tf-trace-viewer",

--- a/tensorboard/components/tf_utils/BUILD
+++ b/tensorboard/components/tf_utils/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_utils",
     srcs = [
         "utils.ts",

--- a/tensorboard/components/vz_line_chart/BUILD
+++ b/tensorboard/components/vz_line_chart/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "vz_line_chart",
     srcs = [
         "dragZoomInteraction.ts",
@@ -23,7 +23,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"],
     path = "/vz-line-chart",

--- a/tensorboard/components/vz_sorting/BUILD
+++ b/tensorboard/components/vz_sorting/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "vz_sorting",
     srcs = [
         "sorting.ts",

--- a/tensorboard/components/vz_sorting/test/BUILD
+++ b/tensorboard/components/vz_sorting/test/BUILD
@@ -3,11 +3,11 @@ package(
     default_visibility = ["//tensorboard:internal"],
 )
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "test",
     srcs = [
         "sortingTests.ts",

--- a/tensorboard/defs/BUILD
+++ b/tensorboard/defs/BUILD
@@ -3,7 +3,7 @@ package(default_visibility = ["//tensorboard:internal"])
 licenses(["notice"])  # Apache 2.0
 
 filegroup(
-    name = "ts_web_library_default_typings",
+    name = "tf_web_library_default_typings",
     srcs = [
         # Ordering probably matters.
         "@com_microsoft_typescript//:lib.es6.d.ts",

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -41,7 +41,7 @@ _CLOSURE_WORKER = attr.label(
     executable=True,
     cfg="host")
 
-def _ts_web_library(ctx):
+def _tf_web_library(ctx):
   if not ctx.attr.srcs:
     if ctx.attr.deps:
       fail("deps can not be set when srcs is not")
@@ -379,8 +379,8 @@ web_aspect = aspect(
     attr_aspects=["deps", "sticky_deps", "module_deps"],
     attrs={"_ClosureWorkerAspect": _CLOSURE_WORKER})
 
-ts_web_library = rule(
-    implementation=_ts_web_library,
+tf_web_library = rule(
+    implementation=_tf_web_library,
     executable=True,
     attrs=CLUTZ_ATTRIBUTES + {
         "path": attr.string(),
@@ -407,7 +407,7 @@ ts_web_library = rule(
             executable=True,
             cfg="host"),
         "_default_typings": attr.label(
-            default=Label("//tensorboard:ts_web_library_default_typings"),
+            default=Label("//tensorboard:tf_web_library_default_typings"),
             allow_files=True),
         "_WebfilesServer": attr.label(
             default=Label("@io_bazel_rules_closure//java/io/bazel/rules/closure/webfiles/server:WebfilesServer"),
@@ -418,3 +418,7 @@ ts_web_library = rule(
         "_closure_library_deps": CLOSURE_LIBRARY_DEPS_ATTR,
     },
     outputs=CLUTZ_OUTPUTS)
+
+def ts_web_library(**kwargs):
+  print("DEPRECATION: ts_web_library is now tf_web_library")
+  tf_web_library(**kwargs)

--- a/tensorboard/plugins/audio/tf_audio_dashboard/BUILD
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_audio_dashboard",
     srcs = [
         "tf-audio-dashboard.html",
@@ -35,7 +35,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "index",
     srcs = [
         "demo/index.html",

--- a/tensorboard/plugins/audio/tf_audio_dashboard/test/BUILD
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/test/BUILD
@@ -3,11 +3,11 @@ package(
     default_visibility = ["//tensorboard:internal"],
 )
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "test",
     srcs = [
         "audioDashboardTests.ts",

--- a/tensorboard/plugins/beholder/client_side/BUILD
+++ b/tensorboard/plugins/beholder/client_side/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "ts_web_library")
+load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "dashboard",
     srcs = [
         "beholder-dashboard.html",

--- a/tensorboard/plugins/core/BUILD
+++ b/tensorboard/plugins/core/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:zipper.bzl", "tensorboard_zip_file")
 
 licenses(["notice"])  # Apache 2.0
@@ -41,7 +41,7 @@ py_test(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "test_assets",
     testonly = 1,
     srcs = ["index.html"],

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_custom_scalar_dashboard",
     srcs = [
         "tf-custom-scalar-card.html",

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/BUILD
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_distribution_dashboard",
     srcs = [
         "tf-distribution-dashboard.html",
@@ -33,7 +33,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),
     path = "/tf-distribution-dashboard",

--- a/tensorboard/plugins/distribution/vz_distribution_chart/BUILD
+++ b/tensorboard/plugins/distribution/vz_distribution_chart/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "vz_distribution_chart",
     srcs = [
         "vz-distribution-chart.html",
@@ -20,7 +20,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"],
     path = "/vz-distribution-chart",

--- a/tensorboard/plugins/graph/tf_graph/BUILD
+++ b/tensorboard/plugins/graph/tf_graph/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_graph",
     srcs = [
         "tf-graph.html",

--- a/tensorboard/plugins/graph/tf_graph/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph/demo/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
 # bazel run //tensorboard/plugins/graph/tf_graph/demo
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),
     path = "/tf-graph/demo",

--- a/tensorboard/plugins/graph/tf_graph_app/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_app/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_graph_app",
     srcs = [
         "index.html",

--- a/tensorboard/plugins/graph/tf_graph_app/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_app/demo/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
 # bazel run //tensorboard/plugins/graph/tf_graph_app/demo
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),
     path = "/tf-graph-app/demo",

--- a/tensorboard/plugins/graph/tf_graph_board/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_board/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_graph_board",
     srcs = ["tf-graph-board.html"],
     path = "/tf-graph-board",

--- a/tensorboard/plugins/graph/tf_graph_board/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_board/demo/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
 # bazel run //tensorboard/plugins/graph/tf_graph_board/demo
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),
     path = "/tf-graph-board/demo",

--- a/tensorboard/plugins/graph/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_common/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_graph_common",
     srcs = [
         "annotation.ts",

--- a/tensorboard/plugins/graph/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_controls/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_graph_controls",
     srcs = ["tf-graph-controls.html"],
     path = "/tf-graph-controls",

--- a/tensorboard/plugins/graph/tf_graph_controls/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_controls/demo/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
 # bazel run //tensorboard/plugins/graph/tf_graph_controls/demo
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"],
     path = "/tf-graph-controls/demo",

--- a/tensorboard/plugins/graph/tf_graph_dashboard/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_graph_dashboard",
     srcs = ["tf-graph-dashboard.html"],
     path = "/tf-graph-dashboard",

--- a/tensorboard/plugins/graph/tf_graph_dashboard/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/demo/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
 # bazel run //tensorboard/plugins/graph/tf_graph_dashboard/demo
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),
     path = "/tf-graph-dashboard/demo",

--- a/tensorboard/plugins/graph/tf_graph_debugger_data_card/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_debugger_data_card/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_graph_debugger_data_card",
     srcs = [
         "tf-graph-debugger-data-card.html",

--- a/tensorboard/plugins/graph/tf_graph_debugger_data_card/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_debugger_data_card/demo/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
 # bazel run //tensorboard/plugins/graph/tf_graph_debugger_data_card/demo
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),
     path = "/tf-graph-debugger-data-card/demo",

--- a/tensorboard/plugins/graph/tf_graph_info/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_info/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_graph_info",
     srcs = [
         "tf-graph-info.html",
@@ -31,7 +31,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "tf_graph_icon",
     srcs = [
         "tf-graph-icon.html",

--- a/tensorboard/plugins/graph/tf_graph_info/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_info/demo/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
 # bazel run //tensorboard/plugins/graph/tf_graph_info/demo
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),
     path = "/tf-graph-info/demo",

--- a/tensorboard/plugins/graph/tf_graph_loader/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_loader/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_graph_loader",
     srcs = ["tf-graph-loader.html"],
     path = "/tf-graph-loader",

--- a/tensorboard/plugins/graph/tf_graph_loader/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_loader/demo/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
 # bazel run //tensorboard/plugins/graph/tf_graph_loader/demo
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),
     path = "/tf-graph-loader/demo",

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_graph_op_compat_card",
     srcs = [
         "tf-graph-op-compat-card.html",

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_histogram_dashboard",
     srcs = [
         "histogramCore.ts",
@@ -36,7 +36,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),
     path = "/tf-histogram-dashboard",

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/test/BUILD
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/test/BUILD
@@ -3,11 +3,11 @@ package(
     default_visibility = ["//tensorboard:internal"],
 )
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "test",
     srcs = [
         "tests.html",

--- a/tensorboard/plugins/histogram/vz_histogram_timeseries/BUILD
+++ b/tensorboard/plugins/histogram/vz_histogram_timeseries/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "vz_histogram_timeseries",
     srcs = ["vz-histogram-timeseries.html"],
     path = "/vz-histogram-timeseries",
@@ -15,7 +15,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"],
     path = "/vz-histogram-timeseries",

--- a/tensorboard/plugins/image/tf_image_dashboard/BUILD
+++ b/tensorboard/plugins/image/tf_image_dashboard/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_image_dashboard",
     srcs = [
         "tf-image-dashboard.html",
@@ -33,7 +33,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),
     path = "/tf-image-dashboard",

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/BUILD
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/BUILD
@@ -14,11 +14,11 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_pr_curve_dashboard",
     srcs = [
         "tf-pr-curve-card.html",

--- a/tensorboard/plugins/profile/tf_op_profile/BUILD
+++ b/tensorboard/plugins/profile/tf_op_profile/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_op_profile",
     srcs = ["tf-op-profile.html"],
     path = "/tf-op-profile",
@@ -16,7 +16,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "tf_op_details",
     srcs = ["tf-op-details.html"],
     path = "/tf-op-profile",
@@ -26,7 +26,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "tf_op_table",
     srcs = ["tf-op-table.html"],
     path = "/tf-op-profile",
@@ -35,7 +35,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "utils",
     srcs = [
         "utils.html",

--- a/tensorboard/plugins/profile/tf_profile_dashboard/BUILD
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_profile_dashboard",
     srcs = ["tf-profile-dashboard.html"],
     path = "/tf-profile-dashboard",

--- a/tensorboard/plugins/projector/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "vz_projector",
     srcs = [
         "analyticsLogger.ts",
@@ -85,19 +85,19 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "heap",
     srcs = ["heap.ts"],
     path = "/vz-projector",
 )
 
-ts_web_library(
+tf_web_library(
     name = "sptree",
     srcs = ["sptree.ts"],
     path = "/vz-projector",
 )
 
-ts_web_library(
+tf_web_library(
     name = "bh_tsne",
     srcs = ["bh_tsne.ts"],
     path = "/vz-projector",

--- a/tensorboard/plugins/projector/vz_projector/test/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/test/BUILD
@@ -3,11 +3,11 @@ package(
     default_visibility = ["//tensorboard:internal"],
 )
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "test",
     srcs = [
         "assert.ts",

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_scalar_dashboard",
     srcs = [
         "tf-scalar-card.html",

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/demo/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/demo/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"],
     path = "/tf-scalar-dashboard/demo",

--- a/tensorboard/plugins/text/tf_text_dashboard/BUILD
+++ b/tensorboard/plugins/text/tf_text_dashboard/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "ts_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-ts_web_library(
+tf_web_library(
     name = "tf_text_dashboard",
     srcs = [
         "tf-text-dashboard.html",
@@ -35,7 +35,7 @@ ts_web_library(
     ],
 )
 
-ts_web_library(
+tf_web_library(
     name = "demo",
     srcs = ["index.html"] + glob(["data/**"]),
     path = "/tf-text-dashboard",


### PR DESCRIPTION
A deprecation warning has been added to the old name, which we'll remove at some point in the future.