### PR TITLE
Refactored storage for get/set to be more powerful

### DIFF
--- a/tensorboard/components/tf_paginated_view/paginatedViewStore.ts
+++ b/tensorboard/components/tf_paginated_view/paginatedViewStore.ts
@@ -40,7 +40,8 @@ export function removeLimitListener(listener: Listener): void {
 
 export function getLimit() {
   if (_limit == null) {
-    _limit = tf_storage.getNumber(LIMIT_LOCAL_STORAGE_KEY, /*useLocalStorage=*/true);
+    _limit = tf_storage.getNumber(LIMIT_LOCAL_STORAGE_KEY,
+        {useLocalStorage: true});
     if (_limit == null || !isFinite(_limit) || _limit <= 0) {
       _limit = DEFAULT_LIMIT;
     }
@@ -59,7 +60,8 @@ export function setLimit(limit: number) {
     return;
   }
   _limit = limit;
-  tf_storage.setNumber(LIMIT_LOCAL_STORAGE_KEY, _limit, /*useLocalStorage=*/true);
+  tf_storage.setNumber(LIMIT_LOCAL_STORAGE_KEY, _limit,
+      {useLocalStorage: true});
   listeners.forEach(listener => {
     listener();
   });

--- a/tensorboard/components/tf_storage/test/storageTests.ts
+++ b/tensorboard/components/tf_storage/test/storageTests.ts
@@ -17,47 +17,47 @@ namespace tf_storage {
 /* tslint:disable:no-namespace */
 describe('URIStorage', () => {
   it('get/setString', () => {
-    setString('key_a', 'hello', false);
-    setString('key_b', 'there', false);
-    chai.assert.equal('hello', getString('key_a', false));
-    chai.assert.equal('there', getString('key_b', false));
-    chai.assert.equal(null, getString('key_c', false));
+    setString('key_a', 'hello', {useLocalStorage: false});
+    setString('key_b', 'there', {useLocalStorage: false});
+    chai.assert.equal('hello', getString('key_a', {useLocalStorage: false}));
+    chai.assert.equal('there', getString('key_b', {useLocalStorage: false}));
+    chai.assert.equal(null, getString('key_c', {useLocalStorage: false}));
   });
 
   it('get/setNumber', () => {
-    setNumber('key_a', 12, false);
-    setNumber('key_b', 3.4, false);
-    chai.assert.equal(12, getNumber('key_a', false));
-    chai.assert.equal(3.4, getNumber('key_b', false));
-    chai.assert.equal(null, getNumber('key_c', false));
+    setNumber('key_a', 12, {useLocalStorage: false});
+    setNumber('key_b', 3.4, {useLocalStorage: false});
+    chai.assert.equal(12, getNumber('key_a', {useLocalStorage: false}));
+    chai.assert.equal(3.4, getNumber('key_b', {useLocalStorage: false}));
+    chai.assert.equal(null, getNumber('key_c', {useLocalStorage: false}));
   });
 
   it('get/setObject', () => {
     const obj = {'foo': 2.3, 'bar': 'barstr'};
-    setObject('key_a', obj, false);
-    chai.assert.deepEqual(obj, getObject('key_a', false));
+    setObject('key_a', obj, {useLocalStorage: false});
+    chai.assert.deepEqual(obj, getObject('key_a', {useLocalStorage: false}));
   });
 
   it('get/setWeirdValues', () => {
-    setNumber('key_a', NaN, false);
-    chai.assert.deepEqual(NaN, getNumber('key_a', false));
+    setNumber('key_a', NaN, {useLocalStorage: false});
+    chai.assert.deepEqual(NaN, getNumber('key_a', {useLocalStorage: false}));
 
-    setNumber('key_a', +Infinity, false);
-    chai.assert.equal(+Infinity, getNumber('key_a', false));
+    setNumber('key_a', +Infinity, {useLocalStorage: false});
+    chai.assert.equal(+Infinity, getNumber('key_a', {useLocalStorage: false}));
 
-    setNumber('key_a', -Infinity, false);
-    chai.assert.equal(-Infinity, getNumber('key_a', false));
+    setNumber('key_a', -Infinity, {useLocalStorage: false});
+    chai.assert.equal(-Infinity, getNumber('key_a', {useLocalStorage: false}));
 
-    setNumber('key_a', 1 / 3, false);
-    chai.assert.equal(1 / 3, getNumber('key_a', false));
+    setNumber('key_a', 1 / 3, {useLocalStorage: false});
+    chai.assert.equal(1 / 3, getNumber('key_a', {useLocalStorage: false}));
 
-    setNumber('key_a', -0, false);
-    chai.assert.equal(-0, getNumber('key_a', false));
+    setNumber('key_a', -0, {useLocalStorage: false});
+    chai.assert.equal(-0, getNumber('key_a', {useLocalStorage: false}));
   });
 
   it('set/getTab', () => {
-    setString(TAB, 'scalars', false);
-    chai.assert.equal('scalars', getString(TAB, false));
+    setString(TAB, 'scalars', {useLocalStorage: false});
+    chai.assert.equal('scalars', getString(TAB, {useLocalStorage: false}));
   });
 });
 

--- a/tensorboard/components/tf_storage/test/storageTests.ts
+++ b/tensorboard/components/tf_storage/test/storageTests.ts
@@ -14,50 +14,145 @@ limitations under the License.
 ==============================================================================*/
 namespace tf_storage {
 
+const {assert} = chai;
+
+
+function setHash(hash) {
+  tf_globals.setFakeHash(hash);
+}
+
+function getHash(): string {
+  return tf_globals.getFakeHash();
+}
+
+
 /* tslint:disable:no-namespace */
 describe('URIStorage', () => {
+  const option = {useLocalStorage: false};
+
+  afterEach(() => {
+    setHash('');
+    window.localStorage.clear();
+  });
+
   it('get/setString', () => {
-    setString('key_a', 'hello', {useLocalStorage: false});
-    setString('key_b', 'there', {useLocalStorage: false});
-    chai.assert.equal('hello', getString('key_a', {useLocalStorage: false}));
-    chai.assert.equal('there', getString('key_b', {useLocalStorage: false}));
-    chai.assert.equal(null, getString('key_c', {useLocalStorage: false}));
+    setString('key_a', 'hello', option);
+    setString('key_b', 'there', option);
+    assert.equal('hello', getString('key_a', option));
+    assert.equal('there', getString('key_b', option));
+    assert.equal(null, getString('key_c', option));
   });
 
   it('get/setNumber', () => {
-    setNumber('key_a', 12, {useLocalStorage: false});
-    setNumber('key_b', 3.4, {useLocalStorage: false});
-    chai.assert.equal(12, getNumber('key_a', {useLocalStorage: false}));
-    chai.assert.equal(3.4, getNumber('key_b', {useLocalStorage: false}));
-    chai.assert.equal(null, getNumber('key_c', {useLocalStorage: false}));
+    setNumber('key_a', 12, option);
+    setNumber('key_b', 3.4, option);
+    assert.equal(12, getNumber('key_a', option));
+    assert.equal(3.4, getNumber('key_b', option));
+    assert.equal(null, getNumber('key_c', option));
   });
 
   it('get/setObject', () => {
     const obj = {'foo': 2.3, 'bar': 'barstr'};
-    setObject('key_a', obj, {useLocalStorage: false});
-    chai.assert.deepEqual(obj, getObject('key_a', {useLocalStorage: false}));
+    setObject('key_a', obj, option);
+    assert.deepEqual(obj, getObject('key_a', option));
   });
 
   it('get/setWeirdValues', () => {
-    setNumber('key_a', NaN, {useLocalStorage: false});
-    chai.assert.deepEqual(NaN, getNumber('key_a', {useLocalStorage: false}));
+    setNumber('key_a', NaN, option);
+    assert.deepEqual(NaN, getNumber('key_a', option));
 
-    setNumber('key_a', +Infinity, {useLocalStorage: false});
-    chai.assert.equal(+Infinity, getNumber('key_a', {useLocalStorage: false}));
+    setNumber('key_a', +Infinity, option);
+    assert.equal(+Infinity, getNumber('key_a', option));
 
-    setNumber('key_a', -Infinity, {useLocalStorage: false});
-    chai.assert.equal(-Infinity, getNumber('key_a', {useLocalStorage: false}));
+    setNumber('key_a', -Infinity, option);
+    assert.equal(-Infinity, getNumber('key_a', option));
 
-    setNumber('key_a', 1 / 3, {useLocalStorage: false});
-    chai.assert.equal(1 / 3, getNumber('key_a', {useLocalStorage: false}));
+    setNumber('key_a', 1 / 3, option);
+    assert.equal(1 / 3, getNumber('key_a', option));
 
-    setNumber('key_a', -0, {useLocalStorage: false});
-    chai.assert.equal(-0, getNumber('key_a', {useLocalStorage: false}));
+    setNumber('key_a', -0, option);
+    assert.equal(-0, getNumber('key_a', option));
   });
 
   it('set/getTab', () => {
-    setString(TAB, 'scalars', {useLocalStorage: false});
-    chai.assert.equal('scalars', getString(TAB, {useLocalStorage: false}));
+    setString(TAB, 'scalars', option);
+    assert.equal('scalars', getString(TAB, option));
+  });
+
+  describe('getInitializer', () => {
+
+    [
+      {useLocalStorage: true, name: 'local storage', eventName: 'storage'},
+      {useLocalStorage: false, name: 'hash storage', eventName: 'hashchange'}
+    ].forEach(({useLocalStorage, name, eventName}) => {
+      describe(name, () => {
+        const options = {
+          useLocalStorage,
+          defaultValue: 'baz',
+          polymerProperty: 'prop',
+        };
+
+        function setValue(key: string, value: string): void {
+          if (useLocalStorage) window.localStorage.setItem(key, value);
+          else setHash(`${key}=${value}`);
+        }
+
+        it('sets the polymerProperty with the value', () => {
+          setValue('foo', 'bar');
+          const initializer = getStringInitializer('foo', options);
+          const fakeScope = {prop: null};
+          initializer.call(fakeScope);
+          assert.equal(fakeScope.prop, 'bar');
+        });
+
+        it('sets the prop with defaultValue when value is missing', () => {
+          const initializer = getStringInitializer('foo', options);
+          const fakeScope = {prop: null};
+          initializer.call(fakeScope);
+          assert.equal(fakeScope.prop, 'baz');
+        });
+
+        it(`reacts to '${eventName}' and sets the new value`, () => {
+          setValue('foo', '');
+
+          const initializer = getStringInitializer('foo', options);
+          const fakeScope = {prop: null};
+          initializer.call(fakeScope);
+
+          // Simulate the hashchange.
+          setValue('foo', 'changed');
+          window.dispatchEvent(new Event(eventName));
+
+          assert.equal(fakeScope.prop, 'changed');
+        });
+      });
+    });
+  });
+
+  describe('advanced setter', () => {
+    const keyName = 'key';
+
+    beforeEach(() => {
+      assert.isFalse(getHash().includes(keyName));
+    });
+
+    it('sets url hash', () => {
+      setNumber(keyName, 1, option);
+      assert.isTrue(getHash().includes(keyName));
+    });
+
+    it('unsets url hash when value equals defaultValue', () => {
+      setNumber(keyName, 1, Object.assign({}, option, {defaultValue: 0}));
+      assert.isTrue(getHash().includes(keyName));
+
+      // If previous value on hash (which is 1 from above) matches the new value
+      // it does not unset the url value.
+      setNumber(keyName, 1, Object.assign({}, option, {defaultValue: 2}));
+      assert.isTrue(getHash().includes(keyName));
+
+      setNumber(keyName, 2, Object.assign({}, option, {defaultValue: 2}));
+      assert.isFalse(getHash().includes(keyName));
+    });
   });
 });
 

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -481,7 +481,7 @@ limitations under the License.
          */
         _selectedDashboard: {
           type: String,
-          value: tf_storage.getString(tf_storage.TAB, /*useLocalStorage=*/false) || null,
+          value: tf_storage.getString(tf_storage.TAB) || null,
           observer: '_selectedDashboardChanged'
         },
         _dashboardToMaybeRemove: String,
@@ -612,7 +612,7 @@ limitations under the License.
        */
       _selectedDashboardChanged(selectedDashboard) {
         const pluginString = selectedDashboard || '';
-        tf_storage.setString(tf_storage.TAB, pluginString, /*useLocalStorage=*/false);
+        tf_storage.setString(tf_storage.TAB, pluginString);
         // Record this dashboard selection as a page view.
         ga('set', 'page', '/' + pluginString);
         ga('send', 'pageview');
@@ -629,8 +629,8 @@ limitations under the License.
             // Use location.replace for this call to avoid breaking back-button navigation.
             // Note that this will precede the update to tf_storage triggered by updating
             // _selectedDashboard and make it a no-op.
-            tf_storage.setString(tf_storage.TAB, selectedDashboard, /*useLocalStorage=*/false,
-                                 /*useLocationReplace=*/true);
+            tf_storage.setString(tf_storage.TAB, selectedDashboard,
+                {useLocationReplace: true});
             // Note: the following line will re-trigger this handler, but it
             // will be a no-op since selectedDashboard is no longer null.
             this._selectedDashboard = selectedDashboard;
@@ -639,7 +639,7 @@ limitations under the License.
       },
 
       _updateSelectedDashboardFromHash() {
-        const dashboardName = tf_storage.getString(tf_storage.TAB, /*useLocalStorage=*/false);
+        const dashboardName = tf_storage.getString(tf_storage.TAB);
         this.set('_selectedDashboard', dashboardName || null);
       },
 


### PR DESCRIPTION
- Polymerized API handles empty value and default values well. We now
  expanded the API to allow for that.
- Refactored the API to have named option argument

Specifically, the setter now removes the key from the hash when a value matches the defaultValue.