### PR TITLE
[CLEANUP] Change tf.SessionLog.* to TB.SessionLog.*

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -108,6 +108,7 @@ py_library(
         ":reservoir",
         "//tensorboard:data_compat",
         "//tensorboard/compat:tensorflow",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins/distribution:compressor",
         "//tensorboard/util:tb_logging",
     ],
@@ -259,6 +260,7 @@ py_library(
         ":event_accumulator",
         ":io_wrapper",
         "//tensorboard/compat:tensorflow",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
     ],
 )
 

--- a/tensorboard/backend/event_processing/db_import_multiplexer.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer.py
@@ -342,7 +342,7 @@ class _SqliteWriterEventSink(_EventSink):
     elif event_type == 'file_version':
       pass  # TODO: reject file version < 2 (at loader level)
     elif event_type == 'session_log':
-      if event.session_log.status == tf.compat.v1.SessionLog.START:
+      if event.session_log.status == event_pb2.SessionLog.START:
         pass  # TODO: implement purging via sqlite writer truncation method
     elif event_type in ('graph_def', 'meta_graph_def'):
       pass  # TODO: support graphs

--- a/tensorboard/backend/event_processing/event_accumulator.py
+++ b/tensorboard/backend/event_processing/event_accumulator.py
@@ -25,8 +25,9 @@ from tensorboard.backend.event_processing import event_file_loader
 from tensorboard.backend.event_processing import io_wrapper
 from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.backend.event_processing import reservoir
-from tensorboard.plugins.distribution import compressor
 from tensorboard.compat import tf
+from tensorboard.compat.proto import event_pb2
+from tensorboard.plugins.distribution import compressor
 from tensorboard.util import tb_logging
 
 
@@ -597,7 +598,7 @@ class EventAccumulator(object):
         previously seen events with a greater event.step will be purged.
     """
     if event.HasField(
-        'session_log') and event.session_log.status == tf.compat.v1.SessionLog.START:
+        'session_log') and event.session_log.status == event_pb2.SessionLog.START:
       self._Purge(event, by_tags=False)
 
   def _CheckForOutOfOrderStepAndMaybePurge(self, event):

--- a/tensorboard/backend/event_processing/event_file_inspector.py
+++ b/tensorboard/backend/event_processing/event_file_inspector.py
@@ -120,6 +120,7 @@ from tensorboard.backend.event_processing import event_accumulator
 from tensorboard.backend.event_processing import event_file_loader
 from tensorboard.backend.event_processing import io_wrapper
 from tensorboard.compat import tf
+from tensorboard.compat.proto import event_pb2
 
 
 # Map of field names within summary.proto to the user-facing names that this
@@ -190,11 +191,11 @@ def get_field_to_observations_map(generator, query_for_tag=''):
       increment('graph', event)
     if event.HasField('session_log') and (not query_for_tag):
       status = event.session_log.status
-      if status == tf.compat.v1.SessionLog.START:
+      if status == event_pb2.SessionLog.START:
         increment('sessionlog:start', event)
-      elif status == tf.compat.v1.SessionLog.STOP:
+      elif status == event_pb2.SessionLog.STOP:
         increment('sessionlog:stop', event)
-      elif status == tf.compat.v1.SessionLog.CHECKPOINT:
+      elif status == event_pb2.SessionLog.CHECKPOINT:
         increment('sessionlog:checkpoint', event)
     elif event.HasField('summary'):
       for value in event.summary.value:

--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -29,6 +29,7 @@ from tensorboard.backend.event_processing import io_wrapper
 from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.backend.event_processing import reservoir
 from tensorboard.compat import tf
+from tensorboard.compat.proto import event_pb2
 from tensorboard.util import tb_logging
 
 
@@ -478,7 +479,7 @@ class EventAccumulator(object):
         previously seen events with a greater event.step will be purged.
     """
     if event.HasField(
-        'session_log') and event.session_log.status == tf.compat.v1.SessionLog.START:
+        'session_log') and event.session_log.status == event_pb2.SessionLog.START:
       self._Purge(event, by_tags=False)
 
   def _CheckForOutOfOrderStepAndMaybePurge(self, event):


### PR DESCRIPTION
Now that TensorBoard hosts all proto definitions required to run it, we
use the TensorBoard version of protos. #1678 has missed few usages of
SessionLog.[CONSTANT] and this change fixes that.

Related: #1718.
