### PR TITLE
Add memory utilization bar in op profile.

### DIFF
--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-details.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-details.html
@@ -116,6 +116,10 @@ tf-op-bar {
           <b>FLOPS utilization: </b>
           <tf-op-bar value="[[_utilization(node)]]"></tf-op-bar>
         </div>
+        <div hidden="[[_hasMemoryUtilization(node)]]">
+          <b>Memory utilization: </b>
+          <tf-op-bar value="[[_memoryUtilization(node)]]"></tf-op-bar>
+        </div>
         <div hidden="[[!node.xla.expression]]">
           <b>Expression: </b>
           <code class="expression">[[node.xla.expression]]</code>
@@ -154,6 +158,10 @@ Polymer({
     },
   },
   _utilization: tf_op_profile.utilization,
+  _memoryUtilization: tf_op_profile.memoryUtilization,
+  _hasMemoryUtilization: function(node) {
+    return !node || !node.metrics || !node.metrics.memoryBandwidth;
+  },
   _updateCard: function(node){
     if (node == null) return;
     var color = tf_op_profile.flameColor(tf_op_profile.utilization(node), 0.7);

--- a/tensorboard/plugins/profile/tf_op_profile/utils.ts
+++ b/tensorboard/plugins/profile/tf_op_profile/utils.ts
@@ -44,6 +44,13 @@ export function utilization(node: any) {
   return node.metrics.flops / node.metrics.time;
 }
 
+export function memoryUtilization(node: any) {
+  // NaN indicates undefined memory utilization (the profile was collected from
+  // older versions of profiler).
+  if (!node || !node.metrics || !node.metrics.memoryBandwidth) return 0/0;
+  return node.metrics.memoryBandwidth;
+}
+
 export function percent(fraction: number) {
   if (isNaN(fraction)) return "-";
   return fraction >= 0.995 ? "100%" : fraction < 0.00001 ? "0.00%" :


### PR DESCRIPTION
Add a bar indicates how much memory is utilized for each Hlo Ops. 

![op_profile_memory](https://user-images.githubusercontent.com/3082188/41249268-7ee71902-6d68-11e8-903c-8c25bdcabf45.png)
