### PR TITLE
ci: update Travis to Bazel 0.21.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   #
   # Grab the BAZEL_SHA256SUM from the Bazel releases page; e.g.:
   # bazel-0.20.0-linux-x86_64.sha256
-  - TF=NIGHTLY BAZEL=0.16.1 BAZEL_SHA256SUM=f1a855ca35043cdb360bba96ca51998a6277797c096b3390e787fdee07398959
+  - TF=NIGHTLY BAZEL=0.21.0 BAZEL_SHA256SUM=7a2f347d779c4c772cdb318f0435f8d489a238be42e7a9bf1e2bad94b1c3094f
 
 cache:
   directories:
@@ -83,6 +83,10 @@ before_install:
   # It's helpful to see the errors on failure.
   - echo "build --verbose_failures" >>~/.bazelrc
   - echo "test --test_output=errors" >>~/.bazelrc
+
+  # We need to pass the PATH from our virtualenv down into our tests,
+  # which is non-hermetic and so disabled by default in Bazel 0.21.0+.
+  - echo "test --action_env=PATH" >>~/.bazelrc
 
 install:
   - pip install flake8==3.5.0


### PR DESCRIPTION
Summary:
Testing on fresh Trusty VMs on GCP suggests that this may suffice to
stop the strange errors wherein Bazel invokes GCC with invalid flags,
though it should be noted that we do not actually understand the root
cause or the mechanism of failure.

Test Plan:
That this build should pass on Travis does not actually indicate that
this commit fixes the underlying problem, because the build will use
a new Bazel cache due to the version change. So: merge now, and hope
that this fixes the problem.

wchargin-branch: travis-bazel-0.21.0
