### PR TITLE
Put large elements under separate GPU context

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.html
+++ b/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.html
@@ -45,13 +45,15 @@ Generic layout for a dashboard.
         max-width: 350px;
         min-width: 270px;
         text-overflow: ellipsis;
+        will-change: transform;
       }
 
       #center {
-        height: 100%;
-        overflow-y: auto;
         flex-grow: 1;
         flex-shrink: 1;
+        height: 100%;
+        overflow-y: auto;
+        will-change: transform;
       }
 
       .tf-graph-dashboard #center {

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
@@ -70,6 +70,7 @@ limitations under the License.
       vz-histogram-timeseries {
         -moz-user-select: none;
         -webkit-user-select: none;
+        will-change: transform;
       }
 
       paper-icon-button {

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -176,6 +176,9 @@ limitations under the License.
         max-width: 540px;
         margin: 80px auto 0 auto;
       }
+      .center {
+        overflow-x: hidden;
+      }
     </style>
   </template>
 


### PR DESCRIPTION
The change should have zero visual change but general scroll performance improvement.

As depicted in picture below, we want larger DOM elements to be in separate GPU context and simply GPU rasterize when there is a repaint required in it. Without the orange boxes around each graph, a change in DOM structure will cause a reflow in entire page causing poor rendering performance in general.
![image](https://user-images.githubusercontent.com/2547313/43162275-60683648-8f3f-11e8-8ba5-b09b1ab86dcb.png)
