### PR TITLE
Add slider and toggle button to show top K nodes within top 90th percentile.

### DIFF
--- a/tensorboard/plugins/profile/tf_op_profile/BUILD
+++ b/tensorboard/plugins/profile/tf_op_profile/BUILD
@@ -32,6 +32,8 @@ tf_web_library(
     path = "/tf-op-profile",
     deps = [
         ":utils",
+        "@org_polymer_paper_slider",
+        "@org_polymer_paper_toggle_button",
     ],
 )
 

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
@@ -34,6 +34,7 @@ You may obtain a copy of the License at
 tf-op-details {
   position: fixed;
   /* don't set top, so it ends up next to tf-op-table */
+  padding-top: 6.5em;
   left: 16px;
   width: 330px;
 }
@@ -41,34 +42,20 @@ tf-op-details {
   display: block;
   margin-right: 1.5em;
 }
+#description {
+  margin-bottom: 2em;
+  width: 600px;
+}
     </style>
     <div class="tf-op-profile">
       <h4>Overall TPU FLOPS utilization is
-        <span style$="color:[[_textColor(_root)]]">[[_utilizationPercent(_root)]]</span>
+        <span style$="color:[[_textColor(_root)]]">
+          [[_utilizationPercent(_root)]]</span>
       </h4>
-      <p>Modifying your model's architecture, data dimensions, and improving the
-      efficiency of CPU operations may help reach the TPU's FLOPS potential.</p>
-      <h4>The most time was spent in a <b>[[_costlyOp.xla.category]] operation</b>
-        ([[_percent(_costlyOp.metrics.time)]])</h4>
-      <p hidden$="[[_hasFlops(_costlyOp)]]">
-        [[_costlyOp.name]] is
-        <span style$="color:[[_textColor(_costlyOp)]];">overhead</span>,
-        and a good target for optimization.
-      </p>
-      <!-- extra div to avoid HTML parsing bugs in polymer/vulcanize -->
-      <div hidden$="[[!_hasFlops(_costlyOp)]]">
-      <p>
-      While active, <code>[[_costlyOp.name]]</code> uses
-        <span style="color:[[_textColor(_costlyOp)]]">[[_utilizationPercent(_costlyOp)]]</span>
-        of the computational potential of the chip.
-        <span hidden$="[[_goodFlops(_costlyOp)]]">
-          This is a good target for optimization.
-        </span>
-        <span hidden$="[[!_goodFlops(_costlyOp)]]">
-          This is pretty good - other operations may be better targets for optimization.
-        </span>
-      </p>
-      </div>
+      <div id="description">
+        <p>Modifying your model's architecture, data dimensions, and improving
+        the efficiency of CPU operations may help reach the TPU's FLOPS potential.
+      </p></div>
       <tf-op-details hidden="[[!_active]]" node="[[_active]]"></tf-op-details>
       <tf-op-table root-node="[[_root]]" active={{_active}}></tf-op-table>
     </div>
@@ -101,10 +88,6 @@ Polymer({
       value: null,
       notify: true,
     },
-    _costlyOp: {
-      type: Object,
-      computed: '_worstOp(_data.byCategory, "time")',
-    },
   },
   _load: function(run) {
     this._requestManager.request(tf_backend.addParams(
@@ -114,22 +97,8 @@ Polymer({
     });
   },
   _getRoot: function(data, breakdown) { return data[breakdown]; },
-  _percent: tf_op_profile.percent,
   _utilizationPercent: function(node) { return tf_op_profile.percent(tf_op_profile.utilization(node)); },
-  _worstOp: function(root, metric) {
-    var worst = null, worstValue = -Infinity;
-    function visit(node) {
-      if (node.xla != null && node.metrics != null && node.metrics[metric] > worstValue) {
-        worst = node;
-        worstValue = node.metrics[metric];
-      }
-      node.children.forEach(visit);
-    }
-    visit(root);
-    return worst;
-  },
   _hasFlops: function(node) { return node.metrics.flops > 0; },
-  _goodFlops: function(node) { return tf_op_profile.utilization(node) > 0.4; },
   _textColor: function(node) { return tf_op_profile.flameColor(tf_op_profile.utilization(node), 0.7); },
 });
   </script>

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-table.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-table.html
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<link rel="import" href="../paper-slider/paper-slider.html">
+<link rel="import" href="../paper-toggle-button/paper-toggle-button.html">
 <link rel="import" href="utils.html">
 
 <!-- tf-op-table-styles contains shared styles used in this file -->
@@ -62,6 +64,41 @@ limitations under the License.
   display: block;
   background-color: white;
 }
+#control {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+
+  overflow:auto;
+  text-transform:uppercase;
+  padding: 0.5em;
+  vertical-align: bottom;
+  text-align: bottom;
+}
+
+.controlRowLeft {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  line-height: 50px;
+  text-align: bottom;
+  justify-content: flex-start;
+}
+
+.controlRowRight{
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  line-height: 50px;
+  text-align: bottom;
+  justify-content: flex-end;
+}
+
+paper-slider {
+  --paper-slider-input: {width: 100px}
+  --paper-slider-height: 3px;
+}
+
 #header {
   font-size: smaller;
   font-weight: bold;
@@ -74,6 +111,20 @@ limitations under the License.
 /* Match indented names */
 #header > #name { padding-left: 2em; }
     </style>
+    <div id="control">
+    <!--
+      paper-slider sets how many child nodes to show for each category.
+      If paper-toggle-button is checked, then only children in top 90th
+      percentile of time spent are listed.
+    -->
+    <span class="controlRowLeft">Show top
+      <paper-slider min="10" max="100" snaps step="10"
+        value="{{childrenCount}}" editable>
+      </paper-slider>ops</span>
+    <span class="controlRowRight">off&nbsp;
+    <paper-toggle-button checked={{showP90}}>
+    </paper-toggle-button>Top 90%</span>
+    </div>
     <div id="header">
       <span id="time">Time</span>
       <span id="name">Name</span>
@@ -83,6 +134,8 @@ limitations under the License.
     <tf-op-table-entry node="[[rootNode]]"
         header-hover="[[_onHeaderHover]]"
         header-click="[[_onHeaderClick]]"
+        children-count="{{childrenCount}}"
+        show-p90="{{showP90}}"
         expanded="true">
     </tf-op-table-entry>
   </template>
@@ -97,6 +150,16 @@ Polymer({
     active: {
       type: Object,
       computed: '_active(_selected, _hover)',
+      notify: true,
+    },
+    showP90: {
+      type: Boolean,
+      value: false,
+      notify: true,
+    },
+    childrenCount: {
+      type: Number,
+      value: 10,
       notify: true,
     },
     _selected: {
@@ -213,9 +276,12 @@ Polymer({
         {{_utilization(node)}}</span>
     </div>
     <template is="dom-if" if="[[expanded]]">
-      <template is="dom-repeat" items="{{node.children}}">
+      <template is="dom-repeat"
+                items="{{_getKChildren(node, childrenCount, showP90, level)}}">
         <tf-op-table-entry
           node="[[item]]"
+          children-count="{{childrenCount}}"
+          show-p90="{{showP90}}"
           level={{_nextLevel(level)}}
           header-hover="{{headerHover}}"
           header-click="{{headerClick}}">
@@ -286,7 +352,22 @@ Polymer({
     return (node.metrics && node.metrics.time)
               ? tf_op_profile.percent(node.metrics.time) : 0;
   },
-  _selectedChanged: function(v) { this.classList.toggle('selected', v); }
+  _selectedChanged: function(v) { this.classList.toggle('selected', v); },
+  /*
+    Returns top K children for the node. If p90 is true, then only children
+    fallen in the top 90th percentile in time are returned. 
+  */
+  _getKChildren: function(node, k, p90, level) {
+    if (p90 && node.children.length > 0 && node.children[0].metrics) {
+      var tot = 0, i = 0, t90 = node.metrics.time * 0.9;
+      for (; i < Math.min(k, node.children.length); i++) {
+          if(tot >= t90) break;
+          tot += node.children[i].metrics.time;
+      }
+      k = i;
+    }
+    return level ? node.children.slice(0, k) : node.children;
+  },
 });
   </script>
 </dom-module>

--- a/tensorboard/plugins/profile/tf_op_profile/utils.ts
+++ b/tensorboard/plugins/profile/tf_op_profile/utils.ts
@@ -36,7 +36,7 @@ export function flameColor(
     rgba(2 * (1 - fraction) * brightness, brightness, 0, opacity);
 }
 
-export function utilization(node) {
+export function utilization(node: any) {
   // NaN indicates undefined utilization for fused operations (we can't measure
   // performance inside a fusion). It could also indicate operations with zero
   // time, but they currently don't appear in the profile.


### PR DESCRIPTION
Add a slider to show top K time consuming ops per category. Also add a toggle button to select whether to show only top 90th percentile ops. The costly op section is removed. 