### PR TITLE
fix pip build script under mac

### DIFF
--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -82,7 +82,11 @@ dest=/tmp/tensorboard
 if [ ! -e $dest ]; then
   mkdir $dest
 else
-  dest="$(mktemp -d -p /tmp -t tensorboard-pip.XXXXXXXXXX)"
+  if [ "$(uname)" == "Darwin" ]; then
+    dest="$(mktemp -d -t tensorboard-pip)"
+  else
+    dest="$(mktemp -d -p /tmp -t tensorboard-pip.XXXXXXXXXX)"
+  fi
 fi
 cd "${dest}"
 


### PR DESCRIPTION
This bug will be triggered if the predefined dest folder exists.
Because mktemp has different argument definition in mac.


