### PR TITLE
Avoid Beholder network usage while video is off-screen

### DIFF
--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -215,6 +215,7 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
         <template is="dom-if" if="[[_is_active]]">
           <tf-beholder-video
             id="video"
+            show-stream="[[_shouldShowVideo]]"
             is-live="[[_isLive]]">
           </tf-beholder-video>
           <template is="dom-if" if="[[_valuesNotFrame(_values)]]">
@@ -413,6 +414,12 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
           computed: '_computeIsLive(_isSelected, _is_active, _FPS)',
         },
 
+        _shouldShowVideo: {
+          type: Boolean,
+          value: true,
+          computed: '_computeShouldShowVideo(_isSelected, _is_active)',
+        },
+
         _controls_disabled: {
           type: Boolean,
           value: false,
@@ -513,6 +520,10 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
 
       _computeIsLive(isSelected, isActive, fps) {
         return isSelected && isActive && fps > 0;
+      },
+
+      _computeShouldShowVideo(isSelected, isActive) {
+        return isSelected && isActive;
       },
     });
     })();

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -213,12 +213,15 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
         </template>
 
         <template is="dom-if" if="[[_is_active]]">
-          <tf-beholder-video id="video"></tf-beholder-video>
-
+          <tf-beholder-video
+            id="video"
+            is-live="[[_isLive]]">
+          </tf-beholder-video>
           <template is="dom-if" if="[[_valuesNotFrame(_values)]]">
             <tf-beholder-info
               id="info"
-              fps="[[_FPS]]">
+              fps="[[_FPS]]"
+              is-live="[[_isLive]]">
             </tf-beholder-info>
           </template>
         </template>
@@ -404,6 +407,12 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
           observer: '_configChanged',
         },
 
+        _isLive: {
+          type: Boolean,
+          value: false,
+          computed: '_computeIsLive(_isSelected, _is_active, _FPS)',
+        },
+
         _controls_disabled: {
           type: Boolean,
           value: false,
@@ -500,6 +509,10 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
           this.set('_is_active', response['is_active']);
           this.set('_controls_disabled', !response['is_config_writable']);
         })
+      },
+
+      _computeIsLive(isSelected, isActive, fps) {
+        return isSelected && isActive && fps > 0;
       },
     });
     })();

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -393,6 +393,11 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
           observer: '_configChanged'
         },
 
+        _isSelected: {
+          type: Boolean,
+          value: false,
+        },
+
         _is_active: {
           type: Boolean,
           value: false,
@@ -465,8 +470,27 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
         this.$.record_button.classList.toggle('is-recording')
       },
 
-      ready() {
-        this.reload()
+      attached() {
+        this._setupSelectedObserver();
+        this.reload();
+      },
+
+      // TODO(nickfelt): more elegant to implement as a 'selected' property
+      // bound directly on the dashboard element by logic in tf-tensorboard.
+      _setupSelectedObserver() {
+        const handleSelectedMutation = mutationRecords => {
+          mutationRecords.forEach(record => {
+            this.set(
+                '_isSelected', record.target.hasAttribute('data-selected'));
+          });
+        };
+        const options = {};
+        options.attributes = true;
+        options.attributeFilter = ['data-selected'];
+        new MutationObserver(handleSelectedMutation.bind(this)).observe(
+            this.parentNode, options);
+        this.set(
+            '_isSelected', this.parentNode.hasAttribute('data-selected'));
       },
 
       reload() {

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-info.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-info.html
@@ -59,29 +59,36 @@ limitations under the License.
           value: () => new tf_backend.RequestManager(),
         },
 
+        isLive: {
+          type: Boolean,
+          value: false,
+          observer: '_isLiveChanged',
+        },
+
         items: {
           type: Array,
           value: [{name:'Loading...'}],
         },
       },
 
-      _reloaditems() {
-        window.setTimeout(function(){
-          this._requestManager.request(INFO_ROUTE).then(function(response){
-            this.splice('items', 0)
-
-            for (var item of response) {
-             this.push('items', item)
-            }
-          }.bind(this))
-
-          this._reloaditems()
-        }.bind(this), 1000/(this.fps === 0 ? 1 : this.fps))
+      _isLiveChanged() {
+        this._reloaditems();
       },
 
-      ready() {
-        this._reloaditems()
-      }
+      _reloaditems() {
+        if (!this.isLive) {
+          return;
+        }
+        this._requestManager.request(INFO_ROUTE).then(function(response){
+          this.splice('items', 0);
+          for (var item of response) {
+            this.push('items', item);
+          }
+        }.bind(this));
+        window.setTimeout(
+            this._reloaditems.bind(this),
+            1000/(this.fps === 0 ? 1 : this.fps));
+      },
     });
     })();
   </script>

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-video.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-video.html
@@ -20,11 +20,9 @@ limitations under the License.
 
 <dom-module id="tf-beholder-video">
   <template>
-  
     <div id="container">
-      <img id="video" src='[[_imageURL]]'></img>
+      <img id="video" src="[[_imageURL]]">
     </div>
-    
     <style>
       img {
         image-rendering: pixelated;
@@ -37,8 +35,9 @@ limitations under the License.
     "use strict";
     (function() {
 
-    const FEED_ROUTE = tf_backend.getRouter().pluginRoute('beholder', '/beholder-frame')
-    const PING_ROUTE = tf_backend.getRouter().pluginRoute('beholder', '/ping')
+    const BLANK_DATA = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+    const FEED_ROUTE = tf_backend.getRouter().pluginRoute('beholder', '/beholder-frame');
+    const PING_ROUTE = tf_backend.getRouter().pluginRoute('beholder', '/ping');
 
     Polymer({
       is: "tf-beholder-video",
@@ -46,6 +45,12 @@ limitations under the License.
         _requestManager: {
           type: Object,
           value: () => new tf_backend.RequestManager(),
+        },
+
+        showStream: {
+          type: Boolean,
+          value: true,
+          observer: '_showStreamChanged',
         },
 
         isLive: {
@@ -62,6 +67,16 @@ limitations under the License.
         _imageURL: {
           type: String,
           value: FEED_ROUTE
+        },
+      },
+
+      _showStreamChanged(newValue, oldValue) {
+        if (oldValue && !newValue) {
+          // Interrupt video stream by setting src to blank data.
+          this.$.video.src = BLANK_DATA;
+        }
+        if (newValue && oldValue === false) {
+          this.restartVideo();
         }
       },
 
@@ -89,14 +104,15 @@ limitations under the License.
       },
 
       restartVideo() {
-        var newImage = document.createElement('img')
-        newImage.src = FEED_ROUTE + '?t=' + new Date().getTime()
-        newImage.id = 'video'
-        newImage.className = 'style-scope beholder-video'
-        this.$.container.appendChild(newImage)
-
-        this.$.container.removeChild(this.$.video)
-        this.$.video = newImage
+        var newImage = document.createElement('img');
+        newImage.src = FEED_ROUTE + '?t=' + new Date().getTime();
+        newImage.id = 'video';
+        newImage.className = 'style-scope beholder-video';
+        this.$.container.appendChild(newImage);
+        let oldImage = this.$.container.removeChild(this.$.video);
+        this.$.video = newImage;
+        // Interrupt old video stream to ensure we don't have two at once.
+        oldImage.src = BLANK_DATA;
       },
 
     });

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-video.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-video.html
@@ -40,8 +40,6 @@ limitations under the License.
     const FEED_ROUTE = tf_backend.getRouter().pluginRoute('beholder', '/beholder-frame')
     const PING_ROUTE = tf_backend.getRouter().pluginRoute('beholder', '/ping')
 
-    var connectionFailed = false
-
     Polymer({
       is: "tf-beholder-video",
       properties: {
@@ -50,26 +48,44 @@ limitations under the License.
           value: () => new tf_backend.RequestManager(),
         },
 
+        isLive: {
+          type: Boolean,
+          value: false,
+          observer: '_isLiveChanged',
+        },
+
+        _pingSucceeded: {
+          type: Boolean,
+          value: true,
+        },
+
         _imageURL: {
           type: String,
           value: FEED_ROUTE
         }
       },
 
-      ready() {
+      _isLiveChanged() {
+        this._ping();
+      },
+
+      _ping() {
+        if (!this.isLive) {
+          return;
+        }
         // Periodically check the connection, restart if needed.
-        window.setInterval(function(){
-          this._requestManager.request(PING_ROUTE).then(
-              function(response){
-                if (connectionFailed) {
-                  this.restartVideo()
-                }
-                connectionFailed = false
-              }.bind(this),
-              function(error){
-                connectionFailed = true
-              }.bind(this))
-        }.bind(this), 1000)
+        const timer = window.setTimeout(
+            () => { this._pingSucceeded = false; },
+            1500);
+        this._requestManager.request(PING_ROUTE).then(
+          function(response) {
+            window.clearTimeout(timer);
+            if (!this._pingSucceeded) {
+              this.restartVideo();
+            }
+            this._pingSucceeded = true;
+          }.bind(this));
+        window.setTimeout(this._ping.bind(this), 1000);
       },
 
       restartVideo() {


### PR DESCRIPTION
This change makes Beholder avoid continuous network use unless the video is actively playing on-screen.

This takes a different route from #1075, the principle differences (organized by commit in this PR) are as follows:

1. Instead of tearing down the Beholder dashboard DOM in order to fire `detached()`, this makes the Beholder plugin auto-detect when it's selected and deselected, by monitoring the `data-selected` attribute on its parent element.  In the long run this would be expressed more concisely by changing tf-tensorboard logic to set a selected property directly on the dashboard element, but for now this works and avoids making any changes to tf-tensorboard.  The benefit of preserving the DOM is that if you navigate away from Beholder and then back, the overall state and in particular control panel settings are retained, which maintains consistency with all the other dashboards.

2. Beholder uses selection state information to explicitly control whether background XHRs (for section info and video frame pings) should be sent, by defining `isLive = isSelected && isActive && fps > 0` and then only sending XHRs when the video is "live".  The benefit here is that now XHRs are disabled not just when the plugin is deselected but also when it's deactivated (e.g. the log directory is removed) and also when the FPS value is set to 0 (i.e. the video frame is "paused" by the user).

3. Beholder uses the selection state information to explicitly tell the tf-beholder-video element to interrupt its video stream by setting the `src` to a blank data URL (technique courtesy of #1075) when the video frame is not visible (i.e. dashboard is deselected or inactive - this differs from `isLive` since Beholder still shows the frame when video is paused).  This ensures that the backend actually stops sending frames to the client.  It turns out that just removing it from the DOM won't stop tf-beholder-video from streaming - it's unclear whether there's some memory handle to the element within our code or polymer or whether the open stream itself is enough to prevent garbage collection, but based on instrumenting the server code and watching chrome://net-internals it keeps consuming video frames even after detached unless you do something to explicitly interrupt the stream.

For the changes in item 2 above, I adjusted the XHR invocation code a little but overall tried to modify it as little as necessary, so that it still uses RequestManager in basically the same ways.  I agree that #1075 is a bit tidier about canceling XHRs; I would prefer revisiting the XHR cancellation and API issue in a separate PR where we can look at it holistically across plugins, since it's actually largely orthogonal to the changes I'm making here.

I did make one change to the ping tracking logic so that it makes pings time out fairly aggressively (1.5 seconds) instead of waiting for the underlying default timeout which seems like 30+ seconds.  The rationale there is that false positives are preferable to false negatives, since the former is a video that reloads itself more often than necessary, whereas the latter is a video that gets "broken" (section info updates but video does not).
