### PR TITLE
Guard use of absl.app.run(flags_parser=??) with import check

### DIFF
--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -47,6 +47,8 @@ def run_main():
                                     default.get_assets_zip_provider())
   try:
     from absl import app
+    # Import this to check that app.run() will accept the flags_parser argument.
+    from absl.flags import argparse_flags
     app.run(tensorboard.main, flags_parser=tensorboard.configure)
     raise AssertionError("absl.app.run() shouldn't return")
   except ImportError:


### PR DESCRIPTION
cc @jameswex 

This fixes an issue with my #1409 PR where on absl-py < 0.4.0, app.run() would fail with an unrecognized keyword argument instead of correctly falling back to the non-app.run() execution mode.