### PR TITLE
Fix custom_scalar displaying duplicated charts

### DIFF
--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
@@ -275,8 +275,11 @@ class CustomScalarsPlugin(base_plugin.TBPlugin):
         for category in layout_proto.category:
           if category.title in title_to_category:
             # A category with this name has been seen before. Do not create a
-            # new one. Merge their charts.
-            title_to_category[category.title].chart.extend(category.chart)
+            # new one. Merge their charts, skipping any duplicates.
+            title_to_category[category.title].chart.extend([
+                c for c in category.chart
+                if c not in title_to_category[category.title].chart
+            ])
           else:
             # This category has not been seen before.
             merged_layout.category.add().MergeFrom(category)

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -78,7 +78,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                 ]
             ),
             # A category with this name is also present in a layout for a
-            # different run (the logdir run)
+            # different run (the logdir run) and also contains a duplicate chart
             layout_pb2.Category(
                 title='cross entropy',
                 chart=[
@@ -91,6 +91,11 @@ class CustomScalarsPluginTest(tf.test.TestCase):
                                     lower='cross entropy lower',
                                     upper='cross entropy upper'),
                             ],
+                        )),
+                    layout_pb2.Chart(
+                        title='cross entropy',
+                        multiline=layout_pb2.MultilineChartContent(
+                            tag=[r'cross entropy'],
                         )),
                 ]
             ),


### PR DESCRIPTION
When using multiple runs with the same custom scalar layout, tensorboard will duplicate the charts for every run.

This PR fixes the problem by deduplicating the charts before adding them to the category.