### PR TITLE
REFACTOR: data-loader to histogram & distrib

### DIFF
--- a/tensorboard/components/tf_dashboard_common/BUILD
+++ b/tensorboard/components/tf_dashboard_common/BUILD
@@ -11,6 +11,8 @@ tf_web_library(
         "array-update-helper.html",
         "array-update-helper.ts",
         "dashboard-style.html",
+        "data-loader-behavior.html",
+        "data-loader-behavior.ts",
         "run-color-style.html",
         "scrollbar-style.html",
         "tensorboard-color.html",

--- a/tensorboard/components/tf_dashboard_common/data-loader-behavior.html
+++ b/tensorboard/components/tf_dashboard_common/data-loader-behavior.html
@@ -1,0 +1,18 @@
+<!--
+@license
+Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script src="data-loader-behavior.js"></script>

--- a/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-namespace tf_line_chart_data_loader {
+namespace tf_dashboard_common {
 
 /**
  * @polymerBehavior
@@ -62,6 +62,7 @@ export const DataLoaderBehavior = {
     dataLoading: {
       type: Boolean,
       readOnly: true,
+      reflectToAttribute: true,
       value: false,
     },
 

--- a/tensorboard/components/tf_line_chart_data_loader/BUILD
+++ b/tensorboard/components/tf_line_chart_data_loader/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])  # Apache 2.0
 tf_web_library(
     name = "tf_line_chart_data_loader",
     srcs = [
-        "data-loader-behavior.ts",
         "tf-line-chart-data-loader.html",
     ],
     path = "/tf-line-chart-data-loader",
@@ -15,6 +14,7 @@ tf_web_library(
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_color_scale",
+        "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/vz_line_chart2",

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -19,8 +19,8 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../tf-dashboard-common/data-loader-behavior.html">
 <link rel="import" href="../vz-line-chart2/vz-line-chart2.html">
-<script src="data-loader-behavior.js"></script>
 
 <!--
   A component that fetches data from the TensorBoard server and renders it into
@@ -176,7 +176,7 @@ limitations under the License.
         },
       },
 
-      behaviors: [tf_line_chart_data_loader.DataLoaderBehavior],
+      behaviors: [tf_dashboard_common.DataLoaderBehavior],
 
       observers: [
         '_dataSeriesChanged(dataSeries.*)',

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/BUILD
@@ -30,6 +30,7 @@ tf_web_library(
         "//tensorboard/components/tf_storage",
         "//tensorboard/components/tf_tensorboard:registry",
         "//tensorboard/components/tf_utils",
+        "//tensorboard/components/vz_chart_helpers",
         "//tensorboard/plugins/scalar/tf_scalar_dashboard",
         "@org_polymer_iron_collapse",
         "@org_polymer_iron_icon",

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-loader.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-loader.html
@@ -20,6 +20,7 @@ limitations under the License.
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-card-heading/tf-card-heading.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../tf-dashboard-common/data-loader-behavior.html">
 <link rel="import" href="../vz-distribution-chart/vz-distribution-chart.html">
 
 <!--
@@ -40,6 +41,7 @@ limitations under the License.
       `setSeriesData`, not with a bound property.
     -->
     <vz-distribution-chart
+      id="chart"
       x-type="[[xType]]"
       color-scale="[[_colorScale]]"
     ></vz-distribution-chart>
@@ -96,6 +98,41 @@ limitations under the License.
         tagMetadata: Object,
         xType: String,
 
+        dataToLoad: {
+          type: Array,
+          computed: '_computeDataToLoad(run, tag)',
+        },
+        getDataLoadName: {
+          type: Function,
+          value: () => ({run}) => run,
+        },
+        getDataLoadUrl: {
+          type: Function,
+          value: () => ({tag, run}) => {
+            const router = tf_backend.getRouter();
+            return tf_backend.addParams(
+                router.pluginRoute('distributions', '/distributions'),
+                {tag, run});
+          },
+        },
+        loadDataCallback: {
+          type: Function,
+          value: function() {
+            return (_, datum, backendData) => {
+              const data = backendData.map(datum => {
+                // `vz-distribution-chart` wants each datum as an array with
+                // extra `wall_time` and `step` properties.
+                const [wall_time, step, bins] = datum;
+                bins.wall_time = new Date(wall_time * 1000);
+                bins.step = step;
+                return bins;
+              });
+              const name = this.getDataLoadName(datum);
+              this.$.chart.setSeriesData(name, data);
+              this.$.chart.setVisibleSeries([name]);
+            };
+          },
+        },
         _colorScale: {
           type: Object,
           value: () => ({scale: tf_color_scale.runsColorScale}),
@@ -120,45 +157,14 @@ limitations under the License.
 
       observers: ['reload(run, tag)'],
 
+      behaviors: [tf_dashboard_common.DataLoaderBehavior],
+
+      _computeDataToLoad(run, tag) {
+        return [{run, tag}];
+      },
+
       _computeRunColor(run) {
         return this._colorScale.scale(run);
-      },
-
-      attached() {
-        this._attached = true;
-        this.reload();
-      },
-
-      /**
-       * Reload data from the backend, updating the distribution chart's
-       * series when the response resolves.
-       */
-      reload() {
-        if (!this._attached) {
-          return;
-        }
-        this._canceller.cancelAll();
-        const router = tf_backend.getRouter();
-        const url = tf_backend.addParams(
-          router.pluginRoute("distributions", "/distributions"),
-          {tag: this.tag, run: this.run});
-        const updateData = this._canceller.cancellable(result => {
-          if (result.cancelled) {
-            return;
-          }
-          const backendData = result.value;
-          const data = backendData.map(datum => {
-            // `vz-distribution-chart` wants each datum as an array with
-            // extra `wall_time` and `step` properties.
-            const [wall_time, step, bins] = datum;
-            bins.wall_time = new Date(wall_time * 1000);
-            bins.step = step;
-            return bins;
-          });
-          this.$$('vz-distribution-chart').setVisibleSeries([this.run]);
-          this.$$('vz-distribution-chart').setSeriesData(this.run, data);
-        });
-        this.requestManager.request(url).then(updateData);
       },
 
       /**
@@ -168,7 +174,7 @@ limitations under the License.
        * recalculate its layout.
        */
       redraw() {
-        this.$$('vz-distribution-chart').redraw();
+        this.$.chart.redraw();
       },
 
       _toggleExpanded(e) {

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
@@ -20,6 +20,7 @@ limitations under the License.
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-card-heading/tf-card-heading.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
+<link rel="import" href="../tf-dashboard-common/data-loader-behavior.html">
 <link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="../vz-histogram-timeseries/vz-histogram-timeseries.html">
 <link rel="import" href="tf-histogram-core.html">
@@ -42,6 +43,7 @@ limitations under the License.
       `setSeriesData`, not with a bound property.
     -->
     <vz-histogram-timeseries
+      id="chart"
       time-property="[[timeProperty]]"
       mode="[[histogramMode]]"
       color-scale="[[_colorScaleFunction]]"
@@ -99,6 +101,33 @@ limitations under the License.
       properties: {
         run: String,
         tag: String,
+        dataToLoad: {
+          type: Array,
+          computed: '_computeDataToLoad(run, tag)',
+        },
+        getDataLoadName: {
+          type: Function,
+          value: () => ({run}) => run,
+        },
+        getDataLoadUrl: {
+          type: Function,
+          value: () => ({tag, run}) => {
+            const router = tf_backend.getRouter();
+            return tf_backend.addParams(
+                router.pluginRoute('histograms', '/histograms'),
+                {tag, run});
+          },
+        },
+        loadDataCallback: {
+          type: Function,
+          value: function() {
+            return (_, datum, data) => {
+              const d3Data = tf_histogram_dashboard.backendToVz(data);
+              const name = this.getDataLoadName(datum);
+              this.$.chart.setSeriesData(name, d3Data);
+            };
+          },
+        },
         /** @type {{description: string, displayName: string}} */
         tagMetadata: Object,
         timeProperty: String,
@@ -118,45 +147,24 @@ limitations under the License.
           value: false,
           reflectToAttribute: true,  // for CSS
         },
-
-        requestManager: Object,
-        _canceller: {
-          type: Object,
-          value: () => new tf_backend.Canceller(),
-        },
       },
 
       observers: [
         'reload(run, tag, requestManager)',
       ],
 
+      behaviors: [tf_dashboard_common.DataLoaderBehavior],
+
+      _computeDataToLoad(run, tag) {
+        return [{run, tag}];
+      },
+
       _computeRunColor(run) {
         return this._colorScaleFunction(run);
       },
 
-      attached() {
-        this.redraw();
-      },
-
-      reload() {
-        this._canceller.cancelAll();
-        const router = tf_backend.getRouter();
-        const url = tf_backend.addParams(router.pluginRoute("histograms", "/histograms"), {
-          tag: this.tag,
-          run: this.run,
-        });
-        const updateData = this._canceller.cancellable(result => {
-          if (result.cancelled) {
-            return;
-          }
-          const backendData = result.value;
-          const d3Data = tf_histogram_dashboard.backendToVz(backendData);
-          this.$$('vz-histogram-timeseries').setSeriesData(this.run, d3Data);
-        });
-        this.requestManager.request(url).then(updateData);
-      },
       redraw() {
-        this.$$('vz-histogram-timeseries').redraw();
+        this.$.chart.redraw();
       },
 
       _toggleExpanded(e) {


### PR DESCRIPTION
data-loader-behaior is a mixin that abstracts out data fetching logic
for all tf-*-loader.html. This change moves it out of the scalars plugin
and now applies to histogram and distribution plugins