### PR TITLE
Extend program.TensorBoard API to allow other servers and absl flags

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -57,6 +57,19 @@ py_library(
     ],
 )
 
+py_test(
+    name = "program_test",
+    size = "small",
+    srcs = ["program_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":program",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:application",
+        "@org_pocoo_werkzeug",
+    ],
+)
+
 py_library(
     name = "default",
     srcs = ["default.py"],
@@ -116,7 +129,7 @@ py_library(
 py_library(
     name = "expect_futures_installed",
     # This is a dummy rule used as a futures dependency in open-source.
-    # We expect numpy to already be installed on the system, e.g. via
+    # We expect futures to already be installed on the system, e.g. via
     # `pip install futures`
     visibility = ["//visibility:public"],
 )

--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -83,8 +83,6 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":application",
-        "//tensorboard",
-        "//tensorboard:default",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -51,23 +51,34 @@ from tensorboard.plugins.text import text_plugin
 
 logger = logging.getLogger(__name__)
 
-PLUGIN_LOADERS = [
+_PLUGINS = [
     core_plugin.CorePluginLoader(),
-    base_plugin.BasicLoader(beholder_plugin.BeholderPlugin),
-    base_plugin.BasicLoader(scalars_plugin.ScalarsPlugin),
-    base_plugin.BasicLoader(custom_scalars_plugin.CustomScalarsPlugin),
-    base_plugin.BasicLoader(images_plugin.ImagesPlugin),
-    base_plugin.BasicLoader(audio_plugin.AudioPlugin),
-    base_plugin.BasicLoader(graphs_plugin.GraphsPlugin),
-    base_plugin.BasicLoader(distributions_plugin.DistributionsPlugin),
-    base_plugin.BasicLoader(histograms_plugin.HistogramsPlugin),
-    base_plugin.BasicLoader(pr_curves_plugin.PrCurvesPlugin),
-    base_plugin.BasicLoader(projector_plugin.ProjectorPlugin),
-    base_plugin.BasicLoader(text_plugin.TextPlugin),
+    beholder_plugin.BeholderPlugin,
+    scalars_plugin.ScalarsPlugin,
+    custom_scalars_plugin.CustomScalarsPlugin,
+    images_plugin.ImagesPlugin,
+    audio_plugin.AudioPlugin,
+    graphs_plugin.GraphsPlugin,
+    distributions_plugin.DistributionsPlugin,
+    histograms_plugin.HistogramsPlugin,
+    pr_curves_plugin.PrCurvesPlugin,
+    projector_plugin.ProjectorPlugin,
+    text_plugin.TextPlugin,
     profile_plugin.ProfilePluginLoader(),
     debugger_plugin_loader.DebuggerPluginLoader(),
 ]
 
+def get_plugins():
+  """Returns a list specifying TensorBoard's default first-party plugins.
+
+  Plugins are specified in this list either via a TBLoader instance to load the
+  plugin, or the TBPlugin class itself which will be loaded using a BasicLoader.
+
+  This list can be passed to the `tensorboard.program.TensorBoard` API.
+
+  :rtype: list[Union[base_plugin.TBLoader, Type[base_plugin.TBPlugin]]]
+  """
+  return _PLUGINS[:]
 
 def get_assets_zip_provider():
   """Opens stock TensorBoard web assets collection.

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -34,32 +34,25 @@ import os
 os.environ['GCS_READ_CACHE_DISABLED'] = '1'
 # pylint: enable=g-import-not-at-top
 
-import logging
 import sys
 
 from tensorboard import default
 from tensorboard import program
 
-logger = logging.getLogger(__name__)
-
 
 def run_main():
   """Initializes flags and calls main()."""
   program.setup_environment()
-  server = program.TensorBoard(default.PLUGIN_LOADERS,
-                               default.get_assets_zip_provider())
-  server.configure(sys.argv[1:])
+  tensorboard = program.TensorBoard(default.get_plugins(),
+                                    default.get_assets_zip_provider())
   try:
     from absl import app
-    app.run(server.main, sys.argv[:1] + server.unparsed_argv)
+    app.run(tensorboard.main, flags_parser=tensorboard.configure)
     raise AssertionError("absl.app.run() shouldn't return")
   except ImportError:
     pass
-  if server.unparsed_argv:
-    sys.stderr.write('Unknown flags: %s\nPass --help for help.\n' %
-                     (server.unparsed_argv,))
-    sys.exit(1)
-  sys.exit(server.main())
+  tensorboard.configure(sys.argv)
+  sys.exit(tensorboard.main())
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -295,7 +295,8 @@ commonly used values are 127.0.0.1 (localhost) and :: (for IPv6).\
         type=int,
         default=6006,
         help='''\
-Port to serve TensorBoard on (default: %(default)s)\
+Port to serve TensorBoard on. Pass 0 to request an unused port selected
+by the operating system. (default: %(default)s)\
 ''')
 
     parser.add_argument(

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -1,0 +1,76 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for program package."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+
+import six
+import tensorflow as tf
+
+from tensorboard import program
+
+
+class WerkzeugServerTest(tf.test.TestCase):
+  """Tests the default Werkzeug implementation of TensorBoardServer.
+
+  Mostly useful for IPv4/IPv6 testing. This test should run with only IPv4, only
+  IPv6, and both IPv4 and IPv6 enabled.
+  """
+
+  class _StubApplication(object):
+    pass
+
+  def make_flags(self, **kwargs):
+    flags = argparse.Namespace()
+    for k, v in six.iteritems(kwargs):
+      setattr(flags, k, v)
+    return flags
+
+  def testMakeServerBlankHost(self):
+    # Test that we can bind to all interfaces without throwing an error
+    server = program.WerkzeugServer(
+        self._StubApplication(),
+        self.make_flags(host='', port=0, path_prefix=''))
+    self.assertStartsWith(server.get_url(), 'http://')
+
+  def testSpecifiedHost(self):
+    one_passed = False
+    try:
+      server = program.WerkzeugServer(
+          self._StubApplication(),
+          self.make_flags(host='127.0.0.1', port=0, path_prefix=''))
+      self.assertStartsWith(server.get_url(), 'http://127.0.0.1:')
+      one_passed = True
+    except program.TensorBoardServerException:
+      # IPv4 is not supported
+      pass
+    try:
+      server = program.WerkzeugServer(
+          self._StubApplication(),
+          self.make_flags(host='::1', port=0, path_prefix=''))
+      self.assertStartsWith(server.get_url(), 'http://[::1]:')
+      one_passed = True
+    except program.TensorBoardServerException:
+      # IPv6 is not supported
+      pass
+    self.assertTrue(one_passed)  # We expect either IPv4 or IPv6 to be supported
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
This PR extends the program.TensorBoard API introduced by #1240 so that it's compatible with internal use of TensorBoard.  It makes the following changes:

- program.TensorBoard() now accepts a server_class parameter specifying a subclass of the new TensorBoardServer abstract class, to customize the serving logic for TensorBoard's WSGI app
- program.TensorBoard() will now use the new [absl flags argparse integration](https://github.com/abseil/abseil-py/commit/6d9df2af09517656d83530d5841aeecfc41223cd) if available so that absl flags get parsed together with the regular argparse ones, and any absl flags from the main module are exposed via TBContext.flags
- program.TensorBoard() now accepts plugins as either TBPlugin classes (as it was before #1240) or TBLoader plugin loader instances, and constructs BasicLoaders automatically for the TBPlugin classes.  This saves some boilerplate and makes it easy to do targeted removal of specific plugins from the default set if desired because they aren't wrapped in an undistinguishable BasicLoader.

The corresponding internal changes are previewed in cl/211881012.  Together these get the internal sync unblocked.