### PR TITLE
FIX: data-loader now responds to loadKey changes

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/data-loader-behavior.ts
+++ b/tensorboard/components/tf_line_chart_data_loader/data-loader-behavior.ts
@@ -23,7 +23,10 @@ export const DataLoaderBehavior = {
      * An unique identifiable string. When changes, it expunges the data
      * cache.
      */
-    loadKey: String,
+    loadKey: {
+      type: String,
+      value: '',
+    },
 
     // List of data to be loaded. A datum is passed to `getDataLoadUrl` to ge
     // URL of an API endpoint and, when request resolves, invokes
@@ -80,7 +83,6 @@ export const DataLoaderBehavior = {
   },
 
   observers: [
-    '_loadKeyChanged(loadKey)',
     '_dataToLoadChanged(isAttached, dataToLoad.*)',
   ],
 
@@ -93,10 +95,12 @@ export const DataLoaderBehavior = {
     this._loadData();
   },
 
-  _loadKeyChanged(_) {
-    // When `key` changes, cancel all handlers from the previous requests.
-    this._canceller.cancelAll();
-    this._loadedData.clear();
+  reset() {
+    // https://github.com/tensorflow/tensorboard/issues/1499
+    // Cannot use the observer to observe `loadKey` changes directly.
+    if (this._canceller) this._canceller.cancelAll();
+    if (this._loadedData) this._loadedData.clear();
+    if (this.isAttached) this._loadData();
   },
 
   _dataToLoadChanged() {

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -234,6 +234,7 @@ limitations under the License.
       },
 
       _loadKeyChanged(_) {
+        this.reset();
         this._resetDomainOnNextLoad = true;
       },
 


### PR DESCRIPTION
Please refer to #1499 for details.
The observer to the `loadKey` change was not triggered even when it
changed. Weirdly, the complex observer for `dataToLoad` was triggering
fine.

Due to the issue, the line-chart appeared stale even when its tag/run
pair has changed.