### PR TITLE
build: temporarily pin working tf-nightly version, and fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ cache:
 # If inline scripts get too long, Travis surprisingly prints them twice.
 
 before_install:
+  - pip uninstall numpy  # Travis preinstalls this. Something is strange right now. Maybe this fixes it?
   - |
     # Download Bazel
     bazel_binary="$(mktemp)" &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ cache:
 # If inline scripts get too long, Travis surprisingly prints them twice.
 
 before_install:
+  - pip freeze
   - pip uninstall numpy  # Travis preinstalls this. Something is strange right now. Maybe this fixes it?
+  - pip freeze
   - |
     # Download Bazel
     bazel_binary="$(mktemp)" &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,9 @@ install:
         pip install -I tensorflow
         ;;
       NIGHTLY)
-        pip install -I tf-nightly
+        # TODO(@wchargin): Unpin once tensorflow/tensorflow#24867 is merged:
+        # https://github.com/tensorflow/tensorflow/pull/24867
+        pip install -I tf-nightly==1.13.0.dev20190104
         ;;
       *)
         pip install -I tensorflow=="${TF}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 
 before_install:
   - pip freeze
-  - pip uninstall numpy  # Travis preinstalls this. Something is strange right now. Maybe this fixes it?
+  - pip uninstall -y numpy  # Travis preinstalls this. Something is strange right now. Maybe this fixes it?
   - pip freeze
   - |
     # Download Bazel

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,9 @@ before_install:
   - echo "build --verbose_failures" >>~/.bazelrc
   - echo "test --test_output=errors" >>~/.bazelrc
 
+  # Absolute hack; don't get this anywhere near my prod
+  - bazel clean --expunge
+
 install:
   - pip install flake8==3.5.0
   - pip install futures==3.1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,10 @@ cache:
 # If inline scripts get too long, Travis surprisingly prints them twice.
 
 before_install:
-  - pip freeze
-  - pip uninstall -y numpy  # Travis preinstalls this. Something is strange right now. Maybe this fixes it?
+  # Travis pre-installs an old version of numpy. Uninstalling it
+  # manually has been known to solve some strange failures that we've
+  # had in the past.
+  - pip uninstall -y numpy
   - pip freeze
   - |
     # Download Bazel
@@ -70,9 +72,6 @@ before_install:
   - echo "build --local_resources=400,2,1.0" >>~/.bazelrc
   - echo "build --worker_max_instances=2" >>~/.bazelrc
 
-  # What goes on when something goes wrong?
-  - echo "build --sandbox_debug" >>~/.bazelrc
-
   # Make Bazel as strict as possible, so TensorBoard will build correctly
   # for users, regardless of their Bazel configuration.
   - echo "build --worker_verbose" >>~/.bazelrc
@@ -84,9 +83,6 @@ before_install:
   # It's helpful to see the errors on failure.
   - echo "build --verbose_failures" >>~/.bazelrc
   - echo "test --test_output=errors" >>~/.bazelrc
-
-  # Absolute hack; don't get this anywhere near my prod
-  - bazel clean --expunge
 
 install:
   - pip install flake8==3.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,9 @@ before_install:
   - echo "build --local_resources=400,2,1.0" >>~/.bazelrc
   - echo "build --worker_max_instances=2" >>~/.bazelrc
 
+  # What goes on when something goes wrong?
+  - echo "build --sandbox_debug" >>~/.bazelrc
+
   # Make Bazel as strict as possible, so TensorBoard will build correctly
   # for users, regardless of their Bazel configuration.
   - echo "build --worker_verbose" >>~/.bazelrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ cache:
 # If inline scripts get too long, Travis surprisingly prints them twice.
 
 before_install:
-  # Travis pre-installs an old version of numpy. Uninstalling it
-  # manually has been known to solve some strange failures that we've
-  # had in the past.
+  # Travis pre-installs an old version of numpy. We uninstall it to
+  # reduce the potential for strange behavior when upgrading in-place
+  # for TensorFlow's numpy dependency.
   - pip uninstall -y numpy
-  - pip freeze
+  - pip freeze  # print installed distributions, for debugging purposes
   - |
     # Download Bazel
     bazel_binary="$(mktemp)" &&

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -38,7 +38,9 @@ while [ "$#" -gt 0 ]; do
 done
 
 smoke() {
-  TF_PACKAGE=tf-nightly
+  # TODO(@wchargin): Unpin once tensorflow/tensorflow#24867 is merged:
+  # https://github.com/tensorflow/tensorflow/pull/24867
+  TF_PACKAGE=tf-nightly==1.13.0.dev20190104
   if [ -n "$TF_VERSION" ]; then
     TF_PACKAGE="tensorflow==${TF_VERSION}"
   fi


### PR DESCRIPTION
Summary:
This unbreaks our build until tensorflow/tensorflow#24867 is merged:
<https://github.com/tensorflow/tensorflow/pull/24867>

Test Plan:
Running `bazel run //tensorboard/pip_package:build_pip_package` includes
a smoke test that fails before this change and passes after it.

wchargin-branch: pin-tf-nightly
