### PR TITLE
BUGFIX: Call expanduser() for multi-part logdir components

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -317,7 +317,7 @@ def parse_event_files_spec(logdir):
       run_name = None
       path = specification
     if uri_pattern.match(path) is None:
-      path = os.path.realpath(path)
+      path = os.path.realpath(os.path.expanduser(path))
     files[path] = run_name
   return files
 

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -290,7 +290,11 @@ class ParseEventFilesSpecTest(tf.test.TestCase):
     with mock.patch('os.path', pathObj):
       self.assertEqual(application.parse_event_files_spec(logdir), expected)
 
-
+  def testBasic(self):
+    self.assertPlatformSpecificLogdirParsing(
+        posixpath, '/lol/cat', {'/lol/cat': None})
+    self.assertPlatformSpecificLogdirParsing(
+        ntpath, 'C:\\lol\cat', {'C:\\lol\cat': None})
 
   def testRunName(self):
     self.assertPlatformSpecificLogdirParsing(
@@ -301,6 +305,34 @@ class ParseEventFilesSpecTest(tf.test.TestCase):
   def testPathWithColonThatComesAfterASlash_isNotConsideredARunName(self):
     self.assertPlatformSpecificLogdirParsing(
         posixpath, '/lol:/cat', {'/lol:/cat': None})
+
+  def testExpandsUser(self):
+    oldhome = os.environ.get('HOME', None)
+    try:
+      os.environ['HOME'] = '/usr/eliza'
+      self.assertPlatformSpecificLogdirParsing(
+          posixpath, '~/lol/cat~dog', {'/usr/eliza/lol/cat~dog': None})
+      os.environ['HOME'] = 'C:\\Users\eliza'
+      self.assertPlatformSpecificLogdirParsing(
+          ntpath, '~\lol\cat~dog', {'C:\\Users\eliza\lol\cat~dog': None})
+    finally:
+      if oldhome is not None:
+        os.environ['HOME'] = oldhome
+
+  def testExpandsUserForMultipleDirectories(self):
+    oldhome = os.environ.get('HOME', None)
+    try:
+      os.environ['HOME'] = '/usr/eliza'
+      self.assertPlatformSpecificLogdirParsing(
+          posixpath, 'a:~/lol,b:~/cat',
+          {'/usr/eliza/lol': 'a', '/usr/eliza/cat': 'b'})
+      os.environ['HOME'] = 'C:\\Users\eliza'
+      self.assertPlatformSpecificLogdirParsing(
+          ntpath, 'aa:~\lol,bb:~\cat',
+          {'C:\\Users\eliza\lol': 'aa', 'C:\\Users\eliza\cat': 'bb'})
+    finally:
+      if oldhome is not None:
+        os.environ['HOME'] = oldhome
 
   def testMultipleDirectories(self):
     self.assertPlatformSpecificLogdirParsing(

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -414,7 +414,6 @@ flag.\
                        'For example `tensorboard --logdir mylogdir` '
                        'or `tensorboard --db sqlite:~/.tensorboard.db`. '
                        'Run `tensorboard --helpfull` for details and examples.')
-    flags.logdir = os.path.expanduser(flags.logdir)
     if flags.path_prefix.endswith('/'):
       flags.path_prefix = flags.path_prefix[:-1]
     if flags.db:


### PR DESCRIPTION
This ensures that `tensorboard --logdir ~/logs/dir1,~/logs/dir2` works.  The call to expanduser() only does anything if the tilde is the first character in the path, so previously this only would have expanded correctly for the first component of the multipart logdir spec.