### PR TITLE
ui: open help in new window/tab

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -132,7 +132,12 @@ limitations under the License.
               on-tap="openSettings"
               id="settings-button"
             ></paper-icon-button>
-            <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md" tabindex="-1">
+            <a
+              href="https://github.com/tensorflow/tensorboard/blob/master/README.md"
+              rel="noopener noreferrer"
+              tabindex="-1"
+              target="_blank"
+            >
               <paper-icon-button icon="help-outline"></paper-icon-button>
             </a>
           </div>


### PR DESCRIPTION
Summary:
In a normal standalone TensorBoard, users probably want the help button
to open in a new tab rather than replacing their current state.

In a Jupyter or Colab notebook context, this is more important, because
the GitHub response’s CSP includes `frameancestors 'none'`.
Consequently, clicking the “help” button causes the frame contents to be
erased entirely, replaced with a white page. The user can right-click
and select “Back” to go back to TensorBoard, but this is far from
obvious, and also bad.

Test Plan:
Build TensorBoard, put it on your path, and run `jupyter notebook`. Then
use a `%tensorboard` command to launch TensorBoard, and verify that the
help link properly opens the documentation in a new tab.

wchargin-branch: ui-help-blank
