### PR TITLE
Suppress warnings in vz_example_viewer third_party deps

### DIFF
--- a/tensorboard/components/vz_example_viewer/index.html
+++ b/tensorboard/components/vz_example_viewer/index.html
@@ -19,7 +19,7 @@ limitations under the License.
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>vz-example-viewer demo</title>
 <link rel="import" href="vz-example-viewer.html">
-<link rel="import" href="../iron-demo-helpers/demo-snippet.html">
+<link rel="import" jscomp-suppress href="../iron-demo-helpers/demo-snippet.html">
 <link rel="import" href="../paper-styles/typography.html">
 <style type="text/css">
   body {


### PR DESCRIPTION
Summary:
The `iron-demo-helpers` package transitively depends on the Prism
highlighting library, which uses `innerHTML` in ways that the Closure
compiler does not like. Short of changing Prism to use goog.dom.safe and
the Closure stack, this commit enables us to compile the dependency
without inheriting its warnings.

Test Plan:
Within Google, make the analogous change, and note that this binary now
builds without error.

wchargin-branch: suppress-prism-warning
