### PR TITLE
Fix graph minimap by removing CSS property

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
@@ -21,36 +21,38 @@ limitations under the License.
 
 <dom-module id="tf-debugger-initial-dialog">
   <template>
-    <!-- We use a custom backdrop to avoid occluding the TensorBoard navbar. -->
-    <template is="dom-if" if="[[_open]]">
-      <div id="dashboard-backdrop"></div>
-    </template>
-    <paper-dialog id="dialog"
-                  modal
-                  opened="{{_open}}"
-                  width="320"
-                  with-backdrop="[[_useNativeBackdrop]]">
-      <h2 id='dialog-title'>Waiting for first Session.run() to connect...</h2>
-      <div class='code-example'>
-        <!-- TODO(cais): Rename id. -->
-        <pre id="session-run-code-example">
-# To connect to the debugger from your tf.Session:
-from tensorflow.python import debug as tf_debug
-sess = tf.Session()
-sess = tf_debug.TensorBoardDebugWrapperSession(sess, "[[_host]]:[[_port]]")
-sess.run(my_fetches)
-        </pre>
-        <pre id="hook-code-example">
-# To connect to the debugger using hooks, e.g., from tf.Estimator:
-from tensorflow.python import debug as tf_debug
-hook = tf_debug.TensorBoardDebugHook("[[_host]]:[[_port]]")
-my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
-        </pre>
-      </div>
-    </paper-dialog>
+    <div id="initial-dialog-container">
+      <!-- We use a custom backdrop to avoid occluding the TensorBoard navbar. -->
+      <template is="dom-if" if="[[_open]]">
+        <div id="dashboard-backdrop"></div>
+      </template>
+      <paper-dialog id="dialog"
+                    modal
+                    opened="{{_open}}"
+                    width="320"
+                    with-backdrop="[[_useNativeBackdrop]]">
+        <h2 id='dialog-title'>Waiting for first Session.run() to connect...</h2>
+        <div class='code-example'>
+          <!-- TODO(cais): Rename id. -->
+          <pre id="session-run-code-example">
+  # To connect to the debugger from your tf.Session:
+  from tensorflow.python import debug as tf_debug
+  sess = tf.Session()
+  sess = tf_debug.TensorBoardDebugWrapperSession(sess, "[[_host]]:[[_port]]")
+  sess.run(my_fetches)
+          </pre>
+          <pre id="hook-code-example">
+  # To connect to the debugger using hooks, e.g., from tf.Estimator:
+  from tensorflow.python import debug as tf_debug
+  hook = tf_debug.TensorBoardDebugHook("[[_host]]:[[_port]]")
+  my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
+          </pre>
+        </div>
+      </paper-dialog>
+    </div>
   </template>
   <style>
-    :host:not([_open]) {
+    :host:not([_open]) #initial-dialog-container {
       display: none;
     }
 


### PR DESCRIPTION
Before this change, the graph explorer minimap had been broken, as
discovered by @nfelt during manual testing. Specifically, the graph
would not render within the minimap.

Surprisingly, this CSS specification within the
`tf-debugger-initial-dialog` component had been hiding the SVG element
for the rendered graph within the minimap:

![image](https://user-images.githubusercontent.com/4221553/35258195-b539fdf4-ffb2-11e7-9958-0355044a7509.png)

```css
:host:not([_open]) {
  display: none;
}
```

That seems odd. The `:host` selector refers to the root of the shadow
DOM for the current component, in this case
`tf-debugger-initial-dialog`. That dialog is only rendered by the
debugger plugin - the debugger dashboard is not even constructed when
the graph dashboard (containing the minimap) is rendered.

I perused the vulcanized HTML and JS, and no issues seem to stand out
there.

This change solves the immediate problem of the minimap not rendering by
making the selector more specific and apply only to the component. I
will later investigate what is causing a CSS specification within the
`tf-debugger-initial-dialog` component to affect the graph explorer
minimap.

The minimap now renders:

![image](https://user-images.githubusercontent.com/4221553/35258252-ff0820e6-ffb2-11e7-8576-0657f3a28150.png)

The dialog (within the debugger dashboard) still renders as expected:

![image](https://user-images.githubusercontent.com/4221553/35258291-35e4ee1e-ffb3-11e7-96aa-4f2248ea203e.png)

The dialog still hides as expected:

![image](https://user-images.githubusercontent.com/4221553/35258350-9ad40ef4-ffb3-11e7-915e-b22ad7b4bd7f.png)
