### PR TITLE
Change tests to use test_util.FileWriter

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -121,6 +121,7 @@ py_test(
         "//tensorboard/plugins/image:summary",
         "//tensorboard/plugins/scalar:summary",
         "//tensorboard/util:tensor_util",
+        "//tensorboard/util:test_util",
     ],
 )
 
@@ -137,6 +138,7 @@ py_test(
         "//tensorboard/plugins/image:summary",
         "//tensorboard/plugins/scalar:summary",
         "//tensorboard/util:tensor_util",
+        "//tensorboard/util:test_util",
         "@org_pythonhosted_six",
     ],
 )
@@ -209,6 +211,7 @@ py_test(
         ":db_import_multiplexer",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/util:tensor_util",
+        "//tensorboard/util:test_util",
     ],
 )
 
@@ -254,5 +257,6 @@ py_test(
     deps = [
         ":event_file_inspector",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/util:test_util",
     ],
 )

--- a/tensorboard/backend/event_processing/db_import_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer_test.py
@@ -23,11 +23,12 @@ import sqlite3
 
 from tensorboard.backend.event_processing import db_import_multiplexer
 from tensorboard.util import tensor_util
+from tensorboard.util import test_util
 import tensorflow as tf
 
 
 def add_event(path):
-  with tf.summary.FileWriterCache.get(path) as writer:
+  with test_util.FileWriterCache.get(path) as writer:
     event = tf.Event()
     event.summary.value.add(tag='tag', tensor=tensor_util.make_tensor_proto(1))
     writer.add_event(event)

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -20,8 +20,8 @@ from __future__ import print_function
 
 import inspect
 
-from tensorboard.compat import tf
 from tensorboard.util import platform_util
+from tensorboard.compat import tf
 
 
 class RawEventFileLoader(object):

--- a/tensorboard/backend/event_processing/io_wrapper.py
+++ b/tensorboard/backend/event_processing/io_wrapper.py
@@ -152,7 +152,7 @@ def ListRecursivelyViaWalking(top):
   Yields:
     A (dir_path, file_paths) tuple for each directory/subdirectory.
   """
-  for dir_path, _, filenames in tf.gfile.Walk(top):
+  for dir_path, _, filenames in tf.gfile.Walk(top, in_order=True):
     yield (dir_path, (os.path.join(dir_path, filename)
                       for filename in filenames))
 

--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -29,6 +29,7 @@ from tensorboard.plugins.audio import summary as audio_summary
 from tensorboard.plugins.image import summary as image_summary
 from tensorboard.plugins.scalar import summary as scalar_summary
 from tensorboard.util import tensor_util
+from tensorboard.util import test_util
 
 
 class _EventGenerator(object):
@@ -335,7 +336,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
   def testNewStyleScalarSummary(self):
     """Verify processing of tensorboard.plugins.scalar.summary."""
     event_sink = _EventGenerator(self, zero_out_timestamps=True)
-    writer = tf.summary.FileWriter(self.get_temp_dir())
+    writer = test_util.FileWriter(self.get_temp_dir())
     writer.event_writer = event_sink
     with self.test_session() as sess:
       step = tf.placeholder(tf.float32, shape=[])
@@ -364,7 +365,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
   def testNewStyleAudioSummary(self):
     """Verify processing of tensorboard.plugins.audio.summary."""
     event_sink = _EventGenerator(self, zero_out_timestamps=True)
-    writer = tf.summary.FileWriter(self.get_temp_dir())
+    writer = test_util.FileWriter(self.get_temp_dir())
     writer.event_writer = event_sink
     with self.test_session() as sess:
       ipt = tf.random_normal(shape=[5, 441, 2])
@@ -398,7 +399,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
   def testNewStyleImageSummary(self):
     """Verify processing of tensorboard.plugins.image.summary."""
     event_sink = _EventGenerator(self, zero_out_timestamps=True)
-    writer = tf.summary.FileWriter(self.get_temp_dir())
+    writer = test_util.FileWriter(self.get_temp_dir())
     writer.event_writer = event_sink
     with self.test_session() as sess:
       ipt = tf.ones([10, 4, 4, 3], tf.uint8)
@@ -436,7 +437,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
   def testTFSummaryTensor(self):
     """Verify processing of tf.summary.tensor."""
     event_sink = _EventGenerator(self, zero_out_timestamps=True)
-    writer = tf.summary.FileWriter(self.get_temp_dir())
+    writer = test_util.FileWriter(self.get_temp_dir())
     writer.event_writer = event_sink
     with self.test_session() as sess:
       tf.summary.tensor_summary('scalar', tf.constant(1.0))
@@ -470,7 +471,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
                                         steps,
                                         expected_count):
     event_sink = _EventGenerator(self, zero_out_timestamps=True)
-    writer = tf.summary.FileWriter(self.get_temp_dir())
+    writer = test_util.FileWriter(self.get_temp_dir())
     writer.event_writer = event_sink
     with self.test_session() as sess:
       summary_metadata = tf.SummaryMetadata(
@@ -542,7 +543,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
       tf.gfile.DeleteRecursively(directory)
     tf.gfile.MkDir(directory)
 
-    writer = tf.summary.FileWriter(directory, max_queue=100)
+    writer = test_util.FileWriter(directory, max_queue=100)
 
     with tf.Graph().as_default() as graph:
       _ = tf.constant([2.0, 1.0])
@@ -614,7 +615,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
       tf.gfile.DeleteRecursively(directory)
     tf.gfile.MkDir(directory)
 
-    writer = tf.summary.FileWriter(directory, max_queue=100)
+    writer = test_util.FileWriter(directory, max_queue=100)
 
     with tf.Graph().as_default() as graph:
       _ = tf.constant([2.0, 1.0])
@@ -651,7 +652,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
         tensor=tensor_util.make_tensor_proto(['po', 'ta', 'to'], dtype=tf.string),
         tag='you_are_it',
         metadata=summary_metadata)
-    writer = tf.summary.FileWriter(logdir, filename_suffix=nonce)
+    writer = test_util.FileWriter(logdir, filename_suffix=nonce)
     writer.add_summary(summary.SerializeToString())
     writer.close()
 

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -39,6 +39,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/core/BUILD
+++ b/tensorboard/plugins/core/BUILD
@@ -35,6 +35,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/custom_scalar/BUILD
+++ b/tensorboard/plugins/custom_scalar/BUILD
@@ -62,6 +62,7 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/util:tensor_util",
+        "//tensorboard/util:test_util",
     ],
 )
 
@@ -80,6 +81,7 @@ py_test(
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/plugins/scalar:scalars_plugin",
         "//tensorboard/plugins/scalar:summary",
+        "//tensorboard/util:test_util",
     ],
 )
 

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -32,6 +32,7 @@ from tensorboard.plugins.custom_scalar import layout_pb2
 from tensorboard.plugins.custom_scalar import summary
 from tensorboard.plugins.scalar import scalars_plugin
 from tensorboard.plugins.scalar import summary as scalar_summary
+from tensorboard.util import test_util
 
 
 class CustomScalarsPluginTest(tf.test.TestCase):
@@ -103,17 +104,17 @@ class CustomScalarsPluginTest(tf.test.TestCase):
     )
 
     # Generate test data.
-    with tf.summary.FileWriter(os.path.join(self.logdir, 'foo')) as writer:
+    with test_util.FileWriterCache.get(os.path.join(self.logdir, 'foo')) as writer:
       writer.add_summary(summary.pb(self.foo_layout))
       for step in range(4):
         writer.add_summary(scalar_summary.pb('squares', step * step), step)
 
-    with tf.summary.FileWriter(os.path.join(self.logdir, 'bar')) as writer:
+    with test_util.FileWriterCache.get(os.path.join(self.logdir, 'bar')) as writer:
       for step in range(3):
         writer.add_summary(scalar_summary.pb('increments', step + 1), step)
 
     # The '.' run lacks scalar data but has a layout.
-    with tf.summary.FileWriter(self.logdir) as writer:
+    with test_util.FileWriterCache.get(self.logdir) as writer:
       writer.add_summary(summary.pb(self.logdir_layout))
 
     self.plugin = self.createPlugin(self.logdir)
@@ -233,7 +234,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
   def testIsNotActiveDueToNoScalarsData(self):
     # Generate a directory with a layout but no scalars data.
     directory = os.path.join(self.logdir, 'no_scalars')
-    with tf.summary.FileWriter(directory) as writer:
+    with test_util.FileWriterCache.get(directory) as writer:
       writer.add_summary(summary.pb(self.logdir_layout))
 
     local_plugin = self.createPlugin(directory)

--- a/tensorboard/plugins/custom_scalar/summary_test.py
+++ b/tensorboard/plugins/custom_scalar/summary_test.py
@@ -27,6 +27,7 @@ from tensorboard.plugins.custom_scalar import layout_pb2
 from tensorboard.plugins.custom_scalar import metadata
 from tensorboard.plugins.custom_scalar import summary
 from tensorboard.util import tensor_util
+from tensorboard.util import test_util
 
 
 class LayoutTest(tf.test.TestCase):
@@ -84,7 +85,7 @@ class LayoutTest(tf.test.TestCase):
         ])
 
     # Write the data as a summary for the '.' run.
-    with tf.Session() as s, tf.summary.FileWriter(self.logdir) as writer:
+    with tf.Session() as s, test_util.FileWriterCache.get(self.logdir) as writer:
       writer.add_summary(s.run(summary.op(layout_proto_to_write)))
 
     # Read the data from disk.

--- a/tensorboard/plugins/distribution/BUILD
+++ b/tensorboard/plugins/distribution/BUILD
@@ -37,6 +37,7 @@ py_test(
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/plugins/histogram:summary",
+        "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/distribution/distributions_plugin_test.py
+++ b/tensorboard/plugins/distribution/distributions_plugin_test.py
@@ -32,6 +32,7 @@ from tensorboard.plugins import base_plugin
 from tensorboard.plugins.distribution import compressor
 from tensorboard.plugins.distribution import distributions_plugin
 from tensorboard.plugins.histogram import summary
+from tensorboard.util import test_util
 
 
 class DistributionsPluginTest(tf.test.TestCase):
@@ -86,13 +87,12 @@ class DistributionsPluginTest(tf.test.TestCase):
     summ = tf.summary.merge_all()
 
     subdir = os.path.join(self.logdir, run_name)
-    writer = tf.summary.FileWriter(subdir)
-    writer.add_graph(sess.graph)
-    for step in xrange(self._STEPS):
-      feed_dict = {placeholder: [1 + step, 2 + step, 3 + step]}
-      s = sess.run(summ, feed_dict=feed_dict)
-      writer.add_summary(s, global_step=step)
-    writer.close()
+    with test_util.FileWriterCache.get(subdir) as writer:
+      writer.add_graph(sess.graph)
+      for step in xrange(self._STEPS):
+        feed_dict = {placeholder: [1 + step, 2 + step, 3 + step]}
+        s = sess.run(summ, feed_dict=feed_dict)
+        writer.add_summary(s, global_step=step)
 
   def test_routes_provided(self):
     """Tests that the plugin offers the correct routes."""

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -36,6 +36,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -29,6 +29,7 @@ from google.protobuf import text_format
 from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.graph import graphs_plugin
+from tensorboard.util import test_util
 
 
 class GraphsPluginTest(tf.test.TestCase):
@@ -62,7 +63,7 @@ class GraphsPluginTest(tf.test.TestCase):
     summary_message = tf.summary.text('summary_message', error_message)
 
     sess = tf.Session()
-    writer = tf.summary.FileWriter(os.path.join(self.logdir, run_name))
+    writer = test_util.FileWriter(os.path.join(self.logdir, run_name))
     if include_graph:
       writer.add_graph(sess.graph)
     options = tf.RunOptions(trace_level=tf.RunOptions.FULL_TRACE)

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -41,6 +41,7 @@ py_test(
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/histogram/histograms_plugin_test.py
+++ b/tensorboard/plugins/histogram/histograms_plugin_test.py
@@ -31,6 +31,7 @@ from tensorboard.backend.event_processing import plugin_event_multiplexer as eve
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.histogram import histograms_plugin
 from tensorboard.plugins.histogram import summary
+from tensorboard.util import test_util
 
 
 class HistogramsPluginTest(tf.test.TestCase):
@@ -85,13 +86,12 @@ class HistogramsPluginTest(tf.test.TestCase):
     summ = tf.summary.merge_all()
 
     subdir = os.path.join(self.logdir, run_name)
-    writer = tf.summary.FileWriter(subdir)
-    writer.add_graph(sess.graph)
-    for step in xrange(self._STEPS):
-      feed_dict = {placeholder: [1 + step, 2 + step, 3 + step]}
-      s = sess.run(summ, feed_dict=feed_dict)
-      writer.add_summary(s, global_step=step)
-    writer.close()
+    with test_util.FileWriterCache.get(subdir) as writer:
+      writer.add_graph(sess.graph)
+      for step in xrange(self._STEPS):
+        feed_dict = {placeholder: [1 + step, 2 + step, 3 + step]}
+        s = sess.run(summ, feed_dict=feed_dict)
+        writer.add_summary(s, global_step=step)
 
   def test_routes_provided(self):
     """Tests that the plugin offers the correct routes."""

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -50,6 +50,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/image/images_plugin_test.py
+++ b/tensorboard/plugins/image/images_plugin_test.py
@@ -36,6 +36,7 @@ from tensorboard.backend.event_processing import plugin_event_multiplexer as eve
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.image import summary
 from tensorboard.plugins.image import images_plugin
+from tensorboard.util import test_util
 
 
 class ImagesPluginTest(tf.test.TestCase):
@@ -54,14 +55,13 @@ class ImagesPluginTest(tf.test.TestCase):
     tf.summary.image(name="baz", tensor=placeholder)
     merged_summary_op = tf.summary.merge_all()
     foo_directory = os.path.join(self.log_dir, "foo")
-    writer = tf.summary.FileWriter(foo_directory)
-    writer.add_graph(sess.graph)
-    for step in xrange(2):
-      writer.add_summary(sess.run(merged_summary_op, feed_dict={
-          placeholder: (numpy.random.rand(1, 16, 42, 3) * 255).astype(
-              numpy.uint8)
-      }), global_step=step)
-    writer.close()
+    with test_util.FileWriterCache.get(foo_directory) as writer:
+      writer.add_graph(sess.graph)
+      for step in xrange(2):
+        writer.add_summary(sess.run(merged_summary_op, feed_dict={
+            placeholder: (numpy.random.rand(1, 16, 42, 3) * 255).astype(
+                numpy.uint8)
+        }), global_step=step)
 
     # Create new-style image summaries for run bar.
     tf.reset_default_graph()
@@ -71,14 +71,13 @@ class ImagesPluginTest(tf.test.TestCase):
                description="how do you pronounce that, anyway?")
     merged_summary_op = tf.summary.merge_all()
     bar_directory = os.path.join(self.log_dir, "bar")
-    writer = tf.summary.FileWriter(bar_directory)
-    writer.add_graph(sess.graph)
-    for step in xrange(2):
-      writer.add_summary(sess.run(merged_summary_op, feed_dict={
-          placeholder: (numpy.random.rand(1, 8, 6, 3) * 255).astype(
-              numpy.uint8)
-      }), global_step=step)
-    writer.close()
+    with test_util.FileWriterCache.get(bar_directory) as writer:
+      writer.add_graph(sess.graph)
+      for step in xrange(2):
+        writer.add_summary(sess.run(merged_summary_op, feed_dict={
+            placeholder: (numpy.random.rand(1, 8, 6, 3) * 255).astype(
+                numpy.uint8)
+        }), global_step=step)
 
     # Start a server with the plugin.
     multiplexer = event_multiplexer.EventMultiplexer({

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -44,6 +44,7 @@ py_test(
     deps = [
         ":projector",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/util:test_util",
     ],
 )
 
@@ -60,6 +61,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
     ],
 )

--- a/tensorboard/plugins/projector/projector_api_test.py
+++ b/tensorboard/plugins/projector/projector_api_test.py
@@ -26,6 +26,7 @@ import tensorflow as tf
 from google.protobuf import text_format
 
 from tensorboard.plugins import projector
+from tensorboard.util import test_util
 
 
 class ProjectorApiTest(tf.test.TestCase):
@@ -41,8 +42,8 @@ class ProjectorApiTest(tf.test.TestCase):
     # Call the API method to save the configuration to a temporary dir.
     temp_dir = self.get_temp_dir()
     self.addCleanup(shutil.rmtree, temp_dir)
-    writer = tf.summary.FileWriter(temp_dir)
-    projector.visualize_embeddings(writer, config)
+    with test_util.FileWriterCache.get(temp_dir) as writer:
+      projector.visualize_embeddings(writer, config)
 
     # Read the configurations from disk and make sure it matches the original.
     with tf.gfile.GFile(os.path.join(temp_dir, 'projector_config.pbtxt')) as f:

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -40,6 +40,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -34,6 +34,7 @@ from tensorboard.plugins import base_plugin
 from tensorboard.plugins.core import core_plugin
 from tensorboard.plugins.scalar import scalars_plugin
 from tensorboard.plugins.scalar import summary
+from tensorboard.util import test_util
 
 
 class ScalarsPluginTest(tf.test.TestCase):
@@ -129,13 +130,12 @@ class ScalarsPluginTest(tf.test.TestCase):
     summ = tf.summary.merge_all()
 
     subdir = os.path.join(self.logdir, run_name)
-    writer = tf.summary.FileWriter(subdir)
-    writer.add_graph(sess.graph)
-    for step in xrange(self._STEPS):
-      feed_dict = {placeholder: [1 + step, 2 + step, 3 + step]}
-      s = sess.run(summ, feed_dict=feed_dict)
-      writer.add_summary(s, global_step=step)
-    writer.close()
+    with test_util.FileWriterCache.get(subdir) as writer:
+      writer.add_graph(sess.graph)
+      for step in xrange(self._STEPS):
+        feed_dict = {placeholder: [1 + step, 2 + step, 3 + step]}
+        s = sess.run(summ, feed_dict=feed_dict)
+        writer.add_summary(s, global_step=step)
 
   def test_index(self):
     self.set_up_with_runs([self._RUN_WITH_LEGACY_SCALARS,

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -42,6 +42,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -85,8 +85,6 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         "//tensorboard/compat:tensorflow",
-        "//tensorboard/compat/proto:protos_all_py_pb2",
-        "//tensorboard/compat/tensorflow_stub",
     ],
 )
 

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -207,9 +207,14 @@ class FileWriter(tf.summary.FileWriter):
     super(FileWriter, self).add_summary(tf_summary, global_step)
 
 
-class FileWriterCache(tf.summary.FileWriterCache):
+class FileWriterCache(object):
   """Cache for TensorBoard test file writers.
   """
+  # Cache, keyed by directory.
+  _cache = {}
+
+  # Lock protecting _FILE_WRITERS.
+  _lock = threading.RLock()
 
   @staticmethod
   def get(logdir):

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -30,9 +30,11 @@ import sqlite3
 import threading
 
 import tensorflow as tf
+from tensorboard.compat.proto.event_pb2 import Event as TbEvent
+from tensorboard.compat.proto.summary_pb2 import Summary as TbSummary
+from tensorboard.util import util
 
 from tensorboard import db
-from tensorboard.util import util
 
 
 class TestCase(tf.test.TestCase):
@@ -175,3 +177,52 @@ class FakeSleep(object):
     :type seconds: float
     """
     self._clock.advance(seconds)
+
+
+class FileWriter(tf.summary.FileWriter):
+  """FileWriter for test.
+
+  TensorFlow FileWriter uses TensorFlow's Protobuf Python binding which is
+  largely discouraged in TensorBoard. We do not want a TB.Writer but require one
+  for testing in integrational style (writing out event files and use the real
+  event readers).
+  """
+
+  def add_event(self, event):
+    if isinstance(event, TbEvent):
+      tf_event = tf.Event.FromString(event.SerializeToString())
+    else:
+      tf.logging.warn('Added TensorFlow event proto. '
+                      'Please prefer TensorBoard copy of the proto')
+      tf_event = event
+    super(FileWriter, self).add_event(tf_event)
+
+  def add_summary(self, summary, global_step=None):
+    if isinstance(summary, TbSummary):
+      tf_summary = tf.Summary.FromString(summary.SerializeToString())
+    else:
+      tf.logging.warn('Added TensorFlow summary proto. '
+                      'Please prefer TensorBoard copy of the proto')
+      tf_summary = summary
+    super(FileWriter, self).add_summary(tf_summary, global_step)
+
+
+class FileWriterCache(tf.summary.FileWriterCache):
+  """Cache for TensorBoard test file writers.
+  """
+
+  @staticmethod
+  def get(logdir):
+    """Returns the FileWriter for the specified directory.
+
+    Args:
+      logdir: str, name of the directory.
+
+    Returns:
+      A `FileWriter`.
+    """
+    with FileWriterCache._lock:
+      if logdir not in FileWriterCache._cache:
+        FileWriterCache._cache[logdir] = FileWriter(
+            logdir, graph=tf.compat.v1.get_default_graph())
+      return FileWriterCache._cache[logdir]


### PR DESCRIPTION
tf.summary.FileWriter makes sure the proto that gets added (via
`add_event` or `add_summary`) is the TensorFlow version of the protobuf.
This makes changing our codebase to use TB proto very cumbersome, so
for now, we will convert TB protos into TF proto in the test writer and warn
user if it is taking any TF proto. Goal is to reduce the warn to 0.