### PR TITLE
wit: fix typos in visualization.py

### DIFF
--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
@@ -324,7 +324,7 @@ class WitConfigBuilder(object):
 
     Args:
       estimator: The TF Estimator which will be used for model inference.
-      feature_spec: The feature_spec object which will be used for exmaple
+      feature_spec: The feature_spec object which will be used for example
       parsing.
 
     Returns:
@@ -349,7 +349,7 @@ class WitConfigBuilder(object):
 
     Args:
       estimator: The TF Estimator which will be used for model inference.
-      feature_spec: The feature_spec object which will be used for exmaple
+      feature_spec: The feature_spec object which will be used for example
       parsing.
 
     Returns:


### PR DESCRIPTION
Summary:
The Google import process complains about common typos; this makes it
happy. :-)

Test Plan:
None.

wchargin-branch: wit-example-typos
