### PR TITLE
Add TF 2.0 summary writing APIs for scalar() and text()

### DIFF
--- a/tensorboard/compat/BUILD
+++ b/tensorboard/compat/BUILD
@@ -7,21 +7,39 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-# This rule provides a TensorFlow API implementation exposed under
-# `tensorboard.compat.tensorflow`. By default this API implementation
-# uses actual TensorFlow if available, and if not falls back to our stub.
+# Compatibility helpers in the `tensorboard.compat` module.
 #
-# Depend on this rule if your code is usable with either real or stub TF.
+# This module provides aliases for importing variations on the TensorFlow APIs.
 #
-# Note that this rule doesn't actually *provide* the TensorFlow dependency; this
-# can be separately expressed using //tensorboard:expect_tensorflow_installed,
-# which is a no-op as written but can be swapped out for a real dependency.
+# `from tensorboard.compat import tf`: this provides the TF API. By default
+# this will try to `import tensorflow` and if it fails, will be undefined. This
+# is useful primarily in combination with the `:tensorflow` rule below.
+#
+# `from tensorboard.compat import tf_v2`: this provides the TF 2.0 API. By
+# default this tries to import the TF 2.0 API from a few places where it may
+# be accessible, and if it fails, will be undefined.
 py_library(
-    name = "tensorflow",
+    name = "compat",
     srcs = ["__init__.py"],
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
+)
+
+# This rule ensures that `from tensorboard.compat import tf` will provide a
+# TensorFlow API. By default this API implementation uses actual TensorFlow if
+# available, and if not falls back to a stub implementation.
+#
+# Depend on this rule if your code is usable with either real or stub TF.
+#
+# External only: targets that need real TF should instead depend on the
+# placeholder rule //tensorboard:expect_tensorflow_installed, which is a no-op
+# as written but can be swapped out for a real dependency.
+py_library(
+    name = "tensorflow",
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
+        ":compat",
         "//tensorboard/compat/tensorflow_stub",
     ],
 )

--- a/tensorboard/compat/__init__.py
+++ b/tensorboard/compat/__init__.py
@@ -12,26 +12,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Compatibility interfaces for TensorBoard."""
+"""Compatibility interfaces for TensorBoard.
+
+This module provides aliases for importing variations on the TensorFlow APIs.
+
+`from tensorboard.compat import tf`: this provides the TF API. By default
+this will try to `import tensorflow` and if it fails, will be undefined. This
+is useful primarily when also depending on //tensorboard/compat:tensorflow.
+
+`from tensorboard.compat import tf_v2`: this provides the TF 2.0 API. By
+default this tries to import the TF 2.0 API from a few places where it may
+be accessible, and if it fails, will be undefined.
+"""
 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+# First, check if using TF is explicitly disabled by request.
 USING_TF = True
-
-# Don't attempt to use TF at all if this import exists due to build rules.
 try:
   from tensorboard.compat import notf
   USING_TF = False
 except ImportError:
   pass
 
+# If TF is not disabled, check if it's available.
 if USING_TF:
   try:
     import tensorflow as tf
   except ImportError:
     USING_TF = False
 
-if not USING_TF:
-  from tensorboard.compat import tensorflow_stub as tf
+if USING_TF:
+  # If we can use TF, try to provide `tf_v2` as well.
+  # Check if this is TF 2.0 by looking for a known 2.0-only tf.summary symbol.
+  # TODO(nickfelt): determine a cleaner way to do this.
+  if hasattr(tf.summary, 'write'):
+    tf_v2 = tf
+  else:
+    # As a fallback, try `tensorflow.compat.v2` if it's defined.
+    try:
+      from tensorflow.compat import v2 as tf_v2
+    except ImportError:
+      pass
+else:
+  # If we can't use TF, try to provide the stub instead.
+  # This will only work if the tensorflow_stub dep is included
+  # in the build, via the `tensorboard/compat:tensorflow` target.
+  try:
+    from tensorboard.compat import tensorflow_stub as tf
+  except ImportError:
+    pass

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -66,7 +66,21 @@ py_library(
     ],
     deps = [
         ":metadata",
+        ":summary_v2",
         "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_library(
+    name = "summary_v2",
+    srcs = ["summary_v2.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//tensorboard:internal",
+    ],
+    deps = [
+        ":metadata",
+        "//tensorboard/compat",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/util:tensor_util",
     ],

--- a/tensorboard/plugins/scalar/summary.py
+++ b/tensorboard/plugins/scalar/summary.py
@@ -15,9 +15,6 @@
 """Scalar summaries and TensorFlow operations to create them.
 
 A scalar summary stores a single floating-point value, as a rank-0 tensor.
-
-NOTE: This module is in beta, and its API is subject to change, but the
-data that it stores to disk will be supported forever.
 """
 
 from __future__ import absolute_import
@@ -27,65 +24,13 @@ from __future__ import print_function
 import tensorflow as tf
 import numpy as np
 
-from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.scalar import metadata
-from tensorboard.util import tensor_util
+from tensorboard.plugins.scalar import summary_v2
 
 
-def scalar(name, tensor, tag=None, description=None, step=None):
-  """Create a scalar summary op.
-
-  Arguments:
-    name: A name for the generated summary node.
-    tensor: A real numeric rank-0 `Tensor`. Must have `dtype` castable
-      to `float32`.
-    tag: Optional rank-0 string `Tensor` to identify this summary in
-      TensorBoard.  Defaults to the generated name of this op.
-    description: Optional long-form description for this summary, as a
-      constant `str`. Markdown is supported. Defaults to empty.
-    step: Optional `int64` monotonic step variable, which defaults
-      to `tf.train.get_global_step`.
-
-  Returns:
-    A TensorFlow summary op.
-  """
-  # TODO(nickfelt): make tag param work
-  summary_metadata = metadata.create_summary_metadata(
-      display_name=None, description=description)
-  with tf.name_scope(name, values=[tensor, tag, step]) as scope:
-    with tf.control_dependencies([tf.assert_scalar(tensor)]):
-      return tf.contrib.summary.generic(name=scope,
-                                        tensor=tf.cast(tensor, tf.float32),
-                                        metadata=summary_metadata,
-                                        step=step)
-
-
-def scalar_pb(tag, tensor, description=None):
-  """Create a scalar summary_pb2.Summary protobuf.
-
-  Arguments:
-    tag: String tag for the summary.
-    tensor: A rank-0 `np.array` or a compatible python number type.
-    description: Optional long-form description for this summary, as a
-      `str`. Markdown is supported. Defaults to empty.
-
-  Returns:
-    A `summary_pb2.Summary` protobuf object.
-  """
-  arr = np.array(tensor)
-  if arr.shape != ():
-    raise ValueError('Expected scalar shape for tensor, got shape: %s.'
-                     % arr.shape)
-  if arr.dtype.kind not in ('b', 'i', 'u', 'f'):  # bool, int, uint, float
-    raise ValueError('Cast %s to float is not supported' % arr.dtype.name)
-  tensor_proto = tensor_util.make_tensor_proto(arr.astype(np.float32))
-  summary_metadata = metadata.create_summary_metadata(
-      display_name=None, description=description)
-  summary = summary_pb2.Summary()
-  summary.value.add(tag=tag,
-                    metadata=summary_metadata,
-                    tensor=tensor_proto)
-  return summary
+# Export V2 versions.
+scalar = summary_v2.scalar
+scalar_pb = summary_v2.scalar_pb
 
 
 def op(name,
@@ -115,11 +60,11 @@ def op(name,
   summary_metadata = metadata.create_summary_metadata(
       display_name=display_name, description=description)
   with tf.name_scope(name):
-    with tf.control_dependencies([tf.assert_scalar(data)]):
-      return tf.summary.tensor_summary(name='scalar_summary',
-                                       tensor=tf.cast(data, tf.float32),
-                                       collections=collections,
-                                       summary_metadata=summary_metadata)
+    with tf.control_dependencies([tf.compat.v1.assert_scalar(data)]):
+      return tf.compat.v1.summary.tensor_summary(name='scalar_summary',
+                                                 tensor=tf.cast(data, tf.float32),
+                                                 collections=collections,
+                                                 summary_metadata=summary_metadata)
 
 
 def pb(name, data, display_name=None, description=None):

--- a/tensorboard/plugins/scalar/summary_test.py
+++ b/tensorboard/plugins/scalar/summary_test.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for the scalar plugin summary generation functions."""
+"""Tests for the scalar plugin summary API."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -26,15 +26,32 @@ import numpy as np
 import six
 import tensorflow as tf
 
-tf.enable_eager_execution()
-
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.scalar import metadata
 from tensorboard.plugins.scalar import summary
 from tensorboard.util import tensor_util
 from tensorboard.util import test_util
 
+try:
+  from tensorboard.compat import tf_v2
+except ImportError:
+  tf_v2 = None
+
+try:
+  tf.enable_eager_execution()
+except AttributeError:
+  # TF 2.0 doesn't have this symbol because eager is the default.
+  pass
+
+
 class SummaryBaseTest(object):
+
+  def scalar(self, *args, **kwargs):
+    raise NotImplementedError()
+
+  def test_tag(self):
+    self.assertEqual('a', self.scalar('a', 1).value[0].tag)
+    self.assertEqual('a/b', self.scalar('a/b', 1).value[0].tag)
 
   def test_metadata(self):
     pb = self.scalar('a', 1.13)
@@ -46,10 +63,9 @@ class SummaryBaseTest(object):
     # There's no content, so successfully parsing is fine.
     metadata.parse_plugin_metadata(content)
 
-  def test_explicit__description(self):
+  def test_explicit_description(self):
     description = 'The first letter of the alphabet.'
-    pb = self.scalar('a', 1.13,
-                     description=description)
+    pb = self.scalar('a', 1.13, description=description)
     summary_metadata = pb.value[0].metadata
     self.assertEqual(summary_metadata.summary_description, description)
     plugin_data = summary_metadata.plugin_data
@@ -81,8 +97,9 @@ class SummaryBaseTest(object):
   def test_string_value(self):
     # Use str.* in regex because PY3 numpy refers to string arrays using
     # length-dependent type names in the format "str%d" % (32 * len(str)).
-    with six.assertRaisesRegex(self, Exception, r'Cast str.*float'):
-      self.scalar('a', np.array("113"))
+    with six.assertRaisesRegex(self, (ValueError, tf.errors.UnimplementedError),
+                               r'Cast str.*float'):
+      self.scalar('a', np.array('113'))
 
   def test_requires_rank_0(self):
     with six.assertRaisesRegex(self, ValueError, r'Expected scalar shape'):
@@ -94,10 +111,23 @@ class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):
     return test_util.ensure_tb_summary_proto(
         summary.pb(*args, **kwargs))
 
+  def test_tag(self):
+    self.assertEqual('a/scalar_summary', self.scalar('a', 1).value[0].tag)
+    self.assertEqual('a/b/scalar_summary', self.scalar('a/b', 1).value[0].tag)
+
 
 class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
   def scalar(self, *args, **kwargs):
     return summary_pb2.Summary.FromString(summary.op(*args, **kwargs).numpy())
+
+  def test_tag(self):
+    self.assertEqual('a/scalar_summary', self.scalar('a', 1).value[0].tag)
+    self.assertEqual('a/b/scalar_summary', self.scalar('a/b', 1).value[0].tag)
+
+  def test_scoped_tag(self):
+    with tf.name_scope('scope'):
+      self.assertEqual('scope/a/scalar_summary',
+                       self.scalar('a', 1).value[0].tag)
 
 
 class SummaryV2PbTest(SummaryBaseTest, tf.test.TestCase):
@@ -106,26 +136,52 @@ class SummaryV2PbTest(SummaryBaseTest, tf.test.TestCase):
 
 
 class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
-  def scalar(self, *args, **kwargs):
-    return self.scalar_event(*args, **kwargs).summary
 
-  def scalar_event(self, *args, **kwargs):
-    writer = tf.contrib.summary.create_file_writer(self.get_temp_dir())
-    with writer.as_default(), tf.contrib.summary.always_record_summaries():
+  def setUp(self):
+    super(SummaryV2OpTest, self).setUp()
+    if tf_v2 is None:
+      self.skipTest('v2 summary API not available')
+
+  def scalar(self, *args, **kwargs):
+    writer = tf_v2.summary.create_file_writer(self.get_temp_dir())
+    with writer.as_default():
       summary.scalar(*args, **kwargs)
-    return self.read_single_event_from_eventfile()
+    writer.close()
+    return self.read_single_event_from_eventfile().summary
 
   def read_single_event_from_eventfile(self):
     event_files = glob.glob(os.path.join(self.get_temp_dir(), '*'))
     self.assertEqual(len(event_files), 1)
-    events = list(tf.train.summary_iterator(event_files[0]))
+    events = list(tf.compat.v1.train.summary_iterator(event_files[0]))
     # Expect a boilerplate event for the file_version, then the summary one.
     self.assertEqual(len(events), 2)
     return events[1]
 
+  def test_scoped_tag(self):
+    with tf.name_scope('scope'):
+      self.assertEqual('scope/a', self.scalar('a', 1).value[0].tag)
+
   def test_step(self):
-    event = self.scalar_event('a', 1.0, step=333)
+    self.scalar('a', 1.0, step=333)
+    event = self.read_single_event_from_eventfile()
     self.assertEqual(333, event.step)
+
+
+class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
+  def scalar(self, *args, **kwargs):
+    # Hack to extract current scope since there's no direct API for it.
+    with tf.name_scope('_') as temp_scope:
+      scope = temp_scope.rstrip('/_')
+    @tf.function
+    def graph_fn():
+      # Recreate the active scope inside the defun since it won't propagate.
+      with tf.name_scope(scope):
+        summary.scalar(*args, **kwargs)
+    writer = tf_v2.summary.create_file_writer(self.get_temp_dir())
+    with writer.as_default():
+      graph_fn()
+    writer.close()
+    return self.read_single_event_from_eventfile().summary
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/scalar/summary_v2.py
+++ b/tensorboard/plugins/scalar/summary_v2.py
@@ -1,0 +1,86 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Scalar summaries and TensorFlow operations to create them, V2 versions.
+
+A scalar summary stores a single floating-point value, as a rank-0 tensor.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from tensorboard.compat.proto import summary_pb2
+from tensorboard.plugins.scalar import metadata
+from tensorboard.util import tensor_util
+
+
+def scalar(name, data, step=0, description=None):
+  """Write a scalar summary.
+
+  Arguments:
+    name: A name for this summary. The summary tag used for TensorBoard will
+      be this name prefixed by any active name scopes.
+    data: A real numeric scalar value, convertible to a `float32` Tensor.
+    step: Required `int64`-castable monotonic step value.
+    description: Optional long-form description for this summary, as a
+      constant `str`. Markdown is supported. Defaults to empty.
+
+  Returns:
+    True on success, or false if no summary was written because no default
+    summary writer was available.
+  """
+  # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
+  from tensorboard.compat import tf_v2 as tf
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=None, description=description)
+  with tf.summary.summary_scope(name, values=[data, step]) as (tag, _):
+    tf.debugging.assert_scalar(data)
+    return tf.summary.write(tag=tag,
+                            tensor=tf.cast(data, tf.float32),
+                            step=step,
+                            metadata=summary_metadata)
+
+
+def scalar_pb(tag, data, description=None):
+  """Create a scalar summary_pb2.Summary protobuf.
+
+  Arguments:
+    tag: String tag for the summary.
+    data: A 0-dimensional `np.array` or a compatible python number type.
+    description: Optional long-form description for this summary, as a
+      `str`. Markdown is supported. Defaults to empty.
+
+  Raises:
+    ValueError: If the type or shape of the data is unsupported.
+
+  Returns:
+    A `summary_pb2.Summary` protobuf object.
+  """
+  arr = np.array(data)
+  if arr.shape != ():
+    raise ValueError('Expected scalar shape for tensor, got shape: %s.'
+                     % arr.shape)
+  if arr.dtype.kind not in ('b', 'i', 'u', 'f'):  # bool, int, uint, float
+    raise ValueError('Cast %s to float is not supported' % arr.dtype.name)
+  tensor_proto = tensor_util.make_tensor_proto(arr.astype(np.float32))
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=None, description=description)
+  summary = summary_pb2.Summary()
+  summary.value.add(tag=tag,
+                    metadata=summary_metadata,
+                    tensor=tensor_proto)
+  return summary

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -67,7 +67,23 @@ py_library(
     ],
     deps = [
         ":metadata",
+        ":summary_v2",
         "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+py_library(
+    name = "summary_v2",
+    srcs = ["summary_v2.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//tensorboard:internal",
+    ],
+    deps = [
+        ":metadata",
+        "//tensorboard/compat",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
+        "//tensorboard/util:tensor_util",
     ],
 )
 

--- a/tensorboard/plugins/text/summary.py
+++ b/tensorboard/plugins/text/summary.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Text summaries and TensorFlow operations to create them.
-A text summary stores a single string value.
-"""
+"""Text summaries and TensorFlow operations to create them."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -23,6 +21,12 @@ from __future__ import print_function
 import tensorflow as tf
 
 from tensorboard.plugins.text import metadata
+from tensorboard.plugins.text import summary_v2
+
+
+# Export V2 versions.
+text = summary_v2.text
+text_pb = summary_v2.text_pb
 
 
 def op(name,
@@ -64,11 +68,11 @@ def op(name,
   summary_metadata = metadata.create_summary_metadata(
       display_name=display_name, description=description)
   with tf.name_scope(name):
-    with tf.control_dependencies([tf.assert_type(data, tf.string)]):
-      return tf.summary.tensor_summary(name='text_summary',
-                                       tensor=data,
-                                       collections=collections,
-                                       summary_metadata=summary_metadata)
+    with tf.control_dependencies([tf.compat.v1.assert_type(data, tf.string)]):
+      return tf.compat.v1.summary.tensor_summary(name='text_summary',
+                                                 tensor=data,
+                                                 collections=collections,
+                                                 summary_metadata=summary_metadata)
 
 
 def pb(name, data, display_name=None, description=None):

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for the text plugin summary generation functions."""
+"""Tests for the text plugin summary API."""
 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+
+import glob
+import os
 
 import numpy as np
 import six
@@ -27,77 +30,42 @@ from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.text import metadata
 from tensorboard.plugins.text import summary
 from tensorboard.util import tensor_util
-from tensorboard.util import test_util
+
+try:
+  from tensorboard.compat import tf_v2
+except ImportError:
+  tf_v2 = None
+
+try:
+  tf.enable_eager_execution()
+except AttributeError:
+  # TF 2.0 doesn't have this symbol because eager is the default.
+  pass
 
 
-class SummaryTest(tf.test.TestCase):
+class SummaryBaseTest(object):
 
-  def pb_via_op(self, summary_op, feed_dict=None):
-    with tf.Session() as sess:
-      actual_pbtxt = sess.run(summary_op, feed_dict=feed_dict or {})
-    actual_proto = summary_pb2.Summary()
-    actual_proto.ParseFromString(actual_pbtxt)
-    return actual_proto
+  def text(self, *args, **kwargs):
+    raise NotImplementedError()
 
-  def normalize_summary_pb(self, pb):
-    """Pass `pb`'s `TensorProto` through a marshalling roundtrip.
-
-    `TensorProto`s can be equal in value even if they are not identical
-    in representation, because data can be stored in either the
-    `tensor_content` field or the `${dtype}_value` field. This
-    normalization ensures a canonical form, and should be used before
-    comparing two `Summary`s for equality.
-    """
-    result = summary_pb2.Summary()
-    if not isinstance(pb, summary_pb2.Summary):
-      pb = test_util.ensure_tb_summary_proto(pb)
-    result.MergeFrom(pb)
-    for value in result.value:
-      if value.HasField('tensor'):
-        new_tensor = tensor_util.make_tensor_proto(
-            tensor_util.make_ndarray(value.tensor))
-        value.ClearField('tensor')
-        value.tensor.MergeFrom(new_tensor)
-    return result
-
-  def compute_and_check_summary_pb(self, name, data,
-                                   display_name=None, description=None,
-                                   data_tensor=None, feed_dict=None):
-    """Use both `op` and `pb` to get a summary, asserting equality.
-
-    Returns:
-      a `summary_pb2.Summary` protocol buffer
-    """
-    if data_tensor is None:
-      data_tensor = tf.constant(data)
-    op = summary.op(
-        name, data, display_name=display_name, description=description)
-    pb = self.normalize_summary_pb(summary.pb(
-        name, data, display_name=display_name, description=description))
-    pb_via_op = self.normalize_summary_pb(
-        self.pb_via_op(op, feed_dict=feed_dict))
-    self.assertProtoEquals(pb, pb_via_op)
-    return pb
+  def test_tag(self):
+    self.assertEqual('a', self.text('a', 'foo').value[0].tag)
+    self.assertEqual('a/b', self.text('a/b', 'foo').value[0].tag)
 
   def test_metadata(self):
-    pb = self.compute_and_check_summary_pb('do', 'A deer. A female deer.')
+    pb = self.text('do', 'A deer. A female deer.')
     summary_metadata = pb.value[0].metadata
     plugin_data = summary_metadata.plugin_data
-    self.assertEqual(summary_metadata.display_name, 'do')
     self.assertEqual(summary_metadata.summary_description, '')
     self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
     content = summary_metadata.plugin_data.content
     # There's no content, so successfully parsing is fine.
     metadata.parse_plugin_metadata(content)
 
-  def test_explicit_display_name_and_description(self):
-    display_name = '"Re"'
+  def test_explicit_description(self):
     description = 'A whole step above do.'
-    pb = self.compute_and_check_summary_pb('re', 'A drop of golden sun.',
-                                           display_name=display_name,
-                                           description=description)
+    pb = self.text('re', 'A drop of golden sun.', description=description)
     summary_metadata = pb.value[0].metadata
-    self.assertEqual(summary_metadata.display_name, display_name)
     self.assertEqual(summary_metadata.summary_description, description)
     plugin_data = summary_metadata.plugin_data
     self.assertEqual(plugin_data.plugin_name, metadata.PLUGIN_NAME)
@@ -106,20 +74,19 @@ class SummaryTest(tf.test.TestCase):
     metadata.parse_plugin_metadata(content)
 
   def test_bytes_value(self):
-    pb = self.compute_and_check_summary_pb(
-        'mi', b'A name\xe2\x80\xa6I call myself')
+    pb = self.text('mi', b'A name\xe2\x80\xa6I call myself')
     value = tensor_util.make_ndarray(pb.value[0].tensor).item()
     self.assertIsInstance(value, six.binary_type)
     self.assertEqual(b'A name\xe2\x80\xa6I call myself', value)
 
   def test_unicode_value(self):
-    pb = self.compute_and_check_summary_pb('mi', u'A name\u2026I call myself')
+    pb = self.text('mi', u'A name\u2026I call myself')
     value = tensor_util.make_ndarray(pb.value[0].tensor).item()
     self.assertIsInstance(value, six.binary_type)
     self.assertEqual(b'A name\xe2\x80\xa6I call myself', value)
 
   def test_np_array_bytes_value(self):
-    pb = self.compute_and_check_summary_pb(
+    pb = self.text(
         'fa',
         np.array(
             [[b'A', b'long', b'long'], [b'way', b'to', b'run \xe2\x80\xbc']]))
@@ -133,11 +100,11 @@ class SummaryTest(tf.test.TestCase):
         self.assertIsInstance(value, six.binary_type)
 
   def test_np_array_unicode_value(self):
-    pb = self.compute_and_check_summary_pb(
+    pb = self.text(
         'fa',
         np.array(
             [[u'A', u'long', u'long'], [u'way', u'to', u'run \u203C']]))
-    values = tensor_util.make_ndarray(pb.value[0].tensor).tolist()
+    values = tensor_util.make_ndarray (pb.value[0].tensor).tolist()
     self.assertEqual(
         [[b'A', b'long', b'long'], [b'way', b'to', b'run \xe2\x80\xbc']],
         values)
@@ -146,20 +113,89 @@ class SummaryTest(tf.test.TestCase):
       for value in vectors:
         self.assertIsInstance(value, six.binary_type)
 
-  def test_non_string_value_in_op(self):
-    with six.assertRaisesRegex(
-        self,
-        Exception,
-        r'must be of type <dtype: \'string\'>'):
-      with tf.Session() as sess:
-        sess.run(summary.op('so', tf.constant(5)))
+  def test_non_string_value(self):
+    with six.assertRaisesRegex(self, TypeError, r'must be of type.*string'):
+      self.text('la', np.array(range(42)))
 
-  def test_non_string_value_in_pb(self):
-    with six.assertRaisesRegex(
-        self,
-        ValueError,
-        r'Expected binary or unicode string, got 0'):
-      summary.pb('la', np.array(range(42)))
+
+class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):
+  def text(self, *args, **kwargs):
+    return summary.pb(*args, **kwargs)
+
+  def test_tag(self):
+    self.assertEqual('a/text_summary', self.text('a', 'foo').value[0].tag)
+    self.assertEqual('a/b/text_summary', self.text('a/b', 'foo').value[0].tag)
+
+  def test_non_string_value(self):
+    with six.assertRaisesRegex(self, ValueError,
+                               r'Expected binary or unicode string, got 0'):
+      self.text('la', np.array(range(42)))
+
+class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
+  def text(self, *args, **kwargs):
+    return tf.Summary.FromString(summary.op(*args, **kwargs).numpy())
+
+  def test_tag(self):
+    self.assertEqual('a/text_summary', self.text('a', 'foo').value[0].tag)
+    self.assertEqual('a/b/text_summary', self.text('a/b', 'foo').value[0].tag)
+
+  def test_scoped_tag(self):
+    with tf.name_scope('scope'):
+      self.assertEqual('scope/a/text_summary',
+                       self.text('a', 'foo').value[0].tag)
+
+
+class SummaryV2PbTest(SummaryBaseTest, tf.test.TestCase):
+  def text(self, *args, **kwargs):
+    return summary.text_pb(*args, **kwargs)
+
+
+class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
+  def setUp(self):
+    super(SummaryV2OpTest, self).setUp()
+    if tf_v2 is None:
+      self.skipTest('TF v2 summary API not available')
+
+  def text(self, *args, **kwargs):
+    writer = tf_v2.summary.create_file_writer(self.get_temp_dir())
+    with writer.as_default():
+      summary.text(*args, **kwargs)
+    writer.close()
+    return self.read_single_event_from_eventfile().summary
+
+  def read_single_event_from_eventfile(self):
+    event_files = glob.glob(os.path.join(self.get_temp_dir(), '*'))
+    self.assertEqual(len(event_files), 1)
+    events = list(tf.compat.v1.train.summary_iterator(event_files[0]))
+    # Expect a boilerplate event for the file_version, then the summary one.
+    self.assertEqual(len(events), 2)
+    return events[1]
+
+  def test_scoped_tag(self):
+    with tf.name_scope('scope'):
+      self.assertEqual('scope/a', self.text('a', 'foo').value[0].tag)
+
+  def test_step(self):
+    self.text('a', 'foo', step=333)
+    event = self.read_single_event_from_eventfile()
+    self.assertEqual(333, event.step)
+
+
+class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
+  def text(self, *args, **kwargs):
+    # Hack to extract current scope since there's no direct API for it.
+    with tf.name_scope('_') as temp_scope:
+      scope = temp_scope.rstrip('/_')
+    @tf.function
+    def graph_fn():
+      # Recreate the active scope inside the defun since it won't propagate.
+      with tf.name_scope(scope):
+        summary.text(*args, **kwargs)
+    writer = tf_v2.summary.create_file_writer(self.get_temp_dir())
+    with writer.as_default():
+      graph_fn()
+    writer.close()
+    return self.read_single_event_from_eventfile().summary
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/text/summary_v2.py
+++ b/tensorboard/plugins/text/summary_v2.py
@@ -1,0 +1,79 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Text summaries and TensorFlow operations to create them, V2 versions."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorboard.compat.proto import summary_pb2
+from tensorboard.plugins.text import metadata
+from tensorboard.util import tensor_util
+
+
+def text(name, data, step=0, description=None):
+  """Emit a text summary.
+
+  Arguments:
+    name: A name for this summary. The summary tag used for TensorBoard will
+      be this name prefixed by any active name scopes.
+    data: A UTF-8 string tensor value.
+    step: Optional `int64`-castable monotonic step value. Defaults to 0.
+    description: Optional long-form description for this summary, as a
+      constant `str`. Markdown is supported. Defaults to empty.
+
+  Returns:
+    True on success, or false if no summary was emitted because no default
+    summary writer was available.
+  """
+  # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
+  from tensorboard.compat import tf_v2 as tf
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=None, description=description)
+  with tf.summary.summary_scope(name, values=[data, step]) as (tag, _):
+    tf.debugging.assert_type(data, tf.string)
+    return tf.summary.write(
+        tag=tag, tensor=data, metadata=summary_metadata, step=step)
+
+
+def text_pb(tag, data, description=None):
+  """Create a text tf.Summary protobuf.
+
+  Arguments:
+    tag: String tag for the summary.
+    data: A Python bytestring (of type bytes), a Unicode string, or a numpy data
+      array of those types.
+    description: Optional long-form description for this summary, as a `str`.
+      Markdown is supported. Defaults to empty.
+
+  Raises:
+    TypeError: If the type of the data is unsupported.
+
+  Returns:
+    A `tf.Summary` protobuf object.
+  """
+  # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
+  from tensorboard.compat import tf
+  try:
+    tensor = tensor_util.make_tensor_proto(data, dtype=tf.string)
+  except TypeError as e:
+    raise TypeError("tensor must be of type string", e)
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=None, description=description)
+  summary = summary_pb2.Summary()
+  summary.value.add(tag=tag,
+                    metadata=summary_metadata,
+                    tensor=tensor)
+  return summary

--- a/tensorboard/summary/BUILD
+++ b/tensorboard/summary/BUILD
@@ -7,8 +7,18 @@ py_library(
     name = "summary",
     srcs = [
         "__init__.py",
+    ],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":summary_v1",
+    ],
+)
+
+py_library(
+    name = "summary_v1",
+    srcs = [
         "v1.py",
-        "v2.py",
     ],
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
@@ -23,6 +33,19 @@ py_library(
     ],
 )
 
+py_library(
+    name = "summary_v2",
+    srcs = [
+        "v2.py",
+    ],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorboard/plugins/scalar:summary_v2",
+        "//tensorboard/plugins/text:summary_v2",
+    ],
+)
+
 py_test(
     name = "summary_test",
     size = "small",
@@ -30,6 +53,8 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":summary",
+        ":summary_v1",
+        ":summary_v2",
         "//tensorboard:expect_tensorflow_installed",
     ],
 )

--- a/tensorboard/summary/__init__.py
+++ b/tensorboard/summary/__init__.py
@@ -20,4 +20,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorboard.summary.v1 import *
+# If the V1 summary API is accessible, export it here.
+try:
+  from tensorboard.summary.v1 import *
+except ImportError:
+  pass


### PR DESCRIPTION
This PR reworks the initial V2 scalar summary API to use the new TF 2.0 summary writing logic, aka `tf.summary.write()`, and adds a V2 text summary API that also uses this logic.  These APIs and their tests have been adjusted to run under the 2.0 preview version of TF.

It also factors out the V2 summary API so that it can be depended on directly as `//tensorboard/summary:summary_v2` without picking up the V1 API and its dependencies.

Lastly, it extends tensorboard.compat so that it can also be used to provide a `tf_v2` alias for the TF 2.0 API if it is available, which is used by the V2 summary APIs.