### PR TITLE
Add option to have dashboard DOM be removable

### DIFF
--- a/tensorboard/components/tf_tensorboard/registry.ts
+++ b/tensorboard/components/tf_tensorboard/registry.ts
@@ -53,6 +53,13 @@ export interface Dashboard {
    * reload() method to be called every few seconds will be disabled.
    */
   isReloadDisabled: boolean;
+
+  /**
+   * Whether or not plugin DOM should be removed when navigated away.
+   *
+   * This allows the Polymer 'detached' event to happen.
+   */
+  shouldRemoveDom: boolean;
 }
 
 /** Typedef mapping plugin names to Dashboard registrations. */

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -457,6 +457,7 @@ limitations under the License.
           value: tf_storage.getString(tf_storage.TAB, /*useLocalStorage=*/false) || null,
           observer: '_selectedDashboardChanged'
         },
+        _dashboardToMaybeRemove: String,
 
         /*
          * Will be set to `true` once our DOM is ready: in particular,
@@ -627,6 +628,16 @@ limitations under the License.
                                       selectedDashboard) {
         if (!containersStamped || !activeDashboards || !selectedDashboard) {
           return;
+        }
+        const previous = this._dashboardToMaybeRemove;
+        this._dashboardToMaybeRemove = selectedDashboard;
+        if (previous && previous != selectedDashboard) {
+          if (tf_tensorboard.dashboardRegistry[previous].shouldRemoveDom) {
+            const div = this.$$(`.dashboard-container[data-dashboard=${previous}]`);
+            if (div.firstChild) {
+              div.firstChild.remove();
+            }
+          }
         }
         const container = this.$$(
             `.dashboard-container[data-dashboard=${selectedDashboard}]`);


### PR DESCRIPTION
This will allow the Polymer 'detached' event to fire when navigating away from
certain plugin tabs, e.g. Beholder, thereby allowing timers and such to be
cleaned up.