### PR TITLE
BUG: fix the scalar plugin for experimentless src

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -82,8 +82,8 @@ limitations under the License.
           selected-item-label="{{_runToDownload}}"
         >
           <paper-menu class="dropdown-content" slot="dropdown-content">
-            <template is="dom-repeat" items="[[runs]]">
-              <paper-item no-label-float=true>[[item]]</paper-item>
+            <template is="dom-repeat" items="[[dataToLoad]]">
+              <paper-item no-label-float=true>[[item.run]]</paper-item>
             </template>
           </paper-menu>
         </paper-dropdown-menu>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -145,7 +145,7 @@ limitations under the License.
                           show-download-links="[[_showDownloadLinks]]"
                           request-manager="[[_requestManager]]"
                           data-to-load="[[item.series]]"
-                          multi-experiments="[[_getMultiExperiments(dataSelection.*)]]"
+                          multi-experiments="[[_getMultiExperiments(dataSelection)]]"
                           tag="[[item.tag]]"
                           tag-metadata="[[_tagMetadata(_runToTagInfo, item.runs, item.tag)]]"
                           active="[[page.active]]"
@@ -196,8 +196,11 @@ limitations under the License.
     Polymer({
       is: 'tf-scalar-dashboard',
       properties: {
-        /** @type {!tf_data_selector.DataSelection} */
-        dataSelection: Object,
+        /** @type {?tf_data_selector.DataSelection} */
+        dataSelection: {
+          type: Object,
+          value: () => null,
+        },
         _showDownloadLinks: {
           type: Boolean,
           notify: true,
@@ -304,9 +307,10 @@ limitations under the License.
 
       _makeCategories(
           runToTagInfo, selectedRuns, tagFilter, categoriesDomReady) {
-        if (this.useDataSelector && this.dataSelection.selections.length == 0) {
+        const usesDataSelection = this.useDataSelector && this.dataSelection;
+        if (usesDataSelection && this.dataSelection.selections.length == 0) {
           return [];
-        } else if (this.useDataSelector &&
+        } else if (usesDataSelection &&
             this.dataSelection.type != SelectionType.WITHOUT_EXPERIMENT) {
           const categories = tf_categorization_utils.categorizeSelection(
               this.dataSelection.selections, PLUGIN_NAME);
@@ -314,7 +318,7 @@ limitations under the License.
         }
 
         let query = tagFilter;
-        if (this.useDataSelector) {
+        if (usesDataSelection) {
           const selection = this.dataSelection.selections[0] || {};
           const {runs = [], tagRegex = ''} = selection;
           query = tagRegex;
@@ -349,7 +353,8 @@ limitations under the License.
       },
 
       _getMultiExperiments() {
-        return this.dataSelection.type == SelectionType.COMPARISON;
+        return Boolean(this.dataSelection) &&
+            this.dataSelection.type == SelectionType.COMPARISON;
       },
     });
 


### PR DESCRIPTION
Polymer observer fails silently when not all properties are initialized.

The PR also addresses the bug where "runs to download" dropdown was not properly populated.