### PR TITLE
manager: add I/O for TensorboardInfo files

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -76,6 +76,7 @@ py_library(
     visibility = ["//tensorboard:internal"],
     deps = [
         ":version",
+        "//tensorboard/util:tb_logging",
         "@org_pythonhosted_six",
     ],
 )
@@ -89,6 +90,7 @@ py_test(
     deps = [
         ":manager",
         ":version",
+        "//tensorboard/util:tb_logging",
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -279,8 +279,16 @@ def get_all():
   results = []
   for filename in os.listdir(info_dir):
     filepath = os.path.join(info_dir, filename)
-    with open(filepath) as infile:
-      contents = infile.read()
+    try:
+      with open(filepath) as infile:
+        contents = infile.read()
+    except IOError as e:
+      if e.errno == errno.EACCES:
+        # May have been written by this module in a process whose
+        # `umask` includes some bits of 0o444.
+        continue
+      else:
+        raise
     try:
       info = _info_from_string(contents)
     except ValueError:

--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -226,7 +226,11 @@ def _get_info_dir():
 
 
 def _get_info_file_path():
-  """Get path to info file for the current process."""
+  """Get path to info file for the current process.
+
+  As with `_get_info_dir`, the info directory will be created if it does
+  not exist.
+  """
   return os.path.join(_get_info_dir(), "pid-%d.info" % os.getpid())
 
 

--- a/tensorboard/manager_test.py
+++ b/tensorboard/manager_test.py
@@ -324,9 +324,12 @@ class TensorboardInfoIoTest(tf.test.TestCase):
       outfile.write("good luck parsing this\n")
     with open(os.path.join(self.info_dir, "pid-5678.info"), "w") as outfile:
       outfile.write('{"valid_json":"yes","valid_tbinfo":"no"}\n')
+    with open(os.path.join(self.info_dir, "pid-9012.info"), "w") as outfile:
+      outfile.write('if a tbinfo has st_mode==0, does it make a sound?\n')
+    os.chmod(os.path.join(self.info_dir, "pid-9012.info"), 0o000)
     with mock.patch.object(tb_logging.get_logger(), "warning") as fn:
       self.assertEqual(manager.get_all(), [])
-    self.assertEqual(fn.call_count, 2)
+    self.assertEqual(fn.call_count, 2)  # 2 invalid, 1 unreadable (silent)
 
 
 if __name__ == "__main__":

--- a/tensorboard/manager_test.py
+++ b/tensorboard/manager_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import datetime
+import errno
 import json
 import os
 import re
@@ -257,6 +258,14 @@ class TensorboardInfoIoTest(tf.test.TestCase):
 
   def _list_info_dir(self):
     return os.listdir(self.info_dir)
+
+  def test_fails_if_info_dir_name_is_taken_by_a_regular_file(self):
+    os.rmdir(self.info_dir)
+    with open(self.info_dir, "w") as outfile:
+      pass
+    with self.assertRaises(OSError) as cm:
+      manager._get_info_dir()
+    self.assertEqual(cm.exception.errno, errno.EEXIST, cm.exception)
 
   @mock.patch("os.getpid", lambda: 76540)
   def test_write_remove_info_file(self):


### PR DESCRIPTION
Summary:
This commit implements functions `write_info_file`, `remove_info_file`,
and `get_all` on the `tensorboard.manager` module. See docs for details.

Supersedes part of #1795.

Test Plan:
Integration tests included; run `bazel test //tensorboard:manager_test`.

wchargin-branch: tensorboardinfo-io
