### PR TITLE
Allow passing --no-smoke to build_pip_package to skip smoke testing

### DIFF
--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -24,9 +24,17 @@ else
 fi
 
 run_smoke_test=1
-if [ "$1" = "--no-smoke" ]; then
-  run_smoke_test=0
-fi
+while arg="$1" && shift; do
+  case "$arg" in
+    "--no-smoke")
+      run_smoke_test=0
+      ;;
+    *)
+      echo >&2 'fatal: unknown argument:' "$arg"
+      exit 1
+      ;;
+  esac
+done
 
 smoke() {
   TF_PACKAGE=tf-nightly

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -23,6 +23,11 @@ else
   sedi="sed -i"
 fi
 
+run_smoke_test=1
+if [ "$1" = "--no-smoke" ]; then
+  run_smoke_test=0
+fi
+
 smoke() {
   TF_PACKAGE=tf-nightly
   if [ -n "$TF_VERSION" ]; then
@@ -115,7 +120,9 @@ pip install -qU wheel 'setuptools>=36.2.0'
 python setup.py bdist_wheel --python-tag py2 >/dev/null
 python setup.py bdist_wheel --python-tag py3 >/dev/null
 
-smoke 2
-smoke 3
+if [ "$run_smoke_test" = 1 ]; then
+  smoke 2
+  smoke 3
+fi
 
 ls -hal "$PWD/dist"


### PR DESCRIPTION
This is useful when trying to quickly iterate on the output of build_pip_package, since running the smoke tests can take 30+ seconds whereas just building the package is often faster.