### PR TITLE
manager: change default timeout from 10s to 60s

### DIFF
--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -358,7 +358,7 @@ StartFailed = collections.namedtuple(
 StartTimedOut = collections.namedtuple("StartTimedOut", ("pid",))
 
 
-def start(arguments, timeout=datetime.timedelta(seconds=20)):
+def start(arguments, timeout=datetime.timedelta(seconds=60)):
   """Start a new TensorBoard instance, or reuse a compatible one.
 
   If the cache key determined by the provided arguments and the current
@@ -378,7 +378,7 @@ def start(arguments, timeout=datetime.timedelta(seconds=20)):
       this time period, `start` will assume that the subprocess is stuck
       in a bad state, and will give up on waiting for it and return a
       `StartTimedOut` result. Note that in such a case the subprocess
-      will not be killed. Default value is 20 seconds.
+      will not be killed. Default value is 60 seconds.
 
   Returns:
     A `StartReused`, `StartLaunched`, `StartFailed`, or `StartTimedOut`

--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -358,7 +358,7 @@ StartFailed = collections.namedtuple(
 StartTimedOut = collections.namedtuple("StartTimedOut", ("pid",))
 
 
-def start(arguments, timeout=datetime.timedelta(seconds=10)):
+def start(arguments, timeout=datetime.timedelta(seconds=20)):
   """Start a new TensorBoard instance, or reuse a compatible one.
 
   If the cache key determined by the provided arguments and the current
@@ -378,7 +378,7 @@ def start(arguments, timeout=datetime.timedelta(seconds=10)):
       this time period, `start` will assume that the subprocess is stuck
       in a bad state, and will give up on waiting for it and return a
       `StartTimedOut` result. Note that in such a case the subprocess
-      will not be killed. Default value is 10 seconds.
+      will not be killed. Default value is 20 seconds.
 
   Returns:
     A `StartReused`, `StartLaunched`, `StartFailed`, or `StartTimedOut`


### PR DESCRIPTION
Summary:
When running on Google-internal Colab, launching a fresh TensorBoard
instance usually takes around 12 seconds. (It’s faster on public Colab.)
Setting the timeout to 60s should do the trick.

This commit updates the default timeout so that users don’t have to run
the `%tensorboard` magic twice (once for it to start and time out, and
once for it to pick up the now-existing instance).

Test Plan:
I made the analogous change inside google3, and `%tensorboard` worked on
the first try; it’s never worked without timing out before.

wchargin-branch: manager-20s
