### PR TITLE
Apply tf-paginated-view2 to scalar plugin

### DIFF
--- a/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
@@ -57,13 +57,21 @@ export const DataLoaderBehavior = {
 
     // A function that takes a datum and returns a string URL for fetching
     // data.
-    getDataLoadUrl: Function,
+    getDataLoadUrl: {
+      type: Function,
+      value: () => '',
+    },
 
     dataLoading: {
       type: Boolean,
       readOnly: true,
       reflectToAttribute: true,
       value: false,
+    },
+
+    requestManager: {
+      type: Object,
+      value: () => null,
     },
 
     /*
@@ -84,7 +92,7 @@ export const DataLoaderBehavior = {
   },
 
   observers: [
-    '_dataToLoadChanged(isAttached, dataToLoad.*)',
+    '_dataToLoadChanged(dataToLoad.*, _canceller, getDataLoadName, getDataLoadUrl, requestManager, isAttached)',
   ],
 
   onLoadFinish() {

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -126,8 +126,6 @@ limitations under the License.
 
         dataSeries: Array,
 
-        requestManager: Object,
-
         logScaleActive: {
           type: Boolean,
           observer: '_logScaleChanged',
@@ -178,6 +176,7 @@ limitations under the License.
       observers: [
         '_dataSeriesChanged(dataSeries.*)',
         '_loadKeyChanged(loadKey)',
+        'redraw(active, isAttached)',
       ],
 
       onLoadFinish() {
@@ -192,10 +191,6 @@ limitations under the License.
         }
 
         this.redraw();
-      },
-
-      detached() {
-        cancelAnimationFrame(this._redrawRaf);
       },
 
       exportAsSvgString() {
@@ -217,16 +212,13 @@ limitations under the License.
       },
 
       redraw() {
-        cancelAnimationFrame(this._redrawRaf);
-        this._redrawRaf = window.requestAnimationFrame(() => {
-          if (this.active) {
-            this.$.chart.redraw();
-          } else {
-            // If we reached a point where we should render while the page
-            // is not active, we've gotten into a bad state.
-            this._maybeRenderedInBadState = true;
-          }
-        });
+        if (this.active) {
+          this.$.chart.redraw();
+        } else {
+          // If we reached a point where we should render while the page
+          // is not active, we've gotten into a bad state.
+          this._maybeRenderedInBadState = true;
+        }
       },
 
       _loadKeyChanged(_) {

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -33,7 +33,7 @@ limitations under the License.
 <link rel="import" href="../tf-data-selector/type.html">
 <link rel="import" href="../tf-globals/tf-globals.html">
 <link rel="import" href="../tf-imports/lodash.html">
-<link rel="import" href="../tf-paginated-view/tf-paginated-view.html">
+<link rel="import" href="../tf-paginated-view/tf-paginated-view2.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 <link rel="import" href="../tf-storage/tf-storage.html">
 <link rel="import" href="../tf-tensorboard/registry.html">
@@ -132,34 +132,32 @@ limitations under the License.
               category="[[category]]"
               opened="[[_getPaneOpened(category)]]"
               on-opened-changed="_onPaneOpenChanged"
+              restamp="[[_restamp]]"
             >
-              <tf-paginated-view
+              <tf-paginated-view2
                 items="[[category.items]]"
-                pages="{{category._pages}}"
+                get-item-key="[[_getItemKey]]"
               >
-                <template is="dom-repeat" items="[[category._pages]]" as="page">
-                  <template is="dom-if" if="[[page.active]]">
-                    <div class="layout horizontal wrap">
-                      <template is="dom-repeat" items="[[page.items]]">
-                        <tf-scalar-card
-                          active="[[page.active]]"
-                          data-to-load="[[item.series]]"
-                          ignore-y-outliers="[[_ignoreYOutliers]]"
-                          multi-experiments="[[_getMultiExperiments(dataSelection)]]"
-                          request-manager="[[_requestManager]]"
-                          show-download-links="[[_showDownloadLinks]]"
-                          smoothing-enabled="[[_smoothingEnabled]]"
-                          smoothing-weight="[[_smoothingWeight]]"
-                          tag-metadata="[[_tagMetadata(category, _runToTagInfo, item)]]"
-                          tag="[[item.tag]]"
-                          tooltip-sorting-method="[[_tooltipSortingMethod]]"
-                          x-type="[[_xType]]"
-                        ></tf-scalar-card>
-                      </template>
-                    </div>
-                  </template>
+                <template>
+                  <!-- TODO(stephanwlee): Remove `active` when all usages of
+                    tf-scalar-card and tf-line-chart-data-loader uses the
+                    tf-paginated-view2. -->
+                  <tf-scalar-card
+                    active
+                    data-to-load="[[item.series]]"
+                    ignore-y-outliers="[[_ignoreYOutliers]]"
+                    multi-experiments="[[_getMultiExperiments(dataSelection)]]"
+                    request-manager="[[_requestManager]]"
+                    show-download-links="[[_showDownloadLinks]]"
+                    smoothing-enabled="[[_smoothingEnabled]]"
+                    smoothing-weight="[[_smoothingWeight]]"
+                    tag-metadata="[[_tagMetadata(category, _runToTagInfo, item)]]"
+                    tag="[[item.tag]]"
+                    tooltip-sorting-method="[[_tooltipSortingMethod]]"
+                    x-type="[[_xType]]"
+                  ></tf-scalar-card>
                 </template>
-              </tf-paginated-view>
+              </tf-paginated-view2>
             </tf-category-pane>
           </template>
         </template>
@@ -271,6 +269,18 @@ limitations under the License.
           type: Boolean,
           value: USE_DATA_SELECTOR,
         },
+
+        _getItemKey: {
+          type: Function,
+          value() {
+            return item => item.tag;
+          },
+        },
+
+        _restamp: {
+          type: Boolean,
+          value: false,
+        },
       },
       behaviors: [
         tf_dashboard_common.ArrayUpdateHelper,
@@ -279,6 +289,16 @@ limitations under the License.
         '_updateCategories(_runToTagInfo, _selectedRuns, _tagFilter, _categoriesDomReady, dataSelection)',
         '_updatePaneOpened(_categories.*)',
       ],
+      listeners: {
+        'content-visibility-changed': '_redrawCategoryPane',
+      },
+
+      _redrawCategoryPane(event, val) {
+        if (!val) return;
+        event.target.querySelectorAll('tf-scalar-card')
+            .forEach(histogram => histogram.redraw());
+      },
+
       _showDownloadLinksObserver: tf_storage.getBooleanObserver(
           '_showDownloadLinks', {defaultValue: false, useLocalStorage: true}),
       _smoothingWeightObserver: tf_storage.getNumberObserver(


### PR DESCRIPTION
tf-paginated-view2 introduces easier API to consume and cleaner data
flow. It also may address the gnarly dom-repeat bug that sometimes
manifests when using tag filter.