### PR TITLE
Re-styled error boxes within the custom scalars plugin

### DIFF
--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -113,7 +113,6 @@ limitations under the License.
     </div>
     <iron-collapse opened="[[_missingTagsCollapsibleOpened]]">
       <div class="error-content">
-        <iron-icon class="error-icon" icon="icons:error"></iron-icon>
         <template is="dom-repeat"
                   items="[[_missingTags]]"
                   as="missingEntry">
@@ -132,7 +131,6 @@ limitations under the License.
 
   <template is="dom-if" if="[[_tagFilterInvalid]]">
     <div class="error-content">
-      <iron-icon class="error-icon" icon="icons:error"></iron-icon>
       This regular expresion is invalid:<br>
       <span class="invalid-regex">[[_tagFilter]]</span>
     </div>
@@ -140,7 +138,6 @@ limitations under the License.
 
   <template is="dom-if" if="[[_stepsMismatch]]">
     <div class="error-content">
-      <iron-icon class="error-icon" icon="icons:error"></iron-icon>
       The steps for value, lower, and upper tags do not match:
       <ul>
         <li>
@@ -196,17 +193,11 @@ limitations under the License.
   <style include="tf-custom-scalar-card-style"></style>
   <style>
     .error-content {
-      background: #f00;
+      background: var(--tb-orange-strong);
       border-radius: 5px;
       color: #fff;
       margin: 10px 0 0 0;
       padding: 10px;
-    }
-
-    .error-icon {
-      display: block;
-      fill: #fff;
-      margin: 0 auto 5px auto;
     }
 
     .invalid-regex {
@@ -243,10 +234,6 @@ limitations under the License.
       font-family: arial, sans-serif;
       display: inline-block;
       width: 10px;
-    }
-
-    .missing-tags-for-run-container {
-      margin: 8px 0 0 0;
     }
   </style>
 </template>


### PR DESCRIPTION
Made error boxes orange instead of overwhelming red. Removed the error
icon from the boxes. Removed unnecessary padding. Thank you to @jart for
the suggestions.

Before:
![image](https://user-images.githubusercontent.com/4221553/36767187-474b68d4-1bee-11e8-806a-8f5ea7db3c9a.png)
![image](https://user-images.githubusercontent.com/4221553/36767192-4b8d28f6-1bee-11e8-9cfd-e570cc73ea2c.png)
![image](https://user-images.githubusercontent.com/4221553/36767194-4f4a10f8-1bee-11e8-9838-1d38c1a7c228.png)

After:
![image](https://user-images.githubusercontent.com/4221553/36767207-5b3c132a-1bee-11e8-843f-84a2feaf13bc.png)
![image](https://user-images.githubusercontent.com/4221553/36767215-61b193ec-1bee-11e8-91f1-ecf8deb6946d.png)
![image](https://user-images.githubusercontent.com/4221553/36767219-6647d524-1bee-11e8-99c9-e1cbe47ddb42.png)
