### PR TITLE
Create vz_chart_helpers component

### DIFF
--- a/tensorboard/components/vz_chart_helpers/BUILD
+++ b/tensorboard/components/vz_chart_helpers/BUILD
@@ -1,0 +1,20 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_library(
+    name = "vz_chart_helpers",
+    srcs = [
+        "vz-chart-helpers.html",
+        "vz-chart-helpers.ts",
+    ],
+    path = "/vz-chart-helpers",
+    deps = [
+        "//tensorboard/components/tf_imports:d3",
+        "//tensorboard/components/tf_imports:lodash",
+        "//tensorboard/components/tf_imports:plottable",
+        "//tensorboard/components/vz_sorting",
+    ],
+)

--- a/tensorboard/components/vz_chart_helpers/vz-chart-helpers.html
+++ b/tensorboard/components/vz_chart_helpers/vz-chart-helpers.html
@@ -1,0 +1,23 @@
+<!--
+@license
+Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../tf-imports/d3.html">
+<link rel="import" href="../tf-imports/lodash.html">
+<link rel="import" href="../tf-imports/plottable.html">
+<link rel="import" href="../vz-sorting/vz-sorting.html">
+
+<script src="vz-chart-helpers.js"></script>

--- a/tensorboard/components/vz_chart_helpers/vz-chart-helpers.ts
+++ b/tensorboard/components/vz_chart_helpers/vz-chart-helpers.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-namespace vz_line_chart {
+namespace vz_chart_helpers {
 
 export interface Datum {
   wall_time: Date;
@@ -265,10 +265,6 @@ export function relativeX(): XComponents {
   };
 }
 
-// a very literal definition of NaN: true for NaN for a non-number type
-// or null, etc. False for Infinity or -Infinity
-export let isNaN = (x) => +x !== x;
-
 export function getXComponents(xType: string): XComponents {
   switch (xType) {
     case XType.STEP:
@@ -282,4 +278,4 @@ export function getXComponents(xType: string): XComponents {
   }
 }
 
-}  // namespace vz_line_chart
+}  // namespace vz_chart_helpers

--- a/tensorboard/components/vz_line_chart/BUILD
+++ b/tensorboard/components/vz_line_chart/BUILD
@@ -9,7 +9,6 @@ tf_web_library(
     name = "vz_line_chart",
     srcs = [
         "dragZoomInteraction.ts",
-        "vz-chart-helpers.ts",
         "vz-line-chart.html",
         "vz-line-chart.ts",
     ],
@@ -20,6 +19,7 @@ tf_web_library(
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:plottable",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/vz_chart_helpers",
     ],
 )
 

--- a/tensorboard/components/vz_line_chart/vz-line-chart.html
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.html
@@ -19,6 +19,7 @@ limitations under the License.
 <link rel="import" href="../tf-imports/d3.html">
 <link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../tf-imports/plottable.html">
+<link rel="import" href="../vz-chart-helpers/vz-chart-helpers.html">
 
 <!--
 vz-line-chart creates an element that draws a line chart for
@@ -118,7 +119,7 @@ such as different X scales (linear and temporal), tooltips and smoothing.
 
     </style>
   </template>
-  <script src="vz-chart-helpers.js"></script>
+  <script src="../vz-chart-helpers/vz-chart-helpers.js"></script>
   <script src="dragZoomInteraction.js"></script>
   <script src="vz-line-chart.js"></script>
 </dom-module>

--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -52,7 +52,7 @@ Polymer({
     /**
      * A function that takes a data series string and returns a
      * Plottable.SymbolFactory to use for rendering that series. This property
-     * implements the SymbolFn interface.
+     * implements the vz_chart_helpers.SymbolFn interface.
      */
     symbolFunction: Object,
 
@@ -96,7 +96,7 @@ Polymer({
     /**
      * This is a helper field for automatically generating commonly used
      * functions for xComponentsCreationMethod. Valid values are what can
-     * be processed by vz_line_chart.getXComponents() and include
+     * be processed by vz_chart_helpers.getXComponents() and include
      * "step", "wall_time", and "relative".
      */
     xType: {type: String, value: ''},
@@ -111,7 +111,7 @@ Polymer({
      * outer function to compute the value. We actually want the value of this
      * property to be the inner function.
      *
-     * @type {function(): XComponents}
+     * @type {function(): vz_chart_helpers.XComponents}
      */
     xComponentsCreationMethod: {
       type: Object,
@@ -151,8 +151,8 @@ Polymer({
     tooltipColumns: {
       type: Array,
       value: function() {
-        const valueFormatter = multiscaleFormatter(
-            Y_TOOLTIP_FORMATTER_PRECISION);
+        const valueFormatter = vz_chart_helpers.multiscaleFormatter(
+            vz_chart_helpers.Y_TOOLTIP_FORMATTER_PRECISION);
         const formatValueOrNaN = (x) => isNaN(x) ? 'NaN' : valueFormatter(x);
 
         return [
@@ -172,16 +172,18 @@ Polymer({
           },
           {
             title: 'Step',
-            evaluate: (d) => stepFormatter(d.datum.step),
+            evaluate: (d) => vz_chart_helpers.stepFormatter(
+                d.datum.step),
           },
           {
             title: 'Time',
-            evaluate: (d) => timeFormatter(d.datum.wall_time),
+            evaluate: (d) => vz_chart_helpers.timeFormatter(
+                d.datum.wall_time),
           },
           {
             title: 'Relative',
-            evaluate: (d) => relativeFormatter(
-                relativeAccessor(d.datum, -1, d.dataset)),
+            evaluate: (d) => vz_chart_helpers.relativeFormatter(
+                vz_chart_helpers.relativeAccessor(d.datum, -1, d.dataset)),
           },
         ];
       }
@@ -299,8 +301,8 @@ Polymer({
    * its name must be in the setVisibleSeries() array.
    *
    * @param {string} name Name of the series.
-   * @param {Array<ScalarDatum>} data Data of the series. This is
-   * an array of objects with at least the following properties:
+   * @param {Array< vz_chart_helpers.ScalarDatum>} data Data of the series.
+   * This is an array of objects with at least the following properties:
    * - step: (Number) - index of the datum.
    * - wall_time: (Date) - Date object with the datum's time.
    * - scalar: (Number) - Value of the datum.
@@ -355,10 +357,10 @@ Polymer({
       _attached) {
     // Find the actual xComponentsCreationMethod.
     if (!xType && !xComponentsCreationMethod) {
-      xComponentsCreationMethod = vz_line_chart.stepX;
+      xComponentsCreationMethod = vz_chart_helpers.stepX;
     } else if (xType) {
       xComponentsCreationMethod = () =>
-          vz_line_chart.getXComponents(xType);
+          vz_chart_helpers.getXComponents(xType);
     }
 
     if (this._makeChartAsyncCallbackId !== null) {
@@ -455,7 +457,7 @@ class LineChart {
   private yAxis: Plottable.Axes.Numeric;
   private outer: Plottable.Components.Table;
   private colorScale: Plottable.Scales.Color;
-  private symbolFunction: SymbolFn;
+  private symbolFunction: vz_chart_helpers.SymbolFn;
   private tooltip: d3.Selection<any, any, any, any>;
   private dzl: DragZoomLayer;
 
@@ -487,16 +489,16 @@ class LineChart {
   private targetSVG: d3.Selection<any, any, any, any>;
 
   constructor(
-      xComponentsCreationMethod: () => XComponents,
+      xComponentsCreationMethod: () => vz_chart_helpers.XComponents,
       yValueAccessor: Plottable.IAccessor<number>,
       yScaleType: string,
       colorScale: Plottable.Scales.Color,
       tooltip: d3.Selection<any, any, any, any>,
-      tooltipColumns: TooltipColumn[],
+      tooltipColumns: vz_chart_helpers.TooltipColumn[],
       fillArea: FillArea,
       defaultXRange?: number[],
       defaultYRange?: number[],
-      symbolFunction?: SymbolFn,
+      symbolFunction?: vz_chart_helpers.SymbolFn,
       xAxisFormatter?: (number) => string) {
     this.seriesNames = [];
     this.name2datasets = {};
@@ -531,10 +533,10 @@ class LineChart {
   }
 
   private buildChart(
-      xComponentsCreationMethod: () => XComponents,
+      xComponentsCreationMethod: () => vz_chart_helpers.XComponents,
       yValueAccessor: Plottable.IAccessor<number>,
       yScaleType: string,
-      tooltipColumns: TooltipColumn[],
+      tooltipColumns: vz_chart_helpers.TooltipColumn[],
       fillArea: FillArea,
       xAxisFormatter: (number) => string) {
     if (this.outer) {
@@ -550,8 +552,8 @@ class LineChart {
     }
     this.yScale = LineChart.getYScaleFromType(yScaleType);
     this.yAxis = new Plottable.Axes.Numeric(this.yScale, 'left');
-    let yFormatter = multiscaleFormatter(
-        Y_AXIS_FORMATTER_PRECISION);
+    let yFormatter = vz_chart_helpers.multiscaleFormatter(
+        vz_chart_helpers.Y_AXIS_FORMATTER_PRECISION);
     this.yAxis.margin(0).tickLabelPadding(5).formatter(yFormatter);
     this.yAxis.usesTextWidthApproximation(true);
     this.fillArea = fillArea;
@@ -588,19 +590,19 @@ class LineChart {
       this.marginAreaPlot.y0(fillArea.lowerAccessor);
       this.marginAreaPlot.attr(
           'fill',
-          (d: Datum, i: number, dataset: Plottable.Dataset) =>
+          (d: vz_chart_helpers.Datum, i: number, dataset: Plottable.Dataset) =>
               this.colorScale.scale(dataset.metadata().name));
       this.marginAreaPlot.attr('fill-opacity', 0.3);
       this.marginAreaPlot.attr('stroke-width', 0);
     }
 
-    this.smoothedAccessor = (d: ScalarDatum) => d.smoothed;
+    this.smoothedAccessor = (d:  vz_chart_helpers.ScalarDatum) => d.smoothed;
     let linePlot = new Plottable.Plots.Line<number|Date>();
     linePlot.x(this.xAccessor, xScale);
     linePlot.y(this.yValueAccessor, yScale);
     linePlot.attr(
         'stroke',
-        (d: Datum, i: number, dataset: Plottable.Dataset) =>
+        (d: vz_chart_helpers.Datum, i: number, dataset: Plottable.Dataset) =>
             this.colorScale.scale(dataset.metadata().name));
     this.linePlot = linePlot;
     const group = this.setupTooltips(linePlot, tooltipColumns);
@@ -610,7 +612,7 @@ class LineChart {
     smoothLinePlot.y(this.smoothedAccessor, yScale);
     smoothLinePlot.attr(
         'stroke',
-        (d: Datum, i: number, dataset: Plottable.Dataset) =>
+        (d: vz_chart_helpers.Datum, i: number, dataset: Plottable.Dataset) =>
             this.colorScale.scale(dataset.metadata().name));
     this.smoothLinePlot = smoothLinePlot;
 
@@ -620,12 +622,12 @@ class LineChart {
       markersScatterPlot.y(this.yValueAccessor, yScale);
       markersScatterPlot.attr(
           'fill',
-          (d: Datum, i: number, dataset: Plottable.Dataset) =>
+          (d: vz_chart_helpers.Datum, i: number, dataset: Plottable.Dataset) =>
               this.colorScale.scale(dataset.metadata().name));
       markersScatterPlot.attr('opacity', 1);
-      markersScatterPlot.size(TOOLTIP_CIRCLE_SIZE * 2);
+      markersScatterPlot.size(vz_chart_helpers.TOOLTIP_CIRCLE_SIZE * 2);
       markersScatterPlot.symbol(
-          (d: Datum, i: number, dataset: Plottable.Dataset) => {
+          (d: vz_chart_helpers.Datum, i: number, dataset: Plottable.Dataset) => {
             return this.symbolFunction(dataset.metadata().name);
           });
       // Use a special dataset because this scatter plot should use the accesor
@@ -641,7 +643,7 @@ class LineChart {
     scatterPlot.y(this.yValueAccessor, yScale);
     scatterPlot.attr('fill', (d: any) => this.colorScale.scale(d.name));
     scatterPlot.attr('opacity', 1);
-    scatterPlot.size(TOOLTIP_CIRCLE_SIZE * 2);
+    scatterPlot.size(vz_chart_helpers.TOOLTIP_CIRCLE_SIZE * 2);
     scatterPlot.datasets([this.lastPointsDataset]);
     this.scatterPlot = scatterPlot;
 
@@ -650,7 +652,7 @@ class LineChart {
     nanDisplay.y((x) => x.displayY, yScale);
     nanDisplay.attr('fill', (d: any) => this.colorScale.scale(d.name));
     nanDisplay.attr('opacity', 1);
-    nanDisplay.size(NAN_SYMBOL_SIZE * 2);
+    nanDisplay.size(vz_chart_helpers.NAN_SYMBOL_SIZE * 2);
     nanDisplay.datasets([this.nanDataset]);
     nanDisplay.symbol(Plottable.SymbolFactories.triangle);
     this.nanDisplay = nanDisplay;
@@ -702,7 +704,7 @@ class LineChart {
                 let idx = nonNanData.length - 1;
                 datum = nonNanData[idx];
                 datum.name = d.metadata().name;
-                datum.relative = relativeAccessor(datum, -1, d);
+                datum.relative = vz_chart_helpers.relativeAccessor(datum, -1, d);
               }
               return datum;
             })
@@ -737,7 +739,7 @@ class LineChart {
         } else {
           data[i].name = d.metadata().name;
           data[i].displayY = displayY;
-          data[i].relative = relativeAccessor(data[i], -1, d);
+          data[i].relative = vz_chart_helpers.relativeAccessor(data[i], -1, d);
           nanData.push(data[i]);
         }
       }
@@ -780,7 +782,7 @@ class LineChart {
       };
       const vals = _.flattenDeep<number>(this.datasets.map(datasetToValues))
           .filter(isFinite);
-      yDomain = computeDomain(vals, this._ignoreYOutliers);
+      yDomain = vz_chart_helpers.computeDomain(vals, this._ignoreYOutliers);
     }
     this.yScale.domain(yDomain);
   }
@@ -802,12 +804,12 @@ class LineChart {
 
   private setupTooltips(
       plot: Plottable.XYPlot<number|Date, number>,
-      tooltipColumns: TooltipColumn[]):
+      tooltipColumns: vz_chart_helpers.TooltipColumn[]):
       Plottable.Components.Group {
     let pi = new Plottable.Interactions.Pointer();
     pi.attachTo(plot);
-    // PointsComponent is a Plottable Component that will hold the little
-    // circles we draw over the closest data points
+    // vz_chart_helpers.PointsComponent is a Plottable Component that will
+    // hold the little circles we draw over the closest data points
     let pointsComponent = new Plottable.Component();
     let group = new Plottable.Components.Group([plot, pointsComponent]);
 
@@ -833,7 +835,7 @@ class LineChart {
       if (!enabled) {
         return;
       }
-      let target: Point = {
+      let target: vz_chart_helpers.Point = {
         x: p.x,
         y: p.y,
         datum: null,
@@ -859,10 +861,10 @@ class LineChart {
       let ptsSelection: any =
           pointsComponent.content().selectAll('.point').data(
               ptsToCircle,
-              (p: Point) => p.dataset.metadata().name);
+              (p: vz_chart_helpers.Point) => p.dataset.metadata().name);
       if (pts.length !== 0) {
         ptsSelection.enter().append('circle').classed('point', true);
-        ptsSelection.attr('r', TOOLTIP_CIRCLE_SIZE)
+        ptsSelection.attr('r', vz_chart_helpers.TOOLTIP_CIRCLE_SIZE)
             .attr('cx', (p) => p.x)
             .attr('cy', (p) => p.y)
             .style('stroke', 'none')
@@ -882,15 +884,15 @@ class LineChart {
   }
 
   private drawTooltips(
-      points: Point[],
-      target: Point,
-      tooltipColumns: TooltipColumn[]) {
+      points: vz_chart_helpers.Point[],
+      target: vz_chart_helpers.Point,
+      tooltipColumns: vz_chart_helpers.TooltipColumn[]) {
     // Formatters for value, step, and wall_time
     this.scatterPlot.attr('opacity', 0);
-    let valueFormatter = multiscaleFormatter(
-        Y_TOOLTIP_FORMATTER_PRECISION);
+    let valueFormatter = vz_chart_helpers.multiscaleFormatter(
+        vz_chart_helpers.Y_TOOLTIP_FORMATTER_PRECISION);
 
-    let dist = (p: Point) =>
+    let dist = (p: vz_chart_helpers.Point) =>
         Math.pow(p.x - target.x, 2) + Math.pow(p.y - target.y, 2);
     let closestDist = _.min(points.map(dist));
 
@@ -966,7 +968,7 @@ class LineChart {
       left = Math.min(parentRect.width, left);
     } else {  // 'bottom'
       left = Math.min(0, left);
-      top = parentRect.height + TOOLTIP_Y_PIXEL_OFFSET;
+      top = parentRect.height + vz_chart_helpers.TOOLTIP_Y_PIXEL_OFFSET;
     }
 
     this.tooltip.style('transform', 'translate(' + left + 'px,' + top + 'px)');
@@ -974,9 +976,9 @@ class LineChart {
   }
 
   private findClosestPoint(
-      target: Point,
-      dataset: Plottable.Dataset): Point {
-    let points: Point[] = dataset.data().map((d, i) => {
+      target: vz_chart_helpers.Point,
+      dataset: Plottable.Dataset): vz_chart_helpers.Point {
+    let points: vz_chart_helpers.Point[] = dataset.data().map((d, i) => {
       let x = this.xAccessor(d, i, dataset);
       let y = this.smoothingEnabled ? this.smoothedAccessor(d, i, dataset) :
                                       this.yValueAccessor(d, i, dataset);
@@ -988,7 +990,7 @@ class LineChart {
       };
     });
     let idx: number =
-        _.sortedIndex(points, target, (p: Point) => p.x);
+        _.sortedIndex(points, target, (p: vz_chart_helpers.Point) => p.x);
     if (idx === points.length) {
       return points[points.length - 1];
     } else if (idx === 0) {
@@ -1100,7 +1102,7 @@ class LineChart {
   /**
    * Set the data of a series on the chart.
    */
-  public setSeriesData(name: string, data: ScalarDatum[]) {
+  public setSeriesData(name: string, data:  vz_chart_helpers.ScalarDatum[]) {
     this.getDataset(name).data(data);
   }
 

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-helpers.ts
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-helpers.ts
@@ -18,7 +18,7 @@ export interface CustomScalarResponse {
   regex_valid: boolean;
 
   // Maps tag name to a list of scalar data.
-  tag_to_events: {[key: string]: vz_line_chart.ScalarDatum[]};
+  tag_to_events: {[key: string]: vz_chart_helpers.ScalarDatum[]};
 }
 
 /**
@@ -58,14 +58,14 @@ export class DataSeries {
   private run: string;
   private tag: string;
   private name: string;
-  private scalarData: vz_line_chart.ScalarDatum[];
-  private symbol: vz_line_chart.LineChartSymbol;
+  private scalarData: vz_chart_helpers.ScalarDatum[];
+  private symbol: vz_chart_helpers.LineChartSymbol;
 
   constructor(run: string,
               tag: string,
               name: string,
-              scalarData: vz_line_chart.ScalarDatum[],
-              symbol: vz_line_chart.LineChartSymbol) {
+              scalarData: vz_chart_helpers.ScalarDatum[],
+              symbol: vz_chart_helpers.LineChartSymbol) {
     this.run = run;
     this.tag = tag;
     this.name = name;
@@ -77,11 +77,11 @@ export class DataSeries {
     return this.name;
   }
 
-  setData(scalarData: vz_line_chart.ScalarDatum[]) {
+  setData(scalarData: vz_chart_helpers.ScalarDatum[]) {
     this.scalarData = scalarData;
   }
 
-  getData(): vz_line_chart.ScalarDatum[] {
+  getData(): vz_chart_helpers.ScalarDatum[] {
     return this.scalarData;
   }
 
@@ -93,7 +93,7 @@ export class DataSeries {
     return this.tag;
   }
 
-  getSymbol(): vz_line_chart.LineChartSymbol {
+  getSymbol(): vz_chart_helpers.LineChartSymbol {
     return this.symbol;
   }
 }

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -362,8 +362,8 @@ limitations under the License.
         _tooltipColumns: {
           type: Array,
           value: function() {
-            const valueFormatter = vz_line_chart.multiscaleFormatter(
-                vz_line_chart.Y_TOOLTIP_FORMATTER_PRECISION);
+            const valueFormatter = vz_chart_helpers.multiscaleFormatter(
+                vz_chart_helpers.Y_TOOLTIP_FORMATTER_PRECISION);
             const formatValueOrNaN =
                 (x) => isNaN(x) ? 'NaN' : valueFormatter(x);
 
@@ -594,7 +594,7 @@ limitations under the License.
         this._runToNextAvailableSymbolIndex[run] |= 0;
 
         // Every data series within a run has a unique symbol.
-        const lineChartSymbol = vz_line_chart.SYMBOLS_LIST[
+        const lineChartSymbol = vz_chart_helpers.SYMBOLS_LIST[
             this._runToNextAvailableSymbolIndex[run]];
 
         // Create a series with this name.
@@ -602,7 +602,7 @@ limitations under the License.
             run, tag, seriesName, dataPoints, lineChartSymbol);
 
         // Loop back to the beginning if we are out of symbols.
-        const numSymbols = vz_line_chart.SYMBOLS_LIST.length;
+        const numSymbols = vz_chart_helpers.SYMBOLS_LIST.length;
         this._runToNextAvailableSymbolIndex[run] =
             (this._runToNextAvailableSymbolIndex[run] + 1) % numSymbols;
         return series;

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
@@ -324,7 +324,7 @@ limitations under the License.
                 }
 
                 // Every data series within a run has a unique symbol.
-                const lineChartSymbol = vz_line_chart.SYMBOLS_LIST[
+                const lineChartSymbol = vz_chart_helpers.SYMBOLS_LIST[
                     this._runToNextAvailableSymbolIndex[run]];
 
                 // Create a series with this name.
@@ -337,7 +337,7 @@ limitations under the License.
                 newMapping[seriesName] = series;
 
                 // Loop back to the beginning if we are out of symbols.
-                const numSymbols = vz_line_chart.SYMBOLS_LIST.length;
+                const numSymbols = vz_chart_helpers.SYMBOLS_LIST.length;
                 this._runToNextAvailableSymbolIndex[run] =
                     (this._runToNextAvailableSymbolIndex[run] + 1) % numSymbols;
               }

--- a/tensorboard/plugins/distribution/vz_distribution_chart/BUILD
+++ b/tensorboard/plugins/distribution/vz_distribution_chart/BUILD
@@ -16,7 +16,7 @@ tf_web_library(
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:plottable",
         "//tensorboard/components/tf_imports:polymer",
-        "//tensorboard/components/vz_line_chart",
+        "//tensorboard/components/vz_chart_helpers",
     ],
 )
 

--- a/tensorboard/plugins/distribution/vz_distribution_chart/vz-distribution-chart.html
+++ b/tensorboard/plugins/distribution/vz_distribution_chart/vz-distribution-chart.html
@@ -17,7 +17,7 @@ limitations under the License.
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-imports/plottable.html">
-<link rel="import" href="../vz-line-chart/vz-line-chart.html">
+<link rel="import" href="../vz-chart-helpers/vz-chart-helpers.html">
 
 <dom-module id="vz-distribution-chart">
   <template>

--- a/tensorboard/plugins/distribution/vz_distribution_chart/vz-distribution-chart.ts
+++ b/tensorboard/plugins/distribution/vz_distribution_chart/vz-distribution-chart.ts
@@ -50,15 +50,15 @@ export class DistributionChart {
     if (this.outer) {
       this.outer.destroy();
     }
-    let xComponents = vz_line_chart.getXComponents(xType);
+    let xComponents = vz_chart_helpers.getXComponents(xType);
     this.xAccessor = xComponents.accessor;
     this.xScale = xComponents.scale;
     this.xAxis = xComponents.axis;
     this.xAxis.margin(0).tickLabelPadding(3);
     this.yScale = new Plottable.Scales.Linear();
     this.yAxis = new Plottable.Axes.Numeric(this.yScale, 'left');
-    let yFormatter = vz_line_chart.multiscaleFormatter(
-        vz_line_chart.Y_AXIS_FORMATTER_PRECISION);
+    let yFormatter = vz_chart_helpers.multiscaleFormatter(
+        vz_chart_helpers.Y_AXIS_FORMATTER_PRECISION);
     this.yAxis.margin(0).tickLabelPadding(5).formatter(yFormatter);
     this.yAxis.usesTextWidthApproximation(true);
 

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -210,10 +210,10 @@ limitations under the License.
               {defaultValue: true, useLocalStorage: true}),
           observer: '_ignoreYOutliersObserver',
         },
-        /** @type {vz_line_chart.XType} */
+        /** @type {vz_chart_helpers.XType} */
         _xType: {
           type: String,
-          value: vz_line_chart.XType.STEP,
+          value: vz_chart_helpers.XType.STEP,
         },
 
         _selectedRuns: Array,


### PR DESCRIPTION
We move logic within the ChartHelpers module to a new vz_chart_helpers
component. This enables other components to depend on logic within that
file.

In the near future, we will add a vz_bar_chart component that will make
use of this new component.

Test plan: Verify that TensorBoard WAI with logs from
[mnist_with_summaries.py](https://github.com/tensorflow/tensorflow/blob/b1c32226cc0cd44da9985a60e6a0ac6dec120fa5/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py).