### PR TITLE
Make pr_curves_demo manually implement clip

### DIFF
--- a/tensorboard/plugins/pr_curve/pr_curve_demo.py
+++ b/tensorboard/plugins/pr_curve/pr_curve_demo.py
@@ -70,33 +70,51 @@ def start_runs(
   # Sample the distribution to generate colors. Lets generate different numbers
   # of each color. The first dimension is the count of examples.
 
+  def clip(value, minValue, maxValue):
+    """Clips an op to the range [minValue, maxValue].
+
+    For now, we intentionally avoid using tf.clip_by_value for now because it
+    apparently exhibits slightly different behavior based on system
+    characteristics. See tensorflow/tensorflow#18527. Tests rely on this demo,
+    so behavior must be deterministic.
+
+    Args:
+      value: The value to clip.
+      minValue: The min value to clip by.
+      maxValue: The max value to clip by.
+
+    Returns:
+      A TensorFlow op that outputs the clipped value.
+    """
+    return tf.maximum(minValue, tf.minimum(maxValue, value))
+
   # Generate reds.
   number_of_reds = 100
-  true_reds = tf.clip_by_value(
+  true_reds = clip(
       tf.concat([
-          255 - tf.abs(channel_distribution.sample([number_of_reds, 1])),
+          255. - tf.abs(channel_distribution.sample([number_of_reds, 1])),
           tf.abs(channel_distribution.sample([number_of_reds, 2]))
       ], axis=1),
-      0, 255)
+      0., 255.)
 
   # Generate greens.
   number_of_greens = 200
-  true_greens = tf.clip_by_value(
+  true_greens = clip(
       tf.concat([
           tf.abs(channel_distribution.sample([number_of_greens, 1])),
-          255 - tf.abs(channel_distribution.sample([number_of_greens, 1])),
+          255. - tf.abs(channel_distribution.sample([number_of_greens, 1])),
           tf.abs(channel_distribution.sample([number_of_greens, 1]))
       ], axis=1),
-      0, 255)
+      0., 255.)
 
   # Generate blues.
   number_of_blues = 150
-  true_blues = tf.clip_by_value(
+  true_blues = clip(
       tf.concat([
           tf.abs(channel_distribution.sample([number_of_blues, 2])),
-          255 - tf.abs(channel_distribution.sample([number_of_blues, 1]))
+          255. - tf.abs(channel_distribution.sample([number_of_blues, 1]))
       ], axis=1),
-      0, 255)
+      0., 255.)
 
   # Assign each color a vector of 3 booleans based on its true label.
   labels = tf.concat([

--- a/tensorboard/plugins/pr_curve/pr_curve_demo.py
+++ b/tensorboard/plugins/pr_curve/pr_curve_demo.py
@@ -73,10 +73,10 @@ def start_runs(
   def clip(value, minValue, maxValue):
     """Clips an op to the range [minValue, maxValue].
 
-    For now, we intentionally avoid using tf.clip_by_value for now because it
-    apparently exhibits slightly different behavior based on system
+    For now, we intentionally avoid using tf.clip_by_value because it 
+    apparently exhibits slightly different behavior based on system 
     characteristics. See tensorflow/tensorflow#18527. Tests rely on this demo,
-    so behavior must be deterministic.
+    so behavior must be consistent.
 
     Args:
       value: The value to clip.

--- a/tensorboard/plugins/pr_curve/pr_curve_demo.py
+++ b/tensorboard/plugins/pr_curve/pr_curve_demo.py
@@ -73,8 +73,8 @@ def start_runs(
   def clip(value, minValue, maxValue):
     """Clips an op to the range [minValue, maxValue].
 
-    For now, we intentionally avoid using tf.clip_by_value because it 
-    apparently exhibits slightly different behavior based on system 
+    For now, we intentionally avoid using tf.clip_by_value because it
+    apparently exhibits slightly different behavior based on system
     characteristics. See tensorflow/tensorflow#18527. Tests rely on this demo,
     so behavior must be consistent.
 


### PR DESCRIPTION
TensorFlow commits https://github.com/tensorflow/tensorflow/commit/083cf6b91a380641933457a4301f9b1efa13af92 and https://github.com/tensorflow/tensorflow/commit/daf0b206b5afde875a19270136ad22d9d2bb138c have made their way into `tf-nightly` build 254. The commits modified the behavior of the `tf.clip_by_value` op in an attempt to resolve https://github.com/tensorflow/tensorflow/issues/7225 in a way that minimizes memory usage by taking different pathways of logic based on characteristics of the system running TensorFlow. Unfortunately, our python 2 and python 3 setups on travis differ along those characteristics, causing the `tf-nightly` build to break `:pr_curves_test` (which relies on the demo to generate test data) for python 2 only.

This PR fixes the test by removing usages of `tf.clip_by_value` from the demo and instead uses `tf.maximum(minValue, tf.minimum(maxValue, value))`. The most fulfilling solution for this bug would be to resolve the mismatch in behavior of `tf.clip_by_value` on the TensorFlow side. However, this PR unblocks development of TensorBoard immediately.