### PR TITLE
Propagate storage change to intra-tab listeners

### DIFF
--- a/tensorboard/components/tf_storage/listeners.ts
+++ b/tensorboard/components/tf_storage/listeners.ts
@@ -30,6 +30,9 @@ const storageListeners = new Set<ListenKey>();
 window.addEventListener('hashchange', () => {
   hashListeners.forEach(listenKey => listenKey.listener());
 });
+
+// [1]: The event only triggers when another tab edits the storage. Changing a
+// value in current browser tab will NOT trigger below event.
 window.addEventListener('storage', () => {
   storageListeners.forEach(listenKey => listenKey.listener());
 });
@@ -44,6 +47,10 @@ export function addStorageListener(fn: Function): ListenKey {
   const key = new ListenKey(fn);
   storageListeners.add(key);
   return key;
+}
+
+export function fireStorageChanged() {
+  storageListeners.forEach(listenKey => listenKey.listener());
 }
 
 export function removeHashListenerByKey(key: ListenKey) {

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -62,6 +62,7 @@ export const {
   set: setBoolean,
   getInitializer: getBooleanInitializer,
   getObserver: getBooleanObserver,
+  disposeBinding: disposeBooleanBinding,
 } = makeBindings(
   s => (s === 'true' ? true: s === 'false' ? false : undefined),
   b => b.toString());
@@ -81,6 +82,7 @@ export const {
   set: setObject,
   getInitializer: getObjectInitializer,
   getObserver: getObjectObserver,
+  disposeBinding: disposeObjectBinding,
 } = makeBindings(
   s => JSON.parse(atob(s)),
   o => btoa(JSON.stringify(o)));

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -128,6 +128,9 @@ export function makeBindings<T>(fromString: (string) => T, toString: (T) => stri
     const stringValue = toString(value);
     if (useLocalStorage) {
       window.localStorage.setItem(key, stringValue);
+      // Because of listeners.ts:[1], we need to manually notify all UI elements
+      // listening to storage within the tab of a change.
+      fireStorageChanged();
     } else if (!_.isEqual(value, get(key, {useLocalStorage}))) {
       if (_.isEqual(value, defaultValue)) {
         unsetFromURI(key);

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -54,6 +54,7 @@ export const {
   set: setString,
   getInitializer: getStringInitializer,
   getObserver: getStringObserver,
+  disposeBinding: disposeStringBinding,
 } = makeBindings(x => x, x => x);
 
 export const {
@@ -70,6 +71,7 @@ export const {
   set: setNumber,
   getInitializer: getNumberInitializer,
   getObserver: getNumberObserver,
+  disposeBinding: disposeNumberBinding,
 } = makeBindings(
   s => +s,
   n => n.toString());

--- a/tensorboard/components/tf_storage/test/storageTests.ts
+++ b/tensorboard/components/tf_storage/test/storageTests.ts
@@ -27,12 +27,14 @@ function getHash(): string {
 
 
 /* tslint:disable:no-namespace */
-describe('URIStorage', () => {
+describe('Storage', () => {
   const option = {useLocalStorage: false};
 
   afterEach(() => {
     setHash('');
     window.localStorage.clear();
+    disposeStringBinding();
+    disposeNumberBinding();
   });
 
   it('get/setString', () => {
@@ -80,7 +82,6 @@ describe('URIStorage', () => {
   });
 
   describe('getInitializer', () => {
-
     [
       {useLocalStorage: true, name: 'local storage', eventName: 'storage'},
       {useLocalStorage: false, name: 'hash storage', eventName: 'hashchange'}
@@ -112,7 +113,7 @@ describe('URIStorage', () => {
           assert.equal(fakeScope.prop, 'baz');
         });
 
-        it(`reacts to '${eventName}' and sets the new value`, () => {
+        it(`reacts to '${eventName}' and sets the new value (simulated)`, () => {
           setValue('foo', '');
 
           const initializer = getStringInitializer('foo', options);
@@ -125,6 +126,25 @@ describe('URIStorage', () => {
 
           assert.equal(fakeScope.prop, 'changed');
         });
+
+        // It is hard to test against real URL hash and we use fakeHash for
+        // testing and fakeHash does not emit any event for a change.
+        if (useLocalStorage) {
+          it(`reacts to change and sets the new value (real)`, () => {
+            setString('foo', '', options);
+
+            const initializer = getStringInitializer('foo', options);
+            const fakeScope1 = {prop: null};
+            initializer.call(fakeScope1);
+            const fakeScope2 = {prop: 'bar'};
+            initializer.call(fakeScope2);
+
+            setString('foo', 'changed', options);
+
+            assert.equal(fakeScope1.prop, 'changed');
+            assert.equal(fakeScope2.prop, 'changed');
+          });
+        }
       });
     });
   });

--- a/tensorboard/components/tf_storage/test/storageTests.ts
+++ b/tensorboard/components/tf_storage/test/storageTests.ts
@@ -35,6 +35,8 @@ describe('Storage', () => {
     window.localStorage.clear();
     disposeStringBinding();
     disposeNumberBinding();
+    disposeBooleanBinding();
+    disposeObjectBinding()
   });
 
   it('get/setString', () => {


### PR DESCRIPTION
localStorage change event does not get triggered when a change is made
within the tab. This lead to very subtle bug where a change in value did
not propagate to another already mounted plugins.