### PR TITLE
Remove redundant logic when setting up the Closure Compiler dependency options.

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -39,7 +39,6 @@ import com.google.javascript.jscomp.DiagnosticGroup;
 import com.google.javascript.jscomp.DiagnosticGroups;
 import com.google.javascript.jscomp.DiagnosticType;
 import com.google.javascript.jscomp.JSError;
-import com.google.javascript.jscomp.ModuleIdentifier;
 import com.google.javascript.jscomp.PropertyRenamingPolicy;
 import com.google.javascript.jscomp.Result;
 import com.google.javascript.jscomp.SourceFile;
@@ -69,7 +68,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Comment;
@@ -440,27 +438,17 @@ public final class Vulcanize {
 
     // Dependency management.
     options.setClosurePass(true);
-    options.setManageClosureDependencies(true);
-    // TODO turn dependency pruning back on. ES6 modules are currently (incorrectly) considered moochers.
-    // Once the compiler no longer considers them moochers the dependencies will be in an incorrect order.
-    // The compiler will put moochers first, then other explicit entry points (if something is an entry
-    // point and a moocher it goes first). vz-example-viewer.ts generates an ES6 module JS, and it will
-    // soon no longer be considered a moocher and be moved after its use in some moochers. The TS 
-    // generation should not generate an ES6 module (a file with just goog.requires is a moocher!), or
-    // vz-example-viewer should be imported by the code that uses it rather than rely on the input order 
-    // to the compiler. Or we should verify that the input order to the compiler is 100% correct and turn
-    // off dependency sorting.
-    options.getDependencyOptions().setDependencyPruning(false);
+    // TODO turn dependency pruning back on. ES6 modules are currently (incorrectly) considered
+    // moochers. Once the compiler no longer considers them moochers the dependencies will be in an
+    // incorrect order. The compiler will put moochers first, then other explicit entry points
+    // (if something is both an entry point and a moocher it goes first). vz-example-viewer.ts
+    // generates an ES6 module JS, and it will soon no longer be considered a moocher and be moved
+    // after its use in some moochers. To reenable dependency pruning, either the TS generation
+    // should not generate an ES6 module (a file with just goog.requires is a moocher!),
+    // or vz-example-viewer should be explicitly imported by the code that uses it. Alternatively,
+    // we could ensure that the input order to the compiler is correct and all inputs are used, and
+    // turn off both sorting and pruning.
     options.getDependencyOptions().setDependencySorting(true);
-    options.getDependencyOptions().setMoocherDropping(false);
-    options.getDependencyOptions()
-        .setEntryPoints(
-            sourceTags
-                .keySet()
-                .stream()
-                .map(Webpath::toString)
-                .map(ModuleIdentifier::forFile)
-                .collect(Collectors.toList()));
 
     // Polymer pass.
     options.setPolymerVersion(1);


### PR DESCRIPTION
- setDependencySorting(false), setDependencyPruning(false) and setMoocherDropping(false) are the initial value of DependencyOptions.
- setManageClosureDependencies(true) is equivalent to setDependencySorting(true), setDependencyPruning(true) and setMoocherDropping(false).
- setEntryPoints() is a no-op unless setDependencyPruning(true).