### PR TITLE
Update references to Dandelion’s GitHub account

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ through setting up and using TensorBoard. There's an associated
 
 [this video tutorial]: https://www.youtube.com/watch?v=eBbEDRsCmv4
 
-[tutorial with an end-to-end example of training TensorFlow and using TensorBoard]: https://github.com/decentralion/tf-dev-summit-tensorboard-tutorial
+[tutorial with an end-to-end example of training TensorFlow and using TensorBoard]: https://github.com/martinwicke/tf-dev-summit-tensorboard-tutorial
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ through setting up and using TensorBoard. There's an associated
 
 [this video tutorial]: https://www.youtube.com/watch?v=eBbEDRsCmv4
 
-[tutorial with an end-to-end example of training TensorFlow and using TensorBoard]: https://github.com/dandelionmane/tf-dev-summit-tensorboard-tutorial
+[tutorial with an end-to-end example of training TensorFlow and using TensorBoard]: https://github.com/decentralion/tf-dev-summit-tensorboard-tutorial
 
 # Usage
 

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -122,7 +122,7 @@ class EventMultiplexer(object):
     with self._accumulators_mutex:
       if name not in self._accumulators or self._paths[name] != path:
         if name in self._paths and self._paths[name] != path:
-          # TODO(@dandelionmane) - Make it impossible to overwrite an old path
+          # TODO(@decentralion) - Make it impossible to overwrite an old path
           # with a new path (just give the new path a distinct name)
           tf.logging.warning('Conflict for name %s: old path %s, new path %s',
                              name, self._paths[name], path)

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer.py
@@ -133,7 +133,7 @@ class EventMultiplexer(object):
     with self._accumulators_mutex:
       if name not in self._accumulators or self._paths[name] != path:
         if name in self._paths and self._paths[name] != path:
-          # TODO(@dandelionmane) - Make it impossible to overwrite an old path
+          # TODO(@decentralion) - Make it impossible to overwrite an old path
           # with a new path (just give the new path a distinct name)
           tf.logging.warning('Conflict for name %s: old path %s, new path %s',
                              name, self._paths[name], path)

--- a/tensorboard/components/vz_line_chart/dragZoomInteraction.ts
+++ b/tensorboard/components/vz_line_chart/dragZoomInteraction.ts
@@ -33,7 +33,7 @@ export class DragZoomLayer extends Plottable.Components.SelectionBoxLayer {
    * Usage: Construct the selection box layer and attach x and y scales,
    * and then add the layer over the plot you are zooming on using a
    * Component Group.
-   * TODO(@dandelionmane) - merge this into Plottable
+   * TODO(@decentralion) - merge this into Plottable
    */
   constructor(
       xScale: Plottable.QuantitativeScale<number|{valueOf(): number}>,

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -40,7 +40,7 @@ _PLUGIN_PREFIX_ROUTE = 'projector'
 
 # FYI - the PROJECTOR_FILENAME is hardcoded in the visualize_embeddings
 # method in tf.contrib.tensorboard.plugins.projector module.
-# TODO(@dandelionmane): Fix duplication when we find a permanent home for the
+# TODO(@decentralion): Fix duplication when we find a permanent home for the
 # projector module.
 PROJECTOR_FILENAME = 'projector_config.pbtxt'
 _PLUGIN_NAME = 'org_tensorflow_tensorboard_projector'


### PR DESCRIPTION
Summary:
Their primary account is now @decentralion. The repository link is
forwarded by GitHub, but it’s better for to link to the canonical
address.

Test Plan:
One link is modified; clicking the link works.

Running `git grep -i 'dan\(delion\)\?mane'` returns no results.

wchargin-branch: decentralionize