### PR TITLE
Add SQLite support to images plugin

### DIFF
--- a/tensorboard/plugins/image/images_plugin.py
+++ b/tensorboard/plugins/image/images_plugin.py
@@ -99,6 +99,8 @@ class ImagesPlugin(base_plugin.TBPlugin):
           WHERE Tags.plugin_name = :plugin
             /* Shape should correspond to a rank-1 tensor. */
             AND NOT INSTR(Tensors.shape, ',')
+            /* Required to use TensorSeriesStepIndex. */
+            AND Tensors.step IS NOT NULL
           GROUP BY Tags.tag_id
           HAVING samples >= 1
           ''',


### PR DESCRIPTION
This adds SQL queries to the images plugin so that it works in database mode.  For now, we don't do any sampling by step count, so each image series will return the full series of available steps in the DB.

There are some inefficiencies in the queries due to mismatches between the way we store image summaries in the DB and the structure of the the image plugin requests.  The worst offender is that in order to satisfy the original index_impl() request - which blocks loading the rest of the dashboard - we end up needing to scan over every single image summary entry in Tensors.  This is because index_impl() needs to know the sample count for each image tag (since each sample gets its own image loader card), but within a tag the sample count of each summary can vary independently.  The current EventMultiplexer code just reads all the image tensors for the tag and takes the max sample count, but without reservoir sampling first this isn't cheap, and we're doing it for every single image tag on every page load.

The main other issue is that the individual image URLs identify images not by their step (which is unchanging) but by their index within the reservoir.  I gather that the reason for this is because by the time the user slides the slider to step X and triggers the request to load that image, it's possible that step X will have been replaced in the reservoir - whereas the reservoir index will still have an image at the index, and even if it's not actually at step X it will be at a probabilistically close step.  This already seems a bit less than ideal but for database mode it's especially suboptimal since unless we can assume contiguous steps, the only way to index into the "reservoir" at index `i` is to scan through the first `i` results sorted by step, e.g. using `LIMIT 1 OFFSET i`, whereas if we were using the step directly it would be an index lookup.

So in both of these cases, data retrieval that should a O(log n) lookup turns into an O(n) scan.

Fixing the first issue would probably require some kind of change to how we store image summaries so that the sample count is known at a tag level.  I'm a little inclined to revisit the `tb.summary.image()` approach of storing multiple image samples within the same tensor, and instead go back to the `tf.summary.image()` behavior where the single summary op generates multiple tags with /0, /1, /2, ... suffixes if the batch has multiple image samples.  I think we could retrofit that into the existing API either by going back to multiple Summary.Values in a single Summary, or potentially by just creating multiple nested summary ops and grouping them with tf.group() or similar for the purpose of returning a single op representing the writing of all samples.

Fixing the second issue probably means replacing the index query parameter with the actual step count stored in the frontend.  If we weren't doing any "live" sampling, that's the entire fix.  To support "live" sampling (i.e. data disappearing from the DB while TensorBoard is running), iif the image at that step is missing we could just replace it with the image at the next higher step (on the assumption that in general, data disappearing means we've added more steps overall, so it makes sense to scan up rather than down).  Note that beyond the discrepancy between the UI-displayed step and the actual step, this could lead to some very pathological cases where e.g. we're showing images out of order because the last step image was automatically loaded (and cached by the browser) but when we slide earlier, so much sampling has happened that the only available images are at significantly higher step counts than the last step's image.  But these issues exist today already.  A better fix might somehow involve having the individual image load queries be able to indicate to the frontend when they're serving data for a different step, so the frontend can either indicate staleness or auto-refresh, but I'm not sure we actually have the ability to get metadata out of those responses.