### PR TITLE
test: mark web driver tests as short and flaky

### DIFF
--- a/tensorboard/components/tf_backend/test/BUILD
+++ b/tensorboard/components/tf_backend/test/BUILD
@@ -12,6 +12,8 @@ py_web_test_suite(
     name = "test",
     srcs = ["test.py"],
     browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    timeout = "short",
+    flaky = True,
     data = [
         ":test_web_library",
     ],

--- a/tensorboard/components/tf_categorization_utils/test/BUILD
+++ b/tensorboard/components/tf_categorization_utils/test/BUILD
@@ -12,6 +12,8 @@ py_web_test_suite(
     name = "test",
     srcs = ["test.py"],
     browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    timeout = "short",
+    flaky = True,
     data = [
         ":test_web_library",
     ],

--- a/tensorboard/components/tf_color_scale/test/BUILD
+++ b/tensorboard/components/tf_color_scale/test/BUILD
@@ -12,6 +12,8 @@ py_web_test_suite(
     name = "test",
     srcs = ["test.py"],
     browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    timeout = "short",
+    flaky = True,
     data = [
         ":test_web_library",
     ],

--- a/tensorboard/components/tf_data_selector/test/BUILD
+++ b/tensorboard/components/tf_data_selector/test/BUILD
@@ -12,6 +12,8 @@ py_web_test_suite(
     name = "test",
     srcs = ["test.py"],
     browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    timeout = "short",
+    flaky = True,
     data = [
         ":test_web_library",
     ],

--- a/tensorboard/components/tf_paginated_view/test/BUILD
+++ b/tensorboard/components/tf_paginated_view/test/BUILD
@@ -12,6 +12,8 @@ py_web_test_suite(
     name = "test",
     srcs = ["test.py"],
     browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    timeout = "short",
+    flaky = True,
     data = [
         ":test_web_library",
     ],

--- a/tensorboard/components/tf_storage/test/BUILD
+++ b/tensorboard/components/tf_storage/test/BUILD
@@ -12,6 +12,8 @@ py_web_test_suite(
     name = "test",
     srcs = ["test.py"],
     browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    timeout = "short",
+    flaky = True,
     data = [
         ":test_web_library",
     ],

--- a/tensorboard/components/vz_line_chart2/test/BUILD
+++ b/tensorboard/components/vz_line_chart2/test/BUILD
@@ -12,6 +12,8 @@ py_web_test_suite(
     name = "test",
     srcs = ["test.py"],
     browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    timeout = "short",
+    flaky = True,
     data = [
         ":test_web_library",
     ],

--- a/tensorboard/components/vz_sorting/test/BUILD
+++ b/tensorboard/components/vz_sorting/test/BUILD
@@ -12,6 +12,8 @@ py_web_test_suite(
     name = "test",
     srcs = ["test.py"],
     browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    timeout = "short",
+    flaky = True,
     data = [
         ":test_web_library",
     ],

--- a/tensorboard/plugins/audio/tf_audio_dashboard/test/BUILD
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/test/BUILD
@@ -14,6 +14,8 @@ py_web_test_suite(
     tags = ["manual"],
     srcs = ["test.py"],
     browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    timeout = "short",
+    flaky = True,
     data = [
         ":test_web_library",
     ],

--- a/tensorboard/plugins/graph/tf_graph_common/test/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_common/test/BUILD
@@ -12,6 +12,8 @@ py_web_test_suite(
     name = "test",
     srcs = ["test.py"],
     browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    timeout = "short",
+    flaky = True,
     data = [
         ":test_web_library",
     ],

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/test/BUILD
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/test/BUILD
@@ -12,6 +12,8 @@ py_web_test_suite(
     name = "test",
     srcs = ["test.py"],
     browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    timeout = "short",
+    flaky = True,
     data = [
         ":test_web_library",
     ],

--- a/tensorboard/plugins/projector/vz_projector/test/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/test/BUILD
@@ -14,6 +14,8 @@ py_web_test_suite(
     tags = ["manual"],
     srcs = ["test.py"],
     browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+    timeout = "short",
+    flaky = True,
     data = [
         ":test_web_library",
     ],


### PR DESCRIPTION
Summary:
These tests have a default timeout of 900s, which is way too long: they
should never take more than 20 seconds to legitimately complete, so
that’s just time spent waiting. The WebDriver connection also appears to
be somewhat flaky (@stephanwlee estimates that each test fails
independently with probability about 1/50), so we mark these tests
accordingly.

Generated with

    awk -i inplace '
        /browsers =/ {
            print;
            print "    timeout = \"short\",";
            print "    flaky = True,";
            next
        }
        1
    ' $(git grep -F --name-only 'name = "test_web_library"')

Test Plan:
Running `bazel test //tensorboard/...` still passes. We’ll see
anecdotally whether this reduces the number of spurious Travis failures.

wchargin-branch: test-webdriver-short-flaky