### PR TITLE
Change usages of tf.pywrap_tensorflow to tf.compat.v1.pywrap_tensorflow.

### DIFF
--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -33,7 +33,7 @@ class RawEventFileLoader(object):
     file_path = platform_util.readahead_file_path(file_path)
     tf.logging.debug('Opening a record reader pointing at %s', file_path)
     with tf.errors.raise_exception_on_not_ok_status() as status:
-      self._reader = tf.pywrap_tensorflow.PyRecordReader_New(
+      self._reader = tf.compat.v1.pywrap_tensorflow.PyRecordReader_New(
           tf.compat.as_bytes(file_path), 0, tf.compat.as_bytes(''), status)
     # Store it for logging purposes.
     self._file_path = file_path

--- a/tensorboard/loader.py
+++ b/tensorboard/loader.py
@@ -74,7 +74,7 @@ class RecordReader(object):
     self.path = tf.compat.as_text(path)
     self._offset = start_offset
     self._size = -1
-    self._reader = None  # type: tf.pywrap_tensorflow.PyRecordReader
+    self._reader = None  # type: tf.compat.v1.pywrap_tensorflow.PyRecordReader
     self._is_closed = False
     self._lock = threading.Lock()
 
@@ -145,7 +145,7 @@ class RecordReader(object):
 
   def _open(self):
     with tf.errors.raise_exception_on_not_ok_status() as status:
-      return tf.pywrap_tensorflow.PyRecordReader_New(
+      return tf.compat.v1.pywrap_tensorflow.PyRecordReader_New(
           platform_util.readahead_file_path(tf.compat.as_bytes(self.path)),
           self._offset, tf.compat.as_bytes(''), status)
 

--- a/tensorboard/plugins/debugger/debugger_plugin_testlib.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_testlib.py
@@ -61,7 +61,7 @@ class DebuggerPluginTestBase(tf.test.TestCase):
     self.log_dir = self.get_temp_dir()
     file_prefix = tf.compat.as_bytes(
         os.path.join(self.log_dir, 'events.debugger'))
-    writer = tf.pywrap_tensorflow.EventsWriter(file_prefix)
+    writer = tf.compat.v1.pywrap_tensorflow.EventsWriter(file_prefix)
     device_name = '/job:localhost/replica:0/task:0/cpu:0'
     writer.WriteEvent(
         self._CreateEventWithDebugNumericSummary(
@@ -107,7 +107,7 @@ class DebuggerPluginTestBase(tf.test.TestCase):
     os.mkdir(run_foo_directory)
     file_prefix = tf.compat.as_bytes(
         os.path.join(run_foo_directory, 'events.debugger'))
-    writer = tf.pywrap_tensorflow.EventsWriter(file_prefix)
+    writer = tf.compat.v1.pywrap_tensorflow.EventsWriter(file_prefix)
     writer.WriteEvent(
         self._CreateEventWithDebugNumericSummary(
             device_name=device_name,

--- a/tensorboard/plugins/debugger/events_writer_manager.py
+++ b/tensorboard/plugins/debugger/events_writer_manager.py
@@ -206,7 +206,7 @@ class EventsWriterManager(object):
         os.path.join(directory, DEBUGGER_EVENTS_FILE_STARTING_TEXT),
         time.time(), self._events_file_count)
     tf.logging.info("Creating events file %s", file_path)
-    return tf.pywrap_tensorflow.EventsWriter(tf.compat.as_bytes(file_path))
+    return tf.compat.v1.pywrap_tensorflow.EventsWriter(tf.compat.as_bytes(file_path))
 
   def _fetch_events_files_on_disk(self):
     """Obtains the names of debugger-related events files within the directory.

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -415,7 +415,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
     reader = None
     if config.model_checkpoint_path and USING_TF:
       try:
-        reader = tf.pywrap_tensorflow.NewCheckpointReader(
+        reader = tf.compat.v1.pywrap_tensorflow.NewCheckpointReader(
             config.model_checkpoint_path)
       except Exception:  # pylint: disable=broad-except
         tf.logging.warning('Failed reading "%s"', config.model_checkpoint_path)


### PR DESCRIPTION
The symbol `pywrap_tensorflow` is deprecated and will only be available through compat.v1.