### PR TITLE
Extend the profile plugin to take per host profile traces

### DIFF
--- a/tensorboard/plugins/profile/input_pipeline_analyzer/BUILD
+++ b/tensorboard/plugins/profile/input_pipeline_analyzer/BUILD
@@ -10,7 +10,7 @@ tf_web_library(
     path = "/tf-input-pipeline",
     visibility = ["//visibility:public"],
     deps = [
-        "//tensorboard/components/tf_imports:plottable",
         "//tensorboard/components/vz_line_chart",
+        "@org_polymer_paper_button",
     ],
 )

--- a/tensorboard/plugins/profile/input_pipeline_analyzer/BUILD
+++ b/tensorboard/plugins/profile/input_pipeline_analyzer/BUILD
@@ -10,7 +10,7 @@ tf_web_library(
     path = "/tf-input-pipeline",
     visibility = ["//visibility:public"],
     deps = [
-	"//tensorboard/components/tf_imports:plottable",
+        "//tensorboard/components/tf_imports:plottable",
         "//tensorboard/components/vz_line_chart",
     ],
 )

--- a/tensorboard/plugins/profile/input_pipeline_analyzer/BUILD
+++ b/tensorboard/plugins/profile/input_pipeline_analyzer/BUILD
@@ -10,7 +10,7 @@ tf_web_library(
     path = "/tf-input-pipeline",
     visibility = ["//visibility:public"],
     deps = [
+	"//tensorboard/components/tf_imports:plottable",
         "//tensorboard/components/vz_line_chart",
-        "@org_polymer_paper_button",
     ],
 )

--- a/tensorboard/plugins/profile/input_pipeline_analyzer/input-pipeline-analyzer.html
+++ b/tensorboard/plugins/profile/input_pipeline_analyzer/input-pipeline-analyzer.html
@@ -208,15 +208,6 @@ You may obtain a copy of the License at
   Polymer({
     is: 'input-pipeline-analyzer',
     properties: {
-      _requestManager: {
-        type: Object,
-        readOnly: true,
-        value: () => new tf_backend.RequestManager(),
-      },
-      run: {
-        type: String,
-        observer: '_reloadToolData',
-      },
       _data: {
         type: Object,
         observer: '_updateView',
@@ -249,25 +240,13 @@ You may obtain a copy of the License at
     onClick: function(e) {
       this.set('_show_host_side_table', !this._show_host_side_table);
     },
-    _reloadToolData: function(run) {
-      if (!run) return;
-      this._requestManager.request(tf_backend.addParams(
-        tf_backend.getRouter().pluginRoute('profile', '/data'),
-        {tag: 'input_pipeline_analyzer', run})
-      ).catch(error => {
-        console.error(error);
-      }).then((data) => {
-        if (data) {
-          this.set('_data', data);
-        }
-      });
-    },
     _getToggleButtonText: function(show_host_side_table) {
       return (show_host_side_table ? 'Hide' : 'Show') + ' Input Op Statistics';
     },
 
     /* Update view according to new data */
     _updateView: function() {
+      if (this._data == null) return;
       var deviceJson = this._data[0];
       var hostJson = this._data[1];
       var recommendationJson = this._data[2];

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -162,15 +162,6 @@ You may obtain a copy of the License at
    Polymer({
      is: 'overview-page',
      properties: {
-       _requestManager: {
-         type: Object,
-         readOnly: true,
-         value: () => new tf_backend.RequestManager(),
-       },
-       run: {
-         type: String,
-         observer: '_reloadToolData',
-       },
        _data: {
          type: Object,
          observer: '_updateView',
@@ -206,17 +197,6 @@ You may obtain a copy of the License at
      _build_target: String,
      _statement: String,
 
-     _reloadToolData: function(run) {
-       this._requestManager.request(tf_backend.addParams(
-         tf_backend.getRouter().pluginRoute('profile', '/data'),
-         {tag: 'overview_page', run})
-       ).then((data) => {
-         if (data) {
-	   this.set('_data', data);
-         }
-       });
-     },
-
      /* Toggles _show_top_ops_table */
      onClickTopOps: function(e) {
        this.set('_show_top_ops_table', !this._show_top_ops_table);
@@ -229,6 +209,7 @@ You may obtain a copy of the License at
 
      /* Updates view according to new data */
      _updateView: function() {
+       if (this._data == null) return;
        var generalAnalysisJson = this._data[0];
        var inputAnalysisJson = this._data[1];
        var runEnvironmentJson = this._data[2];

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -134,12 +134,12 @@ class ProfilePlugin(base_plugin.TBPlugin):
         tool_pattern = '*' + TOOLS[tool]
         path = os.path.join(run_dir, tool_pattern)
         try:
-          files = tf.gfile.Glob(path);
+          files = tf.gfile.Glob(path)
           if len(files) >= 1:
             run_to_tools[run].append(tool)
-        except tf.errors.OpError:
-            logging.warning("Cannot read asset directory: %s, OpError %s",
-                            run_dir, e)
+        except tf.errors.OpError as e:
+          logging.warning("Cannot read asset directory: %s, OpError %s",
+                          run_dir, e)
     return run_to_tools
 
   @wrappers.Request.application
@@ -177,15 +177,15 @@ class ProfilePlugin(base_plugin.TBPlugin):
       return hosts
     run_dir = self._run_dir(run)
     if not run_dir:
-       logging.warning("Cannot find asset directory: %s", run_dir)
-       return;
+      logging.warning("Cannot find asset directory: %s", run_dir)
+      return hosts
     tool_pattern = '*' + TOOLS[tool]
     try:
-      files = tf.gfile.Glob(os.path.join(run_dir,tool_pattern))
-      hosts = [os.path.basename(f).replace(TOOLS[tool],'') for f in files]
-    except tf.errors.OpError:
+      files = tf.gfile.Glob(os.path.join(run_dir, tool_pattern))
+      hosts = [os.path.basename(f).replace(TOOLS[tool], '') for f in files]
+    except tf.errors.OpError as e:
       logging.warning("Cannot read asset directory: %s, OpError %s",
-                        run_dir, e)
+                      run_dir, e)
     return hosts
 
 

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -46,7 +46,7 @@ TOOLS = {
     'trace_viewer': 'trace',
     'op_profile': 'op_profile.json',
     'input_pipeline_analyzer': 'input_pipeline.json',
-    'overview_page': 'overview_page.json'
+    'overview_page': 'overview_page.json',
 }
 
 # Tools that consume raw data.
@@ -172,9 +172,9 @@ class ProfilePlugin(base_plugin.TBPlugin):
       A list of host names e.g.
         {"host1", "host2", "host3"} for the example.
     """
-    tool_to_hosts = {}
+    hosts = {}
     if not tf.gfile.IsDirectory(self.plugin_logdir):
-      return tool_to_hosts
+      return hosts
     run_dir = self._run_dir(run)
     if not run_dir:
        logging.warning("Cannot find asset directory: %s", run_dir)
@@ -182,19 +182,19 @@ class ProfilePlugin(base_plugin.TBPlugin):
     tool_pattern = '*' + TOOLS[tool]
     try:
       files = tf.gfile.Glob(os.path.join(run_dir,tool_pattern))
-      tool_to_hosts = [os.path.basename(f).replace(TOOLS[tool],'') for f in files]
+      hosts = [os.path.basename(f).replace(TOOLS[tool],'') for f in files]
     except tf.errors.OpError:
       logging.warning("Cannot read asset directory: %s, OpError %s",
                         run_dir, e)
-    return tool_to_hosts
+    return hosts
 
 
   @wrappers.Request.application
   def hosts_route(self, request):
     run = request.args.get('run')
     tool = request.args.get('tag')
-    tool_to_hosts = self.host_impl(run, tool)
-    return http_util.Respond(request, tool_to_hosts, 'application/json')
+    hosts = self.host_impl(run, tool)
+    return http_util.Respond(request, hosts, 'application/json')
 
   def data_impl(self, run, tool, host):
     """Retrieves and processes the tool data for a run and a host.

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -237,7 +237,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
     #   run: The run name.
     #   tag: The tool name e.g. trace_viewer. The plugin returns different UI
     #     data for different tools of the same run.
-    #   host: The host name. 
+    #   host: The host name.
     run = request.args.get('run')
     tool = request.args.get('tag')
     host = request.args.get('host')

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -38,6 +38,7 @@ PLUGIN_NAME = 'profile'
 LOGDIR_ROUTE = '/logdir'
 DATA_ROUTE = '/data'
 TOOLS_ROUTE = '/tools'
+HOSTS_ROUTE = '/hosts'
 
 # Available profiling tools -> file name of the tool data.
 _FILE_NAME = 'TOOL_FILE_NAME'
@@ -45,7 +46,7 @@ TOOLS = {
     'trace_viewer': 'trace',
     'op_profile': 'op_profile.json',
     'input_pipeline_analyzer': 'input_pipeline.json',
-    'overview_page': 'overview_page.json',
+    'overview_page': 'overview_page.json'
 }
 
 # Tools that consume raw data.
@@ -92,13 +93,19 @@ class ProfilePlugin(base_plugin.TBPlugin):
     In the plugin log directory, each directory contains profile data for a
     single run (identified by the directory name), and files in the run
     directory contains data for different tools. The file that contains profile
-    for a specific tool "x" will have a fixed name TOOLS["x"].
+    for a specific tool "x" will have a suffix name TOOLS["x"].
     Example:
       log/
         run1/
-          trace
+          plugins/
+            profile/
+              host1.trace
+              host2.trace
         run2/
-          trace
+          plugins/
+            profile/
+              host1.trace
+              host2.trace
 
     Returns:
       A map from runs to tool names e.g.
@@ -110,11 +117,11 @@ class ProfilePlugin(base_plugin.TBPlugin):
     #       run1/
     #         plugins/
     #           profile/
-    #             trace
+    #             host1.trace
     #       run2/
     #         plugins/
     #           profile/
-    #             trace
+    #             host2.trace
     run_to_tools = {}
     if not tf.gfile.IsDirectory(self.plugin_logdir):
       return run_to_tools
@@ -124,9 +131,15 @@ class ProfilePlugin(base_plugin.TBPlugin):
         continue
       run_to_tools[run] = []
       for tool in TOOLS:
-        tool_filename = TOOLS[tool]
-        if tf.gfile.Exists(os.path.join(run_dir, tool_filename)):
-          run_to_tools[run].append(tool)
+        tool_pattern = '*' + TOOLS[tool]
+        path = os.path.join(run_dir, tool_pattern)
+        try:
+          files = tf.gfile.Glob(path);
+          if len(files) >= 1:
+            run_to_tools[run].append(tool)
+        except tf.errors.OpError:
+            logging.warning("Cannot read asset directory: %s, OpError %s",
+                            run_dir, e)
     return run_to_tools
 
   @wrappers.Request.application
@@ -134,21 +147,72 @@ class ProfilePlugin(base_plugin.TBPlugin):
     run_to_tools = self.index_impl()
     return http_util.Respond(request, run_to_tools, 'application/json')
 
-  def data_impl(self, run, tool):
-    """Retrieves and processes the tool data for a run.
+  def host_impl(self, run, tool):
+    """Returns available hosts for the run and tool in the log directory.
+
+    In the plugin log directory, each directory contains profile data for a
+    single run (identified by the directory name), and files in the run
+    directory contains data for different tools and hosts. The file that
+    contains profile for a specific tool "x" will have a prefix name TOOLS["x"].
+
+    Example:
+      log/
+        run1/
+          plugins/
+            profile/
+              host1.trace
+              host2.trace
+        run2/
+          plugins/
+            profile/
+              host1.trace
+              host2.trace
+
+    Returns:
+      A list of host names e.g.
+        {"host1", "host2", "host3"} for the example.
+    """
+    tool_to_hosts = {}
+    if not tf.gfile.IsDirectory(self.plugin_logdir):
+      return tool_to_hosts
+    run_dir = self._run_dir(run)
+    if not run_dir:
+       logging.warning("Cannot find asset directory: %s", run_dir)
+       return;
+    tool_pattern = '*' + TOOLS[tool]
+    try:
+      files = tf.gfile.Glob(os.path.join(run_dir,tool_pattern))
+      tool_to_hosts = [os.path.basename(f).replace(TOOLS[tool],'') for f in files]
+    except tf.errors.OpError:
+      logging.warning("Cannot read asset directory: %s, OpError %s",
+                        run_dir, e)
+    return tool_to_hosts
+
+
+  @wrappers.Request.application
+  def hosts_route(self, request):
+    run = request.args.get('run')
+    tool = request.args.get('tag')
+    tool_to_hosts = self.host_impl(run, tool)
+    return http_util.Respond(request, tool_to_hosts, 'application/json')
+
+  def data_impl(self, run, tool, host):
+    """Retrieves and processes the tool data for a run and a host.
 
     Args:
       run: Name of the run.
       tool: Name of the tool.
+      host: Name of the host.
 
     Returns:
-      A string that can be served to the frontend tool or None if tool or
-        run is invalid.
+      A string that can be served to the frontend tool or None if tool,
+        run or host is invalid.
     """
     # Path relative to the path of plugin directory.
     if tool not in TOOLS:
       return None
-    rel_data_path = os.path.join(run, TOOLS[tool])
+    tool_name = str(host) + TOOLS[tool]
+    rel_data_path = os.path.join(run, tool_name)
     asset_path = os.path.join(self.plugin_logdir, rel_data_path)
     raw_data = None
     try:
@@ -173,9 +237,11 @@ class ProfilePlugin(base_plugin.TBPlugin):
     #   run: The run name.
     #   tag: The tool name e.g. trace_viewer. The plugin returns different UI
     #     data for different tools of the same run.
+    #   host: The host name. 
     run = request.args.get('run')
     tool = request.args.get('tag')
-    data = self.data_impl(run, tool)
+    host = request.args.get('host')
+    data = self.data_impl(run, tool, host)
     if data is None:
       return http_util.Respond(request, '404 Not Found', 'text/plain', code=404)
     return http_util.Respond(request, data, 'text/plain')
@@ -184,6 +250,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
     return {
         LOGDIR_ROUTE: self.logdir_route,
         TOOLS_ROUTE: self.tools_route,
+        HOSTS_ROUTE: self.hosts_route,
         DATA_ROUTE: self.data_route,
     }
 

--- a/tensorboard/plugins/profile/profile_plugin_test.py
+++ b/tensorboard/plugins/profile/profile_plugin_test.py
@@ -44,7 +44,7 @@ class ProfilePluginTest(tf.test.TestCase):
         'empty': [],
     }
     self.run_to_hosts = {
-        'foo': ['host0','host1'],
+        'foo': ['host0', 'host1'],
         'bar': ['host1'],
         'baz': ['host2'],
         'empty': [],
@@ -109,9 +109,9 @@ class ProfilePluginTest(tf.test.TestCase):
 
     # Invalid tool/run.
     self.assertEqual(None, self.plugin.data_impl('foo', 'nonono', 'host0'))
-    self.assertEqual(None, self.plugin.data_impl('foo', 'trace_viewer', 'host2'))
+    self.assertEqual(None, self.plugin.data_impl('foo', 'trace_viewer', ''))
     self.assertEqual(None, self.plugin.data_impl('bar', 'unsupported', 'host1'))
-    self.assertEqual(None, self.plugin.data_impl('empty', 'trace_viewer', 'host3'))
+    self.assertEqual(None, self.plugin.data_impl('empty', 'trace_viewer', ''))
 
   def testActive(self):
     self.assertTrue(self.plugin.is_active())

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
@@ -34,7 +34,7 @@ You may obtain a copy of the License at
 tf-op-details {
   position: fixed;
   /* don't set top, so it ends up next to tf-op-table */
-  padding-top: 6.5em;
+  margin-top: 10em;
   left: 16px;
   width: 330px;
 }
@@ -56,7 +56,7 @@ tf-op-details {
         <p>Modifying your model's architecture, data dimensions, and improving
         the efficiency of CPU operations may help reach the TPU's FLOPS potential.
       </p></div>
-      <tf-op-details hidden="[[!_active]]" node="[[_active]]"></tf-op-details>
+      <tf-op-details hidden="[[!_active]]" node=[[_active]]></tf-op-details>
       <tf-op-table root-node="[[_root]]" active={{_active}}></tf-op-table>
     </div>
   </template>
@@ -65,15 +65,6 @@ tf-op-details {
 Polymer({
   is: 'tf-op-profile',
   properties: {
-    _requestManager: {
-      type: Object,
-      readOnly: true,
-      value: () => new tf_backend.RequestManager(),
-    },
-    run: {
-      type: String,
-      observer: '_load'
-    },
     _data: {
       type: Object,
       notify: true,
@@ -88,15 +79,6 @@ Polymer({
       value: null,
       notify: true,
     },
-  },
-  _load: function(run) {
-    if (!run) return;
-    this._requestManager.request(tf_backend.addParams(
-        tf_backend.getRouter().pluginRoute('profile', '/data'), {tag: 'op_profile', run})
-    ).catch(error => {}
-    ).then((data) => {
-      this._data = data;
-    });
   },
   _getRoot: function(data, breakdown) { return data[breakdown]; },
   _utilizationPercent: function(node) { return tf_op_profile.percent(tf_op_profile.utilization(node)); },

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -127,9 +127,6 @@ profile run can have multiple tools that present the performance profile as diff
 <style include="dashboard-style"></style>
 
 <style>
-  .allcontrols {
-    width: 330px;
-  }
   .center {
     position: relative;
     height: 100%;

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<link rel="import" href="../tf-dashboard-common/dashboard-style.html">
 <link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../paper-item/paper-item.html">
 <link rel="import" href="../paper-menu/paper-menu.html">
@@ -69,31 +70,41 @@ profile run can have multiple tools that present the performance profile as diff
       <div class="sidebar-section">
         <div class="title">Runs <span class="counter">([[_datasets.length]])</span></div>
         <paper-dropdown-menu no-label-float no-animations noink class="run-dropdown">
-          <paper-menu id="select" class="dropdown-content" selected="{{selectedDataset}}" slot="dropdown-content">
-            <template is="dom-repeat" items="[[_datasets]]">
+          <paper-listbox id="list_box_run" class="dropdown-content" selected="{{selectedDatasetIndex}}">
+            <template id="run_items" is="dom-repeat" items="[[_datasets]]">
               <paper-item>[[item.name]]</paper-item>
             </template>
-          </paper-menu>
+          </paper-listbox>
         </paper-dropdown-menu>
       </div>
       <div class="sidebar-section">
-        <div class="title">Tools <span class="counter">([[_activeTools.length]])</span></div>
+        <div class="title">Tools <span class="counter">([[_activeToolsList.length]])</span></div>
         <paper-dropdown-menu no-label-float no-animations noink class="run-dropdown">
-          <paper-menu id="select" class="dropdown-content" selected="{{selectedTool}}" slot="dropdown-content">
-            <template is="dom-repeat" items="[[_activeTools]]">
+          <paper-listbox id="list_box_tool" class="dropdown-content" selected="{{selectedToolIndex}}">
+            <template id="tool_items" is="dom-repeat" items="[[_activeToolsList]]">
               <paper-item>[[item]]</paper-item>
             </template>
-            <template is="dom-if" if="[[!_hasActiveTools(selectedDataset, _datasets)]]" restamp="true">
+            <template is="dom-if" if="[[!_hasActiveTools()]]" restamp="true">
               <paper-item>None</paper-item>
             </template>
-          </paper-menu>
+          </paper-listbox>
+        </paper-dropdown-menu>
+      </div>
+      <div class="sidebar-section">
+        <div class="title">Hosts <span class="counter">([[_activeHostsList.length]])</span></div>
+        <paper-dropdown-menu no-label-float no-animations noink class="run-dropdown">
+          <paper-listbox id="list_box_host" class="dropdown-content" selected="{{selectedHostIndex}}">
+            <template id="host_items" is="dom-repeat" items="[[_activeHostsList]]">
+              <paper-item>[[_getHostDisplayName(item)]]</paper-item>
+            </template>
+          </paper-listbox>
         </paper-dropdown-menu>
       </div>
       <div class="sidebar-section"></div>
     </div>
   </div>
   <div class="center">
-    <template is="dom-if" if="[[_isCurrentTool(_datasets, currentSelected, 'trace_viewer')]]" restamp="true">
+    <template is="dom-if" if="[[_isCurrentTool(_toolInScope, 'trace_viewer')]]" restamp="true">
       <iframe
         id="tv_iframe"
         height="100%"
@@ -101,17 +112,14 @@ profile run can have multiple tools that present the performance profile as diff
         src="[[_traceDataUrl]]">
       </iframe>
     </template>
-    <template is="dom-if" if="[[_isCurrentTool(_datasets, currentSelected, 'op_profile')]]" restamp="true">
-      <tf-op-profile run="[[_getSelectedDataset(_datasets, currentSelected)]]">
-      </tf-op-profile>
+    <template is="dom-if" if="[[_isCurrentTool(_toolInScope, 'op_profile')]]" restamp="true">
+      <tf-op-profile _data="[[_opProfileData]]"></tf-op-profile>
     </template>
-    <template is="dom-if" if="[[_isCurrentTool(_datasets, currentSelected, 'input_pipeline_analyzer')]]" restamp="true">
-      <input-pipeline-analyzer run="[[_getSelectedDataset(_datasets, currentSelected)]]">
-      </input-pipeline-analyzer>
+    <template is="dom-if" if="[[_isCurrentTool(_toolInScope, 'input_pipeline_analyzer')]]" restamp="true">
+      <input-pipeline-analyzer _data="[[_inputPipelineData]]"></input-pipeline-analyzer>
     </template>
-    <template is="dom-if" if="[[_isCurrentTool(_datasets, currentSelected, 'overview_page')]]">
-      <overview-page run="[[_getSelectedDataset(_datasets, currentSelected)]]">
-      </overview-page>
+    <template is="dom-if" if="[[_isCurrentTool(_toolInScope, 'overview_page')]]" restamp="true">
+      <overview-page _data="[[_overviewPageData]]"></overview-page>
     </template>
   </div>
   </tf-dashboard-layout>
@@ -119,6 +127,9 @@ profile run can have multiple tools that present the performance profile as diff
 <style include="dashboard-style"></style>
 
 <style>
+  .allcontrols {
+    width: 330px;
+  }
   .center {
     position: relative;
     height: 100%;
@@ -135,8 +146,6 @@ profile run can have multiple tools that present the performance profile as diff
 <script>
   "use strict";
 
-
-
   Polymer({
     is: "tf-profile-dashboard",
     properties: {
@@ -149,6 +158,35 @@ profile run can have multiple tools that present the performance profile as diff
       // initialized once.
       _initialized: Boolean,
       _dataNotFound: Boolean,
+      _datasets: {
+        type: Array,
+        notify: true,
+        observer: '_datasetsChanged'
+      },
+      _activeToolsList: {
+        type: Array,
+        computed: '_getActiveToolsList(selectedDatasetIndex, _datasets)',
+        observer: '_activeToolsChanged'
+      },
+      _activeHostsList: {
+        type: Array,
+        observer: '_activeHostsChanged'
+      },
+      selectedDatasetIndex: {
+        type: Number,
+        notify: true,
+        value: 0,
+      },
+      selectedToolIndex: {
+        type: Number,
+        notify: true,
+        value: 0,
+      },
+      selectedHostIndex: {
+        type: Number,
+        notify: true,
+        value: 0,
+      },
       // The endpoint that serves trace viewer app.
       traceViewerBaseUrl: {
         type: String,
@@ -159,35 +197,32 @@ profile run can have multiple tools that present the performance profile as diff
         type: String,
         value: "",
       },
-      _datasets: {
-        type: Array,
-        notify: true,
-        observer: '_datasetsChanged'
+      _opProfileData: {
+        type: Object,
       },
-      _activeTools: {
-        type: Array,
-        computed: '_getActiveTools(selectedDataset, _datasets)'
+      _inputPipelineData: {
+        type: Object,
       },
-      selectedDataset: {
-        type: Number,
-        notify: true,
-        value: 0,
-        observer: '_selectedDatasetChanged'
+      _overviewPageData: {
+        type: Object,
       },
-      selectedTool: {
-        type: Number,
+      _selectedDatasetName: {
+        type: String,
         notify: true,
-        value: 0,
-        observer: '_selectedToolChanged'
+        computed: '_getSelectedDatasetName(selectedDatasetIndex, _datasets)'
       },
-      // currentSelected will depends on selectedDataset and selectedTool.
-      // With this arrangement, we can achieve cascading Polymer effects
-      // propagation and atomic change of both dataset and tool.(e.g.
-      // when dataset change, the tool set to the first available one).
-      currentSelected: {
-        type: Number,
+      _selectedToolName: {
+        type: String,
         notify: true,
-        value: () => { return {'datasetIndex': 0, 'toolIndex': 0} },
+        computed: '_getSelected(selectedToolIndex, _activeToolsList)'
+      },
+      _selectedHostName: {
+        type: String,
+        notify: true,
+        computed: '_getSelected(selectedHostIndex, _activeHostsList)'
+      },
+      _toolInScope: {
+        type: String,
       },
     },
     reload: function() {
@@ -196,7 +231,8 @@ profile run can have multiple tools that present the performance profile as diff
     },
     observers: [
       '_maybeInitializeDashboard(_isAttached)',
-      '_maybeUpdateTool(_datasets, currentSelected)',
+      '_maybeUpdateData(_selectedHostName)',
+      '_maybeUpdateActiveHosts(_selectedDatasetName, _selectedToolName)'
     ],
     attached: function() {
       this.set('_isAttached', true);
@@ -230,24 +266,41 @@ profile run can have multiple tools that present the performance profile as diff
         this.set('_datasets', datasets);
       });
     },
-    _getSelectedTool: function(datasets, currentSelected) {
-      var activeTools = this._getActiveTools(currentSelected.datasetIndex, datasets);
-      if (currentSelected.toolIndex >= 0 && currentSelected.toolIndex < activeTools.length) {
-        return activeTools[currentSelected.toolIndex];
+    // Return the item selected from the list
+    _getSelected: function(index, li) {
+      if (index == null) return;
+      if (li && index >= 0 && index < li.length) {
+        return li[index];
       }
       return null;
     },
-    _getSelectedDataset: function(datasets, currentSelected) {
-      if (currentSelected.datasetIndex >= datasets.length) return null;
-      return datasets[currentSelected.datasetIndex].name;
+    _getSelectedDatasetName: function(selectedDatasetIndex, datasets){
+      if (selectedDatasetIndex == null) return;
+      if (datasets && selectedDatasetIndex >= 0 && selectedDatasetIndex < datasets.length) {
+        return datasets[selectedDatasetIndex].name;
+      }
+      return null;
     },
-    _maybeUpdateTool: function(datasets, currentSelected) {
-      var currentTool = this._getSelectedTool(datasets, currentSelected);
-      if (currentTool == null) return;
-      if (currentTool == "trace_viewer") {
+     _getActiveToolsList: function(selectedDatasetIndex, datasets) {
+      if (selectedDatasetIndex == null) return;
+      if (datasets && selectedDatasetIndex >= 0 && selectedDatasetIndex < datasets.length) {
+        this.selectedToolIndex = 0;
+        return datasets[selectedDatasetIndex].activeTools;
+      }
+      return [];
+    },
+    _maybeUpdateData: function(hostName) {
+      if (hostName == null) return;
+      var datasetName = this._selectedDatasetName;
+      var toolName = this._selectedToolName;
+      if (datasetName == null || toolName == null) return;
+      this.toolInScope = "undefined";
+      if (toolName == "trace_viewer") {
         var trace_data_url = tf_backend.addParams(
             tf_backend.getRouter().pluginRoute('profile', '/data'),
-            {tag: 'trace_viewer', run: this._getSelectedDataset(datasets, currentSelected)});
+            {tag: 'trace_viewer',
+             run: datasetName,
+             host: hostName});
         // Make the trace data url relative to the root.
         if (trace_data_url[0] != '/') {
           trace_data_url = '/' + trace_data_url;
@@ -256,45 +309,80 @@ profile run can have multiple tools that present the performance profile as diff
         // viewer app.
         this._traceDataUrl = this.traceViewerBaseUrl + "?trace_data_url=" +
                             encodeURIComponent(trace_data_url);
+        this._toolInScope = "trace_viewer";
+        return;
+      }else{
+        this._requestManager.request(tf_backend.addParams(
+          tf_backend.getRouter().pluginRoute('profile', '/data'),
+          {tag: toolName, host: hostName, run: datasetName})
+        ).catch(error => {}
+        ).then((data) => {
+           if (toolName == "op_profile") {
+               this._opProfileData = data;
+               this._toolInScope = "op_profile";
+           } else if (toolName == "input_pipeline_analyzer") {
+               this._inputPipelineData = data;
+               this._toolInScope = "input_pipeline_analyzer";
+           } else if (toolName == "overview_page") {
+               this._overviewPageData = data;
+               this._toolInScope = "overview_page";
+           }
+        });
         return;
       }
     },
+    _maybeUpdateActiveHosts: function(datasetName, toolName) {
+       if(datasetName == null || toolName == null) return null;
+       var profileHostsUrl = tf_backend.addParams(
+            tf_backend.getRouter().pluginRoute('profile', '/hosts'),
+            {tag: toolName,
+             run: datasetName,
+            });
+       this._requestManager.request(profileHostsUrl).then((hostList) => {
+           this.set('_activeHostsList', hostList.sort((a, b) => {
+               return vz_sorting.compareTagNames(a, b);}
+           ));
+       });
+    },
     _datasetsChanged: function(newDatasets, oldDatasets) {
-      if (oldDatasets != null || this.selected == null) {
-        // Select the first dataset by default.
-        this.set('selectedDataset', 0);
-        this.set('currentSelected', {'datasetIndex': 0, 'toolIndex': 0});
+      if (this._datasets) {
+        this.selectedDatasetIndex = 0;
       }
     },
-    _selectedDatasetChanged: function(newDataset, oldDataset) {
-      if (this._datasets) {
-        // Display the first tool by default when switching to another run.
-        this.set('currentSelected', {'datasetIndex': newDataset, 'toolIndex': 0});
-
-        // Same tool can have differernt index in different runs, therefore we force a change of
-        // 'selectedTool', to make sure the label of the dropdown-menu is synced.
-        this.async(function() {
-          this.set('selectedTool', undefined);
-          this.set('selectedTool', 0);
+    _activeToolsChanged: function(oldActiveTools, newActiveTools) {
+      // Same tool can have differernt index in different runs, therefore we force a change of
+      // 'selectedToolIndex', to make sure the label of the dropdown-menu is synced.
+      if (this._activeToolsList) {
+         this.async(function() {
+          this.set('selectedToolIndex', -1);
+          this.set('selectedToolIndex', 0);
         }.bind(this));
       }
     },
-    _selectedToolChanged: function(newTool, oldTool) {
-      if (this._datasets && !(newTool === undefined)) {
-        this.set('currentSelected', {'datasetIndex': this.selectedDataset, 'toolIndex': newTool});
+    _activeHostsChanged: function(oldActiveHosts, newActiveHosts) {
+      if (this._activeHostsList) {
+        this.async(function() {
+          this.set('selectedHostIndex', -1);
+          this.set('selectedHostIndex', 0);
+        }.bind(this));
       }
     },
-    _getActiveTools: function(selectedDataset, datasets) {
-      if (datasets && selectedDataset < datasets.length) {
-        return datasets[selectedDataset].activeTools;
+    _isCurrentTool: function(current, expected) {
+      return current == expected;
+    },
+    _hasActiveTools: function() {
+      if (this._activeToolsList && this._activeToolsList.length > 0) {
+        return true;
       }
-      return [];
+      return false;
     },
-    _hasActiveTools: function(selectedDataset, datasets) {
-      return datasets[selectedDataset].activeTools.length > 0;
-    },
-    _isCurrentTool: function(datasets, currentSelected, expected) {
-      return this._getSelectedTool(datasets, currentSelected) == expected;
+    _getHostDisplayName: function(host) {
+      // For old traces without a host prefix in file name, return default for
+      // backward compatibility.
+      if (host == null) return "";
+      if (host == "") return "default";
+      // Otherwise, remove the seperator, e.g. "host1_" => "host1".
+      return host.slice(0, -1);
     },
   });
 


### PR DESCRIPTION
* Profile plugin is extended to take per host traces
* Added a host dropdown menu in profile dashboard
* Moved the _request_manager from each tool to tf_profile_dashboard, so that individual tool can be directly used by internal tools
* Add per host test in profile_plugin_test