### PR TITLE
Created empty target to denote absl.flags dep

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -182,6 +182,14 @@ py_library(
 )
 
 py_library(
+    name = "expect_absl_flags_installed",
+    # This is a dummy rule used as a absl-py dependency in open-source.
+    # We expect absl-py to already be installed on the system, e.g. via
+    # `pip install absl-py`
+    visibility = ["//visibility:public"],
+)
+
+py_library(
     name = "expect_absl_logging_installed",
     # This is a dummy rule used as a absl-py dependency in open-source.
     # We expect absl-py to already be installed on the system, e.g. via

--- a/tensorboard/compat/tensorflow_stub/BUILD
+++ b/tensorboard/compat/tensorflow_stub/BUILD
@@ -17,6 +17,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        "//tensorboard:expect_absl_flags_installed",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "@org_pythonhosted_six",


### PR DESCRIPTION
Internal build requires the dependency declaration for the translation.