### PR TITLE
Infer name of exp when using db_import

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -204,8 +204,9 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":db_import_multiplexer",
-        "//tensorboard/backend:application",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:application",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
     ],
 )
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -205,8 +205,6 @@ py_test(
     deps = [
         ":db_import_multiplexer",
         "//tensorboard:expect_tensorflow_installed",
-        "//tensorboard/backend:application",
-        "//tensorboard/compat/proto:protos_all_py_pb2",
     ],
 )
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -197,6 +197,18 @@ py_library(
     ],
 )
 
+py_test(
+    name = "db_import_multiplexer_test",
+    size = "small",
+    srcs = ["db_import_multiplexer_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":db_import_multiplexer",
+        "//tensorboard/backend:application",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
 py_library(
     name = "sqlite_writer",
     srcs = [

--- a/tensorboard/backend/event_processing/db_import_multiplexer.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer.py
@@ -108,10 +108,11 @@ class DbImportMultiplexer(object):
       tf.logging.info('Processing directory %s', subdir)
       if subdir not in self._run_loaders:
         tf.logging.info('Creating DB loader for directory %s', subdir)
+        exp_name, run_name = self._get_exp_and_run_names(path, subdir, name)
         self._run_loaders[subdir] = _RunLoader(
             subdir=subdir,
-            experiment_name=(name or path),
-            run_name=os.path.relpath(subdir, path))
+            experiment_name=exp_name,
+            run_name=run_name)
     tf.logging.info('Done with AddRunsFromDirectory: %s', path)
 
   def Reload(self):
@@ -171,6 +172,13 @@ class DbImportMultiplexer(object):
       del self._run_loaders[loader.subdir]
     tf.logging.info('Finished with DbImportMultiplexer.Reload()')
 
+  def _get_exp_and_run_names(self, path, subdir, exp_name_override=None):
+    if exp_name_override is not None:
+      return (exp_name_override, os.path.relpath(subdir, path))
+    path_parts = os.path.normpath(os.path.relpath(subdir, path)).split(os.sep)
+    exp_name = path_parts[0]
+    run_name = os.sep.join(path_parts[1:]) or '.'
+    return (exp_name, run_name)
 
 # Struct holding a list of tf.Event serialized protos along with metadata about
 # the associated experiment and run.

--- a/tensorboard/backend/event_processing/db_import_multiplexer.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer.py
@@ -172,13 +172,14 @@ class DbImportMultiplexer(object):
       del self._run_loaders[loader.subdir]
     tf.logging.info('Finished with DbImportMultiplexer.Reload()')
 
-  def _get_exp_and_run_names(self, path, subdir, exp_name_override=None):
-    if exp_name_override is not None:
-      return (exp_name_override, os.path.relpath(subdir, path))
-    path_parts = os.path.normpath(os.path.relpath(subdir, path)).split(os.sep)
-    exp_name = path_parts[0]
-    run_name = os.sep.join(path_parts[1:]) or '.'
-    return (exp_name, run_name)
+  def _get_exp_and_run_names(self, path, subdir, experiment_name_override=None):
+    if experiment_name_override is not None:
+      return (experiment_name_override, os.path.relpath(subdir, path))
+    sep = io_wrapper.PathSeparator(path)
+    path_parts = os.path.relpath(subdir, path).split(sep)
+    experiment_name = path_parts[0]
+    run_name = sep.join(path_parts[1:]) or '.'
+    return (experiment_name, run_name)
 
 # Struct holding a list of tf.Event serialized protos along with metadata about
 # the associated experiment and run.

--- a/tensorboard/backend/event_processing/db_import_multiplexer.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer.py
@@ -108,10 +108,11 @@ class DbImportMultiplexer(object):
       tf.logging.info('Processing directory %s', subdir)
       if subdir not in self._run_loaders:
         tf.logging.info('Creating DB loader for directory %s', subdir)
-        exp_name, run_name = self._get_exp_and_run_names(path, subdir, name)
+        names = self._get_exp_and_run_names(path, subdir, name)
+        experiment_name, run_name = names
         self._run_loaders[subdir] = _RunLoader(
             subdir=subdir,
-            experiment_name=exp_name,
+            experiment_name=experiment_name,
             run_name=run_name)
     tf.logging.info('Done with AddRunsFromDirectory: %s', path)
 
@@ -176,9 +177,9 @@ class DbImportMultiplexer(object):
     if experiment_name_override is not None:
       return (experiment_name_override, os.path.relpath(subdir, path))
     sep = io_wrapper.PathSeparator(path)
-    path_parts = os.path.relpath(subdir, path).split(sep)
+    path_parts = os.path.relpath(subdir, path).split(sep, 1)
     experiment_name = path_parts[0]
-    run_name = sep.join(path_parts[1:]) or '.'
+    run_name = path_parts[1] if len(path_parts) == 2 else '.'
     return (experiment_name, run_name)
 
 # Struct holding a list of tf.Event serialized protos along with metadata about

--- a/tensorboard/backend/event_processing/db_import_multiplexer.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer.py
@@ -58,7 +58,7 @@ class DbImportMultiplexer(object):
       use_import_op: If True, use TensorFlow's import_event() op for imports,
         otherwise use TensorBoard's own sqlite ingestion logic.
     """
-    tf.logging.info('DbImportMultiplexer initializing');
+    tf.logging.info('DbImportMultiplexer initializing')
     self._db_connection_provider = db_connection_provider
     self._purge_orphaned_data = purge_orphaned_data
     self._max_reload_threads = max_reload_threads

--- a/tensorboard/backend/event_processing/db_import_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer_test.py
@@ -19,10 +19,9 @@ from __future__ import print_function
 
 import os
 import os.path
-import shutil
 
-from tensorboard.backend.event_processing import db_import_multiplexer
 from tensorboard.backend import application
+from tensorboard.backend.event_processing import db_import_multiplexer
 from tensorboard.compat.proto import event_pb2
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.compat.proto import tensor_pb2
@@ -33,16 +32,16 @@ import tensorflow as tf
 def _AddEvents(path):
   with tf.summary.FileWriter(path) as writer:
     event = event_pb2.Event(
-      summary=summary_pb2.Summary(
-        value=[
-          summary_pb2.Summary.Value(
-            tensor=tensor_pb2.TensorProto(
-              dtype=types_pb2.DT_INT32,
-              int_val=[1],
-            )
-          )
-        ]
-      )
+        summary=summary_pb2.Summary(
+            value=[
+                summary_pb2.Summary.Value(
+                    tensor=tensor_pb2.TensorProto(
+                        dtype=types_pb2.DT_INT32,
+                        int_val=[1],
+                    )
+                )
+            ]
+        )
     )
     native_event = tf.Event()
     native_event.ParseFromString(event.SerializeToString())

--- a/tensorboard/backend/event_processing/db_import_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer_test.py
@@ -26,7 +26,7 @@ import tensorflow as tf
 
 
 def add_event(path):
-  with tf.summary.FileWriter(path) as writer:
+  with tf.summary.FileWriterCache.get(path) as writer:
     event = tf.Event()
     event.summary.value.add(tag='tag', tensor=tf.make_tensor_proto(1))
     writer.add_event(event)

--- a/tensorboard/backend/event_processing/db_import_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer_test.py
@@ -1,0 +1,147 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import os.path
+import shutil
+
+from tensorboard.backend.event_processing import db_import_multiplexer
+from tensorboard.backend import application
+import tensorflow as tf
+
+
+# A simple event with a summary that contains a single TensorProto of int32.
+RECORD = (b'\x0b\x00\x00\x00\x00\x00\x00\x00\x86\x15\xf5\x04*\t\n\x07B'
+          b'\x05\x08\x03:\x01\x01\x85\xb2\x08\x9c')
+
+def _AddEvents(path):
+  if not tf.gfile.IsDirectory(path):
+    tf.gfile.MakeDirs(path)
+  fpath = os.path.join(path, 'hypothetical.tfevents.out')
+  with tf.gfile.GFile(fpath, 'w') as f:
+    f.write(RECORD)
+    return fpath
+
+
+class DbImportMultiplexerTest(tf.test.TestCase):
+
+  def setUp(self):
+    super(DbImportMultiplexerTest, self).setUp()
+
+    db_uri = 'sqlite:%s/db' % (self.get_temp_dir())
+    _, self.db_connection_provider = application.get_database_info(db_uri)
+    self.multiplexer = db_import_multiplexer.DbImportMultiplexer(
+        db_connection_provider=self.db_connection_provider,
+        purge_orphaned_data=False,
+        max_reload_threads=1,
+        use_import_op=False)
+
+  def _getRuns(self):
+    db = self.db_connection_provider()
+    cursor = db.execute('''
+      SELECT
+        Runs.run_name
+      FROM Runs
+    	ORDER BY Runs.run_name
+    ''')
+    return [row[0] for row in cursor]
+
+  def _getExperiments(self):
+    db = self.db_connection_provider()
+    cursor = db.execute('''
+      SELECT
+        Experiments.experiment_name
+      FROM Experiments
+      ORDER BY Experiments.experiment_name
+    ''')
+    return [row[0] for row in cursor]
+
+  def test_init(self):
+    """Tests that DB schema is created when creating DbImportMultiplexer."""
+    # Reading DB before schema initialization raises.
+    self.assertEqual(self._getExperiments(), [])
+    self.assertEqual(self._getRuns(), [])
+
+  def testAddRunsFromDirectory_empty_folder(self):
+    fake_dir = os.path.join(self.get_temp_dir(), 'fake_dir')
+    self.multiplexer.AddRunsFromDirectory(fake_dir)
+    self.assertEqual(self._getExperiments(), [])
+    self.assertEqual(self._getRuns(), [])
+
+  def testAddRunsFromDirectory_flat(self):
+    path = self.get_temp_dir()
+    _AddEvents(path)
+    self.multiplexer.AddRunsFromDirectory(path)
+    self.multiplexer.Reload()
+    # Because we added runs from `path`, there is no folder to infer experiment
+    # and run names from.
+    self.assertEqual(self._getExperiments(), [u'.'])
+    self.assertEqual(self._getRuns(), [u'.'])
+
+  def testAddRunsFromDirectory_single_level(self):
+    path = self.get_temp_dir()
+    _AddEvents(os.path.join(path, 'exp1'))
+    _AddEvents(os.path.join(path, 'exp2'))
+    self.multiplexer.AddRunsFromDirectory(path)
+    self.multiplexer.Reload()
+    self.assertEqual(self._getExperiments(), [u'exp1', u'exp2'])
+    # Run names are '.'. because we already used the directory name for
+    # inferring experiment name. There are two items with the same name but
+    # with different ids.
+    self.assertEqual(self._getRuns(), [u'.', u'.'])
+
+  def testAddRunsFromDirectory_double_level(self):
+    path = self.get_temp_dir()
+    _AddEvents(os.path.join(path, 'exp1/test'))
+    _AddEvents(os.path.join(path, 'exp1/train'))
+    _AddEvents(os.path.join(path, 'exp2/test'))
+    self.multiplexer.AddRunsFromDirectory(path)
+    self.multiplexer.Reload()
+    self.assertEqual(self._getExperiments(), [u'exp1', u'exp2'])
+    # There are two items with the same name but with different ids.
+    self.assertEqual(self._getRuns(), [u'test', u'test', u'train'])
+
+  def testAddRunsFromDirectory_deep(self):
+    path = self.get_temp_dir()
+    _AddEvents(os.path.join(path, 'exp1/run1/foo/bar/train'))
+    _AddEvents(os.path.join(path, 'exp2/run1/foo/baz/train'))
+    self.multiplexer.AddRunsFromDirectory(path)
+    self.multiplexer.Reload()
+    self.assertEqual(self._getExperiments(), [u'exp1', u'exp2'])
+    self.assertEqual(self._getRuns(), [u'run1/foo/bar/train',
+                                       u'run1/foo/baz/train'])
+
+  def testAddRunsFromDirectory_manual_name(self):
+    path1 = os.path.join(self.get_temp_dir(), 'foo')
+    path2 = os.path.join(self.get_temp_dir(), 'bar')
+    _AddEvents(os.path.join(path1, 'some/nested/name'))
+    _AddEvents(os.path.join(path2, 'some/nested/name'))
+    self.multiplexer.AddRunsFromDirectory(path1, 'name1')
+    self.multiplexer.AddRunsFromDirectory(path2, 'name2')
+    self.multiplexer.Reload()
+    self.assertEqual(self._getExperiments(), [u'name1', u'name2'])
+    # Run name ignored 'foo' and 'bar' on 'foo/some/nested/name' and
+    # 'bar/some/nested/name', respectively.
+    # There are two items with the same name but with different ids.
+    self.assertEqual(self._getRuns(), [u'some/nested/name',
+                                       u'some/nested/name'])
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorboard/backend/event_processing/db_import_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer_test.py
@@ -37,9 +37,8 @@ class DbImportMultiplexerTest(tf.test.TestCase):
   def setUp(self):
     super(DbImportMultiplexerTest, self).setUp()
 
-    db_uri = 'sqlite:%s/db' % (self.get_temp_dir())
-    self.db_connection_provider = lambda: sqlite3.connect(
-        os.path.join(self.get_temp_dir(), 'db'))
+    db_file_name = os.path.join(self.get_temp_dir(), 'db')
+    self.db_connection_provider = lambda: sqlite3.connect(db_file_name)
     self.multiplexer = db_import_multiplexer.DbImportMultiplexer(
         db_connection_provider=self.db_connection_provider,
         purge_orphaned_data=False,
@@ -130,7 +129,7 @@ class DbImportMultiplexerTest(tf.test.TestCase):
     self.multiplexer.Reload()
     self.assertEqual(self._get_experiments(), [u'exp1', u'exp2'])
     self.assertEqual(self._get_runs(), [os.path.join('run1', 'bar', 'train'),
-                                       os.path.join('run1', 'baz', 'train')])
+                                        os.path.join('run1', 'baz', 'train')])
 
   def test_manual_name(self):
     path1 = os.path.join(self.get_temp_dir(), 'foo')
@@ -145,7 +144,7 @@ class DbImportMultiplexerTest(tf.test.TestCase):
     # 'bar/some/nested/name', respectively.
     # There are two items with the same name but with different ids.
     self.assertEqual(self._get_runs(), [os.path.join('some', 'nested', 'name'),
-                                       os.path.join('some', 'nested', 'name')])
+                                        os.path.join('some', 'nested', 'name')])
 
 
 if __name__ == '__main__':

--- a/tensorboard/backend/event_processing/io_wrapper.py
+++ b/tensorboard/backend/event_processing/io_wrapper.py
@@ -37,6 +37,8 @@ def IsGCSPath(path):
 def IsCnsPath(path):
   return path.startswith("/cns/")
 
+def PathSeparator(path):
+  return '/' if IsGCSPath(path) or IsCnsPath(path) else os.sep
 
 def IsTensorFlowEventsFile(path):
   """Check the path name to see if it is probably a TF Events file.

--- a/tensorboard/backend/event_processing/io_wrapper_test.py
+++ b/tensorboard/backend/event_processing/io_wrapper_test.py
@@ -46,8 +46,8 @@ class IoWrapperTest(tf.test.TestCase):
     self.assertFalse(io_wrapper.IsCnsPath('/tmp/foo'))
 
   def testPathSeparator(self):
-    # In Nix systems, it would be the same as CNS/GCS path separator making it
-    # hard to tell.
+    # In nix systems, path separator would be the same as that of CNS/GCS
+    # making it hard to tell if something went wrong.
     self.stubs.Set(os, 'sep', '#')
 
     self.assertEqual(io_wrapper.PathSeparator('/tmp/foo'), '#')

--- a/tensorboard/backend/event_processing/io_wrapper_test.py
+++ b/tensorboard/backend/event_processing/io_wrapper_test.py
@@ -27,6 +27,12 @@ from tensorboard.backend.event_processing import io_wrapper
 
 
 class IoWrapperTest(tf.test.TestCase):
+  def setUp(self):
+    self.stubs = tf.test.StubOutForTesting()
+
+  def tearDown(self):
+    self.stubs.CleanUp()
+
   def testIsGcsPathIsTrue(self):
     self.assertTrue(io_wrapper.IsGCSPath('gs://bucket/foo'))
 
@@ -38,6 +44,16 @@ class IoWrapperTest(tf.test.TestCase):
 
   def testIsCnsPathFalse(self):
     self.assertFalse(io_wrapper.IsCnsPath('/tmp/foo'))
+
+  def testPathSeparator(self):
+    # In Nix systems, it would be the same as CNS/GCS path separator making it
+    # hard to tell.
+    self.stubs.Set(os, 'sep', '#')
+
+    self.assertEqual(io_wrapper.PathSeparator('/tmp/foo'), '#')
+    self.assertEqual(io_wrapper.PathSeparator('tmp/foo'), '#')
+    self.assertEqual(io_wrapper.PathSeparator('/cns/tmp/foo'), '/')
+    self.assertEqual(io_wrapper.PathSeparator('gs://foo'), '/')
 
   def testIsIsTensorFlowEventsFileTrue(self):
     self.assertTrue(


### PR DESCRIPTION
Previously, user had to supply name of the experiment when passing
logdir. While this guaranteed correctness, it caused some friction in
adopting the db_import so, when a name is not passed, we infer the name
from the first top level in subdirectories of logdir.