### PR TITLE
Compile TensorBoard HTML payload again

### DIFF
--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -21,6 +21,7 @@ tf_web_library(
 
 tensorboard_html_binary(
     name = "index",
+    compile = True,
     input_path = "/tensorboard.html",
     output_path = "/index.html",
     deps = [":tensorboard"],


### PR DESCRIPTION
By mistake, #1706 has turned off the compilation.
Revert that one liner.
