### PR TITLE
Count regular edges while picking metaedge.

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -710,14 +710,14 @@ export class RenderGraphInfo {
     // an edge may enter a series node.
     let originalMetaEdge: Metaedge;
     let regularEdgeCount = 0;
-    for (let i = 0; i < originalMetaEdges.regular.length; i++) {
-      const metaEdge = originalMetaEdges.regular[i];
+    _.each(originalMetaEdges.regular, metaEdge => {
       regularEdgeCount += metaEdge.numRegularEdges;
       if (regularEdgeCount > inputIndex) {
         originalMetaEdge = metaEdge;
-        break;
+        // Terminate the loop.
+        return false;
       }
-    }
+    });
 
     // Also change any base edges that point into the original node to
     // point to the input arg within the function. These are used to

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -704,7 +704,20 @@ export class RenderGraphInfo {
     // metagraph.
     const originalMetaEdges = this.hierarchy.getPredecessors(
         opNodeToReplace.name);
-    const originalMetaEdge = originalMetaEdges.regular[inputIndex];
+    
+    // Find the metaedge that the input index corresponds to.
+    // A metaedge may correspond to several edges. For instance,
+    // an edge may enter a series node.
+    let originalMetaEdge: Metaedge;
+    let regularEdgeCount = 0;
+    for (let i = 0; i < originalMetaEdges.regular.length; i++) {
+      const metaEdge = originalMetaEdges.regular[i];
+      regularEdgeCount += metaEdge.numRegularEdges;
+      if (regularEdgeCount > inputIndex) {
+        originalMetaEdge = metaEdge;
+        break;
+      }
+    }
 
     // Also change any base edges that point into the original node to
     // point to the input arg within the function. These are used to


### PR DESCRIPTION
The logic for patching inputs to function nodes performs a scan across
metaedges (edges that encapsulate potentially numerous base edges) in
order to determine the correct metaedge to patch. Previously, this logic
had not taken into consideration how a metaedge could represent several
regular edges. This was problematic since the index pertained to the
collective number of regular edges (not metaedges).

This had caused an internal user's graph to fail to render. The graph
contained an edge into a series node within a function. The series node
caused several regular edges to be collapsed into one metaedge.

This change has been tested with that graph as well as other graphs that
make use of TensorFlow functions. The graph WAI.

This logic will be tested within internal integration tests for the graph.