### PR TITLE
Filter placeholder rows with `dtype IS NOT NULL`

### DIFF
--- a/tensorboard/plugins/pr_curve/pr_curves_plugin.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin.py
@@ -87,8 +87,8 @@ class PrCurvesPlugin(base_plugin.TBPlugin):
       # Serve data from the database.
       db = self._db_connection_provider()
 
-      # We select for steps greater than -1 because the writer inserts
-      # placeholder rows en masse. The check for step filters out those rows.
+      # We select for dtype not being null because the writer inserts
+      # placeholder rows en masse. The check for dtype filters out those rows.
       cursor = db.execute('''
         SELECT
           Runs.run_name,
@@ -107,7 +107,7 @@ class PrCurvesPlugin(base_plugin.TBPlugin):
           Runs.run_name IN (%s)
           AND Tags.tag_name = ?
           AND Tags.plugin_name = ?
-          AND Tensors.step > -1
+          AND Tensors.dtype IS NOT NULL
         ORDER BY Tensors.step
       ''' % ','.join(['?'] * len(runs)), runs + [tag, metadata.PLUGIN_NAME])
       response_mapping = {}

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -127,8 +127,8 @@ class ScalarsPlugin(base_plugin.TBPlugin):
     """Result of the form `(body, mime_type)`."""
     if self._db_connection_provider:
       db = self._db_connection_provider()
-      # We select for steps greater than -1 because the writer inserts
-      # placeholder rows en masse. The check for step filters out those rows.
+      # We select for dtype not being null because the writer inserts
+      # placeholder rows en masse. The check for dtype filters out those rows.
       cursor = db.execute('''
         SELECT
           Tensors.step,
@@ -145,7 +145,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
           AND Tags.tag_name = ?
           AND Tags.plugin_name = ?
           AND Tensors.shape = ''
-          AND Tensors.step > -1
+          AND Tensors.dtype IS NOT NULL
         ORDER BY Tensors.step
       ''', (run, tag, metadata.PLUGIN_NAME))
       values = [(wall_time, step, self._get_value(data, dtype_enum))


### PR DESCRIPTION
The DB writer writes placeholder rows en masse. The placeholder rows
will be populated with data later and should be filtered from plugin SQL
queries. To filter them out, plugins had used `step > -1`.

We instead use `dtype IS NOT NULL` per schema guarantees.

Both the scalars and pr_curves plugins seem to WAI in db mode.