### PR TITLE
Suppress py3 pylint import order false positive

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -30,7 +30,7 @@ import threading
 import time
 
 import six
-from six.moves.urllib import parse as urlparse
+from six.moves.urllib import parse as urlparse  # pylint: disable=wrong-import-order
 import tensorflow as tf
 from werkzeug import wrappers
 


### PR DESCRIPTION
I'm not sure why the py3 Travis tests didn't catch this on the original PR, but evidently this snuck through somehow.  I believe this is a false positive where the import order logic is apparently silly enough to decide that just because we're calling the import `urlparse` that makes it a standard library import, even though the actual package we're importing from is `six`.

Note that this only happens for py3 pylint, which is even weirder, since in python 3 `urlparse` is no longer even a package in the standard library, which is the whole point of that `six` import anyway...