### PR TITLE
manager: add a `cache_key` function

### DIFF
--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import base64
 import collections
 import datetime
 import json
@@ -65,7 +66,7 @@ _TENSORBOARD_INFO_FIELDS = collections.OrderedDict((
     ("path_prefix", _type_str),  # may be empty
     ("logdir", _type_str),  # may be empty
     ("db", _type_str),  # may be empty
-    ("cache_key", _type_str),  # opaque
+    ("cache_key", _type_str),  # opaque, as given by `cache_key` below
 ))
 TensorboardInfo = collections.namedtuple(
     "TensorboardInfo",
@@ -150,3 +151,48 @@ def _info_from_string(info_string):
     json_value[key] = field_type.deserialize(json_value[key])
 
   return TensorboardInfo(**json_value)
+
+
+def cache_key(working_directory, arguments, configure_kwargs):
+  """Compute a `TensorboardInfo.cache_key` field.
+
+  The format returned by this function is opaque. Clients may only
+  inspect it by comparing it for equality with other results from this
+  function.
+
+  Args:
+    working_directory: The directory from which TensorBoard was launched
+      and relative to which paths like `--logdir` and `--db` are
+      resolved.
+    arguments: The command-line args to TensorBoard, as `sys.argv[1:]`.
+      Should be a list (or tuple), not an unparsed string. If you have a
+      raw shell command, use `shlex.split` before passing it to this
+      function.
+    configure_kwargs: A dictionary of additional argument values to
+      override the textual `arguments`, with the same semantics as in
+      `tensorboard.program.TensorBoard.configure`. May be an empty
+      dictionary.
+
+  Returns:
+    A string such that if two (prospective or actual) TensorBoard
+    invocations have the same cache key then it is safe to use one in
+    place of the other. The converse is not guaranteed: it is often safe
+    to change the order of TensorBoard arguments, or to explicitly set
+    them to their default values, or to move them between `arguments`
+    and `configure_kwargs`, but such invocations may yield distinct
+    cache keys.
+  """
+  if not isinstance(arguments, (list, tuple)):
+    raise TypeError(
+        "'arguments' should be a list of arguments, but found: %r "
+        "(use `shlex.split` if given a string)"
+        % (arguments,)
+    )
+  datum = {
+      "working_directory": working_directory,
+      "arguments": arguments,
+      "configure_kwargs": configure_kwargs,
+  }
+  return base64.b64encode(
+      json.dumps(datum, sort_keys=True, separators=(",", ":")).encode("utf-8")
+  )


### PR DESCRIPTION
Summary:
This function computes the (opaque) value of the `cache_key` field of
`TensorboardInfo` objects, which is used to determine whether it is safe
to reuse a TensorBoard instance. See docs for more details.

Test Plan:
Unit tests included; run `bazel test //tensorboard:manager_test`.

For a sanity check at the REPL:

```
>>> from tensorboard import manager
>>> import base64, json, os, pprint
>>> ck = manager.cache_key(
...     working_directory=os.getcwd(),
...     arguments=["--logdir", "foo"],
...     configure_kwargs={},
... )
>>> ck
'eyJhcmd1bWVudHMiOlsiLS1sb2dkaXIiLCJmb28iXSwiY29uZmlndXJlX2t3YXJncyI6e30sIndvcmtpbmdfZGlyZWN0b3J5IjoiL3Vzci9sb2NhbC9nb29nbGUv
aG9tZS93Y2hhcmdpbi9naXQvdGVuc29yYm9hcmQifQ=='
>>> pprint.pprint(json.loads(base64.b64decode(ck)))
{u'arguments': [u'--logdir', u'foo'],
 u'configure_kwargs': {},
 u'working_directory': u'/usr/local/google/home/wchargin/git/tensorboard'}
```

Supersedes part of #1795.

wchargin-branch: manager-cache-key
