### PR TITLE
Find runs by glob-ing levels of subdirectories

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -13,6 +13,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -24,6 +24,7 @@ py_test(
     deps = [
         ":io_wrapper",
         "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -94,6 +95,7 @@ py_library(
     deps = [
         ":directory_watcher",
         ":event_file_loader",
+        ":io_wrapper",
         ":plugin_asset_util",
         ":reservoir",
         "//tensorboard:data_compat",
@@ -188,7 +190,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":event_accumulator",
-        ":event_multiplexer",
+        ":io_wrapper",
         "//tensorboard:expect_tensorflow_installed",
     ],
 )

--- a/tensorboard/backend/event_processing/directory_watcher_test.py
+++ b/tensorboard/backend/event_processing/directory_watcher_test.py
@@ -194,9 +194,9 @@ class DirectoryWatcherTest(tf.test.TestCase):
     FakeFactory.has_been_called = False
 
     stub_names = [
-        'GlobAndListFiles',
         'ListDirectoryAbsolute',
-        'WalkAndListFilesPerDirectory'
+        'ListRecursivelyViaGlobbing',
+        'ListRecursivelyViaWalking',
     ]
     for stub_name in stub_names:
       self.stubs.Set(io_wrapper, stub_name,

--- a/tensorboard/backend/event_processing/directory_watcher_test.py
+++ b/tensorboard/backend/event_processing/directory_watcher_test.py
@@ -193,7 +193,12 @@ class DirectoryWatcherTest(tf.test.TestCase):
 
     FakeFactory.has_been_called = False
 
-    for stub_name in ['ListDirectoryAbsolute', 'ListRecursively']:
+    stub_names = [
+        'GlobAndListFiles',
+        'ListDirectoryAbsolute',
+        'WalkAndListFilesPerDirectory'
+    ]
+    for stub_name in stub_names:
       self.stubs.Set(io_wrapper, stub_name,
                      FakeFactory(getattr(io_wrapper, stub_name)))
     for stub_name in ['IsDirectory', 'Exists', 'Stat']:

--- a/tensorboard/backend/event_processing/event_accumulator.py
+++ b/tensorboard/backend/event_processing/event_accumulator.py
@@ -18,13 +18,13 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
-import os
 import threading
 
 import tensorflow as tf
 
 from tensorboard.backend.event_processing import directory_watcher
 from tensorboard.backend.event_processing import event_file_loader
+from tensorboard.backend.event_processing import io_wrapper
 from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.backend.event_processing import reservoir
 from tensorboard.plugins.distribution import compressor
@@ -96,23 +96,6 @@ STORE_EVERYTHING_SIZE_GUIDANCE = {
     HISTOGRAMS: 0,
     TENSORS: 0,
 }
-
-
-def IsTensorFlowEventsFile(path):
-  """Check the path name to see if it is probably a TF Events file.
-
-  Args:
-    path: A file path to check if it is an event file.
-
-  Raises:
-    ValueError: If the path is an empty string.
-
-  Returns:
-    If path is formatted like a TensorFlowEventsFile.
-  """
-  if not path:
-    raise ValueError('Path must be a nonempty string')
-  return 'tfevents' in tf.compat.as_str_any(os.path.basename(path))
 
 
 class EventAccumulator(object):
@@ -747,11 +730,13 @@ def _GeneratorFromPath(path):
   """Create an event generator for file or directory at given path string."""
   if not path:
     raise ValueError('path must be a valid string')
-  if IsTensorFlowEventsFile(path):
+  if io_wrapper.IsTensorFlowEventsFile(path):
     return event_file_loader.EventFileLoader(path)
   else:
     return directory_watcher.DirectoryWatcher(
-        path, event_file_loader.EventFileLoader, IsTensorFlowEventsFile)
+        path,
+        event_file_loader.EventFileLoader,
+        io_wrapper.IsTensorFlowEventsFile)
 
 
 def _ParseFileVersion(file_version):

--- a/tensorboard/backend/event_processing/event_file_inspector.py
+++ b/tensorboard/backend/event_processing/event_file_inspector.py
@@ -120,7 +120,7 @@ import tensorflow as tf
 
 from tensorboard.backend.event_processing import event_accumulator
 from tensorboard.backend.event_processing import event_file_loader
-from tensorboard.backend.event_processing import event_multiplexer
+from tensorboard.backend.event_processing import io_wrapper
 
 FLAGS = tf.flags.FLAGS
 
@@ -323,12 +323,12 @@ def generators_from_logdir(logdir):
   Returns:
     List of event generators for each subdirectory with event files.
   """
-  subdirs = event_multiplexer.GetLogdirSubdirectories(logdir)
+  subdirs = io_wrapper.GetLogdirSubdirectories(logdir)
   generators = [
       itertools.chain(*[
           generator_from_event_file(os.path.join(subdir, f))
           for f in tf.gfile.ListDirectory(subdir)
-          if event_accumulator.IsTensorFlowEventsFile(os.path.join(subdir, f))
+          if io_wrapper.IsTensorFlowEventsFile(os.path.join(subdir, f))
       ]) for subdir in subdirs
   ]
   return generators
@@ -356,13 +356,13 @@ def get_inspection_units(logdir='', event_file='', tag=''):
     A list of InspectionUnit objects.
   """
   if logdir:
-    subdirs = event_multiplexer.GetLogdirSubdirectories(logdir)
+    subdirs = io_wrapper.GetLogdirSubdirectories(logdir)
     inspection_units = []
     for subdir in subdirs:
       generator = itertools.chain(*[
           generator_from_event_file(os.path.join(subdir, f))
           for f in tf.gfile.ListDirectory(subdir)
-          if event_accumulator.IsTensorFlowEventsFile(os.path.join(subdir, f))
+          if io_wrapper.IsTensorFlowEventsFile(os.path.join(subdir, f))
       ])
       inspection_units.append(InspectionUnit(
           name=subdir,
@@ -371,7 +371,7 @@ def get_inspection_units(logdir='', event_file='', tag=''):
     if inspection_units:
       print('Found event files in:\n{}\n'.format('\n'.join(
           [u.name for u in inspection_units])))
-    elif event_accumulator.IsTensorFlowEventsFile(logdir):
+    elif io_wrapper.IsTensorFlowEventsFile(logdir):
       print(
           'It seems that {} may be an event file instead of a logdir. If this '
           'is the case, use --event_file instead of --logdir to pass '

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -166,7 +166,7 @@ class EventMultiplexer(object):
       The `EventMultiplexer`.
     """
     tf.logging.info('Starting AddRunsFromDirectory: %s', path)
-    for subdir in GetLogdirSubdirectories(path):
+    for subdir in io_wrapper.GetLogdirSubdirectories(path):
       tf.logging.info('Adding events from directory %s', subdir)
       rpath = os.path.relpath(subdir, path)
       subname = os.path.join(name, rpath) if name else rpath
@@ -480,17 +480,3 @@ class EventMultiplexer(object):
     """
     with self._accumulators_mutex:
       return self._accumulators[run]
-
-
-def GetLogdirSubdirectories(path):
-  """Returns subdirectories with event files on path."""
-  if tf.gfile.Exists(path) and not tf.gfile.IsDirectory(path):
-    raise ValueError('GetLogdirSubdirectories: path exists and is not a '
-                     'directory, %s' % path)
-
-  # ListRecursively just yields nothing if the path doesn't exist.
-  return (
-      subdir
-      for (subdir, files) in io_wrapper.ListRecursively(path)
-      if list(filter(event_accumulator.IsTensorFlowEventsFile, files))
-  )

--- a/tensorboard/backend/event_processing/io_wrapper.py
+++ b/tensorboard/backend/event_processing/io_wrapper.py
@@ -125,7 +125,7 @@ def ListRecursivelyViaGlobbing(top):
       # directory, replace the current globbing path with that directory as the
       # literal prefix. This should improve efficiency in cases where a single
       # subdir is significantly deeper than the rest of the sudirs.
-      current_glob_string = os.path.join(pairs.keys()[0], '*')
+      current_glob_string = os.path.join(list(pairs.keys())[0], '*')
 
     # Iterate to the next level of subdirectories.
     current_glob_string = os.path.join(current_glob_string, '*')

--- a/tensorboard/backend/event_processing/io_wrapper.py
+++ b/tensorboard/backend/event_processing/io_wrapper.py
@@ -22,8 +22,30 @@ import os
 import tensorflow as tf
 
 
+# TODO(chihuahua): Rename this method to use camel-case for GCS (Gcs).
 def IsGCSPath(path):
   return path.startswith("gs://")
+
+
+def IsCnsPath(path):
+  return path.startswith("/cns/")
+
+
+def IsTensorFlowEventsFile(path):
+  """Check the path name to see if it is probably a TF Events file.
+
+  Args:
+    path: A file path to check if it is an event file.
+
+  Raises:
+    ValueError: If the path is an empty string.
+
+  Returns:
+    If path is formatted like a TensorFlowEventsFile.
+  """
+  if not path:
+    raise ValueError('Path must be a nonempty string')
+  return 'tfevents' in tf.compat.as_str_any(os.path.basename(path))
 
 
 def ListDirectoryAbsolute(directory):
@@ -32,21 +54,108 @@ def ListDirectoryAbsolute(directory):
           for path in tf.gfile.ListDirectory(directory))
 
 
-def ListRecursively(top):
+def GlobAndListFiles(top):
+  """Recursively lists all files within the directory.
+
+  This method does so by glob-ing deeper and deeper directories, ie
+  /foo/*, foo/*/*, foo/*/*/* and so on until all files are listed. All file
+  paths are absolute, and this method lists subdirectories too.
+
+  For certain file systems, Globbing via this method may prove
+  significantly faster than recursively walking a directory.
+  Specifically, file systems that implement analogs to TensorFlow's
+  FileSystem.GetMatchingPaths method could save costly disk reads by using
+  this method. However, for other file systems, this method might prove slower
+  because the file system performs a walk per call to glob (in which case it
+  might as well just perform 1 walk).
+
+  Args:
+    top: A path to a directory.
+
+  Yields:
+    The absolute path of each file.
+  """
+  current_glob_string = top
+  level = 0
+  while True:
+    tf.logging.info('GlobAndListFiles: Starting to glob level %d', level)
+    glob = tf.gfile.Glob(current_glob_string)
+    tf.logging.info(
+        'GlobAndListFiles: %d files glob-ed at level %d', len(glob), level)
+
+    if not glob:
+      # This subdirectory level lacks files. Terminate.
+      return
+
+    for absolute_file_path in glob:
+      yield absolute_file_path
+
+    # Iterate to the next level of subdirectories.
+    current_glob_string = os.path.join(current_glob_string, '*')
+    level += 1
+
+
+def WalkAndListFilesPerDirectory(top):
   """Walks a directory tree, yielding (dir_path, file_paths) tuples.
 
   For each of `top` and its subdirectories, yields a tuple containing the path
   to the directory and the path to each of the contained files.  Note that
   unlike os.Walk()/tf.gfile.Walk(), this does not list subdirectories and the
-  file paths are all absolute.
+  file paths are all absolute. If the directory does not exist, this yields
+  nothing.
 
-  If the directory does not exist, this yields nothing.
+  Walking may be incredibly slow on certain file systems.
 
   Args:
-    top: A path to a directory..
+    top: A path to a directory.
+
   Yields:
-    A list of (dir_path, file_paths) tuples.
+    A (dir_path, file_paths) tuple for each directory/subdirectory.
   """
   for dir_path, _, filenames in tf.gfile.Walk(top):
     yield (dir_path, (os.path.join(dir_path, filename)
                       for filename in filenames))
+
+
+def GetLogdirSubdirectories(path):
+  """Obtains all subdirectories with events files.
+
+  Args:
+    path: The path to a directory under which to find subdirectories.
+
+  Returns:
+    A tuple of absolute paths of all subdirectories each with at least 1 events
+    file directly within the subdirectory.
+
+  Raises:
+    ValueError: If the path passed to the method exists and is not a directory.
+  """
+  if not tf.gfile.Exists(path):
+    # No directory to traverse.
+    return ()
+
+  if not tf.gfile.IsDirectory(path):
+    raise ValueError('GetLogdirSubdirectories: path exists and is not a '
+                     'directory, %s' % path)
+
+  if IsGCSPath(path) or IsCnsPath(path):
+    # Glob-ing for files can be significantly faster than recursively
+    # walking through directories for some file systems.
+    # Use a dict comprehension to unique-ify subdirectories.
+    tf.logging.info(
+        'GetLogdirSubdirectories: Starting to list directories via glob-ing.')
+    return tuple({
+        os.path.dirname(absolute_file_path): True
+        for absolute_file_path in GlobAndListFiles(path)
+        if IsTensorFlowEventsFile(absolute_file_path)
+    })
+
+  # For other file systems, the glob-ing based method might be slower because
+  # each call to glob could involve performing a recursive walk.
+  tf.logging.info(
+      'GetLogdirSubdirectories: Starting to list directories via walking.')
+  return (
+      subdir
+      for (subdir, files) in WalkAndListFilesPerDirectory(path)
+      if any(IsTensorFlowEventsFile(f) for f in files)
+  )

--- a/tensorboard/backend/event_processing/io_wrapper.py
+++ b/tensorboard/backend/event_processing/io_wrapper.py
@@ -21,6 +21,7 @@ import collections
 import os
 import re
 
+import six
 import tensorflow as tf
 
 _ESCAPE_GLOB_CHARACTERS_REGEX = re.compile('([*?[])')
@@ -116,7 +117,7 @@ def ListRecursivelyViaGlobbing(top):
     pairs = collections.defaultdict(list)
     for file_path in glob:
       pairs[os.path.dirname(file_path)].append(file_path)
-    for dir_name, file_paths in pairs.items():
+    for dir_name, file_paths in six.iteritems(pairs):
       yield (dir_name, tuple(file_paths))
 
     if len(pairs) == 1:
@@ -180,7 +181,6 @@ def GetLogdirSubdirectories(path):
   if IsGCSPath(path) or IsCnsPath(path):
     # Glob-ing for files can be significantly faster than recursively
     # walking through directories for some file systems.
-    # Use a dict comprehension to unique-ify subdirectories.
     tf.logging.info(
         'GetLogdirSubdirectories: Starting to list directories via glob-ing.')
     traversal_method = ListRecursivelyViaGlobbing

--- a/tensorboard/backend/event_processing/io_wrapper_test.py
+++ b/tensorboard/backend/event_processing/io_wrapper_test.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import os
 import tempfile
 
+import six
 import tensorflow as tf
 
 from tensorboard.backend.event_processing import io_wrapper
@@ -31,6 +32,27 @@ class IoWrapperTest(tf.test.TestCase):
 
   def testIsGcsPathIsFalse(self):
     self.assertFalse(io_wrapper.IsGCSPath('/tmp/foo'))
+
+  def testIsCnsPathTrue(self):
+    self.assertTrue(io_wrapper.IsCnsPath('/cns/foo/bar'))
+
+  def testIsCnsPathFalse(self):
+    self.assertFalse(io_wrapper.IsCnsPath('/tmp/foo'))
+
+  def testIsIsTensorFlowEventsFileTrue(self):
+    self.assertTrue(
+        io_wrapper.IsTensorFlowEventsFile(
+            '/logdir/events.out.tfevents.1473720042.com'))
+
+  def testIsIsTensorFlowEventsFileFalse(self):
+    self.assertFalse(
+        io_wrapper.IsTensorFlowEventsFile('/logdir/model.ckpt'))
+
+  def testIsIsTensorFlowEventsFileWithEmptyInput(self):
+    with six.assertRaisesRegex(self,
+                               ValueError,
+                               r'Path must be a nonempty string'):
+      io_wrapper.IsTensorFlowEventsFile('')
 
   def testListDirectoryAbsolute(self):
     temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
@@ -64,32 +86,30 @@ class IoWrapperTest(tf.test.TestCase):
         (os.path.join(temp_dir, f) for f in expected_files),
         io_wrapper.ListDirectoryAbsolute(temp_dir))
 
-  def testListRecursivelyForNestedFiles(self):
+  def testGlobAndListFiles(self):
     temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
-
-    # Add a few subdirectories.
-    directory_names = (
+    self._CreateDeepDirectoryStructure(temp_dir)
+    expected = (
         'foo',
         'bar',
-        'bar/baz',
-    )
-    for directory_name in directory_names:
-      os.makedirs(os.path.join(temp_dir, directory_name))
-
-    # Add a few files to the directory.
-    file_names = (
-        'events.out.tfevents.1473720381.meep.com',
-        'model.ckpt',
         'bar/events.out.tfevents.1473720382.bar.com',
         'bar/red_herring.txt',
+        'bar/baz',
         'bar/baz/events.out.tfevents.1473720383.baz.com',
         'bar/baz/events.out.tfevents.1473720384.baz.com',
+        'events.out.tfevents.1473720381.meep.com',
+        'model.ckpt',
     )
-    for file_name in file_names:
-      open(os.path.join(temp_dir, file_name), 'w').close()
+    self.assertItemsEqual(
+        [os.path.join(temp_dir, f) for f in expected] + [temp_dir],
+        list(io_wrapper.GlobAndListFiles(temp_dir)))
+
+  def testWalkAndListFilesPerDirectoryForNestedFiles(self):
+    temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
+    self._CreateDeepDirectoryStructure(temp_dir)
 
     # There were 4 subdirectories in total.
-    listing = io_wrapper.ListRecursively(temp_dir)
+    listing = io_wrapper.WalkAndListFilesPerDirectory(temp_dir)
     directory_to_listing = {
         dir: list(generator) for (dir, generator) in listing}
     expected = (
@@ -131,14 +151,43 @@ class IoWrapperTest(tf.test.TestCase):
         (os.path.join(temp_dir, 'bar/baz', f) for f in expected),
         directory_to_listing[os.path.join(temp_dir, 'bar/baz')])
 
-  def testListRecursivelyForEmptyDirectory(self):
+  def testWalkAndListFilesPerDirectoryForEmptyDirectory(self):
     empty_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
-    subdirectory_entries = list(io_wrapper.ListRecursively(empty_dir))
+    subdirectory_entries = list(
+        io_wrapper.WalkAndListFilesPerDirectory(empty_dir))
     self.assertEqual(1, len(subdirectory_entries))
 
     entry = subdirectory_entries[0]
     self.assertEqual(empty_dir, entry[0])
     self.assertItemsEqual((), entry[1])
+
+  def _CreateDeepDirectoryStructure(self, top_directory):
+    """Creates a reasonable deep structure of subdirectories with files.
+
+    Args:
+      top_directory: The absolute path of the top level directory in
+        which to create the directory structure.
+    """
+    # Add a few subdirectories.
+    directory_names = (
+        'foo',
+        'bar',
+        'bar/baz',
+    )
+    for directory_name in directory_names:
+      os.makedirs(os.path.join(top_directory, directory_name))
+
+    # Add a few files to the directory.
+    file_names = (
+        'events.out.tfevents.1473720381.meep.com',
+        'model.ckpt',
+        'bar/events.out.tfevents.1473720382.bar.com',
+        'bar/red_herring.txt',
+        'bar/baz/events.out.tfevents.1473720383.baz.com',
+        'bar/baz/events.out.tfevents.1473720384.baz.com',
+    )
+    for file_name in file_names:
+      open(os.path.join(top_directory, file_name), 'w').close()
 
 
 if __name__ == '__main__':

--- a/tensorboard/backend/event_processing/io_wrapper_test.py
+++ b/tensorboard/backend/event_processing/io_wrapper_test.py
@@ -56,110 +56,98 @@ class IoWrapperTest(tf.test.TestCase):
 
   def testListDirectoryAbsolute(self):
     temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
-
-    # Add a few subdirectories.
-    directory_names = (
-        'foo',
-        'bar',
-        'we/must/go/deeper'
-    )
-    for directory_name in directory_names:
-      os.makedirs(os.path.join(temp_dir, directory_name))
-
-    # Add a few files to the directory.
-    file_names = (
-        'events.out.tfevents.1473720381.foo.com',
-        'model.ckpt',
-        'we/must_not_include_this_file_in_the_listing.txt'
-    )
-    for file_name in file_names:
-      open(os.path.join(temp_dir, file_name), 'w').close()
+    self._CreateDeepDirectoryStructure(temp_dir)
 
     expected_files = (
         'foo',
         'bar',
-        'we',
-        'events.out.tfevents.1473720381.foo.com',
+        'quuz',
+        'events.out.tfevents.1473720381.meep.com',
         'model.ckpt',
+        'ba*',
     )
     self.assertItemsEqual(
         (os.path.join(temp_dir, f) for f in expected_files),
         io_wrapper.ListDirectoryAbsolute(temp_dir))
 
-  def testGlobAndListFiles(self):
+  def testListRecursivelyViaGlobbing(self):
     temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
     self._CreateDeepDirectoryStructure(temp_dir)
-    expected = (
-        'foo',
-        'bar',
-        'bar/events.out.tfevents.1473720382.bar.com',
-        'bar/red_herring.txt',
-        'bar/baz',
-        'bar/baz/events.out.tfevents.1473720383.baz.com',
-        'bar/baz/events.out.tfevents.1473720384.baz.com',
-        'events.out.tfevents.1473720381.meep.com',
-        'model.ckpt',
-    )
-    self.assertItemsEqual(
-        [os.path.join(temp_dir, f) for f in expected] + [temp_dir],
-        list(io_wrapper.GlobAndListFiles(temp_dir)))
+    expected = [
+        ['', [
+            'foo',
+            'bar',
+            'events.out.tfevents.1473720381.meep.com',
+            'model.ckpt',
+            'quuz',
+            'ba*',
+        ]],
+        ['bar', [
+            'events.out.tfevents.1473720382.bar.com',
+            'red_herring.txt',
+            'baz',
+            'quux',
+        ]],
+        ['bar/baz', [
+            'events.out.tfevents.1473720383.baz.com',
+            'events.out.tfevents.1473720384.baz.com',
+        ]],
+        ['bar/quux', [
+            'some_flume_output.txt',
+            'some_more_flume_output.txt',
+        ]],
+        ['quuz', ['corge', 'grault']],
+        ['quuz/corge', [
+            'events.out.tfevents.1473720642.corge.com']
+        ],
+        ['quuz/grault', ['events.out.tfevents.1473720643.grault.com']],
+        ['ba*', ['baz']],
+        ['ba*/baz', ['events.out.tfevents.1473720644.asterisk.com']],
+    ]
+    for pair in expected:
+      # If this is not the top-level directory, prepend the high-level
+      # directory.
+      pair[0] = os.path.join(temp_dir, pair[0]) if pair[0] else temp_dir
+      pair[1] = [os.path.join(pair[0], f) for f in pair[1]]
+    self._CompareFilesPerSubdirectory(
+        expected, io_wrapper.ListRecursivelyViaGlobbing(temp_dir))
 
-  def testWalkAndListFilesPerDirectoryForNestedFiles(self):
+  def testListRecursivelyViaWalking(self):
     temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
     self._CreateDeepDirectoryStructure(temp_dir)
-
-    # There were 4 subdirectories in total.
-    listing = io_wrapper.WalkAndListFilesPerDirectory(temp_dir)
-    directory_to_listing = {
-        dir: list(generator) for (dir, generator) in listing}
-    expected = (
-        'foo',
-        'bar',
-        'bar/baz'
-    )
-    self.assertItemsEqual(
-        [os.path.join(temp_dir, f) for f in expected] + [temp_dir],
-        directory_to_listing.keys())
-
-    # Test for the listings of individual directories.
-    expected = (
-        'events.out.tfevents.1473720381.meep.com',
-        'model.ckpt',
-    )
-    self.assertItemsEqual(
-        (os.path.join(temp_dir, f) for f in expected),
-        directory_to_listing[temp_dir])
-
-    expected = ()
-    self.assertItemsEqual(
-        (os.path.join(temp_dir, 'foo', f) for f in expected),
-        directory_to_listing[os.path.join(temp_dir, 'foo')])
-
-    expected = (
-        'events.out.tfevents.1473720382.bar.com',
-        'red_herring.txt',
-    )
-    self.assertItemsEqual(
-        (os.path.join(temp_dir, 'bar', f) for f in expected),
-        directory_to_listing[os.path.join(temp_dir, 'bar')])
-
-    expected = (
-        'events.out.tfevents.1473720383.baz.com',
-        'events.out.tfevents.1473720384.baz.com',
-    )
-    self.assertItemsEqual(
-        (os.path.join(temp_dir, 'bar/baz', f) for f in expected),
-        directory_to_listing[os.path.join(temp_dir, 'bar/baz')])
-
-  def testWalkAndListFilesPerDirectoryForEmptyDirectory(self):
-    empty_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
-    subdirectory_entries = list(
-        io_wrapper.WalkAndListFilesPerDirectory(empty_dir))
-    self.assertEqual(1, len(subdirectory_entries))
-
-    entry = subdirectory_entries[0]
-    self.assertEqual(empty_dir, entry[0])
-    self.assertItemsEqual((), entry[1])
+    expected = [
+        ['', [
+            'events.out.tfevents.1473720381.meep.com',
+            'model.ckpt',
+        ]],
+        ['foo', []],
+        ['bar', [
+            'events.out.tfevents.1473720382.bar.com',
+            'red_herring.txt',
+        ]],
+        ['bar/baz', [
+            'events.out.tfevents.1473720383.baz.com',
+            'events.out.tfevents.1473720384.baz.com',
+        ]],
+        ['bar/quux', [
+            'some_flume_output.txt',
+            'some_more_flume_output.txt',
+        ]],
+        ['quuz', []],
+        ['quuz/corge', [
+            'events.out.tfevents.1473720642.corge.com']
+        ],
+        ['quuz/grault', ['events.out.tfevents.1473720643.grault.com']],
+        ['ba*', []],
+        ['ba*/baz', ['events.out.tfevents.1473720644.asterisk.com']],
+    ]
+    for pair in expected:
+      # If this is not the top-level directory, prepend the high-level
+      # directory.
+      pair[0] = os.path.join(temp_dir, pair[0]) if pair[0] else temp_dir
+      pair[1] = [os.path.join(pair[0], f) for f in pair[1]]
+    self._CompareFilesPerSubdirectory(
+        expected, io_wrapper.ListRecursivelyViaWalking(temp_dir))
 
   def _CreateDeepDirectoryStructure(self, top_directory):
     """Creates a reasonable deep structure of subdirectories with files.
@@ -170,9 +158,21 @@ class IoWrapperTest(tf.test.TestCase):
     """
     # Add a few subdirectories.
     directory_names = (
+        # An empty directory.
         'foo',
+        # A directory with an events file (and a text file).
         'bar',
+        # A deeper directory with events files.
         'bar/baz',
+        # A non-empty subdirectory that lacks event files (should be ignored).
+        'bar/quux',
+        # A directory that lacks events files, but contains 2 subdirectories
+        # with events files (first level should be ignored, second level should
+        # be included). corge and grault are thus subling events files.
+        'quuz/corge',
+        'quuz/grault',
+        # A directory with a glob character in its name.
+        'ba*/baz',
     )
     for directory_name in directory_names:
       os.makedirs(os.path.join(top_directory, directory_name))
@@ -185,9 +185,38 @@ class IoWrapperTest(tf.test.TestCase):
         'bar/red_herring.txt',
         'bar/baz/events.out.tfevents.1473720383.baz.com',
         'bar/baz/events.out.tfevents.1473720384.baz.com',
+        'bar/quux/some_flume_output.txt',
+        'bar/quux/some_more_flume_output.txt',
+        'quuz/corge/events.out.tfevents.1473720642.corge.com',
+        'quuz/grault/events.out.tfevents.1473720643.grault.com',
+        'ba*/baz/events.out.tfevents.1473720644.asterisk.com',
     )
     for file_name in file_names:
       open(os.path.join(top_directory, file_name), 'w').close()
+
+  def _CompareFilesPerSubdirectory(self, expected, gotten):
+    """Compares iterables of (subdirectory path, list of absolute paths)
+
+    Args:
+      expected: The expected iterable of 2-tuples.
+      gotten: The gotten iterable of 2-tuples.
+    """
+    expected_directory_to_listing = {
+        result[0]: list(result[1]) for result in expected}
+    gotten_directory_to_listing = {
+        result[0]: list(result[1]) for result in gotten}
+    self.assertItemsEqual(
+        expected_directory_to_listing.keys(),
+        gotten_directory_to_listing.keys())
+
+    for subdirectory, expected_listing in expected_directory_to_listing.items():
+      gotten_listing = gotten_directory_to_listing[subdirectory]
+      self.assertItemsEqual(
+          expected_listing,
+          gotten_listing,
+          'Files for subdirectory %r must match. Expected %r. Got %r.' % (
+              subdirectory, expected_listing, gotten_listing))
+
 
 
 if __name__ == '__main__':

--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -18,7 +18,6 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
-import os
 import threading
 
 import six
@@ -27,6 +26,7 @@ import tensorflow as tf
 from tensorboard import data_compat
 from tensorboard.backend.event_processing import directory_watcher
 from tensorboard.backend.event_processing import event_file_loader
+from tensorboard.backend.event_processing import io_wrapper
 from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.backend.event_processing import reservoir
 
@@ -55,23 +55,6 @@ STORE_EVERYTHING_SIZE_GUIDANCE = {
 }
 
 _TENSOR_RESERVOIR_KEY = "."  # arbitrary
-
-
-def IsTensorFlowEventsFile(path):
-  """Check the path name to see if it is probably a TF Events file.
-
-  Args:
-    path: A file path to check if it is an event file.
-
-  Raises:
-    ValueError: If the path is an empty string.
-
-  Returns:
-    If path is formatted like a TensorFlowEventsFile.
-  """
-  if not path:
-    raise ValueError('Path must be a nonempty string')
-  return 'tfevents' in tf.compat.as_str_any(os.path.basename(path))
 
 
 class EventAccumulator(object):
@@ -577,11 +560,13 @@ def _GeneratorFromPath(path):
   """Create an event generator for file or directory at given path string."""
   if not path:
     raise ValueError('path must be a valid string')
-  if IsTensorFlowEventsFile(path):
+  if io_wrapper.IsTensorFlowEventsFile(path):
     return event_file_loader.EventFileLoader(path)
   else:
     return directory_watcher.DirectoryWatcher(
-        path, event_file_loader.EventFileLoader, IsTensorFlowEventsFile)
+        path,
+        event_file_loader.EventFileLoader,
+        io_wrapper.IsTensorFlowEventsFile)
 
 
 def _ParseFileVersion(file_version):

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer.py
@@ -172,7 +172,7 @@ class EventMultiplexer(object):
       The `EventMultiplexer`.
     """
     tf.logging.info('Starting AddRunsFromDirectory: %s', path)
-    for subdir in GetLogdirSubdirectories(path):
+    for subdir in io_wrapper.GetLogdirSubdirectories(path):
       tf.logging.info('Adding run from directory %s', subdir)
       rpath = os.path.relpath(subdir, path)
       subname = os.path.join(name, rpath) if name else rpath
@@ -432,17 +432,3 @@ class EventMultiplexer(object):
     """
     with self._accumulators_mutex:
       return self._accumulators[run]
-
-
-def GetLogdirSubdirectories(path):
-  """Returns subdirectories with event files on path."""
-  if tf.gfile.Exists(path) and not tf.gfile.IsDirectory(path):
-    raise ValueError('GetLogdirSubdirectories: path exists and is not a '
-                     'directory, %s' % path)
-
-  # ListRecursively just yields nothing if the path doesn't exist.
-  return (
-      subdir
-      for (subdir, files) in io_wrapper.ListRecursively(path)
-      if list(filter(event_accumulator.IsTensorFlowEventsFile, files))
-  )


### PR DESCRIPTION
Previously, TensorBoard found runs within the log directory by
performing a `tf.gfile.Walk` across directories. That turned out to be
very slow for users with expansive log directories (with many
subdirectories and files) because `tf.gfile.Walk` makes many calls at
the python level to C++ logic for reading data from disk (as opposed to
performing much of that logic directly at the C++ level). Disk reads can
be very costly for certain (such as remote and distributed) file systems.

We find runs (subdirectories) much more quickly by iteratively glob-ing
deeper and deeper directory levels. For a certain internal user, this
reduced the time it took to find all runs from 20 minutes to 20 seconds.

We already have tests that check whether the multiplexer correctly finds
subdirectories that are runs, so this pull request adds no further
tests. We preserve that correctness and just speed up that logic. This
change may result in us finding runs in different orders, but that is
fine - TensorBoard documents no guarantees in terms of the order in
which runs are discovered.

Thank you to @nfelt for this idea and the fruitful brainstorming
session.