### PR TITLE
Use v2 API for GFile

### DIFF
--- a/tensorboard/backend/event_processing/event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/event_multiplexer_test.py
@@ -31,7 +31,7 @@ def _AddEvents(path):
   if not tf.io.gfile.isdir(path):
     tf.io.gfile.makedirs(path)
   fpath = os.path.join(path, 'hypothetical.tfevents.out')
-  with tf.compat.v1.gfile.GFile(fpath, 'w') as f:
+  with tf.io.gfile.GFile(fpath, 'w') as f:
     f.write('')
     return fpath
 

--- a/tensorboard/backend/event_processing/plugin_asset_util.py
+++ b/tensorboard/backend/event_processing/plugin_asset_util.py
@@ -90,7 +90,7 @@ def RetrieveAsset(logdir, plugin_name, asset_name):
 
   asset_path = os.path.join(PluginDirectory(logdir, plugin_name), asset_name)
   try:
-    with tf.compat.v1.gfile.Open(asset_path, "r") as f:
+    with tf.io.gfile.GFile(asset_path, "r") as f:
       return f.read()
   except tf.errors.NotFoundError:
     raise KeyError("Asset path %s not found" % asset_path)

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer_test.py
@@ -31,7 +31,7 @@ def _AddEvents(path):
   if not tf.io.gfile.isdir(path):
     tf.io.gfile.makedirs(path)
   fpath = os.path.join(path, 'hypothetical.tfevents.out')
-  with tf.compat.v1.gfile.GFile(fpath, 'w') as f:
+  with tf.io.gfile.GFile(fpath, 'w') as f:
     f.write('')
     return fpath
 

--- a/tensorboard/plugins/beholder/file_system_tools.py
+++ b/tensorboard/plugins/beholder/file_system_tools.py
@@ -28,12 +28,12 @@ logger = tb_logging.get_logger()
 
 
 def write_file(contents, path, mode='wb'):
-  with tf.compat.v1.gfile.Open(path, mode) as new_file:
+  with tf.io.gfile.GFile(path, mode) as new_file:
     new_file.write(contents)
 
 
 def read_tensor_summary(path):
-  with tf.compat.v1.gfile.Open(path, 'rb') as summary_file:
+  with tf.io.gfile.GFile(path, 'rb') as summary_file:
     summary_string = summary_file.read()
 
   if not summary_string:
@@ -48,13 +48,13 @@ def read_tensor_summary(path):
 
 
 def write_pickle(obj, path):
-  with tf.compat.v1.gfile.Open(path, 'wb') as new_file:
+  with tf.io.gfile.GFile(path, 'wb') as new_file:
     pickle.dump(obj, new_file)
 
 
 def read_pickle(path, default=None):
   try:
-    with tf.compat.v1.gfile.Open(path, 'rb') as pickle_file:
+    with tf.io.gfile.GFile(path, 'rb') as pickle_file:
       result = pickle.load(pickle_file)
 
   except (IOError, EOFError, ValueError, tf.errors.NotFoundError) as e:

--- a/tensorboard/plugins/beholder/im_util.py
+++ b/tensorboard/plugins/beholder/im_util.py
@@ -139,12 +139,12 @@ decode_png = PNGDecoder()
 resize = Resizer()
 
 def read_image(filename):
-  with tf.compat.v1.gfile.Open(filename, 'rb') as image_file:
+  with tf.io.gfile.GFile(filename, 'rb') as image_file:
     return np.array(decode_png(image_file.read()))
 
 
 def write_image(array, filename):
-  with tf.compat.v1.gfile.Open(filename, 'w') as image_file:
+  with tf.io.gfile.GFile(filename, 'w') as image_file:
     image_file.write(encoder.encode_png(array))
 
 

--- a/tensorboard/plugins/debugger/debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/debugger_server_lib.py
@@ -256,7 +256,7 @@ class DebuggerDataServer(grpc_debug_server.EventListenerBaseServicer):
 
     if tf.io.gfile.exists(self._registry_backup_file_path):
       # A backup file exists. Read its contents to use for initialization.
-      with tf.compat.v1.gfile.Open(self._registry_backup_file_path, "r") as backup_file:
+      with tf.io.gfile.GFile(self._registry_backup_file_path, "r") as backup_file:
         try:
           # Use the data to initialize the registry.
           initial_data = json.load(backup_file)

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -644,7 +644,7 @@ def get_label_vocab(vocab_path):
   """Returns a list of label strings loaded from the provided path."""
   if vocab_path:
     try:
-      with tf.compat.v1.gfile.GFile(vocab_path, 'r') as f:
+      with tf.io.gfile.GFile(vocab_path, 'r') as f:
         return [line.rstrip('\n') for line in f]
     except tf.errors.NotFoundError as err:
       tf.logging.error('error reading vocab file: %s', err)

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -303,7 +303,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
     asset_path = os.path.join(self.plugin_logdir, rel_data_path)
     raw_data = None
     try:
-      with tf.compat.v1.gfile.Open(asset_path, 'rb') as f:
+      with tf.io.gfile.GFile(asset_path, 'rb') as f:
         raw_data = f.read()
     except tf.errors.NotFoundError:
       logger.warn('Asset path %s not found', asset_path)

--- a/tensorboard/plugins/projector/__init__.py
+++ b/tensorboard/plugins/projector/__init__.py
@@ -58,5 +58,5 @@ def visualize_embeddings(summary_writer, config):
   # Saving the config file in the logdir.
   config_pbtxt = _text_format.MessageToString(config)
   path = os.path.join(logdir, _projector_plugin.PROJECTOR_FILENAME)
-  with tf.compat.v1.gfile.Open(path, 'w') as f:
+  with tf.io.gfile.GFile(path, 'w') as f:
     f.write(config_pbtxt)

--- a/tensorboard/plugins/projector/projector_api_test.py
+++ b/tensorboard/plugins/projector/projector_api_test.py
@@ -48,7 +48,7 @@ class ProjectorApiTest(tf.test.TestCase):
       projector.visualize_embeddings(writer, config)
 
     # Read the configurations from disk and make sure it matches the original.
-    with tf.compat.v1.gfile.GFile(os.path.join(temp_dir, 'projector_config.pbtxt')) as f:
+    with tf.io.gfile.GFile(os.path.join(temp_dir, 'projector_config.pbtxt')) as f:
       config2 = projector.ProjectorConfig()
       text_format.Parse(f.read(), config2)
       self.assertEqual(config, config2)

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -146,7 +146,7 @@ class EmbeddingMetadata(object):
 
 
 def _read_tensor_tsv_file(fpath):
-  with tf.compat.v1.gfile.GFile(fpath, 'r') as f:
+  with tf.io.gfile.GFile(fpath, 'r') as f:
     tensor = []
     for line in f:
       line = line.rstrip('\n')
@@ -170,7 +170,7 @@ def _latest_checkpoints_changed(configs, run_path_pairs):
       config = ProjectorConfig()
       config_fpath = os.path.join(assets_dir, PROJECTOR_FILENAME)
       if tf.io.gfile.exists(config_fpath):
-        with tf.compat.v1.gfile.GFile(config_fpath, 'r') as f:
+        with tf.io.gfile.GFile(config_fpath, 'r') as f:
           file_content = f.read()
         text_format.Merge(file_content, config)
     else:
@@ -381,7 +381,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
       config = ProjectorConfig()
       config_fpath = os.path.join(assets_dir, PROJECTOR_FILENAME)
       if tf.io.gfile.exists(config_fpath):
-        with tf.compat.v1.gfile.GFile(config_fpath, 'r') as f:
+        with tf.io.gfile.GFile(config_fpath, 'r') as f:
           file_content = f.read()
         text_format.Merge(file_content, config)
       has_tensor_files = False
@@ -512,7 +512,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
                      'text/plain', 400)
 
     num_header_rows = 0
-    with tf.compat.v1.gfile.GFile(fpath, 'r') as f:
+    with tf.io.gfile.GFile(fpath, 'r') as f:
       lines = []
       # Stream reading the file with early break in case the file doesn't fit in
       # memory.
@@ -608,7 +608,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
                      'text/plain', 400)
 
     bookmarks_json = None
-    with tf.compat.v1.gfile.GFile(fpath, 'rb') as f:
+    with tf.io.gfile.GFile(fpath, 'rb') as f:
       bookmarks_json = f.read()
     return Respond(request, bookmarks_json, 'application/json')
 
@@ -641,7 +641,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
     if not tf.io.gfile.exists(fpath) or tf.io.gfile.isdir(fpath):
       return Respond(request, '"%s" does not exist or is directory' % fpath,
                      'text/plain', 400)
-    f = tf.compat.v1.gfile.GFile(fpath, 'rb')
+    f = tf.io.gfile.GFile(fpath, 'rb')
     encoded_image_string = f.read()
     f.close()
     image_type = imghdr.what(None, encoded_image_string)

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -80,7 +80,7 @@ class ProjectorAppTest(tf.test.TestCase):
     config.model_checkpoint_path = 'does_not_exist'
     embedding = config.embeddings.add()
     embedding.tensor_name = 'var1'
-    with tf.compat.v1.gfile.GFile(config_path, 'w') as f:
+    with tf.io.gfile.GFile(config_path, 'w') as f:
       f.write(text_format.MessageToString(config))
     self._SetupWSGIApp()
 
@@ -282,12 +282,12 @@ class ProjectorAppTest(tf.test.TestCase):
     # Add an embedding by its canonical tensor name.
     embedding.tensor_name = 'var1:0'
 
-    with tf.compat.v1.gfile.GFile(os.path.join(self.log_dir, 'bookmarks.json'), 'w') as f:
+    with tf.io.gfile.GFile(os.path.join(self.log_dir, 'bookmarks.json'), 'w') as f:
       f.write('{"a": "b"}')
     embedding.bookmarks_path = 'bookmarks.json'
 
     config_pbtxt = text_format.MessageToString(config)
-    with tf.compat.v1.gfile.GFile(config_path, 'w') as f:
+    with tf.io.gfile.GFile(config_path, 'w') as f:
       f.write(config_pbtxt)
 
     # Write a checkpoint with some dummy variables.


### PR DESCRIPTION
GFile was omitted from V2 API by mistake and the migration script
misbehaved. Now that TF has fixed it, we now want to use the V2 API.

Relates to #1718.
