### PR TITLE
Set Travis to build with Bazel 0.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ branches:
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/
 
 env:
-  - BAZEL=0.5.4 TF=NIGHTLY
+  - BAZEL=0.9.0 TF=NIGHTLY
 
 cache:
   directories:


### PR DESCRIPTION
The updated `rules_webtesting` that works with Bazel 0.10.0 in fact *requires* Bazel 0.9.0 or greater, so Travis won't build #931 with its current config.  So I'm going to update Travis to use 0.9.0 in this separate PR, which is easier to notice and revert later if necessary.