### PR TITLE
Let user resize tensor data and graph section

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
@@ -14,7 +14,7 @@ tf_web_library(
         "tf-debugger-dashboard.html",
         "tf-debugger-initial-dialog.html",
         "tf-debugger-line-chart.html",
-        "tf-debugger-vertical-resizer.html",
+        "tf-debugger-resizer.html",
         "tf-op-selector.html",
         "tf-session-runs-view.html",
         "tf-source-code-view.html",

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -36,7 +36,7 @@ limitations under the License.
 <link rel="import" href="../tf-tensorboard/registry.html">
 <link rel="import" href="tf-debugger-continue-dialog.html">
 <link rel="import" href="tf-debugger-initial-dialog.html">
-<link rel="import" href="tf-debugger-vertical-resizer.html">
+<link rel="import" href="tf-debugger-resizer.html">
 <link rel="import" href="tf-op-selector.html">
 <link rel="import" href="tf-session-runs-view.html">
 <link rel="import" href="tf-source-code-view.html">
@@ -77,11 +77,11 @@ limitations under the License.
             continue-to-node="[[_createContinueToNodeHandler()]]"
           ></tf-source-code-view>
         </div>
-        <tf-debugger-vertical-resizer
-          current-width="{{_leftPaneWidth}}"
-          min-width="[[_minleftPaneWidth]]"
-          max-width="[[_maxleftPaneWidth]]">
-        </tf-debugger-vertical-resizer>
+        <tf-debugger-resizer
+          current-length="{{_leftPaneWidth}}"
+          min-length="[[_minleftPaneWidth]]"
+          max-length="[[_maxleftPaneWidth]]">
+        </tf-debugger-resizer>
         <div>
           <tf-session-runs-view
             id="sessionRunsView"
@@ -112,35 +112,33 @@ limitations under the License.
         </div>
       </div>
       <div class="center" id="center-content">
-        <div id="top-right-content-container">
-          <div id="top-right-top-contents">
-            <paper-tabs selected="0" selected="{{_topRightSelected}}">
-              <template is="dom-repeat" items="[[_topRightTabs]]">
-                <paper-tab id="[[item.id]]">[[item.name]]</paper-tab>
+        <div id="top-right-quadrant">
+          <paper-tabs selected="0" selected="{{_topRightSelected}}">
+            <template is="dom-repeat" items="[[_topRightTabs]]">
+              <paper-tab id="[[item.id]]">[[item.name]]</paper-tab>
+            </template>
+          </paper-tabs>
+          <span id="runtime-graph-device-name">
+          </span>
+          <paper-dropdown-menu
+            id="active-runtime-graph-device-name"
+            no-label-float="true"
+            label="Device name"
+            selected-item-label="{{_activeRuntimeGraphDeviceName}}"
+          >
+            <paper-menu class="dropdown-content" slot="dropdown-content">
+              <template is="dom-repeat" items="[[_activeSessionRunDevices]]">
+                <paper-item no-label-float=true>[[item]]</paper-item>
               </template>
-            </paper-tabs>
-            <span id="runtime-graph-device-name">
-            </span>
-            <paper-dropdown-menu
-              id="active-runtime-graph-device-name"
-              no-label-float="true"
-              label="Device name"
-              selected-item-label="{{_activeRuntimeGraphDeviceName}}"
-            >
-              <paper-menu class="dropdown-content" slot="dropdown-content">
-                <template is="dom-repeat" items="[[_activeSessionRunDevices]]">
-                  <paper-item no-label-float=true>[[item]]</paper-item>
-                </template>
-              </paper-menu>
-            </paper-dropdown-menu>
-            <paper-spinner-lite
-              class="spinner"
-              id="top-right-spinner"
-              hidden="[[!_busy]]"
-              active="[[_busy]]">
-            </paper-spinner-lite>
-            <paper-progress id="top-right-progress-bar" value="0"></paper-progress>
-          </div>
+            </paper-menu>
+          </paper-dropdown-menu>
+          <paper-spinner-lite
+            class="spinner"
+            id="top-right-spinner"
+            hidden="[[!_busy]]"
+            active="[[_busy]]">
+          </paper-spinner-lite>
+          <paper-progress id="top-right-progress-bar" value="0"></paper-progress>
           <template is="dom-if" if="[[_isTopRightRuntimeGraphsActive]]">
             <div id="graph-container">
               <tf-graph id="graph"
@@ -163,6 +161,13 @@ limitations under the License.
             </tf-tensor-value-multi-view>
           </template>
         </div>
+
+        <tf-debugger-resizer
+          is-horizontal="true"
+          current-length="{{_topRightQuadrantHeight}}"
+          min-length="[[_minTopRightQuadrantHeight]]"
+          max-length="[[_maxTopRightQuadrantHeight]]">
+        </tf-debugger-resizer>
 
         <div id="tensor-data" class="tensor-data">
           <tf-tensor-data-summary
@@ -211,9 +216,12 @@ limitations under the License.
         /** This matches the default z-index of paper-dialog backdrops. */
         z-index: 102;
       }
+      /** Resize the region for the graph as the user resizes the region. */
       #graph-container {
+        height: calc(100% - 120px);
+        /** Clip the minimap if the height of the graph container is small. */
+        overflow: hidden;
         position: relative;
-        height: 85%;
       }
       #graph {
         position: relative;
@@ -272,6 +280,10 @@ limitations under the License.
         position: absolute;
         right: 0;
       }
+      /** The resizer should have no space to the left of it. */
+      #center-content tf-debugger-resizer[is-horizontal] {
+        margin-left: -23px;
+      }
       .context-menu {
         position: absolute;
         display: none;
@@ -316,7 +328,7 @@ limitations under the License.
         overflow: auto;
         padding: 20px 0;
       }
-      #top-right-content-container {
+      #top-right-quadrant {
         height: 66%;
         overflow: auto;
       }
@@ -355,8 +367,21 @@ limitations under the License.
   <script src="health-pills.js"></script>
   <script src="tensor-shape-helper.js"></script>
   <script>
+    const _COMPUTE_WINDOW_HEIGHT = () => (
+        window.innerHeight ||
+        document.documentElement.clientHeight ||
+        document.body.clientHeight);
+    const _COMPUTE_WINDOW_WIDTH = () => (
+        window.innerWidth ||
+        document.documentElement.clientWidth ||
+        document.body.clientWidth);
+    const _TENSORBOARD_HEADER_HEIGHT = 70
     const _DEFAULT_LEFT_PANE_WIDTH = 450;
     const _MAIN_CONTENT_LEFT_PADDING = 8;
+    const _MIN_TOP_RIGHT_QUADRANT_HEIGHT = 200;
+    // Default to about half the available height.
+    const _DEFAULT_TOP_RIGHT_QUADRANT_HEIGHT = (
+        _COMPUTE_WINDOW_HEIGHT() - _TENSORBOARD_HEADER_HEIGHT) / 2;
 
     Polymer({
       is: 'tf-debugger-dashboard',
@@ -529,6 +554,25 @@ limitations under the License.
           readOnly: true,
         },
 
+        _topRightQuadrantHeight: {
+          type: Number,
+          value: tf_storage.getNumberInitializer(
+              '_topRightQuadrantHeight',
+              {defaultValue: _DEFAULT_TOP_RIGHT_QUADRANT_HEIGHT}),
+          observer: '_topRightQuadrantHeightObserver',
+        },
+
+        _minTopRightQuadrantHeight: {
+          type: Number,
+          value: _MIN_TOP_RIGHT_QUADRANT_HEIGHT,
+          readOnly: true,
+        },
+
+        _maxTopRightQuadrantHeight: {
+          type: Number,
+          computed: '_computeMaxTopRightQuadrantHeight(_windowHeight, _resizerWidth)',
+        },
+
         _resizerWidth: {
           type: Number,
           value: 30,
@@ -536,11 +580,12 @@ limitations under the License.
         },
 
         _windowWidth: Number,
+        _windowHeight: Number,
       },
 
       observers: [
         "_onActiveRuntimeGraphDeviceNameChange(_activeRuntimeGraphDeviceName)",
-        "_sizeDashboardRegions(_leftPaneWidth, _windowWidth)",
+        "_sizeDashboardRegions(_leftPaneWidth, _topRightQuadrantHeight, _windowWidth)",
         "_graphProgressUpdated(_graphProgress)",
       ],
       listeners: {
@@ -1257,13 +1302,13 @@ limitations under the License.
         }
       },
       _handleWindowResize() {
-        this.set(
-            '_windowWidth',
-            window.innerWidth ||
-                document.documentElement.clientWidth ||
-                document.body.clientWidth);
+        this.set('_windowWidth', _COMPUTE_WINDOW_WIDTH());
+        this.set('_windowHeight', _COMPUTE_WINDOW_HEIGHT());
 
-        this._sizeDashboardRegions(this._leftPaneWidth, this._windowWidth);
+        this._sizeDashboardRegions(
+            this._leftPaneWidth,
+            this._topRightQuadrantHeight,
+            this._windowWidth);
       },
       _computeMaxleftPaneWidth(windowWidth, maxMainContentWidth, resizerWidth) {
         // Do not let the main content exceed this width when the user
@@ -1272,16 +1317,26 @@ limitations under the License.
         // able to access the resizer.
         return windowWidth - maxMainContentWidth - resizerWidth;
       },
-      _sizeDashboardRegions(leftPaneWidth, windowWidth) {
+      _computeMaxTopRightQuadrantHeight(windowHeight, resizerWidth) {
+        // Likewise, do not let the explore container exceed this height.
+        return windowHeight - resizerWidth - _TENSORBOARD_HEADER_HEIGHT;
+      },
+      _sizeDashboardRegions(
+          leftPaneWidth, topRightQuadrantHeight, windowWidth) {
         this.$$('#left-pane').style.width = leftPaneWidth + 'px';
         const contentWidth = windowWidth -
             leftPaneWidth -
             this._resizerWidth -
             _MAIN_CONTENT_LEFT_PADDING;
         this.$$('#center-content').style.width = contentWidth + 'px';
+        const height = topRightQuadrantHeight - this._resizerWidth;
+        this.$$('#top-right-quadrant').style.height = height + 'px';
       },
       _leftPaneWidthObserver: tf_storage.getNumberObserver(
           '_leftPaneWidth', {defaultValue: _DEFAULT_LEFT_PANE_WIDTH}),
+      _topRightQuadrantHeightObserver: tf_storage.getNumberObserver(
+          '_topRightQuadrantHeight',
+          {defaultValue: _DEFAULT_TOP_RIGHT_QUADRANT_HEIGHT}),
     });
 
     tf_tensorboard.registerDashboard({

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-resizer.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-resizer.html
@@ -25,7 +25,7 @@ limitations under the License.
     </div>
   </template>
   <style>
-    :host[resizer-identifier] {
+    :host[_resizer-identifier] {
       position: absolute;
       background: #ccc;
       user-select: none;
@@ -54,6 +54,13 @@ limitations under the License.
       left: 50%;
       font-size: 5px;
       transform: translate(-50%, -50%);
+    }
+
+    /** This block prevents the bars rotator from having a height that is 
+        the entire viewport, thus occluding it and giving it an undesired cursor
+        value. */
+    .bars-rotator {
+      display: inline-block;
     }
 
     :host[is-horizontal] .bars-rotator {
@@ -87,15 +94,21 @@ limitations under the License.
         value: false,
         reflectToAttribute: true,  // for CSS
       },
-      resizerIdentifier {
+      // We explicitly use an identifier when applying styles to the host since,
+      // unfortunately, the graph explorer imports all styles within the page
+      // into it (including styles associated with the :host selector within
+      // various components).
+      _resizerIdentifier: {
         type: Boolean,
         value: true,
         readOnly: true,
+        reflectToAttribute: true,  // for CSS
       },
       _isVertical: {
         type: Boolean,
         computed: '_computeIsVertical(isHorizontal)',
         reflectToAttribute: true,  // for CSS
+        readOnly: true,
       },
       // The pixel position at the start of the previous drag.
       _dragStartPosition: Number,

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-resizer.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-resizer.html
@@ -99,6 +99,8 @@ limitations under the License.
       'mousedown': '_handleMouseDown',
     },
     _handleMouseDown(e) {
+      e.preventDefault();
+
       // Start new drag (after ending the previous one if one lingered).
 
       // A drag may linger if for instance the user moused down and then
@@ -107,6 +109,8 @@ limitations under the License.
       this._endDrag();
 
       this._previousMouseMoveCallback = (e) => {
+        e.preventDefault();
+
         // Update the width of the container being resized.
         const deltaPosition =
             this._getPositionRelativeToViewport(e) - this._dragStartPosition;
@@ -119,6 +123,8 @@ limitations under the License.
       };
 
       this._previousMouseUpCallback = (e) => {
+        e.preventDefault();
+
         // Stop listening for relevant events.
         this._endDrag();
       };

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-resizer.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-resizer.html
@@ -15,7 +15,9 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-imports/lodash.html">
 
-
+<!--
+  Lets the user resize a container either vertically or horizontally.
+-->
 <dom-module id="tf-debugger-resizer">
   <template>
     <div class="bars">

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-resizer.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-resizer.html
@@ -25,7 +25,7 @@ limitations under the License.
     </div>
   </template>
   <style>
-    :host {
+    :host[resizer-identifier] {
       position: absolute;
       background: #ccc;
       user-select: none;
@@ -38,7 +38,7 @@ limitations under the License.
       right: 0;
     }
 
-    :host:not([is-horizontal]) {
+    :host[_is-vertical] {
       cursor: col-resize;
       right: -15px;
       top: 0;
@@ -85,6 +85,16 @@ limitations under the License.
       isHorizontal: {
         type: Boolean,
         value: false,
+        reflectToAttribute: true,  // for CSS
+      },
+      resizerIdentifier {
+        type: Boolean,
+        value: true,
+        readOnly: true,
+      },
+      _isVertical: {
+        type: Boolean,
+        computed: '_computeIsVertical(isHorizontal)',
         reflectToAttribute: true,  // for CSS
       },
       // The pixel position at the start of the previous drag.
@@ -145,6 +155,9 @@ limitations under the License.
       window.removeEventListener(
           'mouseup', this._previousMouseUpCallback, false);
       this._previousMouseUpCallback = null;
+    },
+    _computeIsVertical(isHorizontal) {
+      return !isHorizontal;
     },
   });
   </script>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-resizer.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-resizer.html
@@ -16,22 +16,34 @@ limitations under the License.
 <link rel="import" href="../tf-imports/lodash.html">
 
 
-<dom-module id="tf-debugger-vertical-resizer">
+<dom-module id="tf-debugger-resizer">
   <template>
     <div class="bars">
-      <span class="bars-text">| |</span>
+      <div class="bars-rotator">
+        <span class="bars-text">| |</span>
+      </div>
     </div>
   </template>
   <style>
     :host {
-      cursor: col-resize;
       position: absolute;
+      background: #ccc;
+      user-select: none;
+    }
+
+    :host[is-horizontal] {
+      cursor: row-resize;
+      height: 10px;
+      left: 0;
+      right: 0;
+    }
+
+    :host:not([is-horizontal]) {
+      cursor: col-resize;
       right: -15px;
       top: 0;
       bottom: 0;
       width: 10px;
-      background: #ccc;
-      user-select: none;
     }
 
     .bars {
@@ -40,8 +52,12 @@ limitations under the License.
       position: absolute;
       top: 50%;
       left: 50%;
-      transform: translate(-50%, -50%);
       font-size: 5px;
+      transform: translate(-50%, -50%);
+    }
+
+    :host[is-horizontal] .bars-rotator {
+      transform: rotate(90deg);
     }
 
     .bars-text {
@@ -53,20 +69,29 @@ limitations under the License.
   </style>
   <script>
   Polymer({
-    is: "tf-debugger-vertical-resizer",
+    is: "tf-debugger-resizer",
     properties: {
-      // The current width of the container we are resizing.
-      currentWidth: {
+      // The current width/height (depends on whether the dragger is vertical or
+      // horizontal) of the container we are resizing.
+      currentLength: {
         type: Number,
         notify: true,
       },
-      minWidth: Number,
-      maxWidth: Number,
-      // The screen X value at the start of the previous drag.
-      _dragStartScreenX: Number,
-      // The width of the container being resized at the start of the previous
+      minLength: Number,
+      maxLength: Number,
+      // If this is true, the dragger widget looks horizontal (not vertical).
+      // Specifically, if horizontal, the user will be able to vary the height
+      // of the container (instead of its width).
+      isHorizontal: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true,  // for CSS
+      },
+      // The pixel position at the start of the previous drag.
+      _dragStartPosition: Number,
+      // The length of the container being resized at the start of the previous
       // drag.
-      _dragStartWidth: Number,
+      _dragStartLength: Number,
       _previousMouseMoveCallback: Object,
       _previousMouseUpCallback: Object,
     },
@@ -83,29 +108,29 @@ limitations under the License.
 
       this._previousMouseMoveCallback = (e) => {
         // Update the width of the container being resized.
-        const deltaX =
-            this._getViewportXPosition(e) - this._dragStartScreenX;
+        const deltaPosition =
+            this._getPositionRelativeToViewport(e) - this._dragStartPosition;
 
-        let currentWidth = this._dragStartWidth + deltaX;
-        currentWidth = Math.max(currentWidth, this.minWidth);
-        currentWidth = Math.min(currentWidth, this.maxWidth);
+        let currentLength = this._dragStartLength + deltaPosition;
+        currentLength = Math.max(currentLength, this.minLength);
+        currentLength = Math.min(currentLength, this.maxLength);
 
-        this.set('currentWidth', currentWidth);
+        this.set('currentLength', currentLength);
       };
 
       this._previousMouseUpCallback = (e) => {
         // Stop listening for relevant events.
         this._endDrag();
       };
-      this.set('_dragStartScreenX', this._getViewportXPosition(e));
-      this.set('_dragStartWidth', this.currentWidth);
+      this.set('_dragStartPosition', this._getPositionRelativeToViewport(e));
+      this.set('_dragStartLength', this.currentLength);
 
       window.addEventListener('mouseup', this._previousMouseUpCallback, false);
       window.addEventListener(
           'mousemove', this._previousMouseMoveCallback, false);
     },
-    _getViewportXPosition(mouseEvent) {
-      return mouseEvent.clientX;
+    _getPositionRelativeToViewport(mouseEvent) {
+      return this.isHorizontal ? mouseEvent.clientY : mouseEvent.clientX;
     },
     _endDrag() {
       window.removeEventListener(


### PR DESCRIPTION
We add a dragger that lets the user resize the explore container (the section containing the graph or visualizations of tensor values) vs the tensor value overview section.

We achieve this by generalizing the `tf-debugger-vertical-resizer` component, allowing it to support both vertical and horizontal resizing.

As part of this effort, we make the height of the graph scale based on the size of its container, which solves another problem: There will no longer be a giant gap between the graph and the tensor value overview section. Previously, that gap was possible in tall viewports because the height of the graph was fixed.

Screenshots:
![image](https://user-images.githubusercontent.com/4221553/35210550-8daa295e-ff07-11e7-87db-66356bba8ca0.png)
![image](https://user-images.githubusercontent.com/4221553/35210557-91bfadc0-ff07-11e7-9f46-042ce8b3a698.png)
