### PR TITLE
Use QueryParam for data selector config

### DIFF
--- a/tensorboard/components/tf_globals/globals.ts
+++ b/tensorboard/components/tf_globals/globals.ts
@@ -37,4 +37,8 @@ export function getFakeHash() {
   return _fakeHash;
 }
 
+export function getEnableDataSelector(): boolean {
+  return new URLSearchParams(window.location.search).has('EnableDataSelector');
+}
+
 }  // namespace tf_globals

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -20,6 +20,7 @@ tf_web_library(
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_data_selector",
+        "//tensorboard/components/tf_globals",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_line_chart_data_loader",

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -30,6 +30,7 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
 <link rel="import" href="../tf-data-selector/tf-data-selector.html">
+<link rel="import" href="../tf-globals/tf-globals.html">
 <link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../tf-paginated-view/tf-paginated-view.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
@@ -185,8 +186,7 @@ limitations under the License.
 
   <script>
     const PLUGIN_NAME = 'scalars';
-    const USE_DATA_SELECTOR = Boolean(
-        tf_storage.getBoolean('EnableDataSelector', {useLocalStorage: true}));
+    const USE_DATA_SELECTOR = tf_globals.getEnableDataSelector();
 
     Polymer({
       is: 'tf-scalar-dashboard',


### PR DESCRIPTION
URL storage uses two mediums when bootstrapping -- before the TB
application is up, it uses fake hash, then it uses the real URL hash.
This is done for test predictability.

Since whether to use data selection or not is related to the
experiment control and not storage of some user data, we decided to use
the query parameter instaed.