### PR TITLE
Fix lay out of the debugger plugin

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -85,7 +85,7 @@ limitations under the License.
             node-or-tensor-clicked="[[_createFeedFetchTargetClickedHandler()]]">
           </tf-session-runs-view>
         </div>
-        <div>
+        <div class="buttons-container">
           <paper-button raised class="continue-button" on-click="_step">
               <span>[[_stepButtonText]]</span>
           </paper-button>
@@ -164,8 +164,11 @@ limitations under the License.
     <style>
       :host {
         display: block;
-        min-height: 100%;
-        position: relative;
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
       }
       .debugger-section-title {
         font-size: 110%;
@@ -254,15 +257,20 @@ limitations under the License.
       }
       .node-entries {
         height: 66%;
+        width: 100%;
         overflow: auto;
         padding-top: 3px;
         padding-left: 3px;
         padding-right: 3px;
         box-shadow: 3px 3px #ddd;
       }
+      .buttons-container {
+        padding: 20px 0;
+      }
       .tensor-data {
         height: 34%;
         overflow: auto;
+        padding: 20px 0;
       }
       #top-right-content-container {
         height: 66%;

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
@@ -50,6 +50,10 @@ my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
     </paper-dialog>
   </template>
   <style>
+    :host:not([_open]) {
+      display: none;
+    }
+
     :host, #dashboard-backdrop {
       position: absolute;
       top: 0;
@@ -80,7 +84,10 @@ my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
         type: String,
         value: null,
       },
-      _open: Boolean,
+      _open: {
+        type: Boolean,
+        reflectToAttribute: true,  // for CSS 
+      },
       // Suppress the native paper-dialog backdrop. We use a custom one. We make
       // the dialog reference this bound property instead of directly setting
       // the attribute to the string "false" in the HTML because Polymer

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
@@ -36,6 +36,11 @@ limitations under the License.
       </table>
     </div>
     <style>
+      :host {
+        display: block;
+        padding: 20px 0;
+      }
+
       .section-title {
         font-size: 110%;
         font-weight: bold;
@@ -53,6 +58,7 @@ limitations under the License.
         font-size: 90%;
         border-style: solid 1px black;
         table-layout: fixed;
+        width: 100%;
         min-width: 400px;
         max-width: 450px;
         word-break: break-all;


### PR DESCRIPTION
We:

* Make the node list vary in height based on the height of the window
and scroll if necessary during overflow
* Solve an issue in which the UI becomes unclickable after the dialog
disappears.
* Add some top-bottom padding to various elements on the page.

Here is how the dashboard now looks like.

![image](https://user-images.githubusercontent.com/4221553/33960816-ca81ab2a-e000-11e7-805e-0b003dadbcda.png)

And here is how the dialog screen looks like.

![image](https://user-images.githubusercontent.com/4221553/33960836-d8c07e64-e000-11e7-96d9-e91c1a2cc2e0.png)

Some of the issues fixed I had introduced in #806.