### PR TITLE
custom_scalar_demo: migrate to summary_v1 module

### DIFF
--- a/tensorboard/plugins/custom_scalar/BUILD
+++ b/tensorboard/plugins/custom_scalar/BUILD
@@ -97,7 +97,7 @@ py_binary(
     deps = [
         ":protos_all_py_pb2",
         "//tensorboard:expect_tensorflow_installed",
-        "//tensorboard:summary",
+        "//tensorboard/summary:summary_v1",
         "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalar_demo.py
@@ -25,7 +25,7 @@ from absl import app
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
-from tensorboard import summary as summary_lib
+from tensorboard.summary import v1 as summary_lib
 from tensorboard.plugins.custom_scalar import layout_pb2
 
 


### PR DESCRIPTION
Summary:
This is functionally a no-op; we just moved a package.

Test Plan:
Run `bazel run //tensorboard/plugins/custom_scalar:custom_scalar_demo`
and note that the demo still works.

wchargin-branch: migrate-summary-v1
