### PR TITLE
Downsample histogram tensor before conversion

### DIFF
--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -194,8 +194,8 @@ class HistogramsPlugin(base_plugin.TBPlugin):
       except KeyError:
         raise ValueError('No histogram tag %r for run %r' % (tag, run))
       if downsample_to is not None and len(tensor_events) > downsample_to:
-        rand_indices = random.Random(0).sample(list(range(len(tensor_events))),
-            downsample_to)
+        rand_indices = random.Random(0).sample(
+            six.moves.xrange(len(tensor_events)), downsample_to)
         indices = sorted(rand_indices)
         tensor_events = [tensor_events[i] for i in indices]
       events = [[e.wall_time, e.step, tf.make_ndarray(e.tensor_proto).tolist()]

--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -193,12 +193,13 @@ class HistogramsPlugin(base_plugin.TBPlugin):
         tensor_events = self._multiplexer.Tensors(run, tag)
       except KeyError:
         raise ValueError('No histogram tag %r for run %r' % (tag, run))
+      if downsample_to is not None and len(tensor_events) > downsample_to:
+        rand_indices = random.Random(0).sample(list(range(len(tensor_events))),
+            downsample_to)
+        indices = sorted(rand_indices)
+        tensor_events = [tensor_events[i] for i in indices]
       events = [[e.wall_time, e.step, tf.make_ndarray(e.tensor_proto).tolist()]
                 for e in tensor_events]
-      if downsample_to is not None and len(events) > downsample_to:
-        indices = sorted(random.Random(0).sample(list(range(len(events))),
-                                                 downsample_to))
-        events = [events[i] for i in indices]
     return (events, 'application/json')
 
   def _get_values(self, data_blob, dtype_enum, shape_string):


### PR DESCRIPTION
In one of more realistic event file, we had
N=len(tensor_events)=500, M=max(len(event.tensor_proto))=110,000.
When making burst of requests from the histogram plugin, this large
`c*N*M` the /histograms endpoint to perform really poorly (c=number
of histogram charts on the screen). tf.make_ndarray ideally should
perform better wrt to the input but it can be done/studied separately.

Another way to mitigate the issue is to use ForkingWSGIServer instead
of ThreadedWSGIServer as, in this case, compute power is the bottleneck.
However, we do not have too many compute intensive data endpoints and it
is rather an overkill.