### PR TITLE
Filter scalar values based on optional param `experiment`

### DIFF
--- a/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
+++ b/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
@@ -47,7 +47,7 @@ export type TagCategory = Category<{tag: string, runs: string[]}>;
 export type RunTagCategory = Category<{tag: string, run: string}>;
 
 export type Series = {
-  experiment: string,
+  experiment: tf_backend.Experiment,
   run: string,
   tag: string,
 };
@@ -172,7 +172,7 @@ export function categorizeSelection(
     searchCategory.items.forEach(tag => {
       const series = tagToSearchSeries.get(tag) || [];
       series.push(...tagToSelectedRuns.get(tag)
-          .map(run => ({experiment: experiment.name, run})));
+          .map(run => ({experiment, run, tag})));
       tagToSearchSeries.set(tag, series);
     });
   });

--- a/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
+++ b/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
@@ -49,6 +49,7 @@ export type RunTagCategory = Category<{tag: string, run: string}>;
 export type Series = {
   experiment: string,
   run: string,
+  tag: string,
 };
 
 /**
@@ -57,7 +58,7 @@ export type Series = {
  */
 export type SeriesCategory = Category<{
   tag: string,
-  series: Array<Series>,
+  series: Series[],
 }>;
 
 export type RawCategory = Category<string>;  // Intermediate structure.
@@ -146,10 +147,10 @@ export function categorizeTags(
 export function categorizeSelection(
     selection: tf_data_selector.Selection[], pluginName: string):
     SeriesCategory[] {
-  const tagToSeries = new Map<string, Array<Series>>();
+  const tagToSeries = new Map<string, Series[]>();
   // `tagToSearchSeries` contains subset of `tagToSeries`. tagRegex in each
   // selection can omit series from a tag category.
-  const tagToSearchSeries = new Map<string, Array<Series>>();
+  const tagToSearchSeries = new Map<string, Series[]>();
   const searchCategories = [];
 
   selection.forEach(({experiment, runs, tagRegex}) => {
@@ -161,7 +162,7 @@ export function categorizeSelection(
     tags.forEach(tag => {
       const series = tagToSeries.get(tag) || [];
       series.push(...tagToSelectedRuns.get(tag)
-          .map(run => ({experiment: experiment.name, run})));
+          .map(run => ({experiment, run, tag})));
       tagToSeries.set(tag, series);
     });
 

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -174,6 +174,10 @@ class CorePlugin(base_plugin.TBPlugin):
     started time (aka first event time) with empty times sorted last, and then
     ties are broken by sorting on the experiment name.
     """
+    results = self.list_experiments_impl()
+    return http_util.Respond(request, results, 'application/json')
+
+  def list_experiments_impl(self):
     results = []
     if self._db_connection_provider:
       db = self._db_connection_provider()
@@ -193,7 +197,7 @@ class CorePlugin(base_plugin.TBPlugin):
         "startTime": row[2],
       } for row in cursor]
 
-    return http_util.Respond(request, results, 'application/json')
+    return results
 
   @wrappers.Request.application
   def _serve_experiment_runs(self, request):

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
@@ -142,7 +142,7 @@ class CustomScalarsPlugin(base_plugin.TBPlugin):
                         'The scalars plugin is oddly not registered.'))
 
     body, mime_type = scalars_plugin_instance.scalars_impl(
-        tag, run, response_format)
+        tag, run, None, response_format)
     return body, mime_type
 
   @wrappers.Request.application
@@ -226,9 +226,11 @@ class CustomScalarsPlugin(base_plugin.TBPlugin):
                           'The scalars plugin is oddly not registered.'))
 
       form = scalars_plugin.OutputFormat.JSON
-      payload = {tag: scalars_plugin_instance.scalars_impl(tag, run, form)[0]
-                 for tag in tag_to_data.keys()
-                 if regex.match(tag)}
+      payload = {
+        tag: scalars_plugin_instance.scalars_impl(tag, run, None, form)[0]
+            for tag in tag_to_data.keys()
+            if regex.match(tag)
+      }
 
     return {
         _REGEX_VALID_PROPERTY: True,

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -123,7 +123,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
 
     return result
 
-  def scalars_impl(self, tag, run, output_format):
+  def scalars_impl(self, tag, run, experiment, output_format):
     """Result of the form `(body, mime_type)`."""
     if self._db_connection_provider:
       db = self._db_connection_provider()
@@ -141,13 +141,14 @@ class ScalarsPlugin(base_plugin.TBPlugin):
         JOIN Runs
           ON Tags.run_id = Runs.run_id
         WHERE
-          Runs.run_name = ?
+          Runs.experiment_id = ?
+          AND Runs.run_name = ?
           AND Tags.tag_name = ?
           AND Tags.plugin_name = ?
           AND Tensors.shape = ''
           AND Tensors.step > -1
         ORDER BY Tensors.step
-      ''', (run, tag, metadata.PLUGIN_NAME))
+      ''', (experiment, run, tag, metadata.PLUGIN_NAME))
       values = [(wall_time, step, self._get_value(data, dtype_enum))
                 for (step, wall_time, data, dtype_enum) in cursor]
     else:
@@ -191,6 +192,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
     # TODO: return HTTP status code for malformed requests
     tag = request.args.get('tag')
     run = request.args.get('run')
+    experiment = request.args.get('experiment')
     output_format = request.args.get('format')
-    (body, mime_type) = self.scalars_impl(tag, run, output_format)
+    (body, mime_type) = self.scalars_impl(tag, run, experiment, output_format)
     return http_util.Respond(request, body, mime_type)

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -141,7 +141,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
         JOIN Runs
           ON Tags.run_id = Runs.run_id
         WHERE
-          Runs.experiment_id = ?
+          Runs.experiment_id IS ?
           AND Runs.run_name = ?
           AND Tags.tag_name = ?
           AND Tags.plugin_name = ?

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -27,9 +27,11 @@ from six import StringIO
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
+from tensorboard.backend import application
 from tensorboard.backend.event_processing import plugin_event_accumulator as event_accumulator  # pylint: disable=line-too-long
 from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
 from tensorboard.plugins import base_plugin
+from tensorboard.plugins.core import core_plugin
 from tensorboard.plugins.scalar import scalars_plugin
 from tensorboard.plugins.scalar import summary
 
@@ -67,6 +69,51 @@ class ScalarsPluginTest(tf.test.TestCase):
     multiplexer.Reload()
     context = base_plugin.TBContext(logdir=self.logdir, multiplexer=multiplexer)
     self.plugin = scalars_plugin.ScalarsPlugin(context)
+
+  def set_up_db(self):
+    self.db_path = os.path.join(self.get_temp_dir(), 'db.db')
+    self.db_uri = 'sqlite:' + self.db_path
+    db_module, db_connection_provider = application.get_database_info(
+        self.db_uri)
+    context = base_plugin.TBContext(
+        db_module=db_module,
+        db_connection_provider=db_connection_provider,
+        db_uri=self.db_uri)
+    self.core_plugin = core_plugin.CorePlugin(context)
+    self.plugin = scalars_plugin.ScalarsPlugin(context)
+
+  def generate_run_to_db(self, experiment_name, run_name):
+    tf.reset_default_graph()
+    global_step = tf.get_variable(
+      tf.GraphKeys.GLOBAL_STEP,
+      shape=[],
+      dtype=tf.int64,
+      initializer=tf.ones_initializer,
+      trainable=False,
+      collections=[tf.GraphKeys.GLOBAL_VARIABLES, tf.GraphKeys.GLOBAL_STEP],
+      caching_device='/cpu:0',
+      use_resource=True)
+    train_op = global_step.assign_add(1, read_value=False)
+    placeholder = tf.placeholder(tf.float32, shape=[3])
+
+    db_writer = tf.contrib.summary.create_db_writer(
+        db_uri=self.db_path,
+        experiment_name=experiment_name,
+        run_name=run_name,
+        user_name='user')
+
+    scalar_ops = None
+    with db_writer.as_default(), tf.contrib.summary.always_record_summaries():
+      tf.contrib.summary.scalar(self._SCALAR_TAG, tf.reduce_mean(placeholder))
+      flush_op = tf.contrib.summary.flush(db_writer._resource)
+
+    with tf.Session() as sess:
+      sess.run(tf.global_variables_initializer())
+      sess.run(tf.contrib.summary.summary_writer_initializer_op())
+      for step in xrange(self._STEPS):
+        feed_dict = {placeholder: [1 + step, 2 + step, 3 + step]}
+        sess.run(tf.contrib.summary.all_summary_ops(), feed_dict=feed_dict)
+        sess.run([train_op, flush_op])
 
   def testRoutesProvided(self):
     """Tests that the plugin offers the correct routes."""
@@ -127,12 +174,12 @@ class ScalarsPluginTest(tf.test.TestCase):
                            self._RUN_WITH_HISTOGRAM])
     if should_work:
       (data, mime_type) = self.plugin.scalars_impl(
-          tag_name, run_name, scalars_plugin.OutputFormat.JSON)
+          tag_name, run_name, None, scalars_plugin.OutputFormat.JSON)
       self.assertEqual('application/json', mime_type)
       self.assertEqual(len(data), self._STEPS)
     else:
       with self.assertRaises(KeyError):
-        self.plugin.scalars_impl(self._SCALAR_TAG, run_name,
+        self.plugin.scalars_impl(self._SCALAR_TAG, run_name, None,
                                  scalars_plugin.OutputFormat.JSON)
 
   def _test_scalars_csv(self, run_name, tag_name, should_work=True):
@@ -141,7 +188,7 @@ class ScalarsPluginTest(tf.test.TestCase):
                            self._RUN_WITH_HISTOGRAM])
     if should_work:
       (data, mime_type) = self.plugin.scalars_impl(
-          tag_name, run_name, scalars_plugin.OutputFormat.CSV)
+          tag_name, run_name, None, scalars_plugin.OutputFormat.CSV)
       self.assertEqual('text/csv', mime_type)
       s = StringIO(data)
       reader = csv.reader(s)
@@ -149,7 +196,7 @@ class ScalarsPluginTest(tf.test.TestCase):
       self.assertEqual(len(list(reader)), self._STEPS)
     else:
       with self.assertRaises(KeyError):
-        self.plugin.scalars_impl(self._SCALAR_TAG, run_name,
+        self.plugin.scalars_impl(self._SCALAR_TAG, run_name, None,
                                  scalars_plugin.OutputFormat.CSV)
 
   def test_scalars_json_with_legacy_scalars(self):
@@ -194,6 +241,41 @@ class ScalarsPluginTest(tf.test.TestCase):
                            self._RUN_WITH_HISTOGRAM])
     self.assertTrue(self.plugin.is_active())
 
+  def test_scalars_db_without_exp(self):
+    self.set_up_db()
+    self.generate_run_to_db('exp1', self._RUN_WITH_SCALARS)
+
+    (data, mime_type) = self.plugin.scalars_impl(
+        self._SCALAR_TAG, self._RUN_WITH_SCALARS, None,
+        scalars_plugin.OutputFormat.JSON)
+    self.assertEqual('application/json', mime_type)
+    # When querying DB-based backend without an experiment id, it returns all
+    # scalars without an experiment id. Such scalar can only be generated using
+    # raw SQL queries though.
+    self.assertEqual(len(data), 0)
+
+  def test_scalars_db_filter_by_experiment(self):
+    self.set_up_db()
+    self.generate_run_to_db('exp1', self._RUN_WITH_SCALARS)
+    all_exps = self.core_plugin.list_experiments_impl()
+    exp1 = next((x for x in all_exps if x.get('name') == 'exp1'), {})
+
+    (data, mime_type) = self.plugin.scalars_impl(
+        self._SCALAR_TAG, self._RUN_WITH_SCALARS, exp1.get('id'),
+        scalars_plugin.OutputFormat.JSON)
+    self.assertEqual('application/json', mime_type)
+    self.assertEqual(len(data), self._STEPS)
+
+  def test_scalars_db_no_match(self):
+    self.set_up_db()
+    self.generate_run_to_db('exp1', self._RUN_WITH_SCALARS)
+
+    # experiment_id is a number but we passed a string here.
+    (data, mime_type) = self.plugin.scalars_impl(
+        self._SCALAR_TAG, self._RUN_WITH_SCALARS, 'random_exp_id',
+        scalars_plugin.OutputFormat.JSON)
+    self.assertEqual('application/json', mime_type)
+    self.assertEqual(len(data), 0)
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -95,13 +95,14 @@ class ScalarsPluginTest(tf.test.TestCase):
     scalar_ops = None
     with db_writer.as_default(), tf.contrib.summary.always_record_summaries():
       tf.contrib.summary.scalar(self._SCALAR_TAG, 42, step=global_step)
+      flush_op = tf.contrib.summary.flush(db_writer._resource)
 
     with tf.Session() as sess:
-      sess.run(tf.global_variables_initializer())
       sess.run(tf.contrib.summary.summary_writer_initializer_op())
       for step in xrange(self._STEPS):
         feed_dict = {global_step: step}
         sess.run(tf.contrib.summary.all_summary_ops(), feed_dict=feed_dict)
+      sess.run(flush_op)
 
   def testRoutesProvided(self):
     """Tests that the plugin offers the correct routes."""

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -212,7 +212,11 @@ limitations under the License.
             return ({tag, run, experiment}) => {
               return tf_backend.addParams(
                   tf_backend.getRouter().pluginRoute('scalars', '/scalars'),
-                  {tag, run, experiment});
+                  {
+                    tag,
+                    run,
+                    experiment: experiment ? experiment.id : '',
+                  });
             }
           },
         },

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -268,7 +268,7 @@ limitations under the License.
       },
       _getSeriesNameFromDatum(datum) {
         return this.multiExperiments ?
-            `${datum.experiment}/${datum.run}` :
+            `${datum.experiment.name}/${datum.run}` :
             datum.run;
       },
       _getColorScale() {

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -297,28 +297,16 @@ limitations under the License.
             this.dataSelection.type == tf_data_selector.Type.WITH_EXPERIMENT) {
           const categories = tf_categorization_utils.categorizeSelection(
               this.dataSelection.selections, PLUGIN_NAME);
-          categories.forEach(category => {
-            category.items.forEach(item => {
-              // Add tags information to series.
-              item.series = item.series.map(series => ({
-                experiment: series.experiment,
-                run: series.run,
-                tag: item.tag,
-              }));
-            });
-          });
           return categories;
         }
 
         let query = tagFilter;
-
         if (this.useDataSelector) {
           const selection = this.dataSelection.selections[0] || {};
           const {runs = [], tagRegex = ''} = selection;
           query = tagRegex;
           selectedRuns = runs.map(({name}) => name);
         }
-
         const runToTag = _.mapValues(
             _.pick(runToTagInfo, selectedRuns),
             x => Object.keys(x));


### PR DESCRIPTION
Now that selection is populated and categorized by the scalar plugin, it now needs to
filter out scalar values based on the experiment id. 

About test: although not calling implementation method is the preferred way in general,
I decided to honor established pattern at least for this change.