### PR TITLE
Update selenium tests

### DIFF
--- a/tensorboard/functionaltests/core_test.py
+++ b/tensorboard/functionaltests/core_test.py
@@ -63,7 +63,7 @@ class BasicTest(unittest.TestCase):
   def setUp(self):
     self.driver = webtest.new_webdriver_session()
     self.driver.get("http://localhost:%s" % self.port)
-    self.wait = wait.WebDriverWait(self.driver, 2)
+    self.wait = wait.WebDriverWait(self.driver, 10)
 
   def tearDown(self):
     try:
@@ -80,8 +80,7 @@ class BasicTest(unittest.TestCase):
   def testLogdirDisplays(self):
     self.wait.until(
       expected_conditions.text_to_be_present_in_element((
-        by.By.ID, "logdir"), self.logdir))
-
+        by.By.ID, "data_location"), self.logdir))
 
 class DashboardsTest(BasicTest):
   """Tests basic behavior when there is some data in TensorBoard.
@@ -95,6 +94,10 @@ class DashboardsTest(BasicTest):
   def setUpData(cls):
     scalars_demo.run_all(cls.logdir, verbose=False)
     audio_demo.run_all(cls.logdir, verbose=False)
+
+  def testLogdirDisplays(self):
+    # TensorBoard doesn't have logdir display when there is data
+    pass
 
   def testDashboardSelection(self):
     """Test that we can navigate among the different dashboards."""


### PR DESCRIPTION
`bazel test //tensorboard/functionaltests:core_test`
- The `#logdir` element was renamed since `1.7.0`, it should be `#data_location`.
- If there is some data in log dir, TensorBoard doesn't have element `#data_location`, so waiting for this element causes timeout.
- If there is some data in log dir, seems like it takes few seconds (3 - 4 seconds) for the local server to get ready (see the screenshot below), so I ask it to wait up to 10 seconds before throwing timeout exception. If it finds the element will return it in 0 - 10 seconds. 
(Actually 6 seconds works just fine for me, but I am not sure it it's the same on other machines, so I put 10).

![screen shot 2018-05-22 at 5 21 23 pm 2](https://user-images.githubusercontent.com/10496910/40445650-92df4290-5e81-11e8-86aa-506ee163b0f7.png)

Result:
<img width="640" alt="screen shot 2018-05-23 at 12 09 50 pm" src="https://user-images.githubusercontent.com/10496910/40445867-4269d86a-5e82-11e8-9e1e-c7275379d4ab.png">

Any suggestion is appreciated!