### PR TITLE
Split py_binary into py_binary for pr_curve_demo

### DIFF
--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -45,7 +45,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":metadata",
-        ":pr_curve_demo",
+        ":pr_curve_demo_lib",
         ":pr_curves_plugin",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
@@ -94,6 +94,13 @@ tb_proto_library(
 
 py_binary(
     name = "pr_curve_demo",
+    srcs = ["pr_curve_demo.py"],
+    srcs_version = "PY2AND3",
+    deps = [":pr_curve_demo_lib"],
+)
+
+py_library(
+    name = "pr_curve_demo_lib",
     srcs = ["pr_curve_demo.py"],
     srcs_version = "PY2AND3",
     deps = [


### PR DESCRIPTION
Having py_binary in deps is deprecated and will break in 19Q1.
Removed py_binary target in deps of any other target.
