### PR TITLE
Remove outer function wrapper

### DIFF
--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -355,7 +355,7 @@ Polymer({
       _attached) {
     // Find the actual xComponentsCreationMethod.
     if (!xType && !xComponentsCreationMethod) {
-      xComponentsCreationMethod = () => vz_line_chart.stepX;
+      xComponentsCreationMethod = vz_line_chart.stepX;
     } else if (xType) {
       xComponentsCreationMethod = () =>
           vz_line_chart.getXComponents(xType);


### PR DESCRIPTION
We remove the outer function wrapper from the default value for xComponentsCreationMethod because `vz_line_chart.stepX` is already a valid value for the property. Creating a function that returns `vz_line_chart.stepX` results in a bug.

This fixes an internal issue.