### PR TITLE
Remapped alt key for line-chart pan to shift

### DIFF
--- a/tensorboard/components/vz_line_chart2/panZoomDragLayer.ts
+++ b/tensorboard/components/vz_line_chart2/panZoomDragLayer.ts
@@ -44,7 +44,7 @@ export class PanZoomDragLayer extends Plottable.Components.Group {
 
     this.panZoom = new Plottable.Interactions.PanZoom(xScale, yScale);
     this.panZoom.dragInteraction().mouseFilter((event: MouseEvent) => {
-      return Boolean(event.altKey) && event.button === 0;
+      return PanZoomDragLayer.isPanKey(event) && event.button === 0;
     });
     this.panZoom.attachTo(this);
 
@@ -53,7 +53,7 @@ export class PanZoomDragLayer extends Plottable.Components.Group {
         yScale,
         unzoomMethod);
     this.dragZoomLayer.dragInteraction().mouseFilter((event: MouseEvent) => {
-      return !Boolean(event.altKey) && event.button === 0;
+      return !PanZoomDragLayer.isPanKey(event) && event.button === 0;
     });
     this.append(this.dragZoomLayer);
 
@@ -76,6 +76,10 @@ export class PanZoomDragLayer extends Plottable.Components.Group {
     this.dragZoomLayer.dragInteraction().onDragEnd(() => {
       if (this.state == State.DRAG_ZOOMING) this.setState(State.NONE);
     });
+  }
+
+  static isPanKey(event: MouseEvent): boolean {
+    return Boolean(event.shiftKey);
   }
 
   setState(nextState: State): void {

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.html
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.html
@@ -61,7 +61,7 @@ such as different X scales (linear and temporal), tooltips and smoothing.
         cursor: crosshair;
       }
 
-      :host.altdown #chartdiv :not(.drag-zooming) .main {
+      :host.pankey #chartdiv :not(.drag-zooming) .main {
         cursor: -webkit-grab;
         cursor: grab;
       }

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -293,11 +293,11 @@ Polymer({
   },
 
   _onKeyDown(event) {
-    this.toggleClass('altdown', event.altKey);
+    this.toggleClass('pankey', PanZoomDragLayer.isPanKey(event));
   },
 
   _onKeyUp(event) {
-    this.toggleClass('altdown', event.altKey);
+    this.toggleClass('pankey', PanZoomDragLayer.isPanKey(event));
   },
 
   _onMouseDown(event) {


### PR DESCRIPTION
alt collides with some linux window manager's default behavior.