### PR TITLE
[Debugger Plugin] Fix session run list UI

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -321,6 +321,12 @@ limitations under the License.
         padding-right: 3px;
         box-shadow: 3px 3px #ddd;
       }
+      #sessionRunsView {
+        position: relative;
+        width: 100%;
+        overflow: auto;
+        max-height: 25vh;
+      }
       .buttons-container {
         padding: 20px 0;
       }

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
@@ -59,7 +59,6 @@ limitations under the License.
         border-style: solid 1px black;
         table-layout: fixed;
         width: 100%;
-        max-width: 450px;
         word-break: break-all;
         padding-top: 3px;
         padding-left: 3px;
@@ -138,7 +137,7 @@ limitations under the License.
         this._runKey2NumDevices[runKey] = 0;
       }
       this.set('_activeRunKey', runKey);
-      this._renderSessionRunTable();
+      this._renderSessionRunTable();  // TODO(cais): Restore. DO NOT SUBMIT.
     },
 
     updateNumDevices(numDevices) {
@@ -157,14 +156,22 @@ limitations under the License.
       this._clearTable();
       // TODO(cais): Support sorting.
       this._renderHeader();
+      let activeRow;
       for (const runKey in this._runKey2Count) {
         if (this._runKey2Count.hasOwnProperty(runKey)) {
           const sessionRun = JSON.parse(runKey);
           const count = this._runKey2Count[runKey];
           const isActive = this._activeRunKey === runKey;
           const numDevices = this._runKey2NumDevices[runKey];
-          this._renderRow(sessionRun, numDevices, count, isActive, this.soleActive);
+          const row = this._renderRow(sessionRun, numDevices, count, isActive, this.soleActive);
+          if (row) {
+            activeRow = row;
+          }
         }
+      }
+
+      if (activeRow) {
+        activeRow.parentNode.parentNode.parentNode.scrollTop = activeRow.offsetTop;
       }
     },
 
@@ -197,6 +204,21 @@ limitations under the License.
       Polymer.dom(this.$$('#session-runs-table')).appendChild(headerRow);
     },
 
+    // Render a row in the session runs table for a session.run().
+    //
+    // Args:
+    //   sessionRun: An object containing information about the session.run(),
+    //     including the feeds, fetches and targets.
+    //   numDevices: Number of devices the session.run() utilizes.
+    //   count: Cumulative count for how many times the session.run() has been
+    //     executed so far.
+    //   isActive: Whether the session.run is currently active.
+    //   soleActive: Whether the session.run is currently the sole active
+    //     session.run.
+    //
+    // Returns:
+    //   If the session.run is currently active, the DOM element for the row.
+    //   Else, no value is returned.
     _renderRow(sessionRun, numDevices, count, isActive, soleActive) {
       const sessionRunRow = document.createElement('tr');
 
@@ -227,6 +249,10 @@ limitations under the License.
       }
 
       Polymer.dom(this.$$('#session-runs-table')).appendChild(sessionRunRow);
+
+      if (isActive) {
+        return sessionRunRow;
+      }
     },
 
     _renderGraphElements(graphElements) {

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
@@ -137,7 +137,7 @@ limitations under the License.
         this._runKey2NumDevices[runKey] = 0;
       }
       this.set('_activeRunKey', runKey);
-      this._renderSessionRunTable();  // TODO(cais): Restore. DO NOT SUBMIT.
+      this._renderSessionRunTable();
     },
 
     updateNumDevices(numDevices) {

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-session-runs-view.html
@@ -171,7 +171,8 @@ limitations under the License.
       }
 
       if (activeRow) {
-        activeRow.parentNode.parentNode.parentNode.scrollTop = activeRow.offsetTop;
+        Polymer.dom(this.$$('#session-runs-table')).parentNode.parentNode.scrollTop =
+            activeRow.offsetTop;
       }
     },
 


### PR DESCRIPTION
* Let the table occupy 100% of the parent's width
* Let the table not expand to unreasonably large sizes if there are
  many session.run() types and/or a session.run() with many fetches
  or feeds
* When the table is scrolled, auto-scroll to the row that corresponds
  to the active session.run().