### PR TITLE
FindSimilarSubGraph bug fix.

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/template.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/template.ts
@@ -221,7 +221,7 @@ function isSimilarSubgraph(g1: graphlib.Graph<any, any>,
       sub2 = n2.substr(g2prefix.length);
 
     /* tslint:disable */
-    if (visited1[sub1] ^ visited2[sub1]) {
+    if (visited1[sub1] ^ visited2[sub2]) {
       console.warn(
           'different visit pattern', '[' + g1prefix + ']', sub1,
           '[' + g2prefix + ']', sub2);


### PR DESCRIPTION
comparing of visit pattern should be done symmetrically. we should NOT check g2's node inside g1's visit map.