### PR TITLE
Chart is now pannable when pressing alt-key

### DIFF
--- a/tensorboard/components/vz_line_chart/dragZoomInteraction.ts
+++ b/tensorboard/components/vz_line_chart/dragZoomInteraction.ts
@@ -72,6 +72,14 @@ export class DragZoomLayer extends Plottable.Components.SelectionBoxLayer {
     this.onEnd = cb;
   }
 
+  /**
+   * Returns backing drag interaction. Useful for customization to the
+   * interaction.
+   */
+  public dragInteraction(): Plottable.Interactions.Drag {
+    return this._dragInteraction;
+  }
+
   private setupCallbacks() {
     let dragging = false;
     this._dragInteraction.onDragStart((startPoint: Plottable.Point) => {

--- a/tensorboard/components/vz_line_chart2/BUILD
+++ b/tensorboard/components/vz_line_chart2/BUILD
@@ -9,6 +9,8 @@ tf_web_library(
     name = "vz_line_chart2",
     srcs = [
         "line-chart.ts",
+        "panZoomDragLayer.html",
+        "panZoomDragLayer.ts",
         "vz-line-chart2.html",
         "vz-line-chart2.ts",
     ],

--- a/tensorboard/components/vz_line_chart2/panZoomDragLayer.html
+++ b/tensorboard/components/vz_line_chart2/panZoomDragLayer.html
@@ -1,0 +1,5 @@
+<link rel="import" href="../tf-imports/d3.html">
+<link rel="import" href="../tf-imports/plottable.html">
+<link rel="import" href="../vz-line-chart/dragZoomInteraction.html">
+
+<script src="panZoomDragLayer.js"></script>

--- a/tensorboard/components/vz_line_chart2/panZoomDragLayer.ts
+++ b/tensorboard/components/vz_line_chart2/panZoomDragLayer.ts
@@ -1,0 +1,68 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace vz_line_chart2 {
+
+export class PanZoomDragLayer extends Plottable.Components.Group {
+  private panZoom: Plottable.Interactions.PanZoom;
+  private dragZoomLayer: vz_line_chart.DragZoomLayer;
+
+  /**
+   * A Plottable component/layer with a complex interaction for the line chart.
+   * When not pressing alt-key, it behaves like DragZoomLayer -- dragging a
+   * region zooms the area under the gray box and double clicking resets the
+   * zoom. When pressing alt-key, it lets user pan around while having mousedown
+   * on the chart and let user zoom-in/out of cursor when scroll.
+   */
+  constructor(
+      xScale: Plottable.QuantitativeScale<number|{valueOf(): number}>,
+      yScale: Plottable.QuantitativeScale<number|{valueOf(): number}>,
+      unzoomMethod: Function) {
+    super();
+
+    this.panZoom = new Plottable.Interactions.PanZoom(xScale, yScale);
+    this.panZoom.dragInteraction().mouseFilter((event: MouseEvent) => {
+      return Boolean(event.altKey) && event.button === 0;
+    });
+    this.panZoom.attachTo(this);
+
+    this.dragZoomLayer = new vz_line_chart.DragZoomLayer(
+        xScale,
+        yScale,
+        unzoomMethod);
+    this.dragZoomLayer.dragInteraction().mouseFilter((event: MouseEvent) => {
+      return !Boolean(event.altKey) && event.button === 0;
+    });
+    this.append(this.dragZoomLayer);
+
+    this.onAnchor(() => {
+      this.panZoom.attachTo(this);
+    });
+    this.onDetach(() => {
+      this.panZoom.detachFrom(this);
+    });
+  }
+
+  onDragStart(cb) {
+    this.dragZoomLayer.dragInteraction().onDragStart(cb);
+    this.dragZoomLayer.interactionStart(cb);
+  }
+
+  onDragEnd(cb) {
+    this.dragZoomLayer.dragInteraction().onDragEnd(cb);
+    this.dragZoomLayer.interactionEnd(cb);
+  }
+}
+
+}  // namespace vz_line_chart

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.html
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.html
@@ -20,6 +20,7 @@ limitations under the License.
 <link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../tf-imports/plottable.html">
 <link rel="import" href="../vz-chart-helpers/vz-chart-helpers.html">
+<link rel="import" href="panZoomDragLayer.html">
 
 <!--
 vz-line-chart creates an element that draws a line chart for


### PR DESCRIPTION
All line charts are now, in addition to drag zoom, pannable when
pressing alt-key. Pressing alt-key, you can now drag to move around in
the chart or use wheel to zoom-in/out of a chart.