### PR TITLE
Determine if cache should be busted for line-chart

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -108,10 +108,7 @@ limitations under the License.
         if (redrawQueue.length == 0) return;
         const x = redrawQueue.shift();
         if (x.active) {
-          // When incorrectly drawn, Plottable, more specifically, Typesettable,
-          // can have incorrect values in its measurement cache. For correct
-          // axis layout, we must bust the cache.
-          x.redraw(true /* clearCache */);
+          x.redraw();
           x._maybeRenderedInBadState = false;
         }
         window.cancelAnimationFrame(redrawRaf);
@@ -219,11 +216,11 @@ limitations under the License.
         this.$.chart.setSeriesMetadata(name, metadata);
       },
 
-      redraw(clearCache = false) {
+      redraw() {
         cancelAnimationFrame(this._redrawRaf);
         this._redrawRaf = window.requestAnimationFrame(() => {
           if (this.active) {
-            this.$.chart.redraw(clearCache);
+            this.$.chart.redraw();
           } else {
             // If we reached a point where we should render while the page
             // is not active, we've gotten into a bad state.

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -368,9 +368,9 @@ Polymer({
   /**
    * Re-renders the chart. Useful if e.g. the container size changed.
    */
-  redraw: function(clearCache: boolean) {
+  redraw: function() {
     if (this._chart) {
-      this._chart.redraw(clearCache);
+      this._chart.redraw();
     }
   },
 


### PR DESCRIPTION
Plottable caches DOM measurements for performance and it can be poisoned
when used with display: none that dom-if applies. Detect the bad layout
and bust the cache.