### PR TITLE
fix-pip-build for missing v1 API

### DIFF
--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -38,7 +38,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 smoke() {
-  TF_PACKAGE=tf-nightly
+  TF_PACKAGE=tf-nightly-2.0-preview
   if [ -n "$TF_VERSION" ]; then
     TF_PACKAGE="tensorflow==${TF_VERSION}"
   fi


### PR DESCRIPTION
* Motivation for features / changes
The dufault tf-nightly used in the script causes the following error:
```
  File "/tmp/tensorboard/venv2/local/lib/python2.7/site-packages/tensorboard/plugins/scalar/summary.py", line 89, in pb
    import tensorflow.compat.v1 as tf
ImportError: No module named v1
```
* Technical description of changes

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)
`bazel run //tensorboard/pip_package:build_pip_package`
* Alternate designs / implementations considered
