### PR TITLE
[Debugger Plugin] Guard against nodes omitted by Graph visualizer

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -956,15 +956,24 @@ limitations under the License.
         } else {
           // Selecting the node triggers a pan to it.
           const nodeMap = graph.get('renderHierarchy').hierarchy.getNodeMap();
-          if (!nodeMap[nodeName]) {
-            // In some cases, a node with other names using its name as
-            // name scope may not have base-expanded (i.e., normalized) name
-            // in the graph visualizer. In that case, we use the non-expanded
-            // node name.
+          if (nodeMap[nodeName] == null) {
+            // Some nodes may not be present in the graph scene, due to either
+            // of the two reasons:
+            //   1. A node with other names using its name as name scope may
+            //      not have a base-expanded (i.e., normalized) name in the
+            //      graph visualizer.
+            //   2. The node may fall into a type of nodes automatically
+            //      omitted by the graph visualizer, e.g., certain nodes
+            //      related to TensorBoard summaries.
+            // To deal with case 1, we use the non-expanded node name.
+            // To deal with case 2, we check whether `nodeMap[nodeName]` equal
+            // `null` again before setting `selectedNode` below.
             nodeName =
                 tf_debugger_dashboard.removeNodeNameBaseExpansion(nodeName);
           }
-          graph.set('selectedNode', nodeName);
+          if (nodeMap[nodeName] != null) {
+            graph.set('selectedNode', nodeName);
+          }
         }
         this.set('_highlightNodeName', deviceName + '/' + nodeName);
       },


### PR DESCRIPTION
The graph visualizer omits nodes of certain types (e.g., the ones
associated with TensorBoard summaries), e.g.,
'layer2/biases/summaries/mean/tags'. When the debugger plugin
steps to such nodes and attempts to focus the graph visualizer on
the nodes, errors will occur.

This PR fixes this issue by more thoroughly checking whether the
node is omitted by the graph visualizer before setting its
'selectedNode' property.