### PR TITLE
Histogram data download

### DIFF
--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -24,9 +24,11 @@ from __future__ import print_function
 
 import collections
 import random
+import csv
 
 import numpy as np
 import six
+from six import StringIO
 from werkzeug import wrappers
 
 from tensorboard import plugin_util
@@ -34,6 +36,7 @@ from tensorboard.backend import http_util
 from tensorboard.compat import tf
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.histogram import metadata
+from tensorboard.plugins.scalar.scalars_plugin import OutputFormat
 from tensorboard.util import tensor_util
 
 
@@ -63,8 +66,8 @@ class HistogramsPlugin(base_plugin.TBPlugin):
 
   def get_plugin_apps(self):
     return {
-        '/histograms': self.histograms_route,
-        '/tags': self.tags_route,
+      '/histograms': self.histograms_route,
+      '/tags': self.tags_route,
     }
 
   def is_active(self):
@@ -103,10 +106,10 @@ class HistogramsPlugin(base_plugin.TBPlugin):
       for row in cursor:
         tag_name, display_name, run_name = row
         result[run_name][tag_name] = {
-            'displayName': display_name,
-            # TODO(chihuahua): Populate the description. Currently, the tags
-            # table does not link with the description table.
-            'description': '',
+          'displayName': display_name,
+          # TODO(chihuahua): Populate the description. Currently, the tags
+          # table does not link with the description table.
+          'description': '',
         }
       return result
 
@@ -120,11 +123,12 @@ class HistogramsPlugin(base_plugin.TBPlugin):
         summary_metadata = self._multiplexer.SummaryMetadata(run, tag)
         result[run][tag] = {'displayName': summary_metadata.display_name,
                             'description': plugin_util.markdown_to_safe_html(
-                                summary_metadata.summary_description)}
+                              summary_metadata.summary_description)}
 
     return result
 
-  def histograms_impl(self, tag, run, downsample_to=None):
+  def histograms_impl(self, tag, run, experiment,
+                      output_format, downsample_to=None):
     """Result of the form `(body, mime_type)`, or `ValueError`.
 
     At most `downsample_to` events will be returned. If this value is
@@ -136,17 +140,17 @@ class HistogramsPlugin(base_plugin.TBPlugin):
       cursor = db.cursor()
       # Prefetch the tag ID matching this run and tag.
       cursor.execute(
-          '''
-          SELECT
-            tag_id
-          FROM Tags
-          JOIN Runs USING (run_id)
-          WHERE
-            Runs.run_name = :run
-            AND Tags.tag_name = :tag
-            AND Tags.plugin_name = :plugin
-          ''',
-          {'run': run, 'tag': tag, 'plugin': metadata.PLUGIN_NAME})
+        '''
+        SELECT
+          tag_id
+        FROM Tags
+        JOIN Runs USING (run_id)
+        WHERE
+          Runs.run_name = :run
+          AND Tags.tag_name = :tag
+          AND Tags.plugin_name = :plugin
+        ''',
+        {'run': run, 'tag': tag, 'plugin': metadata.PLUGIN_NAME})
       row = cursor.fetchone()
       if not row:
         raise ValueError('No histogram tag %r for run %r' % (tag, run))
@@ -160,32 +164,41 @@ class HistogramsPlugin(base_plugin.TBPlugin):
       # can be formally expressed as the following:
       #   [s_min + math.ceil(i / k * (s_max - s_min)) for i in range(0, k + 1)]
       cursor.execute(
-          '''
+        '''
+        SELECT
+          MIN(step) AS step,
+          computed_time,
+          data,
+          dtype,
+          shape
+        FROM Tensors
+        INNER JOIN (
           SELECT
-            MIN(step) AS step,
-            computed_time,
-            data,
-            dtype,
-            shape
+            MIN(step) AS min_step,
+            MAX(step) AS max_step
           FROM Tensors
-          INNER JOIN (
-            SELECT
-              MIN(step) AS min_step,
-              MAX(step) AS max_step
-            FROM Tensors
-            /* Filter out NULL so we can use TensorSeriesStepIndex. */
-            WHERE series = :tag_id AND step IS NOT NULL
-          )
-          /* Ensure we omit reserved rows, which have NULL step values. */
+          /* Filter out NULL so we can use TensorSeriesStepIndex. */
           WHERE series = :tag_id AND step IS NOT NULL
-          /* Bucket rows into sample_size linearly spaced buckets, or do
-             no sampling if sample_size is NULL. */
-          GROUP BY
-            IFNULL(:sample_size - 1, max_step - min_step)
-            * (step - min_step) / (max_step - min_step)
-          ORDER BY step
-          ''',
-          {'tag_id': tag_id, 'sample_size': downsample_to})
+        )
+        JOIN Tags
+          ON Tensors.series = Tags.tag_id
+        JOIN Runs
+          ON Tags.run_id = Runs.run_id
+        /* Ensure we omit reserved rows, which have NULL step values. */
+        WHERE 
+          /* For backwards compatibility, ignore the experiment id
+             for matching purposes if it is empty. */
+          (:exp == '' OR Runs.experiment_id == CAST(:exp AS INT))
+          AND series = :tag_id 
+          AND step IS NOT NULL
+        /* Bucket rows into sample_size linearly spaced buckets, or do
+           no sampling if sample_size is NULL. */
+        GROUP BY
+          IFNULL(:sample_size - 1, max_step - min_step)
+          * (step - min_step) / (max_step - min_step)
+        ORDER BY step
+        ''',
+        {'tag_id': tag_id, 'sample_size': downsample_to})
       events = [(computed_time, step, self._get_values(data, dtype, shape))
                 for step, computed_time, data, dtype, shape in cursor]
     else:
@@ -196,11 +209,30 @@ class HistogramsPlugin(base_plugin.TBPlugin):
         raise ValueError('No histogram tag %r for run %r' % (tag, run))
       if downsample_to is not None and len(tensor_events) > downsample_to:
         rand_indices = random.Random(0).sample(
-            six.moves.xrange(len(tensor_events)), downsample_to)
+          six.moves.xrange(len(tensor_events)), downsample_to)
         indices = sorted(rand_indices)
         tensor_events = [tensor_events[i] for i in indices]
       events = [[e.wall_time, e.step, tensor_util.make_ndarray(e.tensor_proto).tolist()]
                 for e in tensor_events]
+    if output_format == OutputFormat.CSV:
+      csv_events = []
+      # Convert the events in a way that we can sensibly export
+      # them as csv. Therefore, we split the start, end, value of
+      # each bin by semicolon.
+      for e in events:
+        csv_events.append(
+          [e[0], e[1],
+           ';'.join(['{:.32f}'.format(el[0]) for el in e[2]]),
+           ';'.join(['{:.32f}'.format(el[1]) for el in e[2]]),
+           ';'.join(['{}'.format(el[2]) for el in e[2]]),
+           ]
+        )
+      string_io = StringIO()
+      writer = csv.writer(string_io)
+      writer.writerow(['Wall time', 'Step', 'BinStart', 'BinEnd', 'BinValue'])
+      writer.writerows(csv_events)
+      return (string_io.getvalue(), 'text/csv')
+
     return (events, 'application/json')
 
   def _get_values(self, data_blob, dtype_enum, shape_string):
@@ -225,9 +257,12 @@ class HistogramsPlugin(base_plugin.TBPlugin):
     """Given a tag and single run, return array of histogram values."""
     tag = request.args.get('tag')
     run = request.args.get('run')
+    experiment = request.args.get('experiment')
+    output_format = request.args.get('format')
     try:
       (body, mime_type) = self.histograms_impl(
-          tag, run, downsample_to=self.SAMPLE_SIZE)
+        tag, run, experiment, output_format,
+        downsample_to=self.SAMPLE_SIZE)
       code = 200
     except ValueError as e:
       (body, mime_type) = (str(e), 'text/plain')

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -42,6 +42,14 @@ limitations under the License.
     <tf-dashboard-layout>
       <div class="sidebar">
         <div class="sidebar-section">
+          <div class="line-item">
+            <paper-checkbox
+              id="show-download-links"
+              checked="{{_showDownloadLinks}}"
+            >Show data download links</paper-checkbox>
+          </div>
+        </div>
+        <div class="sidebar-section">
           <tf-option-selector
             id="histogramModeSelector"
             name="Histogram mode"
@@ -107,6 +115,7 @@ limitations under the License.
                     tag="[[item.tag]]"
                     tag-metadata="[[_tagMetadata(_runToTagInfo, item.run, item.tag)]]"
                     time-property="[[_timeProperty]]"
+                    show-download-links="[[_showDownloadLinks]]"
                     histogram-mode="[[_histogramMode]]"
                     request-manager="[[_requestManager]]"
                   ></tf-histogram-loader>
@@ -140,6 +149,13 @@ limitations under the License.
         _timeProperty: {
           type: String,
           value: "step",
+        },
+        _showDownloadLinks: {
+          type: Boolean,
+          notify: true,
+          value: tf_storage.getBooleanInitializer('_showDownloadLinks',
+              {defaultValue: false, useLocalStorage: true}),
+          observer: '_showDownloadLinksObserver',
         },
 
         _selectedRuns: Array,
@@ -178,6 +194,9 @@ limitations under the License.
       listeners: {
         'content-visibility-changed': '_redrawCategoryPane',
       },
+
+      _showDownloadLinksObserver: tf_storage.getBooleanObserver(
+          '_showDownloadLinks', {defaultValue: false, useLocalStorage: true}),
 
       _redrawCategoryPane(event, val) {
         if (!val) return;

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
@@ -32,35 +32,35 @@ limitations under the License.
 <dom-module id="tf-histogram-loader">
   <template>
     <tf-card-heading
-            tag="[[tag]]"
-            run="[[run]]"
-            display-name="[[tagMetadata.displayName]]"
-            description="[[tagMetadata.description]]"
-            color="[[_runColor]]"
+      tag="[[tag]]"
+      run="[[run]]"
+      display-name="[[tagMetadata.displayName]]"
+      description="[[tagMetadata.description]]"
+      color="[[_runColor]]"
     ></tf-card-heading>
     <!--
       The main histogram that we render. Data is set directly with
       `setSeriesData`, not with a bound property.
     -->
     <vz-histogram-timeseries
-            id="chart"
-            time-property="[[timeProperty]]"
-            mode="[[histogramMode]]"
-            color-scale="[[_colorScaleFunction]]"
+      id="chart"
+      time-property="[[timeProperty]]"
+      mode="[[histogramMode]]"
+      color-scale="[[_colorScaleFunction]]"
     ></vz-histogram-timeseries>
     <div style="display: flex; flex-direction: row;">
       <paper-icon-button
-              selected$="[[_expanded]]"
-              icon="fullscreen"
-              on-tap="_toggleExpanded"
+        selected$="[[_expanded]]"
+        icon="fullscreen"
+        on-tap="_toggleExpanded"
       ></paper-icon-button>
     </div>
     <template is="dom-if" if="[[showDownloadLinks]]">
-      <div class="download-links">
+      <div class="download-links" style="display: flex; flex-direction: row;">
         <paper-dropdown-menu
-                no-label-float="true"
-                label="run to download"
-                selected-item-label="{{_runToDownload}}"
+          no-label-float="true"
+          label="run to download"
+          selected-item-label="{{_runToDownload}}"
         >
           <paper-menu class="dropdown-content" slot="dropdown-content">
             <template is="dom-repeat" items="[[dataToLoad]]">
@@ -69,11 +69,11 @@ limitations under the License.
           </paper-menu>
         </paper-dropdown-menu>
         <a
-                download="run_[[_runToDownload]]-tag-[[tag]].csv"
-                href="[[_csvUrl(tag, _runToDownload)]]"
+          download="run_[[_runToDownload]]-tag-[[tag]].csv"
+          href="[[_csvUrl(tag, _runToDownload)]]"
         >CSV</a> <a
-              download="run_[[_runToDownload]]-tag-[[tag]].json"
-              href="[[_jsonUrl(tag, _runToDownload)]]"
+        download="run_[[_runToDownload]]-tag-[[tag]].json"
+        href="[[_jsonUrl(tag, _runToDownload)]]"
       >JSON</a>
       </div>
     </template>

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-loader.html
@@ -32,29 +32,51 @@ limitations under the License.
 <dom-module id="tf-histogram-loader">
   <template>
     <tf-card-heading
-      tag="[[tag]]"
-      run="[[run]]"
-      display-name="[[tagMetadata.displayName]]"
-      description="[[tagMetadata.description]]"
-      color="[[_runColor]]"
+            tag="[[tag]]"
+            run="[[run]]"
+            display-name="[[tagMetadata.displayName]]"
+            description="[[tagMetadata.description]]"
+            color="[[_runColor]]"
     ></tf-card-heading>
     <!--
       The main histogram that we render. Data is set directly with
       `setSeriesData`, not with a bound property.
     -->
     <vz-histogram-timeseries
-      id="chart"
-      time-property="[[timeProperty]]"
-      mode="[[histogramMode]]"
-      color-scale="[[_colorScaleFunction]]"
+            id="chart"
+            time-property="[[timeProperty]]"
+            mode="[[histogramMode]]"
+            color-scale="[[_colorScaleFunction]]"
     ></vz-histogram-timeseries>
     <div style="display: flex; flex-direction: row;">
       <paper-icon-button
-        selected$="[[_expanded]]"
-        icon="fullscreen"
-        on-tap="_toggleExpanded"
+              selected$="[[_expanded]]"
+              icon="fullscreen"
+              on-tap="_toggleExpanded"
       ></paper-icon-button>
     </div>
+    <template is="dom-if" if="[[showDownloadLinks]]">
+      <div class="download-links">
+        <paper-dropdown-menu
+                no-label-float="true"
+                label="run to download"
+                selected-item-label="{{_runToDownload}}"
+        >
+          <paper-menu class="dropdown-content" slot="dropdown-content">
+            <template is="dom-repeat" items="[[dataToLoad]]">
+              <paper-item no-label-float=true>[[item.run]]</paper-item>
+            </template>
+          </paper-menu>
+        </paper-dropdown-menu>
+        <a
+                download="run_[[_runToDownload]]-tag-[[tag]].csv"
+                href="[[_csvUrl(tag, _runToDownload)]]"
+        >CSV</a> <a
+              download="run_[[_runToDownload]]-tag-[[tag]].json"
+              href="[[_jsonUrl(tag, _runToDownload)]]"
+      >JSON</a>
+      </div>
+    </template>
     <style>
       :host {
         display: flex;
@@ -91,6 +113,38 @@ limitations under the License.
         margin-bottom: 10px;
         width: 90%;
       }
+
+
+
+      .download-links {
+        display: flex;
+        height: 32px;
+      }
+
+      .download-links a {
+        align-self: center;
+        font-size: 10px;
+        margin: 2px;
+      }
+
+      .download-links paper-dropdown-menu {
+        width: 100px;
+        --paper-input-container-label: {
+          font-size: 10px;
+        };
+        --paper-input-container-input: {
+          font-size: 10px;
+        }
+      }
+
+      paper-menu-button {
+        padding: 0;
+      }
+      paper-item a {
+        color: inherit;
+        text-decoration: none;
+        white-space: nowrap;
+      }
     </style>
   </template>
   <script>
@@ -111,11 +165,15 @@ limitations under the License.
         },
         getDataLoadUrl: {
           type: Function,
-          value: () => ({tag, run}) => {
+          value: () => ({tag, run, experiment}) => {
             const router = tf_backend.getRouter();
             return tf_backend.addParams(
-                router.pluginRoute('histograms', '/histograms'),
-                {tag, run});
+              router.pluginRoute('histograms', '/histograms'),
+              {
+                tag,
+                run,
+                experiment: experiment ? experiment.id : '',
+              });
           },
         },
         loadDataCallback: {
@@ -128,6 +186,7 @@ limitations under the License.
             };
           },
         },
+
         /** @type {{description: string, displayName: string}} */
         tagMetadata: Object,
         timeProperty: String,
@@ -154,6 +213,16 @@ limitations under the License.
       ],
 
       behaviors: [tf_dashboard_common.DataLoaderBehavior],
+
+
+      _csvUrl(tag, run) {
+        return tf_backend.addParams(
+          this.getDataLoadUrl({tag, run}),
+          {format: 'csv'});
+      },
+      _jsonUrl(tag, run) {
+        return this.getDataLoadUrl({tag, run});
+      },
 
       _computeDataToLoad(run, tag) {
         return [{run, tag}];

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -192,10 +192,14 @@ class ScalarsPlugin(base_plugin.TBPlugin):
   @wrappers.Request.application
   def scalars_route(self, request):
     """Given a tag and single run, return array of ScalarEvents."""
-    # TODO: return HTTP status code for malformed requests
     tag = request.args.get('tag')
     run = request.args.get('run')
     experiment = request.args.get('experiment')
     output_format = request.args.get('format')
-    (body, mime_type) = self.scalars_impl(tag, run, experiment, output_format)
-    return http_util.Respond(request, body, mime_type)
+    try:
+      (body, mime_type) = self.scalars_impl(tag, run, experiment, output_format)
+      code = 200
+    except ValueError as e:
+      (body, mime_type) = (str(e), 'text/plain')
+      code = 400
+    return http_util.Respond(request, body, mime_type, code=code)


### PR DESCRIPTION
* Motivation for features / changes

This pull requests add the option to download the raw histogram data as described in #1275 

* Technical description of changes

- Add the checkbox "Show data download links" to the histogram page.
- Add the download dialog to the individual histogram cards
- Change the Query for the histograms in order to allow filtering for the individual experiment

* Screenshots of UI changes

The button to trigger the download buttons:

![image](https://user-images.githubusercontent.com/1538444/51828205-65145100-22eb-11e9-8395-7bec0937bc5c.png)

The download selection for the data:
![image](https://user-images.githubusercontent.com/1538444/51828392-c89e7e80-22eb-11e9-9ce0-df1f38a7ae0b.png)

* Detailed steps to verify changes work correctly (as executed by you)

- Open a tensorboard with histogram data
- Go to the histograms page
- Select "Show data download links"
- Select experiment in the histograms card
- Download CSV or JSON

* Alternate designs / implementations considered

- Regarding the CSV Export: So far, all the BinStart, BinEnd, BinValue fields are a consecutive string which in itself is ';' separated. Thus, one has 5 comma separated columns. One could also just comma separate these values, but this could lead to an inconsistent number of columns.
