### PR TITLE
lodash: remove uses of deprecated `_.isFinite`

### DIFF
--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -1017,7 +1017,7 @@ class LineChart {
     let numAccum = 0;
     data.forEach((d, i) => {
       let nextVal = this.yValueAccessor(d, i, dataset);
-      if (!_.isFinite(nextVal)) {
+      if (!Number.isFinite(nextVal)) {
         d.smoothed = nextVal;
       } else {
         last = last * smoothingWeight + (1 - smoothingWeight) * nextVal;

--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -709,7 +709,7 @@ export class LineChart {
     let numAccum = 0;
     data.forEach((d, i) => {
       let nextVal = this.yValueAccessor(d, i, dataset);
-      if (!_.isFinite(nextVal)) {
+      if (!Number.isFinite(nextVal)) {
         d.smoothed = nextVal;
       } else {
         last = last * smoothingWeight + (1 - smoothingWeight) * nextVal;

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-continue-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-continue-dialog.html
@@ -236,7 +236,7 @@ limitations under the License.
         }
         // Validate that this._tensorConditionRefValue is a number.
         const refValue = Number(this._tensorConditionRefValue);
-        if (!_.isFinite(refValue)) {
+        if (!Number.isFinite(refValue)) {
           this.set('_tensorConditionRefValue', 0);
           return;
         }


### PR DESCRIPTION
Summary:
Lodash removed `isFinite` and `isNaN` in January 2017; this commit
removes them from our codebase. They are equivalent to `Number.isFinite`
and `Number.isNaN`, respectively, which were introduced in ES6. We
already use `Number.isFinite` elsewhere in our codebase, so I figure
that it’s okay to add more such dependencies.

Test Plan:
Note that `git grep -F -e _.isFinite -e _.isNaN` returns no results.

wchargin-branch: lodash-remove-isfinite