### PR TITLE
Make text plugin's is_active method check for data in multiplexer first before checking plugin assets.

### DIFF
--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -235,7 +235,7 @@ class TextPlugin(base_plugin.TBPlugin):
       if any(self._index_cached.values()):
         return True
 
-    if bool(self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME)):
+    if self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME):
       # Text data is present in the multiplexer. No need to further check for
       # data stored via the outdated plugin assets method.
       return True
@@ -299,13 +299,12 @@ class TextPlugin(base_plugin.TBPlugin):
   def _fetch_run_to_series_from_multiplexer(self):
     # TensorBoard is obtaining summaries related to the text plugin based on
     # SummaryMetadata stored within Value protos.
-    mapping = six.iteritems(
-        self._multiplexer.PluginRunToTagToContent(
-            metadata.PLUGIN_NAME))
+    mapping = self._multiplexer.PluginRunToTagToContent(
+        metadata.PLUGIN_NAME)
     return {
         run: list(tag_to_content.keys())
         for (run, tag_to_content)
-        in mapping
+        in six.iteritems(mapping)
     }
 
   def tags_impl(self):

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
 import json
 import textwrap
 import threading

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
 import json
 import os
 import textwrap
@@ -374,7 +373,7 @@ class TextPluginTest(tf.test.TestCase):
     mock = patcher.start()
     self.addCleanup(patcher.stop)
     self.assertTrue(plugin.is_active(), True)
-    
+
     # Data is available within the multiplexer. No thread should have started
     # for checking plugin assets data.
     self.assertFalse(mock.called)

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -398,8 +398,8 @@ class TextPluginTest(tf.test.TestCase):
     # Initially, the thread for checking for plugin assets data has not run.
     # Hence, the mapping should only have data from the multiplexer.
     self.assertEqual({
-        'fry': [u'message', u'vector'],
-        'leela': [u'message', u'vector']
+        'fry': ['message', 'vector'],
+        'leela': ['message', 'vector']
     }, self.plugin.tags_impl())
     thread = self.plugin._index_impl_thread
     mock.assert_called_once_with(thread)
@@ -407,8 +407,8 @@ class TextPluginTest(tf.test.TestCase):
     # The thread hasn't run yet, so no change in response, and we should not
     # have tried to launch a second thread.
     self.assertEqual({
-        'fry': [u'message', u'vector'],
-        'leela': [u'message', u'vector']
+        'fry': ['message', 'vector'],
+        'leela': ['message', 'vector']
     }, self.plugin.tags_impl())
     mock.assert_called_once_with(thread)
 

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
 import json
 import os
 import textwrap

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -326,7 +326,7 @@ class TextPluginTest(tf.test.TestCase):
       </table>""")
     self.assertEqual(convert(d3), d3_expected)
 
-  def assertIsActive(self, plugin, expected_is_active):
+  def assertIsActive(self, plugin, expected_finally_is_active):
     """Helper to simulate threading for asserting on is_active()."""
     patcher = tf.test.mock.patch('threading.Thread.start', autospec=True)
     mock = patcher.start()
@@ -346,7 +346,7 @@ class TextPluginTest(tf.test.TestCase):
     thread.run()
     self.assertIsNone(plugin._index_impl_thread)
 
-    if expected_is_active:
+    if expected_finally_is_active:
       self.assertTrue(plugin.is_active())
       # The call above shouldn't have launched a new thread.
       mock.assert_called_once_with(thread)
@@ -369,7 +369,15 @@ class TextPluginTest(tf.test.TestCase):
     plugin = text_plugin.TextPlugin(context)
     multiplexer.AddRunsFromDirectory(self.logdir)
     multiplexer.Reload()
-    self.assertIsActive(plugin, True)
+
+    patcher = tf.test.mock.patch('threading.Thread.start', autospec=True)
+    mock = patcher.start()
+    self.addCleanup(patcher.stop)
+    self.assertTrue(plugin.is_active(), True)
+    
+    # Data is available within the multiplexer. No thread should have started
+    # for checking plugin assets data.
+    self.assertFalse(mock.called)
 
   def testPluginIsActiveWhenRunsButNoText(self):
     """The plugin should be inactive when there are runs but none has text."""
@@ -387,14 +395,21 @@ class TextPluginTest(tf.test.TestCase):
     mock = patcher.start()
     self.addCleanup(patcher.stop)
 
-    # Initially we have not computed index_impl() so we'll get the placeholder.
-    self.assertEqual({}, self.plugin.tags_impl())
+    # Initially, the thread for checking for plugin assets data has not run.
+    # Hence, the mapping should only have data from the multiplexer.
+    self.assertEqual({
+        'fry': [u'message', u'vector'],
+        'leela': [u'message', u'vector']
+    }, self.plugin.tags_impl())
     thread = self.plugin._index_impl_thread
     mock.assert_called_once_with(thread)
 
     # The thread hasn't run yet, so no change in response, and we should not
     # have tried to launch a second thread.
-    self.assertEqual({}, self.plugin.tags_impl())
+    self.assertEqual({
+        'fry': [u'message', u'vector'],
+        'leela': [u'message', u'vector']
+    }, self.plugin.tags_impl())
     mock.assert_called_once_with(thread)
 
     # Run the thread; it should clean up after itself.


### PR DESCRIPTION
We make the text plugin's is_active method return true if it detects
relevant data present within the multiplexer. Subsequently, there would
be no more need to check for data stored within plugin assets.

This solves an issue: The text plugin used to be inactive when the user
initially loads into it because the thread for computing whether the plugin
is active would not have completed executing yet.

Part of #625.

Test plan:

Run the [text demo](https://github.com/tensorflow/tensorboard/blob/master/tensorboard/plugins/text/text_demo.py). Verify behavior. The text plugin should be active on
the first load.