### PR TITLE
Fix SQL syntax errors in scalars plugin

### DIFF
--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -134,12 +134,12 @@ class ScalarsPlugin(base_plugin.TBPlugin):
           Tensors.step,
           Tensors.computed_time,
           Tensors.data,
-          Tensors.dtype,
+          Tensors.dtype
         FROM Tensors
         LEFT JOIN Tags
           ON Tensors.series = Tags.tag_id
         LEFT JOIN Runs
-          ON Tags.run_id = Runs.run_id '
+          ON Tags.run_id = Runs.run_id 
         WHERE
           Runs.run_name = ?
           AND Tags.tag_name = ?


### PR DESCRIPTION
We remove a comma and a quote from the SQL query for fetching scalar
values. This fixes a SQL syntax error that had been causing the route to
respond with an error 502.