### PR TITLE
test: add `tf_web_test` Starlark macro

### DIFF
--- a/tensorboard/components/vz_sorting/test/BUILD
+++ b/tensorboard/components/vz_sorting/test/BUILD
@@ -3,25 +3,14 @@ package(
     default_visibility = ["//tensorboard:internal"],
 )
 
-load("//tensorboard/defs:web.bzl", "tf_web_library")
-load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 
-py_web_test_suite(
+tf_web_test(
     name = "test",
-    srcs = ["test.py"],
-    browsers = ["//tensorboard/functionaltests/browsers:chromium"],
-    timeout = "short",
-    flaky = True,
-    data = [
-        ":test_web_library",
-    ],
-    srcs_version = "PY2AND3",
-    deps = [
-        "@io_bazel_rules_webtesting//testing/web",
-        "//tensorboard/functionaltests:wct_test_driver",
-    ],
+    web_library = ":test_web_library",
+    src = "/vz-sorting/test/tests.html",
 )
 
 tf_web_library(

--- a/tensorboard/defs/BUILD
+++ b/tensorboard/defs/BUILD
@@ -12,3 +12,5 @@ filegroup(
     ],
     visibility = ["//visibility:public"],
 )
+
+exports_files(["web_test_python_stub.template.py"])

--- a/tensorboard/defs/web_test_python_stub.template.py
+++ b/tensorboard/defs/web_test_python_stub.template.py
@@ -21,8 +21,8 @@ from tensorboard.functionaltests import wct_test_driver
 
 
 Test = wct_test_driver.create_test_class(
-    "tensorboard/components/vz_sorting/test/test_web_library",
-    "/vz-sorting/test/tests.html")
+    "{BINARY_PATH}",
+    "{WEB_PATH}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
This macro removes the need to create a `test.py` target for each web
test, and centralizes some common options like browser selection,
default test timeout, and flakiness.

A benefit of this change is that it removes the direct dependency on the
webtesting rules in each BUILD file, instead centralizing the dependency
in `web.bzl`. This makes it easier to change this dependency when we
import into Google (where the infrastructure is different).

Test Plan:
Run `bazel test //tensorboard/components/vz_sorting/test` and note that
it passes. Then, change `sortingTests.ts` to make a test fail. Re-run
the bazel command and note that it fails. Run with `bazel run` instead
and note that it opens a browser.

wchargin-branch: tf-web-test

