### PR TITLE
Graph plugin summary for writing conceptual graph

### DIFF
--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -52,6 +52,7 @@ py_library(
     deps = [
         ":protos_all_py_pb2",
         "//tensorboard/compat/proto:protos_all_py_pb2",
+        "//tensorboard/util:tb_logging",
     ],
 )
 

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -5,6 +5,8 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 exports_files(["LICENSE"])
 
 ## Graphs Plugin ##
@@ -41,4 +43,47 @@ py_test(
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],
+)
+
+py_library(
+    name = "metadata",
+    srcs = ["metadata.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":protos_all_py_pb2",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
+    ],
+)
+
+
+py_library(
+    name = "summary_v2",
+    srcs = ["summary_v2.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":metadata",
+        "//tensorboard/compat",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
+        "//tensorboard/util:tensor_util",
+    ],
+)
+
+py_test(
+    name = "summary_test",
+    size = "small",
+    srcs = ["summary_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":metadata",
+        ":summary_v2",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
+        "//tensorboard/util:test_util",
+    ],
+)
+
+tb_proto_library(
+    name = "protos_all",
+    srcs = ["plugin_data.proto"],
+    visibility = ["//visibility:public"],
 )

--- a/tensorboard/plugins/graph/metadata.py
+++ b/tensorboard/plugins/graph/metadata.py
@@ -34,7 +34,7 @@ PROTO_VERSION = 0
 CONCEPTUAL_GRAPH_SUMMARY_TAG = 'graph__conceptual_graph__'
 
 def create_summary_metadata(display_name, description):
-  """Create a `summary_pb2.SummaryMetadata` proto for image plugin data.
+  """Create a `summary_pb2.SummaryMetadata` proto for graph plugin data.
 
   Returns:
     A `summary_pb2.SummaryMetadata` protobuf object.
@@ -55,7 +55,7 @@ def parse_plugin_metadata(content):
 
   Arguments:
     content: The `content` field of a `SummaryMetadata` proto
-      corresponding to the image plugin.
+      corresponding to the graph plugin.
 
   Returns:
     An `GraphPluginData` protobuf object.

--- a/tensorboard/plugins/graph/metadata.py
+++ b/tensorboard/plugins/graph/metadata.py
@@ -20,6 +20,9 @@ from __future__ import print_function
 
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.graph import plugin_data_pb2
+from tensorboard.util import tb_logging
+
+logger = tb_logging.get_logger()
 
 PLUGIN_NAME = 'graphs'
 

--- a/tensorboard/plugins/graph/metadata.py
+++ b/tensorboard/plugins/graph/metadata.py
@@ -1,0 +1,70 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Internal information about the graphs plugin."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorboard.compat.proto import summary_pb2
+from tensorboard.plugins.graph import plugin_data_pb2
+
+PLUGIN_NAME = 'graphs'
+
+# The most recent value for the `version` field of the `GraphPluginData`
+# proto.
+PROTO_VERSION = 0
+
+# A special tag used by graph plugin to denote a conceptual graph
+CONCEPTUAL_GRAPH_SUMMARY_TAG = 'graph__conceptual_graph__'
+
+def create_summary_metadata(display_name, description):
+  """Create a `summary_pb2.SummaryMetadata` proto for image plugin data.
+
+  Returns:
+    A `summary_pb2.SummaryMetadata` protobuf object.
+  """
+  content = plugin_data_pb2.GraphPluginData(
+      version=PROTO_VERSION)
+  metadata = summary_pb2.SummaryMetadata(
+      display_name=display_name,
+      summary_description=description,
+      plugin_data=summary_pb2.SummaryMetadata.PluginData(
+          plugin_name=PLUGIN_NAME,
+          content=content.SerializeToString()))
+  return metadata
+
+
+def parse_plugin_metadata(content):
+  """Parse summary metadata to a Python object.
+
+  Arguments:
+    content: The `content` field of a `SummaryMetadata` proto
+      corresponding to the image plugin.
+
+  Returns:
+    An `GraphPluginData` protobuf object.
+  """
+  if not isinstance(content, bytes):
+    raise TypeError('Content type must be bytes')
+  result = plugin_data_pb2.GraphPluginData.FromString(content)
+  if result.version == 0:
+    return result
+  else:
+    logger.warn(
+        'Unknown metadata version: %s. The latest version known to '
+        'this build of TensorBoard is %s; perhaps a newer build is '
+        'available?', result.version, PROTO_VERSION)
+    return result

--- a/tensorboard/plugins/graph/plugin_data.proto
+++ b/tensorboard/plugins/graph/plugin_data.proto
@@ -1,0 +1,24 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+syntax = "proto3";
+
+package tensorboard;
+
+message GraphPluginData {
+  // NEXT_TAG: 2
+  // Version `0` is the only supported version.
+  int32 version = 1;
+}

--- a/tensorboard/plugins/graph/summary_test.py
+++ b/tensorboard/plugins/graph/summary_test.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the image plugin summary generation functions."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import glob
+from os import path
+
+import tensorflow as tf
+# TODO(stephanwlee): Use a test_utils pattern and break this direct dependency on
+# TF proto.
+from tensorflow.compat.v1 import GraphDef
+
+from tensorboard.compat import tf2
+from tensorboard.compat.proto import graph_pb2
+from tensorboard.plugins.graph import metadata
+from tensorboard.plugins.graph import summary_v2
+from tensorboard.util import test_util
+
+try:
+  tf2.__version__  # Force lazy import to resolve
+except ImportError:
+  tf2 = None
+
+
+class SummaryV2OpTest(tf.test.TestCase):
+
+  def setUp(self):
+    super(SummaryV2OpTest, self).setUp()
+    if tf2 is None:
+      self.skipTest('TF v2 summary API not available')
+
+  def conceptual_graph(self, *args, **kwargs):
+    writer = tf2.summary.create_file_writer(self.get_temp_dir())
+    with writer.as_default():
+      summary_v2.conceptual_graph(*args, **kwargs)
+    writer.close()
+
+    summary = self.read_single_event_from_eventfile().summary
+    return test_util.ensure_tb_summary_proto(summary)
+
+  def get_conceptual_graph_def_from_summary(self, summary):
+    summary_val = summary.value[0]
+    tensor = summary_val.tensor.string_val[0]
+    self.assertEqual(
+        metadata.CONCEPTUAL_GRAPH_SUMMARY_TAG, summary_val.tag)
+    return graph_pb2.GraphDef.FromString(tensor)
+
+  def read_single_event_from_eventfile(self):
+    event_files = sorted(glob.glob(path.join(self.get_temp_dir(), '*')))
+    events = list(tf.compat.v1.train.summary_iterator(event_files[-1]))
+    # Expect a boilerplate event for the file_version, then the summary one.
+    self.assertEqual(len(events), 2)
+    return events[1]
+
+  def test_special_tag_ignores_name_scope(self):
+    graph_def = graph_pb2.GraphDef()
+    with tf.name_scope('scope'):
+      expectd_tag = metadata.CONCEPTUAL_GRAPH_SUMMARY_TAG
+      actual_tag = self.conceptual_graph(graph_def).value[0].tag
+      self.assertEqual(expectd_tag, actual_tag)
+
+  def test_get_graph_def(self):
+    graph_def = graph_pb2.GraphDef()
+
+    summary = self.conceptual_graph(graph_def)
+    actual = self.get_conceptual_graph_def_from_summary(summary)
+    self.assertProtoEquals(graph_def, actual)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorboard/plugins/graph/summary_test.py
+++ b/tensorboard/plugins/graph/summary_test.py
@@ -38,6 +38,12 @@ try:
 except ImportError:
   tf2 = None
 
+try:
+  tf.compat.v1.enable_eager_execution()
+except AttributeError:
+  # TF 2.0 doesn't have this symbol because eager is the default.
+  pass
+
 
 class SummaryV2OpTest(tf.test.TestCase):
 

--- a/tensorboard/plugins/graph/summary_v2.py
+++ b/tensorboard/plugins/graph/summary_v2.py
@@ -1,0 +1,44 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Graph summaries and TensorFlow operations to create them, V2 versions."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorboard.compat import tf2 as tf
+from tensorboard.plugins.graph import metadata
+
+
+def conceptual_graph(graphdef, description=None):
+  """Write an conceptual graph summary.
+
+  Arguments:
+    graphdef: GraphDef representing a conceptual graph.
+    description: Optional long-form description for this summary, as a
+      constant `str`. Markdown is supported. Defaults to empty.
+
+  Returns:
+    True on success, or false if no summary was emitted because no default
+    summary writer was available.
+  """
+  summary_metadata = metadata.create_summary_metadata(
+      display_name=None, description=description)
+  with tf.summary.summary_scope('graph_summary'):
+    return tf.summary.write(
+        tag=metadata.CONCEPTUAL_GRAPH_SUMMARY_TAG,
+        tensor=tf.constant(graphdef.SerializeToString(), dtype=tf.string),
+        step=0,
+        metadata=summary_metadata)

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -183,7 +183,7 @@ class FakeSleep(object):
     self._clock.advance(seconds)
 
 
-class FileWriter(tf.summary.FileWriter):
+class FileWriter(tf.compat.v1.summary.FileWriter):
   """FileWriter for test.
 
   TensorFlow FileWriter uses TensorFlow's Protobuf Python binding which is


### PR DESCRIPTION
Graph summary now lets user write out conceptual graph out.

Note that the plugin uses the canonical  way of writing out
information to the event file instead of using a field in the summary
proto.

Also note that the first edition will not support v1 summary although
nothing technically bar us from supporting v1.
