### PR TITLE
Fix scalars demo summary writing race condition

### DIFF
--- a/tensorboard/plugins/scalar/scalars_demo.py
+++ b/tensorboard/plugins/scalar/scalars_demo.py
@@ -92,11 +92,13 @@ def run(logdir, run_name,
              description='The change in temperature from the previous '
                          'step, in Kelvins.')
 
-  # Now, augment the current temperature by this delta that we computed.
-  update_step = temperature.assign_add(delta)
-
   # Collect all the scalars that we want to keep track of.
   summ = tf.summary.merge_all()
+
+  # Now, augment the current temperature by this delta that we computed,
+  # blocking the assignment on summary collection to avoid race conditions.
+  with tf.control_dependencies([summ]):
+    update_step = temperature.assign_add(delta)
 
   sess = tf.Session()
   writer = tf.summary.FileWriter(os.path.join(logdir, run_name))

--- a/tensorboard/plugins/scalar/scalars_demo.py
+++ b/tensorboard/plugins/scalar/scalars_demo.py
@@ -96,7 +96,8 @@ def run(logdir, run_name,
   summ = tf.summary.merge_all()
 
   # Now, augment the current temperature by this delta that we computed,
-  # blocking the assignment on summary collection to avoid race conditions.
+  # blocking the assignment on summary collection to avoid race conditions
+  # and ensure that the summary always reports the pre-update value.
   with tf.control_dependencies([summ]):
     update_step = temperature.assign_add(delta)
 


### PR DESCRIPTION
This makes the scalars demo generate 100% deterministic deterministic summary output, by correcting for a race condition that probably afflicts a significant amount of TensorFlow summary-writing code.

The general race condition occurs when summary ops are fetched (in a `sess.run()` call) alongside ops that mutate a variable on which the actual summary values depend.  The scalars demo is a particularly simple example of this (there's a temperature variable that is incremented in each step, and also written out as a scalar summary), but many kinds of other TF graphs have a fundamentally similar structure. [1]

The problem lies in the fact that a `sess.run()` call with multiple fetches doesn't guarantee to execute the fetches in any particular order beyond what are expressed in explicit dependencies (either data dependencies, or "manual" control dependencies).  And in particular, if a leaf node (like typical summary ops) depends directly on a variable, it can be executed before *or* after the variable is updated - and indeed in practice the ordering appears to be non-deterministic. [2]

The straightforward fix (and the one I use here) is adding a control dependency so that the variable update op depends on the summary ops that use the original variable value, ensuring that the summaries are generated using the pre-update value.  If instead one wants summaries to report the post-update value, control dependencies are still an option, but it's also easy to achieve that by just dangling the summary ops off the new value, after decomposing the update like this:

```python
new_value = compute_new_value(var)
tb.summary.scalar(new_value)
var.assign(new_value)
```

I believe a similar data-dependency-only strategy would also be possible for summaries using the pre-update value by just inserting a `tf.identity` op to "cache" the original variable value V in a new tensor V', then dangling the summaries and the computation of the new value off of V' - the identity op result will be computed before the variable update due to the data dependency, and since multiple fetches in `sess.run()` do guarantee to execute any shared op in the graph exactly once, the summary op will also pick up V' with the original variable value - though I haven't tested this approach, and it's a bit more subtle/tricky than the control dependency approach.

[1] I tried to reproduce this race condition with the mnist tutorial code and failed to do so, but I suspect it's still affected in theory - I think it only wasn't showing the race because the variable update for even a relatively simple graph like the mnist tutorial one is expensive enough that it always seems to execute after the summary ops.

[2] See for more details:
https://stackoverflow.com/questions/37854477/fixing-race-condition-in-tensorflow-run
https://www.quora.com/Does-TensorFlow-evaluate-common-nodes-to-multiple-ops-multiple-times