### PR TITLE
Hide debugger dialog by using _hidden property

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
@@ -21,38 +21,39 @@ limitations under the License.
 
 <dom-module id="tf-debugger-initial-dialog">
   <template>
-    <div id="initial-dialog-container">
-      <!-- We use a custom backdrop to avoid occluding the TensorBoard navbar. -->
-      <template is="dom-if" if="[[_open]]">
-        <div id="dashboard-backdrop"></div>
-      </template>
-      <paper-dialog id="dialog"
-                    modal
-                    opened="{{_open}}"
-                    width="320"
-                    with-backdrop="[[_useNativeBackdrop]]">
-        <h2 id='dialog-title'>Waiting for first Session.run() to connect...</h2>
-        <div class='code-example'>
-          <!-- TODO(cais): Rename id. -->
-          <pre id="session-run-code-example">
-  # To connect to the debugger from your tf.Session:
-  from tensorflow.python import debug as tf_debug
-  sess = tf.Session()
-  sess = tf_debug.TensorBoardDebugWrapperSession(sess, "[[_host]]:[[_port]]")
-  sess.run(my_fetches)
-          </pre>
-          <pre id="hook-code-example">
-  # To connect to the debugger using hooks, e.g., from tf.Estimator:
-  from tensorflow.python import debug as tf_debug
-  hook = tf_debug.TensorBoardDebugHook("[[_host]]:[[_port]]")
-  my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
-          </pre>
-        </div>
-      </paper-dialog>
-    </div>
+    <!-- We use a custom backdrop to avoid occluding the TensorBoard navbar. -->
+    <template is="dom-if" if="[[_open]]">
+      <div id="dashboard-backdrop"></div>
+    </template>
+    <paper-dialog id="dialog"
+                  modal
+                  opened="{{_open}}"
+                  width="320"
+                  with-backdrop="[[_useNativeBackdrop]]">
+      <h2 id='dialog-title'>Waiting for first Session.run() to connect...</h2>
+      <div class='code-example'>
+        <!-- TODO(cais): Rename id. -->
+        <pre id="session-run-code-example">
+# To connect to the debugger from your tf.Session:
+from tensorflow.python import debug as tf_debug
+sess = tf.Session()
+sess = tf_debug.TensorBoardDebugWrapperSession(sess, "[[_host]]:[[_port]]")
+sess.run(my_fetches)
+        </pre>
+        <pre id="hook-code-example">
+# To connect to the debugger using hooks, e.g., from tf.Estimator:
+from tensorflow.python import debug as tf_debug
+hook = tf_debug.TensorBoardDebugHook("[[_host]]:[[_port]]")
+my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
+        </pre>
+      </div>
+    </paper-dialog>
   </template>
   <style>
-    :host:not([_open]) #initial-dialog-container {
+    /** We rely on a separate `_hidden` property instead of directly making use
+        of the `_open` attribute because this CSS specification may strangely
+        affect other elements throughout TensorBoard. See #899. */
+    :host[_hidden] {
       display: none;
     }
 
@@ -88,6 +89,10 @@ limitations under the License.
       },
       _open: {
         type: Boolean,
+      },
+      _hidden: {
+        type: Boolean,
+        computed: '_computeHidden(_open)',
         reflectToAttribute: true,  // for CSS 
       },
       // Suppress the native paper-dialog backdrop. We use a custom one. We make
@@ -119,6 +124,9 @@ limitations under the License.
                '--debugger_port <port_number>'
       Polymer.dom(this.$$('#session-run-code-example')).textContent = ex;
       Polymer.dom(this.$$('#hook-code-example')).textContent = '';
+    },
+    _computeHidden(open) {
+      return !open;
     },
   });
   </script>


### PR DESCRIPTION
Previously, the user was unable to interact with the debugger dashboard
because the tf-debugger-initial-dialog occluded the dashboard even if
the dialog was closed (and thus visible).

This change fixes the problem by directly altering the display of the
component itself.