### PR TITLE
Let user search nodes by regex

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
+++ b/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
@@ -70,7 +70,7 @@ The pbtxt format is the stringified version of the graphdef.
 .container {
   height: 650px;
 }
-    
+
 /* The no-toolbar class will hide the div.side element, and move div.main over
    to the left hand side. */
 .container.no-toolbar .main {
@@ -79,7 +79,7 @@ The pbtxt format is the stringified version of the graphdef.
 
 .container.no-toolbar .side {
   display: none;
-}  
+}
 </style>
 <div class="container">
   <div class="all">
@@ -89,6 +89,7 @@ The pbtxt format is the stringified version of the graphdef.
           stats="[[stats]]"
           color-by="{{colorBy}}"
           render-hierarchy="[[_renderHierarchy]]"
+          selected-node="{{selectedNode}}"
       ></tf-graph-controls>
       <tf-graph-loader id="loader"
           out-graph-hierarchy="{{graphHierarchy}}"
@@ -106,6 +107,7 @@ The pbtxt format is the stringified version of the graphdef.
           color-by="[[colorBy]]"
           color-by-params="{{colorByParams}}"
           render-hierarchy="{{_renderHierarchy}}"
+          selected-node="{{selectedNode}}"
       ></tf-graph-board>
     </div>
   </div>
@@ -135,7 +137,7 @@ Polymer({
       type: String,
       observer: '_updateGraph',
     },
-      
+
     width: {
       type: Number,
       observer: '_updateWidth'
@@ -147,6 +149,10 @@ Polymer({
     toolbar: {
       type: Boolean,
       observer: '_updateToolbar'
+    },
+    selectedNode: {
+      type: String,
+      notify: true,
     },
 
     _renderHierarchy: Object,

--- a/tensorboard/plugins/graph/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_controls/BUILD
@@ -26,18 +26,6 @@ tf_web_library(
     ],
 )
 
-tf_web_library(
-    name = "tf_graph_node_search",
-    srcs = ["tf-graph-node-search.html"],
-    path = "/tf-graph-node-search",
-    deps = [
-        "//tensorboard/components/tf_dashboard_common",
-        "//tensorboard/components/tf_imports:polymer",
-        "//tensorboard/plugins/graph/tf_graph_common",
-        "@org_polymer_paper_input",
-    ],
-)
-
 tensorboard_webcomponent_library(
     name = "legacy",
     srcs = [":tf_graph_controls"],

--- a/tensorboard/plugins/graph/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_controls/BUILD
@@ -13,14 +13,28 @@ tf_web_library(
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/plugins/graph/tf_graph_common",
+        "//tensorboard/plugins/graph/tf_graph_node_search",
         "@org_polymer_paper_button",
         "@org_polymer_paper_dropdown_menu",
         "@org_polymer_paper_icon_button",
+        "@org_polymer_paper_input",
         "@org_polymer_paper_item",
         "@org_polymer_paper_menu",
         "@org_polymer_paper_radio_group",
         "@org_polymer_paper_toggle_button",
         "@org_polymer_paper_tooltip",
+    ],
+)
+
+tf_web_library(
+    name = "tf_graph_node_search",
+    srcs = ["tf-graph-node-search.html"],
+    path = "/tf-graph-node-search",
+    deps = [
+        "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/plugins/graph/tf_graph_common",
+        "@org_polymer_paper_input",
     ],
 )
 

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -26,6 +26,7 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
 <link rel="import" href="../tf-graph-common/tf-graph-common.html">
+<link rel="import" href="../tf-graph-node-search/tf-graph-node-search.html">
 
 <dom-module id="tf-graph-controls">
 <template>
@@ -280,6 +281,12 @@ table.tf-graph-controls td.input-element-table-data {
 .legend-clarifier paper-tooltip {
   width: 150px;
 }
+
+/** Otherwise, polymer UI controls appear atop node search. */
+tf-graph-node-search {
+  z-index: 1;
+  width: 100%;
+}
 </style>
 <svg width="0" height="0">
   <defs>
@@ -301,6 +308,11 @@ table.tf-graph-controls td.input-element-table-data {
   </defs>
 </svg>
 <div class="allcontrols">
+  <div class="control-holder">
+    <tf-graph-node-search
+      selected-node="{{selectedNode}}"
+      render-hierarchy="[[renderHierarchy]]"></tf-graph-node-search>
+  </div>
   <div class="control-holder">
     <paper-icon-button icon="aspect-ratio" class="iconbutton" on-click="fit" alt="Fit to screen">
     </paper-icon-button>
@@ -801,6 +813,10 @@ Polymer({
       type: Number,
       notify: true,
       value: -1
+    },
+    selectedNode: {
+      type: String,
+      notify: true
     },
     _currentDevices: {
       type: Array,

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -73,6 +73,7 @@ by default. The user can select a different run from a dropdown menu.
         selected-dataset="{{_selectedDataset}}"
         selected-file="{{_selectedFile}}"
         selected-metadata-tag="{{_selectedMetadataTag}}"
+        selected-node="{{_selectedNode}}"
         health-pills-feature-enabled="[[_debuggerDataEnabled]]"
         health-pills-toggled-on="{{healthPillsToggledOn}}"
   ></tf-graph-controls>
@@ -153,7 +154,10 @@ Polymer({
     allStepsModeEnabled: Boolean,
     specificHealthPillStep: {type: Number, value: 0},
     healthPillsToggledOn: {type: Boolean, value: true, observer: '_healthPillsToggledOnChanged'},
-    _selectedNode: Object,
+    selectedNode: {
+      type: String,
+      notify: true,
+    },
     _isAttached: Boolean,
     // Whether this dashboard is initialized. This dashboard should only be initialized once.
     _initialized: Boolean,
@@ -332,11 +336,11 @@ Polymer({
   _determineSelectedDataset(datasets, run) {
     // By default, load the first dataset.
     if (!run) {
-      // By default, load the first dataset. 
+      // By default, load the first dataset.
       this.set('_selectedDataset', 0);
       return;
     }
-    
+
     // If the URL specifies a dataset, load it.
     const dataset = datasets.findIndex(d => d.name === run);
     if (dataset === -1) {

--- a/tensorboard/plugins/graph/tf_graph_node_search/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_node_search/BUILD
@@ -1,0 +1,20 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_library(
+    name = "tf_graph_node_search",
+    srcs = ["tf-graph-node-search.html"],
+    path = "/tf-graph-node-search",
+    deps = [
+        "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/plugins/graph/tf_graph_common",
+        "@org_polymer_paper_input",
+        "@org_polymer_paper_styles",
+    ],
+)
+

--- a/tensorboard/plugins/graph/tf_graph_node_search/tf-graph-node-search.html
+++ b/tensorboard/plugins/graph/tf_graph_node_search/tf-graph-node-search.html
@@ -1,0 +1,183 @@
+<!--
+@license
+Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../paper-styles/paper-styles.html">
+<link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-dashboard-common/tensorboard-color.html">
+<link rel="import" href="../tf-graph-common/tf-graph-common.html">
+
+<dom-module id="tf-graph-node-search">
+<template>
+<div id="search-container">
+  <paper-input
+    id="runs-regex"
+    label="Search nodes. Regexes supported."
+    value="{{_rawRegexInput}}">
+  </paper-input>
+  <div id="search-results-anchor">
+    <div id="search-results">
+      <template is="dom-repeat" items="[[_regexMatches]]">
+        <div id="search-match" on-click="_matchClicked">[[item]]</div>
+      </template>
+    </div>
+  </div>
+</div>
+<style>
+#search-container {
+  width: 100%;
+  overflow: visible;
+}
+
+#runs-regex {
+  width: 100%;
+}
+
+#search-results-anchor {
+  position: relative;
+}
+
+#search-results {
+  color: #fff;
+  position: absolute;
+  max-height: 200px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  text-align: right;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+#search-match {
+  background: var(--tb-orange-strong);
+  padding: 3px;
+  float: right;
+  width: 100%;
+  box-sizing: border-box;
+  direction: rtl;
+}
+
+#search-match:hover {
+  background: var(--tb-orange-weak);
+  cursor: pointer;
+}
+</style>
+</template>
+<script>
+Polymer({
+  is: 'tf-graph-node-search',
+  properties: {
+    renderHierarchy: Object,
+    selectedNode: {
+      type: String,
+      notify: true,
+    },
+    _rawRegexInput: {
+      type: String,
+      value: ''
+    },
+    // This is the cleaned input.
+    _regexInput: {
+      type: String,
+      computed: '_computeRegexInput(renderHierarchy, _rawRegexInput)'
+    },
+    // The value of the regex input for the last search.
+    _previousRegexInput: {
+      type: String,
+      value: ''
+    },
+    _searchTimeoutDelay: {
+      type: Number,
+      value: 150,
+      readOnly: true
+    },
+    _searchPending: Boolean,
+    _maxRegexResults: {
+      type: Number,
+      value: 42
+    },
+    _regexMatches: Array,
+  },
+  observers: [
+    '_regexInputChanged(_regexInput)',
+  ],
+  _computeRegexInput(renderHierarchy, rawRegexInput) {
+    return rawRegexInput.trim();
+  },
+  _regexInputChanged(regexInput) {
+    this._requestSearch();
+  },
+  _clearSearchResults() {
+    this.set('_regexMatches', []);
+  },
+  _requestSearch() {
+    if (this._searchPending) {
+      return;
+    }
+
+    if (this._regexInput === this._previousRegexInput) {
+      // No new search is needed.
+      this._searchPending = false;
+      return;
+    }
+    this._searchPending = true;
+    this._executeSearch();
+
+    // After some time, perhaps execute another search.
+    this.async(() => {
+      this._searchPending = false;
+      this._requestSearch();
+    }, this._searchTimeoutDelay);
+  },
+  _executeSearch() {
+    this._previousRegexInput = this._regexInput;
+    if (!this._regexInput) {
+      this._clearSearchResults();
+      return;
+    }
+
+    try {
+      var regex = new RegExp(this._regexInput);
+    }
+    catch (e) {
+      // The regular expression is invalid.
+      this._clearSearchResults();
+      return;
+    }
+    const matchedNodes = [];
+    const nodeMap = this.renderHierarchy.hierarchy.getNodeMap();
+    _.each(nodeMap, (_, nodeName) => {
+      if (matchedNodes.length >= this._maxRegexResults) {
+        // Terminate.
+        return false;
+      }
+
+      if (!regex.test(nodeName)) {
+        return;
+      }
+
+      matchedNodes.push(nodeName);
+    });
+    this.set('_regexMatches', matchedNodes);
+  },
+  _matchClicked(e) {
+    const node = e.model.item;
+    this.set('selectedNode', node);
+  },
+});
+</script>
+</dom-module>


### PR DESCRIPTION
This change introduces a search box to the graph explorer that lets the user input a regex and then performs a partial regex match on all nodes (both metanodes and ops) within the graph.

When the user clicks on a match, the graph selects the node and pans to it if it is out of view.

![image](https://user-images.githubusercontent.com/4221553/38755137-77b22e60-3f19-11e8-8152-6bfbb5646854.png)

Fixes #76.