### PR TITLE
util: add `tensorboard.util` compatibility wrapper

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -334,3 +334,24 @@ py_library(
     srcs = ["lazy.py"],
     srcs_version = "PY2AND3",
 )
+
+# For legacy use only. Do not add new dependencies on this target.
+py_library(
+    name = "util",
+    srcs = [],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorboard/util:__init__",
+    ],
+)
+
+py_test(
+    name = "util_test",
+    size = "small",
+    srcs = ["util_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":util",
+    ],
+)

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -4,6 +4,19 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])  # Needed for internal repo.
 
+# Legacy interface for compatibility. Prefer importing the relevant
+# submodules directly.
+py_library(
+    name = "__init__",
+    srcs = ["__init__.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":encoder",
+        ":op_evaluator",
+        ":util",
+    ],
+)
+
 py_library(
     name = "encoder",
     srcs = ["encoder.py"],

--- a/tensorboard/util/__init__.py
+++ b/tensorboard/util/__init__.py
@@ -1,0 +1,42 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Legacy interface for `tensorboard.util` exports.
+
+Prefer importing modules directly: `from tensorboard.util import foo`.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+from tensorboard.util import encoder
+from tensorboard.util import op_evaluator
+from tensorboard.util import util
+
+
+encode_png = encoder.encode_png
+encode_wav = encoder.encode_wav
+
+PersistentOpEvaluator = op_evaluator.PersistentOpEvaluator
+
+Ansi = util.Ansi
+LogFormatter = util.LogFormatter
+LogHandler = util.LogHandler
+Retrier = util.Retrier
+close_all = util.close_all
+closeable = util.closeable
+guarded_by = util.guarded_by
+setup_logging = util.setup_logging

--- a/tensorboard/util_test.py
+++ b/tensorboard/util_test.py
@@ -1,0 +1,47 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from tensorboard import util
+
+
+class UtilExportsTest(tf.test.TestCase):
+
+  def test_util_exports(self):
+    desired_exports = frozenset((
+        "Ansi",
+        "LogFormatter",
+        "LogHandler",
+        "PersistentOpEvaluator",
+        "Retrier",
+        "close_all",
+        "closeable",
+        "encode_png",
+        "encode_wav",
+        "guarded_by",
+        "setup_logging",
+    ))
+    actual_exports = frozenset(dir(util))
+    missing_exports = desired_exports - actual_exports
+    self.assertFalse(missing_exports,
+        "tensorboard.util is missing exports: %s" % sorted(missing_exports))
+
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
Summary:
This reintroduces the `tensorboard.util` module removed in #1629; some
targets within Google still depend on its Bazel target, so this will
enable us to migrate them cleanly.

Test Plan:
All tests pass in both Python 2 and Python 3. Removing an export from
`__init__.py` causes `util_test` to fail with a helpful message.

wchargin-branch: util-wrapper