### PR TITLE
test: enable most existing frontend tests

### DIFF
--- a/tensorboard/components/tf_backend/test/BUILD
+++ b/tensorboard/components/tf_backend/test/BUILD
@@ -4,11 +4,26 @@ package(
 )
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+py_web_test_suite(
     name = "test",
+    srcs = ["test.py"],
+    browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    data = [
+        ":test_web_library",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@io_bazel_rules_webtesting//testing/web",
+        "//tensorboard/functionaltests:wct_test_driver",
+    ],
+)
+
+tf_web_library(
+    name = "test_web_library",
     srcs = [
         "tests.html",
         "backendTests.ts",

--- a/tensorboard/components/tf_backend/test/test.py
+++ b/tensorboard/components/tf_backend/test/test.py
@@ -1,0 +1,29 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from tensorboard.functionaltests import wct_test_driver
+
+
+Test = wct_test_driver.create_test_class(
+    "tensorboard/components/tf_backend/test/test_web_library",
+    "/tf-backend/test/tests.html")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorboard/components/tf_categorization_utils/test/BUILD
+++ b/tensorboard/components/tf_categorization_utils/test/BUILD
@@ -4,11 +4,26 @@ package(
 )
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+py_web_test_suite(
     name = "test",
+    srcs = ["test.py"],
+    browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    data = [
+        ":test_web_library",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@io_bazel_rules_webtesting//testing/web",
+        "//tensorboard/functionaltests:wct_test_driver",
+    ],
+)
+
+tf_web_library(
+    name = "test_web_library",
     srcs = [
         "tests.html",
         "categorizationUtilsTests.ts",

--- a/tensorboard/components/tf_categorization_utils/test/test.py
+++ b/tensorboard/components/tf_categorization_utils/test/test.py
@@ -1,0 +1,29 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from tensorboard.functionaltests import wct_test_driver
+
+
+Test = wct_test_driver.create_test_class(
+    "tensorboard/components/tf_categorization_utils/test/test_web_library",
+    "/tf-categorization-utils/test/tests.html")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorboard/components/tf_color_scale/test/BUILD
+++ b/tensorboard/components/tf_color_scale/test/BUILD
@@ -4,11 +4,26 @@ package(
 )
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+py_web_test_suite(
     name = "test",
+    srcs = ["test.py"],
+    browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    data = [
+        ":test_web_library",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@io_bazel_rules_webtesting//testing/web",
+        "//tensorboard/functionaltests:wct_test_driver",
+    ],
+)
+
+tf_web_library(
+    name = "test_web_library",
     srcs = [
         "colorScaleTests.ts",
         "tests.html",

--- a/tensorboard/components/tf_color_scale/test/test.py
+++ b/tensorboard/components/tf_color_scale/test/test.py
@@ -1,0 +1,29 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from tensorboard.functionaltests import wct_test_driver
+
+
+Test = wct_test_driver.create_test_class(
+    "tensorboard/components/tf_color_scale/test/test_web_library",
+    "/tf-color-scale/test/tests.html")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorboard/components/tf_data_selector/test/BUILD
+++ b/tensorboard/components/tf_data_selector/test/BUILD
@@ -4,11 +4,26 @@ package(
 )
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+py_web_test_suite(
     name = "test",
+    srcs = ["test.py"],
+    browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    data = [
+        ":test_web_library",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@io_bazel_rules_webtesting//testing/web",
+        "//tensorboard/functionaltests:wct_test_driver",
+    ],
+)
+
+tf_web_library(
+    name = "test_web_library",
     srcs = [
         "tests.html",
         "storage-utils-test.ts",

--- a/tensorboard/components/tf_data_selector/test/test.py
+++ b/tensorboard/components/tf_data_selector/test/test.py
@@ -1,0 +1,29 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from tensorboard.functionaltests import wct_test_driver
+
+
+Test = wct_test_driver.create_test_class(
+    "tensorboard/components/tf_data_selector/test/test_web_library",
+    "/tf-data-selector/test/tests.html")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorboard/components/tf_paginated_view/test/BUILD
+++ b/tensorboard/components/tf_paginated_view/test/BUILD
@@ -4,11 +4,26 @@ package(
 )
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+py_web_test_suite(
     name = "test",
+    srcs = ["test.py"],
+    browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    data = [
+        ":test_web_library",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@io_bazel_rules_webtesting//testing/web",
+        "//tensorboard/functionaltests:wct_test_driver",
+    ],
+)
+
+tf_web_library(
+    name = "test_web_library",
     srcs = [
         "tests.html",
         "paginatedViewTests.ts",

--- a/tensorboard/components/tf_paginated_view/test/test.py
+++ b/tensorboard/components/tf_paginated_view/test/test.py
@@ -1,0 +1,29 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from tensorboard.functionaltests import wct_test_driver
+
+
+Test = wct_test_driver.create_test_class(
+    "tensorboard/components/tf_paginated_view/test/test_web_library",
+    "/tf-paginated-view/test/tests.html")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorboard/components/tf_storage/test/BUILD
+++ b/tensorboard/components/tf_storage/test/BUILD
@@ -4,11 +4,26 @@ package(
 )
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+py_web_test_suite(
     name = "test",
+    srcs = ["test.py"],
+    browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    data = [
+        ":test_web_library",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@io_bazel_rules_webtesting//testing/web",
+        "//tensorboard/functionaltests:wct_test_driver",
+    ],
+)
+
+tf_web_library(
+    name = "test_web_library",
     srcs = [
         "storageTests.ts",
         "tests.html",

--- a/tensorboard/components/tf_storage/test/test.py
+++ b/tensorboard/components/tf_storage/test/test.py
@@ -1,0 +1,29 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from tensorboard.functionaltests import wct_test_driver
+
+
+Test = wct_test_driver.create_test_class(
+    "tensorboard/components/tf_storage/test/test_web_library",
+    "/tf-storage/test/tests.html")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorboard/components/vz_line_chart2/test/BUILD
+++ b/tensorboard/components/vz_line_chart2/test/BUILD
@@ -4,11 +4,26 @@ package(
 )
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+py_web_test_suite(
     name = "test",
+    srcs = ["test.py"],
+    browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    data = [
+        ":test_web_library",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@io_bazel_rules_webtesting//testing/web",
+        "//tensorboard/functionaltests:wct_test_driver",
+    ],
+)
+
+tf_web_library(
+    name = "test_web_library",
     srcs = [
         "log-scale-test.ts",
         "tests.html",

--- a/tensorboard/components/vz_line_chart2/test/test.py
+++ b/tensorboard/components/vz_line_chart2/test/test.py
@@ -1,0 +1,29 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from tensorboard.functionaltests import wct_test_driver
+
+
+Test = wct_test_driver.create_test_class(
+    "tensorboard/components/vz_line_chart2/test/test_web_library",
+    "/vz-line-chart2/test/tests.html")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorboard/plugins/audio/tf_audio_dashboard/test/BUILD
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/test/BUILD
@@ -4,11 +4,28 @@ package(
 )
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+py_web_test_suite(
     name = "test",
+    # TODO(@wchargin): This test is broken.
+    tags = ["manual"],
+    srcs = ["test.py"],
+    browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    data = [
+        ":test_web_library",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@io_bazel_rules_webtesting//testing/web",
+        "//tensorboard/functionaltests:wct_test_driver",
+    ],
+)
+
+tf_web_library(
+    name = "test_web_library",
     srcs = [
         "audioDashboardTests.ts",
         "tests.html",

--- a/tensorboard/plugins/audio/tf_audio_dashboard/test/test.py
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/test/test.py
@@ -1,0 +1,29 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from tensorboard.functionaltests import wct_test_driver
+
+
+Test = wct_test_driver.create_test_class(
+    "tensorboard/components/tf_audio_dashboard/test/test_web_library",
+    "/tf-audio-dashboard/test/tests.html")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorboard/plugins/graph/tf_graph_common/test/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_common/test/BUILD
@@ -4,11 +4,26 @@ package(
 )
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+py_web_test_suite(
     name = "test",
+    srcs = ["test.py"],
+    browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    data = [
+        ":test_web_library",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@io_bazel_rules_webtesting//testing/web",
+        "//tensorboard/functionaltests:wct_test_driver",
+    ],
+)
+
+tf_web_library(
+    name = "test_web_library",
     srcs = [
         "index.html",
         "graph-test.ts",

--- a/tensorboard/plugins/graph/tf_graph_common/test/test.py
+++ b/tensorboard/plugins/graph/tf_graph_common/test/test.py
@@ -1,0 +1,29 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from tensorboard.functionaltests import wct_test_driver
+
+
+Test = wct_test_driver.create_test_class(
+    "tensorboard/plugins/graph/tf_graph_common/test/test_web_library",
+    "/tf-graph-common/test/index.html")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/test/BUILD
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/test/BUILD
@@ -4,11 +4,26 @@ package(
 )
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+py_web_test_suite(
     name = "test",
+    srcs = ["test.py"],
+    browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    data = [
+        ":test_web_library",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@io_bazel_rules_webtesting//testing/web",
+        "//tensorboard/functionaltests:wct_test_driver",
+    ],
+)
+
+tf_web_library(
+    name = "test_web_library",
     srcs = [
         "tests.html",
         "histogramTests.ts",

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/test/test.py
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/test/test.py
@@ -1,0 +1,29 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from tensorboard.functionaltests import wct_test_driver
+
+
+Test = wct_test_driver.create_test_class(
+    "tensorboard/plugins/histogram/tf_histogram_dashboard/test/test_web_library",
+    "/tf-histogram-dashboard/test/tests.html")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tensorboard/plugins/projector/vz_projector/test/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/test/BUILD
@@ -4,11 +4,28 @@ package(
 )
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+py_web_test_suite(
     name = "test",
+    # TODO(@wchargin): This test does not work in headless mode.
+    tags = ["manual"],
+    srcs = ["test.py"],
+    browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    data = [
+        ":test_web_library",
+    ],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@io_bazel_rules_webtesting//testing/web",
+        "//tensorboard/functionaltests:wct_test_driver",
+    ],
+)
+
+tf_web_library(
+    name = "test_web_library",
     srcs = [
         "assert.ts",
         "data-provider_test.ts",

--- a/tensorboard/plugins/projector/vz_projector/test/test.py
+++ b/tensorboard/plugins/projector/vz_projector/test/test.py
@@ -1,0 +1,29 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+from tensorboard.functionaltests import wct_test_driver
+
+
+Test = wct_test_driver.create_test_class(
+    "tensorboard/plugins/projector/vz_projector/test/test_web_library",
+    "/vz-projector/test/tests.html")
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Summary:
As of #1615, we have the infrastructure necessary to run most of our
frontend tests. This commit processes those test targets listed by

    $ git ls-tree -zr --name-only HEAD | grep -z 'test.*\.ts' | tr '\0' '\n'

with three exceptions:

  - the false positive `web-component-tester.d.ts` is not actually
    itself a test;

  - tests under `//tensorboard/components/tf_tensorboard/test` do not
    have a BUILD file, and the main HTML file appears to use a different
    pattern for loading and running the tests, so we can figure these
    out in a separate commit; and

  - tests under `//tensorboard/plugins/graph/tf_graph_loader/test` do
    not have a BUILD file, and do not actually have any tests, anyway.

Some test cases are not run automatically because they are currently
failing.

Test Plan:
Run `bazel test //tensorboard/...` in Python 2 and Python 3. Verify that
all tests pass, and that there are a bunch of new `:test_chromium`
targets running.

wchargin-branch: enable-frontend-tests
