### PR TITLE
Improve error message when logdir/db  not given.

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -202,8 +202,10 @@ def create_tb_app(plugins, assets_zip_provider=None):
   :rtype: types.FunctionType
   """
   if not FLAGS.db and not FLAGS.logdir:
-    raise ValueError('A logdir must be specified when db is not specified. '
-                     'Run `tensorboard --help` for details and examples.')
+    raise ValueError('A logdir or db must be specified. '
+                     'For example `tensorboard --logdir mylogdir`'
+                     'or `tensorboard --db sqlite:~/.tensorboard.db`.'
+                     'Run `tensorboard --helpfull` for details and examples.')
   return application.standard_tensorboard_wsgi(
       assets_zip_provider=assets_zip_provider,
       db_uri=FLAGS.db,

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -203,8 +203,8 @@ def create_tb_app(plugins, assets_zip_provider=None):
   """
   if not FLAGS.db and not FLAGS.logdir:
     raise ValueError('A logdir or db must be specified. '
-                     'For example `tensorboard --logdir mylogdir`'
-                     'or `tensorboard --db sqlite:~/.tensorboard.db`.'
+                     'For example `tensorboard --logdir mylogdir` '
+                     'or `tensorboard --db sqlite:~/.tensorboard.db`. '
                      'Run `tensorboard --helpfull` for details and examples.')
   return application.standard_tensorboard_wsgi(
       assets_zip_provider=assets_zip_provider,


### PR DESCRIPTION
I can never remember what the actual argument for logdir is.
Is it `tensorboard ./logs/`  ? 
Is it `tensorboard --logdir ./logs/` ?
Is it `tensorboard --log-dir ./logs/` ?

I feel like putting in an example just makes it really obvious.

Also with the version I am using (1.7),
`tensorboard --help` gives no useful information on this argument, so when it needed for details and examples is `tensorboard --helpfull`.