### PR TITLE
FIX: custom scalar now reacts to run selection

### DIFF
--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.html
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.html
@@ -78,6 +78,11 @@ such as different X scales (linear and temporal), tooltips and smoothing.
       #chartdiv:hover {
         will-change: transform;
       }
+
+      .ghost {
+        opacity: .2;
+        stroke-width: 1px;
+      }
     </style>
   </template>
   <script src="line-chart.js"></script>

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -43,7 +43,7 @@ limitations under the License.
       id="loader"
       active="[[active]]"
       color-scale="[[_colorScale]]"
-      data-series="[[_filteredSeriesNames]]"
+      data-series="[[_seriesNames]]"
       get-data-load-url="[[_dataUrl]]"
       fill-area="[[_fillArea]]"
       ignore-y-outliers="[[ignoreYOutliers]]"
@@ -85,17 +85,17 @@ limitations under the License.
           selected-item-label="{{_dataSeriesNameToDownload}}"
         >
           <paper-menu class="dropdown-content" slot="dropdown-content">
-            <template is="dom-repeat" items="[[_filteredSeriesNames]]" as="dataSeriesName">
+            <template is="dom-repeat" items="[[_seriesNames]]" as="dataSeriesName">
               <paper-item no-label-float=true>[[dataSeriesName]]</paper-item>
             </template>
           </paper-menu>
         </paper-dropdown-menu>
         <a
           download="[[_dataSeriesNameToDownload]].csv"
-          href="[[_csvUrl(_filteredNameToSeries, _dataSeriesNameToDownload)]]"
+          href="[[_csvUrl(_nameToDataSeries, _dataSeriesNameToDownload)]]"
         >CSV</a> <a
           download="[[_dataSeriesNameToDownload]].json"
-          href="[[_jsonUrl(_filteredNameToSeries, _dataSeriesNameToDownload)]]"
+          href="[[_jsonUrl(_nameToDataSeries, _dataSeriesNameToDownload)]]"
         >JSON</a>
       </div>
     </template>
@@ -163,7 +163,7 @@ limitations under the License.
 
   <div id="matches-container">
     <div class="collapsible-list-title">
-      <template is="dom-if" if="[[_filteredSeriesNames.length]]">
+      <template is="dom-if" if="[[_seriesNames.length]]">
         <paper-icon-button
           icon="[[_getToggleCollapsibleIcon(_matchesListOpened)]]"
           on-click="_toggleMatchesOpen"
@@ -172,19 +172,19 @@ limitations under the License.
       </template>
 
       <span class="collapsible-title-text">
-        Matches ([[_filteredSeriesNames.length]])
+        Matches ([[_seriesNames.length]])
       </span>
     </div>
-    <template is="dom-if" if="[[_filteredSeriesNames.length]]">
+    <template is="dom-if" if="[[_seriesNames.length]]">
       <iron-collapse opened="[[_matchesListOpened]]">
         <div id="matches-list">
           <template is="dom-repeat"
-                    items="[[_filteredSeriesNames]]"
+                    items="[[_seriesNames]]"
                     as="seriesName">
               <div class="match-list-entry"
                    style="color: [[_determineColor(_colorScale, seriesName)]];">
                 <span class="match-entry-symbol">
-                  [[_determineSymbol(_filteredNameToSeries, seriesName)]]
+                  [[_determineSymbol(_nameToDataSeries, seriesName)]]
                 </span>
                 [[seriesName]]
               </div>
@@ -303,14 +303,14 @@ limitations under the License.
         /**
          * Maps from the name of the data series to the DataSeries object.
          */
-        _filteredNameToSeries: {
+        _nameToDataSeries: {
           type: Object,
-          value: {},
+          value: () => ({}),
         },
 
-        _filteredSeriesNames: {
+        _seriesNames: {
           type: Object,
-          computed: '_computeFilteredSeriesNames(_filteredNameToSeries)',
+          computed: '_computeSeriesNames(_nameToDataSeries, runs)',
         },
 
         _expanded: {
@@ -426,7 +426,7 @@ limitations under the License.
         _stepsMismatch: Object,
       },
       observers: [
-        '_updateChart(_filteredNameToSeries)',
+        '_updateChart(_nameToDataSeries)',
         // Clear the data series when the tag filter changes.
         '_refreshDataSeries(_tagFilter)',
       ],
@@ -449,16 +449,18 @@ limitations under the License.
           chart.resetDomain();
         }
       },
-      _csvUrl(_filteredNameToSeries, dataSeriesName) {
-        const baseUrl = this._downloadDataUrl(_filteredNameToSeries, dataSeriesName);
+      _csvUrl(_nameToDataSeries, dataSeriesName) {
+        if (!dataSeriesName) return '';
+        const baseUrl = this._downloadDataUrl(_nameToDataSeries, dataSeriesName);
         return tf_backend.addParams(baseUrl, {format: 'csv'});
       },
-      _jsonUrl(_filteredNameToSeries, dataSeriesName) {
-        const baseUrl = this._downloadDataUrl(_filteredNameToSeries, dataSeriesName);
+      _jsonUrl(_nameToDataSeries, dataSeriesName) {
+        if (!dataSeriesName) return '';
+        const baseUrl = this._downloadDataUrl(_nameToDataSeries, dataSeriesName);
         return tf_backend.addParams(baseUrl, {format: 'json'});
       },
-      _downloadDataUrl(_filteredNameToSeries, dataSeriesName) {
-        const dataSeries = _filteredNameToSeries[dataSeriesName];
+      _downloadDataUrl(_nameToDataSeries, dataSeriesName) {
+        const dataSeries = _nameToDataSeries[dataSeriesName];
         const getVars = {
             tag: dataSeries.getTag(),
             run: dataSeries.getRun(),
@@ -480,7 +482,7 @@ limitations under the License.
 
           // The user's regular expression was valid.
           // Incorporate these newly loaded values.
-          const newMapping = _.clone(this._filteredNameToSeries);
+          const newMapping = _.clone(this._nameToDataSeries);
           const tagsNotFound = [];
           _.forEach(marginChartSeries, tagsObject => {
             let tagNotFound = false;
@@ -537,17 +539,18 @@ limitations under the License.
             const seriesName =
                 tf_custom_scalar_dashboard.generateDataSeriesName(
                     run, tagsObject.value);
-            let series = newMapping[seriesName];
+            const series = newMapping[seriesName];
 
             if (series) {
               // This series already exists.
               series.setData(dataPoints);
             } else {
-              newMapping[seriesName] = this._createNewDataSeries(
+              const series = this._createNewDataSeries(
                   run, tagsObject.value, seriesName, dataPoints);
+              newMapping[seriesName] = series;
             }
           });
-          this.set('_filteredNameToSeries', newMapping);
+          this.set('_nameToDataSeries', newMapping);
 
           const entryIndex = _.findIndex(this._missingTags, (entry) => {
             return entry.run === run;
@@ -603,28 +606,31 @@ limitations under the License.
             (this._runToNextAvailableSymbolIndex[run] + 1) % numSymbols;
         return series;
       },
-      _updateChart(_filteredNameToSeries) {
+      _updateChart(_nameToDataSeries) {
         // Add new data series.
-        _.forOwn(_filteredNameToSeries, dataSeries => {
+        _.forOwn(_nameToDataSeries, dataSeries => {
           this.$.loader.setSeriesData(
               dataSeries.getName(), dataSeries.getData());
         });
       },
-      _computeFilteredSeriesNames(_) {
-        return Object.keys(this._filteredNameToSeries);
+      _computeSeriesNames() {
+        const runLookup = new Set(this.runs);
+        return Object.entries(this._nameToDataSeries)
+            .filter(([_, series]) => runLookup.has(series.run))
+            .map(([name]) => name);
       },
       _determineColor(colorScale, seriesName) {
         return colorScale.scale(seriesName);
       },
       _refreshDataSeries(_tagFilter) {
-        this.set('_filteredNameToSeries', {});
+        this.set('_nameToDataSeries', {});
       },
       _createSymbolFunction() {
-        return seriesName => (
-            this._filteredNameToSeries[seriesName].getSymbol().method());
+        return seriesName =>
+            this._nameToDataSeries[seriesName].getSymbol().method();
       },
-      _determineSymbol(_filteredNameToSeries, seriesName) {
-        return _filteredNameToSeries[seriesName].getSymbol().character;
+      _determineSymbol(_nameToDataSeries, seriesName) {
+        return _nameToDataSeries[seriesName].getSymbol().character;
       },
       _computeTagFilter(marginChartSeries) {
         const tags = _.flatten(

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
@@ -43,7 +43,7 @@ limitations under the License.
       id="loader"
       active="[[active]]"
       color-scale="[[_colorScale]]"
-      data-series="[[_filteredSeriesNames]]"
+      data-series="[[_seriesNames]]"
       get-data-load-url="[[_dataUrl]]"
       ignore-y-outliers="[[ignoreYOutliers]]"
       load-key="[[_tagFilter]]"
@@ -85,24 +85,24 @@ limitations under the License.
           selected-item-label="{{_dataSeriesNameToDownload}}"
         >
           <paper-menu class="dropdown-content" slot="dropdown-content">
-            <template is="dom-repeat" items="[[_filteredSeriesNames]]" as="dataSeriesName">
+            <template is="dom-repeat" items="[[_seriesNames]]" as="dataSeriesName">
               <paper-item no-label-float=true>[[dataSeriesName]]</paper-item>
             </template>
           </paper-menu>
         </paper-dropdown-menu>
         <a
           download="[[_dataSeriesNameToDownload]].csv"
-          href="[[_csvUrl(_filteredNameToSeries, _dataSeriesNameToDownload)]]"
+          href="[[_csvUrl(_nameToDataSeries, _dataSeriesNameToDownload)]]"
         >CSV</a> <a
           download="[[_dataSeriesNameToDownload]].json"
-          href="[[_jsonUrl(_filteredNameToSeries, _dataSeriesNameToDownload)]]"
+          href="[[_jsonUrl(_nameToDataSeries, _dataSeriesNameToDownload)]]"
         >JSON</a>
       </div>
     </template>
   </div>
   <div id="matches-container">
     <div id="matches-list-title">
-      <template is="dom-if" if="[[_filteredSeriesNames.length]]">
+      <template is="dom-if" if="[[_seriesNames.length]]">
         <paper-icon-button
           icon="[[_getToggleMatchesIcon(_matchesListOpened)]]"
           on-click="_toggleMatchesOpen"
@@ -111,19 +111,19 @@ limitations under the License.
       </template>
 
       <span class="matches-text">
-        Matches ([[_filteredSeriesNames.length]])
+        Matches ([[_seriesNames.length]])
       </span>
     </div>
-    <template is="dom-if" if="[[_filteredSeriesNames.length]]">
+    <template is="dom-if" if="[[_seriesNames.length]]">
       <iron-collapse opened="[[_matchesListOpened]]">
         <div id="matches-list">
           <template is="dom-repeat"
-                    items="[[_filteredSeriesNames]]"
+                    items="[[_seriesNames]]"
                     as="seriesName">
               <div class="match-list-entry"
                    style="color: [[_determineColor(_colorScale, seriesName)]];">
                 <span class="match-entry-symbol">
-                  [[_determineSymbol(_filteredNameToSeries, seriesName)]]
+                  [[_determineSymbol(_nameToDataSeries, seriesName)]]
                 </span>
                 [[seriesName]]
               </div>
@@ -202,16 +202,18 @@ limitations under the License.
         },
 
         /**
-         * Maps from the name of the data series to the DataSeries object.
+         * Maps from some unique name of the data series to the DataSeries
+         * object. It may contain one for a series that is no longer required
+         * for the card (i.e., run that was enabled is now disabled).
          */
-        _filteredNameToSeries: {
+        _nameToDataSeries: {
           type: Object,
           value: () => ({}),
         },
 
-        _filteredSeriesNames: {
+        _seriesNames: {
           type: Object,
-          computed: '_computeFilteredSeriesNames(_filteredNameToSeries)',
+          computed: '_computeSeriesNames(_nameToDataSeries, runs)',
         },
 
         _expanded: {
@@ -250,7 +252,7 @@ limitations under the License.
         },
       },
       observers: [
-        '_updateChart(_filteredNameToSeries)',
+        '_updateChart(_nameToDataSeries)',
         // Clear the data series when the tag filter changes.
         '_refreshDataSeries(_tagFilter)',
       ],
@@ -273,18 +275,20 @@ limitations under the License.
           chart.resetDomain();
         }
       },
-      _csvUrl(filteredNameToSeries, dataSeriesName) {
+      _csvUrl(nameToSeries, dataSeriesName) {
+        if (!dataSeriesName) return '';
         const baseUrl = this._downloadDataUrl(
-            filteredNameToSeries, dataSeriesName);
+            nameToSeries, dataSeriesName);
         return tf_backend.addParams(baseUrl, {format: 'csv'});
       },
-      _jsonUrl(filteredNameToSeries, dataSeriesName) {
+      _jsonUrl(nameToSeries, dataSeriesName) {
+        if (!dataSeriesName) return '';
         const baseUrl = this._downloadDataUrl(
-            filteredNameToSeries, dataSeriesName);
+            nameToSeries, dataSeriesName);
         return tf_backend.addParams(baseUrl, {format: 'json'});
       },
-      _downloadDataUrl(filteredNameToSeries, dataSeriesName) {
-        const dataSeries = filteredNameToSeries[dataSeriesName];
+      _downloadDataUrl(nameToSeries, dataSeriesName) {
+        const dataSeries = nameToSeries[dataSeriesName];
         const getVars = {
             tag: dataSeries.getTag(),
             run: dataSeries.getRun(),
@@ -299,7 +303,7 @@ limitations under the License.
           if (data.regex_valid) {
             // The user's regular expression was valid.
             // Incorporate these newly loaded values.
-            const newMapping = _.clone(this._filteredNameToSeries);
+            const newMapping = _.clone(this._nameToDataSeries);
             _.forOwn(data.tag_to_events, (scalarEvents, tag) => {
               const data = scalarEvents.map(datum => ({
                 wall_time: new Date(datum[0] * 1000),
@@ -309,11 +313,11 @@ limitations under the License.
 
               const seriesName = tf_custom_scalar_dashboard.generateDataSeriesName(
                   run, tag);
-              let series = newMapping[seriesName];
+              const datum = newMapping[seriesName];
 
-              if (series) {
+              if (datum) {
                 // This series already exists.
-                series.setData(data);
+                datum.setData(data);
               } else {
                 if (_.isUndefined(this._runToNextAvailableSymbolIndex[run])) {
                   // The run has not been seen before. Define the next available
@@ -326,7 +330,7 @@ limitations under the License.
                     this._runToNextAvailableSymbolIndex[run]];
 
                 // Create a series with this name.
-                series = new tf_custom_scalar_dashboard.DataSeries(
+                const series = new tf_custom_scalar_dashboard.DataSeries(
                     run,
                     tag,
                     seriesName,
@@ -341,19 +345,17 @@ limitations under the License.
               }
             });
 
-            this.set('_filteredNameToSeries', newMapping);
+            this.set('_nameToDataSeries', newMapping);
           } else {
             // The user's regular expression was invalid.
             // TODO(chihuahua): Handle this.
           }
         });
       },
-      _updateChart(filteredNameToSeries) {
+      _updateChart(_nameToDataSeries) {
         // Add new data series.
-        Object.entries(filteredNameToSeries).forEach(([name, dataSeries]) => {
-          this.$.loader.setSeriesData(
-              name,
-              dataSeries.getData());
+        Object.entries(_nameToDataSeries).forEach(([name, series]) => {
+          this.$.loader.setSeriesData(name, series.getData());
         });
       },
       _computeSelectedRunsSet(runs) {
@@ -363,21 +365,24 @@ limitations under the License.
         });
         return mapping;
       },
-      _computeFilteredSeriesNames() {
-        return Object.keys(this._filteredNameToSeries);
+      _computeSeriesNames() {
+        const runLookup = new Set(this.runs);
+        return Object.entries(this._nameToDataSeries)
+            .filter(([_, series]) => runLookup.has(series.run))
+            .map(([name]) => name);
       },
       _determineColor(colorScale, seriesName) {
         return colorScale.scale(seriesName);
       },
       _refreshDataSeries(_tagFilter) {
-        this.set('_filteredNameToSeries', {});
+        this.set('_nameToDataSeries', {});
       },
       _createSymbolFunction() {
-        return seriesName => (
-            this._filteredNameToSeries[seriesName].getSymbol().method());
+        return seriesName =>
+            this._nameToDataSeries[seriesName].getSymbol().method();
       },
-      _determineSymbol(filteredNameToSeries, seriesName) {
-        return filteredNameToSeries[seriesName].getSymbol().character;
+      _determineSymbol(nameToSeries, seriesName) {
+        return nameToSeries[seriesName].getSymbol().character;
       },
       _computeTagFilter(tagRegexes) {
         if (tagRegexes.length === 1) {


### PR DESCRIPTION
With tf-line-chart-data-loader refactor which now takes `dataToLoad`
separately from `dataSeries` (latter defines series that are to be drawn
onto the chart whereas the former defines data requirement), the custom
scalar plugin broke because it failed to take run selection when setting
the `dataSeries` property.

The change also addresses the issue where smoothed series do not show in
fade.