### PR TITLE
Enable the hparams plugin

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -91,8 +91,8 @@ py_test(
     deps = [
         ":manager",
         ":version",
-        "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/util:tb_logging",
+        "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],
 )
@@ -101,20 +101,20 @@ py_test(
     name = "manager_e2e_test",
     size = "large",  # spawns subprocesses, sleeps, makes requests to localhost
     timeout = "moderate",
-    srcs = ["manager_e2e_test.py"],
-    data = [
-        ":tensorboard",
-    ],
     # On Python 2, this test fails about 0.5% of the time when run with
     # high parallelism; TensorBoard subprocess time out instead of
     # launching successfully.
     flaky = True,
+    srcs = ["manager_e2e_test.py"],
     srcs_version = "PY2AND3",
     visibility = ["//tensorboard:internal"],
     deps = [
         ":manager",
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
+    ],
+    data = [
+        ":tensorboard",
     ],
 )
 
@@ -431,9 +431,9 @@ py_library(
 
 py_test(
     name = "lazy_test",
-    size = "small",
     srcs = ["lazy_test.py"],
     srcs_version = "PY2AND3",
+    size = "small",
     deps = [
         ":lazy",
         "@org_pythonhosted_six",

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -91,8 +91,8 @@ py_test(
     deps = [
         ":manager",
         ":version",
-        "//tensorboard/util:tb_logging",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/util:tb_logging",
         "@org_pythonhosted_six",
     ],
 )
@@ -101,20 +101,20 @@ py_test(
     name = "manager_e2e_test",
     size = "large",  # spawns subprocesses, sleeps, makes requests to localhost
     timeout = "moderate",
+    srcs = ["manager_e2e_test.py"],
+    data = [
+        ":tensorboard",
+    ],
     # On Python 2, this test fails about 0.5% of the time when run with
     # high parallelism; TensorBoard subprocess time out instead of
     # launching successfully.
     flaky = True,
-    srcs = ["manager_e2e_test.py"],
     srcs_version = "PY2AND3",
     visibility = ["//tensorboard:internal"],
     deps = [
         ":manager",
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
-    ],
-    data = [
-        ":tensorboard",
     ],
 )
 
@@ -175,6 +175,7 @@ py_library(
         "//tensorboard/plugins/distribution:distributions_plugin",
         "//tensorboard/plugins/graph:graphs_plugin",
         "//tensorboard/plugins/histogram:histograms_plugin",
+        "//tensorboard/plugins/hparams:hparams_plugin",
         "//tensorboard/plugins/image:images_plugin",
         "//tensorboard/plugins/interactive_inference:interactive_inference_plugin",
         "//tensorboard/plugins/pr_curve:pr_curves_plugin",
@@ -430,9 +431,9 @@ py_library(
 
 py_test(
     name = "lazy_test",
+    size = "small",
     srcs = ["lazy_test.py"],
     srcs_version = "PY2AND3",
-    size = "small",
     deps = [
         ":lazy",
         "@org_pythonhosted_six",

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -59,6 +59,7 @@ tf_web_library(
         "//tensorboard/plugins/distribution/tf_distribution_dashboard",
         "//tensorboard/plugins/graph/tf_graph_dashboard",
         "//tensorboard/plugins/histogram/tf_histogram_dashboard",
+        "//tensorboard/plugins/hparams/tf_hparams_dashboard",
         "//tensorboard/plugins/image/tf_image_dashboard",
         "//tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard",
         "//tensorboard/plugins/pr_curve/tf_pr_curve_dashboard",

--- a/tensorboard/components/tf_tensorboard/default-plugins.html
+++ b/tensorboard/components/tf_tensorboard/default-plugins.html
@@ -39,3 +39,4 @@ limitations under the License.
 <link rel="import" href="../tf-profile-dashboard/tf-profile-dashboard.html">
 <link rel="import" href="../tf-beholder-dashboard/tf-beholder-dashboard.html">
 <link rel="import" href="../tf-interactive-inference-dashboard/tf-interactive-inference-dashboard.html">
+<link rel="import" href="../tf-hparams-dashboard/tf-hparams-dashboard.html">

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -36,10 +36,11 @@ from tensorboard.plugins.audio import audio_plugin
 from tensorboard.plugins.beholder import beholder_plugin
 from tensorboard.plugins.core import core_plugin
 from tensorboard.plugins.custom_scalar import custom_scalars_plugin
+from tensorboard.plugins.debugger import debugger_plugin_loader
 from tensorboard.plugins.distribution import distributions_plugin
 from tensorboard.plugins.graph import graphs_plugin
-from tensorboard.plugins.debugger import debugger_plugin_loader
 from tensorboard.plugins.histogram import histograms_plugin
+from tensorboard.plugins.hparams import hparams_plugin
 from tensorboard.plugins.image import images_plugin
 from tensorboard.plugins.interactive_inference import interactive_inference_plugin
 from tensorboard.plugins.pr_curve import pr_curves_plugin
@@ -67,6 +68,7 @@ _PLUGINS = [
     interactive_inference_plugin.InteractiveInferencePlugin,
     profile_plugin.ProfilePluginLoader(),
     debugger_plugin_loader.DebuggerPluginLoader(),
+    hparams_plugin.HParamsPlugin,
 ]
 
 def get_plugins():


### PR DESCRIPTION
* Motivation for features / changes: Enable the HParams plugin in Tensorboard. HParams allows visualizations of experiments ran for hyperparameter tuning.

* Screenshots of UI changes
![image](https://user-images.githubusercontent.com/14099708/53279889-35c5e980-36c9-11e9-9842-7aa2f5c7db16.png)

* Detailed steps to verify changes work correctly (as executed by you)

```
bazel test //tensorboard/plugins/hparams/...:all
bazel run //tensorboard/plugins/hparams:hparams_demo 
bazel run //tensorboard -- --logdir /tmp/hparams_demo 
```

and (briefly) verified manually that the plugins works as expected.
