### PR TITLE
[Debugger Plugin] Fix bugs related to binary string tensors

### DIFF
--- a/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
@@ -899,7 +899,6 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
     return session_run_thread, session_run_results
 
   def testBinaryStringTensorIsHandledCorrectly(self):
-    print('------------------------------------------------')  # DEBUG
     session_run_thread, session_run_results = self._runBinaryStringNetwork()
     # Activate breakpoint for str1:0.
     self._serverGet(
@@ -936,8 +935,6 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
          'slicing': ''})
     tensor_data = self._deserializeResponse(tensor_response)
     self.assertEqual(None, tensor_data['error'])
-    print(tensor_data['tensor_data'])  # DEBUG
-    print(type(tensor_data['tensor_data']))  # DEBUG
     self.assertEqual(2, len(tensor_data['tensor_data'][0]))
     self.assertEqual(b'=01=01=01', tensor_data['tensor_data'][0][0])
     self.assertEqual(b'=02=02=02', tensor_data['tensor_data'][0][1])

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
@@ -827,7 +827,7 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
     self.assertAllClose(
         np.var([10.0, 20.0, 30.0]), tensor_data[11])  # Variance.
 
-  def _runStringNetwork(self):
+  def _runAsciiStringNetwork(self):
     session_run_results = []
     def session_run_job():
       with tf.Session() as sess:
@@ -841,8 +841,8 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
     session_run_thread.start()
     return session_run_thread, session_run_results
 
-  def testStringTensorIsHandledCorrectly(self):
-    session_run_thread, session_run_results = self._runStringNetwork()
+  def testAsciiStringTensorIsHandledCorrectly(self):
+    session_run_thread, session_run_results = self._runAsciiStringNetwork()
     # Activate breakpoint for str1:0.
     self._serverGet(
         'gated_grpc',
@@ -853,7 +853,7 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
     comm_response = self._serverGet('comm', {'pos': 2})
     comm_data = self._deserializeResponse(comm_response)
     self.assertEqual('tensor', comm_data['type'])
-    self.assertEqual('object', comm_data['data']['dtype'])
+    self.assertEqual('string', comm_data['data']['dtype'])
     self.assertEqual([], comm_data['data']['shape'])
     self.assertEqual('abc', comm_data['data']['values'])
     self.assertEqual(
@@ -872,6 +872,75 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
     tensor_data = self._deserializeResponse(tensor_response)
     self.assertEqual(None, tensor_data['error'])
     self.assertEqual(['abc'], tensor_data['tensor_data'])
+
+    # Get the health pill of a string tensor.
+    tensor_response = self._serverGet(
+        'tensor_data',
+        {'watch_key': 'str1:0:DebugIdentity',
+         'time_indices': '-1',
+         'mapping': 'health-pill',
+         'slicing': ''})
+    tensor_data = self._deserializeResponse(tensor_response)
+    self.assertEqual(None, tensor_data['error'])
+    self.assertEqual([None], tensor_data['tensor_data'])
+
+  def _runBinaryStringNetwork(self):
+    session_run_results = []
+    def session_run_job():
+      with tf.Session() as sess:
+        str1 = tf.Variable([b'\x01' * 3, b'\x02' * 3], name='str1')
+        str2 = tf.Variable([b'\x03' * 3, b'\x04' * 3], name='str2')
+        str_concat = tf.add(str1, str2, name='str_concat')
+        sess.run(tf.global_variables_initializer())
+        sess = tf_debug.TensorBoardDebugWrapperSession(sess, self._debugger_url)
+        session_run_results.append(sess.run(str_concat))
+    session_run_thread = threading.Thread(target=session_run_job)
+    session_run_thread.start()
+    return session_run_thread, session_run_results
+
+  def testBinaryStringTensorIsHandledCorrectly(self):
+    print('------------------------------------------------')  # DEBUG
+    session_run_thread, session_run_results = self._runBinaryStringNetwork()
+    # Activate breakpoint for str1:0.
+    self._serverGet(
+        'gated_grpc',
+        {'mode': 'set_state', 'node_name': 'str1', 'output_slot': 0,
+         'debug_op': 'DebugIdentity', 'state': 'break'})
+    self._serverGet('ack')
+    self._serverGet('ack')
+    comm_response = self._serverGet('comm', {'pos': 2})
+    comm_data = self._deserializeResponse(comm_response)
+    self.assertEqual('tensor', comm_data['type'])
+    self.assertEqual('string', comm_data['data']['dtype'])
+    self.assertEqual([2], comm_data['data']['shape'])
+    self.assertEqual(2, len(comm_data['data']['values']))
+    self.assertEqual(
+        b'=01' * 3, tf.compat.as_bytes(comm_data['data']['values'][0]))
+    self.assertEqual(
+        b'=02' * 3, tf.compat.as_bytes(comm_data['data']['values'][1]))
+    self.assertEqual(
+        'str1/(str1)', comm_data['data']['maybe_base_expanded_node_name'])
+    session_run_thread.join()
+    self.assertEqual(1, len(session_run_results))
+    self.assertAllEqual(
+        np.array([b'\x01\x01\x01\x03\x03\x03', b'\x02\x02\x02\x04\x04\x04'],
+                 dtype=np.object),
+        session_run_results[0])
+
+    # Get the value of a tensor without mapping.
+    tensor_response = self._serverGet(
+        'tensor_data',
+        {'watch_key': 'str1:0:DebugIdentity',
+         'time_indices': '-1',
+         'mapping': '',
+         'slicing': ''})
+    tensor_data = self._deserializeResponse(tensor_response)
+    self.assertEqual(None, tensor_data['error'])
+    print(tensor_data['tensor_data'])  # DEBUG
+    print(type(tensor_data['tensor_data']))  # DEBUG
+    self.assertEqual(2, len(tensor_data['tensor_data'][0]))
+    self.assertEqual(b'=01=01=01', tensor_data['tensor_data'][0][0])
+    self.assertEqual(b'=02=02=02', tensor_data['tensor_data'][0][1])
 
     # Get the health pill of a string tensor.
     tensor_response = self._serverGet(

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
@@ -936,8 +936,10 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
     tensor_data = self._deserializeResponse(tensor_response)
     self.assertEqual(None, tensor_data['error'])
     self.assertEqual(2, len(tensor_data['tensor_data'][0]))
-    self.assertEqual(b'=01=01=01', tensor_data['tensor_data'][0][0])
-    self.assertEqual(b'=02=02=02', tensor_data['tensor_data'][0][1])
+    self.assertEqual(
+        b'=01=01=01', tf.compat.as_bytes(tensor_data['tensor_data'][0][0]))
+    self.assertEqual(
+        b'=02=02=02', tf.compat.as_bytes(tensor_data['tensor_data'][0][1]))
 
     # Get the health pill of a string tensor.
     tensor_response = self._serverGet(

--- a/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_server_lib.py
@@ -64,6 +64,8 @@ UNINITIALIZED_TAG = 'Uninitialized'
 UNSUPPORTED_TAG = 'Unsupported'
 NA_TAG = 'N/A'
 
+STRING_ELEMENT_MAX_LEN = 40
+
 
 def _comm_tensor_data(device_name,
                       node_name,
@@ -73,6 +75,15 @@ def _comm_tensor_data(device_name,
                       tensor_value,
                       wall_time):
   """Create a dict() as the outgoing data in the tensor data comm route.
+
+  Note: The tensor data in the comm route does not include the value of the
+  tensor in its entirety in general. Only if a tensor satisfies the following
+  conditions will its entire value be included in the return value of this
+  method:
+  1. Has a numeric data type (e.g., float32, int32) and has fewer than 5
+     elements.
+  2. Is a string tensor and has fewer than 5 elements. Each string element is
+     up to 40 bytes.
 
   Args:
     device_name: Name of the device that the tensor is on.
@@ -99,13 +110,18 @@ def _comm_tensor_data(device_name,
       tensor_shape = UNSUPPORTED_TAG
     tensor_values = NA_TAG
   else:
-    tensor_dtype = str(tensor_value.dtype)
+    tensor_dtype = tensor_helper.translate_dtype(tensor_value.dtype)
     tensor_shape = tensor_value.shape
+
     # The /comm endpoint should respond with tensor values only if the tensor is
     # small enough. Otherwise, the detailed values sould be queried through a
     # dedicated tensor_data that supports slicing.
     if tensor_helper.numel(tensor_shape) < 5:
       _, _, tensor_values = tensor_helper.array_view(tensor_value)
+      if tensor_dtype == 'string' and tensor_value is not None:
+        tensor_values = tensor_helper.process_buffers_for_display(
+            tensor_values, limit=STRING_ELEMENT_MAX_LEN)
+
   return {
       'type': 'tensor',
       'timestamp': wall_time,

--- a/tensorboard/plugins/debugger/tensor_helper.py
+++ b/tensorboard/plugins/debugger/tensor_helper.py
@@ -65,7 +65,7 @@ def parse_time_indices(s):
 def translate_dtype(dtype):
   """Translate numpy dtype into a string.
 
-  The 'object' type is understood as a tenosrflow string and translated into
+  The 'object' type is understood as a TensorFlow string and translated into
   'string'.
 
   Args:
@@ -85,7 +85,7 @@ def process_buffers_for_display(s, limit=40):
 
   This function performs the following operation on each of the buffers in `s`.
     1. Truncate input buffer if the length of the buffer is greater than
-       `limit`.
+       `limit`, to prevent large strings from overloading the frontend.
     2. Apply `binascii.b2a_qp` on the truncated buffer to make the buffer
        printable and convertible to JSON.
     3. If truncation happened (in step 1), append a string at the end
@@ -105,7 +105,7 @@ def process_buffers_for_display(s, limit=40):
     length = len(s)
     if length > limit:
       return (binascii.b2a_qp(s[:limit]) +
-              b' (length-%s truncated at %s bytes)' % (length, limit))
+              b' (length-%d truncated at %d bytes)' % (length, limit))
     else:
       return binascii.b2a_qp(s)
 

--- a/tensorboard/plugins/debugger/tensor_helper.py
+++ b/tensorboard/plugins/debugger/tensor_helper.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import base64
+import binascii
 
 import numpy as np
 from tensorflow.python.debug.cli import command_parser
@@ -61,6 +62,54 @@ def parse_time_indices(s):
     return parsed[0]
 
 
+def translate_dtype(dtype):
+  """Translate numpy dtype into a string.
+
+  The 'object' type is understood as a tenosrflow string and translated into
+  'string'.
+
+  Args:
+    dtype: A numpy dtype object.
+
+  Returns:
+    A string representing the data type.
+  """
+  out = str(dtype)
+  # String-type TensorFlow Tensors are represented as object-type arrays in
+  # numpy. We map the type name back to 'string' for clarity.
+  return 'string' if out == 'object' else out
+
+
+def process_buffers_for_display(s, limit=40):
+  """Process a buffer for human-readable display.
+
+  This function performs the following operation on each of the buffers in `s`.
+    1. Truncate input buffer if the length of the buffer is greater than
+       `limit`.
+    2. Apply `binascii.b2a_qp` on the truncated buffer to make the buffer
+       printable and convertible to JSON.
+    3. If truncation happened (in step 1), append a string at the end
+       describing the original length and the truncation.
+
+  Args:
+    s: The buffer to be processed, either a single buffer or a nested array of
+      them.
+    limit: Length limit for each buffer, beyond which truncation will occur.
+
+  Return:
+    A single processed buffer or a nested array of processed buffers.
+  """
+  if isinstance(s, (list, tuple)):
+    return [process_buffers_for_display(elem, limit=limit) for elem in s]
+  else:
+    length = len(s)
+    if length > limit:
+      return (binascii.b2a_qp(s[:limit]) +
+              b' (length-%s truncated at %s bytes)' % (length, limit))
+    else:
+      return binascii.b2a_qp(s)
+
+
 def array_view(array, slicing=None, mapping=None):
   """View a slice or the entirety of an ndarray.
 
@@ -81,11 +130,7 @@ def array_view(array, slicing=None, mapping=None):
     3. the potentially sliced values, as a nested `list`.
   """
 
-  dtype = str(array.dtype)
-  # String-type TensorFlow Tensors are represented as object-type arrays in
-  # numpy. We map the type name back to 'string' for clarity.
-  if dtype == 'object':
-    dtype = 'string'
+  dtype = translate_dtype(array.dtype)
   sliced_array = (array[command_parser._parse_slices(slicing)] if slicing
                   else array)
 

--- a/tensorboard/plugins/debugger/tensor_store.py
+++ b/tensorboard/plugins/debugger/tensor_store.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import numpy as np
 import tensorflow as tf
 from tensorflow.python.debug.lib import debug_data
 
@@ -153,7 +154,15 @@ class _WatchStore(object):
       if isinstance(self._data[time_index], _TensorValueDiscarded):
         output.append(None)
       else:
-        output.append(self._data[time_index])
+        data_item = self._data[time_index]
+        if (hasattr(data_item, 'dtype') and
+            tensor_helper.translate_dtype(data_item.dtype) == 'string'):
+          _, _, data_item = tensor_helper.array_view(data_item)
+          data_item = np.array(
+              tensor_helper.process_buffers_for_display(data_item),
+              dtype=np.object)
+        output.append(data_item)
+
     return output
 
   def dispose(self):


### PR DESCRIPTION
* Binary strings (strings that cannot be encoded in JSON, as is the case
  with output tensors of Summary ops) are now converted to a printable
  format using Python's `binascii.b2a_qp()`.
* To prevent overloading the frontend and frontend-backend
  communication, long string elements are truncated at 40 bytes.
* Display dtype 'object' as 'string' for clarity.