### PR TITLE
test: resolve TensorBoard binary relative to test

### DIFF
--- a/tensorboard/manager_e2e_test.py
+++ b/tensorboard/manager_e2e_test.py
@@ -69,8 +69,10 @@ class ManagerEndToEndTest(tf.test.TestCase):
     self.assertEqual(tempfile.gettempdir(), self.tmproot)
     self.info_dir = manager._get_info_dir()  # ensure that directory exists
 
-    # Add our Bazel-provided `tensorboard` to the system path.
-    tensorboard_binary_dir = os.path.realpath("./tensorboard/")
+    # Add our Bazel-provided `tensorboard` to the system path. (The
+    # //tensorboard:tensorboard target is made available in the same
+    # directory as //tensorboard:manager_e2e_test.)
+    tensorboard_binary_dir = os.path.dirname(os.environ["TEST_BINARY"])
     path_environ = {
         "PATH": os.pathsep.join((tensorboard_binary_dir, os.environ["PATH"])),
     }


### PR DESCRIPTION
Summary:
Within Google, the `//tensorboard:tensorboard` target is at a different
path in the build workspace, so tests with a data dependency on it
cannot find it at `./tensorboard/tensorboard`. However, the binary
should always be in the same place relative to the test binary, so we
now use that instead.

Test Plan:
Running `bazel test //tensorboard:manager_e2e_test` still works in
Python 2 and 3.

wchargin-branch: relative-data-path
