### PR TITLE
Set max-width for TensorBoard sidebar

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.html
+++ b/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.html
@@ -39,6 +39,7 @@ Generic layout for a dashboard.
         overflow: ellipsis;
         flex-grow: 0;
         flex-shrink: 0;
+        max-width: 30%;
       }
 
       #center {


### PR DESCRIPTION
Prevent sidebar from getting to big for new plugins that use tf-dashboard-layout.