### PR TITLE
Make tensorboard.compat.{tf,tf2} lazily loaded

### DIFF
--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -19,14 +19,16 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import importlib as _importlib
+
 from tensorboard import lazy
 
-pkg = lambda i: i  # helps google sync process
-mod = lambda i: lazy.LazyLoader(i[i.rindex('.') + 1:], globals(), i)  # noqa: F821
 
-program = mod(pkg('tensorboard.program'))
-summary = mod(pkg('tensorboard.summary'))
+@lazy.lazy_load('tensorboard.program')
+def program():
+  return _importlib.import_module('tensorboard.program')
 
-del lazy
-del mod
-del pkg
+
+@lazy.lazy_load('tensorboard.summary')
+def summary():
+  return _importlib.import_module('tensorboard.summary')

--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -19,16 +19,16 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import importlib as _importlib
-
 from tensorboard import lazy
 
 
 @lazy.lazy_load('tensorboard.program')
 def program():
-  return _importlib.import_module('tensorboard.program')
+  import tensorboard.program as module  # pylint: disable=g-import-not-at-top
+  return module
 
 
 @lazy.lazy_load('tensorboard.summary')
 def summary():
-  return _importlib.import_module('tensorboard.summary')
+  import tensorboard.summary as module  # pylint: disable=g-import-not-at-top
+  return module

--- a/tensorboard/compat/BUILD
+++ b/tensorboard/compat/BUILD
@@ -23,6 +23,9 @@ py_library(
     srcs = ["__init__.py"],
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
+    deps = [
+        "//tensorboard:lazy",
+    ],
 )
 
 # This rule ensures that `from tensorboard.compat import tf` will provide a

--- a/tensorboard/compat/tensorflow_stub/__init__.py
+++ b/tensorboard/compat/tensorflow_stub/__init__.py
@@ -34,3 +34,6 @@ from . import flags  # noqa
 from . import gfile  # noqa
 from . import pywrap_tensorflow  # noqa
 from . import tensor_shape  # noqa
+
+# Set a fake __version__ to help distinguish this as our own stub API.
+__version__ = 'stub'

--- a/tensorboard/lazy.py
+++ b/tensorboard/lazy.py
@@ -19,36 +19,55 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import importlib
+import functools
 import types
 
 
 class LazyLoader(types.ModuleType):
-  """Lazily import a module, mainly to avoid pulling in large dependencies."""
+  """Lazily import a module.
+
+  This can be used to defer importing troublesome dependencies - e.g. ones that
+  are large and infrequently used, or that cause a dependency cycle -
+  until they are actually used.
+  """
 
   # The lint error here is incorrect.
-  def __init__(self, local_name, parent_module_globals, name):  # pylint: disable=super-on-old-class
-    self._local_name = local_name
-    self._parent_module_globals = parent_module_globals
+  def __init__(self, name, load_fn):  # pylint: disable=super-on-old-class
+    """Create a LazyLoader for a module.
 
+    Args:
+      name: the fully-qualified name of the module
+      load_fn: callable that actually does the import and returns the module
+    """
     super(LazyLoader, self).__init__(name)
+    self._load_fn = load_fn
+    self._cached_module = None
 
   def _load(self):
-    # Import the target module and insert it into the parent's namespace
-    module = importlib.import_module(self.__name__)
-    self._parent_module_globals[self._local_name] = module
-
-    # Update this object's dict so that if someone keeps a reference to the
-    #   LazyLoader, lookups are efficient (__getattr__ is only called on lookups
-    #   that fail).
-    self.__dict__.update(module.__dict__)
-
-    return module
+    self._cached_module = self._load_fn()
+    # Update this object's dict to make future lookups efficient (__getattr__ is
+    # only called on lookups that fail).
+    self.__dict__.update(self._cached_module.__dict__)
 
   def __getattr__(self, item):
-    module = self._load()
-    return getattr(module, item)
+    if not self._cached_module:
+      self._load()
+    return getattr(self._cached_module, item)
 
   def __dir__(self):
-    module = self._load()
-    return dir(module)
+    if not self._cached_module:
+      self._load()
+    return dir(self._cached_module)
+
+
+def lazy_load(name):
+  """Decorator to define a function that lazily loads the module 'name'.
+
+  Args:
+    name: the fully-qualified name of the module; typically the last segment
+      of 'name' matches the name of the decorated function
+
+  Returns:
+    Decorator function for lazily loading the module 'name'.
+  """
+  return functools.partial(LazyLoader, name)

--- a/tensorboard/lazy.py
+++ b/tensorboard/lazy.py
@@ -48,6 +48,7 @@ def lazy_load(name):
       self.__dict__.update(module.__dict__)
       load_once.loaded = True
       return module
+    load_once.loaded = False
 
     # Define a module that proxies getattr() and dir() to the result of calling
     # load_once() the first time it's needed. The class is nested so we can close
@@ -60,7 +61,7 @@ def lazy_load(name):
         return dir(load_once(self))
 
       def __repr__(self):
-        if hasattr(load_once, 'loaded'):
+        if load_once.loaded:
           return repr(load_once(self))
         return '<module \'%s\' (LazyModule)>' % self.__name__
 
@@ -72,7 +73,7 @@ def _memoize(f):
   """Memoizing decorator for f, which must have exactly 1 hashable argument."""
   nothing = object()  # Unique "no value" sentinel object.
   cache = {}
-  # Use a reentrank lock so that if f references the resulting wrapper we die
+  # Use a reentrant lock so that if f references the resulting wrapper we die
   # with recursion depth exceeded instead of deadlocking.
   lock = threading.RLock()
   @functools.wraps(f)

--- a/tensorboard/plugins/audio/summary_test.py
+++ b/tensorboard/plugins/audio/summary_test.py
@@ -29,16 +29,16 @@ import tensorflow as tf
 # TODO(nickfelt): get encode_wav() exported in the public API.
 from tensorflow.python.ops import gen_audio_ops
 
+from tensorboard.compat import tf2
 from tensorboard.plugins.audio import metadata
 from tensorboard.plugins.audio import summary
 from tensorboard.util import tensor_util
 
 
 try:
-  from tensorboard import compat
-  tf_v2 = compat.import_tf_v2()
+  tf2.__version__  # Force lazy import to resolve
 except ImportError:
-  tf_v2 = None
+  tf2 = None
 
 try:
   tf.compat.v1.enable_eager_execution()
@@ -198,12 +198,12 @@ class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
 class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
   def setUp(self):
     super(SummaryV2OpTest, self).setUp()
-    if tf_v2 is None:
+    if tf2 is None:
       self.skipTest('TF v2 summary API not available')
 
   def audio(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
-    writer = tf_v2.summary.create_file_writer(self.get_temp_dir())
+    writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       summary.audio(*args, **kwargs)
     writer.close()

--- a/tensorboard/plugins/audio/summary_v2.py
+++ b/tensorboard/plugins/audio/summary_v2.py
@@ -27,6 +27,7 @@ from __future__ import print_function
 
 import functools
 
+from tensorboard.compat import tf2 as tf
 from tensorboard.plugins.audio import metadata
 
 
@@ -64,9 +65,6 @@ def audio(name,
     True on success, or false if no summary was emitted because no default
     summary writer was available.
   """
-  # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
-  from tensorboard import compat
-  tf = compat.import_tf_v2()
   # TODO(nickfelt): get encode_wav() exported in the public API.
   from tensorflow.python.ops import gen_audio_ops
 

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -25,16 +25,16 @@ import os
 import numpy as np
 import tensorflow as tf
 
+from tensorboard.compat import tf2
 from tensorboard.plugins.histogram import metadata
 from tensorboard.plugins.histogram import summary
 from tensorboard.util import tensor_util
 
 
 try:
-  from tensorboard import compat
-  tf_v2 = compat.import_tf_v2()
+  tf2.__version__  # Force lazy import to resolve
 except ImportError:
-  tf_v2 = None
+  tf2 = None
 
 try:
   tf.compat.v1.enable_eager_execution()
@@ -160,12 +160,12 @@ class SummaryV2PbTest(SummaryBaseTest, tf.test.TestCase):
 class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
   def setUp(self):
     super(SummaryV2OpTest, self).setUp()
-    if tf_v2 is None:
+    if tf2 is None:
       self.skipTest('v2 summary API not available')
 
   def histogram(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
-    writer = tf_v2.summary.create_file_writer(self.get_temp_dir())
+    writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       summary.histogram(*args, **kwargs)
     writer.close()
@@ -194,12 +194,12 @@ class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
     # Hack to extract current scope since there's no direct API for it.
     with tf.name_scope('_') as temp_scope:
       scope = temp_scope.rstrip('/_')
-    @tf_v2.function
+    @tf2.function
     def graph_fn():
       # Recreate the active scope inside the defun since it won't propagate.
       with tf.name_scope(scope):
         summary.histogram(*args, **kwargs)
-    writer = tf_v2.summary.create_file_writer(self.get_temp_dir())
+    writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       graph_fn()
     writer.close()

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -31,6 +31,7 @@ from __future__ import print_function
 
 import numpy as np
 
+from tensorboard.compat import tf2 as tf
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.histogram import metadata
 from tensorboard.util import tensor_util
@@ -59,9 +60,6 @@ def histogram(name, data, step, buckets=None, description=None):
     True on success, or false if no summary was emitted because no default
     summary writer was available.
   """
-  # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
-  from tensorboard import compat
-  tf = compat.import_tf_v2()
   summary_metadata = metadata.create_summary_metadata(
       display_name=None, description=description)
   with tf.summary.summary_scope(
@@ -82,9 +80,6 @@ def _buckets(data, bucket_count=None):
     a triple `[left_edge, right_edge, count]` for a single bucket.
     The value of `k` is either `bucket_count` or `1` or `0`.
   """
-  # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
-  from tensorboard import compat
-  tf = compat.import_tf_v2()
   if bucket_count is None:
     bucket_count = DEFAULT_BUCKET_COUNT
   with tf.name_scope('buckets', values=[data, bucket_count]):
@@ -152,8 +147,6 @@ def histogram_pb(tag, data, buckets=None, description=None):
   Returns:
     A `summary_pb2.Summary` protobuf object.
   """
-  # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
-  from tensorboard.compat import tf
   bucket_count = DEFAULT_BUCKET_COUNT if buckets is None else buckets
   data = np.array(data).flatten().astype(float)
   if data.size == 0:
@@ -179,7 +172,7 @@ def histogram_pb(tag, data, buckets=None, description=None):
       left_edges = edges[:-1]
       right_edges = edges[1:]
       buckets = np.array([left_edges, right_edges, bucket_counts]).transpose()
-  tensor = tensor_util.make_tensor_proto(buckets, dtype=tf.float64)
+  tensor = tensor_util.make_tensor_proto(buckets, dtype=np.float64)
 
   summary_metadata = metadata.create_summary_metadata(
       display_name=None, description=description)

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -26,14 +26,14 @@ import numpy as np
 import six
 import tensorflow as tf
 
+from tensorboard.compat import tf2
 from tensorboard.plugins.image import metadata
 from tensorboard.plugins.image import summary
 
 try:
-  from tensorboard import compat
-  tf_v2 = compat.import_tf_v2()
+  tf2.__version__  # Force lazy import to resolve
 except ImportError:
-  tf_v2 = None
+  tf2 = None
 
 try:
   tf.compat.v1.enable_eager_execution()
@@ -181,12 +181,12 @@ class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
 class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
   def setUp(self):
     super(SummaryV2OpTest, self).setUp()
-    if tf_v2 is None:
+    if tf2 is None:
       self.skipTest('TF v2 summary API not available')
 
   def image(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
-    writer = tf_v2.summary.create_file_writer(self.get_temp_dir())
+    writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       summary.image(*args, **kwargs)
     writer.close()

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -22,9 +22,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorboard.compat.proto import summary_pb2
+from tensorboard.compat import tf2 as tf
 from tensorboard.plugins.image import metadata
-from tensorboard.util import tensor_util
 
 
 def image(name,
@@ -55,9 +54,6 @@ def image(name,
     True on success, or false if no summary was emitted because no default
     summary writer was available.
   """
-  # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
-  from tensorboard import compat
-  tf = compat.import_tf_v2()
   summary_metadata = metadata.create_summary_metadata(
       display_name=None, description=description)
   with tf.summary.summary_scope(

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -32,7 +32,6 @@ from google.protobuf import text_format
 
 from tensorboard.backend.http_util import Respond
 from tensorboard.compat import tf
-from tensorboard.compat import USING_TF
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.projector.projector_config_pb2 import ProjectorConfig
 from tensorboard.util import tb_logging
@@ -213,6 +212,11 @@ def _rel_to_abs_asset_path(fpath, config_fpath):
   if not os.path.isabs(fpath):
     return os.path.join(os.path.dirname(config_fpath), fpath)
   return fpath
+
+
+def _using_tf():
+  """Return true if we're not using the fake TF API stub implementation."""
+  return tf.__version__ != 'stub'
 
 
 class ProjectorPlugin(base_plugin.TBPlugin):
@@ -402,7 +406,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
           config.model_checkpoint_path = ckpt_path
 
       # Sanity check for the checkpoint file.
-      if (config.model_checkpoint_path and USING_TF and
+      if (config.model_checkpoint_path and _using_tf() and
           not tf.compat.v1.train.checkpoint_exists(config.model_checkpoint_path)):
         logger.warn('Checkpoint file "%s" not found',
                            config.model_checkpoint_path)
@@ -417,7 +421,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
 
     config = self._configs[run]
     reader = None
-    if config.model_checkpoint_path and USING_TF:
+    if config.model_checkpoint_path and _using_tf():
       try:
         reader = tf.compat.v1.pywrap_tensorflow.NewCheckpointReader(
             config.model_checkpoint_path)
@@ -650,7 +654,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
 
 
 def _find_latest_checkpoint(dir_path):
-  if not USING_TF:
+  if not _using_tf():
     return None
   try:
     ckpt_path = tf.train.latest_checkpoint(dir_path)

--- a/tensorboard/plugins/scalar/summary_test.py
+++ b/tensorboard/plugins/scalar/summary_test.py
@@ -27,15 +27,15 @@ import numpy as np
 import six
 import tensorflow as tf
 
-from tensorboard import compat
+from tensorboard.compat import tf2
 from tensorboard.plugins.scalar import metadata
 from tensorboard.plugins.scalar import summary
 from tensorboard.util import tensor_util
 
 try:
-  tf_v2 = compat.import_tf_v2()
+  tf2.__version__  # Force lazy import to resolve
 except ImportError:
-  tf_v2 = None
+  tf2 = None
 
 try:
   tf.compat.v1.enable_eager_execution()
@@ -138,12 +138,12 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
 
   def setUp(self):
     super(SummaryV2OpTest, self).setUp()
-    if tf_v2 is None:
+    if tf2 is None:
       self.skipTest('v2 summary API not available')
 
   def scalar(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
-    writer = tf_v2.summary.create_file_writer(self.get_temp_dir())
+    writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       summary.scalar(*args, **kwargs)
     writer.close()
@@ -172,12 +172,12 @@ class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
     # Hack to extract current scope since there's no direct API for it.
     with tf.name_scope('_') as temp_scope:
       scope = temp_scope.rstrip('/_')
-    @tf_v2.function
+    @tf2.function
     def graph_fn():
       # Recreate the active scope inside the defun since it won't propagate.
       with tf.name_scope(scope):
         summary.scalar(*args, **kwargs)
-    writer = tf_v2.summary.create_file_writer(self.get_temp_dir())
+    writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       graph_fn()
     writer.close()

--- a/tensorboard/plugins/scalar/summary_v2.py
+++ b/tensorboard/plugins/scalar/summary_v2.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 
 import numpy as np
 
+from tensorboard.compat import tf2 as tf
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.scalar import metadata
 from tensorboard.util import tensor_util
@@ -43,9 +44,6 @@ def scalar(name, data, step, description=None):
     True on success, or false if no summary was written because no default
     summary writer was available.
   """
-  # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
-  from tensorboard import compat
-  tf = compat.import_tf_v2()
   summary_metadata = metadata.create_summary_metadata(
       display_name=None, description=description)
   with tf.summary.summary_scope(

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -27,15 +27,15 @@ import numpy as np
 import six
 import tensorflow as tf
 
-from tensorboard import compat
+from tensorboard.compat import tf2
 from tensorboard.plugins.text import metadata
 from tensorboard.plugins.text import summary
 from tensorboard.util import tensor_util
 
 try:
-  tf_v2 = compat.import_tf_v2()
+  tf2.__version__  # Force lazy import to resolve
 except ImportError:
-  tf_v2 = None
+  tf2 = None
 
 try:
   tf.compat.v1.enable_eager_execution()
@@ -155,12 +155,12 @@ class SummaryV2PbTest(SummaryBaseTest, tf.test.TestCase):
 class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
   def setUp(self):
     super(SummaryV2OpTest, self).setUp()
-    if tf_v2 is None:
+    if tf2 is None:
       self.skipTest('TF v2 summary API not available')
 
   def text(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
-    writer = tf_v2.summary.create_file_writer(self.get_temp_dir())
+    writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       summary.text(*args, **kwargs)
     writer.close()
@@ -189,12 +189,12 @@ class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
     # Hack to extract current scope since there's no direct API for it.
     with tf.name_scope('_') as temp_scope:
       scope = temp_scope.rstrip('/_')
-    @tf_v2.function
+    @tf2.function
     def graph_fn():
       # Recreate the active scope inside the defun since it won't propagate.
       with tf.name_scope(scope):
         summary.text(*args, **kwargs)
-    writer = tf_v2.summary.create_file_writer(self.get_temp_dir())
+    writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       graph_fn()
     writer.close()

--- a/tensorboard/plugins/text/summary_v2.py
+++ b/tensorboard/plugins/text/summary_v2.py
@@ -18,6 +18,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import numpy as np
+
+from tensorboard.compat import tf2 as tf
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.text import metadata
 from tensorboard.util import tensor_util
@@ -38,9 +41,6 @@ def text(name, data, step, description=None):
     True on success, or false if no summary was emitted because no default
     summary writer was available.
   """
-  # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
-  from tensorboard import compat
-  tf = compat.import_tf_v2()
   summary_metadata = metadata.create_summary_metadata(
       display_name=None, description=description)
   with tf.summary.summary_scope(
@@ -66,12 +66,10 @@ def text_pb(tag, data, description=None):
   Returns:
     A `tf.Summary` protobuf object.
   """
-  # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
-  from tensorboard.compat import tf
   try:
-    tensor = tensor_util.make_tensor_proto(data, dtype=tf.string)
+    tensor = tensor_util.make_tensor_proto(data, dtype=np.object)
   except TypeError as e:
-    raise TypeError("tensor must be of type string", e)
+    raise TypeError('tensor must be of type string', e)
   summary_metadata = metadata.create_summary_metadata(
       display_name=None, description=description)
   summary = summary_pb2.Summary()

--- a/tensorboard/summary/BUILD
+++ b/tensorboard/summary/BUILD
@@ -62,3 +62,13 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
     ],
 )
+
+py_test(
+    name = "summary_dep_test",
+    size = "small",
+    srcs = ["summary_dep_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":summary_v2",
+    ],
+)

--- a/tensorboard/summary/summary_dep_test.py
+++ b/tensorboard/summary/summary_dep_test.py
@@ -29,8 +29,12 @@ import unittest
 class SummaryV2DepTest(unittest.TestCase):
 
   def test_summary_v2_has_no_immediate_tf_dep(self):
+    # Check that we can import the module (multiple ways) and list and reference
+    # symbols from it without triggering a tensorflow import.
     import tensorboard.summary.v2
     from tensorboard.summary import v2
+    print(dir(tensorboard.summary.v2))
+    print(tensorboard.summary.v2.scalar)
     self.assertEqual('notfound', sys.modules.get('tensorflow', 'notfound'))
 
 

--- a/tensorboard/summary/summary_dep_test.py
+++ b/tensorboard/summary/summary_dep_test.py
@@ -1,0 +1,38 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Dependency tests for the `tensorboard.summary` APIs.
+
+This test is isolated in its own file to avoid depending on TensorFlow (either
+directly or transitively), since we need to test the *absence* of a TF dep.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
+import unittest
+
+
+class SummaryV2DepTest(unittest.TestCase):
+
+  def test_summary_v2_has_no_immediate_tf_dep(self):
+    import tensorboard.summary.v2
+    from tensorboard.summary import v2
+    self.assertEqual('notfound', sys.modules.get('tensorflow', 'notfound'))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
This PR makes `tensorboard.compat.tf` into a lazy-loading module for accessing the TF API (either real or stub), and introduces a similar `tensorboard.compat.tf2` lazy-loading module for accessing the TF 2.0 API (either as `tf` or `tf.compat.v2`). 

The first change (lazifying `tensorboard.compat.tf`) is necessary so that that the `tensorboard.summary.v2` summary API can be imported without immediately importing TensorFlow, since we want TF to be able to import that without triggering a circular dependency.  Previously, the V2 summary API transitively imports various pieces from under `tensorboard.compat`, and that module's `__init__.py` file was opportunistically importing `tensorflow` at module load time to provide `tensorboard.compat.tf`).  Now that import is deferred until `tf` is actually used, and we avoid using it from within the V2 summary APIs.  I've added `summary_dep_test.py` to enforce this so we don't have a regression.

To implement this lazy-loading behavior, I refactored LazyLoader to let you customize the module loading with your own function, and made it usable as a decorator for convenience.  I also refactored the existing LazyLoader uses in `tensorboard/__init__.py` to use this, and replaced `tensorboard.compat.import_tf_v2()` with a lazy loading `tensorboard.compat.tf2`, which in turn eliminates the need to call `import_tf_v2()` on-demand in the various places that use it (necessary because we don't always have a TF 2.0 API available).
