### PR TITLE
Fix bugs in _tf/summary/__init__.py import logic for tf.summary

### DIFF
--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -32,13 +32,23 @@ else:
     # Check if we can directly import tf.compat.v2. We may not be able to if we
     # reached this import itself while importing tf.compat.v2. Use importlib
     # to simulate 'import tensorflow.compat.v2' but without binding local names
-    # which are hard to clean up. We can't use either of the following:
+    # which are hard to clean up.
+    #
+    # Note that we can't use either of the following internally:
     #
     #   import tensorflow.compat.v2 as other
     #   from tensorflow.compat import v2
     #
-    # because they each fail in a way that doesn't raise ImportError in
-    # different TF API generation contexts. Yay.
+    # The former raises AttributeError until issue 30024 is fixed in python 3.7.
+    # The latter raises ImportError even when it should succeed, until issue
+    # 17636 is fixed in python 3.5.
+    #
+    # In commemoration of this fiasco, I offer the following haiku:
+    #
+    #   import a module
+    #   it works. but add "as other"
+    #   AttributeError
+    #
     importlib.import_module('tensorflow.compat.v2')
   except ImportError:
     # If that failed, go "under the hood" and attempt to directly import the

--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import importlib
+
 import tensorflow as tf
 
 # Re-export all symbols from the original tf.summary.
@@ -26,17 +28,27 @@ import tensorflow as tf
 if getattr(tf, '__version__', '').startswith('2.'):
   from tensorflow.summary import *
 else:
-  # Check if we can directly import tf.compat.v2. We may not be able to if we
-  # reached this import itself while importing tf.compat.v2.
   try:
-    import tensorflow.compat.v2 as test_import
-    del test_import
+    # Check if we can directly import tf.compat.v2. We may not be able to if we
+    # reached this import itself while importing tf.compat.v2. Use importlib
+    # to simulate 'import tensorflow.compat.v2' but without binding local names
+    # which are hard to clean up. We can't use either of the following:
+    #
+    #   import tensorflow.compat.v2 as other
+    #   from tensorflow.compat import v2
+    #
+    # because they each fail in a way that doesn't raise ImportError in
+    # different TF API generation contexts. Yay.
+    importlib.import_module('tensorflow.compat.v2')
   except ImportError:
-    # If that failed, go "under the hood" to directly import the module that
-    # will become tf.compat.v2.summary.
-    from tensorflow._api.v1.compat.v2.summary import *
+    # If that failed, go "under the hood" and attempt to directly import the
+    # module that will become tf.compat.v2.summary.
+    try:
+      from tensorflow._api.v1.compat.v2.summary import *
+    except ImportError:
+      from tensorflow._api.v2.compat.v2.summary import *
   else:
-    from tensorflow.compat.v2 import *
+    from tensorflow.compat.v2.summary import *
 
 from tensorboard.summary.v2 import audio
 from tensorboard.summary.v2 import histogram
@@ -44,4 +56,4 @@ from tensorboard.summary.v2 import image
 from tensorboard.summary.v2 import scalar
 from tensorboard.summary.v2 import text
 
-del absolute_import, division, print_function, tf
+del absolute_import, division, print_function, importlib, tf

--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -39,9 +39,10 @@ else:
     #   import tensorflow.compat.v2 as other
     #   from tensorflow.compat import v2
     #
-    # The former raises AttributeError until issue 30024 is fixed in python 3.7.
-    # The latter raises ImportError even when it should succeed, until issue
-    # 17636 is fixed in python 3.5.
+    # The former raises AttributeError until python 3.7:
+    # <https://bugs.python.org/issue30024>
+    # The latter raises ImportError even when it shouldn't, until python 3.5:
+    # <https://bugs.python.org/issue17636>
     #
     # In commemoration of this fiasco, I offer the following haiku:
     #


### PR DESCRIPTION
This fixes issues with the import logic I already attempted to fix in #1852, which indeed worked in pip package land (mostly) but not internally.

Fixed:
- the "test import" of `tensorflow.compat.v2` has now been fixed so that it works internally as well as in pip package land
- in pip package land for TF 2.0, we now fall back to `tensorflow._api.v2` after `.v1`
- typo in the final `import *`, not that anything was getting that far anyway

I've tested the same changes against `tf-nightly`, `tf-nightly-2.0-preview`, and internal HEAD.