### PR TITLE
Fix the run selector state sync bug

### DIFF
--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -119,7 +119,7 @@ Properties out:
       runSelectionState: {
         type: Object,
         observer: '_storeRunSelectionState',
-        value: () => tf_storage.getObject('runSelectionState') || {},
+        value: tf_storage.getObjectInitializer('runSelectionState', {defaultValue: {}}),
       },
       regexInput: {
         type: String,


### PR DESCRIPTION
Steps to repro:
1. load dashboard 1
2. load dashboard 2
3. change run selection in 2
4. check whether dashboard 1 reflects the change

We want to prevent regression with a test (b/124343760).

Regression caused by https://github.com/tensorflow/tensorboard/pull/1279