### PR TITLE
Make TensorBoard store 100 samples of PR curves

### DIFF
--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -69,6 +69,7 @@ py_library(
         "//tensorboard/plugins/core:core_plugin",
         "//tensorboard/plugins/histogram:metadata",
         "//tensorboard/plugins/image:metadata",
+        "//tensorboard/plugins/pr_curve:metadata",
         "//tensorboard/plugins/scalar:metadata",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -44,6 +44,7 @@ from tensorboard.plugins.audio import metadata as audio_metadata
 from tensorboard.plugins.core import core_plugin
 from tensorboard.plugins.histogram import metadata as histogram_metadata
 from tensorboard.plugins.image import metadata as image_metadata
+from tensorboard.plugins.pr_curve import metadata as pr_curve_metadata
 from tensorboard.plugins.scalar import metadata as scalar_metadata
 
 
@@ -58,6 +59,7 @@ DEFAULT_TENSOR_SIZE_GUIDANCE = {
     image_metadata.PLUGIN_NAME: 10,
     audio_metadata.PLUGIN_NAME: 10,
     histogram_metadata.PLUGIN_NAME: 500,
+    pr_curve_metadata.PLUGIN_NAME: 100,
 }
 
 DATA_PREFIX = '/data'


### PR DESCRIPTION
Previously, TensorBoard had only stored 10 samples of PR curves at once
for each tag, which has proven a bit coarse.

A common threshold for PR curves is 201. Each PR curve summary consists
of 6 rows of num_threshold float32 values. Therefore, storing 100
samples in memory for each tag means that we store

100 * 201 * 6 * 4 B = 482.4 KB for each tag

That seems fine.