### PR TITLE
Change CorePluginTest to use memory-only zipfile

### DIFF
--- a/tensorboard/plugins/core/BUILD
+++ b/tensorboard/plugins/core/BUILD
@@ -28,7 +28,6 @@ py_test(
     name = "core_plugin_test",
     size = "small",
     srcs = ["core_plugin_test.py"],
-    data = ["test_webfiles.zip"],
     srcs_version = "PY2AND3",
     deps = [
         ":core_plugin",
@@ -39,17 +38,4 @@ py_test(
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],
-)
-
-tf_web_library(
-    name = "test_assets",
-    testonly = 1,
-    srcs = ["index.html"],
-    path = "/",
-)
-
-tensorboard_zip_file(
-    name = "test_webfiles",
-    testonly = 1,
-    deps = [":test_assets"],
 )

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -385,7 +385,7 @@ def get_test_assets_zip_provider():
   memfile = six.BytesIO()
   with zipfile.ZipFile(memfile, mode='w', compression=zipfile.ZIP_DEFLATED) as zf:
     zf.writestr('index.html', FAKE_INDEX_HTML)
-  return lambda: six.BytesIO(memfile.getbuffer())
+  return lambda: six.BytesIO(memfile.getvalue())
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -23,6 +23,7 @@ import json
 import os
 import shutil
 import sqlite3
+import zipfile
 
 import six
 import tensorflow as tf
@@ -33,6 +34,9 @@ from tensorboard.backend import application
 from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.core import core_plugin
+
+
+FAKE_INDEX_HTML = b'<!doctype html><title>fake-index</title>'
 
 
 class FakeFlags(object):
@@ -104,7 +108,7 @@ class CorePluginTest(tf.test.TestCase):
     self.assertEqual(200, response.status_code)
     self.assertStartsWith(response.headers.get('Content-Type'), 'text/html')
     html = response.get_data()
-    self.assertStartsWith(html, b'<!doctype html>')
+    self.assertEqual(html, FAKE_INDEX_HTML)
 
   def testDataPaths_disableAllCaching(self):
     """Test the format of the /data/runs endpoint."""
@@ -378,12 +382,10 @@ class CorePluginUsingMetagraphOnlyTest(CorePluginTest):
 
 
 def get_test_assets_zip_provider():
-  path = os.path.join(tf.resource_loader.get_data_files_path(),
-                      'test_webfiles.zip')
-  if not os.path.exists(path):
-    tf.logging.warning('test_webfiles.zip static assets not found: %s', path)
-    return None
-  return lambda: open(path, 'rb')
+  memfile = six.BytesIO()
+  with zipfile.ZipFile(memfile, mode='w', compression=zipfile.ZIP_DEFLATED) as zf:
+    zf.writestr('index.html', FAKE_INDEX_HTML)
+  return lambda: six.BytesIO(memfile.getbuffer())
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import contextlib
 import json
 import os
 import shutil
@@ -385,7 +386,7 @@ def get_test_assets_zip_provider():
   memfile = six.BytesIO()
   with zipfile.ZipFile(memfile, mode='w', compression=zipfile.ZIP_DEFLATED) as zf:
     zf.writestr('index.html', FAKE_INDEX_HTML)
-  return lambda: six.BytesIO(memfile.getvalue())
+  return lambda: contextlib.closing(six.BytesIO(memfile.getvalue()))
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/core/index.html
+++ b/tensorboard/plugins/core/index.html
@@ -1,2 +1,0 @@
-<!doctype html>
-<p>This is a fake TensorBoard index page.


### PR DESCRIPTION
This simplifies CorePluginTest so that it uses a fake `assets_zip_provider` that's backed by a transient in-memory zipfile, rather than actually building a real zipfile from a source-controlled index.html and passing it in as a data dependency to the test.

This way the test can't fail unintentionally due to changes in the index.html file such as those in #1546.