### PR TITLE
Enable fast C++ implementation of python protobuf

### DIFF
--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -26,12 +26,18 @@ from __future__ import division
 from __future__ import print_function
 
 # pylint: disable=g-import-not-at-top
+import os
+
 # Disable the TF GCS filesystem cache which interacts pathologically with the
 # pattern of reads used by TensorBoard for logdirs. See for details:
 #   https://github.com/tensorflow/tensorboard/issues/1225
 # This must be set before the first import of tensorflow.
-import os
 os.environ['GCS_READ_CACHE_DISABLED'] = '1'
+
+# Use fast C++ implementation of Python protocol buffers. See:
+# https://github.com/protocolbuffers/protobuf/blob/v3.6.0/python/google/protobuf/pyext/README
+os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'cpp'
+os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION'] = '2'
 # pylint: enable=g-import-not-at-top
 
 import sys


### PR DESCRIPTION
I tested this by profiling loading a file of 100,000 scalar summaries.  With python protobuf, the protobuf library calls dominate the profiling stats.  With the C++ implementation, these calls drop much lower in the ranking, and the file loads twice as fast.