### PR TITLE
[Projector] Distance and neighborhood selection (Inspector panel)

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 namespace vz_projector {
 
+export type DistanceSpace = (_: DataPoint) => Float32Array;
 export type DistanceFunction = (a: vector.Vector, b: vector.Vector) => number;
 export type ProjectionComponents3D = [string, string, string];
 
@@ -460,13 +461,14 @@ export class DataSet {
 
   /**
    * Finds the nearest neighbors of the query point using a
-   * user-specified distance metric.
+   * user-specified distance space, distance metric and neighborhood function.
    */
-  findNeighbors(pointIndex: number, distFunc: DistanceFunction, numNN: number):
+  findNeighbors(pointIndex: number, numNN: number, distSpace: DistanceSpace,
+      distFunc: DistanceFunction, knnFunc: knn.KNNFunction<DataPoint>):
       knn.NearestEntry[] {
     // Find the nearest neighbors of a particular point.
-    let neighbors = knn.findKNNofPoint(
-        this.points, pointIndex, numNN, (d => d.vector), distFunc);
+    let neighbors = knnFunc(
+        this.points, pointIndex, numNN, distSpace, distFunc);
     // TODO(@dsmilkov): Figure out why we slice.
     let result = neighbors.slice(0, numNN);
     return result;
@@ -572,7 +574,7 @@ export function getProjectionComponents(
     throw new RangeError('components length must be <= 3');
   }
   const projectionComponents: [string, string, string] = [null, null, null];
-  const prefix = (projection === 'custom') ? 'linear' : projection;
+  const prefix = projection;
   for (let i = 0; i < components.length; ++i) {
     if (components[i] == null) {
       continue;
@@ -595,7 +597,7 @@ export function stateGetAccessorDimensions(state: State): Array<number|string> {
       }
       break;
     case 'custom':
-      dimensions = ['x', 'y'];
+      dimensions = [0, 1];
       break;
     default:
       throw new Error('Unexpected fallthrough');

--- a/tensorboard/plugins/projector/vz_projector/knn.ts
+++ b/tensorboard/plugins/projector/vz_projector/knn.ts
@@ -203,6 +203,10 @@ function minDist(
   return Math.sqrt(vector.dist22D([x, y], corner));
 }
 
+export type KNNFunction<T> = (dataPoints: T[], pointIndex: number,
+    k: number, accessor: (dataPoint: T) => Float32Array,
+    distance: (a: vector.Vector, b: vector.Vector) => number) => NearestEntry[];
+
 /**
  * Returns the nearest neighbors of a particular point.
  *
@@ -227,6 +231,95 @@ export function findKNNofPoint<T>(
     kMin.add(dist, {index: i, dist: dist});
   }
   return kMin.getMinKItems();
+}
+
+/**
+ * Use approximate geodesic distance to grow neighborhood over manifold
+ *
+ * @param dataPoints List of data points.
+ * @param pointIndex The index of the point we need the nearest neighbors of.
+ * @param k Number of nearest neighbors to search for.
+ * @param accessor Method that maps a data point => vector (array of numbers).
+ * @param distance Method that takes two vectors and returns their distance.
+*/
+export function findGeodesicKNNofPoint<T>(
+    dataPoints: T[], pointIndex: number, k: number,
+    accessor: (dataPoint: T) => Float32Array,
+    distance: (a: vector.Vector, b: vector.Vector) => number) {
+
+  let selectedPoint = accessor(dataPoints[pointIndex]);
+  let neighbors = findKNNofPoint(dataPoints, pointIndex, k, accessor,
+      distance);
+  // number of nearest neighbors to use for manifold expansion
+  let K = 5;
+  // use direct neighborhood
+  let neighborhood = neighbors.map(n => n.index);
+  // growing manifold to select from
+  let manifold = neighbors.slice(0, K);
+  // sum of edge distances traversed
+  let dist_sum = manifold.reduce((sum, n) => sum + n.dist, 0);
+  let dist_count = manifold.length;
+  // neighbor selection to return after populating
+  neighbors = [];
+
+  // grow to max k points
+  while (neighbors.length < k && manifold.length > 0) {
+    // store list of dist ordered neighbors
+    let knn = [];
+    // get next candidate, referred to as 'candidate'
+    let neighbor = manifold.shift();
+
+    // within 2x avg edge distance && previously unchosen
+    if (neighbor.dist <= 2.0 * dist_sum / dist_count
+        && neighbors.filter(f => f.index == neighbor.index).length == 0) {
+      // add suitable candidate
+      neighbors.push({index: neighbor.index, dist:
+          distance(selectedPoint, accessor(dataPoints[neighbor.index]))});
+      // update dist_sum
+      dist_sum = dist_sum + neighbor.dist;
+      // increment number of manifold
+      dist_count = dist_count + 1;
+      // find point vector representation
+      let point = accessor(dataPoints[neighbor.index]);
+      // choose only from initial neighborhood points
+      neighborhood.forEach(n => {
+        // distance from candidate to n
+        let n_dist = distance(point, accessor(dataPoints[n]));
+        // start checking ordered list at larger distance end
+        let l = K;
+        // add up to K neighbors of candidate
+        if (knn.length < K+1) {
+          // add n as neighbor
+          knn.push({index: n, dist: n_dist});
+        }
+        // already have K neighbors
+        else {
+          // find sorted insertion position
+          while (l >= 0 && n_dist < knn[l].dist) {
+            // move down the distance list
+            l = l - 1;
+          }
+          // n is closer than existing knn
+          if (l < K) {
+            // insert n into list to grow list
+            knn.splice(l + 1, 0, {index: n, dist: n_dist});
+          }
+        }
+      });
+      // add up to K new points to manifold
+      knn.slice(0, K).forEach(n => {
+        // not already in manifold
+        if (manifold.filter(f => f.index == n.index).length == 0) {
+          // add new point, allow reconsideration of earlier failed points
+          manifold.push(n);
+        }
+      });
+      // don't reuse successful candidate
+      neighborhood = neighborhood.filter(n => n != neighbor.index);
+    }
+  }
+  neighbors = neighbors.sort((a, b) => a.dist - b.dist);
+  return neighbors;
 }
 
 }  // namespace vz_projector.knn

--- a/tensorboard/plugins/projector/vz_projector/projectorEventContext.ts
+++ b/tensorboard/plugins/projector/vz_projector/projectorEventContext.ts
@@ -15,10 +15,13 @@ limitations under the License.
 namespace vz_projector {
 
 export type HoverListener = (index: number) => void;
+export type SelectionMode = 'normal' | 'edit';
 export type SelectionChangedListener =
     (selectedPointIndices: number[], neighborsOfFirstPoint: knn.NearestEntry[]) =>
         void;
 export type ProjectionChangedListener = (projection: Projection) => void;
+export type DistanceSpaceChangedListener =
+    (distanceSpace: DistanceSpace) => void;
 export type DistanceMetricChangedListener =
     (distanceMetric: DistanceFunction) => void;
 export interface ProjectorEventContext {
@@ -30,13 +33,17 @@ export interface ProjectorEventContext {
   registerSelectionChangedListener(listener: SelectionChangedListener);
   /**
    * Notify the selection system that a client has changed the selected point
-   * set.
+   * set under a specified selection mode.
    */
-  notifySelectionChanged(newSelectedPointIndices: number[]);
+  notifySelectionChanged(newSelectedPointIndices: number[],
+      selectionMode?: SelectionMode);
   /** Registers a callback to be invoked when the projection changes. */
   registerProjectionChangedListener(listener: ProjectionChangedListener);
   /** Notify listeners that a reprojection occurred. */
   notifyProjectionChanged(projection: Projection);
+  registerDistanceSpaceChangedListener(listener:
+                                            DistanceSpaceChangedListener);
+  notifyDistanceSpaceChanged(distSpace: DistanceSpace);
   registerDistanceMetricChangedListener(listener:
                                             DistanceMetricChangedListener);
   notifyDistanceMetricChanged(distMetric: DistanceFunction);

--- a/tensorboard/plugins/projector/vz_projector/projectorScatterPlotAdapter.ts
+++ b/tensorboard/plugins/projector/vz_projector/projectorScatterPlotAdapter.ts
@@ -73,6 +73,7 @@ export class ProjectorScatterPlotAdapter {
   private renderLabelsIn3D: boolean = false;
   private labelPointAccessor: string;
   private legendPointColorer: (ds: DataSet, index: number) => string;
+  private distanceSpace: DistanceSpace;
   private distanceMetric: DistanceFunction;
 
   private spriteVisualizer: ScatterPlotVisualizerSprites;
@@ -102,6 +103,12 @@ export class ProjectorScatterPlotAdapter {
       this.updateScatterPlotAttributes();
       this.scatterPlot.render();
     });
+    projectorEventContext.registerDistanceSpaceChangedListener(
+        distanceSpace => {
+          this.distanceSpace = distanceSpace;
+          this.updateScatterPlotAttributes();
+          this.scatterPlot.render();
+        });
     projectorEventContext.registerDistanceMetricChangedListener(
         distanceMetric => {
           this.distanceMetric = distanceMetric;

--- a/tensorboard/plugins/projector/vz_projector/scatterPlot.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlot.ts
@@ -313,6 +313,12 @@ export class ScatterPlot {
       this.rectangleSelector.onMouseUp();
       this.render();
     }
+    // right-click and not isDragSequence
+    else if (e.button == 2 && !this.isDragSequence) {
+      const selection = (this.nearestPoint != null) ? [this.nearestPoint] : [];
+      this.projectorEventContext.notifySelectionChanged(selection, 'edit');
+      this.render();
+    }
     this.mouseIsDown = false;
   }
 

--- a/tensorboard/plugins/projector/vz_projector/test/data_test.ts
+++ b/tensorboard/plugins/projector/vz_projector/test/data_test.ts
@@ -95,10 +95,10 @@ describe('stateGetAccessorDimensions', () => {
                      stateGetAccessorDimensions(state));
   });
 
-  it('returns ["x", "y"] for custom projections', () => {
+  it('returns [0, 1] for custom projections', () => {
     const state = new State();
     state.selectedProjection = 'custom';
-    assert.deepEqual(['x', 'y'], stateGetAccessorDimensions(state));
+    assert.deepEqual([0, 1], stateGetAccessorDimensions(state));
   });
 });
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
@@ -43,7 +43,7 @@ limitations under the License.
 
 .buttons {
   display: flex;
-  height: 60px;
+  height: 50px;
 }
 
 .button {
@@ -51,7 +51,7 @@ limitations under the License.
   border: none;
   border-radius: 7px;
   font-size: 13px;
-  padding: 10px;
+  padding: 5px;
   background: #e3e3e3;
 }
 
@@ -128,33 +128,52 @@ limitations under the License.
 
 .search-by paper-dropdown-menu {
   margin-left: 10px;
-  width: 100px;
+  width: 120px;
+  --paper-input-container-input: {
+    font-size: 14px;
+  };
 }
 
-.distance .options {
-  float: right;
+.two-columns {
+  display:flex;
+  justify-content: space-between;
 }
 
-.options a {
-  color: #727272;
-  font-size: 13px;
-  margin-left: 12px;
-  text-decoration: none;
+.two-columns > :first-child {
+  margin-right: 10px;
 }
 
-.options a.selected {
-  color: #009EFE;
+.two-columns > div {
+  width: 50%;
 }
 
-.neighbors {
-  margin-bottom: 30px;
+.distance-selection paper-dropdown-menu {
+  --paper-input-container: {
+    padding: 0;
+  };
+  --paper-input-container-input: {
+    font-size: 14px;
+  };
+}
+
+.neighborhood-selection paper-dropdown-menu {
+  --paper-input-container: {
+    padding: 0;
+  };
+  --paper-input-container-input: {
+    font-size: 14px;
+  };
+}
+
+.list-header {
+  margin-top: -15px;
 }
 
 .neighbors-options {
   margin-top: 6px;
 }
 
-.neighbors-options .option-label, .distance .option-label {
+.neighbors-options .option-label {
   color: #727272;
   margin-right: 2px;
   width: auto;
@@ -171,10 +190,6 @@ limitations under the License.
   --paper-input-container-input: {
     font-size: 14px;
   };
-}
-
-.euclidean {
-  margin-right: 10px;
 }
 
 .matches-list {
@@ -218,26 +233,47 @@ limitations under the License.
 <div class="results">
   <div class="nn" style="display: none">
     <div class="neighbors">
+      <div class="two-columns">
+        <div class="distance-selection">
+          <paper-dropdown-menu no-animations label="Distance">
+            <paper-listbox attr-for-selected="value" class="dropdown-content" slot="dropdown-content"
+                selected="{{selectedDistance}}" on-selected-item-changed="distanceChanged">
+              <template is="dom-repeat" items="[[distanceFields]]">
+                <paper-item value="[[item]]" label="[[item]]">
+                  [[item]]
+                </paper-item>
+              </template>
+            </paper-listbox>
+          </paper-dropdown-menu>
+        </div>
+        <div class="neighborhood-selection">
+          <paper-dropdown-menu no-animations label="Neighborhood">
+            <paper-listbox attr-for-selected="value" class="dropdown-content" slot="dropdown-content"
+                selected="{{selectedNeighborhood}}" on-selected-item-changed="neighborhoodChanged">
+              <template is="dom-repeat" items="[[neighborhoodFields]]">
+                <paper-item value="[[item]]" label="[[item]]">
+                  [[item]]
+                </paper-item>
+              </template>
+            </paper-listbox>
+          </paper-dropdown-menu>
+        </div>
+      </div>
       <div class="neighbors-options">
         <div class="slider num-nn">
           <span class="option-label">neighbors</span>
           <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
           <paper-tooltip position="bottom" animation-delay="0" fit-to-visible-bounds>
-            The number of neighbors (in the original space) to show when clicking on a point.
+            The number of neighbors (in the selected space) to show when clicking on a point.
           </paper-tooltip>
           <paper-slider class="nn-slider" pin min="5" max="999" editable
               value="{{numNN}}" on-change="updateNumNN"></paper-slider>
         </div>
       </div>
-      <div class="distance">
-        <span class="option-label">distance</span>
-        <div class="options">
-          <a class="selected cosine" href="javascript:void(0);">COSINE</a>
-          <a class="euclidean" href="javascript:void(0);">EUCLIDEAN</a>
-        </div>
-      </div>
     </div>
-    <p>Nearest points in the original space:
+    <div class="list-header">
+      <p>{{selectedNeighborhood}} neighbors using {{selectedDistance}} distance:</p>
+    </div>
     <div class="nn-list"></div>
   </div>
   <div class="metadata-info" style="display: none">
@@ -252,7 +288,9 @@ limitations under the License.
             value="{{numNN}}" on-change="updateNumNN"></paper-slider>
       </div>
     </div>
-    <p>{{metadataColumn}} labels (click to apply):</p>
+    <div class="list-header">
+      <p>{{metadataColumn}} labels (click to apply):</p>
+    </div>
     <div class="metadata-list"></div>
   </div>
   <div class="matches-list" style="display: none">

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -548,12 +548,12 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
       return;
     }
     const xDir = vector.sub(this.centroids.xRight, this.centroids.xLeft);
-    this.dataSet.projectLinear(xDir, 'linear-x');
+    this.dataSet.projectLinear(xDir, 'custom-0');
 
     const yDir = vector.sub(this.centroids.yUp, this.centroids.yDown);
-    this.dataSet.projectLinear(yDir, 'linear-y');
+    this.dataSet.projectLinear(yDir, 'custom-1');
 
-    const accessors = getProjectionComponents('custom', ['x', 'y']);
+    const accessors = getProjectionComponents('custom', [0, 1]);
     const projection = new Projection('custom', accessors, 2, this.dataSet);
     this.projector.setProjection(projection);
   }

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -46,6 +46,7 @@ export class Projector extends ProjectorPolymer implements
   private selectionChangedListeners: SelectionChangedListener[];
   private hoverListeners: HoverListener[];
   private projectionChangedListeners: ProjectionChangedListener[];
+  private distanceSpaceChangedListeners: DistanceSpaceChangedListener[];
   private distanceMetricChangedListeners: DistanceMetricChangedListener[];
 
   private originalDataSet: DataSet;
@@ -97,6 +98,7 @@ export class Projector extends ProjectorPolymer implements
     this.selectionChangedListeners = [];
     this.hoverListeners = [];
     this.projectionChangedListeners = [];
+    this.distanceSpaceChangedListeners = [];
     this.distanceMetricChangedListeners = [];
     this.selectedPointIndices = [];
     this.neighborsOfFirstPoint = [];
@@ -262,55 +264,80 @@ export class Projector extends ProjectorPolymer implements
   /**
    * Used by clients to indicate that a selection has occurred.
    */
-  notifySelectionChanged(newSelectedPointIndices: number[]) {
+  notifySelectionChanged(newSelectedPointIndices: number[],
+      selectionMode?: SelectionMode) {
+    let editMode = this.editMode || selectionMode === 'edit';
     let neighbors: knn.NearestEntry[] = [];
-
-    if (this.editMode  // point selection toggle in existing selection
-        && newSelectedPointIndices.length > 0) {  // selection required
-      if (this.selectedPointIndices.length === 1) {  // main point with neighbors
+    // point selection toggle in existing selection && selection required
+    if (editMode && newSelectedPointIndices.length > 0) {
+      // main point with neighbors
+      if (this.selectedPointIndices.length === 1) {
         let main_point_vector = this.dataSet.points[
             this.selectedPointIndices[0]].vector;
-        neighbors = this.neighborsOfFirstPoint.filter(n =>  // deselect
-            newSelectedPointIndices.filter(p => p == n.index).length == 0);
-        newSelectedPointIndices.forEach(p => {  // add additional neighbors
-          if (p != this.selectedPointIndices[0]  // not main point
-              && this.neighborsOfFirstPoint.filter(n => n.index == p).length == 0) {
+        // deselect
+        neighbors = this.neighborsOfFirstPoint.filter(n =>
+            newSelectedPointIndices.filter(p => p === n.index).length === 0);
+        // add additional neighbors
+        newSelectedPointIndices.forEach(p => {
+          // not main point
+          if (p !== this.selectedPointIndices[0]
+              && this.neighborsOfFirstPoint.filter(n => 
+                  n.index === p).length === 0) {
             let p_vector = this.dataSet.points[p].vector;
-            let n_dist = this.inspectorPanel.distFunc(main_point_vector, p_vector);
-            let pos = 0;  // insertion position into dist ordered neighbors
-            while (pos < neighbors.length && neighbors[pos].dist < n_dist)  // find pos
-              pos = pos + 1;  // move up the sorted neighbors list according to dist
-            neighbors.splice(pos, 0, {index: p, dist: n_dist});  // add new neighbor
+            let n_dist =
+                this.inspectorPanel.distFunc(main_point_vector, p_vector);
+            // insertion position into dist ordered neighbors
+            let pos = 0;
+
+            // move up sorted neighbors list according to dist
+            while (pos < neighbors.length && neighbors[pos].dist < n_dist) {
+              pos = pos + 1;
+            }
+            // add new neighbor
+            neighbors.splice(pos, 0, {index: p, dist: n_dist});
           }
         });
       }
-      else {  // multiple selections
+      // multiple selections
+      else {
+        // deselect
         let updatedSelectedPointIndices = this.selectedPointIndices.filter(n =>
-            newSelectedPointIndices.filter(p => p == n).length == 0);  // deselect
-        newSelectedPointIndices.forEach(p => {  // add additional selections
-          if (this.selectedPointIndices.filter(s => s == p).length == 0)  // unselected
+            newSelectedPointIndices.filter(p => p === n).length === 0);
+        // add additional selections
+        newSelectedPointIndices.forEach(p => {
+          if (this.selectedPointIndices.filter(s => s === p).length === 0) {
+            // unselected
             updatedSelectedPointIndices.push(p);
+          }
         });
-        this.selectedPointIndices = updatedSelectedPointIndices;  // update selection
-
-        if (this.selectedPointIndices.length > 0) {  // at least one selected point
-          this.metadataCard.updateMetadata(  // show metadata for first selected point
+        // update selected points
+        this.selectedPointIndices = updatedSelectedPointIndices;
+        // at least one point selected
+        if (this.selectedPointIndices.length > 0) {
+          // show metadata for first point
+          this.metadataCard.updateMetadata(
               this.dataSet.points[this.selectedPointIndices[0]].metadata);
-        } else {  // no points selected
-          this.metadataCard.updateMetadata(null);  // clear metadata
+        }
+        // no points selected
+        else {
+          // clear metadata
+          this.metadataCard.updateMetadata(null);
         }
       }
     }
-    else {  // normal selection mode
+    // normal selection mode
+    else {
       this.selectedPointIndices = newSelectedPointIndices;
 
       if (newSelectedPointIndices.length === 1) {
         neighbors = this.dataSet.findNeighbors(
-            newSelectedPointIndices[0], this.inspectorPanel.distFunc,
-            this.inspectorPanel.numNN);
+            newSelectedPointIndices[0], this.inspectorPanel.numNN,
+            this.inspectorPanel.distSpace, this.inspectorPanel.distFunc,
+            this.inspectorPanel.knnFunc);
         this.metadataCard.updateMetadata(
             this.dataSet.points[newSelectedPointIndices[0]].metadata);
-      } else {
+      }
+      else {
         this.metadataCard.updateMetadata(null);
       }
     }
@@ -339,6 +366,14 @@ export class Projector extends ProjectorPolymer implements
 
   notifyProjectionChanged(projection: Projection) {
     this.projectionChangedListeners.forEach(l => l(projection));
+  }
+
+  registerDistanceSpaceChangedListener(l: DistanceSpaceChangedListener) {
+    this.distanceSpaceChangedListeners.push(l);
+  }
+
+  notifyDistanceSpaceChanged(distSpace: DistanceSpace) {
+    this.distanceSpaceChangedListeners.forEach(l => l(distSpace));
   }
 
   registerDistanceMetricChangedListener(l: DistanceMetricChangedListener) {
@@ -553,6 +588,7 @@ export class Projector extends ProjectorPolymer implements
 
   onProjectionChanged(projection?: Projection) {
     this.dataPanel.projectionChanged(projection);
+    this.inspectorPanel.projectionChanged(projection);
   }
 
   setProjection(projection: Projection) {


### PR DESCRIPTION
Add to the Inspector panel a dropdown-menu for that distance metric/space selection, and a second dropdown-menu for the neighborhood function selection. Automatically update distance metric/space choices upon change in the projection choice, and set to the newest projection choice. Allow for future distance metric/space and neighborhood function definitions to expand the available options.

The functionality proposed here would complement the interactive supervision by allowing for refined/specific neighborhood selection in a variety of projections.

Demo here: http://tensorserve.com:6017
```bash
git clone https://github.com/francoisluus/tensorboard-supervise.git
cd tensorboard-supervise
git checkout e212cbb57ad604d5cab0f2d95637e4e9c85378fc
bazel run tensorboard -- --logdir /home/$USER/emnist-2000 --host 0.0.0.0 --port 6017
```

### Design and behavior
1. The use of two dropdown-menus allows for the direct support of alternative metrics and neighborhood functions.
2. Distance metrics are defined in terms of a chosen distance measure and a metric space in which it is to be used.
3. The projector notifies the inspector panel of a change in the current projection, and then the available selections are automatically updated to refresh the available metric/projection spaces and the current distance metric selection.
4. The font size of the nn slider input is styled in anticipation of https://github.com/PolymerElements/paper-slider/pull/208, but will remain slightly larger until the Polymer update becomes available in TensorBoard.

#### Distance selection
5. Previously two distance metrics were available, namely cosine and euclidean in the original space.
6. Add euclidean distance in the PCA space, and euclidean distance in the t-SNE space as additional distance metrics.
7. In the case of t-SNE, the distance option won't be available until there is already a t-SNE projection calculated.
8. When switching from PCA to t-SNE, the distance option will switch to t-SNE automatically and vice versa.

#### Neighborhood selection
9. Previously only direct knn were selected, based on the distance metric provided.
10. Add geodesic neighborhood selection as an alternative in knn.ts.
11. Neighborhood functions can be defined according to a type template in knn.ts, and new functions can be included in the available selection through minimal hard-coding.

#### Geodesic neighborhoods
12. Geodesic neighborhoods are determined in an approximate manner by hopping from the initial sample into its immediate knn neighborhood and radiating outward, effectively growing the neighborhood over the manifold with edge-count or geodesic distance.
13. The main geodesic selection tuning-parameters are k=5 for the knn neighborhood expansion, and the maximum edge distance to incorporate a candidate sample which is set at twice the average edge distance. Alternative instantiations can be provided, e.g. geodesic (tight), geodesic (medium), geodesic (loose).
14. Geodesic selection is sensitive to the first step distances, so if a relatively isolated sample is chosen then the geodesic selection would be larger as opposed to choosing a sample with closer neighbors. This discrepancy gives some versatility to the user to craft the most agreeable selection size when choosing different samples.

#### Right-click selection mode
15. Now a mouse right-click acts as selection editor, whether in normal or editMode, such that it deselects a currently selected point (unless it is the main/first point) and vice versa. Selection mode types are introduced to support future expansion of different selection interactions.
16. ~Add 'contextmenu' event capture in scatterplot, the standard HTML5 right-click event, and bind to selection 'edit' mode. This allows for quick selection edits without explicitly switching to editMode via the toolbar. This event handler checks that the event is not part of a drag sequence or area select.~
16. Since the contextmenu event only fires after mousedown, we should rather capture the right-click event during mouseup by checking for the right mouse button. During mouseup, if it is not a drag sequence and the right mouse button was clicked, we toggle selection/deselection of the nearest point. This fixes the bug where right-click edited the selection despite mousemove even though it was in fact part of a drag sequence, as the logic failed earlier when contextmenu followed mousedown as opposed to onclick which proceeds mousedown.

### Custom projection (coordinate naming consistency) 
Custom projection coordinates were named 'linear-x' and 'linear-y', this was changed to 'custom-0' and 'custom-1' to allow for naming consistency with pca, tsne and future projections.

This consistent format is then utilized to automate the extraction of available projections from the datapoint coordinates, and auto-set the distance metric/space choice correctly upon projection availability changes.

### Concerns and issues
1) 'Distance' is automatically set to the current projection space, so neighborhoods will be calculated in the current projection space by default, e.g. 'PCA' distance will be set when switching to PCA. The previous default was Cosine as this can use GPU acceleration, so is a faster default. If this is a real concern, we can hardcode the first startup default distance to 'Cosine'.
2) The button heights in the top row of the Inspector panel was reduced, as I could not find a case where all three lines are required, but my search was not exhaustive. If the extra vertical space is indeed to required, I can reset it.

### Inspector panel (before & after)
#### Before
<img width="300" alt="screen shot 2018-01-02 at 4 22 11 pm" src="https://user-images.githubusercontent.com/10847676/34486625-620f3e48-efd9-11e7-8154-90a667811679.png">

#### After
<img width="297" alt="screen shot 2018-01-02 at 3 57 39 pm" src="https://user-images.githubusercontent.com/10847676/34486643-71356e9c-efd9-11e7-9352-4d73f03ec38f.png">

### Distance selection
<img width="300" alt="screen shot 2018-01-02 at 3 58 06 pm" src="https://user-images.githubusercontent.com/10847676/34486673-88a621ca-efd9-11e7-931a-42bc39838217.png">

### Neighborhood selection
<img width="300" alt="screen shot 2018-01-02 at 3 58 46 pm" src="https://user-images.githubusercontent.com/10847676/34486675-9014853c-efd9-11e7-8e8a-b3e3947fdc19.png">