### PR TITLE
PERF: added Array update utility method

### DIFF
--- a/tensorboard/components/tf_dashboard_common/BUILD
+++ b/tensorboard/components/tf_dashboard_common/BUILD
@@ -8,6 +8,8 @@ licenses(["notice"])  # Apache 2.0
 tf_web_library(
     name = "tf_dashboard_common",
     srcs = [
+        "array-update-helper.html",
+        "array-update-helper.ts",
         "dashboard-style.html",
         "run-color-style.html",
         "scrollbar-style.html",

--- a/tensorboard/components/tf_dashboard_common/array-update-helper.html
+++ b/tensorboard/components/tf_dashboard_common/array-update-helper.html
@@ -1,0 +1,18 @@
+<!--
+@license
+Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script src="array-update-helper.js"></script>

--- a/tensorboard/components/tf_dashboard_common/array-update-helper.ts
+++ b/tensorboard/components/tf_dashboard_common/array-update-helper.ts
@@ -1,0 +1,64 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace tf_dashboard_common {
+
+/**
+ * @polymerBehavior
+ */
+export const ArrayUpdateHelper = {
+  updateArrayProp(
+      prop: string,
+      value: Array<any>,
+      getKey: (item: any, ind: number) => string) {
+
+    const orig = this[prop];
+    const newVal = value;
+    const lookup = new Set(newVal.map((item, i) => getKey(item, i)));
+
+    if (!Array.isArray(orig)) {
+      throw RangeError(`Expected '${prop}' to be an array.`);
+    }
+    if (!Array.isArray(value)) {
+      throw RangeError(`Expected new value to '${prop}' to be an array.`);
+    }
+
+    let origInd = 0;
+    let newValInd = 0;
+    while (origInd < orig.length && newValInd < newVal.length) {
+      if (!lookup.has(getKey(orig[origInd], origInd))) {
+        this.splice(prop, origInd, 1);
+        continue;
+      } else if (getKey(orig[origInd], origInd) ==
+          getKey(newVal[newValInd], newValInd)) {
+        // update the element.
+        // TODO(stephanwlee): We may be able to update the original reference of
+        // the `value` by deep-copying the new value over.
+        this.set(`${prop}.${origInd}`, newVal[newValInd]);
+      } else {
+        this.splice(prop, origInd, 0, newVal[newValInd]);
+      }
+      newValInd++;
+      origInd++;
+    }
+    if (origInd < orig.length) {
+      this.splice(prop, origInd);
+    }
+    if (newValInd < newVal.length) {
+      this.push(prop, ...newVal.slice(newValInd));
+    }
+  },
+};
+
+}  // namespace tf_dashboard_common

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -26,6 +26,7 @@ limitations under the License.
 <link rel="import" href="../tf-categorization-utils/tf-categorization-utils.html">
 <link rel="import" href="../tf-categorization-utils/tf-category-pane.html">
 <link rel="import" href="../tf-categorization-utils/tf-tag-filterer.html">
+<link rel="import" href="../tf-dashboard-common/array-update-helper.html">
 <link rel="import" href="../tf-dashboard-common/dashboard-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
@@ -244,10 +245,10 @@ limitations under the License.
         // true and then polymer DOM templating responds to that finding. We
         // thus use this property to guard when categories are computed.
         _categoriesDomReady: Boolean,
+
         _categories: {
           type: Array,
-          computed:
-            '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter, _categoriesDomReady, dataSelection)',
+          value: () => [],
         },
 
         _requestManager: {
@@ -260,6 +261,12 @@ limitations under the License.
           value: USE_DATA_SELECTOR,
         },
       },
+      behaviors: [
+        tf_dashboard_common.ArrayUpdateHelper,
+      ],
+      observers: [
+        '_updateCategories(_runToTagInfo, _selectedRuns, _tagFilter, _categoriesDomReady, dataSelection)',
+      ],
       _showDownloadLinksObserver: tf_storage.getBooleanObserver(
           '_showDownloadLinks', {defaultValue: false, useLocalStorage: true}),
       _smoothingWeightObserver: tf_storage.getNumberObserver(
@@ -305,7 +312,7 @@ limitations under the License.
         });
       },
 
-      _makeCategories(
+      _updateCategories(
           runToTagInfo, selectedRuns, tagFilter, categoriesDomReady) {
         const usesDataSelection = this.useDataSelector && this.dataSelection;
         if (usesDataSelection && this.dataSelection.selections.length == 0) {
@@ -338,7 +345,8 @@ limitations under the License.
             })),
           }));
         });
-        return categories;
+
+        this.updateArrayProp('_categories', categories, (c) => c.name);
       },
 
       _tagMetadata(runToTagsInfo, runs, tag) {


### PR DESCRIPTION
When using Polymer's array manipulation methods, we can leverage the
correct DOM updates on template#dom-repeat. However, since updating
Array imperatively can be cumbersome and non-functional, we added a
behavior that updates an array property without having to know the
internals of the dom-repeat.