### PR TITLE
Adding a callback to data-loader-behavior to allow customizing the HTTP request.

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -45,6 +45,7 @@ limitations under the License.
       data-to-load="[[dataToLoad]]"
       get-data-load-name="[[_getDataLoadName]]"
       get-data-load-url="[[getDataLoadUrl]]"
+      request-data="[[requestData]]"
       ignore-y-outliers="[[ignoreYOutliers]]"
       load-data-callback="[[_loadDataCallback]]"
       load-key="[[tag]]"
@@ -251,6 +252,14 @@ limitations under the License.
             }
           },
         },
+
+        // A function called to fetch the scalars data from the backend.
+        // Should receive a {tag, run, experiment} object and return
+        // a promise resolving with the fetched scalars. The default
+        // implementation of this function executes:
+        // this.requestManager.request(
+        //      this.getDataLoadUrl(tag, run, experiment})
+        requestData: Function,
 
         _getDataLoadName: {
           type: Function,

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -258,7 +258,7 @@ limitations under the License.
         // a promise resolving with the fetched scalars. The default
         // implementation of this function executes:
         // this.requestManager.request(
-        //      this.getDataLoadUrl(tag, run, experiment})
+        //      this.getDataLoadUrl({tag, run, experiment})
         requestData: Function,
 
         _getDataLoadName: {


### PR DESCRIPTION
This is needed in the HParams plugin since the API method that gets the metric values uses a POST not a GET.
@stephanwlee , @nfelt , @jart  Please take a look.