### PR TITLE
 Make Beholder fail gracefully on non-writable config file

### DIFF
--- a/tensorboard/plugins/beholder/README.md
+++ b/tensorboard/plugins/beholder/README.md
@@ -150,4 +150,9 @@ start a new recording.
 
 Beholder has the following limitations and known issues.
 
+* Beholder requires write access to the log directory (specifically, to the
+  `$LOGDIR/plugins/beholder` subdirectory) in order to pass config and
+  visualization parameters to the running code.  If the config file location
+  is not writable, the UI controls will be disabled.
+
 * Beholder currently only works well on local file systems.

--- a/tensorboard/plugins/beholder/beholder_plugin.py
+++ b/tensorboard/plugins/beholder/beholder_plugin.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import threading
 import time
 
 import numpy as np
@@ -47,13 +48,7 @@ class BeholderPlugin(base_plugin.TBPlugin):
     self.most_recent_info = [{
         'name': 'Waiting for data...',
     }]
-
-    if not tf.gfile.Exists(self.PLUGIN_LOGDIR):
-      tf.gfile.MakeDirs(self.PLUGIN_LOGDIR)
-      file_system_tools.write_pickle(
-          shared_config.DEFAULT_CONFIG,
-          '{}/{}'.format(self.PLUGIN_LOGDIR, shared_config.CONFIG_FILENAME))
-
+    self._config_file_lock = threading.Lock()
 
   def get_plugin_apps(self):
     return {
@@ -61,10 +56,8 @@ class BeholderPlugin(base_plugin.TBPlugin):
         '/beholder-frame': self._serve_beholder_frame,
         '/section-info': self._serve_section_info,
         '/ping': self._serve_ping,
-        '/tags': self._serve_tags,
         '/is-active': self._serve_is_active,
     }
-
 
   def is_active(self):
     summary_filename = '{}/{}'.format(
@@ -74,12 +67,34 @@ class BeholderPlugin(base_plugin.TBPlugin):
     return tf.gfile.Exists(summary_filename) and\
            tf.gfile.Exists(info_filename)
 
+  def is_config_writable(self):
+    try:
+      if not tf.gfile.Exists(self.PLUGIN_LOGDIR):
+        tf.gfile.MakeDirs(self.PLUGIN_LOGDIR)
+      config_filename = '{}/{}'.format(
+          self.PLUGIN_LOGDIR, shared_config.CONFIG_FILENAME)
+      with self._config_file_lock:
+        file_system_tools.write_pickle(
+            file_system_tools.read_pickle(
+                config_filename, shared_config.DEFAULT_CONFIG),
+            config_filename)
+      return True
+    except tf.errors.PermissionDeniedError as e:
+      tf.logging.warning(
+          'Unable to write Beholder config, controls will be disabled: %s', e)
+      return False
 
   @wrappers.Request.application
   def _serve_is_active(self, request):
-    return http_util.Respond(request,
-                             {'is_active': self.is_active()},
-                             'application/json')
+    is_active = self.is_active()
+    # If the plugin isn't active, don't check if the configuration is writable
+    # since that will leave traces on disk; instead return True (the default).
+    is_config_writable = self.is_config_writable() if is_active else True
+    response = {
+        'is_active': is_active,
+        'is_config_writable': is_config_writable,
+    }
+    return http_util.Respond(request, response, 'application/json')
 
 
   def _fetch_current_frame(self):
@@ -92,22 +107,6 @@ class BeholderPlugin(base_plugin.TBPlugin):
 
     except (message.DecodeError, IOError, tf.errors.NotFoundError):
       return self.most_recent_frame
-
-
-  @wrappers.Request.application
-  def _serve_tags(self, request):
-    if self.is_active:
-      runs_and_tags = {
-          'plugins/{}'.format(shared_config.PLUGIN_NAME): {
-              'tensors': [shared_config.TAG_NAME]
-          }
-      }
-    else:
-      runs_and_tags = {}
-
-    return http_util.Respond(request,
-                             runs_and_tags,
-                             'application/json')
 
 
   @wrappers.Request.application
@@ -127,9 +126,10 @@ class BeholderPlugin(base_plugin.TBPlugin):
 
     self.FPS = config['FPS']
 
-    file_system_tools.write_pickle(
-        config,
-        '{}/{}'.format(self.PLUGIN_LOGDIR, shared_config.CONFIG_FILENAME))
+    with self._config_file_lock:
+      file_system_tools.write_pickle(
+          config,
+          '{}/{}'.format(self.PLUGIN_LOGDIR, shared_config.CONFIG_FILENAME))
     return http_util.Respond(request, {'config': config}, 'application/json')
 
 

--- a/tensorboard/plugins/beholder/file_system_tools.py
+++ b/tensorboard/plugins/beholder/file_system_tools.py
@@ -53,8 +53,9 @@ def read_pickle(path, default=None):
     with tf.gfile.Open(path, 'rb') as pickle_file:
       result = pickle.load(pickle_file)
 
-  except (IOError, EOFError, ValueError, tf.errors.NotFoundError):
-    # TODO: log this somehow? Could swallow errors I don't intend.
+  except (IOError, EOFError, ValueError, tf.errors.NotFoundError) as e:
+    if not isinstance(e, tf.errors.NotFoundError):
+      tf.logging.error('Error reading pickle value: %s', e)
     if default is not None:
       result = default
     else:

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -29,22 +29,35 @@ limitations under the License.
 
 <dom-module id="tf-beholder-dashboard">
   <template>
-    <paper-dialog with-backdrop id="actual-image-size-dialog"></paper-dialog>
     <tf-dashboard-layout>
       <div class="sidebar">
-
+        <template is="dom-if" if="[[_controls_disabled]]">
+          <div class="sidebar-section">
+            <p class="controls-disabled-message">
+              Controls disabled: directory is not writeable.
+            </p>
+            <p class="disclaimer">
+              Beholder requires write access to the log directory in order
+              to communicate visualization changes to the <code>Beholder</code>
+              instance in your model.
+            </p>
+          </div>
+        </template>
         <div class="sidebar-section">
           <div class="title">Values</div>
           <paper-radio-group
             id="valuesSelector"
             selected="{{_values}}">
-            <paper-radio-button name="trainable_variables">
+            <paper-radio-button name="trainable_variables"
+                                disabled="[[_controls_disabled]]">
               <pre>tf.trainable_variables()</pre>
             </paper-radio-button>
-            <paper-radio-button id="option-arrays" name="arrays">
+            <paper-radio-button id="option-arrays" name="arrays"
+                                disabled="[[_controls_disabled]]">
               <pre>b.update(arrays=[NP_ARRAYS])</pre>
             </paper-radio-button>
-            <paper-radio-button id="option-frames" name="frames">
+            <paper-radio-button id="option-frames" name="frames"
+                                disabled="[[_controls_disabled]]">
               <pre>b.update(frame=NP_ARRAY)</pre>
             </paper-radio-button>
           </paper-radio-group>
@@ -52,6 +65,7 @@ limitations under the License.
           <template is="dom-if" if="[[_valuesNotFrame(_values)]]">
             <paper-checkbox
               checked="{{_showAll}}"
+              disabled="[[_controls_disabled]]"
             >Show all data <i>(can be resource intensive)</i></paper-checkbox>
           </template>
         </div>
@@ -61,10 +75,12 @@ limitations under the License.
           <div class="sidebar-section">
             <div class="title">Mode</div>
             <paper-radio-group id="modeSelector" selected="{{_mode}}">
-              <paper-radio-button name="current">
+              <paper-radio-button name="current"
+                                  disabled="[[_controls_disabled]]">
                 current values
               </paper-radio-button>
-              <paper-radio-button name="variance">
+              <paper-radio-button name="variance"
+                                  disabled="[[_controls_disabled]]">
                 variance over train steps
               </paper-radio-button>
             </paper-radio-group>
@@ -77,7 +93,8 @@ limitations under the License.
                 step="1"
                 min="2"
                 max="20"
-                pin="true">
+                pin="true"
+                disabled="[[_controls_disabled]]">
               </paper-slider>
             </template>
           </div>
@@ -86,14 +103,16 @@ limitations under the License.
             <div class="title">Image scaling</div>
             <paper-radio-group id="scalingSelector" selected="{{_scaling}}">
 
-              <paper-radio-button id="option-layer" name="layer">
+              <paper-radio-button id="option-layer" name="layer"
+                                  disabled="[[_controls_disabled]]">
                 per section
               </paper-radio-button>
               <paper-tooltip for="option-layer" position="right">
                 Black is the lowest value in that section, white is that largest value in that section.
               </paper-tooltip>
 
-              <paper-radio-button id="option-network" name="network">
+              <paper-radio-button id="option-network" name="network"
+                                  disabled="[[_controls_disabled]]">
                 all sections
               </paper-radio-button>
               <paper-tooltip for="option-network" position="right">
@@ -106,6 +125,7 @@ limitations under the License.
               <paper-dropdown-menu
                 no-label-float
                 selected-item-label="{{_colormap}}"
+                disabled="[[_controls_disabled]]"
               >
                 <paper-menu class="dropdown-content" selected="0">
                   <paper-item>magma</paper-item>
@@ -129,7 +149,8 @@ limitations under the License.
             step="1"
             min="0"
             max="30"
-            pin="true">
+            pin="true"
+            disabled="[[_controls_disabled]]">
           </paper-slider>
         </div>
 
@@ -137,7 +158,8 @@ limitations under the License.
           <paper-button
             class="x-button"
             id="record_button"
-            on-tap="_toggleRecord">
+            on-tap="_toggleRecord"
+            disabled="[[_controls_disabled]]">
             [[_recordText]]
           </paper-button>
         </div>
@@ -288,6 +310,11 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
         font-style: italic;
       }
 
+      p.controls-disabled-message {
+        color: #C00;
+        font-weight: bold;
+      }
+
     </style>
   </template>
   <script>
@@ -369,6 +396,13 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
         _is_active: {
           type: Boolean,
           value: false,
+          observer: '_configChanged',
+        },
+
+        _controls_disabled: {
+          type: Boolean,
+          value: false,
+          observer: '_configChanged',
         },
       },
 
@@ -381,6 +415,11 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
       },
 
       _configChanged() {
+        // Skip recording config unless we're active and controls are enabled.
+        if (!this._is_active || this._controls_disabled) {
+          return;
+        }
+
         // In case we aren't finished initializing yet.
         const properties = [
           this._values,
@@ -434,7 +473,8 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
         const url = tf_backend.getRouter().pluginRoute(PLUGIN_NAME, '/is-active');
 
         this._requestManager.request(url).then(response => {
-          this.set('_is_active', response['is_active'])
+          this.set('_is_active', response['is_active']);
+          this.set('_controls_disabled', !response['is_config_writable']);
         })
       },
     });


### PR DESCRIPTION
This change makes Beholder fail gracefully if it can't write a config file.  Previously the plugin attempted to write a default config file to the log directory as early as `__init__()`, so any error on writing the file (e.g. a permissions error on a read-only directory) would kill TensorBoard.

With this change, Beholder only attempts to write a config file if it's already determined that it should be active (i.e. if the `Beholder` class in the model code is writing data).  This ensures that users who aren't intending to use Beholder won't have their log directories written to at all, which avoids leaving "junk" in those directories and ensures that they won't be impacted by missing write permissions.

As a further convenience, we also rewire the Beholder frontend controls to accept a disabled parameter and make the backend indicate that the controls should be disabled when it's unable to write out the config file, which should help reduce user confusion as to why the controls wouldn't be working in a case like this.  When in that state, the control panel looks like this:

![image](https://user-images.githubusercontent.com/710113/37800384-d7f2ba2e-2ddf-11e8-9582-0802fa1a5b8e.png)



