### PR TITLE
Remove some broken demos and demo annotations

### DIFF
--- a/tensorboard/components/vz_chart_helpers/vz-chart-tooltip.html
+++ b/tensorboard/components/vz_chart_helpers/vz-chart-tooltip.html
@@ -26,7 +26,6 @@ This line chart supports drawing multiple lines at the same time, with features
 such as different X scales (linear and temporal), tooltips and smoothing.
 
 @element vz-line-chart
-@demo demo/index.html
 -->
 <dom-module id="vz-chart-tooltip">
   <template>

--- a/tensorboard/components/vz_line_chart/vz-line-chart.html
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.html
@@ -30,7 +30,7 @@ This line chart supports drawing multiple lines at the same time, with features
 such as different X scales (linear and temporal), tooltips and smoothing.
 
 @element vz-line-chart
-@demo demo/index.html
+@demo index.html
 -->
 <dom-module id="vz-line-chart">
   <template>

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.html
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.html
@@ -31,7 +31,6 @@ This line chart supports drawing multiple lines at the same time, with features
 such as different X scales (linear and temporal), tooltips and smoothing.
 
 @element vz-line-chart
-@demo demo/index.html
 -->
 <dom-module id="vz-line-chart2">
   <template>

--- a/tensorboard/plugins/histogram/vz_histogram_timeseries/vz-histogram-timeseries.html
+++ b/tensorboard/plugins/histogram/vz_histogram_timeseries/vz-histogram-timeseries.html
@@ -26,7 +26,7 @@ This histogram supports changing the time axis type and different modes of
 visualization.
 
 @element vz-histogram-timeseries
-@demo demo/index.html
+@demo index.html
 -->
 <dom-module id="vz-histogram-timeseries">
     <template>

--- a/tensorboard/plugins/profile/google_chart/google-chart.html
+++ b/tensorboard/plugins/profile/google_chart/google-chart.html
@@ -70,8 +70,6 @@ You can display the charts in locales other than "en" by setting the `lang` attr
 on the `html` tag of your document.
 
     <html lang="ja">
-
-@demo
 -->
 <dom-module id="google-chart">
   <template>


### PR DESCRIPTION
Summary:
Some modules have `@demo` annotations that point to nonexistent demos,
so we fix or remove those references as appropriate.

The `google-chart` demo is not working and does not appear to have ever
worked: when running it on its initial commit after cherry-picking #1334
we see only a blank page. However, deleting this demo isn’t trivial,
because the main profile dashboard depends on it for some reason. As
this plugin is still being actively developed, we’ll leave the demo
alone for now: it’s not actually causing any problems.

Context: <https://github.com/tensorflow/tensorboard/pull/1645#issuecomment-443000383>

Test Plan:
Note that `git grep @demo` only lists correct paths to working demos.

wchargin-branch: remove-broken-demos