### PR TITLE
Reimplement video writing support in Beholder

### DIFF
--- a/tensorboard/plugins/beholder/beholder.py
+++ b/tensorboard/plugins/beholder/beholder.py
@@ -137,7 +137,7 @@ class Beholder(object):
       if not self.is_recording:
         self.is_recording = True
         print('Starting recording using {}'.format(
-            self.video_writer.default_output().name()))
+            self.video_writer.current_output().name()))
       self.video_writer.write_frame(frame)
     elif self.is_recording:
       self.is_recording = False

--- a/tensorboard/plugins/beholder/beholder.py
+++ b/tensorboard/plugins/beholder/beholder.py
@@ -34,9 +34,13 @@ from tensorboard.plugins.beholder.visualizer import Visualizer
 class Beholder(object):
 
   def __init__(self, logdir):
-    self.video_writer = None
-
     self.PLUGIN_LOGDIR = logdir + '/plugins/' + PLUGIN_NAME
+
+    self.video_writer = video_writing.VideoWriter(
+        self.PLUGIN_LOGDIR,
+        outputs=[
+            video_writing.FFmpegVideoOutput,
+            video_writing.PNGVideoOutput])
 
     self.frame_placeholder = tf.placeholder(tf.uint8, [None, None, None])
     self.summary_op = tf.summary.tensor_summary(TAG_NAME,
@@ -124,29 +128,14 @@ class Beholder(object):
 
 
   def _update_recording(self, frame, config):
-    '''Adds a frame to the video using ffmpeg if possible. If not, writes
-    individual frames as png files in a directory.
-    '''
+    '''Adds a frame to the current video output.'''
     # pylint: disable=redefined-variable-type
     is_recording = config['is_recording']
-    filename = self.PLUGIN_LOGDIR + '/video-{}.mp4'.format(time.time())
 
     if is_recording:
-      if self.video_writer is None or frame.shape != self.video_writer.size:
-        try:
-          self.video_writer = video_writing.FFMPEG_VideoWriter(filename,
-                                                               frame.shape,
-                                                               15)
-        except OSError:
-          message = ('Either ffmpeg is not installed, or something else went '
-                     'wrong. Saving individual frames to disk instead.')
-          print(message)
-          self.video_writer = video_writing.PNGWriter(self.PLUGIN_LOGDIR,
-                                                      frame.shape)
       self.video_writer.write_frame(frame)
-    elif not is_recording and self.video_writer is not None:
-      self.video_writer.close()
-      self.video_writer = None
+    elif self.video_writer is not None:
+      self.video_writer.finish()
 
 
   # TODO: blanket try and except for production? I don't someone's script to die

--- a/tensorboard/plugins/beholder/beholder.py
+++ b/tensorboard/plugins/beholder/beholder.py
@@ -136,13 +136,14 @@ class Beholder(object):
     if should_record:
       if not self.is_recording:
         self.is_recording = True
-        print('Starting recording using {}'.format(
-            self.video_writer.current_output().name()))
+        tf.logging.info(
+            'Starting recording using %s',
+            self.video_writer.current_output().name())
       self.video_writer.write_frame(frame)
     elif self.is_recording:
       self.is_recording = False
       self.video_writer.finish()
-      print('Finished recording')
+      tf.logging.info('Finished recording')
 
 
   # TODO: blanket try and except for production? I don't someone's script to die

--- a/tensorboard/plugins/beholder/beholder.py
+++ b/tensorboard/plugins/beholder/beholder.py
@@ -36,6 +36,7 @@ class Beholder(object):
   def __init__(self, logdir):
     self.PLUGIN_LOGDIR = logdir + '/plugins/' + PLUGIN_NAME
 
+    self.is_recording = False
     self.video_writer = video_writing.VideoWriter(
         self.PLUGIN_LOGDIR,
         outputs=[
@@ -130,12 +131,18 @@ class Beholder(object):
   def _update_recording(self, frame, config):
     '''Adds a frame to the current video output.'''
     # pylint: disable=redefined-variable-type
-    is_recording = config['is_recording']
+    should_record = config['is_recording']
 
-    if is_recording:
+    if should_record:
+      if not self.is_recording:
+        self.is_recording = True
+        print('Starting recording using {}'.format(
+            self.video_writer.default_output().name()))
       self.video_writer.write_frame(frame)
-    elif self.video_writer is not None:
+    elif self.is_recording:
+      self.is_recording = False
       self.video_writer.finish()
+      print('Finished recording')
 
 
   # TODO: blanket try and except for production? I don't someone's script to die

--- a/tensorboard/plugins/beholder/video_writing.py
+++ b/tensorboard/plugins/beholder/video_writing.py
@@ -17,6 +17,8 @@ from __future__ import division
 from __future__ import print_function
 
 import abc
+import os
+import subprocess
 import sys
 import time
 
@@ -121,10 +123,18 @@ class FFmpegVideoOutput(VideoOutput):
 
   @classmethod
   def available(cls):
-    return False
+    # Silently check if ffmpeg is available.
+    try:
+      with open(os.devnull, 'wb') as devnull:
+        subprocess.check_call(
+            ['ffmpeg', '-version'], stdout=devnull, stderr=devnull)
+      return True
+    except (OSError, subprocess.CalledProcessError):
+      return False
 
   def __init__(self, directory, frame_shape):
     self.filename = directory + '/video-{}.mp4'.format(time.time())
+    raise OSError('foo')
 
   def emit_frame(self, np_array):
     pass

--- a/tensorboard/plugins/beholder/video_writing.py
+++ b/tensorboard/plugins/beholder/video_writing.py
@@ -47,13 +47,12 @@ class VideoWriter(object):
 
   def _select_output(self):
     for i, output in enumerate(self.outputs):
-      output_type = output.__name__
       if i > 0:
-        sys.stderr.write('Falling back to video output %s\n' % output_type)
+        sys.stderr.write('Falling back to video output %s\n' % output.name())
       try:
         return output(self.directory, self.frame_shape)
       except Exception:
-        sys.stderr.write('Video output type %s not available\n' % output_type)
+        sys.stderr.write('Video output type %s not available\n' % output.name())
         if i == len(self.outputs) - 1:
           raise
 
@@ -81,6 +80,10 @@ class VideoOutput(object):
   @classmethod
   def available(cls):
     raise NotImplementedError()
+
+  @classmethod
+  def name(cls):
+    return cls.__name__
 
   @abc.abstractmethod
   def emit_frame(self, np_array):

--- a/tensorboard/plugins/beholder/video_writing.py
+++ b/tensorboard/plugins/beholder/video_writing.py
@@ -133,11 +133,6 @@ class PNGVideoOutput(VideoOutput):
 class FFmpegVideoOutput(VideoOutput):
   """Video output implemented by streaming to FFmpeg with .mp4 output."""
 
-  FRAME_RATE = 15
-
-  # PNG is well-suited to our image files that are just blocks of color.
-  OUTPUT_CODEC = 'png'
-
   @classmethod
   def available(cls):
     # Silently check if ffmpeg is available.
@@ -150,7 +145,7 @@ class FFmpegVideoOutput(VideoOutput):
       return False
 
   def __init__(self, directory, frame_shape):
-    self.filename = directory + '/video-{}.mp4'.format(time.time())
+    self.filename = directory + '/video-{}.webm'.format(time.time())
     if len(frame_shape) != 3:
       raise ValueError('Expected rank-3 array for frame, got %s' % str(frame_shape))
     sys.stderr.write('Starting video with frame shape: %s\n' % str(frame_shape))
@@ -163,19 +158,20 @@ class FFmpegVideoOutput(VideoOutput):
 
     command = [
         'ffmpeg',
-        '-y',  # overwite output
-        # input options
-        '-f', 'rawvideo',  # input format
-        '-vcodec', 'rawvideo',  # input codec
-        # shape[1] is width, shape[0] is height
-        '-s', '%dx%d' % (frame_shape[1], frame_shape[0]),
+        '-y',  # Overwite output
+        # Input options - raw video file format and codec.
+        '-f', 'rawvideo',
+        '-vcodec', 'rawvideo',
+        '-s', '%dx%d' % (frame_shape[1], frame_shape[0]),  # Width x height.
         '-pix_fmt', pix_fmt,
-        '-r', '%d' % self.FRAME_RATE,
-        '-i', '-',  # use stdin
-        '-an',  # no audio
-        # output options
-        '-vcodec', 'libx264',#self.OUTPUT_CODEC,  # output format
-        '-pix_fmt', 'yuv420p',#rgb24',
+        '-r', '15',  # Frame rate: arbitrarily use 15 frames per second.
+        '-i', '-',  # Use stdin.
+        '-an',  # No audio.
+        # Output options - use lossless VP9 codec inside .webm.
+        '-vcodec', 'libvpx-vp9',
+        '-lossless', '1',
+        # Using YUV is most compatible, though conversion from RGB skews colors.
+        '-pix_fmt', 'yuv420p',
         self.filename
     ]
     PIPE = subprocess.PIPE

--- a/tensorboard/plugins/beholder/video_writing.py
+++ b/tensorboard/plugins/beholder/video_writing.py
@@ -12,4 +12,119 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(@jart): Rewrite me.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import abc
+import sys
+import time
+
+import numpy as np
+import tensorflow as tf
+
+from tensorboard.plugins.beholder import im_util
+
+
+class VideoWriter(object):
+  """Video file writer that can use different output types.
+
+  Each VideoWriter instance writes video files to a specified directory, using
+  the first available VideoOutput from the provided list.
+  """
+
+  def __init__(self, directory, outputs):
+    self.directory = directory
+    # Filter to the available outputs
+    self.outputs = [out for out in outputs if out.available()]
+    if not self.outputs:
+      raise Exception('No available video outputs')
+    self.output = None
+    self.frame_shape = None
+
+  def default_output(self):
+    return self.outputs[0]
+
+  def _select_output(self):
+    for i, output in enumerate(self.outputs):
+      output_type = output.__name__
+      if i > 0:
+        sys.stderr.write('Falling back to video output %s\n' % output_type)
+      try:
+        return output(self.directory, self.frame_shape)
+      except Exception:
+        sys.stderr.write('Video output type %s not available\n' % output_type)
+        if i == len(self.outputs) - 1:
+          raise
+
+  def write_frame(self, np_array):
+    if self.frame_shape != np_array.shape:
+      if self.output:
+        self.output.close()
+      self.frame_shape = np_array.shape
+      self.output = self._select_output()
+    self.output.emit_frame(np_array)
+
+  def finish(self):
+    if self.output:
+      self.output.close()
+    self.output = None
+    self.frame_shape = None
+
+
+class VideoOutput(object):
+  """Base class for video outputs supported by VideoWriter."""
+
+  __metaclass__ = abc.ABCMeta
+
+  # Would add @abc.abstractmethod in python 3.3+
+  @classmethod
+  def available(cls):
+    raise NotImplementedError()
+
+  @abc.abstractmethod
+  def emit_frame(self, np_array):
+    raise NotImplementedError()
+
+  @abc.abstractmethod
+  def close(self):
+    raise NotImplementedError()
+
+
+class PNGVideoOutput(VideoOutput):
+  """Video output implemented by writing individual PNGs to disk."""
+
+  @classmethod
+  def available(cls):
+    return True
+
+  def __init__(self, directory, frame_shape):
+    del frame_shape  # unused
+    self.directory = directory + '/video-frames-{}'.format(time.time())
+    self.frame_num = 0
+    tf.gfile.MakeDirs(self.directory)
+
+  def emit_frame(self, np_array):
+    filename = self.directory + '/{:05}.png'.format(self.frame_num)
+    im_util.write_image(np_array.astype(np.uint8), filename)
+    self.frame_num += 1
+
+  def close(self):
+    pass
+
+
+class FFmpegVideoOutput(VideoOutput):
+  """Video output implemented by streaming to FFmpeg with .mp4 output."""
+
+  @classmethod
+  def available(cls):
+    return False
+
+  def __init__(self, directory, frame_shape):
+    self.filename = directory + '/video-{}.mp4'.format(time.time())
+
+  def emit_frame(self, np_array):
+    pass
+
+  def close(self):
+    pass


### PR DESCRIPTION
This change reimplements video writing in Beholder.  The new API consists of a VideoWriter class that takes a list of VideoOutput types.  When sending a frame to VideoWriter, it handles cascading through the list of outputs until it finds one that works, as well as re-initializing an output if the frame size changes, which lets us simplify logic in Beholder itself.

Right now there are only two VideoOutputs implemented.  The primary one is FFmpegVideoOutput which uses a subprocess call to FFmpeg and currently is hardcoded to generate lossless-VP9-encoded video wrapped in a .webm container at 15 FPS.  As a fallback that should work in just about any scenario, PNGVideoOutput writes individual frames as PNG files to disk using TensorFlow's own `encode_png()` op.

A note on codecs: previous versions of Beholder used the H.264 codec and .mp4 which has slightly wider support (in particular, it's supported by Internet Explorer and Safari).  I opted instead for VP9 and .webm for several reasons:
- VP9 at least in FFmpeg accepts odd values for width and height, while H.264 requires both values to be even, which is inconvenient since the frame sizes are completely user-controlled
- VP9 has a easy `-lossless 1` option while configuring H.264 for lossless encoding is more complicated and support is unclear; lossless encoding is a nice feature for us since our video data is not regular video and so typical compression algorithms will perform poorly (akin to .JPG-encoding a screenshot)
- VP9 and .webm are completely open and royalty-free; H.264 has some baggage

I tested the codec performance by encoding about 500 frames of the Beholder demo "arrays" output, which has a 768x1857 resolution per frame that would be 1.5-4.5 MB uncompressed (depending on whether we consider one pixel to be an original single uint8 or three bytes of RGB as rendered after colormap application).  The resulting video file is 74 MB, so that's about a 10:1 or greater compression ratio, which isn't fantastic but seems sufficient for now.  We can always experiment with other output settings in the future.