### PR TITLE
Fix a few column names in db.py

### DIFF
--- a/tensorboard/db.py
+++ b/tensorboard/db.py
@@ -109,7 +109,7 @@ def _sync_plugins(names, connection):
   the_whole_table = {}  # type: dict[str, int]
   names = set(names)
   max_id = 0
-  for id_, name in connection.execute('SELECT plugin_id, plugin_name FROM Plugins'):
+  for id_, name in connection.execute('SELECT plugin_id, name FROM Plugins'):
     if id_ > max_id:
       max_id = id_
     the_whole_table[name] = id_
@@ -121,7 +121,7 @@ def _sync_plugins(names, connection):
     new_rows.append((max_id, name))
   if new_rows:
     connection.executemany(
-        'INSERT INTO Plugins (plugin_id, plugin_name) VALUES (?, ?)',
+        'INSERT INTO Plugins (plugin_id, name) VALUES (?, ?)',
         new_rows)
   return the_whole_table
 
@@ -363,7 +363,7 @@ class Schema(object):
       c.execute('''\
         CREATE TABLE IF NOT EXISTS Plugins (
           plugin_id INTEGER PRIMARY KEY,
-          plugin_name VARCHAR(255) NOT NULL
+          name VARCHAR(255) NOT NULL
         )
       ''')
 
@@ -372,7 +372,7 @@ class Schema(object):
     with self._cursor() as c:
       c.execute('''\
         CREATE UNIQUE INDEX IF NOT EXISTS PluginsNameIndex
-        ON Plugins (plugin_name)
+        ON Plugins (name)
       ''')
 
   def create_event_logs_table(self):

--- a/tensorboard/db.py
+++ b/tensorboard/db.py
@@ -194,7 +194,7 @@ class Schema(object):
     with self._cursor() as c:
       c.execute('''\
         CREATE UNIQUE INDEX IF NOT EXISTS ExperimentsNameIndex
-        ON Experiments (name)
+        ON Experiments (experiment_name)
       ''')
 
   def create_runs_table(self):
@@ -245,7 +245,7 @@ class Schema(object):
     with self._cursor() as c:
       c.execute('''\
         CREATE UNIQUE INDEX IF NOT EXISTS RunsNameIndex
-        ON Runs (experiment_id, name)
+        ON Runs (experiment_id, run_name)
       ''')
 
   def create_tags_table(self):
@@ -290,7 +290,7 @@ class Schema(object):
     with self._cursor() as c:
       c.execute('''\
         CREATE UNIQUE INDEX IF NOT EXISTS TagsNameIndex
-        ON Tags (run_id, name)
+        ON Tags (run_id, tag_name)
       ''')
 
   def create_tensors_table(self):

--- a/tensorboard/db.py
+++ b/tensorboard/db.py
@@ -109,7 +109,7 @@ def _sync_plugins(names, connection):
   the_whole_table = {}  # type: dict[str, int]
   names = set(names)
   max_id = 0
-  for id_, name in connection.execute('SELECT plugin_id, name FROM Plugins'):
+  for id_, name in connection.execute('SELECT plugin_id, plugin_name FROM Plugins'):
     if id_ > max_id:
       max_id = id_
     the_whole_table[name] = id_
@@ -121,7 +121,7 @@ def _sync_plugins(names, connection):
     new_rows.append((max_id, name))
   if new_rows:
     connection.executemany(
-        'INSERT INTO Plugins (plugin_id, name) VALUES (?, ?)',
+        'INSERT INTO Plugins (plugin_id, plugin_name) VALUES (?, ?)',
         new_rows)
   return the_whole_table
 

--- a/tensorboard/db.py
+++ b/tensorboard/db.py
@@ -184,7 +184,7 @@ class Schema(object):
       c.execute('''\
         CREATE TABLE IF NOT EXISTS Experiments (
           experiment_id INTEGER PRIMARY KEY,
-          name VARCHAR(500) NOT NULL,
+          experiment_name VARCHAR(500) NOT NULL,
           description TEXT NOT NULL
         )
       ''')
@@ -226,7 +226,7 @@ class Schema(object):
           rowid INTEGER PRIMARY KEY,
           run_id INTEGER NOT NULL,
           experiment_id INTEGER NOT NULL,
-          name VARCHAR(1900) NOT NULL
+          run_name VARCHAR(1900) NOT NULL
         )
       ''')
 
@@ -272,7 +272,7 @@ class Schema(object):
           tag_id INTEGER NOT NULL,
           run_id INTEGER NOT NULL,
           plugin_id INTEGER NOT NULL,
-          name VARCHAR(500) NOT NULL,
+          tag_name VARCHAR(500) NOT NULL,
           display_name VARCHAR(500),
           summary_description TEXT
         )
@@ -363,7 +363,7 @@ class Schema(object):
       c.execute('''\
         CREATE TABLE IF NOT EXISTS Plugins (
           plugin_id INTEGER PRIMARY KEY,
-          name VARCHAR(255) NOT NULL
+          plugin_name VARCHAR(255) NOT NULL
         )
       ''')
 
@@ -372,7 +372,7 @@ class Schema(object):
     with self._cursor() as c:
       c.execute('''\
         CREATE UNIQUE INDEX IF NOT EXISTS PluginsNameIndex
-        ON Plugins (name)
+        ON Plugins (plugin_name)
       ''')
 
   def create_event_logs_table(self):


### PR DESCRIPTION
Some SQL queries within db.py had been referring to columns named
`name`. Such columns don't exist and are actually named a little more
specifically. This is a quick fix for that.