### PR TITLE
CLEANUP: use array-updater in tf-data-selector

### DIFF
--- a/tensorboard/components/tf_dashboard_common/array-update-helper.ts
+++ b/tensorboard/components/tf_dashboard_common/array-update-helper.ts
@@ -23,16 +23,24 @@ export const ArrayUpdateHelper = {
       value: Array<any>,
       getKey: (item: any, ind: number) => string) {
 
-    const orig = this[prop];
-    const newVal = value;
-    const lookup = new Set(newVal.map((item, i) => getKey(item, i)));
-
-    if (!Array.isArray(orig)) {
-      throw RangeError(`Expected '${prop}' to be an array.`);
+    if (this.isAttached && !Array.isArray(this[prop])) {
+      throw RangeError(
+          `Expected '${prop}' to be an array but is ${typeof this[prop]}.`);
     }
+
     if (!Array.isArray(value)) {
       throw RangeError(`Expected new value to '${prop}' to be an array.`);
     }
+
+    // In case using ComplexObserver, the method can be invoked before the prop
+    // had a chance to initialize properly.
+    if (!Array.isArray(this[prop])) {
+      this[prop] = [];
+    }
+
+    const orig = this[prop];
+    const newVal = value;
+    const lookup = new Set(newVal.map((item, i) => getKey(item, i)));
 
     let origInd = 0;
     let newValInd = 0;

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.ts
@@ -95,10 +95,10 @@ Polymer({
   },
 
   observers: [
+    '_immutablePropInvarianceViolated(persistenceId.*)',
+    '_immutablePropInvarianceViolated(experiment.*)',
     '_synchronizeColors(checkboxColor)',
     '_persistSelectedRuns(_selectedRuns)',
-    '_initRunsAndTags(experiment)',
-    '_initFromStorage(persistenceId)',
     '_fireChange(_selectedRuns, _tagRegex)',
   ],
 
@@ -157,6 +157,15 @@ Polymer({
         .then(() => {
           this._isDataReady = true;
         });
+  },
+
+  _immutablePropInvarianceViolated(change) {
+    // We allow property to change many times before the component is attached
+    // to DOM.
+    if (this.isAttached) {
+      throw new Error(`Invariance Violation: ` +
+          `Expected property '${change.path}' not to change.`);
+    }
   },
 
   _synchronizeColors() {

--- a/tensorboard/components/tf_data_selector/tf-data-selector.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.html
@@ -18,6 +18,7 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../tf-dashboard-common/array-update-helper.html">
 <link rel="import" href="../tf-dashboard-common/scrollbar-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-filterable-checkbox-list.html">
 <link rel="import" href="../tf-imports/lodash.html">

--- a/tensorboard/components/tf_data_selector/tf-data-selector.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.ts
@@ -46,7 +46,7 @@ Polymer({
 
     _experiments: {
       type: Array,
-      computed: '_computeExperiments(_allExperiments.*, _experimentIds.*)',
+      value: (): Array<tf_backend.Experiment> => [],
     },
 
     _enabledExperimentIds: {
@@ -88,7 +88,12 @@ Polymer({
 
   },
 
+  behaviors: [
+    tf_dashboard_common.ArrayUpdateHelper,
+  ],
+
   observers: [
+    '_updateExperiments(_allExperiments, _experimentIds)',
     '_pruneSelections(_experimentIds.*)',
     '_pruneExperimentIds(_allExperiments.*)',
     '_pruneEnabledExperiments(_experimentIds.*)',
@@ -244,11 +249,13 @@ Polymer({
     this._selections = newSelections;
   },
 
-  _computeExperiments() {
+  _updateExperiments() {
     const lookup = new Map(this._allExperiments.map(e => [e.id, e]));
-    return this._experimentIds
+    const experiments = this._experimentIds
         .filter(id => lookup.has(id))
         .map(id => lookup.get(id));
+
+    this.updateArrayProp('_experiments', experiments, exp => exp.id);
   },
 
   _addExperiments(event) {


### PR DESCRIPTION
We recently introduced a helper mixin for dom-repeat that updates an
Array property in a way compatible with Polymer v1. The change
incorporates the mixin to the data selector which nicely removes
crufts.