### PR TITLE
FIX: Recolor when color scale changes for run

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.html
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.html
@@ -46,6 +46,7 @@ Properties out:
       vertical-align="top"
       horizontal-align="left"
       no-overlap="true"
+      opened="{{_opened}}"
     >
       <div class="dropdown-trigger" slot="dropdown-trigger">
         <paper-ripple></paper-ripple>
@@ -63,7 +64,7 @@ Properties out:
       </div>
       <div class="dropdown-content">
         <tf-filterable-checkbox-list
-          coloring="[[coloring]]"
+          coloring="[[_coloring]]"
           items="[[items]]"
           label="[[label]]"
           max-items-to-enable-by-default="[[maxItemsToEnableByDefault]]"

--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.ts
@@ -30,6 +30,15 @@ Polymer({
 
     coloring: Object,
 
+    // TODO(stephanwlee): Devise a better way for components to react to color
+    // scale change. Recoloring on open may not be good enough.
+    // The property simply clones the `coloring` to force redraw when dropdown
+    // is opened.
+    _coloring: {
+      type: Object,
+      computed: '_computeColoring(_opened, coloring)',
+    },
+
     items: {
       type: Array,
       value: () => [],
@@ -47,6 +56,13 @@ Polymer({
       notify: true,
       value: () => [],
     },
+
+    // ====== Others ======
+
+    _opened: {
+      type: Boolean,
+      value: false,
+    },
   },
 
   // ====================== COMPUTED ======================
@@ -62,6 +78,10 @@ Polymer({
       return Array.from(uniqueNames).join(', ');
     }
     return `${this.selectedItems.length} Selected`;
+  },
+
+  _computeColoring() {
+    return Object.assign({},  this.coloring);
   },
 
 });

--- a/tensorboard/components/tf_data_selector/tf-data-selector.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.ts
@@ -200,8 +200,10 @@ Polymer({
         newSelections.set(id, updatedSelection);
       });
 
+      const isSingleSelection = this._selections.size ===
+          1 + Number(this._selections.has(NO_EXPERIMENT_ID));
       return {
-        type: this._selections.size == 1 ?
+        type: isSingleSelection ?
             tf_data_selector.Type.SINGLE : tf_data_selector.Type.COMPARISON,
         selections: Array.from(newSelections.values()),
       };

--- a/tensorboard/components/tf_data_selector/tf-data-selector.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.ts
@@ -180,15 +180,15 @@ Polymer({
       const enabledExperiments = new Set(this._enabledExperimentIds);
 
       // Make a copy of the all selections.
-      const newSelections = new Map(this._selections);
+      const enabledSelections = new Map(this._selections);
 
-      // Filter out disabled experiments from next `selection`.
-      newSelections.forEach((_, id) => {
-        if (!enabledExperiments.has(id)) newSelections.delete(id);
+      // Filter out disabled experiments from the `_selections`.
+      enabledSelections.forEach((_, id) => {
+        if (!enabledExperiments.has(id)) enabledSelections.delete(id);
       });
 
       const activePluginNames = new Set(this.activePlugins);
-      newSelections.forEach((sel, id) => {
+      enabledSelections.forEach((sel, id) => {
         const selection = sel as Selection;
         const updatedSelection = Object.assign({}, selection);
         updatedSelection.runs = selection.runs.map(run => {
@@ -197,15 +197,20 @@ Polymer({
           });
         }).filter(run => run.tags.length);
 
-        newSelections.set(id, updatedSelection);
+        enabledSelections.set(id, updatedSelection);
       });
 
-      const isSingleSelection = this._selections.size ===
+      // Single selection: one experimentful selection whether it is enabled or
+      // not.
+      // NOTE: `_selections` can contain not only selections for experiment
+      // diffing but also one for no-experiment mode. If it contains one,
+      // "remove" the size by one.
+      const isSingleSelection = this._selections.size ==
           1 + Number(this._selections.has(NO_EXPERIMENT_ID));
       return {
         type: isSingleSelection ?
             tf_data_selector.Type.SINGLE : tf_data_selector.Type.COMPARISON,
-        selections: Array.from(newSelections.values()),
+        selections: Array.from(enabledSelections.values()),
       };
     }
     return {

--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -579,7 +579,7 @@ export class LineChart {
     const swatchCol = {
       name: 'Swatch',
       evalType: TooltipColumnEvalType.DOM,
-      evaluate: function(d: vz_chart_helpers.Point) {
+      evaluate(d: vz_chart_helpers.Point) {
         d3.select(this)
             .select('span')
             .style(


### PR DESCRIPTION
When list of runs changes, runsScale remaps runName to color. The
change has to be reflected by UI but tooltip or run selector dropdown
reflected the color change.

The change addresses the bug described above but the change is not
final -- a runsColorScale change is picked up by components that also
listens to change of the runsStore, but this is by luck and not design.
RunsColorScale which currently is a function of runs in the runsStore
should emit change separately and componennts should not be aware of
this dependency when consuming the color. The fix does not address this
issue and tf-data-select-row currently has an issue because it does not
listen to the runsStore.