### PR TITLE
Remove reporting of the batch size from the overview page.

### DIFF
--- a/tensorboard/plugins/profile/overview_page/overview-page.html
+++ b/tensorboard/plugins/profile/overview_page/overview-page.html
@@ -153,7 +153,6 @@ You may obtain a copy of the License at
             <p><b>Number of Hosts used</b>: <span>[[_host_count]]</span></p>
             <p><b>TPU type</b>: Cloud TPU</span></p>
             <p><b>Number of TPU cores</b>: <span> [[_tpu_core_count]]</span></p>
-            <p><b>Batch size</b>: <span>[[_batch_size]]</span></p>
           </div>
         </paper-card>
         <paper-card heading="Recommendation for Next Steps">


### PR DESCRIPTION
The batch size is based on heuristics. However, it appears to be wrong very often now.
The right way is to get the batch size from TensorFlow.
Before we fix it, rather than presenting a wrong batch size to the user, let's remove it.