### PR TITLE
Remove Object.values()

### DIFF
--- a/tensorboard/components/tf_imports/BUILD
+++ b/tensorboard/components/tf_imports/BUILD
@@ -5,6 +5,20 @@ load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
+# TODO(jart): Update @io_bazel_rules_closure//closure/library to export
+#             fine-grained build rules, so we won't schlep in that whole
+#             codebase when we're not running the Closure Compiler. Also
+#             note that TensorBoard build tooling auto-includes base.js.
+tf_web_library(
+    name = "closure",
+    srcs = [
+        "closure.html",
+        "@com_google_javascript_closure_library//:closure/goog/object/object.js",
+    ],
+    path = "/tf-imports",
+    visibility = ["//visibility:public"],
+)
+
 tf_web_library(
     name = "webcomponentsjs",
     srcs = ["@org_definitelytyped//:webcomponents.js.d.ts"],
@@ -491,4 +505,3 @@ genrule(
     outs = ["d3-transition.d.ts"],
     cmd = "sed '/^declare module/d' $< | awk '/^}$$/ && !p {p++;next}1' >$@",
 )
-

--- a/tensorboard/components/tf_imports/closure.html
+++ b/tensorboard/components/tf_imports/closure.html
@@ -1,0 +1,18 @@
+<!--
+@license
+Copyright 2006 The Closure Library Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script src="closure/goog/object/object.js"></script>

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -19,6 +19,7 @@ tf_web_library(
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_globals",
+        "//tensorboard/components/tf_imports:closure",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_paginated_view",

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -27,6 +27,7 @@ limitations under the License.
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
 <link rel="import" href="../tf-globals/tf-globals.html">
+<link rel="import" href="../tf-imports/closure.html">
 <link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../tf-paginated-view/tf-paginated-view-store.html">
 <link rel="import" href="../tf-storage/tf-storage.html">
@@ -400,7 +401,7 @@ limitations under the License.
         _dashboardData: {
           type: Array,
           readOnly: true,
-          value: Object.values(tf_tensorboard.dashboardRegistry),
+          value: goog.object.getValues(tf_tensorboard.dashboardRegistry),
         },
 
         /**


### PR DESCRIPTION
According to https://caniuse.com/#search=object.value this does not work in IE
or Chrome <=49 which is 0.82% of the global population. The Closure Library can
solve this problem.

See also: https://stackoverflow.com/q/49355552/1653720