### PR TITLE
Make tf.summary API component package work in pip package land

### DIFF
--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -22,6 +22,7 @@ sh_binary(
         "//tensorboard:version",  # Version module (read by setup.py)
         "//tensorboard/plugins/beholder",  # User-facing beholder API
         "//tensorboard/plugins/projector",  # User-facing projector API
+        "//tensorboard/summary:tf_summary",  #  tf.summary API for TF 2.0
     ],
     tags = [
         "local",

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -65,6 +65,7 @@ tb.summary.scalar_pb('test', 42)
 from tensorboard.plugins.projector import visualize_embeddings
 from tensorboard.plugins.beholder import Beholder, BeholderHook
 tb.notebook.start  # don't invoke; just check existence
+import tensorboard.summary._tf.summary as tf_summary
 "
   deactivate
   cd ..

--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -22,10 +22,21 @@ import tensorflow as tf
 
 # Re-export all symbols from the original tf.summary.
 # pylint: disable=wildcard-import,unused-import,g-import-not-at-top
-if tf.__version__.startswith('2.'):
+
+if getattr(tf, '__version__', '').startswith('2.'):
   from tensorflow.summary import *
 else:
-  from tensorflow.compat.v2.summary import *
+  # Check if we can directly import tf.compat.v2. We may not be able to if we
+  # reached this import itself while importing tf.compat.v2.
+  try:
+    import tensorflow.compat.v2 as test_import
+    del test_import
+  except ImportError:
+    # If that failed, go "under the hood" to directly import the module that
+    # will become tf.compat.v2.summary.
+    from tensorflow._api.v1.compat.v2.summary import *
+  else:
+    from tensorflow.compat.v2 import *
 
 from tensorboard.summary.v2 import audio
 from tensorboard.summary.v2 import histogram


### PR DESCRIPTION
These are two fixes so that the tf.summary API component package introduced in #1847 works properly for users when pip-installing the code.  (It already works internally in the non-pip-package variation.)

1) add the code to the TensorBoard pip package - this was just an oversight
2) fix the import logic used by the API component module to re-export symbols from the original tf.summary module, which was broken because the generated API structure of opensource TF is such that the original logic breaks

The fix for issue 2 isn't as clean as I would like, so I'm going to see if I can find a better way.  This is just to unbreak things.