### PR TITLE
Adds checkbox and remove button on data-select-row

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.html
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.html
@@ -83,6 +83,8 @@ Properties out:
       --paper-input-container-focus-color: var(--tb-orange-strong);
       --paper-input-container: {
         padding: 4px;
+
+        @apply --tf-filterable-checkbox-dropdown-input-container;
       };
       --paper-input-container-input: {
         font-size: 14px;

--- a/tensorboard/components/tf_data_selector/BUILD
+++ b/tensorboard/components/tf_data_selector/BUILD
@@ -21,6 +21,8 @@ tf_web_library(
         ":type",
         "@org_polymer_iron_icon",
         "@org_polymer_paper_button",
+        "@org_polymer_paper_checkbox",
+        "@org_polymer_paper_icon_button",
         "@org_polymer_paper_input",
         "@org_polymer_paper_styles",
         "//tensorboard/components/tf_backend",

--- a/tensorboard/components/tf_data_selector/experiment-selector.html
+++ b/tensorboard/components/tf_data_selector/experiment-selector.html
@@ -88,6 +88,7 @@ Properties out: none.
         border-radius: 4px;
         border: 1px solid var(--google-grey-500);
         margin-bottom: 10px;
+        min-width: 300px;
         padding: 5px 0;
       }
 

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.html
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.html
@@ -16,6 +16,8 @@ limitations under the License.
 -->
 
 <link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../paper-input/paper-input.html">
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
@@ -35,11 +37,18 @@ Properties out:
 
 Event out:
   - selection-changed: Fired when selection or regex filter change.
+  - remove: Fired when user wants to remove the selection row.
 -->
 <dom-module id="tf-data-select-row">
   <template>
     <template is="dom-if" if="[[!noExperiment]]">
-      <span class="exp-name">[[experiment.name]]</span>
+      <paper-checkbox
+        id="checkbox"
+        checked="{{enabled}}"
+        title="[[experiment.name]]"
+      >
+        [[experiment.name]]
+      </paper-checkbox>
     </template>
 
     <tf-filterable-checkbox-dropdown
@@ -58,6 +67,14 @@ Event out:
       <iron-icon prefix icon="search" slot="prefix"></iron-icon>
     </paper-input>
 
+    <template is="dom-if" if="[[!noExperiment]]">
+      <paper-icon-button
+        icon="remove-circle"
+        on-tap="_removeRow"
+        title="Remove the comparison"
+      ></paper-button>
+    </template>
+
     <style>
       :host {
         align-items: center;
@@ -67,6 +84,11 @@ Event out:
         font-size: 14px;
       }
 
+      #checkbox {
+        flex: 1 0;
+        max-width: 200px;
+      }
+
       paper-input {
         --paper-input-prefix: {
           width: 22px;
@@ -74,7 +96,7 @@ Event out:
         };
         --paper-input-container-focus-color: var(--tb-orange-strong);
         --paper-input-container: {
-          padding: 4px 0;
+          padding: 5px 0;
         };
         --paper-input-container-input: {
           font-size: 14px;
@@ -83,6 +105,7 @@ Event out:
           font-size: 14px;
         };
         width: 200px;
+        margin: 0 5px;
       }
 
       paper-input iron-icon {
@@ -92,13 +115,25 @@ Event out:
         color: inherit;
       }
 
-      .exp-name {
-        color: var(--paper-grey-900);
-        padding: 4px 8px;
+      tf-filterable-checkbox-dropdown {
+        --tf-filterable-checkbox-dropdown-input-container: {
+          padding: 5px;
+        };
+
+        padding: 0 5px;
+        margin: 0 5px;
       }
 
-      tf-filterable-checkbox-dropdown {
-        padding: 4px 8px;
+      paper-icon-button {
+        --paper-icon-button: {
+          height: 32px;
+          padding: 5px;
+          width: 32px;
+        };
+
+        color: var(--paper-grey-600);
+        flex-shrink: 0;
+        margin: 0 5px;
       }
     </style>
   </template>

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.ts
@@ -31,6 +31,17 @@ Polymer({
       }),
     },
 
+    enabled: {
+      type: Boolean,
+      notify: true,
+      value: true,
+    },
+
+    checkboxColor: {
+      type: String,
+      value: '',
+    },
+
     // Required field.
     persistenceNumber: Number,
 
@@ -56,6 +67,10 @@ Polymer({
       value: '',
       observer: '_persistRegex',
     },
+  },
+
+  listeners: {
+    'dom-change': '_synchronizeColors',
   },
 
   observers: [
@@ -90,6 +105,19 @@ Polymer({
 
   attached(): void {
     this._fetchRunsAndTags().then(() => this._isDataReady = true);
+  },
+
+  _synchronizeColors() {
+    const cb = this.$$('#checkbox');
+    if (!cb) return;
+
+    const color = this.checkboxColor;
+    cb.customStyle['--paper-checkbox-checked-color'] = color;
+    cb.customStyle['--paper-checkbox-checked-ink-color'] = color;
+    cb.customStyle['--paper-checkbox-unchecked-color'] = color;
+    cb.customStyle['--paper-checkbox-unchecked-ink-color'] = color;
+
+    window.requestAnimationFrame(() => this.updateStyles());
   },
 
   detached(): void {
@@ -155,6 +183,10 @@ Polymer({
       runs: this._selectedRuns.map(({id}) => runMap.get(id)),
       tagRegex: this._tagRegex,
     });
+  },
+
+  _removeRow(): void {
+    this.fire('remove');
   },
 });
 

--- a/tensorboard/components/tf_data_selector/tf-data-selector.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.html
@@ -45,16 +45,18 @@ Properties out:
     </template>
     <template is="dom-repeat" items="[[_comparingExps]]" as="exp">
       <tf-data-select-row
+        checkbox-color="[[_getExperimentColor(exp)]]"
         experiment="[[exp]]"
         persistence-number="[[index]]"
         on-selection-changed="_selectionChanged"
+        on-remove="_removeExperiment"
       ></tf-data-select-row>
     </template>
 
     <experiment-selector
       id="selector"
       exclude-experiments="[[_comparingExps]]"
-      on-experiment-added="_experimentAdded"
+      on-experiment-added="_addExperiments"
     ></experiment-selector>
     <style>
       :host {
@@ -63,12 +65,27 @@ Properties out:
         display: flex;
         flex-direction: column;
         flex-wrap: wrap;
+        width 100%;
       }
 
       #exp-selector {
         display: inline-flex;
         flex-direction: column;
         min-width: 400px;
+      }
+
+      tf-data-select-row {
+        margin: 5px 0;
+        max-width: 720px;
+        width: 100%;
+      }
+
+      tf-data-select-row[no-experiment] {
+        margin-left: -8px;
+      }
+
+      experiment-selector {
+        margin: 10px 0;
       }
     </style>
   </template>

--- a/tensorboard/components/tf_data_selector/tf-data-selector.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.ts
@@ -75,14 +75,6 @@ Polymer({
   _expStringObserver: tf_storage.getStringObserver('e',
       {defaultValue: '', polymerProperty: '_comparingExpsString'}),
 
-  _experimentAdded(event) {
-    const newExperiments = event.detail;
-    const newComparingExpIds = this._comparingExps
-        .concat(newExperiments).map(({id}) => id);
-    this._comparingExpsString = tf_data_selector.encodeIdArray(
-        newComparingExpIds);
-  },
-
   _canCompareExperiments(): boolean {
     return Boolean(this._comparingExps.length);
   },
@@ -91,7 +83,7 @@ Polymer({
    * Prunes away an experiment that has been removed from `_comparingExps` from
    * the _selectionMap.
    */
-  _pruneSelection() {
+  _pruneSelection(): void {
     if (!this._canCompareExperiments()) {
       this._selectionMap.clear();
       return;
@@ -121,6 +113,27 @@ Polymer({
       tagRegex,
     });
     this._setSelection(Array.from(this._selectionMap.values()));
+  },
+
+  _addExperiments(event) {
+    const newExperiments = event.detail;
+    const newComparingExpIds = this._comparingExps
+        .concat(newExperiments).map(({id}) => id);
+    this._comparingExpsString = tf_data_selector.encodeIdArray(
+        newComparingExpIds);
+  },
+
+  _removeExperiment(event) {
+    const expId = event.target.experiment.id;
+    const newComparingExpIds = this._comparingExps
+        .filter(({id}) => id != expId)
+        .map(({id}) => id);
+    this._comparingExpsString = tf_data_selector.encodeIdArray(
+        newComparingExpIds);
+  },
+
+  _getExperimentColor(experiment: tf_backend.Experiment): string {
+    return tf_color_scale.experimentsColorScale(experiment.name);
   },
 });
 


### PR DESCRIPTION
This feature allows user to easily toggle a data selection group
or remove the group entirely from the comparison.

![image](https://user-images.githubusercontent.com/2547313/43296374-ceffa624-90ff-11e8-9e11-88ad0358772c.png)
