### PR TITLE
core: add `--url_file` flag for scripting purposes

### DIFF
--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -449,6 +449,25 @@ keeps 500 scalars and all images. Most users should not need to set this
 flag.\
 ''')
 
+    parser.add_argument(
+        '--url_file',
+        metavar='FILE',
+        type=str,
+        help='''\
+An optional file to which to write a URL from which TensorBoard should
+be reachable. The URL will include scheme, hostname, and port, and
+possibly path if `--path_prefix` is set. Useful when setting `--port=0`,
+which automatically selects an unused port. Primarily intended for use
+by scripts; for human consumers, this same value is already printed to
+stderr.
+
+If provided, this should point to an existing file (which will be
+truncated) or a nonexistent file within a directory that exists.
+
+If TensorBoard fails to start (e.g., because the specified port is
+already in use), this file will not be written.
+''')
+
   def fix_flags(self, flags):
     """Fixes standard TensorBoard CLI flags to parser."""
     if flags.inspect:

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -207,9 +207,13 @@ class TensorBoard(object):
       return 0
     try:
       server = self._make_server()
+      url = server.get_url()
       sys.stderr.write('TensorBoard %s at %s (Press CTRL+C to quit)\n' %
-                       (version.VERSION, server.get_url()))
+                       (version.VERSION, url))
       sys.stderr.flush()
+      if self.flags.url_file is not None:
+        with open(self.flags.url_file, "w") as outfile:
+          outfile.write("%s\n" % server.get_url())
       server.serve_forever()
       return 0
     except TensorBoardServerException as e:


### PR DESCRIPTION
Summary:
When TensorBoard launches its server, it prints a message to stderr
listing the URL on which it serves. This is convenient for humans, but
not for scripts: scripts would have to capture stderr and parse out the
appropriate line. As of this commit, TensorBoard will also write this
URL unadorned to a file given by `--url_file`.

Test Plan:
After building with `bazel build //tensorboard`, invoking TensorBoard
from `./bazel-bin/tensorboard/tensorboard` with `--help` prints the new
argument with its help text (though the nice newlines are removed,
sadly).

Launching with `--logdir x --url_file y --port 0` writes a URL to `./y`
and concurrently launches the server; `curl "$(cat y)"` works.

Running `bazel run //tensorboard -- --logdir x --url_file y` does _not_
output to the right file, because `bazel` invokes `tensorboard` under a
different directory. But using `--url_file /tmp/y` still works even
under `bazel run`.

wchargin-branch: url-file
