### PR TITLE
Change histogram SQL query to use linspaced sampling

### DIFF
--- a/tensorboard/plugins/distribution/distributions_plugin.py
+++ b/tensorboard/plugins/distribution/distributions_plugin.py
@@ -41,6 +41,10 @@ class DistributionsPlugin(base_plugin.TBPlugin):
 
   plugin_name = 'distributions'
 
+  # Use a round number + 1 since sampling includes both start and end steps,
+  # so N+1 samples corresponds to dividing the step sequence into N intervals.
+  SAMPLE_SIZE = 501
+
   def __init__(self, context):
     """Instantiates DistributionsPlugin via TensorBoard core.
 
@@ -67,7 +71,7 @@ class DistributionsPlugin(base_plugin.TBPlugin):
   def distributions_impl(self, tag, run):
     """Result of the form `(body, mime_type)`, or `ValueError`."""
     (histograms, mime_type) = self._histograms_plugin.histograms_impl(
-        tag, run, downsample_to=None)
+        tag, run, downsample_to=self.SAMPLE_SIZE)
     return ([self._compress(histogram) for histogram in histograms],
             mime_type)
 


### PR DESCRIPTION
This replaces the randomized downsampling used in the histograms plugin SQL query with a systematic linear sampling strategy, based on dividing the range into k - 1 equal-sized intervals and then returning the lowest steps at or above the k interval boundaries.  This produces cleaner and more readily understandable/predictable charts, where we now get the nice property that (at least when steps are contiguous) any two adjacent histogram curves will be separated by the same step delta +/- 1 so the actual rate of change is easier to discern.  As a bonus, the new results also always include the lowest and highest steps in the series.

Old sampling:
![image](https://user-images.githubusercontent.com/710113/37019553-803faacc-20cd-11e8-86d4-4bcb0ec71946.png)

New sampling:
![image](https://user-images.githubusercontent.com/710113/37019557-866a3ec6-20cd-11e8-8456-138e7e9a2b62.png)

We can now turn off sampling inline with the same query rather than using string templating.  I factored out finding the tag ID into a separate query since it's used twice in the main query, but we could put that query in a WITH clause and then read it with two inline scalar queries to keep it all in one query, if that's preferred.  I expect that performance-wise this query should be similar to the randomized one (they're both essentially O(n) in series length).  An alternate approach would be computing the k interval boundaries directly (either in python or with a recursive WITH query) and then using correlated subqueries to fetch each result individually, which would theoretically be O(k log(n)).  That would in theory be more efficient when k < n/log(n), though I expect the constant factors dominate until n gets fairly large, so we'd want to do some experimental testing.

I bumped the histogram sample size from 50 to 51 because N+1 samples correspond to N intervals, so making N a round number makes the step counts more likely to be round numbers.  I also set the distributions plugin to use a sample size of 501 (current reservoir size + 1) since we want an upper bound on the number of points returned even if running against an unsampled DB.