### PR TITLE
web.bzl: use Skylint-recommended re-export syntax

### DIFF
--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -32,7 +32,9 @@ load("@io_bazel_rules_closure//closure/private:defs.bzl",
      "long_path",
      "unfurl")
 
-load(":web_testing.bzl", "tf_web_test")
+load(":web_testing.bzl", _tf_web_test = "tf_web_test")
+
+tf_web_test = _tf_web_test
 
 def _tf_web_library(ctx):
   if not ctx.attr.srcs:


### PR DESCRIPTION
Summary:
Per the [“Skylint: Re-exporting `load()`ed names” docs on the Bazel
website][1].

[1]: https://docs.bazel.build/versions/master/skylark/skylint.html#re-exporting-loaded-names

Test Plan:
That existing tests build and pass is sufficient.

wchargin-branch: re-export-syntax-fixup