### PR TITLE
Trim trailing zero when formatting numbers

### DIFF
--- a/tensorboard/components/vz_chart_helpers/vz-chart-helpers.ts
+++ b/tensorboard/components/vz_chart_helpers/vz-chart-helpers.ts
@@ -117,11 +117,11 @@ export function multiscaleFormatter(digits: number): ((v: number) => string) {
     }
     let f: (x: number) => string;
     if (absv >= 1E4) {
-      f = d3.format('.' + digits + 'e');
+      f = d3.format('.' + digits + '~e');
     } else if (absv > 0 && absv < 0.01) {
-      f = d3.format('.' + digits + 'e');
+      f = d3.format('.' + digits + '~e');
     } else {
-      f = d3.format('.' + digits + 'g');
+      f = d3.format('.' + digits + '~g');
     }
     return f(v);
   };
@@ -192,8 +192,7 @@ export interface XComponents {
   /* tslint:enable */
 }
 
-export let stepFormatter =
-    Plottable.Formatters.siSuffix(STEP_FORMATTER_PRECISION);
+export const stepFormatter = d3.format(`.${STEP_FORMATTER_PRECISION}~s`);
 export function stepX(): XComponents {
   let scale = new Plottable.Scales.Linear();
   scale.tickGenerator(Plottable.Scales.TickGenerators.integerTickGenerator());


### PR DESCRIPTION
d3.formatter now supports trim trailing zero with "~". For instance,
number 0.1 used to result in "0.100" but now is "0.1". This does not
affect numbers like "0.1234" and both formatter result in "0.123".

# Screenshots of UI changes
## Before
![image](https://user-images.githubusercontent.com/2547313/51197931-b4985d00-18a7-11e9-9b3e-89ae724fd49e.png)

## After
![image](https://user-images.githubusercontent.com/2547313/51197919-aba78b80-18a7-11e9-8f58-8fcf1f51930a.png)
