### PR TITLE
Enforce py2-only constraint on pip package `futures` dependency (#920)

### DIFF
--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -59,7 +59,7 @@ function main() {
   export PATH="${TMPVENVDIR}/bin:${PATH}"
   unset PYTHON_HOME
 
-  # Require wheel for bdist_wheel command, and setuptools 36.3.0+ so that
+  # Require wheel for bdist_wheel command, and setuptools 36.2.0+ so that
   # env markers are handled (https://github.com/pypa/setuptools/pull/1081)
   pip install -U wheel setuptools>=36.2.0
 

--- a/tensorboard/pip_package/pip_smoke_test.sh
+++ b/tensorboard/pip_package/pip_smoke_test.sh
@@ -78,10 +78,8 @@ echo
 
 if [[ "${PY_VERSION}" == 2 ]]; then
   virtualenv -p python "${VENV_TMP_DIR}"
-  TF_NIGHTLY_URL='https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-1.head-cp27-none-linux_x86_64.whl'
 elif [[ "${PY_VERSION}" == 3 ]]; then
   virtualenv -p python3 "${VENV_TMP_DIR}"
-  TF_NIGHTLY_URL='https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON3,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-1.head-cp34-cp34m-linux_x86_64.whl'
 fi
 
 echo
@@ -110,7 +108,7 @@ echo
 echo "Installing nightly tensorflow pip package."
 echo
 
-pip install "${TF_NIGHTLY_URL}"
+pip install tf-nightly
 
 echo
 echo "Installing the just-built tensorboard pip package"

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -31,13 +31,12 @@ REQUIRED_PACKAGES = [
     'markdown >= 2.6.8',
     'bleach == 1.5.0',
 
-    # futures is a backport of the concurrent.futures module added in
-    # python 3.2
-    'futures >= 3.1.1;python_version < "3.2"',
+    # futures is a backport of the python 3.2+ concurrent.futures module
+    'futures >= 3.1.1; python_version < "3"',
 
     # python3 specifically requires wheel 0.26
-    'wheel;python_version < "3"',
-    'wheel >= 0.26;python_version >= "3"',
+    'wheel; python_version < "3"',
+    'wheel >= 0.26; python_version >= "3"',
 ]
 
 CONSOLE_SCRIPTS = [
@@ -66,6 +65,8 @@ setup(
             'webfiles.zip',
         ],
     },
+    # Disallow python 3.0 and 3.1 which lack a 'futures' module (see above).
+    python_requires='>= 2.7, != 3.0.*, != 3.1.*',
     install_requires=REQUIRED_PACKAGES,
     tests_require=REQUIRED_PACKAGES,
     # PyPI package information.


### PR DESCRIPTION
This fixes the installation issues from #916, specifically items 1 and 2, by:

1. fixing `build_pip_package.sh` to use setuptools > 36.2.0 so that environment markers are preserved upon wheel generation (and hence PyPI upload)
2. adjusting our `futures` dependency to be python 2 only rather than allowing up to python 3.2 (when the `concurrent.futures` python3 module was introduced, which `futures` backports).  The `futures` package is not actually compatible with python 3.0+ and they recently started enforcing this in futures 3.2.0+ which resulted in broken tensorboard and tensorflow installs for some users.

Thanks to @fortran-favors-the-old for the suggested fixes.