### PR TITLE
Add class on image card date for webdriver test

### DIFF
--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -51,7 +51,7 @@ future for loading older images.
           <div class="heading-label">
             step <span style="font-weight: bold">[[_toLocaleString(_stepValue)]]</span>
           </div>
-          <div class="heading-label heading-right">
+          <div class="heading-label heading-right datetime">
             <template is="dom-if" if="[[_currentWallTime]]">
               [[_currentWallTime]]
             </template>


### PR DESCRIPTION
We would like to able to hide datetime in the view that can sometimes
cause unnecessary flakiness. Currently, it is hard to select a datetime
without relying on specific dom structure.