### PR TITLE
Fixed some shrunk histogram issue

### DIFF
--- a/tensorboard/components/tf_categorization_utils/tf-category-pane.html
+++ b/tensorboard/components/tf_categorization_utils/tf-category-pane.html
@@ -20,7 +20,7 @@ limitations under the License.
 
 <dom-module id="tf-category-pane">
   <template>
-    <template is="dom-if" if="[[_rendered]]">
+    <template is="dom-if" if="[[_rendered]]" id="ifRendered">
       <button class="heading"
               on-tap="_togglePane"
               open-button$="[[opened]]">
@@ -52,7 +52,7 @@ limitations under the License.
       </button>
       <iron-collapse opened="[[opened]]">
         <div class="content">
-          <template is="dom-if" if="[[opened]]" restamp="[[restamp]]">
+          <template is="dom-if" if="[[opened]]" id="ifOpened">
             <slot></slot>
           </template>
         </div>
@@ -170,6 +170,23 @@ limitations under the License.
           type: Boolean,
           computed: '_computeIsUniversalSearchQuery(category.metadata)',
         },
+      },
+
+      listeners: {
+        // Q: Why listen to dom-change when you know which property change
+        // triggered dom-if to change?
+        // A: https://github.com/Polymer/polymer/blob/1.x/src/lib/template/dom-if.html#L131
+        // `render` in dom-if is debounced and visibility of content does not
+        // change until it has been invoked.
+        'dom-change': '_notifyVisibilityChange',
+      },
+
+      _notifyVisibilityChange(event) {
+        if (event.target.id == 'ifRendered' ||
+            event.target.id == 'ifOpened') {
+          this.fire(
+              'content-visibility-changed', this._rendered && this.opened);
+        }
       },
 
       _computeCount() {

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -91,7 +91,11 @@ limitations under the License.
         <template is="dom-if" if="[[!_dataNotFound]]">
           <tf-tag-filterer tag-filter="{{_tagFilter}}"></tf-tag-filterer>
           <template is="dom-repeat" items="[[_categories]]" as="category">
-            <tf-category-pane category="[[category]]" opened="[[_shouldOpen(index)]]">
+            <tf-category-pane
+              category="[[category]]"
+              opened="[[_shouldOpen(index)]]"
+              restamp="[[_restamp]]"
+            >
               <tf-paginated-view
                 items="[[category.items]]"
                 pages="{{category._pages}}"
@@ -148,6 +152,10 @@ limitations under the License.
         _runToTagInfo: Object,
         _dataNotFound: Boolean,
         _tagFilter: String,
+        _restamp: {
+          type: Boolean,
+          value: false,
+        },
 
         // Categories must only be computed after _dataNotFound is found to be
         // true and then polymer DOM templating responds to that finding. We
@@ -163,6 +171,16 @@ limitations under the License.
           type: Object,
           value: () => new tf_backend.RequestManager(),
         },
+      },
+
+      listeners: {
+        'content-visibility-changed': '_redrawCategoryPane',
+      },
+
+      _redrawCategoryPane(event, val) {
+        if (!val) return;
+        event.target.querySelectorAll('tf-histogram-loader')
+            .forEach(histogram => histogram.redraw());
       },
 
       ready() {


### PR DESCRIPTION
Repro step
---
1. launch with an empty tag regex
2. type a character (that'd result in few matches) then delete it
   quickly
3. after few moment, type the character again

Cause
---
dom-if has issue where if="false" does not remove the DOM but rather
simply hides the slot.
https://github.com/Polymer/polymer/blob/1.x/src/lib/template/dom-if.html#L127

While the pane is briefly shown in step #2, histogram-loader fetches
data and before it has chance to draw the series, dom-if can hide the
DOM. As data comes back, histogram tries to draw based on the bounding
box that is shrunken to 0x0 since its container is no longer displayed.
To work around these issues, we now listen to category-pane show event
to redraw all histogram.