### PR TITLE
Removed unused import and fixed unbalanced tags

### DIFF
--- a/tensorboard/components/tf_data_selector/experiment-selector.html
+++ b/tensorboard/components/tf_data_selector/experiment-selector.html
@@ -18,7 +18,6 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
-<link rel="import" href="../tf-dashboard-common/scrollbar-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-filterable-checkbox-list.html">
 <link rel="import" href="./tf-data-select-row.html">
 
@@ -50,14 +49,14 @@ Properties out: none.
         <paper-button class="add-comparison" on-tap="_toggle">
           <iron-icon class="add-icon" icon="add-circle-outline"></iron-icon>
           &nbsp;Add comparison
-        </paper-buutton>
+        </paper-button>
       </template>
       <template is="dom-if" if="[[_expanded]]">
         <span>
           <template is="dom-if" if="[[!alwaysExpanded]]">
-              <paper-button on-tap="_toggle">
-                Cancel
-              </paper-buutton>
+            <paper-button on-tap="_toggle">
+              Cancel
+            </paper-button>
           </template>
         </span>
         <span>

--- a/tensorboard/components/tf_data_selector/tf-data-select-row.html
+++ b/tensorboard/components/tf_data_selector/tf-data-select-row.html
@@ -22,7 +22,6 @@ limitations under the License.
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
-<link rel="import" href="../tf-dashboard-common/scrollbar-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-filterable-checkbox-dropdown.html">
 <link rel="import" href="./storage-utils.html">
 

--- a/tensorboard/components/tf_data_selector/tf-data-selector-advanced.html
+++ b/tensorboard/components/tf_data_selector/tf-data-selector-advanced.html
@@ -19,7 +19,6 @@ limitations under the License.
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-dashboard-common/array-update-helper.html">
-<link rel="import" href="../tf-dashboard-common/scrollbar-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-filterable-checkbox-list.html">
 <link rel="import" href="../tf-imports/lodash.html">
 <link rel="import" href="./experiment-selector.html">


### PR DESCRIPTION
We need to import scrollbar only when we <style include> it.
Remove unused scrollbar imports.

- Found the instance of wrong scrollbar-style usage by grepping
- I have been searching for ways to find unbalanced tags without too much noise but have not found a good tool for it
  - tidy is too noisy
  - polymer linter does not catch unbalanced tag
    - parse5 that Polymer tools use fixes unbalanced tag when constructing AST without an ability to complain: https://github.com/inikulin/parse5/issues/180
   - etc