### PR TITLE
Fix the relative path issue when Vulcanizing

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -119,9 +119,7 @@ public final class Vulcanize {
   // third_party/tensorboard/defs/vulcanize.bzl is not set.
   private static final String NO_NOINLINE_FILE_PROVIDED = "NO_REGEXS";
 
-  private static final String DATA_URI_PREFIX = "data:";
-  private static final String HTTP_URI_PREFIX = "http://";
-  private static final String HTTPS_URI_PREFIX = "https://";
+  private static final Pattern ABS_URI_PATTERN = Pattern.compile("^(?:/|[A-Za-z][A-Za-z0-9+.-]*:)");
 
   public static void main(String[] args) throws IOException {
     compilationLevel = CompilationLevel.fromString(args[0]);
@@ -633,11 +631,7 @@ public final class Vulcanize {
    * Webpath.isAbsolute does not take data uri and other forms of absolute path into account.
    */
   private static Boolean isAbsolutePath(Webpath path) {
-    String sPath = path.toString();
-    return path.isAbsolute()
-        || sPath.startsWith(DATA_URI_PREFIX)
-        || sPath.startsWith(HTTP_URI_PREFIX)
-        || sPath.startsWith(HTTPS_URI_PREFIX);
+    return path.isAbsolute() || ABS_URI_PATTERN.matcher(path.toString()).find();
   }
 
   private static String getInlineScriptFromNode(Node node) {

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -1099,28 +1099,28 @@ limitations under the License.
                           all the features and values associated with that example. Some of the things you can
                           do in the datapoint editor are:</div>
                         <div class="datapoint-info-bullet">
-                          <img class="doc-image" src="../tf-interactive-inference-dashboard/editedexample.png">
+                          <img class="doc-image" src="editedexample.png">
                           <div class="datapoint-info-block">
                             <div class="bold">Test inference on edited values</div>
                             <div>Edit features and run inference to see how your model performs</div>
                           </div>
                         </div>
                         <div class="datapoint-info-bullet">
-                          <img class="doc-image" src="../tf-interactive-inference-dashboard/distance.png">
+                          <img class="doc-image" src="distance.png">
                           <div class="datapoint-info-block">
                             <div class="bold">Compute distances from a selected datapoint</div>
                             <div>Have the selected example be an anchor and create a new distance feature for all loaded examples</div>
                           </div>
                         </div>
                         <div class="datapoint-info-bullet">
-                          <img class="doc-image" src="../tf-interactive-inference-dashboard/explorecounterfactuals.png">
+                          <img class="doc-image" src="explorecounterfactuals.png">
                           <div class="datapoint-info-block">
                             <div class="bold">Find closest counterfactuals</div>
                             <div>See the closest example with a different classification</div>
                           </div>
                         </div>
                         <div class="datapoint-info-bullet">
-                          <img class="doc-image" src="../tf-interactive-inference-dashboard/pdplots.png">
+                          <img class="doc-image" src="pdplots.png">
                           <div class="datapoint-info-block">
                             <div class="bold">Partial Dependence Plots</div>
                             <div>Explore plots for every feature that show the change in inference results across different valid values for that feature</div>


### PR DESCRIPTION
When specifying path to resources in, for instance, image tag, we use a
relative path. This path is supposed to be relative to the webpath (at
least when using WebfilesValidator) but vulcanized resources do not
convert this relative path into an appropriate path.

For instance, say we are trying to build index.html that refers to
another HTML file, foo/bar.html. In bar.html, we use a relative path
"./faz.png" to a resource in the same "foo" namespace. Previously, the
relative path was not expanded and was relative to the index.html. After
this change, we now expand faz.png based on foo/bar.html and make it
relative to output file index.html.

Confirmed the fix by running TensorBoard with path_prefix and checking the What-If
tool, the only place where we use relative paths to image resources that is not base64
serialized. 