### PR TITLE
Convey complex search in scalar card header

### DIFF
--- a/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
+++ b/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
@@ -32,6 +32,7 @@ export interface PrefixGroupMetadata {
 }
 export interface SearchResultsMetadata {
   type: CategoryType;
+  compositeSearch?: boolean;
   validRegex: boolean;
   universalRegex: boolean;  // is the search query ".*"? ("(?:)" doesn't count)
 }
@@ -144,6 +145,7 @@ export function categorizeSelection(
     SeriesCategory[] {
   const tagToSeries = new Map();
   const searchTags = new Set();
+  const searchCategories = [];
 
   selection.forEach(({experiment, runs, tagRegex}) => {
     const runNames = runs.map(({name}) => name);
@@ -151,9 +153,7 @@ export function categorizeSelection(
     const tagToSelectedRuns = createTagToRuns(selectedRunToTag);
     const tags = tf_backend.getTags(selectedRunToTag);
 
-    const searchCategory = categorizeBySearchQuery(tags, tagRegex);
-    // list of matching tags.
-    searchCategory.items.forEach(tag => searchTags.add(tag));
+    searchCategories.push(categorizeBySearchQuery(tags, tagRegex))
 
     // list of all tags that has selected runs.
     tags.forEach(tag => {
@@ -164,11 +164,17 @@ export function categorizeSelection(
     });
   });
 
-  const searchCategory = {
-    name: selection.length == 1 ? selection[0].tagRegex : 'multi',
+  // list of matching tags.
+  searchCategories
+      .forEach(({items}) => items.forEach(tag => searchTags.add(tag)));
+
+  // If there is only one searchCategory, use it.
+  const searchCategory = searchCategories.length == 1 ? searchCategories[0] : {
+    name: searchCategories.every(({name}) => !Boolean(name)) ? '' : 'multi',
     metadata: {
       type: CategoryType.SEARCH_RESULTS,
-      validRegex: false,
+      compositeSearch: true,
+      validRegex: true,
       universalRegex: false,
     },
     items: Array.from(searchTags)

--- a/tensorboard/components/tf_categorization_utils/tf-category-pane.html
+++ b/tensorboard/components/tf_categorization_utils/tf-category-pane.html
@@ -25,20 +25,25 @@ limitations under the License.
               on-tap="_togglePane"
               open-button$="[[opened]]">
         <span class="name">
-          <template is="dom-if" if="[[_isSearchResults]]"><!--
-            --><span class="light">Tags matching /</span><!--
-            --><span class="category-name">[[category.name]]</span><!--
-            --><span class="light">/</span><!--
-            --><template is="dom-if" if="[[_isUniversalSearchQuery]]"><!--
-              --><span> (all tags)</span><!--
-            --></template><!--
-            --><template is="dom-if" if="[[_isInvalidSearchResults]]"><!--
-              --><span> <strong>(malformed regular expression)</strong></span><!--
-            --></template><!--
-          --></template><!--
-          --><template is="dom-if" if="[[!_isSearchResults]]"><!--
-            --><span class="category-name">[[category.name]]</span><!--
-          --></template>
+          <template is="dom-if" if="[[_isSearchResults]]">
+            <template is="dom-if" if="[[_isCompositeSearch(category)]]">
+              <span>Tags matching multiple experiments</span>
+            </template>
+            <template is="dom-if" if="[[!_isCompositeSearch(category)]]">
+              <span class="light">Tags matching /</span>
+              <span class="category-name">[[category.name]]</span>
+              <span class="light">/</span>
+              <template is="dom-if" if="[[_isUniversalSearchQuery]]">
+                <span> (all tags)</span>
+              </template>
+              <template is="dom-if" if="[[_isInvalidSearchResults]]">
+                <span> <strong>(malformed regular expression)</strong></span>
+              </template>
+            </template>
+          </template>
+          <template is="dom-if" if="[[!_isSearchResults]]">
+            <span class="category-name">[[category.name]]</span>
+          </template>
         </span>
         <span class="count"><span>[[_count]]</span></span>
       </button>
@@ -89,11 +94,12 @@ limitations under the License.
       }
 
       [open-button] {
-        border-bottom-left-radius: 0px !important;
-        border-bottom-right-radius: 0px !important;
+        border-bottom-left-radius: 0 !important;
+        border-bottom-right-radius: 0 !important;
       }
 
       .name {
+        display: inline-flex;
         float: left;
       }
 
@@ -143,7 +149,7 @@ limitations under the License.
 
         _count: {
           type: Number,
-          computed: '_computeCount(category.items)',
+          computed: '_computeCount(category.items.*)',
         },
         _rendered: {
           type: Boolean,
@@ -175,24 +181,30 @@ limitations under the License.
         // Show a category unless it's a search results category where
         // there wasn't actually a search query.
         return !(
-          category.metadata.type === tf_categorization_utils.CategoryType['SEARCH_RESULTS']
+          category.metadata.type === tf_categorization_utils.CategoryType.SEARCH_RESULTS
           && category.name === "");
       },
 
       _computeIsSearchResults(type) {
-        return type === tf_categorization_utils.CategoryType['SEARCH_RESULTS'];
+        return type === tf_categorization_utils.CategoryType.SEARCH_RESULTS;
       },
 
       _computeIsInvalidSearchResults(metadata) {
         return (
-          metadata.type === tf_categorization_utils.CategoryType['SEARCH_RESULTS']
+          metadata.type === tf_categorization_utils.CategoryType.SEARCH_RESULTS
           && !metadata.validRegex);
       },
 
       _computeIsUniversalSearchQuery(metadata) {
         return (
-          metadata.type === tf_categorization_utils.CategoryType['SEARCH_RESULTS']
+          metadata.type === tf_categorization_utils.CategoryType.SEARCH_RESULTS
           && metadata.universalRegex);
+      },
+
+      _isCompositeSearch() {
+        const {type, compositeSearch} = this.category.metadata;
+        return compositeSearch &&
+            type === tf_categorization_utils.CategoryType.SEARCH_RESULTS;
       },
     });
   </script>


### PR DESCRIPTION
When each data selection has non-empty regex string, we cannot easily
say the results are based on some regex match. In such case, convey that
the results are based on multiple experiments.