### PR TITLE
FIX: chart correctly shows series when toggled

### DIFF
--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -254,7 +254,8 @@ Polymer({
 
   observers: [
     '_makeChart(xComponentsCreationMethod, xType, yValueAccessor, yScaleType, tooltipColumns, colorScale, isAttached)',
-    '_reloadFromCache(_chart)',
+    // Refer to the cache and, if available, load data of a new visible series.
+    '_reloadFromCache(_chart, _visibleSeriesCache)',
     '_smoothingChanged(smoothingEnabled, smoothingWeight, _chart)',
     '_tooltipSortingMethodChanged(tooltipSortingMethod, _chart)',
     '_outliersChanged(ignoreYOutliers, _chart)',
@@ -318,10 +319,6 @@ Polymer({
   setVisibleSeries: function(names) {
     if (_.isEqual(this._visibleSeriesCache, names)) return;
     this._visibleSeriesCache = names;
-    if (this._chart) {
-      this._chart.setVisibleSeries(names);
-      this.redraw();
-    }
   },
 
   /**


### PR DESCRIPTION
Repro steps:
1. Display two series
2. Toggle off one series (using run selector)
3. Create a new chart instance by say toggle log scale
4. Toggle on the series that got turned off
5. ?? where is the second series?

This bug happened at least since TB==1.7 and is not a recent regression.