### PR TITLE
Restore tf-category-pane restamp functionality

### DIFF
--- a/tensorboard/components/tf_categorization_utils/tf-category-pane.html
+++ b/tensorboard/components/tf_categorization_utils/tf-category-pane.html
@@ -52,7 +52,8 @@ limitations under the License.
       </button>
       <iron-collapse opened="[[opened]]">
         <div class="content">
-          <template is="dom-if" if="[[opened]]" id="ifOpened">
+          <template is="dom-if" if="[[opened]]" restamp="[[restamp]]"
+                    id="ifOpened">
             <slot></slot>
           </template>
         </div>


### PR DESCRIPTION
It looks like #1465 removed this inadvertently?  I'm assuming the intent was to leave it customizable on a per-plugin basis, and just set restamp=false for the histogram dashboard.  Without restamping, we hit the chart shrinking bug (#1473) every time we reopen a pane where the charts were redrawn while closed (e.g. due to changing run selections, for example).