### PR TITLE
Added categorization for data_selector.Selection

### DIFF
--- a/tensorboard/components/tf_backend/type.ts
+++ b/tensorboard/components/tf_backend/type.ts
@@ -16,9 +16,18 @@ namespace tf_backend {
 
 export type Experiment = {id: number, name: string, startTime: number};
 
-// `id` is null when data source is logdir.
-export type Run = {id: number | null, name: string, startTime: number};
+export type Run = {
+  id: number | null,
+  name: string,
+  startTime: number,
+  tags: Tag[],
+};
 
-export type Tag = {id: number, name: string, displayName: string};
+export type Tag = {
+  id: number,
+  name: string,
+  displayName: string,
+  pluginName: string,
+};
 
 }  // namespace tf_backend

--- a/tensorboard/components/tf_categorization_utils/BUILD
+++ b/tensorboard/components/tf_categorization_utils/BUILD
@@ -18,6 +18,7 @@ tf_web_library(
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_data_selector:type",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_storage",

--- a/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
+++ b/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
@@ -129,7 +129,7 @@ export function categorizeTags(
     metadata,
     items: items.map(tag => ({
       tag,
-      runs: tagToRuns[tag].slice(),
+      runs: tagToRuns.get(tag).slice(),
     })),
   }));
 }

--- a/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
+++ b/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
@@ -46,7 +46,7 @@ export type TagCategory = Category<{tag: string, runs: string[]}>;
 export type RunTagCategory = Category<{tag: string, run: string}>;
 
 /**
- * Organize data by tagPrefix, tag, then llist of series which is comprised of
+ * Organize data by tagPrefix, tag, then list of series which is comprised of
  * an experiment and a run.
  */
 export type SeriesCategory = Category<{
@@ -172,6 +172,7 @@ export function categorizeSelection(
       universalRegex: false,
     },
     items: Array.from(searchTags)
+        .sort(vz_sorting.compareTagNames)
         .map(tag => ({
           tag,
           series: tagToSeries.get(tag),

--- a/tensorboard/components/tf_categorization_utils/test/categorizationUtilsTests.ts
+++ b/tensorboard/components/tf_categorization_utils/test/categorizationUtilsTests.ts
@@ -199,9 +199,34 @@ describe('categorizationUtils', () => {
     const {categorizeSelection} = tf_categorization_utils;
 
     beforeEach(function() {
-      this.run1 = {id: 1, name: 'run1', startTime: 10};
-      this.run2 = {id: 2, name: 'run2', startTime: 5};
-      this.run3 = {id: 3, name: 'run3', startTime: 0};
+      const tag1 = {
+        id: 1, pluginName: 'scalar',
+        name: 'tag1', displayName: 'tag1',
+
+      };
+      const tag2_1 = {
+        id: 2, pluginName: 'scalar',
+        name: 'tag2/subtag1', displayName: 'tag2/subtag1',
+
+      };
+      const tag2_2 = {
+        id: 3, pluginName: 'scalar',
+        name: 'tag2/subtag2', displayName: 'tag2/subtag2',
+
+      };
+      const tag3 = {
+        id: 4, pluginName: 'scalar',
+        name: 'tag3', displayName: 'tag3',
+      };
+      const tag4 = {
+        id: 5, pluginName: 'custom_scalar',
+        name: 'tag4', displayName: 'tag4',
+      };
+
+      this.run1 = {id: 1, name: 'run1', startTime: 10, tags: [tag1, tag4]};
+      this.run2 = {id: 2, name: 'run2', startTime: 5, tags: [tag2_1, tag2_2]};
+      this.run3 = {id: 3, name: 'run3', startTime: 0, tags: [tag2_1, tag3]};
+
       this.experiment1 = {
         experiment: {id: 1, name: 'exp1', startTime: 0},
         runs: [this.run1, this.run2],
@@ -212,16 +237,16 @@ describe('categorizationUtils', () => {
         runs: [this.run2, this.run3],
         tagRegex: '(subtag1|tag3)',
       };
-
-      this.runToTag = {
-        [this.run1.name]: ['tag1'],
-        [this.run2.name]: ['tag2/subtag1', 'tag2/subtag2'],
-        [this.run3.name]: ['tag2/subtag1', 'tag3'],
+      this.experiment3 = {
+        experiment: {id: 3, name: 'exp3', startTime: 0},
+        runs: [this.run1, this.run2, this.run3],
+        tagRegex: 'junk',
       };
     });
 
     it('merges the results of the query and the prefix groups', function() {
-      const result = categorizeSelection([this.experiment1], this.runToTag);
+      const result = categorizeSelection(
+          [this.experiment1], 'scalar');
 
       expect(result).to.have.lengthOf(3);
       expect(result[0]).to.have.property('metadata')
@@ -236,8 +261,7 @@ describe('categorizationUtils', () => {
     describe('search group', () => {
       it('filters groups by tag with a tagRegex', function() {
         const [searchResult] = categorizeSelection(
-          [this.experiment2],
-          this.runToTag);
+            [this.experiment2], 'scalar');
 
         // should match 'tag2/subtag1' and 'tag3'.
         expect(searchResult).to.have.property('items')
@@ -248,8 +272,7 @@ describe('categorizationUtils', () => {
 
       it('combines selection without tagRegex with one', function() {
         const [searchResult] = categorizeSelection(
-          [this.experiment1, this.experiment2],
-          this.runToTag);
+            [this.experiment1, this.experiment2], 'scalar');
 
         // should match 'tag1', 'tag2/subtag1', 'tag2/subtag2', and 'tag3'.
         expect(searchResult).to.have.property('items')
@@ -259,7 +282,7 @@ describe('categorizationUtils', () => {
         expect(searchResult.items[2]).to.have.property('tag', 'tag2/subtag2');
         expect(searchResult.items[3]).to.have.property('tag', 'tag3');
 
-        expect(searchResult.items[1]).to.have.property('items')
+        expect(searchResult.items[1]).to.have.property('series')
             .that.has.lengthOf(3)
             .and.that.deep.equal([
               {experiment: 'exp1', run: 'run2'},
@@ -270,32 +293,41 @@ describe('categorizationUtils', () => {
 
       it('returns name `multi` when there are multiple selections', function() {
         const [searchResult2] = categorizeSelection(
-          [this.experiment2],
-          this.runToTag);
+            [this.experiment2], 'scalar');
         expect(searchResult2).to.have.property('name', '(subtag1|tag3)');
 
         const [searchResult1] = categorizeSelection(
-          [this.experiment1, this.experiment2],
-          this.runToTag);
+            [this.experiment1, this.experiment2], 'scalar');
         expect(searchResult1).to.have.property('name', 'multi');
+      });
+
+      it('returns an empty array when tagRegex does not match any', function() {
+        const result = categorizeSelection(
+            [this.experiment3], 'custom_scalar');
+
+        expect(result).to.have.lengthOf(2);
+        expect(result[0]).to.have.property('items')
+            .that.has.lengthOf(0);
       });
     });
 
     describe('prefix group', () => {
       it('creates a group when a tag misses separator', function() {
-        const result = categorizeSelection([this.experiment1], this.runToTag);
+        const result = categorizeSelection(
+            [this.experiment1], 'scalar');
 
         expect(result[1]).to.have.property('items')
             .that.has.lengthOf(1);
 
         expect(result[1]).to.have.property('name', 'tag1');
         expect(result[1].items[0]).to.have.property('tag', 'tag1');
-        expect(result[1].items[0]).to.have.property('items')
+        expect(result[1].items[0]).to.have.property('series')
             .that.has.lengthOf(1);
       });
 
       it('creates a grouping when tag has a separator', function() {
-        const result = categorizeSelection([this.experiment1], this.runToTag);
+        const result = categorizeSelection(
+            [this.experiment1], 'scalar');
 
         expect(result[2]).to.have.property('items')
             .that.has.lengthOf(2);
@@ -303,26 +335,43 @@ describe('categorizationUtils', () => {
         expect(result[2]).to.have.property('name', 'tag2');
         expect(result[2].items[0]).to.have.property('tag', 'tag2/subtag1');
         expect(result[2].items[1]).to.have.property('tag', 'tag2/subtag2');
-        expect(result[2].items[0]).to.have.property('items')
+        expect(result[2].items[0]).to.have.property('series')
             .that.has.lengthOf(1);
       });
 
       it('creates a group with items with experiment and run', function() {
-        const result = categorizeSelection([this.experiment1], this.runToTag);
+        const result = categorizeSelection(
+            [this.experiment1], 'scalar');
 
-        expect(result[1].items[0]).to.have.property('items')
+        expect(result[1].items[0]).to.have.property('series')
             .that.has.lengthOf(1)
             .and.that.deep.equal([{experiment: 'exp1', run: 'run1'}]);
       });
 
       it('creates distinct subitems when tags exactly match', function() {
-        const result = categorizeSelection([this.experiment2], this.runToTag);
+        const result = categorizeSelection(
+            [this.experiment2], 'scalar');
 
-        expect(result[1].items[0]).to.have.property('items')
+        expect(result[1].items[0]).to.have.property('series')
             .that.has.lengthOf(2)
             .and.that.deep.equal([
               {experiment: 'exp2', run: 'run2'},
               {experiment: 'exp2', run: 'run3'},
+            ]);
+      });
+
+      it('filters out tags of a different pluguin', function() {
+        const result = categorizeSelection(
+            [this.experiment3], 'custom_scalar');
+
+        expect(result).to.have.lengthOf(2);
+        expect(result[1]).to.have.property('name', 'tag4');
+        expect(result[1]).to.have.property('items')
+            .that.has.lengthOf(1);
+        expect(result[1].items[0]).to.have.property('series')
+            .that.has.lengthOf(1)
+            .and.that.deep.equal([
+              {experiment: 'exp3', run: 'run1'},
             ]);
       });
     });

--- a/tensorboard/components/tf_categorization_utils/test/categorizationUtilsTests.ts
+++ b/tensorboard/components/tf_categorization_utils/test/categorizationUtilsTests.ts
@@ -291,6 +291,19 @@ describe('categorizationUtils', () => {
             ]);
       });
 
+      it('sorts the tag by name', function() {
+        const [searchResult] = categorizeSelection(
+            [this.experiment2, this.experiment1], 'scalar');
+
+        // should match 'tag1', 'tag2/subtag1', 'tag2/subtag2', and 'tag3'.
+        expect(searchResult).to.have.property('items')
+            .that.has.lengthOf(4);
+        expect(searchResult.items[0]).to.have.property('tag', 'tag1');
+        expect(searchResult.items[1]).to.have.property('tag', 'tag2/subtag1');
+        expect(searchResult.items[2]).to.have.property('tag', 'tag2/subtag2');
+        expect(searchResult.items[3]).to.have.property('tag', 'tag3');
+      });
+
       it('returns name `multi` when there are multiple selections', function() {
         const [searchResult2] = categorizeSelection(
             [this.experiment2], 'scalar');

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.ts
@@ -138,8 +138,7 @@ Polymer({
     } else if (this.experiment.id) {
       const url = tf_backend.getRouter().runsForExperiment(this.experiment.id);
       return requestManager.request(url).then(runs => {
-        this.set('_runs',
-            runs.map(({id, name, startTime}) => ({id, name, startTime})));
+        this.set('_runs', runs);
       });
     }
   },
@@ -191,6 +190,7 @@ Polymer({
             id: this.noExperiment ? null : run.id,
             name: run.name,
             startTime: run.startTime,
+            tags: run.tags,
           })),
       tagRegex: this._tagRegex,
     });

--- a/tensorboard/components/tf_data_selector/tf-data-selector.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.ts
@@ -33,12 +33,16 @@ Polymer({
       computed: '_getComparingExps(_comparingExpsString, _allExperiments.*)',
     },
 
+    // TODO(stephanwlee): Add list of active plugin from parent and filter out
+    // the unused tag names in the list of selection.
+
     selection: {
       type: Array,
       notify: true,
       readOnly: true,
       value: (): Array<tf_data_selector.Selection> => ([]),
     },
+
 
     _selectionMap: {
       type: Object,

--- a/tensorboard/http_api.md
+++ b/tensorboard/http_api.md
@@ -101,7 +101,8 @@ Example response:
       "tags": [{
         "id": 789,
         "displayName": "",
-        "name": "loss"
+        "name": "loss",
+        "pluginName": "scalar"
       }]
     }]
 

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -217,10 +217,12 @@ class CorePlugin(base_plugin.TBPlugin):
           Tags.tag_id,
           Tags.tag_name,
           Tags.display_name,
+          Tags.plugin_name,
           Tags.inserted_time
         From Runs
         LEFT JOIN Tags ON Runs.run_id = Tags.run_id
-        WHERE Runs.experiment_id = %s
+        WHERE Runs.experiment_id = ?
+        AND (Tags.tag_id IS NULL OR Tags.plugin_name IS NOT NULL)
         ORDER BY started_time_nulls_last,
           Runs.started_time,
           Runs.run_name,
@@ -228,7 +230,7 @@ class CorePlugin(base_plugin.TBPlugin):
           Tags.tag_name,
           Tags.display_name,
           Tags.inserted_time;
-      ''' % (exp_id,))
+      ''', (exp_id,))
       for row in cursor:
         run_id = row[0]
         if not run_id in runs_dict:
@@ -244,6 +246,7 @@ class CorePlugin(base_plugin.TBPlugin):
             "id": row[4],
             "displayName": row[6],
             "name": row[5],
+            "pluginName": row[7],
           })
       results = list(runs_dict.values())
     return http_util.Respond(request, results, 'application/json')

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -138,6 +138,8 @@ class CorePluginTest(tf.test.TestCase):
     self.assertEqual(len(exp2_runs), 1);
     self.assertEqual(exp2_runs[0].get('name'), 'run3');
 
+    # TODO(stephanwlee): Write test on runs that do not have any tag.
+
     exp_json = self._get_json(self.logdir_based_server, '/data/experiments')
     self.assertEqual(exp_json, [])
 


### PR DESCRIPTION
The utility divides the data, based on selection, into
tag prefix and tags. After those division, it does not make
assumption about how the data is used and returns list of
experiment/run pair that matches the criteria.