### PR TITLE
Converted tf.app.run to absl.app.run

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -279,6 +279,7 @@ py_binary(
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/util",
+        "//tensorboard/util:encoder",
         "//tensorboard/util:tb_logging",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/backend/event_processing/event_file_inspector.py
+++ b/tensorboard/backend/event_processing/event_file_inspector.py
@@ -415,7 +415,3 @@ def inspect(logdir='', event_file='', tag=''):
 
     print_dict(get_dict_to_print(unit.field_to_obs), show_missing=(not tag))
     print(PRINT_SEPARATOR)
-
-
-if __name__ == '__main__':
-  tf.compat.v1.app.run()

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -20,9 +20,9 @@ from __future__ import print_function
 
 import inspect
 
-from tensorboard.util import platform_util
 from tensorboard.compat import tf
 from tensorboard.compat.proto import event_pb2
+from tensorboard.util import platform_util
 from tensorboard.util import tb_logging
 
 
@@ -92,17 +92,3 @@ class EventFileLoader(RawEventFileLoader):
     """
     for record in super(EventFileLoader, self).Load():
       yield event_pb2.Event.FromString(record)
-
-
-def main(argv):
-  if len(argv) != 2:
-    print('Usage: event_file_loader <path-to-the-recordio-file>')
-    return 1
-  loader = EventFileLoader(argv[1])
-  for event in loader.Load():
-    print(event)
-  return 0
-
-
-if __name__ == '__main__':
-  tf.compat.v1.app.run()

--- a/tensorboard/encode_png_benchmark.py
+++ b/tensorboard/encode_png_benchmark.py
@@ -51,6 +51,7 @@ import time
 
 from six.moves import xrange
 
+from absl import app
 from absl import logging
 import numpy as np
 import tensorflow as tf
@@ -139,4 +140,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run()
+  app.run(main)

--- a/tensorboard/plugins/audio/audio_demo.py
+++ b/tensorboard/plugins/audio/audio_demo.py
@@ -22,6 +22,7 @@ import inspect
 import math
 import os.path
 
+from absl import app
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 from tensorboard.plugins.audio import summary
@@ -256,4 +257,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run()
+  app.run(main)

--- a/tensorboard/plugins/beholder/beholder_demo.py
+++ b/tensorboard/plugins/beholder/beholder_demo.py
@@ -24,6 +24,8 @@ from __future__ import print_function
 import argparse
 import sys
 
+from absl import app
+
 import tensorflow as tf
 import tensorflow.examples.tutorials.mnist as mnist
 import tensorboard.plugins.beholder as beholder_lib
@@ -212,4 +214,4 @@ if __name__ == '__main__':
       default='/tmp/tensorflow/mnist/logs/mnist_with_summaries',
       help='Summaries log directory')
   FLAGS, unparsed = parser.parse_known_args()
-  tf.compat.v1.app.run(main=main, argv=[sys.argv[0]] + unparsed)
+  app.run(main=main, argv=[sys.argv[0]] + unparsed)

--- a/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from absl import app
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
@@ -109,4 +110,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run()
+  app.run(main)

--- a/tensorboard/plugins/histogram/histograms_demo.py
+++ b/tensorboard/plugins/histogram/histograms_demo.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from absl import app
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
@@ -109,4 +110,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run()
+  app.run(main)

--- a/tensorboard/plugins/hparams/hparams_demo.py
+++ b/tensorboard/plugins/hparams/hparams_demo.py
@@ -28,6 +28,7 @@ import os.path
 import hashlib
 import shutil
 
+from absl import app
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 from google.protobuf import struct_pb2
@@ -216,4 +217,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run()
+  app.run(main)

--- a/tensorboard/plugins/image/images_demo.py
+++ b/tensorboard/plugins/image/images_demo.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from absl import app
 from absl import logging
 import contextlib
 import os.path
@@ -281,4 +282,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run()
+  app.run(main)

--- a/tensorboard/plugins/pr_curve/pr_curve_demo.py
+++ b/tensorboard/plugins/pr_curve/pr_curve_demo.py
@@ -32,6 +32,7 @@ from __future__ import print_function
 
 import os.path
 
+from absl import app
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
@@ -231,4 +232,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run()
+  app.run(main)

--- a/tensorboard/plugins/profile/profile_demo.py
+++ b/tensorboard/plugins/profile/profile_demo.py
@@ -27,6 +27,8 @@ from __future__ import print_function
 
 import os
 import shutil
+
+from absl import app
 import tensorflow as tf
 
 from google.protobuf import text_format
@@ -83,4 +85,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run()
+  app.run(main)

--- a/tensorboard/plugins/scalar/scalars_demo.py
+++ b/tensorboard/plugins/scalar/scalars_demo.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import os.path
 
+from absl import app
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 from tensorboard.plugins.scalar import summary
@@ -140,4 +141,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run()
+  app.run(main)

--- a/tensorboard/plugins/text/text_demo.py
+++ b/tensorboard/plugins/text/text_demo.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from absl import app
 from absl import logging
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
@@ -131,4 +132,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run()
+  app.run(main)

--- a/tensorboard/scripts/generate_testdata.py
+++ b/tensorboard/scripts/generate_testdata.py
@@ -26,6 +26,7 @@ import os.path
 import random
 import shutil
 
+from absl import app
 import numpy as np
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
@@ -223,4 +224,4 @@ def main(unused_argv=None):
 
 
 if __name__ == "__main__":
-  tf.compat.v1.app.run()
+  app.run(main)

--- a/tensorboard/tools/import_google_fonts.py
+++ b/tensorboard/tools/import_google_fonts.py
@@ -32,6 +32,7 @@ import re
 import sys
 import urlparse
 
+from absl import app
 import tensorflow as tf
 
 ROBOTO_URLS = [
@@ -210,4 +211,4 @@ def main(unused_argv=None):
 
 
 if __name__ == '__main__':
-  tf.compat.v1.app.run(main)
+  app.run(main)


### PR DESCRIPTION
TF 2.0 is removing tf.app. Instead of staying at tf.compat.v1.app,
we are now using absl.app.

This change also deprecates the usages of tf.app.run without py_binary build target (event_file_inspector and event_file_loader).

Relates to #1718.