### PR TITLE
BUG: Fixes run name coloring lookup failure

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -263,7 +263,7 @@ limitations under the License.
         return this.dataToLoad.map(d => this._getSeriesNameFromDatum(d));
       },
       _getSeriesNameFromDatum(datum) {
-        return datum.experiment ?
+        return this.multiExperiments ?
             `${datum.experiment}/${datum.run}` :
             datum.run;
       },
@@ -272,10 +272,9 @@ limitations under the License.
           scale: (name) => {
             const splitIndex = name.indexOf('/');
             const exp = name.slice(0, splitIndex);
-            const run = name.slice(splitIndex + 1);
             return this.multiExperiments ?
                 tf_color_scale.experimentsColorScale(exp) :
-                tf_color_scale.runsColorScale(run);
+                tf_color_scale.runsColorScale(name);
           },
         };
       },


### PR DESCRIPTION
As part of multi-experiment effort, tf_scalar_card recently added
experiment name in the data series with slash. It wrongly pruned the run
name with slash and caused look up to fail.