### PR TITLE
Fix issues with python DB import logic and non-scalars

### DIFF
--- a/tensorboard/backend/event_processing/sqlite_writer.py
+++ b/tensorboard/backend/event_processing/sqlite_writer.py
@@ -193,7 +193,7 @@ class SqliteWriter(object):
         tag_id = tag_to_id[tag]
         for step, wall_time, tensor_proto in tagdata.values:
           dtype = tensor_proto.dtype
-          shape = ','.join(dim.size for dim in tensor_proto.tensor_shape.dim)
+          shape = ','.join(str(d.size) for d in tensor_proto.tensor_shape.dim)
           # Use tensor_proto.tensor_content if it's set, to skip relatively
           # expensive extraction into intermediate ndarray.
           data = self._make_blob(

--- a/tensorboard/plugins/image/images_plugin.py
+++ b/tensorboard/plugins/image/images_plugin.py
@@ -105,8 +105,8 @@ class ImagesPlugin(base_plugin.TBPlugin):
             MAX(CAST (Tensors.shape AS INT)) - 2 AS samples
           FROM Tags
           JOIN Runs USING (run_id)
-          JOIN Descriptions ON Tags.tag_id = Descriptions.id
           JOIN Tensors ON Tags.tag_id = Tensors.series
+          LEFT JOIN Descriptions ON Tags.tag_id = Descriptions.id
           WHERE Tags.plugin_name = :plugin
             /* Shape should correspond to a rank-1 tensor. */
             AND NOT INSTR(Tensors.shape, ',')
@@ -119,6 +119,7 @@ class ImagesPlugin(base_plugin.TBPlugin):
       result = collections.defaultdict(dict)
       for row in cursor:
         run_name, tag_name, display_name, description, samples = row
+        description = description or ''  # Handle missing descriptions.
         result[run_name][tag_name] = {
             'displayName': display_name,
             'description': plugin_util.markdown_to_safe_html(description),


### PR DESCRIPTION
Fixes a bug in #1486 with stringifying non-scalar tensor shapes, and also fixes a latent issue in the images plugin SQL tag-finding query causing it to skip tags with no description (and the python DB import logic doesn't currently populate any descriptions).

The images plugin still doesn't work even with this fix, because it looks for image summary data in TensorStrings, which the python DB import logic doesn't currently populate either.  But at least it shows the detected tags.