### PR TITLE
Add a progress bar to TPU profile plugin.

### DIFF
--- a/tensorboard/plugins/profile/tf_profile_common/BUILD
+++ b/tensorboard/plugins/profile/tf_profile_common/BUILD
@@ -1,0 +1,28 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_library(
+    name = "tf_profile_common",
+    srcs = [
+        "tf-profile-common.html",
+        "util.ts",
+    ],
+    path = "/tf-profile-common",
+    deps = [
+        "//tensorboard/components/tf_imports:polymer",
+    ],
+)
+
+tensorboard_webcomponent_library(
+    name = "legacy",
+    srcs = [":tf_profile_common"],
+    destdir = "tf-profile-common",
+    deps = [
+        "//tensorboard/components/tf_imports_google:lib",
+        "//third_party/javascript/polymer/v1/polymer:lib",
+    ],
+)

--- a/tensorboard/plugins/profile/tf_profile_common/tf-profile-common.html
+++ b/tensorboard/plugins/profile/tf_profile_common/tf-profile-common.html
@@ -1,0 +1,18 @@
+<!--
+@license
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script src="util.js"></script>

--- a/tensorboard/plugins/profile/tf_profile_common/util.ts
+++ b/tensorboard/plugins/profile/tf_profile_common/util.ts
@@ -1,0 +1,93 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/**
+ * @fileoverview Utility functions for the TensorFlow profile plugin.
+ */
+
+module tf.profile.util {
+  /**
+   * Tracks task progress. Each task being passed a progress tracker needs
+   * to call the below-defined methods to notify the caller about the gradual
+   * progress of the task.
+   */
+  export interface ProgressTracker {
+    updateProgress(incrementValue: number): void;
+    setMessage(msg: string): void;
+    reportError(msg: string, err: Error): void;
+  }
+
+  export function time<T>(msg: string, task: () => T) {
+    let start = Date.now();
+    let result = task();
+    /* tslint:disable */
+    console.log(msg, ':', Date.now() - start, 'ms');
+    /* tslint:enable */
+    return result;
+  }
+
+  /**
+   * Creates a tracker that sets the progress property of the
+   * provided polymer component. The provided component must have
+   * a property called 'progress' that is not read-only. The progress
+   * property is an object with a numerical 'value' property and a
+   * string 'msg' property.
+   */
+  export function getTracker(polymerComponent: any) {
+    return {
+      setMessage: function(msg) {
+        polymerComponent.set(
+            'progress', {value: polymerComponent.progress.value, msg: msg});
+      },
+      updateProgress: function(value) {
+        polymerComponent.set('progress', {
+          value: polymerComponent.progress.value + value,
+          msg: polymerComponent.progress.msg
+        });
+      },
+      reportError: function(msg: string, err) {
+        // Log the stack trace in the console.
+        console.error(err.stack);
+        // And send a user-friendly message to the UI.
+        polymerComponent.set(
+            'progress',
+            {value: polymerComponent.progress.value, msg: msg, error: true});
+      },
+    };
+  }
+
+  /**
+   * Runs an expensive task and return the result.
+   */
+  export function runTask<T>(
+      msg: string, incProgressValue: number, task: () => T,
+      tracker: ProgressTracker): T {
+    // Update the progress message to say the current running task.
+    tracker.setMessage(msg);
+    // Run the expensive task with a delay that gives enough time for the
+    // UI to update.
+    try {
+      let result = tf.profile.util.time(msg, task);
+      // Update the progress value.
+      tracker.updateProgress(incProgressValue);
+      // Return the result to be used by other tasks.
+      return result;
+    } catch (e) {
+      // Errors that happen inside asynchronous tasks are
+      // reported to the tracker using a user-friendly message.
+      tracker.reportError('Failed ' + msg, e);
+    }
+  }
+}

--- a/tensorboard/plugins/profile/tf_profile_dashboard/BUILD
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/BUILD
@@ -20,9 +20,11 @@ tf_web_library(
         "//tensorboard/plugins/profile/memory_viewer/memory_viewer_dashboard",
         "//tensorboard/plugins/profile/overview_page",
         "//tensorboard/plugins/profile/tf_op_profile",
+        "//tensorboard/plugins/profile/tf_profile_common",
         "@org_polymer",
         "@org_polymer_paper_dropdown_menu",
         "@org_polymer_paper_item",
         "@org_polymer_paper_menu",
+        "@org_polymer_paper_progress",
     ],
 )

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -19,6 +19,7 @@ limitations under the License.
 <link rel="import" href="../paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../paper-item/paper-item.html">
 <link rel="import" href="../paper-menu/paper-menu.html">
+<link rel="import" href="../paper-progress/paper-progress.html">
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
@@ -26,6 +27,7 @@ limitations under the License.
 <link rel="import" href="../tf-input-pipeline/input-pipeline-analyzer.html">
 <link rel="import" href="../tf-overview-page/overview-page.html">
 <link rel="import" href="../tf-op-profile/tf-op-profile.html">
+<link rel="import" href="../tf-profile-common/tf-profile-common.html">
 <link rel="import" href="../memory-viewer/memory-viewer-dashboard.html">
 <link rel="import" href="../google-chart/google-chart-demo.html">
 <link rel="import" href="../tf-tensorboard/registry.html">
@@ -41,6 +43,12 @@ profile run can have multiple tools that present the performance profile as diff
 
 <dom-module id="tf-profile-dashboard">
 <template>
+<template is="dom-if" if="[[_isNotComplete(progress)]]">
+  <div id="progress-bar">
+    <div id="progress-msg">[[progress.msg]]</div>
+    <paper-progress value="[[progress.value]]"></paper-progress>
+  </div>
+</template>
 <template is="dom-if" if="[[_dataNotFound]]">
   <div style="max-width: 540px; margin: 80px auto 0 auto;">
     <h3>No profile data was found.</h3>
@@ -145,6 +153,26 @@ profile run can have multiple tools that present the performance profile as diff
     height: 100%;
     box-sizing: border-box;
   }
+  #progress-bar {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    position: absolute;
+    top: 40px;
+    left: 0;
+    font-size: 13px;
+  }
+  #progress-msg {
+    width: 400px;
+    margin-bottom: 5px;
+  }
+  paper-progress {
+    width: 400px;
+    --paper-progress-height: 6px;
+    --paper-progress-active-color: #f3913e;
+  }
 </style>
 
 </template>
@@ -176,6 +204,16 @@ profile run can have multiple tools that present the performance profile as diff
       _activeHostsList: {
         type: Array,
         observer: '_activeHostsChanged'
+      },
+      /**
+       * @type {{value: number, msg: string}}
+       *
+       * A number between 0 and 100 denoting the % of progress
+       * for the progress bar and the displayed message.
+       */
+      progress: {
+        type: Object,
+        notify: true,
       },
       selectedDatasetIndex: {
         type: Number,
@@ -243,13 +281,17 @@ profile run can have multiple tools that present the performance profile as diff
     observers: [
       '_maybeInitializeDashboard(_isAttached)',
       '_maybeUpdateData(_selectedHostName)',
-      '_maybeUpdateActiveHosts(_selectedDatasetName, _selectedToolName)'
+      '_maybeUpdateActiveHosts(_selectedDatasetName, _selectedToolName)',
     ],
     attached: function() {
       this.set('_isAttached', true);
     },
     detached: function() {
       this.set('_isAttached', false);
+    },
+    /** True if the progress is not complete yet (< 100 %). */
+    _isNotComplete: function(progress) {
+      return progress.value < 100;
     },
     _maybeInitializeDashboard: function(isAttached) {
       if (this._initialized || !isAttached) {
@@ -262,7 +304,36 @@ profile run can have multiple tools that present the performance profile as diff
       const profileTagsURL =
         tf_backend.getRouter().pluginRoute('profile', '/tools') +
         (tf_backend.getRouter().isDemoMode() ? '.json' : '');
-      this._requestManager.request(profileTagsURL).then((runToTool) => {
+      // Reset the progress bar to 0.
+      this.set('progress', {
+        value: 0,
+        msg: ''
+      });
+      let parent = this;
+      let tracker = tf.profile.util.getTracker(this);
+      tf.profile.util.runTask('Loading datasets', 20, () => {
+        console.log('start counting');
+        return parent._requestManager.request(profileTagsURL);
+      }, tracker)
+      .then((runToTool) => {
+        return tf.profile.util.runTask(
+            'Processing datasets', 70, () => {
+              return new Promise(function(resolve, reject) {
+                parent._processRunToTool(runToTool);
+                return Promise.resolve(null);
+              });
+            }, tracker);
+      })
+      .then(() => {
+        return tf.profile.util.runTask(
+            'Done', 10, () => {
+              return new Promise(function(resolve, reject) {
+                return Promise.resolve(null);
+              });
+            }, tracker);
+      });
+    },
+    _processRunToTool: function(runToTool) {
         var datasets = _.map(runToTool, (tools, run) => ({
           name: run,
           activeTools: tools,
@@ -275,7 +346,6 @@ profile run can have multiple tools that present the performance profile as diff
         });
         this.set('_dataNotFound', datasets.length === 0);
         this.set('_datasets', datasets);
-      });
     },
     // Return the item selected from the list
     _getSelected: function(index, li) {
@@ -287,14 +357,16 @@ profile run can have multiple tools that present the performance profile as diff
     },
     _getSelectedDatasetName: function(selectedDatasetIndex, datasets){
       if (selectedDatasetIndex == null) return;
-      if (datasets && selectedDatasetIndex >= 0 && selectedDatasetIndex < datasets.length) {
+      if (datasets && selectedDatasetIndex >= 0 &&
+          selectedDatasetIndex < datasets.length) {
         return datasets[selectedDatasetIndex].name;
       }
       return '';
     },
      _getActiveToolsList: function(selectedDatasetIndex, datasets) {
       if (selectedDatasetIndex == null) return;
-      if (datasets && selectedDatasetIndex >= 0 && selectedDatasetIndex < datasets.length) {
+      if (datasets && selectedDatasetIndex >= 0 &&
+          selectedDatasetIndex < datasets.length) {
         this.selectedToolIndex = 0;
         return datasets[selectedDatasetIndex].activeTools;
       }
@@ -305,7 +377,7 @@ profile run can have multiple tools that present the performance profile as diff
       var datasetName = this._selectedDatasetName;
       var toolName = this._selectedToolName;
       if (datasetName == null || toolName == null) return;
-      this.toolInScope = "undefined";
+      this._toolInScope = "undefined";
       if (toolName.startsWith("trace_viewer")) {
         var trace_data_url = tf_backend.addParams(
             tf_backend.getRouter().pluginRoute('profile', '/data'),
@@ -325,29 +397,50 @@ profile run can have multiple tools that present the performance profile as diff
         this._toolInScope = "trace_viewer";
         return;
       } else {
-        this._requestManager.request(tf_backend.addParams(
-          tf_backend.getRouter().pluginRoute('profile', '/data'),
-          {tag: toolName, host: hostName, run: datasetName})
-        ).catch(error => {}
-        ).then((data) => {
-           if (toolName == "op_profile") {
-               this._opProfileData = data;
-               this._toolInScope = "op_profile";
-           } else if (toolName == "input_pipeline_analyzer") {
-               this._inputPipelineData = data;
-               this._toolInScope = "input_pipeline_analyzer";
-           } else if (toolName == "overview_page") {
-               this._overviewPageData = data;
-               this._toolInScope = "overview_page";
-           } else if (toolName == "memory_viewer") {
-               this._memoryViewerData = data;
-               this._toolInScope = "memory_viewer";
-           } else if (toolName == "google_chart_demo") {
-               this._googleChartDemoData = data;
-               this._toolInScope = "google_chart_demo";
-           }
+        // Reset the progress bar to 0.
+        this.set('progress', {
+          value: 0,
+          msg: ''
         });
-        return;
+        let parent = this;
+        let tracker = tf.profile.util.getTracker(this);
+        tf.profile.util.runTask('Reading ' + toolName + ' tool data', 20,
+          () => {
+            return parent._requestManager.request(tf_backend.addParams(
+              tf_backend.getRouter().pluginRoute('profile', '/data'),
+              {tag: toolName, host: hostName, run: datasetName}))
+          }, tracker)
+        .catch(error => {})
+        .then((data) => {
+          return tf.profile.util.runTask('Done', 80, () => {
+              parent._updateToolData(toolName, data);
+            }, tracker);
+        });
+      }
+    },
+
+   _updateToolData: function(toolName, data) {
+     switch(toolName) {
+       case "op_profile":
+          this._opProfileData = data;
+          this._toolInScope = "op_profile";
+          break;
+       case "input_pipeline_analyzer":
+          this._inputPipelineData = data;
+          this._toolInScope = "input_pipeline_analyzer";
+          break;
+       case "overview_page":
+          this._overviewPageData = data;
+          this._toolInScope = "overview_page";
+          break;
+      case "memory_viewer":
+          this._memoryViewerData = data;
+          this._toolInScope = "memory_viewer";
+          break;
+      case "google_chart_demo":
+          this._googleChartDemoData = data;
+          this._toolInScope = "google_chart_demo";
+          break;
       }
     },
     _maybeUpdateActiveHosts: function(datasetName, toolName) {
@@ -369,8 +462,9 @@ profile run can have multiple tools that present the performance profile as diff
       }
     },
     _activeToolsChanged: function(oldActiveTools, newActiveTools) {
-      // Same tool can have differernt index in different runs, therefore we force a change of
-      // 'selectedToolIndex', to make sure the label of the dropdown-menu is synced.
+      // Same tool can have differernt index in different runs, therefore we
+      // force a change of 'selectedToolIndex', to make sure the label of the
+      // dropdown-menu is synced.
       if (this._activeToolsList) {
          this.async(function() {
           this.set('selectedToolIndex', -1);


### PR DESCRIPTION
Add a progress bar to TPU profile plugin. It is needed when the input tool data is large, and takes a long time to fetch from GCS.
![progress_bar](https://user-images.githubusercontent.com/3082188/42664169-3259cf50-85ee-11e8-9b29-1d00ce65d1b2.png)
