### PR TITLE
[Debugger Plugin]: Add Source Code View

### DIFF
--- a/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
@@ -358,6 +358,116 @@ class InteractiveDebuggerDataStreamHandler(
             debug_op) in self._run_states.get_breakpoints()
 
 
+# TODO(cais): Consider moving to a seperate python module.
+class SourceManager(object):
+  """Manages source files and tracebacks involved in the debugged TF program.
+
+  """
+
+  def __init__(self):
+    # A dict mapping file path to file content as a list of strings.
+    self._source_file_content = dict()
+    # A dict mapping file path to host name.
+    self._source_file_host = dict()
+    # A dict mapping file path to last modified timestamp.
+    self._source_file_last_modified = dict()
+    # A dict mapping file path to size in bytes.
+    self._source_file_bytes = dict()
+    # Keeps track f the traceback of the latest graph version.
+    self._graph_traceback = None
+    self._graph_version = -1
+
+  def add_debugged_source_file(self, debugged_source_file):
+    """Add a DebuggedSourceFile proto."""
+    # TODO(cais): Should the key include a host name, for certain distributed
+    #   cases?
+    key = debugged_source_file.file_path
+    self._source_file_host[key] = debugged_source_file.host
+    self._source_file_last_modified[key] = debugged_source_file.last_modified
+    self._source_file_bytes[key] = debugged_source_file.bytes
+    self._source_file_content[key] = debugged_source_file.lines
+
+  def add_graph_traceback(self, graph_version, graph_traceback):
+    if graph_version > self._graph_version:
+      self._graph_traceback = graph_traceback
+      self._graph_version = graph_version
+
+  def get_paths(self):
+    """Get the paths to all available source files."""
+    return self._source_file_content.keys()
+
+  def get_content(self, file_path):
+    """Get the content of a source file.
+
+    # TODO(cais): Maybe support getting a range of lines by line number.
+
+    Args:
+      file_path: Path to the source file.
+    """
+    return self._source_file_content[file_path]
+
+  def get_op_traceback(self, op_name):
+    """Get the traceback of an op in the latest version of the TF graph.
+
+    Args:
+      op_name: Name of the op.
+
+    Returns:
+      Creation traceback of the op, in the form of a list of 2-tuples:
+        (file_path, lineno)
+
+    Raises:
+      ValueError: If the op with the given name cannot be found in the latest
+        version of the graph that this SourceManager instance has received, or
+        if this SourceManager instance has not received any graph traceback yet.
+    """
+    if not self._graph_traceback:
+      raise ValueError('No graph traceback has been received yet.')
+    for op_log_entry in self._graph_traceback.log_entries:
+      if op_log_entry.name == op_name:
+        return self._code_def_to_traceback_list(op_log_entry.code_def)
+    raise ValueError(
+        'No op named "%s" can be found in the graph of the latest version '
+        ' (%d).' % (op_name, self._graph_version))
+
+  def get_file_tracebacks(self, file_path):
+    """Get the lists of ops created at lines of a specified source file.
+
+    Args:
+      file_path: Path to the source file.
+
+    Returns:
+      A dict mapping line number to a list of 2-tuples,
+        `(op_name, stack_position)`
+      `op_name` is the name of the name of the op whose creation traceback
+        includes the line.
+      `stack_position` is the position of the line in the op's creation
+        traceback, represented as a 0-based integer.
+
+    Raises:
+      ValueError: If `file_path` does not point to a source file that has been
+        received by this instance of `SourceManager`.
+    """
+    if file_path not in self._source_file_content:
+      raise ValueError(
+          'Source file of path "%s" has not been received by this instance of '
+          'SourceManager.' % file_path)
+
+    lineno_to_op_names_and_stack_position = dict()
+    for op_log_entry in self._graph_traceback.log_entries:
+      for stack_pos, trace in enumerate(op_log_entry.code_def.traces):
+        if self._graph_traceback.id_to_string[trace.file_id] == file_path:
+          if trace.lineno not in lineno_to_op_names_and_stack_position:
+            lineno_to_op_names_and_stack_position[trace.lineno] = []
+          lineno_to_op_names_and_stack_position[trace.lineno].append(
+              (op_log_entry.name, stack_pos))
+    return lineno_to_op_names_and_stack_position
+
+  def _code_def_to_traceback_list(self, code_def):
+    return [
+        (self._graph_traceback.id_to_string[trace.file_id], trace.lineno)
+        for trace in code_def.traces]
+
 
 class InteractiveDebuggerDataServer(
     grpc_debug_server.EventListenerBaseServicer):
@@ -380,6 +490,7 @@ class InteractiveDebuggerDataServer(
     self._outgoing_channel = comm_channel_lib.CommChannel()
     self._run_states = RunStates(breakpoints_func=lambda: self.breakpoints)
     self._tensor_store = tensor_store_lib.TensorStore()
+    self._source_manager = SourceManager()
 
     curried_handler_constructor = functools.partial(
         InteractiveDebuggerDataStreamHandler,
@@ -396,6 +507,18 @@ class InteractiveDebuggerDataServer(
     within the log directory for storing health pill summary events.
     """
     self.run_server()
+
+  def SendTracebacks(self, request, context):
+    self._source_manager.add_graph_traceback(request.graph_version,
+                                             request.graph_traceback)
+    return debug_service_pb2.EventReply()
+
+  def SendSourceFiles(self, request, context):
+    # TODO(cais): Handle case in which the size of the request is greater than
+    #   the 4-MB gRPC limit.
+    for source_file in request.source_files:
+      self._source_manager.add_debugged_source_file(source_file)
+    return debug_service_pb2.EventReply()
 
   def get_graphs(self, run_key, debug=False):
     return self._run_states.get_graphs(run_key, debug=debug)
@@ -439,6 +562,50 @@ class InteractiveDebuggerDataServer(
                                     time_indices=time_indices,
                                     slicing=slicing,
                                     mapping=mapping)
+
+  def query_source_file_paths(self):
+    """Query the source files involved in the current debugged TF program.
+
+    Returns:
+      A `list` of file paths. The files that belong to the TensorFlow Python
+        library itself are *not* included.
+    """
+    return self._source_manager.get_paths()
+
+  def query_source_file_content(self, file_path):
+    """Query the content of a given source file.
+
+    # TODO(cais): Allow query only a range of the source lines.
+
+    Returns:
+      The source lines as a list of `str`.
+    """
+    return list(self._source_manager.get_content(file_path))
+
+  def query_op_traceback(self, op_name):
+    """Query the tracebacks of ops in a TensorFlow graph.
+
+    Returns:
+      TODO(cais):
+    """
+    return self._source_manager.get_op_traceback(op_name)
+
+  def query_file_tracebacks(self, file_path):
+    """Query the lists of ops created at lines of a given source file.
+
+    Args:
+      file_path: Path to the source file to get the tracebacks for.
+
+    Returns:
+      A `dict` mapping line number in the specified source file to a list of
+        2-tuples:
+          `(op_name, stack_position)`.
+        `op_name` is the name of the name of the op whose creation traceback
+          includes the line.
+        `stack_position` is the position of the line in the op's creation
+          traceback, represented as a 0-based integer.
+    """
+    return self._source_manager.get_file_tracebacks(file_path)
 
   def dispose(self):
     """Disposes of this object. Call only after this is done being used."""

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
@@ -15,6 +15,7 @@ tf_web_library(
         "tf-debugger-vertical-resizer.html",
         "tf-op-selector.html",
         "tf-session-runs-view.html",
+        "tf-source-code-view.html",
         "tf-tensor-data-summary.html",
         "tf-tensor-value-multi-view.html",
         "tf-tensor-value-view.html",

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/selection-tree-node.ts
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/selection-tree-node.ts
@@ -124,6 +124,20 @@ export function sortAndBaseExpandDebugWatches(debugWatches: DebugWatch[]) {
   }
 }
 
+/**
+ * Remove any possible base expansion from a node name.
+ * @param nodeName: The node name, possibly with base expansion.
+ * @returns: Node name with any base expansion removed. If `nodeName` does not
+ *   contain any base expansion, the string is returned without modification.
+ */
+export function removeNodeNameBaseExpansion(nodeName: string) {
+  if (nodeName.endsWith(')')) {
+    return nodeName.slice(0, nodeName.lastIndexOf('/('));
+  } else {
+    return nodeName;
+  }
+}
+
 export function assembleDeviceAndNodeNames(nameItems: string[]): string[] {
   const deviceAndNodeNames: string[] = [null, null];
   if (nameItems[0].match(DEVICE_NAME_PATTERN)) {

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -38,6 +38,7 @@ limitations under the License.
 <link rel="import" href="tf-debugger-vertical-resizer.html">
 <link rel="import" href="tf-op-selector.html">
 <link rel="import" href="tf-session-runs-view.html">
+<link rel="import" href="tf-source-code-view.html">
 <link rel="import" href="tf-tensor-data-summary.html">
 <link rel="import" href="tf-tensor-value-multi-view.html">
 
@@ -70,19 +71,36 @@ limitations under the License.
       <div class="sidebar" id="left-pane">
         <div id="node-entries" class="node-entries">
           <div class="debugger-section-title">Node List</div>
+          <paper-button
+            raised
+            id="toggle-source-code-button"
+            on-click="_showSourceCode">
+            <span>[[_toggleSourceCodeButtonText]]</span>
+          </paper-button>
           <tf-op-selector
               debug-watches=[[_debugWatches]]
               debug-watch-change="[[_createDebugWatchChangeHandler()]]"
-              node-clicked="[[_createListNodeClickedHandler()]]"
+              node-clicked="[[_createNodeClickedHandler()]]"
               force-expand-and-check-node-name="[[_forceExpandAndCheckNodeName]]"
               force-expand-node-name="[[_forceExpandNodeName]]">
           </tf-op-selector>
-          <tf-debugger-vertical-resizer
-              current-width="{{_leftPaneWidth}}"
-              min-width="[[_minleftPaneWidth]]"
-              max-width="[[_maxleftPaneWidth]]">
-          </tf-debugger-vertical-resizer>
         </div>
+        <div id="source-code-view-div" class="source-code-view-div" hidden$="{{!_sourceCodeShown}}">
+          <div class="debugger-section-title">Source Code</div>
+          <tf-source-code-view
+            id="sourceCodeView"
+            request-manager="[[_requestManager]]"
+            debug-watches="[[_debugWatches]]"
+            focus-node-name="[[_sourceFocusNodeName]]"
+            node-clicked="[[_createNodeClickedHandler()]]"
+            continue-to-node="[[_createContinueToNodeHandler()]]"
+          ></tf-source-code-view>
+        </div>
+        <tf-debugger-vertical-resizer
+          current-width="{{_leftPaneWidth}}"
+          min-width="[[_minleftPaneWidth]]"
+          max-width="[[_maxleftPaneWidth]]">
+        </tf-debugger-vertical-resizer>
         <div>
           <tf-session-runs-view
             id="sessionRunsView"
@@ -169,7 +187,8 @@ limitations under the License.
             latest-tensor-data="[[_latestTensorData]]"
             expand-handler="[[_createTensorDataExpandHandler()]]"
             continue-to-callback="[[_createContinueToCallback()]]"
-            highlighted-node-name="[[_highlightNodeName]]">
+            highlighted-node-name="[[_highlightNodeName]]"
+            tensor-name-clicked="[[_createNodeClickedHandler()]]">
           </tf-tensor-data-summary>
         </div>
       </div>
@@ -184,6 +203,7 @@ limitations under the License.
         right: 0;
         top: 0;
         bottom: 0;
+        overflow: hidden;
       }
       .debugger-section-title {
         font-size: 110%;
@@ -203,6 +223,7 @@ limitations under the License.
       }
       #graph-container {
         position: relative;
+        height: 100%;
       }
       #graph {
         display: block;
@@ -275,9 +296,22 @@ limitations under the License.
         vertical-align: middle;
       }
       .node-entries {
-        height: 66%;
+        position: relative;
+        height: 80%;
         width: 100%;
+        vertical-align: top;
         overflow: auto;
+        padding-top: 3px;
+        padding-left: 3px;
+        padding-right: 3px;
+        box-shadow: 3px 3px #ddd;
+      }
+      .source-code-view-div {
+        position: relative;
+        height: 40%;
+        width: 100%;
+        vertical-align: top;
+        overflow: hidden;
         padding-top: 3px;
         padding-left: 3px;
         padding-right: 3px;
@@ -287,13 +321,17 @@ limitations under the License.
         padding: 20px 0;
       }
       .tensor-data {
-        height: 34%;
+        height: 30%;
         overflow: auto;
         padding: 20px 0;
       }
       #top-right-content-container {
         height: 66%;
         overflow: auto;
+      }
+      #toggle-source-code-button {
+        font-size: 80%;
+        float: right;
       }
       /deep/ .context-menu ul {
         list-style-type: none;
@@ -335,7 +373,6 @@ limitations under the License.
           value: [
             {id: 'tab-runtime-graphs', name: 'Runtime Graphs'},
             {id: 'tab-tensor-values', name: 'Tensor Values'},
-            {id: 'tab-python-source', name: 'Python Source'}
           ],
           readonly: true,
         },
@@ -344,10 +381,6 @@ limitations under the License.
           value: true,
         },
         _isTopRightTensorValuesActive: {
-          type: Boolean,
-          value: false,
-        },
-        _isTopRightPythonSourceActive: {
           type: Boolean,
           value: false,
         },
@@ -372,6 +405,10 @@ limitations under the License.
         _continueNum: {  // How many times to continue over, e.g., Session.Runs.
             type: Number,
             value: 5,
+        },
+        _toggleSourceCodeButtonText: {
+            type: String,
+            value: 'Show Code >>',
         },
 
         _tensorViewIdCounter: {
@@ -450,6 +487,12 @@ limitations under the License.
         // checkbox for.
         _forceExpandAndCheckNodeName: String,
         _forceExpandNodeName: String,
+        // Focused-on op name for source code.
+        _sourceFocusNodeName: String,
+        _sourceCodeShown: {
+          type: Boolean,
+          value: false,
+        },
 
         _graphProgress: {
           type: Object,
@@ -620,6 +663,12 @@ limitations under the License.
               this._step();
             } else {
               this._clearContinueTo();
+              if (this._sourceCodeShown) {
+                this.set(
+                    '_sourceFocusNodeName',
+                    tf_debugger_dashboard.removeNodeNameBaseExpansion(
+                        maybeBaseExpandedNodeName));
+              }
             }
           } else if (this._continueToType != null && this._continueToType !== '') {
             console.error('Invalid _continueToType:', this._continueToType);
@@ -670,6 +719,19 @@ limitations under the License.
 
       _openContinueDialog() {
         this.$.continueDialog.open();
+      },
+
+      _showSourceCode() {
+        if (this._sourceCodeShown) {
+          this.$$('#node-entries').style.height = '80%';
+          this.set('_sourceCodeShown', false);
+          this.set('_toggleSourceCodeButtonText', 'Show Code >>');
+        } else {
+          this.$$('#node-entries').style.height = '40%';
+          this.set('_sourceCodeShown', true);
+          this.set('_toggleSourceCodeButtonText', 'Hide Code <<');
+          this.$.sourceCodeView.render();
+        }
       },
 
       _showToast(text) {  // TODO(cais): Move to Scrolling Message View.
@@ -758,6 +820,7 @@ limitations under the License.
           // Sort the debug watches and maybe base-expand the leaf nodes.
           tf_debugger_dashboard.sortAndBaseExpandDebugWatches(debugWatches);
           this.set('_debugWatches', debugWatches);
+          this.$.sourceCodeView.render(debugWatches);  // TODO(cais): Is debugWatches necessary?
         });
       },
       _createDebugWatchChangeHandler() {
@@ -791,8 +854,18 @@ limitations under the License.
         }
         this.set('_highlightNodeName', deviceName + '/' + nodeName);
       },
-      _createListNodeClickedHandler() {
-        return((deviceName, nodeName) => {
+      _createNodeClickedHandler() {
+        return((deviceName, nodeName, skipSource) => {
+          // Args:
+          //   deviceName: Name of the device.
+          //   nodeName: Base-expanded node name.
+          //   skipSource: Whether focusing on the source file line is to be skipped.
+          if (this._sourceCodeShown && skipSource !== true) {
+            // If the source view is active, highlight the source lines.
+            this.set(
+                '_sourceFocusNodeName',
+                tf_debugger_dashboard.removeNodeNameBaseExpansion(nodeName));
+          }
           this._focusOnGraphNode(deviceName, nodeName);
           this.set('_forceExpandNodeName', deviceName + '/' + nodeName);
         });
@@ -865,6 +938,11 @@ limitations under the License.
                   this._activeRuntimeGraphDeviceName + '/' + elem.node.name;
               this.set('_forceExpandNodeName', nodeNameWithDevice);
               this.set('_highlightNodeName', nodeNameWithDevice);
+              if (this._sourceCodeShown) {
+                this.set(
+                    '_sourceFocusNodeName',
+                    tf_debugger_dashboard.removeNodeNameBaseExpansion(nodeName));
+              }
             },
           },
           {
@@ -876,6 +954,11 @@ limitations under the License.
                   tf_debugger_dashboard.getCleanNodeName(elem.node.name);
               this.set('_forceExpandAndCheckNodeName',
                        this._activeRuntimeGraphDeviceName + '/' + elem.node.name);
+              if (this._sourceCodeShown) {
+                this.set(
+                    '_sourceFocusNodeName',
+                    tf_debugger_dashboard.removeNodeNameBaseExpansion(nodeName));
+              }
             },
           },
           {
@@ -889,17 +972,30 @@ limitations under the License.
                     '", due to op type "' + elem.node.op + '".');
                 return;
               }
-              const nodeName =
-                  tf_debugger_dashboard.getCleanNodeName(elem.node.name);
-              const nodeNameWithDevice =
-                  this._activeRuntimeGraphDeviceName + '/' + elem.node.name
-              this._requestBreakpointStateChange(nodeName, 0, 'DebugIdentity', 'break');
-              this.set('_forceExpandAndCheckNodeName', nodeNameWithDevice);
-              this._setContinueTo('op', nodeNameWithDevice);
-              this._step();
+              this._continueToNode(this._activeRuntimeGraphDeviceName, elem.node.name);
             },
           }
         ];
+      },
+
+      _continueToNode(deviceName, baseExpandedNodeName) {
+        const cleanNodeName = tf_debugger_dashboard.getCleanNodeName(baseExpandedNodeName);
+        const nodeNameWithDevice = deviceName + '/' + baseExpandedNodeName;
+        this._requestBreakpointStateChange(cleanNodeName, 0, 'DebugIdentity', 'break');
+        this.set('_forceExpandAndCheckNodeName', nodeNameWithDevice);
+        if (this._sourceCodeShown) {
+          this.set(
+              '_sourceFocusNodeName',
+              tf_debugger_dashboard.removeNodeNameBaseExpansion(cleanNodeName));
+        }
+        this._setContinueTo('op', nodeNameWithDevice);
+        this._step();
+      },
+
+      _createContinueToNodeHandler() {
+        return (deviceName, baseExpandedNodeName) => {
+          this._continueToNode(deviceName, baseExpandedNodeName);
+        };
       },
 
       _onActiveRuntimeGraphDeviceNameChange(deviceName) {
@@ -1009,20 +1105,16 @@ limitations under the License.
                  selectedId === 'tab-runtime-graphs');
         this.set('_isTopRightTensorValuesActive',
                  selectedId === 'tab-tensor-values');
-        this.set('_isTopRightPythonSourceActive',
-                 selectedId === 'tab-python-source');
       },
       _setTopRightRuntimeGraphsToActive() {
         this.set('_topRightSelected', '0');
         this.set('_isTopRightRuntimeGraphsActive', true);
         this.set('_isTopRightTensorValuesActive', false);
-        this.set('_isTopRightPythonSourceActive', false);
       },
       _setTopRightTensorValuesToActive() {
         this.set('_topRightSelected', '1');
         this.set('_isTopRightRuntimeGraphsActive', false);
         this.set('_isTopRightTensorValuesActive', true);
-        this.set('_isTopRightPythonSourceActive', false);
       },
 
       /**

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-op-selector.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-op-selector.html
@@ -499,6 +499,9 @@ limitations under the License.
         for (let i = 1; i <= levelItems.length; ++i) {
           let currLevelName = levelItems.slice(0, i).join('/');
           const currTreeNode = this._levelName2Node[currLevelName];
+          if (currTreeNode != null && currTreeNode.levelDom != null) {
+            currTreeNode.levelDom.scrollIntoView({block: 'center', behaviour: 'smooth'});
+          }
 
           if (i < levelItems.length) {
             // At non-lowest level.

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-source-code-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-source-code-view.html
@@ -1,0 +1,665 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/lodash.html">
+
+<!--
+  Presents source code involved in the TensorFlow execution being debugged,
+  along with associated stack traces.
+-->
+<dom-module id="tf-source-code-view">
+  <template>
+    <div id="fullStackDialog" hidden$="[[!_fullStackShown]]">
+      <div id="full-stack-title">
+        <paper-icon-button
+          icon="filter-list"
+          disabled="true">
+        </paper-icon-button>
+        Full Stack Trace of Node:
+        <div id="full-stack-node-name">"[[_fullStackNodeName]]"</div>
+        <paper-icon-button
+          icon="close"
+          id="close-full-stack-button"
+          title="Close Full Stack"
+          on-tap="_closeFullStackDialog">
+        </paper-icon-button>
+      </div>
+      <ul id="full-stack-content"></ul>
+    </div>
+    <paper-tabs id="source-files-tabs" selected="0" selected="{{_filePathSelected}}">
+      <template is="dom-repeat" items="[[_shortFilePaths]]">
+        <paper-tab id="[[item.id]]">[[item.name]]</paper-tab>
+      </template>
+    </paper-tabs>
+    <div id='source-file-content' class='source-content'>
+      <template is="dom-repeat" items="[[_fileLines]]">
+        <div class$="{{item.sourceClass}}" id="source-line-[[item.lineno]]">
+          <span class="source-line-number" id="source-lineno-[[item.lineno]]">
+            [[item.lineno]]
+          </span>
+          <span class="source-line-node-toggle" id="source-line-node-toggle-[[item.lineno]]">
+            [[item.numNodes]]
+          </span>
+          <span class="source-line-text" id="source-line-text-[[item.lineno]]">
+            [[item.text]]
+          </span>
+          <div class="source-line-nodes" id="source-line-nodes-[[item.lineno]]">
+          </div>
+        </div>
+      </template>
+    </div>
+    <style>
+      #source-files-tabs {
+        position: relative;
+        height: 8%;
+      }
+      .source-content {
+        position: relative;
+        height: 90%;
+        font-family: monospace;
+        font-size: 90%;
+        overflow-x: scroll;
+        overflow-y: scroll;
+      }
+      .source-content :hover {
+        background-color: #ffffe0;
+      }
+      .highlighted-source-line {
+        background-color: #ffd6c1;
+      }
+      .source-line-number {
+        display: inline-block;
+        color: lightblue;
+        width: 2em;
+        text-align: right;
+        padding-right: 1em;
+      }
+      .source-line-node-toggle {
+        display: inline-block;
+        color: blue;
+        width: 5em;
+        text-align: right;
+        padding-right: 1em;
+        text-decoration: underline;
+        cursor: pointer;
+      }
+      .source-line-nodes {
+        padding-left: 4em;
+        text-decoration: underline;
+        cursor: pointer;
+        color: blue;
+        margin-top: 0em;
+        margin-bottom: 0em;
+        margin-right: 1em;
+      }
+      .source-line-node-entry {
+        margin-right: 1em;
+        background-color: yellow;
+      }
+      .source-line-nodes span {
+        text-decoration: none;
+        background-color: yellow;
+      }
+      .source-line-text {
+        display: inline;
+        word-wrap: break-word;
+      }
+      #fullStackDialog {
+        z-index: 1000;
+        position: absolute;
+        top:  10%;
+        left: 50%;
+        width: 45%;
+        height: 85%;
+        background-color: white;
+        border: 1px solid gray;
+        font-family: monospace;
+        box-shadow: 3px 3px #ddd;
+        overflow-y: auto;
+      }
+      #full-stack-title {
+        font-size: 110%;
+        position: relative;
+        width: 100%;
+        background-color: #eee;
+        text-align: center;
+        font-weight: bold;
+      }
+      #full-stack-node-name {
+        color: blue;
+      }
+      :host #full-stack-content {
+        padding-top: 1em;
+        padding-right: 0.5em;
+        margin-top: 0.5em;
+        font-size: 90%;
+        word-wrap: break-word;
+        overflow: auto;
+      }
+      .stack-frame-clickable {
+        color: blue;
+        text-decoration: underline;
+        cursor: pointer;
+      }
+      .stack-frame-nonclickable {
+        color: #555;
+      }
+      #close-full-stack-button {
+        float: right;
+      }
+    </style>
+  </template>
+  <script>
+  Polymer({
+    is: "tf-source-code-view",
+    properties: {
+      requestManager: {
+        type: Object,
+        value: null,
+      },
+
+      // The node to focus on. When focused on, the source lines that belong to
+      // the creation stack of the stack, if any, are highlighted in the active
+      // source file content view.
+      focusNodeName: {
+        type: String,
+        value: null,
+      },
+
+      // Keeps track of the old focus node. Used in removing highlighting.
+      _oldFocusNodeName: {
+        type: String,
+        value: null,
+      },
+
+      // A list of debug watches. A debug watch object has 4 properties:
+      // device_name (string), node_name (string), output_slot (number), and
+      // debug_op (string).
+      debugWatches: {
+        type: Array,
+        value: [],
+      },
+
+      // Callback for clicking event on a node.
+      // Signature of the callback:
+      // Args:
+      //   deviceName: Name of the device that the node is partitioned to.
+      //   baseExpandedNodeName: Name of the node, base-expanded if applicable.
+      nodeClicked: {
+        type: Function,
+        value: null,
+      },
+      // Callback for the action of continue to a node.
+      // Signature of the callback:
+      // Args:
+      //   deviceName: Name of the device that the node is partitioned to.
+      //   baseExpandedNodeName: Name of the node, base-expanded if applicable.
+      continueToNode: {
+        type: Function,
+        value: null,
+      },
+
+      // Keeps tracek of the currently highlighted elements.
+      _highlightedElements: {
+        type: Array,
+        value: [],
+      },
+
+      _filePathSelected: String,
+
+      // Full paths to the source files.
+      _fullFilePaths: {
+        type: Array,
+        value: null,
+      },
+
+      // Shortened pathst to the source files.
+      _shortFilePaths: {
+        type: Array,
+        value: null,
+      },
+      _fileLines: {
+        type: Array,
+        value: null,
+      },
+
+      // A map from non-base-expanded node name to device name.
+      _nodeName2DeviceName: {
+        type: Object,
+        value: null,
+      },
+
+      // A map from non-base-expanded node name to device base-expanded node name.
+      _nodeName2BaseExpandedNodeName: {
+        type: Object,
+        value: null,
+      },
+
+      // A map from non-base-expanded node name to node elements.
+      // A node name may correspond to multiple node elements because a source
+      // file may have multiple lines that belong to the creation stack of the
+      // node.
+      _nodeName2NodeElements: {
+        type: Object,
+        value: null,
+      },
+
+      // A map from non-base-expanded node name to node element at the top of
+      // the stack trace for the current active source file.
+      _nodeName2StackTopNodeElement: {
+        type: Object,
+        value: null,
+      },
+
+      // Keeps track of the origin of the setting node highlight (if any).
+      // If it is set, focus will not be unchanged, instead of being changed to
+      // the node element at the topmost stack position of the current source
+      // file.
+      _setHightlightOriginNodeElement: {
+        type: Object,
+        value: null,
+      },
+
+      _fullStackShown: {
+        type: Boolean,
+        value: false,
+      },
+
+      // Name of the node whose full stack is being shown (if _fullStackShown).
+      _fullStackNodeName: {
+        type: String,
+        value: null,
+      },
+
+      _renderDelayMillis: {
+        type: Number,
+        value: 50,
+        readonly: true,
+      },
+    },
+    observers: [
+      "_renderFile(_filePathSelected)",
+      "_focusOnNode(focusNodeName)",
+    ],
+
+    render(debugWatches) {
+      if (debugWatches != null) {
+        this.set('_debugWatches', debugWatches);
+      }
+      this._querySourceCodeEndPoint({'mode': 'paths'}).then(response => {
+        this.set('_fullFilePaths', response['paths']);
+        const shortFilePaths= response['paths'].map(path => {
+            return {id: path, name: this._shortenPath(path, response['paths'])};
+        });
+        this.set('_shortFilePaths', shortFilePaths);
+        if (shortFilePaths.length > 0) {
+          this.set('_filePathSelected', null);
+          this.set('_filePathSelected', 0);
+        }
+      });
+    },
+
+    _shortenPath(path, paths) {
+      // TODO(cais): More sophisticated logic for dealing with name collisions.
+      path = path.replace(/\\/g, '/');
+      const pathItems = path.split('/');
+      return pathItems[pathItems.length - 1];
+    },
+
+    _renderFile(selectedId) {
+      if (selectedId == null) {
+        return;
+      }
+      const filePathSelected = this._shortFilePaths[selectedId].id;
+      this._querySourceCodeEndPoint(
+          {'mode': 'content', 'file_path': filePathSelected}).then(response => {
+        const fileLines = [];
+        const fileContent = response['content'][filePathSelected];
+        const linenoToNodeNameAndStackPos = response['lineno_to_op_name_and_stack_pos'];
+
+        // Get the total number of nodes, to be displayed alongside the number
+        // of active nodes, i.e., the number of nodes that are present in the
+        // active runtime graph.
+        const linenoToTotalNumNodes = {};
+        for (const lineno in linenoToNodeNameAndStackPos) {
+          if (!linenoToNodeNameAndStackPos.hasOwnProperty(lineno)) {
+            continue;
+          }
+          linenoToTotalNumNodes[lineno] = linenoToNodeNameAndStackPos[lineno].length;
+        }
+        // Discard the nodes that are defined by the lines, but are not present
+        // in the watched subset of the current runtime graph.
+        this._filterFileTracebacksByDebugWatches(linenoToNodeNameAndStackPos);
+
+        for (let i = 0; i < fileContent.length; ++i) {
+          const lineno = i + 1;
+          fileLines.push({
+            lineno: lineno,
+            numNodes: linenoToNodeNameAndStackPos[lineno] != null ?
+                String(linenoToNodeNameAndStackPos[lineno].length) + '/' +
+                String(linenoToTotalNumNodes[lineno]) + ' ▼' : '',
+            text: this._htmlEscape(fileContent[i]),
+          });
+        }
+        this.set('_fileLines', fileLines);
+
+        const self = this;
+        setTimeout(() => {
+          // Add the op names to the source-line-nodes-${lineno} divs.
+          const nodeName2NodeElements = {};
+          const nodeName2StackTopNodeElement = {};
+          for (const lineno in linenoToNodeNameAndStackPos) {
+            if (!linenoToNodeNameAndStackPos.hasOwnProperty(lineno)) {
+              continue;
+            }
+            const nodesElement = self.$$('#source-line-nodes-' + lineno);
+            // First, remove all existing children.
+            while (nodesElement.firstChild) {
+              nodesElement.removeChild(nodesElement.firstChild);
+            }
+            const nodeNamesAndStackPositions = linenoToNodeNameAndStackPos[lineno];
+            nodeNamesAndStackPositions.sort(function(a, b) {
+              if (a[0] < b[0]) {
+                return -1;
+              } else if (a[0] > b[0]) {
+                return 1;
+              } else {
+                return 0;
+              }
+            });
+            // TODO(cais): Maybe instead of sorting by name, we should sort
+            // the nodes topologically according to the graph structure.
+
+            for (let i = 0; i < nodeNamesAndStackPositions.length; ++i) {
+              const nodeName = nodeNamesAndStackPositions[i][0];
+              const stackPos = nodeNamesAndStackPositions[i][1];
+
+              const nodeDiv = document.createElement('div');
+
+              const nodeElement = document.createElement('span');
+              nodeElement.setAttribute('class', 'source-line-node-enttry');
+              nodeElement.setAttribute('sourceLineno', lineno);
+              nodeElement.textContent = nodeName;
+              nodeElement.addEventListener('tap', () => {
+                this.nodeClicked(
+                    this._nodeName2DeviceName[nodeName],
+                    this._nodeName2BaseExpandedNodeName[nodeName], true);
+              });
+
+              // Icon button for showing full stack trace.
+              const fullStackLink = document.createElement('paper-icon-button');
+              fullStackLink.setAttribute('icon', 'filter-list');
+              fullStackLink.setAttribute('title', 'Show stack');
+              fullStackLink.addEventListener('tap', () => {
+                this._highlightNodeElements(nodeName);
+                this.set('_fullStackNodeName', nodeName);
+                this.set('_fullStackShown', true);
+                this._populateFullStack(
+                    nodeName, this._fullFilePaths[this._filePathSelected], Number(lineno));
+              });
+
+              // Icon button for continue-to.
+              const continueToLink = document.createElement('paper-icon-button');
+              continueToLink.setAttribute('icon', 'forward');
+              continueToLink.setAttribute('title', 'Continue to');
+              // TOOD(cais): Properly style the paper-icon-button.
+              continueToLink.addEventListener('tap', () => {
+                const deviceName = this._nodeName2DeviceName[nodeName];
+                const baseExpandedNodeName = this._nodeName2BaseExpandedNodeName[nodeName];
+                this.set('_setHightlightOriginNodeElement', nodeElement);
+                this.continueToNode(deviceName, baseExpandedNodeName);
+              });
+
+              nodeDiv.appendChild(fullStackLink);
+              nodeDiv.appendChild(continueToLink);
+              nodeDiv.appendChild(nodeElement);
+              nodesElement.appendChild(nodeDiv);
+              if (!nodeName2NodeElements.hasOwnProperty(nodeName)) {
+                nodeName2NodeElements[nodeName] = [];
+              }
+              nodeName2NodeElements[nodeName].push(nodeElement);
+
+              if (!nodeName2StackTopNodeElement.hasOwnProperty(nodeName)) {
+                nodeName2StackTopNodeElement[nodeName] = [nodeElement, stackPos];
+              }
+              if (stackPos > nodeName2StackTopNodeElement[nodeName][1]) {
+                nodeName2StackTopNodeElement[nodeName] = [nodeElement, stackPos];
+              }
+            }
+            // The node elements are initially hidden.
+            nodesElement.setAttribute('hidden', true);
+
+            const toggleNodesElement = self.$$('#source-line-node-toggle-' + lineno);
+            if (toggleNodesElement.getAttribute('tapCallbackSet') == null) {
+              toggleNodesElement.addEventListener('tap', () => {
+                self._toggleLineNodes(lineno);
+              });
+              toggleNodesElement.setAttribute('tapCallbackSet', true);
+            }
+          }
+          self.set('_nodeName2NodeElements', nodeName2NodeElements);
+
+          for (const nodeName in nodeName2StackTopNodeElement) {
+            if (!nodeName2StackTopNodeElement.hasOwnProperty(nodeName)) {
+              continue;
+            }
+            nodeName2StackTopNodeElement[nodeName] = nodeName2StackTopNodeElement[nodeName][0];
+          }
+          self.set('_nodeName2StackTopNodeElement', nodeName2StackTopNodeElement);
+        }, this._renderDelayMillis);
+      });
+    },
+
+    // Toggle the expand / collapse state of the nodes of a given source line.
+    // Args:
+    //   lineno: 1-based line number.
+    //   expansionState: (Optional) desired expansion state: a Boolean, `true`
+    //     for expanded and `false` for collapsed.
+    _toggleLineNodes(lineno, expansionState) {
+      const nodesElement = this.$$('#source-line-nodes-' + lineno);
+      if (nodesElement.getAttribute('hidden') == null && expansionState !== true) {
+        nodesElement.setAttribute('hidden', true);
+      } else {
+        nodesElement.removeAttribute('hidden');
+      }
+    },
+
+    // Filter file tracebacks by debug watches: discard nodes that are not
+    // present in the debug watches are removed.
+    //
+    // As a side effect, this function also populates the nodeName2DeviceName
+    // and nodeName2BaseExpandedNodeName maps.
+    //
+    // Args:
+    //   linenoToNodeNameAndStackPos: A map from line number (lineno) to Arrays
+    //     of [nodeName, stackPos] tuples.
+    //     nodeName is the name of the node without base expansion.
+    //     stackPos is the 0-based stack position.
+    _filterFileTracebacksByDebugWatches(linenoToNodeNameAndStackPos) {
+      // First, build an Array of node names present in the debugWatches.
+      const watchedNodeNames = this.debugWatches.map(
+          watch => tf_debugger_dashboard.removeNodeNameBaseExpansion(watch.node_name));
+      // Build a map from node name to device name, using the debugWatches.
+      const nodeName2DeviceName = {};
+      const nodeName2BaseExpandedNodeName = {};
+      for (const watch of this.debugWatches) {
+        const nodeName = tf_debugger_dashboard.removeNodeNameBaseExpansion(watch.node_name);
+        nodeName2DeviceName[nodeName] = watch.device_name;
+        nodeName2BaseExpandedNodeName[nodeName] = watch.node_name;
+      }
+      this.set('_nodeName2DeviceName', nodeName2DeviceName);
+      this.set('_nodeName2BaseExpandedNodeName', nodeName2BaseExpandedNodeName);
+
+      for (const lineno in linenoToNodeNameAndStackPos) {
+        if (!linenoToNodeNameAndStackPos.hasOwnProperty(lineno)) {
+          continue;
+        }
+        linenoToNodeNameAndStackPos[lineno] =
+            linenoToNodeNameAndStackPos[lineno].filter(line => {
+              const nodeName = line[0];
+              return _.contains(watchedNodeNames, nodeName);
+            });
+      }
+    },
+
+    _querySourceCodeEndPoint(params) {
+      const baseUrl = tf_backend.getRouter().pluginRoute('debugger',
+                                                         '/source_code');
+      const url = tf_backend.addParams(baseUrl, params);
+      return this.requestManager.request(url);
+    },
+
+    _htmlEscape(string) {
+      // TODO(cais): Deal with other charcters that require HTML-escaping, e.g.,
+      //   '>', '<'.
+      return string.replace(/ /g, '\u00a0');nodeName
+    },
+
+    // Focus on a given op: if any lines in the currently active source file
+    // content view, highlight them.
+    _focusOnNode(nodeName) {
+      if (nodeName == null) {
+        return;
+      }
+      const filePathSelected = this._shortFilePaths[this._filePathSelected].id;
+      const self = this;
+      this._querySourceCodeEndPoint(
+          {'mode': 'op_traceback', 'op_name': nodeName}).then(response => {
+        const opTraceback = response['op_traceback'][nodeName];
+        const highlightLinenos = [];
+        for (let i = 0; i < opTraceback.length; ++i) {
+          const filePath = opTraceback[i][0];
+          const lineno = opTraceback[i][1];
+          if (filePath === filePathSelected) {
+            highlightLinenos.push(lineno);
+          }
+        }
+        const scrollToLineno = highlightLinenos[highlightLinenos.length - 1];
+
+        // Remove old highlight first.
+        for (const highlightedElement of self._highlightedElements) {
+          highlightedElement.classList.remove('highlighted-source-line');
+        }
+        const highlightedElements = [];
+        // Add new highlight to line(s).
+        for (const highlightLineno of highlightLinenos) {
+          const lineElement = this.$$('#source-line-' + highlightLineno);
+          highlightedElements.push(lineElement);
+          lineElement.classList.add('highlighted-source-line');
+          // Expand the node name list.
+          self._toggleLineNodes(highlightLineno, true);
+        }
+        self.set('_highlightedElements', highlightedElements);
+
+        this._highlightNodeElements(nodeName);
+      });
+    },
+
+    // Highlight all node elements corresponding to the specified node.
+    // A node may correspond to multiple node elements, because the creation
+    // stack of the node may involve more than one line in the current source
+    // file.
+    // Args:
+    //   nodeName: Name of the node, without base expansion.
+    _highlightNodeElements(nodeName) {
+      // Remove the higlighting on the node elements of the pervious focus node.
+      if (this._oldFocusNodeName !=  null) {
+        for (const nodeElement of this._nodeName2NodeElements[this._oldFocusNodeName]) {
+          nodeElement.style['font-weight'] = 'normal';
+        }
+      }
+      // Add highlighting on the current focus node.
+      for (const nodeElement of this._nodeName2NodeElements[nodeName]) {
+        nodeElement.style['font-weight'] = 'bold';
+      }
+      // Scroll to the node element at the topmost stack position in the
+      // current source file, unless this is a continue-to action originated from
+      // a given node element, which is not necessarily the topmost stack position.
+      if (this._setHightlightOriginNodeElement == null) {
+        this._nodeName2StackTopNodeElement[nodeName].scrollIntoView(
+            {block: 'center', behaviour: 'smooth'});
+      } else {
+        this.set('_setHightlightOriginNodeElement', null);
+      }
+      this.set('_oldFocusNodeName', nodeName);
+    },
+
+    // Populate the display of node full stack.
+    // Args:
+    //   nodeName: The name of the node whose stack is to be shown.
+    //   currentFullFilePath: The full path to the source file currently being
+    //     displayed.
+    //   curerntLineno: The current source line number being displayed.
+    _populateFullStack(nodeName, currentFullFilePath, currentLineno) {
+      this._querySourceCodeEndPoint(
+          {'mode': 'op_traceback', 'op_name': nodeName}).then(response => {
+        const stackContent = this.$$('#full-stack-content');
+        // First, remove all children of the full stack content div.
+        while (stackContent.firstChild) {
+          stackContent.removeChild(stackContent.firstChild);
+        }
+        // Then, create all the clickable links.
+        for (const stackFrame of response['op_traceback'][nodeName]) {
+          const frameElement = document.createElement('li');
+          const fullFilePath = stackFrame[0];
+          const lineno = Number(stackFrame[1]);
+          frameElement.textContent = fullFilePath + ': ' + String(lineno);
+          if (_.contains(this._fullFilePaths, fullFilePath)) {
+            frameElement.classList.add('stack-frame-clickable');
+            // TODO(cais): Make class CSS work.
+            frameElement.style['color'] = 'blue';
+            frameElement.style['text-decoration'] = 'underline';
+            frameElement.style['cursor'] = 'pointer';
+            if (fullFilePath === currentFullFilePath && lineno === currentLineno) {
+              frameElement.style['font-weight'] = 'bold';
+            }
+            // Create callback for the frame element.
+            frameElement.addEventListener('tap', () => {
+              const fileId = this._fullFilePaths.indexOf(fullFilePath);
+              this.set('_filePathSelected', fileId);
+              setTimeout(() => {
+                this._toggleLineNodes(lineno, true);
+                for (const nodeElement of this._nodeName2NodeElements[nodeName]) {
+                  if (Number(nodeElement.getAttribute('sourceLineno')) === Number(lineno)) {
+                    nodeElement.scrollIntoView({block: 'center', behaviour: 'smooth'});
+                    this.set('_setHightlightOriginNodeElement', frameElement);
+                    this._highlightNodeElements(nodeName);
+                    // If going to a different stack frame, re-render the full stack.
+                    if (currentFullFilePath !== fullFilePath || currentLineno !== lineno) {
+                      this._populateFullStack(nodeName, fullFilePath, lineno);
+                    }
+                  }
+                }
+              }, this._renderDelayMillis * 2);
+            });
+          } else {
+            frameElement.classList.add('stack-frame-nonclickable');
+            // TODO(cais): Make class CSS work.
+            frameElement.style['color'] = '#555';
+          }
+          stackContent.appendChild(frameElement);
+        }
+      });
+    },
+
+    _closeFullStackDialog() {
+      this.set('_fullStackShown', false);
+    }
+  });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
@@ -67,6 +67,10 @@ limitations under the License.
       .value-expansion-link :hover {
         color: blue;
       }
+      .tensor-name {
+        text-decoration: underline;
+        cursor: pointer;
+      }
     </style>
   </template>
   <script>
@@ -95,6 +99,16 @@ limitations under the License.
       // For externally ordered highlighting of a tensor row.
       highlightedNodeName: {
         type: String,
+        value: null,
+      },
+
+      // Callback for clicking/tapping of a tensor name.
+      // Signature of the callback:
+      // Args:
+      //   deviceName
+      //   baseExpandedNodeName
+      tensorNameClicked: {
+        type: Function,
         value: null,
       },
 
@@ -207,7 +221,14 @@ limitations under the License.
 
       const tensorDataRow = document.createElement('tr');
       const tensorNameCell = document.createElement('td');
+      tensorNameCell.classList.add('tensor-name');
       tensorNameCell.textContent = tensorName;
+      tensorNameCell.addEventListener('tap', () => {
+        if (this.tensorNameClicked != null) {
+          this.tensorNameClicked(deviceName, maybeBaseExpandedNodeName);
+        }
+      });
+
       const countCell = document.createElement('td');
       countCell.textContent = count;
       if (isActive) {
@@ -251,6 +272,7 @@ limitations under the License.
       }
 
       Polymer.dom(this.$$('#tensor-data-table')).appendChild(tensorDataRow);
+      tensorDataRow.scrollIntoView({block: 'end', inline: 'nearest', behaviour: 'smooth'});
     },
 
     _highlight(nodeName) {
@@ -274,6 +296,7 @@ limitations under the License.
       // Add highlight to the rows with matching node names.
       for (let i = 0; i < rowsToHighlight.length; ++i) {
         rowsToHighlight[i].classList.add('highlighted');
+        rowsToHighlight[i].scrollIntoView({block: 'end', inline: 'nearest', behaviour: 'smooth'});
       }
     },
   });


### PR DESCRIPTION
Main feature:
* Viewing the Python source code files involved in the creation of nodes
  of the graph. (Only files outside the TensorFlow library are
  included.)
* Lines of the code files are annotated with collapsible views of the
  nodes whose creation stacks involve the lines.
* Clicking the node names in the Source Code View will focus on the
  corresponding node in the Node List, the Graph View and the Tensor
  Value Overview.
* Clicking the "forward" icon button next to the node name in the
  Source Code View will cause the debugger to continue to the node and
  display any tensor values in the Tensor Value Overview.
* Clicking the "stack" icon button right next to the node name will
  open a sticky dialog that shows the full stack trace of the node's
  creation. The stack trace contains clickable links that enables
  the user to navigate to various frames of the stack, potentially
  located in different source files.

Front end tested manually. Backend PyUnit tests added.