### PR TITLE
Use the renamed image.resize TF API

### DIFF
--- a/tensorboard/plugins/beholder/im_util.py
+++ b/tensorboard/plugins/beholder/im_util.py
@@ -119,8 +119,9 @@ class Resizer(op_evaluator.PersistentOpEvaluator):
   def initialize_graph(self):
     self._image_placeholder = tf.compat.v1.placeholder(dtype=tf.float32)
     self._size_placeholder = tf.compat.v1.placeholder(dtype=tf.int32)
-    self._resize_op = tf.compat.v1.image.resize_nearest_neighbor(self._image_placeholder,
-                                                       self._size_placeholder)
+    self._resize_op = tf.image.resize(self._image_placeholder,
+                                      self._size_placeholder,
+                                      method=tf.image.ResizeMethod.NEAREST_NEIGHBOR)
 
   # pylint: disable=arguments-differ
   def run(self, image, height, width):

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -700,7 +700,7 @@ def create_sprite_image(examples):
       def loop_body(i, encoded_images, images):
         encoded_image = encoded_images[i]
         image = tf.image.decode_jpeg(encoded_image, channels=3)
-        resized_image = tf.compat.v1.image.resize_images(image, thumbnail_dims)
+        resized_image = tf.image.resize(image, thumbnail_dims)
         expanded_image = tf.expand_dims(resized_image, 0)
         images = tf.cond(
             tf.equal(i, 0), lambda: expanded_image,


### PR DESCRIPTION
TF 2.0 image API has changed tiny bit in API signature in a way that does not impact us.
We convert to the new 2.0 API and adopted the suggestion from [TF deprecation message](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/image_ops_impl.py#L2987).

Confirmed correctness by running the beholder (based on demo data) and What-If tool (by supplying example file).
