### PR TITLE
FIX: line-chart is rendered properly (no-shrink)

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -45,6 +45,7 @@ limitations under the License.
         default-y-range="[[defaultYRange]]"
         fill-area="[[fillArea]]"
         symbol-function="[[symbolFunction]]"
+        on-chart-attached="_onChartAttached"
       ></vz-line-chart2>
       <template is="dom-if" if="[[dataLoading]]">
         <div id="loading-spinner-container">
@@ -105,7 +106,10 @@ limitations under the License.
         if (redrawQueue.length == 0) return;
         const x = redrawQueue.shift();
         if (x.active) {
-          x.redraw();
+          // When incorrectly drawn, Plottable, more specifically, Typesettable,
+          // can have incorrect values in its measurement cache. For correct
+          // axis layout, we must bust the cache.
+          x.redraw(true /* clearCache */);
           x._maybeRenderedInBadState = false;
         }
         window.cancelAnimationFrame(redrawRaf);
@@ -185,13 +189,7 @@ limitations under the License.
           this.$.chart.resetDomain();
         }
 
-        if (this.active) {
-          this.redraw();
-        } else {
-          // If we reached a point where we should render while the page
-          // is not active, we've gotten into a bad state.
-          this._maybeRenderedInBadState = true;
-        }
+        this.redraw();
       },
 
       detached() {
@@ -212,10 +210,16 @@ limitations under the License.
         this.$.chart.setSeriesMetadata(name, metadata);
       },
 
-      redraw() {
+      redraw(clearCache) {
         cancelAnimationFrame(this._redrawRaf);
         this._redrawRaf = window.requestAnimationFrame(() => {
-          this.$.chart.redraw();
+          if (this.active) {
+            this.$.chart.redraw(clearCache);
+          } else {
+            // If we reached a point where we should render while the page
+            // is not active, we've gotten into a bad state.
+            this._maybeRenderedInBadState = true;
+          }
         });
       },
 
@@ -246,6 +250,12 @@ limitations under the License.
         if (this.active && this._maybeRenderedInBadState) {
           redrawQueue.push(this);
           cascadingRedraw();
+        }
+      },
+
+      _onChartAttached() {
+        if (!this.active) {
+          this._maybeRenderedInBadState = true;
         }
       },
 

--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -849,13 +849,20 @@ export class LineChart {
     }
   }
 
-  public redraw() {
+  public redraw(clearCache: boolean = false) {
+    if (clearCache) {
+      this.outer.invalidateCache();
+    }
     this.outer.redraw();
   }
 
   public destroy() {
     // Destroying outer destroys all subcomponents recursively.
     if (this.outer) this.outer.destroy();
+  }
+
+  public onAnchor(fn: () => void) {
+    if (this.outer) this.outer.onAnchor(fn);
   }
 }
 

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -326,9 +326,9 @@ Polymer({
   /**
    * Re-renders the chart. Useful if e.g. the container size changed.
    */
-  redraw: function() {
+  redraw: function(clearCache: boolean) {
     if (this._chart) {
-      this._chart.redraw();
+      this._chart.redraw(clearCache);
     }
   },
 
@@ -393,6 +393,7 @@ Polymer({
       chart.renderTo(div);
       if (this._chart) this._chart.destroy();
       this._chart = chart;
+      this._chart.onAnchor(() => this.fire('chart-attached'));
     }, 350);
   },
 


### PR DESCRIPTION
When using paginated to scroll through charts quickly, you will trigger
the chart creation (which is debounced for 350ms). The chart creation,
even if it is no longer in foreground ("display:none"d), it will draw and result
in a shrunken line-chart. There is a bad draw detection logic to remedy the
problem, but it did not account for the debounce logic in the line-chart.

To mitigate the problem, we now listen to on Plottable.Component#onAnchor
event to known when a chart is mounted on DOM and know when a drawn
happened while it was in the background.

Alternatively, we can cancel the chart creation debounce by either creating
a new state in chart, `active`, or a method `cancelMakeChart`.