### PR TITLE
Fix and enhance tooltip logic in vz-bar-chart.ts

### DIFF
--- a/tensorboard/components/vz_bar_chart/vz-bar-chart.html
+++ b/tensorboard/components/vz_bar_chart/vz-bar-chart.html
@@ -88,6 +88,9 @@ Polymer.dom(this.$container).appendChild($chart);
         width: 14px;
         height: 14px;
         display: block;
+        border: 2px solid rgba(0, 0, 0, 0);
+      }
+      .closest .swatch {
         border: 2px solid white;
       }
       th {

--- a/tensorboard/components/vz_bar_chart/vz-bar-chart.ts
+++ b/tensorboard/components/vz_bar_chart/vz-bar-chart.ts
@@ -275,7 +275,7 @@ class BarChart {
       rows.append('td').text((d) => {
         // Convince TypeScript to let us pass off a key-value entry of value
         // type Bar as a Point since that's what TooltipColumn.evaluate wants.
-	// TODO(nickfelt): reconcile the incompatible typing here
+        // TODO(nickfelt): reconcile the incompatible typing here
         const barEntryAsPoint = d as any as vz_chart_helpers.Point;
         return column.evaluate(barEntryAsPoint);
       });

--- a/tensorboard/components/vz_bar_chart/vz-bar-chart.ts
+++ b/tensorboard/components/vz_bar_chart/vz-bar-chart.ts
@@ -266,7 +266,7 @@ class BarChart {
     const rows = this.tooltip.select('tbody')
                    .html('')
                    .selectAll('tr')
-                   .data(formattedPoin ts)
+                   .data(formattedPoints)
                    .enter()
                    .append('tr');
 


### PR DESCRIPTION
This fixes the build breakage due to a few TypeScript compilation errors in the newly introduced vz-bar-chart.ts from PR #1037.  One was a typo and the other was a typing issue with the createTooltipHeaders() function not having type information its tooltipColumns parameter necessary to know it has a .title property.

There were a few other fixes necessary to get the tooltips fully working:
- moved it inside BarChart (where it probably belongs more anyway) so the selection can use `this.tooltip` since it wasn't finding `#tooltip-table-header-row` from the old location
- added the insertion of an initial empty header (for the column that contains the swatches of color to identify different data series).
- as a bonus, I added in the "closest" highlighting behavior from the scalars tooltip chart so that the white border on the colored swatch is only added for the currently hovered bar

Just as an aside, IMO we might want to make the tooltip not be positioned dynamically based on the hovered bar's position, since that means unlike with the scalars tooltip chart, when you move the cursor across the chart the tooltip jumps around, so it's harder to scan for changes in the numeric values.  That would make it more of a "chart tooltip" and less of a "bar tooltip".

Finally, I renamed "points" to "bars" everywhere in the drawTooltips() logic since they really are Bar objects and this was confusing - see the comment I reworded to explain that we are really passing in a `{key: String, value: Bar}` key-value pair into TooltipColumn.evaluate() and just telling TypeScript that it's a Point because that's what the signature requires.

