### PR TITLE
build: fix Bazel 0.20.0 compatibility issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/
 
 env:
-  - BAZEL=0.13.0 TF=NIGHTLY
+  - BAZEL=0.16.0 TF=NIGHTLY
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,6 @@ before_install:
   - echo "build --local_resources=400,2,1.0" >>~/.bazelrc
   - echo "build --worker_max_instances=2" >>~/.bazelrc
 
-  # This is the magic incantation for making protobuf build 2x faster.
-  # Unfortunately, it also breaks the build, due to a bug that has
-  # existed since Bazel 0.16.0 and has not been fixed as of Bazel
-  # 0.20.0: <https://github.com/bazelbuild/bazel/issues/5572>
-  # - echo "build --distinct_host_configuration=false" >>~/.bazelrc
-
   # Make Bazel as strict as possible, so TensorBoard will build correctly
   # for users, regardless of their Bazel configuration.
   - echo "build --worker_verbose" >>~/.bazelrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ cache:
 # If inline scripts get too long, Travis surprisingly prints them twice.
 
 before_install:
-  - which java || : STOPSHIP
-  - which javac || : STOPSHIP
-  - java -version || : STOPSHIP
-  - javac -version || : STOPSHIP
-  - dpkg -S "$(which java)" || : STOPSHIP
-  - dpkg -S "$(which javac)" || : STOPSHIP
+  - which java || true  # STOPSHIP
+  - which javac || true  # STOPSHIP
+  - java -version || true  # STOPSHIP
+  - javac -version || true  # STOPSHIP
+  - dpkg -S "$(which java)" || true  # STOPSHIP
+  - dpkg -S "$(which javac)" || true  # STOPSHIP
 
   - wget -t 3 -O bazel https://mirror.bazel.build/github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-linux-x86_64
   - chmod +x bazel

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/
 
 env:
-  - BAZEL=0.16.0 TF=NIGHTLY
+  - BAZEL=0.16.1 TF=NIGHTLY
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/
 
 env:
-  - BAZEL=0.16.1 TF=NIGHTLY
+  - BAZEL=0.20.0 TF=NIGHTLY
 
 cache:
   directories:
@@ -27,6 +27,13 @@ cache:
 # If inline scripts get too long, Travis surprisingly prints them twice.
 
 before_install:
+  - which java || : STOPSHIP
+  - which javac || : STOPSHIP
+  - java -version || : STOPSHIP
+  - javac -version || : STOPSHIP
+  - dpkg -S "$(which java)" || : STOPSHIP
+  - dpkg -S "$(which javac)" || : STOPSHIP
+
   - wget -t 3 -O bazel https://mirror.bazel.build/github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-linux-x86_64
   - chmod +x bazel
   - sudo mv bazel /usr/local/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/
 
 env:
-  - BAZEL=0.20.0 TF=NIGHTLY
+  - BAZEL=0.16.1 TF=NIGHTLY
 
 cache:
   directories:
@@ -51,7 +51,9 @@ before_install:
   - echo "build --worker_max_instances=2" >>~/.bazelrc
 
   # This is the magic incantation for making protobuf build 2x faster.
-  - echo "build --distinct_host_configuration=false" >>~/.bazelrc
+  # Unfortunately, it also breaks the build in Bazel>=0.16.0:
+  # https://github.com/bazelbuild/bazel/issues/5572
+  #- echo "build --distinct_host_configuration=false" >>~/.bazelrc
 
   # Make Bazel as strict as possible, so TensorBoard will build correctly
   # for users, regardless of their Bazel configuration.

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ branches:
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/
 
 env:
+  # Keep this Bazel version in sync with the `versions.check` directive
+  # near the top of our WORKSPACE file.
   - BAZEL=0.16.1 TF=NIGHTLY
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,6 @@ cache:
 # If inline scripts get too long, Travis surprisingly prints them twice.
 
 before_install:
-  - which java || true  # STOPSHIP
-  - which javac || true  # STOPSHIP
-  - java -version || true  # STOPSHIP
-  - javac -version || true  # STOPSHIP
-  - dpkg -S "$(which java)" || true  # STOPSHIP
-  - dpkg -S "$(which javac)" || true  # STOPSHIP
-
   - wget -t 3 -O bazel https://mirror.bazel.build/github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-linux-x86_64
   - chmod +x bazel
   - sudo mv bazel /usr/local/bin
@@ -51,9 +44,10 @@ before_install:
   - echo "build --worker_max_instances=2" >>~/.bazelrc
 
   # This is the magic incantation for making protobuf build 2x faster.
-  # Unfortunately, it also breaks the build in Bazel>=0.16.0:
-  # https://github.com/bazelbuild/bazel/issues/5572
-  #- echo "build --distinct_host_configuration=false" >>~/.bazelrc
+  # Unfortunately, it also breaks the build, due to a bug that has
+  # existed since Bazel 0.16.0 and has not been fixed as of Bazel
+  # 0.20.0: <https://github.com/bazelbuild/bazel/issues/5572>
+  # - echo "build --distinct_host_configuration=false" >>~/.bazelrc
 
   # Make Bazel as strict as possible, so TensorBoard will build correctly
   # for users, regardless of their Bazel configuration.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "org_tensorflow_tensorboard")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "io_bazel_rules_closure",
     sha256 = "b29a8bc2cb10513c864cb1084d6f38613ef14a143797cea0af0f91cd385f5e8c",
@@ -12,33 +14,45 @@ http_archive(
 
 # Needed as a transitive dependency of rules_webtesting below.
 http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "8c333df68fb0096221e2127eda2807384e00cc211ee7e7ea4ed08d212e6a69c1",
-    strip_prefix = "rules_go-0.5.4",
+    name = "bazel_skylib",
+    sha256 = "2b9af2de004d67725c9985540811835389b229c27874f2e15f5e319622a53a3b",
+    strip_prefix = "bazel-skylib-e9fc4750d427196754bebb0e2e1e38d68893490a",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/archive/0.5.4.tar.gz",
-        "https://github.com/bazelbuild/rules_go/archive/0.5.4.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/e9fc4750d427196754bebb0e2e1e38d68893490a.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/archive/e9fc4750d427196754bebb0e2e1e38d68893490a.tar.gz",
     ],
 )
 
 # Needed as a transitive dependency of rules_webtesting below.
 http_archive(
-    name = "bazel_skylib",
-    sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
-    strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
+    name = "io_bazel_rules_go",
+    sha256 = "b7a62250a3a73277ade0ce306d22f122365b513f5402222403e507f2f997d421",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz",  # 2018-01-12
+        # tag 0.16.3 resolves to commit 01e5a9f8483167962eddd167f7689408bdeb4e76 (2018-11-28 16:28:45 -0500)
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/0.16.3/rules_go-0.16.3.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/0.16.3/rules_go-0.16.3.tar.gz",
+    ],
+)
+
+# Needed as a transitive dependency of rules_webtesting below.
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "6e875ab4b6bf64a38c352887760f21203ab054676d9c1b274963907e0768740d",
+    urls = [
+        # tag 0.15.0 resolves to commit c728ce9f663e2bff26361ba5978ec5c9e6816a3c (2018-10-13 00:06:11 +0200)
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz",
     ],
 )
 
 http_archive(
     name = "io_bazel_rules_webtesting",
-    sha256 = "a1264301424f2d920fca04f2d3c5ef5ca1be4f2bbf8c84ef38006e54aaf22753",
-    strip_prefix = "rules_webtesting-9f597bb7d1b40a63dc443d9ef7e931cfad4fb098",
+    sha256 = "89f041028627d801ba3b4ea1ef2211994392d46e25c1fc3501b95d51698e4a1e",
+    strip_prefix = "rules_webtesting-0.2.2",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_webtesting/archive/9f597bb7d1b40a63dc443d9ef7e931cfad4fb098.tar.gz",  # 2017-01-29
-        "https://github.com/bazelbuild/rules_webtesting/archive/9f597bb7d1b40a63dc443d9ef7e931cfad4fb098.tar.gz",
+        # tag 0.2.2 resolves to commit 596d07c1f38486486969302158b9019418a5409e (2018-12-04 09:20:24 -0800)
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_webtesting/archive/0.2.2.tar.gz",
+        "https://github.com/bazelbuild/rules_webtesting/archive/0.2.2.tar.gz",
     ],
 )
 
@@ -73,15 +87,19 @@ load("@org_tensorflow//tensorflow:workspace.bzl", "tf_workspace")
 
 tf_workspace()
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
+# Needed as a transitive dependency of some rules_webtesting targets.
+load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+go_rules_dependencies()
+go_register_toolchains()
 
-go_repositories()
+# Needed as a transitive dependency of some rules_webtesting targets.
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+gazelle_dependencies()
 
-load("@io_bazel_rules_webtesting//web:repositories.bzl", "browser_repositories", "web_test_repositories")
+load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories")
 
 web_test_repositories(
     omit_com_google_code_findbugs_jsr305 = True,
-    omit_com_google_code_gson = True,
     omit_com_google_errorprone_error_prone_annotations = True,
     omit_com_google_guava = True,
     omit_junit = True,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,7 @@ http_archive(
 )
 
 load("@bazel_skylib//lib:versions.bzl", "versions")
-versions.check(minimum_bazel_version = "0.16.0")
+versions.check(minimum_bazel_version = "0.16.1")
 
 http_archive(
     name = "io_bazel_rules_closure",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,6 +14,8 @@ http_archive(
 )
 
 load("@bazel_skylib//lib:versions.bzl", "versions")
+# Keep this version in sync with the BAZEL environment variable defined
+# in our .travis.yml config.
 versions.check(minimum_bazel_version = "0.16.1")
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,16 +2,6 @@ workspace(name = "org_tensorflow_tensorboard")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "io_bazel_rules_closure",
-    sha256 = "b29a8bc2cb10513c864cb1084d6f38613ef14a143797cea0af0f91cd385f5e8c",
-    strip_prefix = "rules_closure-0.8.0",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.8.0.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/0.8.0.tar.gz",  # 2018-08-03
-    ],
-)
-
 # Needed as a transitive dependency of rules_webtesting below.
 http_archive(
     name = "bazel_skylib",
@@ -20,6 +10,19 @@ http_archive(
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/e9fc4750d427196754bebb0e2e1e38d68893490a.tar.gz",
         "https://github.com/bazelbuild/bazel-skylib/archive/e9fc4750d427196754bebb0e2e1e38d68893490a.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//lib:versions.bzl", "versions")
+versions.check(minimum_bazel_version = "0.16.0")
+
+http_archive(
+    name = "io_bazel_rules_closure",
+    sha256 = "b29a8bc2cb10513c864cb1084d6f38613ef14a143797cea0af0f91cd385f5e8c",
+    strip_prefix = "rules_closure-0.8.0",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.8.0.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/0.8.0.tar.gz",  # 2018-08-03
     ],
 )
 

--- a/tensorboard/defs/web_testing.bzl
+++ b/tensorboard/defs/web_testing.bzl
@@ -73,6 +73,7 @@ def tf_web_test(name, web_library, src, **kwargs):
       srcs_version="PY2AND3",
       deps=[
           "@io_bazel_rules_webtesting//testing/web",
+          "@org_pythonhosted_urllib3//:org_pythonhosted_urllib3",
           "//tensorboard/functionaltests:wct_test_driver",
       ],
       **kwargs

--- a/tensorboard/functionaltests/browsers/BUILD
+++ b/tensorboard/functionaltests/browsers/BUILD
@@ -26,6 +26,7 @@ browser(
     metadata = "chromium.json",
     visibility = ["//visibility:public"],
     deps = [
+        "@io_bazel_rules_webtesting//go/wsl",
         "//third_party/chromium",
         "//third_party/chromium:chromedriver",
     ],

--- a/tensorboard/functionaltests/browsers/chromium.json
+++ b/tensorboard/functionaltests/browsers/chromium.json
@@ -1,10 +1,17 @@
 {
-  "environment": "chrome",
+  "environment": "local",
   "capabilities": {
     "browserName": "chrome",
-    "chromeOptions": {
-      "args": ["--no-sandbox"],
-      "binary": "%CHROME%"
+    "goog:chromeOptions": {
+      "args": ["--headless", "--no-sandbox"],
+      "binary": "%FILE:CHROMIUM%"
+    },
+    "google:wslConfig": {
+      "binary": "%FILE:CHROMEDRIVER%",
+      "port":"%WSLPORT:WSL%",
+      "args": ["--port=%WSLPORT:WSL%"],
+      "status": true,
+      "shutdown": true
     }
   }
 }

--- a/third_party/chromium/BUILD
+++ b/third_party/chromium/BUILD
@@ -14,13 +14,14 @@ config_setting(
 
 web_test_archive(
     name = "chromium",
-    archive = "@org_chromium_chromium//:archive",
+    archive = "@org_chromium_chromium//file",
+    extract = "build",
     named_files = select({
         ":linux": {
-            "CHROME": "chrome-linux/chrome",
+            "CHROMIUM": "chrome-linux/chrome",
         },
         ":mac": {
-            "CHROME": "chrome-mac/Chromium.app/Contents/MacOS/chromium",
+            "CHROMIUM": "chrome-mac/Chromium.app/Contents/MacOS/chromium",
         },
     }),
     visibility = ["//tensorboard/functionaltests/browsers:__pkg__"],
@@ -28,7 +29,8 @@ web_test_archive(
 
 web_test_archive(
     name = "chromedriver",
-    archive = "@org_chromium_chromedriver//:archive",
+    archive = "@org_chromium_chromedriver//file",
+    extract = "build",
     named_files = {"CHROMEDRIVER": "chromedriver"},
     visibility = ["//tensorboard/functionaltests/browsers:__pkg__"],
 )

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # TensorBoard external JS dependencies (both infrastructure and frontend libs)
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_closure//closure:defs.bzl", "filegroup_external")
 load("@io_bazel_rules_closure//closure:defs.bzl", "web_library_external")
 
@@ -117,7 +118,7 @@ def tensorboard_js_workspace():
       ]),
   )
 
-  native.new_http_archive(
+  http_archive(
       name = "io_angular_clutz",
       build_file = str(Label("//third_party:clutz.BUILD")),
       sha256 = "7a5c785dbcc3ae0daa1fcf4507de6a23bbecdb2bf80460651e4c2b88c1ad7582",

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -16,8 +16,10 @@
 # Protobuf and six were deliberately left in the top-level workspace, as they
 # are used in TensorFlow as well.
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 def tensorboard_python_workspace():
-  native.new_http_archive(
+  http_archive(
       name = "org_pythonhosted_markdown",
       urls = [
           "https://mirror.bazel.build/pypi.python.org/packages/1d/25/3f6d2cb31ec42ca5bd3bfbea99b63892b735d76e26f20dd2dcc34ffe4f0d/Markdown-2.6.8.tar.gz",
@@ -28,7 +30,20 @@ def tensorboard_python_workspace():
       build_file = str(Label("//third_party:markdown.BUILD")),
   )
 
-  native.new_http_archive(
+  http_archive(
+      name = "org_pythonhosted_urllib3",
+      urls = [
+          "https://mirror.bazel.build/pypi.python.org/packages/b1/53/37d82ab391393565f2f831b8eedbffd57db5a718216f82f1a8b4d381a1c1/urllib3-1.24.1.tar.gz",
+          "https://pypi.python.org/packages/b1/53/37d82ab391393565f2f831b8eedbffd57db5a718216f82f1a8b4d381a1c1/urllib3-1.24.1.tar.gz",
+          "https://files.pythonhosted.org/packages/b1/53/37d82ab391393565f2f831b8eedbffd57db5a718216f82f1a8b4d381a1c1/urllib3-1.24.1.tar.gz",
+
+      ],
+      sha256 = "de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22",
+      strip_prefix = "urllib3-1.24.1/src",
+      build_file = str(Label("//third_party:urllib3.BUILD")),
+  )
+
+  http_archive(
       name = "org_html5lib",
       urls = [
           "https://mirror.bazel.build/github.com/html5lib/html5lib-python/archive/0.9999999.tar.gz",
@@ -39,7 +54,7 @@ def tensorboard_python_workspace():
       build_file = str(Label("//third_party:html5lib.BUILD")),
   )
 
-  native.new_http_archive(
+  http_archive(
       name = "org_mozilla_bleach",
       urls = [
           "https://mirror.bazel.build/github.com/mozilla/bleach/archive/v1.5.tar.gz",
@@ -50,7 +65,7 @@ def tensorboard_python_workspace():
       build_file = str(Label("//third_party:bleach.BUILD")),
   )
 
-  native.new_http_archive(
+  http_archive(
       name = "org_pocoo_werkzeug",
       urls = [
           "https://mirror.bazel.build/pypi.python.org/packages/b7/7f/44d3cfe5a12ba002b253f6985a4477edfa66da53787a2a838a40f6415263/Werkzeug-0.11.10.tar.gz",
@@ -61,7 +76,7 @@ def tensorboard_python_workspace():
       build_file = str(Label("//third_party:werkzeug.BUILD")),
   )
 
-  native.new_http_archive(
+  http_archive(
       name = "org_pythonhosted_six",
       urls = [
           "https://mirror.bazel.build/pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
@@ -72,7 +87,7 @@ def tensorboard_python_workspace():
       build_file = str(Label("//third_party:six.BUILD")),
   )
 
-  native.new_http_archive(
+  http_archive(
       name = "org_python_pypi_portpicker",
       urls = [
           "https://mirror.bazel.build/pypi.python.org/packages/96/48/0e1f20fdc0b85cc8722284da3c5b80222ae4036ad73210a97d5362beaa6d/portpicker-1.1.1.tar.gz",
@@ -83,7 +98,7 @@ def tensorboard_python_workspace():
       build_file = str(Label("//third_party:portpicker.BUILD")),
   )
 
-  native.new_http_archive(
+  http_archive(
       name = "org_tensorflow_serving_api",
       urls = [
           "https://mirror.bazel.build/files.pythonhosted.org/packages/b5/da/bd60d7b245dbe93f35aded752679124a61bb90154d4698f6f3dba30d75c6/tensorflow_serving_api-1.10.1-py2.py3-none-any.whl",

--- a/third_party/urllib3.BUILD
+++ b/third_party/urllib3.BUILD
@@ -1,0 +1,14 @@
+# Description:
+#   urllib3, another url library
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # MIT
+
+exports_files(["LICENSE.md"])
+
+py_library(
+    name = "org_pythonhosted_urllib3",
+    srcs = glob(["urllib3/**/*.py"]),
+    srcs_version = "PY2AND3",
+)

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -14,9 +14,11 @@
 
 # TensorBoard external dependencies that can be loaded in WORKSPACE files.
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_closure//closure/private:java_import_external.bzl", "java_import_external")
 load("@io_bazel_rules_closure//closure:defs.bzl", "filegroup_external")
 load("@io_bazel_rules_closure//closure:defs.bzl", "web_library_external")
+load("@io_bazel_rules_webtesting//web/internal:platform_http_file.bzl", "platform_http_file")
 load("//third_party:fonts.bzl", "tensorboard_fonts_workspace")
 load("//third_party:polymer.bzl", "tensorboard_polymer_workspace")
 load("//third_party:python.bzl", "tensorboard_python_workspace")
@@ -30,7 +32,7 @@ def tensorboard_workspace():
   tensorboard_typings_workspace()
   tensorboard_js_workspace()
 
-  native.new_http_archive(
+  http_archive(
       name = "com_google_protobuf_js",
       strip_prefix = "protobuf-3.6.0/js",
       sha256 = "50a5753995b3142627ac55cfd496cebc418a2e575ca0236e29033c67bd5665f4",
@@ -47,40 +49,42 @@ def tensorboard_workspace():
       actual = "@org_pythonhosted_six",
   )
 
-  filegroup_external(
-      name = "org_chromium_chromedriver",
-      licenses = ["notice"],  # Apache 2.0
-      sha256_urls = {
-          "687d2e15c42908e2911344c08a949461b3f20a83017a7a682ef4d002e05b5d46": [
-              "https://mirror.bazel.build/chromedriver.storage.googleapis.com/2.44/chromedriver_linux64.zip",
-              "http://chromedriver.storage.googleapis.com/2.44/chromedriver_linux64.zip",
-          ],
-      },
-      sha256_urls_macos = {
-          "3fd49c2782a5f93cb48ff2dee021004d9a7fb393798e4c4807b391cedcd30ed9": [
-              "https://mirror.bazel.build/chromedriver.storage.googleapis.com/2.44/chromedriver_mac64.zip",
-              "http://chromedriver.storage.googleapis.com/2.44/chromedriver_mac64.zip",
-          ],
-      },
-      generated_rule_name = "archive",
+  platform_http_file(
+      name = "org_chromium_chromium",
+      licenses = ["notice"],  # BSD 3-clause (maybe more?)
+      amd64_sha256 =
+          "6933d0afce6e17304b62029fbbd246cbe9e130eb0d90d7682d3765d3dbc8e1c8",
+      amd64_urls = [
+          "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/561732/chrome-linux.zip",
+      ],
+      macos_sha256 =
+          "084884e91841a923d7b6e81101f0105bbc3b0026f9f6f7a3477f5b313ee89e32",
+      macos_urls = [
+          "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/561733/chrome-mac.zip",
+      ],
+      windows_sha256 =
+          "d1bb728118c12ea436d8ea07dba980789e7d860aa664dd1fad78bc20e8d9391c",
+      windows_urls = [
+          "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/540270/chrome-win32.zip",
+      ],
   )
 
-  # Last Updated: 2018-11-29
-  # Roughly corresponds to Chrome 70
-  filegroup_external(
-      name = "org_chromium_chromium",
-      licenses = ["restricted"],  # So many licenses
-      sha256_urls = {
-          "ac11a4b8c901622cdd6cebbdac7a0dfe20c32f4d287a44ed19368444a2cd159e": [
-              "https://mirror.bazel.build/commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/582301/chrome-linux.zip",
-              "http://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/582301/chrome-linux.zip",
-          ],
-      },
-      sha256_urls_macos = {
-          "4ffd70a5d3ce02637550fc0d41d15e4e9de053d5bc55621442652b253fc61665": [
-              "https://mirror.bazel.build/commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/582236/chrome-mac.zip",
-              "http://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/582236/chrome-mac.zip",
-          ],
-      },
-      generated_rule_name = "archive",
+  platform_http_file(
+      name = "org_chromium_chromedriver",
+      licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
+      amd64_sha256 =
+          "71eafe087900dbca4bc0b354a1d172df48b31a4a502e21f7c7b156d7e76c95c7",
+      amd64_urls = [
+          "https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip",
+      ],
+      macos_sha256 =
+          "fd32a27148f44796a55f5ce3397015c89ebd9f600d9dda2bcaca54575e2497ae",
+      macos_urls = [
+          "https://chromedriver.storage.googleapis.com/2.41/chromedriver_mac64.zip",
+      ],
+      windows_sha256 =
+          "a8fa028acebef7b931ef9cb093f02865f9f7495e49351f556e919f7be77f072e",
+      windows_urls = [
+          "https://chromedriver.storage.googleapis.com/2.38/chromedriver_win32.zip",
+      ],
   )


### PR DESCRIPTION
Summary:
Bazel 0.20.0 introduced some incompatible changes that broke both our
code and our dependencies. Our dependencies also introduced some
incompatible changes of their own. This commit upgrades our dependencies
and fixes up our code to accommodate them.

An upgrade to transitive dependency `rules_go` introduces a dependency
on the `@bazel_tools//tools/build_defs/cc:action_names.bzl` builtin
target. This target was only introduced in Bazel 0.16.0, so as a
consequence our workspace is no longer compatible with earlier versions
of Bazel. In practice, we must use at least version 0.16.1 to fix a
regression in 0.16.0: <https://github.com/bazelbuild/bazel/issues/5726>.

Unfortunately, Bazel 0.16.0 also introduced a regression that prevents
us from using the `--distinct_host_configuration=false` option; this has
not been fixed as of Bazel 0.20.0. As a result, parts of our build will
now be twice as slow.

The new `urllib3` dependency is due to a transitive Selenium upgrade.

This commit shifts our Bazel version window from [0.13.0, 0.19.2] to
[0.16.1, 0.20.0].

Test Plan:
Running `bazel test //tensorboard/...` passes in Python 2 and 3 in Bazel
versions 0.16.1 and 0.20.0 (latest at time of writing), with
the `.bazelrc` file set up as on Travis:

```sh
>~/.bazelrc
echo "startup --output_base=${HOME}/.bazel-output-base" >>~/.bazelrc
echo "startup --host_jvm_args=-Xms500m" >>~/.bazelrc
echo "startup --host_jvm_args=-Xmx500m" >>~/.bazelrc
echo "startup --host_jvm_args=-XX:-UseParallelGC" >>~/.bazelrc
echo "build --local_resources=400,2,1.0" >>~/.bazelrc
echo "build --worker_max_instances=2" >>~/.bazelrc
echo "build --worker_verbose" >>~/.bazelrc
echo "build --worker_sandboxing" >>~/.bazelrc
echo "build --spawn_strategy=sandboxed" >>~/.bazelrc
echo "build --genrule_strategy=sandboxed" >>~/.bazelrc
echo "test --test_verbose_timeout_warnings" >>~/.bazelrc
echo "build --verbose_failures" >>~/.bazelrc
echo "test --test_output=errors" >>~/.bazelrc
```

wchargin-branch: bazel-0.20.0-fixes
