### PR TITLE
web.bzl: mark end of `tf_web_test` macro

### DIFF
--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -441,3 +441,4 @@ def tf_web_test(name, web_library, src, **kwargs):
       ],
       **kwargs
   )
+  # END tf_web_test


### PR DESCRIPTION
Summary:
This is needed for the Google import process.

wchargin-branch: end-tf-web-test