### PR TITLE
Remove use of non-portable [[ in build_pip_package.sh

### DIFF
--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -35,7 +35,7 @@ smoke() {
   pip install -qU "$TF_PACKAGE"
   pip install -qU ../dist/*py$1*.whl >/dev/null
   # Test TensorBoard application
-  [[ -x ./bin/tensorboard ]]  # Ensure pip package included binary
+  [ -x ./bin/tensorboard ]  # Ensure pip package included binary
   mkfifo pipe
   tensorboard --port=0 --logdir=smokedir 2>pipe &
   perl -ne 'print STDERR;/http:.*:(\d+)/ and print $1.v10 and exit 0' <pipe >port


### PR DESCRIPTION
@martinwicke mind taking a look since Justine is OOO?

This fixes a line I added yesterday that doesn't work on our `tb-nightly` build machine, where apparently `/bin/sh` isn't just an alias to `bash`.