### PR TITLE
Include entire :lib target in pip package

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -15,6 +15,7 @@ package_group(
     packages = ["//tensorboard/..."],
 )
 
+# The standard TensorBoard binary that serves the webapp.
 py_binary(
     name = "tensorboard",
     srcs = ["main.py"],
@@ -28,6 +29,8 @@ py_binary(
     ],
 )
 
+# The public TensorBoard python library, bundled with the pip package and
+# available via 'import tensorboard as tb' once installed.
 py_library(
     name = "lib",
     srcs = ["__init__.py"],

--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -15,7 +15,7 @@ sh_binary(
         "setup.cfg",
         "setup.py",
         "//tensorboard",
-        "//tensorboard:summary",
+        "//tensorboard:lib",
         "//tensorboard:version",
     ],
 )

--- a/tensorboard/pip_package/pip_smoke_test.sh
+++ b/tensorboard/pip_package/pip_smoke_test.sh
@@ -122,6 +122,18 @@ elif [[ "${PY_VERSION}" == 3 ]]; then
   pip install "${PIP_TMP_DIR}"/tensorflow_tensorboard*-py3-*.whl
 fi
 
+echo
+echo "Calling tensorboard public python APIs"
+echo
+
+# Check that we can now use TensorBoard's public python APIs as installed with
+# the pip package. To do this we must cd away from the bazel workspace directory
+# to one that doesn't have a local 'tensorboard' python module hierarchy.
+TEST_API_CALL="import tensorboard as tb; tb.summary.scalar_pb('test', 42)"
+echo "  python>>> $TEST_API_CALL"
+echo
+(cd "${VENV_TMP_DIR}" && python -c "$TEST_API_CALL")
+
 # Check tensorboard binary path.
 TB_BIN_PATH="${VENV_BIN_DIR}/tensorboard"
 if ! [[ -x "${TB_BIN_PATH}" ]]; then
@@ -136,7 +148,7 @@ tensorboard --host=localhost --port="${TEST_PORT}" --logdir="${TMP_LOGDIR}" \
 TB_PID=$!
 
 echo
-echo "waiting for tensorboard binary to start up..."
+echo "Waiting for tensorboard binary to start up..."
 echo
 
 # Wait until the binary has printed its serving URL so we know that it's
@@ -158,7 +170,7 @@ while true; do
 done
 
 echo
-echo "tensorboard binary (pid ${TB_PID}) running at ${TB_URL}"
+echo "Started tensorboard binary (pid ${TB_PID}) at ${TB_URL}"
 echo
 
 test_access_url() {


### PR DESCRIPTION
This fixes our pip package's bundled library (what you get from `import tensorboard`) so that it actually includes the full `:lib` target rather than just `:summary`.  Right now, they're essentially the same, except that `:lib` also includes the lazy-loading functionality that makes `import tensorboard as tb` work as intended.  This is also more future-proof since at some point we may want our consumer python API to include more easily accessible functionality than just `tb.summary`.

I added some clarifying comments and a test in `pip_smoke_test.sh` to avoid regressions.

Note that while `import tensorboard` right now only directly exposes the summary API (via the lazy `tf.*`-style loading), pip package users can of course still access whatever python files we bundled into the pip package to support the tensorboard binary itself, if they know where to look.  IMO this is a bit undesirable since it means that we have little control over what parts of our code become informal API surfaces (like the event processing stuff).  I think it'd be preferable to work towards explicitly including whatever TensorBoard users might normally need to call through the `tensorboard` package directly, and discouraging the calling of any other modules from outside TensorBoard internal code or people hacking on custom tensorboard builds.

One example of a case where this gets tricky is the custom scalars Layout protobuf - right now you need to import from `tensorboard.plugins.custom_scalar.layout_pb2` to access it, but do we want users to start importing whatever they want from `tensorboard.plugins.*`?