### PR TITLE
Make debugger frontend gracefully handle backend errors

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -725,7 +725,13 @@ limitations under the License.
             this._processContinueTo(responseType, responseData);
           }
 
-          // Long polling loop: initialite the next long polling.
+          // Long polling loop: initialize the next long polling.
+          this.long_poll();
+        }).catch(e => {
+          console.error('Error while long-polling. Will try again:', e);
+          if (this._continueToType != null) {
+            this._processContinueTo();
+          }
           this.long_poll();
         });
       },
@@ -955,7 +961,8 @@ limitations under the License.
           graph.panToNode(nodeName);
         } else {
           // Selecting the node triggers a pan to it.
-          const nodeMap = graph.get('renderHierarchy').hierarchy.getNodeMap();
+          const hierarchy = graph.get('renderHierarchy').hierarchy;
+          const nodeMap = hierarchy.getNodeMap();
           if (!nodeMap[nodeName]) {
             // In some cases, a node with other names using its name as
             // name scope may not have base-expanded (i.e., normalized) name
@@ -963,6 +970,14 @@ limitations under the License.
             // node name.
             nodeName =
                 tf_debugger_dashboard.removeNodeNameBaseExpansion(nodeName);
+          }
+          if (!hierarchy.node(nodeName)) {
+            // In some cases, certain nodes in the partition graph may not
+            // appear in the main TensorFlow graph shown to the user. In that
+            // case, setting the selected node causes the graph to err.
+            console.error('Selected node ', nodeName, ' cannot be found.');
+            graph.set('selectedNode', '');
+            return;
           }
           graph.set('selectedNode', nodeName);
         }


### PR DESCRIPTION
The backend of the debugger plugin may error now and then and respond with a status 500. In those cases, the frontend should not leave the user in an invalid state such as one in which the debugger dashboard indicates a false state of continuing.

Furthermore, we prevent the frontend from selecting nodes that do not exist, which may cause a JavaScript error. Otherwise, the debugger dashboard might try to select a non-existent node if the backend errs.