### PR TITLE
Fix scroll issue when overview is injected

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -140,6 +140,7 @@ limitations under the License.
       </paper-toolbar>
 
       <div id="content-pane" class="fit">
+        <slot id="injected-overview"></slot>
         <template is="dom-if" if="[[_isDataSelectorEnabled]]">
           <div id="data-selector">
             <tf-collapsible-data-selector
@@ -149,7 +150,6 @@ limitations under the License.
           </div>
         </template>
         <div id="content">
-          <slot id="injected-overview"></slot>
           <template is="dom-if" if="[[_activeDashboardsFailedToLoad]]">
             <div class="warning-message">
               <h3>Failed to load the set of active dashboards.</h3>


### PR DESCRIPTION
We now place the injected overview above the data-selector and allow the
content to adjust height correctly when injected-overview takes non-zero
height.