### PR TITLE
Implement DbImportMultiplexer python sqlite ingestion logic

### DIFF
--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -64,6 +64,7 @@ py_library(
         "//tensorboard:db",
         "//tensorboard:expect_sqlite3_installed",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend/event_processing:db_import_multiplexer",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins/core:core_plugin",

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -56,6 +56,7 @@ class FakeFlags(object):
       reload_task='auto',
       db='',
       db_import=False,
+      db_import_use_op=False,
       window_title='',
       path_prefix=''):
     self.logdir = logdir
@@ -66,6 +67,7 @@ class FakeFlags(object):
     self.reload_task = reload_task
     self.db = db
     self.db_import = db_import
+    self.db_import_use_op = db_import_use_op
     self.window_title = window_title
     self.path_prefix = path_prefix
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -139,7 +139,6 @@ py_test(
 py_library(
     name = "event_multiplexer",
     srcs = [
-        "db_import_multiplexer.py",
         "event_multiplexer.py",
         "plugin_event_multiplexer.py",
     ],
@@ -175,6 +174,22 @@ py_test(
         ":event_accumulator",
         ":event_multiplexer",
         "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_library(
+    name = "db_import_multiplexer",
+    srcs = [
+        "db_import_multiplexer.py",
+    ],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":directory_watcher",
+        ":event_file_loader",
+        ":io_wrapper",
+        "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -188,6 +188,21 @@ py_library(
         ":directory_watcher",
         ":event_file_loader",
         ":io_wrapper",
+        ":sqlite_writer",
+        "//tensorboard:data_compat",
+        "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
+    ],
+)
+
+py_library(
+    name = "sqlite_writer",
+    srcs = [
+        "sqlite_writer.py",
+    ],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/backend/event_processing/db_import_multiplexer.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer.py
@@ -182,7 +182,7 @@ class _RunLoader(object):
   """Loads a single run directory in batches."""
 
   _BATCH_COUNT = 5000
-  _BATCH_BYTES = 2**20  # 1 MB
+  _BATCH_BYTES = 2**20  # 1 MiB
 
   def __init__(self, subdir, experiment_name, run_name):
     """Constructs a `_RunLoader`.
@@ -217,7 +217,8 @@ class _RunLoader(object):
         if len(events) >= self._BATCH_COUNT or event_bytes >= self._BATCH_BYTES:
           break
       elapsed = time.time() - start
-      tf.logging.debug('RunLoader.load_batch() yielded in %0.3f sec', elapsed)
+      tf.logging.debug('RunLoader.load_batch() yielded in %0.3f sec for %s',
+                       elapsed, self._subdir)
       if not events:
         return
       yield _EventBatch(

--- a/tensorboard/backend/event_processing/db_import_multiplexer.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import abc
+import collections
 import os
 import threading
 import time
@@ -55,7 +57,6 @@ class DbImportMultiplexer(object):
     conn = db_connection_provider()
     # Extract the file path of the DB from the DB connection.
     rows = conn.execute('PRAGMA database_list;').fetchall()
-    tf.logging.info('Got rows %s', type(rows))
     db_name_to_path = {row[1]: row[2] for row in rows}
     self._db_path = db_name_to_path['main']
     tf.logging.info('DbImportMultiplexer using db_path %s', self._db_path)
@@ -63,15 +64,13 @@ class DbImportMultiplexer(object):
     # TODO(nickfelt): investigate weird errors in rollback journal mode
     conn.execute('PRAGMA journal_mode=WAL;')
     conn.execute('PRAGMA synchronous=NORMAL;')  # Recommended for WAL mode
-    self._run_importers = {}
+    self._run_loaders = {}
+    self._event_sink = _ImportOpEventSink(self._db_path)
     self.purge_orphaned_data = purge_orphaned_data
     if self.purge_orphaned_data:
       tf.logging.warning(
           '--db_import does not yet support purging orphaned data')
     self._max_reload_threads = max_reload_threads
-    if self._max_reload_threads > 1:
-      tf.logging.warning(
-          '--db_import does not yet support more than one reload thread')
     tf.logging.info('DbImportMultiplexer done initializing')
 
   def AddRunsFromDirectory(self, path, name=None):
@@ -92,97 +91,175 @@ class DbImportMultiplexer(object):
     tf.logging.info('Starting AddRunsFromDirectory: %s (as %s)', path, name)
     for subdir in io_wrapper.GetLogdirSubdirectories(path):
       tf.logging.info('Processing directory %s', subdir)
-      if subdir not in self._run_importers:
-        tf.logging.info('Creating DB importer for directory %s', subdir)
-        self._run_importers[subdir] = _RunImporter(
-            db_path=self._db_path,
+      if subdir not in self._run_loaders:
+        tf.logging.info('Creating DB loader for directory %s', subdir)
+        self._run_loaders[subdir] = _RunLoader(
             subdir=subdir,
             experiment_name=(name or path),
             run_name=os.path.relpath(subdir, path))
     tf.logging.info('Done with AddRunsFromDirectory: %s', path)
 
   def Reload(self):
-    """Call `Import` on every run to import."""
+    """Load events from every detected run."""
     tf.logging.info('Beginning DbImportMultiplexer.Reload()')
-    items_queue = queue.Queue()
-    for item in six.iteritems(self._run_importers):
-      items_queue.put(item)
+    # Use collections.deque() for speed when we don't need blocking since it
+    # also has thread-safe appends/pops.
+    loader_queue = collections.deque(six.itervalues(self._run_loaders))
+    loader_delete_queue = collections.deque()
 
-    # Methods of built-in python containers are thread-safe so long as the GIL
-    # for the thread exists, but we might as well be careful.
-    names_to_delete = set()
-    names_to_delete_mutex = threading.Lock()
-
-    def Worker():
-      """Keeps importing runs until none are left."""
+    def batch_generator():
       while True:
         try:
-          name, importer = items_queue.get(block=False)
-        except queue.Empty:
-          # No more runs to reload.
-          break
-
+          loader = loader_queue.popleft()
+        except IndexError:
+          return
         try:
-          start = time.time()
-          importer.Import()
-          elapsed = time.time() - start
-          tf.logging.debug('importer.Import() took %0.3f sec', elapsed)
-        except (OSError, IOError) as e:
-          tf.logging.error('Unable to import run %r: %s', name, e)
+          for batch in loader.load_batches():
+            yield batch
         except directory_watcher.DirectoryDeletedError:
-          with names_to_delete_mutex:
-            names_to_delete.add(name)
-        finally:
-          items_queue.task_done()
+          loader_delete_queue.append(loader)
+        except (OSError, IOError) as e:
+          tf.logging.error('Unable to load run %r: %s', loader.subdir, e)
 
-    if self._max_reload_threads > 1:
-      num_threads = min(
-          self._max_reload_threads, len(self._run_importers))
+    num_threads = min(self._max_reload_threads, len(self._run_loaders))
+    if num_threads <= 1:
+      tf.logging.info('Importing runs serially on a single thread')
+      for batch in batch_generator():
+        self._event_sink.write_batch(batch)
+    else:
+      output_queue = queue.Queue()
+      sentinel = object()
+      def producer():
+        try:
+          for batch in batch_generator():
+            output_queue.put(batch)
+        finally:
+          output_queue.put(sentinel)
       tf.logging.info('Starting %d threads to import runs', num_threads)
       for i in xrange(num_threads):
-        thread = threading.Thread(target=Worker, name='Importer %d' % i)
+        thread = threading.Thread(target=producer, name='Loader %d' % i)
         thread.daemon = True
         thread.start()
-      items_queue.join()
-    else:
-      tf.logging.info('Importing runs serially on the main thread')
-      Worker()
-
-    for name in names_to_delete:
-      tf.logging.warning('Deleting importer %r', name)
-      del self._run_importers[name]
+      num_live_threads = num_threads
+      while num_live_threads > 0:
+        output = output_queue.get()
+        if output == sentinel:
+          num_live_threads -= 1
+          continue
+        self._event_sink.write_batch(output)
+    for loader in loader_delete_queue:
+      tf.logging.warning('Deleting loader %r', loader.subdir)
+      del self._run_loaders[loader.subdir]
     tf.logging.info('Finished with DbImportMultiplexer.Reload()')
-    return self
 
 
-class _RunImporter(object):
-  """Helper class to import a single run directory into the sqlite DB."""
+# Struct holding a list of tf.Event serialized protos along with metadata about
+# the associated experiment and run.
+_EventBatch = collections.namedtuple('EventBatch',
+                                     ['events', 'experiment_name', 'run_name'])
 
-  def __init__(self, db_path, subdir, experiment_name, run_name):
-    """Constructs a `_RunImporter` and initializes a DB run.
+
+class _RunLoader(object):
+  """Loads a single run directory in batches."""
+
+  _BATCH_COUNT = 5000
+  _BATCH_BYTES = 2**20  # 1 MB
+
+  def __init__(self, subdir, experiment_name, run_name):
+    """Constructs a `_RunLoader`.
 
     Args:
-      db_path: string, filesystem path of the DB file to open
       subdir: string, filesystem path of the run directory
       experiment_name: string, name of the run's experiment
       run_name: string, name of the run
     """
-    self._directory_generator = directory_watcher.DirectoryWatcher(
+    self._subdir = subdir
+    self._experiment_name = experiment_name
+    self._run_name = run_name
+    self._directory_watcher = directory_watcher.DirectoryWatcher(
         subdir,
         event_file_loader.RawEventFileLoader,
         io_wrapper.IsTensorFlowEventsFile)
+
+  @property
+  def subdir(self):
+    return self._subdir
+
+  def load_batches(self):
+    """Returns a batched event iterator over the run directory event files."""
+    event_iterator = self._directory_watcher.Load()
+    while True:
+      events = []
+      event_bytes = 0
+      start = time.time()
+      for event_proto in event_iterator:
+        events.append(event_proto)
+        event_bytes += len(event_proto)
+        if len(events) >= self._BATCH_COUNT or event_bytes >= self._BATCH_BYTES:
+          break
+      elapsed = time.time() - start
+      tf.logging.debug('RunLoader.load_batch() yielded in %0.3f sec', elapsed)
+      if not events:
+        return
+      yield _EventBatch(
+          events=events,
+          experiment_name=self._experiment_name,
+          run_name=self._run_name)
+
+
+class _EventSink(object):
+  """Abstract sink for batches of serialized tf.Event data."""
+  __metaclass__ = abc.ABCMeta
+
+  @abc.abstractmethod
+  def write_batch(self, event_batch):
+    """Writes the given event batch to the sink.
+
+    Args:
+      event_batch: an _EventBatch of event data.
+    """
+    raise NotImplementedError()
+
+
+class _ImportOpEventSink(_EventSink):
+  """Implementation of EventSink using TF's import_event() op."""
+
+  def __init__(self, db_path):
+    """Constructs an ImportOpEventSink.
+
+    Args:
+      db_path: string, filesystem path of the DB file to open
+    """
+    self._db_path = db_path
+    self._writer_fn_cache = {}
+
+  def _get_writer_fn(self, event_batch):
+    key = (event_batch.experiment_name, event_batch.run_name)
+    if key in self._writer_fn_cache:
+      return self._writer_fn_cache[key]
     with tf.Graph().as_default():
-      self._placeholder = tf.placeholder(shape=[], dtype=tf.string)
+      placeholder = tf.placeholder(shape=[], dtype=tf.string)
       writer = tf.contrib.summary.create_db_writer(
-          db_path, experiment_name=experiment_name, run_name=run_name)
+          self._db_path,
+          experiment_name=event_batch.experiment_name,
+          run_name=event_batch.run_name)
       with writer.as_default():
         # TODO(nickfelt): running import_event() one record at a time is very
         #   slow; we should add an op that accepts a vector of records.
-        self._import_op = tf.contrib.summary.import_event(self._placeholder)
-      self._session = tf.Session()
-      self._session.run(writer.init())
+        import_op = tf.contrib.summary.import_event(placeholder)
+      session = tf.Session()
+      session.run(writer.init())
+      def writer_fn(event_proto):
+        session.run(import_op, feed_dict={placeholder: event_proto})
+    self._writer_fn_cache[key] = writer_fn
+    return writer_fn
 
-  def Import(self):
-    """Imports all events added since the last call to `Import`."""
-    for record in self._directory_generator.Load():
-      self._session.run(self._import_op, feed_dict={self._placeholder: record})
+  def write_batch(self, event_batch):
+    start = time.time()
+    writer_fn = self._get_writer_fn(event_batch)
+    for event_proto in event_batch.events:
+      writer_fn(event_proto)
+    elapsed = time.time() - start
+    tf.logging.debug(
+        'ImportOpEventSink.WriteBatch() took %0.3f sec for %s events', elapsed,
+        len(event_batch.events))

--- a/tensorboard/backend/event_processing/sqlite_writer.py
+++ b/tensorboard/backend/event_processing/sqlite_writer.py
@@ -1,0 +1,425 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===========================================================================
+"""Writer for storing imported summary event data to a SQLite DB."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+import os
+import sys
+import time
+
+import six
+import tensorflow as tf
+
+
+# Struct bundling a tag with its SummaryMetadata and a list of values, each of
+# which are a tuple of step, wall time (as a float), and a TensorProto.
+TagData = collections.namedtuple('TagData', ['tag', 'metadata', 'values'])
+
+
+class SqliteWriter(object):
+  """Sends summary data to SQLite using python's sqlite3 module."""
+
+  def __init__(self, db_connection_provider):
+    """Constructs a SqliteWriterEventSink.
+
+    Args:
+      db_connection_provider: Provider function for creating a DB connection.
+    """
+    self._db = db_connection_provider()
+
+  def _make_blob(self, bytestring):
+    """Helper to ensure SQLite treats the given data as a BLOB."""
+    # Special-case python 2 pysqlite which uses buffers for BLOB.
+    if sys.version_info[0] == 2:
+      return buffer(bytestring)
+    return bytestring
+
+  def _create_id(self):
+    """Returns a freshly created DB-wide unique ID."""
+    cursor = self._db.cursor()
+    cursor.execute('INSERT INTO Ids DEFAULT VALUES')
+    return cursor.lastrowid
+
+  def _maybe_init_user(self):
+    """Returns the ID for the current user, creating the row if needed."""
+    user_name = os.environ.get('USER', '') or os.environ.get('USERNAME', '')
+    cursor = self._db.cursor()
+    cursor.execute('SELECT user_id FROM Users WHERE user_name = ?',
+                   (user_name,))
+    row = cursor.fetchone()
+    if row:
+      return row[0]
+    user_id = self._create_id()
+    cursor.execute(
+        """
+        INSERT INTO USERS (user_id, user_name, inserted_time)
+        VALUES (?, ?, ?)
+        """,
+        (user_id, user_name, time.time()))
+    return user_id
+
+  def _maybe_init_experiment(self, experiment_name):
+    """Returns the ID for the given experiment, creating the row if needed.
+
+    Args:
+      experiment_name: name of experiment.
+    """
+    user_id = self._maybe_init_user()
+    cursor = self._db.cursor()
+    cursor.execute(
+        """
+        SELECT experiment_id FROM Experiments
+        WHERE user_id = ? AND experiment_name = ?
+        """,
+        (user_id, experiment_name))
+    row = cursor.fetchone()
+    if row:
+      return row[0]
+    experiment_id = self._create_id()
+    # TODO: track computed time from run start times
+    computed_time = 0
+    cursor.execute(
+        """
+        INSERT INTO Experiments (
+          user_id, experiment_id, experiment_name,
+          inserted_time, started_time, is_watching
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (user_id, experiment_id, experiment_name, time.time(), computed_time,
+         False))
+    return experiment_id
+
+  def _maybe_init_run(self, experiment_name, run_name):
+    """Returns the ID for the given run, creating the row if needed.
+
+    Args:
+      experiment_name: name of experiment containing this run.
+      run_name: name of run.
+    """
+    experiment_id = self._maybe_init_experiment(experiment_name)
+    cursor = self._db.cursor()
+    cursor.execute(
+        """
+        SELECT run_id FROM Runs
+        WHERE experiment_id = ? AND run_name = ?
+        """,
+        (experiment_id, run_name))
+    row = cursor.fetchone()
+    if row:
+      return row[0]
+    run_id = self._create_id()
+    # TODO: track actual run start times
+    started_time = 0
+    cursor.execute(
+        """
+        INSERT INTO Runs (
+          experiment_id, run_id, run_name, inserted_time, started_time
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        (experiment_id, run_id, run_name, time.time(), started_time))
+    return run_id
+
+  def _maybe_init_tags(self, run_id, tag_to_metadata):
+    """Returns a tag-to-ID map for the given tags, creating rows if needed.
+
+    Args:
+      run_id: the ID of the run to which these tags belong.
+      tag_to_metadata: map of tag name to SummaryMetadata for the tag.
+    """
+    cursor = self._db.cursor()
+    # TODO: for huge numbers of tags (e.g. 1000+), this is slower than just
+    # querying for the known tag names explicitly; find a better tradeoff.
+    cursor.execute('SELECT tag_name, tag_id FROM Tags WHERE run_id = ?',
+                   (run_id,))
+    tag_to_id = {row[0]: row[1] for row in cursor.fetchall()
+                 if row[0] in tag_to_metadata}
+    new_tag_data = []
+    for tag, metadata in six.iteritems(tag_to_metadata):
+      if tag not in tag_to_id:
+        tag_id = self._create_id()
+        tag_to_id[tag] = tag_id
+        new_tag_data.append((run_id, tag_id, tag, time.time(),
+                             metadata.display_name,
+                             metadata.plugin_data.plugin_name,
+                             self._make_blob(metadata.plugin_data.content)))
+    cursor.executemany(
+        """
+        INSERT INTO Tags (
+          run_id, tag_id, tag_name, inserted_time, display_name, plugin_name,
+          plugin_data
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        new_tag_data)
+    return tag_to_id
+
+  def write_summaries(self, tagged_data, experiment_name, run_name):
+    """Transactionally writes the given tagged summary data to the DB.
+
+    Args:
+      tagged_data: map from tag to TagData instances.
+      experiment_name: name of experiment.
+      run_name: name of run.
+    """
+    tf.logging.debug('Writing summaries for %s tags', len(tagged_data))
+    # Connection used as context manager for auto commit/rollback on exit.
+    # We still need an explicit BEGIN, because it doesn't do one on enter,
+    # it waits until the first DML command - which is totally broken.
+    # See: https://stackoverflow.com/a/44448465/1179226
+    with self._db:
+      self._db.execute('BEGIN TRANSACTION')
+      run_id = self._maybe_init_run(experiment_name, run_name)
+      tag_to_metadata = {
+          tag: tagdata.metadata for tag, tagdata in six.iteritems(tagged_data)
+      }
+      tag_to_id = self._maybe_init_tags(run_id, tag_to_metadata)
+      tensor_values = []
+      for tag, tagdata in six.iteritems(tagged_data):
+        tag_id = tag_to_id[tag]
+        for step, wall_time, tensor_proto in tagdata.values:
+          dtype = tensor_proto.dtype
+          shape = ','.join(dim.size for dim in tensor_proto.tensor_shape.dim)
+          # Use tensor_proto.tensor_content if it's set, to skip relatively
+          # expensive extraction into intermediate ndarray.
+          data = self._make_blob(
+              tensor_proto.tensor_content or
+              tf.make_ndarray(tensor_proto).tobytes())
+          tensor_values.append((tag_id, step, wall_time, dtype, shape, data))
+      self._db.executemany(
+          """
+          INSERT OR REPLACE INTO Tensors (
+            series, step, computed_time, dtype, shape, data
+          ) VALUES (?, ?, ?, ?, ?, ?)
+          """,
+          tensor_values)
+
+
+# See tensorflow/contrib/tensorboard/db/schema.cc for documentation.
+_SCHEMA_STATEMENTS = [
+    """
+    CREATE TABLE IF NOT EXISTS Ids (
+      id INTEGER PRIMARY KEY
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS Descriptions (
+      id INTEGER PRIMARY KEY,
+      description TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS Tensors (
+      rowid INTEGER PRIMARY KEY,
+      series INTEGER,
+      step INTEGER,
+      dtype INTEGER,
+      computed_time REAL,
+      shape TEXT,
+      data BLOB
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS
+      TensorSeriesStepIndex
+    ON
+      Tensors (series, step)
+    WHERE
+      series IS NOT NULL
+      AND step IS NOT NULL
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS TensorStrings (
+      rowid INTEGER PRIMARY KEY,
+      tensor_rowid INTEGER NOT NULL,
+      idx INTEGER NOT NULL,
+      data BLOB
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS TensorStringIndex
+    ON TensorStrings (tensor_rowid, idx)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS Tags (
+      rowid INTEGER PRIMARY KEY,
+      run_id INTEGER,
+      tag_id INTEGER NOT NULL,
+      inserted_time DOUBLE,
+      tag_name TEXT,
+      display_name TEXT,
+      plugin_name TEXT,
+      plugin_data BLOB
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS TagIdIndex
+    ON Tags (tag_id)
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS
+      TagRunNameIndex
+    ON
+      Tags (run_id, tag_name)
+    WHERE
+      run_id IS NOT NULL
+      AND tag_name IS NOT NULL
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS Runs (
+      rowid INTEGER PRIMARY KEY,
+      experiment_id INTEGER,
+      run_id INTEGER NOT NULL,
+      inserted_time REAL,
+      started_time REAL,
+      finished_time REAL,
+      run_name TEXT
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS RunIdIndex
+    ON Runs (run_id)
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS RunNameIndex
+    ON Runs (experiment_id, run_name)
+    WHERE run_name IS NOT NULL
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS Experiments (
+      rowid INTEGER PRIMARY KEY,
+      user_id INTEGER,
+      experiment_id INTEGER NOT NULL,
+      inserted_time REAL,
+      started_time REAL,
+      is_watching INTEGER,
+      experiment_name TEXT
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS ExperimentIdIndex
+    ON Experiments (experiment_id)
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS ExperimentNameIndex
+    ON Experiments (user_id, experiment_name)
+    WHERE experiment_name IS NOT NULL
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS Users (
+      rowid INTEGER PRIMARY KEY,
+      user_id INTEGER NOT NULL,
+      inserted_time REAL,
+      user_name TEXT,
+      email TEXT
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS UserIdIndex
+    ON Users (user_id)
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS UserNameIndex
+    ON Users (user_name)
+    WHERE user_name IS NOT NULL
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS UserEmailIndex
+    ON Users (email)
+    WHERE email IS NOT NULL
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS Graphs (
+      rowid INTEGER PRIMARY KEY,
+      run_id INTEGER,
+      graph_id INTEGER NOT NULL,
+      inserted_time REAL,
+      graph_def BLOB
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS GraphIdIndex
+    ON Graphs (graph_id)
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS GraphRunIndex
+    ON Graphs (run_id)
+    WHERE run_id IS NOT NULL
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS Nodes (
+      rowid INTEGER PRIMARY KEY,
+      graph_id INTEGER NOT NULL,
+      node_id INTEGER NOT NULL,
+      node_name TEXT,
+      op TEXT,
+      device TEXT,
+      node_def BLOB
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS NodeIdIndex
+    ON Nodes (graph_id, node_id)
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS NodeNameIndex
+    ON Nodes (graph_id, node_name)
+    WHERE node_name IS NOT NULL
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS NodeInputs (
+      rowid INTEGER PRIMARY KEY,
+      graph_id INTEGER NOT NULL,
+      node_id INTEGER NOT NULL,
+      idx INTEGER NOT NULL,
+      input_node_id INTEGER NOT NULL,
+      input_node_idx INTEGER,
+      is_control INTEGER
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS NodeInputsIndex
+    ON NodeInputs (graph_id, node_id, idx)
+    """,
+]
+
+
+# Defines application ID as hexspeak for "TBOARD[0]", with an expansion digit.
+# This differs from 0xFEEDABEE used in schema.h, which unfortunately exceeds
+# the range of a signed 32-bit int and thus gets interpreted as 0.
+_TENSORBOARD_APPLICATION_ID = 0x7B0A12D0
+
+
+# Arbitrary user-controlled version number.
+_TENSORBOARD_USER_VERSION = 0
+
+
+def initialize_schema(connection):
+  """Initializes the TensorBoard sqlite schema using the given connection.
+
+  Args:
+    connection: A sqlite DB connection.
+  """
+  cursor = connection.cursor()
+  cursor.execute("PRAGMA application_id={}".format(_TENSORBOARD_APPLICATION_ID))
+  cursor.execute("PRAGMA user_version={}".format(_TENSORBOARD_USER_VERSION))
+  with connection:
+    for statement in _SCHEMA_STATEMENTS:
+      lines = statement.strip('\n').split('\n')
+      message = lines[0] + ('...' if len(lines) > 1 else '')
+      tf.logging.debug('Running DB init statement: %s', message)
+      cursor.execute(statement)

--- a/tensorboard/backend/event_processing/sqlite_writer.py
+++ b/tensorboard/backend/event_processing/sqlite_writer.py
@@ -47,7 +47,7 @@ class SqliteWriter(object):
     """Helper to ensure SQLite treats the given data as a BLOB."""
     # Special-case python 2 pysqlite which uses buffers for BLOB.
     if sys.version_info[0] == 2:
-      return buffer(bytestring)
+      return buffer(bytestring)  # noqa: F821 (undefined name)
     return bytestring
 
   def _create_id(self):

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -342,6 +342,15 @@ temporary unless --db is also passed to specify a DB path to use.\
 ''')
 
     parser.add_argument(
+        '--db_import_use_op',
+        action='store_true',
+        help='''\
+[experimental] in combination with --db_import, if passed, use TensorFlow's
+import_event() op for importing event data, otherwise use TensorBoard's own
+sqlite ingestion logic.\
+''')
+
+    parser.add_argument(
         '--inspect',
         action='store_true',
         help='''\


### PR DESCRIPTION
This adds new python sqlite ingestion logic as an option for DbImportMultiplexer, as contrasted with the preexisting logic which uses TensorFlow's C++ SummaryDbWriter and the ImportEvent op (via their python bindings).  The new logic is now the default, but the old logic can be activated with `--db_import_use_op`.

There are several components to the PR:
- Reimplementation of DbImportMultiplexer.Reload(), which now supports multithreading.  RunImporter is replaced with RunLoader that emits events in batches (hardcoded for now to use the lesser of 5000 events or 1 MB), and these batches are channeled from worker threads through a Queue to an EventSink running on the main thread.
- EventSink has two implementations, ImportOpEventSink with the old logic, and SqliteWriterEventSink with the new logic.  SqliteWriterEventSink borrows from PluginEventAccumulator._ProcessEvent() to handle the appropriate conversion of the various types of tf.Event.
- A new SqliteWriter, modeled on C++ SummaryDbWriter, provides the backend for SqliteWriterEventSink.
- A schema initialization routine, which should also take care of the race condition where queries would fail with "no such table" if TensorBoard was loaded before it had imported any data into the DB.

SqliteWriter is much simpler than SummaryDbWriter and omits a bunch of its functionality:
- no pre-reserving rows (mostly was used for removed reservoir sampling behavior)
- no caching run/experiment IDs
- no support (yet) for saving graphs, string tensors, or descriptions
- no randomized ID allocation (instead, it just uses automatic rowid generation)

But what SqliteWriter does provide is transactions that batch across multiple summaries, so we don't do a transaction commit for every single scalar.  In testing, this makes --db_import load data at a similar rate to the regular non-DB loading logic, whereas the import_event() approach, even after tuning, was noticeably slower.