### PR TITLE
build: upgrade to Bazel 0.22, rules_closure HEAD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   #
   # Grab the BAZEL_SHA256SUM from the Bazel releases page; e.g.:
   # bazel-0.20.0-linux-x86_64.sha256
-  - TF_VERSION_ID=tf-nightly BAZEL=0.21.0 BAZEL_SHA256SUM=7a2f347d779c4c772cdb318f0435f8d489a238be42e7a9bf1e2bad94b1c3094f
+  - TF_VERSION_ID=tf-nightly BAZEL=0.22.0 BAZEL_SHA256SUM=8474ed28ed4998e2f5671ddf3a9a80ae9e484a5de3b8b70c8b654c017c65d363
 
 cache:
   directories:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,15 +16,17 @@ http_archive(
 load("@bazel_skylib//lib:versions.bzl", "versions")
 # Keep this version in sync with the BAZEL environment variable defined
 # in our .travis.yml config.
-versions.check(minimum_bazel_version = "0.16.1")
+versions.check(minimum_bazel_version = "0.22.0")
 
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "b29a8bc2cb10513c864cb1084d6f38613ef14a143797cea0af0f91cd385f5e8c",
-    strip_prefix = "rules_closure-0.8.0",
+    sha256 = "0e6de40666f2ebb2b30dc0339745a274d9999334a249b05a3b1f46462e489adf",
+    # The changes that we need for Bazel 0.23 compatibility are not in
+    # any release, so we pin to HEAD as of 2019-02-22.
+    strip_prefix = "rules_closure-87d24b1df8b62405de8dd059cb604fd9d4b1e395",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.8.0.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/0.8.0.tar.gz",  # 2018-08-03
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/87d24b1df8b62405de8dd059cb604fd9d4b1e395.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/87d24b1df8b62405de8dd059cb604fd9d4b1e395.tar.gz",  # 2019-02-22
     ],
 )
 

--- a/third_party/clutz.bzl
+++ b/third_party/clutz.bzl
@@ -50,7 +50,10 @@ def deprecated_extract_dts_from_closure_libraries(ctx):
   if not js.srcs:
     return None
   js_typings = ctx.new_file(ctx.bin_dir, "%s-js-typings.d.ts" % ctx.label.name)
-  srcs = depset(JS_FILE_TYPE.filter(ctx.files._clutz_externs)) + js.srcs
+  srcs = (
+      depset(FileType(JS_FILE_TYPE).filter(ctx.files._clutz_externs)) +
+      js.srcs
+  )
   args = ["-o", js_typings.path]
   for src in srcs:
     args.append(src.path)


### PR DESCRIPTION
Summary:
Fixes #1903. Googlers are now locked to Bazel 0.23, which breaks
`rules_closure` unless we pull in HEAD (they’ve not yet had a release).
Conversely, `rules_closure` HEAD is broken on Bazel 0.21, so our CI
needs to be upgraded to match; Bazel 0.22 is the minimum working
version. Also, `rules_closure` had a breaking change in a package
called `private` whose default visibility is `public`, so our
`clutz.bzl` needs to be updated to work around that.

Test Plan:
Running `bazel build //tensorboard/... && bazel test //tensorboard/...`
passes on Bazel versions 0.22.0 and 0.23.0, failing on version 0.21.0.

Verified that the shasum matches the properly signed Bazel 0.22 binary:

```
$ gpg --verify ./bazel-0.22.0-linux-x86_64{.sig,}
gpg: Signature made Mon 28 Jan 2019 05:30:32 AM PST
gpg:                using RSA key 71A1D0EFCFEB6281FD0437C93D5919B448457EE0
gpg: Good signature from "Bazel Developer (Bazel APT repository key) <bazel-dev@googlegroups.com>" [full]
$ shasum -a 256 --check ./bazel-0.22.0-linux-x86_64.sha256
bazel-0.22.0-linux-x86_64: OK
$ shasum -a 256 ./bazel-0.22.0-linux-x86_64
8474ed28ed4998e2f5671ddf3a9a80ae9e484a5de3b8b70c8b654c017c65d363  ./bazel-0.22.0-linux-x86_64
```

wchargin-branch: bazel-0.23

