### PR TITLE
manager: always return `str` from `cache_key`

### DIFF
--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -193,6 +193,9 @@ def cache_key(working_directory, arguments, configure_kwargs):
       "arguments": arguments,
       "configure_kwargs": configure_kwargs,
   }
-  return base64.b64encode(
+  raw = base64.b64encode(
       json.dumps(datum, sort_keys=True, separators=(",", ":")).encode("utf-8")
   )
+  # `raw` is of type `bytes`, even though it only contains ASCII
+  # characters; we want it to be `str` in both Python 2 and 3.
+  return str(raw.decode("ascii"))

--- a/tensorboard/manager_test.py
+++ b/tensorboard/manager_test.py
@@ -152,6 +152,14 @@ class TensorboardInfoTest(tf.test.TestCase):
 class CacheKeyTest(tf.test.TestCase):
   """Unit tests for `manager.cache_key`."""
 
+  def test_result_is_str(self):
+    result = manager.cache_key(
+        working_directory="/home/me",
+        arguments=["--logdir", "something"],
+        configure_kwargs={},
+    )
+    self.assertIsInstance(result, str)
+
   def test_depends_on_working_directory(self):
     results = [
         manager.cache_key(


### PR DESCRIPTION
Summary:
The previous implementation always returned `six.binary_type`; it now
returns `str` in both Python 2 and Python 3.

Test Plan:
Regression test added; `bazel test //tensorboard:manager_test` passes in
Python 2 and 3, and fails on Python 3 if the code under test is
reverted.

wchargin-branch: cache-key-str
