### PR TITLE
Add experimental --db_import for on-the-fly import of logdir to DB

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -22,10 +22,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import atexit
 import json
 import os
 import re
+import shutil
 import sqlite3
+import tempfile
 import threading
 import time
 
@@ -36,6 +39,7 @@ from werkzeug import wrappers
 
 from tensorboard import db
 from tensorboard.backend import http_util
+from tensorboard.backend.event_processing import db_import_multiplexer
 from tensorboard.backend.event_processing import plugin_event_accumulator as event_accumulator  # pylint: disable=line-too-long
 from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
 from tensorboard.plugins import base_plugin
@@ -104,12 +108,32 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
       tensor_size_guidance=tensor_size_guidance_from_flags(flags),
       purge_orphaned_data=flags.purge_orphaned_data,
       max_reload_threads=flags.max_reload_threads)
-  db_module, db_connection_provider = get_database_info(flags.db)
+  loading_multiplexer = multiplexer
+  reload_interval = flags.reload_interval
+  db_uri = flags.db
+  # For DB import mode, create a DB file if we weren't given one.
+  if flags.db_import and not flags.db:
+    tmpdir = tempfile.mkdtemp(prefix='tbimport')
+    atexit.register(shutil.rmtree, tmpdir)
+    db_uri = 'sqlite:%s/tmp.sqlite' % tmpdir
+  db_module, db_connection_provider = get_database_info(db_uri)
+  if flags.db_import:
+    # DB import mode.
+    if db_module != sqlite3:
+        raise ValueError('--db_import is only compatible with sqlite DBs')
+    tf.logging.info('Importing logdir into DB at %s', db_uri)
+    loading_multiplexer = db_import_multiplexer.DbImportMultiplexer(
+        db_connection_provider=db_connection_provider,
+        purge_orphaned_data=flags.purge_orphaned_data,
+        max_reload_threads=flags.max_reload_threads)
+  elif flags.db:
+    # DB read-only mode, never load event logs.
+    reload_interval = -1
   plugin_name_to_instance = {}
   context = base_plugin.TBContext(
       db_module=db_module,
       db_connection_provider=db_connection_provider,
-      db_uri=flags.db,
+      db_uri=db_uri,
       flags=flags,
       logdir=flags.logdir,
       multiplexer=multiplexer,
@@ -123,8 +147,8 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
       continue
     plugins.append(plugin)
     plugin_name_to_instance[plugin.plugin_name] = plugin
-  return TensorBoardWSGIApp(flags.logdir, plugins, multiplexer,
-                            flags.reload_interval, flags.path_prefix)
+  return TensorBoardWSGIApp(flags.logdir, plugins, loading_multiplexer,
+                            reload_interval, flags.path_prefix)
 
 
 def TensorBoardWSGIApp(logdir, plugins, multiplexer, reload_interval,

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -56,6 +56,7 @@ class FakeFlags(object):
       samples_per_plugin='',
       max_reload_threads=1,
       db='',
+      db_import=False,
       window_title='',
       path_prefix=''):
     self.logdir = logdir
@@ -64,6 +65,7 @@ class FakeFlags(object):
     self.samples_per_plugin = samples_per_plugin
     self.max_reload_threads = max_reload_threads
     self.db = db
+    self.db_import = db_import
     self.window_title = window_title
     self.path_prefix = path_prefix
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -139,6 +139,7 @@ py_test(
 py_library(
     name = "event_multiplexer",
     srcs = [
+        "db_import_multiplexer.py",
         "event_multiplexer.py",
         "plugin_event_multiplexer.py",
     ],

--- a/tensorboard/backend/event_processing/db_import_multiplexer.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer.py
@@ -40,7 +40,7 @@ class DbImportMultiplexer(object):
   def __init__(self,
                db_connection_provider,
                purge_orphaned_data=True,
-               max_reload_threads=None):
+               max_reload_threads=1):
     """Constructor for `DbImportMultiplexer`.
 
     Args:
@@ -68,7 +68,7 @@ class DbImportMultiplexer(object):
     if self.purge_orphaned_data:
       tf.logging.warning(
           '--db_import does not yet support purging orphaned data')
-    self._max_reload_threads = max_reload_threads or 1
+    self._max_reload_threads = max_reload_threads
     if self._max_reload_threads > 1:
       tf.logging.warning(
           '--db_import does not yet support more than one reload thread')

--- a/tensorboard/backend/event_processing/db_import_multiplexer.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer.py
@@ -1,0 +1,188 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===========================================================================
+"""A loading-only EventMultiplexer that actually populates a SQLite DB."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import threading
+import time
+
+import six
+from six.moves import queue, xrange  # pylint: disable=redefined-builtin
+import tensorflow as tf
+
+from tensorboard.backend.event_processing import directory_watcher
+from tensorboard.backend.event_processing import event_file_loader
+from tensorboard.backend.event_processing import io_wrapper
+
+
+class DbImportMultiplexer(object):
+  """A loading-only `EventMultiplexer` that populates a SQLite DB.
+
+  This EventMultiplexer only loads data; it provides no read APIs.
+  """
+
+  def __init__(self,
+               db_connection_provider,
+               purge_orphaned_data=True,
+               max_reload_threads=None):
+    """Constructor for `DbImportMultiplexer`.
+
+    Args:
+      db_connection_provider: Provider function for creating a DB connection.
+      purge_orphaned_data: Whether to discard any events that were "orphaned" by
+        a TensorFlow restart.
+      max_reload_threads: The max number of threads that TensorBoard can use
+        to reload runs. Each thread reloads one run at a time. If not provided,
+        reloads runs serially (one after another).
+    """
+    tf.logging.info('DbImportMultiplexer initializing');
+    conn = db_connection_provider()
+    # Extract the file path of the DB from the DB connection.
+    rows = conn.execute('PRAGMA database_list;').fetchall()
+    tf.logging.info('Got rows %s', type(rows))
+    db_name_to_path = {row[1]: row[2] for row in rows}
+    self._db_path = db_name_to_path['main']
+    tf.logging.info('DbImportMultiplexer using db_path %s', self._db_path)
+    # Set the DB in WAL mode so reads don't block writes.
+    # TODO(nickfelt): investigate weird errors in rollback journal mode
+    conn.execute('PRAGMA journal_mode=WAL;')
+    conn.execute('PRAGMA synchronous=NORMAL;')  # Recommended for WAL mode
+    self._run_importers = {}
+    self.purge_orphaned_data = purge_orphaned_data
+    if self.purge_orphaned_data:
+      tf.logging.warning(
+          '--db_import does not yet support purging orphaned data')
+    self._max_reload_threads = max_reload_threads or 1
+    if self._max_reload_threads > 1:
+      tf.logging.warning(
+          '--db_import does not yet support more than one reload thread')
+    tf.logging.info('DbImportMultiplexer done initializing')
+
+  def AddRunsFromDirectory(self, path, name=None):
+    """Load runs from a directory; recursively walks subdirectories.
+
+    If path doesn't exist, no-op. This ensures that it is safe to call
+      `AddRunsFromDirectory` multiple times, even before the directory is made.
+
+    Args:
+      path: A string path to a directory to load runs from.
+      name: Optional, specifies a name for the experiment under which the
+        runs from this directory hierarchy will be imported. If omitted, the
+        path will be used as the name.
+
+    Raises:
+      ValueError: If the path exists and isn't a directory.
+    """
+    tf.logging.info('Starting AddRunsFromDirectory: %s (as %s)', path, name)
+    for subdir in io_wrapper.GetLogdirSubdirectories(path):
+      tf.logging.info('Processing directory %s', subdir)
+      if subdir not in self._run_importers:
+        tf.logging.info('Creating DB importer for directory %s', subdir)
+        self._run_importers[subdir] = _RunImporter(
+            db_path=self._db_path,
+            subdir=subdir,
+            experiment_name=(name or path),
+            run_name=os.path.relpath(subdir, path))
+    tf.logging.info('Done with AddRunsFromDirectory: %s', path)
+
+  def Reload(self):
+    """Call `Import` on every run to import."""
+    tf.logging.info('Beginning DbImportMultiplexer.Reload()')
+    items_queue = queue.Queue()
+    for item in six.iteritems(self._run_importers):
+      items_queue.put(item)
+
+    # Methods of built-in python containers are thread-safe so long as the GIL
+    # for the thread exists, but we might as well be careful.
+    names_to_delete = set()
+    names_to_delete_mutex = threading.Lock()
+
+    def Worker():
+      """Keeps importing runs until none are left."""
+      while True:
+        try:
+          name, importer = items_queue.get(block=False)
+        except queue.Empty:
+          # No more runs to reload.
+          break
+
+        try:
+          start = time.time()
+          importer.Import()
+          elapsed = time.time() - start
+          tf.logging.debug('importer.Import() took %0.3f sec', elapsed)
+        except (OSError, IOError) as e:
+          tf.logging.error('Unable to import run %r: %s', name, e)
+        except directory_watcher.DirectoryDeletedError:
+          with names_to_delete_mutex:
+            names_to_delete.add(name)
+        finally:
+          items_queue.task_done()
+
+    if self._max_reload_threads > 1:
+      num_threads = min(
+          self._max_reload_threads, len(self._run_importers))
+      tf.logging.info('Starting %d threads to import runs', num_threads)
+      for i in xrange(num_threads):
+        thread = threading.Thread(target=Worker, name='Importer %d' % i)
+        thread.daemon = True
+        thread.start()
+      items_queue.join()
+    else:
+      tf.logging.info('Importing runs serially on the main thread')
+      Worker()
+
+    for name in names_to_delete:
+      tf.logging.warning('Deleting importer %r', name)
+      del self._run_importers[name]
+    tf.logging.info('Finished with DbImportMultiplexer.Reload()')
+    return self
+
+
+class _RunImporter(object):
+  """Helper class to import a single run directory into the sqlite DB."""
+
+  def __init__(self, db_path, subdir, experiment_name, run_name):
+    """Constructs a `_RunImporter` and initializes a DB run.
+
+    Args:
+      db_path: string, filesystem path of the DB file to open
+      subdir: string, filesystem path of the run directory
+      experiment_name: string, name of the run's experiment
+      run_name: string, name of the run
+    """
+    self._directory_generator = directory_watcher.DirectoryWatcher(
+        subdir,
+        event_file_loader.RawEventFileLoader,
+        io_wrapper.IsTensorFlowEventsFile)
+    with tf.Graph().as_default():
+      self._placeholder = tf.placeholder(shape=[], dtype=tf.string)
+      writer = tf.contrib.summary.create_db_writer(
+          db_path, experiment_name=experiment_name, run_name=run_name)
+      with writer.as_default():
+        # TODO(nickfelt): running import_event() one record at a time is very
+        #   slow; we should add an op that accepts a vector of records.
+        self._import_op = tf.contrib.summary.import_event(self._placeholder)
+      self._session = tf.Session()
+      self._session.run(writer.init())
+
+  def Import(self):
+    """Imports all events added since the last call to `Import`."""
+    for record in self._directory_generator.Load():
+      self._session.run(self._import_op, feed_dict={self._placeholder: record})

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -23,8 +23,8 @@ import inspect
 import tensorflow as tf
 
 
-class EventFileLoader(object):
-  """An EventLoader is an iterator that yields Event protos."""
+class RawEventFileLoader(object):
+  """An iterator that yields Event protos as serialized bytestrings."""
 
   def __init__(self, file_path):
     if file_path is None:
@@ -40,13 +40,13 @@ class EventFileLoader(object):
       raise IOError('Failed to open a record reader pointing to %s' % file_path)
 
   def Load(self):
-    """Loads all new values from disk.
+    """Loads all new events from disk as raw serialized proto bytestrings.
 
     Calling Load multiple times in a row will not 'drop' events as long as the
     return value is not iterated over.
 
     Yields:
-      All values that were written to disk that have not been yielded yet.
+      All event proto bytestrings in the file that have not been yielded yet.
     """
     tf.logging.debug('Loading events from %s', self._file_path)
     while True:
@@ -63,10 +63,24 @@ class EventFileLoader(object):
         # PyRecordReader holds the offset prior to the failed read, so retrying
         # will succeed.
         break
-      event = tf.Event()
-      event.ParseFromString(self._reader.record())
-      yield event
+      yield self._reader.record()
     tf.logging.debug('No more events in %s', self._file_path)
+
+
+class EventFileLoader(RawEventFileLoader):
+  """An iterator that yields parsed Event protos."""
+
+  def Load(self):
+    """Loads all new events from disk.
+
+    Calling Load multiple times in a row will not 'drop' events as long as the
+    return value is not iterated over.
+
+    Yields:
+      All events in the file that have not been yielded yet.
+    """
+    for record in super(EventFileLoader, self).Load():
+      yield tf.Event.FromString(record)
 
 
 def main(argv):

--- a/tensorboard/backend/event_processing/event_file_loader_test.py
+++ b/tensorboard/backend/event_processing/event_file_loader_test.py
@@ -89,5 +89,22 @@ class EventFileLoaderTest(tf.test.TestCase):
     self.assertEqual(len(list(loader.Load())), 2)
 
 
+class RawEventFileLoaderTest(EventFileLoaderTest):
+
+  def _LoaderForTestFile(self, filename):
+    return event_file_loader.RawEventFileLoader(
+        os.path.join(self.get_temp_dir(), filename))
+
+  def testSingleWrite(self):
+    filename = tempfile.NamedTemporaryFile(dir=self.get_temp_dir()).name
+    self._WriteToFile(filename, EventFileLoaderTest.RECORD)
+    loader = self._LoaderForTestFile(filename)
+    event_protos = list(loader.Load())
+    self.assertEqual(len(event_protos), 1)
+    # Record format has a 12 byte header and a 4 byte trailer.
+    expected_event_proto = EventFileLoaderTest.RECORD[12:-4]
+    self.assertEqual(event_protos[0], expected_event_proto)
+
+
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorboard/db.py
+++ b/tensorboard/db.py
@@ -607,12 +607,12 @@ class Cursor(object):
       return self._delegate.fetchmany()
 
   def fetchall(self):
-    """Returns next row in result set.
+    """Returns all remaining rows in the result set.
 
-    :rtype: tuple[object]
+    :rtype: list[tuple[object]]
     """
     self._check_that_read_query_was_issued()
-    return self._delegate.fetchone()
+    return self._delegate.fetchall()
 
   @property
   def description(self):

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -113,7 +113,7 @@ class CorePlugin(base_plugin.TBPlugin):
         request,
         {
             'data_location': self._logdir or self._db_uri,
-            'mode': 'logdir' if self._logdir else 'db',
+            'mode': 'db' if self._db_uri else 'logdir',
             'window_title': self._window_title,
         },
         'application/json')
@@ -329,6 +329,11 @@ load just once at startup and a negative number to never reload at all.
         help='[experimental] sets SQL database URI')
 
     parser.add_argument(
+        '--db_import',
+        action='store_true',
+        help='[experimental] imports logdir into a SQL database on the fly')
+
+    parser.add_argument(
         '--inspect',
         action='store_true',
         help='''\
@@ -417,8 +422,6 @@ flag.\
     flags.logdir = os.path.expanduser(flags.logdir)
     if flags.path_prefix.endswith('/'):
       flags.path_prefix = flags.path_prefix[:-1]
-    if flags.db:
-      flags.reload_interval = -1  # Never load event logs in DB mode.
 
   def load(self, context):
     """Creates CorePlugin instance."""

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -318,7 +318,7 @@ disappearance. (default: %(default)s)\
         help='''\
 How often the backend should load more data, in seconds. Set to 0 to
 load just once at startup and a negative number to never reload at all.
-(default: %(default)s)\
+Not relevant for DB read-only mode. (default: %(default)s)\
 ''')
 
     parser.add_argument(
@@ -326,12 +326,19 @@ load just once at startup and a negative number to never reload at all.
         metavar='URI',
         type=str,
         default='',
-        help='[experimental] sets SQL database URI')
+        help='''\
+[experimental] sets SQL database URI and enables DB backend mode, which is
+read-only unless --db_import is also passed.\
+''')
 
     parser.add_argument(
         '--db_import',
         action='store_true',
-        help='[experimental] imports logdir into a SQL database on the fly')
+        help='''\
+[experimental] enables DB read-and-import mode, which in combination with
+--logdir imports event files into a DB backend on the fly. The backing DB is
+temporary unless --db is also passed to specify a DB path to use.\
+''')
 
     parser.add_argument(
         '--inspect',
@@ -394,7 +401,8 @@ routing of an elb when the website base_url is not available e.g.
         default=1,
         help='''\
 The max number of threads that TensorBoard can use to reload runs. Not
-relevant for db mode. Each thread reloads one run at a time.\
+relevant for db read-only mode. Each thread reloads one run at a time.
+(default: %(default)s)\
 ''')
 
     parser.add_argument(


### PR DESCRIPTION
This PR adds a DbImportMultiplexer class which is essentially a version of EventMultiplexer that only implements the data loading API (i.e. `AddRunsFromDirectory()` and `Reload()` methods).  Rather than exposing data through the read API methods, it loads the logdir data into a SQLite DB using the `tf.contrib.summary.create_db_writer()` and `tf.contrib.summary.import_event()`, such that the DB can then be read by the plugins which have been adapted to support DB query mode.

This multiplexer is used for on-the-fly logdir loading when the `--db_import` flag is passed.  By default, it uses a temporary DB file under `/tmp/` that is cleaned up on exit, but if the `--db` flag is passed then it will import the data into a DB file at that path or create a persistent file if no DB exists.  The imported data uses an experiment name corresponding to the overall logdir path; to generate multiple experiments, pass a multipart logdir (e.g. `--logdir one:logs/exp1,two:logs/exp2`).

This approach is intended as a proof-of-concept and has several limitations:
- Loading is very slow because each event imported requires a separate `session.run()` call; this might be possible to address by adding a new `import_event()` op that takes a vector of serialized event protos instead of only one at a time
- The necessary DB schema is only established after at least one event has been successfully imported, and SQLite queries issued before then (e.g. if TensorBoard is loaded from the browser immediately after launch) will fail with table-not-found errors (just keep reloading until it works)
- The SQLite DB must be on disk (`:memory:` is not supported) and must use WAL mode which has [some disadvantages](https://sqlite.org/wal.html) - without WAL mode, reads and writes interfere with each other and would require retry logic or extra user-layer locking
- Multithreaded logdir file reading is not supported yet
- Pruning orphaned data is not supported yet