### PR TITLE
BUG: fixed tooltip sorting and chart domain update

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -171,7 +171,7 @@ limitations under the License.
 
       observers: [
         '_dataSeriesChanged(dataSeries.*)',
-        '_keyChanged(key)',
+        '_loadKeyChanged(loadKey)',
       ],
 
       onLoadFinish() {
@@ -214,7 +214,7 @@ limitations under the License.
         });
       },
 
-      _keyChanged(_) {
+      _loadKeyChanged(_) {
         this._resetDomainOnNextLoad = true;
       },
 

--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -544,7 +544,9 @@ export class LineChart {
         .classed('closest', (p) => dist(p) === closestDist)
         .each(function(point) {
           self.drawTooltipRow(this, tooltipColumns, point);
-        });
+        })
+        // reorders DOM to match the ordering of the `data`.
+        .order();
 
     rows.exit().remove();
     rows.enter().append('tr').each(function(point) {


### PR DESCRIPTION
- Tooltip sorting method change did not take effect in tooltip drawing.
  d3 requires `order` call to make DOM order the same way as the data is
  orderd.
- Chart domain update: data-loader-behavior has changed its properpty
  name but the change was not reflected in the tf-line-chart-data-loader.