### PR TITLE
docs: add instructions for building old revisions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,3 +25,11 @@ To generate fake log data for a plugin, run its demo script. For instance, this 
 ```sh
 (tf)$ bazel run //tensorboard/plugins/scalar:scalars_demo
 ```
+
+If you have Bazel≥0.16 and want to build any commit of TensorBoard prior to 2018-08-07, then you must first cherry-pick [pull request #1334][pr-1334] onto your working tree:
+
+```
+$ git cherry-pick bc4e7a6e5517daf918433a8f5983fc6bd239358f
+```
+
+[pr-1334]: https://github.com/tensorflow/tensorboard/pull/1334


### PR DESCRIPTION
Summary:
When bisecting or exploring the history, it can be useful to build old
commits. Unfortunately, due to backward-incompatible changes in Bazel,
this is not possible natively. This commit describes a workaround.

It’s unfortunately not too discoverable in `DEVELOPMENT.md`, but at
least it’s somewhere.

Test Plan:

    $ git checkout -q "$(git rev-list origin/master --before=2018-08-01 -n 1)"
    $ bazel build //tensorboard 2>&1 | tail -n 1
    FAILED: Build did NOT complete successfully
    $ git cherry-pick bc4e7a6e5517daf918433a8f5983fc6bd239358f >/dev/null
    $ bazel build //tensorboard 2>&1 | tail -n 1
    INFO: Build completed successfully, 117 total actions

wchargin-branch: docs-build-old