### PR TITLE
FIX: two bugs with the data selector

### DIFF
--- a/tensorboard/components/tf_data_selector/tf-data-select-row.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.ts
@@ -268,16 +268,21 @@ Polymer({
     if (selectedIds.length == 0) return STORAGE_NONE_VALUE;
 
     return this.noExperiment ?
-        selectedIds.join(',') :
+        JSON.stringify(selectedIds) :
         tf_data_selector.encodeIdArray((selectedIds as Array<number>));
   },
 
   _deserializeValue(allValues: Array<number|string>, str: string) {
     if (str == STORAGE_ALL_VALUE) return allValues;
     if (str == STORAGE_NONE_VALUE) return [];
-    return this.noExperiment ?
-        str.split(',') :
-        tf_data_selector.decodeIdArray(str);
+    if (!this.noExperiment) return tf_data_selector.decodeIdArray(str);
+    let parsed = [];
+    try {
+      parsed = JSON.parse(str);
+    } catch (e) {
+      /* noop */
+    }
+    return Array.isArray(parsed) ? parsed : [];
   },
 
   _getColoring() {

--- a/tensorboard/components/tf_data_selector/tf-data-selector.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector.ts
@@ -83,7 +83,7 @@ Polymer({
 
     _shouldColorRuns: {
       type: Boolean,
-      computed: '_computeShouldColorRuns(_experiments)',
+      computed: '_computeShouldColorRuns(_experiments.*)',
     },
 
   },


### PR DESCRIPTION
1. Fix the issue where run name contains comma
Run names, when using non-DB mode, can contain random characters and we
need to use the delimiter that is unique. Instead of "," which can be
part of the run name, we now serialize the list of run names using JSON.
stringify.

2. Fix the issue where runs are incorrectly colored
Fix the bug where data selector incorrectly colors the runs in the
filtered run selector list. The bug happened because of incorrect
complex observer: we now update the `experiments` array instance
instead of setting a new array instance onto the property.

