### PR TITLE
Fix DB-based is_active() methods to not always return True

### DIFF
--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -74,7 +74,7 @@ class HistogramsPlugin(base_plugin.TBPlugin):
         WHERE Tags.plugin_name = ?
         LIMIT 1
       ''', (metadata.PLUGIN_NAME,))
-      return bool(cursor)
+      return bool(list(cursor))
 
     return bool(self._multiplexer) and any(self.index_impl().values())
 

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -75,7 +75,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
         WHERE Tags.plugin_name = ?
         LIMIT 1
       ''', (metadata.PLUGIN_NAME,))
-      return bool(cursor)
+      return bool(list(cursor))
 
     if not self._multiplexer:
       return False
@@ -139,7 +139,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
         JOIN Tags
           ON Tensors.series = Tags.tag_id
         JOIN Runs
-          ON Tags.run_id = Runs.run_id 
+          ON Tags.run_id = Runs.run_id
         WHERE
           Runs.run_name = ?
           AND Tags.tag_name = ?


### PR DESCRIPTION
Applying `bool()` to a `sqlite3.Cursor` always returns `True` - while the Cursor can be used like an iterable, it doesn't define `__len__()` (since the result set size isn't necessarily known until you start iterating over it) or `__nonzero__()` and hence is Truthy always, even when the result set is empty.

The fix for this is just to convert it to a list first.