### PR TITLE
Create TensorBoard docs subsite structure

### DIFF
--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -25,5 +25,9 @@ upper_tabs:
         path: /tensorboard/graphs
       - title: Histograms
         path: /tensorboard/histograms
+    - name: API
+      skip_translation: true
+      contents:
+      - include: /tensorboard/api_docs/python/_toc.yaml
 
 - include: /_upper_tabs_right.yaml

--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -1,0 +1,29 @@
+upper_tabs:
+# Tabs left of dropdown menu
+- include: /_upper_tabs_left.yaml
+- include: /api_docs/_upper_tabs_api.yaml
+# Dropdown menu
+- name: Resources
+  path: /resources
+  is_default: true
+  menu:
+  - include: /resources/_menu_toc.yaml
+  lower_tabs:
+    # Subsite tabs
+    other:
+    - name: Tutorials
+      contents:
+      - title: Tutorial example
+        path: /tensorboard/tutorials/tutorial
+    - name: Guide
+      contents:
+      - title: Overview
+        path: /tensorboard/overview
+      - title: Summaries
+        path: /tensorboard/summaries
+      - title: Graphs
+        path: /tensorboard/graphs
+      - title: Histograms
+        path: /tensorboard/histograms
+
+- include: /_upper_tabs_right.yaml

--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -1,0 +1,36 @@
+book_path: /tensorboard/_book.yaml
+project_path: /tensorboard/_project.yaml
+description: <!--no description-->
+landing_page:
+  custom_css_path: /site-assets/css/style.css
+  rows:
+  - heading: TensorFlow's visualization toolkit
+    items:
+    - classname: devsite-landing-row-50
+      description: >
+        The computations you'll use TensorFlow for—like training a massive deep
+        neural network—can be complex and confusing. To make it easier to
+        understand, debug, and optimize TensorFlow programs, we've included a
+        suite of visualization tools called TensorBoard.
+
+      image_path: /images/graph_vis_animation.gif
+
+  - classname: devsite-landing-row-cards
+    items:
+    - heading: "Interactive supervision with TensorBoard"
+      image_path: /resources/images/tf-logo-card-16x9.png
+      path: https://medium.com/tensorflow/interactive-supervision-with-tensorboard-9a101c91d3f7
+      buttons:
+      - label: "Read on TensorFlow blog"
+        path: https://medium.com/tensorflow/interactive-supervision-with-tensorboard-9a101c91d3f7
+    - heading: "Hands-on TensorFlow"
+      youtube_id: eBbEDRsCmv4
+      buttons:
+      - label: Watch the video
+        path: https://www.youtube.com/watch?v=eBbEDRsCmv4
+    - heading: "TensorBoard on GitHub"
+      image_path: /resources/images/github-card-16x9.png
+      path: https://github.com/tensorflow/tensorboard
+      buttons:
+      - label: "View on GitHub"
+        path: https://github.com/tensorflow/tensorboard

--- a/docs/_project.yaml
+++ b/docs/_project.yaml
@@ -1,0 +1,7 @@
+name: TensorBoard
+home_url: /tensorboard/
+parent_project_metadata_path: /_project.yaml
+description: "TensorFlow's visualization toolkit"
+hide_from_products_list: true
+content_license: cc3-apache2
+buganizer_id: 141521

--- a/docs/api_docs/README.md
+++ b/docs/api_docs/README.md
@@ -1,0 +1,4 @@
+# API reference
+
+Create a `build_docs.py` script using the
+[api_generator](https://github.com/tensorflow/docs/tree/master/tools/tensorflow_docs/api_generator) API.

--- a/docs/api_docs/python/_toc.yaml
+++ b/docs/api_docs/python/_toc.yaml
@@ -1,0 +1,6 @@
+# This file will be automatically generated when the API generator is configured
+toc:
+- title: tensorboard
+  section:
+  - title: Overview
+    path: /tensorboard/api_docs/python/

--- a/docs/api_docs/python/index.md
+++ b/docs/api_docs/python/index.md
@@ -1,0 +1,5 @@
+# API reference
+
+This section will be generated when the
+[api_generator](https://github.com/tensorflow/docs/tree/master/tools/tensorflow_docs/api_generator)
+is configured.

--- a/docs/graphs.md
+++ b/docs/graphs.md
@@ -1,0 +1,317 @@
+# TensorBoard: Graph Visualization
+
+TensorFlow computation graphs are powerful but complicated. The graph visualization can help you understand and debug them. Here's an example of the visualization at work.
+
+![Visualization of a TensorFlow graph](https://www.tensorflow.org/images/graph_vis_animation.gif "Visualization of a TensorFlow graph")
+*Visualization of a TensorFlow graph.*
+
+To see your own graph, run TensorBoard pointing it to the log directory of the job, click on the graph tab on the top pane and select the appropriate run using the menu at the upper left corner. For in depth information on how to run TensorBoard and make sure you are logging all the necessary information, see [TensorBoard: Visualizing Learning](../guide/summaries_and_tensorboard.md).
+
+## Name scoping and nodes
+
+Typical TensorFlow graphs can have many thousands of nodes--far too many to see
+easily all at once, or even to lay out using standard graph tools. To simplify,
+variable names can be scoped and the visualization uses this information to
+define a hierarchy on the nodes in the graph.  By default, only the top of this
+hierarchy is shown. Here is an example that defines three operations under the
+`hidden` name scope using
+`tf.name_scope`:
+
+```python
+import tensorflow as tf
+
+with tf.name_scope('hidden') as scope:
+  a = tf.constant(5, name='alpha')
+  W = tf.Variable(tf.random_uniform([1, 2], -1.0, 1.0), name='weights')
+  b = tf.Variable(tf.zeros([1]), name='biases')
+```
+
+This results in the following three op names:
+
+* `hidden/alpha`
+* `hidden/weights`
+* `hidden/biases`
+
+By default, the visualization will collapse all three into a node labeled `hidden`.
+The extra detail isn't lost. You can double-click, or click
+on the orange `+` sign in the top right to expand the node, and then you'll see
+three subnodes for `alpha`, `weights` and `biases`.
+
+Here's a real-life example of a more complicated node in its initial and
+expanded states.
+
+<table width="100%;">
+  <tr>
+    <td style="width: 50%;">
+      <img src="https://www.tensorflow.org/images/pool1_collapsed.png" alt="Unexpanded name scope" title="Unexpanded name scope" />
+    </td>
+    <td style="width: 50%;">
+      <img src="https://www.tensorflow.org/images/pool1_expanded.png" alt="Expanded name scope" title="Expanded name scope" />
+    </td>
+  </tr>
+  <tr>
+    <td style="width: 50%;">
+      Initial view of top-level name scope <code>pool_1</code>. Clicking on the orange <code>+</code> button on the top right or double-clicking on the node itself will expand it.
+    </td>
+    <td style="width: 50%;">
+      Expanded view of <code>pool_1</code> name scope. Clicking on the orange <code>-</code> button on the top right or double-clicking on the node itself will collapse the name scope.
+    </td>
+  </tr>
+</table>
+
+Grouping nodes by name scopes is critical to making a legible graph. If you're
+building a model, name scopes give you control over the resulting visualization.
+**The better your name scopes, the better your visualization.**
+
+The figure above illustrates a second aspect of the visualization. TensorFlow
+graphs have two kinds of connections: data dependencies and control
+dependencies. Data dependencies show the flow of tensors between two ops and
+are shown as solid arrows, while control dependencies use dotted lines. In the
+expanded view (right side of the figure above) all the connections are data
+dependencies with the exception of the dotted line connecting `CheckNumerics`
+and `control_dependency`.
+
+There's a second trick to simplifying the layout. Most TensorFlow graphs have a
+few nodes with many connections to other nodes. For example, many nodes might
+have a control dependency on an initialization step. Drawing all edges between
+the `init` node and its dependencies would create a very cluttered view.
+
+To reduce clutter, the visualization separates out all high-degree nodes to an
+*auxiliary* area on the right and doesn't draw lines to represent their edges.
+Instead of lines, we draw small *node icons* to indicate the connections.
+Separating out the auxiliary nodes typically doesn't remove critical
+information since these nodes are usually related to bookkeeping functions.
+See [Interaction](#interaction) for how to move nodes between the main graph
+and the auxiliary area.
+
+<table width="100%;">
+  <tr>
+    <td style="width: 50%;">
+      <img src="https://www.tensorflow.org/images/conv_1.png" alt="conv_1 is part of the main graph" title="conv_1 is part of the main graph" />
+    </td>
+    <td style="width: 50%;">
+      <img src="https://www.tensorflow.org/images/save.png" alt="save is extracted as auxiliary node" title="save is extracted as auxiliary node" />
+    </td>
+  </tr>
+  <tr>
+    <td style="width: 50%;">
+      Node <code>conv_1</code> is connected to <code>save</code>. Note the little <code>save</code> node icon on its right.
+    </td>
+    <td style="width: 50%;">
+      <code>save</code> has a high degree, and will appear as an auxiliary node. The connection with <code>conv_1</code> is shown as a node icon on its left. To further reduce clutter, since <code>save</code> has a lot of connections, we show the first 5 and abbreviate the others as <code>... 12 more</code>.
+    </td>
+  </tr>
+</table>
+
+One last structural simplification is *series collapsing*. Sequential
+motifs--that is, nodes whose names differ by a number at the end and have
+isomorphic structures--are collapsed into a single *stack* of nodes, as shown
+below. For networks with long sequences, this greatly simplifies the view. As
+with hierarchical nodes, double-clicking expands the series. See
+[Interaction](#interaction) for how to disable/enable series collapsing for a
+specific set of nodes.
+
+<table width="100%;">
+  <tr>
+    <td style="width: 50%;">
+      <img src="https://www.tensorflow.org/images/series.png" alt="Sequence of nodes" title="Sequence of nodes" />
+    </td>
+    <td style="width: 50%;">
+      <img src="https://www.tensorflow.org/images/series_expanded.png" alt="Expanded sequence of nodes" title="Expanded sequence of nodes" />
+    </td>
+  </tr>
+  <tr>
+    <td style="width: 50%;">
+      A collapsed view of a node sequence.
+    </td>
+    <td style="width: 50%;">
+      A small piece of the expanded view, after double-click.
+    </td>
+  </tr>
+</table>
+
+Finally, as one last aid to legibility, the visualization uses special icons
+for constants and summary nodes. To summarize, here's a table of node symbols:
+
+Symbol | Meaning
+--- | ---
+![Name scope](https://www.tensorflow.org/images/namespace_node.png "Name scope") | *High-level* node representing a name scope. Double-click to expand a high-level node.
+![Sequence of unconnected nodes](https://www.tensorflow.org/images/horizontal_stack.png "Sequence of unconnected nodes") | Sequence of numbered nodes that are not connected to each other.
+![Sequence of connected nodes](https://www.tensorflow.org/images/vertical_stack.png "Sequence of connected nodes") | Sequence of numbered nodes that are connected to each other.
+![Operation node](https://www.tensorflow.org/images/op_node.png "Operation node") | An individual operation node.
+![Constant node](https://www.tensorflow.org/images/constant.png "Constant node") | A constant.
+![Summary node](https://www.tensorflow.org/images/summary.png "Summary node") | A summary node.
+![Data flow edge](https://www.tensorflow.org/images/dataflow_edge.png "Data flow edge") | Edge showing the data flow between operations.
+![Control dependency edge](https://www.tensorflow.org/images/control_edge.png "Control dependency edge") | Edge showing the control dependency between operations.
+![Reference edge](https://www.tensorflow.org/images/reference_edge.png "Reference edge") | A reference edge showing that the outgoing operation node can mutate the incoming tensor.
+
+## Interaction {#interaction}
+
+Navigate the graph by panning and zooming. Click and drag to pan, and use a
+scroll gesture to zoom. Double-click on a node, or click on its `+` button, to
+expand a name scope that represents a group of operations. To easily keep
+track of the current viewpoint when zooming and panning, there is a minimap in
+the bottom right corner.
+
+To close an open node, double-click it again or click its `-` button. You can
+also click once to select a node. It will turn a darker color, and details
+about it and the nodes it connects to will appear in the info card at upper
+right corner of the visualization.
+
+<table width="100%;">
+  <tr>
+    <td style="width: 50%;">
+      <img src="https://www.tensorflow.org/images/infocard.png" alt="Info card of a name scope" title="Info card of a name scope" />
+    </td>
+    <td style="width: 50%;">
+      <img src="https://www.tensorflow.org/images/infocard_op.png" alt="Info card of operation node" title="Info card of operation node" />
+    </td>
+  </tr>
+  <tr>
+    <td style="width: 50%;">
+      Info card showing detailed information for the <code>conv2</code> name scope. The inputs and outputs are combined from the inputs and outputs of the operation nodes inside the name scope. For name scopes no attributes are shown.
+    </td>
+    <td style="width: 50%;">
+      Info card showing detailed information for the <code>DecodeRaw</code> operation node. In addition to inputs and outputs, the card shows the device and the attributes associated with the current operation.
+    </td>
+  </tr>
+</table>
+
+TensorBoard provides several ways to change the visual layout of the graph. This
+doesn't change the graph's computational semantics, but it can bring some
+clarity to the network's structure. By right clicking on a node or pressing
+buttons on the bottom of that node's info card, you can make the following
+changes to its layout:
+
+* Nodes can be moved between the main graph and the auxiliary area.
+* A series of nodes can be ungrouped so that the nodes in the series do not
+appear grouped together. Ungrouped series can likewise be regrouped.
+
+Selection can also be helpful in understanding high-degree nodes. Select any
+high-degree node, and the corresponding node icons for its other connections
+will be selected as well. This makes it easy, for example, to see which nodes
+are being saved--and which aren't.
+
+Clicking on a node name in the info card will select it. If necessary, the
+viewpoint will automatically pan so that the node is visible.
+
+Finally, you can choose two color schemes for your graph, using the color menu
+above the legend. The default *Structure View* shows structure: when two
+high-level nodes have the same structure, they appear in the same color of the
+rainbow. Uniquely structured nodes are gray. There's a second view, which shows
+what device the different operations run on. Name scopes are colored
+proportionally to the fraction of devices for the operations inside them.
+
+The images below give an illustration for a piece of a real-life graph.
+
+<table width="100%;">
+  <tr>
+    <td style="width: 50%;">
+      <img src="https://www.tensorflow.org/images/colorby_structure.png" alt="Color by structure" title="Color by structure" />
+    </td>
+    <td style="width: 50%;">
+      <img src="https://www.tensorflow.org/images/colorby_device.png" alt="Color by device" title="Color by device" />
+    </td>
+  </tr>
+  <tr>
+    <td style="width: 50%;">
+      Structure view: The gray nodes have unique structure. The orange <code>conv1</code> and <code>conv2</code> nodes have the same structure, and analogously for nodes with other colors.
+    </td>
+    <td style="width: 50%;">
+      Device view: Name scopes are colored proportionally to the fraction of devices of the operation nodes inside them. Here, purple means GPU and the green is CPU.
+    </td>
+  </tr>
+</table>
+
+## Tensor shape information
+
+When the serialized `GraphDef` includes tensor shapes, the graph visualizer
+labels edges with tensor dimensions, and edge thickness reflects total tensor
+size. To include tensor shapes in the `GraphDef` pass the actual graph object
+(as in `sess.graph`) to the `FileWriter` when serializing the graph.
+The images below show the CIFAR-10 model with tensor shape information:
+<table width="100%;">
+  <tr>
+    <td style="width: 100%;">
+      <img src="https://www.tensorflow.org/images/tensor_shapes.png" alt="CIFAR-10 model with tensor shape information" title="CIFAR-10 model with tensor shape information" />
+    </td>
+  </tr>
+  <tr>
+    <td style="width: 100%;">
+      CIFAR-10 model with tensor shape information.
+    </td>
+  </tr>
+</table>
+
+## Runtime statistics
+
+Often it is useful to collect runtime metadata for a run, such as total memory
+usage, total compute time, and tensor shapes for nodes. The code example below
+is a snippet from the train and test section of a modification of the
+[Estimators MNIST tutorial](../tutorials/estimators/cnn.md), in which we have
+recorded summaries and
+runtime statistics. See the
+[Summaries Tutorial](../guide/summaries_and_tensorboard.md#serializing-the-data)
+for details on how to record summaries.
+Full source is [here](https://www.tensorflow.org/code/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py).
+
+```python
+  # Train the model, and also write summaries.
+  # Every 10th step, measure test-set accuracy, and write test summaries
+  # All other steps, run train_step on training data, & add training summaries
+
+  def feed_dict(train):
+    """Make a TensorFlow feed_dict: maps data onto Tensor placeholders."""
+    if train or FLAGS.fake_data:
+      xs, ys = mnist.train.next_batch(100, fake_data=FLAGS.fake_data)
+      k = FLAGS.dropout
+    else:
+      xs, ys = mnist.test.images, mnist.test.labels
+      k = 1.0
+    return {x: xs, y_: ys, keep_prob: k}
+
+  for i in range(FLAGS.max_steps):
+    if i % 10 == 0:  # Record summaries and test-set accuracy
+      summary, acc = sess.run([merged, accuracy], feed_dict=feed_dict(False))
+      test_writer.add_summary(summary, i)
+      print('Accuracy at step %s: %s' % (i, acc))
+    else:  # Record train set summaries, and train
+      if i % 100 == 99:  # Record execution stats
+        run_options = tf.RunOptions(trace_level=tf.RunOptions.FULL_TRACE)
+        run_metadata = tf.RunMetadata()
+        summary, _ = sess.run([merged, train_step],
+                              feed_dict=feed_dict(True),
+                              options=run_options,
+                              run_metadata=run_metadata)
+        train_writer.add_run_metadata(run_metadata, 'step%d' % i)
+        train_writer.add_summary(summary, i)
+        print('Adding run metadata for', i)
+      else:  # Record a summary
+        summary, _ = sess.run([merged, train_step], feed_dict=feed_dict(True))
+        train_writer.add_summary(summary, i)
+```
+
+This code will emit runtime statistics for every 100th step starting at step99.
+
+When you launch tensorboard and go to the Graph tab, you will now see options
+under "Session runs" which correspond to the steps where run metadata was added.
+Selecting one of these runs will show you the snapshot of the network at that
+step, fading out unused nodes. In the controls on the left hand side, you will
+be able to color the nodes by total memory or total compute time. Additionally,
+clicking on a node will display the exact total memory, compute time, and
+tensor output sizes.
+
+
+<table width="100%;">
+  <tr style="height: 380px">
+    <td>
+      <img src="https://www.tensorflow.org/images/colorby_compute_time.png" alt="Color by compute time" title="Color by compute time"/>
+    </td>
+    <td>
+      <img src="https://www.tensorflow.org/images/run_metadata_graph.png" alt="Run metadata graph" title="Run metadata graph" />
+    </td>
+    <td>
+      <img src="https://www.tensorflow.org/images/run_metadata_infocard.png" alt="Run metadata info card" title="Run metadata info card" />
+    </td>
+  </tr>
+</table>

--- a/docs/histograms.md
+++ b/docs/histograms.md
@@ -1,0 +1,245 @@
+# TensorBoard Histogram Dashboard
+
+The TensorBoard Histogram Dashboard displays how the distribution of some
+`Tensor` in your TensorFlow graph has changed over time. It does this by showing
+many histograms visualizations of your tensor at different points in time.
+
+## A Basic Example
+
+Let's start with a simple case: a normally-distributed variable, where the mean
+shifts over time.
+TensorFlow has an op
+[`tf.random_normal`](https://www.tensorflow.org/api_docs/python/tf/random_normal)
+which is perfect for this purpose. As is usually the case with TensorBoard, we
+will ingest data using a summary op; in this case,
+['tf.summary.histogram'](https://www.tensorflow.org/api_docs/python/tf/summary/histogram).
+For a primer on how summaries work, please see the
+[TensorBoard guide](./summaries_and_tensorboard.md).
+
+Here is a code snippet that will generate some histogram summaries containing
+normally distributed data, where the mean of the distribution increases over
+time.
+
+```python
+import tensorflow as tf
+
+k = tf.placeholder(tf.float32)
+
+# Make a normal distribution, with a shifting mean
+mean_moving_normal = tf.random_normal(shape=[1000], mean=(5*k), stddev=1)
+# Record that distribution into a histogram summary
+tf.summary.histogram("normal/moving_mean", mean_moving_normal)
+
+# Setup a session and summary writer
+sess = tf.Session()
+writer = tf.summary.FileWriter("/tmp/histogram_example")
+
+summaries = tf.summary.merge_all()
+
+# Setup a loop and write the summaries to disk
+N = 400
+for step in range(N):
+  k_val = step/float(N)
+  summ = sess.run(summaries, feed_dict={k: k_val})
+  writer.add_summary(summ, global_step=step)
+```
+
+Once that code runs, we can load the data into TensorBoard via the command line:
+
+
+```sh
+tensorboard --logdir=/tmp/histogram_example
+```
+
+Once TensorBoard is running, load it in Chrome or Firefox and navigate to the
+Histogram Dashboard. Then we can see a histogram visualization for our normally
+distributed data.
+
+![](https://www.tensorflow.org/images/tensorboard/histogram_dashboard/1_moving_mean.png)
+
+`tf.summary.histogram` takes an arbitrarily sized and shaped Tensor, and
+compresses it into a histogram data structure consisting of many bins with
+widths and counts. For example, let's say we want to organize the numbers
+`[0.5, 1.1, 1.3, 2.2, 2.9, 2.99]` into bins. We could make three bins:
+* a bin
+containing everything from 0 to 1 (it would contain one element, 0.5),
+* a bin
+containing everything from 1-2 (it would contain two elements, 1.1 and 1.3),
+* a bin containing everything from 2-3 (it would contain three elements: 2.2,
+2.9 and 2.99).
+
+TensorFlow uses a similar approach to create bins, but unlike in our example, it
+doesn't create integer bins. For large, sparse datasets, that might result in
+many thousands of bins.
+Instead, [the bins are exponentially distributed, with many bins close to 0 and
+comparatively few bins for very large numbers.](https://github.com/tensorflow/tensorflow/blob/c8b59c046895fa5b6d79f73e0b5817330fcfbfc1/tensorflow/core/lib/histogram/histogram.cc#L28)
+However, visualizing exponentially-distributed bins is tricky; if height is used
+to encode count, then wider bins take more space, even if they have the same
+number of elements. Conversely, encoding count in the area makes height
+comparisons impossible. Instead, the histograms [resample the data](https://github.com/tensorflow/tensorflow/blob/17c47804b86e340203d451125a721310033710f1/tensorflow/tensorboard/components/tf_backend/backend.ts#L400)
+into uniform bins. This can lead to unfortunate artifacts in some cases.
+
+Each slice in the histogram visualizer displays a single histogram.
+The slices are organized by step;
+older slices (e.g. step 0) are further "back" and darker, while newer slices
+(e.g. step 400) are close to the foreground, and lighter in color.
+The y-axis on the right shows the step number.
+
+You can mouse over the histogram to see tooltips with some more detailed
+information. For example, in the following image we can see that the histogram
+at timestep 176 has a bin centered at 2.25 with 177 elements in that bin.
+
+![](https://www.tensorflow.org/images/tensorboard/histogram_dashboard/2_moving_mean_tooltip.png)
+
+Also, you may note that the histogram slices are not always evenly spaced in
+step count or time. This is because TensorBoard uses
+[reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling) to keep a
+subset of all the histograms, to save on memory. Reservoir sampling guarantees
+that every sample has an equal likelihood of being included, but because it is
+a randomized algorithm, the samples chosen don't occur at even steps.
+
+## Overlay Mode
+
+There is a control on the left of the dashboard that allows you to toggle the
+histogram mode from "offset" to "overlay":
+
+![](https://www.tensorflow.org/images/tensorboard/histogram_dashboard/3_overlay_offset.png)
+
+In "offset" mode, the visualization rotates 45 degrees, so that the individual
+histogram slices are no longer spread out in time, but instead are all plotted
+on the same y-axis.
+
+![](https://www.tensorflow.org/images/tensorboard/histogram_dashboard/4_overlay.png)
+Now, each slice is a separate line on the chart, and the y-axis shows the item
+count within each bucket. Darker lines are older, earlier steps, and lighter
+lines are more recent, later steps. Once again, you can mouse over the chart to
+see some additional information.
+
+![](https://www.tensorflow.org/images/tensorboard/histogram_dashboard/5_overlay_tooltips.png)
+
+In general, the overlay visualization is useful if you want to directly compare
+the counts of different histograms.
+
+## Multimodal Distributions
+
+The Histogram Dashboard is great for visualizing multimodal
+distributions. Let's construct a simple bimodal distribution by concatenating
+the outputs from two different normal distributions. The code will look like
+this:
+
+```python
+import tensorflow as tf
+
+k = tf.placeholder(tf.float32)
+
+# Make a normal distribution, with a shifting mean
+mean_moving_normal = tf.random_normal(shape=[1000], mean=(5*k), stddev=1)
+# Record that distribution into a histogram summary
+tf.summary.histogram("normal/moving_mean", mean_moving_normal)
+
+# Make a normal distribution with shrinking variance
+variance_shrinking_normal = tf.random_normal(shape=[1000], mean=0, stddev=1-(k))
+# Record that distribution too
+tf.summary.histogram("normal/shrinking_variance", variance_shrinking_normal)
+
+# Let's combine both of those distributions into one dataset
+normal_combined = tf.concat([mean_moving_normal, variance_shrinking_normal], 0)
+# We add another histogram summary to record the combined distribution
+tf.summary.histogram("normal/bimodal", normal_combined)
+
+summaries = tf.summary.merge_all()
+
+# Setup a session and summary writer
+sess = tf.Session()
+writer = tf.summary.FileWriter("/tmp/histogram_example")
+
+# Setup a loop and write the summaries to disk
+N = 400
+for step in range(N):
+  k_val = step/float(N)
+  summ = sess.run(summaries, feed_dict={k: k_val})
+  writer.add_summary(summ, global_step=step)
+```
+
+You already remember our "moving mean" normal distribution from the example
+above. Now we also have a "shrinking variance" distribution. Side-by-side, they
+look like this:
+![](https://www.tensorflow.org/images/tensorboard/histogram_dashboard/6_two_distributions.png)
+
+When we concatenate them, we get a chart that clearly reveals the divergent,
+bimodal structure:
+![](https://www.tensorflow.org/images/tensorboard/histogram_dashboard/7_bimodal.png)
+
+## Some more distributions
+
+Just for fun, let's generate and visualize a few more distributions, and then
+combine them all into one chart. Here's the code we'll use:
+
+```python
+import tensorflow as tf
+
+k = tf.placeholder(tf.float32)
+
+# Make a normal distribution, with a shifting mean
+mean_moving_normal = tf.random_normal(shape=[1000], mean=(5*k), stddev=1)
+# Record that distribution into a histogram summary
+tf.summary.histogram("normal/moving_mean", mean_moving_normal)
+
+# Make a normal distribution with shrinking variance
+variance_shrinking_normal = tf.random_normal(shape=[1000], mean=0, stddev=1-(k))
+# Record that distribution too
+tf.summary.histogram("normal/shrinking_variance", variance_shrinking_normal)
+
+# Let's combine both of those distributions into one dataset
+normal_combined = tf.concat([mean_moving_normal, variance_shrinking_normal], 0)
+# We add another histogram summary to record the combined distribution
+tf.summary.histogram("normal/bimodal", normal_combined)
+
+# Add a gamma distribution
+gamma = tf.random_gamma(shape=[1000], alpha=k)
+tf.summary.histogram("gamma", gamma)
+
+# And a poisson distribution
+poisson = tf.random_poisson(shape=[1000], lam=k)
+tf.summary.histogram("poisson", poisson)
+
+# And a uniform distribution
+uniform = tf.random_uniform(shape=[1000], maxval=k*10)
+tf.summary.histogram("uniform", uniform)
+
+# Finally, combine everything together!
+all_distributions = [mean_moving_normal, variance_shrinking_normal,
+                     gamma, poisson, uniform]
+all_combined = tf.concat(all_distributions, 0)
+tf.summary.histogram("all_combined", all_combined)
+
+summaries = tf.summary.merge_all()
+
+# Setup a session and summary writer
+sess = tf.Session()
+writer = tf.summary.FileWriter("/tmp/histogram_example")
+
+# Setup a loop and write the summaries to disk
+N = 400
+for step in range(N):
+  k_val = step/float(N)
+  summ = sess.run(summaries, feed_dict={k: k_val})
+  writer.add_summary(summ, global_step=step)
+```
+### Gamma Distribution
+![](https://www.tensorflow.org/images/tensorboard/histogram_dashboard/8_gamma.png)
+
+### Uniform Distribution
+![](https://www.tensorflow.org/images/tensorboard/histogram_dashboard/9_uniform.png)
+
+### Poisson Distribution
+![](https://www.tensorflow.org/images/tensorboard/histogram_dashboard/10_poisson.png)
+The poisson distribution is defined over the integers. So, all of the values
+being generated are perfect integers. The histogram compression moves the data
+into floating-point bins, causing the visualization to show little
+bumps over the integer values rather than perfect spikes.
+
+### All Together Now
+Finally, we can concatenate all of the data into one funny-looking curve.
+![](https://www.tensorflow.org/images/tensorboard/histogram_dashboard/11_all_combined.png)
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,367 @@
+# TensorBoard overview
+
+TensorBoard is a suite of web applications for inspecting and understanding your
+TensorFlow runs and graphs.
+
+This overview covers the key concepts in TensorBoard, as well as how to
+interpret the visualizations TensorBoard provides. For an in-depth example of
+using TensorBoard, see the [summaries guide][summaries.md].
+For in-depth information on the Graph Visualizer, see the [graphs guide](graphs.md). 
+
+You may also want to watch
+[this video tutorial][] that walks
+through setting up and using TensorBoard. There's an associated 
+[tutorial with an end-to-end example of training TensorFlow and using TensorBoard][].
+
+[this video tutorial]: https://www.youtube.com/watch?v=eBbEDRsCmv4
+
+[tutorial with an end-to-end example of training TensorFlow and using TensorBoard]: https://github.com/dandelionmane/tf-dev-summit-tensorboard-tutorial
+
+# Usage
+
+Before running TensorBoard, make sure you have generated summary data in a log
+directory by creating a summary writer:
+
+``` python
+# sess.graph contains the graph definition; that enables the Graph Visualizer.
+
+file_writer = tf.summary.FileWriter('/path/to/logs', sess.graph)
+```
+
+For more details, see 
+[the TensorBoard tutorial](https://www.tensorflow.org/get_started/summaries_and_tensorboard).
+Once you have event files, run TensorBoard and provide the log directory. If
+you're using a precompiled TensorFlow package (e.g. you installed via pip), run:
+
+```
+tensorboard --logdir path/to/logs
+```
+
+Or, if you are building from source:
+
+```bash
+bazel build tensorboard:tensorboard
+./bazel-bin/tensorboard/tensorboard --logdir path/to/logs
+
+# or even more succinctly
+bazel run tensorboard -- --logdir path/to/logs
+```
+
+This should print that TensorBoard has started. Next, connect to
+http://localhost:6006.
+
+TensorBoard requires a `logdir` to read logs from. For info on configuring
+TensorBoard, run `tensorboard --help`.
+
+TensorBoard can be used in Google Chrome or Firefox. Other browsers might
+work, but there may be bugs or performance issues.
+
+# Key Concepts
+
+### Summary Ops: How TensorBoard gets data from TensorFlow
+
+The first step in using TensorBoard is acquiring data from your TensorFlow run.
+For this, you need 
+[summary ops](https://www.tensorflow.org/api_docs/python/tf/summary).
+Summary ops are ops, like
+[`tf.matmul`](https://www.tensorflow.org/versions/r1.2/api_docs/python/tf/matmul)
+or
+[`tf.nn.relu`](https://www.tensorflow.org/versions/master/api_docs/python/tf/nn/relu),
+which means they take in tensors, produce tensors, and are evaluated from within
+a TensorFlow graph. However, summary ops have a twist: the Tensors they produce
+contain serialized protobufs, which are written to disk and sent to TensorBoard.
+To visualize the summary data in TensorBoard, you should evaluate the summary
+op, retrieve the result, and then write that result to disk using a
+summary.FileWriter. A full explanation, with examples, is in [the
+tutorial](https://www.tensorflow.org/get_started/summaries_and_tensorboard).
+
+The supported summary ops include:
+* [`tf.summary.scalar`](https://www.tensorflow.org/api_docs/python/tf/summary/scalar)
+* [`tf.summary.image`](https://www.tensorflow.org/api_docs/python/tf/summary/image)
+* [`tf.summary.audio`](https://www.tensorflow.org/api_docs/python/tf/summary/audio)
+* [`tf.summary.text`](https://www.tensorflow.org/api_docs/python/tf/summary/text)
+* [`tf.summary.histogram`](https://www.tensorflow.org/api_docs/python/tf/summary/histogram)
+
+### Tags: Giving names to data
+
+When you make a summary op, you will also give it a `tag`. The tag is basically
+a name for the data recorded by that op, and will be used to organize the data
+in the frontend. The scalar and histogram dashboards organize data by tag, and
+group the tags into folders according to a directory/like/hierarchy. If you have
+a lot of tags, we recommend grouping them with slashes.
+
+### Event Files & LogDirs: How TensorBoard loads the data
+
+`summary.FileWriters` take summary data from TensorFlow, and then write them to a
+specified directory, known as the `logdir`. Specifically, the data is written to
+an append-only record dump that will have "tfevents" in the filename.
+TensorBoard reads data from a full directory, and organizes it into the history
+of a single TensorFlow execution.
+
+Why does it read the whole directory, rather than an individual file? You might
+have been using
+[supervisor.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/training/supervisor.py)
+to run your model, in which case if TensorFlow crashes, the supervisor will
+restart it from a checkpoint. When it restarts, it will start writing to a new
+events file, and TensorBoard will stitch the various event files together to
+produce a consistent history of what happened.
+
+### Runs: Comparing different executions of your model
+
+You may want to visually compare multiple executions of your model; for example,
+suppose you've changed the hyperparameters and want to see if it's converging
+faster. TensorBoard enables this through different "runs". When TensorBoard is
+passed a `logdir` at startup, it recursively walks the directory tree rooted at
+`logdir` looking for subdirectories that contain tfevents data. Every time it
+encounters such a subdirectory, it loads it as a new `run`, and the frontend
+will organize the data accordingly.
+
+For example, here is a well-organized TensorBoard log directory, with two runs,
+"run1" and "run2".
+
+```
+/some/path/mnist_experiments/
+/some/path/mnist_experiments/run1/
+/some/path/mnist_experiments/run1/events.out.tfevents.1456525581.name
+/some/path/mnist_experiments/run1/events.out.tfevents.1456525585.name
+/some/path/mnist_experiments/run2/
+/some/path/mnist_experiments/run2/events.out.tfevents.1456525385.name
+/tensorboard --logdir /some/path/mnist_experiments
+```
+
+You may also pass a comma separated list of log directories, and TensorBoard
+will watch each directory. You can also assign names to individual log
+directories by putting a colon between the name and the path, as in
+
+```
+tensorboard --logdir name1:/path/to/logs/1,name2:/path/to/logs/2
+```
+
+# The Visualizations
+
+### Scalar Dashboard
+
+TensorBoard's Scalar Dashboard visualizes scalar statistics that vary over time;
+for example, you might want to track the model's loss or learning rate. As
+described in *Key Concepts*, you can compare multiple runs, and the data is
+organized by tag. The line charts have the following interactions:
+
+* Clicking on the small blue icon in the lower-left corner of each chart will
+expand the chart
+
+* Dragging a rectangular region on the chart will zoom in
+
+* Double clicking on the chart will zoom out
+
+* Mousing over the chart will produce crosshairs, with data values recorded in
+the run-selector on the left.
+
+Additionally, you can create new folders to organize tags by writing regular
+expressions in the box in the top-left of the dashboard.
+
+### Histogram Dashboard
+
+The HistogramDashboard displays how the statistical distribution of a Tensor
+has varied over time. It visualizes data recorded via `tf.summary.histogram`.
+Each chart shows temporal "slices" of data, where each slice is a histogram of
+the tensor at a given step. It's organized with the oldest timestep in the back,
+and the most recent timestep in front. By changing the Histogram Mode from
+"offset" to "overlay", the perspective will rotate so that every histogram slice
+is rendered as a line and overlaid with one another.
+
+### Distribution Dashboard
+
+The Distribution Dashboard is another way of visualizing histogram data from
+`tf.summary.histogram`. It shows some high-level statistics on a distribution.
+Each line on the chart represents a percentile in the distribution over the
+data: for example, the bottom line shows how the minimum value has changed over
+time, and the line in the middle shows how the median has changed. Reading from
+top to bottom, the lines have the following meaning: `[maximum, 93%, 84%, 69%,
+50%, 31%, 16%, 7%, minimum]`
+
+These percentiles can also be viewed as standard deviation boundaries on a
+normal distribution: `[maximum, μ+1.5σ, μ+σ, μ+0.5σ, μ, μ-0.5σ, μ-σ, μ-1.5σ,
+minimum]` so that the colored regions, read from inside to outside, have widths
+`[σ, 2σ, 3σ]` respectively.
+
+
+### Image Dashboard
+
+The Image Dashboard can display pngs that were saved via a `tf.summary.image`.
+The dashboard is set up so that each row corresponds to a different tag, and
+each column corresponds to a run. Since the image dashboard supports arbitrary
+pngs, you can use this to embed custom visualizations (e.g. matplotlib
+scatterplots) into TensorBoard. This dashboard always shows you the latest image
+for each tag.
+
+### Audio Dashboard
+
+The Audio Dashboard can embed playable audio widgets for audio saved via a
+`tf.summary.audio`. The dashboard is set up so that each row corresponds to a
+different tag, and each column corresponds to a run. This dashboard always
+embeds the latest audio for each tag.
+
+### Graph Explorer
+
+The Graph Explorer can visualize a TensorBoard graph, enabling inspection of the
+TensorFlow model. To get best use of the graph visualizer, you should use name
+scopes to hierarchically group the ops in your graph - otherwise, the graph may
+be difficult to decipher. For more information, including examples, see [the
+graph visualizer tutorial](https://www.tensorflow.org/get_started/graph_viz).
+
+### Embedding Projector
+
+The Embedding Projector allows you to visualize high-dimensional data; for
+example, you may view your input data after it has been embedded in a high-
+dimensional space by your model. The embedding projector reads data from your
+model checkpoint file, and may be configured with additional metadata, like
+a vocabulary file or sprite images. For more details, see [the embedding
+projector tutorial](https://www.tensorflow.org/get_started/embedding_viz).
+
+### Text Dashboard
+
+The Text Dashboard displays text snippets saved via `tf.summary.text`. Markdown
+features including hyperlinks, lists, and tables are all supported.
+
+# Frequently Asked Questions
+
+### My TensorBoard isn't showing any data! What's wrong?
+
+First, check that the directory passed to `--logdir` is correct. You can also
+verify this by navigating to the Scalars dashboard (under the "Inactive" menu)
+and looking for the log directory path at the bottom of the left sidebar.
+
+If you're loading from the proper path, make sure that event files are present.
+TensorBoard will recursively walk its logdir, it's fine if the data is nested
+under a subdirectory. Ensure the following shows at least one result:
+
+`find DIRECTORY_PATH | grep tfevents`
+
+You can also check that the event files actually have data by running
+tensorboard in inspect mode to inspect the contents of your event files.
+
+`tensorboard --inspect --logdir DIRECTORY_PATH`
+
+### TensorBoard is showing only some of my data, or isn't properly updating!
+
+This issue usually comes about because of how TensorBoard iterates through the
+`tfevents` files: it progresses through the events file in timestamp order, and
+only reads one file at a time. Let's suppose we have files with timestamps `a`
+and `b`, where `a<b`. Once TensorBoard has read all the events in `a`, it will
+never return to it, because it assumes any new events are being written in the
+more recent file. This could cause an issue if, for example, you have two
+`FileWriters` simultaneously writing to the same directory. If you have
+multiple summary writers, each one should be writing to a separate directory.
+
+### Does TensorBoard support multiple or distributed summary writers?
+
+No. TensorBoard expects that only one events file will be written to at a time,
+and multiple summary writers means multiple events files. If you are running a
+distributed TensorFlow instance, we encourage you to designate a single worker
+as the "chief" that is responsible for all summary processing. See
+[supervisor.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/training/supervisor.py)
+for an example.
+
+### I'm seeing data overlapped on itself! What gives?
+
+If you are seeing data that seems to travel backwards through time and overlap
+with itself, there are a few possible explanations.
+
+* You may have multiple execution of TensorFlow that all wrote to the same log
+directory. Please have each TensorFlow run write to its own logdir.
+
+* You may have a bug in your code where the global_step variable (passed
+to `FileWriter.add_summary`) is being maintained incorrectly.
+
+* It may be that your TensorFlow job crashed, and was restarted from an earlier
+checkpoint. See *How to handle TensorFlow restarts*, below.
+
+As a workaround, try changing the x-axis display in TensorBoard from `steps` to
+`wall_time`. This will frequently clear up the issue.
+
+### How should I handle TensorFlow restarts?
+
+TensorFlow is designed with a mechanism for graceful recovery if a job crashes
+or is killed: TensorFlow can periodically write model checkpoint files, which
+enable you to restart TensorFlow without losing all your training progress.
+
+However, this can complicate things for TensorBoard; imagine that TensorFlow
+wrote a checkpoint at step `a`, and then continued running until step `b`, and
+then crashed and restarted at timestamp `a`. All of the events written between
+`a` and `b` were "orphaned" by the restart event and should be removed.
+
+To facilitate this, we have a `SessionLog` message in
+`tensorflow/core/util/event.proto` which can record `SessionStatus.START` as an
+event; like all events, it may have a `step` associated with it. If TensorBoard
+detects a `SessionStatus.START` event with step `a`, it will assume that every
+event with a step greater than `a` was orphaned, and it will discard those
+events. This behavior may be disabled with the flag
+`--purge_orphaned_data false` (in versions after 0.7).
+
+### How can I export data from TensorBoard?
+
+The Scalar Dashboard supports exporting data; you can click the "enable
+download links" option in the left-hand bar. Then, each plot will provide
+download links for the data it contains.
+
+If you need access to the full dataset, you can read the event files that
+TensorBoard consumes by using the [`summary_iterator`](
+https://www.tensorflow.org/api_docs/python/tf/train/summary_iterator)
+method.
+
+### Can I customize which lines appear in a plot?
+
+Using the [custom scalars plugin](tensorboard/plugins/custom_scalar), you can
+create scalar plots with lines for custom run-tag pairs. However, within the
+original scalars dashboard, each scalar plot corresponds to data for a specific
+tag and contains lines for each run that includes that tag.
+
+### Can I visualize margins above and below lines?
+
+Margin plots (that visualize lower and upper bounds) may be created with the
+[custom scalars plugin](tensorboard/plugins/custom_scalar). The original
+scalars plugin does not support visualizing margins.
+
+### Can I create scatterplots (or other custom plots)?
+
+This isn't yet possible. As a workaround, you could create your custom plot in
+your own code (e.g. matplotlib) and then write it into an `SummaryProto`
+(`core/framework/summary.proto`) and add it to your `FileWriter`. Then, your
+custom plot will appear in the TensorBoard image tab.
+
+### Is my data being downsampled? Am I really seeing all the data?
+
+TensorBoard uses [reservoir
+sampling](https://en.wikipedia.org/wiki/Reservoir_sampling) to downsample your
+data so that it can be loaded into RAM. You can modify the number of elements it
+will keep per tag in
+[tensorboard/backend/application.py](tensorboard/backend/application.py).
+See this [StackOverflow question](http://stackoverflow.com/questions/43702546/tensorboard-doesnt-show-all-data-points/)
+for some more information.
+
+### I get a network security popup every time I run TensorBoard on a mac!
+
+This is because by default, TensorBoard serves on host `0.0.0.0` which is
+publicly accessible. You can stop the popups by specifying `--host localhost` at
+startup.
+
+### How can I contribute to TensorBoard development?
+
+See [DEVELOPMENT.md](DEVELOPMENT.md).
+
+### I have a different issue that wasn't addressed here!
+
+First, try searching our [GitHub
+issues](https://github.com/tensorflow/tensorboard/issues) and [Stack
+Overflow][stack-overflow]. It may be
+that someone else has already had the same issue or question.
+
+General usage questions (or problems that may be specific to your local setup)
+should go to [Stack Overflow][stack-overflow].
+
+If you have found a bug in TensorBoard, please [file a GitHub issue](
+https://github.com/tensorflow/tensorboard/issues/new) with as much supporting
+information as you can provide (e.g. attaching events files, including the output
+of `tensorboard --inspect`, etc.).
+
+[stack-overflow]: https://stackoverflow.com/questions/tagged/tensorboard

--- a/docs/summaries.md
+++ b/docs/summaries.md
@@ -1,0 +1,222 @@
+# TensorBoard: Visualizing Learning
+
+The computations you'll use TensorFlow for - like training a massive
+deep neural network - can be complex and confusing. To make it easier to
+understand, debug, and optimize TensorFlow programs, we've included a suite of
+visualization tools called TensorBoard. You can use TensorBoard to visualize
+your TensorFlow graph, plot quantitative metrics about the execution of your
+graph, and show additional data like images that pass through it. When
+TensorBoard is fully configured, it looks like this:
+
+![MNIST TensorBoard](https://www.tensorflow.org/images/mnist_tensorboard.png "MNIST TensorBoard")
+
+<div class="video-wrapper">
+  <iframe class="devsite-embedded-youtube-video" data-video-id="eBbEDRsCmv4"
+          data-autohide="1" data-showinfo="0" frameborder="0" allowfullscreen>
+  </iframe>
+</div>
+
+This 30-minute tutorial is intended to get you started with simple TensorBoard
+usage. It assumes a basic understanding of TensorFlow.
+
+There are other resources available as well! The [TensorBoard GitHub](https://github.com/tensorflow/tensorboard)
+has a lot more information on using individual dashboards within TensorBoard
+including tips & tricks and debugging information.
+
+## Setup
+
+[Install TensorFlow](../install/). Installing TensorFlow
+via pip should also automatically install TensorBoard.
+
+## Serializing the data
+
+TensorBoard operates by reading TensorFlow events files, which contain summary
+data that you can generate when running TensorFlow. Here's the general
+lifecycle for summary data within TensorBoard.
+
+First, create the TensorFlow graph that you'd like to collect summary
+data from, and decide which nodes you would like to annotate with the
+`tf.summary` operations.
+
+For example, suppose you are training a convolutional neural network for
+recognizing MNIST digits. You'd like to record how the learning rate
+varies over time, and how the objective function is changing. Collect these by
+attaching `tf.summary.scalar` ops
+to the nodes that output the learning rate and loss respectively. Then, give
+each `scalar_summary` a meaningful `tag`, like `'learning rate'` or `'loss
+function'`.
+
+Perhaps you'd also like to visualize the distributions of activations coming
+off a particular layer, or the distribution of gradients or weights. Collect
+this data by attaching
+`tf.summary.histogram` ops to
+the gradient outputs and to the variable that holds your weights, respectively.
+
+Operations in TensorFlow don't do anything until you run them, or an op that
+depends on their output. And the summary nodes that we've just created are
+peripheral to your graph: none of the ops you are currently running depend on
+them. So, to generate summaries, we need to run all of these summary nodes.
+Managing them by hand would be tedious, so use
+`tf.summary.merge_all`
+to combine them into a single op that generates all the summary data.
+
+Then, you can just run the merged summary op, which will generate a serialized
+`Summary` protobuf object with all of your summary data at a given step.
+Finally, to write this summary data to disk, pass the summary protobuf to a
+`tf.summary.FileWriter`.
+
+The `FileWriter` takes a logdir in its constructor - this logdir is quite
+important, it's the directory where all of the events will be written out.
+Also, the `FileWriter` can optionally take a `Graph` in its constructor.
+If it receives a `Graph` object, then TensorBoard will visualize your graph
+along with tensor shape information. This will give you a much better sense of
+what flows through the graph: see
+[Tensor shape information](../guide/graph_viz.md#tensor-shape-information).
+
+Now that you've modified your graph and have a `FileWriter`, you're ready to
+start running your network! If you want, you could run the merged summary op
+every single step, and record a ton of training data. That's likely to be more
+data than you need, though. Instead, consider running the merged summary op
+every `n` steps.
+
+The code example below is a modification of the
+[simple MNIST tutorial](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/tutorials/mnist/mnist.py),
+in which we have added some summary ops, and run them every ten steps. If you
+run this and then launch `tensorboard --logdir=/tmp/tensorflow/mnist`, you'll be able
+to visualize statistics, such as how the weights or accuracy varied during
+training. The code below is an excerpt; full source is
+[here](https://www.tensorflow.org/code/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py).
+
+```python
+def variable_summaries(var):
+  """Attach a lot of summaries to a Tensor (for TensorBoard visualization)."""
+  with tf.name_scope('summaries'):
+    mean = tf.reduce_mean(var)
+    tf.summary.scalar('mean', mean)
+    with tf.name_scope('stddev'):
+      stddev = tf.sqrt(tf.reduce_mean(tf.square(var - mean)))
+    tf.summary.scalar('stddev', stddev)
+    tf.summary.scalar('max', tf.reduce_max(var))
+    tf.summary.scalar('min', tf.reduce_min(var))
+    tf.summary.histogram('histogram', var)
+
+def nn_layer(input_tensor, input_dim, output_dim, layer_name, act=tf.nn.relu):
+  """Reusable code for making a simple neural net layer.
+
+  It does a matrix multiply, bias add, and then uses relu to nonlinearize.
+  It also sets up name scoping so that the resultant graph is easy to read,
+  and adds a number of summary ops.
+  """
+  # Adding a name scope ensures logical grouping of the layers in the graph.
+  with tf.name_scope(layer_name):
+    # This Variable will hold the state of the weights for the layer
+    with tf.name_scope('weights'):
+      weights = weight_variable([input_dim, output_dim])
+      variable_summaries(weights)
+    with tf.name_scope('biases'):
+      biases = bias_variable([output_dim])
+      variable_summaries(biases)
+    with tf.name_scope('Wx_plus_b'):
+      preactivate = tf.matmul(input_tensor, weights) + biases
+      tf.summary.histogram('pre_activations', preactivate)
+    activations = act(preactivate, name='activation')
+    tf.summary.histogram('activations', activations)
+    return activations
+
+hidden1 = nn_layer(x, 784, 500, 'layer1')
+
+with tf.name_scope('dropout'):
+  keep_prob = tf.placeholder(tf.float32)
+  tf.summary.scalar('dropout_keep_probability', keep_prob)
+  dropped = tf.nn.dropout(hidden1, keep_prob)
+
+# Do not apply softmax activation yet, see below.
+y = nn_layer(dropped, 500, 10, 'layer2', act=tf.identity)
+
+with tf.name_scope('cross_entropy'):
+  # The raw formulation of cross-entropy,
+  #
+  # tf.reduce_mean(-tf.reduce_sum(y_ * tf.log(tf.softmax(y)),
+  #                               reduction_indices=[1]))
+  #
+  # can be numerically unstable.
+  #
+  # So here we use tf.losses.sparse_softmax_cross_entropy on the
+  # raw logit outputs of the nn_layer above.
+  with tf.name_scope('total'):
+    cross_entropy = tf.losses.sparse_softmax_cross_entropy(labels=y_, logits=y)
+tf.summary.scalar('cross_entropy', cross_entropy)
+
+with tf.name_scope('train'):
+  train_step = tf.train.AdamOptimizer(FLAGS.learning_rate).minimize(
+      cross_entropy)
+
+with tf.name_scope('accuracy'):
+  with tf.name_scope('correct_prediction'):
+    correct_prediction = tf.equal(tf.argmax(y, 1), tf.argmax(y_, 1))
+  with tf.name_scope('accuracy'):
+    accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
+tf.summary.scalar('accuracy', accuracy)
+
+# Merge all the summaries and write them out to /tmp/mnist_logs (by default)
+merged = tf.summary.merge_all()
+train_writer = tf.summary.FileWriter(FLAGS.summaries_dir + '/train',
+                                      sess.graph)
+test_writer = tf.summary.FileWriter(FLAGS.summaries_dir + '/test')
+tf.global_variables_initializer().run()
+```
+
+After we've initialized the `FileWriters`, we have to add summaries to the
+`FileWriters` as we train and test the model.
+
+```python
+# Train the model, and also write summaries.
+# Every 10th step, measure test-set accuracy, and write test summaries
+# All other steps, run train_step on training data, & add training summaries
+
+def feed_dict(train):
+  """Make a TensorFlow feed_dict: maps data onto Tensor placeholders."""
+  if train or FLAGS.fake_data:
+    xs, ys = mnist.train.next_batch(100, fake_data=FLAGS.fake_data)
+    k = FLAGS.dropout
+  else:
+    xs, ys = mnist.test.images, mnist.test.labels
+    k = 1.0
+  return {x: xs, y_: ys, keep_prob: k}
+
+for i in range(FLAGS.max_steps):
+  if i % 10 == 0:  # Record summaries and test-set accuracy
+    summary, acc = sess.run([merged, accuracy], feed_dict=feed_dict(False))
+    test_writer.add_summary(summary, i)
+    print('Accuracy at step %s: %s' % (i, acc))
+  else:  # Record train set summaries, and train
+    summary, _ = sess.run([merged, train_step], feed_dict=feed_dict(True))
+    train_writer.add_summary(summary, i)
+```
+
+You're now all set to visualize this data using TensorBoard.
+
+
+## Launching TensorBoard
+
+To run TensorBoard, use the following command (alternatively `python -m
+tensorboard.main`)
+
+```bash
+tensorboard --logdir=path/to/log-directory
+```
+
+where `logdir` points to the directory where the `FileWriter` serialized its
+data.  If this `logdir` directory contains subdirectories which contain
+serialized data from separate runs, then TensorBoard will visualize the data
+from all of those runs. Once TensorBoard is running, navigate your web browser
+to `localhost:6006` to view the TensorBoard.
+
+When looking at TensorBoard, you will see the navigation tabs in the top right
+corner. Each tab represents a set of serialized data that can be visualized.
+
+For in depth information on how to use the *graph* tab to visualize your graph,
+see [TensorBoard: Graph Visualization](../guide/graph_viz.md).
+
+For more usage information on TensorBoard in general, see the
+[TensorBoard GitHub](https://github.com/tensorflow/tensorboard).

--- a/docs/tutorials/tutorial.md
+++ b/docs/tutorials/tutorial.md
@@ -1,0 +1,38 @@
+# TensorBoard tutorial
+
+Before running TensorBoard, make sure you have generated summary data in a log
+directory by creating a summary writer:
+
+``` python
+# sess.graph contains the graph definition; that enables the Graph Visualizer.
+
+file_writer = tf.summary.FileWriter('/path/to/logs', sess.graph)
+```
+
+For more details, see 
+[the TensorBoard tutorial](https://www.tensorflow.org/get_started/summaries_and_tensorboard).
+Once you have event files, run TensorBoard and provide the log directory. If
+you're using a precompiled TensorFlow package (e.g. you installed via pip), run:
+
+```
+tensorboard --logdir path/to/logs
+```
+
+Or, if you are building from source:
+
+```bash
+bazel build tensorboard:tensorboard
+./bazel-bin/tensorboard/tensorboard --logdir path/to/logs
+
+# or even more succinctly
+bazel run tensorboard -- --logdir path/to/logs
+```
+
+This should print that TensorBoard has started. Next, connect to
+http://localhost:6006.
+
+TensorBoard requires a `logdir` to read logs from. For info on configuring
+TensorBoard, run `tensorboard --help`.
+
+TensorBoard can be used in Google Chrome or Firefox. Other browsers might
+work, but there may be bugs or performance issues.


### PR DESCRIPTION
Creates basic structure for a tensorflow.org subsite, see cl/229872850
This moves in the current TensorBoard guides from the main tensorflow/docs repo.

Adding to master branch, let me know if you want it on another branch (and please make it for me).
