### PR TITLE
Refactor: Use shorter notation for @org_polymer_iron_icon

### DIFF
--- a/tensorboard/components/tf_dashboard_common/BUILD
+++ b/tensorboard/components/tf_dashboard_common/BUILD
@@ -38,7 +38,7 @@ tf_web_library(
         "@org_polymer_iron_ajax",
         "@org_polymer_iron_collapse",
         "@org_polymer_iron_flex_layout",
-        "@org_polymer_iron_icon//:org_polymer_iron_icon",
+        "@org_polymer_iron_icon",
         "@org_polymer_iron_icons",
         "@org_polymer_paper_button",
         "@org_polymer_paper_checkbox",


### PR DESCRIPTION
tf_dashboard_common is using more verbose version,
@org_polymer_iron_icon//:org_polymer_iron_icon, and it can be shorter
with @org_polymer_iron_icon.