### PR TITLE
Ignore en locale test if locale is not installed

### DIFF
--- a/tensorboard/loader_test.py
+++ b/tensorboard/loader_test.py
@@ -221,13 +221,7 @@ class ProgressTest(LoaderTestCase):
     self.assertIn('[stalled]', self.logs[1])
 
   def testBigNumberInAmerica_showsCommas(self):
-    try:
-      locale.setlocale(locale.LC_ALL, 'en_US.utf8')
-    except Exception:
-      try:
-        locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
-      except Exception:
-        raise self.skipTest('Environment does not support en_US.utf8/en_US.UTF-8 locale')
+    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
     self.progress.set_progress(0, 1000000)
     self.clock.advance(1.0)
     self.progress.set_progress(1024, 1000000)

--- a/tensorboard/loader_test.py
+++ b/tensorboard/loader_test.py
@@ -221,7 +221,10 @@ class ProgressTest(LoaderTestCase):
     self.assertIn('[stalled]', self.logs[1])
 
   def testBigNumberInAmerica_showsCommas(self):
-    locale.setlocale(locale.LC_ALL, 'en_US.utf8')
+    try:
+      locale.setlocale(locale.LC_ALL, 'en_US.utf8')
+    except Exception:
+      raise self.skipTest('Environment does not support en_US.utf8 locale')
     self.progress.set_progress(0, 1000000)
     self.clock.advance(1.0)
     self.progress.set_progress(1024, 1000000)

--- a/tensorboard/loader_test.py
+++ b/tensorboard/loader_test.py
@@ -224,7 +224,10 @@ class ProgressTest(LoaderTestCase):
     try:
       locale.setlocale(locale.LC_ALL, 'en_US.utf8')
     except Exception:
-      raise self.skipTest('Environment does not support en_US.utf8 locale')
+      try:
+        locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+      except Exception:
+        raise self.skipTest('Environment does not support en_US.utf8/en_US.UTF-8 locale')
     self.progress.set_progress(0, 1000000)
     self.clock.advance(1.0)
     self.progress.set_progress(1024, 1000000)


### PR DESCRIPTION
When I run `bazel test tensorboard/...` it is complaining about `unsupported locale setting`.
Somehow on my machine `en_US.UTF-8` was installed but `en_US.utf8`.
I looked into the `loader_test.py` history and seems like we are skipping German locale test if it's not found, so I created this PR.

Env:
Tensorflow 1.8
Tensorboard 1.8