### PR TITLE
Makes the back button work across tensorboard index (/) landing page

### DIFF
--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -226,7 +226,7 @@ function readComponent(): string {
 function writeComponent(component: string, useLocationReplace = false) {
   if (tf_globals.useHash()) {
       if (useLocationReplace) {
-          window.location.hash.replace(component);
+          window.location.replace(window.location.origin + window.location.pathname + '#' + component);
       } else {
           window.location.hash = component;
       }

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -226,7 +226,7 @@ function readComponent(): string {
 function writeComponent(component: string, useLocationReplace = false) {
   if (tf_globals.useHash()) {
       if (useLocationReplace) {
-          window.location.replace(window.location.origin + window.location.pathname + '#' + component);
+          window.location.replace('#' + component);
       } else {
           window.location.hash = component;
       }

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -226,7 +226,7 @@ function readComponent(): string {
 function writeComponent(component: string, useLocationReplace = false) {
   if (tf_globals.useHash()) {
       if (useLocationReplace) {
-          window.location.replace(window.location.origin + window.location.pathname + component);
+          window.location.hash.replace(component);
       } else {
           window.location.hash = component;
       }

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -103,14 +103,14 @@ function makeBindings<T>(fromString: (string) => T, toString: (T) => string): {
     return value == undefined ? undefined : fromString(value);
   }
 
-  function set(key: string, value: T, useLocalStorage = false): void {
+  function set(key: string, value: T, useLocalStorage = false, useLocationReplace = false): void {
     const stringValue = toString(value);
     if (useLocalStorage) {
       window.localStorage.setItem(key, stringValue);
     } else {
       const items = componentToDict(readComponent());
       items[key] = stringValue;
-      writeComponent(dictToComponent(items));
+      writeComponent(dictToComponent(items), useLocationReplace);
     }
   }
 
@@ -223,9 +223,13 @@ function readComponent(): string {
 /**
  * Write component to URI.
  */
-function writeComponent(component: string) {
+function writeComponent(component: string, useLocationReplace = false) {
   if (tf_globals.useHash()) {
-    window.location.hash = component;
+      if (useLocationReplace) {
+          window.location.replace(window.location.origin + window.location.pathname + component);
+      } else {
+          window.location.hash = component;
+      }
   } else {
     tf_globals.setFakeHash(component);
   }

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -592,7 +592,11 @@ limitations under the License.
         if (activeDashboards && selectedDashboard == null) {
           selectedDashboard = activeDashboards[0] || null;
           if (selectedDashboard != null) {
-            tf_storage.setString(tf_storage.TAB, selectedDashboard, /*useLocalStorage=*/false, /*useLocationReplace=*/true);
+            // Use location.replace for this call to avoid breaking back-button navigation.
+            // Note that this will precede the update to tf_storage triggered by updating
+            // _selectedDashboard.
+            tf_storage.setString(tf_storage.TAB, selectedDashboard, /*useLocalStorage=*/false,
+                                 /*useLocationReplace=*/true);
             // Note: the following line will re-trigger this handler, but it
             // will be a no-op since selectedDashboard is no longer null.
             this._selectedDashboard = selectedDashboard;

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -594,7 +594,7 @@ limitations under the License.
           if (selectedDashboard != null) {
             // Use location.replace for this call to avoid breaking back-button navigation.
             // Note that this will precede the update to tf_storage triggered by updating
-            // _selectedDashboard.
+            // _selectedDashboard and make it a no-op.
             tf_storage.setString(tf_storage.TAB, selectedDashboard, /*useLocalStorage=*/false,
                                  /*useLocationReplace=*/true);
             // Note: the following line will re-trigger this handler, but it

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -592,6 +592,7 @@ limitations under the License.
         if (activeDashboards && selectedDashboard == null) {
           selectedDashboard = activeDashboards[0] || null;
           if (selectedDashboard != null) {
+            tf_storage.setString(tf_storage.TAB, pluginString, /*useLocalStorage=*/false, /*useLocationReplace=*/true);
             // Note: the following line will re-trigger this handler, but it
             // will be a no-op since selectedDashboard is no longer null.
             this._selectedDashboard = selectedDashboard;

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -592,7 +592,7 @@ limitations under the License.
         if (activeDashboards && selectedDashboard == null) {
           selectedDashboard = activeDashboards[0] || null;
           if (selectedDashboard != null) {
-            tf_storage.setString(tf_storage.TAB, pluginString, /*useLocalStorage=*/false, /*useLocationReplace=*/true);
+            tf_storage.setString(tf_storage.TAB, selectedDashboard, /*useLocalStorage=*/false, /*useLocationReplace=*/true);
             // Note: the following line will re-trigger this handler, but it
             // will be a no-op since selectedDashboard is no longer null.
             this._selectedDashboard = selectedDashboard;


### PR DESCRIPTION
Currently, if you come in via link to a tensorboard page on /, a plugin hash will immediately get appended (/#scalars). No amount of back button clicking will get you back to the linking page because the history item for / will get you immediately js-redirected back to /#scalars (or whatever).

This pull request allows us to specify that the storage state set call should be history-replacing (i.e. use 'window.location.replace(...)' instead of 'window.location.hash ='. Now when you link into a tensorboard server, you will be able to navigate back!