### PR TITLE
Make Vulcanize strip sourcemap URLs even when compile=True

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -318,6 +318,7 @@ public final class Vulcanize {
     } else {
       path = me().lookup(Webpath.get(node.attr("src")));
       script = new String(Files.readAllBytes(getWebfile(path)), UTF_8);
+      script = INLINE_SOURCE_MAP_PATTERN.matcher(script).replaceAll("");
     }
     boolean wantsMinify = getAttrTransitive(node, "jscomp-minify").isPresent();
     if (node.attr("src").endsWith(".min.js")


### PR DESCRIPTION
Since PR #1404 changed the main tensorboard_html_binary() to pass compile=True to Vulcanize.java, opening the Chrome devtools causes the TensorBoard command to emit two unexpected 404 warnings for missing sourcemap files as follows:

```
W0911 15:58:29.992902 Thread-3 application.py:300] path /web-animations-next-lite.min.js.map not found, sending 404                              
W0911 15:58:30.172698 Thread-3 application.py:300] path /weblas.map.json not found, sending 404                                                                                                                                                                      
```

This is because the compile=False path of Vulcanize.js strips out the sourceMappingURL comments but the compile=True path did not.  Now they both strip them.