### PR TITLE
Add xAxisFormatter property to vz-line-chart

### DIFF
--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -108,6 +108,14 @@ Polymer({
     xComponentsCreationMethod: {type: Object, value: () => stepX},
 
     /**
+     * A formatter for values along the X-axis. Optional. Defaults to a
+     * reasonable formatter.
+     * 
+     * @type {@type {function(number): string}
+     */
+    xAxisFormatter: Object,
+
+    /**
      * A method that implements the Plottable.IAccessor<number> interface. Used
      * for accessing the y value from a data point.
      *
@@ -358,7 +366,8 @@ Polymer({
           this.fillArea,
           this.defaultXRange,
           this.defaultYRange,
-          this.symbolFunction);
+          this.symbolFunction,
+          this.xAxisFormatter);
       var div = d3.select(this.$.chartdiv);
       chart.renderTo(div);
       this._chart = chart;
@@ -464,7 +473,8 @@ class LineChart {
       fillArea: FillArea,
       defaultXRange?: number[],
       defaultYRange?: number[],
-      symbolFunction?: SymbolFn) {
+      symbolFunction?: SymbolFn,
+      xAxisFormatter?: (number) => string) {
     this.seriesNames = [];
     this.name2datasets = {};
     this.colorScale = colorScale;
@@ -493,7 +503,8 @@ class LineChart {
         yValueAccessor,
         yScaleType,
         tooltipColumns,
-        fillArea);
+        fillArea,
+        xAxisFormatter);
   }
 
   private buildChart(
@@ -501,7 +512,8 @@ class LineChart {
       yValueAccessor: Plottable.IAccessor<number>,
       yScaleType: string,
       tooltipColumns: TooltipColumn[],
-      fillArea: FillArea) {
+      fillArea: FillArea,
+      xAxisFormatter: (number) => string) {
     if (this.outer) {
       this.outer.destroy();
     }
@@ -510,6 +522,9 @@ class LineChart {
     this.xScale = xComponents.scale;
     this.xAxis = xComponents.axis;
     this.xAxis.margin(0).tickLabelPadding(3);
+    if (xAxisFormatter) {
+      this.xAxis.formatter(xAxisFormatter);
+    }
     this.yScale = LineChart.getYScaleFromType(yScaleType);
     this.yAxis = new Plottable.Axes.Numeric(this.yScale, 'left');
     let yFormatter = multiscaleFormatter(

--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -111,7 +111,7 @@ Polymer({
      * A formatter for values along the X-axis. Optional. Defaults to a
      * reasonable formatter.
      * 
-     * @type {@type {function(number): string}
+     * @type {function(number): string}
      */
     xAxisFormatter: Object,
 


### PR DESCRIPTION
This lets the user specify a custom formatter for values along the X
axes of line charts which allows, for instance, plugin authors to round
those values to a certain number of decimal places.

Test plan: Introduce a custom formatter to charts within the scalars
dashboard:

```ts
_xAxisFormatter: {
  type: Object,
  value: () => d3.format('d'),
},
```

Notice that, for instance, this custom formatter rounds values to
integers.

![image](https://user-images.githubusercontent.com/4221553/34808952-b746609e-f646-11e7-8652-aacf527c431f.png)

Without that formatter, the rounding does not happen:

![image](https://user-images.githubusercontent.com/4221553/34808693-660663f6-f645-11e7-9a2e-1f34075cc21a.png)

FYI @trisolaran 