### PR TITLE
build: lock down visibility of unversioned summary targets

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -343,7 +343,7 @@ py_test(
 alias(
     name = "summary",
     actual = "//tensorboard/summary",
-    visibility = ["//visibility:public"],
+    visibility = ["//tensorboard:internal"],
 )
 
 py_library(

--- a/tensorboard/summary/BUILD
+++ b/tensorboard/summary/BUILD
@@ -9,7 +9,7 @@ py_library(
         "__init__.py",
     ],
     srcs_version = "PY2AND3",
-    visibility = ["//visibility:public"],
+    visibility = ["//tensorboard:internal"],
     deps = [
         ":summary_v1",
         ":summary_v2",


### PR DESCRIPTION
Summary:
We’ve migrated all users inside Google to use the explicitly versioned
endpoints (either `summary:summary_v1` or `summary:summary_v2`), so we
can now enforce that going forward.

Any existing users should migrate to `//tensorboard/summary:summary_v1`,
which is API-compatible and stable.

Test Plan:
That `bazel build //tensorboard` and `bazel query 'deps(//...)'` still
work suffices.

wchargin-branch: restrict-summary-visibility
