### PR TITLE
Update protobuf dep to >=3.6.0 which is what is actually required

### DIFF
--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -29,7 +29,7 @@ REQUIRED_PACKAGES = [
     'grpcio >= 1.6.3',
     'markdown >= 2.6.8',
     'numpy >= 1.12.0',
-    'protobuf >= 3.4.0',
+    'protobuf >= 3.6.0',
     'six >= 1.10.0',
     'werkzeug >= 0.11.15',
     # python3 specifically requires wheel 0.26


### PR DESCRIPTION
Tensorflow requires `protobuf>=3.6.0` which has hidden this issue, but TensorBoard itself now requires 3.6.0+ on its own, because we compile our _pb2.py files using the 3.6.0 protoc, and the outputs are not backwards-compatible with older protobuf runtimes - they fail with an error like the following:

```
Traceback (most recent call last):
  File "/usr/local/google/home/nickfelt/scratch/tb-notf/bin/tensorboard", line 6, in <module>
    from tensorboard.main import run_main
  File "/usr/local/google/home/nickfelt/scratch/tb-notf/local/lib/python2.7/site-packages/tensorboard/main.py", line 45, in <module>
    from tensorboard import default
  File "/usr/local/google/home/nickfelt/scratch/tb-notf/local/lib/python2.7/site-packages/tensorboard/default.py", line 37, in <module>
    from tensorboard.plugins.audio import audio_plugin
  File "/usr/local/google/home/nickfelt/scratch/tb-notf/local/lib/python2.7/site-packages/tensorboard/plugins/audio/audio_plugin.py", line 30, in <module>
    from tensorboard.plugins.audio import metadata
  File "/usr/local/google/home/nickfelt/scratch/tb-notf/local/lib/python2.7/site-packages/tensorboard/plugins/audio/metadata.py", line 22, in <module>
    from tensorboard.plugins.audio import plugin_data_pb2
  File "/usr/local/google/home/nickfelt/scratch/tb-notf/local/lib/python2.7/site-packages/tensorboard/plugins/audio/plugin_data_pb2.py", line 22, in <module>
    serialized_pb=_b('\n+tensorboard/plugins/audio/plugin_data.proto\x12\x0btensorboard\"}\n\x0f\x41udioPluginData\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x37\n\x08\x65ncoding\x18\x02 \x01(\x0e\x32%.tensorboard.AudioPluginData.Encoding\" \n\x08\x45ncoding\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x07\n\x03WAV\x10\x0b\x62\x06proto3')
TypeError: __new__() got an unexpected keyword argument 'serialized_options'
```