### PR TITLE
Fix the issue where minimap content gets clipped

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/minimap.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/minimap.ts
@@ -192,6 +192,14 @@ export class Minimap {
     let zoomTransform = $zoomG.attr('transform');
     $zoomG.attr('transform', null);
 
+    // https://github.com/tensorflow/tensorboard/issues/1598
+    // Account for SVG content shift. SVGGraphicsElement.getBBox().width returns
+    // width in pixel value of very tight bounding box of non-empty content.
+    // Since we want to measure the sceneSize from the origin to the right most
+    // edge of the right most node, we need to account for distance from the
+    // origin to the left edge of the bounding box.
+    sceneSize.height += sceneSize.y;
+    sceneSize.width += sceneSize.x;
     // Since we add padding, account for that here.
     sceneSize.height += this.labelPadding * 2;
     sceneSize.width += this.labelPadding * 2;


### PR DESCRIPTION
Bug: https://github.com/tensorflow/tensorboard/issues/1574
Cause: the graph contains no main graph node and all nodes are
auxilliary nodes. As a result, the drawn nodes are shifted right by
predefined amount for visuals. When measuring the bounding box of the
scene to draw the minimap, we were measuring using
SVGGraphicsElement.getBBox which returned BBox without any whitespace.
As a result, although we wanted the width from the origin to right edge
of the right most node, we were omitting the origin to left most edge
of the content resulting in clipped content in the minimap.

Fixes #1598.