### PR TITLE
Show scrollbar when content in the sidebar is tall

### DIFF
--- a/tensorboard/components/tf_dashboard_common/dashboard-style.html
+++ b/tensorboard/components/tf_dashboard_common/dashboard-style.html
@@ -27,8 +27,7 @@ limitations under the License.
         box-sizing: border-box;
         display: flex;
         flex-direction: column;
-        height: 100%;
-        margin-right: 20px;
+        min-height: 100%;
         overflow-x: hidden;
         padding: 5px 0;
         text-overflow: ellipsis;

--- a/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.html
+++ b/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.html
@@ -24,12 +24,12 @@ Generic layout for a dashboard.
 -->
 <dom-module id="tf-dashboard-layout">
   <template>
-    <div id="sidebar">
+    <div id="sidebar" class="scrollbar">
       <content select=".sidebar"></content>
     </div>
 
-    <div id="center">
-      <content select=".center" class="scollbar"></content>
+    <div id="center" class="scrollbar">
+      <content select=".center"></content>
     </div>
     <style include="scrollbar-style"></style>
     <style>
@@ -37,6 +37,7 @@ Generic layout for a dashboard.
         display: flex;
         flex-direction: row;
         height: 100%;
+        --tf-dashboard-layout-right-gutter-size: 20px;
       }
 
       #sidebar {
@@ -45,6 +46,7 @@ Generic layout for a dashboard.
         max-width: 350px;
         min-width: 270px;
         overflow-y: auto;
+        padding-right: var(--tf-dashboard-layout-right-gutter-size);
         text-overflow: ellipsis;
       }
 

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -20,7 +20,6 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
-<link rel="import" href="../tf-dashboard-common/scrollbar-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-multi-checkbox.html">
 
 <!--
@@ -71,18 +70,19 @@ Properties out:
     </template>
     <style>
       :host {
+        box-sizing: border-box;
         display: flex;
         flex-direction: column;
+        min-height: 160px; /* Shows at least 1.5 rows. */
         padding-bottom: 10px;
-        box-sizing: border-box;
       }
       #top-text {
-        width: 100%;
+        box-sizing: border-box;
+        color: var(--paper-grey-800);
         flex-grow: 0;
         flex-shrink: 0;
         padding-right: 16px;
-        box-sizing: border-box;
-        color: var(--paper-grey-800);
+        width: 100%;
       }
       tf-multi-checkbox {
         display: flex;
@@ -90,9 +90,11 @@ Properties out:
         flex-shrink: 1;
       }
       .x-button {
-        font-size: 13px;
         background-color: var(--tb-ui-light-accent);
         color: var(--tb-ui-dark-accent);
+        flex-shrink: 0;
+        font-size: 13px;
+        margin-left: 0;
       }
       #tooltip-help {
         color: var(--paper-grey-800);
@@ -101,11 +103,9 @@ Properties out:
         font-size: 14px;
         margin-bottom: 5px;
       }
-      paper-button {
-        margin-left: 0;
-      }
       #data-location {
         color: var(--tb-ui-dark-accent);
+        flex-shrink: 0;
         font-size: 13px;
         margin: 5px 0 0 0;
         max-width: 288px;

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -73,7 +73,7 @@ Properties out:
         box-sizing: border-box;
         display: flex;
         flex-direction: column;
-        min-height: 160px; /* Shows at least 1.5 rows. */
+        min-height: 180px; /* Shows about 2 rows. */
         padding-bottom: 10px;
       }
       #top-text {

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -124,6 +124,10 @@ by default. The user can select a different run from a dropdown menu.
   height: 100%;
 }
 
+tf-dashboard-layout {
+  --tf-dashboard-layout-right-gutter-size: 0;
+}
+
 .center {
   position: relative;
   height: 100%;


### PR DESCRIPTION
Previously, we had shrunken the content of the sidebar up to an extent
you cannot select any run. Instead, put a minimum height to the run
selector and now show a scrollbar to the sidebar so we can allow
taller content and shorter screen.

Manually inspected most plugins with shorter and taller screens.

![image](https://user-images.githubusercontent.com/2547313/49815792-6b417480-fd21-11e8-8d7c-eea7d5464914.png)
