### PR TITLE
Expand pane when no panes are user controlled

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -128,7 +128,11 @@ limitations under the License.
             <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           </template>
           <template is="dom-repeat" items="[[_categories]]" as="category">
-            <tf-category-pane category="[[category]]" opened="[[_shouldOpen(index)]]">
+            <tf-category-pane
+              category="[[category]]"
+              opened="[[_getPaneOpened(category)]]"
+              on-opened-changed="_onPaneOpenChanged"
+            >
               <tf-paginated-view
                 items="[[category.items]]"
                 pages="{{category._pages}}"
@@ -225,6 +229,12 @@ limitations under the License.
               {defaultValue: true, useLocalStorage: true}),
           observer: '_ignoreYOutliersObserver',
         },
+
+        _paneOpened: {
+          type: Object,
+          value: () => ({}),
+        },
+
         /** @type {vz_chart_helpers.XType} */
         _xType: {
           type: String,
@@ -266,6 +276,7 @@ limitations under the License.
       ],
       observers: [
         '_updateCategories(_runToTagInfo, _selectedRuns, _tagFilter, _categoriesDomReady, dataSelection)',
+        '_updatePaneOpened(_categories.*)',
       ],
       _showDownloadLinksObserver: tf_storage.getBooleanObserver(
           '_showDownloadLinks', {defaultValue: false, useLocalStorage: true}),
@@ -277,8 +288,43 @@ limitations under the License.
         return _smoothingWeight > 0;
       },
 
-      _shouldOpen(index) {
-        return index <= 2;
+      _getCategoryKey(category) {
+        return category.metadata.type ==
+            tf_categorization_utils.CategoryType.SEARCH_RESULTS ?
+                'search' : category.name;
+      },
+
+      _updatePaneOpened() {
+        const paneOpen = this._paneOpened;
+        const nextPaneOpen = {};
+
+        // Copy over the relevant values from the old pane state.
+        this._categories
+            .map(this._getCategoryKey)
+            .filter(name => paneOpen[name] != null)
+            .forEach(name => nextPaneOpen[name] = paneOpen[name]);
+
+        if (Object.keys(nextPaneOpen).length == 0) {
+          this._categories.slice(0, 2)
+              .map(this._getCategoryKey)
+              .forEach(name => {
+                nextPaneOpen[name] = nextPaneOpen[name] != null ?
+                    nextPaneOpen[name] : true;
+              });
+        }
+
+        this._paneOpened = nextPaneOpen;
+      },
+
+      _getPaneOpened(category) {
+        return this._paneOpened[this._getCategoryKey(category)];
+      },
+
+      _onPaneOpenChanged(event) {
+        // The event can be triggered without the pane being mounted.
+        if (!this.isAttached || !event.target.isAttached) return;
+        const name = this._getCategoryKey(event.target.category);
+        this._paneOpened[name] = event.detail.value;
       },
 
       ready() {
@@ -343,7 +389,7 @@ limitations under the License.
            }));
           });
         }
-        this.updateArrayProp('_categories', categories, (c) => c.name);
+        this.updateArrayProp('_categories', categories, this._getCategoryKey);
       },
 
       _tagMetadata(category, runToTagsInfo, item) {

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -197,6 +197,7 @@ limitations under the License.
     const PLUGIN_NAME = 'scalars';
     const USE_DATA_SELECTOR = tf_globals.getEnableDataSelector();
     const SelectionType = tf_data_selector.Type;
+    const NUM_DEFAULT_OPENED_PANE = 2;
 
     Polymer({
       is: 'tf-scalar-dashboard',
@@ -291,29 +292,28 @@ limitations under the License.
       _getCategoryKey(category) {
         return category.metadata.type ==
             tf_categorization_utils.CategoryType.SEARCH_RESULTS ?
-                'search' : category.name;
+                '' : category.name;
       },
 
       _updatePaneOpened() {
         const paneOpen = this._paneOpened;
-        const nextPaneOpen = {};
+        const newPaneOpened = {};
 
         // Copy over the relevant values from the old pane state.
         this._categories
             .map(this._getCategoryKey)
             .filter(name => paneOpen[name] != null)
-            .forEach(name => nextPaneOpen[name] = paneOpen[name]);
+            .forEach(name => newPaneOpened[name] = paneOpen[name]);
 
-        if (Object.keys(nextPaneOpen).length == 0) {
-          this._categories.slice(0, 2)
+        if (Object.keys(newPaneOpened).length == 0) {
+          this._categories.slice(0, NUM_DEFAULT_OPENED_PANE)
               .map(this._getCategoryKey)
               .forEach(name => {
-                nextPaneOpen[name] = nextPaneOpen[name] != null ?
-                    nextPaneOpen[name] : true;
+                newPaneOpened[name] = true;
               });
         }
 
-        this._paneOpened = nextPaneOpen;
+        this._paneOpened = newPaneOpened;
       },
 
       _getPaneOpened(category) {


### PR DESCRIPTION
In scalars plugin, the category panes were expanded/collapsed if index
is less than 2. This made, if categories list changed, panes to reopen
even if it was explicitly disabled.

Now, we expand top 2 panes only when user has no pane  expanded or
collapsed panes explicitly.