### PR TITLE
Refactor: Pass arbitrary data to line-chart-data-loader

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/BUILD
+++ b/tensorboard/components/tf_line_chart_data_loader/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2.0
 tf_web_library(
     name = "tf_line_chart_data_loader",
     srcs = [
+        "data-loader-behavior.ts",
         "tf-line-chart-data-loader.html",
     ],
     path = "/tf-line-chart-data-loader",

--- a/tensorboard/components/tf_line_chart_data_loader/data-loader-behavior.ts
+++ b/tensorboard/components/tf_line_chart_data_loader/data-loader-behavior.ts
@@ -1,0 +1,150 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace tf_line_chart_data_loader {
+
+/**
+ * @polymerBehavior
+ */
+export const DataLoaderBehavior = {
+  properties: {
+    /**
+     * An unique identifiable string. When changes, it expunges the data
+     * cache.
+     */
+    loadKey: String,
+
+    // List of data to be loaded. A datum is passed to `getDataLoadUrl` to ge
+    // URL of an API endpoint and, when request resolves, invokes
+    // `loadDataCallback` with the datum and its response.
+    dataToLoad: {
+      type: Array,
+      value: () => []
+    },
+
+    /**
+     * A function that takes a datum as an input and returns a unique
+     * identifiable string. Used for caching purposes.
+     */
+    getDataLoadId: {
+      type: Function,
+      value: () => (datum) => String(datum),
+    },
+
+    /**
+     * A function that takes as inputs:
+     * 1. Implementing component of data-loader-behavior.
+     * 2. datum of the request.
+     * 3. The response received from the data URL.
+     * This function will be called when a response from a request to that
+     * data URL is successfully received.
+     */
+    loadDataCallback: Function,
+
+    // A function that takes a datum and returns a string URL for fetching
+    // data.
+    getDataLoadUrl: Function,
+
+    dataLoading: {
+      type: Boolean,
+      readOnly: true,
+      value: false,
+    },
+
+    /*
+     * A set of data that has been loaded the data already. This exists to
+     * prevent fetching same data again.
+     * Invoking `reload` or a change in `loadKey` clears the cache.
+     */
+    _loadedData: {
+      type: Object,
+      value: () => new Set(),
+    },
+
+    _canceller: {
+      type: Object,
+      value: () => new tf_backend.Canceller(),
+    },
+
+  },
+
+  observers: [
+    '_loadKeyChanged(loadKey)',
+    '_dataToLoadChanged(isAttached, dataToLoad.*)',
+  ],
+
+  onLoadFinish() {
+    // Override to do something useful.
+  },
+
+  reload() {
+    this._loadedData.clear();
+    this._loadData();
+  },
+
+  _loadKeyChanged(_) {
+    // When `key` changes, cancel all handlers from the previous requests.
+    this._canceller.cancelAll();
+    this._loadedData.clear();
+  },
+
+  _dataToLoadChanged() {
+    if (this.isAttached) this._loadData();
+  },
+
+  created() {
+    this._loadData = _.debounce(
+        this._loadDataImpl,
+        100,
+        {leading: true, trailing: true});
+  },
+
+  detached() {
+    this._canceller.cancelAll();
+    this.cancelAsync(this._loadDataAsync);
+  },
+
+  _loadDataImpl() {
+    this.cancelAsync(this._loadDataAsync);
+    this._loadDataAsync = this.async(() => {
+      if (!this.isAttached) return;
+      this.dataLoading = true;
+
+      // Before updating, cancel any network-pending updates, to
+      // prevent race conditions where older data stomps newer data.
+      this._canceller.cancelAll();
+      const promises = this.dataToLoad.map(datum => {
+        const id = this.getDataLoadId(datum);
+        if (this._loadedData.has(id)) return Promise.resolve();
+
+        const url = this.getDataLoadUrl(datum);
+        const updateSeries = this._canceller.cancellable(result => {
+          if (result.cancelled) return;
+          this._loadedData.add(id);
+          this.loadDataCallback(this, datum, result.value);
+        });
+        return this.requestManager.request(url).then(updateSeries);
+      });
+
+      return Promise.all(promises).then(this._canceller.cancellable(result => {
+        this.dataLoading = false;
+        if (result.cancelled) return;
+        this.onLoadFinish();
+      }));
+    });
+  },
+
+};
+
+}  // namespace tf_line_chart_data_loader

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -20,6 +20,7 @@ limitations under the License.
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../vz-line-chart/vz-line-chart.html">
+<script src="data-loader-behavior.js"></script>
 
 <!--
   A component that fetches data from the TensorBoard server and renders it into
@@ -29,6 +30,7 @@ limitations under the License.
   <template>
     <div id="chart-and-spinner-container">
       <vz-line-chart
+        id="chart"
         x-components-creation-method="[[xComponentsCreationMethod]]"
         x-type="[[xType]]"
         y-value-accessor="[[yValueAccessor]]"
@@ -38,13 +40,13 @@ limitations under the License.
         smoothing-weight="[[smoothingWeight]]"
         tooltip-sorting-method="[[tooltipSortingMethod]]"
         ignore-y-outliers="[[ignoreYOutliers]]"
-        style="[[_computeLineChartStyle(_loading)]]"
+        style="[[_computeLineChartStyle(dataLoading)]]"
         default-x-range="[[defaultXRange]]"
         default-y-range="[[defaultYRange]]"
         fill-area="[[fillArea]]"
         symbol-function="[[symbolFunction]]"
       ></vz-line-chart>
-      <template is="dom-if" if="[[_loading]]">
+      <template is="dom-if" if="[[dataLoading]]">
         <div id="loading-spinner-container">
           <paper-spinner-lite active></paper-spinner-lite>
         </div>
@@ -97,30 +99,33 @@ limitations under the License.
     // We use a cascading queue becuase we don't want to block the UI / make the
     // ripples very slow while everything synchronously redraws.
     const redrawQueue = [];
-    const cascadingRedraw = _.throttle(function internalRedraw() {
-      if (redrawQueue.length > 0) {
+    const cascadingRedraw = (function() {
+      let redrawRaf = 0;
+      return _.throttle(function internalRedraw() {
+        if (redrawQueue.length == 0) return;
         const x = redrawQueue.shift();
         if (x.active) {
           x.redraw();
           x._maybeRenderedInBadState = false;
         }
-        window.setTimeout(internalRedraw, 32);
-      }
-    }, 100);
+        window.cancelAnimationFrame(redrawRaf);
+        window.requestAnimationFrame(internalRedraw);
+      }, 100);
+    })();
 
     Polymer({
       is: 'tf-line-chart-data-loader',
       properties: {
-        // An array of selected runs (strings).
-        runs: Array,
-        tag: String,
+        active: {
+          type: Boolean,
+          observer: '_fixBadStateWhenActive',
+        },
 
-        // An optional list of data series. Each data series is a string that
-        // corresponds to a line in the chart. If this property is not provided,
-        // the list of data series consists of the list of runs.
-        dataSeries: {
-          type: Array,
-          value: [],
+        requestManager: Object,
+
+        logScaleActive: {
+          type: Boolean,
+          observer: '_logScaleChanged',
         },
 
         xComponentsCreationMethod: Object,
@@ -140,72 +145,17 @@ limitations under the License.
         symbolFunction: Object,
 
         /**
-         * A function that takes as inputs:
-         * 1. This tf-line-chart-data-loader component.
-         * 2. The run (string) the response is relevant to.
-         * 3. The response received from the data URL.
-         * This function will be called when a response from a request to that
-         * data URL is successfully received.
-         * @type {Function}
-         */
-        processData: Object,
-
-        active: {
-          type: Boolean,
-          observer: '_fixBadStateWhenActive',
-        },
-
-        requestManager: Object,
-
-        // A function that takes 2 string arguments (tag and run) and returns a
-        // string URL for fetching data.
-        dataUrl: Function,
-
-        logScaleActive: {
-          type: Boolean,
-          observer: '_logScaleChanged',
-        },
-
-        /**
-         * An object with a scale method that maps from data series to color.
+         * An object with a scale method that maps from name of a data series to
+         * a color.
          */
         colorScale: {
           type: Object,
           value: () => ({scale: tf_color_scale.runsColorScale}),
         },
 
-        _loading: {
-          type: Boolean,
-          value: false,
-        },
-
         _resetDomainOnNextLoad: {
           type: Boolean,
           value: true,
-        },
-
-        _canceller: {
-          type: Object,
-          value: () => new tf_backend.Canceller(),
-        },
-
-        /*
-         * A map such that `_loadedRuns[run] === true` iff we've loaded
-         * `run` already, or are in the process of loading it. This
-         * exists so that when there are 100 runs selected and the user
-         * selects an additional run, we only fetch 1 more run instead
-         * of 101.
-         *
-         * `reload` clears this cache.
-         *
-         * Equivalently, this is the set of runs for which, after
-         * callbacks in-flight resolve, the most recent call to
-         * `setSeriesData(run, data)` on the chart object (a) exists
-         * and (b) occurred after all reloads so far.
-         */
-        _loadedRuns: {
-          type: Object,
-          value: () => ({}),
         },
 
         _maybeRenderedInBadState: {
@@ -214,123 +164,69 @@ limitations under the License.
           reflectToAttribute: true,
         },
       },
+
+      behaviors: [tf_line_chart_data_loader.DataLoaderBehavior],
+
       observers: [
-        '_tagChanged(_attached, tag)',
-        '_dataChanged(_attached, dataSeries, runs.*)'
+        '_dataSeriesChanged(dataSeries.*)',
+        '_keyChanged(key)',
       ],
-      created() {
-        this._loadData = _.debounce(
-          this._loadData, 100, {leading: true, trailing: true});
-      },
-      attached() {
-        this._attached = true;
-        this._changeSeries();
-      },
-      reload() {
-        this._loadedRuns = {};
-        this._loadData();
-      },
-      resetDomain() {
-        const chart = this.$$('vz-line-chart');
-        if (chart) {
-          chart.resetDomain();
-        }
-      },
-      setSeriesData(run, data) {
-        this.$$('vz-line-chart').setSeriesData(run, data);
-      },
-      redraw() {
-        this.$$('vz-line-chart').redraw();
-      },
-      _tagChanged(attached, tagUpdateRecord) {
-        this._loadedRuns = {};
-        this._resetDomainOnNextLoad = true;
-        this._loadData();
-      },
-      _dataChanged(attached, dataSeries, runsUpdateRecord) {
-        if (!attached) {
-          return;
+
+      onLoadFinish() {
+        if (this.dataToLoad.length > 0 && this._resetDomainOnNextLoad) {
+          // (Don't unset _resetDomainOnNextLoad when we didn't
+          // load any runs: this has the effect that if all our
+          // runs are deselected, then we toggle them all on, we
+          // properly size the domain once all the data is loaded
+          // instead of just when we're first rendered.)
+          this._resetDomainOnNextLoad = false;
+          this.$.chart.resetDomain();
         }
 
-        let visibleSeries = dataSeries;
-        if (visibleSeries.length === 0) {
-          // The data series is not explicitly set. Default to using runs.
-          visibleSeries = runsUpdateRecord.base;
+        if (this.active) {
+          this.redraw();
+        } else {
+          // If we reached a point where we should render while the page
+          // is not active, we've gotten into a bad state.
+          this._maybeRenderedInBadState = true;
         }
-        this.$$('vz-line-chart').setVisibleSeries(visibleSeries);
-        this._loadData();
       },
-      _loadData() {
-        this.async(() => {
-          if (!this._attached) {
-            return;
-          }
-          this._loading = true;
-          //
-          // Before updating, cancel any network-pending updates, to
-          // prevent race conditions where older data stomps newer data.
-          this._canceller.cancelAll();
-          const tag = this.tag;
-          const runPromises = this.runs.map(run => {
-            if (this._loadedRuns[run]) {
-              return Promise.resolve();
-            }
-            const url = this.dataUrl(tag, run);
-            const updateSeries = this._canceller.cancellable(result => {
-              if (result.cancelled) {
-                return;
-              }
-              if (tag === this.tag) {
-                // Only update the runs cache for the current tag. If we
-                // load data for Tag A, then the tag changes to Tag B
-                // while requests are still in flight, these requests
-                // should not poison the cache.
-                this._loadedRuns[run] = true;
-              }
-              this.processData(this, run, result.value);
-            });
-            return this.requestManager.request(url).then(updateSeries);
-          });
-          const finish = this._canceller.cancellable(result => {
-            if (!result.cancelled) {
-              this._loading = false;
-              const chart = this.$$('vz-line-chart');
-              if (runPromises.length > 0 && this._resetDomainOnNextLoad) {
-                // (Don't unset _resetDomainOnNextLoad when we didn't
-                // load any runs: this has the effect that if all our
-                // runs are deselected, then we toggle them all on, we
-                // properly size the domain once all the data is loaded
-                // instead of just when we're first rendered.)
-                this._resetDomainOnNextLoad = false;
-                chart.resetDomain();
-              }
-              if (!this.active) {
-                // If we reached a point where we should render while the page
-                // is not active, we've gotten into a bad state.
-                this._maybeRenderedInBadState = true;
-              } else {
-                this.redraw();
-              }
-            }
-          });
-          return Promise.all(runPromises).then(finish);
+
+      detached() {
+        cancelAnimationFrame(this._redrawRaf);
+      },
+
+      resetDomain() {
+        const chart = this.$.chart;
+        chart.resetDomain();
+      },
+
+      setSeriesData(name, data) {
+        this.$.chart.setSeriesData(name, data);
+      },
+
+      redraw() {
+        cancelAnimationFrame(this._redrawRaf);
+        this._redrawRaf = window.requestAnimationFrame(() => {
+          this.$.chart.redraw();
         });
       },
-      _changeSeries() {
-        let visibleSeries = this.dataSeries;
-        if (this.dataSeries.length === 0) {
-          // The data series is not explicitly set. Default to using runs.
-          visibleSeries = this.runs;
-        }
 
-        this.$$('vz-line-chart').setVisibleSeries(visibleSeries);
-        this._loadData();
+      _keyChanged(_) {
+        this._resetDomainOnNextLoad = true;
       },
+
+      _dataSeriesChanged(_) {
+        this.$.chart.setVisibleSeries(this.dataSeries);
+        this.redraw();
+      },
+
       _logScaleChanged(logScaleActive) {
-        var chart = this.$$('vz-line-chart');
+        const chart = this.$.chart;
         chart.yScaleType = logScaleActive ? 'log' : 'linear';
         this.redraw();
       },
+
       _computeLineChartStyle(loading) {
         return loading ? 'opacity: 0.3;' : '';
       },
@@ -345,6 +241,7 @@ limitations under the License.
           cascadingRedraw();
         }
       },
+
     });
     })();
   </script>

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -40,21 +40,22 @@ limitations under the License.
   <tf-card-heading display-name="[[_titleDisplayString]]"></tf-card-heading>
   <div id="tf-line-chart-data-loader-container">
     <tf-line-chart-data-loader
-      x-type="[[xType]]"
-      tooltip-sorting-method="[[tooltipSortingMethod]]"
-      ignore-y-outliers="[[ignoreYOutliers]]"
-      request-manager="[[requestManager]]"
-      runs="[[runs]]"
-      tag="[[_tagFilter]]"
+      id="loader"
       active="[[active]]"
-      data-url="[[_dataUrl]]"
-      log-scale-active="[[_logScaleActive]]"
-      process-data="[[_createProcessDataFunction(marginChartSeries)]]"
       color-scale="[[_colorScale]]"
-      data-series="[[_dataSeriesStrings]]"
+      data-series="[[_filteredSeriesNames]]"
+      get-data-load-url="[[_dataUrl]]"
+      fill-area="[[_fillArea]]"
+      ignore-y-outliers="[[ignoreYOutliers]]"
+      load-key="[[_tagFilter]]"
+      data-to-load="[[runs]]"
+      log-scale-active="[[_logScaleActive]]"
+      load-data-callback="[[_createProcessDataFunction(marginChartSeries)]]"
+      request-manager="[[requestManager]]"
       symbol-function="[[_createSymbolFunction()]]"
       tooltip-columns="[[_tooltipColumns]]"
-      fill-area="[[_fillArea]]"
+      tooltip-sorting-method="[[tooltipSortingMethod]]"
+      x-type="[[xType]]"
     >
     </tf-line-chart-data-loader>
   </div>
@@ -84,17 +85,17 @@ limitations under the License.
           selected-item-label="{{_dataSeriesNameToDownload}}"
         >
           <paper-menu class="dropdown-content" slot="dropdown-content">
-            <template is="dom-repeat" items="[[_dataSeriesStrings]]" as="dataSeriesName">
+            <template is="dom-repeat" items="[[_filteredSeriesNames]]" as="dataSeriesName">
               <paper-item no-label-float=true>[[dataSeriesName]]</paper-item>
             </template>
           </paper-menu>
         </paper-dropdown-menu>
         <a
           download="[[_dataSeriesNameToDownload]].csv"
-          href="[[_csvUrl(_nameToDataSeries, _dataSeriesNameToDownload)]]"
+          href="[[_csvUrl(_filteredNameToSeries, _dataSeriesNameToDownload)]]"
         >CSV</a> <a
           download="[[_dataSeriesNameToDownload]].json"
-          href="[[_jsonUrl(_nameToDataSeries, _dataSeriesNameToDownload)]]"
+          href="[[_jsonUrl(_filteredNameToSeries, _dataSeriesNameToDownload)]]"
         >JSON</a>
       </div>
     </template>
@@ -162,7 +163,7 @@ limitations under the License.
 
   <div id="matches-container">
     <div class="collapsible-list-title">
-      <template is="dom-if" if="[[_dataSeriesStrings.length]]">
+      <template is="dom-if" if="[[_filteredSeriesNames.length]]">
         <paper-icon-button
           icon="[[_getToggleCollapsibleIcon(_matchesListOpened)]]"
           on-click="_toggleMatchesOpen"
@@ -171,19 +172,19 @@ limitations under the License.
       </template>
 
       <span class="collapsible-title-text">
-        Matches ([[_dataSeriesStrings.length]])
+        Matches ([[_filteredSeriesNames.length]])
       </span>
     </div>
-    <template is="dom-if" if="[[_dataSeriesStrings.length]]">
+    <template is="dom-if" if="[[_filteredSeriesNames.length]]">
       <iron-collapse opened="[[_matchesListOpened]]">
         <div id="matches-list">
           <template is="dom-repeat"
-                    items="[[_dataSeriesStrings]]"
+                    items="[[_filteredSeriesNames]]"
                     as="seriesName">
               <div class="match-list-entry"
                    style="color: [[_determineColor(_colorScale, seriesName)]];">
                 <span class="match-entry-symbol">
-                  [[_determineSymbol(_nameToDataSeries, seriesName)]]
+                  [[_determineSymbol(_filteredNameToSeries, seriesName)]]
                 </span>
                 [[seriesName]]
               </div>
@@ -302,27 +303,16 @@ limitations under the License.
         /**
          * Maps from the name of the data series to the DataSeries object.
          */
-        _nameToDataSeries: {
+        _filteredNameToSeries: {
           type: Object,
           value: {},
         },
 
-        /**
-         * A mapping between selected runs (strings) to the value 1. This is
-         * effectively a set of strings.
-         */
-        _selectedRunsSet: {
+        _filteredSeriesNames: {
           type: Object,
-          computed: '_computeSelectedRunsSet(runs)',
+          computed: '_computeFilteredSeriesNames(_filteredNameToSeries)',
         },
-        _dataSeriesStrings: {
-          type: Array,
-          computed: '_computeDataSeriesStrings(_selectedRunsSet, _nameToDataSeries)',
-        },
-        _dataSeriesObjects: {
-          type: Array,
-          computed: '_computeDataSeriesObjects(_nameToDataSeries, _dataSeriesStrings)',
-        },
+
         _expanded: {
           type: Boolean,
           value: false,
@@ -331,9 +321,14 @@ limitations under the License.
         _logScaleActive: Boolean,
         _dataUrl: {
           type: Function,
-          value: () => (tag, run) => tf_backend.addParams(
-              tf_backend.getRouter().pluginRoute(
-                  'custom_scalars', '/scalars'), {tag, run}),
+          value: function() {
+            return (run) => {
+              const tag = this._tagFilter;
+              return tf_backend.addParams(
+                  tf_backend.getRouter().pluginRoute(
+                      'custom_scalars', '/scalars'), {tag, run});
+            };
+          },
         },
         /**
          * A mapping from run to the next available symbol for that run. We use
@@ -431,15 +426,15 @@ limitations under the License.
         _stepsMismatch: Object,
       },
       observers: [
-        '_updateChart(_nameToDataSeries)',
+        '_updateChart(_filteredNameToSeries)',
         // Clear the data series when the tag filter changes.
         '_refreshDataSeries(_tagFilter)',
       ],
       reload() {
-        this.$$('tf-line-chart-data-loader').reload();
+        this.$.loader.reload();
       },
       redraw() {
-        this.$$('tf-line-chart-data-loader').redraw();
+        this.$.loader.redraw();
       },
       _toggleExpanded(e) {
         this.set('_expanded', !this._expanded);
@@ -449,21 +444,21 @@ limitations under the License.
         this.set('_logScaleActive', !this._logScaleActive);
       },
       _resetDomain() {
-        const chart = this.$$('tf-line-chart-data-loader');
+        const chart = this.$.loader;
         if (chart) {
           chart.resetDomain();
         }
       },
-      _csvUrl(nameToDataSeries, dataSeriesName) {
-        const baseUrl = this._downloadDataUrl(nameToDataSeries, dataSeriesName);
+      _csvUrl(_filteredNameToSeries, dataSeriesName) {
+        const baseUrl = this._downloadDataUrl(_filteredNameToSeries, dataSeriesName);
         return tf_backend.addParams(baseUrl, {format: 'csv'});
       },
-      _jsonUrl(nameToDataSeries, dataSeriesName) {
-        const baseUrl = this._downloadDataUrl(nameToDataSeries, dataSeriesName);
+      _jsonUrl(_filteredNameToSeries, dataSeriesName) {
+        const baseUrl = this._downloadDataUrl(_filteredNameToSeries, dataSeriesName);
         return tf_backend.addParams(baseUrl, {format: 'json'});
       },
-      _downloadDataUrl(nameToDataSeries, dataSeriesName) {
-        const dataSeries = nameToDataSeries[dataSeriesName];
+      _downloadDataUrl(_filteredNameToSeries, dataSeriesName) {
+        const dataSeries = _filteredNameToSeries[dataSeriesName];
         const getVars = {
             tag: dataSeries.getTag(),
             run: dataSeries.getRun(),
@@ -485,7 +480,7 @@ limitations under the License.
 
           // The user's regular expression was valid.
           // Incorporate these newly loaded values.
-          const newMapping = _.clone(this._nameToDataSeries);
+          const newMapping = _.clone(this._filteredNameToSeries);
           const tagsNotFound = [];
           _.forEach(marginChartSeries, tagsObject => {
             let tagNotFound = false;
@@ -552,7 +547,7 @@ limitations under the License.
                   run, tagsObject.value, seriesName, dataPoints);
             }
           });
-          this.set('_nameToDataSeries', newMapping);
+          this.set('_filteredNameToSeries', newMapping);
 
           const entryIndex = _.findIndex(this._missingTags, (entry) => {
             return entry.run === run;
@@ -608,41 +603,28 @@ limitations under the License.
             (this._runToNextAvailableSymbolIndex[run] + 1) % numSymbols;
         return series;
       },
-      _updateChart(nameToDataSeries) {
+      _updateChart(_filteredNameToSeries) {
         // Add new data series.
-        _.forOwn(nameToDataSeries, dataSeries => {
-          this.$$('tf-line-chart-data-loader').setSeriesData(
+        _.forOwn(_filteredNameToSeries, dataSeries => {
+          this.$.loader.setSeriesData(
               dataSeries.getName(), dataSeries.getData());
         });
       },
-      _computeSelectedRunsSet(runs) {
-        const mapping = {};
-        _.forEach(runs, run => {
-          mapping[run] = 1;
-        });
-        return mapping;
-      },
-      _computeDataSeriesStrings(selectedRunsSet, nameToDataSeries) {
-        return _.values(nameToDataSeries)
-            .filter(series => selectedRunsSet[series.getRun()])
-            .map(series => series.getName());
-      },
-      _computeDataSeriesObjects(nameToDataSeries, dataSeriesStrings) {
-        return dataSeriesStrings.map(
-            seriesName => nameToDataSeries[seriesName]);
+      _computeFilteredSeriesNames(_) {
+        return Object.keys(this._filteredNameToSeries);
       },
       _determineColor(colorScale, seriesName) {
         return colorScale.scale(seriesName);
       },
       _refreshDataSeries(_tagFilter) {
-        this.set('_nameToDataSeries', {});
+        this.set('_filteredNameToSeries', {});
       },
       _createSymbolFunction() {
         return seriesName => (
-            this._nameToDataSeries[seriesName].getSymbol().method());
+            this._filteredNameToSeries[seriesName].getSymbol().method());
       },
-      _determineSymbol(nameToDataSeries, seriesName) {
-        return nameToDataSeries[seriesName].getSymbol().character;
+      _determineSymbol(_filteredNameToSeries, seriesName) {
+        return _filteredNameToSeries[seriesName].getSymbol().character;
       },
       _computeTagFilter(marginChartSeries) {
         const tags = _.flatten(

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
@@ -40,21 +40,22 @@ limitations under the License.
   <tf-card-heading display-name="[[_titleDisplayString]]"></tf-card-heading>
   <div id="tf-line-chart-data-loader-container">
     <tf-line-chart-data-loader
-      x-type="[[xType]]"
+      id="loader"
+      active="[[active]]"
+      color-scale="[[_colorScale]]"
+      data-series="[[_filteredSeriesNames]]"
+      get-data-load-url="[[_dataUrl]]"
+      ignore-y-outliers="[[ignoreYOutliers]]"
+      load-key="[[_tagFilter]]"
+      data-to-load="[[runs]]"
+      log-scale-active="[[_logScaleActive]]"
+      load-data-callback="[[_createProcessDataFunction()]]"
+      request-manager="[[requestManager]]"
       smoothing-enabled="[[smoothingEnabled]]"
       smoothing-weight="[[smoothingWeight]]"
-      tooltip-sorting-method="[[tooltipSortingMethod]]"
-      ignore-y-outliers="[[ignoreYOutliers]]"
-      request-manager="[[requestManager]]"
-      runs="[[runs]]"
-      tag="[[_tagFilter]]"
-      active="[[active]]"
-      data-url="[[_dataUrl]]"
-      log-scale-active="[[_logScaleActive]]"
-      process-data="[[_createProcessDataFunction()]]"
-      color-scale="[[_colorScale]]"
-      data-series="[[_dataSeriesStrings]]"
       symbol-function="[[_createSymbolFunction()]]"
+      tooltip-sorting-method="[[tooltipSortingMethod]]"
+      x-type="[[xType]]"
     >
     </tf-line-chart-data-loader>
   </div>
@@ -84,24 +85,24 @@ limitations under the License.
           selected-item-label="{{_dataSeriesNameToDownload}}"
         >
           <paper-menu class="dropdown-content" slot="dropdown-content">
-            <template is="dom-repeat" items="[[_dataSeriesStrings]]" as="dataSeriesName">
+            <template is="dom-repeat" items="[[_filteredSeriesNames]]" as="dataSeriesName">
               <paper-item no-label-float=true>[[dataSeriesName]]</paper-item>
             </template>
           </paper-menu>
         </paper-dropdown-menu>
         <a
           download="[[_dataSeriesNameToDownload]].csv"
-          href="[[_csvUrl(_nameToDataSeries, _dataSeriesNameToDownload)]]"
+          href="[[_csvUrl(_filteredNameToSeries, _dataSeriesNameToDownload)]]"
         >CSV</a> <a
           download="[[_dataSeriesNameToDownload]].json"
-          href="[[_jsonUrl(_nameToDataSeries, _dataSeriesNameToDownload)]]"
+          href="[[_jsonUrl(_filteredNameToSeries, _dataSeriesNameToDownload)]]"
         >JSON</a>
       </div>
     </template>
   </div>
   <div id="matches-container">
     <div id="matches-list-title">
-      <template is="dom-if" if="[[_dataSeriesStrings.length]]">
+      <template is="dom-if" if="[[_filteredSeriesNames.length]]">
         <paper-icon-button
           icon="[[_getToggleMatchesIcon(_matchesListOpened)]]"
           on-click="_toggleMatchesOpen"
@@ -110,19 +111,19 @@ limitations under the License.
       </template>
 
       <span class="matches-text">
-        Matches ([[_dataSeriesStrings.length]])
+        Matches ([[_filteredSeriesNames.length]])
       </span>
     </div>
-    <template is="dom-if" if="[[_dataSeriesStrings.length]]">
+    <template is="dom-if" if="[[_filteredSeriesNames.length]]">
       <iron-collapse opened="[[_matchesListOpened]]">
         <div id="matches-list">
           <template is="dom-repeat"
-                    items="[[_dataSeriesStrings]]"
+                    items="[[_filteredSeriesNames]]"
                     as="seriesName">
               <div class="match-list-entry"
                    style="color: [[_determineColor(_colorScale, seriesName)]];">
                 <span class="match-entry-symbol">
-                  [[_determineSymbol(_nameToDataSeries, seriesName)]]
+                  [[_determineSymbol(_filteredNameToSeries, seriesName)]]
                 </span>
                 [[seriesName]]
               </div>
@@ -203,27 +204,16 @@ limitations under the License.
         /**
          * Maps from the name of the data series to the DataSeries object.
          */
-        _nameToDataSeries: {
+        _filteredNameToSeries: {
           type: Object,
-          value: {},
+          value: () => ({}),
         },
 
-        /**
-         * A mapping between selected runs (strings) to the value 1. This is
-         * effectively a set of strings.
-         */
-        _selectedRunsSet: {
+        _filteredSeriesNames: {
           type: Object,
-          computed: '_computeSelectedRunsSet(runs)',
+          computed: '_computeFilteredSeriesNames(_filteredNameToSeries)',
         },
-        _dataSeriesStrings: {
-          type: Array,
-          computed: '_computeDataSeriesStrings(_selectedRunsSet, _nameToDataSeries)',
-        },
-        _dataSeriesObjects: {
-          type: Array,
-          computed: '_computeDataSeriesObjects(_nameToDataSeries, _dataSeriesStrings)',
-        },
+
         _expanded: {
           type: Boolean,
           value: false,
@@ -232,9 +222,15 @@ limitations under the License.
         _logScaleActive: Boolean,
         _dataUrl: {
           type: Function,
-          value: () => (tag, run) => tf_backend.addParams(
-              tf_backend.getRouter().pluginRoute(
-                  'custom_scalars', '/scalars'), {tag, run}),
+          value: function() {
+            return (run) => {
+              const tag = this._tagFilter;
+              return tf_backend.addParams(
+                tf_backend.getRouter().pluginRoute(
+                    'custom_scalars', '/scalars'),
+                {tag, run});
+            };
+          },
         },
         /**
          * A mapping from run to the next available symbol for that run. We use
@@ -254,15 +250,15 @@ limitations under the License.
         },
       },
       observers: [
-        '_updateChart(_nameToDataSeries)',
+        '_updateChart(_filteredNameToSeries)',
         // Clear the data series when the tag filter changes.
         '_refreshDataSeries(_tagFilter)',
       ],
       reload() {
-        this.$$('tf-line-chart-data-loader').reload();
+        this.$.loader.reload();
       },
       redraw() {
-        this.$$('tf-line-chart-data-loader').redraw();
+        this.$.loader.redraw();
       },
       _toggleExpanded(e) {
         this.set('_expanded', !this._expanded);
@@ -272,21 +268,23 @@ limitations under the License.
         this.set('_logScaleActive', !this._logScaleActive);
       },
       _resetDomain() {
-        const chart = this.$$('tf-line-chart-data-loader');
+        const chart = this.$.loader;
         if (chart) {
           chart.resetDomain();
         }
       },
-      _csvUrl(nameToDataSeries, dataSeriesName) {
-        const baseUrl = this._downloadDataUrl(nameToDataSeries, dataSeriesName);
+      _csvUrl(filteredNameToSeries, dataSeriesName) {
+        const baseUrl = this._downloadDataUrl(
+            filteredNameToSeries, dataSeriesName);
         return tf_backend.addParams(baseUrl, {format: 'csv'});
       },
-      _jsonUrl(nameToDataSeries, dataSeriesName) {
-        const baseUrl = this._downloadDataUrl(nameToDataSeries, dataSeriesName);
+      _jsonUrl(filteredNameToSeries, dataSeriesName) {
+        const baseUrl = this._downloadDataUrl(
+            filteredNameToSeries, dataSeriesName);
         return tf_backend.addParams(baseUrl, {format: 'json'});
       },
-      _downloadDataUrl(nameToDataSeries, dataSeriesName) {
-        const dataSeries = nameToDataSeries[dataSeriesName];
+      _downloadDataUrl(filteredNameToSeries, dataSeriesName) {
+        const dataSeries = filteredNameToSeries[dataSeriesName];
         const getVars = {
             tag: dataSeries.getTag(),
             run: dataSeries.getRun(),
@@ -301,7 +299,7 @@ limitations under the License.
           if (data.regex_valid) {
             // The user's regular expression was valid.
             // Incorporate these newly loaded values.
-            const newMapping = _.clone(this._nameToDataSeries);
+            const newMapping = _.clone(this._filteredNameToSeries);
             _.forOwn(data.tag_to_events, (scalarEvents, tag) => {
               const data = scalarEvents.map(datum => ({
                 wall_time: new Date(datum[0] * 1000),
@@ -343,18 +341,19 @@ limitations under the License.
               }
             });
 
-            this.set('_nameToDataSeries', newMapping);
+            this.set('_filteredNameToSeries', newMapping);
           } else {
             // The user's regular expression was invalid.
             // TODO(chihuahua): Handle this.
           }
         });
       },
-      _updateChart(nameToDataSeries) {
+      _updateChart(filteredNameToSeries) {
         // Add new data series.
-        _.forOwn(nameToDataSeries, dataSeries => {
-          this.$$('tf-line-chart-data-loader').setSeriesData(
-              dataSeries.getName(), dataSeries.getData());
+        Object.entries(filteredNameToSeries).forEach(([name, dataSeries]) => {
+          this.$.loader.setSeriesData(
+              name,
+              dataSeries.getData());
         });
       },
       _computeSelectedRunsSet(runs) {
@@ -364,27 +363,21 @@ limitations under the License.
         });
         return mapping;
       },
-      _computeDataSeriesStrings(selectedRunsSet, nameToDataSeries) {
-        return _.values(nameToDataSeries)
-            .filter(series => selectedRunsSet[series.getRun()])
-            .map(series => series.getName());
-      },
-      _computeDataSeriesObjects(nameToDataSeries, dataSeriesStrings) {
-        return dataSeriesStrings.map(
-            seriesName => nameToDataSeries[seriesName]);
+      _computeFilteredSeriesNames() {
+        return Object.keys(this._filteredNameToSeries);
       },
       _determineColor(colorScale, seriesName) {
         return colorScale.scale(seriesName);
       },
       _refreshDataSeries(_tagFilter) {
-        this.set('_nameToDataSeries', {});
+        this.set('_filteredNameToSeries', {});
       },
       _createSymbolFunction() {
         return seriesName => (
-            this._nameToDataSeries[seriesName].getSymbol().method());
+            this._filteredNameToSeries[seriesName].getSymbol().method());
       },
-      _determineSymbol(nameToDataSeries, seriesName) {
-        return nameToDataSeries[seriesName].getSymbol().character;
+      _determineSymbol(filteredNameToSeries, seriesName) {
+        return filteredNameToSeries[seriesName].getSymbol().character;
       },
       _computeTagFilter(tagRegexes) {
         if (tagRegexes.length === 1) {

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -43,10 +43,11 @@ limitations under the License.
       default-y-range="[[_defaultYRange]]"
       smoothing-enabled="[[_smoothingEnabled]]"
       request-manager="[[requestManager]]"
-      runs="[[runs]]"
-      tag="[[tag]]"
-      data-url="[[_dataUrl]]"
-      process-data="[[_createProcessDataFunction()]]"
+      data-to-load="[[runs]]"
+      data-series="[[runs]]"
+      load-key="[[tag]]"
+      get-data-load-url="[[_dataUrl]]"
+      load-data-callback="[[_createProcessDataFunction()]]"
       active="[[active]]"
     ></tf-line-chart-data-loader>
 
@@ -292,8 +293,14 @@ limitations under the License.
         },
         _dataUrl: {
           type: Function,
-          value: () => (tag, run) => tf_backend.addParams(
-              tf_backend.getRouter().pluginRoute('pr_curves', '/pr_curves'), {tag, run}),
+          value: function() {
+            return (run) => {
+              const tag = this.tag;
+              return tf_backend.addParams(
+                tf_backend.getRouter().pluginRoute('pr_curves', '/pr_curves'),
+                {tag, run});
+            };
+          },
         },
         _smoothingEnabled: {
           type: Boolean,

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -37,19 +37,21 @@ limitations under the License.
   ></tf-card-heading>
   <div id="tf-line-chart-data-loader-container">
     <tf-line-chart-data-loader
-      x-type="[[xType]]"
+      active="[[active]]"
+      data-series="[[_getDataSeries(dataToLoad.*)]]"
+      data-to-load="[[dataToLoad]]"
+      get-data-load-id="[[_getDataLoadId]]"
+      get-data-load-url="[[getDataLoadUrl]]"
+      ignore-y-outliers="[[ignoreYOutliers]]"
+      load-data-callback="[[_loadDataCallback]]"
+      load-key="[[tag]]"
+      log-scale-active="[[_logScaleActive]]"
+      request-manager="[[requestManager]]"
       smoothing-enabled="[[smoothingEnabled]]"
       smoothing-weight="[[smoothingWeight]]"
-      tooltip-sorting-method="[[tooltipSortingMethod]]"
-      ignore-y-outliers="[[ignoreYOutliers]]"
-      request-manager="[[requestManager]]"
-      runs="[[runs]]"
-      tag="[[tag]]"
       tag-metadata="[[tagMetadata]]"
-      active="[[active]]"
-      data-url="[[dataUrl]]"
-      log-scale-active="[[_logScaleActive]]"
-      process-data="[[_processData]]"
+      tooltip-sorting-method="[[tooltipSortingMethod]]"
+      x-type="[[xType]]"
     >
     </tf-line-chart-data-loader>
   </div>
@@ -163,8 +165,12 @@ limitations under the License.
   Polymer({
       is: 'tf-scalar-card',
       properties: {
-        runs: Array,  // of String
         tag: String,
+
+        /**
+         * @type {Array<Object>}
+         */
+        dataToLoad: Array,
 
         /**
          * @type {vz_chart_helpers.XType}
@@ -174,27 +180,36 @@ limitations under the License.
         active: Boolean,
         ignoreYOutliers: Boolean,
         requestManager: Object,
-        showDownloadLinks: Boolean,
+        showDownLinks: Boolean,
         smoothingEnabled: Boolean,
         smoothingWeight: Number,
         tagMetadata: Object,
         tooltipSortingMethod: String,
-        // Function that takes 2 string arguments (tag and run) and returns a
-        // string URL for fetching data.
-        dataUrl: Function,
+        // Function that takes a data series and returns a string URL for
+        // fetching data.
+        getDataLoadUrl: Function,
 
         // This function is called when data is received from the backend.
-        _processData: {
+        _loadDataCallback: {
           type: Object,
-          value: () => ((scalarChart, run, data) => {
-            const formattedData = data.map(datum => ({
-              wall_time: new Date(datum[0] * 1000),
-              step: datum[1],
-              scalar: datum[2],
-            }));
-            scalarChart.setSeriesData(run, formattedData);
-          }),
+          value: function() {
+            return (scalarChart, datum, data) => {
+              const formattedData = data.map(datum => ({
+                wall_time: new Date(datum[0] * 1000),
+                step: datum[1],
+                scalar: datum[2],
+              }));
+              const name = this._getSeriesNameFromDatum(datum);
+              scalarChart.setSeriesData(name, formattedData);
+            };
+          },
           readOnly: true,
+        },
+
+        // TODO(stephanwlee): Make it experiment aware.
+        _getDataLoadId: {
+          type: Function,
+          value: () => ({run}) => run,
         },
 
         _expanded: {
@@ -226,10 +241,18 @@ limitations under the License.
         }
       },
       _csvUrl(tag, run) {
-        return tf_backend.addParams(this.dataUrl(tag, run), {format: 'csv'});
+        return tf_backend.addParams(
+            this.getDataLoadUrl({tag, run}),
+            {format: 'csv'});
       },
       _jsonUrl(tag, run) {
-        return this.dataUrl(tag, run);
+        return this.getDataLoadUrl({tag, run});
+      },
+      _getDataSeries() {
+        return this.dataToLoad.map(this._getSeriesNameFromDatum);
+      },
+      _getSeriesNameFromDatum(datum) {
+        return datum.run;
       },
   });
 </script>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -138,11 +138,11 @@ limitations under the License.
                           ignore-y-outliers="[[_ignoreYOutliers]]"
                           show-download-links="[[_showDownloadLinks]]"
                           request-manager="[[_requestManager]]"
-                          runs="[[item.runs]]"
+                          data-to-load="[[item.series]]"
                           tag="[[item.tag]]"
                           tag-metadata="[[_tagMetadata(_runToTagInfo, item.runs, item.tag)]]"
                           active="[[page.active]]"
-                          data-url="[[_dataUrl]]"
+                          get-data-load-url="[[_dataUrl]]"
                         ></tf-scalar-card>
                       </template>
                     </div>
@@ -235,7 +235,7 @@ limitations under the License.
         },
         _dataUrl: {
           type: Function,
-          value: () => (tag, run) => tf_backend.addParams(
+          value: () => ({tag, run}) => tf_backend.addParams(
               tf_backend.getRouter().pluginRoute('scalars', '/scalars'),
               {tag, run}),
         },
@@ -288,8 +288,21 @@ limitations under the License.
       _makeCategories(
           runToTagInfo, selectedRuns, tagFilter, categoriesDomReady) {
         const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
-        return tf_categorization_utils.categorizeTags(runToTag, selectedRuns, tagFilter);
+        // TODO(stephanwlee): Apply the new categorization based on selection.
+        const categories = tf_categorization_utils.categorizeTags(
+            runToTag, selectedRuns, tagFilter);
+        categories.forEach(category => {
+          category.items = category.items.map(item => ({
+            tag: item.tag,
+            series: item.runs.map(run => ({
+              run,
+              tag: item.tag,
+            })),
+          }));
+        });
+        return categories;
       },
+
       _tagMetadata(runToTagsInfo, runs, tag) {
         const runToTagInfo = {};
         runs.forEach(run => {
@@ -305,6 +318,8 @@ limitations under the License.
     tf_tensorboard.registerDashboard({
       plugin: 'scalars',
       elementName: 'tf-scalar-dashboard',
+      useDataSelector: Boolean(
+          tf_storage.getBoolean('EnableDataSelector', {useLocalStorage: true})),
     });
 
   </script>


### PR DESCRIPTION
The loader, previously, was very geared towards runs and tag
combination which can be generalized a little bit. 

Also, while working on this, I factored out the loading logic out of 
the line-chart-data-loader as a reusable behavior and, now, the
line-chart-data-loader is responsible for redrawing the chart.