### PR TITLE
server: amend #1851’s port-crawling implementation

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -379,6 +379,10 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
         # chain (type(self).__mro__) it doesn't seem that anything
         # _should_ go wrong (nor does any superclass provide a facility
         # to do this natively).
+        #
+        # TODO(@wchargin): Refactor so that this is no longer necessary,
+        # probably by switching composing around a Werkzeug server
+        # rather than inheriting from it.
         super(WerkzeugServer, self).__init__(host, port, wsgi_app)
         break
       except socket.error as e:

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -352,11 +352,11 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
 
     # base_port: what's the first port to which we should try to bind?
     # should_scan: if that fails, shall we try additional ports?
-    (base_port, should_scan) = (
-        (flags.port, False)
-        if flags.port is not None
-        else (core_plugin.DEFAULT_PORT, True)
-    )
+    # max_attempts: how many ports shall we try?
+    should_scan = flags.port is None
+    base_port = core_plugin.DEFAULT_PORT if flags.port is None else flags.port
+    max_attempts = 10 if should_scan else 1
+
     if base_port > 0xFFFF:
       raise TensorBoardServerException(
           'TensorBoard cannot bind to port %d > %d' % (base_port, 0xFFFF)

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -362,7 +362,7 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
           'TensorBoard cannot bind to port %d > %d' % (base_port, 0xFFFF)
       )
     max_attempts = 10 if should_scan else 1
-    base_port = min(base_port + max_attempts, 65536) - max_attempts
+    base_port = min(base_port + max_attempts, 0x10000) - max_attempts
 
     self._auto_wildcard = False
     if not host:

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -364,15 +364,15 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
     max_attempts = 10 if should_scan else 1
     base_port = min(base_port + max_attempts, 0x10000) - max_attempts
 
-    self._auto_wildcard = False
-    if not host:
-      # Without an explicit host, we default to serving on all interfaces,
-      # and will attempt to serve both IPv4 and IPv6 traffic through one socket.
-      host = self._get_wildcard_address(base_port)
-      self._auto_wildcard = True
+    # Without an explicit host, we default to serving on all interfaces,
+    # and will attempt to serve both IPv4 and IPv6 traffic through one
+    # socket.
+    self._auto_wildcard = not host
 
     for (attempt_index, port) in (
         enumerate(xrange(base_port, base_port + max_attempts))):
+      if self._auto_wildcard:
+        host = self._get_wildcard_address(port)
       try:
         # Yes, this invokes the super initializer potentially many
         # times. This seems to work fine, and looking at the superclass


### PR DESCRIPTION
Summary:
In response to [a helpful post-commit review from @nfelt][1].

Test Plan:
Most of the changes are non-functional. The wildcard address resolution
logic did change, but we don’t expect the behavior to. The test plan
from #1851 suffices, plus explicitly binding `--host` to each of
`localhost`, `"$(hostname)"`, `"$(hostname -s)"`, `127.0.0.1`, and `::`
to verify that each works.

[1]: https://github.com/tensorflow/tensorboard/pull/1851#pullrequestreview-204418466

wchargin-branch: port-search-revisions
