### PR TITLE
Fix memory viewer due to minor compiler changes.

### DIFF
--- a/tensorboard/plugins/profile/memory_viewer/buffer_details/buffer-details.html
+++ b/tensorboard/plugins/profile/memory_viewer/buffer_details/buffer-details.html
@@ -19,7 +19,7 @@ You may obtain a copy of the License at
 <!--
   tf-mv-bar shows a small % utilization bar, colored using flameColor.
 -->
-<dom-module id="tf-nv-bar">
+<dom-module id="tf-mv-bar">
   <style>
 :host {
   display: inline-block;
@@ -74,7 +74,7 @@ tf-mv-bar {
           <tf-mv-bar value="[[utilization]]"></tf-mv-bar>
         </div>
         <div hidden="[[!node.shape]]">
-          <b>Shape: </b>
+          <b>Shape (and minor-to-major order): </b>
           <code class="expression">[[node.shape]]</code>
         </div>
         <div hidden="[[!node.tfOpName]]">

--- a/tensorboard/plugins/profile/memory_viewer/utils/utils.ts
+++ b/tensorboard/plugins/profile/memory_viewer/utils/utils.ts
@@ -51,6 +51,8 @@ export function byteSizeOfPrimitiveType(type: string): number {
       return 8;
     case 'C64':
       return 8;
+    case 'TOKEN':
+      return 0;
     default:
       console.error('Unhandled primitive type ' + type);
       return 0;

--- a/tensorboard/plugins/profile/memory_viewer/xla/shape.ts
+++ b/tensorboard/plugins/profile/memory_viewer/xla/shape.ts
@@ -48,17 +48,20 @@ export class Shape {
 
     // We make a simplifying assumption here that the minimum size of a tuple
     // member is int64.
+    if (this.elementType === 'TOKEN') {
+      return 0;
+    }
     if (this.elementType === 'TUPLE') {
       return INT64_BYTES * this.tupleShapes.length;
     }
     let byteSize = 0;
-    if (this.layout.format == 'DENSE') {
+    // We assume the layout format is 'DENSE' by default.
+    if (!this.layout || this.layout.format == 'DENSE') {
       const allocatedElementCount =
           this.dimensions.reduce((count, item) => count * item, 1);
       byteSize += allocatedElementCount *
           memory_viewer.byteSizeOfPrimitiveType(this.elementType);
-    }
-    if (this.layout.format == 'SPARSE') {
+    }else if (this.layout.format == 'SPARSE') {
       const maxElements = parseInt(this.layout.maxSparseElements, 10);
       byteSize = maxElements * memory_viewer.byteSizeOfPrimitiveType(this.elementType);
 
@@ -82,16 +85,16 @@ export class Shape {
       }
       text += ')';
       return text;
-    } else {
-      let result = this.elementType.toLowerCase() + '[';
-      result += this.dimensions.join() + ']';
-      if (!(this.elementType === 'OPAQUE') && this.dimensions.length > 0) {
-        if (this.layout) {
-          result += this.humanLayoutString(this.layout);
-        }
-      }
-      return result;
     }
+    let result = this.elementType.toLowerCase() + '[';
+    result += this.dimensions.join() + ']';
+    if (!(this.elementType === 'OPAQUE') && !(this.elementType === 'TOKEN') &&
+        this.dimensions.length > 0) {
+      if (this.layout) {
+        result += this.humanLayoutString(this.layout);
+      }
+    }
+    return result;
   }
 
   /**

--- a/tensorboard/plugins/profile/memory_viewer/xla/shape.ts
+++ b/tensorboard/plugins/profile/memory_viewer/xla/shape.ts
@@ -46,11 +46,11 @@ export class Shape {
   unpaddedHeapSizeBytes(): number {
     const INT64_BYTES = 8;
 
-    // We make a simplifying assumption here that the minimum size of a tuple
-    // member is int64.
     if (this.elementType === 'TOKEN') {
       return 0;
     }
+    // We make a simplifying assumption here that the minimum size of a tuple
+    // member is int64.
     if (this.elementType === 'TUPLE') {
       return INT64_BYTES * this.tupleShapes.length;
     }
@@ -63,7 +63,8 @@ export class Shape {
           memory_viewer.byteSizeOfPrimitiveType(this.elementType);
     }else if (this.layout.format == 'SPARSE') {
       const maxElements = parseInt(this.layout.maxSparseElements, 10);
-      byteSize = maxElements * memory_viewer.byteSizeOfPrimitiveType(this.elementType);
+      byteSize = maxElements *
+          memory_viewer.byteSizeOfPrimitiveType(this.elementType);
 
       // Add byte size of sparse indices, assume each indice is int64 type.
       byteSize += maxElements * this.dimensions.length * INT64_BYTES;


### PR DESCRIPTION
Fix a bug that memory_viewer is broken because XLA newly added a 'TOKEN' primitive.