### PR TITLE
populate host in data request, so the server can filter based on host.

### DIFF
--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -258,6 +258,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
       grpc_request.repository_root = self.plugin_logdir
       grpc_request.session_id = run[:-1]
       grpc_request.tool_name = 'trace_viewer'
+      grpc_request.host_name = host
 
       grpc_request.parameters['resolution'] = request.args.get('resolution')
       if request.args.get('start_time_ms') is not None:


### PR DESCRIPTION
if not specified, all hosts' data will be aggregated.