### PR TITLE
Make the LHS of debugger dashboard resizable

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
@@ -12,6 +12,7 @@ tf_web_library(
         "tf-debugger-dashboard.html",
         "tf-debugger-initial-dialog.html",
         "tf-debugger-line-chart.html",
+        "tf-debugger-vertical-resizer.html",
         "tf-op-selector.html",
         "tf-session-runs-view.html",
         "tf-tensor-data-summary.html",

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -35,6 +35,7 @@ limitations under the License.
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 <link rel="import" href="../tf-tensorboard/registry.html">
 <link rel="import" href="tf-debugger-initial-dialog.html">
+<link rel="import" href="tf-debugger-vertical-resizer.html">
 <link rel="import" href="tf-op-selector.html">
 <link rel="import" href="tf-session-runs-view.html">
 <link rel="import" href="tf-tensor-data-summary.html">
@@ -66,7 +67,7 @@ limitations under the License.
     <!-- TODO(caisq, chihuahua): This shouldn't be a dialog. It should be a prettier
       widget that supports showing both text, curves and images. -->
     <tf-dashboard-layout>
-      <div class="sidebar">
+      <div class="sidebar" id="left-menu">
         <div id="node-entries" class="node-entries">
           <div class="debugger-section-title">Node List</div>
           <tf-op-selector
@@ -76,6 +77,11 @@ limitations under the License.
               force-expand-and-check-node-name="[[_forceExpandAndCheckNodeName]]"
               force-expand-node-name="[[_forceExpandNodeName]]">
           </tf-op-selector>
+          <tf-debugger-vertical-resizer
+              current-width="{{_leftMenuWidth}}"
+              min-width="[[_minLeftMenuWidth]]"
+              max-width="[[_maxLeftMenuWidth]]">
+          </tf-debugger-vertical-resizer>
         </div>
         <div>
           <tf-session-runs-view
@@ -106,7 +112,7 @@ limitations under the License.
           ></tf-graph-loader>
         </div>
       </div>
-      <div class="center">
+      <div class="center" id="center-content">
         <div id="top-right-content-container">
           <paper-tabs selected="0" selected="{{_topRightSelected}}">
             <template is="dom-repeat" items="[[_topRightTabs]]">
@@ -249,6 +255,10 @@ limitations under the License.
       .center {
         position: relative;
         height: 100%;
+      }
+      #center-content {
+        position: absolute;
+        right: 0;
       }
       .context-menu {
         position: absolute;
@@ -452,14 +462,45 @@ limitations under the License.
           type: Boolean,
           value: false,
         },
+
+        _leftMenuWidth: {
+          type: Number,
+          value: 450,
+        },
+
+        _minLeftMenuWidth: {
+          type: Number,
+          value: 450,
+          readOnly: true,
+        },
+
+        _maxLeftMenuWidth: Number,
+
+        _maxMainContentWidth: {
+          type: Number,
+          value: 350,
+          readOnly: true,
+        },
+
+        _resizerWidth: {
+          type: Number,
+          value: 30,
+          readOnly: true,
+        },
       },
 
       observers: [
         "_onActiveRuntimeGraphDeviceNameChange(_activeRuntimeGraphDeviceName)",
+        "_sizeDashboardRegions(_leftMenuWidth)",
         "_graphProgressUpdated(_graphProgress)",
       ],
 
       ready() {
+        this._handleWindowResize();
+        window.addEventListener('resize', () => {
+          this._handleWindowResize();
+        }, false);
+
         this.reload();
       },
 
@@ -639,8 +680,6 @@ limitations under the License.
           "path": url,
         }];
         this.$.loader.set("selectedDataset", 0);
-        this.$$('.container').style.width = '600px';
-        this.$$('.container').style.width = '450px';
       },
 
       _processGatedGrpcDebugOps(runKey, pollingForFirstGraph) {
@@ -1015,6 +1054,30 @@ limitations under the License.
           topRightProgressBar.setAttribute('value', progress.value);
           this.set('_busy', progress.value < 100);
         }
+      },
+      _handleWindowResize() {
+        // Do not let the main content exceed this width when the user
+        // resizes the left panel. Otherwise, the resizer would go off
+        // the viewport to the right, and the user would no longer be
+        // able to access the resizer.
+        this.set(
+            '_maxLeftMenuWidth',
+            this._getWindowWidth() -
+                this._maxMainContentWidth -
+                this._resizerWidth);
+        this._sizeDashboardRegions(this._leftMenuWidth);
+      },
+      _sizeDashboardRegions(leftMenuWidth) {
+        this.$$('#left-menu').style.width = leftMenuWidth + 'px';
+
+        const windowWidth = this._getWindowWidth();
+        this.$$('#center-content').style.width = (
+            windowWidth - leftMenuWidth - this._resizerWidth) + 'px';
+      },
+      _getWindowWidth() {
+        return window.innerWidth ||
+            document.documentElement.clientWidth ||
+            document.body.clientWidth;
       },
     });
 

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-vertical-resizer.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-vertical-resizer.html
@@ -1,0 +1,116 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/lodash.html">
+
+
+<dom-module id="tf-debugger-vertical-resizer">
+  <template>
+    <div class="bars">
+      <span class="bars-text">| |</span>
+    </div>
+  </template>
+  <style>
+    :host {
+      cursor: col-resize;
+      position: absolute;
+      right: -15px;
+      top: 0;
+      bottom: 0;
+      width: 10px;
+      background: #ccc;
+      user-select: none;
+    }
+
+    .bars {
+      width: 80%;
+      text-align: center;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      font-size: 5px;
+    }
+
+    .bars-text {
+      transform: scaleY(15);
+      white-space: nowrap;
+      display: block;
+      font-weight: 400;
+    }
+  </style>
+  <script>
+  Polymer({
+    is: "tf-debugger-vertical-resizer",
+    properties: {
+      // The current width of the container we are resizing.
+      currentWidth: {
+        type: Number,
+        notify: true,
+      },
+      minWidth: Number,
+      maxWidth: Number,
+      // The screen X value at the start of the previous drag.
+      _dragStartScreenX: Number,
+      // The width of the container being resized at the start of the previous
+      // drag.
+      _dragStartWidth: Number,
+      _previousMouseMoveCallback: Object,
+      _previousMouseUpCallback: Object,
+    },
+    listeners: {
+      'mousedown': '_handleMouseDown',
+    },
+    _handleMouseDown(e) {
+      // Start new drag (after ending the previous one if one lingered).
+
+      // A drag may linger if for instance the user moused down and then
+      // moved the mouse outside of the browser window, after which the
+      // browser would fail to detect the subsequent mouse up.
+      this._endDrag();
+
+      this._previousMouseMoveCallback = (e) => {
+        // Update the width of the container being resized.
+        const deltaX = e.screenX - this._dragStartScreenX;
+
+        let currentWidth = this._dragStartWidth + deltaX;
+        currentWidth = Math.max(currentWidth, this.minWidth);
+        currentWidth = Math.min(currentWidth, this.maxWidth);
+
+        this.set('currentWidth', currentWidth);
+      };
+
+      this._previousMouseUpCallback = (e) => {
+        // Stop listening for relevant events.
+        this._endDrag();
+      };
+      this.set('_dragStartScreenX', e.screenX);
+      this.set('_dragStartWidth', this.currentWidth);
+
+      window.addEventListener('mouseup', this._previousMouseUpCallback, false);
+      window.addEventListener(
+          'mousemove', this._previousMouseMoveCallback, false);
+    },
+    _endDrag() {
+      window.removeEventListener(
+          'mousemove', this._previousMouseMoveCallback, false);
+      this._previousMouseMoveCallback = null;
+      window.removeEventListener(
+          'mouseup', this._previousMouseUpCallback, false);
+      this._previousMouseUpCallback = null;
+    },
+  });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
@@ -59,7 +59,6 @@ limitations under the License.
         border-style: solid 1px black;
         table-layout: fixed;
         width: 100%;
-        min-width: 400px;
         max-width: 450px;
         word-break: break-all;
         padding-top: 3px;


### PR DESCRIPTION
We introduce a `tf-debugger-vertical-resizer` component that lets the user resize the left hand panel by dragging the component. The component lets the user specify a min and max width (so that for instance (1) both the left and right sides remain usable and (2) the dragger component does not disappear). Logic also responds to resizing of the window.

Screenshots:

![image](https://user-images.githubusercontent.com/4221553/34429413-73b08cfc-ec1d-11e7-8b77-707e4e65863b.png)

![image](https://user-images.githubusercontent.com/4221553/34429417-77b9a78e-ec1d-11e7-89ab-cde86073ae37.png)
