### PR TITLE
Send debugger plugin startup message directly to stderr

### DIFF
--- a/tensorboard/plugins/debugger/debugger_plugin.py
+++ b/tensorboard/plugins/debugger/debugger_plugin.py
@@ -23,6 +23,7 @@ import glob
 import json
 import os
 import re
+import sys
 import threading
 
 import tensorflow as tf
@@ -107,8 +108,9 @@ class DebuggerPlugin(base_plugin.TBPlugin):
           self._grpc_port)
     self._grpc_port = grpc_port
 
-    tf.logging.info('Creating DebuggerDataServer at port %d and logdir %s',
-                    self._grpc_port, self._logdir)
+    sys.stderr.write('Creating DebuggerDataServer at port %d and logdir %s\n' %
+                     (self._grpc_port, self._logdir))
+    sys.stderr.flush()
     self._debugger_data_server = debugger_server_lib.DebuggerDataServer(
         self._grpc_port, self._logdir)
 

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import json
 import platform
+import sys
 import threading
 
 import tensorflow as tf
@@ -87,8 +88,9 @@ class InteractiveDebuggerPlugin(base_plugin.TBPlugin):
           'gRPC port %d' % self._grpc_port)
     self._grpc_port = grpc_port
 
-    tf.logging.info('Creating InteractiveDebuggerPlugin at port %d',
-                    self._grpc_port)
+    sys.stderr.write('Creating InteractiveDebuggerPlugin at port %d\n' %
+                     self._grpc_port)
+    sys.stderr.flush()
     self._debugger_data_server = (
         interactive_debugger_server_lib.InteractiveDebuggerDataServer(
             self._grpc_port))


### PR DESCRIPTION
Partly addresses #454 by changing the debugger plugin startup lines to write directly to stderr rather than using `tf.logging.info()` which is not displayed by default since we set `tf.logging.level` to `WARN`.  Writing directly to stderr is what we do for the main `TensorBoard <version> at <url>` startup message.