### PR TITLE
Make histogram plugin work in SQL mode

### DIFF
--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -17,6 +17,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":metadata",
+        "//tensorboard:expect_numpy_installed",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/plugins:base_plugin",

--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -22,10 +22,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
 import random
 import six
 from werkzeug import wrappers
 
+import numpy as np
 import tensorflow as tf
 
 from tensorboard import plugin_util
@@ -51,6 +53,7 @@ class HistogramsPlugin(base_plugin.TBPlugin):
     Args:
       context: A base_plugin.TBContext instance.
     """
+    self._db_connection_provider = context.db_connection_provider
     self._multiplexer = context.multiplexer
 
   def get_plugin_apps(self):
@@ -61,10 +64,47 @@ class HistogramsPlugin(base_plugin.TBPlugin):
 
   def is_active(self):
     """This plugin is active iff any run has at least one histograms tag."""
+    if self._db_connection_provider:
+      # The plugin is active if one relevant tag can be found in the database.
+      db = self._db_connection_provider()
+      cursor = db.execute('''
+        SELECT
+          1
+        FROM Tags
+        WHERE Tags.plugin_name = ?
+        LIMIT 1
+      ''', (metadata.PLUGIN_NAME,))
+      return bool(cursor)
+
     return bool(self._multiplexer) and any(self.index_impl().values())
 
   def index_impl(self):
     """Return {runName: {tagName: {displayName: ..., description: ...}}}."""
+    if self._db_connection_provider:
+      # Read tags from the database.
+      db = self._db_connection_provider()
+      cursor = db.execute('''
+        SELECT
+          Tags.tag_name,
+          Tags.display_name,
+          Runs.run_name
+        FROM Tags
+        JOIN Runs
+          ON Tags.run_id = Runs.run_id
+        WHERE
+          Tags.plugin_name = ?
+      ''', (metadata.PLUGIN_NAME,))
+      result = collections.defaultdict(dict)
+      for row in cursor:
+        tag_name, display_name, run_name = row
+        result[run_name][tag_name] = {
+            'displayName': display_name,
+            # TODO(chihuahua): Populate the description. Currently, the tags
+            # table does not link with the description table.
+            'description': '',
+        }
+      return result
+
     runs = self._multiplexer.Runs()
     result = {run: {} for run in runs}
 
@@ -85,17 +125,73 @@ class HistogramsPlugin(base_plugin.TBPlugin):
     At most `downsample_to` events will be returned. If this value is
     `None`, then no downsampling will be performed.
     """
-    try:
-      tensor_events = self._multiplexer.Tensors(run, tag)
-    except KeyError:
-      raise ValueError('No histogram tag %r for run %r' % (tag, run))
-    events = [[ev.wall_time, ev.step, tf.make_ndarray(ev.tensor_proto).tolist()]
-              for ev in tensor_events]
-    if downsample_to is not None and len(events) > downsample_to:
-      indices = sorted(random.Random(0).sample(list(range(len(events))),
-                                               downsample_to))
-      events = [events[i] for i in indices]
+    if self._db_connection_provider:
+      # Serve data from the database.
+      db = self._db_connection_provider()
+      # We select for steps greater than -1 because the writer inserts
+      # placeholder rows en masse. The check for step filters out those rows.
+      query = '''
+        SELECT
+          Tensors.computed_time AS computed_time,
+          Tensors.step AS step,
+          Tensors.data AS data,
+          Tensors.dtype AS dtype,
+          Tensors.shape AS shape
+        FROM Tensors
+        JOIN Tags
+          ON Tensors.series = Tags.tag_id
+        JOIN Runs
+          ON Tags.run_id = Runs.run_id 
+        WHERE
+          Runs.run_name = ?
+          AND Tags.tag_name = ?
+          AND Tags.plugin_name = ?
+          AND Tensors.step > -1
+      '''
+      if downsample_to is not None:
+        # Wrap the query in an outer one that samples.
+        query = '''
+          SELECT *
+          FROM 
+            (%(query)s
+             ORDER BY RANDOM()
+             LIMIT %(downsample_to)d)
+        ''' % {
+          'query': query,
+          'downsample_to': downsample_to,
+        }
+      query = '''
+        %s
+        ORDER BY step
+      ''' % query
+      cursor = db.execute(query, (run, tag, metadata.PLUGIN_NAME))
+      events = [(row[0], row[1], self._get_values(row[2], row[3], row[4]))
+                for row in cursor]
+    else:
+      # Serve data from events files.
+      try:
+        tensor_events = self._multiplexer.Tensors(run, tag)
+      except KeyError:
+        raise ValueError('No histogram tag %r for run %r' % (tag, run))
+      events = [[e.wall_time, e.step, tf.make_ndarray(e.tensor_proto).tolist()]
+                for e in tensor_events]
+      if downsample_to is not None and len(events) > downsample_to:
+        indices = sorted(random.Random(0).sample(list(range(len(events))),
+                                                downsample_to))
+        events = [events[i] for i in indices]
     return (events, 'application/json')
+
+  def _get_values(self, data_blob, dtype_enum, shape_string):
+    """Obtains values for histogram data given blob and dtype enum.
+    Args:
+      data_blob: The blob obtained from the database.
+      dtype_enum: The enum representing the dtype.
+      shape_string: A comma-separated string of numbers denoting shape.
+    Returns:
+      The histogram values as a list served to the frontend.
+    """
+    buf = np.frombuffer(data_blob, dtype=tf.DType(dtype_enum).as_numpy_dtype)
+    return buf.reshape([int(i) for i in shape_string.split(',')]).tolist()
 
   @wrappers.Request.application
   def tags_route(self, request):

--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -157,8 +157,8 @@ class HistogramsPlugin(base_plugin.TBPlugin):
              ORDER BY RANDOM()
              LIMIT %(downsample_to)d)
         ''' % {
-          'query': query,
-          'downsample_to': downsample_to,
+            'query': query,
+            'downsample_to': downsample_to,
         }
       query = '''
         %s
@@ -177,7 +177,7 @@ class HistogramsPlugin(base_plugin.TBPlugin):
                 for e in tensor_events]
       if downsample_to is not None and len(events) > downsample_to:
         indices = sorted(random.Random(0).sample(list(range(len(events))),
-                                                downsample_to))
+                                                 downsample_to))
         events = [events[i] for i in indices]
     return (events, 'application/json')
 


### PR DESCRIPTION
Note that logic for serving histogram values performs string templating
to accommodate downsampling.

![image](https://user-images.githubusercontent.com/4221553/36573937-057886a2-17f8-11e8-9ce7-b703ad54e3c9.png)
