### PR TITLE
Add PyPI link to release notes

### DIFF
--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -90,6 +90,6 @@ setup(
     license='Apache 2.0',
     keywords='tensorflow tensorboard tensor machine learning visualizer',
     project_urls={
-        'Changelog': 'https://github.com/tensorflow/tensorboard/blob/master/RELEASE.md',
+        'Release Notes': 'https://github.com/tensorflow/tensorboard/blob/master/RELEASE.md',
     },
 )


### PR DESCRIPTION
* Motivation for features / changes

Whilst upgrading the package it took me some hunting to find the changelog/release notes, especially since the file name is a less common one (typically it's called CHANGELOG or HISTORY).

* Technical description of changes

This makes it easier to find direct from the PyPI page. Example can be seen under "Project links" on https://pypi.org/project/multidict/ .

* Screenshots of UI changes

N/A

* Detailed steps to verify changes work correctly (as executed by you)

Release - I can't do this.

* Alternate designs / implementations considered

N/A