### PR TITLE
compat: use import statements, not importlib

### DIFF
--- a/tensorboard/compat/__init__.py
+++ b/tensorboard/compat/__init__.py
@@ -44,13 +44,15 @@ def tf():
     ImportError: if a TF-like API is not available.
   """
   try:
-    _importlib.import_module('tensorboard.compat.notf')
+    from tensorboard.compat import notf  # pylint: disable=g-import-not-at-top
   except ImportError:
     try:
-      return _importlib.import_module('tensorflow')
+      import tensorflow  # pylint: disable=g-import-not-at-top
+      return tensorflow
     except ImportError:
       pass
-  return _importlib.import_module('tensorboard.compat.tensorflow_stub')  # pylint: disable=line-too-long
+  from tensorboard.compat import tensorflow_stub  # pylint: disable=g-import-not-at-top
+  return tensorflow_stub
 
 
 @_lazy.lazy_load('tensorboard.compat.tf2')


### PR DESCRIPTION
Summary:
This lets the Google sync process detect these as normal imports and
rewrite them internally.

Test Plan:
All non-`manual`, non-`noci` Python tests pass. Making the analogous
change within Google fixes http://b/124321202.

wchargin-branch: compat-normal-imports
