### PR TITLE
Obtain window title from /data/environment route

### DIFF
--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -17,7 +17,6 @@ namespace tf_backend {
 export interface Router {
   runs: () => string;
   pluginsListing: () => string;
-  windowProperties: () => string;
   environment: () => string;
   isDemoMode: () => boolean;
   pluginRoute: (pluginName: string, route: string) => string;
@@ -47,7 +46,6 @@ export function createRouter(dataDir = 'data', demoMode = false): Router {
   return {
     runs: () => dataDir + '/runs' + (demoMode ? '.json' : ''),
     pluginsListing: () => dataDir + '/plugins_listing',
-    windowProperties: () => dataDir + '/window_properties',
     environment: () => dataDir + '/environment',
     isDemoMode: () => demoMode,
     pluginRoute,

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -682,7 +682,6 @@ limitations under the License.
           'dom-change', onDomChange, /*useCapture=*/false);
 
         tf_backend.fetchRuns();
-        this._fetchWindowProperties();
         this._fetchEnvironment();
         this._fetchActiveDashboards();
         this._lastReloadTime = new Date().toString();
@@ -692,6 +691,9 @@ limitations under the License.
         const url = tf_backend.getRouter().environment();
         return this._requestManager.request(url).then(result => {
           this._dataLocation = result.data_location;
+          if (result.window_title) {
+            window.document.title = result.window_title;
+          }
         });
       },
 
@@ -718,15 +720,6 @@ limitations under the License.
         return this._requestManager
           .request(tf_backend.getRouter().pluginsListing())
           .then(updateActiveDashboards, onFailure);
-      },
-
-      _fetchWindowProperties() {
-        const url = tf_backend.getRouter().windowProperties();
-        return this._requestManager.request(url).then(result => {
-          if (result.window_title) {
-            window.document.title = result.window_title;
-          }
-        });
       },
 
       _computeActiveDashboardsNotLoaded(state) {


### PR DESCRIPTION
This PR makes the frontend obtain the window title from the
/data/environment route instead of via the /data/window_properties route
(which we will deprecate).

Test Plan:

Start TensorBoard with the `window_title` flag specified. Note that the
window title is changed appropriately:

```
bazel run //tensorboard -- --logdir /tmp/custom_scalar_demo --window_title foo
```

Start TensorBoard without that flag. Note that the window title defaults
to "TensorBoard".