### PR TITLE
Always reload multiplexer on thread.

### DIFF
--- a/tensorboard/plugins/audio/audio_plugin_test.py
+++ b/tensorboard/plugins/audio/audio_plugin_test.py
@@ -94,10 +94,15 @@ class AudioPluginTest(tf.test.TestCase):
     context = base_plugin.TBContext(
         logdir=self.log_dir, multiplexer=multiplexer)
     self.plugin = audio_plugin.AudioPlugin(context)
+    # Setting a reload interval of -1 disables reloading. We disable reloading
+    # because we seek to block tests from running til after one reload finishes.
+    # This setUp method thus manually reloads the multiplexer. TensorBoard would
+    # otherwise reload in a non-blocking thread.
     wsgi_app = application.TensorBoardWSGIApp(
-        self.log_dir, [self.plugin], multiplexer, reload_interval=0,
+        self.log_dir, [self.plugin], multiplexer, reload_interval=-1,
         path_prefix='')
     self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+    multiplexer.Reload()
 
   def tearDown(self):
     shutil.rmtree(self.log_dir, ignore_errors=True)

--- a/tensorboard/plugins/image/images_plugin_test.py
+++ b/tensorboard/plugins/image/images_plugin_test.py
@@ -88,9 +88,14 @@ class ImagesPluginTest(tf.test.TestCase):
     context = base_plugin.TBContext(
         logdir=self.log_dir, multiplexer=multiplexer)
     plugin = images_plugin.ImagesPlugin(context)
+    # Setting a reload interval of -1 disables reloading. We disable reloading
+    # because we seek to block tests from running til after one reload finishes.
+    # This setUp method thus manually reloads the multiplexer. TensorBoard would
+    # otherwise reload in a non-blocking thread.
     wsgi_app = application.TensorBoardWSGIApp(
-        self.log_dir, [plugin], multiplexer, reload_interval=0, path_prefix='')
+        self.log_dir, [plugin], multiplexer, reload_interval=-1, path_prefix='')
     self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+    multiplexer.Reload()
     self.routes = plugin.get_plugin_apps()
 
   def tearDown(self):


### PR DESCRIPTION
Previously, when the reload_interval flag was set to 0, TensorBoard
would reload the multiplexer once at the beginning of TensorBoard
startup on the main thread. Now, TensorBoard performs that reload on a
separate daemon thread. As comments note, this behavior prevents joining
threads that start while TensorBoard is reloading from blocking
TensorBoard from quitting after the user hits Ctrl + C.

This PR introduces a change in behavior. When the user starts a
TensorBoard with reload_interval set to 0 (no continuous reloading),
TensorBoard server starts up before all data is read from disk.
Previously, TensorBoard would read all events files (reload
multiplexers) before starting its server. A few tests were modified
accordingly.

Test Plan:

Start TensorBoard pointed at logs from mnist_with_summaries.py with the
reload interval set to 0. Verify that TensorBoard starts up successfully
and that the multiplexer only reloads once in the beginning.

Start TensorBoard with the reload interval set to 5 seconds. Verify that
TensorBoard starts up successfully and that the multiplexer continuously
reloads with a 5-second interval in between reloads.

Start TensorBoard with the reload interval set to -1. Verify that
TensorBoard never performs a reload.