### PR TITLE
Show only integer ticks in stepAxis

### DIFF
--- a/tensorboard/components/vz_chart_helpers/vz-chart-helpers.ts
+++ b/tensorboard/components/vz_chart_helpers/vz-chart-helpers.ts
@@ -196,6 +196,7 @@ export let stepFormatter =
     Plottable.Formatters.siSuffix(STEP_FORMATTER_PRECISION);
 export function stepX(): XComponents {
   let scale = new Plottable.Scales.Linear();
+  scale.tickGenerator(Plottable.Scales.TickGenerators.integerTickGenerator());
   let axis = new Plottable.Axes.Numeric(scale, 'bottom');
   axis.formatter(stepFormatter);
   return {


### PR DESCRIPTION
A step is a discrete entity, not a contiguous one. Plottable, without a
custom tick generator, tries to generate predefiend number of ticks
which can result in decimal ticks when domain is small enough.

Instead, we now show only ticks on integer values.