### PR TITLE
Fix ES6 module resolution and polish build tooling

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,11 +2,11 @@ workspace(name = "org_tensorflow_tensorboard")
 
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "6691c58a2cd30a86776dd9bb34898b041e37136f2dc7e24cadaeaf599c95c657",
-    strip_prefix = "rules_closure-08039ba8ca59f64248bb3b6ae016460fe9c9914f",
+    sha256 = "7fb23196455e26d83559cf8a2afa13f720d512f10215228186badfe6d6ad1b18",
+    strip_prefix = "rules_closure-0.6.0",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/08039ba8ca59f64248bb3b6ae016460fe9c9914f.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/08039ba8ca59f64248bb3b6ae016460fe9c9914f.tar.gz",  # 2018-01-16
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.6.0.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/0.6.0.tar.gz",
     ],
 )
 

--- a/tensorboard/defs/vulcanize.bzl
+++ b/tensorboard/defs/vulcanize.bzl
@@ -18,7 +18,7 @@ load("//tensorboard/defs:web.bzl", "web_aspect")
 
 def _tensorboard_html_binary(ctx):
   deps = unfurl(ctx.attr.deps, provider="webfiles")
-  manifests = depset(order="topological")
+  manifests = depset(order="postorder")
   files = depset()
   webpaths = depset()
   for dep in deps:

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -187,10 +187,22 @@ def _tf_web_library(ctx):
   web_srcs.append(dummy)
 
   # define development web server that only applies to this transitive closure
+  if ctx.attr.srcs:
+    devserver_manifests = manifests
+    export_deps = []
+  else:
+    # If a rule exists purely to export other build rules, then it's
+    # appropriate for the exported sources to be included in the
+    # development web server.
+    devserver_manifests = depset(order="postorder")
+    export_deps = unfurl(ctx.attr.exports, provider="webfiles")
+    for dep in export_deps:
+      devserver_manifests += dep.webfiles.manifests
+    devserver_manifests = manifests + devserver_manifests
   params = struct(
       label=str(ctx.label),
       bind="[::]:6006",
-      manifest=[long_path(ctx, man) for man in manifests],
+      manifest=[long_path(ctx, man) for man in devserver_manifests],
       external_asset=[struct(webpath=k, path=v)
                       for k, v in ctx.attr.external_assets.items()])
   params_file = _new_file(ctx, "-params.pbtxt")
@@ -235,6 +247,7 @@ def _tf_web_library(ctx):
               dummy],
           transitive_files=(collect_runfiles([ctx.attr._WebfilesServer]) |
                             collect_runfiles(deps) |
+                            collect_runfiles(export_deps) |
                             collect_runfiles(ctx.attr.data) |
                             aspect_runfiles)))
 
@@ -284,7 +297,7 @@ def _make_manifest(ctx, src_list):
 
 def _run_webfiles_validator(ctx, srcs, deps, manifest):
   dummy = _new_file(ctx, "-webfiles.ignoreme")
-  manifests = depset(order="topological")
+  manifests = depset(order="postorder")
   for dep in deps:
     manifests += dep.webfiles.manifests
   if srcs:
@@ -376,7 +389,7 @@ def _get_strip(ctx):
 
 web_aspect = aspect(
     implementation=_web_aspect_impl,
-    attr_aspects=["deps", "sticky_deps", "module_deps"],
+    attr_aspects=["deps", "sticky_deps", "module_deps", "exports"],
     attrs={"_ClosureWorkerAspect": _CLOSURE_WORKER})
 
 tf_web_library = rule(
@@ -418,4 +431,3 @@ tf_web_library = rule(
         "_closure_library_deps": CLOSURE_LIBRARY_DEPS_ATTR,
     }.items()),
     outputs=CLUTZ_OUTPUTS)
-

--- a/tensorboard/defs/zipper.bzl
+++ b/tensorboard/defs/zipper.bzl
@@ -16,7 +16,7 @@ load("@io_bazel_rules_closure//closure/private:defs.bzl", "unfurl", "long_path")
 
 def _tensorboard_zip_file(ctx):
   deps = unfurl(ctx.attr.deps, provider="webfiles")
-  manifests = depset(order="topological")
+  manifests = depset(order="postorder")
   files = depset()
   webpaths = depset()
   for dep in deps:

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -44,6 +44,7 @@ import com.google.javascript.jscomp.PropertyRenamingPolicy;
 import com.google.javascript.jscomp.Result;
 import com.google.javascript.jscomp.SourceFile;
 import com.google.javascript.jscomp.WarningsGuard;
+import com.google.javascript.jscomp.deps.ModuleLoader;
 import com.google.protobuf.TextFormat;
 import io.bazel.rules.closure.Webpath;
 import io.bazel.rules.closure.webfiles.BuildInfo.Webfiles;
@@ -414,6 +415,7 @@ public final class Vulcanize {
 
     CompilerOptions options = new CompilerOptions();
     compilationLevel.setOptionsForCompilationLevel(options);
+    options.setModuleResolutionMode(ModuleLoader.ResolutionMode.NODE);
 
     // Nice options.
     options.setColorizeErrorOutput(true);

--- a/third_party/polymer.bzl
+++ b/third_party/polymer.bzl
@@ -579,6 +579,23 @@ def tensorboard_polymer_workspace():
   )
 
   web_library_external(
+      name = "org_polymer_iron_validator_behavior",
+      srcs = ["iron-validator-behavior.html"],
+      licenses = ["notice"],  # BSD-3-Clause
+      path = "/iron-validator-behavior",
+      sha256 = "0956488f849c0528d66d5ce28bbfb66e163a7990df2cc5f157a5bf34dcb7dfd2",
+      strip_prefix = "iron-validator-behavior-1.0.2",
+      urls = [
+          "http://mirror.bazel.build/github.com/PolymerElements/iron-validator-behavior/archive/v1.0.2.tar.gz",
+          "https://github.com/PolymerElements/iron-validator-behavior/archive/v1.0.2.tar.gz",
+      ],
+      deps = [
+          "@org_polymer",
+          "@org_polymer_iron_meta",
+      ],
+   )
+
+  web_library_external(
       name = "org_polymer_marked",
       licenses = ["notice"],  # MIT
       sha256 = "4f7c6e0cd96569b3bb762584d20acc3a2602a3442165208535b3f1eff3c1dc41",


### PR DESCRIPTION
This change fixes a regression that might have been introduced by a TypeScript
upgrade a few months ago, where Facets wasn't able to compile, possibly due to
tsc.js no longer adding .js to ES6 imports. The solution was to set module
resolution to NODE in the Closure Compiler. The Polymer dep was upstreamed for
more completeness for Facets.

This change also ensures that the development web server, when we `bazel run` a
`tf_web_library` or `tensorboard_html_binary` rule, will display sources in the
correct order we had originally, before Bazel changed from set() to depset().

r/cc: @jameswex