### PR TITLE
Disable base 36 encoding of IDs

### DIFF
--- a/tensorboard/components/tf_data_selector/storage-utils.ts
+++ b/tensorboard/components/tf_data_selector/storage-utils.ts
@@ -15,7 +15,7 @@ limitations under the License.
 namespace tf_data_selector {
 
 export function decodeIdArray(str: string): Array<number> {
-  return str.split(',').map(idStr => parseInt(idStr, 36)).filter(Boolean);
+  return str.split(',').map(idStr => parseInt(idStr, 10)).filter(Boolean);
 }
 
 export function encodeIdArray(arr: Array<number>): string {
@@ -23,7 +23,7 @@ export function encodeIdArray(arr: Array<number>): string {
 }
 
 export function encodeId(id: number): string {
-  return id.toString(36);
+  return String(id);
 }
 
 export const NO_EXPERIMENT_ID = null;

--- a/tensorboard/components/tf_data_selector/test/storage-utils-test.ts
+++ b/tensorboard/components/tf_data_selector/test/storage-utils-test.ts
@@ -19,7 +19,7 @@ const {assert} = chai;
 describe('storageUtils', () => {
   describe('decodeIdArray', () => {
     it('decodes list of ids from a string', () => {
-      const actual = tf_data_selector.decodeIdArray('1,2,3,2s');
+      const actual = tf_data_selector.decodeIdArray('1,2,3,100');
       assert.deepEqual(actual, [1, 2, 3, 100]);
     });
 
@@ -28,26 +28,21 @@ describe('storageUtils', () => {
       assert.deepEqual(actual, [1]);
     });
 
-    // TODO(@stephanwlee): This test fails:
-    // expected [ 1, 2, 1461559270678 ] to deeply equal [ NaN, 1, 2, NaN, Infinity ]
-    it.skip('decodes with unexpected string', () => {
+    it('filters non-number (including inf) from decoded ids', () => {
       const actual = tf_data_selector.decodeIdArray(',1, 2,!a,Infinity');
-      assert.deepEqual(actual, [NaN, 1, 2, NaN, Infinity]);
+      assert.deepEqual(actual, [1, 2]);
     });
   });
 
-  // TODO(#1625): This behavior is implementation-defined. The expected
-  // values are accurate for some versions of Chrome/Chromium, but not
-  // all.
-  describe.skip('encodeIdArray', () => {
+  describe('encodeIdArray', () => {
     it('encodes list of ids', () => {
       const actual = tf_data_selector.encodeIdArray([1, 2, 3, 100]);
-      assert.equal(actual, '1,2,3,2s');
+      assert.deepEqual(actual, '1,2,3,100');
     });
 
     it('behaves ok for floats', () => {
       const actual = tf_data_selector.encodeIdArray([1, 1.9]);
-      assert.equal(actual, '1,1.weeeeeeeee');
+      assert.equal(actual, '1,1.9');
     });
 
     it('behaves ok with large numbers', () => {


### PR DESCRIPTION
To save space on URL, data_selector persisted IDs by base 36 serializing
the ids. However, this lead to inconsistent behavior across browsers
while achieving very weak compression.

We disable the compression for now in favor of more holistic compression
at the tf_storage level using libraries like lz_string for URL safe
compression.

Related: #1625