### PR TITLE
Add true log scale to line chart

### DIFF
--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -21,7 +21,6 @@ tf_web_library(
 
 tensorboard_html_binary(
     name = "index",
-    compile = True,
     input_path = "/tensorboard.html",
     output_path = "/index.html",
     deps = [":tensorboard"],

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -60,7 +60,6 @@ tf_web_library(
         "//tensorboard/plugins/graph/tf_graph_dashboard",
         "//tensorboard/plugins/histogram/tf_histogram_dashboard",
         "//tensorboard/plugins/image/tf_image_dashboard",
-        "//tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard",
         "//tensorboard/plugins/pr_curve/tf_pr_curve_dashboard",
         "//tensorboard/plugins/profile/tf_profile_dashboard",
         "//tensorboard/plugins/projector/vz_projector",

--- a/tensorboard/components/tf_tensorboard/default-plugins.html
+++ b/tensorboard/components/tf_tensorboard/default-plugins.html
@@ -38,4 +38,3 @@ limitations under the License.
 <link rel="import" href="../tf-pr-curve-dashboard/tf-pr-curve-dashboard.html">
 <link rel="import" href="../tf-profile-dashboard/tf-profile-dashboard.html">
 <link rel="import" href="../tf-beholder-dashboard/tf-beholder-dashboard.html">
-<link rel="import" href="../tf-interactive-inference-dashboard/tf-interactive-inference-dashboard.html">

--- a/tensorboard/components/vz_line_chart2/BUILD
+++ b/tensorboard/components/vz_line_chart2/BUILD
@@ -8,10 +8,13 @@ licenses(["notice"])  # Apache 2.0
 tf_web_library(
     name = "vz_line_chart2",
     srcs = [
-        "line-chart.ts",
         "line-chart-exporter.ts",
+        "line-chart.ts",
+        "linear-scale.ts",
+        "log-scale.ts",
         "panZoomDragLayer.html",
         "panZoomDragLayer.ts",
+        "tf-scale.ts",
         "vz-line-chart2.html",
         "vz-line-chart2.ts",
     ],

--- a/tensorboard/components/vz_line_chart2/linear-scale.ts
+++ b/tensorboard/components/vz_line_chart2/linear-scale.ts
@@ -29,6 +29,7 @@ export class LinearScale extends Plottable.Scales.Linear implements ITfScale {
   }
 
   /**
+   * TODO(nickfelt): Examine whether we truly require `c`.
    * Adds some padding to a given domain. Specifically, it:
    * - returns about [-0.1a - c, 2.1a + c] when a = b and a >= 0.
    * - returns about [-2.1|a| - c, -0.1|a| + c] when a = b and a < 0.

--- a/tensorboard/components/vz_line_chart2/linear-scale.ts
+++ b/tensorboard/components/vz_line_chart2/linear-scale.ts
@@ -30,10 +30,12 @@ export class LinearScale extends Plottable.Scales.Linear implements ITfScale {
 
   /**
    * Adds some padding to a given domain. Specifically, it:
-   * - returns about [-0.1a, 2.1a] when a = b and a >= 0.
-   * - returns about [-2.1a, 0.1a] when a = b and a < 0.
+   * - returns about [-0.1a - c, 2.1a + c] when a = b and a >= 0.
+   * - returns about [-2.1|a| - c, -0.1|a| + c] when a = b and a < 0.
    * - returns [-0.1b, b + padProportion * (b-a)] if b > 2a and a > 0
    * - else, pads by `padProportion`
+   * Note that `c` is a constant offset which specifically is 1.1. Please refer
+   * to [1] for its rationale.
    * @override
    */
   protected _niceDomain(domain: number[], count?: number): number[] {
@@ -51,10 +53,10 @@ export class LinearScale extends Plottable.Scales.Linear implements ITfScale {
 
     let lower: number;
     if (a >= 0 && a < span) {
-      // We include the intercept (y = 0) if doing so less than doubles the span
-      // of the y-axis. (We actually select a lower bound that's slightly less
-      // than 0 so that 0.00 will clearly be written on the lower edge of the
-      // chart. The label on the lowest tick is often filtered out.)
+      // [1]: We include the intercept (y = 0) if doing so less than doubles the
+      // span of the y-axis. (We actually select a lower bound that's slightly
+      // less than 0 so that 0.00 will clearly be written on the lower edge of
+      // the chart. The label on the lowest tick is often filtered out.)
       lower = -0.1 * b;
     } else {
       lower = a - padding;

--- a/tensorboard/components/vz_line_chart2/linear-scale.ts
+++ b/tensorboard/components/vz_line_chart2/linear-scale.ts
@@ -1,0 +1,119 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace vz_line_chart2 {
+
+export class LinearScale extends Plottable.Scales.Linear implements ITfScale {
+  private _ignoreOutlier: boolean = false;
+  protected _valueProviderForDomain: ValueProviderForDomain;
+
+  constructor() {
+    super();
+    this.padProportion(.2);
+  }
+
+  public setValueProviderForDomain(provider: ValueProviderForDomain): this {
+    this._valueProviderForDomain = provider;
+    return this;
+  }
+
+  /**
+   * Adds some padding to a given domain. Specifically, it:
+   * - returns about [-0.1a, 2.1a] when a = b and a >= 0.
+   * - returns about [-2.1a, 0.1a] when a = b and a < 0.
+   * - returns [-0.1b, b + padProportion * (b-a)] if b > 2a and a > 0
+   * - else, pads by `padProportion`
+   * @override
+   */
+  protected _niceDomain(domain: number[], count?: number): number[] {
+    const [a, b] = domain;
+    let padding: number;
+    const span = b - a;
+    if (span === 0) {
+      // If b===a, we would create an empty range. We instead select the range
+      // [0, 2*a] if a > 0, or [-2*a, 0] if a < 0, plus a little bit of
+      // extra padding on the top and bottom of the plot.
+      padding = Math.abs(a) * 1.1 + 1.1;
+    } else {
+      padding = span * this.padProportion();
+    }
+
+    let lower: number;
+    if (a >= 0 && a < span) {
+      // We include the intercept (y = 0) if doing so less than doubles the span
+      // of the y-axis. (We actually select a lower bound that's slightly less
+      // than 0 so that 0.00 will clearly be written on the lower edge of the
+      // chart. The label on the lowest tick is often filtered out.)
+      lower = -0.1 * b;
+    } else {
+      lower = a - padding;
+    }
+    return super._niceDomain([lower, b + padding], count);
+  }
+
+  /**
+   * @override to remove default padding logic.
+   */
+  protected _getUnboundedExtent(ignoreAttachState): number[] {
+    const includedValues = this._getAllIncludedValues(ignoreAttachState);
+    let extent = this._defaultExtent();
+    if (includedValues.length !== 0) {
+      const combinedExtent = [
+        Plottable.Utils.Math.min<number>(includedValues, extent[0]),
+        Plottable.Utils.Math.max<number>(includedValues, extent[1]),
+      ];
+      extent = this._niceDomain(combinedExtent);
+    }
+    return extent;
+  }
+
+  /**
+   * @override
+   */
+  protected _getAllIncludedValues(ignoreAttachState = false): number[] {
+    const values = this._valueProviderForDomain ?
+        this._valueProviderForDomain() : [];
+    return this.extentOfValues(values);
+  }
+
+  /**
+   * @override to apply the outlier logic.
+   */
+  public extentOfValues(values: number[]): number[]  {
+    const legalValues = values
+        .filter(x => Plottable.Utils.Math.isValidNumber(x));
+    let filteredValues = legalValues;
+    if (this.ignoreOutlier()) {
+      const sortedValues = legalValues.sort((a, b) => a - b);
+      const a = d3.quantile(sortedValues, 0.05);
+      const b = d3.quantile(sortedValues, 0.95);
+      filteredValues = legalValues.filter(x => x >= a && x <= b);
+    }
+    const extent = d3.extent(filteredValues);
+    return extent[0] == null || extent[1] == null ? [] : extent;
+  }
+
+  public ignoreOutlier(): boolean;
+  public ignoreOutlier(ignore: boolean): this;
+  public ignoreOutlier(ignore?: boolean): any {
+    if (typeof ignore == 'boolean') {
+      this._ignoreOutlier = ignore;
+      return this;
+    }
+    return this._ignoreOutlier;
+  }
+
+}
+
+}  // namespace vz_line_chart2

--- a/tensorboard/components/vz_line_chart2/log-scale.ts
+++ b/tensorboard/components/vz_line_chart2/log-scale.ts
@@ -14,7 +14,10 @@ limitations under the License.
 ==============================================================================*/
 namespace vz_line_chart2 {
 
-const MIN_VALUE = 1e-15;
+// Smallest positive non-zero value represented by IEEE 754 binary (64 bit)
+// floating-point number.
+// https://www.ecma-international.org/ecma-262/5.1/#sec-8.5
+const MIN_POSITIVE_VALUE = Math.pow(2, -1074);
 
 function log(x: number): number {
   return Math.log10(x);
@@ -62,21 +65,21 @@ export class LogScale extends TfScale {
   protected _setDomain(values: number[]) {
     this._untransformedDomain = values;
     const [min, max] = values;
-    super._setDomain([Math.max(MIN_VALUE, min), max]);
+    super._setDomain([Math.max(MIN_POSITIVE_VALUE, min), max]);
   }
 
   /**
-   * Given a domain, pad it and clip the lower bound to MIN_VALUE.
+   * Given a domain, pad it and clip the lower bound to MIN_POSITIVE_VALUE.
    */
   protected _niceDomain(domain: number[], count?: number): number[] {
     const [low, high] = domain;
-    const adjustedLogLow = Math.max(log(MIN_VALUE), log(low));
+    const adjustedLogLow = Math.max(log(MIN_POSITIVE_VALUE), log(low));
     const logHigh = log(high);
     const pad = (logHigh - adjustedLogLow) * this.padProportion();
     const logLowFloor = Math.floor(adjustedLogLow);
     const logHighCeil = Math.ceil(logHigh);
     return [
-      pow(Math.max(log(MIN_VALUE), adjustedLogLow - pad, logLowFloor)),
+      pow(Math.max(log(MIN_POSITIVE_VALUE), adjustedLogLow - pad, logLowFloor)),
       pow(Math.min(logHigh + pad, logHighCeil)),
     ];
   }
@@ -104,7 +107,7 @@ export class LogScale extends TfScale {
     const values = super._getAllIncludedValues();
     // For log scale, the value cannot be smaller or equal to 0. They are
     // negative infinity.
-    return values.map(x => x > 0 ? x : MIN_VALUE);
+    return values.map(x => x > 0 ? x : MIN_POSITIVE_VALUE);
   }
 
   protected _defaultExtent(): number[] {

--- a/tensorboard/components/vz_line_chart2/log-scale.ts
+++ b/tensorboard/components/vz_line_chart2/log-scale.ts
@@ -1,0 +1,164 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace vz_line_chart2 {
+
+const MIN_VALUE = 1e-15;
+
+function log(x: number): number {
+  return Math.log(x) / Math.log(10);
+}
+
+function pow(x: number): number {
+  return Math.pow(10, x);
+}
+
+export class LogScale extends TfScale {
+  private _d3LogScale = d3.scaleLog();
+  private _untransformedDomain: number[];
+
+  constructor() {
+    super();
+    this.padProportion(.2);
+  }
+
+  public scale(x: number): number {
+    // Returning NaN makes sure line plot does not plot illegal values.
+    if (x <= 0) return NaN;
+    return this._d3LogScale(x);
+  }
+
+  public invert(x: number): number {
+    return this._d3LogScale.invert(x);
+  }
+
+  public scaleTransformation(value: number) {
+    return this.scale(value);
+  }
+
+  public invertedTransformation(value: number) {
+    return this.invert(value);
+  }
+
+  public getTransformationDomain(): [number, number] {
+    return this.domain() as [number, number];
+  }
+
+  protected _getDomain() {
+    return this._untransformedDomain;
+  }
+
+  protected _setDomain(values: number[]) {
+    this._untransformedDomain = values;
+    const [min, max] = values;
+    super._setDomain([Math.max(MIN_VALUE, min), max]);
+  }
+
+  /**
+   * Given a domain, pad it and clip the lower bound to MIN_VALUE.
+   */
+  protected _niceDomain(domain: number[], count?: number): number[] {
+    const [low, high] = domain;
+    const adjustedLogLow = Math.max(log(MIN_VALUE), log(low));
+    const logHigh = log(high);
+    const pad = (logHigh - adjustedLogLow) * this.padProportion();
+    const logLowFloor = Math.floor(adjustedLogLow);
+    const logHighCeil = Math.ceil(logHigh);
+    return [
+      pow(Math.max(log(MIN_VALUE), adjustedLogLow - pad, logLowFloor)),
+      pow(Math.min(logHigh + pad, logHighCeil)),
+    ];
+  }
+
+  /**
+   * Generates a possible extent based on data from all plots the scale is
+   * connected to by taking the minimum and maximum values of all extents for
+   * lower and upper bound, respectively.
+   * @override to remove default padding logic.
+   */
+  protected _getUnboundedExtent(ignoreAttachState): number[] {
+    const includedValues = this._getAllIncludedValues(ignoreAttachState);
+    let extent = this._defaultExtent();
+    if (includedValues.length !== 0) {
+      const combinedExtent = [
+        Plottable.Utils.Math.min<number>(includedValues, extent[0]),
+        Plottable.Utils.Math.max<number>(includedValues, extent[1]),
+      ];
+      extent = this._niceDomain(combinedExtent);
+    }
+    return extent;
+  }
+
+  protected _getAllIncludedValues(ignoreAttachState = false): number[] {
+    const values = super._getAllIncludedValues();
+    // For log scale, the value cannot be smaller or equal to 0. They are
+    // negative infinity.
+    return values.map(x => x > 0 ? x : MIN_VALUE);
+  }
+
+  protected _defaultExtent(): number[] {
+    return [1, 10];
+  }
+
+  protected _backingScaleDomain(): number[]
+  protected _backingScaleDomain(values: number[]): this
+  protected _backingScaleDomain(values?: number[]): any {
+    if (values == null) {
+      return this._d3LogScale.domain();
+    } else {
+      this._d3LogScale.domain(values);
+      return this;
+    }
+  }
+
+  protected _getRange() {
+    return this._d3LogScale.range();
+  }
+
+  protected _setRange(values: number[]) {
+    this._d3LogScale.range(values);
+  }
+
+  public defaultTicks(): number[] {
+    return this._d3LogScale.ticks(1);
+  }
+
+  public ticks(): number[] {
+    return this._d3LogScale.ticks();
+  }
+
+  /**
+   * Returns an `extent` for a data series. In log-scale, we must omit all
+   * non-positive values when computing a `domain`.
+   * @override
+   */
+  public extentOfValues(values: number[]): number[]  {
+    // Log can only take positive values.
+    const legalValues = values
+        .filter(x => Plottable.Utils.Math.isValidNumber(x) && x > 0);
+    let filteredValues = legalValues;
+    if (this.ignoreOutlier()) {
+      const logValues = legalValues.map(log);
+      const sortedLogValues = logValues.sort((a, b) => a - b);
+      const a = d3.quantile(sortedLogValues, 0.05);
+      const b = d3.quantile(sortedLogValues, 0.95);
+      filteredValues = sortedLogValues.filter(x => x >= a && x <= b).map(pow);
+    }
+    const extent = d3.extent(filteredValues);
+    return extent[0] == null || extent[1] == null ? [] : extent;
+  }
+
+}
+
+} //  namespace vz_line_chart2

--- a/tensorboard/components/vz_line_chart2/log-scale.ts
+++ b/tensorboard/components/vz_line_chart2/log-scale.ts
@@ -17,7 +17,7 @@ namespace vz_line_chart2 {
 const MIN_VALUE = 1e-15;
 
 function log(x: number): number {
-  return Math.log(x) / Math.log(10);
+  return Math.log10(x);
 }
 
 function pow(x: number): number {

--- a/tensorboard/components/vz_line_chart2/tf-scale.ts
+++ b/tensorboard/components/vz_line_chart2/tf-scale.ts
@@ -1,0 +1,85 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace vz_line_chart2 {
+
+export type ValueProviderForDomain = () => number[];
+
+/**
+ * Plottable.Scale is a class that wraps the d3.scale that adds many utility
+ * methods that work with the Plottable's `dataset` concept. Here, we will
+ * attempt to explain few basic concepts in plain English.
+ * - domain: [f(min(x)), f(max(x))]
+ * - range: pixel values of the chart
+ *
+ * Plottable.Scale provides some cool feature where a scale is bound to set of
+ * plots (i.e., line, scatter, smooth line chart, etc...) and, when a dataset
+ * of a plot changes, updates the domain based on minimum and maximum values of
+ * each charts. In some Plottable functions, a word `extent` is used to refer to
+ * a possible value for a domain and it often is the minimum and maximum value
+ * of a dataset of a plot.
+ *
+ * Above binding is quite useful in most cases but is rather harmful for the
+ * line-chart. The line-chart draws multiple plots -- a line plot for raw data,
+ * another line plot for smoothed data, a scatter plot for tooltip, and etc...
+ * These plots all derive data from the raw data series, so it is rather odd to
+ * compute `extent` for each plot separately. Moreover, we want to set the
+ * domain with respect to a solid colored line (when using smoothing, it is the
+ * smoothed line plot) regardless of the extent of the raw data. Hence, we need
+ * an ability to disregard dataset of certain plots when computed domain but
+ * such capability is not opened from the Plottable.
+ *
+ * To mitigate the issue, TfScale overrides few methods and receives data from
+ * the LineChart instead of a respective plots the chart draws.
+ */
+export interface ITfScale extends Plottable.QuantitativeScale<number> {
+  setValueProviderForDomain(provider: ValueProviderForDomain): this;
+
+  ignoreOutlier(): boolean;
+  ignoreOutlier(ignore: boolean): this;
+}
+
+export abstract class TfScale extends Plottable.QuantitativeScale<number> implements ITfScale {
+  protected _ignoreOutlier: boolean = false;
+  protected _valueProviderForDomain: ValueProviderForDomain;
+
+  public setValueProviderForDomain(provider: ValueProviderForDomain): this {
+    this._valueProviderForDomain = provider;
+    return this;
+  }
+
+  public ignoreOutlier(): boolean;
+  public ignoreOutlier(ignore: boolean): this;
+  public ignoreOutlier(ignore?: boolean): any {
+    if (typeof ignore == 'boolean') {
+      this._ignoreOutlier = ignore;
+      return this;
+    }
+    return this._ignoreOutlier;
+  }
+
+  /**
+   * Returns possible `extent`s for a dataset. Note that a dataset can contain
+   * multiple series.
+   * Unlike the method name suggests, it uses `values` to return `extent`s.
+   * @override
+   */
+  protected _getAllIncludedValues(ignoreAttachState = false): number[] {
+    const values = this._valueProviderForDomain ?
+        this._valueProviderForDomain() : [];
+    return this.extentOfValues(values);
+  }
+}
+
+} //  namespace vz_line_chart2

--- a/tensorboard/components/vz_line_chart2/tf-scale.ts
+++ b/tensorboard/components/vz_line_chart2/tf-scale.ts
@@ -18,10 +18,7 @@ export type ValueProviderForDomain = () => number[];
 
 /**
  * Plottable.Scale is a class that wraps the d3.scale that adds many utility
- * methods that work with the Plottable's `dataset` concept. Here, we will
- * attempt to explain few basic concepts in plain English.
- * - domain: [f(min(x)), f(max(x))]
- * - range: pixel values of the chart
+ * methods that work with the Plottable's `dataset` concept.
  *
  * Plottable.Scale provides some cool feature where a scale is bound to set of
  * plots (i.e., line, scatter, smooth line chart, etc...) and, when a dataset
@@ -72,7 +69,8 @@ export abstract class TfScale extends Plottable.QuantitativeScale<number> implem
   /**
    * Returns possible `extent`s for a dataset. Note that a dataset can contain
    * multiple series.
-   * Unlike the method name suggests, it uses `values` to return `extent`s.
+   * Unlike the method name suggests, it uses values from each series to
+   * return `extent`s.
    * @override
    */
   protected _getAllIncludedValues(ignoreAttachState = false): number[] {

--- a/tensorboard/components/vz_line_chart2/tf-scale.ts
+++ b/tensorboard/components/vz_line_chart2/tf-scale.ts
@@ -68,9 +68,8 @@ export abstract class TfScale extends Plottable.QuantitativeScale<number> implem
 
   /**
    * Returns possible `extent`s for a dataset. Note that a dataset can contain
-   * multiple series.
-   * Unlike the method name suggests, it uses values from each series to
-   * return `extent`s.
+   * multiple series. Unlike the method name suggests, it uses values from each
+   * series to return `extent`s.
    * @override
    */
   protected _getAllIncludedValues(ignoreAttachState = false): number[] {

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.html
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.html
@@ -85,6 +85,9 @@ such as different X scales (linear and temporal), tooltips and smoothing.
       }
     </style>
   </template>
+  <script src="tf-scale.js"></script>
+  <script src="linear-scale.js"></script>
+  <script src="log-scale.js"></script>
   <script src="line-chart.js"></script>
   <script src="vz-line-chart2.js"></script>
 </dom-module>


### PR DESCRIPTION
Line chart was using Plottable.Scale.ModifiedLogScale which treated
values near (0, 1] very differently than what log does. This handles
negative value (wrong but data is presented) and sometimes present line
chart very nicely but it works against researchers' expectation.

Fixes #57 