### PR TITLE
Don't pass a status to _reader.GetNext()

### DIFF
--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -51,7 +51,7 @@ class EventFileLoader(object):
     tf.logging.debug('Loading events from %s', self._file_path)
     while True:
       try:
-        if len(inspect.getargspec(self._reader.GetNext).args) is 0: # pylint: disable=deprecated-method
+        if not inspect.getargspec(self._reader.GetNext).args[1:]: # pylint: disable=deprecated-method
           self._reader.GetNext()
         else:
           # GetNext() expects a status argument on TF <= 1.7

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -51,7 +51,7 @@ class EventFileLoader(object):
     tf.logging.debug('Loading events from %s', self._file_path)
     while True:
       try:
-        if len(inspect.getargspec(self._reader.GetNext).args) is 0:
+        if len(inspect.getargspec(self._reader.GetNext).args) is 0: # pylint: disable=deprecated-method
           self._reader.GetNext()
         else:
           # GetNext() expects a status argument on TF <= 1.7

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -49,8 +49,7 @@ class EventFileLoader(object):
     tf.logging.debug('Loading events from %s', self._file_path)
     while True:
       try:
-        with tf.errors.raise_exception_on_not_ok_status() as status:
-          self._reader.GetNext(status)
+        self._reader.GetNext()
       except (tf.errors.DataLossError, tf.errors.OutOfRangeError):
         # We ignore partial read exceptions, because a record may be truncated.
         # PyRecordReader holds the offset prior to the failed read, so retrying

--- a/tensorboard/loader.py
+++ b/tensorboard/loader.py
@@ -115,8 +115,7 @@ class RecordReader(object):
     if self._reader is None:
       self._reader = self._open()
     try:
-      with tf.errors.raise_exception_on_not_ok_status() as status:
-        self._reader.GetNext(status)
+      self._reader.GetNext()
     except tf.errors.OutOfRangeError:
       # We ignore partial read exceptions, because a record may be truncated.
       # PyRecordReader holds the offset prior to the failed read, so retrying

--- a/tensorboard/loader.py
+++ b/tensorboard/loader.py
@@ -116,7 +116,7 @@ class RecordReader(object):
     if self._reader is None:
       self._reader = self._open()
     try:
-      if len(inspect.getargspec(self._reader.GetNext).args) is 0: # pylint: disable=deprecated-method
+      if not inspect.getargspec(self._reader.GetNext).args[1:]: # pylint: disable=deprecated-method
         self._reader.GetNext()
       else:
         # GetNext() expects a status argument on TF <= 1.7

--- a/tensorboard/loader.py
+++ b/tensorboard/loader.py
@@ -116,7 +116,7 @@ class RecordReader(object):
     if self._reader is None:
       self._reader = self._open()
     try:
-      if len(inspect.getargspec(self._reader.GetNext).args) is 0:
+      if len(inspect.getargspec(self._reader.GetNext).args) is 0: # pylint: disable=deprecated-method
         self._reader.GetNext()
       else:
         # GetNext() expects a status argument on TF <= 1.7


### PR DESCRIPTION
Tensorflow's C API now will now raise this error using SWIG without having to raise it in explicitly in Python.