### PR TITLE
Add plugin and compat tests for tensorboard-notf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ install:
   - pip install futures==3.1.1
   - pip install grpcio==1.6.3
   - pip install mock==2.0.0
-  - pip install moto==1.3.7
+  - pip install --default-timeout=300 moto==1.3.7
   - pip install yamllint==1.5.0
   - pip install -I "${TF_VERSION_ID}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,9 @@ before_install:
   - chmod +x "${bazel_binary}"
   - sudo mv "${bazel_binary}" /usr/local/bin/bazel
 
+  # Fix Boto and Travis issue https://github.com/travis-ci/travis-ci/issues/7940
+  - sudo rm -f /etc/boto.cfg
+
   # Storing build artifacts in this directory helps Travis cache them. This
   # will sometimes cut latency in half, when we're lucky.
   - echo "startup --output_base=${HOME}/.bazel-output-base" >>~/.bazelrc
@@ -94,10 +97,12 @@ before_install:
   - echo "test --action_env=PATH" >>~/.bazelrc
 
 install:
+  - pip install boto3==1.9.86
   - pip install flake8==3.5.0
   - pip install futures==3.1.1
   - pip install grpcio==1.6.3
   - pip install mock==2.0.0
+  - pip install moto==1.3.7
   - pip install yamllint==1.5.0
   - pip install -I "${TF_VERSION_ID}"
 
@@ -121,6 +126,8 @@ script:
   - bazel fetch //tensorboard/...
   - bazel build //tensorboard/...
   - bazel test //tensorboard/...
+  # Run manual S3 test
+  - bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test
   - bazel run //tensorboard/pip_package:build_pip_package -- --tf-version "${TF_VERSION_ID}" --smoke
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ install:
   - pip install futures==3.1.1
   - pip install grpcio==1.6.3
   - pip install mock==2.0.0
-  - pip install --default-timeout=300 moto==1.3.7
+  - pip install moto==1.3.7
   - pip install yamllint==1.5.0
   - pip install -I "${TF_VERSION_ID}"
 

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -45,6 +45,7 @@ py_test(
     ],
 )
 
+# TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
 py_test(
     name = "audio_plugin_notf_test",
     size = "small",
@@ -55,7 +56,6 @@ py_test(
         ":audio_plugin",
         ":summary",
         "//tensorboard:expect_numpy_installed",
-        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -45,6 +45,28 @@ py_test(
     ],
 )
 
+py_test(
+    name = "audio_plugin_notf_test",
+    size = "small",
+    srcs = ["audio_plugin_test.py"],
+    main = "audio_plugin_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":audio_plugin",
+        ":summary",
+        "//tensorboard:expect_numpy_installed",
+        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:application",
+        "//tensorboard/backend/event_processing:event_multiplexer",
+        "//tensorboard/compat:no_tensorflow",
+        "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
+    ],
+)
+
 py_library(
     name = "summary",
     srcs = ["summary.py"],

--- a/tensorboard/plugins/custom_scalar/BUILD
+++ b/tensorboard/plugins/custom_scalar/BUILD
@@ -88,7 +88,7 @@ py_test(
 )
 
 py_test(
-    name = "custom_scalars_plugin_test_notf",
+    name = "custom_scalars_plugin_notf_test",
     size = "small",
     srcs = ["custom_scalars_plugin_test.py"],
     main = "custom_scalars_plugin_test.py",
@@ -98,6 +98,7 @@ py_test(
         ":protos_all_py_pb2",
         ":summary",
         "//tensorboard:expect_numpy_installed",
+        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/compat:no_tensorflow",

--- a/tensorboard/plugins/custom_scalar/BUILD
+++ b/tensorboard/plugins/custom_scalar/BUILD
@@ -87,6 +87,7 @@ py_test(
     ],
 )
 
+# TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
 py_test(
     name = "custom_scalars_plugin_notf_test",
     size = "small",
@@ -98,7 +99,6 @@ py_test(
         ":protos_all_py_pb2",
         ":summary",
         "//tensorboard:expect_numpy_installed",
-        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/compat:no_tensorflow",

--- a/tensorboard/plugins/custom_scalar/BUILD
+++ b/tensorboard/plugins/custom_scalar/BUILD
@@ -87,6 +87,27 @@ py_test(
     ],
 )
 
+py_test(
+    name = "custom_scalars_plugin_test_notf",
+    size = "small",
+    srcs = ["custom_scalars_plugin_test.py"],
+    main = "custom_scalars_plugin_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":custom_scalars_plugin",
+        ":protos_all_py_pb2",
+        ":summary",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:application",
+        "//tensorboard/compat:no_tensorflow",
+        "//tensorboard/plugins:base_plugin",
+        "//tensorboard/plugins/scalar:scalars_plugin",
+        "//tensorboard/plugins/scalar:summary",
+        "//tensorboard/util:test_util",
+    ],
+)
+
 tb_proto_library(
     name = "protos_all",
     srcs = ["layout.proto"],

--- a/tensorboard/plugins/distribution/BUILD
+++ b/tensorboard/plugins/distribution/BUILD
@@ -43,6 +43,29 @@ py_test(
     ],
 )
 
+py_test(
+    name = "distributions_plugin_notf_test",
+    size = "small",
+    srcs = ["distributions_plugin_test.py"],
+    main = "distributions_plugin_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":compressor",
+        ":distributions_plugin",
+        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:application",
+        "//tensorboard/backend/event_processing:event_accumulator",
+        "//tensorboard/backend/event_processing:event_multiplexer",
+        "//tensorboard/compat:no_tensorflow",
+        "//tensorboard/plugins:base_plugin",
+        "//tensorboard/plugins/histogram:summary",
+        "//tensorboard/util:test_util",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
+    ],
+)
+
 py_library(
     name = "compressor",
     srcs = ["compressor.py"],

--- a/tensorboard/plugins/distribution/BUILD
+++ b/tensorboard/plugins/distribution/BUILD
@@ -43,6 +43,7 @@ py_test(
     ],
 )
 
+# TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
 py_test(
     name = "distributions_plugin_notf_test",
     size = "small",
@@ -52,7 +53,6 @@ py_test(
     deps = [
         ":compressor",
         ":distributions_plugin",
-        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_accumulator",

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -63,6 +63,27 @@ py_test(
     ],
 )
 
+py_test(
+    name = "graphs_plugin_notf_test",
+    size = "small",
+    srcs = ["graphs_plugin_test.py"],
+    main = "graphs_plugin_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":graphs_plugin",
+        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:application",
+        "//tensorboard/backend/event_processing:event_multiplexer",
+        "//tensorboard/compat:no_tensorflow",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
+        "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
+    ],
+)
+
 py_library(
     name = "keras_util",
     srcs = ["keras_util.py"],

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -63,6 +63,7 @@ py_test(
     ],
 )
 
+# TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
 py_test(
     name = "graphs_plugin_notf_test",
     size = "small",
@@ -71,7 +72,6 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":graphs_plugin",
-        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -47,6 +47,7 @@ py_test(
     ],
 )
 
+# TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
 py_test(
     name = "histograms_plugin_notf_test",
     size = "small",
@@ -56,7 +57,6 @@ py_test(
     deps = [
         ":histograms_plugin",
         ":summary",
-        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_accumulator",

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -47,6 +47,28 @@ py_test(
     ],
 )
 
+py_test(
+    name = "histograms_plugin_notf_test",
+    size = "small",
+    srcs = ["histograms_plugin_test.py"],
+    main = "histograms_plugin_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":histograms_plugin",
+        ":summary",
+        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:application",
+        "//tensorboard/backend/event_processing:event_accumulator",
+        "//tensorboard/backend/event_processing:event_multiplexer",
+        "//tensorboard/compat:no_tensorflow",
+        "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
+    ],
+)
+
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -60,7 +60,7 @@ py_test(
 )
 
 py_test(
-    name = "images_plugin_test_notf",
+    name = "images_plugin_notf_test",
     size = "small",
     srcs = ["images_plugin_test.py"],
     main = "images_plugin_test.py",
@@ -69,6 +69,7 @@ py_test(
         ":images_plugin",
         ":summary",
         "//tensorboard:expect_numpy_installed",
+        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -59,6 +59,27 @@ py_test(
     ],
 )
 
+py_test(
+    name = "images_plugin_test_notf",
+    size = "small",
+    srcs = ["images_plugin_test.py"],
+    main = "images_plugin_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":images_plugin",
+        ":summary",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:application",
+        "//tensorboard/backend/event_processing:event_multiplexer",
+        "//tensorboard/compat:no_tensorflow",
+        "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
+    ],
+)
+
 py_library(
     name = "summary",
     srcs = ["summary.py"],

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -59,6 +59,7 @@ py_test(
     ],
 )
 
+# TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
 py_test(
     name = "images_plugin_notf_test",
     size = "small",
@@ -69,7 +70,6 @@ py_test(
         ":images_plugin",
         ":summary",
         "//tensorboard:expect_numpy_installed",
-        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",

--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -57,7 +57,7 @@ py_test(
 )
 
 py_test(
-    name = "pr_curves_plugin_test_notf",
+    name = "pr_curves_plugin_notf_test",
     size = "medium",  # tf integration test
     srcs = ["pr_curves_plugin_test.py"],
     main = "pr_curves_plugin_test.py",
@@ -67,6 +67,7 @@ py_test(
         ":pr_curve_demo_lib",
         ":pr_curves_plugin",
         "//tensorboard:expect_numpy_installed",
+        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/compat:no_tensorflow",

--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -56,6 +56,7 @@ py_test(
     ],
 )
 
+# TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
 py_test(
     name = "pr_curves_plugin_notf_test",
     size = "medium",  # tf integration test
@@ -67,7 +68,6 @@ py_test(
         ":pr_curve_demo_lib",
         ":pr_curves_plugin",
         "//tensorboard:expect_numpy_installed",
-        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/compat:no_tensorflow",

--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -56,6 +56,26 @@ py_test(
     ],
 )
 
+py_test(
+    name = "pr_curves_plugin_test_notf",
+    size = "medium",  # tf integration test
+    srcs = ["pr_curves_plugin_test.py"],
+    main = "pr_curves_plugin_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":metadata",
+        ":pr_curve_demo_lib",
+        ":pr_curves_plugin",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:application",
+        "//tensorboard/compat:no_tensorflow",
+        "//tensorboard/plugins:base_plugin",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
+    ],
+)
+
 py_library(
     name = "summary",
     srcs = ["summary.py"],

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -69,7 +69,7 @@ py_test(
 )
 
 py_test(
-    name = "projector_plugin_test_notf",
+    name = "projector_plugin_notf_test",
     size = "small",
     srcs = ["projector_plugin_test.py"],
     main = "projector_plugin_test.py",
@@ -77,6 +77,7 @@ py_test(
     deps = [
         ":projector_plugin",
         "//tensorboard:expect_numpy_installed",
+        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -68,6 +68,7 @@ py_test(
     ],
 )
 
+# TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
 py_test(
     name = "projector_plugin_notf_test",
     size = "small",
@@ -77,7 +78,6 @@ py_test(
     deps = [
         ":projector_plugin",
         "//tensorboard:expect_numpy_installed",
-        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -68,6 +68,25 @@ py_test(
     ],
 )
 
+py_test(
+    name = "projector_plugin_test_notf",
+    size = "small",
+    srcs = ["projector_plugin_test.py"],
+    main = "projector_plugin_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":projector_plugin",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:application",
+        "//tensorboard/backend/event_processing:event_multiplexer",
+        "//tensorboard/compat:no_tensorflow",
+        "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
+        "@org_pocoo_werkzeug",
+    ],
+)
+
 tb_proto_library(
     name = "protos_all",
     srcs = glob(["*.proto"]),

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -117,29 +117,28 @@ class ProjectorAppTest(tf.test.TestCase):
         'tensorName': 'var3'
     }])
 
+  # TODO(#2007): Cleanly separate out projector tests that require real TF
+  @unittest.skipUnless(USING_REAL_TF, 'Test only passes when using real TF')
   def testInfoWithValidCheckpointAndEventsData(self):
     self._GenerateProjectorTestData()
     self._GenerateEventsData()
     self._SetupWSGIApp()
 
     run_json = self._GetJson('/data/plugin/projector/runs')
-    if USING_REAL_TF:
-        self.assertTrue(run_json)
-        run = run_json[0]
-        info_json = self._GetJson('/data/plugin/projector/info?run=%s' % run)
-        self.assertItemsEqual(info_json['embeddings'], [{
-            'tensorShape': [1, 2],
-            'tensorName': 'var1',
-            'bookmarksPath': 'bookmarks.json'
-        }, {
-            'tensorShape': [10, 10],
-            'tensorName': 'var2'
-        }, {
-            'tensorShape': [100, 100],
-            'tensorName': 'var3'
-        }])
-    else:
-        self.assertFalse(run_json)
+    self.assertTrue(run_json)
+    run = run_json[0]
+    info_json = self._GetJson('/data/plugin/projector/info?run=%s' % run)
+    self.assertItemsEqual(info_json['embeddings'], [{
+        'tensorShape': [1, 2],
+        'tensorName': 'var1',
+        'bookmarksPath': 'bookmarks.json'
+    }, {
+        'tensorShape': [10, 10],
+        'tensorName': 'var2'
+    }, {
+        'tensorShape': [100, 100],
+        'tensorName': 'var3'
+    }])
 
   # TODO(#2007): Cleanly separate out projector tests that require real TF
   @unittest.skipUnless(USING_REAL_TF, 'Test only passes when using real TF')
@@ -212,6 +211,8 @@ class ProjectorAppTest(tf.test.TestCase):
                         expected_tensor.shape)
     self.assertTrue(np.array_equal(tensor, expected_tensor))
 
+  # TODO(#2007): Cleanly separate out projector tests that require real TF
+  @unittest.skipUnless(USING_REAL_TF, 'Test only passes when using real TF')
   def testPluginIsActive(self):
     self._GenerateProjectorTestData()
     self._SetupWSGIApp()
@@ -233,14 +234,13 @@ class ProjectorAppTest(tf.test.TestCase):
 
     self.plugin._thread_for_determining_is_active.run()
 
-    if USING_REAL_TF:
-        # The plugin later finds that embedding data is available.
-        self.assertTrue(self.plugin.is_active())
+    # The plugin later finds that embedding data is available.
+    self.assertTrue(self.plugin.is_active())
 
-        # Subsequent calls to is_active should not start a new thread. The mock
-        # should only have been called once throughout this test.
-        self.assertTrue(self.plugin.is_active())
-        mock.assert_called_once_with(thread)
+    # Subsequent calls to is_active should not start a new thread. The mock
+    # should only have been called once throughout this test.
+    self.assertTrue(self.plugin.is_active())
+    mock.assert_called_once_with(thread)
 
   def testPluginIsNotActive(self):
     self._SetupWSGIApp()

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -25,6 +25,7 @@ import json
 import os
 import numpy as np
 import tensorflow as tf
+import unittest
 
 from werkzeug import test as werkzeug_test
 from werkzeug import wrappers

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -47,6 +47,7 @@ py_test(
     ],
 )
 
+# TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
 py_test(
     name = "scalars_plugin_notf_test",
     size = "small",
@@ -56,7 +57,6 @@ py_test(
     deps = [
         ":scalars_plugin",
         ":summary",
-        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_accumulator",

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -47,6 +47,27 @@ py_test(
     ],
 )
 
+py_test(
+    name = "scalars_plugin_notf_test",
+    size = "small",
+    srcs = ["scalars_plugin_test.py"],
+    main = "scalars_plugin_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":scalars_plugin",
+        ":summary",
+        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend:application",
+        "//tensorboard/backend/event_processing:event_accumulator",
+        "//tensorboard/compat:no_tensorflow",
+        "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
+    ],
+)
+
 py_binary(
     name = "scalars_demo",
     srcs = ["scalars_demo.py"],

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -49,6 +49,7 @@ py_test(
     ],
 )
 
+# TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
 py_test(
     name = "text_plugin_notf_test",
     size = "small",
@@ -57,7 +58,6 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":text_plugin",
-        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:application",

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -49,6 +49,27 @@ py_test(
     ],
 )
 
+py_test(
+    name = "text_plugin_notf_test",
+    size = "small",
+    srcs = ["text_plugin_test.py"],
+    main = "text_plugin_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":text_plugin",
+        # TODO(#2007): Remove this after pruning unnecessary TensorFlow deps in main test
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard:plugin_util",
+        "//tensorboard/backend:application",
+        "//tensorboard/backend/event_processing:event_multiplexer",
+        "//tensorboard/compat:no_tensorflow",
+        "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
+    ],
+)
+
 py_binary(
     name = "text_demo",
     srcs = ["text_demo.py"],


### PR DESCRIPTION
Continuation of https://github.com/tensorflow/tensorboard/pull/1663

This adds plug and TensorFlow compat tests both locally running and in Travis CI.

cc @nfelt, @lanpa 

All the tests can be run with

```
bazel test //tensorboard/compat/proto:proto_test --test_output=errors
bazel test //tensorboard/compat/tensorflow_stub:gfile_test --test_output=errors
bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test --test_output=errors
bazel test //tensorboard/plugins/audio:audio_plugin_notf_test --test_output=errors
bazel test //tensorboard/plugins/custom_scalar:custom_scalars_plugin_notf_test --test_output=errors
bazel test //tensorboard/plugins/distribution:distributions_plugin_notf_test --test_output=errors
bazel test //tensorboard/plugins/graph:graphs_plugin_notf_test --test_output=errors
bazel test //tensorboard/plugins/histogram:histograms_plugin_notf_test --test_output=errors
bazel test //tensorboard/plugins/image:images_plugin_notf_test --test_output=errors
bazel test //tensorboard/plugins/pr_curve:pr_curves_plugin_notf_test --test_output=errors
bazel test //tensorboard/plugins/projector:projector_plugin_notf_test --test_output=errors
bazel test //tensorboard/plugins/scalar:scalars_plugin_notf_test --test_output=errors
bazel test //tensorboard/plugins/text:text_plugin_notf_test --test_output=errors
```