### PR TITLE
Fix raw sources mode for full frontend component

### DIFF
--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -24,7 +24,6 @@ tf_web_library(
         "//tensorboard/components/tf_paginated_view",
         "//tensorboard/components/tf_storage",
         "@com_google_fonts_roboto",
-        "@io_bazel_rules_closure//closure/library/object",
         "@org_polymer_iron_icons",
         "@org_polymer_paper_button",
         "@org_polymer_paper_checkbox",

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -648,7 +648,8 @@ limitations under the License.
           return;
         }
         const dashboard = tf_tensorboard.dashboardRegistry[selectedDashboard];
-        if (container.childNodes.length === 0) {
+        // Use .children, not .childNodes, to avoid counting comment nodes.
+        if (container.children.length === 0) {
           const component = document.createElement(dashboard.elementName);
           component.id = 'dashboard';  // used in `_selectedDashboardComponent`
           container.appendChild(component);

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -327,8 +327,6 @@ limitations under the License.
   </template>
   <script src="autoReloadBehavior.js"></script>
   <script>
-    goog.require('goog.object');
-
     if (_.isEmpty(tf_tensorboard.dashboardRegistry)) {
       throw new Error('HTML import plugin dashboards *before* tf-tensorboard');
     }
@@ -402,7 +400,7 @@ limitations under the License.
         _dashboardData: {
           type: Array,
           readOnly: true,
-          value: goog.object.getValues(tf_tensorboard.dashboardRegistry),
+          value: _.values(tf_tensorboard.dashboardRegistry),
         },
 
         /**


### PR DESCRIPTION
A couple fixes to get raw sources mode working for the full frontend component, so that `bazel run tensorboard/components:tensorboard` produces a working raw-source frontend.

In raw sources mode, `goog.require('goog.object')` fails on a missing `goog` symbol and it wasn't clear how to fix it, so since that was only present for `values()` which is also provided by lodash, an existing depedency, I just changed it to `_.values()`.  I also fixed an issue where when the dashboard stamping logic got confused by a comment node, which in raw sources mode doesn't get stripped.

The raw-source frontend at `bazel run tensorboard/components:tensorboard` doesn't include any demo data by default, but it can be paired with data endpoints from a running TensorBoard backend on another port (e.g. 7006) by using a reverse proxy, for example:

```sh
cat >/tmp/nginx.conf <<EOF
events { worker_connections 1024; }
http {
  access_log /dev/stdout;
  server {
    listen 8080;
    server_name localhost;
    proxy_buffering off;
    location /data/ { proxy_pass http://localhost:7006; }
    location / { proxy_pass http://localhost:6006; }
  }
}
EOF
nginx -g 'daemon off;' -c /tmp/nginx.conf
google-chrome http://localhost:8080/tensorboard.html
```
