### PR TITLE
Make multiplexer work for database mode

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -133,6 +133,7 @@ py_library(
         ":directory_watcher",
         ":event_accumulator",
         ":io_wrapper",
+        "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer.py
@@ -18,9 +18,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
 import os
 import threading
 
+import numpy as np
 import six
 import tensorflow as tf
 
@@ -71,7 +73,8 @@ class EventMultiplexer(object):
                run_path_map=None,
                size_guidance=None,
                tensor_size_guidance=None,
-               purge_orphaned_data=True):
+               purge_orphaned_data=True,
+               db_connection_provider=None):
     """Constructor for the `EventMultiplexer`.
 
     Args:
@@ -86,6 +89,14 @@ class EventMultiplexer(object):
         `event_accumulator.EventAccumulator` for details.
       purge_orphaned_data: Whether to discard any events that were "orphaned" by
         a TensorFlow restart.
+      db_connection_provider: Function taking no arguments that returns a
+          PEP-249 database Connection object, or None if multiplexer should be
+          used instead. The returned value must be closed, and is safe to use in
+          a `with` statement. It is also safe to assume that calling this
+          function is cheap. The returned connection must only be used by a
+          single thread. Things like connection pooling are considered
+          implementation details of the provider. If provided, no events files
+          are read.
     """
     tf.logging.info('Event Multiplexer initializing.')
     self._accumulators_mutex = threading.Lock()
@@ -96,11 +107,15 @@ class EventMultiplexer(object):
                            event_accumulator.DEFAULT_SIZE_GUIDANCE)
     self._tensor_size_guidance = tensor_size_guidance
     self.purge_orphaned_data = purge_orphaned_data
-    if run_path_map is not None:
-      tf.logging.info('Event Multplexer doing initialization load for %s',
-                      run_path_map)
-      for (run, path) in six.iteritems(run_path_map):
-        self.AddRun(path, run)
+    self._db_connection_provider = db_connection_provider
+
+    if self._db_connection_provider is None:
+      # Only add runs if we are reading data from events files.
+      if run_path_map is not None:
+        tf.logging.info('Event Multplexer doing initialization load for %s',
+                        run_path_map)
+        for (run, path) in six.iteritems(run_path_map):
+          self.AddRun(path, run)
     tf.logging.info('Event Multiplexer done initializing')
 
   def AddRun(self, path, name=None):
@@ -119,9 +134,15 @@ class EventMultiplexer(object):
       path: Path to the event files (or event directory) for given run.
       name: Name of the run to add. If not provided, is set to path.
 
+    Raises:
+      RuntimeError: If this method is called while running in database mode.
+
     Returns:
       The `EventMultiplexer`.
     """
+    if self._db_connection_provider:
+      raise RuntimeError('Tried to add a run while in database mode.')
+
     name = name or path
     accumulator = None
     with self._accumulators_mutex:
@@ -167,10 +188,14 @@ class EventMultiplexer(object):
 
     Raises:
       ValueError: If the path exists and isn't a directory.
+      RuntimeError: If this method is called while running in database mode.
 
     Returns:
       The `EventMultiplexer`.
     """
+    if self.IsInDatabaseMode():
+      raise RuntimeError('Tried to add runs while in database mode.')
+
     tf.logging.info('Starting AddRunsFromDirectory: %s', path)
     for subdir in GetLogdirSubdirectories(path):
       tf.logging.info('Adding run from directory %s', subdir)
@@ -181,7 +206,14 @@ class EventMultiplexer(object):
     return self
 
   def Reload(self):
-    """Call `Reload` on every `EventAccumulator`."""
+    """Call `Reload` on every `EventAccumulator`.
+    
+    Raises:
+      RuntimeError: If this method is called while running in database mode.
+    """
+    if self.IsInDatabaseMode():
+      raise RuntimeError('Tried to reload while in database mode.')
+
     tf.logging.info('Beginning EventMultiplexer.Reload()')
     self._reload_called = True
     # Build a list so we're safe even if the list of accumulators is modified
@@ -211,10 +243,16 @@ class EventMultiplexer(object):
     Args:
       plugin_name: Name of the plugin we are checking for.
 
+    Raises:
+      RuntimeError: If this method is called while running in database mode.
+
     Returns:
       A dictionary that maps from run_name to a list of plugin
         assets for that run.
     """
+    if self.IsInDatabaseMode():
+      raise RuntimeError('Tried to retrieve assets while in database mode.')
+
     with self._accumulators_mutex:
       # To avoid nested locks, we construct a copy of the run-accumulator map
       items = list(six.iteritems(self._accumulators))
@@ -234,7 +272,11 @@ class EventMultiplexer(object):
 
     Raises:
       KeyError: If the asset is not available.
+      RuntimeError: If this method is called while running in database mode.
     """
+    if self.IsInDatabaseMode():
+      raise RuntimeError('Tried to retrieve assets while in database mode.')
+
     accumulator = self.GetAccumulator(run)
     return accumulator.RetrievePluginAsset(plugin_name, asset_name)
 
@@ -255,6 +297,15 @@ class EventMultiplexer(object):
       ValueError: If the run has no events loaded and there are no events on
         disk to load.
     """
+    if self.IsInDatabaseMode():
+      db = self._db_connection_provider()
+      cursor = db.execute(
+          'SELECT started_time FROM Runs WHERE run_name = ?', (run,))
+      row = cursor.fetchone()
+      if not row:
+        raise KeyError('No run named %r could be found' % run)
+      return row[0]
+
     accumulator = self.GetAccumulator(run)
     return accumulator.FirstEventTimestamp()
 
@@ -355,8 +406,39 @@ class EventMultiplexer(object):
     Returns:
       An array of `event_accumulator.TensorEvent`s.
     """
-    accumulator = self.GetAccumulator(run)
-    return accumulator.Tensors(tag)
+    if not self.IsInDatabaseMode():
+      # Return data read from events files.
+      accumulator = self.GetAccumulator(run)
+      return accumulator.Tensors(tag)
+
+    # Read a database.
+    db = self._db_connection_provider()
+    cursor = db.execute(
+        ('SELECT '
+         'Tensors.computed_time, Tensors.data, Tensors.shape, Tensors.step, '
+         'Tensors.dtype, Tags.tag_name '
+         'FROM Tensors '
+         'LEFT JOIN Tags ON Tensors.series=Tags.tag_id '
+         'LEFT JOIN Runs ON Tags.run_id=Runs.run_id '
+         'WHERE Tensors.step > -1 '
+         'AND Runs.run_name = ? '
+         'AND Tags.tag_name = ? '),
+        (run, tag))
+    tensor_events = []
+    for row in cursor:
+      wall_time, data, shape, step, dtype, tag = row
+      tensorflow_dtype = tf.DType(dtype)
+      buf = np.frombuffer(data, dtype=tensorflow_dtype.as_numpy_dtype)
+      tensor_proto = tf.make_tensor_proto(
+          values=buf,
+          shape=[int(dim) for dim in (shape or '').split(',') if dim],
+          dtype=tensorflow_dtype)
+      tensor_event = event_accumulator.TensorEvent(
+          wall_time=wall_time,
+          step=step,
+          tensor_proto=tensor_proto)
+      tensor_events.append(tensor_event)
+    return tensor_events
 
   def PluginRunToTagToContent(self, plugin_name):
     """Returns a 2-layer dictionary of the form {run: {tag: content}}.
@@ -370,15 +452,34 @@ class EventMultiplexer(object):
     Returns:
       A dictionary of the form {run: {tag: content}}.
     """
-    mapping = {}
-    for run in self.Runs():
-      try:
-        tag_to_content = self.GetAccumulator(run).PluginTagToContent(
-            plugin_name)
-      except KeyError:
-        # This run lacks content for the plugin. Try the next run.
-        continue
-      mapping[run] = tag_to_content
+    if not self.IsInDatabaseMode():
+      mapping = {}
+      for run in self.Runs():
+        try:
+          tag_to_content = self.GetAccumulator(run).PluginTagToContent(
+              plugin_name)
+        except KeyError:
+          # This run lacks content for the plugin. Try the next run.
+          continue
+        mapping[run] = tag_to_content
+      return mapping
+
+    mapping = collections.defaultdict(dict)
+    db = self._db_connection_provider()
+    cursor = db.execute(
+        ('SELECT '
+         'Runs.run_name, Tags.tag_name, Tags.plugin_data '
+         'FROM Tags '
+         'LEFT JOIN Runs ON Tags.run_id=Runs.run_id '
+         'WHERE Tags.plugin_name = ? '),
+        (plugin_name,))
+    for row in cursor:
+      # How do we interpret blobs?
+      run, tag, plugin_data = row
+      plugin_data = tf.SummaryMetadata.PluginData()
+      self._ConvertBlobToPluginData(plugin_data, plugin_data)
+      mapping[run][tag] = plugin_data.content
+
     return mapping
 
   def SummaryMetadata(self, run, tag):
@@ -397,8 +498,39 @@ class EventMultiplexer(object):
     Returns:
       A `tf.SummaryMetadata` protobuf.
     """
-    accumulator = self.GetAccumulator(run)
-    return accumulator.SummaryMetadata(tag)
+    if not self.IsInDatabaseMode():
+      accumulator = self.GetAccumulator(run)
+      return accumulator.SummaryMetadata(tag)
+
+    db = self._db_connection_provider()
+    cursor = db.execute(
+        ('SELECT '
+         'Tags.display_name, Tags.plugin_data '
+         'FROM Tags '
+         'LEFT JOIN Runs ON Tags.run_id=Runs.run_id '
+         'WHERE Runs.run_name = ? '
+         'AND Tags.tag_name = ? '),
+         (run, tag))
+    row = cursor.fetchone()
+    if not row:
+      raise KeyError('No metadata for run %r and tag %r found' % (run, tag))
+    display_name, plugin_data_bytes = row
+    summary_metadata = tf.SummaryMetadata(
+      display_name=display_name)
+    self._ConvertBlobToPluginData(
+        summary_metadata.plugin_data, plugin_data_bytes)
+    # TODO(chihuahua): Figure out how descriptions are stored.
+    return summary_metadata
+
+  def _ConvertBlobToPluginData(self, plugin_data_proto, plugin_data_blob):
+    """Converts a blob to a plugin data proto.
+    
+    Args:
+      plugin_data_proto: The PluginData proto to merge data into.
+      plugin_data_blob: A blob containing binary plugin data.
+    """
+    data = str(plugin_data_blob).encode('hex')
+    plugin_data_proto.ParseFromString(tf.compat.as_bytes(data))
 
   def Runs(self):
     """Return all the run names in the `EventMultiplexer`.
@@ -409,10 +541,26 @@ class EventMultiplexer(object):
                   graph: true, meta_graph: true}}
     ```
     """
-    with self._accumulators_mutex:
-      # To avoid nested locks, we construct a copy of the run-accumulator map
-      items = list(six.iteritems(self._accumulators))
-    return {run_name: accumulator.Tags() for run_name, accumulator in items}
+    if not self.IsInDatabaseMode():
+      with self._accumulators_mutex:
+        # To avoid nested locks, we construct a copy of the run-accumulator map
+        items = list(six.iteritems(self._accumulators))
+      return {run_name: accumulator.Tags() for run_name, accumulator in items}
+
+    db = self._db_connection_provider()
+    cursor = db.execute(
+        ('SELECT '
+         'Runs.run_name, Tags.tag_name '
+         'FROM Tags '
+         'LEFT JOIN Runs ON Tags.run_id=Runs.run_id '))
+    mapping = collections.defaultdict(lambda : collections.defaultdict(list))
+    for row in cursor:
+      run, tag = row
+      if not run or not tag:
+        continue
+
+      mapping[run][event_accumulator.TENSORS].append(tag)
+    return mapping
 
   def RunPaths(self):
     """Returns a dict mapping run names to event file paths."""
@@ -429,9 +577,20 @@ class EventMultiplexer(object):
 
     Raises:
       KeyError: If run does not exist.
+      RuntimeError: If this method is called while running in database mode.
     """
+    if self.IsInDatabaseMode():
+      raise RuntimeError('Tried to get accumulator while in database mode.')
+
     with self._accumulators_mutex:
       return self._accumulators[run]
+
+  def IsInDatabaseMode(self):
+    """Returns whether the multiplexer operates in database mode.
+    
+    If so, no event files are read from disk.
+    """
+    return bool(self._db_connection_provider)
 
 
 def GetLogdirSubdirectories(path):

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -300,6 +300,8 @@ class ProjectorPlugin(base_plugin.TBPlugin):
   @property
   def configs(self):
     """Returns a map of run paths to `ProjectorConfig` protos."""
+    return {}
+
     run_path_pairs = list(self.run_paths.items())
     self._append_plugin_asset_directories(run_path_pairs)
     # If there are no summary event files, the projector should still work,

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -265,21 +265,23 @@ class TextPlugin(base_plugin.TBPlugin):
         'TextPlugin index_impl() thread ending after %0.3f sec', elapsed)
 
   def index_impl(self):
-    # A previous system of collecting and serving text summaries involved
-    # storing the tags of text summaries within tensors.json files. See if we
-    # are currently using that system. We do not want to drop support for that
-    # use case.
     run_to_series = collections.defaultdict(list)
-    name = 'tensorboard_text'
-    run_to_assets = self._multiplexer.PluginAssets(name)
-    for run, assets in run_to_assets.items():
-      if 'tensors.json' in assets:
-        tensors_json = self._multiplexer.RetrievePluginAsset(
-            run, name, 'tensors.json')
-        tensors = json.loads(tensors_json)
-        run_to_series[run] = tensors
-      else:
-        run_to_series[run] = []
+
+    if not self._multiplexer.IsInDatabaseMode():
+      # A previous system of collecting and serving text summaries involved
+      # storing the tags of text summaries within tensors.json files. See if we
+      # are currently using that system. We do not want to drop support for that
+      # use case. Only applies if not in database mode.
+      name = 'tensorboard_text'
+      run_to_assets = self._multiplexer.PluginAssets(name)
+      for run, assets in run_to_assets.items():
+        if 'tensors.json' in assets:
+          tensors_json = self._multiplexer.RetrievePluginAsset(
+              run, name, 'tensors.json')
+          tensors = json.loads(tensors_json)
+          run_to_series[run] = tensors
+        else:
+          run_to_series[run] = []
 
     # TensorBoard is obtaining summaries related to the text plugin based on
     # SummaryMetadata stored within Value protos.


### PR DESCRIPTION
DO NOT SUBMIT

This is a first attempt at generalizing the multiplexer to also work with
reading from a database. This seems like a quick way to get most of
TensorBoard's dashboards to work with a SQL-backed data source.

Question - what is stored within the plugin_data blob? Is it binary data
for a proto? Or the serialized proto string? For the PluginData proto? Or
the proto stored in the PluginData.content field?

Plugins that read from disk (projector and TPU profile) will be
non-trivial to codge into working with a SQL-based data source, so
we will need to later specially deal with those plugins.