### PR TITLE
Iteration over depsets with explicit .to_list()

### DIFF
--- a/tensorboard/defs/hacks.bzl
+++ b/tensorboard/defs/hacks.bzl
@@ -73,7 +73,7 @@ def tensorboard_typescript_bundle(
   cmd.append(") >$@")
   native.genrule(
       name = name,
-      srcs = list(inputs),
+      srcs = inputs.to_list(),
       outs = [out],
       cmd = "\n".join(cmd),
       **kwargs

--- a/tensorboard/defs/vulcanize.bzl
+++ b/tensorboard/defs/vulcanize.bzl
@@ -37,7 +37,7 @@ def _tensorboard_html_binary(ctx):
     ignore_regexs_file_set = depset([ctx.file.path_regexs_for_noinline])
     ignore_regexs_file_path = ctx.file.path_regexs_for_noinline.path
   ctx.action(
-      inputs=list(manifests | files | jslibs | ignore_regexs_file_set),
+      inputs=(manifests | files | jslibs | ignore_regexs_file_set).to_list(),
       outputs=[ctx.outputs.html],
       executable=ctx.executable._Vulcanize,
       arguments=([ctx.attr.compilation_level,
@@ -47,8 +47,8 @@ def _tensorboard_html_binary(ctx):
                   ctx.attr.output_path,
                   ctx.outputs.html.path,
                   ignore_regexs_file_path] +
-                 [f.path for f in jslibs] +
-                 [f.path for f in manifests]),
+                 [f.path for f in jslibs.to_list()] +
+                 [f.path for f in manifests.to_list()]),
       progress_message="Vulcanizing %s" % ctx.attr.input_path)
 
   # webfiles manifest
@@ -68,7 +68,7 @@ def _tensorboard_html_binary(ctx):
   params = struct(
       label=str(ctx.label),
       bind="[::]:6006",
-      manifest=[long_path(ctx, man) for man in manifests],
+      manifest=[long_path(ctx, man) for man in manifests.to_list()],
       external_asset=[struct(webpath=k, path=v)
                       for k, v in ctx.attr.external_assets.items()])
   params_file = ctx.new_file(ctx.configuration.bin_dir,

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -89,7 +89,7 @@ def _tf_web_library(ctx):
         fail("Relative src path not start with '%s': %s" % (strip, suffix))
       suffix = suffix[len(strip):]
     webpath = "%s/%s" % ("" if path == "/" else path, suffix)
-    _add_webpath(ctx, src, webpath, webpaths, new_webpaths, manifest_srcs)
+    _add_webpath(ctx, src, webpath, webpaths.to_list(), new_webpaths, manifest_srcs)
     if suffix.endswith(".d.ts"):
       web_srcs.append(src)
       entry = (webpath[1:], src.path)
@@ -105,8 +105,8 @@ def _tf_web_library(ctx):
       dts = ctx.new_file(ctx.genfiles_dir, "%s.d.ts" % noext)
       webpath_js = webpath[:-3] + ".js"
       webpath_dts = webpath[:-3] + ".d.ts"
-      _add_webpath(ctx, js, webpath_js, webpaths, new_webpaths, manifest_srcs)
-      _add_webpath(ctx, dts, webpath_dts, webpaths, new_webpaths, manifest_srcs)
+      _add_webpath(ctx, js, webpath_js, webpaths.to_list(), new_webpaths, manifest_srcs)
+      _add_webpath(ctx, dts, webpath_dts, webpaths.to_list(), new_webpaths, manifest_srcs)
       ts_inputs += [src]
       ts_outputs.append(js)
       ts_outputs.append(dts)
@@ -267,13 +267,13 @@ def _run_webfiles_validator(ctx, srcs, deps, manifest):
     direct_manifests = depset()
     for dep in deps:
       inputs.append(dep.webfiles.dummy)
-      for f in dep.files:
+      for f in dep.files.to_list():
         inputs.append(f)
       direct_manifests += [dep.webfiles.manifest]
       inputs.append(dep.webfiles.manifest)
       args.append("--direct_dep")
       args.append(dep.webfiles.manifest.path)
-    for man in difference(manifests, direct_manifests):
+    for man in difference(manifests.to_list(), direct_manifests.to_list()):
       inputs.append(man)
       args.append("--transitive_dep")
       args.append(man.path)

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -71,7 +71,7 @@ def _tf_web_library(ctx):
   new_webpaths = []
   ts_inputs = depset()
   ts_outputs = []
-  ts_files = list(ts_typings_paths)
+  ts_files = ts_typings_paths.to_list()
   new_typings = []
   new_typings_paths = []
   new_typings_execroot = struct(inputs=[])
@@ -158,10 +158,11 @@ def _tf_web_library(ctx):
     ts_inputs += ts_typings_execroots
     ts_inputs += [ts_config, er_config]
     ctx.action(
-        inputs=list(ts_inputs),
+        inputs=ts_inputs.to_list(),
         outputs=ts_outputs,
         executable=ctx.executable._execrooter,
-        arguments=[er_config.path] + [f.path for f in ts_typings_execroots],
+        arguments=[er_config.path] +
+            [f.path for f in ts_typings_execroots.to_list()],
         progress_message="Compiling %d TypeScript files %s" % (
             len(ts_files), ctx.label))
 
@@ -187,7 +188,7 @@ def _tf_web_library(ctx):
   params = struct(
       label=str(ctx.label),
       bind="[::]:6006",
-      manifest=[long_path(ctx, man) for man in devserver_manifests],
+      manifest=[long_path(ctx, man) for man in devserver_manifests.to_list()],
       external_asset=[struct(webpath=k, path=v)
                       for k, v in ctx.attr.external_assets.items()])
   params_file = _new_file(ctx, "-params.pbtxt")

--- a/tensorboard/defs/zipper.bzl
+++ b/tensorboard/defs/zipper.bzl
@@ -24,12 +24,12 @@ def _tensorboard_zip_file(ctx):
     webpaths += dep.webfiles.webpaths
     files += dep.data_runfiles.files
   ctx.action(
-      inputs=list(manifests + files),
+      inputs=(manifests + files).to_list(),
       outputs=[ctx.outputs.zip],
       executable=ctx.executable._Zipper,
       arguments=([ctx.outputs.zip.path] +
-                 [m.path for m in manifests]),
-      progress_message="Zipping %d files" % len(webpaths))
+                 [m.path for m in manifests.to_list()]),
+      progress_message="Zipping %d files" % len(webpaths.to_list()))
   transitive_runfiles = depset()
   for dep in deps:
     transitive_runfiles += dep.data_runfiles.files

--- a/third_party/clutz.bzl
+++ b/third_party/clutz.bzl
@@ -52,19 +52,19 @@ def deprecated_extract_dts_from_closure_libraries(ctx):
   js_typings = ctx.new_file(ctx.bin_dir, "%s-js-typings.d.ts" % ctx.label.name)
   srcs = depset(JS_FILE_TYPE.filter(ctx.files._clutz_externs)) + js.srcs
   args = ["-o", js_typings.path]
-  for src in srcs:
+  for src in srcs.to_list():
     args.append(src.path)
   if getattr(ctx.attr, "clutz_entry_points", None):
     args.append("--closure_entry_points")
     args.extend(ctx.attr.clutz_entry_points)
   ctx.action(
-      inputs=list(srcs),
+      inputs=srcs.to_list(),
       outputs=[js_typings],
       executable=ctx.executable._clutz,
       arguments=args,
       mnemonic="Clutz",
       progress_message="Running Clutz on %d JS files %s" % (
-          len(srcs), ctx.label))
+          len(srcs.to_list()), ctx.label))
   return js_typings
 
 ################################################################################


### PR DESCRIPTION
The old pattern did an implicit iteration over a depset which will be
forbidden in the future since it is potentially expensive. The new
to_list() call is still expensive but it will be more visible.

The API was introduced as part of Bazel 0.4.4. 