### PR TITLE
Integrate selectionCategory to scalar plugin

### DIFF
--- a/tensorboard/components/tf_data_selector/tf-data-selector.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.html
@@ -40,8 +40,11 @@ Properties out:
       if="[[!_canCompareExperiments(_comparingExps)]]"
       restamp
     >
-      <tf-data-select-row no-experiment persistence-number="0">
-      </tf-data-select-row>
+      <tf-data-select-row
+        no-experiment
+        persistence-number="0"
+        on-selection-changed="_selectionChanged"
+      ></tf-data-select-row>
     </template>
     <template is="dom-repeat" items="[[_comparingExps]]" as="exp">
       <tf-data-select-row
@@ -90,5 +93,6 @@ Properties out:
     </style>
   </template>
   <script src="storage-utils.js"></script>
+  <script src="type.js"></script>
   <script src="tf-data-selector.js"></script>
 </dom-module>

--- a/tensorboard/components/tf_data_selector/tf-data-selector.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.ts
@@ -37,10 +37,13 @@ Polymer({
     // the unused tag names in the list of selection.
 
     selection: {
-      type: Array,
+      type: Object,
       notify: true,
       readOnly: true,
-      value: (): Array<tf_data_selector.Selection> => ([]),
+      value: (): DataSelection => ({
+        type: tf_data_selector.Type.WITHOUT_EXPERIMENT,
+        selections: [],
+      }),
     },
 
 
@@ -80,6 +83,8 @@ Polymer({
       {defaultValue: '', polymerProperty: '_comparingExpsString'}),
 
   _canCompareExperiments(): boolean {
+    // TODO(stephanwlee): change this to be based on whether user is using
+    // logdir or db.
     return Boolean(this._comparingExps.length);
   },
 
@@ -99,14 +104,20 @@ Polymer({
         .filter(id => !comparingExpIds.has(id))
         .forEach(id => this._selectionMap.delete(id));
 
-    this._setSelection(Array.from(this._selectionMap.values()));
+    this._setSelection({
+      type: tf_data_selector.Type.WITH_EXPERIMENT,
+      selections: Array.from(this._selectionMap.values()),
+    });
   },
 
   _selectionChanged(event) {
     const {runs, tagRegex} = event.detail;
 
     if (!this._canCompareExperiments()) {
-      this._setSelection([{runs, tagRegex}]);
+      this._setSelection({
+        type: tf_data_selector.Type.WITHOUT_EXPERIMENT,
+        selections: [{runs, tagRegex}],
+      });
       return;
     }
 
@@ -116,7 +127,10 @@ Polymer({
       runs,
       tagRegex,
     });
-    this._setSelection(Array.from(this._selectionMap.values()));
+    this._setSelection({
+      type: tf_data_selector.Type.WITH_EXPERIMENT,
+      selections: Array.from(this._selectionMap.values())
+    });
   },
 
   _addExperiments(event) {

--- a/tensorboard/components/tf_data_selector/type.ts
+++ b/tensorboard/components/tf_data_selector/type.ts
@@ -14,10 +14,20 @@ limitations under the License.
 ==============================================================================*/
 namespace tf_data_selector {
 
+export enum Type {
+  WITHOUT_EXPERIMENT,
+  WITH_EXPERIMENT,
+}
+
 export type Selection = {
   experiment?: tf_backend.Experiment,
   runs: Array<tf_backend.Run>,
   tagRegex: string,
+}
+
+export type DataSelection = {
+  type: Type,
+  selections: Array<Selection>
 }
 
 }  // namespace tf_data_selector

--- a/tensorboard/components/tf_line_chart_data_loader/data-loader-behavior.ts
+++ b/tensorboard/components/tf_line_chart_data_loader/data-loader-behavior.ts
@@ -37,7 +37,7 @@ export const DataLoaderBehavior = {
      * A function that takes a datum as an input and returns a unique
      * identifiable string. Used for caching purposes.
      */
-    getDataLoadId: {
+    getDataLoadName: {
       type: Function,
       value: () => (datum) => String(datum),
     },
@@ -124,14 +124,15 @@ export const DataLoaderBehavior = {
       // Before updating, cancel any network-pending updates, to
       // prevent race conditions where older data stomps newer data.
       this._canceller.cancelAll();
-      const promises = this.dataToLoad.map(datum => {
-        const id = this.getDataLoadId(datum);
-        if (this._loadedData.has(id)) return Promise.resolve();
-
+      const promises = this.dataToLoad.filter(datum => {
+        const name = this.getDataLoadName(datum);
+        return !this._loadedData.has(name);
+      }).map(datum => {
+        const name = this.getDataLoadName(datum);
         const url = this.getDataLoadUrl(datum);
         const updateSeries = this._canceller.cancellable(result => {
           if (result.cancelled) return;
-          this._loadedData.add(id);
+          this._loadedData.add(name);
           this.loadDataCallback(this, datum, result.value);
         });
         return this.requestManager.request(url).then(updateSeries);

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -121,6 +121,8 @@ limitations under the License.
           observer: '_fixBadStateWhenActive',
         },
 
+        dataSeries: Array,
+
         requestManager: Object,
 
         logScaleActive: {

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -504,8 +504,11 @@ limitations under the License.
           value: false,
         },
         _dataSelection: {
-          type: Array,
-          value: () => [],
+          type: Object,
+          value: () => ({
+            type: tf_data_selector.Type.WITHOUT_EXPERIMENT,
+            selections: [],
+          }),
         },
         _lastReloadTime: {
           type: String,

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -19,6 +19,7 @@ tf_web_library(
         "//tensorboard/components/tf_categorization_utils",
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_data_selector",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_line_chart_data_loader",

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -38,9 +38,10 @@ limitations under the License.
   <div id="tf-line-chart-data-loader-container">
     <tf-line-chart-data-loader
       active="[[active]]"
-      data-series="[[_getDataSeries(dataToLoad.*)]]"
+      color-scale="[[_getColorScale(multiExperiments)]]"
+      data-series="[[_getDataSeries(multiExperiments, dataToLoad.*)]]"
       data-to-load="[[dataToLoad]]"
-      get-data-load-id="[[_getDataLoadId]]"
+      get-data-load-name="[[_getDataLoadName]]"
       get-data-load-url="[[getDataLoadUrl]]"
       ignore-y-outliers="[[ignoreYOutliers]]"
       load-data-callback="[[_loadDataCallback]]"
@@ -177,6 +178,8 @@ limitations under the License.
          */
         xType: String,
 
+        multiExperiments: Boolean,
+
         active: Boolean,
         ignoreYOutliers: Boolean,
         requestManager: Object,
@@ -185,9 +188,6 @@ limitations under the License.
         smoothingWeight: Number,
         tagMetadata: Object,
         tooltipSortingMethod: String,
-        // Function that takes a data series and returns a string URL for
-        // fetching data.
-        getDataLoadUrl: Function,
 
         // This function is called when data is received from the backend.
         _loadDataCallback: {
@@ -206,10 +206,22 @@ limitations under the License.
           readOnly: true,
         },
 
-        // TODO(stephanwlee): Make it experiment aware.
-        _getDataLoadId: {
+        getDataLoadUrl: {
           type: Function,
-          value: () => ({run}) => run,
+          value: function() {
+            return ({tag, run, experiment}) => {
+              return tf_backend.addParams(
+                  tf_backend.getRouter().pluginRoute('scalars', '/scalars'),
+                  {tag, run, experiment});
+            }
+          },
+        },
+
+        _getDataLoadName: {
+          type: Function,
+          value: function() {
+            return this._getSeriesNameFromDatum;
+          },
         },
 
         _expanded: {
@@ -219,7 +231,6 @@ limitations under the License.
         },
 
         _logScaleActive: Boolean,
-
       },
       reload() {
         this.$$('tf-line-chart-data-loader').reload();
@@ -249,10 +260,24 @@ limitations under the License.
         return this.getDataLoadUrl({tag, run});
       },
       _getDataSeries() {
-        return this.dataToLoad.map(this._getSeriesNameFromDatum);
+        return this.dataToLoad.map(d => this._getSeriesNameFromDatum(d));
       },
       _getSeriesNameFromDatum(datum) {
-        return datum.run;
+        return datum.experiment ?
+            `${datum.experiment}/${datum.run}` :
+            datum.run;
+      },
+      _getColorScale() {
+        return {
+          scale: (name) => {
+            const splitIndex = name.indexOf('/');
+            const exp = name.slice(0, splitIndex);
+            const run = name.slice(splitIndex + 1);
+            return this.multiExperiments ?
+                tf_color_scale.experimentsColorScale(exp) :
+                tf_color_scale.runsColorScale(run);
+          },
+        };
       },
   });
 </script>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -29,6 +29,7 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/dashboard-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
+<link rel="import" href="../tf-data-selector/tf-data-selector.html">
 <link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../tf-paginated-view/tf-paginated-view.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
@@ -139,10 +140,10 @@ limitations under the License.
                           show-download-links="[[_showDownloadLinks]]"
                           request-manager="[[_requestManager]]"
                           data-to-load="[[item.series]]"
+                          multi-experiments="[[_getMultiExperiments(dataSelection.*)]]"
                           tag="[[item.tag]]"
                           tag-metadata="[[_tagMetadata(_runToTagInfo, item.runs, item.tag)]]"
                           active="[[page.active]]"
-                          get-data-load-url="[[_dataUrl]]"
                         ></tf-scalar-card>
                       </template>
                     </div>
@@ -183,9 +184,15 @@ limitations under the License.
   </template>
 
   <script>
+    const PLUGIN_NAME = 'scalars';
+    const USE_DATA_SELECTOR = Boolean(
+        tf_storage.getBoolean('EnableDataSelector', {useLocalStorage: true}));
+
     Polymer({
       is: 'tf-scalar-dashboard',
       properties: {
+        /** @type {!tf_data_selector.DataSelection} */
+        dataSelection: Object,
         _showDownloadLinks: {
           type: Boolean,
           notify: true,
@@ -226,18 +233,17 @@ limitations under the License.
         _categories: {
           type: Array,
           computed:
-            '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter, _categoriesDomReady)',
+            '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter, _categoriesDomReady, dataSelection)',
         },
 
         _requestManager: {
           type: Object,
           value: () => new tf_backend.RequestManager(50),
         },
-        _dataUrl: {
-          type: Function,
-          value: () => ({tag, run}) => tf_backend.addParams(
-              tf_backend.getRouter().pluginRoute('scalars', '/scalars'),
-              {tag, run}),
+
+        useDataSelector: {
+          type: Boolean,
+          value: USE_DATA_SELECTOR,
         },
       },
       _showDownloadLinksObserver: tf_storage.getBooleanObserver(
@@ -287,10 +293,38 @@ limitations under the License.
 
       _makeCategories(
           runToTagInfo, selectedRuns, tagFilter, categoriesDomReady) {
-        const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
-        // TODO(stephanwlee): Apply the new categorization based on selection.
+        if (this.useDataSelector &&
+            this.dataSelection.type == tf_data_selector.Type.WITH_EXPERIMENT) {
+          const categories = tf_categorization_utils.categorizeSelection(
+              this.dataSelection.selections, PLUGIN_NAME);
+          categories.forEach(category => {
+            category.items.forEach(item => {
+              // Add tags information to series.
+              item.series = item.series.map(series => ({
+                experiment: series.experiment,
+                run: series.run,
+                tag: item.tag,
+              }));
+            });
+          });
+          return categories;
+        }
+
+        let query = tagFilter;
+
+        if (this.useDataSelector) {
+          const {runs, tagRegex} = this.dataSelection.selections[0];
+          query = tagRegex;
+          selectedRuns = this.useDataSelector ?
+              runs.map(({name}) => name) :
+              selectedRuns;
+        }
+
+        const runToTag = _.mapValues(
+            _.pick(runToTagInfo, selectedRuns),
+            x => Object.keys(x));
         const categories = tf_categorization_utils.categorizeTags(
-            runToTag, selectedRuns, tagFilter);
+            runToTag, selectedRuns, query);
         categories.forEach(category => {
           category.items = category.items.map(item => ({
             tag: item.tag,
@@ -313,13 +347,16 @@ limitations under the License.
         const defaultDisplayName = tag.replace(/\/scalar_summary$/, '');
         return tf_utils.aggregateTagInfo(runToTagInfo, defaultDisplayName);
       },
+
+      _getMultiExperiments() {
+        return this.dataSelection.type == tf_data_selector.Type.WITH_EXPERIMENT;
+      },
     });
 
     tf_tensorboard.registerDashboard({
-      plugin: 'scalars',
+      plugin: PLUGIN_NAME,
       elementName: 'tf-scalar-dashboard',
-      useDataSelector: Boolean(
-          tf_storage.getBoolean('EnableDataSelector', {useLocalStorage: true})),
+      useDataSelector: USE_DATA_SELECTOR,
     });
 
   </script>


### PR DESCRIPTION
When using data selector experiment, scalar plugin now uses
the selectionCategory to populate the items.

The change that is not backwards compatible is the name of the
every row in the tooltipe has prefix of "default/" in all cases.