### PR TITLE
router: remove demo mode

### DIFF
--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -17,53 +17,53 @@ namespace tf_backend {
 export interface Router {
   environment: () => string;
   experiments: () => string;
-  isDemoMode: () => boolean;
-  pluginRoute: (pluginName: string, route: string,
-      params?: URLSearchParams, demoCustomExt?: string) => string;
+  pluginRoute: (
+    pluginName: string,
+    route: string,
+    params?: URLSearchParams
+  ) => string;
   pluginsListing: () => string;
   runs: () => string;
   runsForExperiment: (id: tf_backend.ExperimentId) => string;
 };
+
+let _router: Router = createRouter();
 
 /**
  * Create a router for communicating with the TensorBoard backend. You
  * can pass this to `setRouter` to make it the global router.
  *
  * @param dataDir {string=} The base prefix for data endpoints.
- * @param demoMode {boolean=} Whether to modify urls for filesystem demo usage.
  */
-export function createRouter(dataDir = 'data', demoMode = false): Router {
-  if (dataDir[dataDir.length - 1] === '/') {
+export function createRouter(dataDir = "data"): Router {
+  if (dataDir[dataDir.length - 1] === "/") {
     dataDir = dataDir.slice(0, dataDir.length - 1);
   }
-  const createDataPath = demoMode ? createDemoDataPath : createProdDataPath;
-  const ext = demoMode ? '.json' : '';
   return {
-    environment: () => createDataPath(dataDir, '/environment', ext),
-    experiments: () => createDataPath(dataDir, '/experiments', ext),
-    isDemoMode: () => demoMode,
-    pluginRoute: (pluginName: string, route: string,
-        params?: URLSearchParams, demoCustomExt = ext): string => {
-
+    environment: () => createDataPath(dataDir, "/environment"),
+    experiments: () => createDataPath(dataDir, "/experiments"),
+    pluginRoute: (
+      pluginName: string,
+      route: string,
+      params?: URLSearchParams
+    ): string => {
       return createDataPath(
-          demoMode ? dataDir : dataDir + '/plugin',
-          `/${pluginName}${route}`,
-          demoCustomExt,
-          params);
+        dataDir + "/plugin",
+        `/${pluginName}${route}`,
+        params
+      );
     },
-    pluginsListing: () => createDataPath(dataDir, '/plugins_listing', ext),
-    runs: () => createDataPath(dataDir, '/runs', ext),
-    runsForExperiment: id => {
+    pluginsListing: () => createDataPath(dataDir, "/plugins_listing"),
+    runs: () => createDataPath(dataDir, "/runs"),
+    runsForExperiment: (id) => {
       return createDataPath(
-          dataDir,
-          '/experiment_runs',
-          ext,
-          createSearchParam({experiment: String(id)}));
+        dataDir,
+        "/experiment_runs",
+        createSearchParam({experiment: String(id)})
+      );
     },
   };
-};
-
-let _router: Router = createRouter();
+}
 
 /**
  * @return {Router} the global router
@@ -87,55 +87,17 @@ export function setRouter(router: Router): void {
   _router = router;
 }
 
-function createProdDataPath(dataDir: string, route: string,
-    ext: string, params: URLSearchParams = new URLSearchParams()): string {
+function createDataPath(
+  dataDir: string,
+  route: string,
+  params: URLSearchParams = new URLSearchParams()
+): string {
   let relativePath = dataDir + route;
   if (String(params)) {
-    const delimiter = route.includes('?') ? '&' : '?';
+    const delimiter = route.includes("?") ? "&" : "?";
     relativePath += delimiter + String(params);
   }
   return relativePath;
-}
-
-/**
- * Creates a URL for demo apps.
- *
- * [1]: Demo pages are served as files and data routes are served as JSON files.
- * For shareability and ease of use, the data files are served at root[2], "/",
- * thus, the demo data path should return the absolute path regardless of
- * current pathname.
- *
- * [2]: See the path property of tensorboard/demo/BUILD:demo_data.
- *
- * e.g.,
- * > createDemoDataPath('a', '/b', '.json', {a: 1})
- * < '/a/b_a_1.json'
- */
-function createDemoDataPath(dataDir: string, route: string,
-    ext: string, params: URLSearchParams = new URLSearchParams()): string {
-
-  // First, parse the path in a safe manner by constructing a URL. We don't
-  // trust the path supplied by consumer.
-  const absRoute = route.startsWith('/') ? route : '/' + route;
-  const absUrl = new URL(route, window.location.href);
-  let {pathname: normalizedPath, searchParams: normalizedSearchParams} = absUrl;
-  const queryParam = [normalizedSearchParams, params]
-        .map(p => String(p))
-        .filter(Boolean)
-        .join('&');
-  const encodedQueryParam = queryParam.replace(/[&=%]/g, '_');
-
-  // Strip leading slashes.
-  normalizedPath = normalizedPath.replace(/^\/+/g, '');
-  // Convert slashes to underscores.
-  normalizedPath = normalizedPath.replace(/\//g, '_');
-  // Add query parameter as path if it is present.
-  if (encodedQueryParam) normalizedPath += `_${encodedQueryParam}`;
-
-  const pathname = `${dataDir}/${normalizedPath}${ext}`;
-  // See [1] for the reason why we are forming an absolute path here.
-  const absPathname = pathname.startsWith('/') ? pathname : '/' + pathname;
-  return absPathname;
 }
 
 export function createSearchParam(params: QueryParams = {}): URLSearchParams {

--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -44,15 +44,6 @@ function assertIsDatum(x) {
 }
 
 describe('backend tests', () => {
-  let rm: RequestManager;
-  const base = 'data';
-  const demoRouter = createRouter(base, /*demoMode=*/true);
-
-  beforeEach(() => {
-    setRouter(demoRouter);
-    rm = new RequestManager();
-  });
-
   it('runToTag helpers work', () => {
     const r2t: RunToTag = {
       run1: ['foo', 'bar', 'zod'],
@@ -79,21 +70,21 @@ describe('backend tests', () => {
     describe('prod mode', () => {
       let router: Router;
       beforeEach(() => {
-        router = createRouter(base, /*demoMode=*/false);
+        router = createRouter('data');
       });
 
       it('leading slash in pathPrefix is an absolute path', () => {
-        const router = createRouter('/data/', /*demoMode=*/false);
+        const router = createRouter('/data/');
         assert.equal(router.runs(), '/data/runs');
       });
 
       it('returns complete pathname when pathPrefix omits slash', () => {
-        const router = createRouter('data/', /*demoMode=*/false);
+        const router = createRouter('data/');
         assert.equal(router.runs(), 'data/runs');
       });
 
       it('does not prune many leading slashes that forms full url', () => {
-        const router = createRouter('///data/hello', /*demoMode=*/false);
+        const router = createRouter('///data/hello');
         // This becomes 'http://data/hello/runs'
         assert.equal(router.runs(), '///data/hello/runs');
       });
@@ -104,10 +95,6 @@ describe('backend tests', () => {
 
       it('returns correct value for #experiments', () => {
         assert.equal(router.experiments(), 'data/experiments');
-      });
-
-      it('returns correct value for #isDemoMode', () => {
-        assert.equal(router.isDemoMode(), false);
       });
 
       describe('#pluginRoute', () => {
@@ -161,12 +148,6 @@ describe('backend tests', () => {
                   createSearchParam({foo: '()'})),
               addParams('data/plugin/scalars/a', {foo: '()'}));
         });
-
-        it('ignores custom extension', () => {
-          assert.equal(
-              router.pluginRoute('scalars', '/a', undefined, 'meow'),
-              'data/plugin/scalars/a');
-        });
       });
 
       it('returns correct value for #pluginsListing', () => {
@@ -185,102 +166,6 @@ describe('backend tests', () => {
       });
     });
 
-    describe('demoMode', () => {
-      let router: Router;
-
-      beforeEach(() => {
-        router = createRouter(base, /*demoMode=*/true);
-      });
-
-      it('treats pathPrefix with leading slash as absolute path', () => {
-        const router = createRouter('/data/', /*demoMode=*/true);
-        assert.equal(router.runs(), '/data/runs.json');
-      });
-
-      it('treats pathPrefix without leading slash as absolute path', () => {
-        const router = createRouter('data/', /*demoMode=*/true);
-        assert.equal(router.runs(), '/data/runs.json');
-      });
-
-      it('does not form absolute url with multiple leading slashes', () => {
-        const router = createRouter('///data/', /*demoMode=*/true);
-        // For prod url, this would be http://data/runs
-        assert.equal(router.runs(), '///data/runs.json');
-      });
-
-      it('returns correct value for #environment', () => {
-        assert.equal(router.environment(), '/data/environment.json');
-      });
-
-      it('returns correct value for #experiments', () => {
-        assert.equal(router.experiments(), '/data/experiments.json');
-      });
-
-      it('returns correct value for #isDemoMode', () => {
-        assert.equal(router.isDemoMode(), true);
-      });
-
-      describe('#pluginRoute', () => {
-        it('encodes slash correctly', () => {
-          assert.equal(
-              router.pluginRoute('scalars', '/scalar'),
-              '/data/scalars_scalar.json');
-        });
-
-        it('encodes query param correctly', () => {
-          assert.equal(
-              router.pluginRoute(
-                  'scalars',
-                  '/a',
-                  createSearchParam({b: 'c', d: ['1', '2']})),
-              '/data/scalars_a_b_c_d_1_d_2.json');
-        });
-
-        it('deals with existing query param correctly', () => {
-          assert.equal(
-              router.pluginRoute('scalars', '/a?foo=bar',
-                  createSearchParam({hello: 'world'})),
-              '/data/scalars_a_foo_bar_hello_world.json');
-        });
-
-        it('encodes parenthesis correctly', () => {
-          assert.equal(
-              router.pluginRoute(
-                  'scalars',
-                  '/a',
-                  createSearchParam({foo: '()'})),
-              '/data/scalars_a_foo__28_29.json');
-        });
-
-        it('uses custom extension if provided', () => {
-          assert.equal(
-              router.pluginRoute('scalars', '/a', undefined, ''),
-              '/data/scalars_a');
-          assert.equal(
-              router.pluginRoute('scalars', '/a', undefined, '.meow'),
-              '/data/scalars_a.meow');
-          assert.equal(
-              router.pluginRoute('scalars', '/a'),
-              '/data/scalars_a.json');
-        });
-      });
-
-      it('returns correct value for #pluginsListing', () => {
-        assert.equal(
-            router.pluginsListing(),
-            '/data/plugins_listing.json');
-      });
-
-      it('returns correct value for #runs', () => {
-        assert.equal(router.runs(), '/data/runs.json');
-      });
-
-      it('returns correct value for #runsForExperiment', () => {
-        assert.equal(
-            router.runsForExperiment(1),
-            '/data/experiment_runs_experiment_1.json');
-      });
-    });
   });
 });
 

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.html
@@ -222,7 +222,6 @@ backend.
         this.requestManager.request(url).then(updateSteps);
       },
       _createStepDatum(audioMetadata) {
-        const isDemoMode = tf_backend.getRouter().isDemoMode();
         const searchParam = new URLSearchParams(audioMetadata.query);
         // Include wall_time just to disambiguate the URL and force
         // the browser to reload the audio when the URL changes. The
@@ -231,8 +230,8 @@ backend.
         const url = tf_backend.getRouter().pluginRoute(
             'audio',
             '/individualAudio',
-            searchParam,
-            /* demoCustomExt */ '.wav');
+            searchParam
+        );
 
         return {
           wall_time: tf_card_heading.formatDate(new Date(audioMetadata.wall_time * 1000)),

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -292,17 +292,15 @@ Polymer({
         tf_backend.getRouter().pluginRoute('debugger', '/numerics_alert_report'));
   },
   _graphUrl(run, limitAttrSize, largeAttrsKey) {
-    const demoMode = tf_backend.getRouter().isDemoMode();
-    const optional = (p) => (p != null && !demoMode || undefined) && p;
     return tf_backend.getRouter().pluginRoute(
         'graphs',
         '/graph',
         new URLSearchParams({
           'run': run,
-          'limit_attr_size': optional(limitAttrSize),
-          'large_attrs_key': optional(largeAttrsKey),
+          'limit_attr_size': limitAttrSize,
+          'large_attrs_key': largeAttrsKey,
         }),
-        /* demoCustomExt */ '.pbtxt');
+    );
   },
   _shouldRequestHealthPills: function() {
     // Do not load debugger data if the feature is disabled, if the user toggled off the feature,

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -340,8 +340,7 @@ profile run can have multiple tools that present the performance profile as diff
       // Set this to true so we only initialize once.
       this._initialized = true;
       const profileTagsURL =
-        tf_backend.getRouter().pluginRoute('profile', '/tools') +
-        (tf_backend.getRouter().isDemoMode() ? '.json' : '');
+        tf_backend.getRouter().pluginRoute('profile', '/tools');
       // Reset the progress bar to 0.
       this.set('progress', {
         value: 0,


### PR DESCRIPTION
Summary:
Resolves #1640.

Test Plan:
Within TypeScript files, the fact that the code typechecks is sufficient
to verify that callers are correct. To account for JS-in-HTML files,
first note that `git grep isDemoMode` returns no results. Then note that
each call site of `git grep pluginRoute` has been updated to use either
the 2-argument or 3-argument form (i.e., not passing a `demoCustomExt`).
I also manually checked the basic behavior of each plugin on the
frontend.

wchargin-branch: router-remove-demo-mode