### PR TITLE
supporting streaming trace viewer in tensorboard.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bazel-*
 /.idea
+.DS_Store
 *.pyc
 *.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,8 @@ script:
       --local_resources=400,2,1.0 \
       --worker_max_instances=2 \
       --strategy=Javac=worker \
-      --strategy=Closure=worker
+      --strategy=Closure=worker \
+      --distinct_host_configuration=false
 
   - |
     bazel \
@@ -75,7 +76,9 @@ script:
       --test_verbose_timeout_warnings \
       --test_output=errors \
       --spawn_strategy=sandboxed \
-      --local_resources=400,2,1.0
+      --local_resources=400,2,1.0 \
+      --distinct_host_configuration=false
+
   - |
     TB=$(pwd)
     cd bazel-genfiles

--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ summary.FileWriter. A full explanation, with examples, is in [the
 tutorial](https://www.tensorflow.org/get_started/summaries_and_tensorboard).
 
 The supported summary ops include:
-* tf.summary.scalar
-* tf.summary.image
-* tf.summary.audio
-* tf.summary.text
-* tf.summary.histogram
+* [`tf.summary.scalar`](https://www.tensorflow.org/api_docs/python/tf/summary/scalar)
+* [`tf.summary.image`](https://www.tensorflow.org/api_docs/python/tf/summary/image)
+* [`tf.summary.audio`](https://www.tensorflow.org/api_docs/python/tf/summary/audio)
+* [`tf.summary.text`](https://www.tensorflow.org/api_docs/python/tf/summary/text)
+* [`tf.summary.histogram`](https://www.tensorflow.org/api_docs/python/tf/summary/histogram)
 
 ### Tags: Giving names to data
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,11 +2,11 @@ workspace(name = "org_tensorflow_tensorboard")
 
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "6691c58a2cd30a86776dd9bb34898b041e37136f2dc7e24cadaeaf599c95c657",
-    strip_prefix = "rules_closure-08039ba8ca59f64248bb3b6ae016460fe9c9914f",
+    sha256 = "7fb23196455e26d83559cf8a2afa13f720d512f10215228186badfe6d6ad1b18",
+    strip_prefix = "rules_closure-0.6.0",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/08039ba8ca59f64248bb3b6ae016460fe9c9914f.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/08039ba8ca59f64248bb3b6ae016460fe9c9914f.tar.gz",  # 2018-01-16
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.6.0.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/0.6.0.tar.gz",
     ],
 )
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -13,6 +13,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -24,6 +25,7 @@ py_test(
     deps = [
         ":io_wrapper",
         "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -94,6 +96,7 @@ py_library(
     deps = [
         ":directory_watcher",
         ":event_file_loader",
+        ":io_wrapper",
         ":plugin_asset_util",
         ":reservoir",
         "//tensorboard:data_compat",
@@ -188,7 +191,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":event_accumulator",
-        ":event_multiplexer",
+        ":io_wrapper",
         "//tensorboard:expect_tensorflow_installed",
     ],
 )

--- a/tensorboard/backend/event_processing/directory_watcher_test.py
+++ b/tensorboard/backend/event_processing/directory_watcher_test.py
@@ -193,7 +193,12 @@ class DirectoryWatcherTest(tf.test.TestCase):
 
     FakeFactory.has_been_called = False
 
-    for stub_name in ['ListDirectoryAbsolute', 'ListRecursively']:
+    stub_names = [
+        'ListDirectoryAbsolute',
+        'ListRecursivelyViaGlobbing',
+        'ListRecursivelyViaWalking',
+    ]
+    for stub_name in stub_names:
       self.stubs.Set(io_wrapper, stub_name,
                      FakeFactory(getattr(io_wrapper, stub_name)))
     for stub_name in ['IsDirectory', 'Exists', 'Stat']:

--- a/tensorboard/backend/event_processing/event_accumulator.py
+++ b/tensorboard/backend/event_processing/event_accumulator.py
@@ -18,13 +18,13 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
-import os
 import threading
 
 import tensorflow as tf
 
 from tensorboard.backend.event_processing import directory_watcher
 from tensorboard.backend.event_processing import event_file_loader
+from tensorboard.backend.event_processing import io_wrapper
 from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.backend.event_processing import reservoir
 from tensorboard.plugins.distribution import compressor
@@ -96,23 +96,6 @@ STORE_EVERYTHING_SIZE_GUIDANCE = {
     HISTOGRAMS: 0,
     TENSORS: 0,
 }
-
-
-def IsTensorFlowEventsFile(path):
-  """Check the path name to see if it is probably a TF Events file.
-
-  Args:
-    path: A file path to check if it is an event file.
-
-  Raises:
-    ValueError: If the path is an empty string.
-
-  Returns:
-    If path is formatted like a TensorFlowEventsFile.
-  """
-  if not path:
-    raise ValueError('Path must be a nonempty string')
-  return 'tfevents' in tf.compat.as_str_any(os.path.basename(path))
 
 
 class EventAccumulator(object):
@@ -747,11 +730,13 @@ def _GeneratorFromPath(path):
   """Create an event generator for file or directory at given path string."""
   if not path:
     raise ValueError('path must be a valid string')
-  if IsTensorFlowEventsFile(path):
+  if io_wrapper.IsTensorFlowEventsFile(path):
     return event_file_loader.EventFileLoader(path)
   else:
     return directory_watcher.DirectoryWatcher(
-        path, event_file_loader.EventFileLoader, IsTensorFlowEventsFile)
+        path,
+        event_file_loader.EventFileLoader,
+        io_wrapper.IsTensorFlowEventsFile)
 
 
 def _ParseFileVersion(file_version):

--- a/tensorboard/backend/event_processing/event_file_inspector.py
+++ b/tensorboard/backend/event_processing/event_file_inspector.py
@@ -120,7 +120,7 @@ import tensorflow as tf
 
 from tensorboard.backend.event_processing import event_accumulator
 from tensorboard.backend.event_processing import event_file_loader
-from tensorboard.backend.event_processing import event_multiplexer
+from tensorboard.backend.event_processing import io_wrapper
 
 FLAGS = tf.flags.FLAGS
 
@@ -323,12 +323,12 @@ def generators_from_logdir(logdir):
   Returns:
     List of event generators for each subdirectory with event files.
   """
-  subdirs = event_multiplexer.GetLogdirSubdirectories(logdir)
+  subdirs = io_wrapper.GetLogdirSubdirectories(logdir)
   generators = [
       itertools.chain(*[
           generator_from_event_file(os.path.join(subdir, f))
           for f in tf.gfile.ListDirectory(subdir)
-          if event_accumulator.IsTensorFlowEventsFile(os.path.join(subdir, f))
+          if io_wrapper.IsTensorFlowEventsFile(os.path.join(subdir, f))
       ]) for subdir in subdirs
   ]
   return generators
@@ -356,13 +356,13 @@ def get_inspection_units(logdir='', event_file='', tag=''):
     A list of InspectionUnit objects.
   """
   if logdir:
-    subdirs = event_multiplexer.GetLogdirSubdirectories(logdir)
+    subdirs = io_wrapper.GetLogdirSubdirectories(logdir)
     inspection_units = []
     for subdir in subdirs:
       generator = itertools.chain(*[
           generator_from_event_file(os.path.join(subdir, f))
           for f in tf.gfile.ListDirectory(subdir)
-          if event_accumulator.IsTensorFlowEventsFile(os.path.join(subdir, f))
+          if io_wrapper.IsTensorFlowEventsFile(os.path.join(subdir, f))
       ])
       inspection_units.append(InspectionUnit(
           name=subdir,
@@ -371,7 +371,7 @@ def get_inspection_units(logdir='', event_file='', tag=''):
     if inspection_units:
       print('Found event files in:\n{}\n'.format('\n'.join(
           [u.name for u in inspection_units])))
-    elif event_accumulator.IsTensorFlowEventsFile(logdir):
+    elif io_wrapper.IsTensorFlowEventsFile(logdir):
       print(
           'It seems that {} may be an event file instead of a logdir. If this '
           'is the case, use --event_file instead of --logdir to pass '

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import inspect
+
 import tensorflow as tf
 
 
@@ -49,8 +51,12 @@ class EventFileLoader(object):
     tf.logging.debug('Loading events from %s', self._file_path)
     while True:
       try:
-        with tf.errors.raise_exception_on_not_ok_status() as status:
-          self._reader.GetNext(status)
+        if not inspect.getargspec(self._reader.GetNext).args[1:]: # pylint: disable=deprecated-method
+          self._reader.GetNext()
+        else:
+          # GetNext() expects a status argument on TF <= 1.7
+          with tf.errors.raise_exception_on_not_ok_status() as status:
+            self._reader.GetNext(status)
       except (tf.errors.DataLossError, tf.errors.OutOfRangeError):
         # We ignore partial read exceptions, because a record may be truncated.
         # PyRecordReader holds the offset prior to the failed read, so retrying

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -166,7 +166,7 @@ class EventMultiplexer(object):
       The `EventMultiplexer`.
     """
     tf.logging.info('Starting AddRunsFromDirectory: %s', path)
-    for subdir in GetLogdirSubdirectories(path):
+    for subdir in io_wrapper.GetLogdirSubdirectories(path):
       tf.logging.info('Adding events from directory %s', subdir)
       rpath = os.path.relpath(subdir, path)
       subname = os.path.join(name, rpath) if name else rpath
@@ -480,17 +480,3 @@ class EventMultiplexer(object):
     """
     with self._accumulators_mutex:
       return self._accumulators[run]
-
-
-def GetLogdirSubdirectories(path):
-  """Returns subdirectories with event files on path."""
-  if tf.gfile.Exists(path) and not tf.gfile.IsDirectory(path):
-    raise ValueError('GetLogdirSubdirectories: path exists and is not a '
-                     'directory, %s' % path)
-
-  # ListRecursively just yields nothing if the path doesn't exist.
-  return (
-      subdir
-      for (subdir, files) in io_wrapper.ListRecursively(path)
-      if list(filter(event_accumulator.IsTensorFlowEventsFile, files))
-  )

--- a/tensorboard/backend/event_processing/io_wrapper.py
+++ b/tensorboard/backend/event_processing/io_wrapper.py
@@ -17,13 +17,40 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
 import os
+import re
 
+import six
 import tensorflow as tf
 
+_ESCAPE_GLOB_CHARACTERS_REGEX = re.compile('([*?[])')
 
+
+# TODO(chihuahua): Rename this method to use camel-case for GCS (Gcs).
 def IsGCSPath(path):
   return path.startswith("gs://")
+
+
+def IsCnsPath(path):
+  return path.startswith("/cns/")
+
+
+def IsTensorFlowEventsFile(path):
+  """Check the path name to see if it is probably a TF Events file.
+
+  Args:
+    path: A file path to check if it is an event file.
+
+  Raises:
+    ValueError: If the path is an empty string.
+
+  Returns:
+    If path is formatted like a TensorFlowEventsFile.
+  """
+  if not path:
+    raise ValueError('Path must be a nonempty string')
+  return 'tfevents' in tf.compat.as_str_any(os.path.basename(path))
 
 
 def ListDirectoryAbsolute(directory):
@@ -32,21 +59,140 @@ def ListDirectoryAbsolute(directory):
           for path in tf.gfile.ListDirectory(directory))
 
 
-def ListRecursively(top):
+def _EscapeGlobCharacters(path):
+  """Escapes the glob characters in a path.
+
+  Python 3 has a glob.escape method, but python 2 lacks it, so we manually
+  implement this method.
+
+  Args:
+    path: The absolute path to escape.
+
+  Returns:
+    The escaped path string.
+  """
+  drive, path = os.path.splitdrive(path)
+  return '%s%s' % (drive, _ESCAPE_GLOB_CHARACTERS_REGEX.sub(r'[\1]', path))
+
+
+def ListRecursivelyViaGlobbing(top):
+  """Recursively lists all files within the directory.
+
+  This method does not list subdirectories (in addition to regular files), and
+  the file paths are all absolute. If the directory does not exist, this yields
+  nothing.
+
+  This method does so by glob-ing deeper and deeper directories, ie
+  foo/*, foo/*/*, foo/*/*/* and so on until all files are listed. All file
+  paths are absolute, and this method lists subdirectories too.
+
+  For certain file systems, Globbing via this method may prove
+  significantly faster than recursively walking a directory.
+  Specifically, file systems that implement analogs to TensorFlow's
+  FileSystem.GetMatchingPaths method could save costly disk reads by using
+  this method. However, for other file systems, this method might prove slower
+  because the file system performs a walk per call to glob (in which case it
+  might as well just perform 1 walk).
+
+  Args:
+    top: A path to a directory.
+
+  Yields:
+    A (dir_path, file_paths) tuple for each directory/subdirectory.
+  """
+  current_glob_string = os.path.join(_EscapeGlobCharacters(top), '*')
+  level = 0
+
+  while True:
+    tf.logging.info('GlobAndListFiles: Starting to glob level %d', level)
+    glob = tf.gfile.Glob(current_glob_string)
+    tf.logging.info(
+        'GlobAndListFiles: %d files glob-ed at level %d', len(glob), level)
+
+    if not glob:
+      # This subdirectory level lacks files. Terminate.
+      return
+
+    # Map subdirectory to a list of files.
+    pairs = collections.defaultdict(list)
+    for file_path in glob:
+      pairs[os.path.dirname(file_path)].append(file_path)
+    for dir_name, file_paths in six.iteritems(pairs):
+      yield (dir_name, tuple(file_paths))
+
+    if len(pairs) == 1:
+      # If at any point the glob returns files that are all in a single
+      # directory, replace the current globbing path with that directory as the
+      # literal prefix. This should improve efficiency in cases where a single
+      # subdir is significantly deeper than the rest of the sudirs.
+      current_glob_string = os.path.join(list(pairs.keys())[0], '*')
+
+    # Iterate to the next level of subdirectories.
+    current_glob_string = os.path.join(current_glob_string, '*')
+    level += 1
+
+
+def ListRecursivelyViaWalking(top):
   """Walks a directory tree, yielding (dir_path, file_paths) tuples.
 
   For each of `top` and its subdirectories, yields a tuple containing the path
   to the directory and the path to each of the contained files.  Note that
-  unlike os.Walk()/tf.gfile.Walk(), this does not list subdirectories and the
-  file paths are all absolute.
+  unlike os.Walk()/tf.gfile.Walk()/ListRecursivelyViaGlobbing, this does not
+  list subdirectories. The file paths are all absolute. If the directory does
+  not exist, this yields nothing.
 
-  If the directory does not exist, this yields nothing.
+  Walking may be incredibly slow on certain file systems.
 
   Args:
-    top: A path to a directory..
+    top: A path to a directory.
+
   Yields:
-    A list of (dir_path, file_paths) tuples.
+    A (dir_path, file_paths) tuple for each directory/subdirectory.
   """
   for dir_path, _, filenames in tf.gfile.Walk(top):
     yield (dir_path, (os.path.join(dir_path, filename)
                       for filename in filenames))
+
+
+def GetLogdirSubdirectories(path):
+  """Obtains all subdirectories with events files.
+
+  The order of the subdirectories returned is unspecified. The internal logic
+  that determines order varies by scenario.
+
+  Args:
+    path: The path to a directory under which to find subdirectories.
+
+  Returns:
+    A tuple of absolute paths of all subdirectories each with at least 1 events
+    file directly within the subdirectory.
+
+  Raises:
+    ValueError: If the path passed to the method exists and is not a directory.
+  """
+  if not tf.gfile.Exists(path):
+    # No directory to traverse.
+    return ()
+
+  if not tf.gfile.IsDirectory(path):
+    raise ValueError('GetLogdirSubdirectories: path exists and is not a '
+                     'directory, %s' % path)
+
+  if IsGCSPath(path) or IsCnsPath(path):
+    # Glob-ing for files can be significantly faster than recursively
+    # walking through directories for some file systems.
+    tf.logging.info(
+        'GetLogdirSubdirectories: Starting to list directories via glob-ing.')
+    traversal_method = ListRecursivelyViaGlobbing
+  else:
+    # For other file systems, the glob-ing based method might be slower because
+    # each call to glob could involve performing a recursive walk.
+    tf.logging.info(
+        'GetLogdirSubdirectories: Starting to list directories via walking.')
+    traversal_method = ListRecursivelyViaWalking
+
+  return (
+      subdir
+      for (subdir, files) in traversal_method(path)
+      if any(IsTensorFlowEventsFile(f) for f in files)
+  )

--- a/tensorboard/backend/event_processing/io_wrapper_test.py
+++ b/tensorboard/backend/event_processing/io_wrapper_test.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import os
 import tempfile
 
+import six
 import tensorflow as tf
 
 from tensorboard.backend.event_processing import io_wrapper
@@ -32,113 +33,277 @@ class IoWrapperTest(tf.test.TestCase):
   def testIsGcsPathIsFalse(self):
     self.assertFalse(io_wrapper.IsGCSPath('/tmp/foo'))
 
+  def testIsCnsPathTrue(self):
+    self.assertTrue(io_wrapper.IsCnsPath('/cns/foo/bar'))
+
+  def testIsCnsPathFalse(self):
+    self.assertFalse(io_wrapper.IsCnsPath('/tmp/foo'))
+
+  def testIsIsTensorFlowEventsFileTrue(self):
+    self.assertTrue(
+        io_wrapper.IsTensorFlowEventsFile(
+            '/logdir/events.out.tfevents.1473720042.com'))
+
+  def testIsIsTensorFlowEventsFileFalse(self):
+    self.assertFalse(
+        io_wrapper.IsTensorFlowEventsFile('/logdir/model.ckpt'))
+
+  def testIsIsTensorFlowEventsFileWithEmptyInput(self):
+    with six.assertRaisesRegex(self,
+                               ValueError,
+                               r'Path must be a nonempty string'):
+      io_wrapper.IsTensorFlowEventsFile('')
+
   def testListDirectoryAbsolute(self):
     temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
-
-    # Add a few subdirectories.
-    directory_names = (
-        'foo',
-        'bar',
-        'we/must/go/deeper'
-    )
-    for directory_name in directory_names:
-      os.makedirs(os.path.join(temp_dir, directory_name))
-
-    # Add a few files to the directory.
-    file_names = (
-        'events.out.tfevents.1473720381.foo.com',
-        'model.ckpt',
-        'we/must_not_include_this_file_in_the_listing.txt'
-    )
-    for file_name in file_names:
-      open(os.path.join(temp_dir, file_name), 'w').close()
+    self._CreateDeepDirectoryStructure(temp_dir)
 
     expected_files = (
         'foo',
         'bar',
-        'we',
-        'events.out.tfevents.1473720381.foo.com',
+        'quuz',
+        'a.tfevents.1',
         'model.ckpt',
+        'waldo',
     )
     self.assertItemsEqual(
         (os.path.join(temp_dir, f) for f in expected_files),
         io_wrapper.ListDirectoryAbsolute(temp_dir))
 
-  def testListRecursivelyForNestedFiles(self):
+  def testListRecursivelyViaGlobbing(self):
     temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
+    self._CreateDeepDirectoryStructure(temp_dir)
+    expected = [
+        ['', [
+            'foo',
+            'bar',
+            'a.tfevents.1',
+            'model.ckpt',
+            'quuz',
+            'waldo',
+        ]],
+        ['bar', [
+            'b.tfevents.1',
+            'red_herring.txt',
+            'baz',
+            'quux',
+        ]],
+        ['bar/baz', [
+            'c.tfevents.1',
+            'd.tfevents.1',
+        ]],
+        ['bar/quux', [
+            'some_flume_output.txt',
+            'some_more_flume_output.txt',
+        ]],
+        ['quuz', [
+            'e.tfevents.1',
+            'garply',
+        ]],
+        ['quuz/garply', [
+            'f.tfevents.1',
+            'corge',
+            'grault',
+        ]],
+        ['quuz/garply/corge', [
+            'g.tfevents.1'
+        ]],
+        ['quuz/garply/grault', [
+            'h.tfevents.1',
+        ]],
+        ['waldo', [
+            'fred',
+        ]],
+        ['waldo/fred', [
+            'i.tfevents.1',
+        ]],
+    ]
+    for pair in expected:
+      # If this is not the top-level directory, prepend the high-level
+      # directory.
+      pair[0] = os.path.join(temp_dir, pair[0]) if pair[0] else temp_dir
+      pair[1] = [os.path.join(pair[0], f) for f in pair[1]]
+    self._CompareFilesPerSubdirectory(
+        expected, io_wrapper.ListRecursivelyViaGlobbing(temp_dir))
 
-    # Add a few subdirectories.
+  def testListRecursivelyViaGlobbingForPathWithGlobCharacters(self):
+    temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
     directory_names = (
-        'foo',
+        'ba*',
+        'ba*/subdirectory',
         'bar',
-        'bar/baz',
     )
     for directory_name in directory_names:
       os.makedirs(os.path.join(temp_dir, directory_name))
 
-    # Add a few files to the directory.
     file_names = (
-        'events.out.tfevents.1473720381.meep.com',
-        'model.ckpt',
-        'bar/events.out.tfevents.1473720382.bar.com',
-        'bar/red_herring.txt',
-        'bar/baz/events.out.tfevents.1473720383.baz.com',
-        'bar/baz/events.out.tfevents.1473720384.baz.com',
+        'ba*/a.tfevents.1',
+        'ba*/subdirectory/b.tfevents.1',
+        'bar/c.tfevents.1',
     )
     for file_name in file_names:
       open(os.path.join(temp_dir, file_name), 'w').close()
 
-    # There were 4 subdirectories in total.
-    listing = io_wrapper.ListRecursively(temp_dir)
-    directory_to_listing = {
-        dir: list(generator) for (dir, generator) in listing}
-    expected = (
-        'foo',
+    expected = [
+        ['', [
+            'a.tfevents.1',
+            'subdirectory',
+        ]],
+        ['subdirectory', [
+            'b.tfevents.1',
+        ]],
+        # The contents of the bar subdirectory should be excluded from
+        # this listing because the * character should have been escaped.
+    ]
+    top = os.path.join(temp_dir, 'ba*')
+    for pair in expected:
+      # If this is not the top-level directory, prepend the high-level
+      # directory.
+      pair[0] = os.path.join(top, pair[0]) if pair[0] else top
+      pair[1] = [os.path.join(pair[0], f) for f in pair[1]]
+    self._CompareFilesPerSubdirectory(
+        expected, io_wrapper.ListRecursivelyViaGlobbing(top))
+
+  def testListRecursivelyViaWalking(self):
+    temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
+    self._CreateDeepDirectoryStructure(temp_dir)
+    expected = [
+        ['', [
+            'a.tfevents.1',
+            'model.ckpt',
+        ]],
+        ['foo', []],
+        ['bar', [
+            'b.tfevents.1',
+            'red_herring.txt',
+        ]],
+        ['bar/baz', [
+            'c.tfevents.1',
+            'd.tfevents.1',
+        ]],
+        ['bar/quux', [
+            'some_flume_output.txt',
+            'some_more_flume_output.txt',
+        ]],
+        ['quuz', [
+            'e.tfevents.1',
+        ]],
+        ['quuz/garply', [
+            'f.tfevents.1',
+        ]],
+        ['quuz/garply/corge', [
+            'g.tfevents.1',
+        ]],
+        ['quuz/garply/grault', [
+            'h.tfevents.1',
+        ]],
+        ['waldo', []],
+        ['waldo/fred', [
+            'i.tfevents.1',
+        ]],
+    ]
+    for pair in expected:
+      # If this is not the top-level directory, prepend the high-level
+      # directory.
+      pair[0] = os.path.join(temp_dir, pair[0]) if pair[0] else temp_dir
+      pair[1] = [os.path.join(pair[0], f) for f in pair[1]]
+    self._CompareFilesPerSubdirectory(
+        expected, io_wrapper.ListRecursivelyViaWalking(temp_dir))
+
+  def testGetLogdirSubdirectories(self):
+    temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
+    self._CreateDeepDirectoryStructure(temp_dir)
+    # Only subdirectories that immediately contains at least 1 events
+    # file should be listed.
+    expected = [
+        '',
         'bar',
-        'bar/baz'
-    )
+        'bar/baz',
+        'quuz',
+        'quuz/garply',
+        'quuz/garply/corge',
+        'quuz/garply/grault',
+        'waldo/fred',
+    ]
     self.assertItemsEqual(
-        [os.path.join(temp_dir, f) for f in expected] + [temp_dir],
-        directory_to_listing.keys())
+        [(os.path.join(temp_dir, subdir) if subdir else temp_dir)
+         for subdir in expected],
+        io_wrapper.GetLogdirSubdirectories(temp_dir))
 
-    # Test for the listings of individual directories.
-    expected = (
-        'events.out.tfevents.1473720381.meep.com',
+  def _CreateDeepDirectoryStructure(self, top_directory):
+    """Creates a reasonable deep structure of subdirectories with files.
+
+    Args:
+      top_directory: The absolute path of the top level directory in
+        which to create the directory structure.
+    """
+    # Add a few subdirectories.
+    directory_names = (
+        # An empty directory.
+        'foo',
+        # A directory with an events file (and a text file).
+        'bar',
+        # A deeper directory with events files.
+        'bar/baz',
+        # A non-empty subdirectory that lacks event files (should be ignored).
+        'bar/quux',
+        # This 3-level deep set of subdirectories tests logic that replaces the
+        # full glob string with an absolute path prefix if there is only 1
+        # subdirectory in the final mapping.
+        'quuz/garply',
+        'quuz/garply/corge',
+        'quuz/garply/grault',
+        # A directory that lacks events files, but contains a subdirectory
+        # with events files (first level should be ignored, second level should
+        # be included).
+        'waldo',
+        'waldo/fred',
+    )
+    for directory_name in directory_names:
+      os.makedirs(os.path.join(top_directory, directory_name))
+
+    # Add a few files to the directory.
+    file_names = (
+        'a.tfevents.1',
         'model.ckpt',
+        'bar/b.tfevents.1',
+        'bar/red_herring.txt',
+        'bar/baz/c.tfevents.1',
+        'bar/baz/d.tfevents.1',
+        'bar/quux/some_flume_output.txt',
+        'bar/quux/some_more_flume_output.txt',
+        'quuz/e.tfevents.1',
+        'quuz/garply/f.tfevents.1',
+        'quuz/garply/corge/g.tfevents.1',
+        'quuz/garply/grault/h.tfevents.1',
+        'waldo/fred/i.tfevents.1',
     )
+    for file_name in file_names:
+      open(os.path.join(top_directory, file_name), 'w').close()
+
+  def _CompareFilesPerSubdirectory(self, expected, gotten):
+    """Compares iterables of (subdirectory path, list of absolute paths)
+
+    Args:
+      expected: The expected iterable of 2-tuples.
+      gotten: The gotten iterable of 2-tuples.
+    """
+    expected_directory_to_listing = {
+        result[0]: list(result[1]) for result in expected}
+    gotten_directory_to_listing = {
+        result[0]: list(result[1]) for result in gotten}
     self.assertItemsEqual(
-        (os.path.join(temp_dir, f) for f in expected),
-        directory_to_listing[temp_dir])
+        expected_directory_to_listing.keys(),
+        gotten_directory_to_listing.keys())
 
-    expected = ()
-    self.assertItemsEqual(
-        (os.path.join(temp_dir, 'foo', f) for f in expected),
-        directory_to_listing[os.path.join(temp_dir, 'foo')])
+    for subdirectory, expected_listing in expected_directory_to_listing.items():
+      gotten_listing = gotten_directory_to_listing[subdirectory]
+      self.assertItemsEqual(
+          expected_listing,
+          gotten_listing,
+          'Files for subdirectory %r must match. Expected %r. Got %r.' % (
+              subdirectory, expected_listing, gotten_listing))
 
-    expected = (
-        'events.out.tfevents.1473720382.bar.com',
-        'red_herring.txt',
-    )
-    self.assertItemsEqual(
-        (os.path.join(temp_dir, 'bar', f) for f in expected),
-        directory_to_listing[os.path.join(temp_dir, 'bar')])
-
-    expected = (
-        'events.out.tfevents.1473720383.baz.com',
-        'events.out.tfevents.1473720384.baz.com',
-    )
-    self.assertItemsEqual(
-        (os.path.join(temp_dir, 'bar/baz', f) for f in expected),
-        directory_to_listing[os.path.join(temp_dir, 'bar/baz')])
-
-  def testListRecursivelyForEmptyDirectory(self):
-    empty_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
-    subdirectory_entries = list(io_wrapper.ListRecursively(empty_dir))
-    self.assertEqual(1, len(subdirectory_entries))
-
-    entry = subdirectory_entries[0]
-    self.assertEqual(empty_dir, entry[0])
-    self.assertItemsEqual((), entry[1])
 
 
 if __name__ == '__main__':

--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -18,7 +18,6 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
-import os
 import threading
 
 import six
@@ -27,6 +26,7 @@ import tensorflow as tf
 from tensorboard import data_compat
 from tensorboard.backend.event_processing import directory_watcher
 from tensorboard.backend.event_processing import event_file_loader
+from tensorboard.backend.event_processing import io_wrapper
 from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.backend.event_processing import reservoir
 
@@ -55,23 +55,6 @@ STORE_EVERYTHING_SIZE_GUIDANCE = {
 }
 
 _TENSOR_RESERVOIR_KEY = "."  # arbitrary
-
-
-def IsTensorFlowEventsFile(path):
-  """Check the path name to see if it is probably a TF Events file.
-
-  Args:
-    path: A file path to check if it is an event file.
-
-  Raises:
-    ValueError: If the path is an empty string.
-
-  Returns:
-    If path is formatted like a TensorFlowEventsFile.
-  """
-  if not path:
-    raise ValueError('Path must be a nonempty string')
-  return 'tfevents' in tf.compat.as_str_any(os.path.basename(path))
 
 
 class EventAccumulator(object):
@@ -577,11 +560,13 @@ def _GeneratorFromPath(path):
   """Create an event generator for file or directory at given path string."""
   if not path:
     raise ValueError('path must be a valid string')
-  if IsTensorFlowEventsFile(path):
+  if io_wrapper.IsTensorFlowEventsFile(path):
     return event_file_loader.EventFileLoader(path)
   else:
     return directory_watcher.DirectoryWatcher(
-        path, event_file_loader.EventFileLoader, IsTensorFlowEventsFile)
+        path,
+        event_file_loader.EventFileLoader,
+        io_wrapper.IsTensorFlowEventsFile)
 
 
 def _ParseFileVersion(file_version):

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer.py
@@ -172,7 +172,7 @@ class EventMultiplexer(object):
       The `EventMultiplexer`.
     """
     tf.logging.info('Starting AddRunsFromDirectory: %s', path)
-    for subdir in GetLogdirSubdirectories(path):
+    for subdir in io_wrapper.GetLogdirSubdirectories(path):
       tf.logging.info('Adding run from directory %s', subdir)
       rpath = os.path.relpath(subdir, path)
       subname = os.path.join(name, rpath) if name else rpath
@@ -432,17 +432,3 @@ class EventMultiplexer(object):
     """
     with self._accumulators_mutex:
       return self._accumulators[run]
-
-
-def GetLogdirSubdirectories(path):
-  """Returns subdirectories with event files on path."""
-  if tf.gfile.Exists(path) and not tf.gfile.IsDirectory(path):
-    raise ValueError('GetLogdirSubdirectories: path exists and is not a '
-                     'directory, %s' % path)
-
-  # ListRecursively just yields nothing if the path doesn't exist.
-  return (
-      subdir
-      for (subdir, files) in io_wrapper.ListRecursively(path)
-      if list(filter(event_accumulator.IsTensorFlowEventsFile, files))
-  )

--- a/tensorboard/components/tf_trace_viewer/BUILD
+++ b/tensorboard/components/tf_trace_viewer/BUILD
@@ -29,8 +29,7 @@ tf_web_library(
 tf_web_library(
     name = "tf-trace-viewer-helper",
     srcs = [
-        "tf-trace-viewer-helper.html",
-        "tf-trace-viewer-helper.js",
+        "tf-trace-viewer-helper.ts",
     ],
     path = "/tf-trace-viewer",
 )

--- a/tensorboard/components/tf_trace_viewer/BUILD
+++ b/tensorboard/components/tf_trace_viewer/BUILD
@@ -11,6 +11,9 @@ tf_web_library(
         "@org_chromium_catapult_vulcanized_trace_viewer//:trace_viewer_full.html",
     ],
     path = "/tf-trace-viewer",
+    deps = [
+        ":tf-trace-viewer-helper",
+    ],
 )
 
 tf_web_library(
@@ -23,3 +26,11 @@ tf_web_library(
     ],
 )
 
+tf_web_library(
+    name = "tf-trace-viewer-helper",
+    srcs = [
+        "tf-trace-viewer-helper.html",
+        "tf-trace-viewer-helper.js",
+    ],
+    path = "/tf-trace-viewer",
+)

--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer-helper.html
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer-helper.html
@@ -1,1 +1,0 @@
-<script src="tf-trace-viewer-helper.js"></script>

--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer-helper.html
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer-helper.html
@@ -1,0 +1,1 @@
+<script src="tf-trace-viewer-helper.js"></script>

--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer-helper.js
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer-helper.js
@@ -1,0 +1,75 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/**
+ * @fileoverview Helper utilities for the trace viewer within TensorBoard's profile plugin.
+ */
+
+var tf_component_traceViewer = new Object({
+  /** Amount of zooming allowed before re-fetching. */
+  ZOOM_RATIO : 8,
+
+  /** Minimum safety buffer relative to viewport size. */
+  PRESERVE_RATIO : 2,
+
+  /** Amount to fetch relative to viewport size. */
+  FETCH_RATIO : 3,
+
+  /**
+   * Expand the input range by scale, keep the center invariant.
+   */
+  expand: function(range, scale) {
+    var width = range.max - range.min;
+    var mid = range.min + width / 2;
+    return {
+      min: mid - scale * width / 2,
+      max: mid + scale * width / 2,
+    };
+  },
+  /**
+   * Check if range is within (totally included) in bounds.
+   */
+  within: function(range, bounds) {
+    return bounds.min <= range.min && range.max <= bounds.max;
+  },
+  /**
+   * Return length of the range.
+   */
+  length: function(range) {
+    return range.max - range.min;
+  },
+  /**
+   * Return the intersection of two ranges.
+   */
+  intersect: function(range, bounds) {
+    return {
+      min: Math.max(range.min, bounds.min),
+      max: Math.min(range.max, bounds.max),
+    };
+  },
+  /**
+   *  Compute the {min, max} range of a trackView.
+   *  TODO: Spec out an interface for the trackView.
+   */
+  trackViewRange: function(trackView) {
+    var xfm = trackView.viewport.currentDisplayTransform;
+    const pixelRatio = window.devicePixelRatio || 1;
+    const devicePixelWidth = pixelRatio * trackView.viewWidth_;
+    return {
+      min: xfm.xViewToWorld(0),
+      max: xfm.xViewToWorld(devicePixelWidth),
+    };
+  },
+});

--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer-helper.ts
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer-helper.ts
@@ -17,59 +17,51 @@ limitations under the License.
  * @fileoverview Helper utilities for the trace viewer within TensorBoard's profile plugin.
  */
 
-var tf_component_traceViewer = new Object({
+namespace tf_component_traceviewer {
   /** Amount of zooming allowed before re-fetching. */
-  ZOOM_RATIO : 8,
+  export const ZOOM_RATIO = 8;
 
   /** Minimum safety buffer relative to viewport size. */
-  PRESERVE_RATIO : 2,
+  export const PRESERVE_RATIO = 2;
 
   /** Amount to fetch relative to viewport size. */
-  FETCH_RATIO : 3,
+  export const FETCH_RATIO = 3;
+
+  export interface Range {
+    min: number;
+    max: number;
+  }
 
   /**
    * Expand the input range by scale, keep the center invariant.
    */
-  expand: function(range, scale) {
+  export function expand(range: Range, scale: number) : Range {
     var width = range.max - range.min;
     var mid = range.min + width / 2;
     return {
       min: mid - scale * width / 2,
       max: mid + scale * width / 2,
     };
-  },
+  }
   /**
    * Check if range is within (totally included) in bounds.
    */
-  within: function(range, bounds) {
+  export function within(range: Range, bounds: Range): boolean {
     return bounds.min <= range.min && range.max <= bounds.max;
-  },
+  }
   /**
    * Return length of the range.
    */
-  length: function(range) {
+  export function length(range: Range): number {
     return range.max - range.min;
-  },
+  }
   /**
    * Return the intersection of two ranges.
    */
-  intersect: function(range, bounds) {
+  export function intersect(range: Range, bounds: Range): Range {
     return {
       min: Math.max(range.min, bounds.min),
       max: Math.min(range.max, bounds.max),
     };
-  },
-  /**
-   *  Compute the {min, max} range of a trackView.
-   *  TODO: Spec out an interface for the trackView.
-   */
-  trackViewRange: function(trackView) {
-    var xfm = trackView.viewport.currentDisplayTransform;
-    const pixelRatio = window.devicePixelRatio || 1;
-    const devicePixelWidth = pixelRatio * trackView.viewWidth_;
-    return {
-      min: xfm.xViewToWorld(0),
-      max: xfm.xViewToWorld(devicePixelWidth),
-    };
-  },
-});
+  }
+}  // namespace tf_component_traceviewer

--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
@@ -222,8 +222,8 @@ dashboard would integrate trace viewer app using iframe.
         xhr.open('GET', requestURL);
         xhr.onload = function() {
           var contentType = this.getResponseHeader('Content-Type');
-          if (this.status !== 200 |
-            !contentType.startsWith('application/json')) {
+          if (this.status !== 200 ||
+              !contentType.startsWith('application/json')) {
             var msg = requestURL + ' could not be loaded';
             if (contentType.startsWith('text/plain')) {
               msg = msg + ': ' + xhr.statusText;

--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
@@ -109,7 +109,6 @@ dashboard would integrate trace viewer app using iframe.
       var queryString = window.location.href.split("?")[1];
       if (queryString) {
         var parts = queryString.split('&')
-        console.log(queryString);
         for (var i=0; i<parts.length; i++) {
           var components = parts[i].split('=');
           if (components[0] == "trace_data_url") {

--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
@@ -53,6 +53,48 @@ dashboard would integrate trace viewer app using iframe.
 <script>
   "use strict";
 
+  /* streaming mode helper functions */
+  var ZOOM_RATIO = 8;      // Amount of zooming allowed before re-fetching.
+  var PRESERVE_RATIO = 2;  // Minimum safety buffer relative to viewport size.
+  var FETCH_RATIO = 3;     // Amount to fetch relative to viewport size.
+
+  /* Helpers that operate on {min, max} ranges */
+  function expand(range, scale) {
+    var width = range.max - range.min;
+    var mid = range.min + width / 2;
+    return {
+      min: mid - scale * width / 2,
+      max: mid + scale * width / 2,
+    };
+  }
+  function within(range, bounds) {
+    return bounds.min <= range.min && range.max <= bounds.max;
+  }
+  function length(range) {
+    return range.max - range.min;
+  }
+  function intersect(range, bounds) {
+    return {
+      min: Math.max(range.min, bounds.min),
+      max: Math.min(range.max, bounds.max),
+    };
+  }
+  // Access the {min, max} range of a trackView.
+  function trackViewRange(trackView) {
+    var xfm = trackView.viewport.currentDisplayTransform;
+    const pixelRatio = window.devicePixelRatio || 1;
+    const devicePixelWidth = pixelRatio * trackView.viewWidth_;
+    return {
+      min: xfm.xViewToWorld(0),
+      max: xfm.xViewToWorld(devicePixelWidth),
+    };
+  }
+
+  /* tf-trace-viewer will work in two modes: static mode and streaming mode.
+   * in static mode, data are load at 'ready' time,
+   * in streaming mode, data are load on demand when resolution and view port is changed.
+   * static mode limit the amount of trace that we can collect and show to the users.
+   */
   Polymer({
     is: "tf-trace-viewer",
     properties: {
@@ -61,6 +103,7 @@ dashboard would integrate trace viewer app using iframe.
         type: String,
         value: null,
       },
+      // _traceData is used for static mode.
       _traceData: {
         type: Object,
         observer: "_traceDataChanged"
@@ -69,7 +112,16 @@ dashboard would integrate trace viewer app using iframe.
       _traceContainer: Object,
       _traceModel: Object,
       _throbber: Object,
+      _isStreaming: { type: Boolean, value: false },
+      _loadedRange: Object,
+      _loadedTraceEents: Object,
+      _fullBounds: Object,
+      _isLoading: { type:Boolean, value: false },
+      _dirty: { type:Boolean, value: false },
+      _model: Object,
+      _resolution: { type: Number, value: 1000 },
     },
+
     ready: function() {
       // Initiate the trace viewer app.
       this._traceContainer = document.createElement("track-view-container");
@@ -93,48 +145,216 @@ dashboard would integrate trace viewer app using iframe.
       var queryString = window.location.href.split("?")[1];
       if (queryString) {
         var parts = queryString.split('&')
+        console.log(queryString);
         for (var i=0; i<parts.length; i++) {
           var components = parts[i].split('=');
           if (components[0] == "trace_data_url") {
             this.traceDataUrl = decodeURIComponent(components[1]);
-            break;
+          } else if (components[0] == "is_streaming") {
+            this._isStreaming = components[1] == 'true' ? true : false;
           }
         }
       }
 
-      this._throbber.className = "active";
-      this._loadTrace();
-    },
-    _loadTrace : function() {
       if (!this.traceDataUrl) {
         this._displayOverlay("Trace data URL is not provided.", "Trace Viewer");
         return null;
       }
-      // Send HTTP request to get the trace data.
-      var req = new XMLHttpRequest();
-      var is_binary = / [.] gz$ /.test(this.traceDataUrl) ||
-                      / [.] zip$ /.test(this.traceDataUrl);
-      req.overrideMimeType('text/plain; charset=x-user-defined');
-      req.open('GET', this.traceDataUrl, true);
-      if (is_binary) {
-        req.responseType = 'arraybuffer';
+      this._throbber.className = "active";
+
+      this._loadTrace();
+    },
+
+    // Something has changed, so consider reloading the data:
+    //   - if we have zoomed in enough to need more detail
+    //   - if we have scrolled too close to missing data regions
+    // We ensure there's only ever one request in flight.
+    _loadTrace : function() {
+      if (!this._isStreaming) {
+        // Send HTTP request to get the trace data.
+        var req = new XMLHttpRequest();
+        var is_binary = / [.] gz$ /.test(this.traceDataUrl) ||
+                        / [.] zip$ /.test(this.traceDataUrl);
+        req.overrideMimeType('text/plain; charset=x-user-defined');
+        req.open('GET', this.traceDataUrl, true);
+        if (is_binary) {
+          req.responseType = 'arraybuffer';
+        }
+
+        req.onreadystatechange = function(event) {
+          if (req.readyState !== 4) {
+            return;
+          }
+          window.setTimeout(function() {
+            if (req.status === 200) {
+              this._throbber.className = "inactive";
+              this.set("_traceData", is_binary ? req.response : req.responseText);
+            } else {
+              this._displayOverlay(req.status, "Failed to fetch data");
+            }
+          }.bind(this), 0);
+        }.bind(this);
+        req.send(null);
+      } else {
+        this._loadStreamingTrace();
+      }
+    },
+
+    // Something has changed, so consider reloading the data:
+    //   - if we have zoomed in enough to need more detail
+    //   - if we have scrolled too close to missing data regions
+    // We ensure there's only ever one request in flight.
+    _maybeLoad : function() {
+      if (this._isLoading || this._resolution == 0) return;
+      // We have several ranges of interest:
+      //             [viewport]           - what's on-screen
+      //         [----preserve----]       - issue loads to keep this full of data
+      //     [---------fetch----------]   - fetch this much data with each load
+      // [-----------full bounds--------] - the whole profile
+      var viewport = trackViewRange(this._traceViewer.trackView);
+      var preserve = intersect(expand(viewport, PRESERVE_RATIO), this._fullBounds);
+      var fetch = expand(viewport, FETCH_RATIO);
+      var zoomFactor = length(this._loadedRange) / length(fetch);
+      if (!within(preserve, this._loadedRange) || zoomFactor > ZOOM_RATIO) {
+        console.log("loading more data: ", {
+          zoomFactor: zoomFactor,
+          loadedRange: this._loadedRange,
+          viewport: viewport,
+          preserve: preserve,
+          fetch: fetch,
+        });
+        this._loadTrace(fetch, /*replaceModel=*/false);
+      }
+    },
+
+    _loadStreamingTrace : function(requestedRange, replaceModel) {
+      var success = true;
+      this._isLoading = true;
+
+      this._loadJSON(requestedRange).
+	  then((data) => { this._updateModel(data, replaceModel); }).
+	  then(() => { this._updateView(requestedRange); }).
+	  catch((err) => { this._displayOverlay("Trace Viewer", err);})
+	  .then(() => {
+            this._isLoading = false;
+            this._throbber.className = "inactive";
+            // Don't immediately load new data after the very first load. When
+            // we first load the trace viewer, the actual view is not properly
+            // initialized and we get an incorrect viewport leading to a spurious
+            // load of data.
+            if (success && requestedRange) this._maybeLoad();
+          });
+    },
+
+    // Loads a time window (the whole trace if requestedRange is null).
+    // Returns a promise for the JSON event data.
+    _loadJSON : function(requestedRange) {
+      // Set up an XMLHTTPRequest to the JSON endpoint, populating range and
+      // resolution if appropriate.
+      var requestURL = this._buildBaseURL();
+      requestURL.searchParams.set("resolution", this._resolution * ZOOM_RATIO);
+      if (requestedRange != null) {
+        requestURL.searchParams.set("start_time_ms", requestedRange.min);
+        requestURL.searchParams.set("end_time_ms", requestedRange.max);
       }
 
-      req.onreadystatechange = function(event) {
-        if (req.readyState !== 4) {
-          return;
-        }
-        window.setTimeout(function() {
-          if (req.status === 200) {
-            this._throbber.className = "inactive";
-            this.set("_traceData", is_binary ? req.response : req.responseText);
-          } else {
-            this._displayOverlay(req.status, "Failed to fetch data");
+      return fetch(requestURL.toString()).then(
+        function(response) {
+          if (response.status !== 200) {
+            var msg = requestURL + ' could not be loaded';
+            if (response.headers.get('Content-Type').startsWith('text/plain')) {
+              return response.text().then((text) => {
+                throw new Error(msg + ': ' + text);
+              });
+            }
+            throw new Error(msg);
           }
-        }.bind(this), 0);
-      }.bind(this);
-      req.send(null);
+          console.log('loaded:');
+
+          return response.text();
+        });
     },
+    // Decodes the JSON trace events, removes all events that were loaded before
+    // and serializes to JSON again.
+    _filterKnownTraceEvents: function(data) {
+      var traceEvents = data.traceEvents;
+      data.traceEvents = [];
+      for (var i = 0; i < traceEvents.length; i++) {
+        // This is inefficient as we are serializing the events we just
+        // deserialized. If this becomes a problem in practice, we should assign
+        // IDs on the server.
+        var asString = JSON.stringify(traceEvents[i]);
+        if (!this._loadedTraceEvents.has(asString)) {
+          this._loadedTraceEvents.add(asString);
+          data.traceEvents.push(traceEvents[i]);
+        }
+      }
+      return data;
+    },
+
+    // Updates the model with data returned by the JSON endpoint.
+    // If replaceModel is true, the data set is completely replaced; otherwise,
+    // the new data is merged with the old data.
+    // Returns a void promise.
+    _updateModel: function(data, replaceModel) {
+      data = JSON.parse(data);
+      if (!this._model /* first load */ || replaceModel) {
+        this._dirty = true;
+        this._model = new tr.Model();
+        this._loadedTraceEvents = new Set();
+      } else {
+        // Delete metadata and displayTimeUnits as otherwise traceviewer
+        // accumulates them.
+        delete data['metadata'];
+        delete data['displayTimeUnit'];
+      }
+
+      data = this._filterKnownTraceEvents(data);
+      if (data.traceEvents.length > 0) {
+        var opt = new tr.importer.ImportOptions();
+        opt.shiftWorldToZero = false;
+        new tr.importer.Import(this._model, opt).importTraces([data]);
+        this._dirty = true;
+      }
+      return Promise.resolve();
+    },
+
+    // Updates the view based on the current model.
+    _updateView: function(requestedRange) {
+      if (requestedRange == null) {
+        this._fullBounds = {min: this._model.bounds.min, max: this._model.bounds.max};
+        this._loadedRange = expand(this._fullBounds, FETCH_RATIO);
+      } else {
+        this._loadedRange = requestedRange;
+      }
+      if (!this._dirty) {
+        return;
+      }
+      this._dirty = false;
+      // We can't assign the model until the viewer is attached. This may be
+      // delayed indefinitely if the tab is backgrounded. This version of polymer
+      // doesn't provide a direct way to observe the viewer being attached.
+      // This is a hack: the browser won't paint until the viewer is attached.
+      window.requestAnimationFrame(function() {
+        this._traceViewer.model = this._model;
+        if (this._traceViewer.trackView != null) {  // Only initialized if data in nonempty!
+          // Wait 200ms to let an animated zoom/pan operation complete. Ideally,
+          // we could just explicitly wait for its end.
+
+          this._traceViewer.trackView.viewport.addEventListener(
+              "change", () => setTimeout(this._maybeLoad.bind(this), 200));
+        }
+        this._traceViewer.viewTitle = "";
+      }.bind(this));
+    },
+
+    // Builds a base URL for fetching json data. The URL will be assembled with
+    // all filtering URL parameters, except resolution and range.
+    _buildBaseURL: function() {
+      var requestURL = new URL(this.traceDataUrl, window.location.href);
+      return requestURL;
+    },
+
     _traceDataChanged: function(data) {
       if (!data) {
         this._displayOverlay("Trace Viewer", "No trace to display...");
@@ -152,6 +372,7 @@ dashboard would integrate trace viewer app using iframe.
             'Import error', tr.b.normalizeException(err).message);
       });
     },
+
     _displayOverlay: function(title, content) {
       var overlay = new tr.ui.b.Overlay();
       overlay.textContent = content;

--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
@@ -238,8 +238,6 @@ dashboard would integrate trace viewer app using iframe.
             }
             throw new Error(msg);
           }
-          console.log('loaded:');
-
           return response.text();
         });
     },

--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
@@ -128,21 +128,11 @@ dashboard would integrate trace viewer app using iframe.
       this._loadTrace();
     },
 
-    // Something has changed, so consider reloading the data:
-    //   - if we have zoomed in enough to need more details.
-    //   - if we have scrolled too close to missing data regions
-    // We ensure there's only ever one request in flight.
     _loadTrace : function() {
       if (!this._isStreaming) {
         // Send HTTP request to get the trace data.
         var req = new XMLHttpRequest();
-        var is_binary = / [.] gz$ /.test(this.traceDataUrl) ||
-                        / [.] zip$ /.test(this.traceDataUrl);
-        req.overrideMimeType('text/plain; charset=x-user-defined');
         req.open('GET', this.traceDataUrl, true);
-        if (is_binary) {
-          req.responseType = 'arraybuffer';
-        }
 
 	req.onreadystatechange = event => {
           if (req.readyState !== 4) {
@@ -151,7 +141,7 @@ dashboard would integrate trace viewer app using iframe.
 	  window.setTimeout(() => {
             if (req.status === 200) {
               this._throbber.className = "inactive";
-              this.set("_traceData", is_binary ? req.response : req.responseText);
+              this.set("_traceData", req.responseText);
             } else {
               this._displayOverlay(req.status, "Failed to fetch data");
             }
@@ -227,19 +217,26 @@ dashboard would integrate trace viewer app using iframe.
         requestURL.searchParams.set("end_time_ms", requestedRange.max);
       }
 
-      return fetch(requestURL.toString()).then(
-        function(response) {
-          if (response.status !== 200) {
+      return new Promise(function(resolve, reject) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', requestURL);
+        xhr.onload = function() {
+          var contentType = this.getResponseHeader('Content-Type');
+          if (this.status !== 200 |
+            !contentType.startsWith('application/json')) {
             var msg = requestURL + ' could not be loaded';
-            if (response.headers.get('Content-Type').startsWith('text/plain')) {
-              return response.text().then((text) => {
-                throw new Error(msg + ': ' + text);
-              });
+            if (contentType.startsWith('text/plain')) {
+              msg = msg + ': ' + xhr.statusText;
             }
-            throw new Error(msg);
+            reject(msg);
           }
-          return response.text();
-        });
+          resolve(xhr.response);
+        };
+        xhr.onerror = function () {
+          reject(requestURL + 'could not be loaded: ' + xhr.statusText);
+        };
+        xhr.send();
+      });
     },
     // Decodes the JSON trace events, removes all events that were loaded before
     // and serializes to JSON again.

--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
@@ -16,6 +16,7 @@ limitations under the License.
 -->
 
 <link rel="import" href="trace_viewer_full.html">
+<link rel="import" href="tf-trace-viewer-helper.html">
 
 <!--
 tf-trace-viewer is the frontend entry point for Trace Viewer on TensorBoard.
@@ -53,43 +54,6 @@ dashboard would integrate trace viewer app using iframe.
 <script>
   "use strict";
 
-  /* streaming mode helper functions */
-  var ZOOM_RATIO = 8;      // Amount of zooming allowed before re-fetching.
-  var PRESERVE_RATIO = 2;  // Minimum safety buffer relative to viewport size.
-  var FETCH_RATIO = 3;     // Amount to fetch relative to viewport size.
-
-  /* Helpers that operate on {min, max} ranges */
-  function expand(range, scale) {
-    var width = range.max - range.min;
-    var mid = range.min + width / 2;
-    return {
-      min: mid - scale * width / 2,
-      max: mid + scale * width / 2,
-    };
-  }
-  function within(range, bounds) {
-    return bounds.min <= range.min && range.max <= bounds.max;
-  }
-  function length(range) {
-    return range.max - range.min;
-  }
-  function intersect(range, bounds) {
-    return {
-      min: Math.max(range.min, bounds.min),
-      max: Math.min(range.max, bounds.max),
-    };
-  }
-  // Access the {min, max} range of a trackView.
-  function trackViewRange(trackView) {
-    var xfm = trackView.viewport.currentDisplayTransform;
-    const pixelRatio = window.devicePixelRatio || 1;
-    const devicePixelWidth = pixelRatio * trackView.viewWidth_;
-    return {
-      min: xfm.xViewToWorld(0),
-      max: xfm.xViewToWorld(devicePixelWidth),
-    };
-  }
-
   /* tf-trace-viewer will work in two modes: static mode and streaming mode.
    * in static mode, data are load at 'ready' time,
    * in streaming mode, data are load on demand when resolution and view port is changed.
@@ -116,8 +80,8 @@ dashboard would integrate trace viewer app using iframe.
       _loadedRange: Object,
       _loadedTraceEents: Object,
       _fullBounds: Object,
-      _isLoading: { type:Boolean, value: false },
-      _dirty: { type:Boolean, value: false },
+      _isLoading: { type: Boolean, value: false },
+      _dirty: { type: Boolean, value: false },
       _model: Object,
       _resolution: { type: Number, value: 1000 },
     },
@@ -151,7 +115,7 @@ dashboard would integrate trace viewer app using iframe.
           if (components[0] == "trace_data_url") {
             this.traceDataUrl = decodeURIComponent(components[1]);
           } else if (components[0] == "is_streaming") {
-            this._isStreaming = components[1] == 'true' ? true : false;
+            this._isStreaming = components[1] === 'true';
           }
         }
       }
@@ -166,7 +130,7 @@ dashboard would integrate trace viewer app using iframe.
     },
 
     // Something has changed, so consider reloading the data:
-    //   - if we have zoomed in enough to need more detail
+    //   - if we have zoomed in enough to need more details.
     //   - if we have scrolled too close to missing data regions
     // We ensure there's only ever one request in flight.
     _loadTrace : function() {
@@ -181,19 +145,19 @@ dashboard would integrate trace viewer app using iframe.
           req.responseType = 'arraybuffer';
         }
 
-        req.onreadystatechange = function(event) {
+	req.onreadystatechange = event => {
           if (req.readyState !== 4) {
             return;
           }
-          window.setTimeout(function() {
+	  window.setTimeout(() => {
             if (req.status === 200) {
               this._throbber.className = "inactive";
               this.set("_traceData", is_binary ? req.response : req.responseText);
             } else {
               this._displayOverlay(req.status, "Failed to fetch data");
             }
-          }.bind(this), 0);
-        }.bind(this);
+          }, 0);
+        };
         req.send(null);
       } else {
         this._loadStreamingTrace();
@@ -211,11 +175,16 @@ dashboard would integrate trace viewer app using iframe.
       //         [----preserve----]       - issue loads to keep this full of data
       //     [---------fetch----------]   - fetch this much data with each load
       // [-----------full bounds--------] - the whole profile
-      var viewport = trackViewRange(this._traceViewer.trackView);
-      var preserve = intersect(expand(viewport, PRESERVE_RATIO), this._fullBounds);
-      var fetch = expand(viewport, FETCH_RATIO);
-      var zoomFactor = length(this._loadedRange) / length(fetch);
-      if (!within(preserve, this._loadedRange) || zoomFactor > ZOOM_RATIO) {
+      var viewport = tf_component_traceViewer.trackViewRange(this._traceViewer.trackView);
+      var PRESERVE_RATIO = tf_component_traceViewer.PRESERVE_RATIO;
+      var preserve = tf_component_traceViewer.intersect(
+          tf_component_traceViewer.expand(viewport, PRESERVE_RATIO), this._fullBounds);
+      var FETCH_RATIO = tf_component_traceViewer.FETCH_RATIO;
+      var fetch = tf_component_traceViewer.expand(viewport, FETCH_RATIO);
+      var zoomFactor = tf_component_traceViewer.length(this._loadedRange) /
+	               tf_component_traceViewer.length(fetch);
+      if (!tf_component_traceViewer.within(preserve, this._loadedRange) ||
+          zoomFactor > tf_component_traceViewer.ZOOM_RATIO) {
         console.log("loading more data: ", {
           zoomFactor: zoomFactor,
           loadedRange: this._loadedRange,
@@ -252,6 +221,7 @@ dashboard would integrate trace viewer app using iframe.
       // Set up an XMLHTTPRequest to the JSON endpoint, populating range and
       // resolution if appropriate.
       var requestURL = this._buildBaseURL();
+      var ZOOM_RATIO = tf_component_traceViewer.ZOOM_RATIO;
       requestURL.searchParams.set("resolution", this._resolution * ZOOM_RATIO);
       if (requestedRange != null) {
         requestURL.searchParams.set("start_time_ms", requestedRange.min);
@@ -323,11 +293,12 @@ dashboard would integrate trace viewer app using iframe.
     _updateView: function(requestedRange) {
       if (requestedRange == null) {
         this._fullBounds = {min: this._model.bounds.min, max: this._model.bounds.max};
-        this._loadedRange = expand(this._fullBounds, FETCH_RATIO);
+        this._loadedRange = tf_component_traceViewer.expand(
+	    this._fullBounds, tf_component_traceViewer.FETCH_RATIO);
       } else {
         this._loadedRange = requestedRange;
       }
-      if (!this._dirty) {
+      if (!this._dirty){
         return;
       }
       this._dirty = false;

--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
@@ -16,7 +16,6 @@ limitations under the License.
 -->
 
 <link rel="import" href="trace_viewer_full.html">
-<link rel="import" href="tf-trace-viewer-helper.html">
 
 <!--
 tf-trace-viewer is the frontend entry point for Trace Viewer on TensorBoard.
@@ -51,6 +50,7 @@ dashboard would integrate trace viewer app using iframe.
     transition-delay: 0.3s;
   }
 </style>
+<script src="tf-trace-viewer-helper.js"></script>
 <script>
   "use strict";
 
@@ -175,16 +175,16 @@ dashboard would integrate trace viewer app using iframe.
       //         [----preserve----]       - issue loads to keep this full of data
       //     [---------fetch----------]   - fetch this much data with each load
       // [-----------full bounds--------] - the whole profile
-      var viewport = tf_component_traceViewer.trackViewRange(this._traceViewer.trackView);
-      var PRESERVE_RATIO = tf_component_traceViewer.PRESERVE_RATIO;
-      var preserve = tf_component_traceViewer.intersect(
-          tf_component_traceViewer.expand(viewport, PRESERVE_RATIO), this._fullBounds);
-      var FETCH_RATIO = tf_component_traceViewer.FETCH_RATIO;
-      var fetch = tf_component_traceViewer.expand(viewport, FETCH_RATIO);
-      var zoomFactor = tf_component_traceViewer.length(this._loadedRange) /
-	               tf_component_traceViewer.length(fetch);
-      if (!tf_component_traceViewer.within(preserve, this._loadedRange) ||
-          zoomFactor > tf_component_traceViewer.ZOOM_RATIO) {
+      var viewport = this._trackViewRange(this._traceViewer.trackView);
+      var PRESERVE_RATIO = tf_component_traceviewer.PRESERVE_RATIO;
+      var preserve = tf_component_traceviewer.intersect(
+          tf_component_traceviewer.expand(viewport, PRESERVE_RATIO), this._fullBounds);
+      var FETCH_RATIO = tf_component_traceviewer.FETCH_RATIO;
+      var fetch = tf_component_traceviewer.expand(viewport, FETCH_RATIO);
+      var zoomFactor = tf_component_traceviewer.length(this._loadedRange) /
+	               tf_component_traceviewer.length(fetch);
+      if (!tf_component_traceviewer.within(preserve, this._loadedRange) ||
+          zoomFactor > tf_component_traceviewer.ZOOM_RATIO) {
         console.log("loading more data: ", {
           zoomFactor: zoomFactor,
           loadedRange: this._loadedRange,
@@ -221,7 +221,7 @@ dashboard would integrate trace viewer app using iframe.
       // Set up an XMLHTTPRequest to the JSON endpoint, populating range and
       // resolution if appropriate.
       var requestURL = this._buildBaseURL();
-      var ZOOM_RATIO = tf_component_traceViewer.ZOOM_RATIO;
+      var ZOOM_RATIO = tf_component_traceviewer.ZOOM_RATIO;
       requestURL.searchParams.set("resolution", this._resolution * ZOOM_RATIO);
       if (requestedRange != null) {
         requestURL.searchParams.set("start_time_ms", requestedRange.min);
@@ -293,8 +293,8 @@ dashboard would integrate trace viewer app using iframe.
     _updateView: function(requestedRange) {
       if (requestedRange == null) {
         this._fullBounds = {min: this._model.bounds.min, max: this._model.bounds.max};
-        this._loadedRange = tf_component_traceViewer.expand(
-	    this._fullBounds, tf_component_traceViewer.FETCH_RATIO);
+        this._loadedRange = tf_component_traceviewer.expand(
+	    this._fullBounds, tf_component_traceviewer.FETCH_RATIO);
       } else {
         this._loadedRange = requestedRange;
       }
@@ -317,6 +317,17 @@ dashboard would integrate trace viewer app using iframe.
         }
         this._traceViewer.viewTitle = "";
       }.bind(this));
+    },
+
+    // Access the {min, max} range of a trackView.
+    _trackViewRange: function(trackView) {
+      var xfm = trackView.viewport.currentDisplayTransform;
+      const pixelRatio = window.devicePixelRatio || 1;
+      const devicePixelWidth = pixelRatio * trackView.viewWidth_;
+      return {
+        min: xfm.xViewToWorld(0),
+        max: xfm.xViewToWorld(devicePixelWidth),
+      };
     },
 
     // Builds a base URL for fetching json data. The URL will be assembled with

--- a/tensorboard/defs/vulcanize.bzl
+++ b/tensorboard/defs/vulcanize.bzl
@@ -18,7 +18,7 @@ load("//tensorboard/defs:web.bzl", "web_aspect")
 
 def _tensorboard_html_binary(ctx):
   deps = unfurl(ctx.attr.deps, provider="webfiles")
-  manifests = depset(order="topological")
+  manifests = depset(order="postorder")
   files = depset()
   webpaths = depset()
   for dep in deps:

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -187,10 +187,22 @@ def _tf_web_library(ctx):
   web_srcs.append(dummy)
 
   # define development web server that only applies to this transitive closure
+  if ctx.attr.srcs:
+    devserver_manifests = manifests
+    export_deps = []
+  else:
+    # If a rule exists purely to export other build rules, then it's
+    # appropriate for the exported sources to be included in the
+    # development web server.
+    devserver_manifests = depset(order="postorder")
+    export_deps = unfurl(ctx.attr.exports, provider="webfiles")
+    for dep in export_deps:
+      devserver_manifests += dep.webfiles.manifests
+    devserver_manifests = manifests + devserver_manifests
   params = struct(
       label=str(ctx.label),
       bind="[::]:6006",
-      manifest=[long_path(ctx, man) for man in manifests],
+      manifest=[long_path(ctx, man) for man in devserver_manifests],
       external_asset=[struct(webpath=k, path=v)
                       for k, v in ctx.attr.external_assets.items()])
   params_file = _new_file(ctx, "-params.pbtxt")
@@ -235,6 +247,7 @@ def _tf_web_library(ctx):
               dummy],
           transitive_files=(collect_runfiles([ctx.attr._WebfilesServer]) |
                             collect_runfiles(deps) |
+                            collect_runfiles(export_deps) |
                             collect_runfiles(ctx.attr.data) |
                             aspect_runfiles)))
 
@@ -284,7 +297,7 @@ def _make_manifest(ctx, src_list):
 
 def _run_webfiles_validator(ctx, srcs, deps, manifest):
   dummy = _new_file(ctx, "-webfiles.ignoreme")
-  manifests = depset(order="topological")
+  manifests = depset(order="postorder")
   for dep in deps:
     manifests += dep.webfiles.manifests
   if srcs:
@@ -376,7 +389,7 @@ def _get_strip(ctx):
 
 web_aspect = aspect(
     implementation=_web_aspect_impl,
-    attr_aspects=["deps", "sticky_deps", "module_deps"],
+    attr_aspects=["deps", "sticky_deps", "module_deps", "exports"],
     attrs={"_ClosureWorkerAspect": _CLOSURE_WORKER})
 
 tf_web_library = rule(
@@ -418,4 +431,3 @@ tf_web_library = rule(
         "_closure_library_deps": CLOSURE_LIBRARY_DEPS_ATTR,
     }.items()),
     outputs=CLUTZ_OUTPUTS)
-

--- a/tensorboard/defs/zipper.bzl
+++ b/tensorboard/defs/zipper.bzl
@@ -16,7 +16,7 @@ load("@io_bazel_rules_closure//closure/private:defs.bzl", "unfurl", "long_path")
 
 def _tensorboard_zip_file(ctx):
   deps = unfurl(ctx.attr.deps, provider="webfiles")
-  manifests = depset(order="topological")
+  manifests = depset(order="postorder")
   files = depset()
   webpaths = depset()
   for dep in deps:

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -44,6 +44,7 @@ import com.google.javascript.jscomp.PropertyRenamingPolicy;
 import com.google.javascript.jscomp.Result;
 import com.google.javascript.jscomp.SourceFile;
 import com.google.javascript.jscomp.WarningsGuard;
+import com.google.javascript.jscomp.deps.ModuleLoader;
 import com.google.protobuf.TextFormat;
 import io.bazel.rules.closure.Webpath;
 import io.bazel.rules.closure.webfiles.BuildInfo.Webfiles;
@@ -414,6 +415,7 @@ public final class Vulcanize {
 
     CompilerOptions options = new CompilerOptions();
     compilationLevel.setOptionsForCompilationLevel(options);
+    options.setModuleResolutionMode(ModuleLoader.ResolutionMode.NODE);
 
     // Nice options.
     options.setColorizeErrorOutput(true);

--- a/tensorboard/loader.py
+++ b/tensorboard/loader.py
@@ -24,13 +24,14 @@ from __future__ import print_function
 import collections
 import contextlib
 import functools
+import inspect
 import locale
 import logging
 import os
 import re
 import sys
-import time
 import threading
+import time
 import types  # pylint: disable=unused-import
 
 import six
@@ -115,8 +116,12 @@ class RecordReader(object):
     if self._reader is None:
       self._reader = self._open()
     try:
-      with tf.errors.raise_exception_on_not_ok_status() as status:
-        self._reader.GetNext(status)
+      if not inspect.getargspec(self._reader.GetNext).args[1:]: # pylint: disable=deprecated-method
+        self._reader.GetNext()
+      else:
+        # GetNext() expects a status argument on TF <= 1.7
+        with tf.errors.raise_exception_on_not_ok_status() as status:
+          self._reader.GetNext(status)
     except tf.errors.OutOfRangeError:
       # We ignore partial read exceptions, because a record may be truncated.
       # PyRecordReader holds the offset prior to the failed read, so retrying

--- a/tensorboard/plugins/audio/audio_plugin_test.py
+++ b/tensorboard/plugins/audio/audio_plugin_test.py
@@ -94,10 +94,15 @@ class AudioPluginTest(tf.test.TestCase):
     context = base_plugin.TBContext(
         logdir=self.log_dir, multiplexer=multiplexer)
     self.plugin = audio_plugin.AudioPlugin(context)
+    # Setting a reload interval of -1 disables reloading. We disable reloading
+    # because we seek to block tests from running til after one reload finishes.
+    # This setUp method thus manually reloads the multiplexer. TensorBoard would
+    # otherwise reload in a non-blocking thread.
     wsgi_app = application.TensorBoardWSGIApp(
-        self.log_dir, [self.plugin], multiplexer, reload_interval=0,
+        self.log_dir, [self.plugin], multiplexer, reload_interval=-1,
         path_prefix='')
     self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+    multiplexer.Reload()
 
   def tearDown(self):
     shutil.rmtree(self.log_dir, ignore_errors=True)

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
@@ -72,7 +72,7 @@ from tensorflow.python import debug as tf_debug
 import keras
 
 keras.backend.set_session(
-    tf_debug.LocalCLIDebugWrapperSession(tf.Session()), "[[_host]]:[[_port]]")
+    tf_debug.TensorBoardDebugWrapperSession(tf.Session(), "[[_host]]:[[_port]]"))
 # Define your keras model, called "model".
 model.fit(...)
             </pre>

--- a/tensorboard/plugins/graph/tf_graph_common/externs.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/externs.ts
@@ -21,6 +21,7 @@ limitations under the License.
 
 declare module graphlib {
   interface GraphOptions {
+    compound?: boolean;
     name?: string;
     /**
      * Direction for rank nodes. Can be TB, BT, LR, or RL, where T = top,

--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -794,9 +794,15 @@ export class MetaedgeImpl implements Metaedge {
   }
 }
 
-export function createSeriesNode(prefix: string, suffix: string,
-    parent: string, clusterId: number, name: string): SeriesNode {
-  return new SeriesNodeImpl(prefix, suffix, parent, clusterId, name);
+export function createSeriesNode(
+    prefix: string,
+    suffix: string,
+    parent: string,
+    clusterId: number,
+    name: string,
+    graphOptions: graphlib.GraphOptions): SeriesNode {
+  return new SeriesNodeImpl(
+      prefix, suffix, parent, clusterId, name, graphOptions);
 }
 
 export function getSeriesNodeName(prefix: string, suffix: string,
@@ -830,8 +836,13 @@ class SeriesNodeImpl implements SeriesNode {
   include: InclusionType;
   nodeAttributes: {[key: string]: any;};
 
-  constructor(prefix: string, suffix: string, parent: string,
-      clusterId: number, name: string) {
+  constructor(
+      prefix: string,
+      suffix: string,
+      parent: string,
+      clusterId: number,
+      name: string,
+      graphOptions: graphlib.GraphOptions) {
     this.name = name || getSeriesNodeName(prefix, suffix, parent);
     this.type = NodeType.SERIES;
     this.hasLoop = false;
@@ -842,7 +853,8 @@ class SeriesNodeImpl implements SeriesNode {
     this.parent = parent;
     this.isGroupNode = true;
     this.cardinality = 0;
-    this.metagraph = createGraph<Metanode, Metaedge>(name, GraphType.SERIES);
+    this.metagraph = createGraph<Metanode, Metaedge>(
+        name, GraphType.SERIES, graphOptions);
     // bridgegraph must be constructed lazily-see hierarchy.getBridgegraph()
     this.bridgegraph = null;
     this.parentNode = null;
@@ -1244,12 +1256,14 @@ export function build(
 /**
  * Create a new graphlib.Graph() instance with default parameters
  */
-export function createGraph<N, E>(name: string, type, opt = {}):
-    graphlib.Graph<N, E> {
-  let graph = new graphlib.Graph<N, E>(opt);
+export function createGraph<N, E>(
+    name: string, type,
+    opt?: graphlib.GraphOptions): graphlib.Graph<N, E> {
+  const graphOptions = opt || {};
+  let graph = new graphlib.Graph<N, E>(graphOptions);
   graph.setGraph({
     name: name,
-    rankdir: 'BT',  // BT,TB,LR,RL
+    rankdir: graphOptions.rankdir || 'BT',  // BT,TB,LR,RL
     type: type
   });
   return graph;

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -49,6 +49,7 @@ export interface Hierarchy {
   hasShapeInfo: boolean;
   /** The maximum size across all meta edges. Used for scaling thickness. */
   maxMetaEdgeSize: number;
+  graphOptions: graphlib.GraphOptions;
   getNodeMap(): {[nodeName: string]: GroupNode|OpNode};
   node(name: string): GroupNode|OpNode;
   setNode(name: string, node: GroupNode|OpNode): void;
@@ -72,9 +73,17 @@ class HierarchyImpl implements Hierarchy {
   hasShapeInfo = false;
   maxMetaEdgeSize = 1;
   orderings: { [nodeName: string]: { [childName: string]: number } };
+  graphOptions: graphlib.GraphOptions;
 
-  constructor() {
-    this.root = createMetanode(ROOT_NAME, {compound: true});
+  /**
+   * Constructs a hierarchy.
+   * @param graphOptions Options passed to dagre for creating the graph. Note
+   *   that the `compound` argument will be overriden to true.
+   */
+  constructor(graphOptions: graphlib.GraphOptions) {
+    this.graphOptions = graphOptions || {};
+    this.graphOptions.compound = true;
+    this.root = createMetanode(ROOT_NAME, this.graphOptions);
     this.libraryFunctions = {};
     this.templates = null;
     this.devices = null;
@@ -119,7 +128,7 @@ class HierarchyImpl implements Hierarchy {
     }
     let bridgegraph = groupNode.bridgegraph =
         createGraph<GroupNode|OpNode, Metaedge>(
-            'BRIDGEGRAPH', GraphType.BRIDGE);
+            'BRIDGEGRAPH', GraphType.BRIDGE, this.graphOptions);
     if (!node.parentNode || !('metagraph' in node.parentNode)) {
       return bridgegraph;
     }
@@ -399,6 +408,9 @@ export interface HierarchyParams {
   verifyTemplate: boolean;
   seriesNodeMinSize: number;
   seriesMap: { [name: string]: tf.graph.SeriesGroupingType };
+  // This string is supplied to dagre as the 'rankdir' property for laying out
+  // the graph. TB, BT, LR, or RL. The default is 'BT' (bottom to top).
+  rankDirection: string;
 }
 
 /**
@@ -407,7 +419,7 @@ export interface HierarchyParams {
  */
 export function build(graph: tf.graph.SlimGraph, params: HierarchyParams,
     tracker: ProgressTracker): Promise<Hierarchy|void> {
-  let h = new HierarchyImpl();
+  let h = new HierarchyImpl({'rankdir': params.rankDirection});
   let seriesNames: { [name: string]: string } = {};
   return tf.graph.util
       .runAsyncTask(
@@ -611,7 +623,7 @@ function addNodes(h: Hierarchy, graph: SlimGraph) {
       let name = path[i];
       let child = <Metanode>h.node(name);
       if (!child) {
-        child = createMetanode(name);
+        child = createMetanode(name, h.graphOptions);
         child.parentNode = parent;
         h.setNode(name, child);
         parent.metagraph.setNode(name, child);
@@ -762,7 +774,7 @@ function groupSeries(metanode: Metanode, hierarchy: Hierarchy,
   });
 
   let clusters = clusterNodes(metagraph);
-  let seriesDict = detectSeries(clusters, metagraph);
+  let seriesDict = detectSeries(clusters, metagraph, hierarchy.graphOptions);
 
   // Add each series node to the graph and add its grouped children to its own
   // metagraph.
@@ -864,8 +876,10 @@ function clusterNodes(metagraph: graphlib.Graph<GroupNode|OpNode, Metaedge>):
  * @param metagraph
  * @return A dictionary from series name => seriesNode
  */
-function detectSeries(clusters: {[clusterId: string]: string[]},
-     metagraph: graphlib.Graph<GroupNode|OpNode, Metaedge>):
+function detectSeries(
+    clusters: {[clusterId: string]: string[]},
+    metagraph: graphlib.Graph<GroupNode|OpNode, Metaedge>,
+    graphOptions: graphlib.GraphOptions):
      {[seriesName: string]: SeriesNode} {
   let seriesDict: {[seriesName: string]: SeriesNode} = {};
   _.each(clusters, function(members, clusterId: string) {
@@ -900,7 +914,8 @@ function detectSeries(clusters: {[clusterId: string]: string[]},
       }
       let seriesName = getSeriesNodeName(prefix, suffix, parent);
       candidatesDict[seriesName] = candidatesDict[seriesName] || [];
-      let seriesNode = createSeriesNode(prefix, suffix, parent, +id, name);
+      let seriesNode = createSeriesNode(
+          prefix, suffix, parent, +id, name, graphOptions);
       candidatesDict[seriesName].push(seriesNode);
     });
 
@@ -924,10 +939,12 @@ function detectSeries(clusters: {[clusterId: string]: string[]},
           seriesNodes.push(nextNode);
           continue;
         }
-        addSeriesToDict(seriesNodes, seriesDict, +clusterId, metagraph);
+        addSeriesToDict(
+            seriesNodes, seriesDict, +clusterId, metagraph, graphOptions);
         seriesNodes = [nextNode];
       }
-      addSeriesToDict(seriesNodes, seriesDict, +clusterId, metagraph);
+      addSeriesToDict(
+          seriesNodes, seriesDict, +clusterId, metagraph, graphOptions);
     });
   });
   return seriesDict;
@@ -941,11 +958,13 @@ function detectSeries(clusters: {[clusterId: string]: string[]},
  * @param seriesDict the dictionary of series
  * @param clusterId ID of the template of the nodes of the series
  * @param metagraph
+ * @param graphOptions
  */
 function addSeriesToDict(seriesNodes: SeriesNode[],
     seriesDict: {[seriesName: string]: SeriesNode},
     clusterId: number,
-    metagraph: graphlib.Graph<GroupNode|OpNode, Metaedge>) {
+    metagraph: graphlib.Graph<GroupNode|OpNode, Metaedge>,
+    graphOptions: graphlib.GraphOptions) {
   if (seriesNodes.length > 1) {
     let curSeriesName = getSeriesNodeName(
       seriesNodes[0].prefix, seriesNodes[0].suffix,
@@ -953,7 +972,7 @@ function addSeriesToDict(seriesNodes: SeriesNode[],
       seriesNodes[seriesNodes.length - 1].clusterId);
     let curSeriesNode = createSeriesNode(seriesNodes[0].prefix,
       seriesNodes[0].suffix, seriesNodes[0].parent, clusterId,
-      curSeriesName);
+      curSeriesName, graphOptions);
     _.each(seriesNodes, function(node) {
       curSeriesNode.ids.push(node.clusterId);
       curSeriesNode.metagraph.setNode(node.name, metagraph.node(node.name));

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -224,7 +224,7 @@ export class RenderGraphInfo {
     // Maps node name to whether the rendering hierarchy was already
     // constructed.
     this.hasSubhierarchy = {};
-    this.root = new RenderGroupNodeInfo(hierarchy.root);
+    this.root = new RenderGroupNodeInfo(hierarchy.root, hierarchy.graphOptions);
     this.index[hierarchy.root.name] = this.root;
     this.renderedOpNames.push(hierarchy.root.name);
     this.buildSubhierarchy(hierarchy.root.name);
@@ -315,7 +315,7 @@ export class RenderGraphInfo {
       return null;
     }
     let renderInfo = node.isGroupNode ?
-        new RenderGroupNodeInfo(<GroupNode>node) :
+        new RenderGroupNodeInfo(<GroupNode>node, this.hierarchy.graphOptions) :
         new RenderNodeInfo(node);
     this.index[nodeName] = renderInfo;
     this.renderedOpNames.push(nodeName);
@@ -1788,13 +1788,14 @@ export class RenderGroupNodeInfo extends RenderNodeInfo {
   /** Array of nodes to show in the function library scene group. */
   libraryFunctionsExtract: RenderNodeInfo[];
 
-  constructor(groupNode: GroupNode) {
+  constructor(groupNode: GroupNode, graphOptions: graphlib.GraphOptions) {
     super(groupNode);
     let metagraph = groupNode.metagraph;
     let gl = metagraph.graph();
+    graphOptions.compound = true;
     this.coreGraph =
         createGraph<RenderNodeInfo, RenderMetaedgeInfo>(
-            gl.name, GraphType.CORE, { compound: true });
+            gl.name, GraphType.CORE, graphOptions);
     this.inExtractBox = {width: 0, height: 0};
     this.outExtractBox = {width: 0, height: 0};
     this.libraryFunctionsBox = {width: 0, height: 0};

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -42,9 +42,16 @@ Polymer({
     },
     datasets: Array,
     selectedDataset: Number,
-    selectedFile: {
-      type: Object,
-      observer: '_selectedFileChanged'
+    selectedFile: Object,
+    /**
+     * This experimental (and optional) property determines the direction in
+     * which the graph is rendered. This value could be one of BT,TB,LR,RL. The
+     * default is BT (bottom to top).
+     * @type {string}
+     */
+    rankDirection: {
+      type: String,
+      value: '',
     },
     outGraphHierarchy: {
       type: Object,
@@ -69,8 +76,9 @@ Polymer({
     },
   },
   observers: [
-    '_selectedDatasetChanged(selectedDataset, datasets)',
-    '_readAndParseMetadata(selectedMetadataTag)'
+    '_selectedDatasetChanged(selectedDataset, datasets, rankDirection)',
+    '_selectedFileChanged(selectedFile, rankDirection)',
+    '_readAndParseMetadata(selectedMetadataTag, rankDirection)',
   ],
   _readAndParseMetadata: function(metadataIndex) {
     if (metadataIndex == -1 || this.datasets[this.selectedDataset] == null ||
@@ -95,7 +103,8 @@ Polymer({
    * @param {string?} path
    * @param {string=} pbTxtFile
    */
-  _parseAndConstructHierarchicalGraph: function(path, pbTxtFile) {
+  _parseAndConstructHierarchicalGraph: function(
+      path, pbTxtFile, rankDirection) {
     // Reset the progress bar to 0.
     this.set('progress', {
       value: 0,
@@ -112,6 +121,10 @@ Polymer({
       // Starts out empty which allows the renderer to decide which series
       // are initially rendered grouped and which aren't.
       seriesMap: {},
+      // An experimental feature that enables the graph explorer to generalize.
+      // The direction in which the graph renders. This string is passed to
+      // dagre as the 'rankdir' graph option.
+      rankDirection: rankDirection,
     };
     this._setOutHierarchyParams(hierarchyParams);
     var dataTracker = tf.graph.util.getSubtaskTracker(tracker, 30, 'Data');
@@ -170,10 +183,11 @@ Polymer({
       tracker.reportError("Graph visualization failed: " + e, e);
     });
   },
-  _selectedDatasetChanged: function(datasetIndex, datasets) {
-    this._parseAndConstructHierarchicalGraph(datasets[datasetIndex].path);
+  _selectedDatasetChanged: function(datasetIndex, datasets, rankDirection) {
+    this._parseAndConstructHierarchicalGraph(
+        datasets[datasetIndex].path, undefined, rankDirection);
   },
-  _selectedFileChanged: function(e) {
+  _selectedFileChanged: function(e, rankDirection) {
     if (!e) {
       return;
     }
@@ -186,7 +200,7 @@ Polymer({
     // selects the same file, we'll re-read it.
     e.target.value = '';
 
-    this._parseAndConstructHierarchicalGraph(null, file);
+    this._parseAndConstructHierarchicalGraph(null, file, rankDirection);
   }
 });
 </script>

--- a/tensorboard/plugins/image/images_plugin_test.py
+++ b/tensorboard/plugins/image/images_plugin_test.py
@@ -88,9 +88,14 @@ class ImagesPluginTest(tf.test.TestCase):
     context = base_plugin.TBContext(
         logdir=self.log_dir, multiplexer=multiplexer)
     plugin = images_plugin.ImagesPlugin(context)
+    # Setting a reload interval of -1 disables reloading. We disable reloading
+    # because we seek to block tests from running til after one reload finishes.
+    # This setUp method thus manually reloads the multiplexer. TensorBoard would
+    # otherwise reload in a non-blocking thread.
     wsgi_app = application.TensorBoardWSGIApp(
-        self.log_dir, [plugin], multiplexer, reload_interval=0, path_prefix='')
+        self.log_dir, [plugin], multiplexer, reload_interval=-1, path_prefix='')
     self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+    multiplexer.Reload()
     self.routes = plugin.get_plugin_apps()
 
   def tearDown(self):

--- a/tensorboard/plugins/profile/input_pipeline_analyzer/input-pipeline-analyzer.html
+++ b/tensorboard/plugins/profile/input_pipeline_analyzer/input-pipeline-analyzer.html
@@ -39,16 +39,6 @@ You may obtain a copy of the License at
       #summary-host {
         font-weight: bold; 
       }
-      .summary-conclusion {
-        font-weight: bold;
-        font-style: italic;
-        color: var(--summary-color, black);
-      }
-      .host-conclusion {
-        font-weight: bold;
-        font-style: italic;
-        color: green;
-      }
       .highlighted-text {
         text-decoration: underline;
         font-weight: bold;
@@ -90,23 +80,29 @@ You may obtain a copy of the License at
         color: #ff33cc;
         text-decoration: underline;
       }
+      #summary_conclusion{
+        font-weight:bolder;
+        font-style:italic;
+        color: var(--summary-color, green);
+      }
+      #summary_nextstep{
+        font-weight:bolder;
+        font-style:italic;
+        color:green;
+      }
+      #recommendation_title{
+        font-weight:bolder;
+        font-style:normal;
+        color:black;
+      }
     </style>
     <div>
       <div id="section_summary">
         <div id="title_summary">
           <p class="section-header"> Section 1: Summary of input-pipeline analysis</p>
         </div>
-        <p id="summary">
-          <span>The overall performance is </span>
-          <span class="summary-conclusion">[[_summary_text]]</span>
-          <span>input-bounded because on average (over all steps) the device has spent </span>
-          <span><span class="summary-conclusion">[[_infeed_percent_average]]%</span> of time </span>
-          <span>(standard deviation = [[_infeed_percent_stddev]]) waiting for input data </span>
-          <span>[see Section 2 below for details].</span>
-        </p>
-        <p id="summary-host">
-          Recommendation for next step: <span class="host-conclusion">[[_host_conclusion]]</span>
-        </p>
+        <p><span id="summary_conclusion">[[_summary_conclusion]]</span></p>
+        <p><span id="recommendation_title">Recommendation for next step: </span><span id="summary_nextstep">[[_summary_nextstep]]</span></p>
       </div>
       <div id="section_device_side_analysis">
         <div id="title_device_side_analysis">
@@ -227,7 +223,8 @@ You may obtain a copy of the License at
         computed: '_getToggleButtonText(_show_host_side_table)'
       },
     },
-    _summary_text: String,
+    _summary_conclusion: String,
+    _summary_nextstep: String, 
     _infeed_percent_average: String,
     _infeed_percent_stddev: String,
     _infeed_percent_minimum: String,
@@ -236,7 +233,6 @@ You may obtain a copy of the License at
     _steptime_ms_stddev: String,
     _steptime_ms_minimum: String,
     _steptime_ms_maximum: String,
-    _host_conclusion: String,
     onClick: function(e) {
       this.set('_show_host_side_table', !this._show_host_side_table);
     },
@@ -248,9 +244,11 @@ You may obtain a copy of the License at
     _updateView: function() {
       if (this._data == null) return;
       var deviceJson = this._data[0];
-      var hostJson = this._data[1];
-      var recommendationJson = this._data[2];
-      this.set('_summary_text', deviceJson.p['summary_text']);
+      var hostJson = this._data[2];
+      var recommendationJson = this._data[3];
+      var conclusion = deviceJson.p['summary_conclusion'];
+      this.set('_summary_conclusion', conclusion);
+      this.set('_summary_nextstep', deviceJson.p['summary_nextstep']);
       this.set('_infeed_percent_average', deviceJson.p['infeed_percent_average']);
       this.set('_infeed_percent_stddev', deviceJson.p['infeed_percent_standard_deviation']);
       this.set('_infeed_percent_minimum', deviceJson.p['infeed_percent_minimum']);
@@ -259,8 +257,11 @@ You may obtain a copy of the License at
       this.set('_steptime_ms_stddev', deviceJson.p['steptime_ms_standard_deviation']);
       this.set('_steptime_ms_minimum', deviceJson.p['steptime_ms_minimum']);
       this.set('_steptime_ms_maximum', deviceJson.p['steptime_ms_maximum']);
-      this.set('_host_conclusion', recommendationJson.p['overall']);
-      this.customStyle['--summary-color'] =  deviceJson.p['summary_color'];
+      if (conclusion.includes('HIGHLY')) {
+        this.customStyle['--summary-color'] =  'red';
+      } else if (conclusion.includes('MODERATE')) {
+        this.customStyle['--summary-color'] =  'orange';
+      }
       this.updateStyles();
       this._showDeviceStepChart(deviceJson);
       this._showDeviceInfeedChart(deviceJson);

--- a/tensorboard/plugins/profile/input_pipeline_analyzer/input-pipeline-analyzer.html
+++ b/tensorboard/plugins/profile/input_pipeline_analyzer/input-pipeline-analyzer.html
@@ -208,15 +208,6 @@ You may obtain a copy of the License at
   Polymer({
     is: 'input-pipeline-analyzer',
     properties: {
-      _requestManager: {
-        type: Object,
-        readOnly: true,
-        value: () => new tf_backend.RequestManager(),
-      },
-      run: {
-        type: String,
-        observer: '_reloadToolData',
-      },
       _data: {
         type: Object,
         observer: '_updateView',
@@ -249,25 +240,13 @@ You may obtain a copy of the License at
     onClick: function(e) {
       this.set('_show_host_side_table', !this._show_host_side_table);
     },
-    _reloadToolData: function(run) {
-      if (!run) return;
-      this._requestManager.request(tf_backend.addParams(
-        tf_backend.getRouter().pluginRoute('profile', '/data'),
-        {tag: 'input_pipeline_analyzer', run})
-      ).catch(error => {
-        console.error(error);
-      }).then((data) => {
-        if (data) {
-          this.set('_data', data);
-        }
-      });
-    },
     _getToggleButtonText: function(show_host_side_table) {
       return (show_host_side_table ? 'Hide' : 'Show') + ' Input Op Statistics';
     },
 
     /* Update view according to new data */
     _updateView: function() {
+      if (this._data == null) return;
       var deviceJson = this._data[0];
       var hostJson = this._data[1];
       var recommendationJson = this._data[2];

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -162,15 +162,6 @@ You may obtain a copy of the License at
    Polymer({
      is: 'overview-page',
      properties: {
-       _requestManager: {
-         type: Object,
-         readOnly: true,
-         value: () => new tf_backend.RequestManager(),
-       },
-       run: {
-         type: String,
-         observer: '_reloadToolData',
-       },
        _data: {
          type: Object,
          observer: '_updateView',
@@ -206,17 +197,6 @@ You may obtain a copy of the License at
      _build_target: String,
      _statement: String,
 
-     _reloadToolData: function(run) {
-       this._requestManager.request(tf_backend.addParams(
-         tf_backend.getRouter().pluginRoute('profile', '/data'),
-         {tag: 'overview_page', run})
-       ).then((data) => {
-         if (data) {
-	   this.set('_data', data);
-         }
-       });
-     },
-
      /* Toggles _show_top_ops_table */
      onClickTopOps: function(e) {
        this.set('_show_top_ops_table', !this._show_top_ops_table);
@@ -229,6 +209,7 @@ You may obtain a copy of the License at
 
      /* Updates view according to new data */
      _updateView: function() {
+       if (this._data == null) return;
        var generalAnalysisJson = this._data[0];
        var inputAnalysisJson = this._data[1];
        var runEnvironmentJson = this._data[2];

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -23,9 +23,9 @@ from __future__ import print_function
 import logging
 import os
 import grpc
-import tensorflow as tf
 from werkzeug import wrappers
 
+import tensorflow as tf
 from tensorflow.contrib.tpu.profiler import tpu_profiler_analysis_pb2
 from tensorflow.contrib.tpu.profiler import tpu_profiler_analysis_pb2_grpc
 

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -326,7 +326,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
 >>>>>>> supporting streaming trace viewer in tensorboard.
     if data is None:
       return http_util.Respond(request, '404 Not Found', 'text/plain', code=404)
-    return http_util.Respond(request, data, 'text/plain')
+    return http_util.Respond(request, data, 'application/json')
 
   def get_plugin_apps(self):
     return {

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -113,8 +113,8 @@ class ProfilePlugin(base_plugin.TBPlugin):
                    ('grpc.max_receive_message_length', gigabyte)]
         tpu_profiler_port = FLAGS.master_tpu_unsecure_channel + ':8466'
         channel = grpc.insecure_channel(tpu_profiler_port, options)
-        self.stub = 
-            tpu_profiler_analysis_pb2_grpc.TPUProfileAnalysisStub(channel)
+        self.stub = tpu_profiler_analysis_pb2_grpc.TPUProfileAnalysisStub(
+            channel)
 
   def index_impl(self):
     """Returns available runs and available tool data in the log directory.

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -38,6 +38,7 @@ PLUGIN_NAME = 'profile'
 LOGDIR_ROUTE = '/logdir'
 DATA_ROUTE = '/data'
 TOOLS_ROUTE = '/tools'
+HOSTS_ROUTE = '/hosts'
 
 # Available profiling tools -> file name of the tool data.
 _FILE_NAME = 'TOOL_FILE_NAME'
@@ -92,13 +93,19 @@ class ProfilePlugin(base_plugin.TBPlugin):
     In the plugin log directory, each directory contains profile data for a
     single run (identified by the directory name), and files in the run
     directory contains data for different tools. The file that contains profile
-    for a specific tool "x" will have a fixed name TOOLS["x"].
+    for a specific tool "x" will have a suffix name TOOLS["x"].
     Example:
       log/
         run1/
-          trace
+          plugins/
+            profile/
+              host1.trace
+              host2.trace
         run2/
-          trace
+          plugins/
+            profile/
+              host1.trace
+              host2.trace
 
     Returns:
       A map from runs to tool names e.g.
@@ -110,11 +117,11 @@ class ProfilePlugin(base_plugin.TBPlugin):
     #       run1/
     #         plugins/
     #           profile/
-    #             trace
+    #             host1.trace
     #       run2/
     #         plugins/
     #           profile/
-    #             trace
+    #             host2.trace
     run_to_tools = {}
     if not tf.gfile.IsDirectory(self.plugin_logdir):
       return run_to_tools
@@ -124,9 +131,15 @@ class ProfilePlugin(base_plugin.TBPlugin):
         continue
       run_to_tools[run] = []
       for tool in TOOLS:
-        tool_filename = TOOLS[tool]
-        if tf.gfile.Exists(os.path.join(run_dir, tool_filename)):
-          run_to_tools[run].append(tool)
+        tool_pattern = '*' + TOOLS[tool]
+        path = os.path.join(run_dir, tool_pattern)
+        try:
+          files = tf.gfile.Glob(path)
+          if len(files) >= 1:
+            run_to_tools[run].append(tool)
+        except tf.errors.OpError as e:
+          logging.warning("Cannot read asset directory: %s, OpError %s",
+                          run_dir, e)
     return run_to_tools
 
   @wrappers.Request.application
@@ -134,21 +147,72 @@ class ProfilePlugin(base_plugin.TBPlugin):
     run_to_tools = self.index_impl()
     return http_util.Respond(request, run_to_tools, 'application/json')
 
-  def data_impl(self, run, tool):
-    """Retrieves and processes the tool data for a run.
+  def host_impl(self, run, tool):
+    """Returns available hosts for the run and tool in the log directory.
+
+    In the plugin log directory, each directory contains profile data for a
+    single run (identified by the directory name), and files in the run
+    directory contains data for different tools and hosts. The file that
+    contains profile for a specific tool "x" will have a prefix name TOOLS["x"].
+
+    Example:
+      log/
+        run1/
+          plugins/
+            profile/
+              host1.trace
+              host2.trace
+        run2/
+          plugins/
+            profile/
+              host1.trace
+              host2.trace
+
+    Returns:
+      A list of host names e.g.
+        {"host1", "host2", "host3"} for the example.
+    """
+    hosts = {}
+    if not tf.gfile.IsDirectory(self.plugin_logdir):
+      return hosts
+    run_dir = self._run_dir(run)
+    if not run_dir:
+      logging.warning("Cannot find asset directory: %s", run_dir)
+      return hosts
+    tool_pattern = '*' + TOOLS[tool]
+    try:
+      files = tf.gfile.Glob(os.path.join(run_dir, tool_pattern))
+      hosts = [os.path.basename(f).replace(TOOLS[tool], '') for f in files]
+    except tf.errors.OpError as e:
+      logging.warning("Cannot read asset directory: %s, OpError %s",
+                      run_dir, e)
+    return hosts
+
+
+  @wrappers.Request.application
+  def hosts_route(self, request):
+    run = request.args.get('run')
+    tool = request.args.get('tag')
+    hosts = self.host_impl(run, tool)
+    return http_util.Respond(request, hosts, 'application/json')
+
+  def data_impl(self, run, tool, host):
+    """Retrieves and processes the tool data for a run and a host.
 
     Args:
       run: Name of the run.
       tool: Name of the tool.
+      host: Name of the host.
 
     Returns:
-      A string that can be served to the frontend tool or None if tool or
-        run is invalid.
+      A string that can be served to the frontend tool or None if tool,
+        run or host is invalid.
     """
     # Path relative to the path of plugin directory.
     if tool not in TOOLS:
       return None
-    rel_data_path = os.path.join(run, TOOLS[tool])
+    tool_name = str(host) + TOOLS[tool]
+    rel_data_path = os.path.join(run, tool_name)
     asset_path = os.path.join(self.plugin_logdir, rel_data_path)
     raw_data = None
     try:
@@ -173,9 +237,11 @@ class ProfilePlugin(base_plugin.TBPlugin):
     #   run: The run name.
     #   tag: The tool name e.g. trace_viewer. The plugin returns different UI
     #     data for different tools of the same run.
+    #   host: The host name.
     run = request.args.get('run')
     tool = request.args.get('tag')
-    data = self.data_impl(run, tool)
+    host = request.args.get('host')
+    data = self.data_impl(run, tool, host)
     if data is None:
       return http_util.Respond(request, '404 Not Found', 'text/plain', code=404)
     return http_util.Respond(request, data, 'text/plain')
@@ -184,6 +250,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
     return {
         LOGDIR_ROUTE: self.logdir_route,
         TOOLS_ROUTE: self.tools_route,
+        HOSTS_ROUTE: self.hosts_route,
         DATA_ROUTE: self.data_route,
     }
 

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -26,13 +26,14 @@ import grpc
 import tensorflow as tf
 from werkzeug import wrappers
 
+from tensorflow.contrib.tpu.profiler import tpu_profiler_analysis_pb2
+from tensorflow.contrib.tpu.profiler import tpu_profiler_analysis_pb2_grpc
+
 from tensorboard.backend import http_util
 from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.profile import trace_events_json
 from tensorboard.plugins.profile import trace_events_pb2
-from tensorflow.contrib.tpu.profiler import tpu_profiler_analysis_pb2
-from tensorflow.contrib.tpu.profiler import tpu_profiler_analysis_pb2_grpc
 
 # The prefix of routes provided by this plugin.
 PLUGIN_NAME = 'profile'

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+# pylint: disable=g-line-too-long
 
 """The TensorBoard plugin for performance profiling."""
 
@@ -112,7 +113,8 @@ class ProfilePlugin(base_plugin.TBPlugin):
                    ('grpc.max_receive_message_length', gigabyte)]
         tpu_profiler_port = FLAGS.master_tpu_unsecure_channel + ':8466'
         channel = grpc.insecure_channel(tpu_profiler_port, options)
-        self.stub = tpu_profiler_analysis_pb2_grpc.TPUProfileAnalysisStub(channel)
+        self.stub = 
+            tpu_profiler_analysis_pb2_grpc.TPUProfileAnalysisStub(channel)
 
   def index_impl(self):
     """Returns available runs and available tool data in the log directory.

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-# pylint: disable=g-line-too-long
 
 """The TensorBoard plugin for performance profiling."""
 
@@ -105,7 +104,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
     if FLAGS.master_tpu_unsecure_channel and self.logdir.startswith('gs://'):
       if self.stub is None:
         import grpc
-        from tensorflow.contrib.tpu.profiler import tpu_profiler_analysis_pb2_grpc
+        from tensorflow.contrib.tpu.profiler import tpu_profiler_analysis_pb2_grpc # pyline: disable=line-too-long
         # Workaround the grpc's 4MB message limitation.
         gigabyte = 1024 * 1024 * 1024
         options = [('grpc.max_message_length', gigabyte),

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -104,7 +104,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
     if FLAGS.master_tpu_unsecure_channel and self.logdir.startswith('gs://'):
       if self.stub is None:
         import grpc
-        from tensorflow.contrib.tpu.profiler import tpu_profiler_analysis_pb2_grpc # pyline: disable=line-too-long
+        from tensorflow.contrib.tpu.profiler import tpu_profiler_analysis_pb2_grpc # pylint: disable=line-too-long
         # Workaround the grpc's 4MB message limitation.
         gigabyte = 1024 * 1024 * 1024
         options = [('grpc.max_message_length', gigabyte),

--- a/tensorboard/plugins/profile/profile_plugin_test.py
+++ b/tensorboard/plugins/profile/profile_plugin_test.py
@@ -94,13 +94,18 @@ class ProfilePluginTest(tf.test.TestCase):
     trace = json.loads(self.plugin.data_impl('foo', 'trace_viewer', 'host0'))
 =======
   def makeRequest(self, run, tag):
-    req = Request({});
+    req = Request({})
     req.args = {'run': run, 'tag': tag}
     return req
 
   def testData(self):
+<<<<<<< HEAD
     trace = json.loads(self.plugin.data_impl(self.makeRequest('foo', 'trace_viewer')))
 >>>>>>> fix test
+=======
+    trace = json.loads(self.plugin.data_impl(
+        self.makeRequest('foo', 'trace_viewer')))
+>>>>>>> fix format
     self.assertEqual(trace,
                      dict(
                          displayTimeUnit='ns',
@@ -120,6 +125,7 @@ class ProfilePluginTest(tf.test.TestCase):
 
     # Invalid tool/run.
 <<<<<<< HEAD
+<<<<<<< HEAD
     self.assertEqual(None, self.plugin.data_impl('foo', 'nonono', 'host0'))
     self.assertEqual(None, self.plugin.data_impl('foo', 'trace_viewer', ''))
     self.assertEqual(None, self.plugin.data_impl('bar', 'unsupported', 'host1'))
@@ -129,6 +135,14 @@ class ProfilePluginTest(tf.test.TestCase):
     self.assertEqual(None, self.plugin.data_impl(self.makeRequest('bar', 'unsupported')))
     self.assertEqual(None, self.plugin.data_impl(self.makeRequest('empty', 'trace_viewer')))
 >>>>>>> fix test
+=======
+    self.assertEqual(None, self.plugin.data_impl(
+        self.makeRequest('foo', 'nonono')))
+    self.assertEqual(None, self.plugin.data_impl(
+        self.makeRequest('bar', 'unsupported')))
+    self.assertEqual(None, self.plugin.data_impl(
+        self.makeRequest('empty', 'trace_viewer')))
+>>>>>>> fix format
 
   def testActive(self):
     self.assertTrue(self.plugin.is_active())

--- a/tensorboard/plugins/profile/profile_plugin_test.py
+++ b/tensorboard/plugins/profile/profile_plugin_test.py
@@ -85,27 +85,18 @@ class ProfilePluginTest(tf.test.TestCase):
     self.assertItemsEqual(runs['bar'], [])
     self.assertItemsEqual(runs['empty'], [])
 
-<<<<<<< HEAD
+  def makeRequest(self, run, tag, host):
+    req = Request({})
+    req.args = {'run': run, 'tag': tag, 'host': host,}
+    return req
+
   def testHosts(self):
     hosts = self.plugin.host_impl('foo', 'trace_viewer')
     self.assertItemsEqual(['host0', 'host1'], sorted(hosts))
 
   def testData(self):
-    trace = json.loads(self.plugin.data_impl('foo', 'trace_viewer', 'host0'))
-=======
-  def makeRequest(self, run, tag):
-    req = Request({})
-    req.args = {'run': run, 'tag': tag}
-    return req
-
-  def testData(self):
-<<<<<<< HEAD
-    trace = json.loads(self.plugin.data_impl(self.makeRequest('foo', 'trace_viewer')))
->>>>>>> fix test
-=======
     trace = json.loads(self.plugin.data_impl(
-        self.makeRequest('foo', 'trace_viewer')))
->>>>>>> fix format
+        self.makeRequest('foo', 'trace_viewer', 'host0')))
     self.assertEqual(trace,
                      dict(
                          displayTimeUnit='ns',
@@ -124,25 +115,14 @@ class ProfilePluginTest(tf.test.TestCase):
                          ]))
 
     # Invalid tool/run.
-<<<<<<< HEAD
-<<<<<<< HEAD
-    self.assertEqual(None, self.plugin.data_impl('foo', 'nonono', 'host0'))
-    self.assertEqual(None, self.plugin.data_impl('foo', 'trace_viewer', ''))
-    self.assertEqual(None, self.plugin.data_impl('bar', 'unsupported', 'host1'))
-    self.assertEqual(None, self.plugin.data_impl('empty', 'trace_viewer', ''))
-=======
-    self.assertEqual(None, self.plugin.data_impl(self.makeRequest('foo', 'nonono')))
-    self.assertEqual(None, self.plugin.data_impl(self.makeRequest('bar', 'unsupported')))
-    self.assertEqual(None, self.plugin.data_impl(self.makeRequest('empty', 'trace_viewer')))
->>>>>>> fix test
-=======
     self.assertEqual(None, self.plugin.data_impl(
-        self.makeRequest('foo', 'nonono')))
+        self.makeRequest('foo', 'nonono', 'host0')))
     self.assertEqual(None, self.plugin.data_impl(
-        self.makeRequest('bar', 'unsupported')))
+        self.makeRequest('foo', 'trace_viewer', '')))
     self.assertEqual(None, self.plugin.data_impl(
-        self.makeRequest('empty', 'trace_viewer')))
->>>>>>> fix format
+        self.makeRequest('bar', 'unsupported', 'host1')))
+    self.assertEqual(None, self.plugin.data_impl(
+        self.makeRequest('empty', 'trace_viewer', '')))
 
   def testActive(self):
     self.assertTrue(self.plugin.is_active())

--- a/tensorboard/plugins/profile/profile_plugin_test.py
+++ b/tensorboard/plugins/profile/profile_plugin_test.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 import json
 import os
 import tensorflow as tf
+from werkzeug import Request
 
 from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.plugins import base_plugin
@@ -84,12 +85,22 @@ class ProfilePluginTest(tf.test.TestCase):
     self.assertItemsEqual(runs['bar'], [])
     self.assertItemsEqual(runs['empty'], [])
 
+<<<<<<< HEAD
   def testHosts(self):
     hosts = self.plugin.host_impl('foo', 'trace_viewer')
     self.assertItemsEqual(['host0', 'host1'], sorted(hosts))
 
   def testData(self):
     trace = json.loads(self.plugin.data_impl('foo', 'trace_viewer', 'host0'))
+=======
+  def makeRequest(self, run, tag):
+    req = Request({});
+    req.args = {'run': run, 'tag': tag}
+    return req
+
+  def testData(self):
+    trace = json.loads(self.plugin.data_impl(self.makeRequest('foo', 'trace_viewer')))
+>>>>>>> fix test
     self.assertEqual(trace,
                      dict(
                          displayTimeUnit='ns',
@@ -108,10 +119,16 @@ class ProfilePluginTest(tf.test.TestCase):
                          ]))
 
     # Invalid tool/run.
+<<<<<<< HEAD
     self.assertEqual(None, self.plugin.data_impl('foo', 'nonono', 'host0'))
     self.assertEqual(None, self.plugin.data_impl('foo', 'trace_viewer', ''))
     self.assertEqual(None, self.plugin.data_impl('bar', 'unsupported', 'host1'))
     self.assertEqual(None, self.plugin.data_impl('empty', 'trace_viewer', ''))
+=======
+    self.assertEqual(None, self.plugin.data_impl(self.makeRequest('foo', 'nonono')))
+    self.assertEqual(None, self.plugin.data_impl(self.makeRequest('bar', 'unsupported')))
+    self.assertEqual(None, self.plugin.data_impl(self.makeRequest('empty', 'trace_viewer')))
+>>>>>>> fix test
 
   def testActive(self):
     self.assertTrue(self.plugin.is_active())

--- a/tensorboard/plugins/profile/profile_plugin_test.py
+++ b/tensorboard/plugins/profile/profile_plugin_test.py
@@ -43,21 +43,29 @@ class ProfilePluginTest(tf.test.TestCase):
         'baz': ['trace_viewer'],
         'empty': [],
     }
+    self.run_to_hosts = {
+        'foo': ['host0', 'host1'],
+        'bar': ['host1'],
+        'baz': ['host2'],
+        'empty': [],
+    }
     for run in self.run_to_tools:
       run_dir = os.path.join(plugin_logdir, run)
       os.mkdir(run_dir)
       for tool in self.run_to_tools[run]:
         if tool not in profile_plugin.TOOLS:
           continue
-        tool_file = os.path.join(run_dir, profile_plugin.TOOLS[tool])
-        if tool == 'trace_viewer':
-          trace = trace_events_pb2.Trace()
-          trace.devices[0].name = run
-          data = trace.SerializeToString()
-        else:
-          data = tool
-        with open(tool_file, 'wb') as f:
-          f.write(data)
+        for host in self.run_to_hosts[run]:
+          file_name = host + profile_plugin.TOOLS[tool]
+          tool_file = os.path.join(run_dir, file_name)
+          if tool == 'trace_viewer':
+            trace = trace_events_pb2.Trace()
+            trace.devices[0].name = run
+            data = trace.SerializeToString()
+          else:
+            data = tool
+          with open(tool_file, 'wb') as f:
+            f.write(data)
     with open(os.path.join(plugin_logdir, 'noise'), 'w') as f:
       f.write('Not a dir, not a run.')
 
@@ -76,8 +84,12 @@ class ProfilePluginTest(tf.test.TestCase):
     self.assertItemsEqual(runs['bar'], [])
     self.assertItemsEqual(runs['empty'], [])
 
+  def testHosts(self):
+    hosts = self.plugin.host_impl('foo', 'trace_viewer')
+    self.assertItemsEqual(['host0', 'host1'], sorted(hosts))
+
   def testData(self):
-    trace = json.loads(self.plugin.data_impl('foo', 'trace_viewer'))
+    trace = json.loads(self.plugin.data_impl('foo', 'trace_viewer', 'host0'))
     self.assertEqual(trace,
                      dict(
                          displayTimeUnit='ns',
@@ -96,9 +108,10 @@ class ProfilePluginTest(tf.test.TestCase):
                          ]))
 
     # Invalid tool/run.
-    self.assertEqual(None, self.plugin.data_impl('foo', 'nonono'))
-    self.assertEqual(None, self.plugin.data_impl('bar', 'unsupported'))
-    self.assertEqual(None, self.plugin.data_impl('empty', 'trace_viewer'))
+    self.assertEqual(None, self.plugin.data_impl('foo', 'nonono', 'host0'))
+    self.assertEqual(None, self.plugin.data_impl('foo', 'trace_viewer', ''))
+    self.assertEqual(None, self.plugin.data_impl('bar', 'unsupported', 'host1'))
+    self.assertEqual(None, self.plugin.data_impl('empty', 'trace_viewer', ''))
 
   def testActive(self):
     self.assertTrue(self.plugin.is_active())

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
@@ -34,7 +34,7 @@ You may obtain a copy of the License at
 tf-op-details {
   position: fixed;
   /* don't set top, so it ends up next to tf-op-table */
-  padding-top: 6.5em;
+  margin-top: 10em;
   left: 16px;
   width: 330px;
 }
@@ -56,7 +56,7 @@ tf-op-details {
         <p>Modifying your model's architecture, data dimensions, and improving
         the efficiency of CPU operations may help reach the TPU's FLOPS potential.
       </p></div>
-      <tf-op-details hidden="[[!_active]]" node="[[_active]]"></tf-op-details>
+      <tf-op-details hidden="[[!_active]]" node=[[_active]]></tf-op-details>
       <tf-op-table root-node="[[_root]]" active={{_active}}></tf-op-table>
     </div>
   </template>
@@ -65,15 +65,6 @@ tf-op-details {
 Polymer({
   is: 'tf-op-profile',
   properties: {
-    _requestManager: {
-      type: Object,
-      readOnly: true,
-      value: () => new tf_backend.RequestManager(),
-    },
-    run: {
-      type: String,
-      observer: '_load'
-    },
     _data: {
       type: Object,
       notify: true,
@@ -88,15 +79,6 @@ Polymer({
       value: null,
       notify: true,
     },
-  },
-  _load: function(run) {
-    if (!run) return;
-    this._requestManager.request(tf_backend.addParams(
-        tf_backend.getRouter().pluginRoute('profile', '/data'), {tag: 'op_profile', run})
-    ).catch(error => {}
-    ).then((data) => {
-      this._data = data;
-    });
   },
   _getRoot: function(data, breakdown) { return data[breakdown]; },
   _utilizationPercent: function(node) { return tf_op_profile.percent(tf_op_profile.utilization(node)); },

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -286,40 +286,31 @@ profile run can have multiple tools that present the performance profile as diff
       }
       return [];
     },
-<<<<<<< HEAD
     _maybeUpdateData: function(hostName) {
       if (hostName == null) return;
       var datasetName = this._selectedDatasetName;
       var toolName = this._selectedToolName;
       if (datasetName == null || toolName == null) return;
       this.toolInScope = "undefined";
-      if (toolName == "trace_viewer") {
+      if (toolName.startsWith("trace_viewer")) {
         var trace_data_url = tf_backend.addParams(
             tf_backend.getRouter().pluginRoute('profile', '/data'),
-            {tag: 'trace_viewer',
+            {tag: toolName,
              run: datasetName,
              host: hostName});
-=======
-    _maybeUpdateTool: function(datasets, currentSelected) {
-      var currentTool = this._getSelectedTool(datasets, currentSelected);
-      if (currentTool == '') return;
-      if (currentTool.startsWith('trace_viewer')) {
-        var trace_data_url = tf_backend.addParams(
-            tf_backend.getRouter().pluginRoute('profile', '/data'),
-            {tag: currentTool, run: this._getSelectedDataset(datasets, currentSelected)});
->>>>>>> supporting streaming trace viewer in tensorboard.
         // Make the trace data url relative to the root.
         if (trace_data_url[0] != '/') {
           trace_data_url = '/' + trace_data_url;
         }
         // Pass the URL of trace data via GET parameter to the iframed trace
         // viewer app.
-<<<<<<< HEAD
-        this._traceDataUrl = this.traceViewerBaseUrl + "?trace_data_url=" +
-                            encodeURIComponent(trace_data_url);
+        var is_streaming = toolName.endsWith('@');
+        this._traceDataUrl = this.traceViewerBaseUrl + '?trace_data_url=' +
+            encodeURIComponent(trace_data_url) +
+            '&is_streaming=' + is_streaming;
         this._toolInScope = "trace_viewer";
         return;
-      }else{
+      } else {
         this._requestManager.request(tf_backend.addParams(
           tf_backend.getRouter().pluginRoute('profile', '/data'),
           {tag: toolName, host: hostName, run: datasetName})
@@ -336,12 +327,6 @@ profile run can have multiple tools that present the performance profile as diff
                this._toolInScope = "overview_page";
            }
         });
-=======
-        var is_streaming = currentTool.endsWith('@');
-        this._traceDataUrl = this.traceViewerBaseUrl + '?trace_data_url=' +
-	                            encodeURIComponent(trace_data_url) + '&is_streaming=' +
-			                                is_streaming;
->>>>>>> supporting streaming trace viewer in tensorboard.
         return;
       }
     },
@@ -390,7 +375,6 @@ profile run can have multiple tools that present the performance profile as diff
       }
       return false;
     },
-<<<<<<< HEAD
     _getHostDisplayName: function(host) {
       // For old traces without a host prefix in file name, return default for
       // backward compatibility.
@@ -398,10 +382,6 @@ profile run can have multiple tools that present the performance profile as diff
       if (host == "") return "default";
       // Otherwise, remove the seperator, e.g. "host1_" => "host1".
       return host.slice(0, -1);
-=======
-    _isCurrentTool: function(datasets, currentSelected, expected) {
-      return this._getSelectedTool(datasets, currentSelected).startsWith(expected);
->>>>>>> supporting streaming trace viewer in tensorboard.
     },
   });
 

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
 <link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../paper-item/paper-item.html">
 <link rel="import" href="../paper-menu/paper-menu.html">
@@ -69,31 +70,41 @@ profile run can have multiple tools that present the performance profile as diff
       <div class="sidebar-section">
         <div class="title">Runs <span class="counter">([[_datasets.length]])</span></div>
         <paper-dropdown-menu no-label-float no-animations noink class="run-dropdown">
-          <paper-menu id="select" class="dropdown-content" selected="{{selectedDataset}}" slot="dropdown-content">
-            <template is="dom-repeat" items="[[_datasets]]">
+          <paper-listbox id="list_box_run" class="dropdown-content" selected="{{selectedDatasetIndex}}">
+            <template id="run_items" is="dom-repeat" items="[[_datasets]]">
               <paper-item>[[item.name]]</paper-item>
             </template>
-          </paper-menu>
+          </paper-listbox>
         </paper-dropdown-menu>
       </div>
       <div class="sidebar-section">
-        <div class="title">Tools <span class="counter">([[_activeTools.length]])</span></div>
+        <div class="title">Tools <span class="counter">([[_activeToolsList.length]])</span></div>
         <paper-dropdown-menu no-label-float no-animations noink class="run-dropdown">
-          <paper-menu id="select" class="dropdown-content" selected="{{selectedTool}}" slot="dropdown-content">
-            <template is="dom-repeat" items="[[_activeTools]]">
+          <paper-listbox id="list_box_tool" class="dropdown-content" selected="{{selectedToolIndex}}">
+            <template id="tool_items" is="dom-repeat" items="[[_activeToolsList]]">
               <paper-item>[[item]]</paper-item>
             </template>
-            <template is="dom-if" if="[[!_hasActiveTools(selectedDataset, _datasets)]]" restamp="true">
+            <template is="dom-if" if="[[!_hasActiveTools()]]" restamp="true">
               <paper-item>None</paper-item>
             </template>
-          </paper-menu>
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </div>
+      <div class="sidebar-section">
+        <div class="title">Hosts <span class="counter">([[_activeHostsList.length]])</span></div>
+        <paper-dropdown-menu no-label-float no-animations noink class="run-dropdown">
+          <paper-listbox id="list_box_host" class="dropdown-content" selected="{{selectedHostIndex}}">
+            <template id="host_items" is="dom-repeat" items="[[_activeHostsList]]">
+              <paper-item>[[_getHostDisplayName(item)]]</paper-item>
+            </template>
+          </paper-listbox>
         </paper-dropdown-menu>
       </div>
       <div class="sidebar-section"></div>
     </div>
   </div>
   <div class="center">
-    <template is="dom-if" if="[[_isCurrentTool(_datasets, currentSelected, 'trace_viewer')]]" restamp="true">
+    <template is="dom-if" if="[[_isCurrentTool(_toolInScope, 'trace_viewer')]]" restamp="true">
       <iframe
         id="tv_iframe"
         height="100%"
@@ -101,17 +112,14 @@ profile run can have multiple tools that present the performance profile as diff
         src="[[_traceDataUrl]]">
       </iframe>
     </template>
-    <template is="dom-if" if="[[_isCurrentTool(_datasets, currentSelected, 'op_profile')]]" restamp="true">
-      <tf-op-profile run="[[_getSelectedDataset(_datasets, currentSelected)]]">
-      </tf-op-profile>
+    <template is="dom-if" if="[[_isCurrentTool(_toolInScope, 'op_profile')]]" restamp="true">
+      <tf-op-profile _data="[[_opProfileData]]"></tf-op-profile>
     </template>
-    <template is="dom-if" if="[[_isCurrentTool(_datasets, currentSelected, 'input_pipeline_analyzer')]]" restamp="true">
-      <input-pipeline-analyzer run="[[_getSelectedDataset(_datasets, currentSelected)]]">
-      </input-pipeline-analyzer>
+    <template is="dom-if" if="[[_isCurrentTool(_toolInScope, 'input_pipeline_analyzer')]]" restamp="true">
+      <input-pipeline-analyzer _data="[[_inputPipelineData]]"></input-pipeline-analyzer>
     </template>
-    <template is="dom-if" if="[[_isCurrentTool(_datasets, currentSelected, 'overview_page')]]">
-      <overview-page run="[[_getSelectedDataset(_datasets, currentSelected)]]">
-      </overview-page>
+    <template is="dom-if" if="[[_isCurrentTool(_toolInScope, 'overview_page')]]" restamp="true">
+      <overview-page _data="[[_overviewPageData]]"></overview-page>
     </template>
   </div>
   </tf-dashboard-layout>
@@ -135,8 +143,6 @@ profile run can have multiple tools that present the performance profile as diff
 <script>
   "use strict";
 
-
-
   Polymer({
     is: "tf-profile-dashboard",
     properties: {
@@ -149,6 +155,35 @@ profile run can have multiple tools that present the performance profile as diff
       // initialized once.
       _initialized: Boolean,
       _dataNotFound: Boolean,
+      _datasets: {
+        type: Array,
+        notify: true,
+        observer: '_datasetsChanged'
+      },
+      _activeToolsList: {
+        type: Array,
+        computed: '_getActiveToolsList(selectedDatasetIndex, _datasets)',
+        observer: '_activeToolsChanged'
+      },
+      _activeHostsList: {
+        type: Array,
+        observer: '_activeHostsChanged'
+      },
+      selectedDatasetIndex: {
+        type: Number,
+        notify: true,
+        value: 0,
+      },
+      selectedToolIndex: {
+        type: Number,
+        notify: true,
+        value: 0,
+      },
+      selectedHostIndex: {
+        type: Number,
+        notify: true,
+        value: 0,
+      },
       // The endpoint that serves trace viewer app.
       traceViewerBaseUrl: {
         type: String,
@@ -159,35 +194,32 @@ profile run can have multiple tools that present the performance profile as diff
         type: String,
         value: "",
       },
-      _datasets: {
-        type: Array,
-        notify: true,
-        observer: '_datasetsChanged'
+      _opProfileData: {
+        type: Object,
       },
-      _activeTools: {
-        type: Array,
-        computed: '_getActiveTools(selectedDataset, _datasets)'
+      _inputPipelineData: {
+        type: Object,
       },
-      selectedDataset: {
-        type: Number,
-        notify: true,
-        value: 0,
-        observer: '_selectedDatasetChanged'
+      _overviewPageData: {
+        type: Object,
       },
-      selectedTool: {
-        type: Number,
+      _selectedDatasetName: {
+        type: String,
         notify: true,
-        value: 0,
-        observer: '_selectedToolChanged'
+        computed: '_getSelectedDatasetName(selectedDatasetIndex, _datasets)'
       },
-      // currentSelected will depends on selectedDataset and selectedTool.
-      // With this arrangement, we can achieve cascading Polymer effects
-      // propagation and atomic change of both dataset and tool.(e.g.
-      // when dataset change, the tool set to the first available one).
-      currentSelected: {
-        type: Number,
+      _selectedToolName: {
+        type: String,
         notify: true,
-        value: () => { return {'datasetIndex': 0, 'toolIndex': 0} },
+        computed: '_getSelected(selectedToolIndex, _activeToolsList)'
+      },
+      _selectedHostName: {
+        type: String,
+        notify: true,
+        computed: '_getSelected(selectedHostIndex, _activeHostsList)'
+      },
+      _toolInScope: {
+        type: String,
       },
     },
     reload: function() {
@@ -196,7 +228,8 @@ profile run can have multiple tools that present the performance profile as diff
     },
     observers: [
       '_maybeInitializeDashboard(_isAttached)',
-      '_maybeUpdateTool(_datasets, currentSelected)',
+      '_maybeUpdateData(_selectedHostName)',
+      '_maybeUpdateActiveHosts(_selectedDatasetName, _selectedToolName)'
     ],
     attached: function() {
       this.set('_isAttached', true);
@@ -230,24 +263,41 @@ profile run can have multiple tools that present the performance profile as diff
         this.set('_datasets', datasets);
       });
     },
-    _getSelectedTool: function(datasets, currentSelected) {
-      var activeTools = this._getActiveTools(currentSelected.datasetIndex, datasets);
-      if (currentSelected.toolIndex >= 0 && currentSelected.toolIndex < activeTools.length) {
-        return activeTools[currentSelected.toolIndex];
+    // Return the item selected from the list
+    _getSelected: function(index, li) {
+      if (index == null) return;
+      if (li && index >= 0 && index < li.length) {
+        return li[index];
       }
       return null;
     },
-    _getSelectedDataset: function(datasets, currentSelected) {
-      if (currentSelected.datasetIndex >= datasets.length) return null;
-      return datasets[currentSelected.datasetIndex].name;
+    _getSelectedDatasetName: function(selectedDatasetIndex, datasets){
+      if (selectedDatasetIndex == null) return;
+      if (datasets && selectedDatasetIndex >= 0 && selectedDatasetIndex < datasets.length) {
+        return datasets[selectedDatasetIndex].name;
+      }
+      return null;
     },
-    _maybeUpdateTool: function(datasets, currentSelected) {
-      var currentTool = this._getSelectedTool(datasets, currentSelected);
-      if (currentTool == null) return;
-      if (currentTool == "trace_viewer") {
+     _getActiveToolsList: function(selectedDatasetIndex, datasets) {
+      if (selectedDatasetIndex == null) return;
+      if (datasets && selectedDatasetIndex >= 0 && selectedDatasetIndex < datasets.length) {
+        this.selectedToolIndex = 0;
+        return datasets[selectedDatasetIndex].activeTools;
+      }
+      return [];
+    },
+    _maybeUpdateData: function(hostName) {
+      if (hostName == null) return;
+      var datasetName = this._selectedDatasetName;
+      var toolName = this._selectedToolName;
+      if (datasetName == null || toolName == null) return;
+      this.toolInScope = "undefined";
+      if (toolName == "trace_viewer") {
         var trace_data_url = tf_backend.addParams(
             tf_backend.getRouter().pluginRoute('profile', '/data'),
-            {tag: 'trace_viewer', run: this._getSelectedDataset(datasets, currentSelected)});
+            {tag: 'trace_viewer',
+             run: datasetName,
+             host: hostName});
         // Make the trace data url relative to the root.
         if (trace_data_url[0] != '/') {
           trace_data_url = '/' + trace_data_url;
@@ -256,45 +306,80 @@ profile run can have multiple tools that present the performance profile as diff
         // viewer app.
         this._traceDataUrl = this.traceViewerBaseUrl + "?trace_data_url=" +
                             encodeURIComponent(trace_data_url);
+        this._toolInScope = "trace_viewer";
+        return;
+      }else{
+        this._requestManager.request(tf_backend.addParams(
+          tf_backend.getRouter().pluginRoute('profile', '/data'),
+          {tag: toolName, host: hostName, run: datasetName})
+        ).catch(error => {}
+        ).then((data) => {
+           if (toolName == "op_profile") {
+               this._opProfileData = data;
+               this._toolInScope = "op_profile";
+           } else if (toolName == "input_pipeline_analyzer") {
+               this._inputPipelineData = data;
+               this._toolInScope = "input_pipeline_analyzer";
+           } else if (toolName == "overview_page") {
+               this._overviewPageData = data;
+               this._toolInScope = "overview_page";
+           }
+        });
         return;
       }
     },
+    _maybeUpdateActiveHosts: function(datasetName, toolName) {
+       if(datasetName == null || toolName == null) return null;
+       var profileHostsUrl = tf_backend.addParams(
+            tf_backend.getRouter().pluginRoute('profile', '/hosts'),
+            {tag: toolName,
+             run: datasetName,
+            });
+       this._requestManager.request(profileHostsUrl).then((hostList) => {
+           this.set('_activeHostsList', hostList.sort((a, b) => {
+               return vz_sorting.compareTagNames(a, b);}
+           ));
+       });
+    },
     _datasetsChanged: function(newDatasets, oldDatasets) {
-      if (oldDatasets != null || this.selected == null) {
-        // Select the first dataset by default.
-        this.set('selectedDataset', 0);
-        this.set('currentSelected', {'datasetIndex': 0, 'toolIndex': 0});
+      if (this._datasets) {
+        this.selectedDatasetIndex = 0;
       }
     },
-    _selectedDatasetChanged: function(newDataset, oldDataset) {
-      if (this._datasets) {
-        // Display the first tool by default when switching to another run.
-        this.set('currentSelected', {'datasetIndex': newDataset, 'toolIndex': 0});
-
-        // Same tool can have differernt index in different runs, therefore we force a change of
-        // 'selectedTool', to make sure the label of the dropdown-menu is synced.
-        this.async(function() {
-          this.set('selectedTool', undefined);
-          this.set('selectedTool', 0);
+    _activeToolsChanged: function(oldActiveTools, newActiveTools) {
+      // Same tool can have differernt index in different runs, therefore we force a change of
+      // 'selectedToolIndex', to make sure the label of the dropdown-menu is synced.
+      if (this._activeToolsList) {
+         this.async(function() {
+          this.set('selectedToolIndex', -1);
+          this.set('selectedToolIndex', 0);
         }.bind(this));
       }
     },
-    _selectedToolChanged: function(newTool, oldTool) {
-      if (this._datasets && !(newTool === undefined)) {
-        this.set('currentSelected', {'datasetIndex': this.selectedDataset, 'toolIndex': newTool});
+    _activeHostsChanged: function(oldActiveHosts, newActiveHosts) {
+      if (this._activeHostsList) {
+        this.async(function() {
+          this.set('selectedHostIndex', -1);
+          this.set('selectedHostIndex', 0);
+        }.bind(this));
       }
     },
-    _getActiveTools: function(selectedDataset, datasets) {
-      if (datasets && selectedDataset < datasets.length) {
-        return datasets[selectedDataset].activeTools;
+    _isCurrentTool: function(current, expected) {
+      return current == expected;
+    },
+    _hasActiveTools: function() {
+      if (this._activeToolsList && this._activeToolsList.length > 0) {
+        return true;
       }
-      return [];
+      return false;
     },
-    _hasActiveTools: function(selectedDataset, datasets) {
-      return datasets[selectedDataset].activeTools.length > 0;
-    },
-    _isCurrentTool: function(datasets, currentSelected, expected) {
-      return this._getSelectedTool(datasets, currentSelected) == expected;
+    _getHostDisplayName: function(host) {
+      // For old traces without a host prefix in file name, return default for
+      // backward compatibility.
+      if (host == null) return "";
+      if (host == "") return "default";
+      // Otherwise, remove the seperator, e.g. "host1_" => "host1".
+      return host.slice(0, -1);
     },
   });
 

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -276,7 +276,7 @@ profile run can have multiple tools that present the performance profile as diff
       if (datasets && selectedDatasetIndex >= 0 && selectedDatasetIndex < datasets.length) {
         return datasets[selectedDatasetIndex].name;
       }
-      return null;
+      return '';
     },
      _getActiveToolsList: function(selectedDatasetIndex, datasets) {
       if (selectedDatasetIndex == null) return;
@@ -286,6 +286,7 @@ profile run can have multiple tools that present the performance profile as diff
       }
       return [];
     },
+<<<<<<< HEAD
     _maybeUpdateData: function(hostName) {
       if (hostName == null) return;
       var datasetName = this._selectedDatasetName;
@@ -298,12 +299,22 @@ profile run can have multiple tools that present the performance profile as diff
             {tag: 'trace_viewer',
              run: datasetName,
              host: hostName});
+=======
+    _maybeUpdateTool: function(datasets, currentSelected) {
+      var currentTool = this._getSelectedTool(datasets, currentSelected);
+      if (currentTool == '') return;
+      if (currentTool.startsWith('trace_viewer')) {
+        var trace_data_url = tf_backend.addParams(
+            tf_backend.getRouter().pluginRoute('profile', '/data'),
+            {tag: currentTool, run: this._getSelectedDataset(datasets, currentSelected)});
+>>>>>>> supporting streaming trace viewer in tensorboard.
         // Make the trace data url relative to the root.
         if (trace_data_url[0] != '/') {
           trace_data_url = '/' + trace_data_url;
         }
         // Pass the URL of trace data via GET parameter to the iframed trace
         // viewer app.
+<<<<<<< HEAD
         this._traceDataUrl = this.traceViewerBaseUrl + "?trace_data_url=" +
                             encodeURIComponent(trace_data_url);
         this._toolInScope = "trace_viewer";
@@ -325,6 +336,12 @@ profile run can have multiple tools that present the performance profile as diff
                this._toolInScope = "overview_page";
            }
         });
+=======
+        var is_streaming = currentTool.endsWith('@');
+        this._traceDataUrl = this.traceViewerBaseUrl + '?trace_data_url=' +
+	                            encodeURIComponent(trace_data_url) + '&is_streaming=' +
+			                                is_streaming;
+>>>>>>> supporting streaming trace viewer in tensorboard.
         return;
       }
     },
@@ -373,6 +390,7 @@ profile run can have multiple tools that present the performance profile as diff
       }
       return false;
     },
+<<<<<<< HEAD
     _getHostDisplayName: function(host) {
       // For old traces without a host prefix in file name, return default for
       // backward compatibility.
@@ -380,6 +398,10 @@ profile run can have multiple tools that present the performance profile as diff
       if (host == "") return "default";
       // Otherwise, remove the seperator, e.g. "host1_" => "host1".
       return host.slice(0, -1);
+=======
+    _isCurrentTool: function(datasets, currentSelected, expected) {
+      return this._getSelectedTool(datasets, currentSelected).startsWith(expected);
+>>>>>>> supporting streaming trace viewer in tensorboard.
     },
   });
 

--- a/third_party/polymer.bzl
+++ b/third_party/polymer.bzl
@@ -20,11 +20,11 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "2c38cf73bdd09e0f80a4b7210fd58f88a6bdd8624da73fb3e028e66a84c9e095",
-      strip_prefix = "polymer-1.8.1",
+      sha256 = "cf0d486e17ed8be8bb4d468564568ba7f1a23f217ed9995df31ca0c7c2a83dc2",
+      strip_prefix = "polymer-1.11.3",
       urls = [
-          "https://mirror.bazel.build/github.com/polymer/polymer/archive/v1.8.1.tar.gz",
-          "https://github.com/polymer/polymer/archive/v1.8.1.tar.gz",
+          "https://mirror.bazel.build/github.com/polymer/polymer/archive/v1.11.3.tar.gz",
+          "https://github.com/polymer/polymer/archive/v1.11.3.tar.gz",
       ],
       path = "/polymer",
       srcs = [
@@ -37,12 +37,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_hydrolysis",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "703b50f6b00f9e0546b5a3451da57bb20f77a166e27e4967923b9e835bab9b80",
+      sha256 = "c404d453a31082c023457f2635ef4019bfd9e9fbb11c0d186ef55cda15bcab67",
       urls = [
-          "https://mirror.bazel.build/github.com/Polymer/polymer-analyzer/archive/v1.19.3.tar.gz",
-          "https://github.com/Polymer/polymer-analyzer/archive/v1.19.3.tar.gz",
+          "https://mirror.bazel.build/github.com/Polymer/polymer-analyzer/archive/v1.24.1.tar.gz",
+          "https://github.com/Polymer/polymer-analyzer/archive/v1.24.1.tar.gz",
       ],
-      strip_prefix = "polymer-analyzer-1.19.3",
+      strip_prefix = "polymer-analyzer-1.24.1",
       path = "/hydrolysis",
       srcs = [
           "hydrolysis-analyzer.html",
@@ -55,12 +55,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_a11y_announcer",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "53114ceb57d9f33a7a8058488cf06450e48502e5d033adf51c91330f61620353",
+      sha256 = "355f9a0b0509acbe9abb0aaab4cdd3d8621a56ca55a9bbf696dde9c68a2ff304",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-a11y-announcer/archive/v2.0.0.tar.gz",
-          "https://github.com/PolymerElements/iron-a11y-announcer/archive/v2.0.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-a11y-announcer/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/iron-a11y-announcer/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "iron-a11y-announcer-2.0.0",
+      strip_prefix = "iron-a11y-announcer-2.1.0",
       path = "/iron-a11y-announcer",
       srcs = ["iron-a11y-announcer.html"],
       deps = ["@org_polymer"],
@@ -69,12 +69,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_a11y_keys_behavior",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "09274155c8d537f8bb567b3be5e747253ef760995a59ee06cb0ab38e704212fb",
+      sha256 = "0cb94443c5277b2eb022bbf6f64d1573e087ed528f3ad39da40de5d6f51c3af0",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-a11y-keys-behavior/archive/v2.0.0.tar.gz",
-          "https://github.com/PolymerElements/iron-a11y-keys-behavior/archive/v2.0.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-a11y-keys-behavior/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/iron-a11y-keys-behavior/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "iron-a11y-keys-behavior-2.0.0",
+      strip_prefix = "iron-a11y-keys-behavior-2.1.0",
       path = "/iron-a11y-keys-behavior",
       srcs = ["iron-a11y-keys-behavior.html"],
       deps = ["@org_polymer"],
@@ -83,12 +83,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_ajax",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "9162d8af4611e911ac3ebbfc08bb7038ac04f6e79a9287b1476fe36ad6770bc5",
+      sha256 = "80faddb20ac559d04fe32bf4d4652e2cf48bc0bb7567af665ebcabfafd85c557",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-ajax/archive/v1.2.0.tar.gz",
-          "https://github.com/PolymerElements/iron-ajax/archive/v1.2.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-ajax/archive/v2.1.3.tar.gz",
+          "https://github.com/PolymerElements/iron-ajax/archive/v2.1.3.tar.gz",
       ],
-      strip_prefix = "iron-ajax-1.2.0",
+      strip_prefix = "iron-ajax-2.1.3",
       path = "/iron-ajax",
       srcs = [
           "iron-ajax.html",
@@ -103,12 +103,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_autogrow_textarea",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "50bbb901d2c8f87462e3552e3d671a552faa12c37c485e548d7a234ebffbc427",
+      sha256 = "a6a20edde3621f6d99d5a1ec9f4ba499d02d9d8d74ddf95e29bf0966fc55e812",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-autogrow-textarea/archive/v1.0.12.tar.gz",
-          "https://github.com/PolymerElements/iron-autogrow-textarea/archive/v1.0.12.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-autogrow-textarea/archive/v2.2.0.tar.gz",
+          "https://github.com/PolymerElements/iron-autogrow-textarea/archive/v2.2.0.tar.gz",
       ],
-      strip_prefix = "iron-autogrow-textarea-1.0.12",
+      strip_prefix = "iron-autogrow-textarea-2.2.0",
       path = "/iron-autogrow-textarea",
       srcs = ["iron-autogrow-textarea.html"],
       deps = [
@@ -123,12 +123,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_behaviors",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "a1e8d4b7a13f3d36beba9c2a6b186ed33a53e6af2e79f98c1fcc7e85e7b53f89",
+      sha256 = "71ecbe6a01bc302cdea01c80bf7b5801e1f570c88cc4ac491591e5cf19fdedfe",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-behaviors/archive/v1.0.17.tar.gz",
-          "https://github.com/PolymerElements/iron-behaviors/archive/v1.0.17.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-behaviors/archive/v2.1.1.tar.gz",
+          "https://github.com/PolymerElements/iron-behaviors/archive/v2.1.1.tar.gz",
       ],
-      strip_prefix = "iron-behaviors-1.0.17",
+      strip_prefix = "iron-behaviors-2.1.1",
       path = "/iron-behaviors",
       srcs = [
           "iron-button-state.html",
@@ -143,12 +143,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_checked_element_behavior",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "539a0e1c4df0bc702d3bd342388e4e56c77ec4c2066cce69e41426a69f92e8bd",
+      sha256 = "3037ede91593eb2880cf2e0c8d0198ae0b5802221e7386578263ab831a058bfc",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-checked-element-behavior/archive/v1.0.4.tar.gz",
-          "https://github.com/PolymerElements/iron-checked-element-behavior/archive/v1.0.4.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-checked-element-behavior/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/iron-checked-element-behavior/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "iron-checked-element-behavior-1.0.4",
+      strip_prefix = "iron-checked-element-behavior-2.1.0",
       path = "/iron-checked-element-behavior",
       srcs = ["iron-checked-element-behavior.html"],
       deps = [
@@ -161,12 +161,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_component_page",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "3636e8b9a1f229fc33b5aad3933bd02a9825f66e679a0be31855d7c8245c4b4b",
+      sha256 = "d26b9bf200fedc76a9bac54da95e84b5d06b37598fdf99e18c3b943d737aff75",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-component-page/archive/v1.1.4.tar.gz",
-          "https://github.com/PolymerElements/iron-component-page/archive/v1.1.4.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-component-page/archive/v1.1.9.tar.gz",
+          "https://github.com/PolymerElements/iron-component-page/archive/v1.1.9.tar.gz",
       ],
-      strip_prefix = "iron-component-page-1.1.4",
+      strip_prefix = "iron-component-page-1.1.9",
       path = "/iron-component-page",
       srcs = ["iron-component-page.html"],
       deps = [
@@ -186,12 +186,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_collapse",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "eb72f459a2a5adbcd922327eea02ed909e8056ad72fd8a32d04a14ce54b2e480",
+      sha256 = "cad8c568ed26b2c3d67a5c63f53df709591b64b9f2aa724995a2d644a1076fea",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-collapse/archive/v2.0.0.tar.gz",
-          "https://github.com/PolymerElements/iron-collapse/archive/v2.0.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-collapse/archive/v2.2.0.tar.gz",
+          "https://github.com/PolymerElements/iron-collapse/archive/v2.2.0.tar.gz",
       ],
-      strip_prefix = "iron-collapse-2.0.0",
+      strip_prefix = "iron-collapse-2.2.0",
       path = "/iron-collapse",
       srcs = ["iron-collapse.html"],
       deps = [
@@ -203,12 +203,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_demo_helpers",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "e196985cb7e50108283c3fc189a3a018e697b4648107d597df71a5c17f5ee907",
+      sha256 = "4e7c148fc35ad1b8d0cf90fca1bc535801513b4ed62953faf37a2d664100a27f",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-demo-helpers/archive/v2.0.0.tar.gz",
-          "https://github.com/PolymerElements/iron-demo-helpers/archive/v2.0.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-demo-helpers/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/iron-demo-helpers/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "iron-demo-helpers-2.0.0",
+      strip_prefix = "iron-demo-helpers-2.1.0",
       path = "/iron-demo-helpers",
       srcs = [
           "demo-pages-shared-styles.html",
@@ -254,12 +254,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_dropdown",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "db9d6598157f8b114f1be1e6ed1c74917d4c37e660b2dda1e31f6873f1a33b80",
+      sha256 = "f265bf731b96eee431d27d1639acfc5b1c76d5aade2bcf395a65fbcdbfae5ef4",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-dropdown/archive/v1.5.5.tar.gz",
-          "https://github.com/PolymerElements/iron-dropdown/archive/v1.5.5.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-dropdown/archive/v1.5.6.tar.gz",
+          "https://github.com/PolymerElements/iron-dropdown/archive/v1.5.6.tar.gz",
       ],
-      strip_prefix = "iron-dropdown-1.5.5",
+      strip_prefix = "iron-dropdown-1.5.6",
       path = "/iron-dropdown",
       srcs = [
           "iron-dropdown.html",
@@ -278,12 +278,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_fit_behavior",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "10132a2ea309a37c4c07b8fead71f64abc588ee6107931e34680f5f36dd8291e",
+      sha256 = "e0f6ee291103b64ca19e75e42afb0d4dcce87b60b5033a522cd9d2c0260486a7",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-fit-behavior/archive/v1.2.5.tar.gz",
-          "https://github.com/PolymerElements/iron-fit-behavior/archive/v1.2.5.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-fit-behavior/archive/v2.1.1.tar.gz",
+          "https://github.com/PolymerElements/iron-fit-behavior/archive/v2.1.1.tar.gz",
       ],
-      strip_prefix = "iron-fit-behavior-1.2.5",
+      strip_prefix = "iron-fit-behavior-2.1.1",
       path = "/iron-fit-behavior",
       srcs = ["iron-fit-behavior.html"],
       deps = ["@org_polymer"],
@@ -292,16 +292,16 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_flex_layout",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "79287f6ca1c2d4e003f68b88fe19d03a1b6a0011e2b4cae579fe4d1474163a2e",
+      sha256 = "2c147ed1e99870f44aa6e36ff718eee056e49417f64d0ca25caaed781d479ffc",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-flex-layout/archive/v1.3.0.tar.gz",
-          "https://github.com/PolymerElements/iron-flex-layout/archive/v1.3.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-flex-layout/archive/v2.0.3.tar.gz",
+          "https://github.com/PolymerElements/iron-flex-layout/archive/v2.0.3.tar.gz",
       ],
-      strip_prefix = "iron-flex-layout-1.3.0",
+      strip_prefix = "iron-flex-layout-2.0.3",
       path = "/iron-flex-layout",
       srcs = [
-          "classes/iron-flex-layout.html",  # Deprecated, but needed by paper-styles component.
-          "classes/iron-shadow-flex-layout.html",
+          # "classes/iron-flex-layout.html",  # Deprecated, but needed by paper-styles component.
+          # "classes/iron-shadow-flex-layout.html",
           "iron-flex-layout.html",
           "iron-flex-layout-classes.html",
       ],
@@ -311,12 +311,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_form_element_behavior",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "1dd9371c638e5bc2ecba8a64074aa680dfb8712198e9612f9ed24d387efc8f26",
+      sha256 = "c4541ac5f6c8f2677ab05fde9c5d911af58070e1b97f9d603fe489c40a10c1f0",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-form-element-behavior/archive/v1.0.6.tar.gz",
-          "https://github.com/PolymerElements/iron-form-element-behavior/archive/v1.0.6.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-form-element-behavior/archive/v2.1.1.tar.gz",
+          "https://github.com/PolymerElements/iron-form-element-behavior/archive/v2.1.1.tar.gz",
       ],
-      strip_prefix = "iron-form-element-behavior-1.0.6",
+      strip_prefix = "iron-form-element-behavior-2.1.1",
       path = "/iron-form-element-behavior",
       srcs = ["iron-form-element-behavior.html"],
       deps = ["@org_polymer"],
@@ -325,12 +325,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_icon",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "9ed58a69159a02c07a6050d242e6d4e585a29f3245b8c8c390cfd52ddb786dc4",
+      sha256 = "5030eb65f935ee75bec682e71c6b55a421ff365f9f876f0e920080625fc63694",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-icon/archive/v1.0.11.tar.gz",
-          "https://github.com/PolymerElements/iron-icon/archive/v1.0.11.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-icon/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/iron-icon/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "iron-icon-1.0.11",
+      strip_prefix = "iron-icon-2.1.0",
       path = "/iron-icon",
       srcs = ["iron-icon.html"],
       deps = [
@@ -343,12 +343,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_icons",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "3b18542c147c7923dc3a36b1a51984a73255d610f297d43c9aaccc52859bd0d0",
+      sha256 = "779174b4acd9ac8fbbb3e1bf81394db13189f294bd6683c4a0e79f68da8f1911",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-icons/archive/v1.1.3.tar.gz",
-          "https://github.com/PolymerElements/iron-icons/archive/v1.1.3.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-icons/archive/v2.1.1.tar.gz",
+          "https://github.com/PolymerElements/iron-icons/archive/v2.1.1.tar.gz",
       ],
-      strip_prefix = "iron-icons-1.1.3",
+      strip_prefix = "iron-icons-2.1.1",
       path = "/iron-icons",
       srcs = [
           "av-icons.html",
@@ -372,12 +372,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_iconset_svg",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "75cfb41e78f86ef6cb5d201ad12021785ef9e192b490ad46dcc15a9c19bdf71a",
+      sha256 = "31c513ea52648d7b6e716909fea5921272e6244bd560c23571eb2a50e37694de",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-iconset-svg/archive/v2.0.0.tar.gz",
-          "https://github.com/PolymerElements/iron-iconset-svg/archive/v2.0.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-iconset-svg/archive/v2.2.0.tar.gz",
+          "https://github.com/PolymerElements/iron-iconset-svg/archive/v2.2.0.tar.gz",
       ],
-      strip_prefix = "iron-iconset-svg-2.0.0",
+      strip_prefix = "iron-iconset-svg-2.2.0",
       path = "/iron-iconset-svg",
       srcs = ["iron-iconset-svg.html"],
       deps = [
@@ -403,16 +403,15 @@ def tensorboard_polymer_workspace():
       ],
   )
 
-
   web_library_external(
       name = "org_polymer_iron_input",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "c505101ead08ab25526b1f49baecc8c28b4221b92a65e7334c783bdc81553c36",
+      sha256 = "e26c49cfa8f013d09d6cc45f6ca76b390ebbe5baea4755d2d0900df083d5ae44",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-input/archive/1.0.10.tar.gz",
-          "https://github.com/PolymerElements/iron-input/archive/1.0.10.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-input/archive/v1.0.11.tar.gz",
+          "https://github.com/PolymerElements/iron-input/archive/v1.0.11.tar.gz",
       ],
-      strip_prefix = "iron-input-1.0.10",
+      strip_prefix = "iron-input-1.0.11",
       path = "/iron-input",
       srcs = ["iron-input.html"],
       deps = [
@@ -425,12 +424,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_list",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "72a6530b9f0ad5557f5d287845792a0ada74d8b159198e27f940e226313dc116",
+      sha256 = "02ae4546cd0bd2691cfd4d108be15920047cf0d4478b0e3db7b5b0665d7ab376",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-list/archive/v1.3.9.tar.gz",
-          "https://github.com/PolymerElements/iron-list/archive/v1.3.9.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-list/archive/v2.0.14.tar.gz",
+          "https://github.com/PolymerElements/iron-list/archive/v2.0.14.tar.gz",
       ],
-      strip_prefix = "iron-list-1.3.9",
+      strip_prefix = "iron-list-2.0.14",
       path = "/iron-list",
       srcs = ["iron-list.html"],
       deps = [
@@ -444,12 +443,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_menu_behavior",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "35d33d1ae55c6efaa0c3744ebe8a06cc0a8b2af9286dd8d36e20726a8540a11a",
+      sha256 = "482c3cad0ad1857fdfeb55d1e22378246379f77e7ac0eb747c248afd87f77146",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-menu-behavior/archive/v2.0.0.tar.gz",
-          "https://github.com/PolymerElements/iron-menu-behavior/archive/v2.0.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-menu-behavior/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/iron-menu-behavior/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "iron-menu-behavior-2.0.0",
+      strip_prefix = "iron-menu-behavior-2.1.0",
       path = "/iron-menu-behavior",
       srcs = [
           "iron-menu-behavior.html",
@@ -465,12 +464,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_meta",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "fb05e6031bae6b4effe5f15d44b3f548d5807f9e3b3aa2442ba17cf4b8b84361",
+      sha256 = "65366ae55474fd058e052aac01f379a5ca3fd8219e0f51cb9e379e2766d607d7",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-meta/archive/v1.1.1.tar.gz",
-          "https://github.com/PolymerElements/iron-meta/archive/v1.1.1.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-meta/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/iron-meta/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "iron-meta-1.1.1",
+      strip_prefix = "iron-meta-2.1.0",
       path = "/iron-meta",
       srcs = ["iron-meta.html"],
       deps = ["@org_polymer"],
@@ -479,18 +478,19 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_overlay_behavior",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "3df5b54ff2e0510c87a2aff8c9d730d3fe83d3d11277cc1a49fa29b549acb46c",
+      sha256 = "1f678414a71ab0fe6ed4b8df1f47ed820191073063d3abe8a61d05dff266078f",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-overlay-behavior/archive/v1.10.1.tar.gz",
-          "https://github.com/PolymerElements/iron-overlay-behavior/archive/v1.10.1.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-overlay-behavior/archive/v2.3.3.tar.gz",
+          "https://github.com/PolymerElements/iron-overlay-behavior/archive/v2.3.3.tar.gz",
       ],
-      strip_prefix = "iron-overlay-behavior-1.10.1",
+      strip_prefix = "iron-overlay-behavior-2.3.3",
       path = "/iron-overlay-behavior",
       srcs = [
           "iron-focusables-helper.html",
           "iron-overlay-backdrop.html",
           "iron-overlay-behavior.html",
           "iron-overlay-manager.html",
+          "iron-scroll-manager.html",
       ],
       deps = [
           "@org_polymer",
@@ -503,12 +503,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_range_behavior",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "b2f2b6d52284542330bd30b586e217926eb0adec5e13934a3cef557717c22dc2",
+      sha256 = "79c2c1b7f03bf41d7b3a798cbd074419945576add48bfb7c2994f45ac3782fd7",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-range-behavior/archive/v1.0.4.tar.gz",
-          "https://github.com/PolymerElements/iron-range-behavior/archive/v1.0.4.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-range-behavior/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/iron-range-behavior/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "iron-range-behavior-1.0.4",
+      strip_prefix = "iron-range-behavior-2.1.0",
       path = "/iron-range-behavior",
       srcs = ["iron-range-behavior.html"],
       deps = ["@org_polymer"],
@@ -517,12 +517,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_resizable_behavior",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "a87a78ee9223c2f6afae7fc94a3ff91cbce6f7e2a7ed3f2979af7945c9281616",
+      sha256 = "1bd7875d419a63f3c8d4ca3309b53ecf93d8dddb9703913f5442d04903a89976",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-resizable-behavior/archive/v1.0.3.tar.gz",
-          "https://github.com/PolymerElements/iron-resizable-behavior/archive/v1.0.3.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-resizable-behavior/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/iron-resizable-behavior/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "iron-resizable-behavior-1.0.3",
+      strip_prefix = "iron-resizable-behavior-2.1.0",
       path = "/iron-resizable-behavior",
       srcs = ["iron-resizable-behavior.html"],
       deps = ["@org_polymer"],
@@ -531,12 +531,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_scroll_target_behavior",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "7c6614c07d354375666ee96eea9f6d485dbf7898146a444ec26094a70d4e0afa",
+      sha256 = "9fd59de543198d88e5ca314091954aececf8e5509df6df5bd62232e36886cb58",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-scroll-target-behavior/archive/v1.1.1.tar.gz",
-          "https://github.com/PolymerElements/iron-scroll-target-behavior/archive/v1.1.1.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-scroll-target-behavior/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/iron-scroll-target-behavior/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "iron-scroll-target-behavior-1.1.1",
+      strip_prefix = "iron-scroll-target-behavior-2.1.0",
       path = "/iron-scroll-target-behavior",
       srcs = ["iron-scroll-target-behavior.html"],
       deps = ["@org_polymer"],
@@ -545,12 +545,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_selector",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "ba28a47443bad3b744611c9d7a79fb21dbdf2e35edc5ef8f812e2dcd72b16747",
+      sha256 = "dcd7e180f05c9b66c30eedaee030a30e2f87d997f0de132e08ea4a58d494b01b",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-selector/archive/v1.5.2.tar.gz",
-          "https://github.com/PolymerElements/iron-selector/archive/v1.5.2.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-selector/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/iron-selector/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "iron-selector-1.5.2",
+      strip_prefix = "iron-selector-2.1.0",
       path = "/iron-selector",
       srcs = [
           "iron-multi-selectable.html",
@@ -564,12 +564,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_iron_validatable_behavior",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "aef4901e68043824f36104799269573dd345ffaac494186e466fdc79c06fdb63",
+      sha256 = "91ad35efdbc9438a41242a4f9aad31284d8749a45968f3a960f4c844c31b3917",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-validatable-behavior/archive/v1.1.1.tar.gz",
-          "https://github.com/PolymerElements/iron-validatable-behavior/archive/v1.1.1.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/iron-validatable-behavior/archive/v1.1.2.tar.gz",
+          "https://github.com/PolymerElements/iron-validatable-behavior/archive/v1.1.2.tar.gz",
       ],
-      strip_prefix = "iron-validatable-behavior-1.1.1",
+      strip_prefix = "iron-validatable-behavior-1.1.2",
       path = "/iron-validatable-behavior",
       srcs = ["iron-validatable-behavior.html"],
       deps = [
@@ -581,12 +581,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_marked",
       licenses = ["notice"],  # MIT
-      sha256 = "93d30bd593736ca440938d77808b7ef5972da0f3fcfe4ae63ae7b4ce117da2cb",
+      sha256 = "4f7c6e0cd96569b3bb762584d20acc3a2602a3442165208535b3f1eff3c1dc41",
       urls = [
-          "https://mirror.bazel.build/github.com/chjj/marked/archive/v0.3.2.zip",
-          "https://github.com/chjj/marked/archive/v0.3.2.zip",
+          "https://mirror.bazel.build/github.com/chjj/marked/archive/v0.3.19.tar.gz",
+          "https://github.com/chjj/marked/archive/v0.3.19.tar.gz",
       ],
-      strip_prefix = "marked-0.3.2",
+      strip_prefix = "marked-0.3.19",
       path = "/marked",
       srcs = ["lib/marked.js"],
   )
@@ -594,12 +594,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_marked_element",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "2ac1f7fae0c1b656e671b2772492809714d836f27c9efa7f2c5fe077ee760f3c",
+      sha256 = "27abd2ef1cc122d4db32d5308c724e9a4cf9cdb1c224a4409d92cd1f5677e0c1",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/marked-element/archive/v2.1.0.tar.gz",
-          "https://github.com/PolymerElements/marked-element/archive/v2.1.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/marked-element/archive/v2.4.0.tar.gz",
+          "https://github.com/PolymerElements/marked-element/archive/v2.4.0.tar.gz",
       ],
-      strip_prefix = "marked-element-2.1.0",
+      strip_prefix = "marked-element-2.4.0",
       path = "/marked-element",
       srcs = [
           "marked-element.html",
@@ -614,12 +614,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_neon_animation",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "8800c314a76b2da190a2b203259c1091f6d38e0057ed37c2a3d0b734980fa9a5",
+      sha256 = "64dfd4f0603a6670ae2558eb8cae39920c089961bedf8811ddab426fc1e21372",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/neon-animation/archive/v1.2.2.tar.gz",
-          "https://github.com/PolymerElements/neon-animation/archive/v1.2.2.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/neon-animation/archive/v2.2.1.tar.gz",
+          "https://github.com/PolymerElements/neon-animation/archive/v2.2.1.tar.gz",
       ],
-      strip_prefix = "neon-animation-1.2.2",
+      strip_prefix = "neon-animation-2.2.1",
       path = "/neon-animation",
       srcs = [
           "animations/cascaded-animation.html",
@@ -663,12 +663,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_behaviors",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "7cfcb9082ef9909da262df6b5c120bc62dbeaff278cb563e8fc60465ddd387e5",
+      sha256 = "74090426df1f50d1071095591cf35deb5d645b9116299b2d8e9d538490bd7f32",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-behaviors/archive/v1.0.12.tar.gz",
-          "https://github.com/PolymerElements/paper-behaviors/archive/v1.0.12.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-behaviors/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-behaviors/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-behaviors-1.0.12",
+      strip_prefix = "paper-behaviors-2.1.0",
       path = "/paper-behaviors",
       srcs = [
           "paper-button-behavior.html",
@@ -707,12 +707,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_button",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "896c0a7e34bfcce63fc23c63e105ed9c4d62fa3a6385b7161e1e5cd4058820a6",
+      sha256 = "c3a21e81822f824ab50fe3f36d9fa3f182fefc9884d95ebebd2c3c7878f6dd00",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-button/archive/v1.0.11.tar.gz",
-          "https://github.com/PolymerElements/paper-button/archive/v1.0.11.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-button/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-button/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-button-1.0.11",
+      strip_prefix = "paper-button-2.1.0",
       path = "/paper-button",
       srcs = ["paper-button.html"],
       deps = [
@@ -721,18 +721,19 @@ def tensorboard_polymer_workspace():
           "@org_polymer_paper_behaviors",
           "@org_polymer_paper_material",
           "@org_polymer_paper_ripple",
+          "@org_polymer_paper_styles",
       ],
   )
 
   web_library_external(
       name = "org_polymer_paper_checkbox",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "0a291d0c64de1b6b807d66697bead9c66c0d7bc3c68b8037e6667f3d66a5904c",
+      sha256 = "029ccba430b0c9a5ee48f337a5a32b7cdff444bd129b4c4715b27d7bcd48f9e5",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-checkbox/archive/v2.0.0.tar.gz",
-          "https://github.com/PolymerElements/paper-checkbox/archive/v2.0.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-checkbox/archive/v2.0.3.tar.gz",
+          "https://github.com/PolymerElements/paper-checkbox/archive/v2.0.3.tar.gz",
       ],
-      strip_prefix = "paper-checkbox-2.0.0",
+      strip_prefix = "paper-checkbox-2.0.3",
       path = "/paper-checkbox",
       srcs = ["paper-checkbox.html"],
       deps = [
@@ -745,12 +746,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_dialog",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "cf60d3aa6ad57ba4eb8b1c16713e65057735eed94b009aeebdbcf3436c95a161",
+      sha256 = "ddc83d55f98161e8109fa6bfdbc908902c221ff92134b4215ca4765c386b0c97",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-dialog/archive/v2.0.0.tar.gz",
-          "https://github.com/PolymerElements/paper-dialog/archive/v2.0.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-dialog/archive/v2.1.1.tar.gz",
+          "https://github.com/PolymerElements/paper-dialog/archive/v2.1.1.tar.gz",
       ],
-      strip_prefix = "paper-dialog-2.0.0",
+      strip_prefix = "paper-dialog-2.1.1",
       path = "/paper-dialog",
       srcs = ["paper-dialog.html"],
       deps = [
@@ -763,12 +764,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_dialog_behavior",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "d78e4f7d008c22537a9255ccda1e919fddae5cc125ef26a66eb2c47f648c20ab",
+      sha256 = "ab218c9b45218042dc30e0a1c053b995683c32b92692165f0514f5b027adff9f",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-dialog-behavior/archive/v1.2.7.tar.gz",
-          "https://github.com/PolymerElements/paper-dialog-behavior/archive/v1.2.7.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-dialog-behavior/archive/v1.2.9.tar.gz",
+          "https://github.com/PolymerElements/paper-dialog-behavior/archive/v1.2.9.tar.gz",
       ],
-      strip_prefix = "paper-dialog-behavior-1.2.7",
+      strip_prefix = "paper-dialog-behavior-1.2.9",
       path = "/paper-dialog-behavior",
       srcs = [
           "paper-dialog-behavior.html",
@@ -786,12 +787,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_dialog_scrollable",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "a2e69283e7674f782c44d811387a0f8da2d01fac0172743d1add65e253e6b5ff",
+      sha256 = "e25a40f3bbc7416485e804bdbfcd683d86c2d900cf60951985ef225c482d5fce",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-dialog-scrollable/archive/1.1.5.tar.gz",
-          "https://github.com/PolymerElements/paper-dialog-scrollable/archive/1.1.5.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-dialog-scrollable/archive/v2.2.0.tar.gz",
+          "https://github.com/PolymerElements/paper-dialog-scrollable/archive/v2.2.0.tar.gz",
       ],
-      strip_prefix = "paper-dialog-scrollable-1.1.5",
+      strip_prefix = "paper-dialog-scrollable-2.2.0",
       path = "/paper-dialog-scrollable",
       srcs = ["paper-dialog-scrollable.html"],
       deps = [
@@ -805,12 +806,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_dropdown_menu",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "9d88f654ec03ee9be211df9e69bede9e8a22b51bf1dbcc63b79762e4256d81ad",
+      sha256 = "95519f37380476ef6d95119bce6aa6a6271c90a3b83c74f8874e62d601c4d43b",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-dropdown-menu/archive/v1.4.0.tar.gz",
-          "https://github.com/PolymerElements/paper-dropdown-menu/archive/v1.4.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-dropdown-menu/archive/v1.5.1.tar.gz",
+          "https://github.com/PolymerElements/paper-dropdown-menu/archive/v1.5.1.tar.gz",
       ],
-      strip_prefix = "paper-dropdown-menu-1.4.0",
+      strip_prefix = "paper-dropdown-menu-1.5.1",
       path = "/paper-dropdown-menu",
       srcs = [
           "paper-dropdown-menu.html",
@@ -837,12 +838,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_header_panel",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "0db4bd8a4bf6f20dcd0dffb4f907b31c93a8647c9c021344239cf30b40b87075",
+      sha256 = "78c76966c5bd92227f02614c3daae7a467118ac40db7ac3ad1a4234a92e30f86",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-header-panel/archive/v1.1.4.tar.gz",
-          "https://github.com/PolymerElements/paper-header-panel/archive/v1.1.4.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-header-panel/archive/v1.1.7.tar.gz",
+          "https://github.com/PolymerElements/paper-header-panel/archive/v1.1.7.tar.gz",
       ],
-      strip_prefix = "paper-header-panel-1.1.4",
+      strip_prefix = "paper-header-panel-1.1.7",
       path = "/paper-header-panel",
       srcs = ["paper-header-panel.html"],
       deps = [
@@ -854,12 +855,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_icon_button",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "9cba5bcfd6aeb4c41581c1392c678cf2278d360e9d122f4d9db54a9ebb404496",
+      sha256 = "3026c61abdfaf9621070c879b9a6dbbdd0236d4453467b54f5672e1c22af4c27",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-icon-button/archive/v1.1.3.tar.gz",
-          "https://github.com/PolymerElements/paper-icon-button/archive/v1.1.3.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-icon-button/archive/v2.2.0.tar.gz",
+          "https://github.com/PolymerElements/paper-icon-button/archive/v2.2.0.tar.gz",
       ],
-      strip_prefix = "paper-icon-button-1.1.3",
+      strip_prefix = "paper-icon-button-2.2.0",
       path = "/paper-icon-button",
       srcs = [
           "paper-icon-button.html",
@@ -876,12 +877,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_input",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "17c3dea9bb1c2026cc61324696c6c774214a0dc37686b91ca214a6af550994db",
+      sha256 = "56129da805dd811ad07cafa11ba34071e7ba191093b731d606816763d64c5f55",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-input/archive/v1.1.18.tar.gz",
-          "https://github.com/PolymerElements/paper-input/archive/v1.1.18.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-input/archive/v1.2.1.tar.gz",
+          "https://github.com/PolymerElements/paper-input/archive/v1.2.1.tar.gz",
       ],
-      strip_prefix = "paper-input-1.1.18",
+      strip_prefix = "paper-input-1.2.1",
       path = "/paper-input",
       srcs = [
           "paper-input.html",
@@ -907,12 +908,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_item",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "12ee0dcb61b0d5721c5988571f6974d7b2211e97724f4195893fbcc9058cdac8",
+      sha256 = "710dc8ae3d3aad12513de4d111aab3b0bcb31159d9fb73c9ef6d02642df4bce2",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-item/archive/v1.1.4.tar.gz",
-          "https://github.com/PolymerElements/paper-item/archive/v1.1.4.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-item/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-item/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-item-1.1.4",
+      strip_prefix = "paper-item-2.1.0",
       path = "/paper-item",
       srcs = [
           "paper-icon-item.html",
@@ -932,12 +933,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_listbox",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "674992d882b18a0618fa697180f196dbc052fb2f5d9ce4e19026a918b568ffd6",
+      sha256 = "294819be85502bef21fe3aa240597f8a60f38d81075acb15ede06ed0867c7832",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-listbox/archive/v2.0.0.tar.gz",
-          "https://github.com/PolymerElements/paper-listbox/archive/v2.0.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-listbox/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-listbox/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-listbox-2.0.0",
+      strip_prefix = "paper-listbox-2.1.0",
       path = "/paper-listbox",
       srcs = ["paper-listbox.html"],
       deps = [
@@ -950,12 +951,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_material",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "913e9c63cf5c8286b0fab817079d7dc900a343d2c05809995d8d9ba0e41f8a29",
+      sha256 = "065935ba7946d3f94c61fb536db79658bc87b20d6c44b9914512f496527845fc",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-material/archive/v2.0.0.tar.gz",
-          "https://github.com/PolymerElements/paper-material/archive/v2.0.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-material/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-material/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-material-2.0.0",
+      strip_prefix = "paper-material-2.1.0",
       path = "/paper-material",
       srcs = [
           "paper-material.html",
@@ -995,12 +996,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_menu_button",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "be3290c288a2bd4f9887213db22c75add99cc29ff4d088100c0bc4eb0e57997b",
+      sha256 = "9de3bc8caa1dbad8578013b3455e71894490095bd30cc24f5fc27cfc449942c1",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-menu-button/archive/v1.5.1.tar.gz",
-          "https://github.com/PolymerElements/paper-menu-button/archive/v1.5.1.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-menu-button/archive/v1.5.2.tar.gz",
+          "https://github.com/PolymerElements/paper-menu-button/archive/v1.5.2.tar.gz",
       ],
-      strip_prefix = "paper-menu-button-1.5.1",
+      strip_prefix = "paper-menu-button-1.5.2",
       path = "/paper-menu-button",
       srcs = [
           "paper-menu-button.html",
@@ -1019,12 +1020,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_progress",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "2b6776b2f023c1f344feea17ba29b58d879e46f8ed43b7256495054b5183fff6",
+      sha256 = "01557e6385f8ab8fa3fc21fb8eab467ecc3f30a58dc650a6a17032befe427b0c",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-progress/archive/v1.0.9.tar.gz",
-          "https://github.com/PolymerElements/paper-progress/archive/v1.0.9.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-progress/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-progress/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-progress-1.0.9",
+      strip_prefix = "paper-progress-2.1.0",
       path = "/paper-progress",
       srcs = ["paper-progress.html"],
       deps = [
@@ -1038,16 +1039,17 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_radio_button",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "6e911d0c308aa388136b3af79d1bdcbe5a1f4159cbc79d71efb4ff3b6c0b4e91",
+      sha256 = "7dece68725e512273e754821dd30019006bdb31064dcd3287d373de4c06d8c1e",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-radio-button/archive/v1.1.2.tar.gz",
-          "https://github.com/PolymerElements/paper-radio-button/archive/v1.1.2.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-radio-button/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-radio-button/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-radio-button-1.1.2",
+      strip_prefix = "paper-radio-button-2.1.0",
       path = "/paper-radio-button",
       srcs = ["paper-radio-button.html"],
       deps = [
           "@org_polymer",
+          "@org_polymer_iron_flex_layout",
           "@org_polymer_paper_behaviors",
           "@org_polymer_paper_styles",
       ],
@@ -1056,17 +1058,18 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_radio_group",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "7885ad1f81e9dcc03dcea4139b54a201ff55c18543770cd44f94530046c9e163",
+      sha256 = "d7f83c4ae7b529760c766bfff3a67a198e67e96201029fd68b574a70cbb49360",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-radio-group/archive/v1.0.9.tar.gz",
-          "https://github.com/PolymerElements/paper-radio-group/archive/v1.0.9.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-radio-group/archive/v2.2.0.tar.gz",
+          "https://github.com/PolymerElements/paper-radio-group/archive/v2.2.0.tar.gz",
       ],
-      strip_prefix = "paper-radio-group-1.0.9",
+      strip_prefix = "paper-radio-group-2.2.0",
       path = "/paper-radio-group",
       srcs = ["paper-radio-group.html"],
       deps = [
           "@org_polymer",
           "@org_polymer_iron_a11y_keys_behavior",
+          "@org_polymer_iron_menu_behavior",
           "@org_polymer_iron_selector",
           "@org_polymer_paper_radio_button",
       ],
@@ -1075,12 +1078,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_ripple",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "ba76bfb1c737260a8a103d3ca97faa1f7c3288c7db9b2519f401b7a782147c09",
+      sha256 = "e7a032f1c194e6222b3b4c80e04f28a201c5d12c7e94a33b77f10ab371a19d84",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-ripple/archive/v1.0.5.tar.gz",
-          "https://github.com/PolymerElements/paper-ripple/archive/v1.0.5.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-ripple/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-ripple/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-ripple-1.0.5",
+      strip_prefix = "paper-ripple-2.1.0",
       path = "/paper-ripple",
       srcs = ["paper-ripple.html"],
       deps = [
@@ -1092,12 +1095,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_slider",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "8bb4db532e8b11b11f78006d9aefa217841392c1aeb449ee2a12e3b56748b774",
+      sha256 = "5d922f348e3058d9b52bbccd8847a6d6c9e39c4282317ecd6acaa90d59c0212f",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-slider/archive/v1.0.14.tar.gz",
-          "https://github.com/PolymerElements/paper-slider/archive/v1.0.14.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-slider/archive/v2.0.6.tar.gz",
+          "https://github.com/PolymerElements/paper-slider/archive/v2.0.6.tar.gz",
       ],
-      strip_prefix = "paper-slider-1.0.14",
+      strip_prefix = "paper-slider-2.0.6",
       path = "/paper-slider",
       srcs = ["paper-slider.html"],
       deps = [
@@ -1116,16 +1119,18 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_spinner",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "6a752907fab7899cbeed15b478e7b9299047c15fbf9d1561d6eb4d204bdbd178",
+      sha256 = "df74ce25bdf16df7f82d4567b0a353073de811f6d3d38df95477b7cefa773688",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-spinner/archive/v1.1.1.tar.gz",
-          "https://github.com/PolymerElements/paper-spinner/archive/v1.1.1.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-spinner/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-spinner/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-spinner-1.1.1",
+      strip_prefix = "paper-spinner-2.1.0",
       path = "/paper-spinner",
       srcs = [
-          "paper-spinner.html", "paper-spinner-behavior.html",
-          "paper-spinner-lite.html", "paper-spinner-styles.html"
+          "paper-spinner-behavior.html",
+          "paper-spinner-lite.html",
+          "paper-spinner-styles.html",
+          "paper-spinner.html",
       ],
       deps = [
           "@org_polymer",
@@ -1137,24 +1142,24 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_styles",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "6d26b0a4c286402098853dc7388f6b22f30dfb7a74e47b34992ac03380144bb2",
+      sha256 = "37359c72f96f1f3dd90fe7a9ba50d079dc32241de359d5c19c013b564b48bd3f",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-styles/archive/v1.1.4.tar.gz",
-          "https://github.com/PolymerElements/paper-styles/archive/v1.1.4.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-styles/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-styles/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-styles-1.1.4",
+      strip_prefix = "paper-styles-2.1.0",
       path = "/paper-styles",
       srcs = [
           "classes/global.html",
           "classes/shadow.html",
-          "classes/shadow-layout.html",
           "classes/typography.html",
           "color.html",
           "default-theme.html",
-          "demo.css",
           "demo-pages.html",
-          "paper-styles.html",
+          "element-styles/paper-item-styles.html",
+          "element-styles/paper-material-styles.html",
           "paper-styles-classes.html",
+          "paper-styles.html",
           "shadow.html",
           "typography.html",
       ],
@@ -1168,12 +1173,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_tabs",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "c23b6a5221db35e5b1ed3eb8e8696b952572563e285adaec96aba1e3134db825",
+      sha256 = "c09fcd78d1e1c79451c6c12c203ec32c6b36f063f25ad6cdf18da81e33bd9a2d",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-tabs/archive/v1.7.0.tar.gz",
-          "https://github.com/PolymerElements/paper-tabs/archive/v1.7.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-tabs/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-tabs/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-tabs-1.7.0",
+      strip_prefix = "paper-tabs-2.1.0",
       path = "/paper-tabs",
       srcs = [
           "paper-tab.html",
@@ -1197,12 +1202,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_toast",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "b1c677e1681ef8d3f688a83da8f7b263902f757f395a9354a1c35f93b9125b60",
+      sha256 = "d47c0be0387d0f13fa756413f192c4719e1b36c0aa0e2373176733d6224e7001",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-toast/archive/v2.0.0.tar.gz",
-          "https://github.com/PolymerElements/paper-toast/archive/v2.0.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-toast/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-toast/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-toast-2.0.0",
+      strip_prefix = "paper-toast-2.1.0",
       path = "/paper-toast",
       srcs = ["paper-toast.html"],
       deps = [
@@ -1215,12 +1220,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_toggle_button",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "4aa7cf0396fa2994a8bc2ac6e8428f48b07b945bb7c41bd52041ef5827b45de3",
+      sha256 = "adf4b41d7e2cfd0d267f62c94506c409be39212e0deadcec7b25526b4d9acd2c",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-toggle-button/archive/v1.2.0.tar.gz",
-          "https://github.com/PolymerElements/paper-toggle-button/archive/v1.2.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-toggle-button/archive/v1.3.0.tar.gz",
+          "https://github.com/PolymerElements/paper-toggle-button/archive/v1.3.0.tar.gz",
       ],
-      strip_prefix = "paper-toggle-button-1.2.0",
+      strip_prefix = "paper-toggle-button-1.3.0",
       path = "/paper-toggle-button",
       srcs = ["paper-toggle-button.html"],
       deps = [
@@ -1234,12 +1239,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_toolbar",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "dbddffc0654d9fb5fb48843087eebe16bf7a134902495a664c96c11bf8a2c63d",
+      sha256 = "6ce97a7cd55b7aadbe0fbd2c1ef768759e5f8f516645c61a2871018828dccffe",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-toolbar/archive/v1.1.4.tar.gz",
-          "https://github.com/PolymerElements/paper-toolbar/archive/v1.1.4.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-toolbar/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/paper-toolbar/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "paper-toolbar-1.1.4",
+      strip_prefix = "paper-toolbar-2.1.0",
       path = "/paper-toolbar",
       srcs = ["paper-toolbar.html"],
       deps = [
@@ -1252,12 +1257,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_paper_tooltip",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "4c6667acf01f73da14c3cbc0aa574bf14280304567987ee0314534328377d2ad",
+      sha256 = "07eacd783507d4aad3e5e6e0c128c3816aa7e3149bf8f7dfce525ea5568d0565",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-tooltip/archive/v1.1.2.tar.gz",
-          "https://github.com/PolymerElements/paper-tooltip/archive/v1.1.2.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/paper-tooltip/archive/v2.1.1.tar.gz",
+          "https://github.com/PolymerElements/paper-tooltip/archive/v2.1.1.tar.gz",
       ],
-      strip_prefix = "paper-tooltip-1.1.2",
+      strip_prefix = "paper-tooltip-2.1.1",
       path = "/paper-tooltip",
       srcs = ["paper-tooltip.html"],
       deps = [
@@ -1269,12 +1274,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_prism",
       licenses = ["notice"],  # MIT
-      sha256 = "e06eb54f2a80e6b3cd0bd4d59f900423bcaee53fc03998a056df63740c684683",
+      sha256 = "9dc3e68c9f34794a6edb3fc54eb39f4905f1ac6b8e12ecc27836cff1abbccf36",
       urls = [
-          "https://mirror.bazel.build/github.com/PrismJS/prism/archive/abee2b7587f1925e57777044270e2a1860810994.tar.gz",
-          "https://github.com/PrismJS/prism/archive/abee2b7587f1925e57777044270e2a1860810994.tar.gz",
+          "https://mirror.bazel.build/github.com/PrismJS/prism/archive/v1.13.0.tar.gz",
+          "https://github.com/PrismJS/prism/archive/v1.13.0.tar.gz",
       ],
-      strip_prefix = "prism-abee2b7587f1925e57777044270e2a1860810994",
+      strip_prefix = "prism-1.13.0",
       path = "/prism",
       srcs = [
           "prism.js",
@@ -1285,12 +1290,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_prism_element",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "c5c03c17520d4992a3576e397aa7a375e64c7f6794ec2af58031f47eef458945",
+      sha256 = "b7c222f2f9254eae469ef6fa0baa208b376d37b33f7511a4a2471db35bdc40c7",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/prism-element/archive/v1.2.0.tar.gz",
-          "https://github.com/PolymerElements/prism-element/archive/v1.2.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerElements/prism-element/archive/v2.1.0.tar.gz",
+          "https://github.com/PolymerElements/prism-element/archive/v2.1.0.tar.gz",
       ],
-      strip_prefix = "prism-element-1.2.0",
+      strip_prefix = "prism-element-2.1.0",
       path = "/prism-element",
       srcs = [
           "prism-highlighter.html",
@@ -1306,11 +1311,11 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_promise_polyfill",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "4495450e5d884c3e16b537b43afead7f84d17c7dc061bcfcbf440eac083e4ef5",
-      strip_prefix = "promise-polyfill-1.0.0",
+      sha256 = "d83edb667c393efb3e7b40a2c22d439e1d84056be5d36174be6507a45f709daa",
+      strip_prefix = "promise-polyfill-1.0.1",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerLabs/promise-polyfill/archive/v1.0.0.tar.gz",
-          "https://github.com/PolymerLabs/promise-polyfill/archive/v1.0.0.tar.gz",
+          "https://mirror.bazel.build/github.com/PolymerLabs/promise-polyfill/archive/v1.0.1.tar.gz",
+          "https://github.com/PolymerLabs/promise-polyfill/archive/v1.0.1.tar.gz",
       ],
       path = "/promise-polyfill",
       srcs = [
@@ -1338,12 +1343,12 @@ def tensorboard_polymer_workspace():
   web_library_external(
       name = "org_polymer_webcomponentsjs",
       licenses = ["notice"],  # BSD-3-Clause
-      sha256 = "1f58decac693deb926e6b62b5dbd459fb7c2e961f7241e6e646d1cd9a60281d2",
+      sha256 = "2164e6d07d72d4326865ab7c0acee5493870e1ae5f31e9d22665dff4a4773078",
       urls = [
-          "https://mirror.bazel.build/github.com/webcomponents/webcomponentsjs/archive/v0.7.23.tar.gz",
-          "https://github.com/webcomponents/webcomponentsjs/archive/v0.7.23.tar.gz",
+          "https://mirror.bazel.build/github.com/webcomponents/webcomponentsjs/archive/v0.7.24.tar.gz",
+          "https://github.com/webcomponents/webcomponentsjs/archive/v0.7.24.tar.gz",
       ],
-      strip_prefix = "webcomponentsjs-0.7.23",
+      strip_prefix = "webcomponentsjs-0.7.24",
       path = "/webcomponentsjs",
       srcs = [
           "CustomElements.js",

--- a/third_party/polymer.bzl
+++ b/third_party/polymer.bzl
@@ -579,6 +579,23 @@ def tensorboard_polymer_workspace():
   )
 
   web_library_external(
+      name = "org_polymer_iron_validator_behavior",
+      srcs = ["iron-validator-behavior.html"],
+      licenses = ["notice"],  # BSD-3-Clause
+      path = "/iron-validator-behavior",
+      sha256 = "0956488f849c0528d66d5ce28bbfb66e163a7990df2cc5f157a5bf34dcb7dfd2",
+      strip_prefix = "iron-validator-behavior-1.0.2",
+      urls = [
+          "http://mirror.bazel.build/github.com/PolymerElements/iron-validator-behavior/archive/v1.0.2.tar.gz",
+          "https://github.com/PolymerElements/iron-validator-behavior/archive/v1.0.2.tar.gz",
+      ],
+      deps = [
+          "@org_polymer",
+          "@org_polymer_iron_meta",
+      ],
+   )
+
+  web_library_external(
       name = "org_polymer_marked",
       licenses = ["notice"],  # MIT
       sha256 = "4f7c6e0cd96569b3bb762584d20acc3a2602a3442165208535b3f1eff3c1dc41",


### PR DESCRIPTION
trace viewer normally involve huge amount of data which browser can not
handle. streaming trace viewer use grpc to connect to a tpu profiler
analysis service to get small part of whole trace and display to user.
the amount of data depends on current view port (defined by a start and
end timestamp) and resolution (defined by zoom level).
currently the server reside on google owned virtual machine. there are
plans to open source those part.

to avoid confusing user, the patch is done in a backward compatible
fashion. user are expected to use old trace viewer (which limit the
event to 1 million), if the user specify the MASTER_TPU environment to
the IP address of the green VM, we will try to estabilish a grpc stub to
that IP:8466 port. only if stub is successfully connected we will use
new tools 'trace_viewer@' to OVERRIDE the old trace_viewer. Override
will hide old trace viewer tools to avoid confusing user.

Upon receiving the tool/data probing in python, we will determine which
tools to use. using 'trace_viewer@' will signal the downstream
componenet that streaming trace viewer is in use.

Most of the trace viewer related code already exist within google3. I
removed host filters etc for the reason that we don't support multiple
hosts yet.