### PR TITLE
[Debugger Plugin]: Add health pills and handle special tensor values

### DIFF
--- a/tensorboard/plugins/debugger/BUILD
+++ b/tensorboard/plugins/debugger/BUILD
@@ -42,6 +42,7 @@ py_library(
     srcs = ["tensor_helper.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":health_pill_calc",
         "//tensorboard:util",
         "//tensorboard:expect_numpy_installed"
     ],
@@ -167,6 +168,16 @@ py_test(
         ":constants",
         ":numerics_alert",
         "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_library(
+    name = "health_pill_calc",
+    srcs = ["health_pill_calc.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorboard:expect_numpy_installed",
     ],
 )
 

--- a/tensorboard/plugins/debugger/health_pill_calc.py
+++ b/tensorboard/plugins/debugger/health_pill_calc.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Python module for calculating health pills.
 
-"Health pills" are succinct summary of tensor values, including data such as
+"Health pills" are succinct summaries of tensor values, including data such as
 total number of elements, counts of NaN and infinity elements, counts of
 positive, negative and zero elements, min, max, mean and variances, etc.
 

--- a/tensorboard/plugins/debugger/health_pill_calc.py
+++ b/tensorboard/plugins/debugger/health_pill_calc.py
@@ -1,0 +1,105 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Python module for calculating health pills.
+
+"Health pills" are succinct summary of tensor values, including data such as
+total number of elements, counts of NaN and infinity elements, counts of
+positive, negative and zero elements, min, max, mean and variances, etc.
+
+N.B.: tfdbg's DebugNumericSummary op calculates health pills as well. This
+module computes the same health pill values, but in Python. See the following
+code for a detailed description of of elements of a health pill:
+https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/ops/debug_ops.cc#L157
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+
+def calc_health_pill(tensor):
+  """Calculate health pill of a tensor.
+
+  Args:
+    tensor: An instance of `np.array` (for initialized tensors) or
+      `tensorflow.python.debug.lib.debug_data.InconvertibleTensorProto`
+      (for unininitialized tensors).
+
+  Returns:
+    If `tensor` is an initialized tensor of numeric or boolean types:
+      the calculated health pill, as a `list` of `float`s.
+    Else if `tensor` is an initialized tensor with `string`, `resource` or any
+      other non-numeric types:
+      `None`.
+    Else (i.e., if `tensor` is uninitialized): An all-zero `list`, with the
+      first element signifying that the tensor is uninitialized.
+  """
+  health_pill = [0.0] * 14
+
+  # TODO(cais): Add unit test for this method that compares results with
+  #   DebugNumericSummary output.
+
+  # Is tensor initialized.
+  if not isinstance(tensor, np.ndarray):
+    return health_pill
+  health_pill[0] = 1.0
+
+  if not (np.issubdtype(tensor.dtype, np.float) or
+          np.issubdtype(tensor.dtype, np.complex) or
+          np.issubdtype(tensor.dtype, np.integer) or
+          tensor.dtype == np.bool):
+    return None
+
+  # Total number of elements.
+  health_pill[1] = float(np.size(tensor))
+
+  # TODO(cais): Further performance optimization?
+  nan_mask = np.isnan(tensor)
+  inf_mask = np.isinf(tensor)
+  # Number of NaN elements.
+  health_pill[2] = float(np.sum(nan_mask))
+  # Number of -Inf elements.
+  health_pill[3] = float(np.sum(tensor == -np.inf))
+  # Number of finite negative elements.
+  health_pill[4] = float(np.sum(
+      np.logical_and(np.logical_not(inf_mask), tensor < 0.0)))
+  # Number of zero elements.
+  health_pill[5] = float(np.sum(tensor == 0.0))
+  # Number finite positive elements.
+  health_pill[6] = float(np.sum(
+      np.logical_and(np.logical_not(inf_mask), tensor > 0.0)))
+  # Number of +Inf elements.
+  health_pill[7] = float(np.sum(tensor == np.inf))
+
+  finite_subset = tensor[
+      np.logical_and(np.logical_not(nan_mask), np.logical_not(inf_mask))]
+  # Minimum of the non-NaN non-Inf elements.
+  health_pill[8] = float(np.min(finite_subset))
+  # Maximum of the non-NaN non-Inf elements.
+  health_pill[9] = float(np.max(finite_subset))
+  # Mean of the non-NaN non-Inf elements.
+  health_pill[10] = float(np.mean(finite_subset))
+  # Variance of the non-NaN non-Inf elements.
+  health_pill[11] = float(np.var(finite_subset))
+  # DType encoded as a number.
+  # TODO(cais): Convert numpy dtype to corresponding tensorflow dtype enum.
+  health_pill[12] = -1.0
+  # ndims.
+  health_pill[13] = float(len(tensor.shape))
+  # Size of the dimensions.
+  health_pill.extend([float(x) for x in tensor.shape])
+  return health_pill

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
@@ -30,6 +30,7 @@ import shutil
 import tempfile
 import threading
 
+import numpy as np
 import portpicker  # pylint: disable=import-error
 from six.moves import urllib  # pylint: disable=wrong-import-order
 import tensorflow as tf  # pylint: disable=wrong-import-order
@@ -701,6 +702,109 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
     session_run_thread.join()
     self.assertAllClose([[230.0]], session_run_results)
 
+  def _runInitializer(self):
+    session_run_results = []
+    def session_run_job():
+      with tf.Session() as sess:
+        a = tf.Variable([10.0] * 10, name='a')
+        sess = tf_debug.TensorBoardDebugWrapperSession(sess, self._debugger_url)
+        # Run the initializer with a debugger-wrapped tf.Session.
+        session_run_results.append(sess.run(a.initializer))
+        session_run_results.append(sess.run(a))
+    session_run_thread = threading.Thread(target=session_run_job)
+    session_run_thread.start()
+    return session_run_thread, session_run_results
+
+  def testUnitializedTensorIsHandledCorrectly(self):
+    session_run_thread, session_run_results = self._runInitializer()
+    # Activate breakpoint for a:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'a', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+    self._serverGet('ack')
+    self._serverGet('ack')
+    self._serverGet('ack')
+    self._serverGet('ack')
+    session_run_thread.join()
+    self.assertEqual(2, len(session_run_results))
+    self.assertIsNone(session_run_results[0])
+    self.assertAllClose([10.0] * 10, session_run_results[1])
+
+    # Get tensor data without slicing.
+    tensor_response = self._serverGet(
+        'tensor_data',
+        {'watch_key': 'a:0:DebugIdentity',
+         'time_indices': ':',
+         'mapping': '',
+         'slicing': ''})
+    tensor_data = self._deserializeResponse(tensor_response)
+    self.assertIsNone(tensor_data['error'])
+    tensor_data = tensor_data['tensor_data']
+    self.assertEqual(2, len(tensor_data))
+    self.assertIsNone(tensor_data[0])
+    self.assertAllClose([10.0] * 10, tensor_data[1])
+
+    # Get tensor data with slicing.
+    tensor_response = self._serverGet(
+        'tensor_data',
+        {'watch_key': 'a:0:DebugIdentity',
+         'time_indices': ':',
+         'mapping': '',
+         'slicing': '[:5]'})
+    tensor_data = self._deserializeResponse(tensor_response)
+    self.assertIsNone(tensor_data['error'])
+    tensor_data = tensor_data['tensor_data']
+    self.assertEqual(2, len(tensor_data))
+    self.assertIsNone(tensor_data[0])
+    self.assertAllClose([10.0] * 5, tensor_data[1])
+
+  def _runHealthPillNetwork(self):
+    session_run_results = []
+    def session_run_job():
+      with tf.Session() as sess:
+        a = tf.Variable(
+            [np.nan, np.inf, np.inf, -np.inf, -np.inf, -np.inf, 10, 20, 30],
+            dtype=tf.float32, name='a')
+        session_run_results.append(sess.run(a.initializer))
+        sess = tf_debug.TensorBoardDebugWrapperSession(sess, self._debugger_url)
+        session_run_results.append(sess.run(a))
+    session_run_thread = threading.Thread(target=session_run_job)
+    session_run_thread.start()
+    return session_run_thread, session_run_results
+
+  def testHealthPill(self):
+    session_run_thread, _ = self._runHealthPillNetwork()
+    # Activate breakpoint for a:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'a', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+    self._serverGet('ack')
+    self._serverGet('ack')
+    session_run_thread.join()
+    tensor_response = self._serverGet(
+        'tensor_data',
+        {'watch_key': 'a:0:DebugIdentity',
+         'time_indices': '-1',
+         'mapping': 'health-pill',
+         'slicing': ''})
+    tensor_data = self._deserializeResponse(tensor_response)
+    self.assertIsNone(tensor_data['error'])
+    tensor_data = tensor_data['tensor_data'][0]
+    self.assertAllClose(1.0, tensor_data[0])  # IsInitialized.
+    self.assertAllClose(9.0, tensor_data[1])  # Total count.
+    self.assertAllClose(1.0, tensor_data[2])  # NaN count.
+    self.assertAllClose(3.0, tensor_data[3])  # -Infinity count.
+    self.assertAllClose(0.0, tensor_data[4])  # Finite negative count.
+    self.assertAllClose(0.0, tensor_data[5])  # Zero count.
+    self.assertAllClose(3.0, tensor_data[6])  # Positive count.
+    self.assertAllClose(2.0, tensor_data[7])  # +Infinity count.
+    self.assertAllClose(10.0, tensor_data[8])  # Min.
+    self.assertAllClose(30.0, tensor_data[9])  # Max.
+    self.assertAllClose(20.0, tensor_data[10])  # Mean.
+    self.assertAllClose(
+        np.var([10.0, 20.0, 30.0]), tensor_data[11])  # Variance.
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
@@ -715,7 +715,7 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
     session_run_thread.start()
     return session_run_thread, session_run_results
 
-  def testUnitializedTensorIsHandledCorrectly(self):
+  def testTensorDataForUnitializedTensorIsHandledCorrectly(self):
     session_run_thread, session_run_results = self._runInitializer()
     # Activate breakpoint for a:0.
     self._serverGet(
@@ -758,6 +758,27 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
     self.assertEqual(2, len(tensor_data))
     self.assertIsNone(tensor_data[0])
     self.assertAllClose([10.0] * 5, tensor_data[1])
+
+  def testCommDataForUninitializedTensorIsHandledCorrectly(self):
+    session_run_thread, _ = self._runInitializer()
+    # Activate breakpoint for a:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'a', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 2})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertEqual('tensor', comm_data['type'])
+    self.assertEqual('Uninitialized', comm_data['data']['dtype'])
+    self.assertEqual('Uninitialized', comm_data['data']['shape'])
+    self.assertEqual('N/A', comm_data['data']['values'])
+    self.assertEqual(
+        'a/(a)', comm_data['data']['maybe_base_expanded_node_name'])
+    self._serverGet('ack')
+    self._serverGet('ack')
+    self._serverGet('ack')
+    session_run_thread.join()
 
   def _runHealthPillNetwork(self):
     session_run_results = []
@@ -805,6 +826,63 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
     self.assertAllClose(20.0, tensor_data[10])  # Mean.
     self.assertAllClose(
         np.var([10.0, 20.0, 30.0]), tensor_data[11])  # Variance.
+
+  def _runStringNetwork(self):
+    session_run_results = []
+    def session_run_job():
+      with tf.Session() as sess:
+        str1 = tf.Variable('abc', name='str1')
+        str2 = tf.Variable('def', name='str2')
+        str_concat = tf.add(str1, str2, name='str_concat')
+        sess.run(tf.global_variables_initializer())
+        sess = tf_debug.TensorBoardDebugWrapperSession(sess, self._debugger_url)
+        session_run_results.append(sess.run(str_concat))
+    session_run_thread = threading.Thread(target=session_run_job)
+    session_run_thread.start()
+    return session_run_thread, session_run_results
+
+  def testStringTensorIsHandledCorrectly(self):
+    session_run_thread, session_run_results = self._runStringNetwork()
+    # Activate breakpoint for str1:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'str1', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+    self._serverGet('ack')
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 2})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertEqual('tensor', comm_data['type'])
+    self.assertEqual('object', comm_data['data']['dtype'])
+    self.assertEqual([], comm_data['data']['shape'])
+    self.assertEqual('abc', comm_data['data']['values'])
+    self.assertEqual(
+        'str1/(str1)', comm_data['data']['maybe_base_expanded_node_name'])
+    session_run_thread.join()
+    self.assertEqual(1, len(session_run_results))
+    self.assertEqual("abcdef", session_run_results[0])
+
+    # Get the value of a tensor without mapping.
+    tensor_response = self._serverGet(
+        'tensor_data',
+        {'watch_key': 'str1:0:DebugIdentity',
+         'time_indices': '-1',
+         'mapping': '',
+         'slicing': ''})
+    tensor_data = self._deserializeResponse(tensor_response)
+    self.assertEqual(None, tensor_data['error'])
+    self.assertEqual(['abc'], tensor_data['tensor_data'])
+
+    # Get the health pill of a string tensor.
+    tensor_response = self._serverGet(
+        'tensor_data',
+        {'watch_key': 'str1:0:DebugIdentity',
+         'time_indices': '-1',
+         'mapping': 'health-pill',
+         'slicing': ''})
+    tensor_data = self._deserializeResponse(tensor_response)
+    self.assertEqual(None, tensor_data['error'])
+    self.assertEqual([None], tensor_data['tensor_data'])
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
@@ -60,6 +60,11 @@ def _comm_metadata(run_key, timestamp):
   }
 
 
+UNINITIALIZED_TAG = 'Uninitialized'
+UNSUPPORTED_TAG = 'Unsupported'
+NA_TAG = 'N/A'
+
+
 def _comm_tensor_data(device_name,
                       node_name,
                       maybe_base_expanded_node_name,
@@ -87,12 +92,12 @@ def _comm_tensor_data(device_name,
   tensor_values = None
   if isinstance(tensor_value, debug_data.InconvertibleTensorProto):
     if not tensor_value.initialized:
-      tensor_dtype = 'Uninitialized'
-      tensor_shape = 'Uninitialized'
+      tensor_dtype = UNINITIALIZED_TAG
+      tensor_shape = UNINITIALIZED_TAG
     else:
-      tensor_dtype = 'Unsupported'
-      tensor_dtype = 'Unsupported'
-    tensor_values = 'N/A'
+      tensor_dtype = UNSUPPORTED_TAG
+      tensor_dtype = UNSUPPORTED_TAG
+    tensor_values = NA_TAG
   else:
     tensor_dtype = str(tensor_value.dtype)
     tensor_shape = tensor_value.shape

--- a/tensorboard/plugins/debugger/tensor_helper.py
+++ b/tensorboard/plugins/debugger/tensor_helper.py
@@ -24,6 +24,7 @@ import numpy as np
 from tensorflow.python.debug.cli import command_parser
 
 from tensorboard import util
+from tensorboard.plugins.debugger import health_pill_calc
 
 
 def numel(shape):
@@ -71,6 +72,8 @@ def array_view(array, slicing=None, mapping=None):
       `'image/png'`: Image encoding of a 2D sliced array or 3D sliced array
         with 3 as the last dimension. If the sliced array is not 2D or 3D with
         3 as the last dimension, a `ValueError` will be thrown.
+      `health-pill`: A succinct summary of the numeric values of a tensor.
+        See documentation in [`health_pill_calc.py`] for more details.
 
   Returns:
     1. dtype as a `str`.
@@ -91,6 +94,9 @@ def array_view(array, slicing=None, mapping=None):
     else:
       raise ValueError("Invalid rank for image/png mapping: %d" %
                        len(sliced_array.shape))
+  elif mapping == 'health-pill':
+    health_pill = health_pill_calc.calc_health_pill(array)
+    return dtype, shape, health_pill
   elif mapping is None or mapping == '' or  mapping.lower() == 'none':
     return dtype, shape, sliced_array.tolist()
   else:

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -977,7 +977,7 @@ limitations under the License.
         return (watchKey, callback) => {
           const parameters = {
             'watch_key': watchKey,
-            'time_indices': '-1',
+            'time_indices': '-1',   // '-1' means the latest time point.
             'mapping': 'health-pill',
           };
           const baseUrl = tf_backend.getRouter().pluginRoute('debugger', '/tensor_data');

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -71,12 +71,11 @@ limitations under the License.
       <div class="sidebar" id="left-pane">
         <div id="node-entries" class="node-entries">
           <div class="debugger-section-title">Node List</div>
-          <paper-button
-            raised
-            id="toggle-source-code-button"
-            on-click="_showSourceCode">
-            <span>[[_toggleSourceCodeButtonText]]</span>
-          </paper-button>
+          <div class="toggle-source-code">
+            Show Code:
+            <paper-toggle-button class="toggle-source-code" id="show-source-code">
+            </paper-toggle-button>
+          </div>
           <tf-op-selector
               debug-watches=[[_debugWatches]]
               debug-watch-change="[[_createDebugWatchChangeHandler()]]"
@@ -182,13 +181,13 @@ limitations under the License.
         </div>
 
         <div id="tensor-data" class="tensor-data">
-          <div class="debugger-section-title">Tensor Value Overview</div>
           <tf-tensor-data-summary
             latest-tensor-data="[[_latestTensorData]]"
             expand-handler="[[_createTensorDataExpandHandler()]]"
             continue-to-callback="[[_createContinueToCallback()]]"
             highlighted-node-name="[[_highlightNodeName]]"
-            tensor-name-clicked="[[_createNodeClickedHandler()]]">
+            tensor-name-clicked="[[_createNodeClickedHandler()]]"
+            get-health-pill="[[_createGetHealthPill()]]">
           </tf-tensor-data-summary>
         </div>
       </div>
@@ -321,7 +320,7 @@ limitations under the License.
         padding: 20px 0;
       }
       .tensor-data {
-        height: 30%;
+        height: 29%;
         overflow: auto;
         padding: 20px 0;
       }
@@ -329,7 +328,8 @@ limitations under the License.
         height: 66%;
         overflow: auto;
       }
-      #toggle-source-code-button {
+      .toggle-source-code {
+        margin-right: 1em;
         font-size: 80%;
         float: right;
       }
@@ -405,10 +405,6 @@ limitations under the License.
         _continueNum: {  // How many times to continue over, e.g., Session.Runs.
             type: Number,
             value: 5,
-        },
-        _toggleSourceCodeButtonText: {
-            type: String,
-            value: 'Show Code >>',
         },
 
         _tensorViewIdCounter: {
@@ -546,6 +542,9 @@ limitations under the License.
         "_sizeDashboardRegions(_leftPaneWidth, _windowWidth)",
         "_graphProgressUpdated(_graphProgress)",
       ],
+      listeners: {
+        'show-source-code.change': '_showSourceCodeChanged',
+      },
 
       ready() {
         this._handleWindowResize();
@@ -721,16 +720,13 @@ limitations under the License.
         this.$.continueDialog.open();
       },
 
-      _showSourceCode() {
+      _showSourceCodeChanged(event) {
+        this.set('_sourceCodeShown', event.target.active);
         if (this._sourceCodeShown) {
-          this.$$('#node-entries').style.height = '80%';
-          this.set('_sourceCodeShown', false);
-          this.set('_toggleSourceCodeButtonText', 'Show Code >>');
-        } else {
           this.$$('#node-entries').style.height = '40%';
-          this.set('_sourceCodeShown', true);
-          this.set('_toggleSourceCodeButtonText', 'Hide Code <<');
           this.$.sourceCodeView.render();
+        } else {
+          this.$$('#node-entries').style.height = '80%';
         }
       },
 
@@ -895,15 +891,14 @@ limitations under the License.
       },
 
       _createTensorDataExpandHandler() {
-        const self = this;
-        function handleTensorDataExpand(tensorData) {
-          self._setTopRightTensorValuesToActive();
+        return (tensorData) => {
+          this._setTopRightTensorValuesToActive();
           // Use setTimeout() so that the DOMs in the top-right tabs have a
           // chance to update.
           setTimeout(() =>  {
-            const multiView = self.$$('#tensorValueMultiView');
+            const multiView = this.$$('#tensorValueMultiView');
             multiView.addView({
-              viewId: self._createTensorViewId(),
+              viewId: this._createTensorViewId(),
               deviceName: tensorData.deviceName,
               tensorName: tensorData.tensorName,
               nodeName: tensorData.nodeName,
@@ -914,7 +909,6 @@ limitations under the License.
             });
           }, 10);
         };
-        return handleTensorDataExpand;
       },
 
       _createTensorViewId() {
@@ -976,6 +970,22 @@ limitations under the License.
             },
           }
         ];
+      },
+
+      // Create a function that gives the health pill of a tensor.
+      _createGetHealthPill() {
+        return (watchKey, callback) => {
+          const parameters = {
+            'watch_key': watchKey,
+            'time_indices': '-1',
+            'mapping': 'health-pill',
+          };
+          const baseUrl = tf_backend.getRouter().pluginRoute('debugger', '/tensor_data');
+          const url = tf_backend.addParams(baseUrl, parameters);
+          this._requestManager.request(url).then(response => {
+            callback(response.tensor_data[0]);
+          });
+        };
       },
 
       _continueToNode(deviceName, baseExpandedNodeName) {

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-source-code-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-source-code-view.html
@@ -200,6 +200,8 @@ limitations under the License.
       // Args:
       //   deviceName: Name of the device that the node is partitioned to.
       //   baseExpandedNodeName: Name of the node, base-expanded if applicable.
+      //   skipSource: Whether focusing on the source file line is to be
+      //     skipped.
       nodeClicked: {
         type: Function,
         value: null,

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-source-code-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-source-code-view.html
@@ -77,10 +77,10 @@ limitations under the License.
         overflow-y: scroll;
       }
       .source-content :hover {
-        background-color: #ffffe0;
+        background-color: #FFFF00;
       }
       .highlighted-source-line {
-        background-color: #ffd6c1;
+        background-color: #FFFFE0;
       }
       .source-line-number {
         display: inline-block;
@@ -419,6 +419,9 @@ limitations under the License.
               continueToLink.setAttribute('title', 'Continue to');
               // TOOD(cais): Properly style the paper-icon-button.
               continueToLink.addEventListener('tap', () => {
+                this.nodeClicked(
+                    this._nodeName2DeviceName[nodeName],
+                    this._nodeName2BaseExpandedNodeName[nodeName], true);
                 const deviceName = this._nodeName2DeviceName[nodeName];
                 const baseExpandedNodeName = this._nodeName2BaseExpandedNodeName[nodeName];
                 this.set('_setHightlightOriginNodeElement', nodeElement);

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
@@ -23,6 +23,7 @@ limitations under the License.
 -->
 <dom-module id="tf-tensor-data-summary">
   <template>
+    <span class="section-title">Tensor Value Overview</span>
     <div id="tensor-data-div" class="tensor-data-div">
       <table id="tensor-data-table" align="left" class="tensor-data-table">
         <tr align="left">
@@ -30,48 +31,74 @@ limitations under the License.
           <th>Count</th>
           <th>DType</th>
           <th>Shape</th>
-          <th width="30%">Value</th>
+          <th width="25%">Value</th>
+          <th width="25%">
+            Health Pill
+            <paper-toggle-button id="show-health-pills" checked>
+            </paper-toggle-button>
+            <paper-card>
+              <div class="health-pill-legend" id="health-pill-legend"></div>
+            </paper-card>
+          </th>
           <th width="5%"></th>
         </tr>
       </table>
     </div>
     <style>
-      .section-title {
-        font-size: 110%;
-        font-weight: bold;
-      }
-      :host .indented-level-container .content-container {
-        margin: 0 0 0 10px;
-      }
-      :host .tensor-data-table {
-        align-content: left;
-        align-items: left;
-        text-align: left;
-        border-style: solid 1px black;
-        width: 100%;
-        padding-top: 3px;
-        padding-left: 3px;
-        padding-right: 3px;
-        box-shadow: 3px 3px #ddd;
-      }
-      :host .active-tensor {
-        background-color: #FFFFE0;
-      }
-      :host .highlighted {
-        color: red;
-      }
-      .value-expansion-link {
-        text-decoration: underline;
-        cursor: pointer;
-      }
-      .value-expansion-link :hover {
-        color: blue;
-      }
-      .tensor-name {
-        text-decoration: underline;
-        cursor: pointer;
-      }
-    </style>
+        .section-title {
+          font-size: 110%;
+          font-weight: bold;
+        }
+        :host .indented-level-container .content-container {
+          margin: 0 0 0 10px;
+        }
+        :host .tensor-data-table {
+          align-content: left;
+          align-items: left;
+          text-align: left;
+          vertical-align: middle;
+          width: 100%;
+          padding-top: 3px;
+          padding-left: 3px;
+          padding-right: 3px;
+          box-shadow: 3px 3px #ddd;
+        }
+        :host .tensor-data-table th {
+          vertical-align: top;
+        }
+        :host .active-tensor {
+          background-color: #FFFFE0;
+          font-weight: bold;
+          border: solid 1px #888;
+        }
+        :host .highlighted {
+          color: red;
+        }
+        :host .health-pill-legend {
+          float: right;
+          font-weight: normal;
+        }
+        :host #show-health-pills {
+          display: inline-block;
+        }
+        .value-expansion-link {
+          text-decoration: underline;
+          cursor: pointer;
+        }
+        .value-expansion-link :hover {
+          color: blue;
+        }
+        .health-pill :hover {
+          cursor: pointer;
+        }
+        .tensor-name {
+          text-decoration: underline;
+          cursor: pointer;
+        }
+        .tensor-name :hover {
+          color: blue;
+        }
+      </style>
   </template>
   <script>
 
@@ -112,6 +139,17 @@ limitations under the License.
         value: null,
       },
 
+      // A function with which the latest health pill of a tensor can be
+      // obtained.
+      // Signature of the function:
+      // Args:
+      //   watchKey: Watch key of the tensor of which the health pill is to be
+      //     obtained. Does not include device name.
+      //   callback: A callback to invoke when the health pill values become
+      //     available. The callback should take exactly one input argument,
+      //     i.e., the health pill values as an Array of Numbers.
+      getHealthPill: Function,
+
       _watchKeys: {
         type: Array,
         value: [],
@@ -134,23 +172,72 @@ limitations under the License.
         type: Object,
         value: {},
       },
+      // A map from watch key to an existing rendered row in the table.
+      _watchKey2Row: {
+        type: Object,
+        value: {},
+      },
       _activeWatchKey: String,
+      _showHealthPills: {
+        type: Boolean,
+        value: true,
+      },
+
+      _healthPillWidth: {
+        type: Number,
+        value: 200,
+        readonly: true,
+      },
+      _healthPillHeight: {
+        type: Number,
+        value: 32,
+        readonly: true,
+      },
     },
     observers: [
       "_renderLatest(latestTensorData, expandHandler)",
       "_highlight(highlightedNodeName)",
     ],
+    listeners: {
+      'show-health-pills.change': '_showHealthPillsChanged',
+    },
+
+    ready() {
+      this._renderHealthPillLegend();
+    },
+
+    _showHealthPillsChanged(event) {
+      // Flip the state of the show-health-pills flag.
+      this.set('_showHealthPills', event.target.active);
+      if (this._showHealthPills) {
+        this._renderHealthPillLegend();
+      } else {
+        this._clearHealthPillLegend();
+      }
+      this._renderAll();
+    },
+
+    _renderAll(sortBy) {
+      this._clearTensorDataTable();
+      for (const watchKey of this._watchKeys) {
+        const tensorData = this._watchKey2Data[watchKey];
+        const expandHandler = this._watchKey2ExpandHandler[watchKey];
+        this._renderLatest(tensorData, expandHandler);
+      }
+    },
 
     _renderLatest(latestTensorData, expandHandler) {
       const watchKey = latestTensorData.deviceName + '/' +
                        latestTensorData.tensorName + ':' +
                        latestTensorData.debugOp;
-      const instanceExpandHandler = () => {
-        expandHandler(latestTensorData);
-      };
+      let instanceExpandHandler = null;
+      if (!(latestTensorData.dtype === 'Uninitialized' ||
+            latestTensorData.dtype === 'Unsupported')) {
+        instanceExpandHandler = () =>  expandHandler(latestTensorData);
+      }
 
       let valueShort;
-      if (latestTensorData.value !== null) {
+      if (latestTensorData.value != null) {
         valueShort = JSON.stringify(latestTensorData.value,
             (key, val) => {
               return val.toFixed ? Number(val.toFixed(3)) : val;
@@ -163,51 +250,93 @@ limitations under the License.
       if (this._watchKeys.indexOf(watchKey) === -1) {
         this._watchKeys.push(watchKey);
         this._watchKey2Count[watchKey] = 1;
-        this._watchKey2ExpandHandler[watchKey] = instanceExpandHandler;
       } else {
         this._watchKey2Count[watchKey] += 1;
       }
+      // Always update instance expand handler, because the tensor's shape
+      // might have changed (e.g., from unitialized to an initialized, concrete
+      // shape), necessitating an updating to the value expand callback.
+      this._watchKey2ExpandHandler[watchKey] = instanceExpandHandler;
       this._watchKey2ValueShort[watchKey] = valueShort;
       this._activeWatchKey = watchKey;
 
-      this._clearTensorDataTable();
       // TODO(cais): Support sorting by clicking headers.
-      this._renderHeader();
-      for (let i = 0; i < this._watchKeys.length; ++i) {
-        this._renderRow(this._watchKeys[i]);
-      }
+      this._removeActiveStatusFromAllRows();
+      this._renderRow(watchKey);
     },
 
     _clearTensorDataTable() {
-      const tensorDataTable = this.$$('#tensor-data-table');
-      while (tensorDataTable.firstChild) {
-        tensorDataTable.removeChild(tensorDataTable.firstChild);
+      for (const watchKey in this._watchKey2Row) {
+        if (!this._watchKey2Row.hasOwnProperty(watchKey)) {
+          continue;
+        }
+        const row = this._watchKey2Row[watchKey];
+        row.remove();
+        delete this._watchKey2Row[watchKey];
       }
     },
 
-    _renderHeader() {
-      const headerRow = document.createElement('tr');
-      const nameCell = document.createElement('th');
-      nameCell.textContent = 'Name';
-      const countCell = document.createElement('th');
-      countCell.textContent = 'Count';
-      const dtypeCell = document.createElement('th');
-      dtypeCell.textContent = 'DType';
-      const shapeCell = document.createElement('th');
-      shapeCell.textContent = 'Shape';
-      const valueShortCell = document.createElement('th');
-      valueShortCell.textContent = 'Value';
+    _clearTensorDataRow(tensorDataRow) {
+      while (tensorDataRow.firstChild) {
+        tensorDataRow.removeChild(tensorDataRow.firstChild);
+      }
+    },
 
-      headerRow.appendChild(nameCell);
-      headerRow.appendChild(countCell);
-      headerRow.appendChild(dtypeCell);
-      headerRow.appendChild(shapeCell);
-      headerRow.appendChild(valueShortCell);
+    _clearHealthPillLegend() {
+      const legend = this.$$('#health-pill-legend');
+      while (legend.firstChild) {
+        legend.removeChild(legend.firstChild);
+      }
+    },
 
-      Polymer.dom(this.$$('#tensor-data-table')).appendChild(headerRow);
+    _renderHealthPillLegend() {
+      this._clearHealthPillLegend();
+      const legend = this.$$('#health-pill-legend');
+      const legendTitle = document.createElement('div');
+      legendTitle.textContent = 'Legend:';
+      legend.appendChild(legendTitle);
+      legendTitle.style['margin-right'] = '0.5em';
+      legendTitle.style['display'] = 'inline-block';
+      for (let i = 0; i < tf.graph.scene.healthPillEntries.length; ++i) {
+        const entry = tf.graph.scene.healthPillEntries[i];
+        const entryDiv = document.createElement('div');
+        // TODO(cais): Make class css work.
+        entryDiv.style['display'] = 'inline-block';
+        entryDiv.style['margin-right'] = '0.25em';
+        const rectangle = document.createElement('span');
+        rectangle.textContent = '■';
+        rectangle.style['color'] = entry.background_color;
+        const label = document.createElement('span');
+        label.textContent = entry.label;
+        label.style['color'] = entry.background_color;
+        entryDiv.appendChild(rectangle);
+        entryDiv.appendChild(label);
+        legend.appendChild(entryDiv);
+      }
+    },
+
+    // Remove active status from all rows.
+    _removeActiveStatusFromAllRows() {
+      for (const watchKey in this._watchKey2Row) {
+        if (!this._watchKey2Row.hasOwnProperty(watchKey)) {
+          continue;
+        }
+        const row = this._watchKey2Row[watchKey];
+        Polymer.dom(row).classList.remove('active-tensor');
+        Polymer.dom(row).classList.remove('highlighted');
+      };
     },
 
     _renderRow(watchKey) {
+      let tensorDataRow;
+      if (this._watchKey2Row[watchKey] != null) {
+        tensorDataRow = this._watchKey2Row[watchKey];
+        this._clearTensorDataRow(tensorDataRow);
+      } else {
+        tensorDataRow = document.createElement('tr');
+        Polymer.dom(this.$$('#tensor-data-table')).appendChild(tensorDataRow);
+      }
+
       const deviceName = this._watchKey2Data[watchKey]['deviceName'];
       const maybeBaseExpandedNodeName =
           this._watchKey2Data[watchKey]['maybeBaseExpandedNodeName'];
@@ -219,9 +348,11 @@ limitations under the License.
       const expandHandler = this._watchKey2ExpandHandler[watchKey];
       const isActive = (watchKey === this._activeWatchKey);
 
-      const tensorDataRow = document.createElement('tr');
       const tensorNameCell = document.createElement('td');
-      tensorNameCell.classList.add('tensor-name');
+      Polymer.dom(tensorNameCell).classList.add('tensor-name');
+      // TODO(cais): Make class CSS work.
+      tensorNameCell.style['text-decoration'] = 'underline';
+      tensorNameCell.style['cursor'] = 'pointer';
       tensorNameCell.textContent = tensorName;
       tensorNameCell.addEventListener('tap', () => {
         if (this.tensorNameClicked != null) {
@@ -231,23 +362,46 @@ limitations under the License.
 
       const countCell = document.createElement('td');
       countCell.textContent = count;
-      if (isActive) {
-        countCell.style.fontWeight = 'bold';
-      }
       // TODO(cais): Display debug op only if it is not the default
       // (DebugIdentity). The following commented-out lines of code may be
       // useful for that purpose.
       // const debugOpCell = document.createElement('td');
       // debugOpCell.textContent = (debugOp === 'DebugIdentity') ? '' : debugOp;
+      const dtype = this._watchKey2Data[watchKey]['dtype'];
       const dtypeCell = document.createElement('td');
-      dtypeCell.textContent = this._watchKey2Data[watchKey]['dtype'];
+      const shape = this._watchKey2Data[watchKey]['shape']
+      dtypeCell.textContent = dtype;
       const shapeCell = document.createElement('td');
-      shapeCell.textContent = JSON.stringify(
-          this._watchKey2Data[watchKey]['shape']);
+      shapeCell.textContent = JSON.stringify(shape);
+
+      // Create cell for a short summary of the tensor's value.
       const valueCell = document.createElement('td');
       valueCell.textContent = valueShort;
-      valueCell.setAttribute('class', 'value-expansion-link');
-      valueCell.addEventListener('click', expandHandler, false);
+      Polymer.dom(valueCell).classList.add('value-expansion-link');
+      // TODO(cais): Make class CSS work.
+      if (expandHandler != null) {
+        valueCell.addEventListener('tap', expandHandler, false);
+        valueCell.style['text-decoration'] = 'underline';
+        valueCell.style['cursor'] = 'pointer';
+      }
+
+      // Create health pill.
+      let healthPillCell = null;
+      if (this._showHealthPills) {
+        const healthPillWatchKey = tensorName + ':' + debugOp;
+        const healthPillWithoutValue = {
+          device_name: deviceName,
+          node_name: maybeBaseExpandedNodeName,
+          dtype: dtype,
+          shape: shape,
+          value: null,
+        };
+        healthPillCell = this._renderHealthPill(
+            healthPillWatchKey, healthPillWithoutValue, expandHandler);
+      } else {
+        healthPillCell = document.createElement('td');
+      }
+
       const continueToCell = document.createElement('td');
       const continueToLink = document.createElement('paper-icon-button');
       continueToLink.setAttribute('icon', 'forward');
@@ -258,35 +412,83 @@ limitations under the License.
       continueToCell.appendChild(continueToLink);
 
       tensorDataRow.appendChild(tensorNameCell);
-      // tensorDataRow.appendChild(debugOpCell);
       tensorDataRow.appendChild(countCell);
       tensorDataRow.appendChild(dtypeCell);
       tensorDataRow.appendChild(shapeCell);
       tensorDataRow.appendChild(valueCell);
+      tensorDataRow.appendChild(healthPillCell);
       tensorDataRow.appendChild(continueToCell);
       tensorDataRow.setAttribute('nodeNameWithDevice', nodeNameWithDevice);
 
       if (isActive) {
-        tensorDataRow.classList.add('active-tensor');
-        tensorDataRow.classList.add('highlighted');
+        Polymer.dom(tensorDataRow).classList.add('active-tensor');
+        Polymer.dom(tensorDataRow).classList.add('highlighted');
       }
 
-      Polymer.dom(this.$$('#tensor-data-table')).appendChild(tensorDataRow);
+      this._watchKey2Row[watchKey] = tensorDataRow;
       tensorDataRow.scrollIntoView({block: 'end', inline: 'nearest', behaviour: 'smooth'});
+    },
+
+    // Render health pill for a tensor.
+    // Args:
+    //   healthPillWatchKey: a watch key for the tensor of which the health pill
+    //     is to be rendered. It should not include the device name.
+    //   healthPillWithoutValue: A HealthPill (TypeScript interface) without
+    //     the 'value' field filled in. In otherwords, it is expected to include
+    //     the following fields: device_name, node_name, dtype, shape.
+    //   tapHandler: A handler for 'tap' event on the health pill.
+    // Returns:
+    //   A rendered HTML element.
+    _renderHealthPill(
+        healthPillWatchKey, healthPillWithoutValue, tapHandler) {
+      healthPillCell = document.createElement('td');
+      Polymer.dom(healthPillCell).classList.add('health-pill');
+      if (tapHandler != null) {
+        healthPillCell.addEventListener('tap', tapHandler, false);
+      }
+      const healthPillOuter = document.createElementNS(
+          tf.graph.scene.SVG_NAMESPACE, 'svg');
+      healthPillOuter.setAttribute('width', this._healthPillWidth);
+      healthPillOuter.setAttribute('height', this._healthPillHeight);
+      const healthPillInner = document.createElementNS(
+          tf.graph.scene.SVG_NAMESPACE, 'g');
+      healthPillOuter.appendChild(healthPillInner);
+      healthPillCell.appendChild(healthPillOuter);
+      // Prepend the health pill ID with 'tdp/' to avoid duplication with health
+      // pills in the graph visualizer (if present).
+      const healthPillId = 'tdp/' + healthPillWatchKey;
+      this.getHealthPill(healthPillWatchKey, healthPillValue => {
+        if (healthPillValue == null) {
+          // DTypes unsupported by health pills, e.g, string, resource.
+          healthPillCell.textContent = 'N/A';
+          healthPillCell.style['color'] = 'gray';
+        } else {
+          const healthPill = healthPillWithoutValue;
+          healthPill.value = healthPillValue;
+          tf.graph.scene.addHealthPill(
+              healthPillInner, healthPill, null, healthPillId,
+              this._healthPillWidth, this._healthPillHeight / 2,
+              this._healthPillHeight / 2, 0);
+        }
+      });
+      return healthPillCell;
     },
 
     _highlight(nodeName) {
       const table = Polymer.dom(this.$$('#tensor-data-table'));
       const rowsToHighlight = [];
       // First, remove highlight from all rows.
-      for (let i = 0; i < table.childNodes.length; ++i) {
-        const row = table.childNodes[i];
+      for (const watchKey in this._watchKey2Row) {
+        if (!this._watchKey2Row.hasOwnProperty(watchKey)) {
+          continue;
+        }
+        const row = this._watchKey2Row[watchKey];
         if (row.getAttribute != null) {
           const nodeNameWithDevice = row.getAttribute('nodeNameWithDevice');
           if (nodeNameWithDevice === nodeName) {
             rowsToHighlight.push(row);
           } else {
-            row.classList.remove('highlighted');
+            Polymer.dom(row).classList.remove('highlighted');
           }
         }
       }
@@ -295,7 +497,7 @@ limitations under the License.
       }
       // Add highlight to the rows with matching node names.
       for (let i = 0; i < rowsToHighlight.length; ++i) {
-        rowsToHighlight[i].classList.add('highlighted');
+        Polymer.dom(rowsToHighlight[i]).classList.add('highlighted');
         rowsToHighlight[i].scrollIntoView({block: 'end', inline: 'nearest', behaviour: 'smooth'});
       }
     },

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-multi-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-multi-view.html
@@ -61,6 +61,7 @@ limitations under the License.
         viewCard.viewId = view.viewId;
         viewCard.tensorName = view.tensorName;
         viewCard.debugOp = view.debugOp;
+        // TODO(cais): Investigate shape from uninitialized tensor.
         viewCard.slicing = view.slicing;
         viewCard.timeIndices = view.timeIndices;
         viewCard.closeButtonCallback = this._createCloseButtonCallback(view.viewId);

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-multi-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-multi-view.html
@@ -61,7 +61,6 @@ limitations under the License.
         viewCard.viewId = view.viewId;
         viewCard.tensorName = view.tensorName;
         viewCard.debugOp = view.debugOp;
-        // TODO(cais): Investigate shape from uninitialized tensor.
         viewCard.slicing = view.slicing;
         viewCard.timeIndices = view.timeIndices;
         viewCard.closeButtonCallback = this._createCloseButtonCallback(view.viewId);


### PR DESCRIPTION
* Add health pills to Tensor Value Overview. Health pills are succinct
  graphical summaries of the values of tensors with numerical and
  boolean types. They present a color-coded breakdown of the composition
  of the tensor's elements, such as NaN, Infinity, positve, negative and
  zero elements, as well as simple statistics including min, max, mean
  and standard deviation. They are updated in real time as debugging
  progresses. This is based on the prior work by @chihuahua 
* A legend is provided for health pills' color codes in Tensor Value
  Overview.
* Add logic for handling uninitialized tensors.
* Add logic for handling string-type tensors.
* To this end, make the addHealthPill() method in the graph plugin
  public.