### PR TITLE
Improve line-chart tooltip logic.

### DIFF
--- a/tensorboard/components/vz_line_chart/vz-line-chart.html
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.html
@@ -66,12 +66,12 @@ such as different X scales (linear and temporal), tooltips and smoothing.
       td {
         padding-left: 5px;
         padding-right: 5px;
-        font-size: 13px;
+        font-size: .92em;
         opacity: 1;
       }
       #tooltip {
         pointer-events: none;
-        position: absolute;
+        position: fixed;
         opacity: 0;
         box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
         font-size: 14px;
@@ -117,6 +117,11 @@ such as different X scales (linear and temporal), tooltips and smoothing.
         stroke-width: 1.5px;
       }
 
+      @media (max-width: 1280px) {
+        #tooltip {
+          font-size: 12px;
+        }
+      }
     </style>
   </template>
   <script src="dragZoomInteraction.js"></script>

--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -975,7 +975,7 @@ class LineChart {
     }
 
     this.tooltip.style('transform', 'translate(' + left + 'px,' + top + 'px)');
-    this.tooltip.style('opacity', 1);
+    this.tooltip.style('opacity', rows.size() > 0 ? 1 : 0);
   }
 
   private findClosestPoint(


### PR DESCRIPTION
Fixes #1170 

1. Hide the tooltip completely when there are no rows
2. Show tooltip on top of other UI elements
3. Makes the tooltip font size a bit smaller in smaller screens.