### PR TITLE
Fixes path_prefix flag

### DIFF
--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -18,7 +18,8 @@ export interface Router {
   environment: () => string;
   experiments: () => string;
   isDemoMode: () => boolean;
-  pluginRoute: (pluginName: string, route: string) => string;
+  pluginRoute: (pluginName: string, route: string,
+      params?: URLSearchParams, demoCustomExt?: string) => string;
   pluginsListing: () => string;
   runs: () => string;
   runsForExperiment: (id: tf_backend.ExperimentId) => string;

--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -90,9 +90,9 @@ export function setRouter(router: Router): void {
 function createProdDataPath(dataDir: string, route: string,
     ext: string, params?: URLSearchParams): string {
   let relativePath = dataDir + route;
-  if (params) {
+  if (params && String(params)) {
     const delimiter = route.includes('?') ? '&' : '?';
-    relativePath += delimiter + params.toString();
+    relativePath += delimiter + String(params);
   }
   return relativePath;
 }

--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -88,9 +88,9 @@ export function setRouter(router: Router): void {
 }
 
 function createProdDataPath(dataDir: string, route: string,
-    ext: string, params?: URLSearchParams): string {
+    ext: string, params: URLSearchParams = new URLSearchParams()): string {
   let relativePath = dataDir + route;
-  if (params && String(params)) {
+  if (String(params)) {
     const delimiter = route.includes('?') ? '&' : '?';
     relativePath += delimiter + String(params);
   }

--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -28,10 +28,10 @@ export interface Router {
  * Create a router for communicating with the TensorBoard backend. You
  * can pass this to `setRouter` to make it the global router.
  *
- * @param pathPrefix {string} The base prefix for data endpoints.
+ * @param pathPrefix {string=} The base prefix for data endpoints.
  * @param demoMode {boolean=} Whether to modify urls for filesystem demo usage.
  */
-export function createRouter(pathPrefix, demoMode = false): Router {
+export function createRouter(pathPrefix = 'data', demoMode = false): Router {
   if (pathPrefix[pathPrefix.length - 1] === '/') {
     pathPrefix = pathPrefix.slice(0, pathPrefix.length - 1);
   }
@@ -62,13 +62,7 @@ export function createRouter(pathPrefix, demoMode = false): Router {
   };
 };
 
-export function getDefaultRouter(): Router {
-  const sep = window.location.pathname.endsWith('/') ? '' : '/';
-  const pathPrefix = window.location.pathname + sep + 'data';
-  return createRouter(pathPrefix);
-}
-
-let _router: Router = getDefaultRouter();
+let _router: Router = createRouter();
 
 /**
  * @return {Router} the global router
@@ -94,9 +88,9 @@ export function setRouter(router: Router): void {
 
 function createProdPath(pathPrefix: string, path: string,
     ext: string, params?: URLSearchParams): string {
-  const url = new URL(window.location.origin);
   // Use URL to normalize pathPrefix with leading slash and without.
-  url.pathname = pathPrefix + path;
+  const maybeRelativePath = pathPrefix + path;
+  const url = new URL(maybeRelativePath, window.location.href);
   if (params) url.search = params.toString();
   return url.pathname + url.search;
 }

--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -28,10 +28,10 @@ export interface Router {
  * Create a router for communicating with the TensorBoard backend. You
  * can pass this to `setRouter` to make it the global router.
  *
- * @param pathPrefix {string=} The base prefix for data endpoints.
+ * @param pathPrefix {string} The base prefix for data endpoints.
  * @param demoMode {boolean=} Whether to modify urls for filesystem demo usage.
  */
-export function createRouter(pathPrefix = 'data', demoMode = false): Router {
+export function createRouter(pathPrefix, demoMode = false): Router {
   if (pathPrefix[pathPrefix.length - 1] === '/') {
     pathPrefix = pathPrefix.slice(0, pathPrefix.length - 1);
   }
@@ -62,7 +62,13 @@ export function createRouter(pathPrefix = 'data', demoMode = false): Router {
   };
 };
 
-let _router: Router = createRouter();
+export function getDefaultRouter(): Router {
+  const sep = window.location.pathname.endsWith('/') ? '' : '/';
+  const pathPrefix = window.location.pathname + sep + 'data';
+  return createRouter(pathPrefix);
+}
+
+let _router: Router = getDefaultRouter();
 
 /**
  * @return {Router} the global router

--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -123,11 +123,11 @@ function createDemoPath(dataDir: string, route: string,
   normalizedPath = normalizedPath.replace(/\//g, '_');
   // Add query parameter as path if it is present.
   if (encodedQueryParam) normalizedPath += `_${encodedQueryParam}`;
-  const url = new URL(window.location.href);
+  const url = new URL(window.location.origin);
 
   // All demo data are serialized in JSON format.
   url.pathname = `${dataDir}/${normalizedPath}${ext}`;
-  return url.pathname + url.search;
+  return url.pathname;
 }
 
 export function createSearchParam(params: QueryParams = {}): URLSearchParams {

--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -81,6 +81,23 @@ describe('backend tests', () => {
       assert.equal(r.runs(), '/foo/runs');
     });
 
+    describe('default router', () => {
+      beforeEach(function() {
+        this.router = getDefaultRouter();
+      });
+
+      it('makes sure test is not degenerate', function() {
+        // Test becomes degenerate if location.pathname is empty.
+        assert.notEqual('/', window.location.pathname);
+      });
+
+      it('creates a URL including the pathname', function() {
+        assert.equal(
+            this.router.runs(),
+            `${window.location.pathname}/data/runs`);
+      });
+    });
+
     describe('prod mode', () => {
       beforeEach(function() {
         this.router = createRouter(base, /*demoMode=*/false);

--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -104,26 +104,26 @@ describe('backend tests', () => {
         assert.equal(router.runs(), '/hello/runs');
       });
 
-      it('returns correct value for #environment', function() {
+      it('returns correct value for #environment', () => {
         assertRelativePath(router.environment(), 'data/environment');
       });
 
-      it('returns correct value for #experiments', function() {
+      it('returns correct value for #experiments', () => {
         assertRelativePath(router.experiments(), 'data/experiments');
       });
 
-      it('returns correct value for #isDemoMode', function() {
+      it('returns correct value for #isDemoMode', () => {
         assert.equal(router.isDemoMode(), false);
       });
 
       describe('#pluginRoute', () => {
-        it('encodes slash correctly', function() {
+        it('encodes slash correctly', () => {
           assertRelativePath(
               router.pluginRoute('scalars', '/scalar'),
               'data/plugin/scalars/scalar');
         });
 
-        it('encodes query param correctly', function() {
+        it('encodes query param correctly', () => {
           assertRelativePath(
               router.pluginRoute(
                   'scalars',
@@ -132,14 +132,14 @@ describe('backend tests', () => {
               'data/plugin/scalars/a?b=c&d=1&d=2');
         });
 
-        it('encodes parenthesis correctly', function() {
+        it('encodes parenthesis correctly', () => {
           assertRelativePath(
               router.pluginRoute('scalars', '/a',
               createSearchParam({foo: '()'})),
               'data/plugin/scalars/a?foo=%28%29');
         });
 
-        it('encodes query param the same as #addParams', function() {
+        it('encodes query param the same as #addParams', () => {
           assertRelativePath(
               router.pluginRoute(
                   'scalars',
@@ -154,23 +154,23 @@ describe('backend tests', () => {
               addParams('data/plugin/scalars/a', {foo: '()'}));
         });
 
-        it('ignores custom extension', function() {
+        it('ignores custom extension', () => {
           assertRelativePath(
               router.pluginRoute('scalars', '/a', undefined, 'meow'),
               'data/plugin/scalars/a');
         });
       });
 
-      it('returns correct value for #pluginsListing', function() {
+      it('returns correct value for #pluginsListing', () => {
         assertRelativePath(
             router.pluginsListing(), 'data/plugins_listing');
       });
 
-      it('returns correct value for #runs', function() {
+      it('returns correct value for #runs', () => {
         assertRelativePath(router.runs(), 'data/runs');
       });
 
-      it('returns correct value for #runsForExperiment', function() {
+      it('returns correct value for #runsForExperiment', () => {
         assertRelativePath(
             router.runsForExperiment(1),
             'data/experiment_runs?experiment=1');
@@ -200,26 +200,26 @@ describe('backend tests', () => {
         assert.equal(router.runs(), '///data/runs.json');
       });
 
-      it('returns correct value for #environment', function() {
+      it('returns correct value for #environment', () => {
         assert.equal(router.environment(), '/data/environment.json');
       });
 
-      it('returns correct value for #experiments', function() {
+      it('returns correct value for #experiments', () => {
         assert.equal(router.experiments(), '/data/experiments.json');
       });
 
-      it('returns correct value for #isDemoMode', function() {
+      it('returns correct value for #isDemoMode', () => {
         assert.equal(router.isDemoMode(), true);
       });
 
       describe('#pluginRoute', () => {
-        it('encodes slash correctly', function() {
+        it('encodes slash correctly', () => {
           assert.equal(
               router.pluginRoute('scalars', '/scalar'),
               '/data/scalars_scalar.json');
         });
 
-        it('encodes query param correctly', function() {
+        it('encodes query param correctly', () => {
           assert.equal(
               router.pluginRoute(
                   'scalars',
@@ -228,7 +228,7 @@ describe('backend tests', () => {
               '/data/scalars_a_b_c_d_1_d_2.json');
         });
 
-        it('encodes parenthesis correctly', function() {
+        it('encodes parenthesis correctly', () => {
           assert.equal(
               router.pluginRoute(
                   'scalars',
@@ -237,7 +237,7 @@ describe('backend tests', () => {
               '/data/scalars_a_foo__28_29.json');
         });
 
-        it('uses custom extension if provided', function() {
+        it('uses custom extension if provided', () => {
           assert.equal(
               router.pluginRoute('scalars', '/a', undefined, ''),
               '/data/scalars_a');
@@ -250,17 +250,17 @@ describe('backend tests', () => {
         });
       });
 
-      it('returns correct value for #pluginsListing', function() {
+      it('returns correct value for #pluginsListing', () => {
         assert.equal(
             router.pluginsListing(),
             '/data/plugins_listing.json');
       });
 
-      it('returns correct value for #runs', function() {
+      it('returns correct value for #runs', () => {
         assert.equal(router.runs(), '/data/runs.json');
       });
 
-      it('returns correct value for #runsForExperiment', function() {
+      it('returns correct value for #runsForExperiment', () => {
         assert.equal(
             router.runsForExperiment(1),
             '/data/experiment_runs_experiment_1.json');

--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -126,6 +126,13 @@ describe('backend tests', () => {
               'data/plugin/scalars/a?b=c&d=1&d=2');
         });
 
+        it('does not put ? when passed an empty URLSearchParams', () => {
+          assert.equal(
+              router.pluginRoute('scalars', '/a',
+                  new URLSearchParams()),
+              'data/plugin/scalars/a');
+        });
+
         it('encodes parenthesis correctly', () => {
           assert.equal(
               router.pluginRoute('scalars', '/a',

--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -82,12 +82,6 @@ describe('backend tests', () => {
         router = createRouter(base, /*demoMode=*/false);
       });
 
-      function assertRelativePath(actual, expectedRelativePath) {
-        // Path prefix is /tf-backend/test should match path of the
-        // test_web_library in the test build target.
-        assert.equal(actual, `/tf-backend/test/${expectedRelativePath}`);
-      }
-
       it('leading slash in pathPrefix is an absolute path', () => {
         const router = createRouter('/data/', /*demoMode=*/false);
         assert.equal(router.runs(), '/data/runs');
@@ -95,21 +89,21 @@ describe('backend tests', () => {
 
       it('returns complete pathname when pathPrefix omits slash', () => {
         const router = createRouter('data/', /*demoMode=*/false);
-        assertRelativePath(router.runs(), 'data/runs');
+        assert.equal(router.runs(), 'data/runs');
       });
 
-      it('treats more than two slashes as absolute url', () => {
+      it('does not prune many leading slashes that forms full url', () => {
         const router = createRouter('///data/hello', /*demoMode=*/false);
         // This becomes 'http://data/hello/runs'
-        assert.equal(router.runs(), '/hello/runs');
+        assert.equal(router.runs(), '///data/hello/runs');
       });
 
       it('returns correct value for #environment', () => {
-        assertRelativePath(router.environment(), 'data/environment');
+        assert.equal(router.environment(), 'data/environment');
       });
 
       it('returns correct value for #experiments', () => {
-        assertRelativePath(router.experiments(), 'data/experiments');
+        assert.equal(router.experiments(), 'data/experiments');
       });
 
       it('returns correct value for #isDemoMode', () => {
@@ -118,13 +112,13 @@ describe('backend tests', () => {
 
       describe('#pluginRoute', () => {
         it('encodes slash correctly', () => {
-          assertRelativePath(
+          assert.equal(
               router.pluginRoute('scalars', '/scalar'),
               'data/plugin/scalars/scalar');
         });
 
         it('encodes query param correctly', () => {
-          assertRelativePath(
+          assert.equal(
               router.pluginRoute(
                   'scalars',
                   '/a',
@@ -133,20 +127,27 @@ describe('backend tests', () => {
         });
 
         it('encodes parenthesis correctly', () => {
-          assertRelativePath(
+          assert.equal(
               router.pluginRoute('scalars', '/a',
-              createSearchParam({foo: '()'})),
+                  createSearchParam({foo: '()'})),
               'data/plugin/scalars/a?foo=%28%29');
         });
 
+        it('deals with existing query param correctly', () => {
+          assert.equal(
+              router.pluginRoute('scalars', '/a?foo=bar',
+                  createSearchParam({hello: 'world'})),
+              'data/plugin/scalars/a?foo=bar&hello=world');
+        });
+
         it('encodes query param the same as #addParams', () => {
-          assertRelativePath(
+          assert.equal(
               router.pluginRoute(
                   'scalars',
                   '/a',
                   createSearchParam({b: 'c', d: ['1']})),
               addParams('data/plugin/scalars/a', {b: 'c', d: ['1']}));
-          assertRelativePath(
+          assert.equal(
               router.pluginRoute(
                   'scalars',
                   '/a',
@@ -155,23 +156,23 @@ describe('backend tests', () => {
         });
 
         it('ignores custom extension', () => {
-          assertRelativePath(
+          assert.equal(
               router.pluginRoute('scalars', '/a', undefined, 'meow'),
               'data/plugin/scalars/a');
         });
       });
 
       it('returns correct value for #pluginsListing', () => {
-        assertRelativePath(
+        assert.equal(
             router.pluginsListing(), 'data/plugins_listing');
       });
 
       it('returns correct value for #runs', () => {
-        assertRelativePath(router.runs(), 'data/runs');
+        assert.equal(router.runs(), 'data/runs');
       });
 
       it('returns correct value for #runsForExperiment', () => {
-        assertRelativePath(
+        assert.equal(
             router.runsForExperiment(1),
             'data/experiment_runs?experiment=1');
       });
@@ -226,6 +227,13 @@ describe('backend tests', () => {
                   '/a',
                   createSearchParam({b: 'c', d: ['1', '2']})),
               '/data/scalars_a_b_c_d_1_d_2.json');
+        });
+
+        it('deals with existing query param correctly', () => {
+          assert.equal(
+              router.pluginRoute('scalars', '/a?foo=bar',
+                  createSearchParam({hello: 'world'})),
+              '/data/scalars_a_foo_bar_hello_world.json');
         });
 
         it('encodes parenthesis correctly', () => {

--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -77,8 +77,9 @@ describe('backend tests', () => {
 
   describe('router', () => {
     describe('prod mode', () => {
-      beforeEach(function() {
-        this.router = createRouter(base, /*demoMode=*/false);
+      let router: Router;
+      beforeEach(() => {
+        router = createRouter(base, /*demoMode=*/false);
       });
 
       function assertRelativePath(actual, expectedRelativePath) {
@@ -104,27 +105,27 @@ describe('backend tests', () => {
       });
 
       it('returns correct value for #environment', function() {
-        assertRelativePath(this.router.environment(), 'data/environment');
+        assertRelativePath(router.environment(), 'data/environment');
       });
 
       it('returns correct value for #experiments', function() {
-        assertRelativePath(this.router.experiments(), 'data/experiments');
+        assertRelativePath(router.experiments(), 'data/experiments');
       });
 
       it('returns correct value for #isDemoMode', function() {
-        assert.equal(this.router.isDemoMode(), false);
+        assert.equal(router.isDemoMode(), false);
       });
 
       describe('#pluginRoute', () => {
         it('encodes slash correctly', function() {
           assertRelativePath(
-              this.router.pluginRoute('scalars', '/scalar'),
+              router.pluginRoute('scalars', '/scalar'),
               'data/plugin/scalars/scalar');
         });
 
         it('encodes query param correctly', function() {
           assertRelativePath(
-              this.router.pluginRoute(
+              router.pluginRoute(
                   'scalars',
                   '/a',
                   createSearchParam({b: 'c', d: ['1', '2']})),
@@ -133,20 +134,20 @@ describe('backend tests', () => {
 
         it('encodes parenthesis correctly', function() {
           assertRelativePath(
-              this.router.pluginRoute('scalars', '/a',
+              router.pluginRoute('scalars', '/a',
               createSearchParam({foo: '()'})),
               'data/plugin/scalars/a?foo=%28%29');
         });
 
         it('encodes query param the same as #addParams', function() {
           assertRelativePath(
-              this.router.pluginRoute(
+              router.pluginRoute(
                   'scalars',
                   '/a',
                   createSearchParam({b: 'c', d: ['1']})),
               addParams('data/plugin/scalars/a', {b: 'c', d: ['1']}));
           assertRelativePath(
-              this.router.pluginRoute(
+              router.pluginRoute(
                   'scalars',
                   '/a',
                   createSearchParam({foo: '()'})),
@@ -155,37 +156,32 @@ describe('backend tests', () => {
 
         it('ignores custom extension', function() {
           assertRelativePath(
-              this.router.pluginRoute('scalars', '/a', undefined, 'meow'),
+              router.pluginRoute('scalars', '/a', undefined, 'meow'),
               'data/plugin/scalars/a');
         });
       });
 
       it('returns correct value for #pluginsListing', function() {
         assertRelativePath(
-            this.router.pluginsListing(), 'data/plugins_listing');
+            router.pluginsListing(), 'data/plugins_listing');
       });
 
       it('returns correct value for #runs', function() {
-        assertRelativePath(this.router.runs(), 'data/runs');
+        assertRelativePath(router.runs(), 'data/runs');
       });
 
       it('returns correct value for #runsForExperiment', function() {
-        // No experiment id is passed.
         assertRelativePath(
-            this.router.runsForExperiment(''),
-            'data/experiment_runs');
-        assertRelativePath(
-            this.router.runsForExperiment('1'),
+            router.runsForExperiment(1),
             'data/experiment_runs?experiment=1');
-        assertRelativePath(
-            this.router.runsForExperiment('1&foo=false'),
-            'data/experiment_runs?experiment=1%26foo%3Dfalse');
       });
     });
 
     describe('demoMode', () => {
-      beforeEach( function() {
-        this.router = createRouter(base, /*demoMode=*/true);
+      let router: Router;
+
+      beforeEach(() => {
+        router = createRouter(base, /*demoMode=*/true);
       });
 
       it('treats pathPrefix with leading slash as absolute path', () => {
@@ -205,27 +201,27 @@ describe('backend tests', () => {
       });
 
       it('returns correct value for #environment', function() {
-        assert.equal(this.router.environment(), '/data/environment.json');
+        assert.equal(router.environment(), '/data/environment.json');
       });
 
       it('returns correct value for #experiments', function() {
-        assert.equal(this.router.experiments(), '/data/experiments.json');
+        assert.equal(router.experiments(), '/data/experiments.json');
       });
 
       it('returns correct value for #isDemoMode', function() {
-        assert.equal(this.router.isDemoMode(), true);
+        assert.equal(router.isDemoMode(), true);
       });
 
       describe('#pluginRoute', () => {
         it('encodes slash correctly', function() {
           assert.equal(
-              this.router.pluginRoute('scalars', '/scalar'),
+              router.pluginRoute('scalars', '/scalar'),
               '/data/scalars_scalar.json');
         });
 
         it('encodes query param correctly', function() {
           assert.equal(
-              this.router.pluginRoute(
+              router.pluginRoute(
                   'scalars',
                   '/a',
                   createSearchParam({b: 'c', d: ['1', '2']})),
@@ -234,7 +230,7 @@ describe('backend tests', () => {
 
         it('encodes parenthesis correctly', function() {
           assert.equal(
-              this.router.pluginRoute(
+              router.pluginRoute(
                   'scalars',
                   '/a',
                   createSearchParam({foo: '()'})),
@@ -243,38 +239,31 @@ describe('backend tests', () => {
 
         it('uses custom extension if provided', function() {
           assert.equal(
-              this.router.pluginRoute('scalars', '/a', undefined, ''),
+              router.pluginRoute('scalars', '/a', undefined, ''),
               '/data/scalars_a');
           assert.equal(
-              this.router.pluginRoute('scalars', '/a', undefined, '.meow'),
+              router.pluginRoute('scalars', '/a', undefined, '.meow'),
               '/data/scalars_a.meow');
           assert.equal(
-              this.router.pluginRoute('scalars', '/a'),
+              router.pluginRoute('scalars', '/a'),
               '/data/scalars_a.json');
         });
       });
 
       it('returns correct value for #pluginsListing', function() {
         assert.equal(
-            this.router.pluginsListing(),
+            router.pluginsListing(),
             '/data/plugins_listing.json');
       });
 
       it('returns correct value for #runs', function() {
-        assert.equal(this.router.runs(), '/data/runs.json');
+        assert.equal(router.runs(), '/data/runs.json');
       });
 
       it('returns correct value for #runsForExperiment', function() {
-        // No experiment id is passed.
         assert.equal(
-            this.router.runsForExperiment(''),
-            '/data/experiment_runs.json');
-        assert.equal(
-            this.router.runsForExperiment('1'),
+            router.runsForExperiment(1),
             '/data/experiment_runs_experiment_1.json');
-        assert.equal(
-            this.router.runsForExperiment('1&foo=false'),
-            '/data/experiment_runs_experiment_1_26foo_3Dfalse.json');
       });
     });
   });


### PR DESCRIPTION
PR #1512 introduced a bug where it formed a complete path without using
existing pathname. Previously without forming the complete path, it was
treated as a relative path from current window.location.pathname.