### PR TITLE
Two fixes to debugger plugin

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-continue-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-continue-dialog.html
@@ -186,7 +186,7 @@ limitations under the License.
       // stopped, either because it reached the end, or because of forced
       // stopping.
       notifyContinuationStop() {
-        this._updateContinueButtonText(false);
+        this.updateContinueButtonText(false);
       },
 
       _openDialog() {
@@ -208,7 +208,7 @@ limitations under the License.
       // Update the text of the continue button.
       // Args:
       //   active: Whether continuation is currently ongoing.
-      _updateContinueButtonText(active) {
+      updateContinueButtonText(active) {
         this.set(
             '_continueButtonText',
             active ? this._continueButtonStopText : this._continueButtonContinueText);
@@ -217,7 +217,7 @@ limitations under the License.
       _sessionRunGoButtonCallback() {
         if (this.continueNum > 0) {
           this.sessionRunGo(this.continueNum);
-          this._updateContinueButtonText(true);
+          this.updateContinueButtonText(true);
           this._closeDialog();
         } else {
           this.set('continueNum', 1);
@@ -241,7 +241,7 @@ limitations under the License.
           return;
         }
         this.tensorConditionGo(tensorConditionKey, refValue);
-        this._updateContinueButtonText(true);
+        this.updateContinueButtonText(true);
         this._closeDialog();
       },
 

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -764,21 +764,19 @@ limitations under the License.
           // continue-to-tensor action was initiated. Notify the user as such.
           this._announceNewSessionRun();
         }
-
         const deviceName = responseData['device_name'];
-        const maybeBaseExpandedNodeName = responseData[
-            'maybe_base_expanded_node_name'];
-        const nodeNameWithDevice = deviceName + '/' + maybeBaseExpandedNodeName;
-        if (nodeNameWithDevice !== this._continueToTarget) {
-          this._step();
-        } else {
+        const maybeBaseExpandedNodeName = responseData['maybe_base_expanded_node_name'];
+        const notBaseExpandedNodeName =
+            maybeBaseExpandedNodeName == null ? null :
+            tf_debugger_dashboard.removeNodeNameBaseExpansion(maybeBaseExpandedNodeName);
+        if (deviceName + '/' + maybeBaseExpandedNodeName === this._continueToTarget ||
+            deviceName + '/' + notBaseExpandedNodeName === this._continueToTarget) {
           this._clearContinueTo();
           if (this._sourceCodeShown) {
-            this.set(
-                '_sourceFocusNodeName',
-                tf_debugger_dashboard.removeNodeNameBaseExpansion(
-                    maybeBaseExpandedNodeName));
+            this.set('_sourceFocusNodeName', notBaseExpandedNodeName);
           }
+        } else {
+          this._step();
         }
       },
 
@@ -951,7 +949,7 @@ limitations under the License.
         } else {
           // Selecting the node triggers a pan to it.
           const nodeMap = graph.get('renderHierarchy').hierarchy.getNodeMap();
-          if (nodeMap[nodeName] == null) {
+          if (!nodeMap[nodeName]) {
             // In some cases, a node with other names using its name as
             // name scope may not have base-expanded (i.e., normalized) name
             // in the graph visualizer. In that case, we use the non-expanded

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -449,6 +449,12 @@ limitations under the License.
           type: String,
           value: null,
         },
+        // Counts Session Runs in aggregation, regardless of fetch/feed/target.
+        _sessionRunTotalCounter: {
+          type: Number,
+          value: 0,
+        },
+        // Counts Session Runs by their fetch/feed/target combinations.
         _sessionRunCounters: {
           type: Object,
           value: {},
@@ -651,6 +657,7 @@ limitations under the License.
             } else {
               this._sessionRunCounters[runInfo] = 1;
             }
+            this._sessionRunTotalCounter++;
             this.$.initialDialog.closeDialog();
 
             // Do not refresh node list if we are in continue model and the
@@ -659,7 +666,7 @@ limitations under the License.
                 !this._continueToType || !_.isEqual(previousRunKey, runKey);
             if (toProcessNewSessionRun) {
               this._processGatedGrpcDebugOps(runKey, false);
-              this._showToast('A new Session.run() has begun.');
+              this._announceNewSessionRun();
             }
           } else if (responseType === 'tensor') {
             const deviceName = responseData['device_name'];
@@ -732,7 +739,7 @@ limitations under the License.
             // condition, it'll stop the continuation by setting _continueStop
             // to true.
           } else if (this._continueToType === 'op') {
-            this._processContinueToOp(responseData);
+            this._processContinueToOp(responseType === 'meta', responseData);
           } else if (this._continueToType != null && this._continueToType !== '') {
             console.error('Invalid _continueToType:', this._continueToType);
           }
@@ -750,7 +757,14 @@ limitations under the License.
         }
       },
 
-      _processContinueToOp(responseData) {
+      _processContinueToOp(isSessionRunBeginning, responseData) {
+        if (isSessionRunBeginning) {
+          // A new Session.run() has started, which implies that the requested
+          // tensor was not hit in the previous Session.run, after the
+          // continue-to-tensor action was initiated. Notify the user as such.
+          this._announceNewSessionRun();
+        }
+
         const deviceName = responseData['device_name'];
         const maybeBaseExpandedNodeName = responseData[
             'maybe_base_expanded_node_name'];
@@ -819,6 +833,10 @@ limitations under the License.
       _showToast(text) {  // TODO(cais): Move to Scrolling Message View.
         this.$.toast.setAttribute('text', text);
         this.$.toast.open();
+      },
+      _announceNewSessionRun() {
+        this._showToast(
+            'Session.run() #' + this._sessionRunTotalCounter + ' is starting.');
       },
 
       _displayGraph(runKey, deviceName) {
@@ -932,6 +950,15 @@ limitations under the License.
           graph.panToNode(nodeName);
         } else {
           // Selecting the node triggers a pan to it.
+          const nodeMap = graph.get('renderHierarchy').hierarchy.getNodeMap();
+          if (nodeMap[nodeName] == null) {
+            // In some cases, a node with other names using its name as
+            // name scope may not have base-expanded (i.e., normalized) name
+            // in the graph visualizer. In that case, we use the non-expanded
+            // node name.
+            nodeName =
+                tf_debugger_dashboard.removeNodeNameBaseExpansion(nodeName);
+          }
           graph.set('selectedNode', nodeName);
         }
         this.set('_highlightNodeName', deviceName + '/' + nodeName);
@@ -1122,6 +1149,7 @@ limitations under the License.
               tf_debugger_dashboard.removeNodeNameBaseExpansion(cleanNodeName));
         }
         this._setContinueTo('op', nodeNameWithDevice);
+        this.$.continueDialog.updateContinueButtonText(true);
         this._step();
       },
 


### PR DESCRIPTION
1. In some cases, a node with other nodes whose name scopes are the
   nodes name will not have a normalized (i.e., base-expanded) node
   name in the graph visualizer. E.g., consider a graph with two
   nodes, "Reshape" and "Reshape/shape". The "Reshape" node will
   be named as simply "Reshape", instead of "Reshape/(Reshape)" in
   the graph visualizer. As such, assuming base expansion always
   happens will lead to problems focusing on graph nodes through
   clicking nodes in the Node List or the Source Code View. This
   CL relaxes this assumption, which ensures the correct behavior.

2. When continuing to a given tensor, notify the user when a
   new Session Run has started. Also give user the option to stop
   continuation during the continue-to-tensor actions.