### PR TITLE
hparams: fix typo in comment

### DIFF
--- a/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot/tf-hparams-scatter-plot-matrix-plot.html
+++ b/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot/tf-hparams-scatter-plot-matrix-plot.html
@@ -162,7 +162,7 @@ the vulcanization build step. Figure out why.
         }, 100);
       },
 
-      // Creates the DOM elements comprising the scatter-plot-matix plot and
+      // Creates the DOM elements comprising the scatter-plot-matrix plot and
       // registers event handlers to handle user actions.
       _draw() {
         const utils = tf.hparams.utils;


### PR DESCRIPTION
Summary:
This fixes a lint warning raised by the Google import bot.

Test Plan:
None.

wchargin-branch: hparams-fix-typo
