### PR TITLE
Debounce data-selection change for performance

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-list.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-list.ts
@@ -87,6 +87,9 @@ Polymer({
     'dom-change': '_synchronizeColors',
   },
 
+  detached() {
+    this.cancelDebouncer('_setRegex');
+  },
 
   // ====================== COMPUTED ======================
 


### PR DESCRIPTION
Previously, every keydown in regex input caused the plugin to redraw and it was very CPU intensive (not forgetting to mention network request initially). 

Try to cause least amount of redraws. 