### PR TITLE
Change graph plugin backend for v2 compatibility

### DIFF
--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -31,7 +31,7 @@ logger = tb_logging.get_logger()
 
 _PLUGIN_PREFIX_ROUTE = 'graphs'
 
-_PLUGIN_NAME_RUN_METADATA_WITH_GRAPH = 'graph_run_metadata_with_graph'
+_PLUGIN_NAME_RUN_METADATA_WITH_GRAPH = 'graph_run_metadata_graph'
 
 
 class GraphsPlugin(base_plugin.TBPlugin):

--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -54,21 +54,22 @@ class GraphsPlugin(base_plugin.TBPlugin):
   def get_plugin_apps(self):
     return {
         '/graph': self.graph_route,
-        '/meta': self.meta_route,
+        '/info': self.info_route,
         '/run_metadata': self.run_metadata_route,
     }
 
   def is_active(self):
     """The graphs plugin is active iff any run has a graph."""
-    return bool(self._multiplexer and self.meta_impl())
+    return bool(self._multiplexer and self.info_impl())
 
-  def meta_impl(self):
+  def info_impl(self):
     """Returns a dict of all runs and tags and their data availabilities."""
     result = {}
     def add_row_item(run, tag=None):
       run_item = result.setdefault(run, {
           'run': run,
           'tags': {},
+          # A run-wide GraphDef of ops.
           'run_graph': False})
 
       tag_item = None
@@ -76,6 +77,7 @@ class GraphsPlugin(base_plugin.TBPlugin):
         tag_item = run_item.get('tags').setdefault(tag, {
             'tag': tag,
             'conceptual_graph': False,
+            # A tagged GraphDef of ops.
             'op_graph': False,
             'profile': False})
       return (run_item, tag_item)
@@ -126,8 +128,8 @@ class GraphsPlugin(base_plugin.TBPlugin):
     return (str(run_metadata), 'text/x-protobuf')  # pbtxt
 
   @wrappers.Request.application
-  def meta_route(self, request):
-    meta = self.meta_impl()
+  def info_route(self, request):
+    meta = self.info_impl()
     return http_util.Respond(request, meta, 'application/json')
 
   @wrappers.Request.application

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -112,7 +112,12 @@ class GraphsPluginTest(tf.test.TestCase):
         'run': 'w_graph_w_meta',
         'run_graph': True,
         'tags': {
-          'secret-stats': {'conceptual_graph': False, 'profile': True, 'tag': 'secret-stats', 'op_graph': False},
+          'secret-stats': {
+            'conceptual_graph': False,
+            'profile': True,
+            'tag': 'secret-stats',
+            'op_graph': False,
+          },
         },
       },
       'w_graph_wo_meta': {
@@ -124,7 +129,12 @@ class GraphsPluginTest(tf.test.TestCase):
         'run': 'wo_graph_w_meta',
         'run_graph': False,
         'tags': {
-          'secret-stats': {'conceptual_graph': False, 'profile': True, 'tag': 'secret-stats', 'op_graph': False},
+          'secret-stats': {
+            'conceptual_graph': False,
+            'profile': True,
+            'tag': 'secret-stats',
+            'op_graph': False,
+          },
         },
       },
     }

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -106,7 +106,7 @@ class GraphsPluginTest(tf.test.TestCase):
     self.assertIsInstance(routes['/run_metadata'], collections.Callable)
     self.assertIsInstance(routes['/info'], collections.Callable)
 
-  def test_meta(self):
+  def test_info(self):
     expected = {
       'w_graph_w_meta': {
         'run': 'w_graph_w_meta',

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -104,7 +104,7 @@ class GraphsPluginTest(tf.test.TestCase):
     routes = self.plugin.get_plugin_apps()
     self.assertIsInstance(routes['/graph'], collections.Callable)
     self.assertIsInstance(routes['/run_metadata'], collections.Callable)
-    self.assertIsInstance(routes['/meta'], collections.Callable)
+    self.assertIsInstance(routes['/info'], collections.Callable)
 
   def test_meta(self):
     expected = {
@@ -143,7 +143,7 @@ class GraphsPluginTest(tf.test.TestCase):
                       include_run_metadata=False)
     self.bootstrap_plugin()
 
-    self.assertItemsEqual(expected, self.plugin.meta_impl())
+    self.assertItemsEqual(expected, self.plugin.info_impl())
 
   def _get_graph(self, *args, **kwargs):
     """Set up runs, then fetch and return the graph as a proto."""

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -48,7 +48,10 @@ class GraphsPluginTest(tf.test.TestCase):
     self.logdir = None
     self.plugin = None
 
-  def generate_run(self, run_name, include_graph):
+  def setUp(self):
+    self.logdir = self.get_temp_dir()
+
+  def generate_run(self, run_name, include_graph, include_run_metadata):
     """Create a run with a text summary, metadata, and optionally a graph."""
     tf.compat.v1.reset_default_graph()
     k1 = tf.constant(math.pi, name='k1')
@@ -73,15 +76,22 @@ class GraphsPluginTest(tf.test.TestCase):
     run_metadata = config_pb2.RunMetadata()
     s = sess.run(summary_message, options=options, run_metadata=run_metadata)
     writer.add_summary(s)
-    writer.add_run_metadata(run_metadata, self._METADATA_TAG)
+    if include_run_metadata:
+      writer.add_run_metadata(run_metadata, self._METADATA_TAG)
     writer.close()
 
   def set_up_with_runs(self, with_graph=True, without_graph=True):
-    self.logdir = self.get_temp_dir()
     if with_graph:
-      self.generate_run(self._RUN_WITH_GRAPH, include_graph=True)
+      self.generate_run(self._RUN_WITH_GRAPH,
+                        include_graph=True,
+                        include_run_metadata=True)
     if without_graph:
-      self.generate_run(self._RUN_WITHOUT_GRAPH, include_graph=False)
+      self.generate_run(self._RUN_WITHOUT_GRAPH,
+                        include_graph=False,
+                        include_run_metadata=True)
+    self.bootstrap_plugin()
+
+  def bootstrap_plugin(self):
     multiplexer = event_multiplexer.EventMultiplexer()
     multiplexer.AddRunsFromDirectory(self.logdir)
     multiplexer.Reload()
@@ -90,23 +100,50 @@ class GraphsPluginTest(tf.test.TestCase):
 
   def testRoutesProvided(self):
     """Tests that the plugin offers the correct routes."""
-    self.set_up_with_runs(with_graph=True, without_graph=False)
+    self.set_up_with_runs()
     routes = self.plugin.get_plugin_apps()
     self.assertIsInstance(routes['/graph'], collections.Callable)
-    self.assertIsInstance(routes['/runs'], collections.Callable)
     self.assertIsInstance(routes['/run_metadata'], collections.Callable)
-    self.assertIsInstance(routes['/run_metadata_tags'], collections.Callable)
+    self.assertIsInstance(routes['/index'], collections.Callable)
 
   def test_index(self):
-    self.set_up_with_runs()
-    self.assertItemsEqual([self._RUN_WITH_GRAPH], self.plugin.index_impl())
+    expected = {
+      'w_graph_w_meta': {
+        'run': 'w_graph_w_meta',
+        'run_graph': True,
+        'tags': {
+          'secret-stats': {'conceptual_graph': False, 'profile': True, 'tag': 'secret-stats', 'op_graph': False},
+        },
+      },
+      'w_graph_wo_meta': {
+        'run': 'w_graph_wo_meta',
+        'run_graph': True,
+        'tags': {},
+      },
+      'wo_graph_w_meta': {
+        'run': 'wo_graph_w_meta',
+        'run_graph': False,
+        'tags': {
+          'secret-stats': {'conceptual_graph': False, 'profile': True, 'tag': 'secret-stats', 'op_graph': False},
+        },
+      },
+    }
 
-  def test_run_metadata_index(self):
-    self.set_up_with_runs()
-    self.assertDictEqual({
-        self._RUN_WITH_GRAPH: [self._METADATA_TAG],
-        self._RUN_WITHOUT_GRAPH: [self._METADATA_TAG],
-    }, self.plugin.run_metadata_index_impl())
+    self.generate_run('w_graph_w_meta',
+                      include_graph=True,
+                      include_run_metadata=True)
+    self.generate_run('w_graph_wo_meta',
+                      include_graph=True,
+                      include_run_metadata=False)
+    self.generate_run('wo_graph_w_meta',
+                      include_graph=False,
+                      include_run_metadata=True)
+    self.generate_run('wo_graph_wo_meta',
+                      include_graph=False,
+                      include_run_metadata=False)
+    self.bootstrap_plugin()
+
+    self.assertItemsEqual(expected, self.plugin.index_impl())
 
   def _get_graph(self, *args, **kwargs):
     """Set up runs, then fetch and return the graph as a proto."""
@@ -146,17 +183,33 @@ class GraphsPluginTest(tf.test.TestCase):
     text_format.Parse(metadata_pbtxt, config_pb2.RunMetadata())
     # If it parses, we're happy.
 
-  def test_is_active_with_graph(self):
-    self.set_up_with_runs(with_graph=True, without_graph=False)
+  def test_is_active_with_graph_without_run_metadata(self):
+    self.generate_run('w_graph_wo_meta',
+                      include_graph=True,
+                      include_run_metadata=False)
+    self.bootstrap_plugin()
     self.assertTrue(self.plugin.is_active())
 
-  def test_is_active_without_graph(self):
-    self.set_up_with_runs(with_graph=False, without_graph=True)
-    self.assertFalse(self.plugin.is_active())
+  def test_is_active_without_graph_with_run_metadata(self):
+    self.generate_run('wo_graph_w_meta',
+                      include_graph=False,
+                      include_run_metadata=True)
+    self.bootstrap_plugin()
+    self.assertTrue(self.plugin.is_active())
 
   def test_is_active_with_both(self):
-    self.set_up_with_runs(with_graph=True, without_graph=True)
+    self.generate_run('w_graph_w_meta',
+                      include_graph=True,
+                      include_run_metadata=True)
+    self.bootstrap_plugin()
     self.assertTrue(self.plugin.is_active())
+
+  def test_is_active_without_both(self):
+    self.generate_run('wo_graph_wo_meta',
+                      include_graph=False,
+                      include_run_metadata=False)
+    self.bootstrap_plugin()
+    self.assertFalse(self.plugin.is_active())
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -104,9 +104,9 @@ class GraphsPluginTest(tf.test.TestCase):
     routes = self.plugin.get_plugin_apps()
     self.assertIsInstance(routes['/graph'], collections.Callable)
     self.assertIsInstance(routes['/run_metadata'], collections.Callable)
-    self.assertIsInstance(routes['/index'], collections.Callable)
+    self.assertIsInstance(routes['/meta'], collections.Callable)
 
-  def test_index(self):
+  def test_meta(self):
     expected = {
       'w_graph_w_meta': {
         'run': 'w_graph_w_meta',
@@ -143,7 +143,7 @@ class GraphsPluginTest(tf.test.TestCase):
                       include_run_metadata=False)
     self.bootstrap_plugin()
 
-    self.assertItemsEqual(expected, self.plugin.index_impl())
+    self.assertItemsEqual(expected, self.plugin.meta_impl())
 
   def _get_graph(self, *args, **kwargs):
     """Set up runs, then fetch and return the graph as a proto."""

--- a/tensorboard/plugins/graph/http_api.md
+++ b/tensorboard/plugins/graph/http_api.md
@@ -3,7 +3,7 @@
 The graph plugin name is `graphs`, so all its routes are under
 `/data/plugin/graphs`.
 
-## `/data/plugin/graphs/index`
+## `/data/plugin/graphs/meta`
 
 Returns meta information about data availabilities for a given run and a tag.
 Below fields describe the data availabilities:

--- a/tensorboard/plugins/graph/http_api.md
+++ b/tensorboard/plugins/graph/http_api.md
@@ -3,15 +3,16 @@
 The graph plugin name is `graphs`, so all its routes are under
 `/data/plugin/graphs`.
 
-## `/data/plugin/graphs/meta`
+## `/data/plugin/graphs/info`
 
 Returns meta information about data availabilities for a given run and a tag.
 Below fields describe the data availabilities:
-- "run_graph": Whether a GraphDef is present for entire run. Note that this is
-      for v1 compatibility and, in v2, all graphs should have a tag.
-- "op_graph": Whether a GraphDef of Op nodes is present.
-- "profile": Whether a profile information is present with a RunMetadata.
-- "conceptual_graph": Whether a GraphDef descriving conceptual graph is present.
+- "run_graph": v1 only. Whether a GraphDef of op nodes is present for an entire run.
+      Historically, in v1, an op graph was written out for an entire run as a field on
+      Event proto. In v2, graphs are written out as a Summary with respective tags.
+- "op_graph": v2 only. Whether a GraphDef of op nodes is present with a tag.
+- "profile": Whether a profile information is present with a RunMetadata and a tag.
+- "conceptual_graph": Whether a GraphDef describing conceptual graph is present.
       The graph plugin currently only supports a Keras model written out as a
       JSON.
 

--- a/tensorboard/plugins/graph/http_api.md
+++ b/tensorboard/plugins/graph/http_api.md
@@ -3,18 +3,39 @@
 The graph plugin name is `graphs`, so all its routes are under
 `/data/plugin/graphs`.
 
-## `/data/plugin/graphs/runs`
+## `/data/plugin/graphs/index`
 
-Returns a list of runs that have associated graphs.
+Returns meta information about data availabilities for a given run and a tag.
+Below fields describe the data availabilities:
+- "run_graph": Whether a GraphDef is present for entire run. Note that this is
+      for v1 compatibility and, in v2, all graphs should have a tag.
+- "op_graph": Whether a GraphDef of Op nodes is present.
+- "profile": Whether a profile information is present with a RunMetadata.
+- "conceptual_graph": Whether a GraphDef descriving conceptual graph is present.
+      The graph plugin currently only supports a Keras model written out as a
+      JSON.
 
-For example:
+Please refer to below example for the full structure.
 
-    ["train"]
+    {
+      "train": {
+        "run: "train",
+        "tags": {
+          "tag_1": {
+            "tag": "tag_1",
+            "op_graph": true,
+            "profile": false,
+            "conceptual_graph": false
+          }
+        },
+        "run_graph": true
+      }
+    }
 
 ## `/data/plugin/graphs/graph?run=foo&limit_attr_size=1024&large_attrs_key=key`
 
-Returns the graph definition for the given run in pbtxt format. The
-graph is composed of a list of nodes, where each node is a specific
+Returns the graph definition for the given run and/or tag in pbtxt format.
+The graph is composed of a list of nodes, where each node is a specific
 TensorFlow operation which takes as inputs other nodes (operations).
 
 The query parameters `limit_attr_size` and `large_attrs_key` are
@@ -90,24 +111,6 @@ Prior to filtering, the original node "B" had the following content:
       }
     }
 
-## `/data/graphs/run_metadata_tags`
-
-Retrieves an index of run metadata tags. The result is a dictionary that
-maps each run name (a string) to a list of tag names (as strings).
-
-Here is an example response:
-
-    {
-      "train": [
-        "step_0000",
-        "step_0100",
-        "step_0200",
-      ],
-      "eval": [],
-    }
-
-Note that runs without any run metadata tags are included as keys with
-value the empty array.
 
 ## `/data/run_metadata?run=foo&tag=bar`
 

--- a/tensorboard/plugins/graph/tf_graph_common/common.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/common.ts
@@ -35,7 +35,7 @@ namespace tf.graph {
   // Note that tf-graph-control depends on the value of the enum.
   // Polymer does not let one use JS variable as a prop.
   export enum SelectionType {
-    OP_GRAPH = 'opgraph',
+    OP_GRAPH = 'op_graph',
     CONCEPTUAL_GRAPH = 'conceptual_graph',
     PROFILE = 'profile',
   };

--- a/tensorboard/plugins/graph/tf_graph_common/common.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/common.ts
@@ -29,3 +29,14 @@ module tf {
     reportError(msg: string, err: Error): void;
   }
 } // close module tf
+
+
+namespace tf.graph {
+  // Note that tf-graph-control depends on the value of the enum.
+  // Polymer does not let one use JS variable as a prop.
+  export enum SelectionType {
+    OP_GRAPH = 'opgraph',
+    CONCEPTUAL_GRAPH = 'conceptual_graph',
+    PROFILE = 'profile',
+  };
+}  // namespace tf.graph

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -865,6 +865,9 @@ Polymer({
       value: 0,
       observer: '_selectedTagIndexChanged',
     },
+    /**
+     * @type {tf.graph.SelectionType}
+     */
     _selectedGraphType: {
       type: String,
       value: tf.graph.SelectionType.OP_GRAPH,

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -832,6 +832,13 @@ Polymer({
       type: Object,
       notify: true,
     },
+    /**
+     * {
+     *    run: string,
+     *    tag: string,
+     *    type: tf.graph.SelectionType,
+     * }
+     */
     selection: {
       type: Object,
       notify: true,

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -284,7 +284,7 @@ table.tf-graph-controls td.input-element-table-data {
 
 /** Override inline styles that suppress pointer events for disabled buttons. Otherwise, the */
 /*  tooltips do not appear. */
-#color-by-radio-group paper-radio-button {
+paper-radio-group paper-radio-button {
   pointer-events: auto !important;
 }
 
@@ -350,7 +350,7 @@ paper-dropdown-menu {
   <div class="control-holder runs">
     <div class="title">Run <span class="counter">([[datasets.length]])</span></div>
     <paper-dropdown-menu no-label-float no-animations noink horizontal-align="left" class="run-dropdown">
-      <paper-menu id="select" class="dropdown-content" selected="{{_selectedRunIndex}}" slot="dropdown-content">
+      <paper-menu class="dropdown-content" selected="{{_selectedRunIndex}}" slot="dropdown-content">
         <template is="dom-repeat" items="[[datasets]]">
           <paper-item>[[item.name]]</paper-item>
         </template>
@@ -361,9 +361,9 @@ paper-dropdown-menu {
     <div class="control-holder">
       <div class="title">Tag <span class="counter">([[_numTags(datasets, _selectedRunIndex)]])</span></div>
       <paper-dropdown-menu no-label-float no-animations horizontal-align="left" noink class="run-dropdown">
-        <paper-menu id="select" class="dropdown-content" selected="{{_selectedTagIndex}}" slot="dropdown-content">
+        <paper-menu class="dropdown-content" selected="{{_selectedTagIndex}}" slot="dropdown-content">
           <template is="dom-repeat" items="[[_getTags(datasets, _selectedRunIndex)]]">
-            <paper-item>[[item.tagName]]</paper-item>
+            <paper-item>[[item.displayName]]</paper-item>
           </template>
         </paper-menu>
       </paper-dropdown-menu>
@@ -388,9 +388,9 @@ paper-dropdown-menu {
     </div>
   </template>
   <div class="control-holder">
-    <paper-radio-group id="color-by-radio-group" selected="{{_selectedGraphType}}">
+    <paper-radio-group selected="{{_selectedGraphType}}">
       <!-- Note that the name has to match that of tf.graph.SelectionType. -->
-      <paper-radio-button name="opgraph"
+      <paper-radio-button name="op_graph"
           disabled="{{_getSelectionOpGraphDisabled(datasets, _selectedRunIndex, _selectedTagIndex)}}"
       >Graph</paper-radio-button>
       <paper-radio-button name="profile"
@@ -413,7 +413,7 @@ paper-dropdown-menu {
   </template>
   <div class="control-holder">
     <div class="title">Color</div>
-    <paper-radio-group id="color-by-radio-group" selected="{{colorBy}}">
+    <paper-radio-group selected="{{colorBy}}">
       <paper-radio-button name="structure">Structure</paper-radio-button>
 
       <paper-radio-button name="device">Device</paper-radio-button>
@@ -809,7 +809,7 @@ Polymer({
       value: null,
       type: Object,
       notify: true,
-      // TODO(stephanwlee): FIX this to readOnly and fix the setter.
+      // TODO(stephanwlee): Change readonly -> readOnly and fix the setter.
       readonly: true,
     },
     colorBy: {
@@ -820,7 +820,7 @@ Polymer({
     colorByParams: {
       type: Object,
       notify: true,
-      // TODO(stephanwlee): FIX this to readOnly and fix the setter.
+      // TODO(stephanwlee): Change readonly -> readOnly and fix the setter.
       readonly: true,
     },
     datasets: {
@@ -860,7 +860,7 @@ Polymer({
       observer: '_selectedTagIndexChanged',
     },
     _selectedGraphType: {
-      type: Number,
+      type: String,
       value: tf.graph.SelectionType.OP_GRAPH,
     },
     selectedNode: {
@@ -1073,7 +1073,6 @@ Polymer({
     if (oldDatasets != null) {
       // Select the first dataset by default.
       this._selectedRunIndex = 0;
-      this._setDownloadFilename(this.datasets[this._selectedRunIndex].name);
     }
   },
   _computeSelection: function(datasets, _selectedRunIndex, _selectedTagIndex, _selectedGraphType) {
@@ -1088,14 +1087,14 @@ Polymer({
       type: _selectedGraphType,
     }
   },
-  _selectedRunIndexChanged: function(newDataset, oldDataset) {
+  _selectedRunIndexChanged: function(runIndex) {
     if (!this.datasets) return;
     // Reset the states when user pick a different run.
     this.colorBy = 'structure';
     this._selectedTagIndex = 0;
     this._selectedGraphType = this._getDefaultSelectionType();
     this.$['trace-inputs'].active = false; // Set trace input to off-state.
-    this._setDownloadFilename(this.datasets[newDataset] ? this.datasets[newDataset].name : '');
+    this._setDownloadFilename(this.datasets[runIndex] ? this.datasets[runIndex].name : '');
   },
   _selectedTagIndexChanged() {
      this._selectedGraphType = this._getDefaultSelectionType();

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -796,6 +796,16 @@ var DEVICE_STATS_DEFAULT_OFF = [
 //  }
 ];
 
+/**
+ * TODO(stephanwlee): Convert this to proper type when converting to TypeScript.
+ * @typedef {{
+ *   run: string,
+ *   tag: ?string,
+ *   type: tf.graph.SelectionType,
+ * }}
+ */
+const Selection = {};
+
 Polymer({
   is: 'tf-graph-controls',
   properties: {
@@ -833,11 +843,7 @@ Polymer({
       notify: true,
     },
     /**
-     * {
-     *    run: string,
-     *    tag: string,
-     *    type: tf.graph.SelectionType,
-     * }
+     * @type {!Selection}
      */
     selection: {
       type: Object,

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -350,7 +350,7 @@ paper-dropdown-menu {
   <div class="control-holder runs">
     <div class="title">Run <span class="counter">([[datasets.length]])</span></div>
     <paper-dropdown-menu no-label-float no-animations noink horizontal-align="left" class="run-dropdown">
-      <paper-menu id="select" class="dropdown-content" selected="{{selectedDataset}}" slot="dropdown-content">
+      <paper-menu id="select" class="dropdown-content" selected="{{_selectedRunIndex}}" slot="dropdown-content">
         <template is="dom-repeat" items="[[datasets]]">
           <paper-item>[[item.name]]</paper-item>
         </template>
@@ -359,13 +359,12 @@ paper-dropdown-menu {
   </div>
   <template is="dom-if" if="[[showSessionRunsDropdown]]">
     <div class="control-holder">
-      <div class="title">Session runs <span class="counter">([[_numSessionRuns(metadataTags)]])</span></div>
+      <div class="title">Tag <span class="counter">([[_numTags(datasets, _selectedRunIndex)]])</span></div>
       <paper-dropdown-menu no-label-float no-animations horizontal-align="left" noink class="run-dropdown">
-        <paper-menu id="select" class="dropdown-content" selected="{{selectedMetadataTag}}" slot="dropdown-content">
-          <template is="dom-repeat" items="[[metadataTags]]">
-            <paper-item>[[item.tag]]</paper-item>
+        <paper-menu id="select" class="dropdown-content" selected="{{_selectedTagIndex}}" slot="dropdown-content">
+          <template is="dom-repeat" items="[[_getTags(datasets, _selectedRunIndex)]]">
+            <paper-item>[[item.tagName]]</paper-item>
           </template>
-          <paper-item>None</paper-item>
         </paper-menu>
       </paper-dropdown-menu>
     </div>
@@ -388,6 +387,17 @@ paper-dropdown-menu {
       </div>
     </div>
   </template>
+  <div class="control-holder">
+    <paper-radio-group id="color-by-radio-group" selected="{{_selectedGraphType}}">
+      <!-- Note that the name has to match that of tf.graph.SelectionType. -->
+      <paper-radio-button name="opgraph"
+          disabled="{{_getSelectionOpGraphDisabled(datasets, _selectedRunIndex, _selectedTagIndex)}}"
+      >Graph</paper-radio-button>
+      <paper-radio-button name="profile"
+          disabled="{{_getSelectionProfileDisabled(datasets, _selectedRunIndex, _selectedTagIndex)}}"
+      >Profile</paper-radio-button>
+    </paper-radio-group>
+  </div>
   <div class="control-holder">
     <div>
       <paper-toggle-button id="trace-inputs" class="title">
@@ -799,17 +809,18 @@ Polymer({
       value: null,
       type: Object,
       notify: true,
+      // TODO(stephanwlee): FIX this to readOnly and fix the setter.
       readonly: true,
     },
     colorBy: {
       type: String,
       value: 'structure',
       notify: true,
-      readonly: true
     },
     colorByParams: {
       type: Object,
       notify: true,
+      // TODO(stephanwlee): FIX this to readOnly and fix the setter.
       readonly: true,
     },
     datasets: {
@@ -820,24 +831,29 @@ Polymer({
       type: Object,
       notify: true,
     },
-    metadataTags: {
-      type: Array,
-      computed: '_getMetadataTags(selectedDataset, datasets)'
-    },
-    selectedDataset: {
-      type: Number,
+    selection: {
+      type: Object,
       notify: true,
-      value: 0,
-      observer: '_selectedDatasetChanged'
+      readOnly: true,
+      computed: '_computeSelection(datasets, _selectedRunIndex, _selectedTagIndex, _selectedGraphType)',
     },
     selectedFile: {
       type: Object,
       notify: true
     },
-    selectedMetadataTag: {
+    _selectedRunIndex: {
       type: Number,
-      notify: true,
-      value: -1
+      value: 0,
+      observer: '_selectedRunIndexChanged',
+    },
+    _selectedTagIndex: {
+      type: Number,
+      value: 0,
+      observer: '_selectedTagIndexChanged',
+    },
+    _selectedGraphType: {
+      type: Number,
+      value: tf.graph.SelectionType.OP_GRAPH,
     },
     selectedNode: {
       type: String,
@@ -957,11 +973,11 @@ Polymer({
     }
     this.set('devicesForStats', devicesForStats);
   },
-  _numSessionRuns: function(metadataTags) {
-    return metadataTags != null ? metadataTags.length : 0;
+  _numTags: function(datasets, _selectedRunIndex) {
+    return this._getTags(datasets, _selectedRunIndex).length;
   },
-  _getBackgroundColor: function(color) {
-    return 'background-color:' + color;
+  _getTags: function(datasets, _selectedRunIndex) {
+    return datasets[_selectedRunIndex].tags;
   },
   fit: function() {
     document.querySelector('#scene').fit();
@@ -1025,46 +1041,80 @@ Polymer({
     this.$.graphdownload.click();
   },
   _updateFileInput: function(e) {
-    var file = e.target.files[0];
-    if (!file) {
-      return;
+    const file = e.target.files[0];
+    if (!file) return;
+
+    // Strip off everything before the last "/" and strip off the file
+    // extension in order to get the name of the PNG for the graph.
+    let filePath = file.name;
+    const dotIndex = filePath.lastIndexOf('.');
+    if (dotIndex >= 0) {
+      filePath = filePath.substring(0, dotIndex);
     }
-    this._setDownloadFilename(file.name);
+    const lastSlashIndex = filePath.lastIndexOf('/');
+    if (lastSlashIndex >= 0) {
+      filePath = filePath.substring(lastSlashIndex + 1);
+    }
+    this._setDownloadFilename(filePath);
     this.set('selectedFile', e);
   },
   _datasetsChanged: function(newDatasets, oldDatasets) {
-    if (oldDatasets != null || this.selected == null) {
+    if (oldDatasets != null) {
       // Select the first dataset by default.
-      this.set('selectedDataset', 0);
-      this._setDownloadFilename(this.datasets[this.selectedDataset].path);
+      this._selectedRunIndex = 0;
+      this._setDownloadFilename(this.datasets[this._selectedRunIndex].name);
     }
   },
-  _getMetadataTags: function(selectedDataset, datasets) {
-    return this.datasets[selectedDataset].runMetadata;
+  _computeSelection: function(datasets, _selectedRunIndex, _selectedTagIndex, _selectedGraphType) {
+    if (!datasets[_selectedRunIndex] ||
+        !datasets[_selectedRunIndex].tags[_selectedTagIndex]) {
+      return null;
+    }
+
+    return {
+      run: datasets[_selectedRunIndex].name,
+      tag: datasets[_selectedRunIndex].tags[_selectedTagIndex].tag,
+      type: _selectedGraphType,
+    }
   },
-  _selectedDatasetChanged: function(newDataset, oldDataset) {
+  _selectedRunIndexChanged: function(newDataset, oldDataset) {
     if (this.datasets) {
-      this.set('selectedMetadataTag', -1);
-      this.set('colorBy', 'structure');
+      // Reset the states when user pick a different run.
+      this.colorBy = 'structure';
+      this._selectedTagIndex = 0;
+      this._selectedGraphType = this._getDefaultSelectionType();
       this.$['trace-inputs'].active = false; // Set trace input to off-state.
-      this._setDownloadFilename(this.datasets[newDataset].path);
+      this._setDownloadFilename(this.datasets[newDataset].name);
     }
+  },
+  _selectedTagIndexChanged() {
+     this._selectedGraphType = this._getDefaultSelectionType();
+  },
+  _getDefaultSelectionType() {
+    const {
+      datasets,
+      _selectedRunIndex: run,
+      _selectedTagIndex: tag,
+    } = this;
+    if (!datasets ||
+        !datasets[run] ||
+        !datasets[run].tags[tag] ||
+        datasets[run].tags[tag].opGraph) {
+      return tf.graph.SelectionType.OP_GRAPH;
+    }
+    if (datasets[run].tags[tag].profile) {
+      return tf.graph.SelectionType.PROFILE;
+    }
+    if (datasets[run].tags[tag].conceptualGraph) {
+      return tf.graph.SelectionType.CONCEPTUAL_GRAPH;
+    }
+    return tf.graph.SelectionType.OP_GRAPH;
   },
   _getFile: function() {
     this.$$("#file").click();
   },
-  _setDownloadFilename: function(graphPath) {
-    // Strip off everything before the last "/" and strip off the file
-    // extension in order to get the name of the PNG for the graph.
-    var dotIndex = graphPath.lastIndexOf('.');
-    if (dotIndex) {
-      graphPath = graphPath.substring(0, dotIndex);
-    }
-    var slashIndex = graphPath.lastIndexOf('/');
-    if (slashIndex) {
-      graphPath = graphPath.substring(slashIndex + 1);
-    }
-    this.$.graphdownload.setAttribute('download', graphPath + '.png');
+  _setDownloadFilename: function(name) {
+    this.$.graphdownload.setAttribute('download', name + '.png');
   },
   _statsNotNull: function(stats) {
     return stats !== null;
@@ -1082,6 +1132,16 @@ Polymer({
     // expand in the downwards direction. This collapsible expands upwards
     // though, so we reverse the icons.
     return legendOpened ? "expand-more" : "expand-less";
+  },
+  _getSelectionOpGraphDisabled(datasets, _selectedRunIndex, _selectedTagIndex) {
+    return !datasets[_selectedRunIndex] ||
+        !datasets[_selectedRunIndex].tags[_selectedTagIndex] ||
+        !datasets[_selectedRunIndex].tags[_selectedTagIndex].opGraph;
+  },
+  _getSelectionProfileDisabled(datasets, _selectedRunIndex, _selectedTagIndex) {
+    return !datasets[_selectedRunIndex] ||
+        !datasets[_selectedRunIndex].tags[_selectedTagIndex] ||
+        !datasets[_selectedRunIndex].tags[_selectedTagIndex].profile;
   },
 });
 })(); // Closing private scope.

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -825,7 +825,8 @@ Polymer({
     },
     datasets: {
       type: Array,
-      observer: '_datasetsChanged'
+      observer: '_datasetsChanged',
+      value: () => [],
     },
     renderHierarchy: {
       type: Object,
@@ -977,6 +978,9 @@ Polymer({
     return this._getTags(datasets, _selectedRunIndex).length;
   },
   _getTags: function(datasets, _selectedRunIndex) {
+    if (!datasets || !datasets[_selectedRunIndex]) {
+      return [];
+    }
     return datasets[_selectedRunIndex].tags;
   },
   fit: function() {
@@ -1078,14 +1082,13 @@ Polymer({
     }
   },
   _selectedRunIndexChanged: function(newDataset, oldDataset) {
-    if (this.datasets) {
-      // Reset the states when user pick a different run.
-      this.colorBy = 'structure';
-      this._selectedTagIndex = 0;
-      this._selectedGraphType = this._getDefaultSelectionType();
-      this.$['trace-inputs'].active = false; // Set trace input to off-state.
-      this._setDownloadFilename(this.datasets[newDataset].name);
-    }
+    if (!this.datasets) return;
+    // Reset the states when user pick a different run.
+    this.colorBy = 'structure';
+    this._selectedTagIndex = 0;
+    this._selectedGraphType = this._getDefaultSelectionType();
+    this.$['trace-inputs'].active = false; // Set trace input to off-state.
+    this._setDownloadFilename(this.datasets[newDataset] ? this.datasets[newDataset].name : '');
   },
   _selectedTagIndexChanged() {
      this._selectedGraphType = this._getDefaultSelectionType();

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -273,11 +273,7 @@ Polymer({
       }),
   _fetchDataset() {
     return this._requestManager.request(
-        tf_backend.getRouter().pluginRoute('graphs', '/index'));
-  },
-  _fetchRunMetadataTags() {
-    return this._requestManager.request(
-        tf_backend.getRouter().pluginRoute('graphs', '/run_metadata_tags'));
+        tf_backend.getRouter().pluginRoute('graphs', '/meta'));
   },
   /*
    * See also _maybeFetchHealthPills, _initiateNetworkRequestForHealthPills.

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -72,18 +72,15 @@ by default. The user can select a different run from a dropdown menu.
         color-by="{{_colorBy}}"
         datasets="[[_datasets]]"
         render-hierarchy="[[_renderHierarchy]]"
-        selected-dataset="{{_selectedDataset}}"
+        selection="{{_selection}}"
         selected-file="{{_selectedFile}}"
-        selected-metadata-tag="{{_selectedMetadataTag}}"
         selected-node="{{_selectedNode}}"
         health-pills-feature-enabled="[[_debuggerDataEnabled]]"
         health-pills-toggled-on="{{healthPillsToggledOn}}"
   ></tf-graph-controls>
   <div class="center">
     <tf-graph-loader id="loader"
-          datasets="[[_datasets]]"
-          selected-dataset="[[_selectedDataset]]"
-          selected-metadata-tag="[[_selectedMetadataTag]]"
+          selection="[[_selection]]"
           selected-file="[[_selectedFile]]"
           out-graph-hierarchy="{{_graphHierarchy}}"
           out-graph="{{_graph}}"
@@ -213,9 +210,8 @@ Polymer({
           }),
       observer: '_runObserver',
     },
-    _selectedDataset: {
-      type: Number,
-      notify: true,
+    _selection: {
+      type: Object,
     },
     _compatibilityProvider: Object
   },
@@ -263,9 +259,9 @@ Polymer({
         polymerProperty: 'run',
         useLocalStorage: false,
       }),
-  _fetchGraphRuns() {
+  _fetchDataset() {
     return this._requestManager.request(
-        tf_backend.getRouter().pluginRoute('graphs', '/runs'));
+        tf_backend.getRouter().pluginRoute('graphs', '/index'));
   },
   _fetchRunMetadataTags() {
     return this._requestManager.request(
@@ -324,25 +320,38 @@ Polymer({
 
     // Set this to true so we only initialize once.
     this._initialized = true;
-    Promise.all([this._fetchGraphRuns(), this._fetchRunMetadataTags()])
-      .then(result => {
-        const runsWithGraph = result[0].sort(vz_sorting.compareTagNames);
-        const runToMetadata = result[1];
-        const datasets = _.map(runsWithGraph, runName => ({
-          name: runName,
-          path: this._graphUrl(
-              runName, tf.graph.LIMIT_ATTR_SIZE, tf.graph.LARGE_ATTRS_KEY),
-          runMetadata: _.map(
-            (runToMetadata[runName] || []).sort(vz_sorting.compareTagNames),
-            tag => ({
-              tag: tag,
-              path: tf_backend.addParams(
-                tf_backend.getRouter().pluginRoute('graphs', '/run_metadata'),
-                {tag: tag, run: runName}),
-            })),
-        }));
-        this.set('_datasets', datasets);
+    this._fetchDataset().then(dataset => {
+      const runNames = Object.keys(dataset);
+      // Transform raw data into UI friendly data.
+      this._datasets = runNames.sort(vz_sorting.compareTagNames).map(runName => {
+        const runData = dataset[runName];
+
+        const tagNames = Object.keys(runData.tags).sort(vz_sorting.compareTagNames);
+        const tags = tagNames
+            .map(name => runData.tags[name])
+            .map(({tag, conceptual_graph, op_graph, profile}) => ({
+              tag,
+              tagName: tag,
+              conceptualGraph: conceptual_graph,
+              opGraph: op_graph,
+              profile,
+            }));
+
+        const tagsWithV1Graph = runData.run_graph ?
+            [
+                {
+                  tag: null,
+                  tagName: 'Default',
+                  conceptualGraph: false,
+                  opGraph: true,
+                  profile: false,
+                },
+                ...tags
+            ] : tags;
+
+        return {name: runName, tags: tagsWithV1Graph};
       });
+    });
   },
   _determineSelectedDataset(datasets, run) {
     // By default, load the first dataset.
@@ -367,6 +376,8 @@ Polymer({
     this.set('_selectedDataset', dataset);
   },
   _updateSelectedDatasetName(datasets, selectedDataset) {
+    // Cannot update `run` to update the hash in case datasets for graph is empty.
+    if (datasets.length <= selectedDataset) return;
     this.set('run', datasets[selectedDataset].name);
   },
   _requestHealthPills: function() {

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -158,7 +158,7 @@ const RUN_STORAGE_KEY = 'run';
  * TODO(stephanwlee): Convert this to proper type when converting to TypeScript.
  * @typedef {{
  *   name: string,
- *   tags: Arary<!TagItem>,
+ *   tags: !Array<!TagItem>,
  * }}
  */
 const RunItem = {};
@@ -167,7 +167,7 @@ Polymer({
   is: 'tf-graph-dashboard',
   properties: {
     /**
-     * Array<!RunItem>
+     * @type {!Array<!RunItem>}
      */
     _datasets: Array,
     _renderHierarchy: {type: Object, observer: '_renderHierarchyChanged'},

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -145,6 +145,18 @@ const RUN_STORAGE_KEY = 'run';
 Polymer({
   is: 'tf-graph-dashboard',
   properties: {
+    /**
+     * Array<{
+     *   name: string,
+     *   tags: Array<{
+     *     tag: ?string,
+     *     tagName: !string,
+     *     conceptualGraph: boolean,
+     *     opGraph: boolean,
+     *     profile: boolean,
+     *   }>,
+     * }>
+     */
     _datasets: Array,
     _renderHierarchy: {type: Object, observer: '_renderHierarchyChanged'},
     _requestManager: {

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -142,20 +142,32 @@ paper-dialog {
  */
 const RUN_STORAGE_KEY = 'run';
 
+/**
+ * TODO(stephanwlee): Convert this to proper type when converting to TypeScript.
+ * @typedef {{
+ *   tag: ?string,
+ *   displayName: string,
+ *   conceptualGraph: boolean,
+ *   opGraph: boolean,
+ *   profile: boolean,
+ * }}
+ */
+ const TagItem = {};
+
+/**
+ * TODO(stephanwlee): Convert this to proper type when converting to TypeScript.
+ * @typedef {{
+ *   name: string,
+ *   tags: Arary<!TagItem>,
+ * }}
+ */
+const RunItem = {};
+
 Polymer({
   is: 'tf-graph-dashboard',
   properties: {
     /**
-     * Array<{
-     *   name: string,
-     *   tags: Array<{
-     *     tag: ?string,
-     *     tagName: !string,
-     *     conceptualGraph: boolean,
-     *     opGraph: boolean,
-     *     profile: boolean,
-     *   }>,
-     * }>
+     * Array<!RunItem>
      */
     _datasets: Array,
     _renderHierarchy: {type: Object, observer: '_renderHierarchyChanged'},
@@ -273,7 +285,7 @@ Polymer({
       }),
   _fetchDataset() {
     return this._requestManager.request(
-        tf_backend.getRouter().pluginRoute('graphs', '/meta'));
+        tf_backend.getRouter().pluginRoute('graphs', '/info'));
   },
   /*
    * See also _maybeFetchHealthPills, _initiateNetworkRequestForHealthPills.
@@ -339,22 +351,25 @@ Polymer({
             .map(name => runData.tags[name])
             .map(({tag, conceptual_graph, op_graph, profile}) => ({
               tag,
-              tagName: tag,
+              displayName: tag,
               conceptualGraph: conceptual_graph,
               opGraph: op_graph,
               profile,
             }));
 
+        // Translate a run-wide GraphDef into specially named (without a tag) op graph
+        // to abstract the difference between run_graph vs. op_graph from other
+        // components.
         const tagsWithV1Graph = runData.run_graph ?
             [
                 {
                   tag: null,
-                  tagName: 'Default',
+                  displayName: 'Default',
                   conceptualGraph: false,
                   opGraph: true,
                   profile: false,
                 },
-                ...tags
+                ...tags,
             ] : tags;
 
         return {name: runName, tags: tagsWithV1Graph};

--- a/tensorboard/plugins/graph/tf_graph_loader/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_loader/BUILD
@@ -10,6 +10,7 @@ tf_web_library(
     srcs = ["tf-graph-loader.html"],
     path = "/tf-graph-loader",
     deps = [
+        "//tensorboard/components/tf_backend",
         "//tensorboard/plugins/graph/tf_graph_common",
         "//tensorboard/components/tf_imports:polymer",
     ],
@@ -20,8 +21,8 @@ tensorboard_webcomponent_library(
     srcs = [":tf_graph_loader"],
     destdir = "tf-graph-loader",
     deps = [
+        "//tensorboard/components/tf_backend:legacy",
         "//tensorboard/plugins/graph/tf_graph_common:legacy",
         "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )
-

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -92,7 +92,7 @@ Polymer({
     this.debounce('selectionchange', () => this._load());
   },
   _load: function() {
-    const {selection, overridingHierarchyParams, compatibilityProvider} = this;
+    const {selection, overridingHierarchyParams} = this;
     const {run, tag, type: selectionType} = selection;
     if (selectionType == tf.graph.SelectionType.OP_GRAPH) {
       // Clear stats about the previous graph.

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -16,6 +16,7 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-graph-common/tf-graph-common.html">
 
 <!--
@@ -40,8 +41,9 @@ Polymer({
       type: Object,
       notify: true,
     },
-    datasets: Array,
-    selectedDataset: Number,
+    selection: {
+      type: Object,
+    },
     selectedFile: Object,
     compatibilityProvider: {
       type: Object,
@@ -81,18 +83,33 @@ Polymer({
     },
   },
   observers: [
-    '_selectedDatasetChanged(selectedDataset, datasets, overridingHierarchyParams, compatibilityProvider)',
+    '_selectionChanged(selection, overridingHierarchyParams, compatibilityProvider)',
     '_selectedFileChanged(selectedFile, overridingHierarchyParams, compatibilityProvider)',
-    '_readAndParseMetadata(selectedMetadataTag, overridingHierarchyParams)',
   ],
-  _readAndParseMetadata: function(metadataIndex) {
-    if (metadataIndex == -1 || this.datasets[this.selectedDataset] == null ||
-        this.datasets[this.selectedDataset].runMetadata == null ||
-        this.datasets[this.selectedDataset].runMetadata[metadataIndex] == null) {
+  _selectionChanged() {
+    // selection can change a lot within a microtask.
+    // Don't fetch too much too fast and introduce race condition.
+    this.debounce('selectionchange', () => this._load());
+  },
+  _load: function() {
+    const {selection, overridingHierarchyParams, compatibilityProvider} = this;
+    const {run, tag, type: selectionType} = selection;
+    if (selectionType == tf.graph.SelectionType.OP_GRAPH) {
+      // Clear stats about the previous graph.
       this._setOutStats(null);
-      return;
+      const graphPath = tf_backend.addParams(
+          tf_backend.getRouter().pluginRoute('graphs', '/graph'),
+          {tag, run});
+      this._fetchAndConstructHierarchicalGraph(
+          graphPath, null, overridingHierarchyParams);
+    } else if (selectionType == tf.graph.SelectionType.PROFILE) {
+      const metadataPath = tf_backend.addParams(
+          tf_backend.getRouter().pluginRoute('graphs', '/run_metadata'),
+          {tag, run});
+      this._readAndParseMetadata(metadataPath);
     }
-    var path = this.datasets[this.selectedDataset].runMetadata[metadataIndex].path;
+  },
+  _readAndParseMetadata: function(path) {
     // Reset the progress bar to 0.
     this.set('progress', {
       value: 0,
@@ -109,7 +126,7 @@ Polymer({
    * @param {string=} pbTxtFile
    * @param {Object=} overridingHierarchyParams
    */
-  _parseAndConstructHierarchicalGraph: function(
+  _fetchAndConstructHierarchicalGraph: function(
       path, pbTxtFile, overridingHierarchyParams) {
     // Reset the progress bar to 0.
     this.set('progress', {
@@ -188,11 +205,6 @@ Polymer({
       tracker.reportError("Graph visualization failed: " + e, e);
     });
   },
-  _selectedDatasetChanged: function(
-      datasetIndex, datasets, overridingHierarchyParams) {
-    this._parseAndConstructHierarchicalGraph(
-        datasets[datasetIndex].path, undefined, overridingHierarchyParams);
-  },
   _selectedFileChanged: function(e, overridingHierarchyParams) {
     if (!e) {
       return;
@@ -206,7 +218,7 @@ Polymer({
     // selects the same file, we'll re-read it.
     e.target.value = '';
 
-    this._parseAndConstructHierarchicalGraph(
+    this._fetchAndConstructHierarchicalGraph(
         null, file, overridingHierarchyParams);
   }
 });


### PR DESCRIPTION
# Motivation for features / changes
With TensorFlow v2, graph will be part of RunMetadata and will be
tagged. In order to keep the backwards compatibility, we established new
contract between graph plugin backend and frontend.

# Screenshots of UI changes
### Before
![image](https://user-images.githubusercontent.com/2547313/52834493-fc70f680-3096-11e9-9b7b-e91338741736.png)

### After
![image](https://user-images.githubusercontent.com/2547313/52834377-72c12900-3096-11e9-97cf-290a462984fb.png)
![image](https://user-images.githubusercontent.com/2547313/52834499-072b8b80-3097-11e9-838c-16830bbe58c9.png)

Reviewers: Due to changes in backend APIs, both BE and FE have to be updated at the same time. However, I have broken the changes down into two commits, one for BE and one for FE, for "easier review".