### PR TITLE
Update FAQ for TensorBoard not showing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,32 +232,20 @@ features including hyperlinks, lists, and tables are all supported.
 
 ### My TensorBoard isn't showing any data! What's wrong?
 
-The first thing to do is ensure that TensorBoard is properly loading data from
-the correct directory. Launch `tensorboard --logdir DIRECTORY_PATH --debug` and
-look for output of the form
-
-`INFO:tensorflow:TensorBoard path_to_run is: {'DIRECTORY_PATH': None}`
-
-Verify that the DIRECTORY_PATH TensorBoard is looking at is the path you expect.
-(Note: There's a known issue where TensorBoard [does not handle paths starting
-in ~ properly](https://github.com/tensorflow/tensorflow/issues/1587)).
+First, check that the directory passed to `--logdir` is correct. You can also
+verify this by navigating to the Scalars dashboard (under the "Inactive" menu)
+and looking for the log directory path at the bottom of the left sidebar.
 
 If you're loading from the proper path, make sure that event files are present.
 TensorBoard will recursively walk its logdir, it's fine if the data is nested
-under a subdirectory. Try running the command:
+under a subdirectory. Ensure the following shows at least one result:
 
 `find DIRECTORY_PATH | grep tfevents`
 
-If you have at least one result, then TensorBoard should be able to load data.
-
-Finally, let's make sure that the event files actually have data. Run
-tensorboard in inspector mode to inspect the contents of your event files.
+You can also check that the event files actually have data by running
+tensorboard in inspect mode to inspect the contents of your event files.
 
 `tensorboard --inspect --logdir DIRECTORY_PATH`
-
-If after running this procedure, it's still not working, please file an [issue
-on GitHub](https://github.com/tensorflow/tensorflow/issues). It will be much
-easier for us to debug it if you provide an event file that isn't working.
 
 ### TensorBoard is showing only some of my data, or isn't properly updating!
 
@@ -322,7 +310,8 @@ download links" option in the left-hand bar. Then, each plot will provide
 download links for the data it contains.
 
 If you need access to the full dataset, you can read the event files that
-TensorBoard consumes by using the [`summary_iterator`](https://github.com/tensorflow/tensorflow/blob/e7f333b5f8b3c53b21d149d8d14c0cebbde431aa/tensorflow/python/summary/summary_iterator.py#L313)
+TensorBoard consumes by using the [`summary_iterator`](
+https://www.tensorflow.org/api_docs/python/tf/train/summary_iterator)
 method.
 
 ### Can I customize which lines appear in a plot?
@@ -369,19 +358,15 @@ See [DEVELOPMENT.md](DEVELOPMENT.md).
 
 First, try searching our [GitHub
 issues](https://github.com/tensorflow/tensorboard/issues) and [Stack
-Overflow](https://stackoverflow.com/questions/tagged/tensorboard). It may be
+Overflow][stack-overflow]. It may be
 that someone else has already had the same issue or question.
 
-If you have a bug, please [file a GitHub
-issue](https://github.com/tensorflow/tensorboard/issues). If the bug is related
-to your specific data (e.g. the events aren't loading properly), please do both
-of the following things to make it easier for us to debug and fix:
+General usage questions (or problems that may be specific to your local setup)
+should go to [Stack Overflow][stack-overflow].
 
-- Run tensorboard in --inspect mode and copy paste the debug output.
-- Upload some events files that will reproduce the issue.
+If you have found a bug in TensorBoard, please [file a GitHub issue](
+https://github.com/tensorflow/tensorboard/issues/new) with as much supporting
+information as you can provide (e.g. attaching events files, including the output
+of `tensorboard --inspect`, etc.).
 
-If you have a feature request, please [file a GitHub
-issue](https://github.com/tensorflow/tensorboard/issues).
-
-General usage questions should go to [Stack
-Overflow](http://stackoverflow.com/questions/tagged/tensorflow).
+[stack-overflow]: https://stackoverflow.com/questions/tagged/tensorboard


### PR DESCRIPTION
Changes some FAQ wording to emphasize that GitHub issues should be primarily for actual TensorBoard bugs; not being able to load data is often a user-specific error or misconfiguration, and for those issues, self-driven debugging using `--inspect` with Stack Overflow as a fallback is a better option.

Fixes #815 by removing stale reference to a `--debug` flag that no longer exists (and where trying to pass it generates a confusing error).