### PR TITLE
Mark pr_curve test size as medium

### DIFF
--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -38,7 +38,7 @@ py_library(
 
 py_test(
     name = "pr_curves_plugin_test",
-    size = "small",
+    size = "medium",  # tf integration test
     srcs = ["pr_curves_plugin_test.py"],
     srcs_version = "PY2AND3",
     deps = [


### PR DESCRIPTION
This is a TF integration test that takes at minimum 30 seconds.