### PR TITLE
Fix observers when using data selector

### DIFF
--- a/tensorboard/components/tf_categorization_utils/tf-tag-filterer.html
+++ b/tensorboard/components/tf_categorization_utils/tf-tag-filterer.html
@@ -48,6 +48,7 @@ Regex search input UI at tops of dashboards.
         tagFilter: {
           type: String,
           notify: true,
+          readOnly: true,
           value: tf_storage.getStringInitializer('tagFilter',
               {defaultValue: '', useLocalStorage: false}),
           observer: '_tagFilterObserver',

--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.html
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-dropdown.html
@@ -51,7 +51,7 @@ Properties out:
         slot="dropdown-trigger"
         label="[[label]]"
         label-float="[[labelFloat]]"
-        name="[[_getValueLabel(selectedItems.*)]]"
+        name="[[_getValueLabel(selectedItems, items)]]"
       ></tf-dropdown-trigger>
       <div class="dropdown-content">
         <tf-filterable-checkbox-list

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -248,7 +248,10 @@ limitations under the License.
         },
         _runToTagInfo: Object,
         _dataNotFound: Boolean,
-        _tagFilter: String,
+        _tagFilter: {
+          type: String,
+          value: ''
+        },
         // Categories must only be computed after _dataNotFound is found to be
         // true and then polymer DOM templating responds to that finding. We
         // thus use this property to guard when categories are computed.


### PR DESCRIPTION
Polymer's complex observer require values it listens to be instantiated.
`tagFilter` was previously removed because tf-tag-filterer took the
value from its parent instead of bootstrapping from the storage.

This change ensures that complex observers are properly set up with all
listed properties instantiated and to take all consumed properties in
callback to be listed in the observer definition.