### PR TITLE
Persist simple data selection to storage

### DIFF
--- a/tensorboard/components/tf_data_selector/storage-utils.ts
+++ b/tensorboard/components/tf_data_selector/storage-utils.ts
@@ -26,4 +26,17 @@ export function encodeId(id: number): string {
   return id.toString(36);
 }
 
+export const NO_EXPERIMENT_ID = null;
+
+export const STORAGE_ALL_VALUE = '$all';
+export const STORAGE_NONE_VALUE = '$none';
+
+export const {
+  getInitializer: getIdInitializer,
+  getObserver: getIdObserver,
+  set: setId,
+} = tf_storage.makeBindings(
+    (str: string): number[] => tf_data_selector.decodeIdArray(str),
+    (ids: number[]): string => tf_data_selector.encodeIdArray(ids));
+
 }  // namespace tf_data_selector

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.ts
@@ -20,8 +20,6 @@ enum Type {
 }
 
 const MAX_RUNS_TO_ENABLE_BY_DEFAULT = 20;
-const STORAGE_ALL_VALUE = '$all';
-const STORAGE_NONE_VALUE = '$none';
 
 Polymer({
   is: 'tf-data-select-row',

--- a/tensorboard/components/tf_data_selector/tf-data-selector-advanced.ts
+++ b/tensorboard/components/tf_data_selector/tf-data-selector-advanced.ts
@@ -14,14 +14,6 @@ limitations under the License.
 ==============================================================================*/
 namespace tf_data_selector {
 
-const NO_EXPERIMENT_ID = null;
-export const {
-  getInitializer: getIdInitializer,
-  getObserver: getIdObserver,
-} = tf_storage.makeBindings(
-    (str: string): number[] => tf_data_selector.decodeIdArray(str),
-    (ids: number[]): string => tf_data_selector.encodeIdArray(ids));
-
 Polymer({
   is: 'tf-data-selector-advanced',
   properties: {

--- a/tensorboard/components/tf_data_selector/tf-data-selector-simple.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector-simple.html
@@ -43,6 +43,7 @@ Properties out:
       max-items-to-enable-by-default="1"
       label-float
       selected-items="{{_selectedExperiments}}"
+      selection-state="{{_getExperimentsSelectionState(_selectedExperimentIds, _allExperiments)}}"
     ></tf-filterable-checkbox-dropdown>
     <tf-filterable-checkbox-dropdown
       coloring="[[_getRunColor()]]"
@@ -51,6 +52,7 @@ Properties out:
       label-float
       selected-items="{{_selectedRuns}}"
       use-checkbox-colors="[[_getRunsUsesCheckboxColors(_selectedExperiments)]]"
+      selection-state="{{_getRunsSelectionState(_selectedRunNames, _allRuns)}}"
     ></tf-filterable-checkbox-dropdown>
     <paper-input
       label="Tag Regex"


### PR DESCRIPTION
Simple data selection was not connected to the storage for brevity of
the code review. Now, all field are appropriately connected to the
storage.