### PR TITLE
Make debugger plugin backdrop not block navbar

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -162,6 +162,11 @@ limitations under the License.
 
     <style include="dashboard-style"></style>
     <style>
+      :host {
+        display: block;
+        min-height: 100%;
+        position: relative;
+      }
       .debugger-section-title {
         font-size: 110%;
         font-weight: bold;
@@ -173,6 +178,9 @@ limitations under the License.
       paper-tab.iron-selected {
         color: black;
         font-weight: bold;
+      }
+      #initialDialog {
+        z-index: 102;
       }
       #graph-container {
         position: relative;

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -180,6 +180,7 @@ limitations under the License.
         font-weight: bold;
       }
       #initialDialog {
+        /** This matches the default z-index of paper-dialog backdrops. */
         z-index: 102;
       }
       #graph-container {

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
@@ -21,7 +21,11 @@ limitations under the License.
 
 <dom-module id="tf-debugger-initial-dialog">
   <template>
-    <paper-dialog with-backdrop id="dialog" width="320" modal>
+    <!-- We use a custom backdrop to avoid occluding the TensorBoard navbar. -->
+    <template is="dom-if" if="[[_open]]">
+      <div id="dashboard-backdrop"></div>
+    </template>
+    <paper-dialog id="dialog" width="320" modal with-backdrop="[[_useNativeBackdrop]]">
       <h2 id='dialog-title'>Waiting for first Session.run() to connect...</h2>
       <div class='code-example'>
         <!-- TODO(cais): Rename id. -->
@@ -42,10 +46,22 @@ my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
     </paper-dialog>
   </template>
   <style>
-      .code-example {
-        margin: 10px;
-        font-family: monospace;
-      }
+    :host, #dashboard-backdrop {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+
+    #dashboard-backdrop {
+      background: rgba(0, 0, 0, 0.6);
+    }
+
+    .code-example {
+      margin: 10px;
+      font-family: monospace;
+    }
   </style>
   <script>
 
@@ -60,9 +76,19 @@ my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
         type: String,
         value: null,
       },
+      _open: {
+        type: Boolean,
+        value: false,
+      },
+      // Suppress the native paper-dialog backdrop. We use a custom one.
+      _useNativeBackdrop: {
+        type: Boolean,
+        value: false,
+        readOnly: true,
+      },
     },
-
     openDialog(host, port) {
+      this.set('_open', true);
       this.$.dialog.open();
       if (host != null && port != null) {
         // TODO(cais): Use markdown; syntax highlight Python code.
@@ -71,10 +97,11 @@ my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
       }
     },
     closeDialog() {
+      this.set('_open', false);
       this.$.dialog.close();
     },
     renderDebuggerNotEnabledMessage() {
-      this.$.dialog.open();
+      this.openDialog();
       Polymer.dom(this.$$('#dialog-title')).textContent =
           'ERROR: debugger is not enabled in this TensorBoard instance.';
       let ex = 'To enable the debugger in tensorboard, use the flag: ' +

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
@@ -25,7 +25,11 @@ limitations under the License.
     <template is="dom-if" if="[[_open]]">
       <div id="dashboard-backdrop"></div>
     </template>
-    <paper-dialog id="dialog" width="320" modal with-backdrop="[[_useNativeBackdrop]]">
+    <paper-dialog id="dialog"
+                  modal
+                  opened="{{_open}}"
+                  width="320"
+                  with-backdrop="[[_useNativeBackdrop]]">
       <h2 id='dialog-title'>Waiting for first Session.run() to connect...</h2>
       <div class='code-example'>
         <!-- TODO(cais): Rename id. -->
@@ -76,11 +80,11 @@ my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
         type: String,
         value: null,
       },
-      _open: {
-        type: Boolean,
-        value: false,
-      },
-      // Suppress the native paper-dialog backdrop. We use a custom one.
+      _open: Boolean,
+      // Suppress the native paper-dialog backdrop. We use a custom one. We make
+      // the dialog reference this bound property instead of directly setting
+      // the attribute to the string "false" in the HTML because Polymer
+      // unfortunately parses "false" as a true-ey value (a non-empty string).
       _useNativeBackdrop: {
         type: Boolean,
         value: false,
@@ -88,7 +92,6 @@ my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
       },
     },
     openDialog(host, port) {
-      this.set('_open', true);
       this.$.dialog.open();
       if (host != null && port != null) {
         // TODO(cais): Use markdown; syntax highlight Python code.
@@ -97,11 +100,10 @@ my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
       }
     },
     closeDialog() {
-      this.set('_open', false);
       this.$.dialog.close();
     },
     renderDebuggerNotEnabledMessage() {
-      this.openDialog();
+      this.$.dialog.open();
       Polymer.dom(this.$$('#dialog-title')).textContent =
           'ERROR: debugger is not enabled in this TensorBoard instance.';
       let ex = 'To enable the debugger in tensorboard, use the flag: ' +


### PR DESCRIPTION
We make the debugger plugin use a custom backdrop that does not occlude
the main TensorBoard navigation bar. This lets the user navigate to a
different dashboard after arriving at the debugger dashboard and
encountering the dialog that notes how the plugin is waiting for the
first session run.

Screenshot:
![image](https://user-images.githubusercontent.com/4221553/33857320-0076d7aa-de80-11e7-948c-7e630dc63e2c.png)

Fixes #793.