### PR TITLE
Make frontend use /data/environment route

### DIFF
--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -15,10 +15,10 @@ limitations under the License.
 namespace tf_backend {
 
 export interface Router {
-  logdir: () => string;
   runs: () => string;
   pluginsListing: () => string;
   windowProperties: () => string;
+  environment: () => string;
   isDemoMode: () => boolean;
   pluginRoute: (pluginName: string, route: string) => string;
 }
@@ -45,10 +45,10 @@ export function createRouter(dataDir = 'data', demoMode = false): Router {
     return `${dataDir}/plugin/${pluginName}${route}`;
   }
   return {
-    logdir: () => dataDir + '/logdir',
     runs: () => dataDir + '/runs' + (demoMode ? '.json' : ''),
     pluginsListing: () => dataDir + '/plugins_listing',
     windowProperties: () => dataDir + '/window_properties',
+    environment: () => dataDir + '/environment',
     isDemoMode: () => demoMode,
     pluginRoute,
   };

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -40,9 +40,9 @@ Properties out:
         out-color-scale="{{colorScale}}"
       ></tf-color-scale>
     </div>
-    <paper-dialog with-backdrop id="logdir-dialog">
-      <h2>logdir</h2>
-      <div inner-h-t-m-l="{{_breakString(logdir)}}"></div>
+    <paper-dialog with-backdrop id="data-location-dialog">
+      <h2>Data Location</h2>
+      <div inner-h-t-m-l="{{_breakString(dataLocation)}}"></div>
     </paper-dialog>
     <div id="top-text">
       <h3 id="tooltip-help" class="tooltip-container">Runs</h3>
@@ -62,14 +62,14 @@ Properties out:
     </paper-button>
     <template
       is="dom-if"
-      if="[[logdir]]">
-      <div id="logdir">
-        <span id="clipped-logdir" inner-h-t-m-l="[[_clippedLogdir]]"></span><!--
+      if="[[dataLocation]]">
+      <div id="data-location">
+        <span id="clipped-dataLocation" inner-h-t-m-l="[[_clippeddataLocation]]"></span><!--
           We use HTML comments to remove spaces before the ellipsis.
         --><template
                      is="dom-if"
-                     if="[[_shouldShowExpandLogdirButton(logdir, _logdirClipLength)]]"><!--
-          --><a href="" on-click="_openLogdirDialog">…</a>
+                     if="[[_shouldShowExpanddataLocationButton(dataLocation, _dataLocationClipLength)]]"><!--
+          --><a href="" on-click="_opendataLocationDialog">…</a>
         </template>
       </div>
     </template>
@@ -108,7 +108,7 @@ Properties out:
       paper-button {
         margin-left: 0;
       }
-      #logdir {
+      #data-location {
         color: var(--tb-ui-dark-accent);
         font-size: 13px;
         margin: 5px 0 0 0;
@@ -123,16 +123,16 @@ Properties out:
       selectedRuns: {type: Array, notify: true},
       // runs: an array of strings, representing the run names that may be chosen
       runs: Array,
-      logdir: {
+      dataLocation: {
         type: String,
         notify: true,
       },
-      // This is the potentially clipped portion of the logdir we show at the bottom of the sidebar.
-      _clippedLogdir: {
+      // This is the potentially clipped portion of the dataLocation we show at the bottom of the sidebar.
+      _clippeddataLocation: {
         type: String,
-        computed: '_getClippedLogdir(logdir, _logdirClipLength)',
+        computed: '_getClippedDataLocation(dataLocation, _dataLocationClipLength)',
       },
-      _logdirClipLength: {
+      _dataLocationClipLength: {
         type: Number,
         value: 250,
         readOnly: true,
@@ -146,11 +146,12 @@ Properties out:
       updateRuns();
 
       var requestManager = new tf_backend.RequestManager();
-      requestManager.request(tf_backend.getRouter().logdir()).then(logdirObject => {
-        this.set('logdir', logdirObject.logdir);
+      requestManager.request(
+          tf_backend.getRouter().environment()).then(environmentObject => {
+        this.set('dataLocation', environmentObject.data_location);
       }).catch(e => {
-        // Fetching the logdir failed. Prevent the exception from logging to
-        // console. The console already logs a 404 network event.
+        // Fetching the dataLocation failed. Prevent the exception from
+        // logging to console. The console already logs a 404 network event.
       });
     },
     _toggleAll: function() {
@@ -160,26 +161,26 @@ Properties out:
     _breakString: function(originalString) {
       return originalString.replace(/([\/=\-_,])/g, "$1<wbr>");
     },
-    _getClippedLogdir: function(logdir, logdirClipLength) {
-      if (logdir === undefined) {
-        // The logdir has not been set yet.
+    _getClippedDataLocation: function(dataLocation, dataLocationClipLength) {
+      if (dataLocation === undefined) {
+        // The dataLocation has not been set yet.
         return undefined;
       }
 
-      if (logdir.length > logdirClipLength) {
-        // Clip the logdir to avoid blocking the runs selector. Let the user view a more full
-        // version of the logdir.
-        return this._breakString(logdir.substring(0, logdirClipLength));
+      if (dataLocation.length > dataLocationClipLength) {
+        // Clip the dataLocation to avoid blocking the runs selector. Let the
+        // user view a more full version of the dataLocation.
+        return this._breakString(dataLocation.substring(0, dataLocationClipLength));
       } else {
-        return this._breakString(logdir);
+        return this._breakString(dataLocation);
       }
     },
-    _openLogdirDialog: function(event) {
+    _opendataLocationDialog: function(event) {
       event.preventDefault();
-      this.$$('#logdir-dialog').open();
+      this.$$('#data-location-dialog').open();
     },
-    _shouldShowExpandLogdirButton(logdir, _logdirClipLength) {
-      return logdir && logdir.length > _logdirClipLength;
+    _shouldShowExpanddataLocationButton(dataLocation, _dataLocationClipLength) {
+      return dataLocation && dataLocation.length > _dataLocationClipLength;
     },
   });
   </script>

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -64,12 +64,12 @@ Properties out:
       is="dom-if"
       if="[[dataLocation]]">
       <div id="data-location">
-        <span id="clipped-dataLocation" inner-h-t-m-l="[[_clippeddataLocation]]"></span><!--
+        <span id="clipped-dataLocation" inner-h-t-m-l="[[_clippedDataLocation]]"></span><!--
           We use HTML comments to remove spaces before the ellipsis.
         --><template
                      is="dom-if"
-                     if="[[_shouldShowExpanddataLocationButton(dataLocation, _dataLocationClipLength)]]"><!--
-          --><a href="" on-click="_opendataLocationDialog">…</a>
+                     if="[[_shouldShowExpandDataLocationButton(dataLocation, _dataLocationClipLength)]]"><!--
+          --><a href="" on-click="_openDataLocationDialog">…</a>
         </template>
       </div>
     </template>
@@ -128,7 +128,7 @@ Properties out:
         notify: true,
       },
       // This is the potentially clipped portion of the dataLocation we show at the bottom of the sidebar.
-      _clippeddataLocation: {
+      _clippedDataLocation: {
         type: String,
         computed: '_getClippedDataLocation(dataLocation, _dataLocationClipLength)',
       },
@@ -175,11 +175,11 @@ Properties out:
         return this._breakString(dataLocation);
       }
     },
-    _opendataLocationDialog: function(event) {
+    _openDataLocationDialog: function(event) {
       event.preventDefault();
       this.$$('#data-location-dialog').open();
     },
-    _shouldShowExpanddataLocationButton(dataLocation, _dataLocationClipLength) {
+    _shouldShowExpandDataLocationButton(dataLocation, _dataLocationClipLength) {
       return dataLocation && dataLocation.length > _dataLocationClipLength;
     },
   });

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -151,8 +151,8 @@ limitations under the License.
             We’ll try to reload every [[autoReloadIntervalSecs]]&nbsp;seconds as well.
             </template>
             <p><i>Last reload: [[_lastReloadTime]]</i>
-            <template is="dom-if" if="[[_data_location]]">
-              <p><i>Log directory: <span id="data_location">[[_data_location]]</span></i></p>
+            <template is="dom-if" if="[[_dataLocation]]">
+              <p><i>Log directory: <span id="data_location">[[_dataLocation]]</span></i></p>
             </template>
           </div>
         </template>
@@ -173,8 +173,8 @@ limitations under the License.
             <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong">the section of the README devoted to missing data problems</a>
             and consider filing an issue on GitHub.
             <p><i>Last reload: [[_lastReloadTime]]</i>
-            <template is="dom-if" if="[[_data_location]]">
-              <p><i>Data location: <span id="data_location">[[_data_location]]</span></i></p>
+            <template is="dom-if" if="[[_dataLocation]]">
+              <p><i>Data location: <span id="data_location">[[_dataLocation]]</span></i></p>
             </template>
           </div>
         </template>
@@ -185,8 +185,8 @@ limitations under the License.
               <p>You can select a dashboard from the list above.
             </template>
             <p><i>Last reload: [[_lastReloadTime]]</i>
-            <template is="dom-if" if="[[_data_location]]">
-              <p><i>Data location: <span id="data_location">[[_data_location]]</span></i></p>
+            <template is="dom-if" if="[[_dataLocation]]">
+              <p><i>Data location: <span id="data_location">[[_dataLocation]]</span></i></p>
             </template>
           </div>
         </template>
@@ -467,22 +467,18 @@ limitations under the License.
           type: Boolean,
           value: false,
         },
-
         _isReloadDisabled: {
           type: Boolean,
           value: false,
         },
-
         _lastReloadTime: {
           type: String,
           value: "not yet loaded",
         },
-
-        _data_location: {
+        _dataLocation: {
           type: String,
           value: null,
         },
-
         _requestManager: {
           type: Object,
           value: () => new tf_backend.RequestManager(),
@@ -695,7 +691,7 @@ limitations under the License.
       _fetchEnvironment() {
         const url = tf_backend.getRouter().environment();
         return this._requestManager.request(url).then(result => {
-          this._data_location = result.data_location;
+          this._dataLocation = result.data_location;
         });
       },
 

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -151,8 +151,8 @@ limitations under the License.
             We’ll try to reload every [[autoReloadIntervalSecs]]&nbsp;seconds as well.
             </template>
             <p><i>Last reload: [[_lastReloadTime]]</i>
-            <template is="dom-if" if="[[_logdir]]">
-              <p><i>Log directory: <span id="logdir">[[_logdir]]</span></i></p>
+            <template is="dom-if" if="[[_data_location]]">
+              <p><i>Log directory: <span id="data_location">[[_data_location]]</span></i></p>
             </template>
           </div>
         </template>
@@ -173,8 +173,8 @@ limitations under the License.
             <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong">the section of the README devoted to missing data problems</a>
             and consider filing an issue on GitHub.
             <p><i>Last reload: [[_lastReloadTime]]</i>
-            <template is="dom-if" if="[[_logdir]]">
-              <p><i>Log directory: <span id="logdir">[[_logdir]]</span></i></p>
+            <template is="dom-if" if="[[_data_location]]">
+              <p><i>Data location: <span id="data_location">[[_data_location]]</span></i></p>
             </template>
           </div>
         </template>
@@ -185,8 +185,8 @@ limitations under the License.
               <p>You can select a dashboard from the list above.
             </template>
             <p><i>Last reload: [[_lastReloadTime]]</i>
-            <template is="dom-if" if="[[_logdir]]">
-              <p><i>Log directory: <span id="logdir">[[_logdir]]</span></i></p>
+            <template is="dom-if" if="[[_data_location]]">
+              <p><i>Data location: <span id="data_location">[[_data_location]]</span></i></p>
             </template>
           </div>
         </template>
@@ -478,7 +478,7 @@ limitations under the License.
           value: "not yet loaded",
         },
 
-        _logdir: {
+        _data_location: {
           type: String,
           value: null,
         },
@@ -687,15 +687,15 @@ limitations under the License.
 
         tf_backend.fetchRuns();
         this._fetchWindowProperties();
-        this._fetchLogdir();
+        this._fetchEnvironment();
         this._fetchActiveDashboards();
         this._lastReloadTime = new Date().toString();
       },
 
-      _fetchLogdir() {
-        const url = tf_backend.getRouter().logdir();
+      _fetchEnvironment() {
+        const url = tf_backend.getRouter().environment();
         return this._requestManager.request(url).then(result => {
-          this._logdir = result.logdir;
+          this._data_location = result.data_location;
         });
       },
 
@@ -766,7 +766,7 @@ limitations under the License.
         if (this._isReloadDisabled) {
           return;
         }
-        this._fetchLogdir();
+        this._fetchEnvironment();
         Promise.all([this._fetchActiveDashboards(), tf_backend.fetchRuns()]).then(() => {
           const dashboard = this._selectedDashboardComponent();
           if (dashboard) {


### PR DESCRIPTION
Previously, the frontend displayed the logdir under the run selector.
This change makes that area display either the logdir or the SQL URI
depending on which is used.

![image](https://user-images.githubusercontent.com/4221553/36468674-2a57ccfe-1699-11e8-8b55-a98be15f1206.png)
