### PR TITLE
manager_e2e_test: mark as moderate

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -99,7 +99,7 @@ py_test(
 py_test(
     name = "manager_e2e_test",
     size = "large",  # spawns subprocesses, sleeps, makes requests to localhost
-    timeout = "short",  # about 15 seconds on my machine
+    timeout = "moderate",
     # On Python 2, this test fails about 0.5% of the time when run with
     # high parallelism; TensorBoard subprocess time out instead of
     # launching successfully.


### PR DESCRIPTION
Summary:
This can take longer on Google-internal infrastructure in some cases.

(Note that this commit will introduce a test size warning when the test
takes less than a minute, which is common in the open-source version.)

Test Plan:
The BUILD file is still valid, and the test still passes.

wchargin-branch: manager-e2e-moderate
