### PR TITLE
Rewrite WerkzeugServer for better IPv4/v6 handling

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -187,9 +187,7 @@ class TensorBoard(object):
     if self.flags.inspect:
       logger.info('Not bringing up TensorBoard, but inspecting event files.')
       event_file = os.path.expanduser(self.flags.event_file)
-      efi.inspect(self.flags.logdir,
-                  self.flags.event_file,
-                  self.flags.tag)
+      efi.inspect(self.flags.logdir, event_file, self.flags.tag)
       return 0
     try:
       server = self._make_server()

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -309,16 +309,17 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
     fallback_address = '::' if socket.has_ipv6 else '0.0.0.0'
     if hasattr(socket, 'AI_PASSIVE'):
       try:
-        wildcard_addrs = socket.getaddrinfo(
-            None, port, socket.AF_UNSPEC, socket.SOCK_STREAM,
-            socket.IPPROTO_TCP, socket.AI_PASSIVE)
+        addrinfos = socket.getaddrinfo(None, port, socket.AF_UNSPEC,
+                                       socket.SOCK_STREAM, socket.IPPROTO_TCP,
+                                       socket.AI_PASSIVE)
       except socket.gaierror as e:
         logger.warn('Failed to auto-detect wildcard address, assuming %s: %s',
                     fallback_address, str(e))
         return fallback_address
       addrs_by_family = defaultdict(list)
-      for family, _, _, _, sockaddr in wildcard_addrs:
-        # Format of sockaddr varies by family, but [0] is always the address.
+      for family, _, _, _, sockaddr in addrinfos:
+        # Format of the "sockaddr" socket address varies by address family,
+        # but [0] is always the IP address portion.
         addrs_by_family[family].append(sockaddr[0])
       if hasattr(socket, 'AF_INET6') and addrs_by_family[socket.AF_INET6]:
         return addrs_by_family[socket.AF_INET6][0]

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -299,7 +299,7 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
     """Returns a wildcard address for the port in question.
 
     This will attempt to follow the best practice of calling getaddrinfo() with
-    a null host and AI_PASSIVE to request a server-side socket wilcard address.
+    a null host and AI_PASSIVE to request a server-side socket wildcard address.
     If that succeeds, this returns the first IPv6 address found, or if none,
     then returns the first IPv4 address. If that fails, then this returns the
     hardcoded address "::" if socket.has_ipv6 is True, else "0.0.0.0".

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -283,17 +283,19 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
       super(WerkzeugServer, self).__init__(host, flags.port, wsgi_app)
     except socket.error as e:
       if hasattr(errno, 'EACCES') and e.errno == errno.EACCES:
-        msg = ('TensorBoard must be run as superuser to bind to port %d'
-               % flags.port)
+        raise TensorBoardServerException(
+            'TensorBoard must be run as superuser to bind to port %d' %
+            flags.port)
       elif hasattr(errno, 'EADDRINUSE') and e.errno == errno.EADDRINUSE:
         if flags.port == 0:
-          msg = 'TensorBoard unable to find any open port'
+          raise TensorBoardServerException(
+              'TensorBoard unable to find any open port')
         else:
-          msg = ('TensorBoard could not bind to port %d, it was already in use'
-                 % flags.port)
-      else:
-        raise
-      raise TensorBoardServerException(msg)
+          raise TensorBoardServerException(
+              'TensorBoard could not bind to port %d, it was already in use' %
+              flags.port)
+      # Raise the raw exception if it wasn't identifiable as a user error.
+      raise
 
   def _get_wildcard_address(self, port):
     """Returns a wildcard address for the port in question.


### PR DESCRIPTION
This rewrites the WerkzeugServer wrapper introduced in #1409 to eliminate some issues with the old approach to IPv4/v6 handling and in particular fix #1320.  Gory details are in https://github.com/tensorflow/tensorboard/issues/1320#issuecomment-423364207

This change also streamlines the class so that it now directly inherits from Werkzeug's ThreadedWSGIServer class, which gives us a `serve_forever()` implementation for free and cleans up the `handle_error()` behavior so it's an overridden method instead of monkey-patched.

Fixes #1320
 

