### PR TITLE
Make "from tensorboard.plugins.beholder import Beholder" work

### DIFF
--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -14,13 +14,10 @@ sh_binary(
         "README.rst",
         "setup.cfg",
         "setup.py",
-        # Main tensorboard binary and everything it uses
-        "//tensorboard",
-        # User-facing python library ('import tensorboard')
-        "//tensorboard:lib",
-        # Version module (read by setup.py)
-        "//tensorboard:version",
-        # User-facing projector API ('import tensorboard.plugins.projector')
-        "//tensorboard/plugins/projector",
+        "//tensorboard",  # Main tensorboard binary and everything it uses
+        "//tensorboard:lib",  # User-facing overall TensorBoard API
+        "//tensorboard:version",  # Version module (read by setup.py)
+        "//tensorboard/plugins/beholder",  # User-facing beholder API
+        "//tensorboard/plugins/projector",  # User-facing projector API
     ],
 )

--- a/tensorboard/pip_package/pip_smoke_test.sh
+++ b/tensorboard/pip_package/pip_smoke_test.sh
@@ -131,6 +131,7 @@ TEST_API_CALL="
 import tensorboard as tb
 tb.summary.scalar_pb('test', 42)
 from tensorboard.plugins.projector import visualize_embeddings
+from tensorboard.plugins.beholder import Beholder, BeholderHook
 "
 
 echo "  python>>> $TEST_API_CALL"

--- a/tensorboard/plugins/beholder/BUILD
+++ b/tensorboard/plugins/beholder/BUILD
@@ -9,7 +9,10 @@ exports_files(["LICENSE"])
 
 py_library(
     name = "beholder",
-    srcs = ["beholder.py"],
+    srcs = [
+        "__init__.py",
+        "beholder.py",
+    ],
     data = ["resources"],
     srcs_version = "PY2AND3",
     deps = [

--- a/tensorboard/plugins/beholder/__init__.py
+++ b/tensorboard/plugins/beholder/__init__.py
@@ -11,3 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from tensorboard.plugins.beholder.beholder import Beholder
+from tensorboard.plugins.beholder.beholder import BeholderHook

--- a/tensorboard/plugins/beholder/beholder.py
+++ b/tensorboard/plugins/beholder/beholder.py
@@ -208,10 +208,10 @@ class BeholderHook(tf.train.SessionRunHook):
       logdir: Directory where Beholder is to write data.
     """
     self._logdir = logdir
-    self.visualizer = None
+    self.beholder = None
 
   def begin(self):
-    self.visualizer = Beholder(self._logdir)
+    self.beholder = Beholder(self._logdir)
 
   def after_run(self, run_context, unused_run_values):
-    self.visualizer.update(run_context.session)
+    self.beholder.update(run_context.session)

--- a/tensorboard/plugins/beholder/beholder_demo.py
+++ b/tensorboard/plugins/beholder/beholder_demo.py
@@ -25,9 +25,8 @@ import argparse
 import sys
 
 import tensorflow as tf
-from tensorflow.examples.tutorials.mnist import input_data
-
-from tensorboard.plugins.beholder.beholder import Beholder
+import tensorflow.examples.tutorials.mnist as mnist
+import tensorboard.plugins.beholder as beholder
 
 FLAGS = None
 
@@ -35,9 +34,8 @@ LOG_DIRECTORY = '/tmp/beholder-demo'
 
 
 def train():
-  mnist = input_data.read_data_sets(FLAGS.data_dir,
-                                    one_hot=True,
-                                    fake_data=FLAGS.fake_data)
+  mnist_data = mnist.input_data.read_data_sets(
+      FLAGS.data_dir, one_hot=True, fake_data=FLAGS.fake_data)
 
   sess = tf.InteractiveSession()
 
@@ -136,7 +134,8 @@ def train():
 
   with tf.name_scope('train'):
     optimizer = tf.train.AdamOptimizer(FLAGS.learning_rate)
-    gradients, train_step = Beholder.gradient_helper(optimizer, cross_entropy)
+    gradients, train_step = beholder.Beholder.gradient_helper(
+        optimizer, cross_entropy)
 
   with tf.name_scope('accuracy'):
     with tf.name_scope('correct_prediction'):
@@ -150,15 +149,15 @@ def train():
   test_writer = tf.summary.FileWriter(LOG_DIRECTORY + '/test')
   tf.global_variables_initializer().run()
 
-  visualizer = Beholder(logdir=LOG_DIRECTORY)
+  visualizer = beholder.Beholder(logdir=LOG_DIRECTORY)
 
 
   def feed_dict(is_train):
     if is_train or FLAGS.fake_data:
-      xs, ys = mnist.train.next_batch(100, fake_data=FLAGS.fake_data)
+      xs, ys = mnist_data.train.next_batch(100, fake_data=FLAGS.fake_data)
       k = FLAGS.dropout
     else:
-      xs, ys = mnist.test.images, mnist.test.labels
+      xs, ys = mnist_data.test.images, mnist_data.test.labels
       k = 1.0
     return {x: xs, y_: ys, keep_prob: k}
 


### PR DESCRIPTION
This imports Beholder and BeholderHook into the top-level `tensorboard.plugins.beholder` module so we can use that distinction to emphasize what parts of that package are public vs "internal".  I also changed the pip package BUILD rule and smoke test to include the beholder build target, so that `tensorboard.plugins.beholder` will actually be included with our pip package.

Updated the demo to use this import style.  Doc updates to come in a future PR.