### PR TITLE
Add line charts for memory viewer tool

### DIFF
--- a/tensorboard/plugins/profile/memory_viewer/buffer_details/BUILD
+++ b/tensorboard/plugins/profile/memory_viewer/buffer_details/BUILD
@@ -1,0 +1,20 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_library(
+    name = "buffer_details",
+    srcs = [
+            "buffer-details.html",
+            "buffer-details.ts",
+           ],
+    path = "/memory-viewer",
+    deps = [
+        "//tensorboard/plugins/profile/memory_viewer/utils",
+        "//tensorboard/components/tf_imports:polymer",
+        "@org_polymer_paper_card",
+    ],
+)
+

--- a/tensorboard/plugins/profile/memory_viewer/buffer_details/buffer-details.html
+++ b/tensorboard/plugins/profile/memory_viewer/buffer_details/buffer-details.html
@@ -1,0 +1,91 @@
+<!--
+@license
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../paper-card/paper-card.html">
+<link rel="import" href="utils.html">
+
+<!--
+  tf-mv-bar shows a small % utilization bar, colored using flameColor.
+-->
+<dom-module id="tf-nv-bar">
+  <style>
+:host {
+  display: inline-block;
+  height: 1.5em;
+  line-height: 1.5em;
+}
+  </style>
+</dom-module>
+
+<!--
+  buffer-details is a card that describes a buffer allocation.
+-->
+<dom-module id="buffer-details">
+  <style>
+paper-card {
+  --paper-card-header-color: white;
+  width: 330px;
+}
+tf-mv-bar {
+  width: 100%;
+}
+#subheader {
+  padding: 0 16px 16px;
+  color: rgba(255, 255, 255, 0.7);
+  position: relative;
+  top: -10px;
+}
+.card-content > div {
+  margin-bottom: 1em;
+}
+.expression {
+  display: block;
+  word-wrap: break-word;
+}
+  </style>
+  <template>
+    <paper-card id="card" heading="[[node.instructionName]]" hidden="[[!node]]"
+      elevation="2">
+      <div id="subheader">[[_subheader(node)]]</div>
+      <div class="card-content">
+        <div hidden="[[!size]]">
+          <h4>Size: <span>[[size]]</span><b> MiB</b></h4>
+        </div>
+        <div hidden="[[!unpaddedSize]]">
+          <b>Unpadded Size: </b><span>[[unpaddedSize]]</span><b> MiB</b>
+        </div>
+        <div hidden="[[!padding]]">
+          <b>Extra memory due to padding: </b><span>[[padding]]</span><b> MiB</b>
+        </div>
+        <div hidden="[[!expansion]]">
+          <b>Expansion: </b><span>[[expansion]]</span><b>X</b>
+          <tf-mv-bar value="[[utilization]]"></tf-mv-bar>
+        </div>
+        <div hidden="[[!node.shape]]">
+          <b>Shape: </b>
+          <code class="expression">[[node.shape]]</code>
+        </div>
+        <div hidden="[[!node.tfOpName]]">
+          <b>Tf Op Name: </b>
+          <code class="expression">[[node.tfOpName]]</code>
+        </div>
+        <div hidden="[[!node.groupName]]">
+          <b>Allocation Type: </b><span>[[node.groupName]]</span>
+        </div>
+      </div>
+    </paper-card>
+  </template>
+  <script src="buffer-details.js"></script>
+</dom-module>

--- a/tensorboard/plugins/profile/memory_viewer/buffer_details/buffer-details.ts
+++ b/tensorboard/plugins/profile/memory_viewer/buffer_details/buffer-details.ts
@@ -1,0 +1,100 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+namespace memory_viewer {
+
+Polymer({
+  is:'tf-mv-bar',
+  properties:{
+    value:{
+      type:Number,
+      notify:true,
+      observer:'_updateValue',
+    },
+  }, 
+  /**
+   * Updates the utilization bar.
+   */
+  _updateValue:function(value: number) {
+    const color = memory_viewer.flameColor(value);
+    const length = memory_viewer.percent(value);
+    this.style.background =
+        `linear-gradient(to right, ${color} ${length}, #ccc ${length})`;
+  }
+});
+
+Polymer({
+  is:'buffer-details',
+  properties:{
+    node:{
+      type:Object,
+      notify:true,
+      observer:'_updateCard'
+    },
+    size:{
+      type:String,
+      notify:true,
+    },
+    unpaddedSize:{
+      type:String,
+      notify:true,
+    },
+    padding:{
+      type:String,
+      notify:true,
+    },
+    expansion:{
+      type:String,
+      notify:true,
+    },
+    utilization:{
+      type:Number,
+      notify:true,
+    },
+  },
+  /**
+   * Updates the details card.
+   */
+  _updateCard:function(node) {
+    if (node == null) {
+      return;
+    }
+    this.size = node.sizeMiB.toFixed(1);
+    let color = 'rgb(192,192,192)';
+    if (node.unpaddedSizeMiB) {
+      this.unpaddedSize = node.unpaddedSizeMiB.toFixed(1);
+      this.padding = (node.sizeMiB - node.unpaddedSizeMiB).toFixed(1);
+      this.utilization = node.unpaddedSizeMiB / node.sizeMiB;
+      this.expansion = (1 / this.utilization).toFixed(1);
+      color = memory_viewer.flameColor(this.utilization, 0.7);
+    }
+    this.$.card.updateStyles({'--paper-card-header':'background-color:' + color});
+    this.$.subheader.style.backgroundColor = color;
+  },
+  /**
+   * Returns the sub header of the buffer details card.
+   */
+  _subheader:function(node): string {
+    if (!node) {
+      return null;
+    }
+    if (node.opcode) {
+      return node.opcode + ' operation';
+    }
+    return '';
+  },
+});
+
+} // namespace memory_viewer

--- a/tensorboard/plugins/profile/memory_viewer/memory_usage/memory-usage.ts
+++ b/tensorboard/plugins/profile/memory_viewer/memory_usage/memory-usage.ts
@@ -23,6 +23,9 @@ export class MemoryUsage {
   private nameToHlo_: {[key: string]: HloInstruction} = {};
   private unSeenLogicalBuffers_: Set<number>;
   private seenBufferAllocations_: Set<number>;
+  private nColor_: number = 0;
+  private rest_: number = 0;
+
   peakHeapSizeBytes: number = 0;
   unpaddedPeakHeapSizeBytes: number = 0;
   peakLogicalBuffers: number[] = [];
@@ -41,8 +44,6 @@ export class MemoryUsage {
    * display.
    */
   smallBufferSize: number;
-  nColor_: number = 0;
-  rest_: number = 0;
 
   /**
    * @param json Json message that contains the hloModule,
@@ -131,10 +132,10 @@ export class MemoryUsage {
       'unpaddedSizeMiB': unpaddedSize,
       'tfOpName': inst.tfOpName,
       'opcode': inst.opcode,
-      'data': [[memory_viewer.bytesToMiB(buffer.size), 0]],
+      'sizeMiB': memory_viewer.bytesToMiB(buffer.size),
       'color': color,
       'shape': shape ? shape.humanStringWithLayout() : '',
-      'groupName': groupName
+      'groupName': groupName,
     };
     return dict;
   }
@@ -178,7 +179,7 @@ export class MemoryUsage {
       const small = 'small (<' + this.smallBufferSize / 1024 + ' KiB)';
       this.maxHeap.push({
         'instructionName': small,
-        'data': [[memory_viewer.bytesToMiB(this.rest_), 0]],
+        'sizeMiB': memory_viewer.bytesToMiB(this.rest_),
         'color': 0,
         'groupName': small
       });
@@ -186,7 +187,7 @@ export class MemoryUsage {
     let indexedMaxHeap = this.maxHeap.map(function(e, i) {
       return {ind: i, val: e};
     });
-    indexedMaxHeap.sort((a, b) => b.val.data[0][0] - a.val.data[0][0]);
+    indexedMaxHeap.sort((a, b) => b.val.sizeMiB - a.val.sizeMiB);
     this.maxHeapBySize = indexedMaxHeap.map(function(e) {
       return e.val;
     });

--- a/tensorboard/plugins/profile/memory_viewer/memory_viewer_dashboard/BUILD
+++ b/tensorboard/plugins/profile/memory_viewer/memory_viewer_dashboard/BUILD
@@ -15,6 +15,8 @@ tf_web_library(
         "//tensorboard/plugins/profile/memory_viewer/memory_usage",
         "//tensorboard/plugins/profile/memory_viewer/utils",
         "//tensorboard/plugins/profile/memory_viewer/xla",
+        "//tensorboard/plugins/profile/memory_viewer/mv_line_chart",
+        "//tensorboard/plugins/profile/memory_viewer/buffer_details",
         "//tensorboard/components/tf_imports:polymer",
     ],
 )

--- a/tensorboard/plugins/profile/memory_viewer/memory_viewer_dashboard/memory-viewer-dashboard.html
+++ b/tensorboard/plugins/profile/memory_viewer/memory_viewer_dashboard/memory-viewer-dashboard.html
@@ -19,6 +19,8 @@ You may obtain a copy of the License at
 -->
 
 <link rel="import" href="memory-usage.html">
+<link rel="import" href="mv-line-chart.html">
+<link rel="import" href="buffer-details.html">
 
 <dom-module id="memory-viewer-dashboard">
   <template>
@@ -33,26 +35,27 @@ mv-line-chart {
 }
 buffer-details {
   position: fixed;
-  margin-top: 6.5em;
+  margin-top: 7.5em;
   left: 16px;
   width: 330px;
 }
     </style>
     <div class="memory-viewer-dashboard" style="overflow:auto">
-      <h4> Module name: <span>[[moduleName_]]</span>
-      </h4>
-      <h4> Peak memory allocation is
+      <h3> Module name: <span>[[moduleName_]]</span>
+      </h3>
+      <h3> Peak memory allocation is
         <span>{{peakHeapSizeMiB_}}</span> MiB <span style="font-size:20px"
           hidden={{!unpaddedPeakHeapSizeMiB_}}>(
           {{unpaddedPeakHeapSizeMiB_}} MiB without padding)</span>
-      </h4>
+      </h3>
       <div id="description">
         <p>Modifying your model's architecture, batch size and data dimentions
            may help reduce the memory footprint.
         </p>
       </div>
-   </div>
+      <buffer-details hidden="[[!active_]]" node="[[active_]]"></buffer-details>
+      <mv-line-chart data="{{usage}}" active={{active_}}></mv-line-chart>
+    </div>
   </template>
   <script src="memory-viewer-dashboard.js"></script>
 </dom-module>
-

--- a/tensorboard/plugins/profile/memory_viewer/mv_line_chart/BUILD
+++ b/tensorboard/plugins/profile/memory_viewer/mv_line_chart/BUILD
@@ -1,0 +1,20 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_library(
+    name = "mv_line_chart",
+    srcs = [
+            "mv-line-chart.html",
+            "mv-line-chart.ts",
+           ],
+    path = "/memory-viewer",
+    deps = [
+        "//tensorboard/components/tf_imports:plottable",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_imports:d3",
+    ],
+)
+

--- a/tensorboard/plugins/profile/memory_viewer/mv_line_chart/mv-line-chart.html
+++ b/tensorboard/plugins/profile/memory_viewer/mv_line_chart/mv-line-chart.html
@@ -1,0 +1,38 @@
+<!--
+@license
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<!--
+  mv-line-chart is a line chart for the memory viewer tool.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/d3.html">
+<link rel="import" href="../tf-imports/plottable.html">
+
+<dom-module id='mv-line-chart'>
+  <template>
+    <div class="mv-line-chart">
+      <h2>Working Space Size (MiB) vs Program Order (HLO Sequence)</h2>
+      <div id="chartdiv" style="width:1200px;height:384px"></div>
+      <div id='maxheap-details'>
+        <em>Hover over a bar for buffer details to appear on the left.</em>
+      </div>
+      <h3>By Program Order</h3>
+      <div id="maxheapchart" style="width:1200px;height:200px"></div>
+      <h3>By Size</h3>
+      <div id="maxheapsizechart" style="width:1200px;height:200px"></div>
+    </div>
+  </template>
+  <script src="mv-line-chart.js"></script>
+</dom-module>

--- a/tensorboard/plugins/profile/memory_viewer/mv_line_chart/mv-line-chart.ts
+++ b/tensorboard/plugins/profile/memory_viewer/mv_line_chart/mv-line-chart.ts
@@ -1,0 +1,238 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+namespace memory_viewer {
+
+Polymer({
+  is:'mv-line-chart',
+  properties:{
+    data:{
+      type:Object,
+      notify:true,
+      observer:'_dataChanged'
+    },
+    active:{
+      type:Object,
+      notify:true,
+    },
+    bufferSizes:{
+      type:Array,
+      notify:true,
+    },
+    unpaddedBufferSizes:{
+      type:Array,
+      notify:true,
+    },
+    maxHeap:{
+      type:Array,
+      notify:true,
+    },
+    maxHeapBySize:{
+      type:Array,
+      notify:true,
+    },
+    spanPlot: {
+      type:Object,
+      notify:true,
+    },
+    colorScale: {
+      type:Object,
+      notify:true,
+    },
+  },
+  _makeChartDataset() {
+    if (!this.data) { return;}
+    this.bufferSizes = this.data.heapSizes.map((val, index) => [index, val]);
+    this.unpaddedBufferSizes = this.data.unpaddedHeapSizes.map((val, index) =>
+                                                               [index, val]);
+    let maxHeap = this.data.maxHeap;
+    this.data.maxHeap.reduce(function(sum, item, i) {
+        maxHeap[i]['offset'] = sum;
+        return sum + item.sizeMiB;
+      }, 0);
+    this.maxHeap = maxHeap;
+    let maxHeapBySize = this.data.maxHeapBySize;
+    this.data.maxHeapBySize.reduce(function(sum, item, i) {
+        maxHeapBySize[i]['offsetBySize'] = sum;
+        return sum + item.sizeMiB;
+      }, 0);
+    this.maxHeapBySize = maxHeapBySize;
+  },
+  /**
+   * Draw heap memory allocation line charts in program order. We also draw the
+   * breakdown of peak heap allocation in program order and by size. The
+   * position of the peak heap allocation is annotated on the graph. And an
+   * additional span is plotted to indicate the life range of the logical buffer
+   * allocation.
+   */
+  _drawProgramOrder() {
+    if (!this.data) { return;}
+    let xScale = new Plottable.Scales.Linear();
+    let yScale = new Plottable.Scales.Linear();
+    let xAxis = new Plottable.Axes.Numeric(xScale, "bottom");
+    let yAxis = new Plottable.Axes.Numeric(yScale, "left");
+
+    // Draw buffer sizes line.
+    let bufferSizesLine = new Plottable.Plots.Line();
+    bufferSizesLine.addDataset(new Plottable.Dataset(this.bufferSizes));
+    bufferSizesLine.x(function(d) {return d[0]; }, xScale)
+                   .y(function(d) {return d[1]; }, yScale)
+                   .attr("stroke", "#888888");
+
+    let unpaddedBufferSizesLine = new Plottable.Plots.Line();
+    unpaddedBufferSizesLine.addDataset(
+        new Plottable.Dataset(this.unpaddedBufferSizes));
+    unpaddedBufferSizesLine.x(function(d) {return d[0]; }, xScale)
+                           .y(function(d) {return d[1]; }, yScale)
+                           .attr("stroke", "#DE4406");
+
+    // Draw a band of width 10 to indicate the peak heap size location.
+    let bandPlot = new Plottable.Plots.Rectangle();
+    bandPlot.addDataset(
+        new Plottable.Dataset(
+          [this.bufferSizes[this.data.peakHeapSizePosition]]));
+    bandPlot.x(function(d) { return d[0]; }, xScale)
+            .y(function(d) { return 0; }, yScale)
+            .x2(function(d) { return d[0] + 10; })
+            .y2(function(d) { return d[1]; })
+            .attr("fill", "#DE4406")
+            .attr("opacity", 0.3);
+
+    // Draw a span to indicate the life range of this buffer allocation.
+    let colorScale = this.colorScale;
+    let spanPlot = new Plottable.Plots.Rectangle();
+    let logicalBufferSpans = this.data.logicalBufferSpans;
+    let spans = this.maxHeap.map((item) => {
+        const span = logicalBufferSpans[item.logicalBufferId];
+        if (!span) return null;
+        return {'id': item.logicalBufferId,
+            'span': span,
+            'size': item.sizeMiB,
+            'color': item.color};
+            });
+    spans = spans.filter(d => d !== null);
+    spanPlot.addDataset(new Plottable.Dataset(spans));
+    spanPlot.x(function(d) { return d.span[0]; }, xScale)
+              .y(function(d) { return 0; }, yScale)
+              .x2(function(d) { return d.span[1]; })
+              .y2(function(d) { return d.size; })
+              .attr('fill', function(d) { return (d.color % 10).toString(); },
+                                          colorScale)
+              .attr('fill-opacity', 0);
+    this.spanPlot = spanPlot;
+
+    let cs = new Plottable.Scales.Color();
+    cs.range(["#888888", "#DE4406"]);
+    cs.domain(["Sizes", "Unpadded Sizes"]);
+    let legend = new Plottable.Components.Legend(cs);
+    legend.maxEntriesPerRow(2);
+
+    let gridlines = new Plottable.Components.Gridlines(xScale, yScale);
+
+    let plots = new Plottable.Components.Group(
+        [bandPlot, bufferSizesLine, unpaddedBufferSizesLine,
+         gridlines, spanPlot]);
+
+    let table = new Plottable.Components.Table([[null, legend],
+                                               [yAxis, plots],
+                                               [null, xAxis]]);
+
+    table.renderTo(d3.select(this.$.chartdiv));
+  },
+  /**
+   * Draw maxHeap stack boxes and add the interactions.
+   */
+  _drawMaxHeap() {
+    let yScale = new Plottable.Scales.Linear();
+    let xScale = new Plottable.Scales.Linear();
+
+    let xAxis = new Plottable.Axes.Numeric(xScale, "top");
+    let yAxis = new Plottable.Axes.Numeric(yScale, "left");
+
+    let cs = this.colorScale;
+
+    let maxHeapChart = new Plottable.Plots.Rectangle();
+    maxHeapChart.addDataset(new Plottable.Dataset(this.maxHeap))
+                .x(function(d) { return d.offset; }, xScale)
+                .y(function(d) { return 0; }, yScale)
+                .x2(function(d) { return d.offset + d.sizeMiB; })
+                .y2(function(d) { return 12; })
+                .attr('fill', function(d) {
+                                return (d.color % 10).toString(); }, cs)
+                .attr('opacity', '0.6')
+                .renderTo(d3.select(this.$.maxheapchart));
+
+    let maxHeapSizeChart = new Plottable.Plots.Rectangle();
+    maxHeapSizeChart.addDataset(new Plottable.Dataset(this.maxHeapBySize))
+                .x(function(d) { return d.offsetBySize; }, xScale)
+                .y(function(d) { return 0; }, yScale)
+                .x2(function(d) { return d.offsetBySize + d.sizeMiB; })
+                .y2(function(d) { return 12; })
+                .attr('fill', function(d) {
+                                return (d.color % 10).toString(); }, cs)
+                .attr('opacity', '0.6')
+                .renderTo(d3.select(this.$.maxheapsizechart));
+
+    let parent = this;
+    new Plottable.Interactions.Pointer()
+    .attachTo(maxHeapChart)
+    .onPointerMove(function(p) {
+      parent._onHoverInteraction(p, maxHeapChart, maxHeapSizeChart,
+                                 parent.data.maxHeapToBySize);
+    });
+
+    new Plottable.Interactions.Pointer()
+    .attachTo(maxHeapSizeChart)
+    .onPointerMove(function(p) {
+      parent._onHoverInteraction(p, maxHeapSizeChart, maxHeapChart,
+                                 parent.data.bySizeToMaxHeap);
+    });
+  },
+  /**
+   * Highlights the item when mouse hovering over an item in the srcChart.
+   * Also highlight the item in the other chart. Renders the buffer details.
+   */
+  _onHoverInteraction(point, srcChart, dstChart, map) {
+    let entity = srcChart.entityNearest(point);
+    srcChart.selections().attr('opacity', '0.6');
+    entity.selection.attr('opacity', '1.0');
+    const dstIndex = map[entity.index];
+    // Unhighlight all the items in the dstChart.
+    dstChart.selections().attr('opacity', '0.6');
+    // Highlight the selected item in the dstChart.
+    dstChart.entities()[dstIndex].selection.attr('opacity', '1.0');
+    this._renderDetails(entity.datum);
+  },
+  /**
+   * Render the buffer details card and annotate the span on the line charts.
+   */
+  _renderDetails(item) {
+    this.spanPlot.selections().attr('fill-opacity', '0');
+    this.spanPlot.entities().forEach(function(entity) {
+        entity.selection.attr(
+            'fill-opacity', entity.datum.id === item.logicalBufferId ? 1.0 : 0);
+    });
+    this.active = item;
+  },
+  /**
+   * Redraw the chart when data changes.
+   */
+  _dataChanged:function() {
+    if (!this.data) { return;}
+    this.colorScale = new Plottable.Scales.Color("Category10");
+    this._makeChartDataset();
+    this._drawProgramOrder();
+    this._drawMaxHeap();
+  }
+});
+
+} // namespace memory_viewer

--- a/tensorboard/plugins/profile/memory_viewer/mv_line_chart/mv-line-chart.ts
+++ b/tensorboard/plugins/profile/memory_viewer/mv_line_chart/mv-line-chart.ts
@@ -97,14 +97,14 @@ Polymer({
     bufferSizesLine.addDataset(new Plottable.Dataset(this.bufferSizes));
     bufferSizesLine.x(function(d) {return d[0]; }, xScale)
                    .y(function(d) {return d[1]; }, yScale)
-                   .attr("stroke", "#888888");
+                   .attr("stroke", "red");
 
     let unpaddedBufferSizesLine = new Plottable.Plots.Line();
     unpaddedBufferSizesLine.addDataset(
         new Plottable.Dataset(this.unpaddedBufferSizes));
     unpaddedBufferSizesLine.x(function(d) {return d[0]; }, xScale)
                            .y(function(d) {return d[1]; }, yScale)
-                           .attr("stroke", "#DE4406");
+                           .attr("stroke", "grey");
 
     // Draw a band of width 10 to indicate the peak heap size location.
     let bandPlot = new Plottable.Plots.Rectangle();
@@ -115,7 +115,7 @@ Polymer({
             .y(function(d) { return 0; }, yScale)
             .x2(function(d) { return d[0] + 10; })
             .y2(function(d) { return d[1]; })
-            .attr("fill", "#DE4406")
+            .attr("fill", "red")
             .attr("opacity", 0.3);
 
     // Draw a span to indicate the life range of this buffer allocation.
@@ -142,7 +142,7 @@ Polymer({
     this.spanPlot = spanPlot;
 
     let cs = new Plottable.Scales.Color();
-    cs.range(["#888888", "#DE4406"]);
+    cs.range(["red", "grey"]);
     cs.domain(["Sizes", "Unpadded Sizes"]);
     let legend = new Plottable.Components.Legend(cs);
     legend.maxEntriesPerRow(2);

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -38,6 +38,9 @@ You may obtain a copy of the License at
        --paper-card-header-color: #F5F5F5;
        --paper-card-header: background-color: #4285F4;
      }
+     .flex-horizontal {
+       @apply --layout-horizontal;
+     }
      .steptime-average {
        font-weight: bold;
        font-style: italic;
@@ -96,64 +99,65 @@ You may obtain a copy of the License at
     </style>
     <div class="errorMessage" hidden$="[[!_show_error_message]]"> <span>[[_error_message]]</span></div>
     <div class="while_page_content" hidden$="[[_show_error_message]]">
-      <div class="horizontal layout">
-	<paper-card heading="Performance Summary">
-	  <div class="card-content">
-	    <p><b>Average step time</b> (lower is better): <b><span class="steptime-average" >[[_steptime_ms_average]] ms</span> </b> <i style="opacity:0.7">(standard deviation = <span>[[_steptime_ms_stddev]]</span> ms)</i></p>
-	    <p><b>Host idle time</b> (lower is better): <span>[[_host_idle_time_percent]]</span></p>
-	    <p><b>TPU idle time</b> (lower is better): <span>[[_device_idle_time_percent]]</p>
-	      <p><b>Utilization of TPU Matrix Units</b> (higher is better): <span>[[_mxu_utilization_percent]]</span></p>
-	  </div>
-	</paper-card>
-	<paper-card heading="Step-time Graph" >
-	  <div class="card-content">
-	    <table class="table-style">
-	      <tr>
-		<td><div class="y-axis-title">milliseconds</div></td>
-		<td>
-		  <vz-line-chart class="step-graph" id="device_step_chart"></vz-line-chart>
+      <div class="container flex-horizontal">
+        <paper-card heading="Performance Summary">
+          <div class="card-content">
+            <p><b>Average step time</b> (lower is better): <b><span class="steptime-average" >[[_steptime_ms_average]] ms</span> </b> <i style="opacity:0.7">(standard deviation = <span>[[_steptime_ms_stddev]]</span> ms)</i></p>
+            <p><b>Host idle time</b> (lower is better): <span>[[_host_idle_time_percent]]</span></p>
+            <p><b>TPU idle time</b> (lower is better): <span>[[_device_idle_time_percent]]</p>
+            <p><b>Utilization of TPU Matrix Units</b> (higher is better): <span>[[_mxu_utilization_percent]]</span></p>
+          </div>
+        </paper-card>
+        <paper-card heading="Step-time Graph">
+          <div class="card-content">
+            <table class="table-style">
+              <tr>
+                <td><div class="y-axis-title">milliseconds</div></td>
+                <td>
+                  <vz-line-chart class="step-graph" id="device_step_chart">
+                  </vz-line-chart>
                   <div><p class="x-axis-title">training step number</p></div>
-		</td>
-	      </tr>
-	    </table>
-	  </div>
-	</paper-card>
+                </td>
+              </tr>
+            </table>
+          </div>
+        </paper-card>
       </div>
-      <div class="horizontal layout">
-	<paper-card heading$="[[_top_ops_heading]]">
-	  <div class="card-content">
-	    <button on-click="onClickTopOps">[[_top_ops_button_text]]</button>
-	    <table class="top-ops-table" hidden$="[[!_show_top_ops_table]]">
-	      <thread>
-		<th>Time (%)</th>
-		<th>Cumulative time (%)</th>
-		<th>Category</th>
-		<th>Operation</th>
-		<th>GFlops/sec</th>
-	      </thread>
-	      <tbody id="top_ops_table_content">
-	      </tbody>
-	    </table>
-	  </div>
-	</paper-card>
+      <div class="container flex-horizontal">
+        <paper-card heading$="[[_top_ops_heading]]">
+          <div class="card-content">
+            <button on-click="onClickTopOps">[[_top_ops_button_text]]</button>
+            <table class="top-ops-table" hidden$="[[!_show_top_ops_table]]">
+              <thread>
+                <th>Time (%)</th>
+                <th>Cumulative time (%)</th>
+                <th>Category</th>
+                <th>Operation</th>
+                <th>GFlops/sec</th>
+              </thread>
+              <tbody id="top_ops_table_content">
+              </tbody>
+            </table>
+          </div>
+        </paper-card>
       </div>
-      <div class="horizontal layout">
-	<paper-card heading="Run Environment">
-	  <div class="card-content">
-	    <p><b>Number of Hosts used</b>: <span>[[_host_count]]</span></p>
+      <div class="container flex-horizontal">
+        <paper-card heading="Run Environment">
+          <div class="card-content">
+            <p><b>Number of Hosts used</b>: <span>[[_host_count]]</span></p>
             <p><b>TPU type</b>: Cloud TPU</span></p>
             <p><b>Number of TPU cores</b>: <span> [[_tpu_core_count]]</span></p>
             <p><b>Batch size</b>: <span>[[_batch_size]]</span></p>
-	  </div>
-	</paper-card>
-	<paper-card heading="Recommendation for Next Steps">
-	  <div class="card-content">
-	    <div class="bottleneck-statement"> <span>[[_statement]]</span></div>
-	    <div id="host_side_tips"></div>
+          </div>
+        </paper-card>
+        <paper-card heading="Recommendation for Next Steps">
+        <div class="card-content">
+          <div class="bottleneck-statement"> <span>[[_statement]]</span></div>
+            <div id="host_side_tips"></div>
             <div id="device_side_tips"></div>
-	    <div id="documentation_tips"></div>
-	  </div>
-	</paper-card>
+            <div id="documentation_tips"></div>
+          </div>
+        </paper-card>
       </div>
     </div>
   </template>

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -66,7 +66,7 @@ profile run can have multiple tools that present the performance profile as diff
 </template>
 <template is="dom-if" if="[[!_dataNotFound]]">
   <tf-dashboard-layout>
-  <div class="sidebar">
+  <div class="sidebar" style="width: 340px">
     <div class="allcontrols">
       <div class="sidebar-section">
         <div class="title">Runs <span class="counter">([[_datasets.length]])</span></div>


### PR DESCRIPTION
* Added charts and interactions of memory viewer.
* Shows up a buffer details card when mouse hovering over a buffer allocation.
* Fixed a bug that overview page doesn't align correctly horizontally.

![memory_viewer](https://user-images.githubusercontent.com/3082188/41259106-33ce22e8-6d87-11e8-9c40-add290e4275c.png)

![overview-page](https://user-images.githubusercontent.com/3082188/41186982-75ed8df0-6b55-11e8-8275-9725d53a4e1c.png)
