### PR TITLE
Cleanup: Upgrade lodash and plottable

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -149,6 +149,7 @@ filegroup(
     srcs = [
         # Ordering probably matters.
         "@com_microsoft_typescript//:lib.es6.d.ts",
+        "@com_microsoft_typescript//:lib.dom.d.ts",
         "@io_angular_clutz//:src/resources/closure.lib.d.ts",
         "//tensorboard/defs:clutz.d.ts",
     ],

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -149,7 +149,6 @@ filegroup(
     srcs = [
         # Ordering probably matters.
         "@com_microsoft_typescript//:lib.es6.d.ts",
-        "@com_microsoft_typescript//:lib.dom.d.ts",
         "@io_angular_clutz//:src/resources/closure.lib.d.ts",
         "//tensorboard/defs:clutz.d.ts",
     ],

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -248,13 +248,14 @@ function dictToComponent(items: StringDict): string {
   }
 
   // Join other strings with &key=value notation
-  const nonTab = _.pairs(items)
-                   .filter((pair) =>  pair[0] !== TAB)
-                   .map((pair) => {
-                     return encodeURIComponent(pair[0]) + '=' +
-                         encodeURIComponent(pair[1]);
-                   })
-                   .join('&');
+  const nonTab = Object.keys(items)
+      .map(key => [key, items[key]])
+      .filter((pair) =>  pair[0] !== TAB)
+      .map((pair) => {
+       return encodeURIComponent(pair[0]) + '=' +
+           encodeURIComponent(pair[1]);
+      })
+      .join('&');
 
   return nonTab.length > 0 ? (component + '&' + nonTab) : component;
 }

--- a/tensorboard/components/vz_chart_helpers/vz-chart-helpers.ts
+++ b/tensorboard/components/vz_chart_helpers/vz-chart-helpers.ts
@@ -30,7 +30,7 @@ export type DataFn = (run: string, tag: string) => Promise<Array<Datum>>;
 
 export interface LineChartSymbol {
   // A single unicode character string representing the symbol. Maybe a diamond
-  // unicode character for instance. 
+  // unicode character for instance.
   character: string;
   // A special method used by Plottable to draw the symbol in the line chart.
   method: (() => Plottable.SymbolFactories.SymbolFactory);

--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -995,7 +995,7 @@ class LineChart {
       };
     });
     let idx: number =
-        _.sortedIndex(points, target, (p: vz_chart_helpers.Point) => p.x);
+        sortedIndexBy(points, target, (p: vz_chart_helpers.Point) => p.x);
     if (idx === points.length) {
       return points[points.length - 1];
     } else if (idx === 0) {
@@ -1178,6 +1178,32 @@ class LineChart {
     // Destroying outer destroys all subcomponents recursively.
     if (this.outer) this.outer.destroy();
   }
+}
+
+/**
+ * Binary searches and finds "closest" index of a value in an array. As the name
+ * indicates, `array` must be sorted. When there is no exact match, it returns
+ * index of a first item that is larger than the value.
+ * API Signature and method inspired by lodash#sortedIndexBy.
+ * TODO(stephanwlee): Use _.sortedIndexBy when types are migrated to v4.
+ */
+function sortedIndexBy<T>(array: T[], value: T, iteratee: (val: T) => number):
+    number {
+  const query = iteratee(value);
+
+  let low = 0;
+  let high = array.length;
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    const midVal = iteratee(array[mid]);
+    if (midVal < query) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return high;
 }
 
 }  // namespace vz_line_chart

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html
@@ -985,9 +985,9 @@ Polymer({
   _colorByChanged: function() {
     if (this.renderHierarchy != null) {
       // We iterate through each svg node and update its state.
-      _.each(this._nodeGroupIndex, function(nodeGroup, nodeName) {
+      _.each(this._nodeGroupIndex, (nodeGroup, nodeName) => {
         this._updateNodeState(nodeName);
-      }, this);
+      });
       // Notify also the minimap.
       this.minimap.update();
     }
@@ -1045,7 +1045,7 @@ Polymer({
     if (nodeGroup) {
       tf.graph.scene.node.stylize(nodeGroup, node, this);
     }
-    
+
     if (node.node.type === tf.graph.NodeType.META &&
         node.node.associatedFunction &&
         !node.isLibraryFunction) {
@@ -1062,10 +1062,10 @@ Polymer({
     }
 
     var annotationGroupIndex = this.getAnnotationGroupsIndex(n);
-    _.each(annotationGroupIndex, function(aGroup, hostName) {
+    _.each(annotationGroupIndex, (aGroup, hostName) => {
       tf.graph.scene.node.stylize(aGroup, node, this,
           tf.graph.scene.Class.Annotation.NODE);
-    }, this);
+    });
   },
 
   /**
@@ -1103,7 +1103,7 @@ Polymer({
     }
     // Ensure each parent metanode is built and expanded.
     var topParentNodeToBeExpanded;
-    _.forEachRight(nodeParents, function(parentName) {
+    _.forEachRight(nodeParents, (parentName)  => {
       this.renderHierarchy.buildSubhierarchy(parentName);
       var renderNode = this.renderHierarchy.getRenderNodeByName(parentName);
       if (renderNode.node.isGroupNode && !renderNode.expanded) {
@@ -1112,7 +1112,7 @@ Polymer({
           topParentNodeToBeExpanded = renderNode;
         }
       }
-    }, this);
+    });
     // If any expansion was needed to display this selected node, then
     // inform the scene of the top-most expansion.
     if (topParentNodeToBeExpanded) {

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -141,10 +141,9 @@ class HierarchyImpl implements Hierarchy {
     // For each of the parent node's two Metaedge containing graphs, process
     // each Metaedge involving this node.
     _.each([parentMetagraph, parentBridgegraph], parentGraph => {
-      _(parentGraph.edges())
+      parentGraph.edges()
         .filter(e => e.v === nodeName || e.w === nodeName)
-        .each(parentEdgeObj => {
-
+        .forEach(parentEdgeObj => {
           let inbound = parentEdgeObj.w === nodeName;
           let parentMetaedge = parentGraph.edge(parentEdgeObj);
 
@@ -182,8 +181,7 @@ class HierarchyImpl implements Hierarchy {
             // bridgegraph Metaedge.
             bridgeMetaedge.addBaseEdge(baseEdge, this);
           });
-        })
-        .value(); // force lodash chain execution.
+        });
     });
 
     return bridgegraph;

--- a/tensorboard/plugins/graph/tf_graph_common/layout.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/layout.ts
@@ -202,7 +202,7 @@ export const PARAMS = {
 
 /**
  * The minimum width we confer upon the auxiliary nodes section if functions
- * also appear. Without enforcing this minimum, metanodes in the function 
+ * also appear. Without enforcing this minimum, metanodes in the function
  * library section could jut into the auxiliary nodes section because the
  * title "Auxiliary Nodes" is longer than the width of the auxiliary nodes
  * section itself.
@@ -453,8 +453,11 @@ function layoutMetanode(renderNodeInfo: render.RenderGroupNodeInfo): void {
   // Calculate the position of nodes in isolatedInExtract relative to the
   // top-left corner of inExtractBox (the bounding box for all inExtract nodes)
   // and calculate the size of the inExtractBox.
-  let maxInExtractWidth = _.max(renderNodeInfo.isolatedInExtract,
-      renderNode => renderNode.width).width;
+  let maxInExtractWidth = renderNodeInfo.isolatedInExtract.length ?
+      _.max(
+          renderNodeInfo.isolatedInExtract,
+          renderNode => renderNode.width,
+      ).width : null;
   renderNodeInfo.inExtractBox.width = maxInExtractWidth != null ?
       maxInExtractWidth : 0;
 
@@ -470,8 +473,11 @@ function layoutMetanode(renderNodeInfo: render.RenderGroupNodeInfo): void {
   // Calculate the position of nodes in isolatedOutExtract relative to the
   // top-left corner of outExtractBox (the bounding box for all outExtract
   // nodes) and calculate the size of the outExtractBox.
-  let maxOutExtractWidth = _.max(renderNodeInfo.isolatedOutExtract,
-      renderNode => renderNode.width).width;
+  let maxOutExtractWidth = renderNodeInfo.isolatedOutExtract.length ?
+      _.max(
+          renderNodeInfo.isolatedOutExtract,
+          renderNode => renderNode.width,
+      ).width : null;
   renderNodeInfo.outExtractBox.width = maxOutExtractWidth != null ?
       maxOutExtractWidth : 0;
 
@@ -487,8 +493,11 @@ function layoutMetanode(renderNodeInfo: render.RenderGroupNodeInfo): void {
   // Calculate the position of nodes in libraryFunctionsExtract relative to the
   // top-left corner of libraryFunctionsBox (the bounding box for all library
   // function nodes) and calculate the size of the libraryFunctionsBox.
-  let maxLibraryFunctionsWidth = _.max(renderNodeInfo.libraryFunctionsExtract,
-      renderNode => renderNode.width).width;
+  let maxLibraryFunctionsWidth = renderNodeInfo.libraryFunctionsExtract.length ?
+      _.max(
+          renderNodeInfo.libraryFunctionsExtract,
+          renderNode => renderNode.width,
+      ).width : null;
   renderNodeInfo.libraryFunctionsBox.width = maxLibraryFunctionsWidth != null ?
       maxLibraryFunctionsWidth : 0;
 

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -299,7 +299,7 @@ export class RenderGraphInfo {
       Array<{color: string, proportion: number}> {
     if (Object.keys(histogram).length > 0) {
       // Compute the total # of items.
-      const numItems = _.sum(Object.keys(histogram).map(key => histogram[key]);
+      const numItems = _.sum(Object.keys(histogram).map(key => histogram[key]));
       return Object.keys(histogram).map(key => ({
         color: colors(key),
         // Normalize to a proportion of total # of items.

--- a/tensorboard/plugins/graph/tf_graph_common/render.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/render.ts
@@ -297,15 +297,14 @@ export class RenderGraphInfo {
       histogram: {[name: string]: number},
       colors: d3.ScaleOrdinal<string, string>):
       Array<{color: string, proportion: number}> {
-    let pairs = _.pairs(histogram);
-    if (pairs.length > 0) {
+    if (Object.keys(histogram).length > 0) {
       // Compute the total # of items.
-      let numItems = _.sum(pairs, _.last);
-      return _.map(pairs, pair => ({
-                            color: colors(pair[0]),
-                            // Normalize to a proportion of total # of items.
-                            proportion: pair[1] / numItems
-                          }));
+      const numItems = _.sum(Object.keys(histogram).map(key => histogram[key]);
+      return Object.keys(histogram).map(key => ({
+        color: colors(key),
+        // Normalize to a proportion of total # of items.
+        proportion: histogram[key] / numItems,
+      }));
     }
     console.info('no pairs found!');
     return null;

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
@@ -599,8 +599,8 @@ limitations under the License.
            * Unpacks the metaedge into a list of base edge information
            * that can be rendered.
            */
-          var unpackMetaedge = function(metaedge) {
-            return _.map(metaedge.baseEdgeList, function(baseEdge) {
+          var unpackMetaedge = (metaedge) => {
+            return _.map(metaedge.baseEdgeList, (baseEdge) => {
               var name = isPredecessor ? baseEdge.v : baseEdge.w;
               return {
                 name: name,
@@ -609,8 +609,8 @@ limitations under the License.
                     this.renderHierarchy),
                 renderInfo: this._getRenderInfo(name, this.renderHierarchy)
               };
-            }, this);
-          }.bind(this);
+            });
+          };
 
           /**
            * Converts a list of metaedges to a list of edge information
@@ -618,7 +618,7 @@ limitations under the License.
            */
           var toEdgeInfoList = function(edges) {
             var edgeInfoList = [];
-            _.each(edges, function(metaedge) {
+            _.each(edges, (metaedge) => {
               var name = isPredecessor ? metaedge.v : metaedge.w;
               // Enumerate all the base edges if the node is an OpNode, or the
               // metaedge has only 1 edge in it.
@@ -633,7 +633,7 @@ limitations under the License.
                   renderInfo: this._getRenderInfo(name, this.renderHierarchy)
                 });
               }
-            }, this);
+            });
             return edgeInfoList;
           }.bind(this);
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
@@ -220,7 +220,7 @@ export class DataPanel extends DataPanelPolymer {
       }
       return stats.name;
     });
-    
+
     if (this.selectedLabelOption == null || this.labelOptions.filter(name =>
         name === this.selectedLabelOption).length === 0) {
       this.selectedLabelOption = this.labelOptions[Math.max(0, labelIndex)];
@@ -301,7 +301,7 @@ export class DataPanel extends DataPanelPolymer {
   private metadataEditorInputChange() {
     let col = this.metadataEditorColumn;
     let value = this.metadataEditorInput;
-    let selectionSize = this.selectedPointIndices.length + 
+    let selectionSize = this.selectedPointIndices.length +
         this.neighborsOfFirstPoint.length;
     if (selectionSize > 0) {
       if (value != null && value.trim() !== '') {
@@ -369,7 +369,7 @@ export class DataPanel extends DataPanelPolymer {
         && this.projector.dataSet.spriteAndMetadataInfo) {
       let tsvFile = this.projector.dataSet.spriteAndMetadataInfo.stats.map(s =>
           s.name).join('\t');
-      
+
       this.projector.dataSet.spriteAndMetadataInfo.pointsInfo.forEach(p => {
         let vals = [];
 
@@ -425,14 +425,14 @@ export class DataPanel extends DataPanelPolymer {
     if (this.projector && this.projector.dataSet) {
       let numMatches = this.projector.dataSet.points.filter(p =>
           p.metadata[this.superviseColumn].toString().trim() === value).length;
-      
+
       if (numMatches === 0) {
-        this.superviseInputLabel = 
+        this.superviseInputLabel =
             `Supervising without '${this.superviseInputSelected}'`;
       }
       else {
         this.superviseInputSelected = value;
-        this.superviseInputLabel = 
+        this.superviseInputLabel =
             `Supervising without '${value}' [${numMatches} points]`;
         this.setSupervision(this.superviseColumn, value);
       }

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -213,9 +213,9 @@ def tensorboard_js_workspace():
           # Plottable doesn't have a release tarball on GitHub. Using the
           # sources directly from git also requires running Node tooling
           # beforehand to generate files. NPM is the only place to get it.
-          "377159c707151d2aa393c720a668a599a92194d55eb2a2d2cecabe4a3f164036": [
-              "https://mirror.bazel.build/registry.npmjs.org/plottable/-/plottable-3.8.3.tgz",
-              "https://registry.npmjs.org/plottable/-/plottable-3.8.3.tgz",
+          "08df639782baf9b8cfeeb5fcdfbe3a1ce25b5a916903fc580e201a0a1142a6c4": [
+              "https://mirror.bazel.build/registry.npmjs.org/plottable/-/plottable-3.7.0.tgz",
+              "https://registry.npmjs.org/plottable/-/plottable-3.7.0.tgz",
           ],
       },
   )

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -76,15 +76,19 @@ def tensorboard_js_workspace():
       sha256_urls = {
           "a7d00bfd54525bc694b6e32f64c7ebcf5e6b7ae3657be5cc12767bce74654a47": [
               "https://mirror.bazel.build/raw.githubusercontent.com/Microsoft/TypeScript/v2.7.2/LICENSE.txt",
-              "https://raw.githubusercontent.com/Microsoft/TypeScript/v2.7.2/LICENSE.txt",
+              "https://raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/LICENSE.txt",
           ],
-          "142835127a60e881e0cc476678392179b5c77565e3a1b930a4ba032c0fa04de4": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/Microsoft/TypeScript/v2.7.2/lib/tsc.js",
-              "https://raw.githubusercontent.com/Microsoft/TypeScript/v2.7.2/lib/tsc.js",
+          "9632bfccde117a8c82690a324bc5c18c3869e9b89ac536fc134ba655d7ec1e98": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/tsc.js",
+              "https://raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/tsc.js",
           ],
-          "aeaa3ed17f0fca1e8519e323dfbddee1fb8870f1fd4752a89a6578580b17a88c": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/Microsoft/TypeScript/v2.7.2/lib/lib.es6.d.ts",
-              "https://raw.githubusercontent.com/Microsoft/TypeScript/v2.7.2/lib/lib.es6.d.ts",
+          "529c9f8b45939e0fa80950208bf80452ccb982b460cc25433813c919b67a3b2f": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/lib.es6.d.ts",
+              "https://raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/lib.es6.d.ts",
+          ],
+          "f6e6efe57fb9fcf72eed013e2755d04505300f32b78577118ca5dacc85ec852d": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/lib.dom.d.ts",
+              "https://raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/lib.dom.d.ts",
           ],
       },
       extra_build_file_content = "\n".join([

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -222,12 +222,12 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "6a349742a6cb219d5a2fc8d0844f6d89a6efc62e20c664450d884fc7ff2d6015": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/cpettitt/dagre/v0.7.4/LICENSE",
-              "https://raw.githubusercontent.com/cpettitt/dagre/v0.7.4/LICENSE",
+              "https://mirror.bazel.build/raw.githubusercontent.com/cpettitt/dagre/v0.8.2/LICENSE",
+              "https://raw.githubusercontent.com/cpettitt/dagre/v0.8.2/LICENSE",
           ],
-          "7323829ddd77924a69e2b1235ded3eac30acd990da0f037e0fbd3c8e9035b50d": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/cpettitt/dagre/v0.7.4/dist/dagre.core.js",
-              "https://raw.githubusercontent.com/cpettitt/dagre/v0.7.4/dist/dagre.core.js",
+          "43cb4e919196c177c149b63880d262074670af99db6a1e174b25e266da4935a9": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/cpettitt/dagre/v0.8.2/dist/dagre.core.js",
+              "https://raw.githubusercontent.com/cpettitt/dagre/v0.8.2/dist/dagre.core.js",
           ],
       },
   )
@@ -237,12 +237,12 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "6a349742a6cb219d5a2fc8d0844f6d89a6efc62e20c664450d884fc7ff2d6015": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/cpettitt/graphlib/v1.0.7/LICENSE",
-              "https://raw.githubusercontent.com/cpettitt/graphlib/v1.0.7/LICENSE",
+              "https://mirror.bazel.build/raw.githubusercontent.com/cpettitt/graphlib/v2.1.5/LICENSE",
+              "https://raw.githubusercontent.com/cpettitt/graphlib/v2.1.5/LICENSE",
           ],
-          "772045d412b1513b549be991c2e1846c38019429d43974efcae943fbe83489bf": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/cpettitt/graphlib/v1.0.7/dist/graphlib.core.js",
-              "https://raw.githubusercontent.com/cpettitt/graphlib/v1.0.7/dist/graphlib.core.js",
+          "ddc33a6aaf955ee24b0e0d30110adf350c65eedc5c0f2c424ca85bc128199a66": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/cpettitt/graphlib/v2.1.5/dist/graphlib.core.js",
+              "https://raw.githubusercontent.com/cpettitt/graphlib/v2.1.5/dist/graphlib.core.js",
           ],
       },
   )

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -268,9 +268,9 @@ def tensorboard_js_workspace():
       # no @license header
       licenses = ["notice"],  # BSD-3-Clause
       sha256_urls_extract = {
-          "d858c0878af36bd00e2af6029029106328d408c2bff0a60a9d78c4e27f47b99a": [
-              "https://mirror.bazel.build/github.com/d3/d3/releases/download/v4.9.1/d3.zip",
-              "https://github.com/d3/d3/releases/download/v4.9.1/d3.zip",
+          "29288a2be82014ffa03f8ee1f8519bd43b71f09790409dcfa300ee3bb77fd81b": [
+              "https://mirror.bazel.build/github.com/d3/d3/releases/download/v4.13.0/d3.zip",
+              "https://github.com/d3/d3/releases/download/v4.13.0/d3.zip",
           ],
       },
       # TODO(jart): Use srcs=["d3.js"] instead of this once supported.

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -209,9 +209,9 @@ def tensorboard_js_workspace():
           # Plottable doesn't have a release tarball on GitHub. Using the
           # sources directly from git also requires running Node tooling
           # beforehand to generate files. NPM is the only place to get it.
-          "e3159beb279391c47433789f22b32bac88488cfcad6c0b6ec8605ce6b0081b0d": [
-              "https://mirror.bazel.build/registry.npmjs.org/plottable/-/plottable-3.1.0.tgz",
-              "https://registry.npmjs.org/plottable/-/plottable-3.1.0.tgz",
+          "377159c707151d2aa393c720a668a599a92194d55eb2a2d2cecabe4a3f164036": [
+              "https://mirror.bazel.build/registry.npmjs.org/plottable/-/plottable-3.8.3.tgz",
+              "https://registry.npmjs.org/plottable/-/plottable-3.8.3.tgz",
           ],
       },
   )

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -173,12 +173,12 @@ def tensorboard_js_workspace():
   web_library_external(
       name = "com_lodash",
       licenses = ["notice"],  # MIT
-      sha256 = "0e88207e5f90af4ce8790d6e1e7d09d2702d81bce0bafdc253d18c0a5bf7661e",
+      sha256 = "6c5fa80d0fa9dc4eba634ab042404ff7c162dcb4cfe3473338801aeca0042285",
       urls = [
-          "https://mirror.bazel.build/github.com/lodash/lodash/archive/3.10.1.tar.gz",
-          "https://github.com/lodash/lodash/archive/3.10.1.tar.gz",
+          "https://mirror.bazel.build/github.com/lodash/lodash/archive/4.17.5.tar.gz",
+          "https://github.com/lodash/lodash/archive/4.17.5.tar.gz",
       ],
-      strip_prefix = "lodash-3.10.1",
+      strip_prefix = "lodash-4.17.5",
       path = "/lodash",
       srcs = ["lodash.js"],
       extra_build_file_content = "exports_files([\"LICENSE\"])",

--- a/third_party/typings.bzl
+++ b/third_party/typings.bzl
@@ -29,6 +29,9 @@ def tensorboard_typings_workspace():
               "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/5d0f2126c8dac8fce0ff020218aea06607213b0d/google.analytics/ga.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/5d0f2126c8dac8fce0ff020218aea06607213b0d/google.analytics/ga.d.ts",
           ],
+          # TODO(jart): Upgrade to Lodash v4 typing: Lodash package is broken
+          # down into small subpackages with many smaller type files. Loading
+          # one type file is no longer enough.
           "e4cd3d5de0eb3bc7b1063b50d336764a0ac82a658b39b5cf90511f489ffdee60": [
               "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/efd40e67ff323f7147651bdbef03c03ead7b1675/lodash/lodash.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/efd40e67ff323f7147651bdbef03c03ead7b1675/lodash/lodash.d.ts",

--- a/third_party/typings.bzl
+++ b/third_party/typings.bzl
@@ -63,9 +63,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_array",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "61e7abb7b1f01fbcb0cab8cf39003392f422566209edd681fbd070eaa84ca000": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-array/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-array/index.d.ts",  # 2017-06-08
+          "4dcaaf18d720a1aa200ee455fe5d2a3bc577366ee5ba825bf9cabb6ed313f94c": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-array/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-array/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -74,9 +74,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_axis",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "95f75c8dcc89850b2e72581d96a7b5f46ea4ac852f828893f141f14a597421f9": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-axis/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-axis/index.d.ts",  # 2017-06-08
+          "6a43110a41bbf3190ef6c515fc8b932086122b7d2fd32e841f4756ba507406c3": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-axis/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-axis/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -85,9 +85,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_brush",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "a2738e693ce8a8640c2d29001e77582c9c361fd23bda44db471629866b60ada7": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-brush/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-brush/index.d.ts",  # 2017-06-08
+          "fb5d5bef5af05e086085892946769b9ec8c0f9217876933671038b665a6ec603": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-brush/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-brush/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -96,9 +96,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_chord",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "c54d24756eb6d744b31e538ad9bab3a75f6d54e2288b29cc72338d4a057d3e83": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-chord/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-chord/index.d.ts",  # 2017-06-08
+          "9a06f750a483ae5ce10ceda48c5004cd918c4d803762661dca52eedfd2ed7afd": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-chord/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-chord/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -107,9 +107,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_collection",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "39e8599a768f45f80aa70ca3032f026111da50d409c7e39a2ef091667cc343d9": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-collection/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-collection/index.d.ts",  # 2017-06-08
+          "8f6ec0925d0ba17efa0dcfea9ab8b3f73114222a569704849e8a169533ea0f95": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-collection/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-collection/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -118,9 +118,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_color",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "6dd19edd11276476c5d535279237d1a009c1a733611cc44621a88fda1ca04377": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-color/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-color/index.d.ts",  # 2017-06-08
+          "83a206846be71cca27273fa5c39544b7d51c9aab8336ae6b5135c6b71a178bbf": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-color/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-color/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -129,9 +129,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_dispatch",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "af1474301e594fcb4bbdb134361fb6d26c7b333386c3213821532acde59e61a3": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-dispatch/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-dispatch/index.d.ts",  # 2017-06-08
+          "4ddaa6005cfd5fd07df24e8af735d2c1a90d896bd5cacc2f657fe8748ae25af9": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-dispatch/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-dispatch/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -140,9 +140,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_drag",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "2f8248ae2bf33fb1d61bb1ea4271cb4bacfd9a9939dc8d7bde7ec8b66d4441ed": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-drag/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-drag/index.d.ts",  # 2017-06-08
+          "99c4e6872495378bcb768d8cc99551aaee43ba2324fd56282f8f03d81c499975": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-drag/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-drag/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -151,9 +151,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_dsv",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "62594d00cf9e4bb895339c8e56f64330e202a5eb2a0fa580a1f6e6336f2c93ce": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-dsv/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-dsv/index.d.ts",  # 2017-06-08
+          "5fccc13fc4d3b1c6a434cb277c491ac8d47baed9baba86bdb441ee18ec5bc76e": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-dsv/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-dsv/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -163,8 +163,8 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "d5a9be5316b2d1823a3faa7f75de1e2c2efda5c75f0631b44a0f7b69e11f3a90": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-ease/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-ease/index.d.ts",  # 2017-06-08
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-ease/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-ease/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -173,9 +173,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_force",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "288421e2008668d2076a4684657dd3d29b992832ef02c552981eb94a91042553": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-force/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-force/index.d.ts",  # 2017-06-08
+          "a6941d869584c8f426d5dfbe89ad0f082c104477f81c7d2fe432ccae3cc2ece8": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-force/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-force/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -184,9 +184,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_format",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "b42cb17e580c1fd0b64d478f7bd80ca806efaefda24426a833cf1f30a7275bca": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-format/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-format/index.d.ts",  # 2017-06-08
+          "b5b8cf2707e4c60ea98341e3c5c913f1af2e2bd7c61b90a8329260692fe1f694": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-format/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-format/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -195,9 +195,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_hierarchy",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "a5683f5835d8716c6b89c075235078438cfab5897023ed720bfa492e244e969e": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-hierarchy/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-hierarchy/index.d.ts",  # 2017-06-08
+          "eb527ec61d4a7d81db35f823104fa57cb3def41d72eaa9ce827295d440283206": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-hierarchy/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-hierarchy/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -206,9 +206,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_interpolate",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "effeefea9ac02539def43d7b9aa2f39e8672c03aac9b407a61b09563ff141fad": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-interpolate/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-interpolate/index.d.ts",  # 2017-06-08
+          "e2f3ebafe2b7c6011fe76d19f9e32d8c8b67076b39f7cfa945d543e39f3ef18f": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-interpolate/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-interpolate/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -217,9 +217,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_path",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "deea4ab3654925d365dd1ffab69a2140808c6173e7f23c461ded2852c309eb9c": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-path/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-path/index.d.ts",  # 2017-06-08
+          "daad2baf9dd5af11d3c3095c6fb93f7749e581943873b29b6dfc4a6f22d3d6e2": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-path/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-path/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -228,9 +228,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_polygon",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "ec7a42affe79c87066f14173fcbc8d8b5747f54bfbe0e60111e2786ee4d227bf": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-polygon/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-polygon/index.d.ts",  # 2017-06-08
+          "a76d53d353351cabaaca7f149a57c5ffc7d90c0f181d7f3f40e4a51424289a75": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-polygon/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-polygon/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -239,9 +239,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_quadtree",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "2908631a7da3bfb0096e3b89f464b45390bbb31ec798d1b6c0898ff82e344560": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-quadtree/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-quadtree/index.d.ts",  # 2017-06-08
+          "4ebfae1202903a6d8d2ab52dede7631f2d8d277cbec8107607df7372d19ebbb6": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-quadtree/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-quadtree/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -250,9 +250,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_queue",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "4fc0503e3558d136b855335f36ea8984937ab63a2a28b8c7b293d35825388615": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-queue/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-queue/index.d.ts",  # 2017-06-08
+          "3d48a2e31ee7b4bc687a6b85b49bcb37e043e0dec4c83fcda8baad27fda7c114": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-queue/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-queue/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -261,9 +261,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_random",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "5130e803ba26d2dc931ddd0fa574b5abbb0fc4486e7975f97a83c01630763676": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-random/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-random/index.d.ts",  # 2017-06-08
+          "e30e9105a9c2e11410a452a02e320aebe66a1856e6b9410035ee7b3ad7d80839": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-random/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-random/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -273,8 +273,8 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "fc2b7c2c05498011eb039825aab76a7916698fb3e7133e278fc92ae529ae99f0": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-request/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-request/index.d.ts",  # 2017-06-08
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-request/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-request/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -283,9 +283,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_scale",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "ff3e2d2033a37d698c3bd2896ffd9dd4ceab1903d96aa90d388a6a2d14d8ee05": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-scale/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-scale/index.d.ts",  # 2017-06-08
+          "a4d4d1605d835182b2e7af77ea00c982cac6835e4692ab0931c7e3cd68c320a2": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-scale/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-scale/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -294,9 +294,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_selection",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "47fae7c4bc425101490daae067727b74ee09e6c830331a4cf333cdb532a5d108": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-selection/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-selection/index.d.ts",  # 2017-06-08
+          "0e1bf1308ca27649010d5ae91783decd1337bda581b66aaa8be12060110662fa": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-selection/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-selection/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -305,9 +305,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_shape",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "7fec580ba54bc29417dc9030bb3731c9756a65c5e57dcce5a4f183fff7180cd8": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-shape/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-shape/index.d.ts",  # 2017-06-08
+          "47c61d4d8ba88c113fe9f3b37585656c66eddd95262554108a6507674a6c3b3a": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-shape/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-shape/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -316,9 +316,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_time",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "4b68f2a4ee428f21f2e7d706c0a64f628f0ff5f130cd9f023ab23a04a8fe31de": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-time/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-time/index.d.ts",  # 2017-06-08
+          "39fb4b2ad57ef393eabd017356f05854a44268a6b98cd2b235c8732fb9989d83": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-time/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-time/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -327,9 +327,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_timer",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "a196f42560be9fa1a77d473c0180f9f2f8d570ed0eee616aad0da94d90ef3661": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-timer/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-timer/index.d.ts",  # 2017-06-08
+          "79021d12162bdd6a850ce4c1a9014b342067db30816f907d4118578c2a59db76": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-timer/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-timer/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -338,9 +338,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_transition",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "10c6cf259d6f965014e75a63925f302911c5afb8581d6d63b0597544fe104bd7": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-transition/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-transition/index.d.ts",  # 2017-06-08
+          "88e6d462d5a592a2ebbdad7865142160341c93698c50701c4186bcb65a7685a7": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-transition/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-transition/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -349,9 +349,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_voronoi",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "411482515e2ccda4659f7b3d2fbd3a7ef5ea2c7053eec62c95a174b68ad60c3d": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-voronoi/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-voronoi/index.d.ts",  # 2017-06-08
+          "8936e0e6b0f0416c4c08f79e1555869a8553dc04723c4d8fa12990e755f460f5": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-voronoi/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-voronoi/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -360,9 +360,9 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_zoom",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "df0bedbb7711366a43418d6a3b47c4688ccb02a3d8ad0c2468cafcb6c2faa346": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-zoom/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/dc27c3788c00d279ae5ff61e8e2dfd568aae5e8e/types/d3-zoom/index.d.ts",  # 2017-06-08
+          "65ea463a1297778ebf88e37444722bacd4d33db9a59ac69e78127e1c23670dd3": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-zoom/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-zoom/index.d.ts",  # 2018-08-06
           ],
       },
   )

--- a/third_party/typings.bzl
+++ b/third_party/typings.bzl
@@ -63,9 +63,11 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_array",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "4dcaaf18d720a1aa200ee455fe5d2a3bc577366ee5ba825bf9cabb6ed313f94c": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-array/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-array/index.d.ts",  # 2018-08-06
+          # TODO(stephanwlee): d3-array is pinned at b6746d. number[] does not
+          # cast to d3.ArrayLike<number> for some reason.
+          "61e7abb7b1f01fbcb0cab8cf39003392f422566209edd681fbd070eaa84ca000": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/b6746d73a2ddf103c6825449ee2b0953f716d994/types/d3-array/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/b6746d73a2ddf103c6825449ee2b0953f716d994/types/d3-array/index.d.ts",  # 2018-08-06
           ],
       },
   )
@@ -283,9 +285,13 @@ def tensorboard_typings_workspace():
       name = "org_definitelytyped_types_d3_scale",
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "a4d4d1605d835182b2e7af77ea00c982cac6835e4692ab0931c7e3cd68c320a2": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-scale/index.d.ts",
-              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-scale/index.d.ts",  # 2018-08-06
+          # TODO(stephanwlee): Pinned at ff2359 because versions after this
+          # upgrades to d3-scale v2 which is part of d3 v5. In d3 v5, it splits
+          # d3-scale into d3-scale and d3-scale-chromatic and deprecates
+          # d3.schemeCategory20.
+          "58646b85fbbeaa88ff29342e9f1a89cea2d6fa8cb1b5549dc7ec8e9f7e021894": [
+              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ff2359e74ce1c539097e47dc586d49d348a94587/types/d3-scale/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ff2359e74ce1c539097e47dc586d49d348a94587/types/d3-scale/index.d.ts",  # 2018-08-06
           ],
       },
   )


### PR DESCRIPTION
- Lodash renamed `pairs` to `toPairs`.
- `sortedIndex` renamed to `sortedIndexBy`

Unfortunately, type information lacks reference to the new ones
so we wrote the POJO version of these utilities at least for now.

