### PR TITLE
Reduce build latency on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,8 @@ script:
       --local_resources=400,2,1.0 \
       --worker_max_instances=2 \
       --strategy=Javac=worker \
-      --strategy=Closure=worker
+      --strategy=Closure=worker \
+      --distinct_host_configuration=false
 
   - |
     bazel \
@@ -75,7 +76,9 @@ script:
       --test_verbose_timeout_warnings \
       --test_output=errors \
       --spawn_strategy=sandboxed \
-      --local_resources=400,2,1.0
+      --local_resources=400,2,1.0 \
+      --distinct_host_configuration=false
+
   - |
     TB=$(pwd)
     cd bazel-genfiles


### PR DESCRIPTION
Without this flag, Bazel basically builds the entire codebase twice. Once for
AMD k8 CPUs from 2003, and a second time for -march=native (host).