### PR TITLE
Fix broken storage-utils.js reference for data selector

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -118,9 +118,8 @@ tf_web_library(
     path = "/",
     deps = [
         "//tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard:wit_assets",
-        "@com_google_fonts_roboto"
+        "@com_google_fonts_roboto",
     ],
-    suppress= ["strictDependencies"],
 )
 
 py_library(

--- a/tensorboard/components/tf_data_selector/BUILD
+++ b/tensorboard/components/tf_data_selector/BUILD
@@ -9,6 +9,7 @@ tf_web_library(
     srcs = [
         "experiment-selector.html",
         "experiment-selector.ts",
+        "storage-utils.html",
         "storage-utils.ts",
         "tf-collapsible-data-selector.html",
         "tf-collapsible-data-selector.ts",

--- a/tensorboard/components/tf_data_selector/storage-utils.html
+++ b/tensorboard/components/tf_data_selector/storage-utils.html
@@ -1,0 +1,18 @@
+<!--
+@license
+Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script src="storage-utils.js"></script>

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.html
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.html
@@ -24,6 +24,7 @@ limitations under the License.
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/scrollbar-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-filterable-checkbox-dropdown.html">
+<link rel="import" href="./storage-utils.html">
 
 <!--
 tf-data-select-row creates a row of a data filteration widgets. It allows user
@@ -139,7 +140,6 @@ Event out:
       }
     </style>
   </template>
-  <script src="storage-utils.js"></script>
   <script src="tf-data-select-row.js"></script>
 
 </dom-module>

--- a/tensorboard/components/tf_data_selector/tf-data-selector.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.html
@@ -23,6 +23,7 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/tf-filterable-checkbox-list.html">
 <link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="./experiment-selector.html">
+<link rel="import" href="./storage-utils.html">
 <link rel="import" href="./tf-data-select-row.html">
 
 <!--
@@ -105,7 +106,6 @@ Properties out:
       }
     </style>
   </template>
-  <script src="storage-utils.js"></script>
   <script src="type.js"></script>
   <script src="tf-data-selector.js"></script>
 </dom-module>


### PR DESCRIPTION
This fixes a breakage in the data selector when compile=True is used for tensorboard_html_binary, as was done for PR #1404.  For some reason, the vulcanization logic stopped inlining storage-utils.js properly.  This resulted in a later build error from building //tensorboard:assets (which was just suppressed to a warning by #1404):

```
  INFO: From Checking webfiles //tensorboard:assets:
  WARNING: bazel-out/k8-fastbuild/bin/tensorboard/components/index.html: Referenced storage-utils.js (/storage-utils.js) without depending on a web_library() rule providing it
```

But by ignoring this, at runtime, storage-utils.js can't be loaded, resulting in 404s and a broken data selector.

The way I fixed this was by adding a storage-utils.html "shell" file and then referencing that via HTML imports rather than direct `<script>` tags.  @jart if you know of a better fix I'm happy to do that instead.