### PR TITLE
Avoid superfluous loads on GCS

### DIFF
--- a/tensorboard/backend/event_processing/directory_watcher.py
+++ b/tensorboard/backend/event_processing/directory_watcher.py
@@ -88,7 +88,9 @@ class DirectoryWatcher(object):
       for event in self._LoadInternal():
         yield event
     except tf.errors.OpError:
-      if not tf.gfile.Exists(self._directory):
+      # Directories don't actually exist on GCS.
+      if (not tf.gfile.Exists(self._directory) and
+          not io_wrapper.ListDirectoryAbsolute(self._directory)):
         raise DirectoryDeletedError(
             'Directory %s has been permanently deleted' % self._directory)
 


### PR DESCRIPTION
This change fixes a Google Cloud Storage performance issue where TensorBoard
would read event logs multiple times. This was caused by code checking if the
Run directory was deleted, but GCS does not have real directories.

Progress on #158