### PR TITLE
[Beholder plugin] use different summary key to avoid merging with the other summaries

### DIFF
--- a/tensorboard/plugins/beholder/beholder.py
+++ b/tensorboard/plugins/beholder/beholder.py
@@ -26,7 +26,7 @@ from tensorboard.plugins.beholder import im_util
 from tensorboard.plugins.beholder.file_system_tools import read_pickle,\
   write_pickle, write_file
 from tensorboard.plugins.beholder.shared_config import PLUGIN_NAME, TAG_NAME,\
-  SUMMARY_FILENAME, DEFAULT_CONFIG, CONFIG_FILENAME
+  SUMMARY_FILENAME, DEFAULT_CONFIG, CONFIG_FILENAME, SUMMARY_COLLECTION_KEY_NAME
 from tensorboard.plugins.beholder import video_writing
 from tensorboard.plugins.beholder.visualizer import Visualizer
 
@@ -45,7 +45,10 @@ class Beholder(object):
 
     self.frame_placeholder = tf.placeholder(tf.uint8, [None, None, None])
     self.summary_op = tf.summary.tensor_summary(TAG_NAME,
-                                                self.frame_placeholder)
+                                                self.frame_placeholder,
+                                                collections=[
+                                                    SUMMARY_COLLECTION_KEY_NAME
+                                                ])
 
     self.last_image_shape = []
     self.last_update_time = time.time()

--- a/tensorboard/plugins/beholder/shared_config.py
+++ b/tensorboard/plugins/beholder/shared_config.py
@@ -21,6 +21,7 @@ TAG_NAME = 'beholder-frame'
 SUMMARY_FILENAME = 'frame.summary'
 CONFIG_FILENAME = 'config.pkl'
 SECTION_INFO_FILENAME = 'section-info.pkl'
+SUMMARY_COLLECTION_KEY_NAME = 'summaries_beholder'
 
 DEFAULT_CONFIG = {
     'values': 'trainable_variables',


### PR DESCRIPTION
This PR suggests to use a different summary key instead of using a default one for Beholder plugin.

Using Beholder plugin with `tf.estimator.Estimator` results in the following InvalidArgumentError.

```
tensorflow.python.framework.errors_impl.InvalidArgumentError: You must feed a value for placeholder tensor 'Placeholder' with dtype uint8 and shape [?,?,?]
	 [[Node: Placeholder = Placeholder[dtype=DT_UINT8, shape=[?,?,?], _device="/job:localhost/replica:0/task:0/device:CPU:0"]()]]
```

This is because `tf.estimator.Estimator` registers a loss scalar summary with a default collection key and merge it with the other summaries with the default key including Beholder's summary. As a result, we are required to feed `frame_placeholder` when running  a training op.

Since beholder writes summaries with a different cycle from a training op, it is better to separate them.