### PR TITLE
manager: use portable epoch time computation

### DIFF
--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -47,7 +47,8 @@ _FieldType = collections.namedtuple(
 _type_timestamp = _FieldType(
     serialized_type=int,  # seconds since epoch
     runtime_type=datetime.datetime,  # microseconds component ignored
-    serialize=lambda dt: int(dt.strftime("%s")),
+    serialize=lambda dt: int(
+        (dt - datetime.datetime.fromtimestamp(0)).total_seconds()),
     deserialize=lambda n: datetime.datetime.fromtimestamp(n),
 )
 _type_int = _FieldType(


### PR DESCRIPTION
Summary:
Fixes #1895 by replacing the (apparently unportable) `%s` format
specifier with an explicit subtraction from epoch.

Test Plan:
I don’t have easy access to a Windows machine with a Bazel/TensorBoard
setup, but I verified that this expression can be evaluated by itself:

```
Python 3.6.8 (tags/v3.6.8:3c6b436a57, Dec 24 2018, 00:16:47) [MSC v.1916 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license()" for more information.
>>> import datetime
>>> dt = datetime.datetime.now()
>>> dt.strftime("%s")
Traceback (most recent call last):
  File "<pyshell#2>", line 1, in <module>
    dt.strftime("%s")
ValueError: Invalid format string
>>> int((dt - datetime.datetime.fromtimestamp(0)).total_seconds())
1551203889
```

Running `git grep strftime.*%s` returns no matches as of this commit.

wchargin-branch: windows-strftime
