### PR TITLE
Fix frontend logic to use vz_chart_helpers module

### DIFF
--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -259,7 +259,7 @@ limitations under the License.
 
         /**
          * This property must take on values from the XType enum defined within
-         * the vz_line_chart component.
+         * the vz_chart_helpers component.
          */
         xType: String,
 
@@ -386,16 +386,17 @@ limitations under the License.
               },
               {
                 title: 'Step',
-                evaluate: (d) => vz_line_chart.stepFormatter(d.datum.step),
+                evaluate: (d) => vz_chart_helpers.stepFormatter(d.datum.step),
               },
               {
                 title: 'Time',
-                evaluate: (d) => vz_line_chart.timeFormatter(d.datum.wall_time),
+                evaluate: (d) => vz_chart_helpers.timeFormatter(
+                    d.datum.wall_time),
               },
               {
                 title: 'Relative',
-                evaluate: (d) => vz_line_chart.relativeFormatter(
-                    vz_line_chart.relativeAccessor(d.datum, -1, d.dataset)),
+                evaluate: (d) => vz_chart_helpers.relativeFormatter(
+                    vz_chart_helpers.relativeAccessor(d.datum, -1, d.dataset)),
               },
             ];
           }

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -225,8 +225,8 @@ limitations under the License.
           type: Array,
           readOnly: true,
           value: () => {
-            const valueFormatter = vz_line_chart.multiscaleFormatter(
-                vz_line_chart.Y_TOOLTIP_FORMATTER_PRECISION);
+            const valueFormatter = vz_chart_helpers.multiscaleFormatter(
+                vz_chart_helpers.Y_TOOLTIP_FORMATTER_PRECISION);
             const formatValueOrNaN =
                 (x) => isNaN(x) ? 'NaN' : valueFormatter(x);
             return [

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -167,7 +167,7 @@ limitations under the License.
         tag: String,
 
         /**
-         * @type {vz_line_chart.XType}
+         * @type {vz_chart_helpers.XType}
          */
         xType: String,
 


### PR DESCRIPTION
PR #1033 had forgotten to migrate `tf-pr-curve-card.html` and `tf-custom-scalar-margin-chart-card.html` to use the `vz_chart_helpers` component.