### PR TITLE
CHERRYPICK: Add 1.9.0 relnotes to RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,34 @@
+# Release 1.9.0
+
+The 1.9 minor series tracks TensorFlow 1.9.
+
+## Highlights
+
+- Improved performance with log directories on GCS (Google Cloud Storage) with
+  faster traversal time and reduced bandwidth consumption (PRs #1087, #1226)
+- Profile dashboard improvements, including:
+  - New memory viewer tool that visualizes peak memory usage (#1223)
+  - Trace viewer tool now supports streaming mode, that dynamically renders a
+    much longer trace (#1128)
+  - Op profile tool now shows memory utilization in op details card (#1238)
+  - Profile dashboard now supports visualizing data from multiple hosts (#1117)
+
+## Features
+- Graph dashboard now allows searching nodes by regex (#1130)
+- New --samples_per_plugin flag to control how many samples are kept (#1138)
+- Better error when --logdir/--db flag is omitted (#1189) - thanks @oxinabox
+- Debugger plugin can now show single elements of string tensors (#1131)
+
+## Bug fixes
+- #1107 - Beholder plugin should no longer reserve GPU (PR #1114)
+- #1190 - Beholder plugin summary placeholder no longer interferes with normal
+          summary use and/or Estimator - thanks @TanUkkii007 (PR #1148)
+- #427 and #588 - removed pip package deps on bleach and html5lib (PR #1142)
+- #1191 - fixed debugger plugin UnboundLocalError - thanks @cfroehli
+- #1200 - fixed debugger plugin binary-valued string tensor issues
+- #1201 - fixed "dictionary changed size" race condition in reloader (PR #1235)
+
+
 # Release 1.8.0
 
 The 1.8 minor series tracks TensorFlow 1.8.


### PR DESCRIPTION
Cherrypicking our 1.9.0 release notes from the 1.9 branch onto master (I normally do this right after the release but I must have overlooked it).