### PR TITLE
Make debugger plugin wait on dialog open

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -526,6 +526,7 @@ limitations under the License.
           return;
         }
 
+        this.set('alreadyStarted', true);
         const url = tf_backend.getRouter().pluginRoute(
             'debugger', '/debugger_grpc_host_port');
         this._requestManager.request(url).then(response => {
@@ -534,12 +535,10 @@ limitations under the License.
           this.$.initialDialog.openDialog(response.host, response.port);
         }).catch(error => {
           this.$.initialDialog.renderDebuggerNotEnabledMessage();
+        }).then(() => {
+          // Initiate long-polling.
+          this.long_poll();
         });
-
-        // Initiate long-polling.
-        this.long_poll();
-
-        this.set('alreadyStarted', true);
       },
 
       _openContinueDialog() {


### PR DESCRIPTION
Make the debugger plugin only start long-polling after opening the
dialog that notes we're waiting for the first session run.

Otherwise, if the user starts the TF run time before starting
TensorBoard, the dialog might be closed before it is opened, so the
dialog perpetually appears.