### PR TITLE
Remove inconsistent custom scalars center-div styling

### DIFF
--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
@@ -204,12 +204,6 @@ writer.add_summary(layout_summary)
 
     <style include="dashboard-style"></style>
     <style>
-      .center {
-        font-size: 14px;
-        height: 100%;
-        padding: 10px 20px;
-        box-sizing: border-box;
-      }
       #tooltip-sorting {
         align-items: center;
         display: flex;


### PR DESCRIPTION
As a follow-up to #1296, this removes a style rule for the `.center` div for the custom scalars dashboard that was inconsistent relative to the to other dashboards (in particular, the scalars dashboard).  The rule added extra padding within that div, causing the custom scalars category panes to be shifted rightward relative to their position in other dashboards.  With the rule removed, the alignment is now consistent.