### PR TITLE
Check for content of lists within text_plugin_test

### DIFF
--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -397,19 +397,19 @@ class TextPluginTest(tf.test.TestCase):
 
     # Initially, the thread for checking for plugin assets data has not run.
     # Hence, the mapping should only have data from the multiplexer.
-    self.assertEqual({
-        'fry': ['message', 'vector'],
-        'leela': ['message', 'vector']
-    }, self.plugin.tags_impl())
+    run_to_tags = self.plugin.tags_impl()
+    self.assertItemsEqual(['fry', 'leela'], run_to_tags.keys())
+    self.assertItemsEqual(['message', 'vector'], run_to_tags['fry'])
+    self.assertItemsEqual(['message', 'vector'], run_to_tags['leela'])
     thread = self.plugin._index_impl_thread
     mock.assert_called_once_with(thread)
 
     # The thread hasn't run yet, so no change in response, and we should not
     # have tried to launch a second thread.
-    self.assertEqual({
-        'fry': ['message', 'vector'],
-        'leela': ['message', 'vector']
-    }, self.plugin.tags_impl())
+    run_to_tags = self.plugin.tags_impl()
+    self.assertItemsEqual(['fry', 'leela'], run_to_tags.keys())
+    self.assertItemsEqual(['message', 'vector'], run_to_tags['fry'])
+    self.assertItemsEqual(['message', 'vector'], run_to_tags['leela'])
     mock.assert_called_once_with(thread)
 
     # Run the thread; it should clean up after itself.


### PR DESCRIPTION
Previously, text_plugin_test sometimes failed because #1021 made the test check for complete dictionary equality, and tags may appear in different orders for each test run. This fix makes the test check for equality of content within lists, regardless of order. This makes the test parallel previous test logic for tags.

Fixes #1072.