### PR TITLE
Support conceptual graph in graph plugin

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -1292,7 +1292,9 @@ function getEmbedPredicate(types: string[]) {
     // check types
     for (let i = 0; i < types.length; i++) {
       let regExp = new RegExp(types[i]);
-      if (node.op.match(regExp)) { return true; }
+      if (node.op && node.op.match(regExp)) {
+        return true;
+      }
     }
     return false;
   };

--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -1292,7 +1292,7 @@ function getEmbedPredicate(types: string[]) {
     // check types
     for (let i = 0; i < types.length; i++) {
       let regExp = new RegExp(types[i]);
-      if (node.op && node.op.match(regExp)) {
+      if (typeof node.op === 'string' && node.op.match(regExp)) {
         return true;
       }
     }

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -393,6 +393,9 @@ paper-dropdown-menu {
       <paper-radio-button name="op_graph"
           disabled="{{_getSelectionOpGraphDisabled(datasets, _selectedRunIndex, _selectedTagIndex)}}"
       >Graph</paper-radio-button>
+      <paper-radio-button name="conceptual_graph"
+          disabled="{{_getSelectionConceptualGraphDisabled(datasets, _selectedRunIndex, _selectedTagIndex)}}"
+      >Conceptual Graph</paper-radio-button>
       <paper-radio-button name="profile"
           disabled="{{_getSelectionProfileDisabled(datasets, _selectedRunIndex, _selectedTagIndex)}}"
       >Profile</paper-radio-button>
@@ -1160,6 +1163,11 @@ Polymer({
     return !datasets[_selectedRunIndex] ||
         !datasets[_selectedRunIndex].tags[_selectedTagIndex] ||
         !datasets[_selectedRunIndex].tags[_selectedTagIndex].profile;
+  },
+  _getSelectionConceptualGraphDisabled(datasets, _selectedRunIndex, _selectedTagIndex) {
+    return !datasets[_selectedRunIndex] ||
+        !datasets[_selectedRunIndex].tags[_selectedTagIndex] ||
+        !datasets[_selectedRunIndex].tags[_selectedTagIndex].conceptualGraph;
   },
 });
 })(); // Closing private scope.

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -391,13 +391,13 @@ paper-dropdown-menu {
     <paper-radio-group selected="{{_selectedGraphType}}">
       <!-- Note that the name has to match that of tf.graph.SelectionType. -->
       <paper-radio-button name="op_graph"
-          disabled="{{_getSelectionOpGraphDisabled(datasets, _selectedRunIndex, _selectedTagIndex)}}"
+          disabled="[[_getSelectionOpGraphDisabled(datasets, _selectedRunIndex, _selectedTagIndex)]]"
       >Graph</paper-radio-button>
       <paper-radio-button name="conceptual_graph"
-          disabled="{{_getSelectionConceptualGraphDisabled(datasets, _selectedRunIndex, _selectedTagIndex)}}"
+          disabled="[[_getSelectionConceptualGraphDisabled(datasets, _selectedRunIndex, _selectedTagIndex)]]"
       >Conceptual Graph</paper-radio-button>
       <paper-radio-button name="profile"
-          disabled="{{_getSelectionProfileDisabled(datasets, _selectedRunIndex, _selectedTagIndex)}}"
+          disabled="[[_getSelectionProfileDisabled(datasets, _selectedRunIndex, _selectedTagIndex)]]"
       >Profile</paper-radio-button>
     </paper-radio-group>
   </div>

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -80,7 +80,7 @@ by default. The user can select a different run from a dropdown menu.
   ></tf-graph-controls>
   <div class="center">
     <tf-graph-loader id="loader"
-          datasets="[[_datasets]"
+          datasets="[[_datasets]]"
           selection="[[_selection]]"
           selected-file="[[_selectedFile]]"
           out-graph-hierarchy="{{_graphHierarchy}}"

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -80,6 +80,7 @@ by default. The user can select a different run from a dropdown menu.
   ></tf-graph-controls>
   <div class="center">
     <tf-graph-loader id="loader"
+          datasets="[[_datasets]"
           selection="[[_selection]]"
           selected-file="[[_selectedFile]]"
           out-graph-hierarchy="{{_graphHierarchy}}"

--- a/tensorboard/plugins/graph/tf_graph_info/tf-graph-icon.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-graph-icon.html
@@ -274,7 +274,7 @@ limitations under the License.
         _isSummary: function(inputNode, inputSummary) {
           if (inputNode) {
             return this._isType(inputNode, null, 'OP') &&
-                inputNode.op.substr(-7) === 'Summary';
+                inputNode.op && inputNode.op.substr(-7) === 'Summary';
           }
           return !!inputSummary;
         },

--- a/tensorboard/plugins/graph/tf_graph_info/tf-graph-icon.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-graph-icon.html
@@ -274,7 +274,7 @@ limitations under the License.
         _isSummary: function(inputNode, inputSummary) {
           if (inputNode) {
             return this._isType(inputNode, null, 'OP') &&
-                inputNode.op && inputNode.op.substr(-7) === 'Summary';
+                typeof inputNode.op === 'string' && inputNode.op.substr(-7) === 'Summary';
           }
           return !!inputSummary;
         },

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -79,7 +79,7 @@ Polymer({
       notify: true
     },
     /**
-     * @type{?GraphRunTag}
+     * @type {?GraphRunTag}
      */
     _graphRunTag: Object,
     outHierarchyParams: {
@@ -101,7 +101,9 @@ Polymer({
   _selectionChanged() {
     // selection can change a lot within a microtask.
     // Don't fetch too much too fast and introduce race condition.
-    this.debounce('selectionchange', () => this._load(this.selection));
+    this.debounce('selectionchange', () => {
+      this._load(this.selection);
+    });
   },
   _load: function({run, tag, type: selectionType}) {
     const {overridingHierarchyParams} = this;
@@ -113,7 +115,7 @@ Polymer({
         this._setOutStats(null);
         const args = {
           run,
-          conceptual: selectionType == tf.graph.SelectionType.CONCEPTUAL_GRAPH,
+          conceptual: selectionType === tf.graph.SelectionType.CONCEPTUAL_GRAPH,
         };
         if (tag) args.tag = tag;
         const graphPath = tf_backend.addParams(
@@ -124,20 +126,20 @@ Polymer({
             });
       }
       case tf.graph.SelectionType.PROFILE: {
-        const {tags} = this.datasets.find(({name}) => name == run);
-        const tagMeta = tags.find(t => t.tag == tag);
+        const {tags} = this.datasets.find(({name}) => name === run);
+        const tagMeta = tags.find(t => t.tag === tag);
         // In case current tag misses opGraph but has profile information,
         // we fallback to the v1 behavior of fetching the run graph.
         const requiredOpGraphTag = tagMeta.opGraph ? tag : null;
 
         console.assert(
-            tags.find(t => t.tag == requiredOpGraphTag),
+            tags.find(t => t.tag === requiredOpGraphTag),
             `Required tag (${requiredOpGraphTag}) is missing.`);
 
         const shouldFetchGraph = !this._graphRunTag ||
             this._graphRunTag.run !== run ||
             this._graphRunTag.tag !== requiredOpGraphTag;
-        const maybeFetchGraph = shouldFetchGraph ?
+        const maybeFetchGraphPromise = shouldFetchGraph ?
             this._load({
               run,
               tag: requiredOpGraphTag,
@@ -146,10 +148,11 @@ Polymer({
         const metadataPath = tf_backend.addParams(
             tf_backend.getRouter().pluginRoute('graphs', '/run_metadata'),
             {tag, run});
-        return maybeFetchGraph.then(() => this._readAndParseMetadata(metadataPath));
+        return maybeFetchGraphPromise
+            .then(() => this._readAndParseMetadata(metadataPath));
       }
       default:
-        console.assert(false, `Unknown selection type: ${selectionType}`);
+        return Promise.reject(`Unknown selection type: ${selectionType}`);
     }
   },
   _readAndParseMetadata: function(path) {
@@ -168,7 +171,7 @@ Polymer({
    * @param {?string} path
    * @param {string=} pbTxtFile
    * @param {Object=} overridingHierarchyParams
-   * @returns {!Promise}
+   * @returns {!Promise<>}
    */
   _fetchAndConstructHierarchicalGraph: function(
       path, pbTxtFile, overridingHierarchyParams) {

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -111,13 +111,13 @@ Polymer({
       case tf.graph.SelectionType.CONCEPTUAL_GRAPH: {
         // Clear stats about the previous graph.
         this._setOutStats(null);
+        const args = {
+          run,
+          conceptual: selectionType == tf.graph.SelectionType.CONCEPTUAL_GRAPH,
+        };
+        if (tag) args.tag = tag;
         const graphPath = tf_backend.addParams(
-            tf_backend.getRouter().pluginRoute('graphs', '/graph'),
-            {
-              run,
-              tag,
-              conceptual: selectionType == tf.graph.SelectionType.CONCEPTUAL_GRAPH,
-            });
+            tf_backend.getRouter().pluginRoute('graphs', '/graph'), args);
         return this._fetchAndConstructHierarchicalGraph(
             graphPath, null, overridingHierarchyParams).then(() => {
               this._graphRunTag = {run, tag};

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -152,7 +152,7 @@ Polymer({
             .then(() => this._readAndParseMetadata(metadataPath));
       }
       default:
-        return Promise.reject(`Unknown selection type: ${selectionType}`);
+        return Promise.reject(new Error(`Unknown selection type: ${selectionType}`));
     }
   },
   _readAndParseMetadata: function(path) {
@@ -171,7 +171,7 @@ Polymer({
    * @param {?string} path
    * @param {string=} pbTxtFile
    * @param {Object=} overridingHierarchyParams
-   * @returns {!Promise<>}
+   * @returns {!Promise<void, Error>}
    */
   _fetchAndConstructHierarchicalGraph: function(
       path, pbTxtFile, overridingHierarchyParams) {
@@ -200,8 +200,8 @@ Polymer({
     return tf.graph.parser.fetchAndParseGraphData(path, pbTxtFile, dataTracker)
     .then(function(graph) {
       if (!graph.node) {
-        throw 'The graph is empty. Make sure that the graph is passed to the ' +
-            'tf.summary.FileWriter after the graph is defined.';
+        throw new Error('The graph is empty. Make sure that the graph is ' +
+            'passed to the tf.summary.FileWriter after the graph is defined.');
       }
 
       // Build the flat graph (consists only of Op nodes).

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -26,11 +26,21 @@ An element which provides a filter parsing for pbtxt to graph output.
 </dom-module>
 
 <script>
+
+/**
+ * @typedef {{
+ *   run: string,
+ *   tag: ?string,
+ * }}
+ */
+const GraphRunTag = {};
+
 Polymer({
 
   is: 'tf-graph-loader',
 
   properties: {
+    datasets: Array,
     /**
      * @type {{value: number, msg: string}}
      *
@@ -41,9 +51,7 @@ Polymer({
       type: Object,
       notify: true,
     },
-    selection: {
-      type: Object,
-    },
+    selection: Object,
     selectedFile: Object,
     compatibilityProvider: {
       type: Object,
@@ -70,6 +78,10 @@ Polymer({
       readOnly: true, //readonly so outsider can't change this via binding
       notify: true
     },
+    /**
+     * @type{?GraphRunTag}
+     */
+    _graphRunTag: Object,
     outHierarchyParams: {
       type: Object,
       readOnly: true,
@@ -89,26 +101,55 @@ Polymer({
   _selectionChanged() {
     // selection can change a lot within a microtask.
     // Don't fetch too much too fast and introduce race condition.
-    this.debounce('selectionchange', () => this._load());
+    this.debounce('selectionchange', () => this._load(this.selection));
   },
-  _load: function() {
-    const {selection, overridingHierarchyParams} = this;
-    const {run, tag, type: selectionType} = selection;
-    if (selectionType == tf.graph.SelectionType.OP_GRAPH) {
-      // Clear stats about the previous graph.
-      this._setOutStats(null);
-      const args = {run};
-      if (tag) args.tag = tag;
-      const graphPath = tf_backend.addParams(
-          tf_backend.getRouter().pluginRoute('graphs', '/graph'),
-          args);
-      this._fetchAndConstructHierarchicalGraph(
-          graphPath, null, overridingHierarchyParams);
-    } else if (selectionType == tf.graph.SelectionType.PROFILE) {
-      const metadataPath = tf_backend.addParams(
-          tf_backend.getRouter().pluginRoute('graphs', '/run_metadata'),
-          {tag, run});
-      this._readAndParseMetadata(metadataPath);
+  _load: function({run, tag, type: selectionType}) {
+    const {overridingHierarchyParams} = this;
+
+    switch (selectionType) {
+      case tf.graph.SelectionType.OP_GRAPH:
+      case tf.graph.SelectionType.CONCEPTUAL_GRAPH: {
+        // Clear stats about the previous graph.
+        this._setOutStats(null);
+        const graphPath = tf_backend.addParams(
+            tf_backend.getRouter().pluginRoute('graphs', '/graph'),
+            {
+              run,
+              tag,
+              conceptual: selectionType == tf.graph.SelectionType.CONCEPTUAL_GRAPH,
+            });
+        return this._fetchAndConstructHierarchicalGraph(
+            graphPath, null, overridingHierarchyParams).then(() => {
+              this._graphRunTag = {run, tag};
+            });
+      }
+      case tf.graph.SelectionType.PROFILE: {
+        const {tags} = this.datasets.find(({name}) => name == run);
+        const tagMeta = tags.find(t => t.tag == tag);
+        // In case current tag misses opGraph but has profile information,
+        // we fallback to the v1 behavior of fetching the run graph.
+        const requiredOpGraphTag = tagMeta.opGraph ? tag : null;
+
+        console.assert(
+            tags.find(t => t.tag == requiredOpGraphTag),
+            `Required tag (${requiredOpGraphTag}) is missing.`);
+
+        const shouldFetchGraph = !this._graphRunTag ||
+            this._graphRunTag.run !== run ||
+            this._graphRunTag.tag !== requiredOpGraphTag;
+        const maybeFetchGraph = shouldFetchGraph ?
+            this._load({
+              run,
+              tag: requiredOpGraphTag,
+              type: tf.graph.SelectionType.OP_GRAPH,
+            }) : Promise.resolve();
+        const metadataPath = tf_backend.addParams(
+            tf_backend.getRouter().pluginRoute('graphs', '/run_metadata'),
+            {tag, run});
+        return maybeFetchGraph.then(() => this._readAndParseMetadata(metadataPath));
+      }
+      default:
+        console.assert(false, `Unknown selection type: ${selectionType}`);
     }
   },
   _readAndParseMetadata: function(path) {
@@ -127,6 +168,7 @@ Polymer({
    * @param {?string} path
    * @param {string=} pbTxtFile
    * @param {Object=} overridingHierarchyParams
+   * @returns {!Promise}
    */
   _fetchAndConstructHierarchicalGraph: function(
       path, pbTxtFile, overridingHierarchyParams) {
@@ -152,7 +194,7 @@ Polymer({
     });
     this._setOutHierarchyParams(hierarchyParams);
     var dataTracker = tf.graph.util.getSubtaskTracker(tracker, 30, 'Data');
-    tf.graph.parser.fetchAndParseGraphData(path, pbTxtFile, dataTracker)
+    return tf.graph.parser.fetchAndParseGraphData(path, pbTxtFile, dataTracker)
     .then(function(graph) {
       if (!graph.node) {
         throw 'The graph is empty. Make sure that the graph is passed to the ' +
@@ -205,6 +247,8 @@ Polymer({
       // Generic error catch, for errors that happened outside
       // asynchronous tasks.
       tracker.reportError("Graph visualization failed: " + e, e);
+      // Don't swallow the error.
+      throw e;
     });
   },
   _selectedFileChanged: function(e, overridingHierarchyParams) {


### PR DESCRIPTION
Few changes are:
- graph plugin assumed all GraphDefs are graph of ops.
  Removed some checks on node.op but in the long run, we should have
  a non-op mode and use something like MetaNode.
- Make sure correct GraphDef is loaded before loading a profile
  information. RunMetadata or profile information is strongly associated
  with a GraphDef. Though via the selection from the graph-control, we
  always GraphDef before the profile, we want better protection in case
  we make changes to the control without knowing this dependency.
