### PR TITLE
Add text dashboard toggle for enabling markdown

### DIFF
--- a/tensorboard/plugins/text/tf_text_dashboard/BUILD
+++ b/tensorboard/plugins/text/tf_text_dashboard/BUILD
@@ -24,6 +24,7 @@ tf_web_library(
         "//tensorboard/components/tf_markdown_view",
         "//tensorboard/components/tf_paginated_view",
         "//tensorboard/components/tf_runs_selector",
+        "//tensorboard/components/tf_storage",
         "//tensorboard/components/tf_tensorboard:registry",
         "@org_polymer_iron_icon",
         "@org_polymer_paper_dialog",

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
@@ -26,6 +26,7 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-paginated-view/tf-paginated-view.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
+<link rel="import" href="../tf-storage/tf-storage.html">
 <link rel="import" href="../tf-tensorboard/registry.html">
 <link rel="import" href="tf-text-loader.html">
 
@@ -36,6 +37,13 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
   <template>
     <tf-dashboard-layout>
       <div class="sidebar">
+        <div class="sidebar-section">
+          <div class="line-item">
+            <paper-checkbox
+              checked="{{_markdownEnabled}}"
+            >Enable markdown</paper-checkbox>
+          </div>
+        </div>
         <div class="sidebar-section">
           <tf-runs-selector selected-runs="{{_selectedRuns}}">
           </tf-runs-selector>
@@ -77,6 +85,7 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
                           tag="[[item.tag]]"
                           run="[[item.run]]"
                           request-manager="[[_requestManager]]"
+                          markdown-enabled="[[_markdownEnabled]]"
                         ></tf-text-loader>
                       </template>
                     </div>
@@ -119,6 +128,13 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
           type: Object,
           value: () => new tf_backend.RequestManager(),
         },
+        _markdownEnabled: {
+          type: Boolean,
+          notify: true,
+          value: tf_storage.getBooleanInitializer('_markdownEnabled',
+              {defaultValue: true, useLocalStorage: true}),
+          observer: '_markdownEnabledObserver',
+        },
       },
       ready() {
         this.reload();
@@ -152,6 +168,8 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
       _makeCategories(runToTag, selectedRuns, tagFilter, categoriesDomReady) {
         return tf_categorization_utils.categorizeRunTagCombinations(runToTag, selectedRuns, tagFilter);
       },
+      _markdownEnabledObserver: tf_storage.getBooleanObserver(
+          '_markdownEnabled', {defaultValue: true, useLocalStorage: true}),
     });
 
     tf_tensorboard.registerDashboard({

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
@@ -105,14 +105,14 @@ tf-text-loader displays markdown text data from the Text plugin.
         display: inline-block;
         margin: 0 0.5em 0 0;
         padding: 0 1em 0 0;
-        width: 30px;
         text-align: right;
+        width: 30px;
       }
       .step-container {
         background-color: var(--tb-ui-light-accent);
         border-bottom: none;
         border-radius: 3px 3px 0 0;
-        border: 1px solid var(--tb-ui-light-accent);
+        border: 1px solid #ccc;
         display: inline-block;
         font-size: 12px;
         font-style: italic;

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
@@ -98,7 +98,7 @@ tf-text-loader displays markdown text data from the Text plugin.
         line-height: 1.5rem;
       }
       .raw-text-container pre span:before {
-        border-right: 1px solid #ddd;
+        border-right: 1px solid var(--tb-ui-light-accent);
         color: var(--tb-ui-dark-accent);
         content: counter(line);
         counter-increment: line;

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-loader.html
@@ -43,7 +43,19 @@ tf-text-loader displays markdown text data from the Text plugin.
           step <span class="step-value">[[_formatStep(item.step)]]</span>
         </paper-material>
         <paper-material elevation="1" class="text">
-          <tf-markdown-view html="[[item.text]]"></tf-markdown-view>
+          <template is="dom-if" if="[[markdownEnabled]]">
+            <tf-markdown-view html="[[item.text]]"></tf-markdown-view>
+          </template>
+          <template is="dom-if" if="[[!markdownEnabled]]">
+            <div class="raw-text-container">
+              <!-- Use comments to remove empty space. -->
+              <pre><!--
+                --><template is="dom-repeat" items="[[_splitIntoLines(item.text)]]" as="line"><!--
+                  --><span>[[line]]</span>
+<!--            --></template><!--
+           --></pre>
+            </div>
+          </template>
         </paper-material>
       </template>
     </paper-material>
@@ -71,11 +83,36 @@ tf-text-loader displays markdown text data from the Text plugin.
         padding: 5px;
         word-break: break-word;
       }
+      .raw-text-container {
+        overflow: auto;
+        max-height: 500px;
+        padding: 5px;
+        width: 100%;
+      }
+      .raw-text-container pre {
+        counter-reset: line;
+        line-height: 0;
+      }
+      .raw-text-container pre span {
+        display: block;
+        line-height: 1.5rem;
+      }
+      .raw-text-container pre span:before {
+        border-right: 1px solid #ddd;
+        color: var(--tb-ui-dark-accent);
+        content: counter(line);
+        counter-increment: line;
+        display: inline-block;
+        margin: 0 0.5em 0 0;
+        padding: 0 1em 0 0;
+        width: 30px;
+        text-align: right;
+      }
       .step-container {
         background-color: var(--tb-ui-light-accent);
         border-bottom: none;
         border-radius: 3px 3px 0 0;
-        border: 1px solid #ccc;
+        border: 1px solid var(--tb-ui-light-accent);
         display: inline-block;
         font-size: 12px;
         font-style: italic;
@@ -98,6 +135,7 @@ tf-text-loader displays markdown text data from the Text plugin.
       properties: {
         run: String,
         tag: String,
+        markdownEnabled: Boolean,
         _runColor: {
           type: String,
           computed: '_computeRunColor(run)',
@@ -152,7 +190,10 @@ tf-text-loader displays markdown text data from the Text plugin.
       },
       _formatStep(n) {
         return d3.format(",")(n);
-      }
+      },
+      _splitIntoLines(rawText) {
+        return rawText.split('\n');
+      },
     });
   </script>
 </dom-module>


### PR DESCRIPTION
Added a checkbox to the text dashboard that lets the user control
whether to enable markdown view of text widgets. The
`markdownEnabled` boolean property is stored within local storage.
The property defaults to true.

If markdown is enabled, we parse text as markdown and render it.
This matches current behavior.

![image](https://user-images.githubusercontent.com/4221553/34235884-7641ffe8-e5a9-11e7-9014-546f328aff14.png)

If markdown is disabled, text is rendered raw, and line numbers are
provided.

![image](https://user-images.githubusercontent.com/4221553/34235883-6ec3cdbe-e5a9-11e7-874d-32f41bc357a6.png)

Fixes #830.