### PR TITLE
Fix broken audio dashboard with tag filter

### DIFF
--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
@@ -108,8 +108,10 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
         _selectedRuns: Array,
         _runToTagInfo: Object,
         _dataNotFound: Boolean,
-
-        _tagFilter: String,
+        _tagFilter: {
+          type: String,
+          value: '',
+        },
         _categories: {
           type: Array,
           computed:


### PR DESCRIPTION
Repro step:
1. Open TB in scalar dashboard
2. Type something into tag filter
3. Navigate to audio dashboard
4. See nothing <- bug

The regression was caused by #1475 which has broken the Polymer
complex observer.