### PR TITLE
Fixed the noExperiment data selection

### DIFF
--- a/tensorboard/components/tf_backend/type.ts
+++ b/tensorboard/components/tf_backend/type.ts
@@ -16,7 +16,8 @@ namespace tf_backend {
 
 export type Experiment = {id: number, name: string, startTime: number};
 
-export type Run = {id: number, name: string, startTime: number};
+// `id` is null when data source is logdir.
+export type Run = {id: number | null, name: string, startTime: number};
 
 export type Tag = {id: number, name: string, displayName: string};
 

--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.html
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.html
@@ -56,7 +56,7 @@ Properties out:
           placeholder="[[placeholder]]"
           readonly
           type="text"
-          value="[[_labelValue]]"
+          value="[[_getValueLabel(selectedItems.*)]]"
         >
           <iron-icon icon="arrow-drop-down" suffix slot="suffix"></iron-icon>
         </paper-input>

--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.ts
@@ -47,18 +47,11 @@ Polymer({
       notify: true,
       value: () => [],
     },
-
-    // ====== Computed properties ======
-
-    _labelValue: {
-      type: String,
-      computed: '_computeValueLabel(selectedItems)',
-    },
   },
 
   // ====================== COMPUTED ======================
 
-  _computeValueLabel(_) {
+  _getValueLabel(_) {
     if (this.selectedItems.length == this.items.length) {
       return `All ${this.label}s`;
     } else if (!this.selectedItems.length) {

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.html
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.html
@@ -53,7 +53,7 @@ Event out:
 
     <tf-filterable-checkbox-dropdown
       label="Run"
-      colorsCheckbox="[[_getIsRunCheckboxesColored(noExperiment)]]"
+      use-checkbox-colors="[[_getIsRunCheckboxesColored(noExperiment)]]"
       items="[[_getRunOptions(_runs.*)]]"
       selected-items="{{_selectedRuns}}"
       selection-state="{{_getRunsSelectionState(_runSelectionStateString, _runs.*)}}"


### PR DESCRIPTION
When a run comes from the logdir data source, it does not have an id.
Fixed the type and data selection when the id is missing.