### PR TITLE
docs: fix vz_line_chart smoothing documentation

### DIFF
--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -60,16 +60,6 @@ Polymer({
      * Whether smoothing is enabled or not. If true, smoothed lines will be
      * plotted in the chart while the unsmoothed lines will be ghosted in
      * the background.
-     *
-     * The smoothing algorithm is a simple moving average, which, given a
-     * point p and a window w, replaces p with a simple average of the
-     * points in the [p - floor(w/2), p + floor(w/2)] range.  If there
-     * aren't enough points to cover the entire window to the left, the
-     * window is reduced to fit exactly the amount of elements available.
-     * This means that the smoothed line will be less in and gradually
-     * become more smooth until the desired window is reached. However when
-     * there aren't enough points on the right, the line stops being
-     * rendered at all.
      */
     smoothingEnabled: {
       type: Boolean,
@@ -78,18 +68,12 @@ Polymer({
     },
 
     /**
-     * Weight (between 0.0 and 1.0) of the smoothing. This weight controls
-     * the window size, and a weight of 1.0 means using 50% of the entire
-     * dataset as the window, while a weight of 0.0 means using a window of
-     * 0 (and thus replacing each point with themselves).
+     * Weight (between 0.0 and 1.0) of the smoothing. A value of 0.0
+     * means very little smoothing, possibly no smoothing at all. A
+     * value of 1.0 means a whole lot of smoothing, possibly so much as
+     * to make the whole plot appear as a constant function.
      *
-     * The growth between 0.0 and 1.0 is not linear though. Because
-     * changing the window from 0% to 30% of the dataset smooths the line a
-     * lot more than changing the window from 70% to 100%, an exponential
-     * function is used instead: http://i.imgur.com/bDrhEZU.png. This
-     * function increases the size of the window slowly at the beginning
-     * and gradually speeds up the growth, but 0.0 still means a window of
-     * 0 and 1.0 still means a window of the dataset's length.
+     * Has no effect when `smoothingEnabled` is `false`.
      */
     smoothingWeight: {type: Number, value: 0.6},
 

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -81,16 +81,6 @@ Polymer({
      * Whether smoothing is enabled or not. If true, smoothed lines will be
      * plotted in the chart while the unsmoothed lines will be ghosted in
      * the background.
-     *
-     * The smoothing algorithm is a simple moving average, which, given a
-     * point p and a window w, replaces p with a simple average of the
-     * points in the [p - floor(w/2), p + floor(w/2)] range.  If there
-     * aren't enough points to cover the entire window to the left, the
-     * window is reduced to fit exactly the amount of elements available.
-     * This means that the smoothed line will be less in and gradually
-     * become more smooth until the desired window is reached. However when
-     * there aren't enough points on the right, the line stops being
-     * rendered at all.
      */
     smoothingEnabled: {
       type: Boolean,
@@ -99,18 +89,12 @@ Polymer({
     },
 
     /**
-     * Weight (between 0.0 and 1.0) of the smoothing. This weight controls
-     * the window size, and a weight of 1.0 means using 50% of the entire
-     * dataset as the window, while a weight of 0.0 means using a window of
-     * 0 (and thus replacing each point with themselves).
+     * Weight (between 0.0 and 1.0) of the smoothing. A value of 0.0
+     * means very little smoothing, possibly no smoothing at all. A
+     * value of 1.0 means a whole lot of smoothing, possibly so much as
+     * to make the whole plot appear as a constant function.
      *
-     * The growth between 0.0 and 1.0 is not linear though. Because
-     * changing the window from 0% to 30% of the dataset smooths the line a
-     * lot more than changing the window from 70% to 100%, an exponential
-     * function is used instead: http://i.imgur.com/bDrhEZU.png. This
-     * function increases the size of the window slowly at the beginning
-     * and gradually speeds up the growth, but 0.0 still means a window of
-     * 0 and 1.0 still means a window of the dataset's length.
+     * Has no effect when `smoothingEnabled` is `false`.
      */
     smoothingWeight: {type: Number, value: 0.6},
 


### PR DESCRIPTION
Summary:
Fixes #1621. These docs were far too closely specified. There was a day
where they also happened to be correct, but it is not this day.

Test Plan:
Look at the implementation of `resmoothDataset` in both versions of the
code (v1: `vz-line-chart.ts`, v2: `line-chart.ts`; the implementations
are the same). Observe that the implementation is not a moving average
whose window size is set by the `smoothingWeight`; instead, it is the
attenuation parameter of a low-pass filter.

wchargin-branch: docs-smoothing