### PR TITLE
Fixed flag parsing in TB.configure

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -63,9 +63,11 @@ py_test(
     srcs = ["program_test.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":default",
         ":program",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
+        "//tensorboard/plugins/core:core_plugin",
         "@org_pocoo_werkzeug",
     ],
 )

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -160,7 +160,7 @@ class TensorBoard(object):
           raise ValueError('Conflicting Abseil flag: %s' % flag.name)
         setattr(flags, flag.name, flag.value)
     for k, v in kwargs.items():
-      if hasattr(flags, k):
+      if not hasattr(flags, k):
         raise ValueError('Unknown TensorBoard flag: %s' % k)
       setattr(flags, k, v)
     for loader in self.plugin_loaders:

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -24,6 +24,20 @@ import six
 import tensorflow as tf
 
 from tensorboard import program
+from tensorboard.plugins.core import core_plugin
+
+
+class TensorBoardTest(tf.test.TestCase):
+  """Tests the TensorBoard program."""
+
+  def testConfigure(self):
+    # Many useful flags are defined under the core plugin.
+    tb = program.TensorBoard(plugins=[core_plugin.CorePluginLoader()])
+    tb.configure(logdir='foo')
+    self.assertStartsWith(tb.flags.logdir, 'foo')
+
+    with six.assertRaisesRegex(self, ValueError, 'Unknown TensorBoard flag'):
+      tb.configure(foo='bar')
 
 
 class WerkzeugServerTest(tf.test.TestCase):


### PR DESCRIPTION
Due to the inverted predicate on if, a legal flag was reported as
unknown to TensorBoard.

Added small test that does a sanity check against the bug.