### PR TITLE
Add ability to run reload logic in a child process

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -372,7 +372,7 @@ def reload_multiplexer(multiplexer, path_to_run):
 
 
 def start_reloading_multiplexer(multiplexer, path_to_run, load_interval,
-                                use_process=False):
+                                use_process):
   """Asynchronously starts automatically reloading the given multiplexer.
 
   If `load_interval` is positive, the thread will reload the multiplexer

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -110,6 +110,10 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
       max_reload_threads=flags.max_reload_threads)
   loading_multiplexer = multiplexer
   reload_interval = flags.reload_interval
+  # For db import mode, prefer reloading in a child process. See
+  # https://github.com/tensorflow/tensorboard/issues/1467
+  reload_use_process = (flags.reload_task == 'process' or
+                        (flags.reload_task == 'auto' and flags.db_import))
   db_uri = flags.db
   # For DB import mode, create a DB file if we weren't given one.
   if flags.db_import and not flags.db:
@@ -148,11 +152,12 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
     plugins.append(plugin)
     plugin_name_to_instance[plugin.plugin_name] = plugin
   return TensorBoardWSGIApp(flags.logdir, plugins, loading_multiplexer,
-                            reload_interval, flags.path_prefix)
+                            reload_interval, flags.path_prefix,
+                            reload_use_process)
 
 
 def TensorBoardWSGIApp(logdir, plugins, multiplexer, reload_interval,
-                       path_prefix=''):
+                       path_prefix='', reload_use_process=False):
   """Constructs the TensorBoard application.
 
   Args:
@@ -164,6 +169,7 @@ def TensorBoardWSGIApp(logdir, plugins, multiplexer, reload_interval,
     reload_interval: How often (in seconds) to reload the Multiplexer.
       Zero means reload just once at startup; negative means never load.
     path_prefix: A prefix of the path when app isn't served from root.
+    reload_use_process: If true, reload in a child process; otherwise, a thread.
 
   Returns:
     A WSGI application that implements the TensorBoard backend.
@@ -178,7 +184,8 @@ def TensorBoardWSGIApp(logdir, plugins, multiplexer, reload_interval,
   if reload_interval >= 0:
     # We either reload the multiplexer once when TensorBoard starts up, or we
     # continuously reload the multiplexer.
-    start_reloading_multiplexer(multiplexer, path_to_run, reload_interval)
+    start_reloading_multiplexer(multiplexer, path_to_run, reload_interval,
+                                reload_use_process)
   return TensorBoardWSGI(plugins, path_prefix)
 
 
@@ -364,8 +371,9 @@ def reload_multiplexer(multiplexer, path_to_run):
   tf.logging.info('TensorBoard done reloading. Load took %0.3f secs', duration)
 
 
-def start_reloading_multiplexer(multiplexer, path_to_run, load_interval):
-  """Starts a thread to automatically reload the given multiplexer.
+def start_reloading_multiplexer(multiplexer, path_to_run, load_interval,
+                                use_process=False):
+  """Asynchronously starts automatically reloading the given multiplexer.
 
   If `load_interval` is positive, the thread will reload the multiplexer
   by calling `ReloadMultiplexer` every `load_interval` seconds, starting
@@ -378,9 +386,7 @@ def start_reloading_multiplexer(multiplexer, path_to_run, load_interval):
     load_interval: An integer greater than or equal to 0. If positive, how many
       seconds to wait after one load before starting the next load. Otherwise,
       reloads the multiplexer once and never again (no continuous reloading).
-
-  Returns:
-    A started `threading.Thread` that reloads the multiplexer.
+    use_process: If true, reload in a child process; otherwise use a thread.
 
   Raises:
     ValueError: If `load_interval` is negative.
@@ -398,10 +404,20 @@ def start_reloading_multiplexer(multiplexer, path_to_run, load_interval):
         break
       time.sleep(load_interval)
 
-  thread = threading.Thread(target=_reload, name='Reloader')
-  thread.daemon = True
-  thread.start()
-  return thread
+  if use_process:
+    tf.logging.info('Launching reload in a child process')
+    import multiprocessing
+    process = multiprocessing.Process(target=_reload, name='Reloader')
+    # Best-effort cleanup; on exit, the main TB parent process will attempt to
+    # kill all its daemonic children.
+    process.daemon = True
+    process.start()
+  else:
+    tf.logging.info('Launching reload in a daemon thread')
+    thread = threading.Thread(target=_reload, name='Reloader')
+    # Make this a daemon thread, which won't block TB from exiting.
+    thread.daemon = True
+    thread.start()
 
 
 def get_database_info(db_uri):

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -53,6 +53,7 @@ class FakeFlags(object):
       reload_interval=60,
       samples_per_plugin='',
       max_reload_threads=1,
+      reload_task='auto',
       db='',
       db_import=False,
       window_title='',
@@ -62,6 +63,7 @@ class FakeFlags(object):
     self.reload_interval = reload_interval
     self.samples_per_plugin = samples_per_plugin
     self.max_reload_threads = max_reload_threads
+    self.reload_task = reload_task
     self.db = db
     self.db_import = db_import
     self.window_title = window_title

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -407,6 +407,19 @@ relevant for db read-only mode. Each thread reloads one run at a time.
 ''')
 
     parser.add_argument(
+        '--reload_task',
+        metavar='TYPE',
+        type=str,
+        default='auto',
+        choices=['auto', 'thread', 'process'],
+        help='''\
+[experimental] The mechanism to use for the background data reload task.
+The default "auto" option will conditionally use threads for legacy reloading
+and a child process for DB import reloading. The "process" option is only
+useful with DB import mode. (default: %(default)s)\
+''')
+
+    parser.add_argument(
         '--samples_per_plugin',
         type=str,
         default='',


### PR DESCRIPTION
This adds an experimental `--reload_task=auto|thread|process` flag to allow running the reloading logic in a child process rather than a background thread, to work around the `--db_import` issues on macOS described in #1467.  Now by default, a process will be used when `--db_import` mode is active, and a thread otherwise (the process version isn't useful with regular logdir importing, since the data would be imported into the child process's EventMultiplexer instance only).

cc wicke@

