### PR TITLE
[Debugger plugin] Fix UnboundLocalError: variable tensor_shape refere…

### DIFF
--- a/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
@@ -96,7 +96,7 @@ def _comm_tensor_data(device_name,
       tensor_shape = UNINITIALIZED_TAG
     else:
       tensor_dtype = UNSUPPORTED_TAG
-      tensor_dtype = UNSUPPORTED_TAG
+      tensor_shape = UNSUPPORTED_TAG
     tensor_values = NA_TAG
   else:
     tensor_dtype = str(tensor_value.dtype)


### PR DESCRIPTION
…nced before assigment

Seems the wrong variable name was used on line 99 (console filled with exception message and debugger gui doesnt update some values while debugging due to the early bail-out)