### PR TITLE
Improved log scale padding logic

### DIFF
--- a/tensorboard/components/vz_line_chart2/log-scale.ts
+++ b/tensorboard/components/vz_line_chart2/log-scale.ts
@@ -17,7 +17,7 @@ namespace vz_line_chart2 {
 // Smallest positive non-zero value represented by IEEE 754 binary (64 bit)
 // floating-point number.
 // https://www.ecma-international.org/ecma-262/5.1/#sec-8.5
-const MIN_POSITIVE_VALUE = Math.pow(2, -1074);
+export const MIN_POSITIVE_VALUE = Math.pow(2, -1074);
 
 function log(x: number): number {
   return Math.log10(x);
@@ -27,6 +27,13 @@ function pow(x: number): number {
   return Math.pow(10, x);
 }
 
+/**
+ * A logarithmic scale that returns NaN for all non-positive values as it
+ * mathematically is supposed to be -Infinity. Also, due to the floating point
+ * precision issue, it treats all values smaller than MIN_POSITIVE_VALUE as
+ * non-positive. Lastly, if using autoDomain feature and if all values are the
+ * same value, it pads 10% of the value.
+ */
 export class LogScale extends TfScale {
   private _d3LogScale = d3.scaleLog();
   private _untransformedDomain: number[];
@@ -75,12 +82,11 @@ export class LogScale extends TfScale {
     const [low, high] = domain;
     const adjustedLogLow = Math.max(log(MIN_POSITIVE_VALUE), log(low));
     const logHigh = log(high);
-    const pad = (logHigh - adjustedLogLow) * this.padProportion();
-    const logLowFloor = Math.floor(adjustedLogLow);
-    const logHighCeil = Math.ceil(logHigh);
+    const spread = logHigh - adjustedLogLow;
+    const pad = spread ? spread * this.padProportion() : 1;
     return [
-      pow(Math.max(log(MIN_POSITIVE_VALUE), adjustedLogLow - pad, logLowFloor)),
-      pow(Math.min(logHigh + pad, logHighCeil)),
+      pow(Math.max(log(MIN_POSITIVE_VALUE), adjustedLogLow - pad)),
+      pow(logHigh + pad),
     ];
   }
 

--- a/tensorboard/components/vz_line_chart2/test/BUILD
+++ b/tensorboard/components/vz_line_chart2/test/BUILD
@@ -1,0 +1,24 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//tensorboard:internal"],
+)
+
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_library(
+    name = "test",
+    srcs = [
+        "log-scale-test.ts",
+        "tests.html",
+    ],
+    path = "/vz-line-chart2/test",
+    deps = [
+        "//tensorboard/components/tf_imports:plottable",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_imports:web_component_tester",
+        "//tensorboard/components/tf_imports:webcomponentsjs",
+        "//tensorboard/components/vz_line_chart2",
+    ],
+)

--- a/tensorboard/components/vz_line_chart2/test/log-scale-test.ts
+++ b/tensorboard/components/vz_line_chart2/test/log-scale-test.ts
@@ -1,0 +1,142 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace vz_line_chart2 {
+
+const {expect} = chai;
+
+describe('LogScale', () => {
+  beforeEach(function() {
+    this.scale = new LogScale();
+    this.scale.range([0, 1]);
+    this.scale.setValueProviderForDomain(() => [1, 1000]);
+  });
+
+  describe('manual domain', () => {
+    beforeEach(function() {
+      this.scale.domain([1, 1000]);
+    });
+
+    it('returns scales input correctly to an output between 0-1', function() {
+      expect(this.scale.scale(1)).to.equal(0);
+      expect(this.scale.scale(1000)).to.equal(1);
+    });
+
+    it('returns value outside of range when given input smaller/larger ' +
+        'than the domain', function() {
+      expect(this.scale.scale(1e-3)).to.equal(-1);
+      expect(this.scale.scale(1e6)).to.equal(2);
+      expect(this.scale.scale(1e9)).to.equal(3);
+    });
+
+    it('returns NaN for non-positive values', function() {
+      expect(this.scale.scale(0)).to.be.NaN;
+      expect(this.scale.scale(-1)).to.be.NaN;
+      expect(this.scale.scale(-.00001)).to.be.NaN;
+      expect(this.scale.scale(-Infinity)).to.be.NaN;
+      expect(this.scale.scale(NaN)).to.be.NaN;
+    });
+
+    it('ignores padProportion', function() {
+      this.scale.padProportion(0.3);
+      expect(this.scale.scale(1)).to.equal(0);
+      expect(this.scale.scale(1000)).to.equal(1);
+
+      this.scale.padProportion(1);
+      expect(this.scale.scale(1)).to.equal(0);
+      expect(this.scale.scale(1000)).to.equal(1);
+    });
+  });
+
+  describe('auto domain', () => {
+    beforeEach(function() {
+      this.scale.autoDomain();
+    });
+
+    describe('padding-less', () => {
+      beforeEach(function() {
+        this.scale.padProportion(0);
+      });
+
+      it('returns scales input correctly to an output between 0-1', function() {
+        expect(this.scale.scale(1)).to.equal(0);
+        expect(this.scale.scale(1000)).to.equal(1);
+      });
+
+      it('returns value outside of range when given input smaller/larger ' +
+          'than the domain', function() {
+        expect(this.scale.scale(1e-3)).to.equal(-1);
+        expect(this.scale.scale(1e6)).to.equal(2);
+        expect(this.scale.scale(1e9)).to.equal(3);
+      });
+
+      it('returns NaN for non-positive values', function() {
+        expect(this.scale.scale(0)).to.be.NaN;
+        expect(this.scale.scale(-1)).to.be.NaN;
+        expect(this.scale.scale(-.00001)).to.be.NaN;
+        expect(this.scale.scale(-Infinity)).to.be.NaN;
+        expect(this.scale.scale(NaN)).to.be.NaN;
+      });
+    });
+
+    describe('padding-full', () => {
+      beforeEach(function() {
+        // Spread is 3 = log_10(1000) - log_10(1) and since we want 33% of the
+        // spread to be the padding, pad = 3 * .33333 ~ 1, the domain should be
+        // from ~0.1 to ~1e4
+        this.scale.padProportion(.33333);
+      });
+
+      it('pads domain', function() {
+        expect(this.scale.invert(0)).to.be.closeTo(.1, .01);
+        expect(this.scale.invert(1)).to.be.closeTo(1e4, 10);
+      });
+
+      it('puts some padding even if there is no spread', function() {
+        this.scale.setValueProviderForDomain(() => [1, 1]);
+        this.scale.autoDomain();
+        expect(this.scale.invert(0)).to.equal(.1);
+        expect(this.scale.invert(1)).to.equal(10);
+
+        this.scale.setValueProviderForDomain(() => [1000, 1000]);
+        this.scale.autoDomain();
+        expect(this.scale.invert(0)).to.equal(100);
+        expect(this.scale.invert(1)).to.equal(10000);
+
+        this.scale.setValueProviderForDomain(() => [.01, .01]);
+        this.scale.autoDomain();
+        expect(this.scale.invert(0)).to.equal(.001);
+        expect(this.scale.invert(1)).to.equal(.1);
+
+        this.scale.setValueProviderForDomain(
+            () => [MIN_POSITIVE_VALUE, MIN_POSITIVE_VALUE]);
+        this.scale.autoDomain();
+        expect(this.scale.invert(0)).to.be.equal(5e-324);
+        expect(this.scale.invert(1)).to.be.equal(5e-323);
+      });
+
+      it('puts padding even if values are very even number', function() {
+        // domain of [1, 1000] result in very clean mapping between domain and
+        // the range -- i.e., 1 -> 0 and 1000 to 1. If naively use ceil or floor
+        // to compute a "nice domain" for [1, 1000], it can lead to no padding
+        // causing some visual issue. Make sure there are padding present even
+        // with these very even number.
+        expect(this.scale.invert(0)).to.be.closeTo(.1, .01).and.not.equal(1);
+        expect(this.scale.invert(1)).to.be.closeTo(1e4, 10).and.not.equal(1000);
+      });
+    });
+  });
+});
+
+}  // namespace vz_line_chart2

--- a/tensorboard/components/vz_line_chart2/test/tests.html
+++ b/tensorboard/components/vz_line_chart2/test/tests.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<!--
+@license
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<meta charset="utf-8">
+<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../web-component-tester/browser.js"></script>
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../tf-imports/plottable.html">
+<script src="../tf-scale.js"></script>
+<script src="../log-scale.js"></script>
+<body>
+<script src="log-scale-test.js"></script>


### PR DESCRIPTION
When min and max values are multiple of 10, it had no padding causing
some visual discomfort.
Also, when value do not vary like [1, 1, 1], now we put some padding.

Added few basic tests around it.