### PR TITLE
Fix a profile plugin progress bar bug

### DIFF
--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -291,7 +291,7 @@ profile run can have multiple tools that present the performance profile as diff
     },
     /** True if the progress is not complete yet (< 100 %). */
     _isNotComplete: function(progress) {
-      return progress.value < 100;
+      return !this._dataNotFound && progress.value < 100;
     },
     _maybeInitializeDashboard: function(isAttached) {
       if (this._initialized || !isAttached) {


### PR DESCRIPTION
Address the bug that even when the profile plugin isn't active (and is showing the "no data" screen) the progress bar still appears, with the "Processing datasets" message.
