### PR TITLE
util: add __init__.py for REPL convenience

### DIFF
--- a/tensorboard/util/__init__.py
+++ b/tensorboard/util/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================


### PR DESCRIPTION
Summary:
Having an (empty) `__init__.py` file enables us to import modules under
`tensorboard.util` at a Python 2 REPL. (It works either way in Python 3,
because `tensorboard.util` is interpreted as a namespace package.)

Test Plan:
Running `python -c 'from tensorboard.util import tb_logging'` after this
change works in both Python 2 and Python 3, but before this change works
in Python 3 but fails in Python 2 (after removing any cached `.pyc`
bytecode file).

wchargin-branch: util-init-py
