### PR TITLE
Make streaming_op for PR curves use tf.group.

### DIFF
--- a/tensorboard/plugins/pr_curve/summary.py
+++ b/tensorboard/plugins/pr_curve/summary.py
@@ -328,8 +328,10 @@ def streaming_op(name,
           collections)
 
     pr_curve = compute_summary(tp, fp, tn, fn, metrics_collections)
-    update_op = compute_summary(update_tp, update_fp, update_tn, update_fn,
-                                updates_collections)
+    update_op = tf.group(update_tp, update_fp, update_tn, update_fn)
+    if updates_collections:
+      for collection in updates_collections:
+        tf.add_to_collection(collection, update_op)
 
     return pr_curve, update_op
 

--- a/tensorboard/plugins/pr_curve/summary_test.py
+++ b/tensorboard/plugins/pr_curve/summary_test.py
@@ -405,13 +405,13 @@ class StreamingOpTest(tf.test.TestCase):
 
   def test_only_1_summary_generated(self):
     """Tests that the streaming op only generates 1 summary for PR curves.
-    
+
     This test was made in response to a bug in which calling the streaming op
     actually introduced 2 tags.
     """
     predictions = tf.constant([0.2, 0.4, 0.5, 0.6, 0.8], dtype=tf.float32)
     labels = tf.constant([False, True, True, False, True], dtype=tf.bool)
-    pr_curve, update_op = summary.streaming_op(name='pr_curve',
+    _, update_op = summary.streaming_op(name='pr_curve',
                                                predictions=predictions,
                                                labels=labels,
                                                num_thresholds=10)

--- a/tensorboard/plugins/pr_curve/summary_test.py
+++ b/tensorboard/plugins/pr_curve/summary_test.py
@@ -412,9 +412,9 @@ class StreamingOpTest(tf.test.TestCase):
     predictions = tf.constant([0.2, 0.4, 0.5, 0.6, 0.8], dtype=tf.float32)
     labels = tf.constant([False, True, True, False, True], dtype=tf.bool)
     _, update_op = summary.streaming_op(name='pr_curve',
-                                               predictions=predictions,
-                                               labels=labels,
-                                               num_thresholds=10)
+                                        predictions=predictions,
+                                        labels=labels,
+                                        num_thresholds=10)
     with self.test_session() as sess:
       sess.run(tf.local_variables_initializer())
       sess.run(update_op)

--- a/tensorboard/plugins/pr_curve/summary_test.py
+++ b/tensorboard/plugins/pr_curve/summary_test.py
@@ -403,6 +403,28 @@ class StreamingOpTest(tf.test.TestCase):
 
       self.assertProtoEquals(expected_proto, proto)
 
+  def test_only_1_summary_generated(self):
+    """Tests that the streaming op only generates 1 summary for PR curves.
+    
+    This test was made in response to a bug in which calling the streaming op
+    actually introduced 2 tags.
+    """
+    predictions = tf.constant([0.2, 0.4, 0.5, 0.6, 0.8], dtype=tf.float32)
+    labels = tf.constant([False, True, True, False, True], dtype=tf.bool)
+    pr_curve, update_op = summary.streaming_op(name='pr_curve',
+                                               predictions=predictions,
+                                               labels=labels,
+                                               num_thresholds=10)
+    with self.test_session() as sess:
+      sess.run(tf.local_variables_initializer())
+      sess.run(update_op)
+      summary_proto = tf.Summary()
+      summary_proto.ParseFromString(sess.run(tf.summary.merge_all()))
+
+    tags = [v.tag for v in summary_proto.value]
+    # Only 1 tag should have been introduced.
+    self.assertEqual(['pr_curve/pr_curves'], tags)
+
 
 if __name__ == "__main__":
   tf.test.main()


### PR DESCRIPTION
Previously, the streaming op for computing PR curves had relied on the
`tensor_summary` method to both produce a single update op to return as
well as add the update ops to various collections. That turned out
problematic since it wrote a duplicate summary, yielding an extra PR
curve plot in TensorBoard.

We now use a `tf.group` op and manually add individual update ops to
each collection.

Fixes #965.