### PR TITLE
tf_color_scale: fix test case

### DIFF
--- a/tensorboard/components/tf_color_scale/test/colorScaleTests.ts
+++ b/tensorboard/components/tf_color_scale/test/colorScaleTests.ts
@@ -41,8 +41,8 @@ describe('ColorScale', function() {
   it('Throws an error if string is not in the domain', function() {
     ccs.setDomain(['red', 'yellow', 'green']);
     assert.throws(() => {
-      ccs.getColor('not in domain');
-    }, 'String was not in the domain.');
+      ccs.getColor('WAT');
+    }, 'String WAT was not in the domain.');
   });
 });
 


### PR DESCRIPTION
Summary:
This test was broken in #810 when the code was changed but the test was
not updated appropriately. The failure was not caught because we do not
run our tests.

Test Plan:
Run `bazel run //tensorboard/components/tf_color_scale/test`, then
navigate to <http://localhost:6006/tf-color-scale/test/tests.html> and
verify that the page title reads, “3 passing tests”. A future change
will make this test run automatically.

wchargin-branch: tf_color_scale-fix-test