### PR TITLE
Revert category pane behavior to 1.10

### DIFF
--- a/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
+++ b/tensorboard/components/tf_categorization_utils/categorizationUtils.ts
@@ -124,17 +124,16 @@ export function categorizeTags(
     runToTag: RunToTag,
     selectedRuns: string[],
     query?: string): TagCategory[] {
-  runToTag = _.pick(runToTag, selectedRuns);
   const tags = tf_backend.getTags(runToTag);
   const categories = categorize(tags, query);
-  const tagToRuns = createTagToRuns(runToTag);
+  const tagToRuns = createTagToRuns(_.pick(runToTag, selectedRuns));
 
   return categories.map(({name, metadata, items}) => ({
     name,
     metadata,
     items: items.map(tag => ({
       tag,
-      runs: tagToRuns.get(tag).slice(),
+      runs: (tagToRuns.get(tag) || []).slice(),
     })),
   }));
 }

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -197,7 +197,7 @@ limitations under the License.
     const PLUGIN_NAME = 'scalars';
     const USE_DATA_SELECTOR = tf_globals.getEnableDataSelector();
     const SelectionType = tf_data_selector.Type;
-    const NUM_DEFAULT_OPENED_PANE = 2;
+    const NUM_DEFAULT_OPENED_PANE = 3;
 
     Polymer({
       is: 'tf-scalar-dashboard',
@@ -377,9 +377,7 @@ limitations under the License.
             query = tagRegex;
             selectedRuns = runs.map(({name}) => name);
           }
-          const runToTag = _.mapValues(
-              _.pick(runToTagInfo, selectedRuns),
-              x => Object.keys(x));
+          const runToTag = _.mapValues(runToTagInfo, x => Object.keys(x));
           categories = tf_categorization_utils.categorizeTags(
               runToTag, selectedRuns, query);
           categories.forEach(category => {


### PR DESCRIPTION
This reverts the new behavior introduced as part of #1324.
It used to remove pane that has no matching tag/run.