### PR TITLE
Fixed to show spinner on data load

### DIFF
--- a/tensorboard/components/tf_categorization_utils/tf-category-pane.html
+++ b/tensorboard/components/tf_categorization_utils/tf-category-pane.html
@@ -50,7 +50,11 @@ limitations under the License.
         </span>
         <span class="count"><span>[[_count]]</span></span>
       </button>
-      <iron-collapse opened="[[opened]]">
+      <!-- TODO(stephanwlee): investigate further. For some reason,
+        transitionend that the iron-collapse relies on sometimes does not
+        trigger when rendering a chart with a spinner. A toy example cannot
+        reproduce this bug. -->
+      <iron-collapse opened="[[opened]]" no-animation>
         <div class="content">
           <template is="dom-if" if="[[opened]]" restamp="[[restamp]]"
                     id="ifOpened">

--- a/tensorboard/components/tf_line_chart_data_loader/data-loader-behavior.ts
+++ b/tensorboard/components/tf_line_chart_data_loader/data-loader-behavior.ts
@@ -58,6 +58,7 @@ export const DataLoaderBehavior = {
 
     dataLoading: {
       type: Boolean,
+      readOnly: true,
       value: false,
     },
 
@@ -119,8 +120,8 @@ export const DataLoaderBehavior = {
 
     if (!this.isAttached) return;
     this._loadDataAsync = this.async(() => {
-      // Using a setter does not notify the impl observers.
-      this.set('dataLoading', true);
+      // Read-only property have a special setter.
+      this._setDataLoading(true);
 
       // Before updating, cancel any network-pending updates, to
       // prevent race conditions where older data stomps newer data.
@@ -140,7 +141,8 @@ export const DataLoaderBehavior = {
       });
 
       return Promise.all(promises).then(this._canceller.cancellable(result => {
-        this.set('dataLoading', false);
+        // Read-only property have a special setter.
+        this._setDataLoading(false);
         if (result.cancelled) return;
         this.onLoadFinish();
       }));

--- a/tensorboard/components/tf_line_chart_data_loader/data-loader-behavior.ts
+++ b/tensorboard/components/tf_line_chart_data_loader/data-loader-behavior.ts
@@ -58,7 +58,6 @@ export const DataLoaderBehavior = {
 
     dataLoading: {
       type: Boolean,
-      readOnly: true,
       value: false,
     },
 
@@ -120,7 +119,8 @@ export const DataLoaderBehavior = {
 
     if (!this.isAttached) return;
     this._loadDataAsync = this.async(() => {
-      this.dataLoading = true;
+      // Using a setter does not notify the impl observers.
+      this.set('dataLoading', true);
 
       // Before updating, cancel any network-pending updates, to
       // prevent race conditions where older data stomps newer data.
@@ -140,7 +140,7 @@ export const DataLoaderBehavior = {
       });
 
       return Promise.all(promises).then(this._canceller.cancellable(result => {
-        this.dataLoading = false;
+        this.set('dataLoading', false);
         if (result.cancelled) return;
         this.onLoadFinish();
       }));


### PR DESCRIPTION
Also fixed the issue where, when showing the spinner, the iron-collapse
does not always open. Note that this collapse bug did exist in version
1,10 too,