### PR TITLE
Fix build issues caused by adding Beholder plugin

### DIFF
--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -64,6 +64,9 @@ setup(
         'tensorboard': [
             'webfiles.zip',
         ],
+        'tensorboard.plugins.beholder': [
+            'resources/*',
+        ],
     },
     # Disallow python 3.0 and 3.1 which lack a 'futures' module (see above).
     python_requires='>= 2.7, != 3.0.*, != 3.1.*',

--- a/tensorboard/plugins/beholder/BUILD
+++ b/tensorboard/plugins/beholder/BUILD
@@ -15,14 +15,13 @@ py_library(
     ],
     srcs_version = "PY2AND3",
     deps = [
-        "//tensorboard/plugins/beholder",
-        "//tensorboard/plugins/beholder:file_system_tools",
-        "//tensorboard/plugins/beholder:im_util",
+        ":beholder",
+        ":file_system_tools",
+        ":im_util",
+        "//tensorboard/backend:http_util",
+        "//tensorboard/backend/event_processing:plugin_asset_util",
+        "//tensorboard/plugins:base_plugin",
         "@org_pocoo_werkzeug",
-        "@org_tensorflow_tensorboard//tensorboard/backend:http_util",
-        "@org_tensorflow_tensorboard//tensorboard/backend/event_processing:event_accumulator",
-        "@org_tensorflow_tensorboard//tensorboard/backend/event_processing:plugin_asset_util",
-        "@org_tensorflow_tensorboard//tensorboard/plugins:base_plugin",
     ],
 )
 

--- a/tensorboard/plugins/beholder/BUILD
+++ b/tensorboard/plugins/beholder/BUILD
@@ -11,13 +11,14 @@ py_library(
     name = "beholder_plugin",
     srcs = [
         "beholder_plugin.py",
-        "//tensorboard/plugins/beholder:shared_config.py",
+        "shared_config.py",
     ],
     srcs_version = "PY2AND3",
     deps = [
         ":beholder",
         ":file_system_tools",
         ":im_util",
+        ":shared_config",
         "//tensorboard/backend:http_util",
         "//tensorboard/backend/event_processing:plugin_asset_util",
         "//tensorboard/plugins:base_plugin",
@@ -41,15 +42,19 @@ py_library(
 )
 
 py_library(
+    name = "shared_config",
+    srcs = ["shared_config.py"],
+    srcs_version = "PY2AND3",
+)
+
+py_library(
     name = "visualizer",
-    srcs = [
-        "shared_config.py",
-        "visualizer.py",
-    ],
+    srcs = ["visualizer.py"],
     srcs_version = "PY2AND3",
     deps = [
         ":file_system_tools",
         ":im_util",
+        ":shared_config",
     ],
 )
 
@@ -64,15 +69,13 @@ py_library(
 
 py_library(
     name = "beholder",
-    srcs = [
-        "beholder.py",
-        "shared_config.py",
-    ],
+    srcs = ["beholder.py"],
     data = ["resources"],
     srcs_version = "PY2AND3",
     deps = [
         ":file_system_tools",
         ":im_util",
+        ":shared_config",
         ":video_writing",
         ":visualizer",
         "//tensorboard/backend/event_processing:plugin_asset_util",

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/BUILD
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@org_tensorflow_tensorboard//tensorboard/defs:web.bzl", "tf_web_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -13,6 +13,16 @@ tf_web_library(
     ],
     path = "/tf-beholder-dashboard",
     deps = [
+        "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_card_heading",
+        "//tensorboard/components/tf_categorization_utils",
+        "//tensorboard/components/tf_color_scale",
+        "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_imports:d3",
+        "//tensorboard/components/tf_imports:lodash",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_runs_selector",
+        "//tensorboard/components/tf_tensorboard:registry",
         "@org_polymer_paper_button",
         "@org_polymer_paper_dialog",
         "@org_polymer_paper_icon_button",
@@ -20,15 +30,5 @@ tf_web_library(
         "@org_polymer_paper_slider",
         "@org_polymer_paper_spinner",
         "@org_polymer_paper_tooltip",
-        "@org_tensorflow_tensorboard//tensorboard/components/tf_backend",
-        "@org_tensorflow_tensorboard//tensorboard/components/tf_card_heading",
-        "@org_tensorflow_tensorboard//tensorboard/components/tf_categorization_utils",
-        "@org_tensorflow_tensorboard//tensorboard/components/tf_color_scale",
-        "@org_tensorflow_tensorboard//tensorboard/components/tf_dashboard_common",
-        "@org_tensorflow_tensorboard//tensorboard/components/tf_imports:d3",
-        "@org_tensorflow_tensorboard//tensorboard/components/tf_imports:lodash",
-        "@org_tensorflow_tensorboard//tensorboard/components/tf_imports:polymer",
-        "@org_tensorflow_tensorboard//tensorboard/components/tf_runs_selector",
-        "@org_tensorflow_tensorboard//tensorboard/components/tf_tensorboard:registry",
     ],
 )


### PR DESCRIPTION
This fixes a few build issues with the Beholder plugin:

1. removes `@org_tensorflow_tensorboard` repository identifiers from dep paths
2. removes redundant `//tensorboard/plugins/beholder` within beholder package
3. changes `shared_config.py` to actually be a shared lib vs a src in three libraries
4. whitelists `beholder/resources/*` as pip package data - fixes #1032 

It turns out that (1) was actually breaking our pip package, because somehow having @org_tensorflow_tensorboard was bringing in a whole separate copy of TensorBoard sources into the `build_pip_package` rule's data attribute, and due to Bazel's poor legacy handling of __init__.py files (https://github.com/bazelbuild/rules_python/issues/55), this causes it to clobber our actual tensorboard/__init__.py file with an empty autogenerated one, thus breaking the ability to do `import tensorboard as tb; tb.summary.whatever()`.  This was caught by running `pip_smoke_test.sh` so I'm glad we have kept that around...

For (4) there are maybe better ways to deal with this than whitelisting specific directories under package data, but I guess it does force us to think carefully about adding non-python data.  If we end up with any more of these, it might make sense to develop a whitelisted convention for these directories, e.g. say that a "resources" directory under any package is allowed as package data.
