### PR TITLE
Load color maps with get_data_files_path

### DIFF
--- a/tensorboard/plugins/beholder/file_system_tools.py
+++ b/tensorboard/plugins/beholder/file_system_tools.py
@@ -65,6 +65,4 @@ def read_pickle(path, default=None):
 
 
 def resources_path():
-  script_directory = os.path.dirname(__file__)
-  filename = os.path.join(script_directory, 'resources')
-  return filename
+  return os.path.join(tf.resource_loader.get_data_files_path(), 'resources')

--- a/tensorboard/plugins/beholder/im_util.py
+++ b/tensorboard/plugins/beholder/im_util.py
@@ -91,7 +91,10 @@ def pad_to_shape(array, shape, constant=245):
 #
 # You should have received a copy of the CC0 legalcode along with this
 # work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-colormaps = np.load('{}/colormaps.npy'.format(resources_path()))
+colormaps_path = '{}/colormaps.npy'.format(resources_path())
+with tf.gfile.Open(colormaps_path, 'rb') as colormaps_file:
+  colormaps = np.load(colormaps_file)
+
 magma_data, inferno_data, plasma_data, viridis_data = colormaps
 
 


### PR DESCRIPTION
Previously, beholder loaded its binary color maps file using a relative
path. This logic breaks TensorBoard starting up within Google because
the path to resources is different.

We now use `tf.resource_loader.get_data_files_path()` to construct the
path to the color map as well as use `tf.gfile.Open` to open the file
itself before passing the file handler to numpy's `load` method.

beholder still WAI in the open source code base.

![image](https://user-images.githubusercontent.com/4221553/38116508-3954820e-3365-11e8-8b25-f290168cc436.png)

After sync-ing this logic into Google, we shall see whether TensorBoard
starts up.