### PR TITLE
readme: update Travis badge to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TensorBoard [![Travis build status](https://travis-ci.org/tensorflow/tensorboard.svg?branch=master)](https://travis-ci.org/tensorflow/tensorboard/)
+# TensorBoard [![Travis build status](https://www.travis-ci.com/tensorflow/tensorboard.svg?branch=master)](https://travis-ci.org/tensorflow/tensorboard/)
 
 TensorBoard is a suite of web applications for inspecting and understanding your
 TensorFlow runs and graphs.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TensorBoard [![Travis build status](https://www.travis-ci.com/tensorflow/tensorboard.svg?branch=master)](https://travis-ci.org/tensorflow/tensorboard/)
+# TensorBoard [![Travis build status](https://www.travis-ci.com/tensorflow/tensorboard.svg?branch=master)](https://travis-ci.com/tensorflow/tensorboard/)
 
 TensorBoard is a suite of web applications for inspecting and understanding your
 TensorFlow runs and graphs.


### PR DESCRIPTION
Summary:
Per <https://docs.travis-ci.com/user/status-images/>, via:
<https://docs.travis-ci.com/user/migrate/open-source-repository-migration#do-i-need-to-make-any-other-changes>

Test Plan:
The link resolves to a valid image, though it currently lists “unknown”
status; this is expected, as the status on https://travis-ci.com is the
same.

wchargin-branch: readme-ci-badge
