### PR TITLE
Add direct dependency on paper-material-html target

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_debugger_data_card/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_debugger_data_card/BUILD
@@ -33,6 +33,7 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/iron-list:lib",
         "//third_party/javascript/polymer/v1/paper-icon-button:lib",
         "//third_party/javascript/polymer/v1/paper-item:lib",
+        "//third_party/javascript/polymer/v1/paper-material:paper-material-html",
         "//third_party/javascript/polymer/v1/paper-slider:lib",
         "//third_party/javascript/polymer/v1/paper-spinner:lib",
         "//third_party/javascript/polymer/v1/polymer:lib",

--- a/tensorboard/plugins/graph/tf_graph_info/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_info/BUILD
@@ -56,6 +56,7 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/iron-list:lib",
         "//third_party/javascript/polymer/v1/paper-icon-button:lib",
         "//third_party/javascript/polymer/v1/paper-item:lib",
+        "//third_party/javascript/polymer/v1/paper-material:paper-material-html",
         "//third_party/javascript/polymer/v1/paper-slider:lib",
         "//third_party/javascript/polymer/v1/paper-spinner:lib",
         "//third_party/javascript/polymer/v1/polymer:lib",


### PR DESCRIPTION
Add direct dependency on paper-material-html target, since the latest version of paper-button does not depend on it.
This change is a no-op with the current code, and is required for the update of paper-button to hybrid.