### PR TITLE
Specify recommended file type on graph upload btn

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -373,11 +373,18 @@ paper-dropdown-menu {
   <template is="dom-if" if="[[showUploadButton]]">
     <div class="control-holder">
       <div class="title">Upload</div>
-      <paper-button raised class="upload-button" on-click="_getFile">
+      <paper-button raised class="upload-button"
+          on-click="_getFile"
+          title="Upload a graph pbtxt file to view the graph">
         Choose File
       </paper-button>
       <div class="hidden-input">
-        <input type="file" id="file" name="file" on-change="_updateFileInput" />
+        <input
+            type="file"
+            id="file"
+            name="file"
+            on-change="_updateFileInput"
+            accept=".pbtxt" />
       </div>
     </div>
   </template>


### PR DESCRIPTION
Guide user to upload pbtxt to the graph plugin. Without it
users were confused and tried to upload event file.

User can override the "accepts" and select any file with any extensions.

![image](https://user-images.githubusercontent.com/2547313/48282270-1a7ee900-e40e-11e8-8e81-4c12e6cb880a.png)
