### PR TITLE
 Update bazel rules_webtesting dep to work with Bazel 0.10.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,6 +10,7 @@ http_archive(
     ],
 )
 
+# Needed as a transitive dependency of rules_webtesting below.
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "8c333df68fb0096221e2127eda2807384e00cc211ee7e7ea4ed08d212e6a69c1",
@@ -20,13 +21,26 @@ http_archive(
     ],
 )
 
+# Needed as a transitive dependency of rules_webtesting below.
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
+    strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
+    urls = [
+        # TODO(jart): add to bazel mirror.
+        # "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz", # 2018-01-12
+    ],
+)
+
 http_archive(
     name = "io_bazel_rules_webtesting",
-    sha256 = "4a34918cdb57b7c0976c1d6a9a7af1d657266b239c9c1066c87d6f9a4058bc7d",
-    strip_prefix = "rules_webtesting-a9f624ac542d2be75f6f0bdd255f108f2795924a",
+    sha256 = "a1264301424f2d920fca04f2d3c5ef5ca1be4f2bbf8c84ef38006e54aaf22753",
+    strip_prefix = "rules_webtesting-9f597bb7d1b40a63dc443d9ef7e931cfad4fb098",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_webtesting/archive/a9f624ac542d2be75f6f0bdd255f108f2795924a.tar.gz",  # 2017-09-11
-        "https://github.com/bazelbuild/rules_webtesting/archive/a9f624ac542d2be75f6f0bdd255f108f2795924a.tar.gz",
+        # TODO(jart): add to bazel mirror.
+        # "https://mirror.bazel.build/github.com/bazelbuild/rules_webtesting/archive/9f597bb7d1b40a63dc443d9ef7e931cfad4fb098.tar.gz",  # 2017-01-29
+        "https://github.com/bazelbuild/rules_webtesting/archive/9f597bb7d1b40a63dc443d9ef7e931cfad4fb098.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Fix #929 by following up on #883 to also update the `rules_webtesting` dependency, which was also suffering from a broken version comparison that started failing with Bazel 0.10.0.

cc @jart I have TODOs against you to add the requisite mirror.bazel.build mirror URLs.  I don't seem to have any access to update that mirror myself.