### PR TITLE
Populate `mode` in data/environment

### DIFF
--- a/tensorboard/http_api.md
+++ b/tensorboard/http_api.md
@@ -106,6 +106,20 @@ Example response:
       }]
     }]
 
+## `data/environment`
+
+Returns environment in which the TensorBoard app is running. Possible values of
+the `mode` are: `db` and `logdir`.
+
+Example response:
+
+    {
+      "window_title": "Custom Name",
+      "mode": "db",
+      "data_location": "sqlite:/Users/tbuser/some_session.sqlite"
+    }
+
+
 ## `/data/plugin/scalars/...`
 
 See the [scalar plugin documentation](https://github.com/tensorflow/tensorboard/blob/master/tensorboard/plugins/scalar/http_api.md).

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -113,6 +113,7 @@ class CorePlugin(base_plugin.TBPlugin):
         request,
         {
             'data_location': self._logdir or self._db_uri,
+            'mode': 'logdir' if self._logdir else 'db',
             'window_title': self._window_title,
         },
         'application/json')

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -79,6 +79,17 @@ class CorePluginTest(tf.test.TestCase):
         self.logdir_based_server, '/data/environment')
     self.assertEqual(parsed_object['data_location'], self.logdir)
 
+  def testEnvironmentForModeForDbServer(self):
+    """Tests environment route that returns the mode for db based server."""
+    parsed_object = self._get_json(self.db_based_server, '/data/environment')
+    self.assertEqual(parsed_object['mode'], 'db')
+
+  def testEnvironmentForModeForLogServer(self):
+    """Tests environment route that returns the mode for logdir based server."""
+    parsed_object = self._get_json(
+        self.logdir_based_server, '/data/environment')
+    self.assertEqual(parsed_object['mode'], 'logdir')
+
   def testEnvironmentForWindowTitle(self):
     """Test that the environment route correctly returns the window title."""
     parsed_object_db = self._get_json(


### PR DESCRIPTION
There are two modes that TensorBoard can run in: "db" and "logdir".
Technically, the `mode` can be inferred from data_location, but we
decided to provide a direct information instead of inferring mode from
a string.