### PR TITLE
Fix legacy definition of tf-graph-node-search

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_controls/BUILD
@@ -32,8 +32,11 @@ tensorboard_webcomponent_library(
     deps = [
         "//tensorboard/components/tf_dashboard_common:legacy",
         "//tensorboard/plugins/graph/tf_graph_common:legacy",
+        "//tensorboard/plugins/graph/tf_graph_node_search:legacy",
         "//third_party/javascript/polymer/v1/paper-button:lib",
         "//third_party/javascript/polymer/v1/paper-dropdown-menu:lib",
+        "//third_party/javascript/polymer/v1/paper-icon-button:lib",
+        "//third_party/javascript/polymer/v1/paper-item:lib",
         "//third_party/javascript/polymer/v1/paper-menu:lib",
         "//third_party/javascript/polymer/v1/paper-radio-group:lib",
         "//third_party/javascript/polymer/v1/paper-toggle-button:lib",
@@ -41,4 +44,3 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )
-

--- a/tensorboard/plugins/graph/tf_graph_node_search/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_node_search/BUILD
@@ -1,5 +1,6 @@
 package(default_visibility = ["//tensorboard:internal"])
 
+load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -14,5 +15,17 @@ tf_web_library(
         "//tensorboard/plugins/graph/tf_graph_common",
         "@org_polymer_paper_input",
         "@org_polymer_paper_styles",
+    ],
+)
+
+tensorboard_webcomponent_library(
+    name = "legacy",
+    srcs = [":tf_graph_node_search"],
+    destdir = "tf-graph-node-search",
+    deps = [
+        "//tensorboard/components/tf_dashboard_common:legacy",
+        "//tensorboard/plugins/graph/tf_graph_common:legacy",
+        "//third_party/javascript/polymer/v1/paper-input:lib",
+        "//third_party/javascript/polymer/v1/paper-styles:lib",
     ],
 )


### PR DESCRIPTION
It should be possible to remove this rule bifurcation in a future change.