### PR TITLE
Let custom scalars dashboard plot margin charts

### DIFF
--- a/tensorboard/plugins/custom_scalar/BUILD
+++ b/tensorboard/plugins/custom_scalar/BUILD
@@ -85,3 +85,15 @@ tb_proto_library(
     srcs = ["layout.proto"],
     visibility = ["//visibility:public"],
 )
+
+py_binary(
+    name = "custom_scalar_demo",
+    srcs = ["custom_scalar_demo.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":protos_all_py_pb2",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:summary",
+        "@org_pythonhosted_six",
+    ],
+)

--- a/tensorboard/plugins/custom_scalar/README.md
+++ b/tensorboard/plugins/custom_scalar/README.md
@@ -85,6 +85,12 @@ with tf.name_scope('loss'):
   summary_lib.scalar('foo', tf.pow(0.9, step))
   summary_lib.scalar('bar', tf.pow(0.85, step + 2))
 
+# Log metric baz as well as upper and lower bounds for making a margin chart.
+middle_baz_value = step + 4 * tf.random_uniform() - 2
+summary_lib.scalar('baz', middle_baz_value)
+summary_lib.scalar('baz_lower', middle_baz_value - 0.3 - tf.random_uniform())
+summary_lib.scalar('baz_upper', middle_baz_value + 0.3 + tf.random_uniform())
+
 with tf.name_scope('trigFunctions'):
   summary_lib.scalar('cosine', tf.cos(step))
   summary_lib.scalar('sine', tf.sin(step))
@@ -120,7 +126,7 @@ with tf.Session() as sess, tf.summary.FileWriter('/tmp/logdir') as writer:
 
   for i in xrange(42):
     summary = sess.run(merged_summary, feed_dict={step: i})
-    writer.add_summary(summary, global_step=step)
+    writer.add_summary(summary, global_step=i)
 ```
 
 ## The Dashboard UI

--- a/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
@@ -16,10 +16,10 @@
 
 The logic below logs scalar data and then lays out the custom scalars dashboard.
 """
+import tensorflow as tf
 
 from tensorboard import summary as summary_lib
 from tensorboard.plugins.custom_scalar import layout_pb2
-import tensorflow as tf
 
 step = tf.placeholder(tf.float32, shape=[])
 
@@ -32,8 +32,9 @@ with tf.name_scope('loss'):
   middle_baz_value = step + 4 * tf.random_uniform([]) - 2
   summary_lib.scalar('baz', middle_baz_value)
 
-summary_lib.scalar('baz_lower', middle_baz_value - 0.3 - tf.random_uniform([]))
-summary_lib.scalar('baz_upper', middle_baz_value + 0.3 + tf.random_uniform([]))
+with tf.name_scope('bazMargins'):
+  summary_lib.scalar('lower', middle_baz_value - 0.3 - tf.random_uniform([]))
+  summary_lib.scalar('upper', middle_baz_value + 0.3 + tf.random_uniform([]))
 
 with tf.name_scope('trigFunctions'):
   summary_lib.scalar('cosine', tf.cos(step))
@@ -53,7 +54,7 @@ with tf.Session() as sess, tf.summary.FileWriter(logdir) as writer:
                   layout_pb2.Chart(
                       title='losses',
                       multiline=layout_pb2.MultilineChartContent(
-                        tag=[r'loss.*'],
+                          tag=[r'loss.*'],
                       )),
                   layout_pb2.Chart(
                       title='baz',
@@ -61,11 +62,11 @@ with tf.Session() as sess, tf.summary.FileWriter(logdir) as writer:
                           series=[
                               layout_pb2.MarginChartContent.Series(
                                   value='loss/baz/scalar_summary',
-                                  lower='baz_lower/scalar_summary',
-                                  upper='baz_upper/scalar_summary'),
+                                  lower='bazMargins/lower/scalar_summary',
+                                  upper='bazMargins/upper/scalar_summary'),
                           ],
-                      )), 
-            ]),
+                      )),
+              ]),
           layout_pb2.Category(
               title='trig functions',
               chart=[

--- a/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
@@ -16,6 +16,7 @@
 
 The logic below logs scalar data and then lays out the custom scalars dashboard.
 """
+from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
 from tensorboard import summary as summary_lib
@@ -32,9 +33,8 @@ with tf.name_scope('loss'):
   middle_baz_value = step + 4 * tf.random_uniform([]) - 2
   summary_lib.scalar('baz', middle_baz_value)
 
-with tf.name_scope('bazMargins'):
-  summary_lib.scalar('lower', middle_baz_value - 0.3 - tf.random_uniform([]))
-  summary_lib.scalar('upper', middle_baz_value + 0.3 + tf.random_uniform([]))
+summary_lib.scalar('baz_lower', middle_baz_value - 0.3 - tf.random_uniform([]))
+summary_lib.scalar('baz_upper', middle_baz_value + 0.3 + tf.random_uniform([]))
 
 with tf.name_scope('trigFunctions'):
   summary_lib.scalar('cosine', tf.cos(step))
@@ -54,7 +54,7 @@ with tf.Session() as sess, tf.summary.FileWriter(logdir) as writer:
                   layout_pb2.Chart(
                       title='losses',
                       multiline=layout_pb2.MultilineChartContent(
-                          tag=[r'loss.*'],
+                        tag=[r'loss.*'],
                       )),
                   layout_pb2.Chart(
                       title='baz',
@@ -62,11 +62,11 @@ with tf.Session() as sess, tf.summary.FileWriter(logdir) as writer:
                           series=[
                               layout_pb2.MarginChartContent.Series(
                                   value='loss/baz/scalar_summary',
-                                  lower='bazMargins/lower/scalar_summary',
-                                  upper='bazMargins/upper/scalar_summary'),
+                                  lower='baz_lower/scalar_summary',
+                                  upper='baz_upper/scalar_summary'),
                           ],
                       )),
-              ]),
+            ]),
           layout_pb2.Category(
               title='trig functions',
               chart=[

--- a/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
@@ -32,10 +32,10 @@ with tf.name_scope('loss'):
   # Log metric baz as well as upper and lower bounds for making a margin chart.
   middle_baz_value = step + 4 * tf.random_uniform([]) - 2
   summary_lib.scalar('baz', middle_baz_value)
-
-with tf.name_scope('bazMargins'):
-  summary_lib.scalar('lower', middle_baz_value - 0.3 - tf.random_uniform([]))
-  summary_lib.scalar('upper', middle_baz_value + 0.3 + tf.random_uniform([]))
+  summary_lib.scalar(
+      'baz_lower_margin', middle_baz_value - 0.3 - tf.random_uniform([]))
+  summary_lib.scalar(
+      'baz_upper_margin', middle_baz_value + 0.3 + tf.random_uniform([]))
 
 with tf.name_scope('trigFunctions'):
   summary_lib.scalar('cosine', tf.cos(step))
@@ -55,7 +55,7 @@ with tf.Session() as sess, tf.summary.FileWriter(logdir) as writer:
                   layout_pb2.Chart(
                       title='losses',
                       multiline=layout_pb2.MultilineChartContent(
-                          tag=[r'loss.*'],
+                          tag=[r'loss(?!.*margin.*)'],
                       )),
                   layout_pb2.Chart(
                       title='baz',
@@ -63,8 +63,8 @@ with tf.Session() as sess, tf.summary.FileWriter(logdir) as writer:
                           series=[
                               layout_pb2.MarginChartContent.Series(
                                   value='loss/baz/scalar_summary',
-                                  lower='bazMargins/lower/scalar_summary',
-                                  upper='bazMargins/upper/scalar_summary'),
+                                  lower='loss/baz_lower_margin/scalar_summary',
+                                  upper='loss/baz_upper_margin/scalar_summary'),
                           ],
                       )),
               ]),

--- a/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
@@ -54,7 +54,7 @@ with tf.Session() as sess, tf.summary.FileWriter(logdir) as writer:
                   layout_pb2.Chart(
                       title='losses',
                       multiline=layout_pb2.MultilineChartContent(
-                        tag=[r'loss.*'],
+                          tag=[r'loss.*'],
                       )),
                   layout_pb2.Chart(
                       title='baz',
@@ -66,7 +66,7 @@ with tf.Session() as sess, tf.summary.FileWriter(logdir) as writer:
                                   upper='baz_upper/scalar_summary'),
                           ],
                       )),
-            ]),
+              ]),
           layout_pb2.Category(
               title='trig functions',
               chart=[

--- a/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
@@ -33,8 +33,9 @@ with tf.name_scope('loss'):
   middle_baz_value = step + 4 * tf.random_uniform([]) - 2
   summary_lib.scalar('baz', middle_baz_value)
 
-summary_lib.scalar('baz_lower', middle_baz_value - 0.3 - tf.random_uniform([]))
-summary_lib.scalar('baz_upper', middle_baz_value + 0.3 + tf.random_uniform([]))
+with tf.name_scope('bazMargins'):
+  summary_lib.scalar('lower', middle_baz_value - 0.3 - tf.random_uniform([]))
+  summary_lib.scalar('upper', middle_baz_value + 0.3 + tf.random_uniform([]))
 
 with tf.name_scope('trigFunctions'):
   summary_lib.scalar('cosine', tf.cos(step))
@@ -62,8 +63,8 @@ with tf.Session() as sess, tf.summary.FileWriter(logdir) as writer:
                           series=[
                               layout_pb2.MarginChartContent.Series(
                                   value='loss/baz/scalar_summary',
-                                  lower='baz_lower/scalar_summary',
-                                  upper='baz_upper/scalar_summary'),
+                                  lower='bazMargins/lower/scalar_summary',
+                                  upper='bazMargins/upper/scalar_summary'),
                           ],
                       )),
               ]),

--- a/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
@@ -1,0 +1,91 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Create sample PR curve summary data.
+
+The logic below logs scalar data and then lays out the custom scalars dashboard.
+"""
+
+from tensorboard import summary as summary_lib
+from tensorboard.plugins.custom_scalar import layout_pb2
+import tensorflow as tf
+
+step = tf.placeholder(tf.float32, shape=[])
+
+with tf.name_scope('loss'):
+  # Specify 2 different loss values, each tagged differently.
+  summary_lib.scalar('foo', tf.pow(0.9, step))
+  summary_lib.scalar('bar', tf.pow(0.85, step + 2))
+
+  # Log metric baz as well as upper and lower bounds for making a margin chart.
+  middle_baz_value = step + 4 * tf.random_uniform([]) - 2
+  summary_lib.scalar('baz', middle_baz_value)
+
+summary_lib.scalar('baz_lower', middle_baz_value - 0.3 - tf.random_uniform([]))
+summary_lib.scalar('baz_upper', middle_baz_value + 0.3 + tf.random_uniform([]))
+
+with tf.name_scope('trigFunctions'):
+  summary_lib.scalar('cosine', tf.cos(step))
+  summary_lib.scalar('sine', tf.sin(step))
+  summary_lib.scalar('tangent', tf.tan(step))
+
+merged_summary = tf.summary.merge_all()
+
+logdir = '/tmp/custom_scalar_demo'
+with tf.Session() as sess, tf.summary.FileWriter(logdir) as writer:
+  # We only need to specify the layout once (instead of per step).
+  layout_summary = summary_lib.custom_scalar_pb(layout_pb2.Layout(
+    category=[
+      layout_pb2.Category(
+        title='losses',
+        chart=[
+            layout_pb2.Chart(
+                title='losses',
+                multiline=layout_pb2.MultilineChartContent(
+                  tag=[r'loss.*'],
+                )),
+            layout_pb2.Chart(
+                title='baz',
+                margin=layout_pb2.MarginChartContent(
+                  series=[
+                    layout_pb2.MarginChartContent.Series(
+                      value='loss/baz/scalar_summary',
+                      lower='baz_lower/scalar_summary',
+                      upper='baz_upper/scalar_summary'),
+                  ],
+                )), 
+        ]),
+      layout_pb2.Category(
+        title='trig functions',
+        chart=[
+            layout_pb2.Chart(
+                title='wave trig functions',
+                multiline=layout_pb2.MultilineChartContent(
+                  tag=[r'trigFunctions/cosine', r'trigFunctions/sine'],
+                )),
+            # The range of tangent is different. Lets give it its own chart.
+            layout_pb2.Chart(
+                title='tan',
+                multiline=layout_pb2.MultilineChartContent(
+                  tag=[r'trigFunctions/tangent'],
+                )),
+        ],
+        # This category we care less about. Lets make it initially closed.
+        closed=True),
+    ]))
+  writer.add_summary(layout_summary)
+
+  for i in xrange(42):
+    summary = sess.run(merged_summary, feed_dict={step: i})
+    writer.add_summary(summary, global_step=i)

--- a/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
@@ -46,44 +46,44 @@ logdir = '/tmp/custom_scalar_demo'
 with tf.Session() as sess, tf.summary.FileWriter(logdir) as writer:
   # We only need to specify the layout once (instead of per step).
   layout_summary = summary_lib.custom_scalar_pb(layout_pb2.Layout(
-    category=[
-      layout_pb2.Category(
-        title='losses',
-        chart=[
-            layout_pb2.Chart(
-                title='losses',
-                multiline=layout_pb2.MultilineChartContent(
-                  tag=[r'loss.*'],
-                )),
-            layout_pb2.Chart(
-                title='baz',
-                margin=layout_pb2.MarginChartContent(
-                  series=[
-                    layout_pb2.MarginChartContent.Series(
-                      value='loss/baz/scalar_summary',
-                      lower='baz_lower/scalar_summary',
-                      upper='baz_upper/scalar_summary'),
-                  ],
-                )), 
-        ]),
-      layout_pb2.Category(
-        title='trig functions',
-        chart=[
-            layout_pb2.Chart(
-                title='wave trig functions',
-                multiline=layout_pb2.MultilineChartContent(
-                  tag=[r'trigFunctions/cosine', r'trigFunctions/sine'],
-                )),
-            # The range of tangent is different. Lets give it its own chart.
-            layout_pb2.Chart(
-                title='tan',
-                multiline=layout_pb2.MultilineChartContent(
-                  tag=[r'trigFunctions/tangent'],
-                )),
-        ],
-        # This category we care less about. Lets make it initially closed.
-        closed=True),
-    ]))
+      category=[
+          layout_pb2.Category(
+              title='losses',
+              chart=[
+                  layout_pb2.Chart(
+                      title='losses',
+                      multiline=layout_pb2.MultilineChartContent(
+                        tag=[r'loss.*'],
+                      )),
+                  layout_pb2.Chart(
+                      title='baz',
+                      margin=layout_pb2.MarginChartContent(
+                          series=[
+                              layout_pb2.MarginChartContent.Series(
+                                  value='loss/baz/scalar_summary',
+                                  lower='baz_lower/scalar_summary',
+                                  upper='baz_upper/scalar_summary'),
+                          ],
+                      )), 
+            ]),
+          layout_pb2.Category(
+              title='trig functions',
+              chart=[
+                  layout_pb2.Chart(
+                      title='wave trig functions',
+                      multiline=layout_pb2.MultilineChartContent(
+                          tag=[r'trigFunctions/cosine', r'trigFunctions/sine'],
+                      )),
+                  # The range of tangent is different. Give it its own chart.
+                  layout_pb2.Chart(
+                      title='tan',
+                      multiline=layout_pb2.MultilineChartContent(
+                          tag=[r'trigFunctions/tangent'],
+                      )),
+              ],
+              # This category we care less about. Lets make it initially closed.
+              closed=True),
+      ]))
   writer.add_summary(layout_summary)
 
   for i in xrange(42):

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
@@ -245,34 +245,7 @@ class CustomScalarsPlugin(base_plugin.TBPlugin):
     order of the runs to which the layouts are written.
 
     The response is a JSON object mirroring properties of the Layout proto if a
-    layout for any run is found:
-
-    {
-      categories: [
-        {
-          title: 'Biases',
-          chart: [
-            {
-              title: 'biases',
-              tag: 'foo/layer\d+/biases'
-            },
-            {
-              title: 'biases',
-              tag: 'foo/logits/biases'
-            },
-          ],
-        },
-        {
-          title: 'Activations',
-          chart: [
-            {
-              title: 'activations',
-              tag: 'foo/layer0/activations',
-            },
-          ],
-        },
-      ],
-    }
+    layout for any run is found.
 
     The response is an empty object if no layout could be found.
     """

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -49,7 +49,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                     layout_pb2.Chart(
                         title='cross entropy',
                         multiline=layout_pb2.MultilineChartContent(
-                          tag=[r'cross entropy'],
+                            tag=[r'cross entropy'],
                         )),
                 ],
                 closed=True)
@@ -63,7 +63,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                     layout_pb2.Chart(
                         title='mean layer biases',
                         multiline=layout_pb2.MultilineChartContent(
-                          tag=[r'mean/layer0/biases', r'mean/layer1/biases'],
+                            tag=[r'mean/layer0/biases', r'mean/layer1/biases'],
                         )),
                 ]
             ),
@@ -73,7 +73,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                     layout_pb2.Chart(
                         title='stddev layer weights',
                         multiline=layout_pb2.MultilineChartContent(
-                          tag=[r'stddev/layer\d+/weights'],
+                            tag=[r'stddev/layer\d+/weights'],
                         )),
                 ]
             ),
@@ -86,12 +86,12 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                         title='cross entropy margin chart',
                         margin=layout_pb2.MarginChartContent(
                           series=[
-                            layout_pb2.MarginChartContent.Series(
-                              value='cross entropy',
-                              lower='cross entropy lower',
-                              upper='cross entropy upper'),
+                              layout_pb2.MarginChartContent.Series(
+                                  value='cross entropy',
+                                  lower='cross entropy lower',
+                                  upper='cross entropy upper'),
                           ],
-                        )), 
+                        )),
                 ]
             ),
         ]
@@ -166,16 +166,16 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                     layout_pb2.Chart(
                         title='cross entropy',
                         multiline=layout_pb2.MultilineChartContent(
-                          tag=[r'cross entropy'],
+                            tag=[r'cross entropy'],
                         )),
                     layout_pb2.Chart(
                         title='cross entropy margin chart',
                         margin=layout_pb2.MarginChartContent(
                           series=[
-                            layout_pb2.MarginChartContent.Series(
-                              value='cross entropy',
-                              lower='cross entropy lower',
-                              upper='cross entropy upper'),
+                              layout_pb2.MarginChartContent.Series(
+                                  value='cross entropy',
+                                  lower='cross entropy lower',
+                                  upper='cross entropy upper'),
                           ],
                         )),
                 ],
@@ -187,7 +187,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                     layout_pb2.Chart(
                         title='mean layer biases',
                         multiline=layout_pb2.MultilineChartContent(
-                          tag=[r'mean/layer0/biases', r'mean/layer1/biases'],
+                            tag=[r'mean/layer0/biases', r'mean/layer1/biases'],
                         )),
                 ]
             ),
@@ -197,7 +197,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                     layout_pb2.Chart(
                         title='stddev layer weights',
                         multiline=layout_pb2.MultilineChartContent(
-                          tag=[r'stddev/layer\d+/weights'],
+                            tag=[r'stddev/layer\d+/weights'],
                         )),
                 ]
             ),

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -85,11 +85,11 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                     layout_pb2.Chart(
                         title='cross entropy margin chart',
                         margin=layout_pb2.MarginChartContent(
-                          series=[
-                              layout_pb2.MarginChartContent.Series(
-                                  value='cross entropy',
-                                  lower='cross entropy lower',
-                                  upper='cross entropy upper'),
+                            series=[
+                                layout_pb2.MarginChartContent.Series(
+                                    value='cross entropy',
+                                    lower='cross entropy lower',
+                                    upper='cross entropy upper'),
                           ],
                         )),
                 ]
@@ -171,12 +171,12 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                     layout_pb2.Chart(
                         title='cross entropy margin chart',
                         margin=layout_pb2.MarginChartContent(
-                          series=[
-                              layout_pb2.MarginChartContent.Series(
-                                  value='cross entropy',
-                                  lower='cross entropy lower',
-                                  upper='cross entropy upper'),
-                          ],
+                            series=[
+                                layout_pb2.MarginChartContent.Series(
+                                    value='cross entropy',
+                                    lower='cross entropy lower',
+                                    upper='cross entropy upper'),
+                            ],
                         )),
                 ],
                 closed=True,

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -48,7 +48,9 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                 chart=[
                     layout_pb2.Chart(
                         title='cross entropy',
-                        tag=[r'cross entropy']),
+                        multiline=layout_pb2.MultilineChartContent(
+                          tag=[r'cross entropy'],
+                        )),
                 ],
                 closed=True)
             ]
@@ -60,25 +62,39 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                 chart=[
                     layout_pb2.Chart(
                         title='mean layer biases',
-                        tag=[r'mean/layer0/biases', r'mean/layer1/biases'])
-                ]),
+                        multiline=layout_pb2.MultilineChartContent(
+                          tag=[r'mean/layer0/biases', r'mean/layer1/biases'],
+                        )),
+                ]
+            ),
             layout_pb2.Category(
                 title='std weights',
                 chart=[
                     layout_pb2.Chart(
                         title='stddev layer weights',
-                        tag=[r'stddev/layer\d+/weights'])
-                    ]),
+                        multiline=layout_pb2.MultilineChartContent(
+                          tag=[r'stddev/layer\d+/weights'],
+                        )),
+                ]
+            ),
             # A category with this name is also present in a layout for a
             # different run (the logdir run)
             layout_pb2.Category(
                 title='cross entropy',
                 chart=[
                     layout_pb2.Chart(
-                        title='cross entropy 2',
-                        tag=[r'cross entropy 2']),
-                ])
-            ]
+                        title='cross entropy margin chart',
+                        margin=layout_pb2.MarginChartContent(
+                          series=[
+                            layout_pb2.MarginChartContent.Series(
+                              value='cross entropy',
+                              lower='cross entropy lower',
+                              upper='cross entropy upper'),
+                          ],
+                        )), 
+                ]
+            ),
+        ]
     )
 
     # Generate test data.
@@ -142,35 +158,50 @@ class CustomScalarsPluginTest(tf.test.TestCase):
     json_format.Parse(self.plugin.layout_impl(), parsed_layout)
     correct_layout = layout_pb2.Layout(
         category=[
+            # A category with this name is also present in a layout for a
+            # different run (the logdir run)
             layout_pb2.Category(
                 title='cross entropy',
                 chart=[
-                    # Note that the "cross entropy 2" chart from layout for run
-                    # foo is now merged within the existing "cross entropy"
-                    # category because the categories have the same names.
                     layout_pb2.Chart(
                         title='cross entropy',
-                        tag=[r'cross entropy']),
+                        multiline=layout_pb2.MultilineChartContent(
+                          tag=[r'cross entropy'],
+                        )),
                     layout_pb2.Chart(
-                        title='cross entropy 2',
-                        tag=[r'cross entropy 2']),
+                        title='cross entropy margin chart',
+                        margin=layout_pb2.MarginChartContent(
+                          series=[
+                            layout_pb2.MarginChartContent.Series(
+                              value='cross entropy',
+                              lower='cross entropy lower',
+                              upper='cross entropy upper'),
+                          ],
+                        )),
                 ],
-                closed=True),
+                closed=True,
+            ),
             layout_pb2.Category(
                 title='mean biases',
                 chart=[
                     layout_pb2.Chart(
                         title='mean layer biases',
-                        tag=[r'mean/layer0/biases', r'mean/layer1/biases'])
-                ]),
+                        multiline=layout_pb2.MultilineChartContent(
+                          tag=[r'mean/layer0/biases', r'mean/layer1/biases'],
+                        )),
+                ]
+            ),
             layout_pb2.Category(
                 title='std weights',
                 chart=[
                     layout_pb2.Chart(
                         title='stddev layer weights',
-                        tag=[r'stddev/layer\d+/weights'])
-                    ]),
-            ]
+                        multiline=layout_pb2.MultilineChartContent(
+                          tag=[r'stddev/layer\d+/weights'],
+                        )),
+                ]
+            ),
+        ]
     )
     self.assertProtoEquals(correct_layout, parsed_layout)
 

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -90,7 +90,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                                     value='cross entropy',
                                     lower='cross entropy lower',
                                     upper='cross entropy upper'),
-                          ],
+                            ],
                         )),
                 ]
             ),

--- a/tensorboard/plugins/custom_scalar/layout.proto
+++ b/tensorboard/plugins/custom_scalar/layout.proto
@@ -22,13 +22,50 @@ package tensorboard;
  * Encapsulates information on a single chart. Many charts appear in a category.
  */
 message Chart {
-  // The title shown atop this chart. This field is optional and defaults to a
-  // comma-separated list of tag regular expressions.
+  // The title shown atop this chart. Optional. Defaults to 'untitled'.
   string title = 1;
 
+  // The content of the chart. This depends on the type of the chart.
+  oneof content {
+    MultilineChartContent multiline = 2;
+    MarginChartContent margin = 3;
+  }
+}
+
+/**
+ * Encapsulates information on a single line chart. This line chart may have
+ * lines associated with several tags.
+ */
+message MultilineChartContent {
   // A list of regular expressions for tags that should appear in this chart.
-  // Tags are matched based from beginning to end.
-  repeated string tag = 2;
+  // Tags are matched from beginning to end. Each regex captures a set of tags.
+  repeated string tag = 1;
+}
+
+/**
+ * Encapsulates information on a single margin chart. A margin chart uses fill
+ * area to visualize lower and upper bounds that surround a value.
+ */
+message MarginChartContent {
+  /**
+   * Encapsulates a tag of data for the chart.
+   */
+  message Series {
+    // The exact tag string associated with the scalar summaries making up the
+    // main value between the bounds.
+    string value = 1;
+
+    // The exact tag string associated with the scalar summaries making up the
+    // lower bound.
+    string lower = 2;
+
+    // The exact tag string associated with the scalar summaries making up the
+    // upper bound.
+    string upper = 3;
+  }
+
+  // A list of data series to include within this margin chart.
+  repeated Series series = 1;
 }
 
 /**

--- a/tensorboard/plugins/custom_scalar/summary_test.py
+++ b/tensorboard/plugins/custom_scalar/summary_test.py
@@ -43,7 +43,7 @@ class LayoutTest(tf.test.TestCase):
                     layout_pb2.Chart(
                         title='mean layer biases',
                         multiline=layout_pb2.MultilineChartContent(
-                          tag=[r'mean/layer\d+/biases'],
+                            tag=[r'mean/layer\d+/biases'],
                         )),
                 ]),
             layout_pb2.Category(
@@ -52,7 +52,7 @@ class LayoutTest(tf.test.TestCase):
                     layout_pb2.Chart(
                         title='stddev layer weights',
                         multiline=layout_pb2.MultilineChartContent(
-                          tag=[r'stddev/layer\d+/weights'],
+                            tag=[r'stddev/layer\d+/weights'],
                         )),
                     ]),
             layout_pb2.Category(
@@ -61,22 +61,22 @@ class LayoutTest(tf.test.TestCase):
                     layout_pb2.Chart(
                         title='cross entropy',
                         multiline=layout_pb2.MultilineChartContent(
-                          tag=[r'cross entropy'],
+                            tag=[r'cross entropy'],
                         )),
                     layout_pb2.Chart(
                         title='accuracy',
                         margin=layout_pb2.MarginChartContent(
                           series=[
-                            layout_pb2.MarginChartContent.Series(
-                              value='accuracy',
-                              lower='accuracy_lower_margin',
-                              upper='accuracy_upper_margin')
+                              layout_pb2.MarginChartContent.Series(
+                                  value='accuracy',
+                                  lower='accuracy_lower_margin',
+                                  upper='accuracy_upper_margin')
                           ]
                         )),
                     layout_pb2.Chart(
                         title='max layer weights',
                         multiline=layout_pb2.MultilineChartContent(
-                          tag=[r'max/layer1/.*', r'max/layer2/.*'],
+                            tag=[r'max/layer1/.*', r'max/layer2/.*'],
                         )),
                 ],
                 closed=True)

--- a/tensorboard/plugins/custom_scalar/summary_test.py
+++ b/tensorboard/plugins/custom_scalar/summary_test.py
@@ -66,12 +66,12 @@ class LayoutTest(tf.test.TestCase):
                     layout_pb2.Chart(
                         title='accuracy',
                         margin=layout_pb2.MarginChartContent(
-                          series=[
-                              layout_pb2.MarginChartContent.Series(
-                                  value='accuracy',
-                                  lower='accuracy_lower_margin',
-                                  upper='accuracy_upper_margin')
-                          ]
+                            series=[
+                                layout_pb2.MarginChartContent.Series(
+                                    value='accuracy',
+                                    lower='accuracy_lower_margin',
+                                    upper='accuracy_upper_margin')
+                            ]
                         )),
                     layout_pb2.Chart(
                         title='max layer weights',

--- a/tensorboard/plugins/custom_scalar/summary_test.py
+++ b/tensorboard/plugins/custom_scalar/summary_test.py
@@ -42,27 +42,42 @@ class LayoutTest(tf.test.TestCase):
                 chart=[
                     layout_pb2.Chart(
                         title='mean layer biases',
-                        tag=[r'mean/layer\d+/biases'])
+                        multiline=layout_pb2.MultilineChartContent(
+                          tag=[r'mean/layer\d+/biases'],
+                        )),
                 ]),
             layout_pb2.Category(
                 title='std weights',
                 chart=[
                     layout_pb2.Chart(
                         title='stddev layer weights',
-                        tag=[r'stddev/layer\d+/weights'])
+                        multiline=layout_pb2.MultilineChartContent(
+                          tag=[r'stddev/layer\d+/weights'],
+                        )),
                     ]),
             layout_pb2.Category(
                 title='cross entropy ... and maybe some other values',
                 chart=[
                     layout_pb2.Chart(
                         title='cross entropy',
-                        tag=[r'cross entropy']),
+                        multiline=layout_pb2.MultilineChartContent(
+                          tag=[r'cross entropy'],
+                        )),
                     layout_pb2.Chart(
                         title='accuracy',
-                        tag=[r'accuracy']),
+                        margin=layout_pb2.MarginChartContent(
+                          series=[
+                            layout_pb2.MarginChartContent.Series(
+                              value='accuracy',
+                              lower='accuracy_lower_margin',
+                              upper='accuracy_upper_margin')
+                          ]
+                        )),
                     layout_pb2.Chart(
                         title='max layer weights',
-                        tag=[r'max/layer1/.*', r'max/layer2/.*'])
+                        multiline=layout_pb2.MultilineChartContent(
+                          tag=[r'max/layer1/.*', r'max/layer2/.*'],
+                        )),
                 ],
                 closed=True)
         ])

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/BUILD
@@ -7,9 +7,11 @@ licenses(["notice"])  # Apache 2.0
 tf_web_library(
     name = "tf_custom_scalar_dashboard",
     srcs = [
-        "tf-custom-scalar-card.html",
+        "tf-custom-scalar-card-style.html",
         "tf-custom-scalar-dashboard.html",
         "tf-custom-scalar-helpers.ts",
+        "tf-custom-scalar-margin-chart-card.html",
+        "tf-custom-scalar-multi-line-chart-card.html",
     ],
     path = "/tf-custom-scalar-dashboard",
     visibility = ["//visibility:public"],

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-card-style.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-card-style.html
@@ -1,0 +1,87 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
+
+<dom-module id="tf-custom-scalar-card-style">
+  <template>
+    <style>
+      :host {
+        margin: 5px 10px;
+        display: inline-block;
+        width: 330px;
+        vertical-align: text-top;
+      }
+
+      :host[_expanded] {
+        width: 100%;
+      }
+
+      :host[_expanded] #tf-line-chart-data-loader-container {
+        height: 400px;
+      }
+
+      h1 {
+        font-size: 19px;
+        font-weight: normal;
+      }
+
+      #tf-line-chart-data-loader-container {
+        height: 200px;
+        width: 100%;
+      }
+
+      #buttons {
+        display: flex;
+        flex-direction: row;
+      }
+
+      paper-icon-button {
+        color: #2196F3;
+        border-radius: 100%;
+        width: 32px;
+        height: 32px;
+        padding: 4px;
+      }
+
+      paper-icon-button[selected] {
+        background: var(--tb-ui-light-accent);
+      }
+
+      .download-links {
+        display: flex;
+        height: 32px;
+      }
+
+      .download-links a {
+        font-size: 10px;
+        align-self: center;
+        margin: 2px;
+      }
+
+      .download-links paper-dropdown-menu {
+        width: 100px;
+        --paper-input-container-label: {
+          font-size: 10px;
+        }
+        --paper-input-container-input: {
+          font-size: 10px;
+        }
+      }
+    </style>
+  </template>
+</dom-module>

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
@@ -30,7 +30,8 @@ limitations under the License.
 <link rel="import" href="../tf-scalar-dashboard/tf-smoothing-input.html">
 <link rel="import" href="../tf-tensorboard/registry.html">
 <link rel="import" href="../tf-utils/tf-utils.html">
-<link rel="import" href="tf-custom-scalar-card.html">
+<link rel="import" href="tf-custom-scalar-margin-chart-card.html">
+<link rel="import" href="tf-custom-scalar-multi-line-chart-card.html">
 
 <!--
   A frontend that displays a custom set of line charts.
@@ -108,25 +109,47 @@ from tensorboard.plugins.custom_scalar import layout_pb2
 ...
 # This action does not have to be performed at every step, so the action is not
 # taken care of by an op in the graph. We only need to specify the layout once. 
-summary_writer.add_summary(
-    summary.custom_scalars_pb(
-        layout_pb2.Layout(category=[
-            layout_pb2.Category(
-                title='mean biases',
-                chart=[
-                    layout_pb2.Chart(
-                        title='mean layer biases',
-                        tag=[r'mean/layer\d+/biases'])
+# We only need to specify the layout once (instead of per step).
+layout_summary = summary_lib.custom_scalar_pb(layout_pb2.Layout(
+  category=[
+    layout_pb2.Category(
+      title='losses',
+      chart=[
+          layout_pb2.Chart(
+              title='losses',
+              multiline=layout_pb2.MultilineChartContent(
+                tag=[r'loss.*'],
+              )),
+          layout_pb2.Chart(
+              title='baz',
+              margin=layout_pb2.MarginChartContent(
+                series=[
+                  layout_pb2.MarginChartContent.Series(
+                    value='loss/baz/scalar_summary',
+                    lower='baz_lower/baz/scalar_summary',
+                    upper='baz_upper/baz/scalar_summary'),
                 ],
-                closed=True),
-            layout_pb2.Category(
-                title='std weights',
-                chart=[
-                    layout_pb2.Chart(
-                        title='stddev layer weights',
-                        tag=[r'stddev/layer\d+/weights'])
-                    ])))
-)
+              )), 
+      ]),
+    layout_pb2.Category(
+      title='trig functions',
+      chart=[
+          layout_pb2.Chart(
+              title='wave trig functions',
+              multiline=layout_pb2.MultilineChartContent(
+                tag=[r'trigFunctions/cosine', r'trigFunctions/sine'],
+              )),
+          # The range of tangent is different. Lets give it its own chart.
+          layout_pb2.Chart(
+              title='tan',
+              multiline=layout_pb2.MultilineChartContent(
+                tag=[r'trigFunctions/tangent'],
+              )),
+      ],
+      # This category we care less about. Lets make it initially closed.
+      closed=True),
+  ]))
+writer.add_summary(layout_summary)
 </pre>
         <p>
         If you’re new to using TensorBoard, and want to find out how
@@ -144,19 +167,36 @@ summary_writer.add_summary(
                 on-opened-changed="_categoryOpenedToggled"
               >
               <template is="dom-repeat" items="[[category.items]]" as="chart">
-                <tf-custom-scalar-card
-                  active="[[_active]]"
-                  request-manager="[[_requestManager]]"
-                  runs="[[_selectedRuns]]"
-                  title="[[chart.title]]"
-                  x-type="[[_xType]]"
-                  smoothing-enabled="[[_smoothingEnabled]]"
-                  smoothing-weight="[[_smoothingWeight]]"
-                  tooltip-sorting-method="[[tooltipSortingMethod]]"
-                  ignore-y-outliers="[[ignoreYOutliers]]"
-                  show-download-links="[[_showDownloadLinks]]"
-                  tag-regexes="[[chart.tag]]"
-                ></tf-custom-scalar-card>
+                <template is="dom-if" if="[[chart.multiline]]">
+                  <tf-custom-scalar-multi-line-chart-card
+                    active="[[_active]]"
+                    request-manager="[[_requestManager]]"
+                    runs="[[_selectedRuns]]"
+                    title="[[chart.title]]"
+                    x-type="[[_xType]]"
+                    smoothing-enabled="[[_smoothingEnabled]]"
+                    smoothing-weight="[[_smoothingWeight]]"
+                    tooltip-sorting-method="[[tooltipSortingMethod]]"
+                    ignore-y-outliers="[[ignoreYOutliers]]"
+                    show-download-links="[[_showDownloadLinks]]"
+                    tag-regexes="[[chart.multiline.tag]]"
+                  ></tf-custom-scalar-multi-line-chart-card>
+                </template>
+                <template is="dom-if" if="[[chart.margin]]">
+                  <tf-custom-scalar-margin-chart-card
+                    active="[[_active]]"
+                    request-manager="[[_requestManager]]"
+                    runs="[[_selectedRuns]]"
+                    title="[[chart.title]]"
+                    x-type="[[_xType]]"
+                    smoothing-enabled="[[_smoothingEnabled]]"
+                    smoothing-weight="[[_smoothingWeight]]"
+                    tooltip-sorting-method="[[tooltipSortingMethod]]"
+                    ignore-y-outliers="[[ignoreYOutliers]]"
+                    show-download-links="[[_showDownloadLinks]]"
+                    margin-chart-series="[[chart.margin.series]]"
+                  ></tf-custom-scalar-margin-chart-card>
+                </template>
               </template>
             </tf-category-pane>
           </template>

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
@@ -139,14 +139,14 @@ layout_summary = summary_lib.custom_scalar_pb(layout_pb2.Layout(
               multiline=layout_pb2.MultilineChartContent(
                 tag=[r'trigFunctions/cosine', r'trigFunctions/sine'],
               )),
-          # The range of tangent is different. Lets give it its own chart.
+          # The range of tangent is different. Let's give it its own chart.
           layout_pb2.Chart(
               title='tan',
               multiline=layout_pb2.MultilineChartContent(
                 tag=[r'trigFunctions/tangent'],
               )),
       ],
-      # This category we care less about. Lets make it initially closed.
+      # This category we care less about. Let's make it initially closed.
       closed=True),
   ]))
 writer.add_summary(layout_summary)

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -28,12 +28,13 @@ limitations under the License.
 <link rel="import" href="../tf-line-chart-data-loader/tf-line-chart-data-loader.html">
 <link rel="import" href="../tf-card-heading/tf-card-heading.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="tf-custom-scalar-card-style.html">
 
 <!--
   A card that handles loading data (at the right times), rendering a scalar
   chart, and providing UI affordances (such as buttons) for scalar data.
 -->
-<dom-module id="tf-custom-scalar-card">
+<dom-module id="tf-custom-scalar-margin-chart-card">
 <template>
   <h1>[[_titleDisplayString]]</h1>
   <div id="tf-line-chart-data-loader-container">
@@ -50,10 +51,12 @@ limitations under the License.
       active="[[active]]"
       data-url="[[_dataUrl]]"
       log-scale-active="[[_logScaleActive]]"
-      process-data="[[_createProcessDataFunction()]]"
+      process-data="[[_createProcessDataFunction(marginChartSeries)]]"
       color-scale="[[_colorScale]]"
       data-series="[[_dataSeriesStrings]]"
       symbol-function="[[_createSymbolFunction()]]"
+      tooltip-columns="[[_tooltipColumns]]"
+      fill-area="[[_fillArea]]"
     >
     </tf-line-chart-data-loader>
   </div>
@@ -98,6 +101,22 @@ limitations under the License.
       </div>
     </template>
   </div>
+
+  <template is="dom-if" if="[[_tagsWithNoData]]">
+    <div id="warning-content">
+      &#9888;
+      No data found for these tags:
+      <ul>
+        <template is="dom-repeat" items="[[_tagsWithNoData]]">
+          <li>[[item]]</li>
+        </template>
+      </ul>
+      <br>
+      Tags for the value, lower, and upper bounds of margin charts in the Layout
+      proto must match tags in the SCALARS dashboard.
+    </div>
+  </template>
+  
   <div id="matches-container">
     <div id="matches-list-title">
       <template is="dom-if" if="[[_dataSeriesStrings.length]]">
@@ -132,68 +151,23 @@ limitations under the License.
   </div>
 
   </div>
+  <style include="tf-custom-scalar-card-style"></style>
   <style>
-    :host {
-      margin: 5px 10px;
-      display: inline-block;
-      width: 330px;
-      vertical-align: text-top;
+    #warning-content {
+      background: #f00;
+      border-radius: 5px;
+      color: #fff;
+      margin: 10px 0 0 0;
+      padding: 10px;
     }
 
-    :host[_expanded] {
-      width: 100%;
+    .warning-icon {
+      font-size: 150%;
     }
 
-    :host[_expanded] #tf-line-chart-data-loader-container {
-      height: 400px;
-    }
-
-    h1 {
-      font-size: 19px;
-      font-weight: normal;
-    }
-
-    #tf-line-chart-data-loader-container {
-      height: 200px;
-      width: 100%;
-    }
-
-    #buttons {
-      display: flex;
-      flex-direction: row;
-    }
-
-    paper-icon-button {
-      color: #2196F3;
-      border-radius: 100%;
-      width: 32px;
-      height: 32px;
-      padding: 4px;
-    }
-
-    paper-icon-button[selected] {
-      background: var(--tb-ui-light-accent);
-    }
-
-    .download-links {
-      display: flex;
-      height: 32px;
-    }
-
-    .download-links a {
-      font-size: 10px;
-      align-self: center;
-      margin: 2px;
-    }
-
-    .download-links paper-dropdown-menu {
-      width: 100px;
-      --paper-input-container-label: {
-        font-size: 10px;
-      }
-      --paper-input-container-input: {
-        font-size: 10px;
-      }
+    #warning-content ul {
+      margin: 1px 0 0 0;
+      padding: 0 0 0 19px;
     }
 
     #matches-list-title {
@@ -224,7 +198,7 @@ limitations under the License.
 <script src='tf-custom-scalar-helpers.js'></script>
 <script>
   Polymer({
-      is: 'tf-custom-scalar-card',
+      is: 'tf-custom-scalar-margin-chart-card',
       properties: {
         runs: Array,  // of String
 
@@ -239,7 +213,10 @@ limitations under the License.
           readOnly: true,
         },
         title: String,
-        tagRegexes: Array,
+        // An array of JSON objects that resemble MarginChartContent.Series
+        // protos. The properties of these series differ from those of data
+        // series used by the tf-line-chart-data-loader component.
+        marginChartSeries: Array,
         ignoreYOutliers: Boolean,
         requestManager: Object,
         showDownloadLinks: Boolean,
@@ -260,7 +237,7 @@ limitations under the License.
          */
         _tagFilter: {
           type: String,
-          computed: '_computeTagFilter(tagRegexes)',
+          computed: '_computeTagFilter(marginChartSeries)',
         },
 
         /**
@@ -317,8 +294,64 @@ limitations under the License.
         },
         _titleDisplayString: {
           type: String,
-          computed: '_computeTitleDisplayString(title, _tagFilter)',
+          computed: '_computeTitleDisplayString(title)',
         },
+        _fillArea: {
+          type: Object,
+          readOnly: true,
+          value: {
+              lowerAccessor: d => d.lower,
+              higherAccessor: d => d.upper,
+          },
+        },
+        _tooltipColumns: {
+          type: Array,
+          value: function() {
+            const valueFormatter = vz_line_chart.multiscaleFormatter(
+                vz_line_chart.Y_TOOLTIP_FORMATTER_PRECISION);
+            const formatValueOrNaN =
+                (x) => isNaN(x) ? 'NaN' : valueFormatter(x);
+
+            return [
+              {
+                title: 'Name',
+                evaluate: (d) => d.dataset.metadata().name,
+              },
+              {
+                title: 'Smoothed',
+                evaluate: (d, statusObject) => formatValueOrNaN(
+                    statusObject.smoothingEnabled ? d.datum.smoothed :
+                                                    d.datum.scalar),
+              },
+              {
+                title: 'Value',
+                evaluate: (d) => formatValueOrNaN(d.datum.scalar),
+              },
+              {
+                title: 'Lower Margin',
+                evaluate: (d) => formatValueOrNaN(d.datum.lower),
+              },
+              {
+                title: 'Upper Margin',
+                evaluate: (d) => formatValueOrNaN(d.datum.upper),
+              },
+              {
+                title: 'Step',
+                evaluate: (d) => vz_line_chart.stepFormatter(d.datum.step),
+              },
+              {
+                title: 'Time',
+                evaluate: (d) => vz_line_chart.timeFormatter(d.datum.wall_time),
+              },
+              {
+                title: 'Relative',
+                evaluate: (d) => vz_line_chart.relativeFormatter(
+                    vz_line_chart.relativeAccessor(d.datum, -1, d.dataset)),
+              },
+            ];
+          }
+        },
+        _tagsWithNoData: String,
       },
       observers: [
         '_updateChart(_nameToDataSeries)',
@@ -365,27 +398,85 @@ limitations under the License.
       _computeXComponentsCreationMethod(xType) {
         return () => vz_line_chart.getXComponents(xType);
       },
-      _createProcessDataFunction() {
+      _createProcessDataFunction(marginChartSeries) {
         // This function is called when data is received from the backend.
         return ((scalarChart, run, data) => {
           if (data.regex_valid) {
             // The user's regular expression was valid.
             // Incorporate these newly loaded values.
             const newMapping = _.clone(this._nameToDataSeries);
-            _.forOwn(data.tag_to_events, (scalarEvents, tag) => {
-              const data = scalarEvents.map(datum => ({
+            const tagsNotFound = [];
+            _.forEach(marginChartSeries, tagsObject => {
+              let tagNotFound = false;
+              const scalarEvents = data.tag_to_events[tagsObject.value];
+              const lowerBounds = data.tag_to_events[tagsObject.lower];
+              const upperBounds = data.tag_to_events[tagsObject.upper];
+
+              if (_.isUndefined(scalarEvents)) {
+                tagsNotFound.push(tagsObject.value);
+                tagNotFound = true;
+              }
+              if (_.isUndefined(lowerBounds)) {
+                tagsNotFound.push(tagsObject.lower);
+                tagNotFound = true;
+              }
+              if (_.isUndefined(upperBounds)) {
+                tagsNotFound.push(tagsObject.upper);
+                tagNotFound = true;
+              }
+
+              if (tagNotFound) {
+                return;
+              }
+
+              const dataPoints = scalarEvents.map(datum => ({
                 wall_time: new Date(datum[0] * 1000),
                 step: datum[1],
                 scalar: datum[2],
               }));
+              
+              // Associate the lower bounds with the correct data points.
+              for (let i = j = 0;
+                   i < dataPoints.length && j < lowerBounds.length;) {
+                const boundDataPoint = lowerBounds[j];
+                const step = boundDataPoint[1];
+                const bound = boundDataPoint[2];
+                if (step < dataPoints[i].step) {
+                  j++;
+                } else if (step > dataPoints[i].step) {
+                  i++
+                } else {
+                  dataPoints[i].lower = bound;
+                  i++;
+                  j++;
+                }
+              }
 
-              const seriesName = tf_custom_scalar_dashboard.generateDataSeriesName(
-                  run, tag);
+              // Associate the upper bounds with the correct data points.
+              for (let i = j = 0;
+                   i < dataPoints.length && j < upperBounds.length;) {
+                const boundDataPoint = upperBounds[j];
+                const step = boundDataPoint[1];
+                const bound = boundDataPoint[2];
+                if (step < dataPoints[i].step) {
+                  j++;
+                } else if (step > dataPoints[i].step) {
+                  i++
+                } else {
+                  dataPoints[i].upper = bound;
+                  i++;
+                  j++;
+                }
+              }
+
+              const seriesName =
+                  tf_custom_scalar_dashboard.generateDataSeriesName(
+                      run, tagsObject.value);
               let series = newMapping[seriesName];
 
               if (series) {
                 // This series already exists.
-                series.setData(data);
+                series.setData(dataPoints);
               } else {
                 if (_.isUndefined(this._runToNextAvailableSymbolIndex[run])) {
                   // The run has not been seen before. Define the next available
@@ -400,9 +491,9 @@ limitations under the License.
                 // Create a series with this name.
                 series = new tf_custom_scalar_dashboard.DataSeries(
                     run,
-                    tag,
+                    tagsObject.value,
                     seriesName,
-                    data,
+                    dataPoints,
                     lineChartSymbol);
                 newMapping[seriesName] = series;
 
@@ -412,6 +503,10 @@ limitations under the License.
                     (this._runToNextAvailableSymbolIndex[run] + 1) % numSymbols;
               }
             });
+
+            if (tagsNotFound.length) {
+              this.set('_tagsWithNoData', tagsNotFound);
+            }
 
             this.set('_nameToDataSeries', newMapping);
           } else {
@@ -456,12 +551,18 @@ limitations under the License.
       _determineSymbol(nameToDataSeries, seriesName) {
         return nameToDataSeries[seriesName].getSymbol().character;
       },
-      _computeTagFilter(tagRegexes) {
-        if (tagRegexes.length === 1) {
-          return tagRegexes[0];
-        }
+      _computeTagFilter(marginChartSeries) {
+        const tags = _.flatten(
+            marginChartSeries.map(
+                series => [series.value, series.lower, series.upper]));
+        const escapedTags = tags.map(
+            r => '(' + this._escapeRegexCharacters(r) + ')');
         // Combine the different regexes into a single regex.
-        return tagRegexes.map(r => '(' + r + ')').join('|');
+        return escapedTags.join('|');
+      },
+      _escapeRegexCharacters(stringValue) {
+        return stringValue.replace(
+            /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
       },
       _getToggleMatchesIcon(matchesListOpened) {
         return matchesListOpened ? 'expand-less' : 'expand-more';
@@ -469,9 +570,9 @@ limitations under the License.
       _toggleMatchesOpen() {
         this.set('_matchesListOpened', !this._matchesListOpened);
       },
-      _computeTitleDisplayString(title, tagFilter) {
-        // If no title is provided, use the tag filter.
-        return title || tagFilter;
+      _computeTitleDisplayString(title) {
+        // If no title is provided, use a placeholder string.
+        return title || 'untitled';
       },
   });
 </script>

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -103,8 +103,8 @@ limitations under the License.
   </div>
 
   <template is="dom-if" if="[[_tagsWithNoData]]">
-    <div id="warning-content">
-      &#9888;
+    <div id="error-content">
+      <iron-icon class="error-icon" icon="icons:error"></iron-icon>
       No data found for these tags:
       <ul>
         <template is="dom-repeat" items="[[_tagsWithNoData]]">
@@ -114,6 +114,34 @@ limitations under the License.
       <br>
       Tags for the value, lower, and upper bounds of margin charts in the Layout
       proto must match tags in the SCALARS dashboard.
+    </div>
+  </template>
+
+  <template is="dom-if" if="[[_tagFilterInvalid]]">
+    <div id="error-content">
+      <iron-icon class="error-icon" icon="icons:error"></iron-icon>
+      [[_tagFilter]] is an invalid regular expression.
+    </div>
+  </template>
+
+  <template is="dom-if" if="[[_stepsMismatch]]">
+    <div id="error-content">
+      <iron-icon class="error-icon" icon="icons:error"></iron-icon>
+      The steps for value, lower, and upper tags do not match:
+      <ul>
+        <li>
+          <span class="tag-name">[[_stepsMismatch.seriesObject.value]]</span>:
+          [[_separateWithCommas(_stepsMismatch.valueSteps)]]
+        </li>
+        <li>
+          <span class="tag-name">[[_stepsMismatch.seriesObject.lower]]</span>:
+          [[_separateWithCommas(_stepsMismatch.lowerSteps)]]
+        </li>
+        <li>
+          <span class="tag-name">[[_stepsMismatch.seriesObject.upper]]</span>:
+          [[_separateWithCommas(_stepsMismatch.upperSteps)]]
+        </li>
+      </ul>
     </div>
   </template>
   
@@ -153,7 +181,7 @@ limitations under the License.
   </div>
   <style include="tf-custom-scalar-card-style"></style>
   <style>
-    #warning-content {
+    #error-content {
       background: #f00;
       border-radius: 5px;
       color: #fff;
@@ -161,13 +189,17 @@ limitations under the License.
       padding: 10px;
     }
 
-    .warning-icon {
-      font-size: 150%;
+    .error-icon {
+      fill: #fff;
     }
 
-    #warning-content ul {
+    #error-content ul {
       margin: 1px 0 0 0;
       padding: 0 0 0 19px;
+    }
+
+    .tag-name {
+      font-weight: bold;
     }
 
     #matches-list-title {
@@ -203,7 +235,8 @@ limitations under the License.
         runs: Array,  // of String
 
         /**
-         * TODO: Add type.
+         * This property must take on values from the XType enum defined within
+         * the vz_line_chart component.
          */
         xType: String,
 
@@ -213,7 +246,7 @@ limitations under the License.
           readOnly: true,
         },
         title: String,
-        // An array of JSON objects that resemble MarginChartContent.Series
+        // An array of JSON objects that represent MarginChartContent.Series
         // protos. The properties of these series differ from those of data
         // series used by the tf-line-chart-data-loader component.
         marginChartSeries: Array,
@@ -239,6 +272,11 @@ limitations under the License.
           type: String,
           computed: '_computeTagFilter(marginChartSeries)',
         },
+
+        /**
+         * Whether the tag filter was deemed to be invalid.
+         */
+        _tagFilterInvalid: Boolean,
 
         /**
          * Maps from the name of the data series to the DataSeries object.
@@ -294,7 +332,7 @@ limitations under the License.
         },
         _titleDisplayString: {
           type: String,
-          computed: '_computeTitleDisplayString(title)',
+          computed: '_computeTitleDisplayString(title, _tagFilter)',
         },
         _fillArea: {
           type: Object,
@@ -352,6 +390,18 @@ limitations under the License.
           }
         },
         _tagsWithNoData: String,
+        /**
+         * This field is only set if data retrieved from the server exhibits a
+         * step mismatch: if the lists of values, lower bounds, and upper bounds
+         * do not match in step. If set, this object has these properties:
+         * 
+         * seriesObject: An object that represents a MarginChartContent.Series
+         *     proto.
+         * valueSteps: A list of steps (numbers) for the values.
+         * lowerSteps: A list of steps (numbers) for the lower bounds.
+         * upperSteps: A list of steps (numbers) for the upper bounds.
+         */
+        _stepsMismatch: Object,
       },
       observers: [
         '_updateChart(_nameToDataSeries)',
@@ -401,119 +451,130 @@ limitations under the License.
       _createProcessDataFunction(marginChartSeries) {
         // This function is called when data is received from the backend.
         return ((scalarChart, run, data) => {
-          if (data.regex_valid) {
-            // The user's regular expression was valid.
-            // Incorporate these newly loaded values.
-            const newMapping = _.clone(this._nameToDataSeries);
-            const tagsNotFound = [];
-            _.forEach(marginChartSeries, tagsObject => {
-              let tagNotFound = false;
-              const scalarEvents = data.tag_to_events[tagsObject.value];
-              const lowerBounds = data.tag_to_events[tagsObject.lower];
-              const upperBounds = data.tag_to_events[tagsObject.upper];
+          if (!data.regex_valid) {
+            // The regular expression is constructed from frontend logic that
+            // pieces together different tags. Hence, this case should never be
+            // reached if the dashboard behaves correctly.
+            this.set('_tagFilterInvalid', true);
+            return;
+          }
 
-              if (_.isUndefined(scalarEvents)) {
-                tagsNotFound.push(tagsObject.value);
-                tagNotFound = true;
-              }
-              if (_.isUndefined(lowerBounds)) {
-                tagsNotFound.push(tagsObject.lower);
-                tagNotFound = true;
-              }
-              if (_.isUndefined(upperBounds)) {
-                tagsNotFound.push(tagsObject.upper);
-                tagNotFound = true;
-              }
+          // The user's regular expression was valid.
+          // Incorporate these newly loaded values.
+          const newMapping = _.clone(this._nameToDataSeries);
+          const tagsNotFound = [];
+          _.forEach(marginChartSeries, tagsObject => {
+            let tagNotFound = false;
+            const scalarEvents = data.tag_to_events[tagsObject.value];
+            const lowerBounds = data.tag_to_events[tagsObject.lower];
+            const upperBounds = data.tag_to_events[tagsObject.upper];
 
-              if (tagNotFound) {
-                return;
-              }
-
-              const dataPoints = scalarEvents.map(datum => ({
-                wall_time: new Date(datum[0] * 1000),
-                step: datum[1],
-                scalar: datum[2],
-              }));
-              
-              // Associate the lower bounds with the correct data points.
-              for (let i = j = 0;
-                   i < dataPoints.length && j < lowerBounds.length;) {
-                const boundDataPoint = lowerBounds[j];
-                const step = boundDataPoint[1];
-                const bound = boundDataPoint[2];
-                if (step < dataPoints[i].step) {
-                  j++;
-                } else if (step > dataPoints[i].step) {
-                  i++
-                } else {
-                  dataPoints[i].lower = bound;
-                  i++;
-                  j++;
-                }
-              }
-
-              // Associate the upper bounds with the correct data points.
-              for (let i = j = 0;
-                   i < dataPoints.length && j < upperBounds.length;) {
-                const boundDataPoint = upperBounds[j];
-                const step = boundDataPoint[1];
-                const bound = boundDataPoint[2];
-                if (step < dataPoints[i].step) {
-                  j++;
-                } else if (step > dataPoints[i].step) {
-                  i++
-                } else {
-                  dataPoints[i].upper = bound;
-                  i++;
-                  j++;
-                }
-              }
-
-              const seriesName =
-                  tf_custom_scalar_dashboard.generateDataSeriesName(
-                      run, tagsObject.value);
-              let series = newMapping[seriesName];
-
-              if (series) {
-                // This series already exists.
-                series.setData(dataPoints);
-              } else {
-                if (_.isUndefined(this._runToNextAvailableSymbolIndex[run])) {
-                  // The run has not been seen before. Define the next available
-                  // marker index.
-                  this._runToNextAvailableSymbolIndex[run] = 0;
-                }
-
-                // Every data series within a run has a unique symbol.
-                const lineChartSymbol = vz_line_chart.SYMBOLS_LIST[
-                    this._runToNextAvailableSymbolIndex[run]];
-
-                // Create a series with this name.
-                series = new tf_custom_scalar_dashboard.DataSeries(
-                    run,
-                    tagsObject.value,
-                    seriesName,
-                    dataPoints,
-                    lineChartSymbol);
-                newMapping[seriesName] = series;
-
-                // Loop back to the beginning if we are out of symbols.
-                const numSymbols = vz_line_chart.SYMBOLS_LIST.length;
-                this._runToNextAvailableSymbolIndex[run] =
-                    (this._runToNextAvailableSymbolIndex[run] + 1) % numSymbols;
-              }
-            });
-
-            if (tagsNotFound.length) {
-              this.set('_tagsWithNoData', tagsNotFound);
+            // Make sure that data is found for each of the tags.
+            if (_.isUndefined(scalarEvents)) {
+              tagsNotFound.push(tagsObject.value);
+              tagNotFound = true;
+            }
+            if (_.isUndefined(lowerBounds)) {
+              tagsNotFound.push(tagsObject.lower);
+              tagNotFound = true;
+            }
+            if (_.isUndefined(upperBounds)) {
+              tagsNotFound.push(tagsObject.upper);
+              tagNotFound = true;
             }
 
-            this.set('_nameToDataSeries', newMapping);
-          } else {
-            // The user's regular expression was invalid.
-            // TODO(chihuahua): Handle this.
+            // At least one of the tags lacks data. We terminate early because
+            // the line chart requires all 3 pieces of data (value, lower bound,
+            // and upper bound).
+            if (tagNotFound) {
+              return;
+            }
+
+            // Make sure that steps for all the lists correspond with each
+            // other. Otherwise, display an error message.
+            const obtainStep = datum => datum[1];
+            const stepsMismatch = this._findStepMismatch(
+                tagsObject,
+                dataPoints.map(obtainStep),
+                lowerBounds.map(obtainStep),
+                upperBounds.map(obtainStep));
+            if (stepsMismatch) {
+              this.set('_stepsMismatch', stepsMismatch);
+            }
+
+            // Create data points that the line chart can parse.
+            const dataPoints = scalarEvents.map(datum => ({
+              wall_time: new Date(datum[0] * 1000),
+              step: obtainStep(datum),
+              scalar: datum[2],
+            }));
+
+            // Compute the series name, which is based on both the run and the
+            // tag of the value.
+            const seriesName =
+                tf_custom_scalar_dashboard.generateDataSeriesName(
+                    run, tagsObject.value);
+            let series = newMapping[seriesName];
+
+            if (series) {
+              // This series already exists.
+              series.setData(dataPoints);
+            } else {
+              this._createNewDataSeries(
+                  run, tagsObject.value, seriesName, dataPoints);
+            }
+          });
+
+          if (tagsNotFound.length) {
+            // At least 1 tag could not be found. Show an error message.
+            this.set('_tagsWithNoData', tagsNotFound);
+            return;
           }
+
+          this.set('_nameToDataSeries', newMapping);
         });
+      },
+      _findStepMismatch(tagsObject, valueSteps, lowerSteps, upperSteps) {
+        if (lowerBounds.length != valueSteps.length ||
+            upperBounds.length != valueSteps.length) {
+          return {
+            seriesObject: tagsObject,
+            valueSteps: valueSteps,
+            lowerSteps: lowerSteps,
+            upperSteps: upperSteps,
+          };
+        }
+        for (let i = 0; i < valueSteps.length; i++) {
+          if (valueSteps[i] != lowerSteps[i] ||
+              valueSteps[i] != upperSteps[i]) {
+            return {
+              seriesObject: tagsObject,
+              valueSteps: valueSteps,
+              lowerSteps: lowerSteps,
+              upperSteps: upperSteps,
+            };
+          }
+        }
+        return null;
+      },
+      _createNewDataSeries(run, tag, seriesName, dataPoints) {
+        // If the run has not been seen before, define the next
+        // available marker index.
+        this._runToNextAvailableSymbolIndex[run] |= 0;
+
+        // Every data series within a run has a unique symbol.
+        const lineChartSymbol = vz_line_chart.SYMBOLS_LIST[
+            this._runToNextAvailableSymbolIndex[run]];
+
+        // Create a series with this name.
+        series = new tf_custom_scalar_dashboard.DataSeries(
+            run, tag, seriesName, dataPoints, lineChartSymbol);
+        newMapping[seriesName] = series;
+
+        // Loop back to the beginning if we are out of symbols.
+        const numSymbols = vz_line_chart.SYMBOLS_LIST.length;
+        this._runToNextAvailableSymbolIndex[run] =
+            (this._runToNextAvailableSymbolIndex[run] + 1) % numSymbols;
       },
       _updateChart(nameToDataSeries) {
         // Add new data series.
@@ -561,8 +622,7 @@ limitations under the License.
         return escapedTags.join('|');
       },
       _escapeRegexCharacters(stringValue) {
-        return stringValue.replace(
-            /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+        return stringValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       },
       _getToggleMatchesIcon(matchesListOpened) {
         return matchesListOpened ? 'expand-less' : 'expand-more';
@@ -570,9 +630,13 @@ limitations under the License.
       _toggleMatchesOpen() {
         this.set('_matchesListOpened', !this._matchesListOpened);
       },
-      _computeTitleDisplayString(title) {
-        // If no title is provided, use a placeholder string.
-        return title || 'untitled';
+      _computeTitleDisplayString(title, tagFilter) {
+        // If no title is provided, use the tag filter, which is a combination
+        // of the tags for the value, lower, and upper fields.
+        return title || tagFilter;
+      },
+      _separateWithCommas(numbers) {
+        return numbers.join(', ');
       },
   });
 </script>

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -339,7 +339,7 @@ limitations under the License.
         },
         _titleDisplayString: {
           type: String,
-          computed: '_computeTitleDisplayString(title, _tagFilter)',
+          computed: '_computeTitleDisplayString(title)',
         },
         _fillArea: {
           type: Object,
@@ -539,34 +539,23 @@ limitations under the License.
           if (tagsNotFound.length) {
             // At least 1 tag could not be found. Show an error message.
             this.set('_tagsWithNoData', tagsNotFound);
-            return;
           }
 
           this.set('_nameToDataSeries', newMapping);
         });
       },
       _findStepMismatch(tagsObject, valueSteps, lowerSteps, upperSteps) {
-        if (lowerSteps.length != valueSteps.length ||
-            upperSteps.length != valueSteps.length) {
-          return {
-            seriesObject: tagsObject,
-            valueSteps: valueSteps,
-            lowerSteps: lowerSteps,
-            upperSteps: upperSteps,
-          };
+        if (_.isEqual(lowerSteps, valueSteps) &&
+            _.isEqual(upperSteps, valueSteps)) {
+          // There is no mismatch.
+          return null;
         }
-        for (let i = 0; i < valueSteps.length; i++) {
-          if (valueSteps[i] != lowerSteps[i] ||
-              valueSteps[i] != upperSteps[i]) {
-            return {
-              seriesObject: tagsObject,
-              valueSteps: valueSteps,
-              lowerSteps: lowerSteps,
-              upperSteps: upperSteps,
-            };
-          }
-        }
-        return null;
+        return {
+          seriesObject: tagsObject,
+          valueSteps: valueSteps,
+          lowerSteps: lowerSteps,
+          upperSteps: upperSteps,
+        };
       },
       _createNewDataSeries(run, tag, seriesName, dataPoints) {
         // If the run has not been seen before, define the next
@@ -641,10 +630,10 @@ limitations under the License.
       _toggleMatchesOpen() {
         this.set('_matchesListOpened', !this._matchesListOpened);
       },
-      _computeTitleDisplayString(title, tagFilter) {
+      _computeTitleDisplayString(title) {
         // If no title is provided, use the tag filter, which is a combination
-        // of the tags for the value, lower, and upper fields.
-        return title || tagFilter;
+        // of the tags for the value, lower, and upper fields of each series.
+        return title || 'untitled';
       },
       _separateWithCommas(numbers) {
         return numbers.join(', ');

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -191,7 +191,6 @@ limitations under the License.
     }
 
     .error-icon {
-      clear: both;
       display: block;
       fill: #fff;
       margin: 0 auto 5px auto;

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -120,7 +120,8 @@ limitations under the License.
   <template is="dom-if" if="[[_tagFilterInvalid]]">
     <div id="error-content">
       <iron-icon class="error-icon" icon="icons:error"></iron-icon>
-      [[_tagFilter]] is an invalid regular expression.
+      This regular expresion is invalid:<br>
+      <span class="invalid-regex">[[_tagFilter]]</span>
     </div>
   </template>
 
@@ -190,7 +191,14 @@ limitations under the License.
     }
 
     .error-icon {
+      clear: both;
+      display: block;
       fill: #fff;
+      margin: 0 auto 5px auto;
+    }
+    
+    .invalid-regex {
+      font-weight: bold;
     }
 
     #error-content ul {
@@ -495,18 +503,22 @@ limitations under the License.
             const obtainStep = datum => datum[1];
             const stepsMismatch = this._findStepMismatch(
                 tagsObject,
-                dataPoints.map(obtainStep),
+                scalarEvents.map(obtainStep),
                 lowerBounds.map(obtainStep),
                 upperBounds.map(obtainStep));
             if (stepsMismatch) {
               this.set('_stepsMismatch', stepsMismatch);
+              return;
             }
 
             // Create data points that the line chart can parse.
-            const dataPoints = scalarEvents.map(datum => ({
+            const obtainNumber = datum => datum[2];
+            const dataPoints = scalarEvents.map((datum, i) => ({
               wall_time: new Date(datum[0] * 1000),
               step: obtainStep(datum),
-              scalar: datum[2],
+              scalar: obtainNumber(datum),
+              lower: obtainNumber(lowerBounds[i]),
+              upper: obtainNumber(upperBounds[i]),
             }));
 
             // Compute the series name, which is based on both the run and the
@@ -520,7 +532,7 @@ limitations under the License.
               // This series already exists.
               series.setData(dataPoints);
             } else {
-              this._createNewDataSeries(
+              newMapping[seriesName] = this._createNewDataSeries(
                   run, tagsObject.value, seriesName, dataPoints);
             }
           });
@@ -535,8 +547,8 @@ limitations under the License.
         });
       },
       _findStepMismatch(tagsObject, valueSteps, lowerSteps, upperSteps) {
-        if (lowerBounds.length != valueSteps.length ||
-            upperBounds.length != valueSteps.length) {
+        if (lowerSteps.length != valueSteps.length ||
+            upperSteps.length != valueSteps.length) {
           return {
             seriesObject: tagsObject,
             valueSteps: valueSteps,
@@ -569,12 +581,12 @@ limitations under the License.
         // Create a series with this name.
         series = new tf_custom_scalar_dashboard.DataSeries(
             run, tag, seriesName, dataPoints, lineChartSymbol);
-        newMapping[seriesName] = series;
 
         // Loop back to the beginning if we are out of symbols.
         const numSymbols = vz_line_chart.SYMBOLS_LIST.length;
         this._runToNextAvailableSymbolIndex[run] =
             (this._runToNextAvailableSymbolIndex[run] + 1) % numSymbols;
+        return series;
       },
       _updateChart(nameToDataSeries) {
         // Add new data series.

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
@@ -1,0 +1,417 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../iron-collapse/iron-collapse.html">
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../paper-item/paper-item.html">
+<link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="../paper-menu/paper-menu.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
+<link rel="import" href="../tf-line-chart-data-loader/tf-line-chart-data-loader.html">
+<link rel="import" href="../tf-card-heading/tf-card-heading.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="tf-custom-scalar-card-style.html">
+
+<!--
+  A card that handles loading data (at the right times), rendering a scalar
+  chart, and providing UI affordances (such as buttons) for scalar data.
+-->
+<dom-module id="tf-custom-scalar-multi-line-chart-card">
+<template>
+  <h1>[[_titleDisplayString]]</h1>
+  <div id="tf-line-chart-data-loader-container">
+    <tf-line-chart-data-loader
+      x-type="[[xType]]"
+      x-components-creation-method="[[_xComponentsCreationMethod]]"
+      smoothing-enabled="[[smoothingEnabled]]"
+      smoothing-weight="[[smoothingWeight]]"
+      tooltip-sorting-method="[[tooltipSortingMethod]]"
+      ignore-y-outliers="[[ignoreYOutliers]]"
+      request-manager="[[requestManager]]"
+      runs="[[runs]]"
+      tag="[[_tagFilter]]"
+      active="[[active]]"
+      data-url="[[_dataUrl]]"
+      log-scale-active="[[_logScaleActive]]"
+      process-data="[[_createProcessDataFunction()]]"
+      color-scale="[[_colorScale]]"
+      data-series="[[_dataSeriesStrings]]"
+      symbol-function="[[_createSymbolFunction()]]"
+    >
+    </tf-line-chart-data-loader>
+  </div>
+  <div id="buttons">
+    <paper-icon-button
+      selected$="[[_expanded]]"
+      icon="fullscreen"
+      on-tap="_toggleExpanded"
+    ></paper-icon-button>
+    <paper-icon-button
+      selected$="[[_logScaleActive]]"
+      icon="line-weight"
+      on-tap="_toggleLogScale"
+      title="Toggle y-axis log scale"
+    ></paper-icon-button>
+    <paper-icon-button
+      icon="settings-overscan"
+      on-tap="_resetDomain"
+      title="Fit domain to data"
+    ></paper-icon-button>
+    <span style="flex-grow: 1"></span>
+    <template is="dom-if" if="[[showDownloadLinks]]">
+      <div class="download-links">
+        <paper-dropdown-menu
+          no-label-float="true"
+          label="series to download"
+          selected-item-label="{{_dataSeriesNameToDownload}}"
+        >
+          <paper-menu class="dropdown-content" slot="dropdown-content">
+            <template is="dom-repeat" items="[[_dataSeriesStrings]]" as="dataSeriesName">
+              <paper-item no-label-float=true>[[dataSeriesName]]</paper-item>
+            </template>
+          </paper-menu>
+        </paper-dropdown-menu>
+        <a
+          download="[[_dataSeriesNameToDownload]].csv"
+          href="[[_csvUrl(_nameToDataSeries, _dataSeriesNameToDownload)]]"
+        >CSV</a> <a
+          download="[[_dataSeriesNameToDownload]].json"
+          href="[[_jsonUrl(_nameToDataSeries, _dataSeriesNameToDownload)]]"
+        >JSON</a>
+      </div>
+    </template>
+  </div>
+  <div id="matches-container">
+    <div id="matches-list-title">
+      <template is="dom-if" if="[[_dataSeriesStrings.length]]">
+        <paper-icon-button
+          icon="[[_getToggleMatchesIcon(_matchesListOpened)]]"
+          on-click="_toggleMatchesOpen"
+          class="toggle-matches-button">
+        </paper-icon-button>
+      </template>
+
+      <span class="matches-text">
+        Matches ([[_dataSeriesStrings.length]])
+      </span>
+    </div>
+    <template is="dom-if" if="[[_dataSeriesStrings.length]]">
+      <iron-collapse opened="[[_matchesListOpened]]">
+        <div id="matches-list">
+          <template is="dom-repeat"
+                    items="[[_dataSeriesStrings]]"
+                    as="seriesName">
+              <div class="match-list-entry"
+                   style="color: [[_determineColor(_colorScale, seriesName)]];">
+                <span class="match-entry-symbol">
+                  [[_determineSymbol(_nameToDataSeries, seriesName)]]
+                </span>
+                [[seriesName]]
+              </div>
+          </template>
+        </div>
+      </iron-collapse>
+    </template>
+  </div>
+
+  </div>
+  <style include="tf-custom-scalar-card-style"></style>
+  <style>
+    #matches-list-title {
+      margin: 10px 0 5px 0;
+    }
+
+    #matches-list {
+      font-size: 0.8em;
+      max-height: 200px;
+      overflow-y: auto;
+    }
+
+    .match-list-entry {
+      margin: 0 0 5px 0;
+    }
+
+    .match-entry-symbol {
+      font-family: arial, sans-serif;
+      display: inline-block;
+      width: 10px;
+    }
+
+    .matches-text {
+      vertical-align: middle;
+    }
+  </style>
+</template>
+<script src='tf-custom-scalar-helpers.js'></script>
+<script>
+  Polymer({
+      is: 'tf-custom-scalar-multi-line-chart-card',
+      properties: {
+        runs: Array,  // of String
+
+        /**
+         * TODO: Add type.
+         */
+        xType: String,
+
+        active: {
+          type: Boolean,
+          value: true,
+          readOnly: true,
+        },
+        title: String,
+        tagRegexes: Array,
+        ignoreYOutliers: Boolean,
+        requestManager: Object,
+        showDownloadLinks: Boolean,
+        smoothingEnabled: Boolean,
+        smoothingWeight: Number,
+        tagMetadata: Object,
+        tooltipSortingMethod: String,
+
+        // We use a special color scale that wraps the run-based one.
+        _colorScale: {
+          type: Object,
+          value: new tf_custom_scalar_dashboard.DataSeriesColorScale({scale: tf_color_scale.runsColorScale}),
+          readOnly: true,
+        },
+
+        /**
+         * A regular expression to use for matching tags.
+         */
+        _tagFilter: {
+          type: String,
+          computed: '_computeTagFilter(tagRegexes)',
+        },
+
+        /**
+         * Maps from the name of the data series to the DataSeries object.
+         */
+        _nameToDataSeries: {
+          type: Object,
+          value: {},
+        },
+
+        /**
+         * A mapping between selected runs (strings) to the value 1. This is
+         * effectively a set of strings.
+         */
+        _selectedRunsSet: {
+          type: Object,
+          computed: '_computeSelectedRunsSet(runs)',
+        },
+        _dataSeriesStrings: {
+          type: Array,
+          computed: '_computeDataSeriesStrings(_selectedRunsSet, _nameToDataSeries)',
+        },
+        _dataSeriesObjects: {
+          type: Array,
+          computed: '_computeDataSeriesObjects(_nameToDataSeries, _dataSeriesStrings)',
+        },
+        _expanded: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,  // for CSS
+        },
+        _logScaleActive: Boolean,
+        _dataUrl: {
+          type: Function,
+          value: () => (tag, run) => tf_backend.addParams(
+              tf_backend.getRouter().pluginRoute(
+                  'custom_scalars', '/scalars'), {tag, run}),
+        },
+        _xComponentsCreationMethod: {
+          type: Object,
+          computed: '_computeXComponentsCreationMethod(xType)',
+        },
+        /**
+         * A mapping from run to the next available symbol for that run. We use
+         * symbols to differentiate data series within the same run.
+         */
+        _runToNextAvailableSymbolIndex: {
+          type: Object,
+          value: {},
+        },
+        _matchesListOpened: {
+          type: Boolean,
+          value: false,
+        },
+        _titleDisplayString: {
+          type: String,
+          computed: '_computeTitleDisplayString(title)',
+        },
+      },
+      observers: [
+        '_updateChart(_nameToDataSeries)',
+        // Clear the data series when the tag filter changes.
+        '_refreshDataSeries(_tagFilter)',
+      ],
+      reload() {
+        this.$$('tf-line-chart-data-loader').reload();
+      },
+      redraw() {
+        this.$$('tf-line-chart-data-loader').redraw();
+      },
+      _toggleExpanded(e) {
+        this.set('_expanded', !this._expanded);
+        this.redraw();
+      },
+      _toggleLogScale() {
+        this.set('_logScaleActive', !this._logScaleActive);
+      },
+      _resetDomain() {
+        const chart = this.$$('tf-line-chart-data-loader');
+        if (chart) {
+          chart.resetDomain();
+        }
+      },
+      _csvUrl(nameToDataSeries, dataSeriesName) {
+        const baseUrl = this._downloadDataUrl(nameToDataSeries, dataSeriesName);
+        return tf_backend.addParams(baseUrl, {format: 'csv'});
+      },
+      _jsonUrl(nameToDataSeries, dataSeriesName) {
+        const baseUrl = this._downloadDataUrl(nameToDataSeries, dataSeriesName);
+        return tf_backend.addParams(baseUrl, {format: 'json'});
+      },
+      _downloadDataUrl(nameToDataSeries, dataSeriesName) {
+        const dataSeries = nameToDataSeries[dataSeriesName];
+        const getVars = {
+            tag: dataSeries.getTag(),
+            run: dataSeries.getRun(),
+        };
+        return tf_backend.addParams(
+              tf_backend.getRouter().pluginRoute(
+                  'custom_scalars', '/download_data'), getVars);
+      },
+      _computeXComponentsCreationMethod(xType) {
+        return () => vz_line_chart.getXComponents(xType);
+      },
+      _createProcessDataFunction() {
+        // This function is called when data is received from the backend.
+        return ((scalarChart, run, data) => {
+          if (data.regex_valid) {
+            // The user's regular expression was valid.
+            // Incorporate these newly loaded values.
+            const newMapping = _.clone(this._nameToDataSeries);
+            _.forOwn(data.tag_to_events, (scalarEvents, tag) => {
+              const data = scalarEvents.map(datum => ({
+                wall_time: new Date(datum[0] * 1000),
+                step: datum[1],
+                scalar: datum[2],
+              }));
+
+              const seriesName = tf_custom_scalar_dashboard.generateDataSeriesName(
+                  run, tag);
+              let series = newMapping[seriesName];
+
+              if (series) {
+                // This series already exists.
+                series.setData(data);
+              } else {
+                if (_.isUndefined(this._runToNextAvailableSymbolIndex[run])) {
+                  // The run has not been seen before. Define the next available
+                  // marker index.
+                  this._runToNextAvailableSymbolIndex[run] = 0;
+                }
+
+                // Every data series within a run has a unique symbol.
+                const lineChartSymbol = vz_line_chart.SYMBOLS_LIST[
+                    this._runToNextAvailableSymbolIndex[run]];
+
+                // Create a series with this name.
+                series = new tf_custom_scalar_dashboard.DataSeries(
+                    run,
+                    tag,
+                    seriesName,
+                    data,
+                    lineChartSymbol);
+                newMapping[seriesName] = series;
+
+                // Loop back to the beginning if we are out of symbols.
+                const numSymbols = vz_line_chart.SYMBOLS_LIST.length;
+                this._runToNextAvailableSymbolIndex[run] =
+                    (this._runToNextAvailableSymbolIndex[run] + 1) % numSymbols;
+              }
+            });
+
+            this.set('_nameToDataSeries', newMapping);
+          } else {
+            // The user's regular expression was invalid.
+            // TODO(chihuahua): Handle this.
+          }
+        });
+      },
+      _updateChart(nameToDataSeries) {
+        // Add new data series.
+        _.forOwn(nameToDataSeries, dataSeries => {
+          this.$$('tf-line-chart-data-loader').setSeriesData(
+              dataSeries.getName(), dataSeries.getData());
+        });
+      },
+      _computeSelectedRunsSet(runs) {
+        const mapping = {};
+        _.forEach(runs, run => {
+          mapping[run] = 1;
+        });
+        return mapping;
+      },
+      _computeDataSeriesStrings(selectedRunsSet, nameToDataSeries) {
+        return _.values(nameToDataSeries)
+            .filter(series => selectedRunsSet[series.getRun()])
+            .map(series => series.getName());
+      },
+      _computeDataSeriesObjects(nameToDataSeries, dataSeriesStrings) {
+        return dataSeriesStrings.map(
+            seriesName => nameToDataSeries[seriesName]);
+      },
+      _determineColor(colorScale, seriesName) {
+        return colorScale.scale(seriesName);
+      },
+      _refreshDataSeries(_tagFilter) {
+        this.set('_nameToDataSeries', {});
+      },
+      _createSymbolFunction() {
+        return seriesName => (
+            this._nameToDataSeries[seriesName].getSymbol().method());
+      },
+      _determineSymbol(nameToDataSeries, seriesName) {
+        return nameToDataSeries[seriesName].getSymbol().character;
+      },
+      _computeTagFilter(tagRegexes) {
+        if (tagRegexes.length === 1) {
+          return tagRegexes[0];
+        }
+        // Combine the different regexes into a single regex.
+        return tagRegexes.map(r => '(' + r + ')').join('|');
+      },
+      _getToggleMatchesIcon(matchesListOpened) {
+        return matchesListOpened ? 'expand-less' : 'expand-more';
+      },
+      _toggleMatchesOpen() {
+        this.set('_matchesListOpened', !this._matchesListOpened);
+      },
+      _computeTitleDisplayString(title) {
+        // If no title is provided, use a placeholder string.
+        return title || 'untitled';
+      },
+  });
+</script>
+</dom-module>


### PR DESCRIPTION
We let the user plot both margin charts as well as (the pre-existing)
multi-line charts within the custom scalars dashboard. Margin charts are
configured with a list of series. Each series takes 3 tag strings
(value, lower, and upper) that correspond to scalar summaries (logged as
usual via `tf.summary.scalar` or via TensorBoard's summary module).

Those 3 tag strings are used to populate the value, lower bounds, and
upper bounds of margins. See changes to the Layout proto for details.

This screenshot shows a working margin chart.

![image](https://user-images.githubusercontent.com/4221553/34022272-3403df1c-e0f3-11e7-8d2d-8964b97cf7b9.png)

If data for a tag cannot be found, the custom scalars dashboard issues
a warning message, as this screenshot shows.

![image](https://user-images.githubusercontent.com/4221553/34022312-6a795716-e0f3-11e7-972e-41773353aaf3.png)

Also introduced a custom_scalar_demo.py script for generating demo data.