### PR TITLE
Add --samples_per_plugin to specify explicit sampling counts

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -128,6 +128,16 @@ tf.flags.DEFINE_integer(
     'The max number of threads that TensorBoard can use to reload runs. Not '
     'relevant for db mode. Each thread reloads one run at a time.')
 
+tf.flags.DEFINE_string(
+    'samples_per_plugin', '', 'An optional comma separated list of '
+    'plugin_name=num_samples pairs to explicitly specify how many samples to '
+    'keep per tag for that plugin. For unspecified plugins, TensorBoard '
+    'randomly downsamples logged summaries to reasonable values to prevent '
+    'out-of-memory errors for long running jobs. This flag allows fine control '
+    'over that downsampling. Note that 0 means keep all samples of that type. '
+    'For instance, "scalars=500,images=0" keeps 500 scalars and all images. '
+    'Most users should not need to set this flag.')
+
 FLAGS = tf.flags.FLAGS
 
 


### PR DESCRIPTION
Add TensorBoard flag `samples_per_plugin` that allows for custom specification of samples to keep per summary type. 

Previously, TensorBoard always downsampled summaries for OOM reasons but some users wanted the ability to keep all their summaries of some types.

With this flag, --samples_per_plugin='histogram=2,images=0'
 keeps TensorBoard defaults for other summaries, restricts the number of histograms to 2, and keeps all image summaries.