### PR TITLE
web_testing.bzl: fix miscellaneous lint errors

### DIFF
--- a/tensorboard/defs/web_testing.bzl
+++ b/tensorboard/defs/web_testing.bzl
@@ -17,64 +17,65 @@
 load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
 
 def _tf_web_test_python_stub_impl(ctx):
-  ctx.actions.expand_template(
-      template=ctx.file._template,
-      output=ctx.outputs.main,
-      substitutions={
-          "{BINARY_PATH}": ctx.executable.web_library.short_path,
-          "{WEB_PATH}": ctx.attr.web_path,
-      }
-  )
+    ctx.actions.expand_template(
+        template = ctx.file._template,
+        output = ctx.outputs.main,
+        substitutions = {
+            "{BINARY_PATH}": ctx.executable.web_library.short_path,
+            "{WEB_PATH}": ctx.attr.web_path,
+        },
+    )
 
 _tf_web_test_python_stub = rule(
-    implementation=_tf_web_test_python_stub_impl,
-    attrs={
-        "web_library": attr.label(executable=True, cfg="host", mandatory=True),
-        "web_path": attr.string(mandatory=True),
+    implementation = _tf_web_test_python_stub_impl,
+    attrs = {
+        "web_library": attr.label(executable = True, cfg = "host", mandatory = True),
+        "web_path": attr.string(mandatory = True),
         "main": attr.output(),
         "_template": attr.label(
-            default=Label("//tensorboard/defs:web_test_python_stub.template.py"),
-            allow_single_file=True,
+            default = Label("//tensorboard/defs:web_test_python_stub.template.py"),
+            allow_single_file = True,
         ),
     },
 )
 
 def tf_web_test(name, web_library, src, **kwargs):
-  """Run tests defined by a `tf_web_library`.
+    """Run tests defined by a `tf_web_library`.
 
-  By default, the test will have timeout = "short" and flaky = True.
-  These options can be overridden.
+    By default, the test will have timeout = "short" and flaky = True.
+    These options can be overridden.
 
-  Arguments:
-    web_library: label of a `tf_web_library` target that defines the
-        test cases to be run
-    src: web path to the main HTML entry point of the test cases, which
-        should be the concatenation of the tf_web_library's `path` with
-        the name of the main HTML source file; e.g.:
-        "/vz-foo/test/tests.html"
-    **kwargs: forwarded to `py_web_test_suite` and thus indirectly to
-        the `py_test` native rule
-  """
-  python_stub_name = name + "_python_stub"
-  python_stub_output = name + ".py"
-  _tf_web_test_python_stub(
-      name=python_stub_name,
-      web_library=web_library,
-      web_path=src,
-      main=python_stub_output,
-  )
-  kwargs.setdefault("flaky", True)
-  kwargs.setdefault("timeout", "short")
-  py_web_test_suite(
-      name=name,
-      srcs=[python_stub_output],
-      browsers=["//tensorboard/functionaltests/browsers:chromium"],
-      data=[web_library],
-      srcs_version="PY2AND3",
-      deps=[
-          "@io_bazel_rules_webtesting//testing/web",
-          "@org_pythonhosted_urllib3//:org_pythonhosted_urllib3",
-          "//tensorboard/functionaltests:wct_test_driver",
-      ],
-      **kwargs
-  )
+    Args:
+      name: name to use for the test target
+      web_library: label of a `tf_web_library` target that defines the
+          test cases to be run
+      src: web path to the main HTML entry point of the test cases, which
+          should be the concatenation of the tf_web_library's `path` with
+          the name of the main HTML source file; e.g.:
+          "/vz-foo/test/tests.html"
+      **kwargs: forwarded to `py_web_test_suite` and thus indirectly to
+          the `py_test` native rule
+    """
+    python_stub_name = name + "_python_stub"
+    python_stub_output = name + ".py"
+    _tf_web_test_python_stub(
+        name = python_stub_name,
+        web_library = web_library,
+        web_path = src,
+        main = python_stub_output,
+    )
+    kwargs.setdefault("flaky", True)
+    kwargs.setdefault("timeout", "short")
+    py_web_test_suite(
+        name = name,
+        srcs = [python_stub_output],
+        browsers = ["//tensorboard/functionaltests/browsers:chromium"],
+        data = [web_library],
+        srcs_version = "PY2AND3",
+        deps = [
+            "@io_bazel_rules_webtesting//testing/web",
+            "@org_pythonhosted_urllib3//:org_pythonhosted_urllib3",
+            "//tensorboard/functionaltests:wct_test_driver",
+        ],
+        **kwargs
+    )


### PR DESCRIPTION
Summary:

  - Change “Arguments” to “Args”
  - Document the `name` parameter
  - Reformat with `buildifier`

Recommend reviewing with `-w`.

Test Plan:
None.

wchargin-branch: buildify-webtesting