### PR TITLE
Fix issues related to panning to a node

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
@@ -1113,10 +1113,15 @@ Polymer({
       this._updateNodeState(selectedNode);
     }
 
-    if (tf.graph.scene.panToNode(selectedNode, this.$.svg, this.$.root,
-        this._zoom)) {
-      this._zoomed = true;
-    }
+    // Give time for any expanding to finish before panning to a node.
+    // Otherwise, the pan will be computed from incorrect measurements.
+    setTimeout(() => {
+      const zoomed = tf.graph.scene.panToNode(
+          selectedNode, this.$.svg, this.$.root, this._zoom);
+      if (zoomed) {
+        this._zoomed = true;
+      }
+    }, tf.graph.layout.PARAMS.animation.duration);
   },
   _highlightedNodeChanged: function(highlightedNode, oldHighlightedNode) {
     if (highlightedNode === oldHighlightedNode) {

--- a/tensorboard/plugins/graph/tf_graph_common/scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/scene.ts
@@ -216,8 +216,12 @@ export function panToNode(nodeName: String, svg, zoomG, d3zoom): boolean {
     return end < 0 || start > bound;
   };
   let svgRect = svg.getBoundingClientRect();
-  if (isOutsideOfBounds(pointTL.x, pointBR.x, svgRect.width) ||
-      isOutsideOfBounds(pointTL.y, pointBR.y, svgRect.height)) {
+
+  // Subtract to make sure that the node is not hidden behind the minimap.
+  const horizontalBound = svgRect.left + svgRect.width - 320;
+  const verticalBound = svgRect.top + svgRect.height - 150;
+  if (isOutsideOfBounds(pointTL.x, pointBR.x, horizontalBound) ||
+      isOutsideOfBounds(pointTL.y, pointBR.y, verticalBound)) {
     // Determine the amount to translate the graph in both X and Y dimensions in
     // order to center the selected node. This takes into account the position
     // of the node, the size of the svg scene, the amount the scene has been
@@ -225,14 +229,16 @@ export function panToNode(nodeName: String, svg, zoomG, d3zoom): boolean {
     // by this logic.
     let centerX = (pointTL.x + pointBR.x) / 2;
     let centerY = (pointTL.y + pointBR.y) / 2;
-    let dx = ((svgRect.width / 2) - centerX);
-    let dy = ((svgRect.height / 2) - centerY);
+    let dx = svgRect.left + svgRect.width / 2 - centerX;
+    let dy = svgRect.top + svgRect.height / 2 - centerY;
 
     // We translate by this amount. We divide the X and Y translations by the
     // scale to undo how translateBy scales the translations (in d3 v4).
     const svgTransform = d3.zoomTransform(svg);
     d3.select(svg).transition().duration(500).call(
-        d3zoom.translateBy, dx / svgTransform.k, dy / svgTransform.k);
+        d3zoom.translateBy,
+        dx / svgTransform.k,
+        dy / svgTransform.k);
 
     return true;
   }

--- a/tensorboard/plugins/graph/tf_graph_common/scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/scene.ts
@@ -74,6 +74,12 @@ module tf.graph.scene {
   };
 
   /**
+   * The dimensions of the minimap including padding and margin.
+   */
+  const MINIMAP_BOX_WIDTH = 320;
+  const MINIMAP_BOX_HEIGHT = 150;
+
+  /**
    * A health pill encapsulates an overview of tensor element values. The value
    * field is a list of 12 numbers that shed light on the status of the tensor.
    * Visualized in health pills are the 3rd through 8th (inclusive) numbers of
@@ -218,8 +224,8 @@ export function panToNode(nodeName: String, svg, zoomG, d3zoom): boolean {
   let svgRect = svg.getBoundingClientRect();
 
   // Subtract to make sure that the node is not hidden behind the minimap.
-  const horizontalBound = svgRect.left + svgRect.width - 320;
-  const verticalBound = svgRect.top + svgRect.height - 150;
+  const horizontalBound = svgRect.left + svgRect.width - MINIMAP_BOX_WIDTH;
+  const verticalBound = svgRect.top + svgRect.height - MINIMAP_BOX_HEIGHT;
   if (isOutsideOfBounds(pointTL.x, pointBR.x, horizontalBound) ||
       isOutsideOfBounds(pointTL.y, pointBR.y, verticalBound)) {
     // Determine the amount to translate the graph in both X and Y dimensions in


### PR DESCRIPTION
When a user selects a node that is out of view, the graph explorer pans
to it and centers it. Unfortunately, this feature had some issues.

0. Panning happened before graph expansion completed. This led to pan
target calculations that relied on incorrect, outdated measurements. We
fix by waiting 250ms (the default duration for animations in the graph
explorer) before panning in order to give enough time for node expansion
to complete.

1. The graph explorer did not take into account the position of the
graph's root SVG element with respect to the viewport. This led to
panning calculations that were off by a constant amount along the X and Y
dimensions. We fix by taking those 2 values into account.

2. Nodes could sometimes be occluded by the minimap - those nodes are
strictly speaking still in the view of the graph explorer, so we
previously did not pan to nodes occluded by the minimap. Now, we do.

Screenshot:

![image](https://user-images.githubusercontent.com/4221553/34067251-db869c5c-e1d4-11e7-94d8-239a4d094e63.png)

There are still issues related to panning that are not fixed. For
instance, we do not pan to extracted nodes.

Also, Panning sometimes yields a console error:

```js
Error: <text> attribute x: Expected length, "NaN".
```

However, this PR does fix several big issues.