### PR TITLE
Use absl.flags instead of tf.flags

### DIFF
--- a/tensorboard/plugins/audio/audio_demo.py
+++ b/tensorboard/plugins/audio/audio_demo.py
@@ -23,21 +23,22 @@ import math
 import os.path
 
 from absl import app
+from absl import flags
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 from tensorboard.plugins.audio import summary
 
-FLAGS = tf.compat.v1.flags.FLAGS
+FLAGS = flags.FLAGS
 
-tf.compat.v1.flags.DEFINE_string('logdir', '/tmp/audio_demo',
+flags.DEFINE_string('logdir', '/tmp/audio_demo',
                        'Directory into which to write TensorBoard data.')
 
-tf.compat.v1.flags.DEFINE_integer('steps', 50,
+flags.DEFINE_integer('steps', 50,
                         'Number of frequencies of each waveform to generate.')
 
 # Parameters for the audio output.
-tf.compat.v1.flags.DEFINE_integer('sample_rate', 44100, 'Sample rate, in Hz.')
-tf.compat.v1.flags.DEFINE_float('duration', 2.0, 'Duration of each waveform, in s.')
+flags.DEFINE_integer('sample_rate', 44100, 'Sample rate, in Hz.')
+flags.DEFINE_float('duration', 2.0, 'Duration of each waveform, in s.')
 
 
 def _samples():

--- a/tensorboard/plugins/pr_curve/pr_curve_demo.py
+++ b/tensorboard/plugins/pr_curve/pr_curve_demo.py
@@ -33,18 +33,19 @@ from __future__ import print_function
 import os.path
 
 from absl import app
+from absl import flags
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
 from tensorboard.plugins.pr_curve import summary
 
 tf.compat.v1.disable_v2_behavior()
-FLAGS = tf.compat.v1.flags.FLAGS
+FLAGS = flags.FLAGS
 
-tf.compat.v1.flags.DEFINE_string('logdir', '/tmp/pr_curve_demo',
+flags.DEFINE_string('logdir', '/tmp/pr_curve_demo',
                        'Directory into which to write TensorBoard data.')
 
-tf.compat.v1.flags.DEFINE_integer('steps', 10,
+flags.DEFINE_integer('steps', 10,
                         'Number of steps to generate for each PR curve.')
 
 def start_runs(

--- a/tensorboard/scripts/generate_testdata.py
+++ b/tensorboard/scripts/generate_testdata.py
@@ -27,18 +27,19 @@ import random
 import shutil
 
 from absl import app
+from absl import flags
 import numpy as np
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
 
-tf.compat.v1.flags.DEFINE_string("target", None, """The directory where serialized data
+flags.DEFINE_string("target", None, """The directory where serialized data
 will be written""")
 
-tf.compat.v1.flags.DEFINE_boolean("overwrite", False, """Whether to remove and overwrite
+flags.DEFINE_boolean("overwrite", False, """Whether to remove and overwrite
 TARGET if it already exists.""")
 
-FLAGS = tf.compat.v1.flags.FLAGS
+FLAGS = flags.FLAGS
 
 # Hardcode a start time and reseed so script always generates the same data.
 _start_time = 0

--- a/tensorboard/tools/import_google_fonts.py
+++ b/tensorboard/tools/import_google_fonts.py
@@ -33,6 +33,7 @@ import sys
 import urlparse
 
 from absl import app
+from absl import flags
 import tensorflow as tf
 
 ROBOTO_URLS = [
@@ -59,23 +60,23 @@ limitations under the License.
 -->
 '''
 
-tf.compat.v1.flags.DEFINE_string('urls', ';'.join(ROBOTO_URLS),
+flags.DEFINE_string('urls', ';'.join(ROBOTO_URLS),
                        'Google Fonts stylesheet URLs (semicolons delimited)')
-tf.compat.v1.flags.DEFINE_string('path', '/font-roboto/roboto.html', 'Path of HTML file')
-tf.compat.v1.flags.DEFINE_string('repo', 'com_google_fonts_roboto', 'Name of repository')
-tf.compat.v1.flags.DEFINE_string('license', 'notice', 'Bazel category of license')
-tf.compat.v1.flags.DEFINE_string('license_summary', 'Apache 2.0', 'License description')
-tf.compat.v1.flags.DEFINE_string('license_html', GOOGLE_LICENSE_HTML,
+flags.DEFINE_string('path', '/font-roboto/roboto.html', 'Path of HTML file')
+flags.DEFINE_string('repo', 'com_google_fonts_roboto', 'Name of repository')
+flags.DEFINE_string('license', 'notice', 'Bazel category of license')
+flags.DEFINE_string('license_summary', 'Apache 2.0', 'License description')
+flags.DEFINE_string('license_html', GOOGLE_LICENSE_HTML,
                        'HTML @license comment')
-tf.compat.v1.flags.DEFINE_string('user_agent',
+flags.DEFINE_string('user_agent',
                        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) '
                        'AppleWebKit/537.36 (KHTML, like Gecko) '
                        'Chrome/62.0.3202.94 '
                        'Safari/537.36',
                        'HTTP User-Agent header to send to Google Fonts')
-tf.compat.v1.flags.DEFINE_string('mirror', 'https://mirror.bazel.build/',
+flags.DEFINE_string('mirror', 'https://mirror.bazel.build/',
                        'Mirror URL prefix')
-FLAGS = tf.app.flags.FLAGS
+FLAGS = flags.FLAGS
 
 BAR = '/%s/' % ('*' * 78)
 NON_REPO_PATTERN = re.compile(r'[^_a-z0-9]')


### PR DESCRIPTION
TF is deprecating tf.flags. Migrate to absl.
Note that absl.flags by itself does not parse sys.argv like [1]
indicates. However, it is passed as part of absl.app.run which we use so
the change should have no behavioral difference.

Confirmed that the flags are parsed as expected by manually running the
demos and script/tools.

[1]: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/platform/flags.py#L66
[2]: https://github.com/abseil/abseil-py/blob/master/absl/app.py#L292

Related to #1718.