### PR TITLE
[Debugger Plugin] Set font-family of space/time slicing to monospace

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
@@ -152,6 +152,16 @@ limitations under the License.
       font-size: 90%;
       color: blue;
     }
+    #slicing {
+      --paper-input-container-input: {
+        font-family: monospace;
+      };
+    }
+    #time-indices {
+      --paper-input-container-input: {
+        font-family: monospace;
+      };
+    }
   </style>
   <script>
 

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
@@ -152,12 +152,7 @@ limitations under the License.
       font-size: 90%;
       color: blue;
     }
-    #slicing {
-      --paper-input-container-input: {
-        font-family: monospace;
-      };
-    }
-    #time-indices {
+    #slicing, #time-indices {
       --paper-input-container-input: {
         font-family: monospace;
       };


### PR DESCRIPTION
This makes it easier to read and enter.