### PR TITLE
build: declare sqlite3 dep where appropriate

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -207,6 +207,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":db_import_multiplexer",
+        "//tensorboard:expect_sqlite3_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/util:tensor_util",
     ],

--- a/tensorboard/plugins/core/BUILD
+++ b/tensorboard/plugins/core/BUILD
@@ -31,6 +31,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":core_plugin",
+        "//tensorboard:expect_sqlite3_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",


### PR DESCRIPTION
Summary:
This is breaking some Google-internal tests.

Test Plan:
Note that those files that `import sqlite3` are in correspondence with
those targets that depend on `expect_sqlite3_installed`:

```
$ bazel query 'attr("deps", "expect_sqlite3_installed", //...)' | sort
//tensorboard/backend:application
//tensorboard/backend/event_processing:db_import_multiplexer_test
//tensorboard:db
//tensorboard/plugins/core:core_plugin_test
//tensorboard/util:test_util
$ git grep --name-only 'import sqlite3' | sort
tensorboard/backend/application.py
tensorboard/backend/event_processing/db_import_multiplexer_test.py
tensorboard/db.py
tensorboard/plugins/core/core_plugin_test.py
tensorboard/util/test_util.py
```

wchargin-branch: declare-sqlite3-dep