### PR TITLE
Fix flaky eventfile usage in summary V2 tests

### DIFF
--- a/tensorboard/plugins/audio/summary_test.py
+++ b/tensorboard/plugins/audio/summary_test.py
@@ -216,6 +216,7 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
     # Expect a boilerplate event for the file_version, then the summary one.
     self.assertEqual(len(events), 2)
     # Delete the event file to reset to an empty directory for later calls.
+    # TODO(nickfelt): use a unique subdirectory per writer instead.
     os.remove(event_files[0])
     return events[1]
 

--- a/tensorboard/plugins/audio/summary_test.py
+++ b/tensorboard/plugins/audio/summary_test.py
@@ -202,18 +202,21 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
       self.skipTest('TF v2 summary API not available')
 
   def audio(self, *args, **kwargs):
+    return self.audio_event(*args, **kwargs).summary
+
+  def audio_event(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
     writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       summary.audio(*args, **kwargs)
     writer.close()
-    return self.read_single_event_from_eventfile().summary
-
-  def read_single_event_from_eventfile(self):
     event_files = sorted(glob.glob(os.path.join(self.get_temp_dir(), '*')))
-    events = list(tf.compat.v1.train.summary_iterator(event_files[-1]))
+    self.assertEqual(len(event_files), 1)
+    events = list(tf.compat.v1.train.summary_iterator(event_files[0]))
     # Expect a boilerplate event for the file_version, then the summary one.
     self.assertEqual(len(events), 2)
+    # Delete the event file to reset to an empty directory for later calls.
+    os.remove(event_files[0])
     return events[1]
 
   def test_scoped_tag(self):
@@ -223,8 +226,7 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
 
   def test_step(self):
     data = np.array(1, np.float32, ndmin=3)
-    self.audio('a', data, 44100, step=333)
-    event = self.read_single_event_from_eventfile()
+    event = self.audio_event('a', data, 44100, step=333)
     self.assertEqual(333, event.step)
 
 

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -164,33 +164,41 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
       self.skipTest('v2 summary API not available')
 
   def histogram(self, *args, **kwargs):
+    return self.histogram_event(*args, **kwargs).summary
+
+  def histogram_event(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
     writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       summary.histogram(*args, **kwargs)
     writer.close()
-    return self.read_single_event_from_eventfile().summary
-
-  def read_single_event_from_eventfile(self):
     event_files = sorted(glob.glob(os.path.join(self.get_temp_dir(), '*')))
     self.assertEqual(len(event_files), 1)
     events = list(tf.compat.v1.train.summary_iterator(event_files[0]))
     # Expect a boilerplate event for the file_version, then the summary one.
     self.assertEqual(len(events), 2)
+    # Delete the event file to reset to an empty directory for later calls.
+    os.remove(event_files[0])
     return events[1]
+
+  def write_histogram_event(self, *args, **kwargs):
+    kwargs.setdefault('step', 1)
+    writer = tf2.summary.create_file_writer(self.get_temp_dir())
+    with writer.as_default():
+      summary.histogram(*args, **kwargs)
+    writer.close()
 
   def test_scoped_tag(self):
     with tf.name_scope('scope'):
       self.assertEqual('scope/a', self.histogram('a', []).value[0].tag)
 
   def test_step(self):
-    self.histogram('a', [], step=333)
-    event = self.read_single_event_from_eventfile()
+    event = self.histogram_event('a', [], step=333)
     self.assertEqual(333, event.step)
 
 
 class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
-  def histogram(self, *args, **kwargs):
+  def write_histogram_event(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
     # Hack to extract current scope since there's no direct API for it.
     with tf.name_scope('_') as temp_scope:
@@ -204,7 +212,6 @@ class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
     with writer.as_default():
       graph_fn()
     writer.close()
-    return self.read_single_event_from_eventfile().summary
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -173,7 +173,8 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
 
   def read_single_event_from_eventfile(self):
     event_files = sorted(glob.glob(os.path.join(self.get_temp_dir(), '*')))
-    events = list(tf.compat.v1.train.summary_iterator(event_files[-1]))
+    self.assertEqual(len(event_files), 1)
+    events = list(tf.compat.v1.train.summary_iterator(event_files[0]))
     # Expect a boilerplate event for the file_version, then the summary one.
     self.assertEqual(len(events), 2)
     return events[1]

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -178,6 +178,7 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
     # Expect a boilerplate event for the file_version, then the summary one.
     self.assertEqual(len(events), 2)
     # Delete the event file to reset to an empty directory for later calls.
+    # TODO(nickfelt): use a unique subdirectory per writer instead.
     os.remove(event_files[0])
     return events[1]
 

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -199,6 +199,7 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
     # Expect a boilerplate event for the file_version, then the summary one.
     self.assertEqual(len(events), 2)
     # Delete the event file to reset to an empty directory for later calls.
+    # TODO(nickfelt): use a unique subdirectory per writer instead.
     os.remove(event_files[0])
     return events[1]
 

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -185,18 +185,21 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
       self.skipTest('TF v2 summary API not available')
 
   def image(self, *args, **kwargs):
+    return self.image_event(*args, **kwargs).summary
+
+  def image_event(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
     writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       summary.image(*args, **kwargs)
     writer.close()
-    return self.read_single_event_from_eventfile().summary
-
-  def read_single_event_from_eventfile(self):
     event_files = sorted(glob.glob(os.path.join(self.get_temp_dir(), '*')))
-    events = list(tf.compat.v1.train.summary_iterator(event_files[-1]))
+    self.assertEqual(len(event_files), 1)
+    events = list(tf.compat.v1.train.summary_iterator(event_files[0]))
     # Expect a boilerplate event for the file_version, then the summary one.
     self.assertEqual(len(events), 2)
+    # Delete the event file to reset to an empty directory for later calls.
+    os.remove(event_files[0])
     return events[1]
 
   def test_scoped_tag(self):
@@ -206,8 +209,7 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
 
   def test_step(self):
     data = np.array(1, np.uint8, ndmin=4)
-    self.image('a', data, step=333)
-    event = self.read_single_event_from_eventfile()
+    event = self.image_event('a', data, step=333)
     self.assertEqual(333, event.step)
 
   def test_floating_point_data(self):

--- a/tensorboard/plugins/scalar/summary_test.py
+++ b/tensorboard/plugins/scalar/summary_test.py
@@ -142,32 +142,37 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
       self.skipTest('v2 summary API not available')
 
   def scalar(self, *args, **kwargs):
+    return self.scalar_event(*args, **kwargs).summary
+
+  def scalar_event(self, *args, **kwargs):
+    self.write_scalar_event(*args, **kwargs)
+    event_files = sorted(glob.glob(os.path.join(self.get_temp_dir(), '*')))
+    self.assertEqual(len(event_files), 1)
+    events = list(tf.compat.v1.train.summary_iterator(event_files[0]))
+    # Expect a boilerplate event for the file_version, then the summary one.
+    self.assertEqual(len(events), 2)
+    # Delete the event file to reset to an empty directory for later calls.
+    os.remove(event_files[0])
+    return events[1]
+
+  def write_scalar_event(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
     writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       summary.scalar(*args, **kwargs)
     writer.close()
-    return self.read_single_event_from_eventfile().summary
-
-  def read_single_event_from_eventfile(self):
-    event_files = sorted(glob.glob(os.path.join(self.get_temp_dir(), '*')))
-    events = list(tf.compat.v1.train.summary_iterator(event_files[-1]))
-    # Expect a boilerplate event for the file_version, then the summary one.
-    self.assertEqual(len(events), 2)
-    return events[1]
 
   def test_scoped_tag(self):
     with tf.name_scope('scope'):
       self.assertEqual('scope/a', self.scalar('a', 1).value[0].tag)
 
   def test_step(self):
-    self.scalar('a', 1.0, step=333)
-    event = self.read_single_event_from_eventfile()
+    event = self.scalar_event('a', 1.0, step=333)
     self.assertEqual(333, event.step)
 
 
 class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
-  def scalar(self, *args, **kwargs):
+  def write_scalar_event(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
     # Hack to extract current scope since there's no direct API for it.
     with tf.name_scope('_') as temp_scope:
@@ -181,7 +186,6 @@ class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
     with writer.as_default():
       graph_fn()
     writer.close()
-    return self.read_single_event_from_eventfile().summary
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/scalar/summary_test.py
+++ b/tensorboard/plugins/scalar/summary_test.py
@@ -152,6 +152,7 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
     # Expect a boilerplate event for the file_version, then the summary one.
     self.assertEqual(len(events), 2)
     # Delete the event file to reset to an empty directory for later calls.
+    # TODO(nickfelt): use a unique subdirectory per writer instead.
     os.remove(event_files[0])
     return events[1]
 

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -169,6 +169,7 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
     # Expect a boilerplate event for the file_version, then the summary one.
     self.assertEqual(len(events), 2)
     # Delete the event file to reset to an empty directory for later calls.
+    # TODO(nickfelt): use a unique subdirectory per writer instead.
     os.remove(event_files[0])
     return events[1]
 

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -159,32 +159,37 @@ class SummaryV2OpTest(SummaryBaseTest, tf.test.TestCase):
       self.skipTest('TF v2 summary API not available')
 
   def text(self, *args, **kwargs):
+    return self.text_event(*args, **kwargs).summary
+
+  def text_event(self, *args, **kwargs):
+    self.write_text_event(*args, **kwargs)
+    event_files = sorted(glob.glob(os.path.join(self.get_temp_dir(), '*')))
+    self.assertEqual(len(event_files), 1)
+    events = list(tf.compat.v1.train.summary_iterator(event_files[0]))
+    # Expect a boilerplate event for the file_version, then the summary one.
+    self.assertEqual(len(events), 2)
+    # Delete the event file to reset to an empty directory for later calls.
+    os.remove(event_files[0])
+    return events[1]
+
+  def write_text_event(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
     writer = tf2.summary.create_file_writer(self.get_temp_dir())
     with writer.as_default():
       summary.text(*args, **kwargs)
     writer.close()
-    return self.read_single_event_from_eventfile().summary
-
-  def read_single_event_from_eventfile(self):
-    event_files = sorted(glob.glob(os.path.join(self.get_temp_dir(), '*')))
-    events = list(tf.compat.v1.train.summary_iterator(event_files[-1]))
-    # Expect a boilerplate event for the file_version, then the summary one.
-    self.assertEqual(len(events), 2)
-    return events[1]
 
   def test_scoped_tag(self):
     with tf.name_scope('scope'):
       self.assertEqual('scope/a', self.text('a', 'foo').value[0].tag)
 
   def test_step(self):
-    self.text('a', 'foo', step=333)
-    event = self.read_single_event_from_eventfile()
+    event = self.text_event('a', 'foo', step=333)
     self.assertEqual(333, event.step)
 
 
 class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
-  def text(self, *args, **kwargs):
+  def write_text_event(self, *args, **kwargs):
     kwargs.setdefault('step', 1)
     # Hack to extract current scope since there's no direct API for it.
     with tf.name_scope('_') as temp_scope:
@@ -198,7 +203,6 @@ class SummaryV2OpGraphTest(SummaryV2OpTest, tf.test.TestCase):
     with writer.as_default():
       graph_fn()
     writer.close()
-    return self.read_single_event_from_eventfile().summary
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR avoids flaky behavior in the way that eventfiles get read in the test cases for V2 summary ops, which in turn unblocks https://github.com/tensorflow/tensorboard/pull/1891 which otherwise needs to hack around the flakiness.

The implemented change is to fully encapsulate the creation of an eventfile as an implementation detail of the test helpers that construct V2 summary API `Summary` protos, and ensure that at most 1 eventfile is on disk at any given time by deleting it after we read it in.

---

Motivation: the summary API tests all use helpers that attempt to encapsulate the process of converting the API call into a resulting `Summary` protobuf.  For the V1 ops, this is easy because they're designed to produce this output directly.  For the V2 ops, there is no intermediate way to collect the protos before they hit disk, so we write the single event of output to an eventfile and read it back in.

The issue is that some of the tests for convenience call the API several times with different parameters when testing related behavior, which writes multiple separate eventfiles to disk.  Previously this was a non-issue; we just read from the last file found, since the new file was always last in sort order - either by overwriting the previous file, or having a later UNIX timestamp.  Astute readers might note that this is not quite guaranteed because the sort uses the stringified timestamp, not its integer value, and this only works for numbers with the same digit count.  That being said, all unix timestamps from 2001 to 2286 will have 10 digits, so this is not a problem in practice.

However, the recent change in https://github.com/tensorflow/tensorflow/commit/826027dbd4277a2636fc2935ed245700fd01e7cd changes the eventfile naming strategy to avoid precisely these collisions (which are usually undesirable) by baking the PID followed by a per-TF-process UID into the filename after the timestamp.  The UID is basically an autoincrement int so UIDs in the 3-4 digit range are typical, and unfortunately for us, it's much easier to encounter the numeric != lexicographic sort issue with these small numbers.  This means that seemingly unrelated behavior (e.g. inserting new test methods) caused the filenames written by these tests to no longer sort in the order of creation, and thus the wrong data got read and the tests would fail.  (Deterministically, at least in my testing, but I don't think that's actually guaranteed since the UID can be incremented across threads.)