### PR TITLE
[Debugger Plugin] Fix a python-3 bug

### DIFF
--- a/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
@@ -658,7 +658,7 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
     # of op names and their stack heights are included.
     op_linenos = collections.defaultdict(set)
     for lineno in response_data['lineno_to_op_name_and_stack_pos']:
-      self.assertGreater(lineno, 0)
+      self.assertGreater(int(lineno), 0)
       for op_name, stack_pos in response_data[
           'lineno_to_op_name_and_stack_pos'][lineno]:
         op_linenos[op_name].add(lineno)
@@ -860,7 +860,7 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
         'str1/(str1)', comm_data['data']['maybe_base_expanded_node_name'])
     session_run_thread.join()
     self.assertEqual(1, len(session_run_results))
-    self.assertEqual("abcdef", session_run_results[0])
+    self.assertEqual(b"abcdef", session_run_results[0])
 
     # Get the value of a tensor without mapping.
     tensor_response = self._serverGet(

--- a/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
@@ -410,6 +410,8 @@ class SourceManager(object):
 
   def get_paths(self):
     """Get the paths to all available source files."""
+    # print('source file keys: %s' % self._source_file_content.keys())  # DEBUG
+    # return self._source_file_content.keys()
     return list(self._source_file_content.keys())
 
   def get_content(self, file_path):

--- a/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
@@ -410,7 +410,7 @@ class SourceManager(object):
 
   def get_paths(self):
     """Get the paths to all available source files."""
-    return self._source_file_content.keys()
+    return list(self._source_file_content.keys())
 
   def get_content(self, file_path):
     """Get the content of a source file.


### PR DESCRIPTION
* keys() returns a `dict_keys` object in python-3, which can cause
  errors durinng json serialization sometimes.