### PR TITLE
Travis CI: Python syntax errors or undefined names 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
   - echo "test --test_output=errors" >>~/.bazelrc
 
 install:
-  - pip install flake8
+  - pip install flake8==3.5.0
   - pip install futures==3.1.1
   - pip install grpcio==1.6.3
   - pip install mock==2.0.0
@@ -81,7 +81,8 @@ before_script:
   # fail the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  # a comment of '# noqa' or better yet '# noqa: <error code>' added to the code to silence flake8
+  - flake8 . --count --exit-zero --ignore=E111,E114 --max-complexity=10 --max-line-length=127 --statistics
 
 # Commands in this section should only fail if it's our fault. Travis will
 # categorize them as 'failed', rather than 'error' for other sections.

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ before_install:
   - echo "test --test_output=errors" >>~/.bazelrc
 
 install:
+  - pip install flake8
   - pip install futures==3.1.1
   - pip install grpcio==1.6.3
   - pip install mock==2.0.0
@@ -75,6 +76,12 @@ install:
         pip install -I tensorflow=="${TF}"
         ;;
     esac
+
+before_script:
+  # fail the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 # Commands in this section should only fail if it's our fault. Travis will
 # categorize them as 'failed', rather than 'error' for other sections.

--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 from tensorboard import lazy
 
 pkg = lambda i: i  # helps google sync process
-mod = lambda i: lazy.LazyLoader(i[i.rindex('.') + 1:], globals(), i)
+mod = lambda i: lazy.LazyLoader(i[i.rindex('.') + 1:], globals(), i)  # noqa
 
 program = mod(pkg('tensorboard.program'))
 summary = mod(pkg('tensorboard.summary'))

--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 from tensorboard import lazy
 
 pkg = lambda i: i  # helps google sync process
-mod = lambda i: lazy.LazyLoader(i[i.rindex('.') + 1:], globals(), i)  # noqa
+mod = lambda i: lazy.LazyLoader(i[i.rindex('.') + 1:], globals(), i)  # noqa: F821
 
 program = mod(pkg('tensorboard.program'))
 summary = mod(pkg('tensorboard.summary'))


### PR DESCRIPTION
Automatically detect issues like #1417

Use [flake8](http://flake8.pycqa.org) to look for Python syntax errors or undefined names on both Python 2 and Python 3.

__E901,E999,F821,F822,F823__ are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc.  Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.  This PR therefore recommends a flake8 run of these tests on the entire codebase.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable `name` referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

@nfelt 