### PR TITLE
build: unpin tf-nightly version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,9 +96,7 @@ install:
         pip install -I tensorflow
         ;;
       NIGHTLY)
-        # TODO(@wchargin): Unpin once tensorflow/tensorflow#24867 is merged:
-        # https://github.com/tensorflow/tensorflow/pull/24867
-        pip install -I tf-nightly==1.13.0.dev20190104
+        pip install -I tf-nightly
         ;;
       *)
         pip install -I tensorflow=="${TF}"

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -38,9 +38,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 smoke() {
-  # TODO(@wchargin): Unpin once tensorflow/tensorflow#24867 is merged:
-  # https://github.com/tensorflow/tensorflow/pull/24867
-  TF_PACKAGE=tf-nightly==1.13.0.dev20190104
+  TF_PACKAGE=tf-nightly
   if [ -n "$TF_VERSION" ]; then
     TF_PACKAGE="tensorflow==${TF_VERSION}"
   fi


### PR DESCRIPTION
Summary:
This reverts part of d285c7de73a09e9ece5a13368a58c00e1dcabda9 because
the upstream package has been fixed.

Test Plan:
Running `from tensorflow.compat import v1` fails in the 20190114
virtualenv but works in the 20190115 virtualenv. Building the Pip
package with `bazel run //tensorboard/pip_package:build_pip_package`
also works.

wchargin-branch: unpin-tf-nightly
