### PR TITLE
Correct position of context menu

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/annotation.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/annotation.ts
@@ -170,6 +170,7 @@ function addInteraction(selection, d: render.RenderNodeInfo,
       annotation.annotationType !== render.AnnotationType.CONSTANT) {
     selection.on(
         'contextmenu', contextmenu.getMenu(
+                           sceneElement,
                            node.getContextMenu(annotation.node, sceneElement)));
   }
 };

--- a/tensorboard/plugins/graph/tf_graph_common/contextmenu.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/contextmenu.ts
@@ -34,11 +34,32 @@ export interface ContextMenuItem {
 }
 
 /**
+ * Returns the top and left distance of the scene element from the top left
+ * corner of the screen.
+ */
+function getOffset(sceneElement) {
+    let leftDistance = 0;
+    let topDistance = 0;
+    let currentElement = sceneElement;
+    while (currentElement &&
+           currentElement.offsetLeft >= 0 &&
+           currentElement.offsetTop >= 0) {
+        leftDistance += currentElement.offsetLeft - currentElement.scrollLeft;
+        topDistance += currentElement.offsetTop - currentElement.scrollTop;
+        currentElement = currentElement.offsetParent;
+    }
+    return {
+        left: leftDistance,
+        top: topDistance
+    };
+}
+
+/**
  * Returns the event listener, which can be used as an argument for the d3
  * selection.on function. Renders the context menu that is to be displayed
  * in response to the event.
  */
-export function getMenu(menu: ContextMenuItem[]) {
+export function getMenu(sceneElement, menu: ContextMenuItem[]) {
   let menuSelection = d3.select('.context-menu');
   // Close the menu when anything else is clicked.
   d3.select('body').on(
@@ -48,10 +69,11 @@ export function getMenu(menu: ContextMenuItem[]) {
   return function(data, index: number): void {
     // Position and display the menu.
     let event = <MouseEvent>d3.event;
+    const sceneOffset = getOffset(sceneElement);
     menuSelection
       .style('display', 'block')
-      .style('left', (event.layerX + 1) + 'px')
-      .style('top', (event.layerY + 1) + 'px');
+      .style('left', (event.clientX - sceneOffset.left + 1) + 'px')
+      .style('top', (event.clientY - sceneOffset.top + 1) + 'px');
 
     // Stop the event from propagating further.
     event.preventDefault();

--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -218,7 +218,7 @@ function addInteraction(selection, d: render.RenderNodeInfo,
   }
 
   let contextMenuFunction = contextmenu.getMenu(
-    getContextMenu(d.node, sceneElement));
+      sceneElement, getContextMenu(d.node, sceneElement));
   selection
       .on('dblclick',
           d => {


### PR DESCRIPTION
Previously, the context menu was often incorrecrtly positioned due to
unexpected behavior of the layerX and layerY properties. They returned
distances in non-device spaces and thus varied based on local CSS.

![image](https://user-images.githubusercontent.com/4221553/35603547-ae5c66fc-05f2-11e8-9114-7640ff4a2149.png)

Furthermore, the layerX and layerY properties will [soon be deprecated](https://bugs.webkit.org/show_bug.cgi?id=21868).
We therefore redo the logic for positioning the context menu by making
use of the clientX and clientY properties. We subtract the offset of the
scene element from those properties. This correctly positions the
context menu.

![image](https://user-images.githubusercontent.com/4221553/35603644-1a28781c-05f3-11e8-9856-9f54230a59d0.png)
