### PR TITLE
Rebuild graph hierarchy if callbacks changed

### DIFF
--- a/tensorboard/plugins/graph/tf_graph/tf-graph.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.html
@@ -125,9 +125,6 @@ Polymer({
     // An array of ContextMenuItem objects. Items that appear in the context
     // menu for a node.
     nodeContextMenuItems: Array,
-    // A function with signature EdgeThicknessFunction that computes the
-    // thickness of a given edge.
-    edgeWidthFunction: Object,
     _renderDepth: {
       type: Number,
       value: 1
@@ -141,29 +138,64 @@ Polymer({
     // The step of health pills to show throughout the graph.
     healthPillStepIndex: Number,
     /**
+     * A function with signature EdgeThicknessFunction that computes the
+     * thickness of a given edge.
+     *
+     * We initialize with the empty string value so that the observer that
+     * builds the graph hierarchy is called even if this is not defined.
+     */
+    edgeWidthFunction: {
+      type: Object,
+      value: '',
+    },
+    /**
      * An optional function that takes a node selected event (whose `detail`
      * property is the selected node ... which could be null if a node is
      * deselected). Called whenever a node is selected or deselected.
+     *
+     * We initialize with the empty string value so that the observer that
+     * builds the graph hierarchy is called even if this is not defined.
      * @type {Function}
      */
-    handleNodeSelected: Object,
+    handleNodeSelected: {
+      type: Object,
+      value: '',
+    },
     /**
      * An optional function that computes the label for an edge. Should
      * implement the EdgeLabelFunction signature.
+     *
+     * We initialize with the empty string value so that the observer that
+     * builds the graph hierarchy is called even if this is not defined.
      * @type {Function}
      */
-    edgeLabelFunction: Object,
+    edgeLabelFunction: {
+      type: Object,
+      value: '',
+    },
     /**
      * An optional callback that implements the
      * tf.graph.edge.EdgeSelectionCallback signature. If provided, edges are
      * selectable, and this callback is run when an edge is selected.
+     *
+     * We initialize with the empty string value so that the observer that
+     * builds the graph hierarchy is called even if this is not defined.
      * @type {Function}
      */
-    handleEdgeSelected: Object,
+    handleEdgeSelected: {
+      type: Object,
+      value: '',
+    },
   },
   observers: [
     '_statsChanged(stats, devicesForStats)',
-    '_buildRenderHierarchy(graphHierarchy)',
+    // We must re-render the graph hierarchy if any handlers are defined.
+    // Otherwise, the graph hierarchy might be created before the handlers are
+    // set on the hierarchy, and the handlers will not be taken into
+    // consideration by graph rendering logic. That would unfortunately for
+    // instance result in the edge width function sometimes failing to take
+    // effect on some page loads.
+    '_buildNewRenderHierarchy(graphHierarchy, edgeWidthFunction, handleNodeSelected, edgeLabelFunction, handleEdgeSelected)',
     '_selectedNodeChanged(selectedNode)',
     '_selectedEdgeChanged(selectedEdge)',
   ],
@@ -173,6 +205,9 @@ Polymer({
    */
   panToNode(nodeName) {
     this.$$('tf-graph-scene').panToNode(nodeName);
+  },
+  _buildNewRenderHierarchy(graphHierarchy) {
+    this._buildRenderHierarchy(graphHierarchy);
   },
   _statsChanged: function(stats, devicesForStats) {
     if (this.graphHierarchy) {


### PR DESCRIPTION
We make the `tf-graph` component rebuild the graph hierarchy if any of the handlers related to edges or nodes are set on the component. This is necessary because the graph would render incorrectly if the graph hierarchy is built without taking into account the handlers. This fixes a race condition in the internal mapper tool in which the edge width function is occasionally not taken into consideration on certain page loads.