### PR TITLE
Let users specify and store tagFilter in the URL

### DIFF
--- a/tensorboard/components/tf_categorization_utils/BUILD
+++ b/tensorboard/components/tf_categorization_utils/BUILD
@@ -11,6 +11,7 @@ tf_web_library(
         "categorizationUtils.ts",
         "tf-categorization-utils.html",
         "tf-category-pane.html",
+        "tf-tag-filterer.html",
     ],
     path = "/tf-categorization-utils",
     visibility = ["//visibility:public"],
@@ -19,7 +20,10 @@ tf_web_library(
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_storage",
         "//tensorboard/components/vz_sorting",
         "@org_polymer_iron_collapse",
+        "@org_polymer_iron_icon",
+        "@org_polymer_paper_input",
     ],
 )

--- a/tensorboard/components/tf_categorization_utils/tf-category-pane.html
+++ b/tensorboard/components/tf_categorization_utils/tf-category-pane.html
@@ -57,7 +57,7 @@ limitations under the License.
       }
 
       :host:first-of-type {
-        margin-top: 20px;
+        margin-top: 10px;
       }
 
       :host:last-of-type {

--- a/tensorboard/components/tf_categorization_utils/tf-tag-filterer.html
+++ b/tensorboard/components/tf_categorization_utils/tf-tag-filterer.html
@@ -1,0 +1,62 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-storage/tf-storage.html">
+
+<!--
+Regex search input UI at tops of dashboards.
+
+@element tf-tag-filterer
+-->
+<dom-module id="tf-tag-filterer">
+  <template>
+    <paper-input no-label-float
+                 label="Filter tags (regular expressions supported)"
+                 value="{{tagFilter}}"
+                 class="search-input">
+      <iron-icon prefix icon="search" slot="prefix"></iron-icon>
+    </paper-input>
+  </template>
+  <style>
+    :host {
+      display: block;
+      margin: 10px 5px 10px 10px;
+    }
+  </style>
+  <script>
+    Polymer({
+      is: "tf-tag-filterer",
+      properties: {
+
+        /** Value of the search box. */
+        tagFilter: {
+          type: String,
+          notify: true,
+          value: tf_storage.getStringInitializer('tagFilter',
+              {defaultValue: '', useLocalStorage: true}),
+          observer: '_tagFilterObserver',
+        },
+      },
+
+      _tagFilterObserver: tf_storage.getStringObserver(
+          'tagFilter', {defaultValue: '', useLocalStorage: true}),
+    });
+  </script>
+</dom-module>

--- a/tensorboard/components/tf_categorization_utils/tf-tag-filterer.html
+++ b/tensorboard/components/tf_categorization_utils/tf-tag-filterer.html
@@ -44,7 +44,6 @@ Regex search input UI at tops of dashboards.
     Polymer({
       is: "tf-tag-filterer",
       properties: {
-
         /** Value of the search box. */
         tagFilter: {
           type: String,

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
@@ -137,10 +137,14 @@ limitations under the License.
         _dataNotFound: Boolean,
         _tagFilter: String,
 
+        // Categories must only be computed after _dataNotFound is found to be
+        // true and then polymer DOM templating responds to that finding. We
+        // thus use this property to guard when categories are computed.
+        _categoriesDomReady: Boolean,
         _categories: {
           type: Array,
           computed:
-            '_makeCategories(_runToTag, _selectedRuns, _tagFilter)',
+            '_makeCategories(_runToTag, _selectedRuns, _tagFilter, _categoriesDomReady)',
         },
 
         _requestManager: {
@@ -168,6 +172,10 @@ limitations under the License.
           this.set('_dataNotFound', tags.length === 0);
           this.set('_runToTag', runToTag);
           this.set('_runToTagInfo', runToTagInfo);
+          this.async(() => {
+            // See the comment above `_categoriesDomReady`.
+            this.set('_categoriesDomReady', true);
+          });
         });
       },
       _reloadDistributions() {
@@ -176,7 +184,7 @@ limitations under the License.
         });
       },
 
-      _makeCategories(runToTag, selectedRuns, tagFilter) {
+      _makeCategories(runToTag, selectedRuns, tagFilter, categoriesDomReady) {
         return tf_categorization_utils.categorizeRunTagCombinations(runToTag, selectedRuns, tagFilter);
       },
       _tagMetadata(runToTagInfo, run, tag) {

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
@@ -22,6 +22,7 @@ limitations under the License.
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
 <link rel="import" href="../tf-categorization-utils/tf-category-pane.html">
+<link rel="import" href="../tf-categorization-utils/tf-tag-filterer.html">
 <link rel="import" href="../tf-dashboard-common/dashboard-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
@@ -81,14 +82,7 @@ limitations under the License.
           </div>
         </template>
         <template is="dom-if" if="[[!_dataNotFound]]">
-          <paper-input
-            no-label-float
-            label="Filter tags (regular expressions supported)"
-            value="{{_tagFilter}}"
-            class="search-input"
-          >
-            <iron-icon prefix icon="search"></iron-icon>
-          </paper-input>
+          <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
             <tf-category-pane category="[[category]]">
               <tf-paginated-view
@@ -141,11 +135,8 @@ limitations under the License.
         _runToTag: Object,  // map<run: string, tags: string[]>
         _runToTagInfo: Object,
         _dataNotFound: Boolean,
+        _tagFilter: String,
 
-        _tagFilter: {
-          type: String,  // upward bound from paper-input
-          value: '',
-        },
         _categories: {
           type: Array,
           computed:

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -149,10 +149,14 @@ limitations under the License.
         _dataNotFound: Boolean,
         _tagFilter: String,
 
+        // Categories must only be computed after _dataNotFound is found to be
+        // true and then polymer DOM templating responds to that finding. We
+        // thus use this property to guard when categories are computed.
+        _categoriesDomReady: Boolean,
         _categories: {
           type: Array,
           computed:
-            '_makeCategories(_runToTag, _selectedRuns, _tagFilter)',
+            '_makeCategories(_runToTag, _selectedRuns, _tagFilter, _categoriesDomReady)',
         },
 
         _requestManager: {
@@ -181,6 +185,10 @@ limitations under the License.
           this.set('_dataNotFound', tags.length === 0);
           this.set('_runToTag', runToTag);
           this.set('_runToTagInfo', runToTagInfo);
+          this.async(() => {
+            // See the comment above `_categoriesDomReady`.
+            this.set('_categoriesDomReady', true);
+          });
         });
       },
       _reloadHistograms() {
@@ -189,7 +197,7 @@ limitations under the License.
         });
       },
 
-      _makeCategories(runToTag, selectedRuns, tagFilter) {
+      _makeCategories(runToTag, selectedRuns, tagFilter, categoriesDomReady) {
         return tf_categorization_utils.categorizeRunTagCombinations(runToTag, selectedRuns, tagFilter);
       },
       _tagMetadata(runToTagInfo, run, tag) {

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -22,6 +22,7 @@ limitations under the License.
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
 <link rel="import" href="../tf-categorization-utils/tf-category-pane.html">
+<link rel="import" href="../tf-categorization-utils/tf-tag-filterer.html">
 <link rel="import" href="../tf-dashboard-common/dashboard-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
@@ -88,14 +89,7 @@ limitations under the License.
           </div>
         </template>
         <template is="dom-if" if="[[!_dataNotFound]]">
-          <paper-input
-            no-label-float
-            label="Filter tags (regular expressions supported)"
-            value="{{_tagFilter}}"
-            class="search-input"
-          >
-            <iron-icon prefix icon="search"></iron-icon>
-          </paper-input>
+          <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
             <tf-category-pane category="[[category]]">
               <tf-paginated-view
@@ -153,11 +147,8 @@ limitations under the License.
         _runToTag: Object,  // map<run: string, tags: string[]>
         _runToTagInfo: Object,
         _dataNotFound: Boolean,
+        _tagFilter: String,
 
-        _tagFilter: {
-          type: String,  // upward bound from paper-input
-          value: '',
-        },
         _categories: {
           type: Array,
           computed:

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
@@ -21,6 +21,7 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
+<link rel="import" href="../tf-categorization-utils/tf-tag-filterer.html">
 <link rel="import" href="../tf-dashboard-common/dashboard-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-dashboard-common/tf-regex-group.html">
@@ -72,14 +73,7 @@ TensorFlow run.
           </div>
         </template>
         <template is="dom-if" if="[[!_dataNotFound]]">
-          <paper-input
-            no-label-float
-            label="Filter tags (regular expressions supported)"
-            value="{{_tagFilter}}"
-            class="search-input"
-          >
-            <iron-icon prefix icon="search"></iron-icon>
-          </paper-input>
+          <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
             <tf-category-pane category="[[category]]">
               <tf-paginated-view
@@ -128,11 +122,8 @@ TensorFlow run.
         _runToTagInfo: Object,
         _dataNotFound: Boolean,
         _actualSize: Boolean,
+        _tagFilter: String,
 
-        _tagFilter: {
-          type: String,  // upward bound from paper-input
-          value: '',
-        },
         _categories: {
           type: Array,
           computed:

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
@@ -124,10 +124,14 @@ TensorFlow run.
         _actualSize: Boolean,
         _tagFilter: String,
 
+        // Categories must only be computed after _dataNotFound is found to be
+        // true and then polymer DOM templating responds to that finding. We
+        // thus use this property to guard when categories are computed.
+        _categoriesDomReady: Boolean,
         _categories: {
           type: Array,
           computed:
-            '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter)',
+            '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter, _categoriesDomReady)',
         },
 
         _requestManager: {
@@ -155,6 +159,10 @@ TensorFlow run.
           const tags = tf_backend.getTags(runToTag);
           this.set('_dataNotFound', tags.length === 0);
           this.set('_runToTagInfo', runToTagInfo);
+          this.async(() => {
+            // See the comment above `_categoriesDomReady`.
+            this.set('_categoriesDomReady', true);
+          });
         });
       },
       _reloadImages() {
@@ -163,7 +171,8 @@ TensorFlow run.
         });
       },
 
-      _makeCategories(runToTagInfo, selectedRuns, tagFilter) {
+      _makeCategories(
+          runToTagInfo, selectedRuns, tagFilter, categoriesDomReady) {
         const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
         const baseCategories =
           tf_categorization_utils.categorizeRunTagCombinations(runToTag, selectedRuns, tagFilter);

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
@@ -19,6 +19,7 @@ limitations under the License.
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
 <link rel="import" href="../tf-categorization-utils/tf-category-pane.html">
+<link rel="import" href="../tf-categorization-utils/tf-tag-filterer.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/dashboard-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
@@ -89,14 +90,7 @@ limitations under the License.
           </div>
         </template>
         <template is="dom-if" if="[[!_dataNotFound]]">
-          <paper-input
-            no-label-float
-            label="Filter tags (regular expressions supported)"
-            value="{{_tagFilter}}"
-            class="search-input"
-          >
-            <iron-icon prefix icon="search"></iron-icon>
-          </paper-input>
+          <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
             <tf-category-pane category="[[category]]">
               <tf-paginated-view
@@ -172,10 +166,7 @@ limitations under the License.
         notify: true,
       },
       _dataNotFound: Boolean,
-      _tagFilter: {
-        type: String,  // upward bound from paper-input
-        value: '',
-      },
+      _tagFilter: String,
       _categories: {
         type: Array,
         computed: '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter)',

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
@@ -167,9 +167,13 @@ limitations under the License.
       },
       _dataNotFound: Boolean,
       _tagFilter: String,
+      // Categories must only be computed after _dataNotFound is found to be
+      // true and then polymer DOM templating responds to that finding. We
+      // thus use this property to guard when categories are computed.
+      _categoriesDomReady: Boolean,
       _categories: {
         type: Array,
-        computed: '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter)',
+        computed: '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter, _categoriesDomReady)',
       },
       _requestManager: {
         type: Object,
@@ -201,6 +205,10 @@ limitations under the License.
         const tags = tf_backend.getTags(runToTag);
         this.set('_dataNotFound', tags.length === 0);
         this.set('_runToTagInfo', runToTagInfo);
+        this.async(() => {
+          // See the comment above `_categoriesDomReady`.
+          this.set('_categoriesDomReady', true);
+        });
       });
     },
     _fetchTimeEntriesPerRun() {
@@ -228,7 +236,7 @@ limitations under the License.
         card.reload();
       });
     },
-    _makeCategories(runToTagInfo, selectedRuns, tagFilter) {
+    _makeCategories(runToTagInfo, selectedRuns, tagFilter, categoriesDomReady) {
       const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
       return tf_categorization_utils.categorizeTags(runToTag, selectedRuns, tagFilter);
     },

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -28,7 +28,6 @@ tf_web_library(
         "//tensorboard/components/tf_tensorboard:registry",
         "//tensorboard/components/tf_utils",
         "@org_polymer_iron_collapse",
-        "@org_polymer_iron_icon",
         "@org_polymer_paper_button",
         "@org_polymer_paper_checkbox",
         "@org_polymer_paper_dropdown_menu",

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -15,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../paper-button/paper-button.html">
 <link rel="import" href="../paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
@@ -26,6 +25,7 @@ limitations under the License.
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
 <link rel="import" href="../tf-categorization-utils/tf-category-pane.html">
+<link rel="import" href="../tf-categorization-utils/tf-tag-filterer.html">
 <link rel="import" href="../tf-dashboard-common/dashboard-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
@@ -119,14 +119,7 @@ limitations under the License.
           </div>
         </template>
         <template is="dom-if" if="[[!_dataNotFound]]">
-          <paper-input
-            no-label-float
-            label="Filter tags (regular expressions supported)"
-            value="{{_tagFilter}}"
-            class="search-input"
-          >
-            <iron-icon prefix icon="search" slot="prefix"></iron-icon>
-          </paper-input>
+          <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
             <tf-category-pane category="[[category]]">
               <tf-paginated-view
@@ -226,11 +219,7 @@ limitations under the License.
         _selectedRuns: Array,
         _runToTagInfo: Object,
         _dataNotFound: Boolean,
-
-        _tagFilter: {
-          type: String,  // upward bound from paper-input
-          value: '',
-        },
+        _tagFilter: String,
         _categories: {
           type: Array,
           computed:

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -220,10 +220,14 @@ limitations under the License.
         _runToTagInfo: Object,
         _dataNotFound: Boolean,
         _tagFilter: String,
+        // Categories must only be computed after _dataNotFound is found to be
+        // true and then polymer DOM templating responds to that finding. We
+        // thus use this property to guard when categories are computed.
+        _categoriesDomReady: Boolean,
         _categories: {
           type: Array,
           computed:
-            '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter)',
+            '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter, _categoriesDomReady)',
         },
 
         _requestManager: {
@@ -240,7 +244,6 @@ limitations under the License.
       _computeSmoothingEnabled(_smoothingWeight) {
         return _smoothingWeight > 0;
       },
-
 
       ready() {
         this.reload();
@@ -261,6 +264,10 @@ limitations under the License.
           const tags = tf_backend.getTags(runToTag);
           this.set('_dataNotFound', tags.length === 0);
           this.set('_runToTagInfo', runToTagInfo);
+          this.async(() => {
+            // See the comment above `_categoriesDomReady`.
+            this.set('_categoriesDomReady', true);
+          });
         });
       },
       _reloadCharts() {
@@ -269,7 +276,8 @@ limitations under the License.
         });
       },
 
-      _makeCategories(runToTagInfo, selectedRuns, tagFilter) {
+      _makeCategories(
+          runToTagInfo, selectedRuns, tagFilter, categoriesDomReady) {
         const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
         return tf_categorization_utils.categorizeTags(runToTag, selectedRuns, tagFilter);
       },

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
@@ -21,6 +21,7 @@ limitations under the License.
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
 <link rel="import" href="../tf-categorization-utils/tf-category-pane.html">
+<link rel="import" href="../tf-categorization-utils/tf-tag-filterer.html">
 <link rel="import" href="../tf-dashboard-common/dashboard-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-paginated-view/tf-paginated-view.html">
@@ -61,14 +62,7 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
           </div>
         </template>
         <template is="dom-if" if="[[!_dataNotFound]]">
-          <paper-input
-            no-label-float
-            label="Filter tags (regular expressions supported)"
-            value="{{_tagFilter}}"
-            class="search-input"
-          >
-            <iron-icon prefix icon="search"></iron-icon>
-          </paper-input>
+          <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
             <tf-category-pane category="[[category]]">
               <tf-paginated-view
@@ -110,11 +104,8 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
         _selectedRuns: Array,
         _runToTag: Object,  // map<run: string, tags: string[]>
         _dataNotFound: Boolean,
+        _tagFilter: String,
 
-        _tagFilter: {
-          type: String,  // upward bound from paper-input
-          value: '',
-        },
         _categories: {
           type: Array,
           computed:

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
@@ -105,11 +105,14 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
         _runToTag: Object,  // map<run: string, tags: string[]>
         _dataNotFound: Boolean,
         _tagFilter: String,
-
+        // Categories must only be computed after _dataNotFound is found to be
+        // true and then polymer DOM templating responds to that finding. We
+        // thus use this property to guard when categories are computed.
+        _categoriesDomReady: Boolean,
         _categories: {
           type: Array,
           computed:
-            '_makeCategories(_runToTag, _selectedRuns, _tagFilter)',
+            '_makeCategories(_runToTag, _selectedRuns, _tagFilter, _categoriesDomReady)',
         },
 
         _requestManager: {
@@ -135,6 +138,10 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
           const tags = tf_backend.getTags(runToTag);
           this.set('_dataNotFound', tags.length === 0);
           this.set('_runToTag', runToTag);
+          this.async(() => {
+            // See the comment above `_categoriesDomReady`.
+            this.set('_categoriesDomReady', true);
+          });
         });
       },
       _reloadTexts() {
@@ -142,7 +149,7 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
           textLoader.reload();
         });
       },
-      _makeCategories(runToTag, selectedRuns, tagFilter) {
+      _makeCategories(runToTag, selectedRuns, tagFilter, categoriesDomReady) {
         return tf_categorization_utils.categorizeRunTagCombinations(runToTag, selectedRuns, tagFilter);
       },
     });


### PR DESCRIPTION
@jart spearheaded this effort by introducing the tf-tag-filterer component. For each dashboard, we guard the rendering of categories until the DOM is ready.

Test Plan: Run the mnist_with_summaries model as well as the PR curves demo and the text demo. For each of the scalars, images, distributions, histograms, text, and PR curves dashboards, try loading the dashboard with and without a tagFilter GET parameter. Also, clear the tag filter and modify it.

Fixes #782