### PR TITLE
Fix font mismatch in custom scalars dashboard

### DIFF
--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
@@ -205,6 +205,7 @@ writer.add_summary(layout_summary)
     <style include="dashboard-style"></style>
     <style>
       .center {
+        font-size: 14px;
         height: 100%;
         padding: 10px 20px;
         box-sizing: border-box;

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -36,7 +36,7 @@ limitations under the License.
 -->
 <dom-module id="tf-custom-scalar-margin-chart-card">
 <template>
-  <h1>[[_titleDisplayString]]</h1>
+  <tf-card-heading display-name="[[_titleDisplayString]]"></tf-card-heading>
   <div id="tf-line-chart-data-loader-container">
     <tf-line-chart-data-loader
       x-type="[[xType]]"
@@ -231,7 +231,6 @@ limitations under the License.
     }
 
     #matches-list {
-      font-size: 0.8em;
       max-height: 200px;
       overflow-y: auto;
     }

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
@@ -36,7 +36,7 @@ limitations under the License.
 -->
 <dom-module id="tf-custom-scalar-multi-line-chart-card">
 <template>
-  <h1>[[_titleDisplayString]]</h1>
+  <tf-card-heading display-name="[[_titleDisplayString]]"></tf-card-heading>
   <div id="tf-line-chart-data-loader-container">
     <tf-line-chart-data-loader
       x-type="[[xType]]"
@@ -139,7 +139,6 @@ limitations under the License.
     }
 
     #matches-list {
-      font-size: 0.8em;
       max-height: 200px;
       overflow-y: auto;
     }


### PR DESCRIPTION
Previously, the font sizes of chart titles and various other pieces of
content within the custom scalars dashboard did not match the font sizes
of corresponding content within the scalars dashboard (and other
dashboards). Thank you to @jart for noticing.

![image](https://user-images.githubusercontent.com/4221553/36620889-18f7c258-18aa-11e8-9aae-1a9c246a3d17.png)

This PR makes those font sizes match.

![image](https://user-images.githubusercontent.com/4221553/36620894-2001ced6-18aa-11e8-9806-557de0ac641b.png)
