### PR TITLE
Created modes to data selector

### DIFF
--- a/tensorboard/components/tf_data_selector/BUILD
+++ b/tensorboard/components/tf_data_selector/BUILD
@@ -15,10 +15,10 @@ tf_web_library(
         "tf-collapsible-data-selector.ts",
         "tf-data-select-row.html",
         "tf-data-select-row.ts",
-        "tf-data-selector-alt.html",
-        "tf-data-selector-alt.ts",
-        "tf-data-selector.html",
-        "tf-data-selector.ts",
+        "tf-data-selector-advanced.html",
+        "tf-data-selector-advanced.ts",
+        "tf-data-selector-simple.html",
+        "tf-data-selector-simple.ts",
     ],
     path = "/tf-data-selector",
     visibility = ["//visibility:public"],
@@ -43,6 +43,7 @@ tf_web_library(
 tf_web_library(
     name = "type",
     srcs = [
+        "type.html",
         "type.ts",
     ],
     path = "/tf-data-selector",

--- a/tensorboard/components/tf_data_selector/tf-collapsible-data-selector.html
+++ b/tensorboard/components/tf_data_selector/tf-collapsible-data-selector.html
@@ -21,7 +21,8 @@ limitations under the License.
 <link rel="import" href="../paper-tooltip/paper-tooltip.html">
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
-<link rel="import" href="./tf-data-selector.html">
+<link rel="import" href="./tf-data-selector-advanced.html">
+<link rel="import" href="./tf-data-selector-simple.html">
 
 <!--
 tf-collapsible-data-selector creates a minimizeable data selection widget -
@@ -37,13 +38,33 @@ Properties out:
 <dom-module id="tf-collapsible-data-selector">
   <template>
     <iron-collapse id="collapse" opened="[[opened]]" no-animation>
-      <tf-data-selector
-        selection="{{selection}}"
-        active-plugins="[[activePlugins]]"
-      ></tf-data-selector>
+      <template is="dom-if" if="[[_isSimpleMode(_mode)]]">
+        <tf-data-selector-simple
+          selection="{{_simpleSelection}}"
+          active-plugins="[[activePlugins]]"
+        ></tf-data-selector>
+      </template>
+      <template is="dom-if" if="[[!_isSimpleMode(_mode)]]">
+        <tf-data-selector-advanced
+          selection="{{_advancedSelection}}"
+          active-plugins="[[activePlugins]]"
+        ></tf-data-selector>
+      </template>
+      <paper-button on-tap="_toggleMode" class="toggle-mode">
+        <template is="dom-if" if="[[_isSimpleMode(_mode)]]">
+          Use advanced mode
+        </template>
+        <template is="dom-if" if="[[!_isSimpleMode(_mode)]]">
+          Use simple mode
+        </template>
+      </paper-button>
     </iron-collapse>
     <span>
-      <paper-button on-tap="_toggleSelector" title="Toggle Data Selector">
+      <paper-button
+        on-tap="_toggleOpened"
+        title="Toggle Data Selector"
+        class="selector"
+      >
         <template is="dom-if" if="[[opened]]">
           <iron-icon icon="expand-less"></iron-icon>
         </template>
@@ -79,10 +100,10 @@ Properties out:
         flex-direction: column;
         flex-wrap: wrap;
         min-height: 32px;
-        width 100%;
+        width: 100%;
       }
 
-      :host:not([opened]) paper-button {
+      :host:not([opened]) .selector {
         border-color: var(--paper-grey-500);
         position: absolute;
         top: 0;
@@ -95,7 +116,7 @@ Properties out:
         width: 100%;
       }
 
-      paper-button {
+      .selector {
         border-radius: 0;
         border: 0 solid var(--tb-ui-dark-accent);
         border-width: 0 1px 1px;
@@ -103,6 +124,13 @@ Properties out:
         font-size: 12px;
         margin: 0;
         padding: 3px;
+      }
+
+      .toggle-mode {
+        color: var(--paper-blue-600);
+        font-size: 14px;
+        margin: 5px 0;
+        text-transform: none;
       }
 
       .experiment {

--- a/tensorboard/components/tf_data_selector/tf-collapsible-data-selector.ts
+++ b/tensorboard/components/tf_data_selector/tf-collapsible-data-selector.ts
@@ -14,12 +14,27 @@ limitations under the License.
 ==============================================================================*/
 namespace tf_data_selector {
 
+enum Mode {
+  SIMPLE,
+  ADVANCED,
+}
+
 Polymer({
   is: 'tf-collapsible-data-selector',
   properties: {
+    _simpleSelection: {
+      type: Object,
+      value: () => ({}),
+    },
+
+    _advancedSelection: {
+      type: Object,
+      value: () => ({}),
+    },
 
     selection: {
       type: Object,
+      computed: '_computeSelection(_simpleSelection, _advancedSelection, _mode)',
       notify: true,
     },
 
@@ -30,9 +45,19 @@ Polymer({
       reflectToAttribute: true,
       value: true,
     },
+
+    _mode: {
+      type: Number,
+      value: Mode.SIMPLE,
+    },
   },
 
-  _toggleSelector() {
+  _computeSelection() {
+    if (this._mode == Mode.SIMPLE) return this._simpleSelection;
+    return this._advancedSelection;
+  },
+
+  _toggleOpened() {
     this.opened = !this.opened;
   },
 
@@ -41,6 +66,16 @@ Polymer({
 
     const color = tf_color_scale.experimentsColorScale(experiment.name);
     return `background-color: ${color};`;
+  },
+
+  _isSimpleMode(mode) {
+    return mode == Mode.SIMPLE;
+  },
+
+  _toggleMode() {
+    const curMode = this._mode;
+    const nextMode = curMode == Mode.SIMPLE ? Mode.ADVANCED : Mode.SIMPLE;
+    this._mode = nextMode;
   },
 
 });

--- a/tensorboard/components/tf_data_selector/tf-data-selector-advanced.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector-advanced.html
@@ -25,10 +25,12 @@ limitations under the License.
 <link rel="import" href="./experiment-selector.html">
 <link rel="import" href="./storage-utils.html">
 <link rel="import" href="./tf-data-select-row.html">
+<link rel="import" href="./type.html">
 
 <!--
-tf-data-selector creates a widget for creating a group of data, a filtered data
-by experiment, runs, and tags. It allows user to add more groups too.
+tf-data-selector-advanced creates a widget for creating a group of data, a
+filtered data by experiment, runs, and tags. It allows user to add more groups
+too.
 
 Properties in: none.
 Properties out:
@@ -36,7 +38,7 @@ Properties out:
     tf_data_selector.Selection for its data type.
 
 -->
-<dom-module id="tf-data-selector">
+<dom-module id="tf-data-selector-advanced">
   <template>
     <template
       is="dom-if"
@@ -105,6 +107,6 @@ Properties out:
       }
     </style>
   </template>
-  <script src="type.js"></script>
-  <script src="tf-data-selector.js"></script>
+
+  <script src="tf-data-selector-advanced.js"></script>
 </dom-module>

--- a/tensorboard/components/tf_data_selector/tf-data-selector-advanced.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector-advanced.ts
@@ -23,7 +23,7 @@ export const {
     (ids: number[]): string => tf_data_selector.encodeIdArray(ids));
 
 Polymer({
-  is: 'tf-data-selector',
+  is: 'tf-data-selector-advanced',
   properties: {
     _allExperimentsFetched: {
       type: Boolean,

--- a/tensorboard/components/tf_data_selector/tf-data-selector-simple.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector-simple.html
@@ -22,18 +22,19 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/tf-filterable-checkbox-dropdown.html">
 <link rel="import" href="./experiment-selector.html">
 <link rel="import" href="./tf-data-select-row.html">
+<link rel="import" href="./type.html">
 
 <!--
-tf-data-selector-alt creates a widget for creating a group of data, a filtered
-data by experiment, runs, and tags. It allows user to add more groups too.
+tf-data-selector-simple creates a widget for selecting experiments, runs, and
+tag filter for data comparison.
 
 Properties in: none.
 Properties out:
   - selection: array of data selection. Please refer to
     tf_data_selector.Selection for its data type.
-.
+
 -->
-<dom-module id="tf-data-selector-alt">
+<dom-module id="tf-data-selector-simple">
   <template>
     <tf-filterable-checkbox-dropdown
       coloring="[[_getExperimentColor()]]"
@@ -66,6 +67,11 @@ Properties out:
         width: 100%;
       }
 
+      tf-filterable-checkbox-dropdown {
+        padding: 0;
+        margin: 0 4px;
+      }
+
       paper-input {
         --paper-input-container-focus-color: var(--tb-orange-strong);
         --paper-input-container: {
@@ -77,11 +83,8 @@ Properties out:
         --paper-input-container-label: {
           font-size: 14px;
         };
-
-        padding: 8px;
       }
     </style>
   </template>
-  <script src="type.js"></script>
-  <script src="tf-data-selector-alt.js"></script>
+  <script src="tf-data-selector-simple.js"></script>
 </dom-module>

--- a/tensorboard/components/tf_data_selector/tf-data-selector-simple.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector-simple.ts
@@ -17,7 +17,7 @@ namespace tf_data_selector {
 const NO_EXPERIMENT_ID = null;
 
 Polymer({
-  is: 'tf-data-selector-alt',
+  is: 'tf-data-selector-simple',
   properties: {
     _allExperiments: {
       type: Array,

--- a/tensorboard/components/tf_data_selector/type.html
+++ b/tensorboard/components/tf_data_selector/type.html
@@ -1,0 +1,17 @@
+<!--
+@license
+Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<script src="type.js"></script>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -19,7 +19,7 @@ tf_web_library(
         "//tensorboard/components/tf_categorization_utils",
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
-        "//tensorboard/components/tf_data_selector",
+        "//tensorboard/components/tf_data_selector:type",
         "//tensorboard/components/tf_globals",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -30,7 +30,7 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/dashboard-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
-<link rel="import" href="../tf-data-selector/tf-data-selector.html">
+<link rel="import" href="../tf-data-selector/type.html">
 <link rel="import" href="../tf-globals/tf-globals.html">
 <link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../tf-paginated-view/tf-paginated-view.html">


### PR DESCRIPTION
For most of the user, data-selector-alt is the appropriate UI while
data-selector is more appropriate for more advanced user who wants to
fine tune what to compare.

Instead of TB deciding what to display, we now make use of both of them
with a simple toggle button to toggle between two modes.

![image](https://user-images.githubusercontent.com/2547313/46316957-78eeb700-c586-11e8-980c-9a1b908bb166.png)
