### PR TITLE
Make toolbar title to be a link to root page

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -59,7 +59,7 @@ limitations under the License.
     <paper-header-panel>
       <paper-toolbar id="toolbar" slot="header">
         <div id="toolbar-content" slot="top">
-          <div class="toolbar-title">[[brand]]</div>
+          <a class="toolbar-title" href="/">[[brand]]</a>
           <template is="dom-if" if="[[_activeDashboardsNotLoaded]]">
             <span class="toolbar-message">
               Loading active dashboards&hellip;
@@ -237,6 +237,8 @@ limitations under the License.
         letter-spacing: -0.025em;
         font-weight: 500;
         display: var(--tb-toolbar-title-display, block);
+        color: unset;
+        text-decoration: none;
       }
 
       .toolbar-message {


### PR DESCRIPTION
There is toolbar title at the top left of every page:

![image](https://user-images.githubusercontent.com/6505554/47458922-842eae80-d7e3-11e8-87bd-69585b85f236.png)

This pr changes it to be a link to root page (that is `/`)?
It is common practice and also will be useful to reset display settings which are stored in url.

Thank you.