### PR TITLE
Remove height 29% from tensor data table

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -324,7 +324,6 @@ limitations under the License.
         padding: 20px 0;
       }
       .tensor-data {
-        height: 29%;
         overflow: auto;
         padding: 20px 0;
       }

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -323,9 +323,19 @@ limitations under the License.
       .buttons-container {
         padding: 20px 0;
       }
-      .tensor-data {
-        overflow: auto;
+      #tensor-data {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
         padding: 20px 0;
+      }
+      #tensorDataSummary {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        top: 0;
       }
       #top-right-quadrant {
         height: 66%;
@@ -1330,6 +1340,7 @@ limitations under the License.
         this.$$('#center-content').style.width = contentWidth + 'px';
         const height = topRightQuadrantHeight - this._resizerWidth;
         this.$$('#top-right-quadrant').style.height = height + 'px';
+        this.$$('#tensor-data').style.top = topRightQuadrantHeight + 'px';
       },
       _leftPaneWidthObserver: tf_storage.getNumberObserver(
           '_leftPaneWidth', {defaultValue: _DEFAULT_LEFT_PANE_WIDTH}),

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -329,6 +329,7 @@ limitations under the License.
         left: 0;
         right: 0;
         padding: 20px 0;
+        margin: 0 0 20px 0;
       }
       #tensorDataSummary {
         position: absolute;

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
@@ -67,7 +67,7 @@ limitations under the License.
           text-align: left;
           vertical-align: middle;
           width: 100%;
-          padding-top: 53px;
+          padding-top: 3px;
           padding-left: 3px;
           padding-right: 3px;
           box-shadow: 3px 3px #ddd;

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
@@ -51,6 +51,7 @@ limitations under the License.
     <style>
         :host #tensor-data-div {
           height: 100%;
+          overflow-x: hidden;
           overflow-y: auto;
         }
         .section-title {

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
@@ -51,7 +51,6 @@ limitations under the License.
     <style>
         :host #tensor-data-div {
           height: 100%;
-          overflow-x: hidden;
           overflow-y: auto;
         }
         .section-title {

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-data-summary.html
@@ -26,25 +26,33 @@ limitations under the License.
     <span class="section-title">Tensor Value Overview</span>
     <div id="tensor-data-div" class="tensor-data-div">
       <table id="tensor-data-table" align="left" class="tensor-data-table">
-        <tr align="left">
-          <th>Tensor</th>
-          <th>Count</th>
-          <th>DType</th>
-          <th>Shape</th>
-          <th width="25%">Value</th>
-          <th width="25%">
-            Health Pill
-            <paper-toggle-button id="show-health-pills" checked="{{_healthPillsEnabled}}">
-            </paper-toggle-button>
-            <paper-card>
-              <div class="health-pill-legend" id="health-pill-legend"></div>
-            </paper-card>
-          </th>
-          <th width="5%"></th>
-        </tr>
+        <thead>
+          <tr align="left">
+            <th>Tensor</th>
+            <th>Count</th>
+            <th>DType</th>
+            <th>Shape</th>
+            <th width="25%">Value</th>
+            <th width="25%">
+              Health Pill
+              <paper-toggle-button id="show-health-pills" checked="{{_healthPillsEnabled}}">
+              </paper-toggle-button>
+              <paper-card>
+                <div class="health-pill-legend" id="health-pill-legend"></div>
+              </paper-card>
+            </th>
+            <th width="5%"></th>
+          </tr>
+        </thead>
+        <tbody>
+        </tbody>
       </table>
     </div>
     <style>
+        :host #tensor-data-div {
+          height: 100%;
+          overflow-y: auto;
+        }
         .section-title {
           font-size: 110%;
           font-weight: bold;
@@ -55,15 +63,16 @@ limitations under the License.
         :host .tensor-data-table {
           align-content: left;
           align-items: left;
+          display: block;
           text-align: left;
           vertical-align: middle;
           width: 100%;
-          padding-top: 3px;
+          padding-top: 53px;
           padding-left: 3px;
           padding-right: 3px;
           box-shadow: 3px 3px #ddd;
         }
-        :host .tensor-data-table th {
+        :host #tensor-data-table th {
           vertical-align: top;
         }
         :host .active-tensor {
@@ -336,12 +345,14 @@ limitations under the License.
 
     _renderRow(watchKey) {
       let tensorDataRow;
+      let rowInserted = false;
       if (this._watchKey2Row[watchKey] != null) {
         tensorDataRow = this._watchKey2Row[watchKey];
         this._clearTensorDataRow(tensorDataRow);
+        rowInserted = false;
       } else {
         tensorDataRow = document.createElement('tr');
-        Polymer.dom(this.$$('#tensor-data-table')).appendChild(tensorDataRow);
+        rowInserted = true;
       }
 
       const deviceName = this._watchKey2Data[watchKey]['deviceName'];
@@ -433,7 +444,12 @@ limitations under the License.
       }
 
       this._watchKey2Row[watchKey] = tensorDataRow;
-      tensorDataRow.scrollIntoView({block: 'end', inline: 'nearest', behaviour: 'smooth'});
+      if (rowInserted) {
+        Polymer.dom(this.$$('#tensor-data-table tbody')).appendChild(
+            tensorDataRow);
+      }
+      tensorDataRow.scrollIntoView(
+          {block: 'end', inline: 'nearest', behaviour: 'smooth'});
     },
 
     // Render health pill for a tensor.


### PR DESCRIPTION
That height caused blank space to be under the tensor data table.

Before:
![image](https://user-images.githubusercontent.com/4221553/35783025-1e95e68e-09b6-11e8-94b9-51c1bb569611.png)
