### PR TITLE
Improved categorizeSelection for search

### DIFF
--- a/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
+++ b/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
@@ -180,11 +180,11 @@ export function categorizeSelection(
   const searchCategory: RawCategory = searchCategories.length == 1 ?
       searchCategories[0] :
       {
-        name: selection.length == 1 ? selection[0].tagRegex : 'multi',
+        name: searchCategories.every(c => !c.name) ? '' : 'multi',
         metadata: {
           type: CategoryType.SEARCH_RESULTS,
           compositeSearch: true,
-          validRegex: true,
+          validRegex: searchCategories.every(c => c.metadata.validRegex),
           universalRegex: false,
         },
         items: Array.from(tagToSearchSeries.keys())
@@ -270,4 +270,4 @@ export function categorizeRunTagCombinations(
   return tagCategories.map(explodeCategory);
 }
 
-}  // namespace tf_categorization_utils
+}  // namespace wtf_categorization_utils

--- a/tensorboard/components/tf_categorization_utils/test/categorizationUtilsTests.ts
+++ b/tensorboard/components/tf_categorization_utils/test/categorizationUtilsTests.ts
@@ -266,13 +266,25 @@ describe('categorizationUtils', () => {
         expect(searchResult.items[0]).to.have.property('tag', 'tag2/subtag1');
         expect(searchResult.items[0]).to.have.property('series')
             .that.deep.equal([
-              {experiment: 'exp2', run: 'run2'},
-              {experiment: 'exp2', run: 'run3'},
+              {
+                experiment: this.selection2.experiment,
+                run: 'run2',
+                tag: 'tag2/subtag1',
+              },
+              {
+                experiment: this.selection2.experiment,
+                run: 'run3',
+                tag: 'tag2/subtag1',
+              },
             ]);
         expect(searchResult.items[1]).to.have.property('tag', 'tag3');
         expect(searchResult.items[1]).to.have.property('series')
             .that.deep.equal([
-              {experiment: 'exp2', run: 'run3'},
+              {
+                experiment: this.selection2.experiment,
+                run: 'run3',
+                tag: 'tag3'
+              },
             ]);
       });
 
@@ -296,6 +308,25 @@ describe('categorizationUtils', () => {
               {experiment: sel2.experiment, run: 'run2', tag: 'tag2/subtag1'},
               {experiment: sel2.experiment, run: 'run3', tag: 'tag2/subtag1'},
             ]);
+      });
+
+      it('keeps name as empty if all selections have no regex', function() {
+        const sel1 = this.selection1;
+        const sel2 = Object.assign({}, this.selection2, {tagRegex: ''});
+        const [searchResult] = categorizeSelection([sel1, sel2], 'scalar');
+
+        expect(searchResult).to.have.property('items')
+            .that.has.lengthOf(4);
+        expect(searchResult).to.have.property('name', '');
+      });
+
+      it('reports bad regex when at least one selection is bad', function() {
+        const sel1 = this.selection1;
+        const sel2 = Object.assign({}, this.selection2, {tagRegex: '))'});
+        const [searchResult] = categorizeSelection([sel1, sel2], 'scalar');
+
+        expect(searchResult).to.have.property('metadata')
+            .that.has.property('validRegex', false);
       });
 
       it('sorts the tag by name', function() {
@@ -332,7 +363,7 @@ describe('categorizationUtils', () => {
       it('omits selection from tag series when its regex does not match',
           function() {
         const [searchResult] = categorizeSelection(
-            [this.experiment1, this.experiment3], 'scalar');
+            [this.selection1, this.selection3], 'scalar');
 
         // should match 'tag1', 'tag2/subtag1', 'tag2/subtag2', and 'tag3'.
         expect(searchResult).to.have.property('items')
@@ -344,7 +375,11 @@ describe('categorizationUtils', () => {
         // experiment3 also matches the tag1 but it has tagRegex of `junk`.
         expect(searchResult.items[0]).to.have.property('series')
             .that.deep.equal([
-              {experiment: 'exp1', run: 'run1'},
+              {
+                experiment: this.selection1.experiment,
+                run: 'run1',
+                tag: 'tag1',
+              },
             ]);
       });
     });

--- a/tensorboard/components/tf_categorization_utils/tf-category-pane.html
+++ b/tensorboard/components/tf_categorization_utils/tf-category-pane.html
@@ -28,6 +28,9 @@ limitations under the License.
           <template is="dom-if" if="[[_isSearchResults]]">
             <template is="dom-if" if="[[_isCompositeSearch(category)]]">
               <span>Tags matching multiple experiments</span>
+              <template is="dom-if" if="[[_isInvalidSearchResults]]">
+                <span>&nbsp;<strong>(malformed regular expression)</strong></span>
+              </template>
             </template>
             <template is="dom-if" if="[[!_isCompositeSearch(category)]]">
               <span class="light">Tags matching /</span>


### PR DESCRIPTION
- When no selection has a regex search, keep the name as an enpty string
- Report malformed regex

Also fixed the broken tests that were not caught by Travis.

- Show that compositeSearch has invalid regex