### PR TITLE
Remove a couple un-needed lines

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_controls/BUILD
@@ -17,7 +17,6 @@ tf_web_library(
         "@org_polymer_paper_button",
         "@org_polymer_paper_dropdown_menu",
         "@org_polymer_paper_icon_button",
-        "@org_polymer_paper_input",
         "@org_polymer_paper_item",
         "@org_polymer_paper_menu",
         "@org_polymer_paper_radio_group",

--- a/tensorboard/plugins/graph/tf_graph_node_search/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_node_search/BUILD
@@ -1,6 +1,5 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -17,4 +16,3 @@ tf_web_library(
         "@org_polymer_paper_styles",
     ],
 )
-


### PR DESCRIPTION
We remove the statement that loads the
`tensorboard_webcomponent_library` symbol into the BUILD
file for the `tf_graph_node_search` component.
`tensorboard_webcomponent_library` is not used.

We remove an empty line from the BUILD file for the
`tf_graph_node_search` component.

We remove an un-needed dep from the tf_graph_controls BUILD
target.

The graph explorer's node search feature still WAI after this PR:

![image](https://user-images.githubusercontent.com/4221553/39412088-c01d559e-4bcb-11e8-88be-c97257ebd98f.png)
