### PR TITLE
[Debugger Plugin]: Continue to condition & misc. improvements

### DIFF
--- a/tensorboard/plugins/debugger/tensor_store.py
+++ b/tensorboard/plugins/debugger/tensor_store.py
@@ -186,7 +186,11 @@ class TensorStore(object):
           mem_bytes_limit=self._watch_mem_bytes_limit)
     self._tensor_data[watch_key].add(tensor_value)
 
-  def query(self, watch_key, time_indices=None, slicing=None, mapping=None):
+  def query(self,
+            watch_key,
+            time_indices=None,
+            slicing=None,
+            mapping=None):
     """Query tensor store for a given watch_key.
 
     Args:
@@ -195,7 +199,7 @@ class TensorStore(object):
         `-1`, `:-2`, `[::2]`. If not provided (`None`), will use -1.
       slicing: A numpy-style slicing string for individual time steps.
       mapping: An mapping string or a list of them. Supported mappings:
-        `{None, 'image/png'}`.
+        `{None, 'image/png', 'health-pill'}`.
 
     Returns:
       The potentially sliced values as a nested list of values or its mapped

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
@@ -7,8 +7,10 @@ licenses(["notice"])  # Apache 2.0
 tf_web_library(
     name = "tf_debugger_dashboard",
     srcs = [
+        "health-pills.ts",
         "selection-tree-node.ts",
         "tensor-shape-helper.ts",
+        "tf-debugger-continue-dialog.html",
         "tf-debugger-dashboard.html",
         "tf-debugger-initial-dialog.html",
         "tf-debugger-line-chart.html",

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/health-pills.ts
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/health-pills.ts
@@ -1,0 +1,182 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/* TypeScript module for predicates on health pills. */
+
+namespace tf_debugger_dashboard {
+
+function checkRefValue(refValue: number, condition: string) {
+  if (refValue == null) {
+    throw new Error(`Missing refValue for condition (${condition}).`);
+  }
+}
+
+/**
+ * Check if a health pill meets the given condition.
+ *
+ * Any condition value that involves numerical comparison require a value
+ *   in the `refValue` argument (see below).
+ * @param healthPill The health pill.
+ * @param refValue Threshold required by some of the condition values. If not
+ *   provided for such conditions, an Error will be thrown.
+ * @return Whether the condition is met.
+ * @throws Error on in valid condition values or missing refValue for conditions
+ *   that requires it.
+ */
+export type TensoConditionPredicate =
+    (healthPill: number[], refValue?: number) => boolean;
+
+
+export interface TensorCondition {
+  description: string;
+  predicate: TensoConditionPredicate;
+}
+
+function isHealthPillUninitizliedOrUnsupported(healthPill: number[]): boolean {
+  return healthPill == null || healthPill.length == 0 || healthPill[0] !== 1;
+}
+
+/**
+ * A collection of tensor value conditions.
+ *
+ * With the human-readable description and the predicate function for each
+ *   condition.
+ */
+const tensorConditions: {[key: string]: TensorCondition} = {
+  INF_OR_NAN: {
+    description: 'Contains +/-∞ or NaN',
+    predicate: (healthPill: number[], refValue?: number) => {
+      return healthPill[2] > 0 || healthPill[3] > 0 || healthPill[7] > 0;
+    },
+  },
+  INF: {
+    description: 'Contains +/-∞',
+    predicate: (healthPill: number[], refValue?: number) => {
+      return healthPill[3] > 0 || healthPill[7] > 0;
+    },
+  },
+  NAN: {
+    description: 'Contains NaN',
+    predicate: (healthPill: number[], refValue?: number) => {
+      return healthPill[2] > 0;
+    },
+  },
+  MAX_GT: {
+    description: 'Max >',
+    predicate: (healthPill: number[], refValue?: number) => {
+      checkRefValue(refValue, 'MAX_GT');
+      return healthPill[9] > refValue;
+    },
+  },
+  MAX_LT: {
+    description: 'Max <',
+    predicate: (healthPill: number[], refValue?: number) => {
+      checkRefValue(refValue, 'MAX_LT');
+      return healthPill[9] < refValue;
+    },
+  },
+  MIN_GT: {
+    description: 'Min >',
+    predicate: (healthPill: number[], refValue?: number) => {
+      checkRefValue(refValue, 'MIN_GT');
+      return healthPill[8] > refValue;
+    },
+  },
+  MIN_LT: {
+    description: 'Min <',
+    predicate: (healthPill: number[], refValue?: number) => {
+      checkRefValue(refValue, 'MIN_LT');
+      return healthPill[8] < refValue;
+    },
+  },
+  MEAN_GT: {
+    description: 'Mean >',
+    predicate: (healthPill: number[], refValue?: number) => {
+      checkRefValue(refValue, 'MEAN_GT');
+      return healthPill[10] > refValue;
+    },
+  },
+  MEAN_LT: {
+    description: 'Mean <',
+    predicate: (healthPill: number[], refValue?: number) => {
+      checkRefValue(refValue, 'MEAN_LT');
+      return healthPill[10] < refValue;
+    },
+  },
+  RANGE_GT: {
+    description: 'Max - Min >',
+    predicate: (healthPill: number[], refValue?: number) => {
+      checkRefValue(refValue, 'RANGE_GT');
+      return healthPill[9] - healthPill[8] > refValue;
+    },
+  },
+  RANGE_LT: {
+    description: 'Max - Min <',
+    predicate: (healthPill: number[], refValue?: number) => {
+      checkRefValue(refValue, 'RANGE_LT');
+      return healthPill[9] - healthPill[8] < refValue;
+    },
+  },
+  STDDEV_GT: {
+    description: 'Standard deviation >',
+    predicate: (healthPill: number[], refValue?: number) => {
+      checkRefValue(refValue, 'STDDEV_GT');
+      return Math.sqrt(healthPill[11]) > refValue;
+    },
+  },
+  STDDEV_LT: {
+    description: 'Standard deviation <',
+    predicate: (healthPill: number[], refValue?: number) => {
+      checkRefValue(refValue, 'STDDEV_LT');
+      return Math.sqrt(healthPill[11]) < refValue;
+    },
+  },
+};
+
+/**
+ * Convert the human-readable description of a tensor-value conditio to its key.
+ * @param description Human-readable description.
+ * @returns The key, if exists. Else, `null`.
+ */
+export function tensorConditionDescription2Key(description: string): string {
+  for (const key in tensorConditions) {
+    if (!tensorConditions.hasOwnProperty(key)) {
+      continue;
+    }
+    if (tensorConditions[key].description === description) {
+      return key;
+    }
+  }
+  return null;
+}
+
+
+/**
+ * Test a health pill against a tensor-value condition.
+ * @param key Key for the tensor-value condition, see `tensorConditions` for
+ *   details.
+ * @param healthPill The health pill.
+ * @param refValue The reference value required by some of the tensor-value
+ *   conditions, e.g., `MEAN_LT`.
+ */
+export function checkHealthPillAgainstTensorConditionKey(
+    key: string, healthPill: number[], refValue?: number): boolean {
+  if (isHealthPillUninitizliedOrUnsupported(healthPill)) {
+    return false;
+  }
+  const predicate = tensorConditions[key].predicate;
+  return predicate(healthPill, refValue);
+}
+
+}

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/health-pills.ts
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/health-pills.ts
@@ -34,16 +34,16 @@ function checkRefValue(refValue: number, condition: string) {
  * @throws Error on in valid condition values or missing refValue for conditions
  *   that requires it.
  */
-export type TensoConditionPredicate =
+export type TensorConditionPredicate =
     (healthPill: number[], refValue?: number) => boolean;
 
 
 export interface TensorCondition {
   description: string;
-  predicate: TensoConditionPredicate;
+  predicate: TensorConditionPredicate;
 }
 
-function isHealthPillUninitizliedOrUnsupported(healthPill: number[]): boolean {
+function isHealthPillUninitializedOrUnsupported(healthPill: number[]): boolean {
   return healthPill == null || healthPill.length == 0 || healthPill[0] !== 1;
 }
 
@@ -145,7 +145,7 @@ const tensorConditions: {[key: string]: TensorCondition} = {
 };
 
 /**
- * Convert the human-readable description of a tensor-value conditio to its key.
+ * Convert human-readable description of a tensor-value condition to its key.
  * @param description Human-readable description.
  * @returns The key, if exists. Else, `null`.
  */
@@ -174,7 +174,7 @@ export function tensorConditionDescription2Key(description: string): string {
  */
 export function checkHealthPillAgainstTensorConditionKey(
     key: string, healthPill: number[], refValue?: number): boolean {
-  if (isHealthPillUninitizliedOrUnsupported(healthPill)) {
+  if (isHealthPillUninitializedOrUnsupported(healthPill)) {
     return false;
   }
   const predicate = tensorConditions[key].predicate;

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/health-pills.ts
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/health-pills.ts
@@ -169,6 +169,8 @@ export function tensorConditionDescription2Key(description: string): string {
  * @param healthPill The health pill.
  * @param refValue The reference value required by some of the tensor-value
  *   conditions, e.g., `MEAN_LT`.
+ * @returns Whether the tensor condition specified by `key` (and potentially
+ *   also `revValue` for some `key` values) is satisfied by `healthPill`.
  */
 export function checkHealthPillAgainstTensorConditionKey(
     key: string, healthPill: number[], refValue?: number): boolean {

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-continue-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-continue-dialog.html
@@ -1,0 +1,187 @@
+<!--
+@license
+Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/lodash.html">
+
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
+
+<dom-module id="tf-debugger-continue-dialog">
+  <template>
+    <paper-dialog with-backdrop id="continueDialog">
+      <h2>Continue...</h2>
+      <div class="continue-to-type">
+        <div class="continue-to-type-name">
+          Over Session Runs:
+        </div>
+        <paper-input
+          id="continueNum"
+          class="input-box"
+          label="Number of Session Runs (including the current one):"
+          always-float-label
+          type="number"
+          min="1"
+          step="1"
+          value="{{continueNum}}"
+        ></paper-input>
+        <paper-icon-button
+          class="go-button"
+          icon="arrow-forward"
+          title="Session Runs Go"
+          on-tap="_sessionRunGoButtonCallback">
+        </paper-icon-button>
+      </div>
+      <div class="continue-to-type">
+        <div class="continue-to-type-name">
+          Till Condition Met by Watched Tensor
+        </div>
+        <paper-dropdown-menu
+          id="tensorConditionDropdown"
+          class="input-box"
+          no-label-float="true"
+          label="Tensor Condition"
+          selected-item-label="{{_selectedTensorCondition}}">
+          <paper-menu id="tensorConditionMenu" class="dropdown-content" slot="dropdown-content">
+            <paper-item no-label-float=true>Contains +/-∞ or NaN</paper-item>
+            <paper-item no-label-float=true>Contains +/-∞</paper-item>
+            <paper-item no-label-float=true>Contains NaN</paper-item>
+            <paper-item no-label-float=true>Max &gt;</paper-item>
+            <paper-item no-label-float=true>Max &lt;</paper-item>
+            <paper-item no-label-float=true>Min &gt;</paper-item>
+            <paper-item no-label-float=true>Min &lt;</paper-item>
+            <paper-item no-label-float=true>Max - Min &gt;</paper-item>
+            <paper-item no-label-float=true>Max - Min &lt;</paper-item>
+            <paper-item no-label-float=true>Mean &gt;</paper-item>
+            <paper-item no-label-float=true>Mean &lt;</paper-item>
+            <paper-item no-label-float=true>Standard deviation &gt;</paper-item>
+            <paper-item no-label-float=true>Standard deviation &lt;</paper-item>
+          </paper-menu>
+        </paper-dropdown-menu>
+        <paper-icon-button
+          class="go-button"
+          icon="arrow-forward"
+          title="Tensor Condition Go"
+          on-tap="_tensorContinueGoButtonCallback">
+        </paper-icon-button>
+        <paper-input
+          id="ref-value"
+          class="input-box"
+          label="Reference value to compare to"
+          value="{{_tensorConditionRefValue}}"
+          hidden="[[_isRefValueInputHidden]]"
+        </paper-input>
+      </div>
+    </paper-dialog>
+    <style include="dashboard-style"></style>
+    <style>
+      :host .continue-to-type-name {
+        font-weight: bold;
+      }
+      :host paper-dialog {
+        width: 36vw;
+      }
+      :host .input-box {
+        display: inline-block;
+        position: relative;
+        width: 80%;
+        font-size: 110%;
+      }
+      :host .go-button {
+        position: relative;
+        width: 15%;
+        display: inline-block;
+      }
+    </style>
+  </template>
+  <script src="health-pills.js"></script>
+  <script>
+    Polymer({
+      is: 'tf-debugger-continue-dialog',
+      properties: {
+        continueNum: {  // How many times to continue over, e.g., Session.Runs.
+          type: Number,
+          value: 5,
+        },
+
+        // Callback for the session-runs go button.
+        sessionRunGo: Function,
+
+        // Handler for tensor-condition go, invoked by the callback of the
+        // tensor-condition go button.
+        // Signature of this function:
+        // Args:
+        //   conditionKey: Key of the tensor-value condition (e.g., NAN_OR_INF),
+        //     see health-pills.ts for more details.
+        //   refValue: Optional reference value. It is required by some of the
+        //     tensor-value conditions (e.g., STDDEV_GT).
+        tensorConditionGo: Function,
+
+        _selectedTensorCondition: String,
+
+        _tensorConditionRefValue: {
+          type: Number,
+          value: 0,
+          notify: true,
+        },
+
+        _isRefValueInputHidden: {
+          type: Boolean,
+          value: true,
+          notify: true,
+        }
+      },
+
+      observers: [
+        "_onSelectedTensorConditionChanged(_selectedTensorCondition)",
+      ],
+
+
+      open() {
+        this.$.continueDialog.open();
+      },
+
+      close() {
+        this.$.continueDialog.close();
+      },
+
+      _sessionRunGoButtonCallback() {
+        this.sessionRunGo();
+      },
+
+      _tensorContinueGoButtonCallback() {
+        if (this._selectedTensorCondition == null) {
+          return;
+        }
+        const tensorConditionKey =
+            tf_debugger_dashboard.tensorConditionDescription2Key(this._selectedTensorCondition);
+        if (tensorConditionKey == null) {
+          console.error(
+              'Invalid Tensor Condition name:' + this._selectedTensorCondition);
+        }
+        this.tensorConditionGo(tensorConditionKey, this._tensorConditionRefValue);
+      },
+
+      _onSelectedTensorConditionChanged(selectedTensorCondition) {
+        const tensorConditionKey =
+            tf_debugger_dashboard.tensorConditionDescription2Key(selectedTensorCondition);
+        this.set(
+            '_isRefValueInputHidden',
+            ['INF_OR_NAN', 'INF', 'NAN'].indexOf(tensorConditionKey) !== -1);
+      }
+    });
+  </script>
+</dom-module>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-continue-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-continue-dialog.html
@@ -55,6 +55,8 @@ limitations under the License.
           no-label-float="true"
           label="Tensor Condition"
           selected-item-label="{{_selectedTensorCondition}}">
+          <!-- TODO(cais): Maybe dynamically set the menu items using some variable
+                           exported from health-pills.ts. -->
           <paper-menu id="tensorConditionMenu" class="dropdown-content" slot="dropdown-content">
             <paper-item no-label-float=true>Contains +/-∞ or NaN</paper-item>
             <paper-item no-label-float=true>Contains +/-∞</paper-item>
@@ -174,11 +176,12 @@ limitations under the License.
               'Invalid Tensor Condition name:' + this._selectedTensorCondition);
         }
         // Validate that this._tensorConditionRefValue is a number.
-        if (isNaN(this._tensorConditionRefValue)) {
+        const refValue = Number(this._tensorConditionRefValue);
+        if (!_.isFinite(refValue)) {
           this.set('_tensorConditionRefValue', 0);
           return;
         }
-        this.tensorConditionGo(tensorConditionKey, this._tensorConditionRefValue);
+        this.tensorConditionGo(tensorConditionKey, refValue);
       },
 
       _onSelectedTensorConditionChanged(selectedTensorCondition) {

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-continue-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-continue-dialog.html
@@ -81,8 +81,9 @@ limitations under the License.
           id="ref-value"
           class="input-box"
           label="Reference value to compare to"
+          type="number"
           value="{{_tensorConditionRefValue}}"
-          hidden="[[_isRefValueInputHidden]]"
+          hidden="[[_isRefValueInputHidden]]">
         </paper-input>
       </div>
     </paper-dialog>
@@ -171,6 +172,11 @@ limitations under the License.
         if (tensorConditionKey == null) {
           console.error(
               'Invalid Tensor Condition name:' + this._selectedTensorCondition);
+        }
+        // Validate that this._tensorConditionRefValue is a number.
+        if (isNaN(this._tensorConditionRefValue)) {
+          this.set('_tensorConditionRefValue', 0);
+          return;
         }
         this.tensorConditionGo(tensorConditionKey, this._tensorConditionRefValue);
       },

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -564,7 +564,8 @@ limitations under the License.
         };
         let path = tf_backend.getRouter().pluginRoute('debugger', '/comm');
         path = tf_backend.addParams(path, parameters);
-        console.log('Sending long-polling request to: ', path);
+        // Uncomment the following line for debugging.
+        // console.log('Sending long-polling request to: ', path);
         this._requestManager.request(path).then(response => {
           const responseType = response['type'];
           const responseData = response['data'];
@@ -1045,8 +1046,16 @@ limitations under the License.
             this.set('_sourceFocusNodeName', nodeName);
           }
           this._focusOnGraphNode(deviceName, maybeBaseExpandedNodeName);
-          this.set('_forceExpandNodeName',
-                   deviceName + '/' + maybeBaseExpandedNodeName);
+          const nodeNameWithDeviceName =
+              deviceName + '/' + maybeBaseExpandedNodeName;
+          this.set('_forceExpandNodeName', nodeNameWithDeviceName);
+          // Wait a little for any concurrent ongoing row rendering in the
+          // Tensor Value Overview table to settle before focusing on the
+          // node that just met the tensor condition.
+          setTimeout(() => {
+            this.set('_highlightNodeName', null);
+            this.set('_highlightNodeName', nodeNameWithDeviceName);
+          }, 100);
           this._showToast('Tensor condition "' + this._continueToTarget +
                           '" is met by watch key: "' + watchKey + '".\n' +
                           'Stopping continuation.');

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -34,6 +34,7 @@ limitations under the License.
 <link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 <link rel="import" href="../tf-tensorboard/registry.html">
+<link rel="import" href="tf-debugger-continue-dialog.html">
 <link rel="import" href="tf-debugger-initial-dialog.html">
 <link rel="import" href="tf-debugger-vertical-resizer.html">
 <link rel="import" href="tf-op-selector.html">
@@ -45,26 +46,12 @@ limitations under the License.
 <dom-module id="tf-debugger-dashboard">
   <template>
     <paper-toast id="toast" text="" always-on-top></paper-toast>
-    <paper-dialog with-backdrop id="continueDialog" width="320">
-      <h2>Continue...</h2>
-      <paper-input
-        id="continueNum"
-        label="Number of times (including current one):"
-        always-float-label
-        type="number"
-        min="1"
-        step="1"
-        value="[[_continueNum]]"
-        on-change="_continueNumChanged"
-      ></paper-input>
-      <paper-button raised class="continue-go-button" on-click="_continueGo">
-        <span>Go</span>
-      </paper-button>
-    </paper-dialog>
-    <tf-debugger-initial-dialog
-      id="initialDialog"
-    >
-    </tf-debugger-initial-dialog>
+    <tf-debugger-initial-dialog id="initialDialog"></tf-debugger-initial-dialog>
+    <tf-debugger-continue-dialog
+      id="continueDialog"
+      session-run-go="[[_createSessionRunGo()]]"
+      tensor-condition-go="[[_createTensorConditionGo()]]">
+    </tf-debugger-continue-dialog>
     <!-- TODO(caisq, chihuahua): This shouldn't be a dialog. It should be a prettier
       widget that supports showing both text, curves and images. -->
     <tf-dashboard-layout>
@@ -182,6 +169,7 @@ limitations under the License.
 
         <div id="tensor-data" class="tensor-data">
           <tf-tensor-data-summary
+            id="tensorDataSummary"
             latest-tensor-data="[[_latestTensorData]]"
             expand-handler="[[_createTensorDataExpandHandler()]]"
             continue-to-callback="[[_createContinueToCallback()]]"
@@ -203,6 +191,12 @@ limitations under the License.
         top: 0;
         bottom: 0;
         overflow: hidden;
+      }
+      :host paper-toast {
+        text-align: center;
+        font-size: 110%;
+        width: 40vw;
+        margin-left: 30vw;
       }
       .debugger-section-title {
         font-size: 110%;
@@ -360,6 +354,7 @@ limitations under the License.
       }
     </style>
   </template>
+  <script src="health-pills.js"></script>
   <script src="tensor-shape-helper.js"></script>
   <script>
     const _DEFAULT_LEFT_PANE_WIDTH = 450;
@@ -401,10 +396,6 @@ limitations under the License.
         _continueButtonText: {
             type: String,
             value: 'Continue...',
-        },
-        _continueNum: {  // How many times to continue over, e.g., Session.Runs.
-            type: Number,
-            value: 5,
         },
 
         _tensorViewIdCounter: {
@@ -458,16 +449,28 @@ limitations under the License.
         },
 
         // What kind of entity to continue over. Possibilities:
-        // {'', 'SessionRun', 'op'}.
+        // {'', 'SessionRun', 'TensorCondition', 'op'}.
         // '' is the default state, i.e., a state where the UI is not continuing
         // over anything.
         _continueToType: {
           type: String,
           value: '',
         },
-        // The target of the continue-to action. For example, for _continueToType ==
-        // 'SessionRun', this can be the session run string. For _continueToType ==
-        // 'op', this can be a debug tensor name.
+        _continueToCounter: {
+          type: Number,
+          value: 0,
+        },
+        // A flag used to force continuation to stop.
+        _continueStop: {
+          type: Boolean,
+          value: false,
+        },
+        // The target of the continue-to action.
+        // For _continueToType == 'SessionRun', this can be a number of times
+        //   to run Session.run for.
+        // For _continueToType == 'TensorCondition', this can be the string
+        //   value for a tensor value, e.g., INF_OR_NAN.
+        // For _continueToType == 'op', this can be a debug tensor name.
         _continueToTarget: {
           type: String,
           value: '',
@@ -565,11 +568,12 @@ limitations under the License.
         this._requestManager.request(path).then(response => {
           const responseType = response['type'];
           const responseData = response['data'];
-          if (responseType == 'meta') {
+          if (responseType === 'meta') {
             const runKey = responseData['run_key'];
             const feedNames = runKey[0].split(',');
             const fetchNames = runKey[1].split(',');
             const targetNames = runKey[2].split(',');
+            const previousRunKey = this._activeSessionRunKey;
             this.set('_activeSessionRunKey', runKey);
             this.set('_latestSessionRun', {
               'feeds': feedNames,
@@ -595,12 +599,15 @@ limitations under the License.
             }
             this.$.initialDialog.closeDialog();
 
-            if (!this._continueToType) {
-              // Do not refresh node list if we are in continue model.
+            // Do not refresh node list if we are in continue model and the
+            // the Sesssion.run key hasn't changed.
+            const toProcessNewSessionRun =
+                !this._continueToType || !_.isEqual(previousRunKey, runKey);
+            if (toProcessNewSessionRun) {
               this._processGatedGrpcDebugOps(runKey, false);
               this._showToast('A new Session.run() has begun.');
             }
-          } else if (responseType == 'tensor') {
+          } else if (responseType === 'tensor') {
             const deviceName = responseData['device_name'];
             const nodeName = responseData['node_name'];
             const maybeBaseExpandedNodeName = responseData[
@@ -646,36 +653,65 @@ limitations under the License.
                 'Invalid long-polling response type: ', responseType);
           }
 
-          if (this._continueToType === 'SessionRun') {
-            if (this._sessionRunCounters[this._currentSessionRunInfo] <
-                this._continueToCounterTarget) {
-              this._step();
-            } else {
-              this._clearContinueTo();
-            }
-          } else if (this._continueToType === 'op') {
-            const deviceName = responseData['device_name'];
-            const maybeBaseExpandedNodeName = responseData[
-                'maybe_base_expanded_node_name'];
-            const nodeNameWithDevice = deviceName + '/' + maybeBaseExpandedNodeName;
-            if (nodeNameWithDevice !== this._continueToTarget) {
-              this._step();
-            } else {
-              this._clearContinueTo();
-              if (this._sourceCodeShown) {
-                this.set(
-                    '_sourceFocusNodeName',
-                    tf_debugger_dashboard.removeNodeNameBaseExpansion(
-                        maybeBaseExpandedNodeName));
-              }
-            }
-          } else if (this._continueToType != null && this._continueToType !== '') {
-            console.error('Invalid _continueToType:', this._continueToType);
+          if (this._continueToType != null) {
+            this._processContinueTo(responseType, responseData);
           }
 
           // Long polling loop: initialite the next long polling.
           this.long_poll();
         });
+      },
+
+      _processContinueTo(responseType, responseData) {
+        // Check the flag for forced stop of continuation, e.g., due to user's
+        // UI action or tensor condition being met during continuation type
+        // 'TensorCondition'.
+        if (this._continueStop) {
+          this._clearContinueTo();
+        } else {
+          if (this._continueToType === 'SessionRun') {
+            this._processContinueToSessionRun(responseType === 'meta');
+          } else if (this._continueToType === 'TensorCondition') {
+            this._step();
+            // Note: _conditionalHealthPillStop() will be invoked on each
+            // health pill value. If it detects a health pill that matches the
+            // condition, it'll stop the continuation by setting _continueStop
+            // to true.
+          } else if (this._continueToType === 'op') {
+            this._processContinueToOp(responseData);
+          } else if (this._continueToType != null && this._continueToType !== '') {
+            console.error('Invalid _continueToType:', this._continueToType);
+          }
+        }
+      },
+
+      _processContinueToSessionRun(isSessionRunBeginning) {
+        if (isSessionRunBeginning) {
+          this.set('_continueToCounter',  this._continueToCounter + 1);
+        }
+        if (this._continueToCounter < this._continueToCounterTarget) {
+          this._step();
+        } else {
+          this._clearContinueTo();
+        }
+      },
+
+      _processContinueToOp(responseData) {
+        const deviceName = responseData['device_name'];
+        const maybeBaseExpandedNodeName = responseData[
+            'maybe_base_expanded_node_name'];
+        const nodeNameWithDevice = deviceName + '/' + maybeBaseExpandedNodeName;
+        if (nodeNameWithDevice !== this._continueToTarget) {
+          this._step();
+        } else {
+          this._clearContinueTo();
+          if (this._sourceCodeShown) {
+            this.set(
+                '_sourceFocusNodeName',
+                tf_debugger_dashboard.removeNodeNameBaseExpansion(
+                    maybeBaseExpandedNodeName));
+          }
+        }
       },
 
       _maybeUpdateTensorValueViews(tensorName, debugOp) {
@@ -974,7 +1010,7 @@ limitations under the License.
 
       // Create a function that gives the health pill of a tensor.
       _createGetHealthPill() {
-        return (watchKey, callback) => {
+        return (watchKey, deviceName, maybeBaseExpandedNodeName, callback) => {
           const parameters = {
             'watch_key': watchKey,
             'time_indices': '-1',   // '-1' means the latest time point.
@@ -983,9 +1019,38 @@ limitations under the License.
           const baseUrl = tf_backend.getRouter().pluginRoute('debugger', '/tensor_data');
           const url = tf_backend.addParams(baseUrl, parameters);
           this._requestManager.request(url).then(response => {
-            callback(response.tensor_data[0]);
+            const healthPill = response.tensor_data[0];
+            callback(healthPill);
+            this._conditionalHealthPillStop(
+                watchKey, deviceName, maybeBaseExpandedNodeName, healthPill);
           });
         };
+      },
+
+      // Under 'TensorCondition' continuation type, check health pills and stop
+      // when they meet the given condition.
+      _conditionalHealthPillStop(
+          watchKey, deviceName, maybeBaseExpandedNodeName, healthPill) {
+        if (this._continueToType !== 'TensorCondition') {
+          return;
+        }
+        if (tf_debugger_dashboard.checkHealthPillAgainstTensorConditionKey(
+                this._continueToTarget, healthPill,
+                this._continueToCounterTarget)) {
+          this.set('_continueStop', true);
+          const nodeName =
+              tf_debugger_dashboard.removeNodeNameBaseExpansion(maybeBaseExpandedNodeName);
+          if (this._sourceCodeShown) {
+            // If the source view is active, highlight the source lines.
+            this.set('_sourceFocusNodeName', nodeName);
+          }
+          this._focusOnGraphNode(deviceName, maybeBaseExpandedNodeName);
+          this.set('_forceExpandNodeName',
+                   deviceName + '/' + maybeBaseExpandedNodeName);
+          this._showToast('Tensor condition "' + this._continueToTarget +
+                          '" is met by watch key: "' + watchKey + '".\n' +
+                          'Stopping continuation.');
+        }
       },
 
       _continueToNode(deviceName, baseExpandedNodeName) {
@@ -1027,8 +1092,7 @@ limitations under the License.
             }
           }
         }
-        if (!this._continueToType) {
-          // Do not refresh graph if we are in continue mode.
+        if (deviceName != null) {
           this._displayGraph(this._activeSessionRunKey, deviceName);
         }
       },
@@ -1070,29 +1134,47 @@ limitations under the License.
         });
       },
 
-      _continueGo() {
-        if (this._continueNum > 0) {
-          this._setContinueTo('SessionRun', this._currentSessionRunInfo,
-              this._sessionRunCounters[this._currentSessionRunInfo] +
-              this._continueNum);
+      // Create a callback for the Session.runs Go button of the continue
+      // dialog.
+      _createSessionRunGo() {
+        return () => {
+          if (this.$.continueDialog.continueNum > 0) {
+            this._setContinueTo(
+                'SessionRun', this._currentSessionRunInfo,
+                this.$.continueDialog.continueNum);
+            this._step();
+            this.$.continueDialog.close();
+          } else {
+            this.$.continueDialog.set('continueNum', 1);
+          }
+        };
+      },
+
+      // Create a callback for the tensor condition Go button of the continue
+      // dialog.
+      _createTensorConditionGo() {
+        return (conditionKey, refValue) => {
+          this._setContinueTo('TensorCondition', conditionKey, refValue);
+          // Force enable health pills during TensorCondition continuation.
+          this.$.tensorDataSummary.enableHealthPills();
           this._step();
           this.$.continueDialog.close();
-        } else {
-          this._continueNum = 1;
-        }
+        };
       },
-      _continueNumChanged(e) {
-        this._continueNum = e.target.valueAsNumber;
-      },
-      _setContinueTo(type, target, counter_target) {
+
+      _setContinueTo(type, target, counterTarget) {
         this._continueToType = type;
         this._continueToTarget = target;
-        this._continueToCounterTarget = counter_target;
+        this._continueToCounterTarget = counterTarget;
+        this._continueToCounter = 0;
+        this._continueStop = false;
       },
       _clearContinueTo() {
         this._continueToType = '';
         this._continueToTarget = '';
         this._continueToCounterTarget = -1;
+        this._continueToCounter = 0;
+        this._continueStop = false;
         this.set('_busy', false);
       },
 

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
@@ -34,7 +34,7 @@ limitations under the License.
           <th width="25%">Value</th>
           <th width="25%">
             Health Pill
-            <paper-toggle-button id="show-health-pills" checked>
+            <paper-toggle-button id="show-health-pills" checked="{{_healthPillsEnabled}}">
             </paper-toggle-button>
             <paper-card>
               <div class="health-pill-legend" id="health-pill-legend"></div>
@@ -150,6 +150,12 @@ limitations under the License.
       //     i.e., the health pill values as an Array of Numbers.
       getHealthPill: Function,
 
+      _healthPillsEnabled: {
+        type: Boolean,
+        value: true,
+        notify: true,
+      },
+
       _watchKeys: {
         type: Array,
         value: [],
@@ -178,11 +184,6 @@ limitations under the License.
         value: {},
       },
       _activeWatchKey: String,
-      _showHealthPills: {
-        type: Boolean,
-        value: true,
-      },
-
       _healthPillWidth: {
         type: Number,
         value: 200,
@@ -206,10 +207,13 @@ limitations under the License.
       this._renderHealthPillLegend();
     },
 
+    enableHealthPills() {
+      this.set('_healthPillsEnabled', true);
+      this._renderHealthPillLegend();
+    },
+
     _showHealthPillsChanged(event) {
-      // Flip the state of the show-health-pills flag.
-      this.set('_showHealthPills', event.target.active);
-      if (this._showHealthPills) {
+      if (this._healthPillsEnabled) {
         this._renderHealthPillLegend();
       } else {
         this._clearHealthPillLegend();
@@ -226,10 +230,13 @@ limitations under the License.
       }
     },
 
+    _tensorData2WatchKey(tensorData) {
+      return tensorData.deviceName + '/' + tensorData.tensorName + ':' +
+             tensorData.debugOp;
+    },
+
     _renderLatest(latestTensorData, expandHandler) {
-      const watchKey = latestTensorData.deviceName + '/' +
-                       latestTensorData.tensorName + ':' +
-                       latestTensorData.debugOp;
+      const watchKey = this._tensorData2WatchKey(latestTensorData);
       let instanceExpandHandler = null;
       if (!(latestTensorData.dtype === 'Uninitialized' ||
             latestTensorData.dtype === 'Unsupported')) {
@@ -387,7 +394,7 @@ limitations under the License.
 
       // Create health pill.
       let healthPillCell = null;
-      if (this._showHealthPills) {
+      if (this._healthPillsEnabled) {
         const healthPillWatchKey = tensorName + ':' + debugOp;
         const healthPillWithoutValue = {
           device_name: deviceName,
@@ -457,7 +464,10 @@ limitations under the License.
       // Prepend the health pill ID with 'tdp/' to avoid duplication with health
       // pills in the graph visualizer (if present).
       const healthPillId = 'tdp/' + healthPillWatchKey;
-      this.getHealthPill(healthPillWatchKey, healthPillValue => {
+      this.getHealthPill(healthPillWatchKey,
+                         healthPillWithoutValue.device_name,
+                         healthPillWithoutValue.node_name,
+                         healthPillValue => {
         if (healthPillValue == null) {
           // DTypes unsupported by health pills, e.g, string, resource.
           healthPillCell.textContent = 'N/A';


### PR DESCRIPTION
Main new feature:
* Ability to continue to a given condition for any of the watched
  tensors. This is presented as a new section in the pop-up dialog
  of the "Continue..." button, while the existing continue n times
  of Session.run is put into the first section of the dialog.
* The new continue-to momde supports the following modes:
  * Contains inf or nan
  * Contains inf
  * Contains nan
  * Max > or < ref value
  * Min > or < ref value
  * Range (Max - Min) > or < ref value
  * Mean > or < ref value
  * Stddev > or < ref value
* The pop-up dialog for Continue... is refactored into its own
  Polymer component: tf-debugger-continue-to-dialog.html

Misc. improvements:
* Fix a bug wherein continue across multiple Session.run keys does
  not render graph for new run key.
* Move the toast from the bottom left to the bottom center. This
  prevents the toast from obscuring the Step and Continue... buttons.