### PR TITLE
Update master based on 1.5.0 release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,42 @@
+# Release 1.5.0
+
+The 1.5 minor series tracks TensorFlow 1.5.
+
+## Highlights
+
+- New Custom Scalars dashboard, which can display configurable custom line and
+  margin charts based on the same data as the regular Scalars dashboard. See
+  for details: https://github.com/tensorflow/tensorboard/tree/1.5/tensorboard/plugins/custom_scalar
+- Many projector plugin enhancements thanks to @francoisluus, which enable
+  cognitive-assisted labeling via semi-supervised t-SNE
+  - t-SNE specific features: semi-supervision (#811) plus perturb (#705) and
+    pause/resume (#691) buttons
+  - general features: metadata editor (#753), selection edit mode (#697), edit
+    box for neighbors slider (#733), 2D sprite element zooming (#696)
+
+## Features
+
+- Image dashboard brightness and constrast sliders (#771) - thanks @edmundtong
+- Top-level dashboard tabs now scroll when there are too many to fit (#730)
+- Settable browser window title with --window_title flag (#804) - thanks @tkunic
+- Tag filters are now reflected in the URL, making them saveable (#787)
+- Pane-based dashboards now only load charts from first two panes by default,
+  which should improve responsiveness (#643 defaults tag filter search string
+  to empty, and #871 makes first two panes open by default)
+- Lower latency to serve TensorBoard HTML thanks to preloading in memory (#708)
+- Lazy imports ("import tensorboard as tb") now work for summary APIs (#778)
+- PR curve summaries now have pb (#633) and raw_data_pb (#646) versions
+
+## Bug fixes
+
+- #265 - fixed `--logdir` to handle Windows drive letters - thanks @shakedel
+- #784 - fixed bug in find similar subgraph algo - thanks @trisolaran
+- Graph plugin fixed to
+  - correctly render function nodes (#817)
+  - pan to nodes more reliably (#824, #837)
+  - rebuild hierarchy if callbacks change to avoid race in rendering (#879)
+
+
 # Release 0.4.0
 
 The 0.4 minor series tracks TensorFlow 1.4.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,21 +4,21 @@ The 0.4 minor series tracks TensorFlow 1.4.
 
 ## Features
 
- - PR Curve plugin has a full-featured new dashboard (#387, #426, many others)
- - PR Curve plugin has new streaming and raw summary-writing ops (#520, #587)
- - Graph plugin has a new "Functions" scene group to show function libraries and
-   links to function calls (#394, #395, #497, #551, others)
- - Graph plugin metanodes are now colored more helpfully (#467)
- - Graph plugin selected run is now persisted to URL (#505)
- - Standard dashboard card header UI is more compact and readable (#430)
- - Pagination limit can now be configured in settings (#535)
- - Text plugin now has op and pb summary writing methods (#510)
- - Reduced boilerplate and cleaner API hooks for custom plugins (#611, #620)
- - Faster initial loads due to improved active plugin detection (#621, #663)
- - Reuse of TCP connections with switch to using HTTP/1.1 (#617)
+- PR Curve plugin has a full-featured new dashboard (#387, #426, many others)
+- PR Curve plugin has new streaming and raw summary-writing ops (#520, #587)
+- Graph plugin has a new "Functions" scene group to show function libraries and
+  links to function calls (#394, #395, #497, #551, others)
+- Graph plugin metanodes are now colored more helpfully (#467)
+- Graph plugin selected run is now persisted to URL (#505)
+- Standard dashboard card header UI is more compact and readable (#430)
+- Pagination limit can now be configured in settings (#535)
+- Text plugin now has op and pb summary writing methods (#510)
+- Reduced boilerplate and cleaner API hooks for custom plugins (#611, #620)
+- Faster initial loads due to improved active plugin detection (#621, #663)
+- Reuse of TCP connections with switch to using HTTP/1.1 (#617)
 
 ## Bug fixes
 
- - #477 - fixed URLs to properly URI-encode run and tag names
- - #610 - fixed smoothing algorithm to prevent biasing on initial values
- - #647 - fixed text plugin decoding error that led to bad markdown processing
+- #477 - fixed URLs to properly URI-encode run and tag names
+- #610 - fixed smoothing algorithm initial value bias - thanks @alexirpan
+- #647 - fixed text plugin decoding error that led to bad markdown processing

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '1.5.1a0'
+VERSION = '1.6.0a0'

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '1.5.0a0'
+VERSION = '1.5.1a0'


### PR DESCRIPTION
Adds the 1.5.0 release notes back to master's RELEASE.md, reformats the 0.4.0 notes slightly, and bumps the version number at HEAD to ~1.5.1a0~ 1.6.0a0 since ~1.5.1~ 1.6.0 will be the next release _that gets branched from HEAD_.