### PR TITLE
Fix debugger plugin source code viewer "_.contains not found" error

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-source-code-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-source-code-view.html
@@ -516,7 +516,7 @@ limitations under the License.
         linenoToNodeNameAndStackPos[lineno] =
             linenoToNodeNameAndStackPos[lineno].filter(line => {
               const nodeName = line[0];
-              return _.contains(watchedNodeNames, nodeName);
+              return _.includes(watchedNodeNames, nodeName);
             });
       }
     },
@@ -623,7 +623,7 @@ limitations under the License.
           const fullFilePath = stackFrame[0];
           const lineno = Number(stackFrame[1]);
           frameElement.textContent = fullFilePath + ': ' + String(lineno);
-          if (_.contains(this._fullFilePaths, fullFilePath)) {
+          if (_.includes(this._fullFilePaths, fullFilePath)) {
             frameElement.classList.add('stack-frame-clickable');
             // TODO(cais): Make class CSS work.
             frameElement.style['color'] = 'blue';


### PR DESCRIPTION
Hi all,

The source code view in the debugger plugin isn't working. The code tries to call `_.contains`, which is a method in Underscore, but not Lodash, which is the actual library used. Changing the call to `_.includes` fixes things.