### PR TITLE
Use `pip install tf-nightly` within .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,7 @@ before_install:
         pip install -I tensorflow
         ;;
       NIGHTLY)
-        if [[ "${TRAVIS_PYTHON_VERSION}" == 2* ]]; then
-        NIGHTLY_URL='https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-1.head-cp27-none-linux_x86_64.whl'
-        else
-        NIGHTLY_URL='https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-1.head-cp34-cp34m-linux_x86_64.whl'
-        fi
-        pip install -I "${NIGHTLY_URL}"
+        pip install -I tf-nightly
         ;;
       *)
         pip install -I tensorflow=="${TF}"


### PR DESCRIPTION
The security certificate of ci.tensorflow.org expired, causing TensorBoard's tests on travis to fail. See https://github.com/tensorflow/tensorflow/issues/15827.

This change enables our travis environment to successfully install tf-nightly.

Unfortunately, the travis tests still fail after this PR goes in, but that is because of https://github.com/tensorflow/tensorflow/issues/15777. We are still deciding what to do there - we might have to dockerize tests.

Anyways, fixing the issue caused by the expired certificate will let us focus on that different issue. Thanks to @nfelt for suggesting that we try using `pip install tf-nightly`.