### PR TITLE
Travis CI: Python syntax errors or undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ before_install:
   - echo "test --test_output=errors" >>~/.bazelrc
 
 install:
+  - pip install flake8
   - pip install futures==3.1.1
   - pip install grpcio==1.6.3
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,12 @@ install:
         ;;
     esac
 
+before_script:
+  # fail the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
 # Commands in this section should only fail if it's our fault. Travis will
 # categorize them as 'failed', rather than 'error' for other sections.
 script:

--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -27,6 +27,6 @@ mod = lambda i: LazyLoader(i[i.rindex('.') + 1:], globals(), i)
 program = mod(pkg('tensorboard.program'))
 summary = mod(pkg('tensorboard.summary'))
 
-del lazy
+del LazyLoader
 del mod
 del pkg

--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -19,10 +19,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorboard import lazy
+from tensorboard.lazy import LazyLoader
 
 pkg = lambda i: i  # helps google sync process
-mod = lambda i: lazy.LazyLoader(i[i.rindex('.') + 1:], globals(), i)
+mod = lambda i: LazyLoader(i[i.rindex('.') + 1:], globals(), i)
 
 program = mod(pkg('tensorboard.program'))
 summary = mod(pkg('tensorboard.summary'))


### PR DESCRIPTION
Use [flake8](http://flake8.pycqa.org) to look for Python syntax errors or undefined names on both Python 2 and Python 3.

flake8 testing of https://github.com/tensorflow/tensorboard on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tensorboard/__init__.py:25:17: F821 undefined name 'lazy'
mod = lambda i: lazy.LazyLoader(i[i.rindex('.') + 1:], globals(), i)
                ^
1     F821 undefined name 'lazy'
1
```

__E901,E999,F821,F822,F823__ are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc.  Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.  This PR therefore recommends a flake8 run of these tests on the entire codebase.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable `name` referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree