### PR TITLE
Only open first two panes by default

### DIFF
--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
@@ -72,7 +72,7 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
             <iron-icon prefix icon="search"></iron-icon>
           </paper-input>
           <template is="dom-repeat" items="[[_categories]]" as="category">
-            <tf-category-pane category="[[category]]">
+            <tf-category-pane category="[[category]]" opened="[[_shouldOpen(index)]]">
               <tf-paginated-view
                 items="[[category.items]]"
                 pages="{{category._pages}}"
@@ -158,6 +158,10 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
         this.querySelectorAll('tf-audio-loader').forEach(audio => {
           audio.reload();
         });
+      },
+
+      _shouldOpen(index) {
+        return index <= 2;
       },
 
       _makeCategories(runToTagInfo, selectedRuns, tagFilter) {

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
@@ -84,7 +84,7 @@ limitations under the License.
         <template is="dom-if" if="[[!_dataNotFound]]">
           <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
-            <tf-category-pane category="[[category]]">
+            <tf-category-pane category="[[category]]" opened="[[_shouldOpen(index)]]">
               <tf-paginated-view
                 items="[[category.items]]"
                 pages="{{category._pages}}"
@@ -182,6 +182,10 @@ limitations under the License.
         this.querySelectorAll('tf-distribution-loader').forEach(loader => {
           loader.reload();
         });
+      },
+
+      _shouldOpen(index) {
+        return index <= 2;
       },
 
       _makeCategories(runToTag, selectedRuns, tagFilter, categoriesDomReady) {

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -91,7 +91,7 @@ limitations under the License.
         <template is="dom-if" if="[[!_dataNotFound]]">
           <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
-            <tf-category-pane category="[[category]]">
+            <tf-category-pane category="[[category]]" opened="[[_shouldOpen(index)]]">
               <tf-paginated-view
                 items="[[category.items]]"
                 pages="{{category._pages}}"
@@ -195,6 +195,10 @@ limitations under the License.
         this.querySelectorAll('tf-histogram-loader').forEach(histogram => {
           histogram.reload();
         });
+      },
+
+      _shouldOpen(index) {
+        return index <= 2;
       },
 
       _makeCategories(runToTag, selectedRuns, tagFilter, categoriesDomReady) {

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
@@ -115,7 +115,7 @@ TensorFlow run.
         <template is="dom-if" if="[[!_dataNotFound]]">
           <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
-            <tf-category-pane category="[[category]]">
+            <tf-category-pane category="[[category]]" opened="[[_shouldOpen(index)]]">
               <tf-paginated-view
                 items="[[category.items]]"
                 pages="{{category._pages}}"
@@ -268,6 +268,10 @@ TensorFlow run.
         this.querySelectorAll('tf-image-loader').forEach(image => {
           image.reload();
         });
+      },
+
+      _shouldOpen(index) {
+        return index <= 2;
       },
 
       _resetBrightness() {

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
@@ -92,7 +92,7 @@ limitations under the License.
         <template is="dom-if" if="[[!_dataNotFound]]">
           <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
-            <tf-category-pane category="[[category]]">
+            <tf-category-pane category="[[category]]" opened="[[_shouldOpen(index)]]">
               <tf-paginated-view
                 items="[[category.items]]"
                 pages="{{category._pages}}"
@@ -193,6 +193,9 @@ limitations under the License.
           [this._fetchTags(), this._fetchTimeEntriesPerRun()]).then(() => {
         this._reloadCards();
       });
+    },
+    _shouldOpen(index) {
+      return index <= 2;
     },
     _fetchTags() {
       const url = tf_backend.getRouter().pluginRoute('pr_curves', '/tags');

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -121,7 +121,7 @@ limitations under the License.
         <template is="dom-if" if="[[!_dataNotFound]]">
           <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
-            <tf-category-pane category="[[category]]">
+            <tf-category-pane category="[[category]]" opened="[[_shouldOpen(index)]]">
               <tf-paginated-view
                 items="[[category.items]]"
                 pages="{{category._pages}}"
@@ -243,6 +243,10 @@ limitations under the License.
           '_ignoreYOutliers', {defaultValue: true, useLocalStorage: true}),
       _computeSmoothingEnabled(_smoothingWeight) {
         return _smoothingWeight > 0;
+      },
+
+      _shouldOpen(index) {
+        return index <= 2;
       },
 
       ready() {

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
@@ -64,7 +64,7 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
         <template is="dom-if" if="[[!_dataNotFound]]">
           <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
-            <tf-category-pane category="[[category]]">
+            <tf-category-pane category="[[category]]" opened="[[_shouldOpen(index)]]">
               <tf-paginated-view
                 items="[[category.items]]"
                 pages="{{category._pages}}"
@@ -127,6 +127,9 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
         this._fetchTags().then(() => {
           this._reloadTexts();
         });
+      },
+      _shouldOpen(index) {
+        return index <= 2;
       },
       _fetchTags() {
         const url = tf_backend.getRouter().pluginRoute('text', '/tags');


### PR DESCRIPTION
This will prevent TensorBoard from using too many resources for anyone with a
large number of tags. In the near future we might want to solve this in a
smarter way, possibly by not rendering things outside the viewport.

See also #728