### PR TITLE
lazy: properly handle errors during load

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -431,10 +431,7 @@ py_library(
 
 py_test(
     name = "lazy_test",
-    srcs = [
-        "lazy_test.py",
-        "lazy_test_bad_import.py",
-    ],
+    srcs = ["lazy_test.py"],
     srcs_version = "PY2AND3",
     size = "small",
     deps = [

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -431,7 +431,10 @@ py_library(
 
 py_test(
     name = "lazy_test",
-    srcs = ["lazy_test.py"],
+    srcs = [
+        "lazy_test.py",
+        "lazy_test_bad_import.py",
+    ],
     srcs_version = "PY2AND3",
     size = "small",
     deps = [

--- a/tensorboard/lazy.py
+++ b/tensorboard/lazy.py
@@ -47,7 +47,10 @@ def lazy_load(name):
       if load_once.loading:
         raise ImportError("Circular import when resolving LazyModule %r" % name)
       load_once.loading = True
-      module = load_fn()
+      try:
+        module = load_fn()
+      finally:
+        load_once.loading = False
       self.__dict__.update(module.__dict__)
       load_once.loaded = True
       return module

--- a/tensorboard/lazy_test.py
+++ b/tensorboard/lazy_test.py
@@ -19,7 +19,6 @@ from __future__ import division
 from __future__ import print_function
 
 import six
-import re
 import unittest
 
 from tensorboard import lazy
@@ -79,11 +78,10 @@ class LazyTest(unittest.TestCase):
     self.assertEquals(repr(foo), "<%r via LazyModule (loaded)>" % collections)
 
   def test_failed_load_idempotent(self):
+    expected_message = "you will never stop me"
     @lazy.lazy_load("tensorboard.lazy_test_bad_import")
     def bad():
-      from tensorboard import lazy_test_bad_import
-      return lazy_test_bad_import
-    expected_message = re.escape("This module cannot be imported. :-(")
+      raise ValueError(expected_message)
     with six.assertRaisesRegex(self, ValueError, expected_message):
       bad.day
     with six.assertRaisesRegex(self, ValueError, expected_message):

--- a/tensorboard/lazy_test.py
+++ b/tensorboard/lazy_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import six
+import re
 import unittest
 
 from tensorboard import lazy
@@ -76,6 +77,17 @@ class LazyTest(unittest.TestCase):
       return collections
     foo.namedtuple
     self.assertEquals(repr(foo), "<%r via LazyModule (loaded)>" % collections)
+
+  def test_failed_load_idempotent(self):
+    @lazy.lazy_load("tensorboard.lazy_test_bad_import")
+    def bad():
+      from tensorboard import lazy_test_bad_import
+      return lazy_test_bad_import
+    expected_message = re.escape("This module cannot be imported. :-(")
+    with six.assertRaisesRegex(self, ValueError, expected_message):
+      bad.day
+    with six.assertRaisesRegex(self, ValueError, expected_message):
+      bad.day
 
 
 if __name__ == '__main__':

--- a/tensorboard/lazy_test.py
+++ b/tensorboard/lazy_test.py
@@ -79,7 +79,7 @@ class LazyTest(unittest.TestCase):
 
   def test_failed_load_idempotent(self):
     expected_message = "you will never stop me"
-    @lazy.lazy_load("tensorboard.lazy_test_bad_import")
+    @lazy.lazy_load("bad")
     def bad():
       raise ValueError(expected_message)
     with six.assertRaisesRegex(self, ValueError, expected_message):


### PR DESCRIPTION
Summary:
If a module fails to load once, we propagate its raised error. If the
module fails to load again, we mistakenly think that we’re still
executing the first load, so we raise the _wrong_ error the second time.
This patch fixes that.

Test Plan:
Unit test added. Running `bazel test //tensorboard:lazy_test` passes,
but fails if you revert the change to `lazy.py`.

wchargin-branch: lazy-errors
