### PR TITLE
Add summary/_tf/ package for providing tf.summary API component

### DIFF
--- a/tensorboard/summary/BUILD
+++ b/tensorboard/summary/BUILD
@@ -1,6 +1,8 @@
 # Description:
 # Summary API for TensorBoard.
 
+package(default_visibility = ["//tensorboard:internal"])
+
 licenses(["notice"])  # Apache 2.0
 
 py_library(
@@ -47,6 +49,30 @@ py_library(
         "//tensorboard/plugins/image:summary_v2",
         "//tensorboard/plugins/scalar:summary_v2",
         "//tensorboard/plugins/text:summary_v2",
+    ],
+)
+
+# This library provides a _tf.summary package with summary API symbols from
+# TensorBoard, meant to be overlayed into TensorFlow's namespace as tf.summary.
+#
+# Due to the mechanics of the component_api_helper() insertion mechanism, this
+# must be a package (not module) without any sibling-level packages, where the
+# desired name at the insertion point ("summary") must be the final component
+# of the real package name, which necessitates putting this under two levels
+# of dedicated directories. The inner __init__.py is the real code.
+py_library(
+    name = "tf_summary",
+    srcs = [
+        "_tf/__init__.py",
+        "_tf/summary/__init__.py",
+    ],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//tensorboard:internal",
+    ],
+    deps = [
+        ":summary_v2",
+        "//tensorboard:expect_tensorflow_installed",
     ],
 )
 

--- a/tensorboard/summary/_tf/__init__.py
+++ b/tensorboard/summary/_tf/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -1,0 +1,36 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""TensorFlow component package for providing tf.summary from TensorBoard."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+# Re-export all symbols from the original tf.summary.
+# pylint: disable=wildcard-import,unused-import,g-import-not-at-top
+if tf.__version__.startswith('2.'):
+  from tensorflow.summary import *
+else:
+  from tensorflow.compat.v2.summary import *
+
+from tensorboard.summary.v2 import audio
+from tensorboard.summary.v2 import histogram
+from tensorboard.summary.v2 import image
+from tensorboard.summary.v2 import scalar
+from tensorboard.summary.v2 import text
+
+del absolute_import, division, print_function, tf


### PR DESCRIPTION
This change provides a package suitable for injection into TensorFlow's API generation as an API "component package" providing the `tf.summary` API.  It re-exports symbols from the original `tf.summary` module so that when used with `component_api_helper` from TensorFlow and inserted into the TF namespace, the effect is to overlay symbols from TensorBoard over the existing module.

The component package approach mitigates circular dependency issues (a risk because the TensorBoard ops in turn depend on TF) because the TF API __init__.py imports the core TF API symbols before it imports components, so if they in turn `import tensorflow` the module has been mostly initialized. It also means that TensorBoard needn't be importable at API generation time, only when TF is actually imported, which avoids issues like https://github.com/tensorflow/tensorflow/issues/22395.