### PR TITLE
Fixed domain reset bug on charts refresh

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -212,7 +212,6 @@ limitations under the License.
       },
 
       setSeriesData(name, data) {
-        this._resetDomainOnNextLoad = true;
         this.$.chart.setSeriesData(name, data);
       },
 


### PR DESCRIPTION
PR #1375 conflated the ideas and caused explicitly resetted the domain
on any data fetch (even if it is already loaded). This will cause some
other "regression" (typing on tag filter then deleting it quickly causes
chart to not draw any axis) but it should be addressed in other PRs.