### PR TITLE
[CHERRYPICK] Change PyPI package name to just 'tensorboard'

### DIFF
--- a/tensorboard/pip_package/README.rst
+++ b/tensorboard/pip_package/README.rst
@@ -1,2 +1,5 @@
 TensorBoard is a suite of web applications for inspecting and understanding
 your TensorFlow runs and graphs.
+
+Releases prior to 1.6.0 were published under the ``tensorflow-tensorboard`` name
+and may be found at https://pypi.python.org/pypi/tensorflow-tensorboard.

--- a/tensorboard/pip_package/pip_smoke_test.sh
+++ b/tensorboard/pip_package/pip_smoke_test.sh
@@ -115,9 +115,9 @@ echo "Installing the just-built tensorboard pip package"
 echo
 
 if [[ "${PY_VERSION}" == 2 ]]; then
-  pip install "${PIP_TMP_DIR}"/tensorflow_tensorboard*-py2-*.whl
+  pip install "${PIP_TMP_DIR}"/tensorboard*-py2-*.whl
 elif [[ "${PY_VERSION}" == 3 ]]; then
-  pip install "${PIP_TMP_DIR}"/tensorflow_tensorboard*-py3-*.whl
+  pip install "${PIP_TMP_DIR}"/tensorboard*-py3-*.whl
 fi
 
 echo

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -48,7 +48,7 @@ def get_readme():
     return f.read()
 
 setup(
-    name='tensorflow-tensorboard',
+    name='tensorboard',
     version=tensorboard.version.VERSION.replace('-', ''),
     description='TensorBoard lets you watch Tensors Flow',
     long_description=get_readme(),


### PR DESCRIPTION
This is a cherry-pick of 71a816bd38785adf0b478fd75d733858c4698bed from 1.6 to master, since I realized we never actually merged this change back into master.  We'll want it for the 1.7 release onwards.