### PR TITLE
[Debugger Plugin] Harden health pills against all-inf/nan and empty t…

### DIFF
--- a/tensorboard/plugins/debugger/BUILD
+++ b/tensorboard/plugins/debugger/BUILD
@@ -181,6 +181,19 @@ py_library(
     ],
 )
 
+py_test(
+    name = "health_pill_calc_test",
+    size = "small",
+    srcs = ["health_pill_calc_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":health_pill_calc",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+
 py_library(
     name = "debugger_server_lib",
     srcs = ["debugger_server_lib.py"],

--- a/tensorboard/plugins/debugger/health_pill_calc.py
+++ b/tensorboard/plugins/debugger/health_pill_calc.py
@@ -87,14 +87,27 @@ def calc_health_pill(tensor):
 
   finite_subset = tensor[
       np.logical_and(np.logical_not(nan_mask), np.logical_not(inf_mask))]
-  # Minimum of the non-NaN non-Inf elements.
-  health_pill[8] = float(np.min(finite_subset))
-  # Maximum of the non-NaN non-Inf elements.
-  health_pill[9] = float(np.max(finite_subset))
-  # Mean of the non-NaN non-Inf elements.
-  health_pill[10] = float(np.mean(finite_subset))
-  # Variance of the non-NaN non-Inf elements.
-  health_pill[11] = float(np.var(finite_subset))
+  if np.size(finite_subset):
+    # Finite subset is not empty.
+    # Minimum of the non-NaN non-Inf elements.
+    health_pill[8] = float(np.min(finite_subset))
+    # Maximum of the non-NaN non-Inf elements.
+    health_pill[9] = float(np.max(finite_subset))
+    # Mean of the non-NaN non-Inf elements.
+    health_pill[10] = float(np.mean(finite_subset))
+    # Variance of the non-NaN non-Inf elements.
+    health_pill[11] = float(np.var(finite_subset))
+  else:
+    # If no finite element exists:
+    # Set minimum to +inf.
+    health_pill[8] = np.inf
+    # Set maximum to -inf.
+    health_pill[9] = -np.inf
+    # Set mean to NaN.
+    health_pill[10] = np.nan
+    # Set variance to NaN.
+    health_pill[11] = np.nan
+
   # DType encoded as a number.
   # TODO(cais): Convert numpy dtype to corresponding tensorflow dtype enum.
   health_pill[12] = -1.0

--- a/tensorboard/plugins/debugger/health_pill_calc_test.py
+++ b/tensorboard/plugins/debugger/health_pill_calc_test.py
@@ -1,0 +1,128 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for health_pill_calc."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+
+from tensorboard.plugins.debugger import health_pill_calc
+
+
+class HealthPillCalcTest(tf.test.TestCase):
+
+  def testInfOnlyArray(self):
+    x = np.array([[np.inf, -np.inf], [np.inf, np.inf]])
+    health_pill = health_pill_calc.calc_health_pill(x)
+    self.assertEqual(16, len(health_pill))
+    self.assertEqual(1.0, health_pill[0])  # Is initialized.
+    self.assertEqual(4.0, health_pill[1])  # numel.
+    self.assertEqual(0, health_pill[2])  # NaN count.
+    self.assertEqual(1, health_pill[3])  # -Infinity count.
+    self.assertEqual(0, health_pill[4])  # Finite negative count.
+    self.assertEqual(0, health_pill[5])  # Zero count.
+    self.assertEqual(0, health_pill[6])  # Finite positive count.
+    self.assertEqual(3, health_pill[7])  # +Infinity count.
+    self.assertEqual(np.inf, health_pill[8])
+    self.assertEqual(-np.inf, health_pill[9])
+    self.assertTrue(np.isnan(health_pill[10]))
+    self.assertTrue(np.isnan(health_pill[11]))
+    self.assertEqual(2, health_pill[13])  # Number of dimensions.
+    self.assertEqual(2, health_pill[14])  # Size is (2, 2).
+    self.assertEqual(2, health_pill[15])
+
+  def testNanOnlyArray(self):
+    x = np.array([[np.nan, np.nan, np.nan]])
+    health_pill = health_pill_calc.calc_health_pill(x)
+    self.assertEqual(16, len(health_pill))
+    self.assertEqual(1, health_pill[0])  # Is initialized.
+    self.assertEqual(3, health_pill[1])  # numel.
+    self.assertEqual(3, health_pill[2])  # NaN count.
+    self.assertEqual(0, health_pill[3])  # -Infinity count.
+    self.assertEqual(0, health_pill[4])  # Finite negative count.
+    self.assertEqual(0, health_pill[5])  # Zero count.
+    self.assertEqual(0, health_pill[6])  # Finite positive count.
+    self.assertEqual(0, health_pill[7])  # +Infinity count.
+    self.assertEqual(np.inf, health_pill[8])
+    self.assertEqual(-np.inf, health_pill[9])
+    self.assertTrue(np.isnan(health_pill[10]))
+    self.assertTrue(np.isnan(health_pill[11]))
+    self.assertEqual(2, health_pill[13])  # Number of dimensions.
+    self.assertEqual(1, health_pill[14])  # Size is (1, 3)
+    self.assertEqual(3, health_pill[15])
+
+  def testInfAndNanOnlyArray(self):
+    x = np.array([np.inf, -np.inf, np.nan])
+    health_pill = health_pill_calc.calc_health_pill(x)
+    self.assertEqual(15, len(health_pill))
+    self.assertEqual(1, health_pill[0])  # Is initialized.
+    self.assertEqual(3, health_pill[1])  # numel.
+    self.assertEqual(1, health_pill[2])  # NaN count.
+    self.assertEqual(1, health_pill[3])  # -Infinity count.
+    self.assertEqual(0, health_pill[4])  # Finite negative count.
+    self.assertEqual(0, health_pill[5])  # Zero count.
+    self.assertEqual(0, health_pill[6])  # Finite positive count.
+    self.assertEqual(1, health_pill[7])  # +Infinity count.
+    self.assertEqual(np.inf, health_pill[8])
+    self.assertEqual(-np.inf, health_pill[9])
+    self.assertTrue(np.isnan(health_pill[10]))
+    self.assertTrue(np.isnan(health_pill[11]))
+    self.assertEqual(1, health_pill[13])  # Number of dimensions.
+    self.assertEqual(3, health_pill[14])  # Size is (3,).
+
+  def testEmptyArray(self):
+    x = np.array([[], []])
+    health_pill = health_pill_calc.calc_health_pill(x)
+    self.assertEqual(16, len(health_pill))
+    self.assertEqual(1, health_pill[0])  # Is initialized.
+    self.assertEqual(0, health_pill[1])  # numel.
+    self.assertEqual(0, health_pill[2])  # NaN count.
+    self.assertEqual(0, health_pill[3])  # -Infinity count.
+    self.assertEqual(0, health_pill[4])  # Finite negative count.
+    self.assertEqual(0, health_pill[5])  # Zero count.
+    self.assertEqual(0, health_pill[6])  # Finite positive count.
+    self.assertEqual(0, health_pill[7])  # +Infinity count.
+    self.assertEqual(np.inf, health_pill[8])
+    self.assertEqual(-np.inf, health_pill[9])
+    self.assertTrue(np.isnan(health_pill[10]))
+    self.assertTrue(np.isnan(health_pill[11]))
+    self.assertEqual(2, health_pill[13])  # Number of dimensions.
+    self.assertEqual(2, health_pill[14])  # Size is (2, 0).
+    self.assertEqual(0, health_pill[15])
+
+  def testScalar(self):
+    x = np.array(-1337.0)
+    health_pill = health_pill_calc.calc_health_pill(x)
+    self.assertEqual(14, len(health_pill))
+    self.assertEqual(1, health_pill[0])  # Is initialized.
+    self.assertEqual(1, health_pill[1])  # numel.
+    self.assertEqual(0, health_pill[2])  # NaN count.
+    self.assertEqual(0, health_pill[3])  # -Infinity count.
+    self.assertEqual(1, health_pill[4])  # Finite negative count.
+    self.assertEqual(0, health_pill[5])  # Zero count.
+    self.assertEqual(0, health_pill[6])  # Finite positive count.
+    self.assertEqual(0, health_pill[7])  # +Infinity count.
+    self.assertEqual(-1337.0, health_pill[8])
+    self.assertEqual(-1337.0, health_pill[9])
+    self.assertEqual(-1337.0, health_pill[10])
+    self.assertEqual(0, health_pill[11])
+    self.assertEqual(0, health_pill[13])  # Number of dimensions.
+
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/tensorboard/plugins/debugger/tensor_helper.py
+++ b/tensorboard/plugins/debugger/tensor_helper.py
@@ -146,7 +146,6 @@ def array_to_base64_png(array):
     # Finite subset is not empty.
     minval = np.min(array[finite_indices])
     maxval = np.max(array[finite_indices])
-    # TODO(cais): Deal with the case in which minval == maxval.
     scaled = np.array((array - minval) / (maxval - minval) * 255,
                       dtype=np.uint8)
     rgb = np.repeat(np.expand_dims(scaled, -1), IMAGE_COLOR_CHANNELS, axis=-1)

--- a/tensorboard/plugins/debugger/tensor_helper.py
+++ b/tensorboard/plugins/debugger/tensor_helper.py
@@ -103,6 +103,12 @@ def array_view(array, slicing=None, mapping=None):
     raise ValueError("Invalid mapping: %s" % mapping)
 
 
+IMAGE_COLOR_CHANNELS = 3
+POSITIVE_INFINITY_RGB = (0, 62, 212)  # +inf --> Blue.
+NEGATIVE_INFINITY_RGB = (255, 127, 0)  # -inf --> Orange.
+NAN_RGB = (221, 47, 45)  # nan -> Red.
+
+
 def array_to_base64_png(array):
   """Convert an array into base64-enoded PNG image.
 
@@ -113,20 +119,44 @@ def array_to_base64_png(array):
     A base64-encoded string the image. The image is grayscale if the array is
     2D. The image is RGB color if the image is 3D with lsat dimension equal to
     3.
+
+  Raises:
+    ValueError: If the input `array` is not rank-2, or if the rank-2 `array` is
+      empty.
   """
   # TODO(cais): Deal with 3D case.
   # TODO(cais): If there are None values in here, replace them with all NaNs.
   array = np.array(array, dtype=np.float32)
-  assert len(array.shape) == 2
+  if len(array.shape) != 2:
+    raise ValueError(
+        "Expected rank-2 array; received rank-%d array." % len(array.shape))
+  if not np.size(array):
+    raise ValueError(
+        "Cannot encode an empty array (size: %s) as image." % (array.shape,))
 
-  healthy_indices = np.where(np.logical_and(np.logical_not(np.isnan(array)),
-                                            np.logical_not(np.isinf(array))))
-  # TODO(cais): Deal with case in which there is no health elements, i.e., all
-  # elements are NaN of Inf.
-  minval = np.min(array[healthy_indices])
-  maxval = np.max(array[healthy_indices])
-  # TODO(cais): Deal with the case in which minval == maxval.
-  scaled = np.array((array - minval) / (maxval - minval) * 255, dtype=np.uint8)
-  rgb = np.repeat(np.expand_dims(scaled, -1), 3, axis=-1)
+  is_infinity = np.isinf(array)
+  is_positive = array > 0.0
+  is_positive_infinity = np.logical_and(is_infinity, is_positive)
+  is_negative_infinity = np.logical_and(is_infinity,
+                                        np.logical_not(is_positive))
+  is_nan = np.isnan(array)
+  finite_indices = np.where(np.logical_and(np.logical_not(is_infinity),
+                                           np.logical_not(is_nan)))
+  if np.size(finite_indices):
+    # Finite subset is not empty.
+    minval = np.min(array[finite_indices])
+    maxval = np.max(array[finite_indices])
+    # TODO(cais): Deal with the case in which minval == maxval.
+    scaled = np.array((array - minval) / (maxval - minval) * 255,
+                      dtype=np.uint8)
+    rgb = np.repeat(np.expand_dims(scaled, -1), IMAGE_COLOR_CHANNELS, axis=-1)
+  else:
+    rgb = np.zeros(array.shape + (IMAGE_COLOR_CHANNELS,), dtype=np.uint8)
+
+  # Color-code pixels that correspond to infinities and nans.
+  rgb[is_positive_infinity] = POSITIVE_INFINITY_RGB
+  rgb[is_negative_infinity] = NEGATIVE_INFINITY_RGB
+  rgb[is_nan] = NAN_RGB
+
   image_encoded = base64.b64encode(util.encode_png(rgb))
   return image_encoded

--- a/tensorboard/plugins/debugger/tensor_helper_test.py
+++ b/tensorboard/plugins/debugger/tensor_helper_test.py
@@ -70,6 +70,63 @@ class TensorHelperTest(tf.test.TestCase):
     self.assertEqual((5, 8), shape)
     decoded_x = im_util.decode_png(base64.b64decode(data))
     self.assertEqual((5, 8, 3), decoded_x.shape)
+    self.assertEqual(np.uint8, decoded_x.dtype)
+    self.assertAllClose(np.zeros([5, 8, 3]), decoded_x)
+
+  def testImagePngMappingWorksForArrayWithOnlyOneElement(self):
+    x = np.array([[-42]], dtype=np.int16)
+    dtype, shape, data = tensor_helper.array_view(x, mapping="image/png")
+    self.assertEqual("int16", dtype)
+    self.assertEqual((1, 1), shape)
+    decoded_x = im_util.decode_png(base64.b64decode(data))
+    self.assertEqual((1, 1, 3), decoded_x.shape)
+    self.assertEqual(np.uint8, decoded_x.dtype)
+    self.assertAllClose(np.zeros([1, 1, 3]), decoded_x)
+
+  def testImagePngMappingWorksForArrayWithInfAndNaN(self):
+    x = np.array([[1.1, 2.2, np.inf], [-np.inf, 3.3, np.nan]], dtype=np.float32)
+    dtype, shape, data = tensor_helper.array_view(x, mapping="image/png")
+    self.assertEqual("float32", dtype)
+    self.assertEqual((2, 3), shape)
+    decoded_x = im_util.decode_png(base64.b64decode(data))
+    self.assertEqual((2, 3, 3), decoded_x.shape)
+    self.assertEqual(np.uint8, decoded_x.dtype)
+    self.assertAllClose([0, 0, 0], decoded_x[0, 0, :])  # 1.1.
+    self.assertAllClose([127, 127, 127], decoded_x[0, 1, :])  # 2.2.
+    self.assertAllClose(tensor_helper.POSITIVE_INFINITY_RGB,
+                        decoded_x[0, 2, :])  # +infinity.
+    self.assertAllClose(tensor_helper.NEGATIVE_INFINITY_RGB,
+                        decoded_x[1, 0, :])  # -infinity.
+    self.assertAllClose([255, 255, 255], decoded_x[1, 1, :])  # 3.3.
+    self.assertAllClose(tensor_helper.NAN_RGB, decoded_x[1, 2, :])  # nan.
+
+  def testImagePngMappingWorksForArrayWithOnlyInfAndNaN(self):
+    x = np.array([[np.nan, -np.inf], [np.inf, np.nan]], dtype=np.float32)
+    dtype, shape, data = tensor_helper.array_view(x, mapping="image/png")
+    self.assertEqual("float32", dtype)
+    self.assertEqual((2, 2), shape)
+    decoded_x = im_util.decode_png(base64.b64decode(data))
+    self.assertEqual((2, 2, 3), decoded_x.shape)
+    self.assertEqual(np.uint8, decoded_x.dtype)
+    self.assertAllClose(tensor_helper.NAN_RGB, decoded_x[0, 0, :])  # nan.
+    self.assertAllClose(tensor_helper.NEGATIVE_INFINITY_RGB,
+                        decoded_x[0, 1, :])  # -infinity.
+    self.assertAllClose(tensor_helper.POSITIVE_INFINITY_RGB,
+                        decoded_x[1, 0, :])  # +infinity.
+    self.assertAllClose(tensor_helper.NAN_RGB, decoded_x[1, 1, :])  # nan.
+
+  def testImagePngMappingRaisesExceptionForEmptyArray(self):
+    x = np.zeros([0, 0])
+    with self.assertRaisesRegexp(
+        ValueError, r"Cannot encode an empty array .* \(0, 0\)"):
+      tensor_helper.array_view(x, mapping="image/png")
+
+  def testImagePngMappingRaisesExceptionForNonRank2Array(self):
+    x = np.ones([2, 2, 2])
+    with self.assertRaisesRegexp(
+        ValueError, r"Expected rank-2 array; received rank-3 array"):
+      tensor_helper.array_to_base64_png(x)
+
 
 class ArrayToBase64PNGTest(tf.test.TestCase):
 

--- a/tensorboard/plugins/graph/tf_graph_common/scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/scene.ts
@@ -612,6 +612,7 @@ export function humanizeHealthPillStat(stat, shouldRoundOnesDigit) {
     return stat.toFixed(0);
   }
 
+  // TODO(cais): Case in which stat is inf or nan.
   if (Math.abs(stat) >= 1) {
     return stat.toFixed(1);
   }
@@ -799,14 +800,18 @@ export function addHealthPill(
   }
 
   let statsSvg = document.createElementNS(SVG_NAMESPACE, 'text');
-  const minString =
-      humanizeHealthPillStat(numericStats.min, shouldRoundOnesDigit);
-  const maxString =
-      humanizeHealthPillStat(numericStats.max, shouldRoundOnesDigit);
-  if (totalCount > 1) {
-    statsSvg.textContent = minString + ' ~ ' + maxString;
+  if (Number.isFinite(numericStats.min) && Number.isFinite(numericStats.max)) {
+    const minString =
+        humanizeHealthPillStat(numericStats.min, shouldRoundOnesDigit);
+    const maxString =
+        humanizeHealthPillStat(numericStats.max, shouldRoundOnesDigit);
+    if (totalCount > 1) {
+      statsSvg.textContent = minString + ' ~ ' + maxString;
+    } else {
+      statsSvg.textContent = minString;
+    }
   } else {
-    statsSvg.textContent = minString;
+    statsSvg.textContent = '(No finite elements)';
   }
   statsSvg.classList.add('health-pill-stats');
   if (textXOffset == null) {

--- a/tensorboard/plugins/graph/tf_graph_common/scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/scene.ts
@@ -611,8 +611,6 @@ export function humanizeHealthPillStat(stat, shouldRoundOnesDigit) {
   if (shouldRoundOnesDigit) {
     return stat.toFixed(0);
   }
-
-  // TODO(cais): Case in which stat is inf or nan.
   if (Math.abs(stat) >= 1) {
     return stat.toFixed(1);
   }


### PR DESCRIPTION
…ensors.

* Let health_pill_calc.calc_health_pill be capable of handling input
  arrays with only nans and/or infinities.
* Let the 'image/png' mapping be capable of handling the aforementioned
  type of arrays, and let it color-code +inf, -inf and nan elements,
  respectively.

chaser