### PR TITLE
tf_web_library: serve webfiles on IPv4, not IPv6

### DIFF
--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -186,7 +186,7 @@ def _tf_web_library(ctx):
     devserver_manifests = manifests + devserver_manifests
   params = struct(
       label=str(ctx.label),
-      bind="[::]:6006",
+      bind="localhost:6006",
       manifest=[long_path(ctx, man) for man in devserver_manifests],
       external_asset=[struct(webpath=k, path=v)
                       for k, v in ctx.attr.external_assets.items()])


### PR DESCRIPTION
Summary:
Our Travis environment does not support IPv6. If we try to spin up a
webfiles server on Travis with the current config, we see an error:

    java.net.SocketException: Protocol family unavailable
            at java.net.PlainSocketImpl.socketBind(Native Method)
            at java.net.AbstractPlainSocketImpl.bind(AbstractPlainSocketImpl.java:387)
            at java.net.ServerSocket.bind(ServerSocket.java:375)
            at java.net.ServerSocket.<init>(ServerSocket.java:237)
            at javax.net.DefaultServerSocketFactory.createServerSocket(ServerSocketFactory.java:231)
            at io.bazel.rules.closure.webfiles.server.NetworkUtils.createServerSocket(NetworkUtils.java:51)
            at io.bazel.rules.closure.webfiles.server.WebfilesServer.runForever(WebfilesServer.java:136)
            at io.bazel.rules.closure.webfiles.server.WebfilesServer.run(WebfilesServer.java:124)
            at io.bazel.rules.closure.webfiles.server.WebfilesServer.main(WebfilesServer.java:75)

We want to be able to run webfiles servers from Travis for testing
purposes, so this commit changes the `tf_web_library` configuration to
bind to IPv4 `localhost` instead of IPv6 `[::]`.

This does not affect the main TensorBoard target, which is a `py_binary`
and has a completely separate pipeline.

Test Plan:
To verify that this has the desired effect, run

    $ bazel run //tensorboard/components/vz_sorting/test

before and after this change, and look for the “Listening on:” line.
Before this change, it said `http://HOSTNAME:6006/` (with your actual
hostname); now, it says `http://localhost:6006/`. Either URL actually
works both before and after this change.

To verify that this fixes Travis, cherry-pick it onto dependent pull
request #1615, which works only with this change.

wchargin-branch: tf_web_library-ipv4