### PR TITLE
BUG: make select-row update when shifted

### DIFF
--- a/tensorboard/components/tf_data_selector/tf-data-selector.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.ts
@@ -255,7 +255,6 @@ Polymer({
   },
 
   _removeExperiment(event) {
-    console.log('removed experiment');
     const removedId = event.target.experiment.id;
     // Changing _experimentIds will remove the id from _enabledExperimentIds.
     this._experimentIds = this._experimentIds.filter(id => id != removedId);

--- a/tensorboard/components/tf_storage/BUILD
+++ b/tensorboard/components/tf_storage/BUILD
@@ -8,6 +8,7 @@ licenses(["notice"])  # Apache 2.0
 tf_web_library(
     name = "tf_storage",
     srcs = [
+        "listeners.ts",
         "storage.ts",
         "tf-storage.html",
     ],

--- a/tensorboard/components/tf_storage/listeners.ts
+++ b/tensorboard/components/tf_storage/listeners.ts
@@ -1,0 +1,57 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace tf_storage {
+
+// TODO(stephanwlee): Combine this with tf_backend.ListenKey and put it in a
+// sensible place.
+// A unique reference to a listener for an easier dereferencing.
+export class ListenKey {
+  public readonly listener: Function;
+  constructor(listener: Function) {
+    this.listener = listener;
+  }
+}
+
+const hashListeners = new Set<ListenKey>();
+const storageListeners = new Set<ListenKey>();
+
+window.addEventListener('hashchange', () => {
+  hashListeners.forEach(listenKey => listenKey.listener());
+});
+window.addEventListener('storage', () => {
+  storageListeners.forEach(listenKey => listenKey.listener());
+});
+
+export function addHashListener(fn: Function): ListenKey {
+  const key = new ListenKey(fn);
+  hashListeners.add(key);
+  return key;
+}
+
+export function addStorageListener(fn: Function): ListenKey {
+  const key = new ListenKey(fn);
+  storageListeners.add(key);
+  return key;
+}
+
+export function removeHashListenerByKey(key: ListenKey) {
+  hashListeners.delete(key);
+}
+
+export function removeStorageListenerByKey(key: ListenKey) {
+  storageListeners.delete(key);
+}
+
+}  // namespace tf_storage

--- a/tensorboard/components/tf_storage/tf-storage.html
+++ b/tensorboard/components/tf_storage/tf-storage.html
@@ -18,4 +18,5 @@ limitations under the License.
 <link rel="import" href="../tf-globals/tf-globals.html">
 <link rel="import" href="../tf-imports/lodash.html">
 
+<script src="listeners.js"></script>
 <script src="storage.js"></script>


### PR DESCRIPTION
Say there were two selection: A and B. When removing A, Polymer does not
remove DOM for A but, rather, one for B. As a result, A will be updated
with parameter of B and it will need to be reinitialized including
binding to the storage.

When updated, not only should it refetch the list of runs, but also needs
to detach event listeners with the previous storage keys. If not done,
any change in hash will trigger the callback and set the value
incorrectly.