### PR TITLE
Display unselected dashboards in height 0 divs

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -199,7 +199,7 @@ limitations under the License.
           <div
             class="dashboard-container"
             data-dashboard$="[[dashboardDatum.plugin]]"
-            style="display: [[_displayStyle(_selectedDashboard, dashboardDatum.plugin)]]"
+            data-selected$="[[_selectedStatus(_selectedDashboard, dashboardDatum.plugin)]]"
           ><!-- Dashboards will be injected here dynamically. --></div>
         </template>
       </div>
@@ -299,6 +299,15 @@ limitations under the License.
 
       .dashboard-container {
         height: 100%;
+      }
+
+      /* Hide unselected dashboards. We still display them within a container 
+         of height 0 since Plottable produces degenerate charts when charts are 
+         reloaded while not displayed. */
+      .dashboard-container:not([data-selected]) {
+        max-height: 0;
+        overflow: hidden;
+        position: relative;
       }
 
       .warning-message {
@@ -555,9 +564,8 @@ limitations under the License.
         return dashboards[index];
       },
 
-      _displayStyle(selectedDashboard, candidateDashboard) {
-         // Display only the selected dashboard.
-        return selectedDashboard === candidateDashboard ? 'inherit' : 'none';
+      _selectedStatus(selectedDashboard, candidateDashboard) {
+        return selectedDashboard === candidateDashboard;
       },
 
       /**


### PR DESCRIPTION
Previously, containers of unselected dashboards would not be displayed
(They are set to `display:none;`). We now "display" unselected
dashboards within a container of max-height 0, effectively hiding it,
but also allowing Plottable logic to obtain correct container
measurements. Fixes #554.

Test Plan (for Chrome and Firefox):

Run mnist_with_summaries.py and start TensorBoard. Switch from the
scalars to the images dashboard. Toggle the train run. Navigate back to
the scalars dashboards. Note that no line charts are degenerate.