### PR TITLE
Colors run checkboxes in data-selector

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-list.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-list.ts
@@ -87,6 +87,11 @@ Polymer({
     'dom-change': '_synchronizeColors',
   },
 
+  observers: [
+    '_synchronizeColors(useCheckboxColors)',
+    '_synchronizeColors(coloring)',
+  ],
+
   detached() {
     this.cancelDebouncer('_setRegex');
   },

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.html
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.html
@@ -54,8 +54,8 @@ Event out:
 
     <tf-filterable-checkbox-dropdown
       label="Run"
-      use-checkbox-colors="[[_getIsRunCheckboxesColored(noExperiment)]]"
-      coloring="[[_getColoring(noExperiment)]]"
+      use-checkbox-colors="[[shouldColorRuns]]"
+      coloring="[[_getColoring(shouldColorRuns)]]"
       items="[[_getRunOptions(_runs.*)]]"
       selected-items="{{_selectedRuns}}"
       selection-state="{{_getRunsSelectionState(_runSelectionStateString, _runs.*)}}"

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.ts
@@ -56,6 +56,16 @@ Polymer({
       value: false,
     },
 
+    shouldColorRuns: {
+      type: Boolean,
+      value: false,
+    },
+
+    _coloring: {
+      type: Object,
+      computed: '_getColoring(shouldColorRuns)',
+    },
+
     _runs: {
       type: Array,
       value: (): Array<tf_backend.Run> => [],
@@ -174,10 +184,6 @@ Polymer({
     }));
   },
 
-  _getIsRunCheckboxesColored(_): boolean {
-    return this.noExperiment;
-  },
-
   _persistSelectedRuns(): void {
     if (!this._isDataReady) return;
     const value = this._serializeValue(
@@ -250,8 +256,8 @@ Polymer({
 
   _getColoring() {
     return {
-      getColor: this.noExperiment ?
-          (item) => tf_color_scale.runsColorScale(item.id) :
+      getColor: this.shouldColorRuns ?
+          (item) => tf_color_scale.runsColorScale(item.title) :
           () => '',
     };
   },

--- a/tensorboard/components/tf_data_selector/tf-data-selector.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.html
@@ -42,12 +42,14 @@ Properties out:
     >
       <tf-data-select-row
         no-experiment
+        should-color-runs
         persistence-id="_default"
         on-selection-changed="_selectionChanged"
       ></tf-data-select-row>
     </template>
     <template is="dom-repeat" items="[[_experiments]]" as="exp">
       <tf-data-select-row
+        should-color-runs="[[_shouldColorRuns]]"
         checkbox-color="[[_getExperimentColor(exp)]]"
         enabled="[[_isExperimentEnabled(exp)]]"
         experiment="[[exp]]"

--- a/tensorboard/components/tf_data_selector/tf-data-selector.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.ts
@@ -81,6 +81,11 @@ Polymer({
       value: '',
     },
 
+    _shouldColorRuns: {
+      type: Boolean,
+      computed: '_computeShouldColorRuns(_experiments)',
+    },
+
   },
 
   observers: [
@@ -133,6 +138,10 @@ Polymer({
 
   _getExperimentColor(experiment: tf_backend.Experiment): string {
     return tf_color_scale.experimentsColorScale(experiment.name);
+  },
+
+  _computeShouldColorRuns() {
+    return this._experiments.length <= 1;
   },
 
   /**
@@ -252,6 +261,7 @@ Polymer({
     return this._canCompareExperiments() &&
         this._allExperiments.length > this._experiments.length;
   },
+
 });
 
 /**


### PR DESCRIPTION
When not comparing experiments and only selected one experiment, color
the run checkbox lists like the runs-selector.