### PR TITLE
Add support for custom prediction function in colab and jupyter notebook modes.

### DIFF
--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -358,7 +358,7 @@ StartFailed = collections.namedtuple(
 StartTimedOut = collections.namedtuple("StartTimedOut", ("pid",))
 
 
-def start(arguments, timeout=datetime.timedelta(seconds=10)):
+def start(arguments, timeout=datetime.timedelta(seconds=60)):
   """Start a new TensorBoard instance, or reuse a compatible one.
 
   If the cache key determined by the provided arguments and the current
@@ -378,7 +378,7 @@ def start(arguments, timeout=datetime.timedelta(seconds=10)):
       this time period, `start` will assume that the subprocess is stuck
       in a bad state, and will give up on waiting for it and return a
       `StartTimedOut` result. Note that in such a case the subprocess
-      will not be killed. Default value is 10 seconds.
+      will not be killed. Default value is 60 seconds.
 
   Returns:
     A `StartReused`, `StartLaunched`, `StartFailed`, or `StartTimedOut`

--- a/tensorboard/plugins/interactive_inference/README.md
+++ b/tensorboard/plugins/interactive_inference/README.md
@@ -57,8 +57,8 @@ You can use the What-If Tool to analyze a classification or regression
 that takes TensorFlow Example or SequenceExample protos
 (data points) as inputs directly in a jupyter or colab notebook.
 
-You can also use What-If-Tool with your own custom prediction function that takes
-Tensorflow Example and produces predictions. In this mode, you can load any model
+You can also use What-If-Tool with a custom prediction function that takes
+Tensorflow examples and produces predictions. In this mode, you can load any model
 (including non-TensorFlow models) as long as your custom function's input and output
 specifications are correct.
 

--- a/tensorboard/plugins/interactive_inference/README.md
+++ b/tensorboard/plugins/interactive_inference/README.md
@@ -57,6 +57,11 @@ You can use the What-If Tool to analyze a classification or regression
 that takes TensorFlow Example or SequenceExample protos
 (data points) as inputs directly in a jupyter or colab notebook.
 
+You can also use What-If-Tool with your own custom prediction function that takes
+Tensorflow Example and produces predictions. In this mode, you can load any model
+(including non-TensorFlow models) as long as your custom functions input and output
+specifications match.
+
 If you want to train an ML model from a dataset and explore the dataset and
 model, check out the [What_If_Tool_Notebook_Usage.ipynb notebook](https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/tensorboard/plugins/interactive_inference/What_If_Tool_Notebook_Usage.ipynb) in colab, which starts from a CSV file,
 converts the data to tf.Example protos, trains a classifier, and then uses the
@@ -254,11 +259,13 @@ The WitConfigBuilder object takes a list of tf.Example or tf.SequenceExample
 protos as a constructor argument. These protos will be shown in the tool and
 inferred in the specified model.
 
-The model to be used for inference by the tool can be specified one of two ways:
+The model to be used for inference by the tool can be specified one of three ways:
 - As a TensorFlow [Estimator](https://www.tensorflow.org/guide/estimators)
   object that is provided through the `set_estimator_and_feature_spec` method.
   In this case the inference will be done inside the notebook using the
   provided estimator.
+- As a custom prediction function provided through `set_custom_predict_fn` method.
+  In this case WIT will directly call the function for inference.
 - As an endpoint for a model being served by [TensorFlow Serving](https://github.com/tensorflow/serving),
   through the `set_inference_address` and `set_model_name` methods. In this case
   the inference will be done on the model server specified. To query a model served

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -181,7 +181,7 @@ class ServingBundle(object):
       Predict API.
     estimator: An estimator to use instead of calling an external model.
     feature_spec: A feature spec for use with the estimator.
-    custom_predict_fn: A custom prediction function
+    custom_predict_fn: A custom prediction function.
 
   Raises:
     ValueError: If ServingBundle fails init validation.

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
@@ -195,6 +195,18 @@ class WitWidget(object):
     if 'compare_estimator_and_spec' in copied_config:
       del copied_config['compare_estimator_and_spec']
 
+    self.custom_predict_fn = (
+      config.get('custom_predict_fn')
+      if 'custom_predict_fn' in config else None)
+    self.compare_custom_predict_fn = (
+      config.get('compare_custom_predict_fn')
+      if 'compare_custom_predict_fn' in config else None)
+    if 'custom_predict_fn' in copied_config:
+      del copied_config['custom_predict_fn']
+    if 'compare_custom_predict_fn' in copied_config:
+      del copied_config['compare_custom_predict_fn']
+
+
     self._set_examples(config['examples'])
     del copied_config['examples']
 
@@ -248,11 +260,13 @@ class WitWidget(object):
       self.config.get('predict_input_tensor'),
       self.config.get('predict_output_tensor'),
       self.estimator_and_spec.get('estimator'),
-      self.estimator_and_spec.get('feature_spec'))
+      self.estimator_and_spec.get('feature_spec'),
+      self.custom_predict_fn)
     infer_objs.append(inference_utils.run_inference_for_inference_results(
         examples_to_infer, serving_bundle))
     if ('inference_address_2' in self.config or
-        self.compare_estimator_and_spec.get('estimator')):
+        self.compare_estimator_and_spec.get('estimator') or
+        self.compare_custom_predict_fn):
       serving_bundle = inference_utils.ServingBundle(
         self.config.get('inference_address_2'),
         self.config.get('model_name_2'),
@@ -263,7 +277,8 @@ class WitWidget(object):
         self.config.get('predict_input_tensor'),
         self.config.get('predict_output_tensor'),
         self.compare_estimator_and_spec.get('estimator'),
-        self.compare_estimator_and_spec.get('feature_spec'))
+        self.compare_estimator_and_spec.get('feature_spec'),
+        self.compare_custom_predict_fn)
       infer_objs.append(inference_utils.run_inference_for_inference_results(
           examples_to_infer, serving_bundle))
     self.updated_example_indices = set()
@@ -314,9 +329,11 @@ class WitWidget(object):
       self.config.get('predict_input_tensor'),
       self.config.get('predict_output_tensor'),
       self.estimator_and_spec.get('estimator'),
-      self.estimator_and_spec.get('feature_spec')))
+      self.estimator_and_spec.get('feature_spec'),
+      self.custom_predict_fn))
     if ('inference_address_2' in self.config or
-        self.compare_estimator_and_spec.get('estimator')):
+        self.compare_estimator_and_spec.get('estimator') or
+        self.compare_custom_predict_fn):
       serving_bundles.append(inference_utils.ServingBundle(
         self.config.get('inference_address_2'),
         self.config.get('model_name_2'),
@@ -327,7 +344,8 @@ class WitWidget(object):
         self.config.get('predict_input_tensor'),
         self.config.get('predict_output_tensor'),
         self.compare_estimator_and_spec.get('estimator'),
-        self.compare_estimator_and_spec.get('feature_spec')))
+        self.compare_estimator_and_spec.get('feature_spec'),
+        self.compare_custom_predict_fn))
     viz_params = inference_utils.VizParams(
       info['x_min'], info['x_max'],
       scan_examples, 10,

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/wit.py
@@ -73,6 +73,17 @@ class WitWidget(widgets.DOMWidget):
     if 'compare_estimator_and_spec' in copied_config:
       del copied_config['compare_estimator_and_spec']
 
+    self.custom_predict_fn = (
+      config.get('custom_predict_fn')
+      if 'custom_predict_fn' in config else None)
+    self.compare_custom_predict_fn = (
+      config.get('compare_custom_predict_fn')
+      if 'compare_custom_predict_fn' in config else None)
+    if 'custom_predict_fn' in copied_config:
+      del copied_config['custom_predict_fn']
+    if 'compare_custom_predict_fn' in copied_config:
+      del copied_config['compare_custom_predict_fn']
+
     self._set_examples(config['examples'])
     del copied_config['examples']
 
@@ -109,11 +120,13 @@ class WitWidget(widgets.DOMWidget):
       self.config.get('predict_input_tensor'),
       self.config.get('predict_output_tensor'),
       self.estimator_and_spec.get('estimator'),
-      self.estimator_and_spec.get('feature_spec'))
+      self.estimator_and_spec.get('feature_spec'),
+      self.custom_predict_fn)
     infer_objs.append(inference_utils.run_inference_for_inference_results(
       examples_to_infer, serving_bundle))
     if ('inference_address_2' in self.config or
-        self.compare_estimator_and_spec.get('estimator')):
+        self.compare_estimator_and_spec.get('estimator') or
+        self.compare_custom_predict_fn):
       serving_bundle = inference_utils.ServingBundle(
         self.config.get('inference_address_2'),
         self.config.get('model_name_2'),
@@ -124,7 +137,8 @@ class WitWidget(widgets.DOMWidget):
         self.config.get('predict_input_tensor'),
         self.config.get('predict_output_tensor'),
         self.compare_estimator_and_spec.get('estimator'),
-        self.compare_estimator_and_spec.get('feature_spec'))
+        self.compare_estimator_and_spec.get('feature_spec'),
+        self.compare_custom_predict_fn)
       infer_objs.append(inference_utils.run_inference_for_inference_results(
         examples_to_infer, serving_bundle))
     self.updated_example_indices = set()
@@ -160,9 +174,11 @@ class WitWidget(widgets.DOMWidget):
       self.config.get('predict_input_tensor'),
       self.config.get('predict_output_tensor'),
       self.estimator_and_spec.get('estimator'),
-      self.estimator_and_spec.get('feature_spec')))
+      self.estimator_and_spec.get('feature_spec'),
+      self.custom_predict_fn))
     if ('inference_address_2' in self.config or
-        self.compare_estimator_and_spec.get('estimator')):
+        self.compare_estimator_and_spec.get('estimator') or
+        self.compare_custom_predict_fn):
       serving_bundles.append(inference_utils.ServingBundle(
         self.config.get('inference_address_2'),
         self.config.get('model_name_2'),
@@ -173,7 +189,8 @@ class WitWidget(widgets.DOMWidget):
         self.config.get('predict_input_tensor'),
         self.config.get('predict_output_tensor'),
         self.compare_estimator_and_spec.get('estimator'),
-        self.compare_estimator_and_spec.get('feature_spec')))
+        self.compare_estimator_and_spec.get('feature_spec'),
+        self.compare_custom_predict_fn))
     viz_params = inference_utils.VizParams(
       info['x_min'], info['x_max'],
       scan_examples, 10,

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
@@ -342,7 +342,6 @@ class WitConfigBuilder(object):
     """
     # If custom function is set, remove it before setting estimator
     self.delete('custom_predict_fn')
-    self.delete('compare_custom_predict_fn')
 
     self.store('estimator_and_spec', {
       'estimator': estimator, 'feature_spec': feature_spec})
@@ -372,7 +371,6 @@ class WitConfigBuilder(object):
       self, in order to enabled method chaining.
     """
     # If custom function is set, remove it before setting estimator
-    self.delete('custom_predict_fn')
     self.delete('compare_custom_predict_fn')
 
     self.store('compare_estimator_and_spec', {
@@ -404,7 +402,6 @@ class WitConfigBuilder(object):
     """
     # If estimator is set, remove it before setting predict_fn
     self.delete('estimator_and_spec')
-    self.delete('compare_estimator_and_spec')
 
     self.store('custom_predict_fn', predict_fn)
     self.set_inference_address('custom_predict_fn')
@@ -436,7 +433,6 @@ class WitConfigBuilder(object):
       self, in order to enabled method chaining.
     """
     # If estimator is set, remove it before setting predict_fn
-    self.delete('estimator_and_spec')
     self.delete('compare_estimator_and_spec')
 
     self.store('compare_custom_predict_fn', predict_fn)

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
@@ -408,7 +408,9 @@ class WitConfigBuilder(object):
 
     self.store('custom_predict_fn', predict_fn)
     self.set_inference_address('custom_predict_fn')
-    self.set_model_name('custom_predict_fn')
+    # If no model name has been set, give a default
+    if not self.has_model_name():
+      self.set_model_name('1')
     return self
 
   def set_compare_custom_predict_fn(self, predict_fn):
@@ -439,5 +441,7 @@ class WitConfigBuilder(object):
 
     self.store('compare_custom_predict_fn', predict_fn)
     self.set_compare_inference_address('custom_predict_fn')
-    self.set_compare_model_name('custom_predict_fn')
+    # If no model name has been set, give a default
+    if not self.has_compare_model_name():
+      self.set_compare_model_name('2')
     return self

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
@@ -44,20 +44,24 @@ class WitConfigBuilder(object):
     self.set_examples(examples)
     self.set_model_type('classification')
     self.set_label_vocab([])
-  
+
   def build(self):
     """Returns the configuration set through use of this builder object.
 
     Used by WitWidget to set the settings on an instance of the What-If Tool.
     """
     return self.config
-  
+
   def store(self, key, value):
     self.config[key] = value
 
+  def delete(self, key):
+    if key in self.config:
+      del self.config[key]
+
   def set_examples(self, examples):
     """Sets the examples to be displayed in WIT.
-    
+
     Args:
       examples: List of example protos.
 
@@ -69,7 +73,7 @@ class WitConfigBuilder(object):
       self.store('are_sequence_examples',
                  isinstance(examples[0], tf.train.SequenceExample))
     return self
-      
+
   def set_model_type(self, model):
     """Sets the type of the model being used for inference.
 
@@ -82,7 +86,7 @@ class WitConfigBuilder(object):
     """
     self.store('model_type', model)
     return self
-  
+
   def set_inference_address(self, address):
     """Sets the inference address for model inference through TF Serving.
 
@@ -95,7 +99,7 @@ class WitConfigBuilder(object):
     """
     self.store('inference_address', address)
     return self
-    
+
   def set_model_name(self, name):
     """Sets the model name for model inference through TF Serving.
 
@@ -111,7 +115,7 @@ class WitConfigBuilder(object):
     """
     self.store('model_name', name)
     return self
-  
+
   def set_model_version(self, version):
     """Sets the optional model version for model inference through TF Serving.
 
@@ -125,7 +129,7 @@ class WitConfigBuilder(object):
     """
     self.store('model_version', version)
     return self
-      
+
   def set_model_signature(self, signature):
     """Sets the optional model signature for model inference through TF Serving.
 
@@ -139,7 +143,7 @@ class WitConfigBuilder(object):
     """
     self.store('model_signature', signature)
     return self
-      
+
   def set_compare_inference_address(self, address):
     """Sets the inference address for model inference for a second model hosted
     by TF Serving.
@@ -156,7 +160,7 @@ class WitConfigBuilder(object):
     """
     self.store('inference_address_2', address)
     return self
-      
+
   def set_compare_model_name(self, name):
     """Sets the model name for a second model hosted by TF Serving.
 
@@ -175,7 +179,7 @@ class WitConfigBuilder(object):
     """
     self.store('model_name_2', name)
     return self
-  
+
   def set_compare_model_version(self, version):
     """Sets the optional model version for a second model hosted by TF Serving.
 
@@ -192,7 +196,7 @@ class WitConfigBuilder(object):
     """
     self.store('model_version_2', version)
     return self
-      
+
   def set_compare_model_signature(self, signature):
     """Sets the optional model signature for a second model hosted by TF
     Serving.
@@ -210,7 +214,7 @@ class WitConfigBuilder(object):
     """
     self.store('model_signature_2', signature)
     return self
-      
+
   def set_uses_predict_api(self, predict):
     """Indicates that the model uses the Predict API, as opposed to the
     Classification or Regression API.
@@ -230,7 +234,7 @@ class WitConfigBuilder(object):
     """
     self.store('uses_predict_api', predict)
     return self
-  
+
   def set_max_classes_to_display(self, max_classes):
     """Sets the maximum number of class results to display for multiclass
     classification models.
@@ -249,7 +253,7 @@ class WitConfigBuilder(object):
     """
     self.store('max_classes', max_classes)
     return self
-  
+
   def set_multi_class(self, multiclass):
     """Sets if the model(s) to query are mutliclass classification models.
 
@@ -262,7 +266,7 @@ class WitConfigBuilder(object):
     """
     self.store('multiclass', multiclass)
     return self
-      
+
   def set_predict_input_tensor(self, tensor):
     """Sets the name of the input tensor for models that use the Predict API.
 
@@ -330,12 +334,16 @@ class WitConfigBuilder(object):
     Returns:
       self, in order to enabled method chaining.
     """
+    # If custom function is set, remove it before setting estimator
+    self.delete('custom_predict_fn')
+    self.delete('compare_custom_predict_fn')
+
     self.store('estimator_and_spec', {
       'estimator': estimator, 'feature_spec': feature_spec})
     self.set_inference_address('estimator')
     self.set_model_name('estimator')
     return self
-  
+
   def set_compare_estimator_and_feature_spec(self, estimator, feature_spec):
     """Sets a second model for inference as a TF Estimator.
 
@@ -355,8 +363,71 @@ class WitConfigBuilder(object):
     Returns:
       self, in order to enabled method chaining.
     """
+    # If custom function is set, remove it before setting estimator
+    self.delete('custom_predict_fn')
+    self.delete('compare_custom_predict_fn')
+
     self.store('compare_estimator_and_spec', {
       'estimator': estimator, 'feature_spec': feature_spec})
     self.set_compare_inference_address('estimator')
     self.set_compare_model_name('estimator')
+    return self
+
+  def set_custom_predict_fn(self, predict_fn):
+    """Sets a custom function for inference.
+
+    Instead of using TF Serving to host a model for WIT to query, WIT can
+    directly use a custom function as the model to query. In this case, the
+    provided function should accept example protos and return:
+      - For classification: A 2D list of numbers. The first dimension is for
+        each example being predicted. The second dimension are the probabilities
+        for each class ID in the prediction.
+      - For regression: A 1D list of numbers, with a regression score for each
+        example being predicted.
+
+    Args:
+      predict_fn: The custom python function which will be used for model
+      inference.
+
+    Returns:
+      self, in order to enabled method chaining.
+    """
+    # If estimator is set, remove it before setting predict_fn
+    self.delete('estimator_and_spec')
+    self.delete('compare_estimator_and_spec')
+
+    self.store('custom_predict_fn', predict_fn)
+    self.set_inference_address('custom_predict_fn')
+    self.set_model_name('custom_predict_fn')
+    return self
+
+  def set_compare_custom_predict_fn(self, predict_fn):
+    """Sets a second custom function for inference.
+
+    If you wish to compare the results of two models in WIT, use this method
+    to setup the details of the second model.
+
+    Instead of using TF Serving to host a model for WIT to query, WIT can
+    directly use a custom function as the model to query. In this case, the
+    provided function should accept example protos and return:
+      - For classification: A 2D list of numbers. The first dimension is for
+        each example being predicted. The second dimension are the probabilities
+        for each class ID in the prediction.
+      - For regression: A 1D list of numbers, with a regression score for each
+        example being predicted.
+
+    Args:
+      predict_fn: The custom python function which will be used for model
+      inference.
+
+    Returns:
+      self, in order to enabled method chaining.
+    """
+    # If estimator is set, remove it before setting predict_fn
+    self.delete('estimator_and_spec')
+    self.delete('compare_estimator_and_spec')
+
+    self.store('compare_custom_predict_fn', predict_fn)
+    self.set_compare_inference_address('custom_predict_fn')
+    self.set_compare_model_name('custom_predict_fn')
     return self

--- a/tensorboard/plugins/interactive_inference/witwidget/version.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/version.py
@@ -14,4 +14,4 @@
 
 """Contains the version string."""
 
-VERSION = '0.1.6a4'
+VERSION = '0.1.7a0'


### PR DESCRIPTION
* Motivation for features / changes

Add custom prediction function support in colab and jupyter mode so it is easier to load non-TensorFlow models into WIT.

* Technical description of changes

WITConfigBuilder now has a "set_custom_predict_fn" method to pass a python function for prediction purposes. Parts of notebook backend and inference_utils are updated to use the custom function when provided.

* Screenshots of UI changes

No UI changes.

* Detailed steps to verify changes work correctly (as executed by you)

Ran WIT Toxicity Text Model Comparison and WIT Model Comparison colabs with custom_predict_fn to verify the tool is getting inferences correctly. 

* Alternate designs / implementations considered
