### PR TITLE
Persisted experiment, run, and tag selection

### DIFF
--- a/tensorboard/components/tf_backend/experimentsStore.ts
+++ b/tensorboard/components/tf_backend/experimentsStore.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 namespace tf_backend {
 
-export type Experiment = {name: string};
+export type Experiment = {id: string, name: string, startTime: number};
 
 export class ExperimentsStore extends BaseStore {
   private _experiments: Experiment[] = [];

--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -21,6 +21,7 @@ export interface Router {
   pluginRoute: (pluginName: string, route: string) => string;
   pluginsListing: () => string;
   runs: () => string;
+  runsForExperiment: (id: string) => string;
 };
 
 /**
@@ -50,6 +51,7 @@ export function createRouter(dataDir = 'data', demoMode = false): Router {
     pluginRoute,
     pluginsListing: () => dataDir + '/plugins_listing',
     runs: () => dataDir + '/runs' + (demoMode ? '.json' : ''),
+    runsForExperiment: (id) => dataDir + `/experiment_runs?experiment=${id}`,
   };
 };
 

--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.html
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.html
@@ -32,10 +32,9 @@ Properties in:
   - colorsCheckbox: whether to color the check boxes.
   - coloring: an object that contains method, getColor. Used only when
               colorsCheckbox is true,
-  - items: items of choices.
-  - regexString: string for the regex filter.
-  - selectionState: object of checkbox selections.
+  - items: items of {id: string, title: string, subtitle: ?string}.
   - maxItemsToEnableByDefault: maximum number of items to automatically enable.
+  - selectionState: object of checkbox selections.
 
 Properties out:
   - selectedItems: Array of items that are selected and not filterd out.
@@ -68,9 +67,8 @@ Properties out:
           items="[[items]]"
           label="[[label]]"
           max-items-to-enable-by-default="[[maxItemsToEnableByDefault]]"
-          regex-string="{{regexString}}"
           selected-items="{{selectedItems}}"
-          selection-state="{{selectionState}}"
+          selection-state="[[selectionState]]"
           uses-checkbox-colors="[[useCheckboxColors]]"
         >
         </tf-filterable-checkbox-list>

--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.ts
@@ -37,17 +37,8 @@ Polymer({
 
     maxItemsToEnableByDefault: Number,
 
-    regexString: {
-      type: String,
-      notify: true,
-      value: '',
-    },
-
     selectionState: {
-      // if an item is explicitly enabled, True, if explicitly disabled, False.
-      // if undefined, default value (enable for first k items, disable after).
       type: Object,
-      notify: true,
       value: () => ({}),
     },
 
@@ -73,7 +64,8 @@ Polymer({
     } else if (!this.selectedItems.length) {
       return '';
     } else if (this.selectedItems.length <= 3) {
-      const uniqueNames = new Set(this.selectedItems);
+      const titles = this.selectedItems.map(({title}) => title);
+      const uniqueNames = new Set(titles);
       return Array.from(uniqueNames).join(', ');
     }
     return `${this.selectedItems.length} Selected`;

--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-list.html
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-list.html
@@ -29,10 +29,9 @@ Properties in:
   - colorsCheckbox: whether to color the check boxes.
   - coloring: an object that contains method, getColor. Used only when
               colorsCheckbox is true,
-  - items: items of choices.
-  - regexString: string for the regex filter.
-  - selectionState: object of checkbox selections.
+  - items: items of {id: string, title: string, subtitle: ?string}.
   - maxItemsToEnableByDefault: maximum number of items to automatically enable.
+  - selectionState: object denoting selection state of the checkboxes.
 
 Properties out:
   - selectedItems: Array of items that are selected and not filterd out.
@@ -49,7 +48,7 @@ Properties out:
         class="input"
         no-label-float
         label="Write a regex to filter [[label]]s"
-        value="[[regexString]]"
+        value="[[_regexString]]"
         on-bind-value-changed="_debouncedRegexChange"
       />
     </div>
@@ -60,14 +59,18 @@ Properties out:
         </div>
       </template>
       <template is="dom-repeat" items="[[_itemsMatchingRegex]]">
-        <div class="item">
+        <div class="item" id="[[item.id]]">
             <paper-checkbox
               class="checkbox"
               name="[[item]]"
               checked$="[[_isChecked(item, selectionState.*)]]"
               on-change="_checkboxChange"
             >
-              [[item]]
+              <span>[[item.title]]</span>
+
+              <template is="dom-if" if="[[item.subtitle]]">
+                <span>[[item.subtitle]]</span>
+              </template>
             </paper-checkbox>
         </div>
       </template>

--- a/tensorboard/components/tf_data_selector/BUILD
+++ b/tensorboard/components/tf_data_selector/BUILD
@@ -7,6 +7,9 @@ licenses(["notice"])  # Apache 2.0
 tf_web_library(
     name = "tf_data_selector",
     srcs = [
+        "experiment-selector.html",
+        "experiment-selector.ts",
+        "storage-utils.ts",
         "tf-data-select-row.html",
         "tf-data-select-row.ts",
         "tf-data-selector.html",

--- a/tensorboard/components/tf_data_selector/experiment-selector.html
+++ b/tensorboard/components/tf_data_selector/experiment-selector.html
@@ -1,0 +1,124 @@
+<!--
+@license
+Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
+<link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../tf-dashboard-common/scrollbar-style.html">
+<link rel="import" href="../tf-dashboard-common/tf-filterable-checkbox-list.html">
+<link rel="import" href="./tf-data-select-row.html">
+
+<!--
+experiment-selector creates a widget for creating a group of data, a filtered data
+by experiment, runs, and tags. It allows user to add more groups too.
+
+Properties in: none.
+Properties out: none.
+
+-->
+<dom-module id="experiment-selector">
+  <template>
+    <template is="dom-if" if="[[_expanded]]">
+      <div class="exp-selector">
+        <h4>Select data for comparison</h4>
+        <tf-filterable-checkbox-list
+          all-toggle-disabled
+          coloring="[[_experimentColoring]]"
+          items="[[_getExperimentOptions(_allExperiments.*, excludeExperiments.*)]]"
+          label="Experiment"
+          max-items-to-enable-by-default="1"
+          selected-items="{{_selectedExpOptions}}"
+        ></tf-filterable-checkbox-list>
+      </div>
+    </template>
+    <div class="buttons">
+      <template is="dom-if" if="[[!_expanded]]">
+        <paper-button class="add-comparison" on-tap="_toggle">
+          <iron-icon class="add-icon" icon="add-circle-outline"></iron-icon>
+          &nbsp;Add comparison
+        </paper-buutton>
+      </template>
+      <template is="dom-if" if="[[_expanded]]">
+        <span>
+          <paper-button on-tap="_toggle">
+            Cancel
+          </paper-buutton>
+        </span>
+        <span>
+          <paper-button
+            id="add-button"
+            on-tap="_addExperiments"
+            disabled$="[[!_selectedExpOptions.length]]"
+          >
+            [[_getAddLabel(_selectedExpOptions.*)]]
+          </paper-button>
+        </span>
+      </template>
+    </div>
+    <style>
+      :host {
+        align-items: stretch;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        flex-wrap: wrap;
+      }
+
+      h4 {
+        font-weight: 400;
+        margin: 20px 16px 5px;
+      }
+
+      .exp-selector {
+        background: #fff;
+        border-radius: 4px;
+        border: 1px solid var(--google-grey-500);
+        margin-bottom: 10px;
+        padding: 5px 0;
+      }
+
+      tf-filterable-checkbox-list {
+        --tf-filterable-checkbox-list-content-max-width: 600px;
+      }
+
+      #add-button {
+        background-color: var(--google-blue-500);
+        color: #fff;
+      }
+
+      #add-button[disabled] {
+        background-color: var(--google-grey-300);
+        color: var(--google-grey-700);
+      }
+
+      paper-button {
+        font-size: 12px;
+      }
+
+      .add-comparison {
+        border: 1px solid var(--google-grey-500);
+        color: var(--paper-grey-800);
+      }
+
+      .add-icon {
+        --iron-icon-height: 20px;
+        --iron-icon-width: 20px;
+      }
+    </style>
+  </template>
+  <script src="experiment-selector.js"></script>
+</dom-module>

--- a/tensorboard/components/tf_data_selector/storage-utils.ts
+++ b/tensorboard/components/tf_data_selector/storage-utils.ts
@@ -1,0 +1,25 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace tf_data_selector {
+
+export function decodeIdArray(str: string): Array<number> {
+  return str.split(',').map(idStr => parseInt(idStr, 36)).filter(Boolean);
+}
+
+export function encodeIdArray(arr: Array<number>): string {
+  return arr.map(id => id.toString(36)).join(',');
+}
+
+}  // namespace tf_data_selector

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.html
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.html
@@ -34,28 +34,42 @@ Properties out:
 -->
 <dom-module id="tf-data-select-row">
   <template>
-    <template is="dom-if" if="[[experiment]]">
-      <span>[[experiment]]</span>
+    <template is="dom-if" if="[[!noExperiment]]">
+      <span class="exp-name">[[experiment.name]]</span>
     </template>
 
     <tf-filterable-checkbox-dropdown
       label="Run"
-      colorsCheckbox="false"
-      items="[[_runs]]"
-      regex="{{_runRegexInput}}"
+      colorsCheckbox="[[_getIsRunCheckboxesColored(noExperiment)]]"
+      items="[[_getRunOptions(_runs.*)]]"
       selected-items="{{_selectedRuns}}"
-      selection-state="{{_runSelectionState}}"
+      selection-state="{{_getRunsSelectionState(_runSelectionStateString, _runs.*)}}"
+    ></tf-filterable-checkbox-dropdown>
+
+    <tf-filterable-checkbox-dropdown
+      label="Tag"
+      colorsCheckbox="false"
+      items="[[_getTagOptions(_tags.*)]]"
+      selected-items="{{_selectedTags}}"
+      selection-state="{{_getTagsSelectionState(_tagSelectionStateString, _tags.*)}}"
     ></tf-filterable-checkbox-dropdown>
 
     <style>
       :host {
+        align-items: center;
         box-sizing: border-box;
         display: flex;
         flex-direction: row;
+        font-size: 14px;
+      }
+
+      .exp-name {
+        color: var(--paper-grey-900);
+        padding: 4px 8px;
       }
 
       paper-dropdown-menu {
-        padding: 8px;
+        padding: 4px 8px;
 
         --paper-dropdown-menu-input: {
           --paper-input-container-input: {
@@ -70,5 +84,7 @@ Properties out:
       }
     </style>
   </template>
+  <script src="storage-utils.js"></script>
   <script src="tf-data-select-row.js"></script>
+
 </dom-module>

--- a/tensorboard/components/tf_data_selector/tf-data-selector.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.html
@@ -20,6 +20,7 @@ limitations under the License.
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/scrollbar-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-filterable-checkbox-list.html">
+<link rel="import" href="./experiment-selector.html">
 <link rel="import" href="./tf-data-select-row.html">
 
 <!--
@@ -32,47 +33,21 @@ Properties out: none.
 -->
 <dom-module id="tf-data-selector">
   <template>
-    <tf-data-select-row></tf-data-select-row>
+    <template is="dom-if" if="[[!_comparingExps.length]]">
+      <tf-data-select-row no-experiment></tf-data-select-row>
+    </template>
+    <template is="dom-repeat" items="[[_comparingExps]]" as="exp">
+      <tf-data-select-row
+        experiment="[[exp]]"
+        persistence-number="[[index]]"
+      ></tf-data-select-row>
+    </template>
 
-    <div id="exp-add">
-      <template is="dom-if" if="[[_showExperimentAdder]]">
-        <div class="exp-selector">
-          <h4>Select data for comparison</h4>
-          <tf-filterable-checkbox-list
-            all-toggle-disabled
-            coloring="[[_experimentColoring]]"
-            items="[[_experiments]]"
-            label="Experiment"
-            max-items-to-enable-by-default="1"
-            selected-items="{{_selectedExperiments}}"
-          ></tf-filterable-checkbox-list>
-        </div>
-      </template>
-      <div class="buttons">
-        <template is="dom-if" if="[[!_showExperimentAdder]]">
-          <paper-button class="add-comparison" on-tap="_toggleExperimentAdder">
-            <iron-icon class="add" icon="add-circle-outline"></iron-icon>
-            &nbsp;Add comparison
-          </paper-buutton>
-        </template>
-        <template is="dom-if" if="[[_showExperimentAdder]]">
-          <span>
-            <paper-button on-tap="_toggleExperimentAdder">
-              Cancel
-            </paper-buutton>
-          </span>
-          <span>
-            <paper-button
-              id="add-button"
-              on-tap="_addExperiments"
-              disabled$="[[!_selectedExperiments.length]]"
-            >
-              [[_getAddLabel(_selectedExperiments.*)]]
-            </paper-button>
-          </span>
-        </template>
-      </div>
-    </div>
+    <experiment-selector
+      id="selector"
+      exclude-experiments="[[_comparingExps]]"
+      on-experiment-added="_experimentAdded"
+    ></experiment-selector>
     <style>
       :host {
         align-items: flex-start;
@@ -82,50 +57,13 @@ Properties out: none.
         flex-wrap: wrap;
       }
 
-      #exp-add {
+      #exp-selector {
         display: inline-flex;
         flex-direction: column;
         min-width: 400px;
       }
-
-      .exp-selector {
-        background: #fff;
-        border-radius: 4px;
-        border: 1px solid var(--google-grey-500);
-        margin-bottom: 10px;
-      }
-
-      h4 {
-        font-weight: 400;
-        margin: 20px 16px 5px;
-      }
-
-      tf-filterable-checkbox-list {
-        --tf-filterable-checkbox-list-content-max-width: 600px;
-      }
-
-      #add-button[disabled] {
-        color: var(--google-grey-500);
-      }
-
-      #add-button {
-        color: var(--google-blue-700);
-      }
-
-      paper-button {
-        font-size: 12px;
-      }
-
-      .add-comparison {
-        border: 1px solid var(--google-grey-500);
-        color: var(--paper-grey-800);
-      }
-
-      .add {
-        --iron-icon-height: 20px;
-        --iron-icon-width: 20px;
-      }
     </style>
   </template>
+  <script src="storage-utils.js"></script>
   <script src="tf-data-selector.js"></script>
 </dom-module>


### PR DESCRIPTION
While working on it, it alos adds,
- Refactored filterable-checbox-list to allow title and subtitle
- Factored out experiemnt selection from tf-data-selector

What is missing in this commit:
- piping data selection to a plugin
- data-selector-row removal
