### PR TITLE
Fixed graph edge size computation

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -781,6 +781,7 @@ export class MetaedgeImpl implements Metaedge {
     h.hasShapeInfo = true;
 
     // Sum the sizes of all output tensors.
+    // TODO(stephanwlee): Use Object.values after es2017.
     const values = Object.keys(opNode.outputShapes)
         .map(k => opNode.outputShapes[k])
         .map((shape: number[]) => {

--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -322,7 +322,7 @@ export interface Metanode extends GroupNode {
 
   // The name of the function this metanode is associated with if any.
   associatedFunction: string;
-  
+
   getFirstChild(): GroupNode|OpNode;
   getRootOp(): OpNode;
   /** Return name of all leaves inside a metanode. */
@@ -396,7 +396,7 @@ export class OpNodeImpl implements OpNode {
   // This field is only defined if the op node represents an input_arg to a
   // library function. It is the index of the input_arg.
   functionInputIndex: number;
-  
+
   // This field is only defined if the op node represents an output_arg of a
   // library function. It is the index of the output_arg.
   functionOutputIndex: number;
@@ -781,24 +781,27 @@ export class MetaedgeImpl implements Metaedge {
     h.hasShapeInfo = true;
 
     // Sum the sizes of all output tensors.
-    return _(opNode.outputShapes).mapValues((shape: number[]) => {
-      // If the shape is unknown, treat it as 1 when computing
-      // total size. This gives a lower bound for the total size.
-      if (shape == null) {
-        return 1;
-      }
-      // Multiply all shapes to get the total size of the tensor.
-      // E.g. The total size of [4, 2, 1] is 4 * 2 * 1.
-      return _(shape).reduce((accumulated, currSize) => {
-        // If this particular dimension is unknown, treat
-        // it as 1 when computing total size. This gives a lower bound
-        // for the total size.
-        if (currSize === -1) {
-          currSize = 1;
-        }
-        return accumulated * currSize;
-      }, 1);
-    }).sum();
+    const values = Object.keys(opNode.outputShapes)
+        .map(k => opNode.outputShapes[k])
+        .map((shape: number[]) => {
+          // If the shape is unknown, treat it as 1 when computing
+          // total size. This gives a lower bound for the total size.
+          if (shape == null) {
+            return 1;
+          }
+          // Multiply all shapes to get the total size of the tensor.
+          // E.g. The total size of [4, 2, 1] is 4 * 2 * 1.
+          return shape.reduce((accumulated, currSize) => {
+            // If this particular dimension is unknown, treat
+            // it as 1 when computing total size. This gives a lower bound
+            // for the total size.
+            if (currSize === -1) {
+              currSize = 1;
+            }
+            return accumulated * currSize;
+          }, 1);
+        });
+    return _.sum(values);
   }
 }
 

--- a/tensorboard/plugins/graph/tf_graph_common/template.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/template.ts
@@ -81,21 +81,23 @@ function getSignature(metanode) {
  */
 function clusterSimilarSubgraphs(h: hierarchy.Hierarchy) {
   /** a dict from metanode.signature() => Array of tf.graph.Groups */
-  let hashDict = _(h.getNodeMap()).reduce(
-      (hash, node: OpNode|Metanode, name) => {
+  const map = h.getNodeMap();
+  let hashDict = Object.keys(map).reduce(
+      (reduced: Object, name: string) => {
+    const node: OpNode|GroupNode = map[name];
     if (node.type !== NodeType.META) {
-      return hash;
+      return reduced;
     }
     let levelOfMetaNode = name.split('/').length - 1;
     let signature = getSignature(node);
-    let templateInfo = hash[signature] ||
+    let templateInfo = reduced[signature] ||
       {nodes: [], level: levelOfMetaNode};
-    hash[signature] = templateInfo;
+    reduced[signature] = templateInfo;
     templateInfo.nodes.push(node);
     if (templateInfo.level > levelOfMetaNode) {
       templateInfo.level = levelOfMetaNode;
     }
-    return hash;
+    return reduced;
   }, {});
 
   return Object.keys(hashDict)

--- a/tensorboard/plugins/graph/tf_graph_common/test/hierarchy-test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/test/hierarchy-test.ts
@@ -12,12 +12,150 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+const {expect} = chai;
 
-describe('graph', () => {
-  let assert = chai.assert;
+describe('hierarchy', () => {
+  beforeEach(function() {
+    const pbtxt = tf.graph.test.util.stringToArrayBuffer(`
+      node {
+        name: "Q"
+        op: "VariableV2"
+        attr {
+          key: "_output_shapes"
+          value {
+            list {
+              shape {
+                dim {
+                  size: 100
+                }
+                dim {
+                  size: 200
+                }
+              }
+            }
+          }
+        }
+        attr {
+          key: "container"
+          value {
+            s: ""
+          }
+        }
+        attr {
+          key: "dtype"
+          value {
+            type: DT_FLOAT
+          }
+        }
+        attr {
+          key: "shape"
+          value {
+            shape {
+              dim {
+                size: 100
+              }
+              dim {
+                size: 200
+              }
+            }
+          }
+        }
+      }
+      node {
+        name: "W"
+        op: "VariableV2"
+        attr {
+          key: "_output_shapes"
+          value {
+            list {
+              shape {
+                dim {
+                  size: 200
+                }
+                dim {
+                  size: 100
+                }
+              }
+            }
+          }
+        }
+        attr {
+          key: "container"
+          value {
+            s: ""
+          }
+        }
+        attr {
+          key: "dtype"
+          value {
+            type: DT_FLOAT
+          }
+        }
+        attr {
+          key: "shape"
+          value {
+            shape {
+              dim {
+                size: 200
+              }
+              dim {
+                size: 100
+              }
+            }
+          }
+        }
+      }
+      node {
+        name: "Y"
+        op: "MatMul"
+        input: "Q"
+        input: "W"
+      }`);
+    const buildParams: tf.graph.BuildParams = {
+      enableEmbedding: true,
+      inEmbeddingTypes: ['Const'],
+      outEmbeddingTypes: ['^[a-zA-Z]+Summary$'],
+      refEdges: {}
+    };
+    this.dummyTracker = tf.graph.util.getTracker({
+      set: () => {},
+      progress: 0,
+    });
+    this.options = {
+      verifyTemplate: true,
+      seriesNodeMinSize: 5,
+      seriesMap: {},
+      rankDirection: '',
+      useGeneralizedSeriesPatterns: false,
+    };
+    return tf.graph.parser.parseGraphPbTxt(pbtxt)
+        .then(nodes => tf.graph.build(nodes, buildParams, this.dummyTracker))
+        .then((graph: tf.graph.SlimGraph) => this.slimGraph = graph)
+  });
 
-  it('graphlib exists', () => { assert.isTrue(graphlib != null); });
+  it('builds hierarchy with metagraph', function() {
+    return tf.graph.hierarchy
+        .build(this.slimGraph, this.options, this.dummyTracker)
+        .then(hierarchy => {
+          if (!hierarchy) throw new Error('Expected hierarchy to be built')
+          expect(hierarchy.hasShapeInfo).to.be.true
+          expect(hierarchy.maxMetaEdgeSize).to.equal(20000);
+          expect(hierarchy.root.metagraph.edge('Q', 'Y')).to.exist;
+          expect(hierarchy.root.metagraph.edge('W', 'Y')).to.exist;
+          // Not symmetric.
+          expect(hierarchy.root.metagraph.edge('Y', 'Q')).to.not.exist;
+          // Two variables are not connected directly.
+          expect(hierarchy.root.metagraph.edge('Q', 'W')).to.not.exist;
 
-  // TODO: write tests.
+          const edge = hierarchy.root.metagraph.edge('Q', 'Y');
+          expect(edge.totalSize).to.equal(20000);
+          expect(edge.v).to.equal('Q');
+          expect(edge.w).to.equal('Y');
+        });
+  });
 
+  /* TODO(tensorflow-authors): write more test on cases when there are no
+   *  connections, misses shape info, scalar, and graph with grouping.
+   * Might be better to write an integrational test with a complex graph.pbtxt.
+   */
 });

--- a/tensorboard/plugins/graph/tf_graph_common/test/util-test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/test/util-test.ts
@@ -43,14 +43,4 @@ describe('util', () => {
     result = tf.graph.util.removeCommonPrefix(['q/w/', 'q/w/b', 'q/w/c/f']);
     assert.deepEqual(result, ['q/w/', 'q/w/b', 'q/w/c/f']);
   });
-
-  it('query params', () => {
-    // Starts with question mark.
-    let queryParams = tf.graph.util.getQueryParams('?foo=1&bar=2');
-    assert.deepEqual(queryParams, {'foo': '1', 'bar': '2'});
-
-    // No question mark.
-    queryParams = tf.graph.util.getQueryParams('foo=1&bar=2');
-    assert.deepEqual(queryParams, {'foo': '1', 'bar': '2'});
-  });
 });

--- a/tensorboard/plugins/graph/tf_graph_common/util.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/util.ts
@@ -270,26 +270,6 @@ module tf.graph.util {
   }
 
   /**
-   * Given a queryString, aka ?foo=1&bar=2, return the object representation.
-   */
-  export function getQueryParams(queryString: string) {
-    if (queryString.charAt(0) === '?') {
-      queryString = queryString.slice(1);
-    }
-
-    let queryParams = _.chain(queryString.split('&'))
-                          .map((item) => {
-                            if (item) {
-                              return item.split('=');
-                            }
-                          })
-                          .compact()
-                          .value();
-
-    return _.object(queryParams);
-  }
-
-  /**
    * Given a timestamp in microseconds, return a human-friendly string denoting
    * how long ago the timestamp was.
    */


### PR DESCRIPTION
When we upgraded the Lodash from 3 to 4, it broke one of the private
method used to comput the size. According to
https://lodash.com/docs/4.17.10#lodash, `sum` is no longer chainable
breaking the method.

Though we tried to add tests to detect such breakage but graph code
is massive nad is largely untested. Since we cannot add all the tests at
once, we added one simple test, as a start.