### PR TITLE
Graph plugin populates graph and RunMeta v2.

### DIFF
--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -14,6 +14,8 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        ":keras_util",
+        ":graph_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/backend:process_graph",
         "//tensorboard/backend/event_processing:event_accumulator",
@@ -39,8 +41,25 @@ py_test(
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/util:test_util",
+        "@com_google_protobuf//:protobuf_python",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
+    ],
+)
+
+py_test(
+    name = "graphs_plugin_v2_test",
+    size = "small",
+    srcs = ["graphs_plugin_v2_test.py"],
+    main = "graphs_plugin_v2_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":graphs_plugin",
+        ":graphs_plugin_test",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )
 

--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -18,13 +18,18 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import json
 import six
 from werkzeug import wrappers
 
 from tensorboard.backend import http_util
 from tensorboard.backend import process_graph
 from tensorboard.backend.event_processing import plugin_event_accumulator as event_accumulator  # pylint: disable=line-too-long
+from tensorboard.compat.proto import config_pb2
+from tensorboard.compat.proto import graph_pb2
 from tensorboard.plugins import base_plugin
+from tensorboard.plugins.graph import graph_util
+from tensorboard.plugins.graph import keras_util
 from tensorboard.util import tb_logging
 
 logger = tb_logging.get_logger()
@@ -34,8 +39,12 @@ _PLUGIN_PREFIX_ROUTE = 'graphs'
 # The Summary API is implemented in TensorFlow because it uses TensorFlow internal APIs.
 # As a result, this SummaryMetadata is a bit unconventional and uses non-public
 # hardcoded name as the plugin name. Please refer to link below for the summary ops.
+# https://github.com/tensorflow/tensorflow/blob/11f4ecb54708865ec757ca64e4805957b05d7570/tensorflow/python/ops/summary_ops_v2.py#L757
+_PLUGIN_NAME_RUN_METADATA = 'graph_run_metadata'
 # https://github.com/tensorflow/tensorflow/blob/11f4ecb54708865ec757ca64e4805957b05d7570/tensorflow/python/ops/summary_ops_v2.py#L788
 _PLUGIN_NAME_RUN_METADATA_WITH_GRAPH = 'graph_run_metadata_graph'
+# https://github.com/tensorflow/tensorflow/blob/565952cc2f17fdfd995e25171cf07be0f6f06180/tensorflow/python/ops/summary_ops_v2.py#L825
+_PLUGIN_NAME_KERAS_MODEL = 'graph_keras_model'
 
 
 class GraphsPlugin(base_plugin.TBPlugin):
@@ -84,16 +93,41 @@ class GraphsPlugin(base_plugin.TBPlugin):
 
     mapping = self._multiplexer.PluginRunToTagToContent(
         _PLUGIN_NAME_RUN_METADATA_WITH_GRAPH)
-    for (run_name, tag_to_content) in six.iteritems(mapping):
+    for run_name, tag_to_content in six.iteritems(mapping):
       for (tag, content) in six.iteritems(tag_to_content):
         # The Summary op is defined in TensorFlow and does not use a stringified proto
         # as a content of plugin data. It contains single string that denotes a version.
         # https://github.com/tensorflow/tensorflow/blob/11f4ecb54708865ec757ca64e4805957b05d7570/tensorflow/python/ops/summary_ops_v2.py#L789-L790
-        if content is not '1':
+        if content != b'1':
           logger.warn('Ignoring unrecognizable version of RunMetadata.')
           continue
         (_, tag_item) = add_row_item(run_name, tag)
         tag_item['op_graph'] = True
+
+    # Tensors associated with plugin name _PLUGIN_NAME_RUN_METADATA contain
+    # both op graph and profile information.
+    mapping = self._multiplexer.PluginRunToTagToContent(
+        _PLUGIN_NAME_RUN_METADATA)
+    for run_name, tag_to_content in six.iteritems(mapping):
+      for (tag, content) in six.iteritems(tag_to_content):
+        if content != b'1':
+          logger.warn('Ignoring unrecognizable version of RunMetadata.')
+          continue
+        (_, tag_item) = add_row_item(run_name, tag)
+        tag_item['profile'] = True
+        tag_item['op_graph'] = True
+
+    # Tensors associated with plugin name _PLUGIN_NAME_KERAS_MODEL contain
+    # serialized Keras model in JSON format.
+    mapping = self._multiplexer.PluginRunToTagToContent(
+        _PLUGIN_NAME_KERAS_MODEL)
+    for run_name, tag_to_content in six.iteritems(mapping):
+      for (tag, content) in six.iteritems(tag_to_content):
+        if content != b'1':
+          logger.warn('Ignoring unrecognizable version of RunMetadata.')
+          continue
+        (_, tag_item) = add_row_item(run_name, tag)
+        tag_item['conceptual_graph'] = True
 
     for (run_name, run_data) in six.iteritems(self._multiplexer.Runs()):
       if run_data.get(event_accumulator.GRAPH):
@@ -108,10 +142,26 @@ class GraphsPlugin(base_plugin.TBPlugin):
 
     return result
 
-  def graph_impl(self, run, limit_attr_size=None, large_attrs_key=None):
+  def graph_impl(self, run, tag, is_conceptual, limit_attr_size=None, large_attrs_key=None):
     """Result of the form `(body, mime_type)`, or `None` if no graph exists."""
     try:
-      graph = self._multiplexer.Graph(run)
+      if is_conceptual:
+        tensor_events = self._multiplexer.Tensors(run, tag)
+        # Take the first event if there are multiple events written from different
+        # steps.
+        keras_model_config = json.loads(tensor_events[0].tensor_proto.string_val[0])
+        graph = keras_util.keras_model_to_graph_def(keras_model_config)
+      elif tag:
+        tensor_events = self._multiplexer.Tensors(run, tag)
+        # Take the first event if there are multiple events written from different
+        # steps.
+        run_metadata = config_pb2.RunMetadata.FromString(
+            tensor_events[0].tensor_proto.string_val[0])
+        graph = graph_pb2.GraphDef()
+        for func_graph in run_metadata.function_graphs:
+          graph_util.combine_graph_defs(graph, func_graph.pre_optimization_graph)
+      else:
+        graph = self._multiplexer.Graph(run)
     except ValueError:
       return None
     # This next line might raise a ValueError if the limit parameters
@@ -124,18 +174,32 @@ class GraphsPlugin(base_plugin.TBPlugin):
     try:
       run_metadata = self._multiplexer.RunMetadata(run, tag)
     except ValueError:
+      # TODO(stephanwlee): Should include whether FE is fetching for v1 or v2 RunMetadata
+      # so we can remove this try/except.
+      tensor_events = self._multiplexer.Tensors(run, tag)
+      if tensor_events is None:
+        return None
+      # Take the first event if there are multiple events written from different
+      # steps.
+      run_metadata = config_pb2.RunMetadata.FromString(
+          tensor_events[0].tensor_proto.string_val[0])
+    if run_metadata is None:
       return None
     return (str(run_metadata), 'text/x-protobuf')  # pbtxt
 
   @wrappers.Request.application
   def info_route(self, request):
-    meta = self.info_impl()
-    return http_util.Respond(request, meta, 'application/json')
+    info = self.info_impl()
+    return http_util.Respond(request, info, 'application/json')
 
   @wrappers.Request.application
   def graph_route(self, request):
     """Given a single run, return the graph definition in protobuf format."""
     run = request.args.get('run')
+    tag = request.args.get('tag', '')
+    conceptual_arg = request.args.get('conceptual', False)
+    is_conceptual = True if conceptual_arg == 'true' else False
+
     if run is None:
       return http_util.Respond(
           request, 'query parameter "run" is required', 'text/plain', 400)
@@ -152,7 +216,7 @@ class GraphsPlugin(base_plugin.TBPlugin):
     large_attrs_key = request.args.get('large_attrs_key', None)
 
     try:
-      result = self.graph_impl(run, limit_attr_size, large_attrs_key)
+      result = self.graph_impl(run, tag, is_conceptual, limit_attr_size, large_attrs_key)
     except ValueError as e:
       return http_util.Respond(request, e.message, 'text/plain', code=400)
     else:

--- a/tensorboard/plugins/graph/graphs_plugin_v2_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_v2_test.py
@@ -1,0 +1,100 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Integration tests for the Graphs Plugin for TensorFlow v2."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import os.path
+
+from google.protobuf import text_format
+import tensorflow as tf
+
+from tensorboard.compat.proto import graph_pb2
+from tensorboard.plugins.graph import graphs_plugin_test
+
+
+class GraphsPluginV2Test(graphs_plugin_test.GraphsPluginBaseTest, tf.test.TestCase):
+
+  def generate_run(self, run_name, include_graph, include_run_metadata):
+    x, y = np.ones((10, 10)), np.ones((10, 1))
+    val_x, val_y = np.ones((4, 10)), np.ones((4, 1))
+
+    model = tf.keras.Sequential([
+        tf.keras.layers.Dense(10, activation='relu'),
+        tf.keras.layers.Dense(1, activation='sigmoid')])
+    model.compile('rmsprop', 'binary_crossentropy')
+
+    model.fit(
+        x,
+        y,
+        validation_data=(val_x, val_y),
+        batch_size=2,
+        epochs=1,
+        callbacks=[tf.compat.v2.keras.callbacks.TensorBoard(
+            log_dir=os.path.join(self.logdir, run_name),
+            write_graph=include_graph)])
+
+  def _get_graph(self, *args, **kwargs):
+    """Fetch and return the graph as a proto."""
+    (graph_pbtxt, mime_type) = self.plugin.graph_impl(*args, **kwargs)
+    self.assertEqual(mime_type, 'text/x-protobuf')
+    return text_format.Parse(graph_pbtxt, graph_pb2.GraphDef())
+
+  def test_info(self):
+    raise self.skipTest('TODO: enable this after tf-nightly writes a conceptual graph.')
+
+    expected = {
+      'w_graph_wo_meta': {
+        'run': 'w_graph_wo_meta',
+        'run_graph': True,
+        'tags': {
+          'keras': {
+            'conceptual_graph': True,
+            'profile': False,
+            'tag': 'keras',
+            'op_graph': False,
+          },
+        },
+      },
+    }
+
+    self.generate_run('w_graph_wo_meta',
+                      include_graph=True,
+                      include_run_metadata=False)
+    self.generate_run('wo_graph_wo_meta',
+                      include_graph=False,
+                      include_run_metadata=False)
+    self.bootstrap_plugin()
+
+    self.assertEqual(expected, self.plugin.info_impl())
+
+  def test_graph_conceptual_graph(self):
+    raise self.skipTest('TODO: enable this after tf-nightly writes a conceptual graph.')
+
+    self.generate_run(self._RUN_WITH_GRAPH,
+                      include_graph=True,
+                      include_run_metadata=False)
+    self.bootstrap_plugin()
+
+    graph = self._get_graph(self._RUN_WITH_GRAPH, tag='keras', is_conceptual=True)
+    node_names = set(node.name for node in graph.node)
+    self.assertEqual({'sequential/dense', 'sequential/dense_1'}, node_names)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -97,9 +97,11 @@ Polymer({
     if (selectionType == tf.graph.SelectionType.OP_GRAPH) {
       // Clear stats about the previous graph.
       this._setOutStats(null);
+      const args = {run};
+      if (tag) args.tag = tag;
       const graphPath = tf_backend.addParams(
           tf_backend.getRouter().pluginRoute('graphs', '/graph'),
-          {tag, run});
+          args);
       this._fetchAndConstructHierarchicalGraph(
           graphPath, null, overridingHierarchyParams);
     } else if (selectionType == tf.graph.SelectionType.PROFILE) {


### PR DESCRIPTION
This change pipes more data into the graph plugin that is persisted
on the TensorFlow's side with the new summary ops.

Also refactored the test a bit but it is hard to test anything
because the nightlies do not contain the required changes yet.
In a follow up changes, we will add test using more public APIs.

The PR as is contains #1873. Please review the last commit starting from 
face82a9.
