### PR TITLE
Let users blacklist subdirectories by regex

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -103,7 +103,9 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
       size_guidance=DEFAULT_SIZE_GUIDANCE,
       tensor_size_guidance=tensor_size_guidance_from_flags(flags),
       purge_orphaned_data=flags.purge_orphaned_data,
-      max_reload_threads=flags.max_reload_threads)
+      max_reload_threads=flags.max_reload_threads,
+      subdirectory_blacklist_regex=_compile_subdirectory_blacklist_regex(
+          flags.subdirectory_blacklist_regex))
   db_module, db_connection_provider = get_database_info(flags.db)
   plugin_name_to_instance = {}
   context = base_plugin.TBContext(
@@ -453,3 +455,24 @@ def _clean_path(path, path_prefix=""):
   if path != path_prefix + '/' and path.endswith('/'):
     return path[:-1]
   return path
+
+
+def _compile_subdirectory_blacklist_regex(regex_string):
+  """Compiles a subdirectory_blacklist_regex value from a raw string.
+
+  Args:
+    regex_string: The raw string for the regex.
+
+  Raises:
+    ValueError: if the string cannot be compiled into a regular expression.
+
+  Returns:
+    The compiled regex. Or None if the `regex_string` argument is empty.
+  """
+  if not regex_string:
+    return None
+
+  try:
+    return re.compile(regex_string)
+  except re.error:
+    raise ValueError('%r is an invalid regex string' % regex_string)

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
@@ -363,6 +363,18 @@ class EventMultiplexerTest(tf.test.TestCase):
     self.assertEqual(0, start_mock.call_count)
     self.assertEqual(0, join_mock.call_count)
 
+  def testBlacklistedSubdirectoriesNotLoaded(self):
+    x = event_multiplexer.EventMultiplexer(subdirectory_blacklist_regex=r'ba.')
+    logdir = self.get_temp_dir()
+    for potential_run in ('foo', 'bar', 'baz'):
+      subdirectory = os.path.join(logdir, potential_run)
+      _CreateCleanDirectory(subdirectory)
+      _AddEvents(subdirectory)
+    x.AddRunsFromDirectory(logdir)
+
+    # The other runs (bar and baz) should have been filtered away by the regex.
+    self.assertItemsEqual(x.Runs(), ['foo'])
+
 
 class EventMultiplexerWithRealAccumulatorTest(tf.test.TestCase):
 

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -402,6 +402,16 @@ keeps 500 scalars and all images. Most users should not need to set this
 flag.\
 ''')
 
+    parser.add_argument(
+        '--subdirectory_blacklist_regex',
+        type=str,
+        default='',
+        help='''\
+If provided, any subdirectory whose absolute path partially matches this regular
+expression will not be read from: Data within the subdirectory will be excluded
+from TensorBoard. This flag is irrelevant to db mode.\
+''')
+
   def fix_flags(self, flags):
     """Fixes standard TensorBoard CLI flags to parser."""
     if not flags.db and not flags.logdir:


### PR DESCRIPTION
Introduce a subdirectory_blacklist_regex flag to TensorBoard. If
provided, TensorBoard excludes data from any subdirectory with an
absolute path that partially matches this regular expression.

This flag allows users to point TensorBoard to a path containing many,
many subdirectories and exclude runs that are not interesting for
comparison. Users could toggle runs in the UI, but that requires effort
when there are many runs/experiments. Subdirectories that are filtered
away by the regular expression are logged for later debugging.