### PR TITLE
notebook: add Colab integration shell

### DIFF
--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -278,6 +278,26 @@ def _display(port=None, height=None, print_message=False, display_handle=None):
 
 
 def _display_colab(port, height, display_handle):
+  """Display a TensorBoard instance in a Colab output frame.
+
+  The Colab VM is not directly exposed to the network, so the Colab
+  runtime provides a service worker tunnel to proxy requests from the
+  end user's browser through to servers running on the Colab VM: the
+  output frame may issue requests to https://localhost:<port> (HTTPS
+  only), which will be forwarded to the specified port on the VM.
+
+  It does not suffice to create an `iframe` and let the service worker
+  redirect its traffic (`<iframe src="https://localhost:6006">`),
+  because for security reasons service workers cannot intercept iframe
+  traffic. Instead, we manually fetch the TensorBoard index page with an
+  XHR in the output frame, and inject the raw HTML into `document.body`.
+
+  By default, the TensorBoard web app requests resources against
+  relative paths, like `./data/logdir`. Within the output frame, these
+  requests must instead hit `https://localhost:<port>/data/logdir`. To
+  redirect them, we change the document base URI, which transparently
+  affects all requests (XHRs and resources alike).
+  """
   import IPython.display
   shell = """
     <script>

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -286,7 +286,7 @@ def _display_colab(port, height, display_handle):
         const tftb = document.querySelector("tf-tensorboard");
         tftb.removeAttribute("use-hash");
       }
-      function rehydrate() {
+      function executeAllScripts() {
         for (const script of document.querySelectorAll("script")) {
           const newScript = document.createElement("script");
           newScript.type = script.type;
@@ -299,7 +299,7 @@ def _display_colab(port, height, display_handle):
         .then((x) => x.text())
         .then((html) => void (document.body.innerHTML = html))
         .then(() => fixUpTensorboard())
-        .then(() => rehydrate());
+        .then(() => executeAllScripts());
     </script>
     <div id="spacer" style="height: %dpx"></div>
   """ % (port, height)

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -285,6 +285,12 @@ def _display_colab(port, height, display_handle):
         document.querySelector("base").href = "https://localhost:%s";
         function fixUpTensorboard() {
           const tftb = document.querySelector("tf-tensorboard");
+          // Disable the fragment manipulation behavior in Colab. Not
+          // only is the behavior not useful (as the iframe's location
+          // is not visible to the user), it causes TensorBoard's usage
+          // of `window.replace` to navigate away from the page and to
+          // the `localhost:<port>` URL specified by the base URI, which
+          // in turn causes the frame to (likely) crash.
           tftb.removeAttribute("use-hash");
         }
         function executeAllScripts() {

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -294,6 +294,10 @@ def _display_colab(port, height, display_handle):
           tftb.removeAttribute("use-hash");
         }
         function executeAllScripts() {
+          // When `script` elements are inserted into the DOM by
+          // assigning to an element's `innerHTML`, the scripts are not
+          // executed. Thus, we manually re-insert these scripts so that
+          // TensorBoard can initialize itself.
           for (const script of document.querySelectorAll("script")) {
             const newScript = document.createElement("script");
             newScript.type = script.type;

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -278,9 +278,36 @@ def _display(port=None, height=None, print_message=False, display_handle=None):
 
 
 def _display_colab(port, height, display_handle):
-  # TODO(@wchargin): Implement this after merging this code into
-  # google3, where it's easier to develop and test against Colab.
-  raise NotImplementedError()
+  import IPython.display
+  shell = """
+    <script>
+      document.querySelector("base").href = "https://localhost:%s";
+      function fixUpTensorboard() {
+        const tftb = document.querySelector("tf-tensorboard");
+        tftb.removeAttribute("use-hash");
+      }
+      function rehydrate() {
+        for (const script of document.querySelectorAll("script")) {
+          const newScript = document.createElement("script");
+          newScript.type = script.type;
+          newScript.textContent = script.textContent;
+          document.body.appendChild(newScript);
+          newScript.remove();
+        }
+      }
+      fetch(".")
+        .then((x) => x.text())
+        .then((html) => void (document.body.innerHTML = html))
+        .then(() => fixUpTensorboard())
+        .then(() => rehydrate());
+    </script>
+    <div id="spacer" style="height: %dpx"></div>
+  """ % (port, height)
+  html = IPython.display.HTML(shell)
+  if display_handle:
+    display_handle.update(html)
+  else:
+    IPython.display.display(html)
 
 
 def _display_ipython(port, height, display_handle):

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -281,25 +281,27 @@ def _display_colab(port, height, display_handle):
   import IPython.display
   shell = """
     <script>
-      document.querySelector("base").href = "https://localhost:%s";
-      function fixUpTensorboard() {
-        const tftb = document.querySelector("tf-tensorboard");
-        tftb.removeAttribute("use-hash");
-      }
-      function executeAllScripts() {
-        for (const script of document.querySelectorAll("script")) {
-          const newScript = document.createElement("script");
-          newScript.type = script.type;
-          newScript.textContent = script.textContent;
-          document.body.appendChild(newScript);
-          newScript.remove();
+      (function() {
+        document.querySelector("base").href = "https://localhost:%s";
+        function fixUpTensorboard() {
+          const tftb = document.querySelector("tf-tensorboard");
+          tftb.removeAttribute("use-hash");
         }
-      }
-      fetch(".")
-        .then((x) => x.text())
-        .then((html) => void (document.body.innerHTML = html))
-        .then(() => fixUpTensorboard())
-        .then(() => executeAllScripts());
+        function executeAllScripts() {
+          for (const script of document.querySelectorAll("script")) {
+            const newScript = document.createElement("script");
+            newScript.type = script.type;
+            newScript.textContent = script.textContent;
+            document.body.appendChild(newScript);
+            newScript.remove();
+          }
+        }
+        fetch(".")
+          .then((x) => x.text())
+          .then((html) => void (document.body.innerHTML = html))
+          .then(() => fixUpTensorboard())
+          .then(() => executeAllScripts());
+      })();
     </script>
     <div id="spacer" style="height: %dpx"></div>
   """ % (port, height)

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -300,7 +300,7 @@ def _display_colab(port, height, display_handle):
   """
   import IPython.display
   shell = """
-    <div id="root" style="height: %HEIGHT%px"></div>
+    <div id="root"></div>
     <script>
       (function() {
         window.TENSORBOARD_ENV = window.TENSORBOARD_ENV || {};
@@ -329,12 +329,24 @@ def _display_colab(port, height, display_handle):
             script.remove();
           }
         }
+        function setHeight(root, height) {
+          // We set the height dynamically after the TensorBoard UI has
+          // been initialized. This avoids an intermediate state in
+          // which the container plus the UI become taller than the
+          // final width and cause the Colab output frame to be
+          // permanently resized, eventually leading to an empty
+          // vertical gap below the TensorBoard UI. It's not clear
+          // exactly what causes this problematic intermediate state,
+          // but setting the height late seems to fix it.
+          root.style.height = `${height}px`;
+        }
         const root = document.getElementById("root");
         fetch(".")
           .then((x) => x.text())
           .then((html) => void (root.innerHTML = html))
           .then(() => fixUpTensorboard())
-          .then(() => executeAllScripts(root));
+          .then(() => executeAllScripts(root))
+          .then(() => setHeight(root, %HEIGHT%));
       })();
     </script>
   """.replace("%PORT%", "%d" % port).replace("%HEIGHT%", "%d" % height)

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -306,8 +306,8 @@ def _display_colab(port, height, display_handle):
         window.TENSORBOARD_ENV = window.TENSORBOARD_ENV || {};
         window.TENSORBOARD_ENV["IN_COLAB"] = true;
         document.querySelector("base").href = "https://localhost:%PORT%";
-        function fixUpTensorboard() {
-          const tftb = document.querySelector("tf-tensorboard");
+        function fixUpTensorboard(root) {
+          const tftb = root.querySelector("tf-tensorboard");
           // Disable the fragment manipulation behavior in Colab. Not
           // only is the behavior not useful (as the iframe's location
           // is not visible to the user), it causes TensorBoard's usage
@@ -344,7 +344,7 @@ def _display_colab(port, height, display_handle):
         fetch(".")
           .then((x) => x.text())
           .then((html) => void (root.innerHTML = html))
-          .then(() => fixUpTensorboard())
+          .then(() => fixUpTensorboard(root))
           .then(() => executeAllScripts(root))
           .then(() => setHeight(root, %HEIGHT%));
       })();

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -302,6 +302,8 @@ def _display_colab(port, height, display_handle):
   shell = """
     <script>
       (function() {
+        window.TENSORBOARD_ENV = window.TENSORBOARD_ENV || {};
+        window.TENSORBOARD_ENV["IN_COLAB"] = true;
         document.querySelector("base").href = "https://localhost:%s";
         function fixUpTensorboard() {
           const tftb = document.querySelector("tf-tensorboard");

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -306,6 +306,7 @@ def _display_colab(port, height, display_handle):
             newScript.remove();
           }
         }
+        google.colab.output.setIframeHeight(%d);
         fetch(".")
           .then((x) => x.text())
           .then((html) => void (document.body.innerHTML = html))
@@ -313,7 +314,6 @@ def _display_colab(port, height, display_handle):
           .then(() => executeAllScripts());
       })();
     </script>
-    <div id="spacer" style="height: %dpx"></div>
   """ % (port, height)
   html = IPython.display.HTML(shell)
   if display_handle:


### PR DESCRIPTION
Summary:
This hooks up the `notebook` module to Colab. The Colab runtime
sandboxes the contents of the output frame, but provides a service
worker tunnel so that the frame may communicate with underlying VM. We
take advantage of this by loading TensorBoard through a JavaScript shell
that changes the document `baseURI` to proxy requests through this
worker.

Test Plan:
Add `//tensorboard:notebook` to the deps of `build_pip_package`, then
build the Pip package and manually upload it onto a public Colab
instance. Then run:

    !pip uninstall -q -y tensorflow tf-nightly-2.0-preview
    !pip install -q tf-nightly-2.0-preview
    !pip uninstall -q -y tensorboard
    !pip install -q ./tensorboard-1.13.0a0-py3-none-any.whl

    %load_ext tensorboard.notebook
    %tensorboard --logdir ./tensorboard_data/mnist

and watch TensorBoard come to life as desired.

Googlers, see <http://cl/233129221> to test this against the internal
version of Colab.

wchargin-branch: notebook-colab-integration
