### PR TITLE
Make build_pip_package.sh use only one python binary

### DIFF
--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -41,17 +41,17 @@ function main() {
   cp "${RUNFILES}/tensorboard/pip_package/MANIFEST.in" "${TMPDIR}"
   cp -R "${RUNFILES}/tensorboard" "${TMPDIR}"
 
-  pushd ${TMPDIR}
+  pushd ${TMPDIR} >/dev/null
   rm -f MANIFEST
-  echo $(date) : "=== Building wheel"
-  echo $(pwd)
-  python setup.py bdist_wheel >/dev/null
-  python3 setup.py bdist_wheel >/dev/null
+  echo $(date) : "=== Building python2 wheel in $PWD"
+  python setup.py bdist_wheel --python-tag py2 >/dev/null
+  echo $(date) : "=== Building python3 wheel in $PWD"
+  python setup.py bdist_wheel --python-tag py3 >/dev/null
   mkdir -p ${DEST}
   cp dist/* ${DEST}
-  popd
+  popd >/dev/null
   rm -rf ${TMPDIR}
-  echo $(date) : "=== Output wheel file is in: ${DEST}"
+  echo $(date) : "=== Output wheel files are in: ${DEST}"
 }
 
 main "$@"


### PR DESCRIPTION
This change ensures that `build_pip_package.sh` uses just one python binary - whatever is available as `python` - rather than building the py2 wheel file with `python` and the py3 one with `python3`.  Building a wheel file for pyX doesn't actually require running `setup.py` with the matching pythonX binary; you can just specify the version the wheel file should be built for explicitly.

It's better to use just `python` because that means that within a virtualenv that only provides `bin/python` (e.g. a python2 virtualenv), you still pick up the hermetization of the virtualenv.  Otherwise, under a python2 virtualenv, the invocation of `python3` will break out of the virtualenv to the system's python3 and whatever old crufty package versions it shipped with, instead of using the virtualenv's python and its freshly updated packages.

And in particular, for my machine with these old crufty packages, this fixes `pip_smoke_test.sh` - which otherwise fails with an error in the `python3 setup.py bdist_wheel >/dev/null` line of `build_pip_package.sh` saying that the `install_requires` spec is invalid, when this is actually caused by my machine's python3 not having a sufficiently up-to-date version of setuptools that recognizes an `install_requires` that uses environment markers like `python_version >= "3"`.