### PR TITLE
test: add Travis test for “DO NOT SUBMIT” in files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,8 @@ before_script:
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   # a comment of '# noqa' or better yet '# noqa: <error code>' added to the code to silence flake8
   - flake8 . --count --exit-zero --ignore=E111,E114 --max-complexity=10 --max-line-length=127 --statistics
+  # Make sure we aren't accidentally including work-in-progress code.
+  - tensorboard/tools/do_not_submit_test.sh
   # Make sure all necessary files have the license information.
   - tensorboard/tools/license_test.sh
 

--- a/tensorboard/tools/do_not_submit_test.sh
+++ b/tensorboard/tools/do_not_submit_test.sh
@@ -35,4 +35,4 @@ while true; do
     cd ../
 done
 
-! grep -rI -e 'DO NOT'' ''SUBMIT' -e 'DO_NOT''_''SUBMIT' tensorboard
+! grep -rI -e 'DO NOT'' ''SUBMIT' -e 'DO_NOT''_''SUBMIT' .

--- a/tensorboard/tools/do_not_submit_test.sh
+++ b/tensorboard/tools/do_not_submit_test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Check that the capitalized strings "do not submit" and "do_not_submit"
+# do not appear in any code files.
+
+! grep -r -e 'DO NOT'' ''SUBMIT' -e 'DO_NOT''_''SUBMIT' \
+    --include='*.*' \
+    --exclude='*.{pyc,json,png,wav,pbtxt,md,in,rst,cfg,ipynb}' \
+    tensorboard

--- a/tensorboard/tools/do_not_submit_test.sh
+++ b/tensorboard/tools/do_not_submit_test.sh
@@ -19,20 +19,9 @@
 
 set -e
 
-# Traverse up to the root of the repository. (The directory structure is
-# slightly different in open-source vs. Google-internal, so we can't use
-# a fixed offset.)
-cd "$(dirname "$0")"
-while true; do
-    if [ -f LICENSE ]; then
-        break
-    fi
-    if [ "$(readlink -f .)" = "$(readlink -f ..)" ]; then
-        printf >&2 'fatal: cannot find TensorBoard repository root\n'
-        printf >&2 'fatal: (is there no longer a LICENSE file?)\n'
-        exit 2
-    fi
-    cd ../
-done
+if ! [ -f WORKSPACE ]; then
+    printf >&2 'fatal: no WORKSPACE file found (are you at TensorBoard root?)\n'
+    exit 2
+fi
 
 ! grep -rI -e 'DO NOT'' ''SUBMIT' -e 'DO_NOT''_''SUBMIT' .

--- a/tensorboard/tools/do_not_submit_test.sh
+++ b/tensorboard/tools/do_not_submit_test.sh
@@ -17,4 +17,22 @@
 # Check that the capitalized strings "do not submit" and "do_not_submit"
 # do not appear in any code files.
 
+set -e
+
+# Traverse up to the root of the repository. (The directory structure is
+# slightly different in open-source vs. Google-internal, so we can't use
+# a fixed offset.)
+cd "$(dirname "$0")"
+while true; do
+    if [ -f LICENSE ]; then
+        break
+    fi
+    if [ "$(readlink -f .)" = "$(readlink -f ..)" ]; then
+        printf >&2 'fatal: cannot find TensorBoard repository root\n'
+        printf >&2 'fatal: (is there no longer a LICENSE file?)\n'
+        exit 2
+    fi
+    cd ../
+done
+
 ! grep -rI -e 'DO NOT'' ''SUBMIT' -e 'DO_NOT''_''SUBMIT' tensorboard

--- a/tensorboard/tools/do_not_submit_test.sh
+++ b/tensorboard/tools/do_not_submit_test.sh
@@ -24,4 +24,6 @@ if ! [ -f WORKSPACE ]; then
     exit 2
 fi
 
-! grep -rI -e 'DO NOT'' ''SUBMIT' -e 'DO_NOT''_''SUBMIT' .
+# Exclude the .git directory, whose reflog entries can include the first
+# lines of commit messages. Include all other non-binary files.
+! grep -rI -e 'DO NOT'' ''SUBMIT' -e 'DO_NOT''_''SUBMIT' --exclude-dir=.git .

--- a/tensorboard/tools/do_not_submit_test.sh
+++ b/tensorboard/tools/do_not_submit_test.sh
@@ -26,4 +26,7 @@ fi
 
 # Exclude the .git directory, whose reflog entries can include the first
 # lines of commit messages. Include all other non-binary files.
-! grep -rI -e 'DO NOT'' ''SUBMIT' -e 'DO_NOT''_''SUBMIT' --exclude-dir=.git .
+! grep -rI . --exclude-dir=.git \
+    -e 'DO'' ''NOT'' ''SUBMIT' \
+    -e 'DO''_''NOT''_''SUBMIT' \
+    ;

--- a/tensorboard/tools/do_not_submit_test.sh
+++ b/tensorboard/tools/do_not_submit_test.sh
@@ -17,7 +17,4 @@
 # Check that the capitalized strings "do not submit" and "do_not_submit"
 # do not appear in any code files.
 
-! grep -r -e 'DO NOT'' ''SUBMIT' -e 'DO_NOT''_''SUBMIT' \
-    --include='*.*' \
-    --exclude='*.{pyc,json,png,wav,pbtxt,md,in,rst,cfg,ipynb}' \
-    tensorboard
+! grep -rI -e 'DO NOT'' ''SUBMIT' -e 'DO_NOT''_''SUBMIT' tensorboard


### PR DESCRIPTION
Summary:
Google-internal tools perform this check, which is useful for preventing
premature merging of in-progress code. This commit adds equivalent
functionality to the Travis build only and not as a Bazel test,
analagous to our existing license test.

Test Plan:
Invoke the script and note that it passes with no output. Run

    printf >hmmm 'DO NOT SUBMIT'

and note that the script fails with a helpful error message. Then run

    printf >hmmm 'DO NOT SUBMIT\0'

and note that the script passes because this is a binary file.

Then, run `(cd tensorboard && ./tools/do_not_submit_test.sh)`, and note
that the script fails because it is not being run from TensorBoard root.

wchargin-branch: test-dns
