### PR TITLE
Make smoothing not affect margin charts

### DIFF
--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
@@ -189,8 +189,6 @@ writer.add_summary(layout_summary)
                     runs="[[_selectedRuns]]"
                     title="[[chart.title]]"
                     x-type="[[_xType]]"
-                    smoothing-enabled="[[_smoothingEnabled]]"
-                    smoothing-weight="[[_smoothingWeight]]"
                     tooltip-sorting-method="[[tooltipSortingMethod]]"
                     ignore-y-outliers="[[ignoreYOutliers]]"
                     show-download-links="[[_showDownloadLinks]]"
@@ -260,15 +258,16 @@ writer.add_summary(layout_summary)
               {defaultValue: false, useLocalStorage: true}),
           observer: '_showDownloadLinksObserver',
         },
+        // Note that smoothing does not apply to margin charts.
+        _smoothingEnabled: {
+          type: Boolean,
+          computed: '_computeSmoothingEnabled(_smoothingWeight)',
+        },
         _smoothingWeight: {
           type: Number,
           notify: true,
           value: tf_storage.getNumberInitializer('_smoothingWeight', {defaultValue: 0.6}),
           observer: '_smoothingWeightObserver',
-        },
-        _smoothingEnabled: {
-          type: Boolean,
-          computed: '_computeSmoothingEnabled(_smoothingWeight)',
         },
         _ignoreYOutliers: {
           type: Boolean,

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -40,8 +40,6 @@ limitations under the License.
   <div id="tf-line-chart-data-loader-container">
     <tf-line-chart-data-loader
       x-type="[[xType]]"
-      smoothing-enabled="[[smoothingEnabled]]"
-      smoothing-weight="[[smoothingWeight]]"
       tooltip-sorting-method="[[tooltipSortingMethod]]"
       ignore-y-outliers="[[ignoreYOutliers]]"
       request-manager="[[requestManager]]"
@@ -259,8 +257,6 @@ limitations under the License.
         ignoreYOutliers: Boolean,
         requestManager: Object,
         showDownloadLinks: Boolean,
-        smoothingEnabled: Boolean,
-        smoothingWeight: Number,
         tagMetadata: Object,
         tooltipSortingMethod: String,
 
@@ -356,12 +352,6 @@ limitations under the License.
               {
                 title: 'Name',
                 evaluate: (d) => d.dataset.metadata().name,
-              },
-              {
-                title: 'Smoothed',
-                evaluate: (d, statusObject) => formatValueOrNaN(
-                    statusObject.smoothingEnabled ? d.datum.smoothed :
-                                                    d.datum.scalar),
               },
               {
                 title: 'Value',


### PR DESCRIPTION
Previously, smoothing would affect the main line within margin charts,
but not the lower and upper bounds. That confused the user.

Hence, we avoid making smoothing affect margin charts. The alternative
of smoothing the bounds in addition to the main line raises statistical
concerns about how valid the smoothing is when applied to bounds. The
first team that might find this feature valuable also noted that just
making margin charts unsmoothed would likely work nicely.

The main line now lies within the bounds.
![image](https://user-images.githubusercontent.com/4221553/35362570-b605add2-011a-11e8-8d41-ba169a5d8911.png)
