### PR TITLE
nit: fix typo in interactive_inference README

### DIFF
--- a/tensorboard/plugins/interactive_inference/README.md
+++ b/tensorboard/plugins/interactive_inference/README.md
@@ -58,7 +58,7 @@ that takes TensorFlow Example or SequenceExample protos
 (data points) as inputs directly in a jupyter or colab notebook.
 
 If you want to train an ML model from a dataset and explore the dataset and
-model, check out the the [What_If_Tool_Notebook_Usage.ipynb notebook](https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/tensorboard/plugins/interactive_inference/What_If_Tool_Notebook_Usage.ipynb) in colab, which starts from a CSV file,
+model, check out the [What_If_Tool_Notebook_Usage.ipynb notebook](https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/tensorboard/plugins/interactive_inference/What_If_Tool_Notebook_Usage.ipynb) in colab, which starts from a CSV file,
 converts the data to tf.Example protos, trains a classifier, and then uses the
 What-If Tool to show the classifier performance on the data.
 


### PR DESCRIPTION
Summary:
Word on the street is that this is a common typo.

Test Plan:
None.
