### PR TITLE
Projector: Semi-supervised t-SNE

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/bh_tsne.ts
+++ b/tensorboard/plugins/projector/vz_projector/bh_tsne.ts
@@ -332,7 +332,7 @@ export class TSNE {
     // dimensions. Here area is proportional to pi*radius^2, to skip root calc.
     for (let i = 0; i < N; ++i) {
       let area = 0;
-      
+
       for (let d = 0; d < this.dim; ++d) {
         area += Math.pow(this.Y[i * this.dim + d], 2);
       }

--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -125,8 +125,9 @@ export class DataSet {
   tSNEIteration: number = 0;
   tSNEShouldPause = false;
   tSNEShouldStop = true;
-  tSNEShouldPerturb = false;
-  perturbFactor: number = 0.4;
+  superviseFactor: number;
+  superviseLabels: string[];
+  superviseInput: string = '';
   dim: [number, number] = [0, 0];
   hasTSNERun: boolean = false;
   spriteAndMetadataInfo: SpriteAndMetadataInfo;
@@ -308,14 +309,16 @@ export class DataSet {
     let k = Math.floor(3 * perplexity);
     let opt = {epsilon: learningRate, perplexity: perplexity, dim: tsneDim};
     this.tsne = new TSNE(opt);
+    this.tsne.setSupervision(this.superviseLabels, this.superviseInput);
+    this.tsne.setSuperviseFactor(this.superviseFactor);
     this.tSNEShouldPause = false;
     this.tSNEShouldStop = false;
-    this.tSNEShouldPerturb = false;
     this.tSNEIteration = 0;
 
     let sampledIndices = this.shuffledDataIndices.slice(0, TSNE_SAMPLE_SIZE);
     let step = () => {
       if (this.tSNEShouldStop) {
+        this.projections['tsne'] = false;
         stepCallback(null);
         this.tsne = null;
         this.hasTSNERun = false;
@@ -323,8 +326,7 @@ export class DataSet {
       }
 
       if (!this.tSNEShouldPause) {
-        this.tsne.step(this.tSNEShouldPerturb ? this.perturbFactor : 0.0);
-        this.tSNEShouldPerturb = false;
+        this.tsne.step();
         let result = this.tsne.getSolution();
         sampledIndices.forEach((index, i) => {
           let dataPoint = this.points[index];
@@ -335,6 +337,7 @@ export class DataSet {
             dataPoint.projections['tsne-2'] = result[i * tsneDim + 2];
           }
         });
+        this.projections['tsne'] = true;
         this.tSNEIteration++;
         stepCallback(this.tSNEIteration);
       }
@@ -362,6 +365,52 @@ export class DataSet {
             this.tsne.initDataDist(this.nearest);
           }).then(step);
     });
+  }
+
+  /* Perturb TSNE and update dataset point coordinates. */
+  perturbTsne() {
+    if (this.hasTSNERun && this.tsne) {
+      this.tsne.perturb();
+      let tsneDim = this.tsne.getDim();
+      let result = this.tsne.getSolution();
+      let sampledIndices = this.shuffledDataIndices.slice(0, TSNE_SAMPLE_SIZE);
+
+      sampledIndices.forEach((index, i) => {
+        let dataPoint = this.points[index];
+
+        dataPoint.projections['tsne-0'] = result[i * tsneDim + 0];
+        dataPoint.projections['tsne-1'] = result[i * tsneDim + 1];
+        if (tsneDim === 3) {
+          dataPoint.projections['tsne-2'] = result[i * tsneDim + 2];
+        }
+      });
+    }
+  }
+
+  setSupervision(superviseColumn: string, superviseInput?: string) {
+    if (superviseColumn != null) {
+      let sampledIndices =
+          this.shuffledDataIndices.slice(0, TSNE_SAMPLE_SIZE);
+      let labels = new Array(sampledIndices.length);
+      sampledIndices.forEach((index, i) => 
+          labels[i] = this.points[index].metadata[superviseColumn].toString());
+      this.superviseLabels = labels;
+    }
+    if (superviseInput != null) {
+      this.superviseInput = superviseInput;
+    }
+    if (this.tsne) {
+      this.tsne.setSupervision(this.superviseLabels, this.superviseInput);
+    }
+  }
+
+  setSuperviseFactor(superviseFactor: number) {
+    if (superviseFactor != null) {
+      this.superviseFactor = superviseFactor;
+      if (this.tsne) {
+        this.tsne.setSuperviseFactor(superviseFactor);
+      }
+    }
   }
 
   /**

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
@@ -137,8 +137,26 @@ paper-dropdown-menu paper-item {
   margin: 10px 0;
 }
 
-.metadata-editor {
+.metadata-editor, .supervise-settings, .colorlabel-container {
   display: flex;
+}
+
+#labelby {
+  width: 100px;
+  margin-right: 10px;
+}
+
+#colorby {
+  width: calc(100% - 110px);
+}
+
+.supervise-settings paper-dropdown-menu {
+  width: 100px;
+  margin-right: 10px;
+}
+
+.supervise-settings paper-input {
+  width: calc(100% - 110px);
 }
 
 .metadata-editor paper-dropdown-menu {
@@ -237,6 +255,7 @@ paper-dropdown-menu paper-item {
   display: none;
   margin-top: 10px;
 }
+
 </style>
 <div class="title">DATA</div>
 <div class="container">
@@ -268,31 +287,31 @@ paper-dropdown-menu paper-item {
       </paper-listbox>
     </paper-dropdown-menu>
   </template>
-  <!-- Label by -->
-  <template is="dom-if" if="[[_hasChoices(labelOptions)]]">
-    <paper-dropdown-menu no-animations label="Label by">
-      <paper-listbox attr-for-selected="value" class="dropdown-content" selected="{{selectedLabelOption}}" slot="dropdown-content">
-        <template is="dom-repeat" items="[[labelOptions]]">
-          <paper-item value="[[item]]" label="[[item]]">
-            [[item]]
-          </paper-item>
-        </template>
-      </paper-listbox>
-    </paper-dropdown-menu>
-  </template>
-
-  <!-- Color by -->
-  <div hidden$="[[!_hasChoices(colorOptions)]]" class="colorby-container">
-    <paper-dropdown-menu id="colorby" no-animations label="Color by">
-      <paper-listbox attr-for-selected="value" class="dropdown-content" selected="{{selectedColorOptionName}}" slot="dropdown-content">
-        <template is="dom-repeat" items="[[colorOptions]]">
-          <paper-item class$="[[getSeparatorClass(item.isSeparator)]]" value="[[item.name]]" label="[[item.name]]" disabled="[[item.isSeparator]]">
-            [[item.name]]
-            <span class="item-details">[[item.desc]]</span>
-          </paper-item>
-        </template>
-      </paper-listbox>
-    </paper-dropdown-menu>
+  
+  <div hidden$="[[!_hasChoices(colorOptions)]]">
+    <div class="colorlabel-container">
+      <!-- Label by -->
+      <paper-dropdown-menu id="labelby" no-animations label="Label by">
+        <paper-listbox attr-for-selected="value" class="dropdown-content" selected="{{selectedLabelOption}}" slot="dropdown-content">
+          <template is="dom-repeat" items="[[labelOptions]]">
+            <paper-item value="[[item]]" label="[[item]]">
+              [[item]]
+            </paper-item>
+          </template>
+        </paper-listbox>
+      </paper-dropdown-menu>
+      <!-- Color by -->
+      <paper-dropdown-menu id="colorby" no-animations label="Color by">
+        <paper-listbox attr-for-selected="value" class="dropdown-content" selected="{{selectedColorOptionName}}" slot="dropdown-content">
+          <template is="dom-repeat" items="[[colorOptions]]">
+            <paper-item class$="[[getSeparatorClass(item.isSeparator)]]" value="[[item.name]]" label="[[item.name]]" disabled="[[item.isSeparator]]">
+              [[item.name]]
+              <span class="item-details">[[item.desc]]</span>
+            </paper-item>
+          </template>
+        </paper-listbox>
+      </paper-dropdown-menu>
+    </div>
     <div hidden$="[[!showForceCategoricalColorsCheckbox]]">
       <paper-checkbox id="force-categorical-checkbox"></paper-checkbox>
       Use categorical coloring
@@ -308,6 +327,23 @@ paper-dropdown-menu paper-item {
     </template>
   </div>
   <template is="dom-if" if="[[_hasChoice(labelOptions)]]">
+    <!-- Supervise by -->
+    <div hidden$="[[!showSuperviseSettings]]" class="supervise-settings">
+      <paper-dropdown-menu no-animations label="Supervise with">
+        <paper-listbox attr-for-selected="value" class="dropdown-content"
+            on-selected-item-changed="superviseColumnChanged"
+            selected="{{superviseColumn}}" slot="dropdown-content">
+          <template is="dom-repeat" items="[[metadataFields]]">
+            <paper-item value="[[item]]" label="[[item]]">
+              [[item]]
+            </paper-item>
+          </template>
+        </paper-listbox>
+      </paper-dropdown-menu>
+      <paper-input value="{{superviseInput}}" label="{{superviseInputLabel}}"
+          on-change="superviseInputChange" on-input="superviseInputTyping">
+      </paper-input>
+    </div>
     <!-- Edit by -->
     <div class="metadata-editor">
       <paper-dropdown-menu no-animations label="Edit by">

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
@@ -401,7 +401,7 @@ export class DataPanel extends DataPanelPolymer {
     if (this.projector && this.projector.dataSet) {
       let numMatches = this.projector.dataSet.points.filter(p =>
           p.metadata[this.superviseColumn].toString().trim() === value).length;
-      
+
       if (numMatches === 0) {
         this.superviseInputLabel = 'Label not found';
       }

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
@@ -35,7 +35,14 @@ export let DataPanelPolymer = PolymerElement({
     metadataEditorColumnChange: {type: Object},
     metadataEditorButtonClicked: {type: Object},
     metadataEditorButtonDisabled: {type: Boolean},
-    downloadMetadataClicked: {type: Boolean}
+    downloadMetadataClicked: {type: Boolean},
+    superviseInput: {type: String},
+    superviseInputTyping: {type: Object},
+    superviseInputChange: {type: Object},
+    superviseInputLabel: {type: String, value: 'Ignored label'},
+    superviseColumn: {type: String},
+    superviseColumnChanged: {type: Object},
+    showSuperviseSettings: {type: Boolean, value: false}
   },
   observers: [
     '_generateUiForNewCheckpointForRun(selectedRun)',
@@ -46,6 +53,7 @@ export class DataPanel extends DataPanelPolymer {
   selectedLabelOption: string;
   selectedColorOptionName: string;
   showForceCategoricalColorsCheckbox: boolean;
+  showSuperviseSettings: boolean;
 
   private normalizeData: boolean;
   private labelOptions: string[];
@@ -55,6 +63,10 @@ export class DataPanel extends DataPanelPolymer {
   private metadataEditorInput: string;
   private metadataEditorInputLabel: string;
   private metadataEditorButtonDisabled: boolean;
+  private superviseInput: string;
+  private superviseInputLabel: string;
+  private superviseInputSelected: string;
+  private superviseColumn: string;
 
   private selectedPointIndices: number[];
   private neighborsOfFirstPoint: knn.NearestEntry[];
@@ -71,6 +83,7 @@ export class DataPanel extends DataPanelPolymer {
 
   ready() {
     this.normalizeData = true;
+    this.superviseInputSelected = '';
   }
 
   initialize(projector: Projector, dp: DataProvider) {
@@ -153,6 +166,27 @@ export class DataPanel extends DataPanelPolymer {
         name === this.metadataEditorColumn).length === 0) {
       // Make the default label the first non-numeric column.
       this.metadataEditorColumn = this.metadataFields[Math.max(0, labelIndex)];
+    }
+
+    if (this.superviseColumn == null || this.metadataFields.filter(name =>
+        name === this.superviseColumn).length === 0) {
+      // Make the default supervise class the first non-numeric column.
+      this.superviseColumn = this.metadataFields[Math.max(0, labelIndex)];
+      this.superviseInput = '';
+    }
+    this.superviseInputChange();
+  }
+
+  projectionChanged(projection: Projection) {
+    if (projection) {
+      switch (projection.projectionType) {
+        case 'tsne':
+          this.set('showSuperviseSettings', true);
+          break;
+
+        default:
+          this.set('showSuperviseSettings', false);
+      }
     }
   }
 
@@ -349,6 +383,70 @@ export class DataPanel extends DataPanelPolymer {
       this.$.downloadMetadataLink.download = 'metadata-edited.tsv';
       this.$.downloadMetadataLink.href = window.URL.createObjectURL(textBlob);
       this.$.downloadMetadataLink.click();
+    }
+  }
+
+  private superviseInputTyping() {
+    let value = this.superviseInput.trim();
+    if (value == null || value.trim() === '') {
+      if (this.superviseInputSelected === '') {
+        this.superviseInputLabel = 'No ignored label';
+      }
+      else {
+        this.superviseInputLabel =
+            `Supervising without '${this.superviseInputSelected}'`;
+      }
+      return;
+    }
+    if (this.projector && this.projector.dataSet) {
+      let numMatches = this.projector.dataSet.points.filter(p =>
+          p.metadata[this.superviseColumn].toString().trim() === value).length;
+      
+      if (numMatches === 0) {
+        this.superviseInputLabel = 'Label not found';
+      }
+      else {
+        if (this.projector.dataSet.superviseInput != value) {
+          this.superviseInputLabel =
+              `Supervise without '${value}' [${numMatches} points]`;
+        }
+      }
+    }
+  }
+
+  private superviseInputChange() {
+    let value = this.superviseInput.trim();
+    if (value == null || value.trim() === '') {
+      this.superviseInputSelected = '';
+      this.superviseInputLabel = 'No ignored label';
+      this.setSupervision(this.superviseColumn, '');
+      return;
+    }
+    if (this.projector && this.projector.dataSet) {
+      let numMatches = this.projector.dataSet.points.filter(p =>
+          p.metadata[this.superviseColumn].toString().trim() === value).length;
+      
+      if (numMatches === 0) {
+        this.superviseInputLabel = 
+            `Supervising without '${this.superviseInputSelected}'`;
+      }
+      else {
+        this.superviseInputSelected = value;
+        this.superviseInputLabel = 
+            `Supervising without '${value}' [${numMatches} points]`;
+        this.setSupervision(this.superviseColumn, value);
+      }
+    }
+  }
+
+  private superviseColumnChanged() {
+    this.superviseInput = '';
+    this.superviseInputChange();
+  }
+
+  private setSupervision(superviseColumn: string, superviseInput: string) {
+    if (this.projector && this.projector.dataSet) {
+      this.projector.dataSet.setSupervision(superviseColumn, superviseInput);
     }
   }
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
@@ -101,6 +101,10 @@ limitations under the License.
   min-height: 35px;
 }
 
+.tsne-supervise-factor {
+  margin-bottom: -8px;
+}
+
 #z-container {
   display: flex;
   align-items: center;
@@ -212,17 +216,17 @@ limitations under the License.
         </paper-slider>
         <span></span>
       </div>
-      <div class="slider tsne-perturb-factor">
+      <div class="slider tsne-supervise-factor">
         <label>
-          Perturb factor
+          Supervise
           <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
           <paper-tooltip position="right" animation-delay="0" fit-to-visible-bounds>
-            The multiplicative factor that determines the extent of the perturb offset, 
-            which is applied to positions independently per point and dimension.
+            The label importance used for supervision, from 0 (disabled) to 100
+            (full importance).
           </paper-tooltip>
         </label>
-        <paper-slider id="perturb-factor-slider" snaps min="0.1" max="0.8" step="0.1"
-            value="0.4" max-markers="8">
+        <paper-slider id="supervise-factor-slider" min="0" max="100" pin
+            value="{{superviseFactor}}">
         </paper-slider>
         <span></span>
       </div>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -24,6 +24,7 @@ export let ProjectionsPanelPolymer = PolymerElement({
         {type: Boolean, value: true, observer: '_pcaDimensionToggleObserver'},
     tSNEis3d:
         {type: Boolean, value: true, observer: '_tsneDimensionToggleObserver'},
+    superviseFactor: {type: Number, value: 0},
     // PCA projection.
     pcaComponents: Array,
     pcaX: {type: Number, value: 0, observer: 'showPCAIfEnabled'},
@@ -68,6 +69,8 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   private perplexity: number;
   /** T-SNE learning rate. */
   private learningRate: number;
+  /** T-SNE perturb interval identifier, required to terminate perturbation. */
+  private perturbInterval: number;
 
   private searchByMetadataOptions: string[];
 
@@ -92,7 +95,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   private perturbTsneButton: HTMLButtonElement;
   private perplexitySlider: HTMLInputElement;
   private learningRateInput: HTMLInputElement;
-  private perturbFactorInput: HTMLInputElement;
+  private superviseFactorInput: HTMLInputElement;
   private zDropdown: HTMLElement;
   private iterationLabel: HTMLElement;
 
@@ -119,14 +122,16 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   ready() {
     this.zDropdown = this.querySelector('#z-dropdown') as HTMLElement;
     this.runTsneButton = this.querySelector('.run-tsne') as HTMLButtonElement;
-    this.pauseTsneButton = this.querySelector('.pause-tsne') as HTMLButtonElement;
-    this.perturbTsneButton = this.querySelector('.perturb-tsne') as HTMLButtonElement;
+    this.pauseTsneButton =
+        this.querySelector('.pause-tsne') as HTMLButtonElement;
+    this.perturbTsneButton =
+        this.querySelector('.perturb-tsne') as HTMLButtonElement;
     this.perplexitySlider =
         this.querySelector('#perplexity-slider') as HTMLInputElement;
     this.learningRateInput =
         this.querySelector('#learning-rate-slider') as HTMLInputElement;
-    this.perturbFactorInput =
-        this.querySelector('#perturb-factor-slider') as HTMLInputElement;
+    this.superviseFactorInput =
+        this.querySelector('#supervise-factor-slider') as HTMLInputElement;
     this.iterationLabel = this.querySelector('.run-tsne-iter') as HTMLElement;
   }
 
@@ -154,12 +159,12 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
         .innerText = '' + this.learningRate;
   }
 
-  private updateTSNEPerturbFactorFromUIChange() {
-    if (this.perturbFactorInput && this.dataSet) {
-      this.dataSet.perturbFactor = +this.perturbFactorInput.value;
+  private updateTSNESuperviseFactorFromUIChange() {
+    (this.querySelector('.tsne-supervise-factor span') as HTMLSpanElement)
+        .innerText = ('' + this.superviseFactor);
+    if (this.dataSet) {
+      this.dataSet.setSuperviseFactor(this.superviseFactor);
     }
-    (this.querySelector('.tsne-perturb-factor span') as HTMLSpanElement)
-        .innerText = '' + this.perturbFactorInput.value;
   }
 
   private setupUIControls() {
@@ -186,17 +191,26 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
     this.pauseTsneButton.addEventListener('click', () => {
       if (this.dataSet.tSNEShouldPause) {
         this.dataSet.tSNEShouldPause = false;
-        this.perturbTsneButton.disabled = false;
         this.pauseTsneButton.innerText = 'Pause';
       } else {
         this.dataSet.tSNEShouldPause = true;
-        this.perturbTsneButton.disabled = true;
         this.pauseTsneButton.innerText = 'Resume';
       }
     });
 
-    this.perturbTsneButton.addEventListener('click', () => {
-      this.dataSet.tSNEShouldPerturb = !this.dataSet.tSNEShouldPerturb;
+    this.perturbTsneButton.addEventListener('mousedown', () => {
+      if (this.dataSet && this.projector) {
+        this.dataSet.perturbTsne();
+        this.projector.notifyProjectionPositionsUpdated();
+        this.perturbInterval = setInterval(() => {
+            this.dataSet.perturbTsne();
+            this.projector.notifyProjectionPositionsUpdated();
+        }, 100);
+      }
+    });
+
+    this.perturbTsneButton.addEventListener('mouseup', () => {
+      clearInterval(this.perturbInterval);
     });
 
     this.perplexitySlider.value = this.perplexity.toString();
@@ -208,9 +222,9 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
         'change', () => this.updateTSNELearningRateFromUIChange());
     this.updateTSNELearningRateFromUIChange();
 
-    this.perturbFactorInput.addEventListener(
-        'change', () => this.updateTSNEPerturbFactorFromUIChange());
-    this.updateTSNEPerturbFactorFromUIChange();
+    this.superviseFactorInput.addEventListener(
+        'change', () => this.updateTSNESuperviseFactorFromUIChange());
+    this.updateTSNESuperviseFactorFromUIChange();
 
     this.setupCustomProjectionInputFields();
     // TODO: figure out why `--paper-input-container-input` css mixin didn't
@@ -266,7 +280,6 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
     this.setZDropdownEnabled(this.pcaIs3d);
     this.updateTSNEPerplexityFromSliderChange();
     this.updateTSNELearningRateFromUIChange();
-    this.updateTSNEPerturbFactorFromUIChange();
     if (this.iterationLabel) {
       this.iterationLabel.innerText = bookmark.tSNEIteration.toString();
     }
@@ -452,11 +465,12 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
   }
 
   private runTSNE() {
+    let projectionChangeNotified = false;
     this.runTsneButton.innerText = 'Stop';
     this.runTsneButton.disabled = true;
     this.pauseTsneButton.innerText = 'Pause';
     this.pauseTsneButton.disabled = true;
-    this.perturbTsneButton.disabled = true;
+    this.perturbTsneButton.disabled = false;
 
     this.dataSet.projectTSNE(
         this.perplexity, this.learningRate, this.tSNEis3d ? 3 : 2,
@@ -464,9 +478,13 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
           if (iteration != null) {
             this.runTsneButton.disabled = false;
             this.pauseTsneButton.disabled = false;
-            this.perturbTsneButton.disabled = false;
             this.iterationLabel.innerText = '' + iteration;
             this.projector.notifyProjectionPositionsUpdated();
+
+            if (!projectionChangeNotified && this.dataSet.projections['tsne']) {
+              this.projector.onProjectionChanged();
+              projectionChangeNotified = true;
+            }
           }
           else {
             this.runTsneButton.innerText = 'Re-run';
@@ -474,6 +492,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
             this.pauseTsneButton.innerText = 'Pause';
             this.pauseTsneButton.disabled = true;
             this.perturbTsneButton.disabled = true;
+            this.projector.onProjectionChanged();
           }
         });
   }

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -509,6 +509,9 @@ export class Projector extends ProjectorPolymer implements
     this.registerHoverListener(
         (hoverIndex: number) => this.onHover(hoverIndex));
 
+    this.registerProjectionChangedListener((projection: Projection) =>
+        this.onProjectionChanged(projection));
+
     this.registerSelectionChangedListener(
         (selectedPointIndices: number[],
          neighborsOfFirstPoint: knn.NearestEntry[]) =>
@@ -546,6 +549,10 @@ export class Projector extends ProjectorPolymer implements
         this.selectedPointIndices.length + neighborsOfFirstPoint.length;
     this.statusBar.innerText = `Selected ${totalNumPoints} points`;
     this.statusBar.style.display = totalNumPoints > 0 ? null : 'none';
+  }
+
+  onProjectionChanged(projection?: Projection) {
+    this.dataPanel.projectionChanged(projection);
   }
 
   setProjection(projection: Projection) {


### PR DESCRIPTION
Integrates/supersedes:
1) #756 Projector: Supervision and metadata editor (semi-supervised t-SNE)
2) #762 Projector: t-SNE perturb v2

https://medium.com/@fpsluus/interactive-supervision-with-tensorboard-9a101c91d3f7

Demo here: http://tensorserve.com:6016
```bash
git clone https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout 84e9c55c56fc358a1f9a7746d896ccdc62db6128
bazel run tensorboard -- --logdir /home/$USER/emnist-2000 --host 0.0.0.0 --port 6016
```

### Pairwise label similarity priors
Notice the repeating contraction in the below image, relating to repetitively turning supervision on and off, which incorporates the prior probabilities based on pairwise label similarity/dissimilarity when supervision is turned on.
![1_5ryfnhag661937c00nabza](https://user-images.githubusercontent.com/10847676/33885723-d5939320-df4c-11e7-82c2-5737196592bc.gif)


### Design and behavior
#### Semi-supervised t-SNE
Add supervise metadata column selection and unlabeled class input in data-panel, and supervise factor in t-SNE projections-panel. Use available labels to modify t-SNE input similarities so that same-label samples have amplified attraction and different-label samples have attenuated attraction to a degree specified by the supervise factor (0 no supervision, 100 full supervision). Metadata edits immediately update the labels used by t-SNE, which effectively provides interactive supervision by being able to label a continuous semi-supervised t-SNE embedding process.

1. When the supervision slider is set to 0, t-SNE functions exactly as before as the supervision clause is not entered.
2. The supervision slider changes a visible percentage value from 0 to 100, corresponding to label importance values of 0 to 1. The supervision slider sets the label importance value in range [0, 1], where 0 turns off supervision and 1 sets full label importance. The concept of label importance is used from McInnes et al. [1].
3. An unlabeled class label, also known as an ignored label can be specified, which would consider corresponding points as unlabeled points that receive a default pairwise prior probability. The supervision settings in the data panel names this field superviseInput to generalize and allow for other uses of the text field in future, e.g. for other types of supervision.
4. A supervise column specifier gets the metadata column to use to determine which labels the supervision is conducted with.
5. t-SNE does cause some unexpected behavior when choosing a metadata column with many hundreds of classes, then a re-run is required.
6. Changes in the supervision settings are updated first in the dataset class, and then propagated to the TSNE class itself to use in the gradient step function, where a snapshot is made to prevent supervision changes during the step (not 100% sure if deep copy actually happens).
7. The supervision settings may change from step to step, e.g. such that one step may include supervision while the next step is without supervision, i.e. if the user slides the supervision factor from a non-zero value to zero.
8. The metadata editor dropdown-menu is moved below the supervision settings, so that the metadata label field and status messages are paired with the 'Label' button in the row below.
9. The supervision settings only appear for select projections, such as t-SNE in this case, otherwise it is hidden. The supervision settings are moved to the data panel as it may be a common element for multiple supervised projections.
10. Other projections could be added, like the t-SNE successor UMAP, and its semi-supervised version where the supervision settings elements in the data panel can then be reused with only a supervision slider required for the corresponding projections panel.
11. 'Label by' and 'Color by' are moved into the same row for a more compact, yet still neat, data panel.
#### Perturb v2
Now t-SNE perturb works only with mousedown, firing every 0.1 sec randomly offsetting points within their 5% hyperspheres while remaining within the t-SNE hypersphere. This has the effect of producing an even more homogenized spherical uniform distribution upon successive perturbation, with points doing random walks. Now mousedown duration is used to choose the extent of perturbation, and the perturb slider can thus be removed.

1. Behavior remains exactly the same when the perturb button is never clicked.
2. Perturbation of point locations are now performed as a random walk within the bounds of the assumed t-SNE plotting space modeled as a hypersphere.
3. A perturbation step is done uniformly within a small hypersphere, set at 5% of the t-SNE hypersphere size, centered around each point.
4. A randomly chosen perturbation has to place the perturbed point inside the t-SNE hypersphere, so sampling is performed until this condition is met, which should happen at least with probability equal to the inverse proportion of a small 5% hypersphere to its intersection with the t-SNE hypersphere centered on the hypersphere surface. For most points well inside the t-SNE hypersphere the first random perturbation sampling will very likely be valid.
5. The perturb slider is no longer required, as the perturb button alone is enough to apply a random walk of all points as long as it is pressed with visual feedback via the updated projection after every perturbation.
6. The perturbation can happen while t-SNE is running or when it is paused, as long as it hasTSNERun.
7. The perturbation fires immediately on mousedown, then it fires approximately every 0.1 seconds as a new perturbation calculation.
8. The t-SNE embedding may have slight asymmetry to begin with, but it is assumed that its dimensions are approximately normalized with respect to one another, otherwise the hypersphere assumption will not hold.
9. Perturbation keeps points within the approximate hypersphere and the random walks produce a more uniform distribution of the points and make the t-SNE more spherical.


### Semi-supervised t-SNE
1. The pairwise prior probabilities are set according to McInnes et al. [1], where neighbors are used and where current labeling is not representative of class prior probabilities.
2. However, the normalization is computed over all pairwise prior probabilities according to Yang et al. [2], and not only within neighborhoods as in [1].
3. The naive pairwise prior probability is 1/N, which is used for interactions with unlabeled class samples.
4. For different label pairs we subtract superviseFactor/otherCount from the naive prior, where otherCount is the number of samples with a different label, so if superviseFactor is sufficiently large the attractive force between two samples with different labels will be set to epsilon. Attractive force is easily zeroed between different labeled samples.
5. For same-label pairs we add superviseFactor/sameCount to the naive prior, and the maximum sum is limited close to 1. Attractive force scales up more gradually between same-label pairs.

### Data and projection panel before & after
<img width="313" alt="screen shot 2017-12-12 at 3 03 35 pm" src="https://user-images.githubusercontent.com/10847676/33886011-c913e298-df4d-11e7-848c-c10f9b267817.png"><img width="313" alt="screen shot 2017-12-12 at 3 04 10 pm" src="https://user-images.githubusercontent.com/10847676/33886014-cac3c568-df4d-11e7-822e-8ef82a425f16.png">
<img width="298" alt="screen shot 2017-12-12 at 3 06 08 pm" src="https://user-images.githubusercontent.com/10847676/33886065-08fd9516-df4e-11e7-8818-099b8278e0ac.png"><img width="298" alt="screen shot 2017-12-12 at 3 05 33 pm" src="https://user-images.githubusercontent.com/10847676/33886070-0c8bf63c-df4e-11e7-8785-95e8b578ca1e.png">

### Color-by views
<img width="298" alt="screen shot 2017-12-12 at 3 24 07 pm" src="https://user-images.githubusercontent.com/10847676/33886840-8d0bb232-df50-11e7-9c2e-6123caa1c299.png"><img width="298" alt="screen shot 2017-12-12 at 3 24 58 pm" src="https://user-images.githubusercontent.com/10847676/33886890-a89bb416-df50-11e7-8bf1-ef86e2e0a540.png">
<img width="298" alt="screen shot 2017-12-12 at 3 25 45 pm" src="https://user-images.githubusercontent.com/10847676/33886941-cdbe0d20-df50-11e7-9206-8aaaa179a12d.png">

### Supervision settings status messages
<img width="298" alt="screen shot 2017-11-20 at 6 31 06 pm" src="https://user-images.githubusercontent.com/10847676/33029762-1e638c90-ce22-11e7-8da2-a79d3130a92b.png">
<img width="298" alt="screen shot 2017-11-20 at 6 30 49 pm" src="https://user-images.githubusercontent.com/10847676/33029764-2088e3e4-ce22-11e7-8b8d-0452bf760660.png">
<img width="298" alt="screen shot 2017-11-20 at 6 31 22 pm" src="https://user-images.githubusercontent.com/10847676/33029771-232134b2-ce22-11e7-813c-cdec9995bb1e.png">
<img width="298" alt="screen shot 2017-11-20 at 6 31 33 pm" src="https://user-images.githubusercontent.com/10847676/33029774-25131308-ce22-11e7-9c93-e02000ce7609.png">
<img width="298" alt="screen shot 2017-11-20 at 6 31 57 pm" src="https://user-images.githubusercontent.com/10847676/33029778-26bb20d8-ce22-11e7-93ba-89b54872cc6f.png">
<img width="298" alt="screen shot 2017-11-20 at 6 32 18 pm" src="https://user-images.githubusercontent.com/10847676/33029787-29f5a7c8-ce22-11e7-8f10-ad071958f2a8.png">
<img width="298" alt="screen shot 2017-11-20 at 6 32 59 pm" src="https://user-images.githubusercontent.com/10847676/33029790-2bca4e50-ce22-11e7-9715-5ebd12ab2c9d.png">

### Semi-Supervised t-SNE of McInnes et al. [1]

From https://github.com/lmcinnes/sstsne/blob/master/sstsne/_utils.pyx :
```python
for i in range(n_samples):
    sum_Pi = 0
    if using_neighbors:
        for k in range(K):
            j = neighbors[i, k]
            n_same_label = label_sizes[labels[i] + 1]
            n_other_label = n_samples - n_same_label - n_unlabelled
            if rep_samples:
                ...
            else:
                if labels[i] == -1 or labels[j] == -1:
                    prior_prob = 1.0 / n_samples
                elif labels[j] == labels[i]:
                    prior_prob = min((1.0 / n_samples) + (label_importance / n_same_label), 1.0 - EPSILON_DBL)
                else:
                    prior_prob = max((1.0 / n_samples) - (label_importance / n_other_label), EPSILON_DBL)
            P[i, j] *= prior_prob
            sum_Pi += P[i, j]
        for k in range(K):
            j = neighbors[i, k]
            P[i, j] /= sum_Pi
```

### Attraction normalization of Yang et al. [2]

From Yang et al. [1] the attractive and repulsive forces in weighted t-SNE are balanced with a connection scalar:

<img src="https://latex.codecogs.com/svg.latex?%5Cfrac%7B%5Cpartial%20D_%7B%5Ctext%7Bws-SNE%7D%7D%28Y%29%7D%7B%5Cpartial%20y_i%7D%3D%5Csum_jp_%7Bij%7Dq_%7Bij%7D%5E%7B%5Ctheta%7D%28y_i-y_j%29-cd_id_jq_%7Bij%7D%5E%7B1&plus;%5Ctheta%7D%28y_i-y_j%29">
where the connection scalar is given as <img src="https://latex.codecogs.com/svg.latex?%5Cinline%20c%3D%5Csum_%7Bij%7Dp_%7Bij%7D%5Cleft/%5Cleft%28%5Csum_%7Bij%7Dd_id_jq_%7Bij%7D%20%5Cright%20%29%5Cright.">
The issue here is that if the sum of the prior probabilities are small, then the effective gradient gets scaled down accordingly, which is the case here with a nominal prior of 1/N. So we normalize the gradient size by dividing with the sum of prior probabilities and leaving the repulsion normalization unaffected:

<img src="https://latex.codecogs.com/svg.latex?%5Cfrac%7B1%7D%7B%5Csum_%7Bij%7Dp_%7Bij%7D%7D%5Cfrac%7B%5Cpartial%20D_%7B%5Ctext%7Bws-SNE%7D%7D%28Y%29%7D%7B%5Cpartial%20y_i%7D%3D%5Cfrac%7B%5Csum_jp_%7Bij%7Dq_%7Bij%7D%5E%7B%5Ctheta%7D%28y_i-y_j%29%7D%7B%5Csum_%7Bij%7Dp_%7Bij%7D%7D-%5Cfrac%7Bd_id_jq_%7Bij%7D%5E%7B1&plus;%5Ctheta%7D%28y_i-y_j%29%7D%7B%5Csum_%7Bij%7Dd_id_jq_%7Bij%7D%7D">

Note that the result here is shown for weighted t-SNE, but it holds for normal t-SNE and its Barnes-Hut implementation.

```typescript
    let sum_pij = 0;
    let forces: [number[], number[]][] = new Array(N);
    for (let i = 0; i < N; ++i) {
      let pointI = points[i];
      if (supervise) {
        var sameCount = labelCounts[labels[i]];
        var otherCount = N - sameCount - unlabeledCount;
      }
      // Compute the positive forces for the i-th node.
      let Fpos = this.dim === 3 ? [0, 0, 0] : [0, 0];
      let neighbors = this.nearest[i];
      for (let k = 0; k < neighbors.length; ++k) {
        let j = neighbors[k].index;
        let pij = P[i * N + j];
        // apply semi-supervised prior probabilities
        if (supervised) {
          if (labels[i] == unlabeledClass || labels[j] == unlabeledClass) {
            pij *= 1. / N;
          }
          else if (labels[i] != labels[j]) {
            pij *= Math.max(1. / N - superviseFactor / otherCount, 1E-7);
          }
          else if (labels[i] == labels[j]) {
            pij *= Math.min(1. / N + superviseFactor / sameCount, 1. - 1E-7);
          }
          sum_pij += pij;
        }
    
    ...
    
    let A = 4 * alpha;
    if (supervised) {
      A /= sum_pij;
    }
    const B = 4 / Z;
```

### References
[1] Leland McInnes, Alexander Fabisch, Christopher Moody, Nick Travers, "Semi-Supervised t-SNE using a Bayesian prior based on partial labelling", https://github.com/lmcinnes/sstsne. 2016.

[2] Yang, Zhirong, Jaakko Peltonen, and Samuel Kaski. ["Optimization equivalence of divergences improves neighbor embedding"](http://proceedings.mlr.press/v32/yange14.pdf). International Conference on Machine Learning. 2014.