### PR TITLE
Bump version at HEAD to 1.10.0a0

### DIFF
--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '1.9.0a0'
+VERSION = '1.10.0a0'


### PR DESCRIPTION
We've cut the 1.9 branch, so head is now an alpha of 1.10.0a0.