### PR TITLE
Fixed the zombie selection bug

### DIFF
--- a/tensorboard/components/tf_backend/baseStore.ts
+++ b/tensorboard/components/tf_backend/baseStore.ts
@@ -28,6 +28,7 @@ export abstract class BaseStore {
   protected requestManager: RequestManager =
       new RequestManager(1 /* simultaneous request */);
   private _listeners: Set<ListenKey> = new Set<ListenKey>();
+  public initialized: boolean = false;
 
   /**
    * Asynchronously load or reload the runs data. Listeners will be
@@ -36,7 +37,13 @@ export abstract class BaseStore {
    * @see addListener
    * @return {Promise<void>} a promise that resolves when new data have loaded.
    */
-  abstract refresh(): Promise<void>;
+  protected abstract load(): Promise<void>;
+
+  refresh(): Promise<void> {
+    return this.load().then(() => {
+      this.initialized = true;
+    });
+  }
 
   /**
    * Register a listener (nullary function) to be called when new runs are

--- a/tensorboard/components/tf_backend/environmentStore.ts
+++ b/tensorboard/components/tf_backend/environmentStore.ts
@@ -28,7 +28,7 @@ interface Environment {
 export class EnvironmentStore extends BaseStore {
   private environment: Environment;
 
-  refresh() {
+  load() {
     const url = tf_backend.getRouter().environment();
     return this.requestManager.request(url).then(result => {
       const environment = {

--- a/tensorboard/components/tf_backend/experimentsStore.ts
+++ b/tensorboard/components/tf_backend/experimentsStore.ts
@@ -17,7 +17,7 @@ namespace tf_backend {
 export class ExperimentsStore extends BaseStore {
   private _experiments: Experiment[] = [];
 
-  refresh() {
+  load() {
     const url = getRouter().experiments();
     return this.requestManager.request(url).then(newExperiments => {
       if (!_.isEqual(this._experiments, newExperiments)) {

--- a/tensorboard/components/tf_backend/runsStore.ts
+++ b/tensorboard/components/tf_backend/runsStore.ts
@@ -17,7 +17,7 @@ namespace tf_backend {
 export class RunsStore extends BaseStore {
   private _runs: string[] = [];
 
-  refresh() {
+  load() {
     const url = getRouter().runs();
     return this.requestManager.request(url).then(newRuns => {
       if (!_.isEqual(this._runs, newRuns)) {

--- a/tensorboard/components/tf_data_selector/BUILD
+++ b/tensorboard/components/tf_data_selector/BUILD
@@ -32,6 +32,7 @@ tf_web_library(
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
     ],
 )

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.ts
@@ -14,8 +14,6 @@ limitations under the License.
 ==============================================================================*/
 namespace tf_data_selector {
 
-const CHANGE_EVENT_DEBOUNCE_MS = 250;
-
 enum Type {
   RUN = 1,
   TAG,
@@ -140,7 +138,6 @@ Polymer({
 
   detached(): void {
     this._isDataReady = false;
-    this.cancelDebouncer('fire');
   },
 
   _fetchRunsAndTags(): Promise<void> {
@@ -204,21 +201,19 @@ Polymer({
   },
 
   _fireChange(_, __): void {
-    this.debounce('fire', () => {
-      const runMap = new Map(
-          this._runs.map(run => [this._getSyntheticRunId(run), run]));
-      this.fire('selection-changed', {
-        runs: this._selectedRuns.map(({id}) => runMap.get(id))
-            .filter(Boolean)
-            .map(run => ({
-              id: run.id,
-              name: run.name,
-              startTime: run.startTime,
-              tags: run.tags,
-            })),
-        tagRegex: this._tagRegex,
-      });
-    }, CHANGE_EVENT_DEBOUNCE_MS);
+    const runMap = new Map(
+        this._runs.map(run => [this._getSyntheticRunId(run), run]));
+    this.fire('selection-changed', {
+      runs: this._selectedRuns.map(({id}) => runMap.get(id))
+          .filter(Boolean)
+          .map(run => ({
+            id: run.id,
+            name: run.name,
+            startTime: run.startTime,
+            tags: run.tags,
+          })),
+      tagRegex: this._tagRegex,
+    });
   },
 
   _removeRow(): void {

--- a/tensorboard/components/tf_data_selector/tf-data-selector.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.html
@@ -20,6 +20,7 @@ limitations under the License.
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/scrollbar-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-filterable-checkbox-list.html">
+<link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="./experiment-selector.html">
 <link rel="import" href="./tf-data-select-row.html">
 


### PR DESCRIPTION
When removing an experiment, because of debounce and asyncness,
selection that has been removed gets reinserted to the list of
selection. This is fixed by removing the debounce and making the higher
order component, data-selector, emit-less change when data does not
change. Also, it added some safeguard where we ignore events from a
removed experiments.

Also, we now populate the internal state of `_dataReady` correctly.