### PR TITLE
[CLEANUP] tf.RunMetadata to tb.RunMetadata

### DIFF
--- a/tensorboard/backend/event_processing/event_accumulator.py
+++ b/tensorboard/backend/event_processing/event_accumulator.py
@@ -26,6 +26,7 @@ from tensorboard.backend.event_processing import io_wrapper
 from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.backend.event_processing import reservoir
 from tensorboard.compat import tf
+from tensorboard.compat.proto import config_pb2
 from tensorboard.compat.proto import event_pb2
 from tensorboard.plugins.distribution import compressor
 from tensorboard.util import tb_logging
@@ -482,7 +483,7 @@ class EventAccumulator(object):
     if tag not in self._tagged_metadata:
       raise ValueError('There is no run metadata with this tag name')
 
-    run_metadata = tf.compat.v1.RunMetadata()
+    run_metadata = config_pb2.RunMetadata()
     run_metadata.ParseFromString(self._tagged_metadata[tag])
     return run_metadata
 

--- a/tensorboard/backend/event_processing/event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/event_accumulator_test.py
@@ -25,6 +25,7 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
 from tensorboard.backend.event_processing import event_accumulator as ea
+from tensorboard.compat.proto import config_pb2
 from tensorboard.compat.proto import event_pb2
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.distribution import compressor
@@ -777,7 +778,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
         add_shapes=True))
     writer.add_meta_graph(meta_graph_def)
 
-    run_metadata = tf.compat.v1.RunMetadata()
+    run_metadata = config_pb2.RunMetadata()
     device_stats = run_metadata.step_stats.dev_stats.add()
     device_stats.device = 'test device'
     writer.add_run_metadata(run_metadata, 'test run')

--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -29,6 +29,7 @@ from tensorboard.backend.event_processing import io_wrapper
 from tensorboard.backend.event_processing import plugin_asset_util
 from tensorboard.backend.event_processing import reservoir
 from tensorboard.compat import tf
+from tensorboard.compat.proto import config_pb2
 from tensorboard.compat.proto import event_pb2
 from tensorboard.util import tb_logging
 
@@ -415,7 +416,7 @@ class EventAccumulator(object):
     if tag not in self._tagged_metadata:
       raise ValueError('There is no run metadata with this tag name')
 
-    run_metadata = tf.compat.v1.RunMetadata()
+    run_metadata = config_pb2.RunMetadata()
     run_metadata.ParseFromString(self._tagged_metadata[tag])
     return run_metadata
 

--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -25,6 +25,7 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
 from tensorboard.backend.event_processing import plugin_event_accumulator as ea
+from tensorboard.compat.proto import config_pb2
 from tensorboard.compat.proto import event_pb2
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.audio import summary as audio_summary
@@ -568,7 +569,7 @@ class RealisticEventAccumulatorTest(EventAccumulatorTest):
         add_shapes=True))
     writer.add_meta_graph(meta_graph_def)
 
-    run_metadata = tf.compat.v1.RunMetadata()
+    run_metadata = config_pb2.RunMetadata()
     device_stats = run_metadata.step_stats.dev_stats.add()
     device_stats.device = 'test device'
     writer.add_run_metadata(run_metadata, 'test run')

--- a/tensorboard/plugins/debugger/BUILD
+++ b/tensorboard/plugins/debugger/BUILD
@@ -33,6 +33,7 @@ py_test(
     deps = [
         ":debug_graphs_helper",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/util:tb_logging",
         "@org_python_pypi_portpicker",
     ],

--- a/tensorboard/plugins/debugger/debug_graphs_helper_test.py
+++ b/tensorboard/plugins/debugger/debug_graphs_helper_test.py
@@ -19,10 +19,12 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-from tensorboard.plugins.debugger import debug_graphs_helper
-from tensorboard.util import tb_logging
 from tensorflow.python import debug as tf_debug
 from tensorflow.python.debug.lib import grpc_debug_test_server
+
+from tensorboard.compat.proto import config_pb2
+from tensorboard.plugins.debugger import debug_graphs_helper
+from tensorboard.util import tb_logging
 
 tf.compat.v1.disable_v2_behavior()
 logger = tb_logging.get_logger()
@@ -71,7 +73,7 @@ class ExtractGatedGrpcDebugOpsTest(tf.test.TestCase):
       z, run_options = self._createTestGraphAndRunOptions(sess, gated_grpc=True)
 
       sess.run(tf.compat.v1.global_variables_initializer())
-      run_metadata = tf.compat.v1.RunMetadata()
+      run_metadata = config_pb2.RunMetadata()
       self.assertAllClose(
           [10.0], sess.run(z, options=run_options, run_metadata=run_metadata))
 
@@ -106,7 +108,7 @@ class ExtractGatedGrpcDebugOpsTest(tf.test.TestCase):
       z, run_options = self._createTestGraphAndRunOptions(sess, gated_grpc=True)
 
       sess.run(tf.compat.v1.global_variables_initializer())
-      run_metadata = tf.compat.v1.RunMetadata()
+      run_metadata = config_pb2.RunMetadata()
       self.assertAllClose(
           [10.0], sess.run(z, options=run_options, run_metadata=run_metadata))
 
@@ -121,7 +123,7 @@ class ExtractGatedGrpcDebugOpsTest(tf.test.TestCase):
                                                           gated_grpc=False)
 
       sess.run(tf.compat.v1.global_variables_initializer())
-      run_metadata = tf.compat.v1.RunMetadata()
+      run_metadata = config_pb2.RunMetadata()
       self.assertAllClose(
           [10.0], sess.run(z, options=run_options, run_metadata=run_metadata))
 

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -35,6 +35,7 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -27,6 +27,7 @@ import tensorflow as tf
 
 from google.protobuf import text_format
 from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
+from tensorboard.compat.proto import config_pb2
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.graph import graphs_plugin
 from tensorboard.util import test_util
@@ -69,7 +70,7 @@ class GraphsPluginTest(tf.test.TestCase):
     if include_graph:
       writer.add_graph(sess.graph)
     options = tf.compat.v1.RunOptions(trace_level=tf.compat.v1.RunOptions.FULL_TRACE)
-    run_metadata = tf.compat.v1.RunMetadata()
+    run_metadata = config_pb2.RunMetadata()
     s = sess.run(summary_message, options=options, run_metadata=run_metadata)
     writer.add_summary(s)
     writer.add_run_metadata(run_metadata, self._METADATA_TAG)
@@ -142,7 +143,7 @@ class GraphsPluginTest(tf.test.TestCase):
     (metadata_pbtxt, mime_type) = self.plugin.run_metadata_impl(
         self._RUN_WITH_GRAPH, self._METADATA_TAG)
     self.assertEqual(mime_type, 'text/x-protobuf')
-    text_format.Parse(metadata_pbtxt, tf.compat.v1.RunMetadata())
+    text_format.Parse(metadata_pbtxt, config_pb2.RunMetadata())
     # If it parses, we're happy.
 
   def test_is_active_with_graph(self):

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -34,6 +34,7 @@ py_binary(
         ":summary",
         "//tensorboard:expect_absl_logging_installed",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/util:tb_logging",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/image/images_demo.py
+++ b/tensorboard/plugins/image/images_demo.py
@@ -27,6 +27,8 @@ from six.moves import urllib
 from six.moves import xrange  # pylint: disable=redefined-builtin
 
 import tensorflow as tf
+
+from tensorboard.compat.proto import config_pb2
 from tensorboard.plugins.image import summary as image_summary
 from tensorboard.util import tb_logging
 
@@ -180,7 +182,7 @@ def run_box_to_gaussian(logdir, verbose=False):
         logger.info('--- box_to_gaussian: step: %s' % step)
         feed_dict = {blur_radius: step}
       run_options = tf.compat.v1.RunOptions(trace_level=tf.compat.v1.RunOptions.FULL_TRACE)
-      run_metadata = tf.compat.v1.RunMetadata()
+      run_metadata = config_pb2.RunMetadata()
       s = sess.run(summ, feed_dict=feed_dict,
                    options=run_options, run_metadata=run_metadata)
       writer.add_summary(s, global_step=step)
@@ -254,7 +256,7 @@ def run_sobel(logdir, verbose=False):
         logger.info("--- sobel: step: %s" % step)
         feed_dict = {kernel_radius: step}
       run_options = tf.compat.v1.RunOptions(trace_level=tf.compat.v1.RunOptions.FULL_TRACE)
-      run_metadata = tf.compat.v1.RunMetadata()
+      run_metadata = config_pb2.RunMetadata()
       s = sess.run(summ, feed_dict=feed_dict,
                    options=run_options, run_metadata=run_metadata)
       writer.add_summary(s, global_step=step)


### PR DESCRIPTION
We are deprecating usage of tf.proto but have missed few usage of
RunMetadata in #1678.

Confirmed that this is not causing regression by:
1. running TB with variety of event files
2. reading the code: change in graphs_plugin is innocuous as we are
   serializing proto into string.

Do note that this changes output of event_accumulators#RunMetadata but
we do not seem to be using it at least in our repo.

Relates to #1718.