### PR TITLE
Add /data/environment route

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -118,6 +118,7 @@ def standard_tensorboard_wsgi(
   context = base_plugin.TBContext(
       db_module=db_module,
       db_connection_provider=db_connection_provider,
+      db_uri=db_uri,
       logdir=logdir,
       multiplexer=multiplexer,
       assets_zip_provider=assets_zip_provider,

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -357,7 +357,9 @@ class TensorBoardPluginsTest(tf.test.TestCase):
     ]
 
     # The application should have added routes for both plugins.
-    self.app = application.standard_tensorboard_wsgi('', True, 60, plugins)
+    self.logdir = self.get_temp_dir()
+    self.app = application.standard_tensorboard_wsgi(
+        self.logdir, True, 60, plugins)
 
   def _foo_handler(self):
     pass

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -86,6 +86,7 @@ class TBContext(object):
       assets_zip_provider=None,
       db_connection_provider=None,
       db_module=None,
+      db_uri=None,
       logdir=None,
       multiplexer=None,
       plugin_name_to_instance=None,
@@ -112,7 +113,10 @@ class TBContext(object):
       db_module: A PEP-249 DB Module, e.g. sqlite3. This is useful for accessing
           things like date time constructors. This value will be None if we are
           not in SQL mode and multiplexer should be used instead.
-      logdir: The string logging directory TensorBoard was started with.
+      db_uri: The string db URI TensorBoard was started with. If this is set,
+          the logdir should be None.
+      logdir: The string logging directory TensorBoard was started with. If this
+          is set, the db_uri should be None.
       multiplexer: An EventMultiplexer with underlying TB data. Plugins should
           copy this data over to the database when the db fields are set.
       plugin_name_to_instance: A mapping between plugin name to instance.
@@ -123,9 +127,12 @@ class TBContext(object):
           mapping, lest a KeyError is raised.
       window_title: A string specifying the the window title.
     """
+    assert not (db_uri and logdir)
+
     self.assets_zip_provider = assets_zip_provider
     self.db_connection_provider = db_connection_provider
     self.db_module = db_module
+    self.db_uri = db_uri
     self.logdir = logdir
     self.multiplexer = multiplexer
     self.plugin_name_to_instance = plugin_name_to_instance

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -126,8 +126,17 @@ class TBContext(object):
           logic should handle cases in which a plugin is absent from this
           mapping, lest a KeyError is raised.
       window_title: A string specifying the the window title.
+
+    Raises:
+      ValueError: If both logdir and db_uri are provided (or if neither are 
+          provided).
     """
-    assert not (db_uri and logdir)
+    if db_uri and logdir:
+      raise ValueError(
+          'Both db_uri (%r) and logdir (%r) are provided', db_uri, logdir)
+
+    if not db_uri and not logdir:
+      raise ValueError('Neither db_uri nor logdir are provided')
 
     self.assets_zip_provider = assets_zip_provider
     self.db_connection_provider = db_connection_provider

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -131,13 +131,6 @@ class TBContext(object):
       ValueError: If both logdir and db_uri are provided (or if neither are
           provided).
     """
-    if db_uri and logdir:
-      raise ValueError(
-          'Both db_uri (%r) and logdir (%r) are provided' % (db_uri, logdir))
-
-    if not db_uri and not logdir:
-      raise ValueError('Neither db_uri nor logdir are provided')
-
     self.assets_zip_provider = assets_zip_provider
     self.db_connection_provider = db_connection_provider
     self.db_module = db_module

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -128,12 +128,12 @@ class TBContext(object):
       window_title: A string specifying the the window title.
 
     Raises:
-      ValueError: If both logdir and db_uri are provided (or if neither are 
+      ValueError: If both logdir and db_uri are provided (or if neither are
           provided).
     """
     if db_uri and logdir:
       raise ValueError(
-          'Both db_uri (%r) and logdir (%r) are provided', db_uri, logdir)
+          'Both db_uri (%r) and logdir (%r) are provided' % (db_uri, logdir))
 
     if not db_uri and not logdir:
       raise ValueError('Neither db_uri nor logdir are provided')

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -126,10 +126,6 @@ class TBContext(object):
           logic should handle cases in which a plugin is absent from this
           mapping, lest a KeyError is raised.
       window_title: A string specifying the the window title.
-
-    Raises:
-      ValueError: If both logdir and db_uri are provided (or if neither are
-          provided).
     """
     self.assets_zip_provider = assets_zip_provider
     self.db_connection_provider = db_connection_provider

--- a/tensorboard/plugins/core/BUILD
+++ b/tensorboard/plugins/core/BUILD
@@ -32,6 +32,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":core_plugin",
+        "//tensorboard:db",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -100,22 +100,22 @@ class CorePlugin(base_plugin.TBPlugin):
   def _serve_environment(self, request):
     """Serve a JSON object containing some base properties used by the frontend.
 
-    * data_location is eitgher a path to a directory or an address to a 
+    * data_location is eitgher a path to a directory or an address to a
       database (depending on which mode TensorBoard is running in).
     * window_title is the title of the TensorBoard web page.
     """
     return http_util.Respond(
         request,
         {
-          'data_location': self._logdir or self._db_uri,
-          'window_title': self._window_title,
+            'data_location': self._logdir or self._db_uri,
+            'window_title': self._window_title,
         },
         'application/json')
 
   @wrappers.Request.application
   def _serve_logdir(self, request):
     """Respond with a JSON object containing this TensorBoard's logdir.
-    
+
     TODO(chihuahua): Remove this method once the frontend instead uses the
     /environment route (and no deps throughout Google use the /logdir route).
     """
@@ -125,7 +125,7 @@ class CorePlugin(base_plugin.TBPlugin):
   @wrappers.Request.application
   def _serve_window_properties(self, request):
     """Serve a JSON object containing this TensorBoard's window properties.
-    
+
     TODO(chihuahua): Remove this method once the frontend instead uses the
     /environment route.
     """

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -100,7 +100,7 @@ class CorePlugin(base_plugin.TBPlugin):
   def _serve_environment(self, request):
     """Serve a JSON object containing some base properties used by the frontend.
 
-    * data_location is eitgher a path to a directory or an address to a
+    * data_location is either a path to a directory or an address to a
       database (depending on which mode TensorBoard is running in).
     * window_title is the title of the TensorBoard web page.
     """
@@ -114,21 +114,19 @@ class CorePlugin(base_plugin.TBPlugin):
 
   @wrappers.Request.application
   def _serve_logdir(self, request):
-    """Respond with a JSON object containing this TensorBoard's logdir.
-
-    TODO(chihuahua): Remove this method once the frontend instead uses the
-    /environment route (and no deps throughout Google use the /logdir route).
-    """
+    """Respond with a JSON object containing this TensorBoard's logdir."""
+    # TODO(chihuahua): Remove this method once the frontend instead uses the
+    # /data/environment route (and no deps throughout Google use the
+    # /data/logdir route).
+    route).
     return http_util.Respond(
         request, {'logdir': self._logdir}, 'application/json')
 
   @wrappers.Request.application
   def _serve_window_properties(self, request):
-    """Serve a JSON object containing this TensorBoard's window properties.
-
-    TODO(chihuahua): Remove this method once the frontend instead uses the
-    /environment route.
-    """
+    """Serve a JSON object containing this TensorBoard's window properties."""
+    # TODO(chihuahua): Remove this method once the frontend instead uses the
+    # /environment route.
     return http_util.Respond(
         request, {'window_title': self._window_title}, 'application/json')
 

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -126,7 +126,7 @@ class CorePlugin(base_plugin.TBPlugin):
   def _serve_window_properties(self, request):
     """Serve a JSON object containing this TensorBoard's window properties."""
     # TODO(chihuahua): Remove this method once the frontend instead uses the
-    # /environment route.
+    # /data/environment route.
     return http_util.Respond(
         request, {'window_title': self._window_title}, 'application/json')
 

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -61,7 +61,7 @@ class CorePlugin(base_plugin.TBPlugin):
     apps = {
         '/___rPc_sWiTcH___': self._send_404_without_logging,
         '/audio': self._redirect_to_index,
-        '/data/data_location': self._serve_data_location,
+        '/data/environment': self._serve_environment,
         '/data/logdir': self._serve_logdir,
         '/data/runs': self._serve_runs,
         '/data/window_properties': self._serve_window_properties,
@@ -97,15 +97,19 @@ class CorePlugin(base_plugin.TBPlugin):
         request, gzipped_asset_bytes, mimetype, content_encoding='gzip')
 
   @wrappers.Request.application
-  def _serve_data_location(self, request):
-    """Serve a JSON object containing a string denoting the location of data.
+  def _serve_environment(self, request):
+    """Serve a JSON object containing some base properties used by the frontend.
 
-    That location can either be a path to a directory or an address to a 
-    database (depending on which mode TensorBoard is running in).
+    * data_location is eitgher a path to a directory or an address to a 
+      database (depending on which mode TensorBoard is running in).
+    * window_title is the title of the TensorBoard web page.
     """
     return http_util.Respond(
         request,
-        {'data_location': self._logdir or self._db_uri},
+        {
+          'data_location': self._logdir or self._db_uri,
+          'window_title': self._window_title,
+        },
         'application/json')
 
   @wrappers.Request.application
@@ -113,14 +117,18 @@ class CorePlugin(base_plugin.TBPlugin):
     """Respond with a JSON object containing this TensorBoard's logdir.
     
     TODO(chihuahua): Remove this method once the frontend instead uses the
-    /data_location route (and no deps throughout Google use the /logdir route).
+    /environment route (and no deps throughout Google use the /logdir route).
     """
     return http_util.Respond(
         request, {'logdir': self._logdir}, 'application/json')
 
   @wrappers.Request.application
   def _serve_window_properties(self, request):
-    """Serve a JSON object containing this TensorBoard's window properties."""
+    """Serve a JSON object containing this TensorBoard's window properties.
+    
+    TODO(chihuahua): Remove this method once the frontend instead uses the
+    /environment route.
+    """
     return http_util.Respond(
         request, {'window_title': self._window_title}, 'application/json')
 

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -118,7 +118,6 @@ class CorePlugin(base_plugin.TBPlugin):
     # TODO(chihuahua): Remove this method once the frontend instead uses the
     # /data/environment route (and no deps throughout Google use the
     # /data/logdir route).
-    route).
     return http_util.Respond(
         request, {'logdir': self._logdir}, 'application/json')
 

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import contextlib
 import json
 import os
 import shutil
@@ -27,6 +28,7 @@ import tensorflow as tf
 from werkzeug import test as werkzeug_test
 from werkzeug import wrappers
 
+from tensorboard import db
 from tensorboard.backend import application
 from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
 from tensorboard.plugins import base_plugin
@@ -37,30 +39,58 @@ class CorePluginTest(tf.test.TestCase):
   _only_use_meta_graph = False  # Server data contains only a GraphDef
 
   def setUp(self):
-    self.logdir = self.get_temp_dir()
-    self.addCleanup(shutil.rmtree, self.logdir)
+    self.temp_dir = self.get_temp_dir()
+    self.addCleanup(shutil.rmtree, self.temp_dir)
+
+    self.startLogdirBasedServer(self.temp_dir)
+    self.startDbBasedServer(self.temp_dir)
+
+  def startLogdirBasedServer(self, temp_dir):
+    self.logdir = temp_dir
     self._generate_test_data(run_name='run1')
     self.multiplexer = event_multiplexer.EventMultiplexer(
         size_guidance=application.DEFAULT_SIZE_GUIDANCE,
         purge_orphaned_data=True)
-    self._context = base_plugin.TBContext(
+    context = base_plugin.TBContext(
         assets_zip_provider=get_test_assets_zip_provider(),
         logdir=self.logdir,
         multiplexer=self.multiplexer)
-    self.plugin = core_plugin.CorePlugin(self._context)
+    self.logdir_based_plugin = core_plugin.CorePlugin(context)
     app = application.TensorBoardWSGIApp(
-        self.logdir, [self.plugin], self.multiplexer, 0, path_prefix='')
-    self.server = werkzeug_test.Client(app, wrappers.BaseResponse)
+        self.logdir,
+        [self.logdir_based_plugin],
+        self.multiplexer,
+        0,
+        path_prefix='')
+    self.logdir_based_server = werkzeug_test.Client(app, wrappers.BaseResponse)
+
+  def startDbBasedServer(self, temp_dir):
+    self.db_uri = 'sqlite:' + os.path.join(temp_dir, 'db.sqlite')
+    db_module, db_connection_provider = application.get_database_info(
+        self.db_uri)
+    if db_connection_provider is not None:
+      with contextlib.closing(db_connection_provider()) as db_conn:
+        schema = db.Schema(db_conn)
+        schema.create_tables()
+        schema.create_indexes()
+    context = base_plugin.TBContext(
+        assets_zip_provider=get_test_assets_zip_provider(),
+        db_module=db_module,
+        db_connection_provider=db_connection_provider,
+        db_uri=self.db_uri)
+    self.db_based_plugin = core_plugin.CorePlugin(context)
+    app = application.TensorBoardWSGI([self.db_based_plugin])
+    self.db_based_server = werkzeug_test.Client(app, wrappers.BaseResponse)
 
   def testRoutesProvided(self):
     """Tests that the plugin offers the correct routes."""
-    routes = self.plugin.get_plugin_apps()
+    routes = self.logdir_based_plugin.get_plugin_apps()
     self.assertIsInstance(routes['/data/logdir'], collections.Callable)
     self.assertIsInstance(routes['/data/runs'], collections.Callable)
 
   def testIndex_returnsActualHtml(self):
     """Test the format of the /data/runs endpoint."""
-    response = self.server.get('/')
+    response = self.logdir_based_server.get('/')
     self.assertEqual(200, response.status_code)
     self.assertStartsWith(response.headers.get('Content-Type'), 'text/html')
     html = response.get_data()
@@ -69,18 +99,29 @@ class CorePluginTest(tf.test.TestCase):
   def testDataPaths_disableAllCaching(self):
     """Test the format of the /data/runs endpoint."""
     for path in ('/data/runs', '/data/logdir'):
-      response = self.server.get(path)
+      response = self.logdir_based_server.get(path)
       self.assertEqual(200, response.status_code, msg=path)
       self.assertEqual('0', response.headers.get('Expires'), msg=path)
 
+  def testDataLocationForDbUri(self):
+    """Test that the data location route correctly returns the database URI."""
+    parsed_object = self._get_json(self.db_based_server, '/data/data_location')
+    self.assertEqual(parsed_object, {'data_location': self.db_uri})
+
+  def testDataLocationForLogdir(self):
+    """Test that the data location route correctly returns the logdir."""
+    parsed_object = self._get_json(
+        self.logdir_based_server, '/data/data_location')
+    self.assertEqual(parsed_object, {'data_location': self.logdir})
+
   def testLogdir(self):
     """Test the format of the data/logdir endpoint."""
-    parsed_object = self._get_json('/data/logdir')
+    parsed_object = self._get_json(self.logdir_based_server, '/data/logdir')
     self.assertEqual(parsed_object, {'logdir': self.logdir})
 
   def testRuns(self):
     """Test the format of the /data/runs endpoint."""
-    run_json = self._get_json('/data/runs')
+    run_json = self._get_json(self.logdir_based_server, '/data/runs')
     self.assertEqual(run_json, ['run1'])
 
   def testRunsAppendOnly(self):
@@ -120,23 +161,23 @@ class CorePluginTest(tf.test.TestCase):
 
     # Add one run: it should come last.
     add_run('avocado')
-    self.assertEqual(self._get_json('/data/runs'),
+    self.assertEqual(self._get_json(self.logdir_based_server, '/data/runs'),
                      ['run1', 'avocado'])
 
     # Add another run: it should come last, too.
     add_run('zebra')
-    self.assertEqual(self._get_json('/data/runs'),
+    self.assertEqual(self._get_json(self.logdir_based_server, '/data/runs'),
                      ['run1', 'avocado', 'zebra'])
 
     # And maybe there's a run for which we somehow have no timestamp.
     add_run('mysterious')
-    self.assertEqual(self._get_json('/data/runs'),
+    self.assertEqual(self._get_json(self.logdir_based_server, '/data/runs'),
                      ['run1', 'avocado', 'zebra', 'mysterious'])
 
     stubs.UnsetAll()
 
-  def _get_json(self, path):
-    response = self.server.get(path)
+  def _get_json(self, server, path):
+    response = server.get(path)
     self.assertEqual(200, response.status_code)
     return self._get_json_payload(response)
 

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -124,7 +124,7 @@ class CorePluginTest(tf.test.TestCase):
         self.logdir_based_server, '/data/environment')
     self.assertEqual(
         parsed_object_db['window_title'], parsed_object_logdir['window_title'])
-    self.assertEqual(parsed_object_db['window_title'], 'foo title')
+    self.assertEqual(parsed_object_db['window_title'], 'title foo')
 
   def testLogdir(self):
     """Test the format of the data/logdir endpoint."""

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -358,14 +358,14 @@ class TextPluginTest(tf.test.TestCase):
   def testPluginIsActiveWhenNoRuns(self):
     """The plugin should be inactive when there are no runs."""
     multiplexer = event_multiplexer.EventMultiplexer()
-    context = base_plugin.TBContext(logdir=None, multiplexer=multiplexer)
+    context = base_plugin.TBContext(logdir=self.logdir, multiplexer=multiplexer)
     plugin = text_plugin.TextPlugin(context)
     self.assertIsActive(plugin, False)
 
   def testPluginIsActiveWhenTextRuns(self):
     """The plugin should be active when there are runs with text."""
     multiplexer = event_multiplexer.EventMultiplexer()
-    context = base_plugin.TBContext(logdir=None, multiplexer=multiplexer)
+    context = base_plugin.TBContext(logdir=self.logdir, multiplexer=multiplexer)
     plugin = text_plugin.TextPlugin(context)
     multiplexer.AddRunsFromDirectory(self.logdir)
     multiplexer.Reload()
@@ -373,10 +373,10 @@ class TextPluginTest(tf.test.TestCase):
 
   def testPluginIsActiveWhenRunsButNoText(self):
     """The plugin should be inactive when there are runs but none has text."""
-    multiplexer = event_multiplexer.EventMultiplexer()
-    context = base_plugin.TBContext(logdir=None, multiplexer=multiplexer)
-    plugin = text_plugin.TextPlugin(context)
     logdir = os.path.join(self.get_temp_dir(), 'runs_with_no_text')
+    multiplexer = event_multiplexer.EventMultiplexer()
+    context = base_plugin.TBContext(logdir=logdir, multiplexer=multiplexer)
+    plugin = text_plugin.TextPlugin(context)
     self.generate_testdata(include_text=False, logdir=logdir)
     multiplexer.AddRunsFromDirectory(logdir)
     multiplexer.Reload()


### PR DESCRIPTION
This new `/data/environment` route (of the core plugin) responds with
base properties relevant to the frontend upon startup of TensorBoard.

These properties include:
* the window title
* the location of data - either a path to a log directory or a database
URI. This new route will enable the frontend to display the data
location on the bottom left when TensorBoard runs in database mode
(once the frontend makes use of this backend change in a different PR):
![image](https://user-images.githubusercontent.com/4221553/35950853-7c5f8a44-0c2d-11e8-97d8-49024d9a640c.png)

I was also hoping to use this relatively innocuous change to jumpstart
discussions. For example, as we progress towards getting TensorBoard to
run in database mode, tests for plugins will have to test behavior for
both logdir and database mode. What are the norms we expect tests to
follow?

One proposal is to have tests start a `logdir_based_server` alongside a
`db_based_server`. If we later find that tests end up sharing much logic
related to starting both servers, we can refactor logic into a base
class that tests inherit from. In the short term, that probably is not
necessary.