### PR TITLE
Add a new TPU profiling tool called Overview Page as a plugin

### DIFF
--- a/tensorboard/plugins/profile/README.md
+++ b/tensorboard/plugins/profile/README.md
@@ -1,62 +1,119 @@
 # The Profile Plugin Dashboard
 
+## JSON format for the Overview Page and the Input-pipeline Analyzer
 
-##JSON format for input pipeline analyzer:
-  Input pipeline analyzer are ported from Google internal tools where
-  google-chart is used extensively. The original consumer for this JSON format
-  is [google.visualization.DataTable](https://developers.google.com/chart/interactive/docs/reference#DataTable).
-  We are in a process to moving from google-chart to Plottable and other
-  visualization tools provided by Tensorboard.
-  JSON for input pipeline analyzer use two separate DataTables: the first entry
-  contains stats for device side state; the second entry contains stats for
-  host side state. Each DataTable is associated with some table properties and
-  some tabular data.
+The Overview Page and Input-pipeline analyzer are ported from Google internal
+tools where google-chart is used extensively. The original consumer for this
+JSON format is
+[google.visualization.DataTable](https://developers.google.com/chart/interactive/docs/reference#DataTable).
+We are in a process of moving from google-chart to Plottable and other
+visualization tools provided by Tensorboard.
 
-###1. Device Side Table
-1.1 Properties:
+### 1. JSON format for the Overview Page
 
-  * infeed_percent_average
-  * infeed_percent_maximum
-  * infeed_percent_minimum
-  * infeed_percent_standard_deviation
-  * steptime_ms_average
-  * steptime_ms_maximum
-  * steptime_ms_minimum
-  * steptime_ms_standard_deviation
-  * summary_color
-  * summary_text
+JSON for the Overview Page includes four seperate DataTables described below.
+Each table may have some properties, or some tabular data, or both.
 
-1.2 Tabular data: rows are training steps. column ids are defined below.
+#### 1.1 Performance Summary DataTable
 
-  * stepnum: string
-  * noninfeedTimeMs: number
-  * infeedTimeMs: number
-  * tooltip: string (NOT USED)
-  * infeedPercentAverage: number
-  * infeedPercentMin: number
-  * infeedPercentMax: number
+1.1.1 Properties:
 
-###2. Host Side Table
-2.1 Properties:
+*   matrix_unit_utilization_percent
+*   device_idle_time_percent
+*   host_idle_time_percent
 
-  * advanced_file_read_us
-  * conclusion
-  * demanded_file_read_us
-  * enqueue_us
-  * preprocessing_us
+1.1.2 Tabular data: rows are TensorFlow operations. Column ids are defined
+below.
 
-2.2 Tabular data: rows are input-pipeline related tensorflow ops. column
-    ids are defined below.
+*   self_time_fraction: number
+*   cumulative_time_fraction: number
+*   category: string
+*   name: string
+*   flop_rate: number
 
-  * opName: string
-  * count: number
-  * timeInMs: number
-  * timeInPercent: number
-  * selfTimeInMs: number
-  * selfTimeInPercent: number
-  * category: string
+#### 1.2 Device Step-time DataTable
 
+1.2.1 Properties:
 
+*   infeed_percent_average
+*   infeed_percent_maximum
+*   infeed_percent_minimum
+*   infeed_percent_standard_deviation
+*   steptime_ms_average
+*   steptime_ms_maximum
+*   steptime_ms_minimum
+*   steptime_ms_standard_deviation
+*   summary_color
+*   summary_text
 
+1.2.2 Tabular data: rows are training steps. Column ids are defined below.
 
+*   stepnum: string
+*   noninfeedTimeMs: number
+*   infeedTimeMs: number
+*   tooltip: string (NOT USED)
+*   infeedPercentAverage: number
+*   infeedPercentMin: number
+*   infeedPercentMax: number
 
+#### 1.3 Run-environment DataTable
+
+1.3.1 Properties:
+
+*   host_count
+*   tpu_type
+*   tpu_core_count
+*   batch_size
+*   change_list
+*   build_time
+*   build_target
+
+1.3.2 Tabular data: rows are hosts. Column ids are defined below.
+
+*   host_id: string
+*   command_line: string
+*   start_time: string
+
+#### 1.4 Recommendation DataTable
+
+1.4.1 Properties:
+
+*   bottleneck
+*   statement
+
+1.4.2 Tabular data: rows are recommendations. Column ids are defined below.
+
+*   tip_type: string
+*   link: string
+
+### 2. JSON format for the Input-pipeline Analyzer
+
+JSON for the Input-pipeline Analyzer uses two separate DataTables: the first
+DataTable contains statistics for device step time; the second DataTable
+contains statistics for host side state. Each DataTable is associated with some
+table properties and some tabular data.
+
+#### 2.1. Device Step-time DataTable
+
+The same as the one described in Section 1.2.
+
+#### 2.2 Host Side DataTable
+
+2.2.1 Properties:
+
+*   advanced_file_read_us
+*   conclusion
+*   demanded_file_read_us
+*   enqueue_us
+*   preprocessing_us
+
+2.2.2 Tabular data: rows are input-pipeline related tensorflow ops. column ids
+are defined below.
+
+*   opName: string
+*   count: number
+*   timeInMs: number
+*   timeInPercent: number
+*   selfTimeInMs: number
+*   selfTimeInPercent: number
+*   category: string

--- a/tensorboard/plugins/profile/overview_page/BUILD
+++ b/tensorboard/plugins/profile/overview_page/BUILD
@@ -1,0 +1,17 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_library(
+    name = "overview_page",
+    srcs = ["overview-page.html"],
+    path = "/tf-overview-page",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorboard/components/tf_imports:plottable",
+        "//tensorboard/components/vz_line_chart",
+        "@org_polymer_paper_card",
+    ],
+)

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -1,0 +1,314 @@
+<!--
+     @license
+     Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+   -->
+
+<!--
+     The Overview Page ...??
+   -->
+
+<link rel="import" href="../vz-line-chart/vz-line-chart.html">
+<link rel="import" href="../paper-card/paper-card.html">
+
+<dom-module id="overview-page">
+  <template>
+    <style>
+     .steptime-average {
+       font-weight:bold;
+       font-style:italic;
+       color:red;
+     }
+     .table-style {
+       table-layout:auto;
+       width:95%;
+     }
+     .top-ops-table {
+       width:100%;
+     }
+     .x-axis-title {
+       width:80%;
+       text-align:center;
+       text-transform: capitalize;
+     }
+     .y-axis-title {
+       width:10px;
+       writing-mode:bt-rl;
+       transform: rotate(270deg);
+       text-align:center;
+       white-space: nowrap;
+       text-transform: capitalize;
+     }
+     div.bottleneck-statement{
+       color:red;
+       font-weight:bolder;
+       font-style:italic;
+     }
+     div.bottleneckTips{
+       color:#000000;
+     }
+     div.bottleneckTips a{
+       color:#ff33cc;
+       text-decoration:underline;
+     }
+    </style>
+    <div class="horizontal layout">
+      <div class="flex self-stretch">
+	<paper-card heading="Performance Summary">
+	  <div class="card-content">
+	    <p><b>Average step time</b> (lower is better): <b><span class="steptime-average" >[[_steptime_ms_average]] ms</span> </b> <i style="opacity:0.7">(standard deviation = <span>[[_steptime_ms_stddev]]</span> ms)</i></p>
+	    <p><b>Host idle time</b> (lower is better): <span>[[_host_idle_time_percent]]</span></p>
+	    <p><b>TPU idle time</b> (lower is better): <span>[[_device_idle_time_percent]]</p>
+	      <p><b>Utilization of TPU Matrix Units</b> (higher is better): <span>[[_mxu_utilization_percent]]</span></p>
+	  </div>
+	</paper-card>
+      </div>
+      <div class="flex self-stretch">
+	<paper-card heading="Step-time Graph" >
+	  <div class="card-content">
+	    <table class="table-style">
+	      <tr>
+		<td><div class="y-axis-title">milliseconds</div></td>
+		<td>
+		  <vz-line-chart id="device_step_chart" style="width:600px; height:300px"></vz-line-chart>
+                  <div><p class="x-axis-title">training step number</p></div>
+		</td>
+	      </tr>
+	    </table>
+	  </div>
+	</paper-card>
+      </div>
+    </div>
+    <div class="horizontal layout">
+      <paper-card heading$="[[_top_ops_heading]]">
+	<div class="card-content">
+	  <button on-click="onClickTopOps">[[_top_ops_button_text]]</button>
+	  <table class="top-ops-table" hidden$="[[!_show_top_ops_table]]">
+	    <thread>
+	      <th>Time (%)</th>
+	      <th>Cumulative time (%)</th>
+	      <th>Category</th>
+	      <th>Operation</th>
+	      <th>GFlops/sec</th>
+	    </thread>
+	    <tbody id="top_ops_table_content">
+	    </tbody>
+	  </table>
+	</div>
+      </paper-card>
+    </div>
+    <div class="horizontal layout">
+      <paper-card heading="Run Environment">
+	<div class="card-content">
+	  <p><b>Number of Hosts used</b>: <span>[[_host_count]]</span></p>
+          <p><b>TPU type</b>: Cloud TPU</span></p>
+          <p><b>Number of TPU cores</b>: <span> [[_tpu_core_count]]</span></p>
+          <p><b>Batch size</b>: <span>[[_batch_size]]</span></p>
+	</div>
+      </paper-card>
+      <paper-card heading="Recommendation for Next Steps">
+	<div class="card-content">
+	  <div class="bottleneck-statement"> <span>[[_statement]]</span></div>
+	  <div id="host_side_tips"></div>
+          <div id="device_side_tips"></div>
+	</div>
+      </paper-card>
+    </div>
+  </template>
+
+  <script>
+   Polymer({
+     is: 'overview-page',
+     properties: {
+       _requestManager: {
+         type: Object,
+         readOnly: true,
+         value: () => new tf_backend.RequestManager(),
+       },
+       run: {
+         type: String,
+         observer: '_reloadToolData',
+       },
+       _data: {
+         type: Object,
+         observer: '_updateView',
+       },
+       _show_top_ops_table: {
+         type: Boolean,
+         value: false,
+         notify: true,
+       },
+       _top_ops_button_text: {
+         type: String,
+         computed: '_getTopOpsButtonText(_show_top_ops_table)'
+       },
+     },
+     _host_idle_time_percent: String,
+     _device_idle_time_percent: String,
+     _mxu_utilization_percent: String,
+     _steptime_ms_average: String,
+     _steptime_ms_stddev: String,
+     _top_ops_heading: String,
+     _error_message: String,
+     _host_count: String,
+     _tpu_type: String,
+     _tpu_core_count: String,
+     _batch_size: String,
+     _change_list: String,
+     _build_time: String,
+     _build_target: String,
+     _statement: String,
+
+     _reloadToolData: function(run) {
+       this._requestManager.request(tf_backend.addParams(
+         tf_backend.getRouter().pluginRoute('profile', '/data'),
+         {tag: 'overview_page', run})
+       ).then((data) => {
+         if (data) {
+	   this.set('_data', data);
+         }
+       });
+     },
+
+     onClickTopOps: function(e) {
+       this.set('_show_top_ops_table', !this._show_top_ops_table);
+     },
+
+     _getTopOpsButtonText: function(show_top_ops_table) {
+       return (show_top_ops_table ? 'Hide' : 'Show') + ' table';
+     },
+
+     /* Update view according to new data */
+     _updateView: function() {
+       var generalAnalysisJson = this._data[0];
+       var inputAnalysisJson = this._data[1];
+       var runEnvironmentJson = this._data[2];
+       var recommendationJson = this._data[3];
+
+       this.set('_host_idle_time_percent', generalAnalysisJson.p['host_idle_time_percent']);
+       this.set('_device_idle_time_percent', generalAnalysisJson.p['device_idle_time_percent']);
+       this.set('_mxu_utilization_percent', generalAnalysisJson.p['mxu_utilization_percent']);
+       this.set('_steptime_ms_average', inputAnalysisJson.p['steptime_ms_average']);
+       this.set('_steptime_ms_stddev', inputAnalysisJson.p['steptime_ms_standard_deviation']);
+       this.set('_error_message', runEnvironmentJson.p['error_message']);
+       this.set('_host_count', runEnvironmentJson.p['host_count']);
+       this.set('_tpu_type', runEnvironmentJson.p['tpu_type']);
+       this.set('_tpu_core_count', runEnvironmentJson.p['tpu_core_count']);
+       this.set('_batch_size', runEnvironmentJson.p['batch_size']);
+       this.set('_change_list', runEnvironmentJson.p['change_list']);
+       this.set('_build_time', runEnvironmentJson.p['build_time']);
+       this.set('_build_target', runEnvironmentJson.p['build_target']);
+       this.set('_statement', recommendationJson.p['statement']);
+
+       this.updateStyles(); /* Do we need this? */
+       this._showDeviceStepChart(inputAnalysisJson);
+       this._showTopOpsTable(generalAnalysisJson);
+       this._showRecommendation(recommendationJson);
+     },
+
+     /* Plots a graph of step time (in ms) against step number */
+     _showDeviceStepChart : function(deviceJson) {
+       var deviceStepSeries = [];
+       var hostStepSeries = [];
+       var maxStepTime = 0;
+       var step = -1;
+       deviceJson.rows.forEach(function(row, index) {
+         step = step > 0 ? ++step : Number(row.c[0].v);
+         deviceStepSeries.push({"scalar": row.c[1].v,
+				"step": step,
+				"tpu_step": Number(row.c[0].v),
+				"low_watermark": 0})
+         hostStepSeries.push({"scalar": row.c[1].v + row.c[2].v,
+                              "step": step,
+                              "low_watermark": row.c[1].v})
+         maxStepTime = Math.max(maxStepTime, row.c[1].v + row.c[2].v)
+       })
+       var chart = this.$.device_step_chart;
+       if (chart) {
+         chart.setVisibleSeries(['device step time', 'compute time']);
+         chart.setSeriesData('device step time', hostStepSeries);
+         chart.setSeriesData('compute time', deviceStepSeries);
+         chart.defaultYRange = [0, maxStepTime * 1.1]
+         chart.smoothingEnabled = false;
+         chart.tooltipColumns = [
+           { title: 'Name', evaluate: (d) => d.dataset.metadata().name },
+           { title: 'Time(ms)', evaluate: (d) => (d.datum.scalar).toFixed(2) },
+           { title: 'Step', evaluate: (d) => d.datum.step }];
+         chart.fillArea = {
+           higherAccessor: (d) => d.scalar,
+           lowerAccessor: (d) => d.low_watermark,
+         };
+         chart.xAxisFormatter = d3.format('d');
+       }
+     },
+
+     /* Draws a table of TensorFlow Op statistics */
+     _showTopOpsTable: function(opsTableJson) {
+       var numRows = 0;
+       var opsTableBody = this.$.top_ops_table_content;
+       opsTableBody.innerHTML = '';
+       opsTableJson.rows.forEach(function(rowJson, index) {
+	 var row = document.createElement('tr');
+	 Polymer.dom(opsTableBody).appendChild(row);
+	 var cellTexts = [];
+	 cellTexts.push((rowJson.c[0].v*100).toFixed(2)+'%');
+	 cellTexts.push((rowJson.c[1].v*100).toFixed(2)+'%');
+	 cellTexts.push(rowJson.c[2].v);
+	 cellTexts.push(rowJson.c[3].v);
+	 cellTexts.push((rowJson.c[4].v).toFixed(2));
+	 cellTexts.forEach(function(cellText, index) {
+           var td = document.createElement('td');
+           Polymer.dom(row).appendChild(td);
+           Polymer.dom(td).appendChild(document.createTextNode(cellText));
+         });
+	 numRows += 1;
+       })
+       this.set('_top_ops_heading', 'Top ' + numRows + ' TensorFlow operations executed on TPU');
+       this.set('_show_top_ops_table', false);
+     },
+
+     _generateRecommendationHtml: function(tipsTableJson, cssClassName, wantedTipType, titleString) {
+       var content = '<p>&nbsp;</p>';
+       content += '<div class="' + cssClassName + '">';
+       content += '<font size="3"><b>' + titleString + ':</b></font>';
+       tipsTableJson.rows.forEach(function(rowJson, index) {
+	 var tipType = rowJson.c[0].v;
+	 if (tipType == wantedTipType) {
+	   var link = rowJson.c[1].v;
+	   content += '<li>' + link + '</li>';
+	 }
+       });
+       content += '</div>';
+       return content;
+     },
+
+     _showRecommendation: function(recommendationJson) {
+       var bottleneck =  recommendationJson.p['bottleneck'];
+       var hostTipsBody = this.$.host_side_tips;
+       var deviceTipsBody = this.$.device_side_tips;
+       
+       if (bottleneck == 'device') {
+	 hostTipsBody.innerHTML = '';
+	 deviceTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'device', 'Next tools to use for reducing the TPU time');
+       } else if (bottleneck == 'host') {
+	 hostTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'host', 'Next tools to use for reducing the input time');
+	 deviceTipsBody.innerHTML = '';
+       } else {
+	 hostTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'host', 'Next tools to use for reducing the input time');
+	 deviceTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'device', 'Next tools to use for reducing the TPU time');
+       }
+     },
+   });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -25,6 +25,11 @@
 <dom-module id="overview-page">
   <template>
     <style>
+     paper-card {
+       margin: 5px;
+       --paper-card-header-color: white;
+       --paper-card-header: background-color: blue;
+     }
      .steptime-average {
        font-weight:bold;
        font-style:italic;
@@ -64,7 +69,6 @@
      }
     </style>
     <div class="horizontal layout">
-      <div class="flex self-stretch">
 	<paper-card heading="Performance Summary">
 	  <div class="card-content">
 	    <p><b>Average step time</b> (lower is better): <b><span class="steptime-average" >[[_steptime_ms_average]] ms</span> </b> <i style="opacity:0.7">(standard deviation = <span>[[_steptime_ms_stddev]]</span> ms)</i></p>
@@ -73,22 +77,19 @@
 	      <p><b>Utilization of TPU Matrix Units</b> (higher is better): <span>[[_mxu_utilization_percent]]</span></p>
 	  </div>
 	</paper-card>
-      </div>
-      <div class="flex self-stretch">
 	<paper-card heading="Step-time Graph" >
 	  <div class="card-content">
 	    <table class="table-style">
 	      <tr>
 		<td><div class="y-axis-title">milliseconds</div></td>
 		<td>
-		  <vz-line-chart id="device_step_chart" style="width:600px; height:300px"></vz-line-chart>
+		  <vz-line-chart id="device_step_chart" style="width:860px; height:200px"></vz-line-chart>
                   <div><p class="x-axis-title">training step number</p></div>
 		</td>
 	      </tr>
 	    </table>
 	  </div>
 	</paper-card>
-      </div>
     </div>
     <div class="horizontal layout">
       <paper-card heading$="[[_top_ops_heading]]">

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -50,6 +50,10 @@ You may obtain a copy of the License at
      .top-ops-table {
        width: 100%;
      }
+     vz-line-chart.step-graph {
+       width: 860px;
+       height: 200px;
+     }
      .x-axis-title {
        width: 80%;
        text-align: center;
@@ -63,7 +67,7 @@ You may obtain a copy of the License at
        white-space: nowrap;
        text-transform: capitalize;
      }
-     div.bottleneck-statement{
+     div.bottleneck-statement {
        color: red;
        font-weight: bolder;
        font-style: italic;
@@ -75,7 +79,7 @@ You may obtain a copy of the License at
        margin-top: 0.5cm;
        margin-bottom: 0.5cm;
      }
-     div.bottleneckTips{
+     div.bottleneckTips {
        color: #000000;
      }
      div.bottleneckTips a{
@@ -107,7 +111,7 @@ You may obtain a copy of the License at
 	      <tr>
 		<td><div class="y-axis-title">milliseconds</div></td>
 		<td>
-		  <vz-line-chart id="device_step_chart" style="width:860px; height:200px"></vz-line-chart>
+		  <vz-line-chart class="step-graph" id="device_step_chart"></vz-line-chart>
                   <div><p class="x-axis-title">training step number</p></div>
 		</td>
 	      </tr>

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -60,6 +60,13 @@
        font-weight:bolder;
        font-style:italic;
      }
+     div.errorMessage {
+       color:red;
+       font-size:0.5cm;
+       font-weight: bolder;
+       margin-top:0.5cm;
+       margin-bottom:0.5cm;
+     }
      div.bottleneckTips{
        color:#000000;
      }
@@ -68,7 +75,9 @@
        text-decoration:underline;
      }
     </style>
-    <div class="horizontal layout">
+    <div class="errorMessage" hidden$="[[!_show_error_message]]"> <span>[[_error_message]]</span></div>
+    <div class="while_page_content" hidden$="[[_show_error_message]]">
+      <div class="horizontal layout">
 	<paper-card heading="Performance Summary">
 	  <div class="card-content">
 	    <p><b>Average step time</b> (lower is better): <b><span class="steptime-average" >[[_steptime_ms_average]] ms</span> </b> <i style="opacity:0.7">(standard deviation = <span>[[_steptime_ms_stddev]]</span> ms)</i></p>
@@ -90,41 +99,42 @@
 	    </table>
 	  </div>
 	</paper-card>
-    </div>
-    <div class="horizontal layout">
-      <paper-card heading$="[[_top_ops_heading]]">
-	<div class="card-content">
-	  <button on-click="onClickTopOps">[[_top_ops_button_text]]</button>
-	  <table class="top-ops-table" hidden$="[[!_show_top_ops_table]]">
-	    <thread>
-	      <th>Time (%)</th>
-	      <th>Cumulative time (%)</th>
-	      <th>Category</th>
-	      <th>Operation</th>
-	      <th>GFlops/sec</th>
-	    </thread>
-	    <tbody id="top_ops_table_content">
-	    </tbody>
-	  </table>
-	</div>
-      </paper-card>
-    </div>
-    <div class="horizontal layout">
-      <paper-card heading="Run Environment">
-	<div class="card-content">
-	  <p><b>Number of Hosts used</b>: <span>[[_host_count]]</span></p>
-          <p><b>TPU type</b>: Cloud TPU</span></p>
-          <p><b>Number of TPU cores</b>: <span> [[_tpu_core_count]]</span></p>
-          <p><b>Batch size</b>: <span>[[_batch_size]]</span></p>
-	</div>
-      </paper-card>
-      <paper-card heading="Recommendation for Next Steps">
-	<div class="card-content">
-	  <div class="bottleneck-statement"> <span>[[_statement]]</span></div>
-	  <div id="host_side_tips"></div>
-          <div id="device_side_tips"></div>
-	</div>
-      </paper-card>
+      </div>
+      <div class="horizontal layout">
+	<paper-card heading$="[[_top_ops_heading]]">
+	  <div class="card-content">
+	    <button on-click="onClickTopOps">[[_top_ops_button_text]]</button>
+	    <table class="top-ops-table" hidden$="[[!_show_top_ops_table]]">
+	      <thread>
+		<th>Time (%)</th>
+		<th>Cumulative time (%)</th>
+		<th>Category</th>
+		<th>Operation</th>
+		<th>GFlops/sec</th>
+	      </thread>
+	      <tbody id="top_ops_table_content">
+	      </tbody>
+	    </table>
+	  </div>
+	</paper-card>
+      </div>
+      <div class="horizontal layout">
+	<paper-card heading="Run Environment">
+	  <div class="card-content">
+	    <p><b>Number of Hosts used</b>: <span>[[_host_count]]</span></p>
+            <p><b>TPU type</b>: Cloud TPU</span></p>
+            <p><b>Number of TPU cores</b>: <span> [[_tpu_core_count]]</span></p>
+            <p><b>Batch size</b>: <span>[[_batch_size]]</span></p>
+	  </div>
+	</paper-card>
+	<paper-card heading="Recommendation for Next Steps">
+	  <div class="card-content">
+	    <div class="bottleneck-statement"> <span>[[_statement]]</span></div>
+	    <div id="host_side_tips"></div>
+            <div id="device_side_tips"></div>
+	  </div>
+	</paper-card>
+      </div>
     </div>
   </template>
 
@@ -153,6 +163,11 @@
        _top_ops_button_text: {
          type: String,
          computed: '_getTopOpsButtonText(_show_top_ops_table)'
+       },
+       _show_error_message: {
+         type: Boolean,
+         value: false,
+         notify: true,
        },
      },
      _host_idle_time_percent: String,
@@ -211,7 +226,8 @@
        this.set('_build_time', runEnvironmentJson.p['build_time']);
        this.set('_build_target', runEnvironmentJson.p['build_target']);
        this.set('_statement', recommendationJson.p['statement']);
-
+       this.set('_show_error_message', this._error_message!='');
+       
        this.updateStyles(); /* Do we need this? */
        this._showDeviceStepChart(inputAnalysisJson);
        this._showTopOpsTable(generalAnalysisJson);
@@ -220,26 +236,26 @@
 
      /* Plots a graph of step time (in ms) against step number */
      _showDeviceStepChart : function(deviceJson) {
-       var deviceStepSeries = [];
-       var hostStepSeries = [];
+       var computeTimeSeries = [];
+       var stepTimeSeries = [];
        var maxStepTime = 0;
        var step = -1;
        deviceJson.rows.forEach(function(row, index) {
          step = step > 0 ? ++step : Number(row.c[0].v);
-         deviceStepSeries.push({"scalar": row.c[1].v,
-				"step": step,
-				"tpu_step": Number(row.c[0].v),
-				"low_watermark": 0})
-         hostStepSeries.push({"scalar": row.c[1].v + row.c[2].v,
+         computeTimeSeries.push({"scalar": row.c[1].v,
+				 "step": step,
+				 "tpu_step": Number(row.c[0].v),
+				 "low_watermark": 0})
+         stepTimeSeries.push({"scalar": row.c[1].v + row.c[2].v,
                               "step": step,
                               "low_watermark": row.c[1].v})
          maxStepTime = Math.max(maxStepTime, row.c[1].v + row.c[2].v)
        })
        var chart = this.$.device_step_chart;
        if (chart) {
-         chart.setVisibleSeries(['device step time', 'compute time']);
-         chart.setSeriesData('device step time', hostStepSeries);
-         chart.setSeriesData('compute time', deviceStepSeries);
+         chart.setVisibleSeries(['compute-time', 'step-time = input-time + compute-time']);
+	 chart.setSeriesData('compute-time', computeTimeSeries);
+         chart.setSeriesData('step-time = input-time + compute-time', stepTimeSeries);
          chart.defaultYRange = [0, maxStepTime * 1.1]
          chart.smoothingEnabled = false;
          chart.tooltipColumns = [
@@ -298,7 +314,7 @@
        var bottleneck =  recommendationJson.p['bottleneck'];
        var hostTipsBody = this.$.host_side_tips;
        var deviceTipsBody = this.$.device_side_tips;
-       
+
        if (bottleneck == 'device') {
 	 hostTipsBody.innerHTML = '';
 	 deviceTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'device', 'Next tools to use for reducing the TPU time');

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -17,7 +17,7 @@ You may obtain a copy of the License at
 
 <!--
   The Overview Page is a view within the tf-profile-dashboard.
-  It is the first page that users would look at in order to under
+  It is the first page that users would look at in order to understand
   the overall performance of their TPU workloads. The page has five
   sections of results:
      (1) Performance summary
@@ -39,55 +39,55 @@ You may obtain a copy of the License at
        --paper-card-header: background-color: blue;
      }
      .steptime-average {
-       font-weight:bold;
-       font-style:italic;
-       color:red;
+       font-weight: bold;
+       font-style: italic;
+       color: red;
      }
      .table-style {
-       table-layout:auto;
-       width:95%;
+       table-layout: auto;
+       width: 95%;
      }
      .top-ops-table {
-       width:100%;
+       width: 100%;
      }
      .x-axis-title {
-       width:80%;
-       text-align:center;
+       width: 80%;
+       text-align: center;
        text-transform: capitalize;
      }
      .y-axis-title {
-       width:10px;
-       writing-mode:bt-rl;
+       width: 10px;
+       writing-mode: bt-rl;
        transform: rotate(270deg);
-       text-align:center;
+       text-align: center;
        white-space: nowrap;
        text-transform: capitalize;
      }
      div.bottleneck-statement{
-       color:red;
-       font-weight:bolder;
-       font-style:italic;
+       color: red;
+       font-weight: bolder;
+       font-style: italic;
      }
      div.errorMessage {
-       color:red;
-       font-size:0.5cm;
+       color: red;
+       font-size: 0.5cm;
        font-weight: bolder;
-       margin-top:0.5cm;
-       margin-bottom:0.5cm;
+       margin-top: 0.5cm;
+       margin-bottom: 0.5cm;
      }
      div.bottleneckTips{
-       color:#000000;
+       color: #000000;
      }
      div.bottleneckTips a{
-       color:#ff33cc;
-       text-decoration:underline;
+       color: #ff33cc;
+       text-decoration: underline;
      }
      div.documentationTips {
-       color:#666699;
+       color: #666699;
      }
      div.documentationTips a{
-       color:#33cc00;
-       text-decoration:underline;
+       color: #33cc00;
+       text-decoration: underline;
      }
     </style>
     <div class="errorMessage" hidden$="[[!_show_error_message]]"> <span>[[_error_message]]</span></div>
@@ -317,7 +317,7 @@ You may obtain a copy of the License at
      _generateRecommendationHtml: function(tipsTableJson, cssClassName, wantedTipType, titleString) {
        var content = '<p>&nbsp;</p>';
        content += '<div class="' + cssClassName + '">';
-       content += '<font size="3"><b>' + titleString + ':</b></font>';
+       content += '<b>' + titleString + ':</b>';
        tipsTableJson.rows.forEach(function(rowJson, index) {
 	 var tipType = rowJson.c[0].v;
 	 if (tipType == wantedTipType) {

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -82,6 +82,13 @@ You may obtain a copy of the License at
        color:#ff33cc;
        text-decoration:underline;
      }
+     div.documentationTips {
+       color:#666699;
+     }
+     div.documentationTips a{
+       color:#33cc00;
+       text-decoration:underline;
+     }
     </style>
     <div class="errorMessage" hidden$="[[!_show_error_message]]"> <span>[[_error_message]]</span></div>
     <div class="while_page_content" hidden$="[[_show_error_message]]">
@@ -140,6 +147,7 @@ You may obtain a copy of the License at
 	    <div class="bottleneck-statement"> <span>[[_statement]]</span></div>
 	    <div id="host_side_tips"></div>
             <div id="device_side_tips"></div>
+	    <div id="documentation_tips"></div>
 	  </div>
 	</paper-card>
       </div>
@@ -337,6 +345,8 @@ You may obtain a copy of the License at
 	 hostTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'host', 'Next tools to use for reducing the input time');
 	 deviceTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'device', 'Next tools to use for reducing the TPU time');
        }
+       var documentationTipsBody = this.$.documentation_tips;
+       documentationTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'documentationTips', 'doc', 'Other useful resources');
      },
    });
   </script>

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -235,8 +235,8 @@ You may obtain a copy of the License at
        this.set('_build_target', runEnvironmentJson.p['build_target']);
        this.set('_statement', recommendationJson.p['statement']);
        this.set('_show_error_message', this._error_message!='');
-       
-       this.updateStyles(); /* Do we need this? */
+       this.updateStyles();
+
        this._showDeviceStepChart(inputAnalysisJson);
        this._showTopOpsTable(generalAnalysisJson);
        this._showRecommendation(recommendationJson);

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -20,11 +20,11 @@ You may obtain a copy of the License at
   It is the first page that users would look at in order to understand
   the overall performance of their TPU workloads. The page has five
   sections of results:
-     (1) Performance summary
-     (2) Step-time graph
-     (3) Top 10 TensorFlow Operations executed on TPU
-     (4) Run environment
-     (5) Recommendation for next steps
+    (1) Performance summary
+    (2) Step-time graph
+    (3) Top 10 TensorFlow Operations executed on TPU
+    (4) Run environment
+    (5) Recommendation for next steps
 -->
 
 <link rel="import" href="../vz-line-chart/vz-line-chart.html">
@@ -323,7 +323,7 @@ You may obtain a copy of the License at
        content += '<div class="' + cssClassName + '">';
        content += '<b>' + titleString + ':</b>';
        tipsTableJson.rows.forEach(function(rowJson, index) {
-	 var tipType = rowJson.c[0].v;
+         var tipType = rowJson.c[0].v;
 	 if (tipType == wantedTipType) {
 	   var link = rowJson.c[1].v;
 	   content += '<li>' + link + '</li>';
@@ -340,14 +340,14 @@ You may obtain a copy of the License at
        var deviceTipsBody = this.$.device_side_tips;
 
        if (bottleneck == 'device') {
-	 hostTipsBody.innerHTML = '';
-	 deviceTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'device', 'Next tools to use for reducing the TPU time');
+         hostTipsBody.innerHTML = '';
+         deviceTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'device', 'Next tools to use for reducing the TPU time');
        } else if (bottleneck == 'host') {
-	 hostTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'host', 'Next tools to use for reducing the input time');
-	 deviceTipsBody.innerHTML = '';
+         hostTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'host', 'Next tools to use for reducing the input time');
+         deviceTipsBody.innerHTML = '';
        } else {
-	 hostTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'host', 'Next tools to use for reducing the input time');
-	 deviceTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'device', 'Next tools to use for reducing the TPU time');
+         hostTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'host', 'Next tools to use for reducing the input time');
+         deviceTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'device', 'Next tools to use for reducing the TPU time');
        }
        var documentationTipsBody = this.$.documentation_tips;
        documentationTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'documentationTips', 'doc', 'Other useful resources');

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -16,8 +16,16 @@
    -->
 
 <!--
-     The Overview Page ...??
-   -->
+  The Overview Page is a view within the tf-profile-dashboard.
+  It is the first page that users would look at in order to under
+  the overall performance of their TPU workloads. The page has five
+  sections of results:
+     (1) Performance summary
+     (2) Step-time graph
+     (3) Top 10 TensorFlow Operations executed on TPU
+     (4) Run environment
+     (5) Recommendation for next steps
+-->
 
 <link rel="import" href="../vz-line-chart/vz-line-chart.html">
 <link rel="import" href="../paper-card/paper-card.html">

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -205,15 +205,17 @@ You may obtain a copy of the License at
        });
      },
 
+     /* Toggles _show_top_ops_table */
      onClickTopOps: function(e) {
        this.set('_show_top_ops_table', !this._show_top_ops_table);
      },
 
+     /* Gets the current text of the "show-top-ops" button */
      _getTopOpsButtonText: function(show_top_ops_table) {
        return (show_top_ops_table ? 'Hide' : 'Show') + ' table';
      },
 
-     /* Update view according to new data */
+     /* Updates view according to new data */
      _updateView: function() {
        var generalAnalysisJson = this._data[0];
        var inputAnalysisJson = this._data[1];
@@ -303,6 +305,7 @@ You may obtain a copy of the License at
        this.set('_show_top_ops_table', false);
      },
 
+     /* Generates the HTML for a recommendation link */
      _generateRecommendationHtml: function(tipsTableJson, cssClassName, wantedTipType, titleString) {
        var content = '<p>&nbsp;</p>';
        content += '<div class="' + cssClassName + '">';
@@ -318,6 +321,7 @@ You may obtain a copy of the License at
        return content;
      },
 
+     /* Shows the recommendation section */
      _showRecommendation: function(recommendationJson) {
        var bottleneck =  recommendationJson.p['bottleneck'];
        var hostTipsBody = this.$.host_side_tips;

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -1,10 +1,10 @@
 <!--
-     @license
-     Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
      http://www.apache.org/licenses/LICENSE-2.0
 

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -49,7 +49,9 @@ TOOLS = {
 }
 
 # Tools that consume raw data.
-_RAW_DATA_TOOLS = frozenset(['input_pipeline_analyzer', 'op_profile', 'overview_page'])
+_RAW_DATA_TOOLS = frozenset(['input_pipeline_analyzer',
+                             'op_profile',
+                             'overview_page'])
 
 def process_raw_trace(raw_trace):
   """Processes raw trace data and returns the UI data."""

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -49,8 +49,7 @@ TOOLS = {
 }
 
 # Tools that consume raw data.
-_RAW_DATA_TOOLS = frozenset(
-['input_pipeline_analyzer', 'op_profile', 'overview_page'])
+_RAW_DATA_TOOLS = frozenset(['input_pipeline_analyzer', 'op_profile', 'overview_page'])
 
 def process_raw_trace(raw_trace):
   """Processes raw trace data and returns the UI data."""

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -48,6 +48,9 @@ TOOLS = {
     'overview_page': 'overview_page.json',
 }
 
+# Tools that consume raw data.
+_RAW_DATA_TOOLS = frozenset(
+['input_pipeline_analyzer', 'op_profile', 'overview_page'])
 
 def process_raw_trace(raw_trace):
   """Processes raw trace data and returns the UI data."""
@@ -159,7 +162,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
       return None
     if tool == 'trace_viewer':
       return process_raw_trace(raw_data)
-    if tool in set(['op_profile', 'input_pipeline_analyzer', 'overview_page']):
+    if tool in _RAW_DATA_TOOLS:
       return raw_data
     return None
 

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -44,7 +44,8 @@ _FILE_NAME = 'TOOL_FILE_NAME'
 TOOLS = {
     'trace_viewer': 'trace',
     'op_profile': 'op_profile.json',
-    'input_pipeline_analyzer': 'input_pipeline.json'
+    'input_pipeline_analyzer': 'input_pipeline.json',
+    'overview_page': 'overview_page.json',
 }
 
 
@@ -158,7 +159,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
       return None
     if tool == 'trace_viewer':
       return process_raw_trace(raw_data)
-    if tool == 'op_profile' or tool == 'input_pipeline_analyzer':
+    if tool in set(['op_profile', 'input_pipeline_analyzer', 'overview_page']):
       return raw_data
     return None
 

--- a/tensorboard/plugins/profile/tf_profile_dashboard/BUILD
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/BUILD
@@ -16,6 +16,7 @@ tf_web_library(
         "//tensorboard/components/vz_sorting",
         "//tensorboard/plugins/graph/tf_graph_controls",
         "//tensorboard/plugins/profile/input_pipeline_analyzer",
+        "//tensorboard/plugins/profile/overview_page",
         "//tensorboard/plugins/profile/tf_op_profile",
         "@org_polymer",
         "@org_polymer_paper_dropdown_menu",

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -91,7 +91,7 @@ profile run can have multiple tools that present the performance profile as diff
       <input-pipeline-analyzer run="[[_getSelectedDataset(_datasets, currentSelected)]]">
       </input-pipeline-analyzer>
     </template>
-    <template is="dom-if" if="[[_isCurrentTool(_datasets, currentSelected, 'overview_page')]]" restamp="true">
+    <template is="dom-if" if="[[_isCurrentTool(_datasets, currentSelected, 'overview_page')]]">
       <overview-page run="[[_getSelectedDataset(_datasets, currentSelected)]]">
       </overview-page>
     </template>

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -23,6 +23,7 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-graph-controls/tf-graph-controls.html">
 <link rel="import" href="../tf-input-pipeline/input-pipeline-analyzer.html">
+<link rel="import" href="../tf-overview-page/overview-page.html">
 <link rel="import" href="../tf-op-profile/tf-op-profile.html">
 <link rel="import" href="../tf-tensorboard/registry.html">
 <link rel="import" href="../vz-sorting/vz-sorting.html">
@@ -89,6 +90,10 @@ profile run can have multiple tools that present the performance profile as diff
     <template is="dom-if" if="[[_isCurrentTool(_datasets, currentSelected, 'input_pipeline_analyzer')]]" restamp="true">
       <input-pipeline-analyzer run="[[_getSelectedDataset(_datasets, currentSelected)]]">
       </input-pipeline-analyzer>
+    </template>
+    <template is="dom-if" if="[[_isCurrentTool(_datasets, currentSelected, 'overview_page')]]" restamp="true">
+      <overview-page run="[[_getSelectedDataset(_datasets, currentSelected)]]">
+      </overview-page>
     </template>
   </div>
   </tf-dashboard-layout>


### PR DESCRIPTION
Add a new TPU profiling tool called Overview Page, which gives an overview of the performance of the workload run on the TPU. 
A screenshot of the tool output is attached.
![tb_overview_page](https://user-images.githubusercontent.com/20428269/35068495-1286debc-fb8c-11e7-9853-6aeff4270f26.png)

Note that the step-time graph won't be shown in the current version of TensorBoard because of a bug in vz-line-chart. The screenshot was generated using an older version of TensorBoard.
