### PR TITLE
Include iron-flex styles within dashboard styles

### DIFF
--- a/tensorboard/components/tf_dashboard_common/BUILD
+++ b/tensorboard/components/tf_dashboard_common/BUILD
@@ -33,6 +33,7 @@ tf_web_library(
         "//tensorboard/components/vz_sorting",
         "@org_polymer_iron_ajax",
         "@org_polymer_iron_collapse",
+        "@org_polymer_iron_flex_layout",
         "@org_polymer_iron_icons",
         "@org_polymer_paper_button",
         "@org_polymer_paper_checkbox",

--- a/tensorboard/components/tf_dashboard_common/dashboard-style.html
+++ b/tensorboard/components/tf_dashboard_common/dashboard-style.html
@@ -15,11 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<link rel="import" href="../iron-flex-layout/iron-flex-layout-classes.html">
 <link rel="import" href="../paper-styles/paper-styles.html">
 <link rel="import" href="tensorboard-color.html">
 
 <dom-module id="dashboard-style">
   <template>
+    <style include="iron-flex"></style>
     <style>
       .sidebar {
         display: flex;

--- a/third_party/polymer.bzl
+++ b/third_party/polymer.bzl
@@ -300,7 +300,7 @@ def tensorboard_polymer_workspace():
       strip_prefix = "iron-flex-layout-1.3.0",
       path = "/iron-flex-layout",
       srcs = [
-          "classes/iron-flex-layout.html",
+          "classes/iron-flex-layout.html",  # Deprecated, but needed by paper-styles component.
           "classes/iron-shadow-flex-layout.html",
           "iron-flex-layout.html",
           "iron-flex-layout-classes.html",


### PR DESCRIPTION
The classes/iron-flex-layout.html file is deprecated.
Previously, this caused line charts within TensorBoard run in Google to
stack atop each other - the file contained CSS necessary for flex
positioning.

![image](https://user-images.githubusercontent.com/4221553/35366618-4050b9dc-012f-11e8-941b-f410d58dc605.png)

We now instead include the recommended file
iron-flex-layout/iron-flex-layout-classes.html in order to import those
necessary flex styles. This causes the line charts to lie next to each
other (flex-positioned) as expected.

![image](https://user-images.githubusercontent.com/4221553/35366622-464b5f9a-012f-11e8-9c10-e78972d8df0f.png)

We still can't drop classes/iron-flex-layout.html from BUILD
dependencies, however, because TensorBoard's version of the paper-styles
component still imports that file. We may want to consider upgrading the
version of paper-styles.