### PR TITLE
Update clutz.bzl to use deprecated symbol naming expected internally

### DIFF
--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -15,10 +15,10 @@
 """Same as web_library but supports TypeScript."""
 
 load("//third_party:clutz.bzl",
-     "CLUTZ_ATTRIBUTES",
-     "CLUTZ_OUTPUTS",
-     "clutz_aspect",
-     "extract_dts_from_closure_libraries")
+     "DEPRECATED_CLUTZ_ATTRIBUTES",
+     "DEPRECATED_CLUTZ_OUTPUTS",
+     "deprecated_clutz_aspect",
+     "deprecated_extract_dts_from_closure_libraries")
 
 load("@io_bazel_rules_closure//closure:defs.bzl",
      "closure_js_aspect")
@@ -123,7 +123,7 @@ def _tf_web_library(ctx):
       web_srcs.append(src)
 
   # get typings for closure code
-  clutz_dts = extract_dts_from_closure_libraries(ctx)
+  clutz_dts = deprecated_extract_dts_from_closure_libraries(ctx)
   if clutz_dts:
     entry = (long_path(ctx, clutz_dts), clutz_dts.path)
     ts_inputs += [clutz_dts]
@@ -343,12 +343,12 @@ def _get_strip(ctx):
 tf_web_library = rule(
     implementation=_tf_web_library,
     executable=True,
-    attrs=dict(CLUTZ_ATTRIBUTES.items() + {
+    attrs=dict(DEPRECATED_CLUTZ_ATTRIBUTES.items() + {
         "path": attr.string(),
         "srcs": attr.label_list(allow_files=True),
         "deps": attr.label_list(
             aspects=[
-                clutz_aspect,
+                deprecated_clutz_aspect,
                 closure_js_aspect,
             ]),
         "exports": attr.label_list(),
@@ -376,4 +376,4 @@ tf_web_library = rule(
         "_ClosureWorker": CLOSURE_WORKER_ATTR,
         "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
     }.items()),
-    outputs=CLUTZ_OUTPUTS)
+    outputs=DEPRECATED_CLUTZ_OUTPUTS)

--- a/third_party/clutz.bzl
+++ b/third_party/clutz.bzl
@@ -19,7 +19,7 @@ load("@io_bazel_rules_closure//closure/private:defs.bzl",
      "collect_js",
      "unfurl")
 
-CLUTZ_ATTRIBUTES = {
+DEPRECATED_CLUTZ_ATTRIBUTES = {
     "_clutz": attr.label(
         default=Label("@io_angular_clutz//:clutz"),
         executable=True,
@@ -32,7 +32,7 @@ CLUTZ_ATTRIBUTES = {
         allow_files=True),
 }
 
-def extract_dts_from_closure_libraries(ctx):
+def deprecated_extract_dts_from_closure_libraries(ctx):
   """Extracts type definitions from closure dependencies.
 
   This just generates one big .d.ts file for all transitive Closure sources,
@@ -68,13 +68,13 @@ def extract_dts_from_closure_libraries(ctx):
   return js_typings
 
 ################################################################################
-# The following definitions are for API compatibility with internal clutz.bzl
+# The following definitions are for API compatibility with internal deprecated_clutz.bzl
 
-CLUTZ_OUTPUTS = {}
+DEPRECATED_CLUTZ_OUTPUTS = {}
 
 def _clutz_aspect_impl(target, ctx):
   return struct()
 
-clutz_aspect = aspect(
+deprecated_clutz_aspect = aspect(
     implementation=_clutz_aspect_impl,
     attr_aspects=["exports"])


### PR DESCRIPTION
Corresponds to internal change cl/216429546.