### PR TITLE
Store left pane width in local storage and URL

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -324,6 +324,8 @@ limitations under the License.
   </template>
   <script src="tensor-shape-helper.js"></script>
   <script>
+    const _DEFAULT_LEFT_PANE_WIDTH = 450;
+    const _MAIN_CONTENT_LEFT_PADDING = 8;
 
     Polymer({
       is: 'tf-debugger-dashboard',
@@ -465,12 +467,14 @@ limitations under the License.
 
         _leftPaneWidth: {
           type: Number,
-          value: 450,
+          value: tf_storage.getNumberInitializer(
+              '_leftPaneWidth', {defaultValue: _DEFAULT_LEFT_PANE_WIDTH}),
+          observer: '_leftPaneWidthObserver',
         },
 
         _minleftPaneWidth: {
           type: Number,
-          value: 450,
+          value: _DEFAULT_LEFT_PANE_WIDTH,
           readOnly: true,
         },
 
@@ -1078,9 +1082,14 @@ limitations under the License.
       },
       _sizeDashboardRegions(leftPaneWidth, windowWidth) {
         this.$$('#left-pane').style.width = leftPaneWidth + 'px';
-        this.$$('#center-content').style.width = (
-            windowWidth - leftPaneWidth - this._resizerWidth) + 'px';
+        const contentWidth = windowWidth -
+            leftPaneWidth -
+            this._resizerWidth -
+            _MAIN_CONTENT_LEFT_PADDING;
+        this.$$('#center-content').style.width = contentWidth + 'px';
       },
+      _leftPaneWidthObserver: tf_storage.getNumberObserver(
+          '_leftPaneWidth', {defaultValue: _DEFAULT_LEFT_PANE_WIDTH}),
     });
 
     tf_tensorboard.registerDashboard({


### PR DESCRIPTION
We store the left pane width of the debugger dashboard within local
storage as well as within the _leftPaneWidth GET param. That way, when
the user revisits the debugger dashboard, the width will be restored.

We store the default width of the left pane within a
`_DEFAULT_LEFT_PANE_WIDTH` variable.

We also add 8px of padding to the main content area:

![image](https://user-images.githubusercontent.com/4221553/34544652-6ac38cb0-f09c-11e7-9c0f-20eca0901037.png)

This change makes it easier to review #848.
  
  
  