### PR TITLE
Bump version at HEAD to 1.7.0a0

### DIFF
--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '1.6.0a0'
+VERSION = '1.7.0a0'


### PR DESCRIPTION
I propose that going forward we should maintain our version at HEAD as +1 minor release ahead of our most recent release, i.e. as soon as we release the first release or release candidate for 1.N then we should move head up to 1.(N+1).0a0.  Or concretely, in this case since we've release 1.6.0-rc0 we should be at 1.7.0a0 at HEAD.

This is because logically, at HEAD we may already have new features that aren't going to be in 1.6.x and will be instead only incorporated into 1.7.0.  So HEAD is really an "alpha prerelease" for 1.7.0, not for 1.6.0.

Once we've bumped the version and have at least one 1.(N+1).0a<date> nightly release on PyPI, but no earlier than the TensorFlow release 1.N.0-rc0 release, we would send a PR to TensorFlow updating their tb-nightly dep to >= 1.(N+1).0a0 < 1.(N+2).0a0.  This would ensure that as soon as tf-nightly will start to diverge past the TF 1.N branch, tb-nightly is appropriately pinned to 1.(N+1).

(Note that at that point it would be decoupled from the PRs we send to their release branches to update the regular tensorboard dep.) 

