### PR TITLE
program: write TensorboardInfo on server startup

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -102,11 +102,13 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        ":manager",
         ":version",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_file_inspector",
         "//tensorboard/util",
         "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 


### PR DESCRIPTION
Summary:
This commit wires up `TensorBoard.main` to the `TensorboardInfo` I/O
introduced in #1806.

Test Plan:
Run `bazel run //tensorboard -- --logdir ./whatever/`, then verify that
an info file has been created…

    $ ls /tmp/.tensorboard-info/
    pid-85532.info

…and that the file is visible to the Python APIs:

    $ python
    >>> from tensorboard import manager
    >>> infos = manager.get_all()
    >>> len(infos)
    1
    >>> infos[0].pid
    85532
    >>> infos[0].port
    6006

Then, SIGTERM the server and verify that this is reflected from Python…

    >>> import os
    >>> os.kill(infos[0].pid, 15)
    >>> manager.get_all()
    []

…and that the underlying file is gone:

    $ ls /tmp/.tensorboard-info/ | wc -l
    0

wchargin-branch: write-tensorboardinfo
