### PR TITLE
Disable event file loading when --db is passed

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -68,9 +68,10 @@ tf.flags.DEFINE_boolean(
     'Disabling purge_orphaned_data can be used to debug data '
     'disappearance.')
 
-tf.flags.DEFINE_integer('reload_interval', 5,
-                        'How often the backend should load '
-                        'more data.')
+tf.flags.DEFINE_integer(
+    'reload_interval', 5,
+    'How often the backend should load more data, in seconds. Set to 0 to load '
+    'just once at startup and a negative number to never reload at all.')
 
 tf.flags.DEFINE_string('db', "", """\
 [Experimental] Sets SQL database URI.


### PR DESCRIPTION
This disables event file loading when --db is passed.  It does this by making a negative value for --reload_interval have the effect of disabling all the Multiplexer run-adding and reloading logic (even the initial load that you get by passing 0), and then conditionally setting reload_interval to -1 if we got a DB.

Currently, even when you pass --db and do not pass --logdir, we still try to load event files, which could lead to inconsistent state across the DB-enabled and not-yet-DB-enabled plugins.  It's especially bad if you don't pass --logdir at all, since that gets interpreted as the empty directory i.e. the current directory, and so we can easily waste a lot of cycles on the Reloader thread searching through the entire current directory tree looking for tfevents files.