### PR TITLE
REFACTOR: make series name separate from title

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -208,8 +208,8 @@ limitations under the License.
         this.$.chart.setSeriesData(name, data);
       },
 
-      setSeriesTitleGetter(name, getTitle) {
-        this.$.chart.setSeriesTitleGetter(name, getTitle);
+      setSeriesMetadata(name, metadata) {
+        this.$.chart.setSeriesMetadata(name, metadata);
       },
 
       redraw() {

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -208,6 +208,10 @@ limitations under the License.
         this.$.chart.setSeriesData(name, data);
       },
 
+      setSeriesTitleGetter(name, getTitle) {
+        this.$.chart.setSeriesTitleGetter(name, getTitle);
+      },
+
       redraw() {
         cancelAnimationFrame(this._redrawRaf);
         this._redrawRaf = window.requestAnimationFrame(() => {

--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -31,6 +31,10 @@ enum TooltipColumnEvalType {
   DOM,
 }
 
+export type LineChartStatus = {
+  smoothingEnabled: boolean
+};
+
 /**
  * Adds private APIs for default swatch column on the first column.
  */
@@ -38,6 +42,11 @@ interface TooltipColumn extends vz_chart_helpers.TooltipColumn {
   evalType?: TooltipColumnEvalType;
   enter: () => void;
 }
+
+export type Metadata = {
+  name: string,
+  meta: any,
+};
 
 /**
  * The maximum number of marker symbols within any line for a data series. Too
@@ -608,7 +617,7 @@ export class LineChart {
       point: vz_chart_helpers.Point) {
     const {smoothingEnabled} = this;
     if (tooltipCol.evalType == TooltipColumnEvalType.DOM) {
-      tooltipCol.evaluate.call(column, point);
+      tooltipCol.evaluate.call(column, point, {smoothingEnabled});
     } else {
       d3.select(column)
           .text(tooltipCol.evaluate.call(column, point, {smoothingEnabled}));
@@ -705,7 +714,7 @@ export class LineChart {
     if (this.name2datasets[name] === undefined) {
       this.name2datasets[name] = new Plottable.Dataset([], {
         name,
-        getTitle: name => name,
+        meta: null,
       });
     }
     return this.name2datasets[name];
@@ -774,16 +783,11 @@ export class LineChart {
   }
 
   /**
-   * Sets getTitle callback on a series.
+   * Sets the metadata of a series on the chart.
    */
-  public setSeriesTitleGetter(name: string, getTitle: (name: string) => string) {
-    this.getDataset(name).metadata(
-        Object.assign(
-            {},
-            this.getDataset(name).metadata(),
-            {
-              getTitle: (name) => getTitle(name),
-            }));
+  public setSeriesMetadata(name: string, meta: any) {
+    const newMeta = Object.assign({}, this.getDataset(name).metadata(), {meta});
+    this.getDataset(name).metadata(newMeta);
   }
 
   public smoothingUpdate(weight: number) {

--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -569,9 +569,14 @@ export class LineChart {
     const self = this;
     const swatchCol = {
       name: 'Swatch',
-      static: true,
       evalType: TooltipColumnEvalType.DOM,
-      evaluate: function(d: vz_chart_helpers.Point) {},
+      evaluate: function(d: vz_chart_helpers.Point) {
+        d3.select(this)
+            .select('span')
+            .style(
+                'background-color',
+                () => colorScale.scale(d.dataset.metadata().name));
+      },
       enter(d: vz_chart_helpers.Point) {
         d3.select(this)
             .append('span')
@@ -698,7 +703,10 @@ export class LineChart {
 
   private getDataset(name: string) {
     if (this.name2datasets[name] === undefined) {
-      this.name2datasets[name] = new Plottable.Dataset([], {name: name});
+      this.name2datasets[name] = new Plottable.Dataset([], {
+        name,
+        getTitle: name => name,
+      });
     }
     return this.name2datasets[name];
   }
@@ -759,10 +767,23 @@ export class LineChart {
   }
 
   /**
-   * Set the data of a series on the chart.
+   * Sets the data of a series on the chart.
    */
-  public setSeriesData(name: string, data:  vz_chart_helpers.ScalarDatum[]) {
+  public setSeriesData(name: string, data: vz_chart_helpers.ScalarDatum[]) {
     this.getDataset(name).data(data);
+  }
+
+  /**
+   * Sets getTitle callback on a series.
+   */
+  public setSeriesTitleGetter(name: string, getTitle: (name: string) => string) {
+    this.getDataset(name).metadata(
+        Object.assign(
+            {},
+            this.getDataset(name).metadata(),
+            {
+              getTitle: (name) => getTitle(name),
+            }));
   }
 
   public smoothingUpdate(weight: number) {

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -301,8 +301,7 @@ Polymer({
   },
 
   /**
-   * Sets the data of one of the series. Note that to display this series
-   * its name must be in the setVisibleSeries() array.
+   * Sets the metadata of one of the series.
    *
    * @param {string} name Name of the series.
    * @param {*} meta Metadata of the dataset used for later

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -200,6 +200,9 @@ limitations under the License.
                 scalar: datum[2],
               }));
               const name = this._getSeriesNameFromDatum(datum);
+              scalarChart.setSeriesTitleGetter(name, () => {
+                return this._getSeriesTitleFromDatum(datum);
+              });
               scalarChart.setSeriesData(name, formattedData);
             };
           },
@@ -266,7 +269,12 @@ limitations under the License.
       _getDataSeries() {
         return this.dataToLoad.map(d => this._getSeriesNameFromDatum(d));
       },
-      _getSeriesNameFromDatum(datum) {
+      // name is a stable identifier for a series.
+      _getSeriesNameFromDatum({run, experiment = {name: '_default'}}) {
+        return `${experiment.name}/${run}`;
+      },
+      // title is a visible string of a series for the UI.
+      _getSeriesTitleFromDatum(datum) {
         return this.multiExperiments ?
             `${datum.experiment.name}/${datum.run}` :
             datum.run;
@@ -276,9 +284,10 @@ limitations under the License.
           scale: (name) => {
             const splitIndex = name.indexOf('/');
             const exp = name.slice(0, splitIndex);
+            const run = name.slice(splitIndex + 1);
             return this.multiExperiments ?
                 tf_color_scale.experimentsColorScale(exp) :
-                tf_color_scale.runsColorScale(name);
+                tf_color_scale.runsColorScale(run);
           },
         };
       },

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -51,6 +51,7 @@ limitations under the License.
       smoothing-enabled="[[smoothingEnabled]]"
       smoothing-weight="[[smoothingWeight]]"
       tag-metadata="[[tagMetadata]]"
+      tooltip-columns="[[_tooltipColumns]]"
       tooltip-sorting-method="[[tooltipSortingMethod]]"
       x-type="[[xType]]"
     >
@@ -200,9 +201,7 @@ limitations under the License.
                 scalar: datum[2],
               }));
               const name = this._getSeriesNameFromDatum(datum);
-              scalarChart.setSeriesTitleGetter(name, () => {
-                return this._getSeriesTitleFromDatum(datum);
-              });
+              scalarChart.setSeriesMetadata(name, datum);
               scalarChart.setSeriesData(name, formattedData);
             };
           },
@@ -238,6 +237,22 @@ limitations under the License.
         },
 
         _logScaleActive: Boolean,
+
+        _tooltipColumns: {
+          type: Array,
+          value: function() {
+            const columns = vz_line_chart2.DEFAULT_TOOLTIP_COLUMNS.slice();
+            const ind = columns.findIndex(c => c.title == 'Name');
+            columns.splice(ind, 1, {
+              title: 'Name',
+              evaluate: (d) => {
+                const datum = d.dataset.metadata().meta;
+                return this._getSeriesDisplayNameFromDatum(datum);
+              },
+            });
+            return columns;
+          },
+        }
       },
       reload() {
         this.$$('tf-line-chart-data-loader').reload();
@@ -274,7 +289,7 @@ limitations under the License.
         return `${experiment.name}/${run}`;
       },
       // title is a visible string of a series for the UI.
-      _getSeriesTitleFromDatum(datum) {
+      _getSeriesDisplayNameFromDatum(datum) {
         return this.multiExperiments ?
             `${datum.experiment.name}/${datum.run}` :
             datum.run;


### PR DESCRIPTION
Series title needs to update based on whether user is comparing multiple
experiment or not. However, changing the name, which was previously used
as an id to LineChart class, caused various issues. Instead of changing
the name depending on setting, we now set the TitleGetter.