### PR TITLE
 Add projector module API to pip package

### DIFF
--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -1,5 +1,5 @@
 # Description:
-#  Tools for building the TensorFlow pip package.
+#  Tools for building the TensorBoard pip package.
 
 package(default_visibility = ["//visibility:private"])
 
@@ -14,8 +14,13 @@ sh_binary(
         "README.rst",
         "setup.cfg",
         "setup.py",
+        # Main tensorboard binary and everything it uses.
         "//tensorboard",
+        # User-facing python library ('import tensorboard')
         "//tensorboard:lib",
+        # Version module (read by setup.py)
         "//tensorboard:version",
+        # Projector module user-facing API.
+        "//tensorboard/plugins/projector",
     ],
 )

--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -14,13 +14,13 @@ sh_binary(
         "README.rst",
         "setup.cfg",
         "setup.py",
-        # Main tensorboard binary and everything it uses.
+        # Main tensorboard binary and everything it uses
         "//tensorboard",
         # User-facing python library ('import tensorboard')
         "//tensorboard:lib",
         # Version module (read by setup.py)
         "//tensorboard:version",
-        # Projector module user-facing API.
+        # User-facing projector API ('import tensorboard.plugins.projector')
         "//tensorboard/plugins/projector",
     ],
 )

--- a/tensorboard/pip_package/pip_smoke_test.sh
+++ b/tensorboard/pip_package/pip_smoke_test.sh
@@ -127,7 +127,12 @@ echo
 # Check that we can now use TensorBoard's public python APIs as installed with
 # the pip package. To do this we must cd away from the bazel workspace directory
 # to one that doesn't have a local 'tensorboard' python module hierarchy.
-TEST_API_CALL="import tensorboard as tb; tb.summary.scalar_pb('test', 42)"
+TEST_API_CALL="
+import tensorboard as tb
+tb.summary.scalar_pb('test', 42)
+from tensorboard.plugins.projector import visualize_embeddings
+"
+
 echo "  python>>> $TEST_API_CALL"
 echo
 (cd "${VENV_TMP_DIR}" && python -c "$TEST_API_CALL")


### PR DESCRIPTION
Fix #926 by explicitly including the projector module API, i.e. `import tensorboard.plugins.projector`, which provides access to `visualize_embeddings`, when building the pip package.