### PR TITLE
Paginated-view: forward parent props to child

### DIFF
--- a/tensorboard/components/tf_paginated_view/test/paginatedViewTests.ts
+++ b/tensorboard/components/tf_paginated_view/test/paginatedViewTests.ts
@@ -49,6 +49,7 @@ describe('tf-paginated-view tests', () => {
     view._limit = 2;
     view.getItemKey = ({id}) => id;
     view.items = createItems(5);
+    view.randomNumber = 42;
 
     // allow dom-if to be flushed.
     await flushAllP();
@@ -60,6 +61,13 @@ describe('tf-paginated-view tests', () => {
 
     // 2-4 should be in another page.
     expect(view.querySelector('#id2')).to.be.null;
+  });
+
+  it('responds to ancestor prop change that is bound on template', () => {
+    expect(view.querySelector('#id0').getAttribute('number')).to.equal('42');
+
+    view.randomNumber = 7;
+    expect(view.querySelector('#id0').getAttribute('number')).to.equal('7');
   });
 
   it('navigates to next page when clicked on a button', async () => {

--- a/tensorboard/components/tf_paginated_view/test/tests.html
+++ b/tensorboard/components/tf_paginated_view/test/tests.html
@@ -21,13 +21,39 @@ limitations under the License.
 <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
 
 <body>
+<dom-module id="testable-wrapper">
+<template>
+  <tf-paginated-view2
+    id="paginedView"
+    _limit="[[_limit]]"
+    get-item-key="[[getItemKey]]"
+    items="[[items]]"
+  >
+    <template>
+      <span id$="[[item.id]]" number$="[[randomNumber]]">
+        [[item.content]]
+      </span>
+    </template>
+  </tf-paginated-view2>
+</template>
+<script>
+  Polymer({
+    is: 'testable-wrapper',
+    properties: {
+      randomNumber: {
+        type: Number,
+        value: 0,
+      },
+      _limit: Number,
+      getItemKey: Function,
+      items: Array,
+    },
+  })
+</script>
+</dom-module>
 <test-fixture id="paginatedViewFixture">
   <template>
-    <tf-paginated-view2>
-      <template>
-        <span id$="[[item.id]]">[[item.content]]</span>
-      </template>
-    </tf-paginated-view2>
+    <testable-wrapper></testable-wrapper>
   </template>
 </test-fixture>
 

--- a/tensorboard/components/tf_paginated_view/tf-paginated-view2.html
+++ b/tensorboard/components/tf_paginated_view/tf-paginated-view2.html
@@ -260,6 +260,11 @@ limitations under the License.
     ],
 
     ready() {
+      // Template instance props that should be excluded from forwarding
+     this._instanceProps = {
+       [this.as]: true,
+     };
+
       this.templatize(this.$.template.querySelector('template'));
     },
 
@@ -451,6 +456,27 @@ limitations under the License.
         pageInput.value = newValue;
       }
     },
+
+    // Implements extension point from Templatizer.
+    // Called as side-effect of a host path change, responsible for notifying
+    // parent path change on each inst. Note that changes for props defined on
+    // `this._instanceProps` are omitted from forwarding.
+    _forwardParentProp(prop, value) {
+      this._renderedTemplateInst.forEach(inst => {
+        inst.notifyPath(prop, value, true /* fromAbove */);
+      });
+    },
+
+    // Implements extension point from Templatizer.
+    // Called as side-effect of a host path change, responsible for notifying
+    // parent path change on each inst. Note that changes for props defined on
+    // `this._instanceProps` are omitted from forwarding.
+    _forwardParentPath(path, value) {
+      this._renderedTemplateInst.forEach(inst => {
+        inst.notifyPath(path, value, true /* fromAbove */);
+      });
+    },
+
   });
   </script>
 </dom-module>


### PR DESCRIPTION
As part of `Templatizer` contract, we need to correctly forward bound
value changes to instances.

These subtlety we keep miss are costly and we should re-evaluate our
strategy should this happen more often in the future.