### PR TITLE
Let developer set rank direction for graph

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/externs.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/externs.ts
@@ -21,6 +21,7 @@ limitations under the License.
 
 declare module graphlib {
   interface GraphOptions {
+    compound?: boolean;
     name?: string;
     /**
      * Direction for rank nodes. Can be TB, BT, LR, or RL, where T = top,

--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -794,9 +794,15 @@ export class MetaedgeImpl implements Metaedge {
   }
 }
 
-export function createSeriesNode(prefix: string, suffix: string,
-    parent: string, clusterId: number, name: string): SeriesNode {
-  return new SeriesNodeImpl(prefix, suffix, parent, clusterId, name);
+export function createSeriesNode(
+    prefix: string,
+    suffix: string,
+    parent: string,
+    clusterId: number,
+    name: string,
+    graphOptions: graphlib.GraphOptions): SeriesNode {
+  return new SeriesNodeImpl(
+      prefix, suffix, parent, clusterId, name, graphOptions);
 }
 
 export function getSeriesNodeName(prefix: string, suffix: string,
@@ -830,8 +836,13 @@ class SeriesNodeImpl implements SeriesNode {
   include: InclusionType;
   nodeAttributes: {[key: string]: any;};
 
-  constructor(prefix: string, suffix: string, parent: string,
-      clusterId: number, name: string) {
+  constructor(
+      prefix: string,
+      suffix: string,
+      parent: string,
+      clusterId: number,
+      name: string,
+      graphOptions: graphlib.GraphOptions) {
     this.name = name || getSeriesNodeName(prefix, suffix, parent);
     this.type = NodeType.SERIES;
     this.hasLoop = false;
@@ -842,7 +853,8 @@ class SeriesNodeImpl implements SeriesNode {
     this.parent = parent;
     this.isGroupNode = true;
     this.cardinality = 0;
-    this.metagraph = createGraph<Metanode, Metaedge>(name, GraphType.SERIES);
+    this.metagraph = createGraph<Metanode, Metaedge>(
+        name, GraphType.SERIES, graphOptions);
     // bridgegraph must be constructed lazily-see hierarchy.getBridgegraph()
     this.bridgegraph = null;
     this.parentNode = null;
@@ -1244,12 +1256,14 @@ export function build(
 /**
  * Create a new graphlib.Graph() instance with default parameters
  */
-export function createGraph<N, E>(name: string, type, opt = {}):
-    graphlib.Graph<N, E> {
-  let graph = new graphlib.Graph<N, E>(opt);
+export function createGraph<N, E>(
+    name: string, type,
+    opt?: graphlib.GraphOptions): graphlib.Graph<N, E> {
+  const graphOptions = opt || {};
+  let graph = new graphlib.Graph<N, E>(graphOptions);
   graph.setGraph({
     name: name,
-    rankdir: 'BT',  // BT,TB,LR,RL
+    rankdir: graphOptions.rankdir || 'BT',  // BT,TB,LR,RL
     type: type
   });
   return graph;

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -409,7 +409,7 @@ export interface HierarchyParams {
   seriesNodeMinSize: number;
   seriesMap: { [name: string]: tf.graph.SeriesGroupingType };
   // This string is supplied to dagre as the 'rankdir' property for laying out
-  // the graph. TB, BT, LR, or RL.
+  // the graph. TB, BT, LR, or RL. The default is 'BT' (bottom to top).
   rankDirection: string;
 }
 

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -224,7 +224,7 @@ export class RenderGraphInfo {
     // Maps node name to whether the rendering hierarchy was already
     // constructed.
     this.hasSubhierarchy = {};
-    this.root = new RenderGroupNodeInfo(hierarchy.root);
+    this.root = new RenderGroupNodeInfo(hierarchy.root, hierarchy.graphOptions);
     this.index[hierarchy.root.name] = this.root;
     this.renderedOpNames.push(hierarchy.root.name);
     this.buildSubhierarchy(hierarchy.root.name);
@@ -315,7 +315,7 @@ export class RenderGraphInfo {
       return null;
     }
     let renderInfo = node.isGroupNode ?
-        new RenderGroupNodeInfo(<GroupNode>node) :
+        new RenderGroupNodeInfo(<GroupNode>node, this.hierarchy.graphOptions) :
         new RenderNodeInfo(node);
     this.index[nodeName] = renderInfo;
     this.renderedOpNames.push(nodeName);
@@ -1788,13 +1788,14 @@ export class RenderGroupNodeInfo extends RenderNodeInfo {
   /** Array of nodes to show in the function library scene group. */
   libraryFunctionsExtract: RenderNodeInfo[];
 
-  constructor(groupNode: GroupNode) {
+  constructor(groupNode: GroupNode, graphOptions: graphlib.GraphOptions) {
     super(groupNode);
     let metagraph = groupNode.metagraph;
     let gl = metagraph.graph();
+    graphOptions.compound = true;
     this.coreGraph =
         createGraph<RenderNodeInfo, RenderMetaedgeInfo>(
-            gl.name, GraphType.CORE, { compound: true });
+            gl.name, GraphType.CORE, graphOptions);
     this.inExtractBox = {width: 0, height: 0};
     this.outExtractBox = {width: 0, height: 0};
     this.libraryFunctionsBox = {width: 0, height: 0};

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -42,9 +42,16 @@ Polymer({
     },
     datasets: Array,
     selectedDataset: Number,
-    selectedFile: {
-      type: Object,
-      observer: '_selectedFileChanged'
+    selectedFile: Object,
+    /**
+     * This experimental (and optional) property determines the direction in
+     * which the graph is rendered. This value could be one of BT,TB,LR,RL. The
+     * default is BT (bottom to top).
+     * @type {string}
+     */
+    rankDirection: {
+      type: String,
+      value: '',
     },
     outGraphHierarchy: {
       type: Object,
@@ -69,8 +76,9 @@ Polymer({
     },
   },
   observers: [
-    '_selectedDatasetChanged(selectedDataset, datasets)',
-    '_readAndParseMetadata(selectedMetadataTag)'
+    '_selectedDatasetChanged(selectedDataset, datasets, rankDirection)',
+    '_selectedFileChanged(selectedFile, rankDirection)',
+    '_readAndParseMetadata(selectedMetadataTag, rankDirection)',
   ],
   _readAndParseMetadata: function(metadataIndex) {
     if (metadataIndex == -1 || this.datasets[this.selectedDataset] == null ||
@@ -95,7 +103,8 @@ Polymer({
    * @param {string?} path
    * @param {string=} pbTxtFile
    */
-  _parseAndConstructHierarchicalGraph: function(path, pbTxtFile) {
+  _parseAndConstructHierarchicalGraph: function(
+      path, pbTxtFile, rankDirection) {
     // Reset the progress bar to 0.
     this.set('progress', {
       value: 0,
@@ -112,6 +121,10 @@ Polymer({
       // Starts out empty which allows the renderer to decide which series
       // are initially rendered grouped and which aren't.
       seriesMap: {},
+      // An experimental feature that enables the graph explorer to generalize.
+      // The direction in which the graph renders. This string is passed to
+      // dagre as the 'rankdir' graph option.
+      rankDirection: rankDirection,
     };
     this._setOutHierarchyParams(hierarchyParams);
     var dataTracker = tf.graph.util.getSubtaskTracker(tracker, 30, 'Data');
@@ -170,10 +183,11 @@ Polymer({
       tracker.reportError("Graph visualization failed: " + e, e);
     });
   },
-  _selectedDatasetChanged: function(datasetIndex, datasets) {
-    this._parseAndConstructHierarchicalGraph(datasets[datasetIndex].path);
+  _selectedDatasetChanged: function(datasetIndex, datasets, rankDirection) {
+    this._parseAndConstructHierarchicalGraph(
+        datasets[datasetIndex].path, undefined, rankDirection);
   },
-  _selectedFileChanged: function(e) {
+  _selectedFileChanged: function(e, rankDirection) {
     if (!e) {
       return;
     }
@@ -186,7 +200,7 @@ Polymer({
     // selects the same file, we'll re-read it.
     e.target.value = '';
 
-    this._parseAndConstructHierarchicalGraph(null, file);
+    this._parseAndConstructHierarchicalGraph(null, file, rankDirection);
   }
 });
 </script>


### PR DESCRIPTION
We add a `rankDirection` property to the `tf-graph-loader` component.
This property is passed to the dagre layout engine as the 'rankdir'
graph option. We hence let the user change which way the graph flows.
For instance, we can let the graph flow from top to bottom.

![image](https://user-images.githubusercontent.com/4221553/38229972-6bdb3f52-36c0-11e8-805c-b9b5142c4e71.png)

This PR is a small part of generalizing the graph explorer. This change
will be tested within internal integration tests.