### PR TITLE
Toggle data-selection-row with toggle button

### DIFF
--- a/tensorboard/components/tf_backend/type.ts
+++ b/tensorboard/components/tf_backend/type.ts
@@ -14,17 +14,21 @@ limitations under the License.
 ==============================================================================*/
 namespace tf_backend {
 
-export type Experiment = {id: number, name: string, startTime: number};
+export type ExperimentId = number;
+export type RunId = number | null;
+export type TagId = number;
+
+export type Experiment = {id: ExperimentId, name: string, startTime: number};
 
 export type Run = {
-  id: number | null,
+  id: RunId,
   name: string,
   startTime: number,
   tags: Tag[],
 };
 
 export type Tag = {
-  id: number,
+  id: TagId,
   name: string,
   displayName: string,
   pluginName: string,

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.html
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.html
@@ -46,6 +46,7 @@ Event out:
         id="checkbox"
         checked="{{enabled}}"
         title="[[experiment.name]]"
+        on-change="_fireCheckboxToggled"
       >
         [[experiment.name]]
       </paper-checkbox>

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.ts
@@ -145,13 +145,14 @@ Polymer({
           startedTime: null,
         })));
       });
-    } else if (this.experiment.id) {
-      const url = tf_backend.getRouter().runsForExperiment(this.experiment.id);
-      return requestManager.request(url).then(runs => {
-        this.set('_runs', runs);
-      });
     }
-    return Promise.resolve();
+
+    console.assert(this.experiment.id != null, 'Expected an experiment Id');
+
+    const url = tf_backend.getRouter().runsForExperiment(this.experiment.id);
+    return requestManager.request(url).then(runs => {
+      this.set('_runs', runs);
+    });
   },
 
   _getRunOptions(_): Array<tf_dashboard_common.FilterableCheckboxListItem> {

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.ts
@@ -146,6 +146,7 @@ Polymer({
         this.set('_runs', runs);
       });
     }
+    return Promise.resolve();
   },
 
   _getRunOptions(_): Array<tf_dashboard_common.FilterableCheckboxListItem> {

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.ts
@@ -242,6 +242,10 @@ Polymer({
   _getSyntheticRunId(run) {
     return this.noExperiment ? run.name : run.id;
   },
+
+  _fireCheckboxToggled() {
+    this.fire('checkbox-toggle');
+  },
 });
 
 }  // namespace tf_data_selector

--- a/tensorboard/components/tf_data_selector/tf-data-selector.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.html
@@ -37,7 +37,7 @@ Properties out:
   <template>
     <template
       is="dom-if"
-      if="[[!_canCompareExperiments(_comparingExps)]]"
+      if="[[!_canCompareExperiments(_experiments)]]"
       restamp
     >
       <tf-data-select-row
@@ -46,23 +46,25 @@ Properties out:
         on-selection-changed="_selectionChanged"
       ></tf-data-select-row>
     </template>
-    <template is="dom-repeat" items="[[_comparingExps]]" as="exp">
+    <template is="dom-repeat" items="[[_experiments]]" as="exp">
       <tf-data-select-row
         checkbox-color="[[_getExperimentColor(exp)]]"
+        enabled="[[_isExperimentEnabled(exp)]]"
         experiment="[[exp]]"
-        persistence-id="[[_getPersistenceId(exp)]]"
-        on-selection-changed="_selectionChanged"
+        on-checkbox-toggle="_experimentCheckboxToggled"
         on-remove="_removeExperiment"
+        on-selection-changed="_selectionChanged"
+        persistence-id="[[_getPersistenceId(exp)]]"
       ></tf-data-select-row>
     </template>
 
     <template
       is="dom-if"
-      if="[[_shouldShowAddComparison(_allExperiments, _comparingExps)]]"
+      if="[[_shouldShowAddComparison(_allExperiments, _experiments)]]"
     >
       <experiment-selector
         id="selector"
-        exclude-experiments="[[_comparingExps]]"
+        exclude-experiments="[[_experiments]]"
         on-experiment-added="_addExperiments"
       ></experiment-selector>
     </template>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -312,8 +312,9 @@ limitations under the License.
 
         let query = tagFilter;
 
-        if (this.useDataSelector && this.dataSelection.selections.length) {
-          const {runs, tagRegex} = this.dataSelection.selections[0];
+        if (this.useDataSelector) {
+          const selection = this.dataSelection.selections[0] || {};
+          const {runs = [], tagRegex = ''} = selection;
           query = tagRegex;
           selectedRuns = runs.map(({name}) => name);
         }

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -312,12 +312,10 @@ limitations under the License.
 
         let query = tagFilter;
 
-        if (this.useDataSelector) {
+        if (this.useDataSelector && this.dataSelection.selections.length) {
           const {runs, tagRegex} = this.dataSelection.selections[0];
           query = tagRegex;
-          selectedRuns = this.useDataSelector ?
-              runs.map(({name}) => name) :
-              selectedRuns;
+          selectedRuns = runs.map(({name}) => name);
         }
 
         const runToTag = _.mapValues(


### PR DESCRIPTION
Data-selection can be easily toggled on/off without having to remove or
insert a new data grouping for comparison by simply clicking on the
checkbox on each row.

Now, the `selection` from `tf-data-selector` will honor the toggle
state of each selection row.