### PR TITLE
Remove `legacy_js` Skylark stub

### DIFF
--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -15,10 +15,3 @@
 def tensorboard_webcomponent_library(**kwargs):
   """Rules referencing this will be deleted from the codebase soon."""
   pass
-
-def _legacy_js_impl(target, ctx):
-  return struct()
-
-legacy_js = aspect(
-    implementation=_legacy_js_impl,
-    attr_aspects=["exports"])

--- a/tensorboard/defs/vulcanize.bzl
+++ b/tensorboard/defs/vulcanize.bzl
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//tensorboard/defs:defs.bzl", "legacy_js")
 load("@io_bazel_rules_closure//closure/private:defs.bzl", "collect_js", "unfurl", "long_path")
 
 def _tensorboard_html_binary(ctx):

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -14,13 +14,14 @@
 
 """Same as web_library but supports TypeScript."""
 
-load("//tensorboard/defs:defs.bzl", "legacy_js")
-
 load("//third_party:clutz.bzl",
      "CLUTZ_ATTRIBUTES",
      "CLUTZ_OUTPUTS",
      "clutz_aspect",
      "extract_dts_from_closure_libraries")
+
+load("@io_bazel_rules_closure//closure:defs.bzl",
+     "closure_js_aspect")
 
 load("@io_bazel_rules_closure//closure/private:defs.bzl",
      "CLOSURE_LIBRARY_BASE_ATTR",
@@ -353,7 +354,7 @@ tf_web_library = rule(
         "deps": attr.label_list(
             aspects=[
                 clutz_aspect,
-                legacy_js,
+                closure_js_aspect,
             ]),
         "exports": attr.label_list(),
         "data": attr.label_list(cfg="data", allow_files=True),


### PR DESCRIPTION
It's an artifact of a rules_closure migration a while back. It's since been
renamed `closure_js_aspect`.