### PR TITLE
Pin 1.8 branch to TensorFlow 1.8.0 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/
 
 env:
-  - BAZEL=0.9.0 TF=1.8.0rc0
+  - BAZEL=0.9.0 TF=1.8.0
 
 cache:
   directories:

--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -38,7 +38,7 @@ py_library(
 
 py_test(
     name = "pr_curves_plugin_test",
-    size = "small",
+    size = "medium",  # tf integration test
     srcs = ["pr_curves_plugin_test.py"],
     srcs_version = "PY2AND3",
     deps = [


### PR DESCRIPTION
Yesterday we helped fix TensorFlow's C++ ABI regression fixed in `tf-nightly`. I'm curious if it impacts 1.8 final.