### PR TITLE
Add standalone mode for the embedding projector

### DIFF
--- a/tensorboard/plugins/projector/README.md
+++ b/tensorboard/plugins/projector/README.md
@@ -1,0 +1,10 @@
+## Development
+
+To develop the Embedding Projector, launch it in standalone mode:
+```sh
+bazel run tensorboard/plugins/projector/vz_projector:devserver
+```
+
+And open `http://localhost:6006/index.html`. The projector uses the local
+`standalone_projector_config.json` to find its datasets and fetch the
+embedding files from Google Cloud Storage.

--- a/tensorboard/plugins/projector/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/BUILD
@@ -1,6 +1,7 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -102,4 +103,29 @@ tf_web_library(
     srcs = ["bh_tsne.ts"],
     path = "/vz-projector",
     deps = [":sptree"],
+)
+
+################# Standalone development #################
+
+tf_web_library(
+    name = "standalone_lib",
+    srcs = [
+      "standalone.html",
+      "standalone_projector_config.json",
+    ],
+    path = "/",
+    deps = [
+        "@org_polymer_iron_icons",
+        "@org_polymer_paper_icon_button",
+        "@org_polymer_paper_tooltip",
+        "@org_polymer_webcomponentsjs",
+        ":vz_projector",
+    ],
+)
+
+tensorboard_html_binary(
+    name = "devserver",
+    input_path = "/standalone.html",
+    output_path = "/index.html",
+    deps = [":standalone_lib"],
 )

--- a/tensorboard/plugins/projector/vz_projector/standalone.html
+++ b/tensorboard/plugins/projector/vz_projector/standalone.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="keywords" content="visualization,embeddings,machine learning,javascript">
+
+  <meta http-equiv="cache-control" content="max-age=0" />
+  <meta http-equiv="cache-control" content="no-cache" />
+  <meta http-equiv="expires" content="0" />
+  <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+  <meta http-equiv="pragma" content="no-cache" />
+  <!-- This script is stripped during vulcanization, available only during development. It provides
+       polyfill for debugging/testing in non-Chrome browsers.
+  -->
+  <script src="webcomponentsjs/webcomponents-lite.min.js"></script>
+  <link rel="import" href="vz-projector/vz-projector-app.html">
+  <link rel="import" href="iron-icons/iron-icons.html">
+  <link rel="import" href="paper-icon-button/paper-icon-button.html">
+  <link rel="import" href="paper-tooltip/paper-tooltip.html">
+
+  <title>Embedding projector - visualization of high-dimensional data</title>
+  <style include="vz-projector-styles"></style>
+  <style>
+    html {
+      width: 100%;
+      height: 100%;
+    }
+
+    body {
+      font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+      margin: 0;
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <vz-projector-app
+      documentation-link="https://www.tensorflow.org/get_started/embedding_viz"
+      bug-report-link="https://github.com/tensorflow/tensorflow/issues"
+      serving-mode="demo"
+      projector-config-json-path="standalone_projector_config.json"
+      page-view-logging>
+  </vz-projector-app>
+</body>
+</html>

--- a/tensorboard/plugins/projector/vz_projector/standalone_projector_config.json
+++ b/tensorboard/plugins/projector/vz_projector/standalone_projector_config.json
@@ -1,0 +1,49 @@
+{
+  "embeddings": [
+    {
+      "tensorName": "Word2Vec 10K",
+      "tensorShape": [
+        10000,
+        200
+      ],
+      "tensorPath": "https://storage.googleapis.com/embedding-projector/data/word2vec_10000_200d_tensors.bytes",
+      "metadataPath": "https://storage.googleapis.com/embedding-projector/data/word2vec_10000_200d_labels.tsv"
+    },
+    {
+      "tensorName": "Word2Vec All",
+      "tensorShape": [
+        71291,
+        200
+      ],
+      "tensorPath": "https://storage.googleapis.com/embedding-projector/data/word2vec_full_200d_tensors.bytes",
+      "metadataPath": "https://storage.googleapis.com/embedding-projector/data/word2vec_full_200d_labels.tsv",
+      "bookmarksPath": "https://storage.googleapis.com/embedding-projector/data/word2vec_full_bookmarks.txt"
+    },
+    {
+      "tensorName": "Mnist with images",
+      "tensorShape": [
+        10000,
+        784
+      ],
+      "tensorPath": "https://storage.googleapis.com/embedding-projector/data/mnist_10k_784d_tensors.bytes",
+      "metadataPath": "https://storage.googleapis.com/embedding-projector/data/mnist_10k_784d_labels.tsv",
+      "sprite": {
+        "imagePath": "https://storage.googleapis.com/embedding-projector/data/mnist_10k_sprite.png",
+        "singleImageDim": [
+          28,
+          28
+        ]
+      }
+    },
+    {
+      "tensorName": "Iris",
+      "tensorShape": [
+        150,
+        4
+      ],
+      "tensorPath": "https://storage.googleapis.com/embedding-projector/data/iris_tensors.bytes",
+      "metadataPath": "https://storage.googleapis.com/embedding-projector/data/iris_labels.tsv"
+    }
+  ],
+  "modelCheckpointPath": "Demo datasets"
+}


### PR DESCRIPTION
Make the development of the Embedding Projector easier by adding a standalone mode with several preset datasets that are hosted on GCS and a short documentation.