### PR TITLE
scalars: use `tf-downloader` for download links

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-downloader.html
+++ b/tensorboard/components/tf_dashboard_common/tf-downloader.html
@@ -81,10 +81,10 @@ limitations under the License.
         return urlFn(tag, run);
       },
       _csvName(tag, run) {
-        return `run_${run}-tag-${tag}.csv`;
+        return `run-${run}-tag-${tag}.csv`;
       },
       _jsonName(tag, run) {
-        return `run_${run}-tag-${tag}.json`;
+        return `run-${run}-tag-${tag}.json`;
       },
     });
   </script>

--- a/tensorboard/components/tf_dashboard_common/tf-downloader.html
+++ b/tensorboard/components/tf_dashboard_common/tf-downloader.html
@@ -70,9 +70,14 @@ limitations under the License.
       is: "tf-downloader",
       properties: {
         _run: String,
-        runs: Array,
+        runs: Array,  // Array<string>
         tag: String,
-        urlFn: Function,  // (tag: string, run: string) => string (JSON URL)
+        // Clients pass `urlFn: (tag: string, run: string) => string`,
+        // which should generate a URL to download data for a given
+        // run/tag combination. The data at the URL should be in JSON
+        // form, and the URL should be such that adding a query
+        // parameter `format=csv` instead yields CSV data.
+        urlFn: Function,
       },
       _csvUrl(tag, run, urlFn) {
         return tf_backend.addParams(urlFn(tag, run), {format: "csv"});

--- a/tensorboard/components/tf_dashboard_common/tf-downloader.html
+++ b/tensorboard/components/tf_dashboard_common/tf-downloader.html
@@ -33,26 +33,19 @@ limitations under the License.
         </template>
       </paper-menu>
     </paper-dropdown-menu>
-    <div class="center">
-      <span>
-        <a
-          download="[[_csvName(tag, _run)]]"
-          href="[[_csvUrl(tag, _run, urlFn)]]"
-          >CSV</a>
-        <a
-          download="[[_jsonName(tag, _run)]]"
-          href="[[_jsonUrl(tag, _run, urlFn)]]"
-          >JSON</a>
-      </span>
-    </div>
+    <a
+      download="[[_csvName(tag, _run)]]"
+      href="[[_csvUrl(tag, _run, urlFn)]]"
+    >CSV</a><!--
+    --><a
+      download="[[_jsonName(tag, _run)]]"
+      href="[[_jsonUrl(tag, _run, urlFn)]]"
+    >JSON</a>
     <style>
       :host {
         display: flex;
+        align-items: center;
         height: 32px;
-      }
-      .center {
-        display: flex;
-        align-self: center;
       }
       paper-dropdown-menu {
         width: 100px;
@@ -65,8 +58,7 @@ limitations under the License.
       }
       a {
         font-size: 10px;
-        border-radius: 3px;
-        border: 1px solid #EEE;
+        margin: 0 0.2em;
       }
       paper-input {
         font-size: 22px;
@@ -80,7 +72,7 @@ limitations under the License.
         _run: String,
         runs: Array,
         tag: String,
-        urlFn: Function,
+        urlFn: Function,  // (tag: string, run: string) => string (JSON URL)
       },
       _csvUrl(tag, run, urlFn) {
         return tf_backend.addParams(urlFn(tag, run), {format: "csv"});
@@ -89,10 +81,10 @@ limitations under the License.
         return urlFn(tag, run);
       },
       _csvName(tag, run) {
-        return `run_${run},tag_${tag}.csv`;
+        return `run_${run}-tag-${tag}.csv`;
       },
       _jsonName(tag, run) {
-        return `run_${run},tag_${tag}.json`;
+        return `run_${run}-tag-${tag}.json`;
       },
     });
   </script>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -50,6 +50,7 @@ tf_web_library(
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_card_heading",
+        "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_line_chart_data_loader",
         "@org_polymer_paper_dropdown_menu",

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -25,6 +25,7 @@ limitations under the License.
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-line-chart-data-loader/tf-line-chart-data-loader.html">
 <link rel="import" href="../tf-card-heading/tf-card-heading.html">
+<link rel="import" href="../tf-dashboard-common/tf-downloader.html">
 
 <!--
   A card that handles loading data (at the right times), rendering a scalar
@@ -97,24 +98,11 @@ limitations under the License.
     <span style="flex-grow: 1"></span>
     <template is="dom-if" if="[[showDownloadLinks]]">
       <div class="download-links">
-        <paper-dropdown-menu
-          no-label-float="true"
-          label="run to download"
-          selected-item-label="{{_runToDownload}}"
-        >
-          <paper-menu class="dropdown-content" slot="dropdown-content">
-            <template is="dom-repeat" items="[[dataToLoad]]">
-              <paper-item no-label-float=true>[[item.run]]</paper-item>
-            </template>
-          </paper-menu>
-        </paper-dropdown-menu>
-        <a
-          download="run_[[_runToDownload]]-tag-[[tag]].csv"
-          href="[[_csvUrl(tag, _runToDownload)]]"
-        >CSV</a> <a
-          download="run_[[_runToDownload]]-tag-[[tag]].json"
-          href="[[_jsonUrl(tag, _runToDownload)]]"
-        >JSON</a>
+        <tf-downloader
+          runs="[[_runsFromData(dataToLoad)]]"
+          tag="[[tag]]"
+          url-fn="[[_downloadUrlFn]]"
+        ></tf-downloader>
       </div>
     </template>
   </div>
@@ -258,6 +246,14 @@ limitations under the License.
           },
         },
 
+        // To be provided as the `url-fn` property to `tf-downloader`.
+        _downloadUrlFn: {
+          type: Function,
+          value: function() {
+            return (tag, run) => this.getDataLoadUrl({tag, run});
+          },
+        },
+
         // A function called to fetch the scalars data from the backend.
         // Should receive a {tag, run, experiment} object and return
         // a promise resolving with the fetched scalars. The default
@@ -323,13 +319,8 @@ limitations under the License.
         // is okay.
         this.$$('#svgLink').href = `data:image/svg+xml;base64,${btoa(svgStr)}`;
       },
-      _csvUrl(tag, run) {
-        return tf_backend.addParams(
-            this.getDataLoadUrl({tag, run}),
-            {format: 'csv'});
-      },
-      _jsonUrl(tag, run) {
-        return this.getDataLoadUrl({tag, run});
+      _runsFromData(data) {
+        return data.map((datum) => datum.run);
       },
       _getDataSeries() {
         return this.dataToLoad.map(d => this._getSeriesNameFromDatum(d));


### PR DESCRIPTION
Summary:
We have a `<tf-downloader>` element that provides CSV and JSON download
links alongside a run selector, but this element is actually unused.
This commit replaces the scalar plugin’s reimplementation, updating the
styling of `<tf-downloader>` to stay mostly consistent with the existing
UI. This will enable us to fix #1845 in a way that can work for other
download links, too.

Test Plan:
Observe that the UI is virtually identical (the only visible change is
that the vertical position of the dropdown menu has shifted slightly):

![“Before” and “after” screenshot.](https://user-images.githubusercontent.com/4317806/52752587-38795e00-2fa8-11e9-8b7c-1d8b9a540e49.png)

Check that the download links download identical files before and after
the change, with the same filenames except that the `run_` prefix has
been changed to `run-` for internal consistency.

wchargin-branch: scalars-tf-downloader
