### PR TITLE
Re-enable travis testing for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ sudo: required
 language: python
 python:
   - "2.7"
-  # TODO(jart): Re-enable when TensorFlow builds are fixed.
-  # - "3.4"
+  - "3.6"
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
         pip install -I tensorflow
         ;;
       NIGHTLY)
-        pip install --no-cache-dir -I https://tensorboard-builds.storage.googleapis.com/tf_nightly_cpu_slow_ubuntu14-123-cp27-cp27mu-linux_x86_64.whl
+        pip install -I tf-nightly
         ;;
       *)
         pip install -I tensorflow=="${TF}"

--- a/tensorboard/plugins/debugger/BUILD
+++ b/tensorboard/plugins/debugger/BUILD
@@ -58,6 +58,7 @@ py_test(
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins/beholder:im_util",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/plugins/debugger/tensor_helper_test.py
+++ b/tensorboard/plugins/debugger/tensor_helper_test.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import base64
 
 import numpy as np
+import six
 import tensorflow as tf
 
 from tensorboard.plugins.beholder import im_util
@@ -117,14 +118,14 @@ class TensorHelperTest(tf.test.TestCase):
 
   def testImagePngMappingRaisesExceptionForEmptyArray(self):
     x = np.zeros([0, 0])
-    with self.assertRaisesRegexp(
-        ValueError, r"Cannot encode an empty array .* \(0, 0\)"):
+    with six.assertRaisesRegex(
+        self, ValueError, r"Cannot encode an empty array .* \(0, 0\)"):
       tensor_helper.array_view(x, mapping="image/png")
 
   def testImagePngMappingRaisesExceptionForNonRank2Array(self):
     x = np.ones([2, 2, 2])
-    with self.assertRaisesRegexp(
-        ValueError, r"Expected rank-2 array; received rank-3 array"):
+    with six.assertRaisesRegex(
+        self, ValueError, r"Expected rank-2 array; received rank-3 array"):
       tensor_helper.array_to_base64_png(x)
 
 


### PR DESCRIPTION
Re-enable Travis for Python 3.x, and use Python 3.6 since that's the most recent version TF supports.