### PR TITLE
Make containers of inactive dashboards invisible

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -309,7 +309,8 @@ limitations under the License.
         overflow: hidden;
         position: relative;
         /** We further make containers invisible. Some elements may anchor to
-            the viewport instead of the container. */ 
+            the viewport instead of the container, in which case setting the max
+            height here to 0 will not hide them. */ 
         visibility: hidden;
       }
 

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -308,6 +308,9 @@ limitations under the License.
         max-height: 0;
         overflow: hidden;
         position: relative;
+        /** We further make containers invisible. Some elements may anchor to
+            the viewport instead of the container. */ 
+        visibility: hidden;
       }
 
       .warning-message {


### PR DESCRIPTION
PR #902 fell short of fixing #554 because some elements such as dialogs
may be fix-positioned, in which case they anchor to the browser viewport
instead of the container. This means that may still be visible even when
the dashboard containing them is not selected.

For instance, here, we navigated to the debugger dashboard before
switching to the graph dashboard.

![image](https://user-images.githubusercontent.com/4221553/35425700-c3ca2072-0211-11e8-834e-9235c1428c00.png)

This fixes that problem by also making containers invisible in addition
to having a max height of 0. Note that invisible elements still have
height (unlike elements that are not displayed) - thus, Plottable can
still obtain accurate measurements of DOM elements and prevent charts
from becoming degenerate.

Test Plan (First run mnist_with_summaries.py):

Start TensorBoard with the debugger_port flag set (to enable the debugger
plugin). Navigate to the debugger dashboard and switch to the graphs (or any
other) dashboard. No dialog should show. Furthermore, switch to the scalars
dashboard, then the images dashboard. Toggle the train run. View the scalars
dashboard. No charts should be degenerate.