### PR TITLE
Make debugger dashboard pan to focused node

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -732,7 +732,15 @@ limitations under the License.
           this.set('_activeRuntimeGraphDeviceName', deviceName);
         }
         this._setTopRightRuntimeGraphsToActive();
-        this.$$('#graph').set('selectedNode', nodeName);
+        const graph = this.$$('#graph');
+        if (graph.selectedNode === nodeName) {
+          // Instead of selecting the node, we pan to it - the node is already
+          // selected, so selecting it would do nothing.
+          graph.panToNode(nodeName);
+        } else {
+          // Selecting the node triggers a pan to it.
+          graph.set('selectedNode', nodeName);
+        }
         this.set('_highlightNodeName', deviceName + '/' + nodeName);
       },
       _createListNodeClickedHandler() {

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
@@ -802,6 +802,17 @@ Polymer({
     this._updateLabels(!this._zoomed);
   },
   /**
+   * Pans to a node. Assumes that the node exists.
+   * @param nodeName {string} The name of the node to pan to.
+   */
+  panToNode(nodeName) {
+    const zoomed = tf.graph.scene.panToNode(
+        nodeName, this.$.svg, this.$.root, this._zoom);
+    if (zoomed) {
+      this._zoomed = true;
+    }
+  },
+  /**
    * Resets the state of the component. Called whenever the whole graph
    * (dataset) changes.
    */
@@ -1116,11 +1127,7 @@ Polymer({
     // Give time for any expanding to finish before panning to a node.
     // Otherwise, the pan will be computed from incorrect measurements.
     setTimeout(() => {
-      const zoomed = tf.graph.scene.panToNode(
-          selectedNode, this.$.svg, this.$.root, this._zoom);
-      if (zoomed) {
-        this._zoomed = true;
-      }
+      this.panToNode(selectedNode);
     }, tf.graph.layout.PARAMS.animation.duration);
   },
   _highlightedNodeChanged: function(highlightedNode, oldHighlightedNode) {

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.html
@@ -167,6 +167,13 @@ Polymer({
     '_selectedNodeChanged(selectedNode)',
     '_selectedEdgeChanged(selectedEdge)',
   ],
+  /**
+   * Pans to a node. Assumes that the node exists.
+   * @param nodeName {string} The name of the node to pan to.
+   */
+  panToNode(nodeName) {
+    this.$$('tf-graph-scene').panToNode(nodeName);
+  },
   _statsChanged: function(stats, devicesForStats) {
     if (this.graphHierarchy) {
       if (stats && devicesForStats) {


### PR DESCRIPTION
Previously, the debugger dashboard would not pan to a node if it had
already been selected. Now, we pan to the node regardless.

There are unfortunately still cases in which the graph does not pan to
a node if it is slightly out of view. Those cases are still being
investigated. Furthermore, the graph does not pan to `const` annotation
nodes, which may appear more than once in the graph ... like this:

![image](https://user-images.githubusercontent.com/4221553/34237169-09ece3f6-e5b0-11e7-9506-cedd9c642c54.png)
