### PR TITLE
Convert LEFT JOINs to JOINs within scalars plugin

### DIFF
--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -93,7 +93,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
           Tags.display_name,
           Runs.run_name
         FROM Tags
-        LEFT JOIN Runs
+        JOIN Runs
           ON Tags.run_id = Runs.run_id
         WHERE
           Tags.plugin_name = ?
@@ -136,9 +136,9 @@ class ScalarsPlugin(base_plugin.TBPlugin):
           Tensors.data,
           Tensors.dtype
         FROM Tensors
-        LEFT JOIN Tags
+        JOIN Tags
           ON Tensors.series = Tags.tag_id
-        LEFT JOIN Runs
+        JOIN Runs
           ON Tags.run_id = Runs.run_id 
         WHERE
           Runs.run_name = ?


### PR DESCRIPTION
This change makes the scalars plugin exclude tags without runs ... as
well as tensors without either a tag or a run.

The scalars dashboard still WAI:

![image](https://user-images.githubusercontent.com/4221553/36574040-85a50a8a-17f8-11e8-8c62-8da4273e1c62.png)
