### PR TITLE
Unbreak the tensorboard windows build

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
@@ -8,7 +8,6 @@ java_binary(
     jvm_flags = [
         "-Xss20m",  # JSCompiler needs big stacks for recursive parsing
         "-XX:+UseParallelGC",  # Best GC when app isn't latency sensitive
-        "-Djava.util.logging.SimpleFormatter.format='%1$$tY-%1$$tm-%1$$td %1$$tH:%1$$tM:%1$$tS.%1$$tL %4$$-6s %5$$s%6$$s%n'",  # Less log spam
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -31,7 +31,7 @@ REQUIRED_PACKAGES = [
     'numpy >= 1.12.0',
     'protobuf >= 3.4.0',
     'six >= 1.10.0',
-    'werkzeug >= 0.11.10',
+    'werkzeug >= 0.11.15',
     # python3 specifically requires wheel 0.26
     'wheel; python_version < "3"',
     'wheel >= 0.26; python_version >= "3"',

--- a/tensorboard/scripts/execrooter.py
+++ b/tensorboard/scripts/execrooter.py
@@ -44,7 +44,7 @@ def run(inputs, program, outputs):
       if not os.path.exists(parent):
         os.makedirs(parent)
       # Use symlink if possible and not on Windows, since on Windows 10
-	  # symlinks exist but they require administrator privileges to use.
+      # symlinks exist but they require administrator privileges to use.
       if hasattr(os, 'symlink') and not os.name == 'nt':
         os.symlink(os.path.join(cwd, real), os.path.join(root, fake))
       else:

--- a/tensorboard/scripts/execrooter.py
+++ b/tensorboard/scripts/execrooter.py
@@ -43,14 +43,23 @@ def run(inputs, program, outputs):
       parent = os.path.join(root, os.path.dirname(fake))
       if not os.path.exists(parent):
         os.makedirs(parent)
-      os.symlink(os.path.join(cwd, real), os.path.join(root, fake))
+      # Use symlink if possible and not on Windows, since on Windows 10
+	  # symlinks exist but they require administrator privileges to use.
+      if hasattr(os, 'symlink') and not os.name == 'nt':
+        os.symlink(os.path.join(cwd, real), os.path.join(root, fake))
+      else:
+        shutil.copyfile(os.path.join(cwd, real), os.path.join(root, fake))
     if subprocess.call(program + [root]) != 0:
       return 1
     for fake, real in outputs:
       shutil.copyfile(os.path.join(root, fake), real)
     return 0
   finally:
-    shutil.rmtree(root)
+    try:
+      shutil.rmtree(root)
+    except EnvironmentError:
+      # Ignore "file in use" errors on Windows; ok since it's just a tmpdir.
+      pass
 
 
 def main(args):

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -69,11 +69,10 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_pocoo_werkzeug",
         urls = [
-            "https://mirror.bazel.build/pypi.python.org/packages/b7/7f/44d3cfe5a12ba002b253f6985a4477edfa66da53787a2a838a40f6415263/Werkzeug-0.11.10.tar.gz",
-            "https://pypi.python.org/packages/b7/7f/44d3cfe5a12ba002b253f6985a4477edfa66da53787a2a838a40f6415263/Werkzeug-0.11.10.tar.gz",
+			"https://files.pythonhosted.org/packages/fe/7f/6d70f765ce5484e07576313897793cb49333dd34e462488ee818d17244af/Werkzeug-0.11.15.tar.gz"
         ],
-        strip_prefix = "Werkzeug-0.11.10",
-        sha256 = "cc64dafbacc716cdd42503cf6c44cb5a35576443d82f29f6829e5c49264aeeee",
+        strip_prefix = "Werkzeug-0.11.15",
+        sha256 = "455d7798ac263266dbd38d4841f7534dd35ca9c3da4a8df303f8488f38f3bcc0",
         build_file = str(Label("//third_party:werkzeug.BUILD")),
     )
 

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -69,7 +69,7 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_pocoo_werkzeug",
         urls = [
-			"https://files.pythonhosted.org/packages/fe/7f/6d70f765ce5484e07576313897793cb49333dd34e462488ee818d17244af/Werkzeug-0.11.15.tar.gz"
+            "https://files.pythonhosted.org/packages/fe/7f/6d70f765ce5484e07576313897793cb49333dd34e462488ee818d17244af/Werkzeug-0.11.15.tar.gz",
         ],
         strip_prefix = "Werkzeug-0.11.15",
         sha256 = "455d7798ac263266dbd38d4841f7534dd35ca9c3da4a8df303f8488f38f3bcc0",


### PR DESCRIPTION
This PR makes it possible to build a working TensorBoard on Windows again, which has evidently been broken for quite some time.  This in turn makes it possible for us to debug Windows-specific TensorBoard issues.

There are three separate fixes in this PR:
- Fixes to execrooter.py to work on Windows, e.g. by using copying instead of symlinks
- Removal of a bug-triggering `jvm_flags` argument to the vulcanize java_binary() rule - this is a bug in bazel's parsing of jvm_flags on windows, see https://github.com/bazelbuild/bazel/issues/7072, which for us manifested itself as #1466 
- Bumping our werkzeug dep to 0.11.15 to pick up fixes from https://github.com/pallets/werkzeug/pull/999 so it's compatible with Windows + python 3.6

With these fixes, I can build and run tensorboard at HEAD on Windows 10, using the hard-won magical incantation of:
- python 3.6.2
  - virtualenv 16.2.0
  - pip 18.1
  - tf-nightly 1.13.0.dev20190110 and its deps
- bazel version 0.21.0, plus its deps for installation plus building C++ and Java binaries (C++ is needed to build the protobuf runtime):
  - MSYS2 (msys2-x86_64-20180531.exe)
  - Visual Studio 2015 Community Edition with Visual C++
  - Windows 10 SDK
  - JDK 8 for windows, specifically build 1.8.0_191-b12
- git version 2.19.0.windows.1 (not part of the build itself, but part of getting this all working)

Fixes #1466
