### PR TITLE
Fix a bug that pie chart in input_pipeline_analyzer is missing

### DIFF
--- a/tensorboard/plugins/profile/input_pipeline_analyzer/input-pipeline-analyzer.html
+++ b/tensorboard/plugins/profile/input_pipeline_analyzer/input-pipeline-analyzer.html
@@ -37,7 +37,7 @@ You may obtain a copy of the License at
         font-size: 150%;
       }
       #summary-host {
-        font-weight: bold; 
+        font-weight: bold;
       }
       .highlighted-text {
         text-decoration: underline;
@@ -104,7 +104,7 @@ You may obtain a copy of the License at
         <p><span id="summary_conclusion">[[_summary_conclusion]]</span></p>
         <p><span id="recommendation_title">Recommendation for next step: </span><span id="summary_nextstep">[[_summary_nextstep]]</span></p>
       </div>
-      <div id="section_device_side_analysis">
+      <div id="section_device_side_analysis" hidden="[[!_show_device_side_analysis]]">
         <div id="title_device_side_analysis">
           <p class="section-header"> Section 2: Device-side analysis details</p>
         </div>
@@ -208,6 +208,11 @@ You may obtain a copy of the License at
         type: Object,
         observer: '_updateView',
       },
+      _show_device_side_analysis: {
+        type: Boolean,
+        value: true,
+        notify: true,
+      },
       _show_host_side_chart: {
         type: Boolean,
         value: true,
@@ -222,56 +227,93 @@ You may obtain a copy of the License at
         type: String,
         computed: '_getToggleButtonText(_show_host_side_table)'
       },
+      _deviceJson: {
+        type: String,
+        notify: true,
+      },
+      _hostJson: {
+        type: String,
+        notify: true,
+      },
+      _recommendationJson: {
+        type: String,
+        notify: true,
+      },
+      _active: {
+        type: Boolean,
+        value: false,
+        notify: true,
+        observer: '_onActiveChanged',
+      },
+      _summary_conclusion: { type: String, notify: true, },
+      _summary_nextstep: { type: String, notify: true, },
+      _infeed_percent_average: { type: String, notify: true, },
+      _infeed_percent_stddev: { type: String, notify: true, },
+      _infeed_percent_minimum: { type: String, notify: true, },
+      _infeed_percent_maximum: { type: String, notify: true, },
+      _steptime_ms_average: { type: String, notify: true, },
+      _steptime_ms_stddev: { type: String, notify: true, },
+      _steptime_ms_minimum: { type: String, notify: true, },
+      _steptime_ms_maximum: { type: String, notify: true, },
     },
-    _summary_conclusion: String,
-    _summary_nextstep: String, 
-    _infeed_percent_average: String,
-    _infeed_percent_stddev: String,
-    _infeed_percent_minimum: String,
-    _infeed_percent_maximum: String,
-    _steptime_ms_average: String,
-    _steptime_ms_stddev: String,
-    _steptime_ms_minimum: String,
-    _steptime_ms_maximum: String,
+    observers: [
+      '_showDeviceStepChart(_deviceJson)',
+      '_showDeviceInfeedChart(_deviceJson)',
+      '_showHostChart(_hostJson)',
+      '_showHostTable(_hostJson)',
+      '_makeRecommendations(_recommendationJson)',
+    ],
     onClick: function(e) {
       this.set('_show_host_side_table', !this._show_host_side_table);
+    },
+    _onActiveChanged: function(active) {
+      if (!active) {
+        this._show_device_side_analysis = false;
+        this._show_host_side_chart = false;
+        this._show_host_side_table = false;
+      }
     },
     _getToggleButtonText: function(show_host_side_table) {
       return (show_host_side_table ? 'Hide' : 'Show') + ' Input Op Statistics';
     },
-
+    _usToMs: function(str) {
+      return Math.abs(Number(str))/1000.0;
+    },
     /* Update view according to new data */
     _updateView: function() {
-      if (this._data == null) return;
-      var deviceJson = this._data[0];
-      var hostJson = this._data[2];
-      var recommendationJson = this._data[3];
-      var conclusion = deviceJson.p['summary_conclusion'];
-      this.set('_summary_conclusion', conclusion);
-      this.set('_summary_nextstep', deviceJson.p['summary_nextstep']);
-      this.set('_infeed_percent_average', deviceJson.p['infeed_percent_average']);
-      this.set('_infeed_percent_stddev', deviceJson.p['infeed_percent_standard_deviation']);
-      this.set('_infeed_percent_minimum', deviceJson.p['infeed_percent_minimum']);
-      this.set('_infeed_percent_maximum', deviceJson.p['infeed_percent_maximum']);
-      this.set('_steptime_ms_average', deviceJson.p['steptime_ms_average']);
-      this.set('_steptime_ms_stddev', deviceJson.p['steptime_ms_standard_deviation']);
-      this.set('_steptime_ms_minimum', deviceJson.p['steptime_ms_minimum']);
-      this.set('_steptime_ms_maximum', deviceJson.p['steptime_ms_maximum']);
-      if (conclusion.includes('HIGHLY')) {
+      if (!this._data || !this._active) {
+        return;
+      }
+      const deviceJson = this._data[0];
+      this._deviceJson = deviceJson;
+      this._hostJson = this._data[2];
+      this._recommendationJson = this._data[3];
+      this._summary_conclusion = deviceJson.p['summary_conclusion'];
+      this._summary_nextstep = deviceJson.p['summary_nextstep'];
+      this._infeed_percent_average = deviceJson.p['infeed_percent_average'];
+      this._infeed_percent_stddev =
+          deviceJson.p['infeed_percent_standard_deviation'];
+      this._infeed_percent_minimum = deviceJson.p['infeed_percent_minimum'];
+      this._infeed_percent_maximum = deviceJson.p['infeed_percent_maximum'];
+      this._steptime_ms_average = deviceJson.p['steptime_ms_average'];
+      this._steptime_ms_stddev = deviceJson.p['steptime_ms_standard_deviation'];
+      this._steptime_ms_minimum = deviceJson.p['steptime_ms_minimum'];
+      this._steptime_ms_maximum = deviceJson.p['steptime_ms_maximum'];
+      if (this._summary_conclusion.includes('HIGHLY')) {
         this.customStyle['--summary-color'] =  'red';
-      } else if (conclusion.includes('MODERATE')) {
+      } else if (this._summary_conclusion.includes('MODERATE')) {
         this.customStyle['--summary-color'] =  'orange';
       }
       this.updateStyles();
-      this._showDeviceStepChart(deviceJson);
-      this._showDeviceInfeedChart(deviceJson);
-      this._showHostChart(hostJson);
-      this._showHostTable(hostJson);
-      this._makeRecommendations(recommendationJson);
     },
 
     /* Plots a graph of step time (in ms) against step number */
     _showDeviceStepChart : function(deviceJson) {
+      if (!deviceJson || deviceJson.rows.length == 0 || !this._active) {
+        this._show_device_side_analysis = false;
+        return;
+      }
+      this._show_device_side_analysis = true;
       var deviceStepSeries = [];
       var hostStepSeries = [];
       var maxStepTime = 0;
@@ -306,8 +348,13 @@ You may obtain a copy of the License at
       }
     },
 
-    /* Plots a graph of infeed dequeue time (in % of the step time) against step number */
+    /* Plots a graph of infeed dequeue time (in % of the step time) against
+       step number */
     _showDeviceInfeedChart: function (deviceJson) {
+      if (!deviceJson || deviceJson.rows.length == 0) {
+        this._show_device_side_analysis = false;
+        return;
+      }
       var deviceInfeedSeries = [];
       var step = -1;
       deviceJson.rows.forEach(function(row, index) {
@@ -325,7 +372,8 @@ You may obtain a copy of the License at
         chart.tooltipColumns = [
           { title: 'Name', evaluate: (d) => d.dataset.metadata().name },
           { title: 'Step', evaluate: (d) => d.datum.tpu_step },
-          { title: 'Average(%)', evaluate: (d) => (d.datum.scalar).toFixed(4) + '%' },
+          { title: 'Average(%)',
+              evaluate: (d) => (d.datum.scalar).toFixed(4) + '%' },
           { title: 'Min(%)', evaluate: (d) => (d.datum.min).toFixed(4) + '%' },
           { title: 'Max(%)', evaluate: (d) => (d.datum.max).toFixed(4) + '%' }];
         chart.fillArea = {
@@ -336,53 +384,63 @@ You may obtain a copy of the License at
       }
     },
 
-    /* Plots a stacked bar chart for the breakdown of input processing time on the host. */
+    /* Plots a stacked bar chart for the breakdown of input processing time on
+       the host. */
     _showHostChart: function(hostJson) {
-      const kUsPerMs = 1000.0;
-      var unclassifiedNonEnqueueMs = Number(hostJson.p['unclassified_nonequeue_us']) / kUsPerMs;
-      var demandedFileReadMs = Number(hostJson.p['demanded_file_read_us']) / kUsPerMs;
-      var advancedFileReadMs = Number(hostJson.p['advanced_file_read_us']) / kUsPerMs;
-      var preprocessingMs = Number(hostJson.p['preprocessing_us']) / kUsPerMs;
-      var enqueueMs = Number(hostJson.p['enqueue_us']) / kUsPerMs;
-      var totalInputTimeMs = unclassifiedNonEnqueueMs + demandedFileReadMs +
-			     advancedFileReadMs + preprocessingMs + enqueueMs;
-      this.set('_show_host_side_chart', totalInputTimeMs > 0);
+      if (!hostJson) return;
+      const unclassifiedNonEnqueueMs =
+          this._usToMs(hostJson.p['unclassified_nonequeue_us']);
+      const demandedFileReadMs =
+          this._usToMs(hostJson.p['demanded_file_read_us']);
+      const advancedFileReadMs =
+          this._usToMs(hostJson.p['advanced_file_read_us']);
+      const preprocessingMs = this._usToMs(hostJson.p['preprocessing_us']);
+      const enqueueMs = this._usToMs(hostJson.p['enqueue_us']);
+      const totalInputTimeMs = unclassifiedNonEnqueueMs + demandedFileReadMs +
+                               advancedFileReadMs + preprocessingMs + enqueueMs;
+      this._show_host_side_chart = totalInputTimeMs > 0;
       if (totalInputTimeMs > 0) {
-	var pie_data = [{ Name:"Other data reading or processing",
-			  Total:unclassifiedNonEnqueueMs / totalInputTimeMs * 100 },
-			{ Name:"Reading data from files on demand",
-			  Total:demandedFileReadMs / totalInputTimeMs * 100 },
-			{ Name:"Reading data from files in advance [including caching, prefetching, interleaving]",
-			  Total:advancedFileReadMs /totalInputTimeMs * 100 },
-			{ Name:"Data preprocessing",
-			  Total:preprocessingMs/totalInputTimeMs * 100 },
-			{ Name:"Enqueuing data to be transferred to device",
-			  Total:enqueueMs/totalInputTimeMs * 100 }];
+          let pie_data = [{ Name:"Other data reading or processing",
+                            Total:unclassifiedNonEnqueueMs /
+                                      totalInputTimeMs * 100 },
+                          { Name:"Reading data from files on demand",
+                            Total:demandedFileReadMs / totalInputTimeMs * 100 },
+                          { Name:"Reading data from files in advance "
+                            + "[including caching, prefetching, interleaving]",
+                            Total:advancedFileReadMs / totalInputTimeMs * 100 },
+                          { Name:"Data preprocessing",
+                            Total:preprocessingMs / totalInputTimeMs * 100 },
+                          { Name:"Enqueuing data to be transferred to device",
+                            Total:enqueueMs / totalInputTimeMs * 100 }];
 
-        var colorScale = new Plottable.Scales.Color();
-        var legend = new Plottable.Components.Legend(colorScale);
+        let colorScale = new Plottable.Scales.Color();
+        let legend = new Plottable.Components.Legend(colorScale);
 
-        var div = d3.select(this.$.host_side_chart);
-        var pie = new Plottable.Plots.Pie()
-          .attr("fill", function(d){ return d.Name; }, colorScale)
-          .addDataset(new Plottable.Dataset(pie_data))
-          .sectorValue(function(d){ return d.Total; } )
-          .labelsEnabled(true)
-          .labelFormatter(function(n){ return Number(n).toFixed(2) + "%" ;});
-        var plot = new Plottable.Components.Table([[pie, legend]]);
+        let div = d3.select(this.$.host_side_chart);
+        let pie = new Plottable.Plots.Pie()
+                  .attr("fill", function(d){ return d.Name; }, colorScale)
+                  .addDataset(new Plottable.Dataset(pie_data))
+                  .sectorValue(function(d){ return d.Total; } )
+                  .labelsEnabled(true)
+                  .labelFormatter(function(n){
+                                  return Number(n).toFixed(2) + "%" ;});
+        let plot = new Plottable.Components.Table([[pie, legend]]);
         plot.renderTo(div);
       }
     },
 
     /* Draws a table of Dataset Op statistics */
     _showHostTable: function(hostJson) {
-      var inputOpsTableBody = this.$.host_side_table_content;
+      if (!hostJson) return;
+      let inputOpsTableBody = this.$.host_side_table_content;
       inputOpsTableBody.innerHTML = '';
+      this._show_host_side_table = false;
+      if (hostJson.rows.length == 0) return;
       hostJson.rows.forEach(function(rowJson, index) {
-        var row = document.createElement('tr');
+        let row = document.createElement('tr');
         Polymer.dom(inputOpsTableBody).appendChild(row);
         /* formatting the cell */
-        var cellTexts = [];
+        let cellTexts = [];
         cellTexts.push(rowJson.c[0].v);
         cellTexts.push(rowJson.c[1].v);
         cellTexts.push((rowJson.c[2].v).toFixed(2));
@@ -391,23 +449,32 @@ You may obtain a copy of the License at
         cellTexts.push((rowJson.c[5].v * 100).toFixed(2) + '%');
         cellTexts.push(rowJson.c[6].v);
         cellTexts.forEach(function(cellText, index) {
-          var td = document.createElement('td');
+          let td = document.createElement('td');
           Polymer.dom(row).appendChild(td);
           Polymer.dom(td).appendChild(document.createTextNode(cellText));
         });
       });
-      this.set('_show_host_side_table', false);
     },
 
     /* Makes a list of detailed recommendations */
     _makeRecommendations: function(recommendationJson) {
+      if (!recommendationJson) return;
       var content = '';
       recommendationJson.rows.forEach(function(rowJson, index) {
-	content += '<li>' + rowJson.c[0].v + '</li>';
+        content += '<li>' + rowJson.c[0].v + '</li>';
       });
       var detailsBody = this.$.recommendation_details;
       detailsBody.innerHTML = content;
     },
+
+    attached: function() {
+      this._active = true;
+      this._updateView();
+    },
+
+    detached: function() {
+      this._active = false;
+    }
   });
   </script>
 </dom-module>

--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -97,8 +97,9 @@ You may obtain a copy of the License at
        text-decoration: underline;
      }
     </style>
-    <div class="errorMessage" hidden$="[[!_show_error_message]]"> <span>[[_error_message]]</span></div>
-    <div class="while_page_content" hidden$="[[_show_error_message]]">
+    <template is="dom-if" if="[[_show_error_message]]" restamp=true>
+      <div class="errorMessage"><span>[[_error_message]]</span></div></template>
+    <template is="dom-if" if="[[!_show_error_message]]" restamp=true>
       <div class="container flex-horizontal">
         <paper-card heading="Performance Summary">
           <div class="card-content">
@@ -151,15 +152,15 @@ You may obtain a copy of the License at
           </div>
         </paper-card>
         <paper-card heading="Recommendation for Next Steps">
-        <div class="card-content">
-          <div class="bottleneck-statement"> <span>[[_statement]]</span></div>
+          <div class="card-content">
+            <div class="bottleneck-statement"> <span>[[_statement]]</span></div>
             <div id="host_side_tips"></div>
             <div id="device_side_tips"></div>
             <div id="documentation_tips"></div>
           </div>
         </paper-card>
       </div>
-    </div>
+   </template>
   </template>
 
   <script>
@@ -181,29 +182,35 @@ You may obtain a copy of the License at
        },
        _show_error_message: {
          type: Boolean,
+         computed: '_shouldShowErrorMessage(_data)',
+         notify: true,
+         observer: '_onErrorChanged',
+       },
+       _active: {
+         type: Boolean,
          value: false,
          notify: true,
        },
+       _host_idle_time_percent: { type: String, },
+       _device_idle_time_percent: { type: String, },
+       _mxu_utilization_percent: { type: String, },
+       _steptime_ms_average: { type: String, },
+       _steptime_ms_stddev: { type: String, },
+       _top_ops_heading: { type: String, },
+       _error_message: { type: String, },
+       _host_count: { type: String, },
+       _tpu_type: { type: String, },
+       _tpu_core_count: { type: String, },
+       _batch_size: { type: String, },
+       _change_list: { type: String, },
+       _build_time: { type: String, },
+       _build_target: { type: String, },
+       _statement: { type: String, },
      },
-     _host_idle_time_percent: String,
-     _device_idle_time_percent: String,
-     _mxu_utilization_percent: String,
-     _steptime_ms_average: String,
-     _steptime_ms_stddev: String,
-     _top_ops_heading: String,
-     _error_message: String,
-     _host_count: String,
-     _tpu_type: String,
-     _tpu_core_count: String,
-     _batch_size: String,
-     _change_list: String,
-     _build_time: String,
-     _build_target: String,
-     _statement: String,
 
      /* Toggles _show_top_ops_table */
      onClickTopOps: function(e) {
-       this.set('_show_top_ops_table', !this._show_top_ops_table);
+       this._show_top_ops_table =  !this._show_top_ops_table;
      },
 
      /* Gets the current text of the "show-top-ops" button */
@@ -211,36 +218,45 @@ You may obtain a copy of the License at
        return (show_top_ops_table ? 'Hide' : 'Show') + ' table';
      },
 
+     _shouldShowErrorMessage: function(data) {
+       if (!data) return true;
+       return data[2].p['error_message'] != '';
+     },
+
      /* Updates view according to new data */
      _updateView: function() {
-       if (this._data == null) return;
+       if (!this._data || !this._active) return;
        var generalAnalysisJson = this._data[0];
        var inputAnalysisJson = this._data[1];
        var runEnvironmentJson = this._data[2];
        var recommendationJson = this._data[3];
 
        var statement = recommendationJson.p['statement'];
-       this.set('_host_idle_time_percent', generalAnalysisJson.p['host_idle_time_percent']);
-       this.set('_device_idle_time_percent', generalAnalysisJson.p['device_idle_time_percent']);
-       this.set('_mxu_utilization_percent', generalAnalysisJson.p['mxu_utilization_percent']);
-       this.set('_steptime_ms_average', inputAnalysisJson.p['steptime_ms_average']);
-       this.set('_steptime_ms_stddev', inputAnalysisJson.p['steptime_ms_standard_deviation']);
-       this.set('_error_message', runEnvironmentJson.p['error_message']);
-       this.set('_host_count', runEnvironmentJson.p['host_count']);
-       this.set('_tpu_type', runEnvironmentJson.p['tpu_type']);
-       this.set('_tpu_core_count', runEnvironmentJson.p['tpu_core_count']);
-       this.set('_batch_size', runEnvironmentJson.p['batch_size']);
-       this.set('_change_list', runEnvironmentJson.p['change_list']);
-       this.set('_build_time', runEnvironmentJson.p['build_time']);
-       this.set('_build_target', runEnvironmentJson.p['build_target']);
-       this.set('_statement', recommendationJson.p['statement']);
-       this.set('_show_error_message', this._error_message!='');
+       this._host_idle_time_percent =
+           generalAnalysisJson.p['host_idle_time_percent'];
+       this._device_idle_time_percent =
+           generalAnalysisJson.p['device_idle_time_percent'];
+       this._mxu_utilization_percent =
+           generalAnalysisJson.p['mxu_utilization_percent'];
+       this._steptime_ms_average =
+           inputAnalysisJson.p['steptime_ms_average'];
+       this._steptime_ms_stddev =
+           inputAnalysisJson.p['steptime_ms_standard_deviation'];
+       this._error_message = runEnvironmentJson.p['error_message'];
+       this._host_count = runEnvironmentJson.p['host_count'];
+       this._tpu_type = runEnvironmentJson.p['tpu_type'];
+       this._tpu_core_count = runEnvironmentJson.p['tpu_core_count'];
+       this._batch_size = runEnvironmentJson.p['batch_size'];
+       this._change_list = runEnvironmentJson.p['change_list'];
+       this._build_time = runEnvironmentJson.p['build_time'];
+       this._build_target = runEnvironmentJson.p['build_target'];
+       this._statement = recommendationJson.p['statement'];
 
        if (statement.includes('HIGHLY')) {
          this.customStyle['--summary-color'] = 'red';
        } else if (statement.includes('MODERATE')) {
          this.customStype['--summary-color'] = 'orange';
-       } 
+       }
 
        this.updateStyles();
 
@@ -251,6 +267,11 @@ You may obtain a copy of the License at
 
      /* Plots a graph of step time (in ms) against step number */
      _showDeviceStepChart : function(deviceJson) {
+       var chart = this.$$('#device_step_chart');
+       if (!deviceJson || !deviceJson.rows ||
+               !deviceJson.rows.length || !this._active) {
+         return;
+       }
        var computeTimeSeries = [];
        var stepTimeSeries = [];
        var maxStepTime = 0;
@@ -258,18 +279,18 @@ You may obtain a copy of the License at
        deviceJson.rows.forEach(function(row, index) {
          step = step > 0 ? ++step : Number(row.c[0].v);
          computeTimeSeries.push({"scalar": row.c[1].v,
-				 "step": step,
-				 "tpu_step": Number(row.c[0].v),
-				 "low_watermark": 0})
+                                 "step": step,
+                                 "tpu_step": Number(row.c[0].v),
+                                 "low_watermark": 0})
          stepTimeSeries.push({"scalar": row.c[1].v + row.c[2].v,
                               "step": step,
                               "low_watermark": row.c[1].v})
          maxStepTime = Math.max(maxStepTime, row.c[1].v + row.c[2].v)
        })
-       var chart = this.$.device_step_chart;
        if (chart) {
-         chart.setVisibleSeries(['compute-time', 'step-time = input-time + compute-time']);
-	 chart.setSeriesData('compute-time', computeTimeSeries);
+         chart.setVisibleSeries(['compute-time',
+             'step-time = input-time + compute-time']);
+         chart.setSeriesData('compute-time', computeTimeSeries);
          chart.setSeriesData('step-time = input-time + compute-time', stepTimeSeries);
          chart.defaultYRange = [0, maxStepTime * 1.1]
          chart.smoothingEnabled = false;
@@ -287,40 +308,49 @@ You may obtain a copy of the License at
 
      /* Draws a table of TensorFlow Op statistics */
      _showTopOpsTable: function(opsTableJson) {
+       if (!opsTableJson || !opsTableJson.rows ||
+               !opsTableJson.rows.length || !this._active) {
+         return;
+       }
        var numRows = 0;
-       var opsTableBody = this.$.top_ops_table_content;
+       var opsTableBody = this.$$('#top_ops_table_content');
+       if (!opsTableBody) { return; }
        opsTableBody.innerHTML = '';
        opsTableJson.rows.forEach(function(rowJson, index) {
-	 var row = document.createElement('tr');
-	 Polymer.dom(opsTableBody).appendChild(row);
-	 var cellTexts = [];
-	 cellTexts.push((rowJson.c[0].v*100).toFixed(2)+'%');
-	 cellTexts.push((rowJson.c[1].v*100).toFixed(2)+'%');
-	 cellTexts.push(rowJson.c[2].v);
-	 cellTexts.push(rowJson.c[3].v);
-	 cellTexts.push((rowJson.c[4].v).toFixed(2));
-	 cellTexts.forEach(function(cellText, index) {
+         var row = document.createElement('tr');
+         Polymer.dom(opsTableBody).appendChild(row);
+         var cellTexts = [];
+         cellTexts.push((rowJson.c[0].v*100).toFixed(2)+'%');
+         cellTexts.push((rowJson.c[1].v*100).toFixed(2)+'%');
+         cellTexts.push(rowJson.c[2].v);
+         cellTexts.push(rowJson.c[3].v);
+         cellTexts.push((rowJson.c[4].v).toFixed(2));
+         cellTexts.forEach(function(cellText, index) {
            var td = document.createElement('td');
            Polymer.dom(row).appendChild(td);
            Polymer.dom(td).appendChild(document.createTextNode(cellText));
          });
-	 numRows += 1;
+         numRows += 1;
        })
-       this.set('_top_ops_heading', 'Top ' + numRows + ' TensorFlow operations executed on TPU');
-       this.set('_show_top_ops_table', false);
+       this._top_ops_heading = 'Top ' + numRows +
+                              ' TensorFlow operations executed on TPU';
+       this._show_top_ops_table = false;
      },
 
      /* Generates the HTML for a recommendation link */
-     _generateRecommendationHtml: function(tipsTableJson, cssClassName, wantedTipType, titleString) {
+     _generateRecommendationHtml: function(tipsTableJson,
+                                           cssClassName,
+                                           wantedTipType,
+                                           titleString) {
        var content = '<p>&nbsp;</p>';
        content += '<div class="' + cssClassName + '">';
        content += '<b>' + titleString + ':</b>';
        tipsTableJson.rows.forEach(function(rowJson, index) {
          var tipType = rowJson.c[0].v;
-	 if (tipType == wantedTipType) {
-	   var link = rowJson.c[1].v;
-	   content += '<li>' + link + '</li>';
-	 }
+         if (tipType == wantedTipType) {
+           var link = rowJson.c[1].v;
+           content += '<li>' + link + '</li>';
+         }
        });
        content += '</div>';
        return content;
@@ -328,22 +358,55 @@ You may obtain a copy of the License at
 
      /* Shows the recommendation section */
      _showRecommendation: function(recommendationJson) {
+       if(!recommendationJson || !this._active) return;
        var bottleneck =  recommendationJson.p['bottleneck'];
-       var hostTipsBody = this.$.host_side_tips;
-       var deviceTipsBody = this.$.device_side_tips;
+       var hostTipsBody = this.$$('#host_side_tips');
+       var deviceTipsBody = this.$$('#device_side_tips');
+       if (!hostTipsBody || !deviceTipsBody) { return; };
 
        if (bottleneck == 'device') {
          hostTipsBody.innerHTML = '';
-         deviceTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'device', 'Next tools to use for reducing the TPU time');
+         deviceTipsBody.innerHTML =
+             this._generateRecommendationHtml(
+                 recommendationJson, 'bottleneckTips', 'device',
+                     'Next tools to use for reducing the TPU time');
        } else if (bottleneck == 'host') {
-         hostTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'host', 'Next tools to use for reducing the input time');
+         hostTipsBody.innerHTML = this._generateRecommendationHtml(
+             recommendationJson, 'bottleneckTips', 'host',
+                 'Next tools to use for reducing the input time');
          deviceTipsBody.innerHTML = '';
        } else {
-         hostTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'host', 'Next tools to use for reducing the input time');
-         deviceTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'bottleneckTips', 'device', 'Next tools to use for reducing the TPU time');
+         hostTipsBody.innerHTML = this._generateRecommendationHtml(
+             recommendationJson, 'bottleneckTips', 'host',
+                 'Next tools to use for reducing the input time');
+         deviceTipsBody.innerHTML = this._generateRecommendationHtml(
+             recommendationJson, 'bottleneckTips', 'device',
+                 'Next tools to use for reducing the TPU time');
        }
-       var documentationTipsBody = this.$.documentation_tips;
-       documentationTipsBody.innerHTML = this._generateRecommendationHtml(recommendationJson, 'documentationTips', 'doc', 'Other useful resources');
+       var documentationTipsBody = this.$$('#documentation_tips');
+       if (documentationTipsBody) {
+         documentationTipsBody.innerHTML = this._generateRecommendationHtml(
+             recommendationJson, 'documentationTips', 'doc',
+                 'Other useful resources');
+       }
+     },
+
+     _onErrorChanged: function() {
+       this._updateView();
+     },
+
+     ready: function() {
+       this._active = true;
+       this._updateView();
+     },
+
+     attached: function() {
+       this._active = true;
+       this._updateView();
+     },
+
+     detached: function() {
+       this._active = false;
      },
    });
   </script>


### PR DESCRIPTION
Input Pipeline Analyzer:
The pie chart in input_pipeline_analyzer is occasionally missing due to two reasons:
(1) When -0.00 is present in the input JSON.
(2) Try to render the pie chart when DOM is not ready.
Fix these two issues and also refactored the code for better performance.

Overview Page:
Fix the 'node' not found error. Need to use dom-if so that isn't a hidden line chart from another RUN.