### PR TITLE
pip: add `tensorboard.notebook` to Pip package

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -64,6 +64,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":lazy",
+        ":notebook",
         ":program",
         "//tensorboard/summary",
     ],

--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -22,6 +22,12 @@ from __future__ import print_function
 from tensorboard import lazy
 
 
+@lazy.lazy_load('tensorboard.notebook')
+def notebook():
+  import tensorboard.notebook as module  # pylint: disable=g-import-not-at-top
+  return module
+
+
 @lazy.lazy_load('tensorboard.program')
 def program():
   import tensorboard.program as module  # pylint: disable=g-import-not-at-top

--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -20,7 +20,6 @@ sh_binary(
         "//tensorboard",  # Main tensorboard binary and everything it uses
         "//tensorboard:lib",  # User-facing overall TensorBoard API
         "//tensorboard:version",  # Version module (read by setup.py)
-        "//tensorboard:notebook",  # User-facing notebook API
         "//tensorboard/plugins/beholder",  # User-facing beholder API
         "//tensorboard/plugins/projector",  # User-facing projector API
     ],

--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -20,6 +20,7 @@ sh_binary(
         "//tensorboard",  # Main tensorboard binary and everything it uses
         "//tensorboard:lib",  # User-facing overall TensorBoard API
         "//tensorboard:version",  # Version module (read by setup.py)
+        "//tensorboard:notebook",  # User-facing notebook API
         "//tensorboard/plugins/beholder",  # User-facing beholder API
         "//tensorboard/plugins/projector",  # User-facing projector API
     ],

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -64,6 +64,7 @@ import tensorboard as tb
 tb.summary.scalar_pb('test', 42)
 from tensorboard.plugins.projector import visualize_embeddings
 from tensorboard.plugins.beholder import Beholder, BeholderHook
+tb.notebook.start  # don't invoke; just check existence
 "
   deactivate
   cd ..


### PR DESCRIPTION
Summary:
Users of the Pip package now have the files necessary to use Jupyter
extensions, by incanting `%load_ext tensorboard.notebook` at the top of
their notebook.

The `notebook` module is also directly exposed on the `tensorboard`
module, so `import tensorboard as tb` followed by `tb.notebook.start`
works (like `program` and `summary`, and unlike `backend` or `plugins`).

Test Plan:
Run `bazel run //tensorboard/pip_package:build_pip_package`, and suppose
that `${WHEEL}` is the path to the emitted Python 3 wheel. Then run

    $ cd "$(mktemp -d)"
    $ virtualenv -q -p python3 ./ve/
    $ . ./ve/bin/activate
    (ve) $ pip install -q tf-nightly-2.0-preview
    (ve) $ pip uninstall -q -y tb-nightly
    (ve) $ pip install -q "${WHEEL}"
    (ve) $ pip install -q jupyter
    (ve) $ jupyter notebook

Then, create a notebook and execute

    %load_ext tensorboard.notebook
    %tensorboard --logdir ~/tensorboard_data/mnist --port 0

to see a new TensorBoard instance.

This process also exercises the smoke test, which passes. Removing the
`def notebook` from `__init__.py` causes that test to fail as expected:

```
Traceback (most recent call last):
  File "<string>", line 6, in <module>
AttributeError: 'module' object has no attribute 'notebook'
```

wchargin-branch: tensorboard-notebook-in-pip
