### PR TITLE
BUG: Fixed chart rendering issues

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/data-loader-behavior.ts
+++ b/tensorboard/components/tf_line_chart_data_loader/data-loader-behavior.ts
@@ -117,8 +117,9 @@ export const DataLoaderBehavior = {
 
   _loadDataImpl() {
     this.cancelAsync(this._loadDataAsync);
+
+    if (!this.isAttached) return;
     this._loadDataAsync = this.async(() => {
-      if (!this.isAttached) return;
       this.dataLoading = true;
 
       // Before updating, cancel any network-pending updates, to
@@ -140,7 +141,7 @@ export const DataLoaderBehavior = {
 
       return Promise.all(promises).then(this._canceller.cancellable(result => {
         this.dataLoading = false;
-        if (result.cancelled || !promises.length) return;
+        if (result.cancelled) return;
         this.onLoadFinish();
       }));
     });

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -204,6 +204,7 @@ limitations under the License.
       },
 
       setSeriesData(name, data) {
+        this._resetDomainOnNextLoad = true;
         this.$.chart.setSeriesData(name, data);
       },
 

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -387,6 +387,8 @@ limitations under the License.
       throw new Error('HTML import plugin dashboards *before* tf-tensorboard');
     }
 
+    const DATA_SELECTION_CHANGE_DEBOUNCE_MS = 200;
+
     Polymer({
       is: "tf-tensorboard",
       behaviors: [tf_tensorboard.AutoReloadBehavior],
@@ -728,6 +730,7 @@ limitations under the License.
           const component = document.createElement(dashboard.elementName);
           component.id = 'dashboard';  // used in `_selectedDashboardComponent`
           if (dashboard.useDataSelector) {
+            this.cancelDebouncer('updateDataSelection');
             component.dataSelection = this._dataSelection;
           }
           container.appendChild(component);
@@ -760,10 +763,20 @@ limitations under the License.
       _updateDataSelection() {
         // The dashboard is not ready yet until it stamped the containers.
         if (!this._dashboardContainersStamped) return;
+
+        this.cancelDebouncer('updateDataSelection');
+
         const component = this._selectedDashboardComponent();
         // The dashboard may not exist.
         if (!component) return;
-        component.dataSelection = this._dataSelection;
+
+        const selectedDashboard = this._selectedDashboard;
+        const dashboard = tf_tensorboard.dashboardRegistry[selectedDashboard];
+        if (dashboard.useDataSelector) {
+          this.debounce('updateDataSelection', () => {
+            component.dataSelection = this._dataSelection;
+          }, DATA_SELECTION_CHANGE_DEBOUNCE_MS);
+        }
       },
 
       ready() {

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -259,7 +259,7 @@ Polymer({
   },
 
   observers: [
-    '_makeChart(xComponentsCreationMethod, xType, yValueAccessor, yScaleType, tooltipColumns, colorScale)',
+    '_makeChart(xComponentsCreationMethod, xType, yValueAccessor, yScaleType, tooltipColumns, colorScale, isAttached)',
     '_reloadFromCache(_chart)',
     '_smoothingChanged(smoothingEnabled, smoothingWeight, _chart)',
     '_tooltipSortingMethodChanged(tooltipSortingMethod, _chart)',

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -224,7 +224,7 @@ limitations under the License.
         _getDataLoadName: {
           type: Function,
           value: function() {
-            return this._getSeriesNameFromDatum;
+            return (datum) => this._getSeriesNameFromDatum(datum);
           },
         },
 


### PR DESCRIPTION
- Experiments did not have the right unique ID for fetching because,
  even in the multi experiment mode, `this` was pointing at the wrong
  instance.
- Fixed the issue where chart did not create when toggling visibility
  with the tag header
- Fixed the issue where data-loader fetched incomplete selection in the
  beginning due to the timing issue. Data-selection was bootstrapping
  from the storage and it changes the output rapidly. Without debounce,
  data-loader starts to fetch and it causes timing issue.
- Set dataSelection only when a dashboard requires it.