### PR TITLE
Make debugger plugin's grpc ImportError handling work on py3

### DIFF
--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -79,15 +79,15 @@ def _ConstructDebuggerPluginWithGrpcPort(context):
     from tensorboard.plugins.debugger import debugger_plugin as debugger_plugin_lib
     from tensorboard.plugins.debugger import interactive_debugger_plugin as interactive_debugger_plugin_lib
     # pylint: enable=line-too-long,g-import-not-at-top
-  except ImportError as err:
-    (unused_type, unused_value, traceback) = sys.exc_info()
-    six.reraise(
-        ImportError,
-        ImportError(
-            err.message +
-            '\n\nTo use the debugger plugin, you need to have '
-            'gRPC installed:\n  pip install grpcio'),
-        traceback)
+  except ImportError as e:
+    e_type, e_value, e_traceback = sys.exc_info()
+    message = e.msg if hasattr(e, 'msg') else e.message  # Handle py2 vs py3
+    if 'grpc' in message:
+      e_value = ImportError(
+          message +
+          '\n\nTo use the debugger plugin, you need to have '
+          'gRPC installed:\n  pip install grpcio')
+    six.reraise(e_type, e_value, e_traceback)
 
   if FLAGS.debugger_port > 0:
     interactive_plugin = (


### PR DESCRIPTION
Without this fix, under python3, we get a second exception because `err.message` does not exist (it was renamed to `msg`).  This fixes that issue, and also changes the logic to reraise any non-grpc ImportErrors without the grcp-related tip.