### PR TITLE
Connect ignoreYOutlier in custom scalars

### DIFF
--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
@@ -177,7 +177,7 @@ writer.add_summary(layout_summary)
                     smoothing-enabled="[[_smoothingEnabled]]"
                     smoothing-weight="[[_smoothingWeight]]"
                     tooltip-sorting-method="[[tooltipSortingMethod]]"
-                    ignore-y-outliers="[[ignoreYOutliers]]"
+                    ignore-y-outliers="[[_ignoreYOutliers]]"
                     show-download-links="[[_showDownloadLinks]]"
                     tag-regexes="[[chart.multiline.tag]]"
                   ></tf-custom-scalar-multi-line-chart-card>
@@ -190,7 +190,7 @@ writer.add_summary(layout_summary)
                     title="[[chart.title]]"
                     x-type="[[_xType]]"
                     tooltip-sorting-method="[[tooltipSortingMethod]]"
-                    ignore-y-outliers="[[ignoreYOutliers]]"
+                    ignore-y-outliers="[[_ignoreYOutliers]]"
                     show-download-links="[[_showDownloadLinks]]"
                     margin-chart-series="[[chart.margin.series]]"
                   ></tf-custom-scalar-margin-chart-card>


### PR DESCRIPTION
Cause: `ignoreYOutlier` instead of `_ignoreYOutlier`
It has always had wrong property value since #664.