### PR TITLE
Remove loop by default from audio summary.

### DIFF
--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
@@ -76,7 +76,6 @@ backend.
     <template is="dom-if" if="[[_hasAtLeastOneStep]]">
       <audio
         controls
-        loop="loop"
         src$="[[_currentDatum.url]]"
         type$="[[_currentDatum.contentType]]"
       ></audio>


### PR DESCRIPTION
Easier when there are multiple audio samples on a summary page that is user is listening to.

More discussion at:
https://github.com/tensorflow/tensorboard/issues/296

cc @rryan 