### PR TITLE
Upgrade the ChromeDriver for Chromium 70

### DIFF
--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -51,15 +51,15 @@ def tensorboard_workspace():
       name = "org_chromium_chromedriver",
       licenses = ["notice"],  # Apache 2.0
       sha256_urls = {
-          "59e6b1b1656a20334d5731b3c5a7400f92a9c6f5043bb4ab67f1ccf1979ee486": [
-              "https://mirror.bazel.build/chromedriver.storage.googleapis.com/2.26/chromedriver_linux64.zip",
-              "http://chromedriver.storage.googleapis.com/2.26/chromedriver_linux64.zip",
+          "687d2e15c42908e2911344c08a949461b3f20a83017a7a682ef4d002e05b5d46": [
+              "https://mirror.bazel.build/chromedriver.storage.googleapis.com/2.44/chromedriver_linux64.zip",
+              "http://chromedriver.storage.googleapis.com/2.44/chromedriver_linux64.zip",
           ],
       },
       sha256_urls_macos = {
-          "70aae3812941ed94ad8065bb4a9432861d7d4ebacdd93ee47bb2c7c57c7e841e": [
-              "https://mirror.bazel.build/chromedriver.storage.googleapis.com/2.26/chromedriver_mac64.zip",
-              "http://chromedriver.storage.googleapis.com/2.26/chromedriver_mac64.zip",
+          "3fd49c2782a5f93cb48ff2dee021004d9a7fb393798e4c4807b391cedcd30ed9": [
+              "https://mirror.bazel.build/chromedriver.storage.googleapis.com/2.44/chromedriver_mac64.zip",
+              "http://chromedriver.storage.googleapis.com/2.44/chromedriver_mac64.zip",
           ],
       },
       generated_rule_name = "archive",


### PR DESCRIPTION
Generally, it is a good idea to update the ChromeDriver along with
Chromium we use since they can sometimes be incompatible. Upgrade
to the latest ChromeDriver that supports 70.

Ran the test 200 times and it does not seem to solve the flakiness issue we were witnessing.
```sh
//tensorboard/components/tf_backend/test:test_chromium                   PASSED in 10.4s
  Stats over 200 runs: max = 10.4s, min = 5.9s, avg = 8.1s, dev = 0.7s
//tensorboard/components/tf_categorization_utils/test:test_chromium      PASSED in 10.2s
  Stats over 200 runs: max = 10.2s, min = 6.7s, avg = 8.3s, dev = 0.7s
//tensorboard/components/tf_color_scale/test:test_chromium               PASSED in 10.0s
  Stats over 200 runs: max = 10.0s, min = 6.7s, avg = 8.1s, dev = 0.7s
//tensorboard/components/tf_data_selector/test:test_chromium             PASSED in 10.0s
  Stats over 200 runs: max = 10.0s, min = 6.4s, avg = 8.1s, dev = 0.6s
//tensorboard/components/tf_storage/test:test_chromium                   PASSED in 10.3s
  Stats over 200 runs: max = 10.3s, min = 6.2s, avg = 8.0s, dev = 0.7s
//tensorboard/components/vz_line_chart2/test:test_chromium               PASSED in 9.6s
  Stats over 200 runs: max = 9.6s, min = 6.4s, avg = 8.0s, dev = 0.6s
//tensorboard/components/tf_paginated_view/test:test_chromium             FLAKY, failed in 1 out of 201 in 10.1s
  Stats over 201 runs: max = 10.1s, min = 1.2s, avg = 8.7s, dev = 0.8s
//tensorboard/components/vz_sorting/test:test_chromium                    FLAKY, failed in 1 out of 201 in 9.2s
  Stats over 201 runs: max = 9.2s, min = 1.5s, avg = 7.7s, dev = 0.7s
```