### PR TITLE
Check whether values are constant before smooth

### DIFF
--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -1020,13 +1020,8 @@ class LineChart {
     // See #786.
     const isConstant = yValues.every((v) => v == yValues[0]);
     data.forEach((d, i) => {
-<<<<<<< HEAD
-      let nextVal = this.yValueAccessor(d, i, dataset);
-      if (!Number.isFinite(nextVal)) {
-=======
       const nextVal = yValues[i];
       if (isConstant || !Number.isFinite(nextVal)) {
->>>>>>> CR review
         d.smoothed = nextVal;
       } else {
         last = last * smoothingWeight + (1 - smoothingWeight) * nextVal;

--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -1015,9 +1015,18 @@ class LineChart {
     // frequency components of the time-series.
     let last = data.length > 0 ? 0 : NaN;
     let numAccum = 0;
+
+    const yValues = data.map((d, i) => this.yValueAccessor(d, i, dataset));
+    // See #786.
+    const isConstant = yValues.every((v) => v == yValues[0]);
     data.forEach((d, i) => {
+<<<<<<< HEAD
       let nextVal = this.yValueAccessor(d, i, dataset);
       if (!Number.isFinite(nextVal)) {
+=======
+      const nextVal = yValues[i];
+      if (isConstant || !Number.isFinite(nextVal)) {
+>>>>>>> CR review
         d.smoothed = nextVal;
       } else {
         last = last * smoothingWeight + (1 - smoothingWeight) * nextVal;

--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -721,8 +721,6 @@ export class LineChart {
 >>>>>>> Check whether values are constant before smooth
         d.smoothed = nextVal;
       } else {
-        // This arithematic causes IEEE 754 floating-point precision error and
-        // cause really janky bounds/chart.
         last = last * smoothingWeight + (1 - smoothingWeight) * nextVal;
         numAccum++;
         // The uncorrected moving average is biased towards the initial value.

--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -707,11 +707,22 @@ export class LineChart {
     // frequency components of the time-series.
     let last = data.length > 0 ? 0 : NaN;
     let numAccum = 0;
+
+    const yValues = data.map((d, i) => this.yValueAccessor(d, i, dataset));
+    // See #786.
+    const isConstant = yValues.every((v) => v == yValues[0]);
     data.forEach((d, i) => {
+<<<<<<< HEAD
       let nextVal = this.yValueAccessor(d, i, dataset);
       if (!Number.isFinite(nextVal)) {
+=======
+      const nextVal = yValues[i];
+      if (isConstant || !_.isFinite(nextVal)) {
+>>>>>>> Check whether values are constant before smooth
         d.smoothed = nextVal;
       } else {
+        // This arithematic causes IEEE 754 floating-point precision error and
+        // cause really janky bounds/chart.
         last = last * smoothingWeight + (1 - smoothingWeight) * nextVal;
         numAccum++;
         // The uncorrected moving average is biased towards the initial value.

--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -712,13 +712,8 @@ export class LineChart {
     // See #786.
     const isConstant = yValues.every((v) => v == yValues[0]);
     data.forEach((d, i) => {
-<<<<<<< HEAD
-      let nextVal = this.yValueAccessor(d, i, dataset);
-      if (!Number.isFinite(nextVal)) {
-=======
       const nextVal = yValues[i];
-      if (isConstant || !_.isFinite(nextVal)) {
->>>>>>> Check whether values are constant before smooth
+      if (isConstant || !Number.isFinite(nextVal)) {
         d.smoothed = nextVal;
       } else {
         last = last * smoothingWeight + (1 - smoothingWeight) * nextVal;


### PR DESCRIPTION
Due to IEEE 754 floating-point precision, multiplying floating smoothing
factor into a value can cause discrepency in otherwise mathematically
constant value.

Please see #786 for examples of weird spikes/messed up y-scale.

Partially addresses #786.