### PR TITLE
Solve the --path_prefix problem

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -486,6 +486,10 @@ def _clean_path(path, path_prefix=""):
     The route to use to serve the request (with the path prefix stripped if
     applicable).
   """
-  if path != path_prefix + '/' and path.endswith('/'):
-    return path[:-1]
-  return path
+  if path == path_prefix:
+    return path + '/'
+  if path == path_prefix + '/':
+    return path
+  if path.endswith('/'):
+    path = path[:-1]
+  return path_prefix+path


### PR DESCRIPTION
Fix a bug on implementing the ```--path_prefix```.
The bug happens because all of the keys in the structure ```self.data_applications```  has ```path_prefix``` as their prefix.
But the function ```_clean_path``` just removes the prefix by mistake.