### PR TITLE
Make data-selector aware of backend mode

### DIFF
--- a/tensorboard/components/tf_data_selector/experiment-selector.html
+++ b/tensorboard/components/tf_data_selector/experiment-selector.html
@@ -54,9 +54,11 @@ Properties out: none.
       </template>
       <template is="dom-if" if="[[_expanded]]">
         <span>
-          <paper-button on-tap="_toggle">
-            Cancel
-          </paper-buutton>
+          <template is="dom-if" if="[[!alwaysExpanded]]">
+              <paper-button on-tap="_toggle">
+                Cancel
+              </paper-buutton>
+          </template>
         </span>
         <span>
           <paper-button

--- a/tensorboard/components/tf_data_selector/experiment-selector.ts
+++ b/tensorboard/components/tf_data_selector/experiment-selector.ts
@@ -22,6 +22,11 @@ Polymer({
       value: (): Array<tf_backend.Experiment> => [],
     },
 
+    alwaysExpanded: {
+      type: Boolean,
+      value: false,
+    },
+
     _expanded: {
       type: Boolean,
       value: false,
@@ -44,6 +49,10 @@ Polymer({
       value: (): Array<tf_dashboard_common.FilterableCheckboxListItem> => [],
     },
   },
+
+  observers: [
+    '_changeExpanded(alwaysExpanded)',
+  ],
 
   attached() {
     this._updateExpKey = tf_backend.experimentsStore
@@ -68,6 +77,12 @@ Polymer({
           title: exp.name,
           subtitle: exp.startedTime,
         }));
+  },
+
+  _changeExpanded() {
+    if (this.alwaysExpanded && !this._expanded) {
+      this._expanded = true;
+    }
   },
 
   _toggle() {

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.ts
@@ -92,6 +92,7 @@ Polymer({
   },
 
   observers: [
+    '_synchronizeColors(checkboxColor)',
     '_persistSelectedRuns(_selectedRuns)',
     '_fireChange(_selectedRuns, _tagRegex)',
   ],

--- a/tensorboard/components/tf_data_selector/tf-data-selector.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.html
@@ -37,7 +37,7 @@ Properties out:
   <template>
     <template
       is="dom-if"
-      if="[[!_canCompareExperiments(_mode)]]"
+      if="[[!_canCompareExperiments]]"
       restamp
     >
       <tf-data-select-row
@@ -62,10 +62,11 @@ Properties out:
 
     <template
       is="dom-if"
-      if="[[_shouldShowAddComparison(_allExperiments, _experiments)]]"
+      if="[[_getAddComparisonVisible(_allExperiments, _experiments, _canCompareExperiments)]]"
     >
       <experiment-selector
         id="selector"
+        always-expanded="[[_getAddComparisonAlwaysExpanded(_canCompareExperiments, _experiments)]]"
         exclude-experiments="[[_experiments]]"
         on-experiment-added="_addExperiments"
       ></experiment-selector>

--- a/tensorboard/components/tf_data_selector/tf-data-selector.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.ts
@@ -76,9 +76,9 @@ Polymer({
       computed: '_computeSelection(_enabledExperimentIds.*, _selections.*, activePlugins.*)',
     },
 
-    _mode: {
-      type: Number,
-      value: '',
+    _canCompareExperiments: {
+      type: Boolean,
+      value: false
     },
 
     _shouldColorRuns: {
@@ -113,18 +113,16 @@ Polymer({
     this._allExperiments = tf_backend.experimentsStore.getExperiments();
 
     this._updateEnvKey = tf_backend.environmentStore.addListener(() => {
-      this._mode = tf_backend.environmentStore.getMode();
+      this._canCompareExperiments = tf_backend.Mode.DB ==
+          tf_backend.environmentStore.getMode();
     });
-    this._mode = tf_backend.environmentStore.getMode();
+    this._canCompareExperiments = tf_backend.Mode.DB ==
+        tf_backend.environmentStore.getMode();
   },
 
   detached() {
     tf_backend.experimentsStore.removeListenerByKey(this._updateExpKey);
     tf_backend.environmentStore.removeListenerByKey(this._updateEnvKey);
-  },
-
-  _canCompareExperiments(): boolean {
-    return this._mode == tf_backend.Mode.DB;
   },
 
   _getPersistenceId(experiment) {
@@ -176,7 +174,7 @@ Polymer({
   },
 
   _computeSelection() {
-    if (this._canCompareExperiments()) {
+    if (this._canCompareExperiments) {
       const enabledExperiments = new Set(this._enabledExperimentIds);
 
       // Make a copy of the all selections.
@@ -257,9 +255,13 @@ Polymer({
     }
   },
 
-  _shouldShowAddComparison() {
-    return this._canCompareExperiments() &&
+  _getAddComparisonVisible() {
+    return this._canCompareExperiments &&
         this._allExperiments.length > this._experiments.length;
+  },
+
+  _getAddComparisonAlwaysExpanded() {
+    return this._canCompareExperiments && !this._experiments.length;
   },
 
 });


### PR DESCRIPTION
When backend is in DB mode, it will require user to make a selection
based on experiments even if one does not want to compare experiments.

Previously, when no experiment was chosen, we had a fallback to original
runs selector (not ID-based) with tag input.

Now that we require user to make selection based on experiments, there
is an awkward UI state in case of cold start (nothing is chosen and "add
comparison" button shows up without a clear affordance). To alleviate
this problem, we now expand the experiment selector when nothing has
been chosen without an ability to minimize the experiment selector.