### PR TITLE
BUG: omit tag from selection based on tagRegex

### DIFF
--- a/tensorboard/components/tf_categorization_utils/test/categorizationUtilsTests.ts
+++ b/tensorboard/components/tf_categorization_utils/test/categorizationUtilsTests.ts
@@ -267,7 +267,16 @@ describe('categorizationUtils', () => {
         expect(searchResult).to.have.property('items')
             .that.has.lengthOf(2);
         expect(searchResult.items[0]).to.have.property('tag', 'tag2/subtag1');
+        expect(searchResult.items[0]).to.have.property('series')
+            .that.deep.equal([
+              {experiment: 'exp2', run: 'run2'},
+              {experiment: 'exp2', run: 'run3'},
+            ]);
         expect(searchResult.items[1]).to.have.property('tag', 'tag3');
+        expect(searchResult.items[1]).to.have.property('series')
+            .that.deep.equal([
+              {experiment: 'exp2', run: 'run3'},
+            ]);
       });
 
       it('combines selection without tagRegex with one', function() {
@@ -321,6 +330,25 @@ describe('categorizationUtils', () => {
         expect(result).to.have.lengthOf(2);
         expect(result[0]).to.have.property('items')
             .that.has.lengthOf(0);
+      });
+
+      it('omits selection from tag series when its regex does not match',
+          function() {
+        const [searchResult] = categorizeSelection(
+            [this.experiment1, this.experiment3], 'scalar');
+
+        // should match 'tag1', 'tag2/subtag1', 'tag2/subtag2', and 'tag3'.
+        expect(searchResult).to.have.property('items')
+            .that.has.lengthOf(3);
+        expect(searchResult.items[0]).to.have.property('tag', 'tag1');
+        expect(searchResult.items[1]).to.have.property('tag', 'tag2/subtag1');
+        expect(searchResult.items[2]).to.have.property('tag', 'tag2/subtag2');
+
+        // experiment3 also matches the tag1 but it has tagRegex of `junk`.
+        expect(searchResult.items[0]).to.have.property('series')
+            .that.deep.equal([
+              {experiment: 'exp1', run: 'run1'},
+            ]);
       });
     });
 


### PR DESCRIPTION
Previously, the series was populated based from `tagToSeries`
which contains all tags in the experiment/run combination regardless
of the tagRegex.

This resulted in very confusing UI as search pane showed a series,
experiment/run/tag tuple, that is supposed to be omited based on
tagRegex criteria.