### PR TITLE
Widen margins for custom scalars demo

### DIFF
--- a/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
@@ -44,9 +44,9 @@ def run():
     middle_baz_value = step + 4 * tf.random_uniform([]) - 2
     summary_lib.scalar('baz', middle_baz_value)
     summary_lib.scalar('baz_lower',
-                       middle_baz_value - 0.3 - tf.random_uniform([]))
+                       middle_baz_value - 6.42 - tf.random_uniform([]))
     summary_lib.scalar('baz_upper',
-                       middle_baz_value + 0.3 + tf.random_uniform([]))
+                       middle_baz_value + 6.42 + tf.random_uniform([]))
 
   with tf.name_scope('trigFunctions'):
     summary_lib.scalar('cosine', tf.cos(step))


### PR DESCRIPTION
Previously, the margins generated by the custom scalars demo were so
thin that it was hard to see that the plots were margin plots. We make
them significantly wider:

![image](https://user-images.githubusercontent.com/4221553/35607000-ff8d21ba-0606-11e8-80ec-62263d078d20.png)
