### PR TITLE
Fix horizontal resizer in debugger

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.html
+++ b/tensorboard/components/tf_dashboard_common/tf-dashboard-layout.html
@@ -40,10 +40,10 @@ Generic layout for a dashboard.
       }
 
       #sidebar {
-        flex: 0 0 25%;
+        flex: 0 0 var(--tf-dashboard-layout-sidebar-basis, 25%);
         height: 100%;
-        max-width: 350px;
-        min-width: 270px;
+        max-width: var(--tf-dashboard-layout-sidebar-max-width, 350px);
+        min-width: var(--tf-dashboard-layout-sidebar-min-width, 270px);
         overflow-y: auto;
         text-overflow: ellipsis;
       }

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -202,6 +202,11 @@ limitations under the License.
         width: 40vw;
         margin-left: 30vw;
       }
+      tf-dashboard-layout {
+        --tf-dashboard-layout-sidebar-basis: auto;
+        --tf-dashboard-layout-sidebar-max-width: unset;
+        --tf-dashboard-layout-sidebar-min-width: unset;
+      }
       .debugger-section-title {
         font-size: 110%;
         font-weight: bold;
@@ -271,12 +276,16 @@ limitations under the License.
         margin: 80px auto 0 auto;
       }
       .sidebar {
-        position: relative;
         height: 100%;
+        overflow-x: visible;
+        position: relative;
       }
       .center {
         position: relative;
         height: 100%;
+      }
+      tf-debugger-resizer {
+        right: -10px;
       }
       #center-content {
         position: absolute;
@@ -301,15 +310,16 @@ limitations under the License.
         vertical-align: middle;
       }
       .node-entries {
-        position: relative;
+        box-shadow: 3px 3px #ddd;
+        box-sizing: border-box;
         height: 80%;
-        width: 100%;
-        vertical-align: top;
         overflow: auto;
-        padding-top: 3px;
         padding-left: 3px;
         padding-right: 3px;
-        box-shadow: 3px 3px #ddd;
+        padding-top: 3px;
+        position: relative;
+        vertical-align: top;
+        width: 100%;
       }
       .source-code-view-div {
         position: relative;


### PR DESCRIPTION
While refactoring the dashboard layout, we inadvertently broke the
horizontal resizing capability. The resizer was clipped and was bound
by the TB global max/min-width limit on the sidebar width.

### Before
![image](https://user-images.githubusercontent.com/2547313/50184351-b2070f80-02c9-11e9-986a-540a98612656.png)
- Note that `Show code` is clipped due to the max-width on the container.

### After 
![image](https://user-images.githubusercontent.com/2547313/50178985-c42d8180-02ba-11e9-889a-b09710b16631.png)
