### PR TITLE
deps: upgrade TensorFlow workspace definition

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,11 +63,11 @@ http_archive(
 
 http_archive(
     name = "org_tensorflow",
-    sha256 = "88324ad9379eae4fdb2aefb8e0d6c7cd0dc748b44daa5cc96ffd9415705c00c3",
-    strip_prefix = "tensorflow-9752b117ff63f204c4975cad52b5aab5c1f5e9a9",
+    sha256 = "a0d7eea4c4e4b526cdba624f706bfbcc87a7923bb09904dfab22589a6bd142f2",
+    strip_prefix = "tensorflow-6ef428bd6e83b0930266bf922eaa2f4a60e8328a",
     urls = [
-        "https://mirror.bazel.build/github.com/tensorflow/tensorflow/archive/9752b117ff63f204c4975cad52b5aab5c1f5e9a9.tar.gz",  # 2018-04-16
-        "https://github.com/tensorflow/tensorflow/archive/9752b117ff63f204c4975cad52b5aab5c1f5e9a9.tar.gz",
+        "https://mirror.bazel.build/github.com/tensorflow/tensorflow/archive/6ef428bd6e83b0930266bf922eaa2f4a60e8328a.tar.gz",  # 2018-12-06
+        "https://github.com/tensorflow/tensorflow/archive/6ef428bd6e83b0930266bf922eaa2f4a60e8328a.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Summary:
Bazel 0.21.0 includes a breaking change to our transitive dependencies
through TensorFlow. TensorFlow has patched its workspace file
accordingly. This commit upgrades our pinned version of the TensorFlow
workspace to accommodate.

Issue #1710 remains open after this change, because Bazel 0.21.0 has a
further breaking change that causes our tests to fail when run with the
default Bazel flags (see test plan below):
<https://github.com/bazelbuild/bazel/issues/6648>.

Test Plan:
On Bazel 0.21.0, running `bazel query 'deps(//...)'` fails before this
change:

    The value 'REPOSITORY_NAME' has been removed in favor of 'repository_name()', please use the latter (https://docs.bazel.build/versions/master/skylark/lib/native.html#repository_name). You can temporarily allow the old name by using --incompatible_package_name_is_a_function=false
    ERROR: Evaluation of query "deps(//tensorboard)" failed: errors were encountered while computing transitive closure

…but passes after it.

Also, `bazel test --incompatible_strict_action_env=false //...` still
passes on nightly. The new flag is needed due to a breaking change in
Bazel 0.21.0 that this commit does not address.

wchargin-branch: deps-tf-workspace-20181220
