### PR TITLE
Fixed various typos

### DIFF
--- a/docs/r2/what-if-tool.md
+++ b/docs/r2/what-if-tool.md
@@ -6,7 +6,7 @@ The What-If Tool (WIT) provides an easy-to-use interface for expanding
 understanding of black-box classification and regression ML models. With the
 plugin, you can perform inference on a large set of examples and immediately
 visualize the results in a variety of ways. Additionally, examples can be
-edited manually or programatically and re-run through the model in order to
+edited manually or programmatically and re-run through the model in order to
 see the results of the changes. It contains tooling for investigating model
 performance and fairness over subsets of a dataset.
 

--- a/tensorboard/compat/tensorflow_stub/io/gfile_s3_test.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile_s3_test.py
@@ -26,7 +26,7 @@ from moto import mock_s3
 from tensorboard.compat.tensorflow_stub import errors
 from tensorboard.compat.tensorflow_stub.io import gfile
 
-# Placeholder values to make sure any local keys are overriden
+# Placeholder values to make sure any local keys are overridden
 # and moto mock is being called
 os.environ.setdefault("AWS_ACCESS_KEY_ID", "foobar_key")
 os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "foobar_secret")

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -78,7 +78,7 @@ class HierarchyImpl implements Hierarchy {
   /**
    * Constructs a hierarchy.
    * @param graphOptions Options passed to dagre for creating the graph. Note
-   *   that the `compound` argument will be overriden to true.
+   *   that the `compound` argument will be overridden to true.
    */
   constructor(graphOptions: graphlib.GraphOptions) {
     this.graphOptions = graphOptions || {};

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -171,7 +171,7 @@ Polymer({
    * @param {?string} path
    * @param {string=} pbTxtFile
    * @param {Object=} overridingHierarchyParams
-   * @returns {!Promise<void, Error>}
+   * @return {!Promise<void, Error>}
    */
   _fetchAndConstructHierarchicalGraph: function(
       path, pbTxtFile, overridingHierarchyParams) {

--- a/tensorboard/plugins/interactive_inference/README.md
+++ b/tensorboard/plugins/interactive_inference/README.md
@@ -6,7 +6,7 @@ The [What-If Tool](https://pair-code.github.io/what-if-tool) (WIT) provides an e
 understanding of a black-box classification or regression ML model.
 With the plugin, you can perform inference on a large set of examples and
 immediately visualize the results in a variety of ways.
-Additionally, examples can be edited manually or programatically and re-run
+Additionally, examples can be edited manually or programmatically and re-run
 through the model in order to see the results of the changes.
 It contains tooling for investigating model performance and fairness over
 subsets of a dataset.
@@ -294,4 +294,3 @@ containing:
 
 Then, use it as seen at the bottom of the
 [What_If_Tool_Notebook_Usage.ipynb notebook](https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/tensorboard/plugins/interactive_inference/What_If_Tool_Notebook_Usage.ipynb).
-

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -1450,7 +1450,7 @@ limitations under the License.
                               plots created for them by specifying the indices to shown partial dependence plots for,
                               if the datapoint contains multiple feature values for a feature.
                             </div>
-                            <div>When the global toggle is turned on, the plots show the the average effect of repeatedly
+                            <div>When the global toggle is turned on, the plots show the average effect of repeatedly
                               changing a single feature across all datapoints. When it is turned off, the plots show the
                               effect of a repeatedly changing a single feature on the selected datapoint.
                             </div>
@@ -1495,7 +1495,7 @@ limitations under the License.
                                               on-input="pdInputChanged"/>
                                     </div>
                                   </div>
-                                  <div class="feature-index-container" hidden$="[[shouldHideFeatureIndiciesSelector(item.name, selected)]]"
+                                  <div class="feature-index-container" hidden$="[[shouldHideFeatureIndicesSelector(item.name, selected)]]"
                                        title="An optional printer-page-style pattern like '0,2,4-6' to select the indices of the feature values to generate plots for. Useful for features with many repeated fields.">
                                     <div class="info-text">
                                       Set feature indices <i>(optional)</i>
@@ -5138,7 +5138,7 @@ limitations under the License.
         this.deletePdPlotSpinner(featureName);
       },
 
-      shouldHideFeatureIndiciesSelector: function(featureName, selected) {
+      shouldHideFeatureIndicesSelector: function(featureName, selected) {
         if (!selected || selected.length == 0 || !this.visdata ||
             this.visdata.length <= selected[0]) {
           return true;
@@ -5150,7 +5150,7 @@ limitations under the License.
       /** Check if pd-input-container has any elements in it and hide it if it
         does not*/
       shouldHidePdInputContainer: function(samples, featureName, selected) {
-        if (!this.shouldHideFeatureIndiciesSelector(featureName, selected)
+        if (!this.shouldHideFeatureIndicesSelector(featureName, selected)
             || !samples){
           return false;
         } else {

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -149,7 +149,7 @@ class TensorBoard(object):
     """Configures TensorBoard behavior via flags.
 
     This method will populate the "flags" property with an argparse.Namespace
-    representing flag values parsed from the provided argv list, overriden by
+    representing flag values parsed from the provided argv list, overridden by
     explicit flags from remaining keyword arguments.
 
     Args:


### PR DESCRIPTION
- overriden -> overridden
- programatically -> programmatically
- `@returns` -> `@return`
- the the -> the
- indicies -> indices
