### PR TITLE
Default compatibilityProvider to tf-graph-loader

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -43,7 +43,10 @@ Polymer({
     datasets: Array,
     selectedDataset: Number,
     selectedFile: Object,
-    compatibilityProvider: Object,
+    compatibilityProvider: {
+      type: Object,
+      value: () => new tf.graph.op.TpuCompatibilityProvider(),
+    },
     /**
      * If this optional object is provided, graph logic will override
      * the HierarchyParams it uses to build the graph with properties within
@@ -78,8 +81,8 @@ Polymer({
     },
   },
   observers: [
-    '_selectedDatasetChanged(selectedDataset, datasets, overridingHierarchyParams)',
-    '_selectedFileChanged(selectedFile, overridingHierarchyParams)',
+    '_selectedDatasetChanged(selectedDataset, datasets, overridingHierarchyParams, compatibilityProvider)',
+    '_selectedFileChanged(selectedFile, overridingHierarchyParams, compatibilityProvider)',
     '_readAndParseMetadata(selectedMetadataTag, overridingHierarchyParams)',
   ],
   _readAndParseMetadata: function(metadataIndex) {


### PR DESCRIPTION
PR #1750 added a new required prop for tf-graph-loader which broke all
use cases of tf-graph-loader: e.g., debugger plugin, tf-graph-app, and
all the custom tf-graph implementations.

Instead of explicitly defining the provider, it looks appropriate to
have the sane default to keep the same behavior we have had for many
minor versions.
