### PR TITLE
Revert Beholder FPS slider to allow setting to 0

### DIFF
--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -213,7 +213,7 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
         </template>
 
         <template is="dom-if" if="[[_is_active]]">
-          <tf-beholder-video id="video"></tf-beholder-video>
+          <tf-beholder-video id="video" fps="[[_FPS]]"></tf-beholder-video>
 
           <template is="dom-if" if="[[_valuesNotFrame(_values)]]">
             <tf-beholder-info

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -147,7 +147,7 @@ limitations under the License.
             value="{{_FPS}}"
             type="number"
             step="1"
-            min="1"
+            min="0"
             max="30"
             pin="true"
             disabled="[[_controls_disabled]]">

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-info.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-info.html
@@ -57,6 +57,7 @@ limitations under the License.
         fps: {  // Not actually FPS!
           type: Number,
           value: 10,
+          observer: '_fpsChanged',
         },
 
         xhrTimeout: {
@@ -124,6 +125,13 @@ limitations under the License.
         }
       },
 
+      _fpsChanged(newValue, oldValue) {
+        if (newValue == 0) {
+          this._clear();
+        } else if (oldValue == 0) {
+          this._load();
+        }
+      },
     });
     })();
   </script>

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-video.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-video.html
@@ -44,6 +44,13 @@ limitations under the License.
     Polymer({
       is: "tf-beholder-video",
       properties: {
+        // Only used for determining ping frequency.
+        fps: {
+          type: Number,
+          value: 10,
+          observer: '_fpsChanged',
+        },
+
         pingSleep: {
           type: Number,
           value: 1000,
@@ -90,7 +97,7 @@ limitations under the License.
           const response = JSON.parse(this._xhr.responseText);
           this._onPing(response['status'] == 'alive', this.pingSleep);
           return;
-        } 
+        }
         this._onPing(false, this.pingSleep);
       },
 
@@ -115,6 +122,13 @@ limitations under the License.
         }
       },
 
+      _fpsChanged(newValue, oldValue) {
+        if (newValue == 0) {
+          this._clear();
+        } else if (oldValue == 0) {
+          this._ping();
+        }
+      },
     });
 
     })();


### PR DESCRIPTION
This restores the 0 value minimum setting of the FPS slider, which is a documented Beholder feature that allows "pausing" the video generation.  See more in https://github.com/tensorflow/tensorboard/pull/1075/files#r177321183.

It adds logic to the tf-beholder-video and tf-beholder-info elements so that they don't send any XHRs when the FPS value is set to 0.