### PR TITLE
Prevent content from intruding into sidebar

### DIFF
--- a/tensorboard/components/tf_dashboard_common/dashboard-style.html
+++ b/tensorboard/components/tf_dashboard_common/dashboard-style.html
@@ -28,7 +28,6 @@ limitations under the License.
         flex-direction: column;
         height: 100%;
         margin-right: 20px;
-        min-width: 350px;
       }
 
       tf-runs-selector {

--- a/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.html
+++ b/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.html
@@ -40,6 +40,7 @@ Generic layout for a dashboard.
         flex-grow: 0;
         flex-shrink: 0;
         max-width: 30%;
+        min-width: 270px;
       }
 
       #center {


### PR DESCRIPTION
Within small viewports, main content had been overlapping with the
sidebar.

![image](https://user-images.githubusercontent.com/4221553/36769398-e5c72c96-1bf8-11e8-8ce8-4b583a0df15b.png)

This change fixes that by removing a `min-width` specification on the
wrong container and placing it on the right one. Changed that min width
to 270px (from 350px). Any lower, and buttons overflow to the next line. 

New behavior:

![image](https://user-images.githubusercontent.com/4221553/36769411-eff6cb2c-1bf8-11e8-801f-16d5940d3b7d.png)
