### PR TITLE
Test against TF2 preview in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
   # Grab the BAZEL_SHA256SUM from the Bazel releases page; e.g.:
   # bazel-0.20.0-linux-x86_64.sha256
   - TF_VERSION_ID=tf-nightly BAZEL=0.22.0 BAZEL_SHA256SUM=8474ed28ed4998e2f5671ddf3a9a80ae9e484a5de3b8b70c8b654c017c65d363
+  - TF_VERSION_ID=tf-nightly-2.0-preview BAZEL=0.22.0 BAZEL_SHA256SUM=8474ed28ed4998e2f5671ddf3a9a80ae9e484a5de3b8b70c8b654c017c65d363
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,12 @@ env:
   #
   # Grab the BAZEL_SHA256SUM from the Bazel releases page; e.g.:
   # bazel-0.20.0-linux-x86_64.sha256
-  - TF_VERSION_ID=tf-nightly BAZEL=0.22.0 BAZEL_SHA256SUM=8474ed28ed4998e2f5671ddf3a9a80ae9e484a5de3b8b70c8b654c017c65d363
-  - TF_VERSION_ID=tf-nightly-2.0-preview BAZEL=0.22.0 BAZEL_SHA256SUM=8474ed28ed4998e2f5671ddf3a9a80ae9e484a5de3b8b70c8b654c017c65d363
+  global:
+    - BAZEL=0.22.0
+    - BAZEL_SHA256SUM=8474ed28ed4998e2f5671ddf3a9a80ae9e484a5de3b8b70c8b654c017c65d363
+  matrix:
+    - TF_VERSION_ID=tf-nightly
+    - TF_VERSION_ID=tf-nightly-2.0-preview
 
 cache:
   directories:

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -319,6 +319,7 @@ py_test(
         "//tensorboard/plugins/scalar:metadata",
         "//tensorboard/plugins/scalar:summary",
         "//tensorboard/util:tensor_util",
+        "//tensorboard/util:test_util",
     ],
 )
 

--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -37,7 +37,6 @@ from tensorboard.util import tb_logging
 from tensorboard.util import tensor_util
 from tensorboard.util import test_util
 
-tf.compat.v1.disable_v2_behavior()
 logger = tb_logging.get_logger()
 
 
@@ -122,6 +121,7 @@ class EventAccumulatorTest(tf.test.TestCase):
         self.assertEqual(actual[key], expected_value)
 
 
+@test_util.run_v1_only('Uses v1 SummaryWriter and v1 audio summary')
 class MockingEventAccumulatorTest(EventAccumulatorTest):
 
   def setUp(self):
@@ -546,6 +546,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
         expected_count=size_small)
 
 
+@test_util.run_v1_only('Uses contrib and v1 SummaryWriter')
 class RealisticEventAccumulatorTest(EventAccumulatorTest):
 
   def testTensorsRealistically(self):

--- a/tensorboard/data_compat_test.py
+++ b/tensorboard/data_compat_test.py
@@ -30,8 +30,8 @@ from tensorboard.plugins.image import summary as image_summary
 from tensorboard.plugins.scalar import metadata as scalar_metadata
 from tensorboard.plugins.scalar import summary as scalar_summary
 from tensorboard.util import tensor_util
+from tensorboard.util import test_util
 
-tf.compat.v1.disable_v2_behavior()
 
 
 class MigrateValueTest(tf.test.TestCase):
@@ -61,22 +61,24 @@ class MigrateValueTest(tf.test.TestCase):
     self.assertEqual(original_pbtxt, value.SerializeToString())
 
   def test_scalar(self):
-    old_op = tf.compat.v1.summary.scalar('important_constants', tf.constant(0x5f3759df))
-    old_value = self._value_from_op(old_op)
-    assert old_value.HasField('simple_value'), old_value
-    new_value = data_compat.migrate_value(old_value)
+    with tf.compat.v1.Session():
+      old_op = tf.compat.v1.summary.scalar('important_constants', tf.constant(0x5f3759df))
+      old_value = self._value_from_op(old_op)
+      assert old_value.HasField('simple_value'), old_value
+      new_value = data_compat.migrate_value(old_value)
 
-    self.assertEqual('important_constants', new_value.tag)
-    expected_metadata = scalar_metadata.create_summary_metadata(
-        display_name='important_constants',
-        description='')
-    self.assertEqual(expected_metadata, new_value.metadata)
-    self.assertTrue(new_value.HasField('tensor'))
-    data = tensor_util.make_ndarray(new_value.tensor)
-    self.assertEqual((), data.shape)
-    low_precision_value = np.array(0x5f3759df).astype('float32').item()
-    self.assertEqual(low_precision_value, data.item())
+      self.assertEqual('important_constants', new_value.tag)
+      expected_metadata = scalar_metadata.create_summary_metadata(
+          display_name='important_constants',
+          description='')
+      self.assertEqual(expected_metadata, new_value.metadata)
+      self.assertTrue(new_value.HasField('tensor'))
+      data = tensor_util.make_ndarray(new_value.tensor)
+      self.assertEqual((), data.shape)
+      low_precision_value = np.array(0x5f3759df).astype('float32').item()
+      self.assertEqual(low_precision_value, data.item())
 
+  @test_util.run_v1_only('v1 audio summary uses contrib')
   def test_audio(self):
     audio = tf.reshape(tf.linspace(0.0, 100.0, 4 * 10 * 2), (4, 10, 2))
     old_op = tf.compat.v1.summary.audio('k488', audio, 44100)
@@ -98,103 +100,112 @@ class MigrateValueTest(tf.test.TestCase):
     self.assertEqual(b'', data[0][1])  # empty label
 
   def test_text(self):
-    op = tf.compat.v1.summary.text('lorem_ipsum', tf.constant('dolor sit amet'))
-    value = self._value_from_op(op)
-    assert value.HasField('tensor'), value
-    self._assert_noop(value)
+    with tf.compat.v1.Session():
+      op = tf.compat.v1.summary.text('lorem_ipsum', tf.constant('dolor sit amet'))
+      value = self._value_from_op(op)
+      assert value.HasField('tensor'), value
+      self._assert_noop(value)
 
   def test_fully_populated_tensor(self):
-    metadata = summary_pb2.SummaryMetadata(
-        plugin_data=summary_pb2.SummaryMetadata.PluginData(
-            plugin_name='font_of_wisdom',
-            content=b'adobe_garamond'))
-    op = tf.compat.v1.summary.tensor_summary(
-        name='tensorpocalypse',
-        tensor=tf.constant([[0.0, 2.0], [float('inf'), float('nan')]]),
-        display_name='TENSORPOCALYPSE',
-        summary_description='look on my works ye mighty and despair',
-        summary_metadata=metadata)
-    value = self._value_from_op(op)
-    assert value.HasField('tensor'), value
-    self._assert_noop(value)
+    with tf.compat.v1.Session():
+      metadata = summary_pb2.SummaryMetadata(
+          plugin_data=summary_pb2.SummaryMetadata.PluginData(
+              plugin_name='font_of_wisdom',
+              content=b'adobe_garamond'))
+      op = tf.compat.v1.summary.tensor_summary(
+          name='tensorpocalypse',
+          tensor=tf.constant([[0.0, 2.0], [float('inf'), float('nan')]]),
+          display_name='TENSORPOCALYPSE',
+          summary_description='look on my works ye mighty and despair',
+          summary_metadata=metadata)
+      value = self._value_from_op(op)
+      assert value.HasField('tensor'), value
+      self._assert_noop(value)
 
   def test_image(self):
-    old_op = tf.compat.v1.summary.image('mona_lisa',
-                              tf.image.convert_image_dtype(
-                                  tf.random.normal(shape=[1, 400, 200, 3]),
-                                  tf.uint8,
-                                  saturate=True))
-    old_value = self._value_from_op(old_op)
-    assert old_value.HasField('image'), old_value
-    new_value = data_compat.migrate_value(old_value)
+    with tf.compat.v1.Session():
+      old_op = tf.compat.v1.summary.image('mona_lisa',
+                                tf.image.convert_image_dtype(
+                                    tf.random.normal(shape=[1, 400, 200, 3]),
+                                    tf.uint8,
+                                    saturate=True))
+      old_value = self._value_from_op(old_op)
+      assert old_value.HasField('image'), old_value
+      new_value = data_compat.migrate_value(old_value)
 
-    self.assertEqual('mona_lisa/image/0', new_value.tag)
-    expected_metadata = image_metadata.create_summary_metadata(
-        display_name='mona_lisa/image/0', description='')
-    self.assertEqual(expected_metadata, new_value.metadata)
-    self.assertTrue(new_value.HasField('tensor'))
-    (width, height, data) = tensor_util.make_ndarray(new_value.tensor)
-    self.assertEqual(b'200', width)
-    self.assertEqual(b'400', height)
-    self.assertEqual(
-        tf.compat.as_bytes(old_value.image.encoded_image_string), data)
+      self.assertEqual('mona_lisa/image/0', new_value.tag)
+      expected_metadata = image_metadata.create_summary_metadata(
+          display_name='mona_lisa/image/0', description='')
+      self.assertEqual(expected_metadata, new_value.metadata)
+      self.assertTrue(new_value.HasField('tensor'))
+      (width, height, data) = tensor_util.make_ndarray(new_value.tensor)
+      self.assertEqual(b'200', width)
+      self.assertEqual(b'400', height)
+      self.assertEqual(
+          tf.compat.as_bytes(old_value.image.encoded_image_string), data)
 
   def test_histogram(self):
-    old_op = tf.compat.v1.summary.histogram('important_data',
-                                  tf.random.normal(shape=[23, 45]))
-    old_value = self._value_from_op(old_op)
-    assert old_value.HasField('histo'), old_value
-    new_value = data_compat.migrate_value(old_value)
+    with tf.compat.v1.Session():
+      old_op = tf.compat.v1.summary.histogram('important_data',
+                                    tf.random.normal(shape=[23, 45]))
+      old_value = self._value_from_op(old_op)
+      assert old_value.HasField('histo'), old_value
+      new_value = data_compat.migrate_value(old_value)
 
-    self.assertEqual('important_data', new_value.tag)
-    expected_metadata = histogram_metadata.create_summary_metadata(
-        display_name='important_data', description='')
-    self.assertEqual(expected_metadata, new_value.metadata)
-    self.assertTrue(new_value.HasField('tensor'))
-    buckets = tensor_util.make_ndarray(new_value.tensor)
-    self.assertEqual(old_value.histo.min, buckets[0][0])
-    self.assertEqual(old_value.histo.max, buckets[-1][1])
-    self.assertEqual(23 * 45, buckets[:, 2].astype(int).sum())
+      self.assertEqual('important_data', new_value.tag)
+      expected_metadata = histogram_metadata.create_summary_metadata(
+          display_name='important_data', description='')
+      self.assertEqual(expected_metadata, new_value.metadata)
+      self.assertTrue(new_value.HasField('tensor'))
+      buckets = tensor_util.make_ndarray(new_value.tensor)
+      self.assertEqual(old_value.histo.min, buckets[0][0])
+      self.assertEqual(old_value.histo.max, buckets[-1][1])
+      self.assertEqual(23 * 45, buckets[:, 2].astype(int).sum())
 
   def test_new_style_histogram(self):
-    op = histogram_summary.op('important_data',
-                              tf.random.normal(shape=[10, 10]),
-                              bucket_count=100,
-                              display_name='Important data',
-                              description='secrets of the universe')
-    value = self._value_from_op(op)
-    assert value.HasField('tensor'), value
-    self._assert_noop(value)
+    with tf.compat.v1.Session():
+      op = histogram_summary.op('important_data',
+                                tf.random.normal(shape=[10, 10]),
+                                bucket_count=100,
+                                display_name='Important data',
+                                description='secrets of the universe')
+      value = self._value_from_op(op)
+      assert value.HasField('tensor'), value
+      self._assert_noop(value)
 
   def test_new_style_image(self):
-    op = image_summary.op(
-        'mona_lisa',
-        tf.image.convert_image_dtype(
-            tf.random.normal(shape=[1, 400, 200, 3]), tf.uint8, saturate=True),
-        display_name='The Mona Lisa',
-        description='A renowned portrait by da Vinci.')
-    value = self._value_from_op(op)
-    assert value.HasField('tensor'), value
-    self._assert_noop(value)
+    with tf.compat.v1.Session():
+      op = image_summary.op(
+          'mona_lisa',
+          tf.image.convert_image_dtype(
+              tf.random.normal(shape=[1, 400, 200, 3]), tf.uint8, saturate=True),
+          display_name='The Mona Lisa',
+          description='A renowned portrait by da Vinci.')
+      value = self._value_from_op(op)
+      assert value.HasField('tensor'), value
+      self._assert_noop(value)
 
+  @test_util.run_v1_only('audio summary uses contrib')
   def test_new_style_audio(self):
-    audio = tf.reshape(tf.linspace(0.0, 100.0, 4 * 10 * 2), (4, 10, 2))
-    op = audio_summary.op('k488',
-                          tf.cast(audio, tf.float32),
-                          sample_rate=44100,
-                          display_name='Piano Concerto No.23',
-                          description='In **A major**.')
-    value = self._value_from_op(op)
-    assert value.HasField('tensor'), value
-    self._assert_noop(value)
+    with tf.compat.v1.Session():
+      audio = tf.reshape(tf.linspace(0.0, 100.0, 4 * 10 * 2), (4, 10, 2))
+      op = audio_summary.op('k488',
+                            tf.cast(audio, tf.float32),
+                            sample_rate=44100,
+                            display_name='Piano Concerto No.23',
+                            description='In **A major**.')
+      value = self._value_from_op(op)
+      assert value.HasField('tensor'), value
+      self._assert_noop(value)
 
   def test_new_style_scalar(self):
-    op = scalar_summary.op('important_constants', tf.constant(0x5f3759df),
-                           display_name='Important constants',
-                           description='evil floating point bit magic')
-    value = self._value_from_op(op)
-    assert value.HasField('tensor'), value
-    self._assert_noop(value)
+    with tf.compat.v1.Session():
+      op = scalar_summary.op('important_constants', tf.constant(0x5f3759df),
+                            display_name='Important constants',
+                            description='evil floating point bit magic')
+      value = self._value_from_op(op)
+      assert value.HasField('tensor'), value
+      self._assert_noop(value)
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -86,6 +86,7 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/util:tensor_util",
+        "//tensorboard/util:test_util",
     ],
 )
 

--- a/tensorboard/plugins/audio/audio_plugin_test.py
+++ b/tensorboard/plugins/audio/audio_plugin_test.py
@@ -38,9 +38,8 @@ from tensorboard.plugins.audio import audio_plugin
 from tensorboard.plugins.audio import summary
 from tensorboard.util import test_util
 
-tf.compat.v1.disable_v2_behavior()
 
-
+@test_util.run_v1_only('Uses tf.contrib in setUp via audio.summary')
 class AudioPluginTest(tf.test.TestCase):
 
   def setUp(self):

--- a/tensorboard/plugins/audio/summary_test.py
+++ b/tensorboard/plugins/audio/summary_test.py
@@ -33,6 +33,7 @@ from tensorboard.compat import tf2
 from tensorboard.plugins.audio import metadata
 from tensorboard.plugins.audio import summary
 from tensorboard.util import tensor_util
+from tensorboard.util import test_util
 
 
 try:
@@ -146,11 +147,10 @@ class SummaryBaseTest(object):
       self.audio('k488', data, 44100, encoding='pptx')
 
 
+@test_util.run_v1_only('Uses tf.contrib')
 class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):
   def setUp(self):
     super(SummaryV1PbTest, self).setUp()
-    if not hasattr(tf, 'contrib'):
-      self.skipTest('TF contrib ffmpeg API not available')
 
   def audio(self, *args, **kwargs):
     return summary.pb(*args, **kwargs)
@@ -166,11 +166,10 @@ class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):
     self.skipTest('summary V1 pb does not actually enforce this')
 
 
+@test_util.run_v1_only('Uses tf.contrib')
 class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
   def setUp(self):
     super(SummaryV1OpTest, self).setUp()
-    if not hasattr(tf, 'contrib'):
-      self.skipTest('TF contrib ffmpeg API not available')
 
   def audio(self, *args, **kwargs):
     return tf.Summary.FromString(summary.op(*args, **kwargs).numpy())

--- a/tensorboard/plugins/beholder/beholder.py
+++ b/tensorboard/plugins/beholder/beholder.py
@@ -21,6 +21,7 @@ import time
 
 import numpy as np
 import tensorflow as tf
+from tensorflow_estimator import estimator
 
 from tensorboard.plugins.beholder import im_util
 from tensorboard.plugins.beholder.file_system_tools import read_pickle,\
@@ -196,7 +197,7 @@ class Beholder(object):
     return grads, optimizer.apply_gradients(grads_and_vars)
 
 
-class BeholderHook(tf.estimator.SessionRunHook):
+class BeholderHook(estimator.SessionRunHook):
   """SessionRunHook implementation that runs Beholder every step.
 
   Convenient when using tf.train.MonitoredSession:

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -40,7 +40,6 @@ from tensorboard.plugins import base_plugin
 from tensorboard.plugins.core import core_plugin
 from tensorboard.util import test_util
 
-tf.compat.v1.disable_v2_behavior()
 FAKE_INDEX_HTML = b'<!doctype html><title>fake-index</title>'
 
 
@@ -159,6 +158,7 @@ class CorePluginTest(tf.test.TestCase):
     parsed_object = self._get_json(self.logdir_based_server, '/data/logdir')
     self.assertEqual(parsed_object, {'logdir': self.logdir})
 
+  @test_util.run_v1_only('Uses tf.contrib when adding runs.')
   def testRuns(self):
     """Test the format of the /data/runs endpoint."""
     self._add_run('run1')
@@ -167,6 +167,7 @@ class CorePluginTest(tf.test.TestCase):
     run_json = self._get_json(self.logdir_based_server, '/data/runs')
     self.assertEqual(run_json, ['run1'])
 
+  @test_util.run_v1_only('Uses tf.contrib when adding runs.')
   def testExperiments(self):
     """Test the format of the /data/experiments endpoint."""
     self._add_run('run1', experiment_name = 'exp1')
@@ -180,6 +181,7 @@ class CorePluginTest(tf.test.TestCase):
     exp_json = self._get_json(self.logdir_based_server, '/data/experiments')
     self.assertEqual(exp_json, [])
 
+  @test_util.run_v1_only('Uses tf.contrib when adding runs.')
   def testExperimentRuns(self):
     """Test the format of the /data/experiment_runs endpoint."""
     self._add_run('run1', experiment_name = 'exp1')
@@ -208,7 +210,7 @@ class CorePluginTest(tf.test.TestCase):
     exp_json = self._get_json(self.logdir_based_server, '/data/experiments')
     self.assertEqual(exp_json, [])
 
-
+  @test_util.run_v1_only('Uses tf.contrib when adding runs.')
   def testRunsAppendOnly(self):
     """Test that new runs appear after old ones in /data/runs."""
     fake_wall_times = {

--- a/tensorboard/plugins/debugger/BUILD
+++ b/tensorboard/plugins/debugger/BUILD
@@ -35,6 +35,7 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/util:tb_logging",
+        "//tensorboard/util:test_util",
         "@org_python_pypi_portpicker",
     ],
 )
@@ -259,6 +260,7 @@ py_test(
         ":debugger_server_lib",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/util:test_util",
         "@org_python_pypi_portpicker",
     ],
 )
@@ -275,6 +277,7 @@ py_test(
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
         "@org_python_pypi_portpicker",
         "@org_pythonhosted_six",

--- a/tensorboard/plugins/debugger/debug_graphs_helper_test.py
+++ b/tensorboard/plugins/debugger/debug_graphs_helper_test.py
@@ -12,7 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests the debug_graphs_helper module."""
+"""Tests the debug_graphs_helper module.
+
+[1]: Below graph creates different ops
+  a = tf.Variable([1.0], name='a')
+  b = tf.Variable([2.0], name='b')
+  _ = tf.add(a, b, name='c')
+
+In v1:
+  a, a/Assign, a/initial_value, a/read,
+  b, b/Assign, b/initial_value, b/read,
+  c
+In v2:
+  a, a/Assign, a/Initializer/initial_value,
+  a/IsInitialized/VarIsInitializedOp, a/Read/ReadVariableOp
+  b, b/Assign, b/Initializer/initial_value,
+  b/IsInitialized/VarIsInitializedOp, b/Read/ReadVariableOp,
+  c, c/ReadVariableOp,  c/ReadVariableOp_1,
+"""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -134,22 +151,9 @@ class ExtractGatedGrpcDebugOpsTest(tf.test.TestCase):
       self.assertEqual([], gated_debug_ops)
 
 
-# [1]: Below graph creates different ops
-#   a = tf.Variable([1.0], name='foo/a')
-#   b = tf.Variable([2.0], name='bar/b')
-#   _ = tf.add(a, b, name='baz/c')
-#
-# In v1:
-#   bar/b, bar/b/Assign, bar/b/initial_value, bar/b/read, baz/c,
-#   foo/a, foo/a/Assign, foo/a/initial_value, foo/a/read
-# In v2:
-#   bar/b, bar/b/Assign, bar/b/Initializer/initial_value,
-#   bar/b/IsInitialized/VarIsInitializedOp, bar/b/Read/ReadVariableOp,
-#   baz/c, baz/c/ReadVariableOp,  baz/c/ReadVariableOp_1,
-#   foo/a, foo/a/Assign, foo/a/Initializer/initial_value,
-#   foo/a/IsInitialized/VarIsInitializedOp, foo/a/Read/ReadVariableOp
-
-@test_util.run_v1_only('Graph creates different op structure in v2. See [1].')
+@test_util.run_v1_only((
+    'Graph creates different op structure in v2. See '
+    'debug_graphs_helper_test.py[1].'))
 class BaseExpandedNodeNameTest(tf.test.TestCase):
 
   def testMaybeBaseExpandedNodeName(self):

--- a/tensorboard/plugins/debugger/debugger_plugin_testlib.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_testlib.py
@@ -178,7 +178,7 @@ class DebuggerPluginTestBase(tf.test.TestCase):
     Returns:
       A `tf.Event` with a health pill summary.
     """
-    event = tf.Event(step=step, wall_time=wall_time)
+    event = tf.compat.v1.Event(step=step, wall_time=wall_time)
     tensor = tf.compat.v1.make_tensor_proto(
         list_of_values, dtype=tf.float64, shape=[len(list_of_values)])
     value = event.summary.value.add(

--- a/tensorboard/plugins/debugger/debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/debugger_server_lib.py
@@ -242,7 +242,7 @@ class DebuggerDataServer(grpc_debug_server.EventListenerBaseServicer):
     # TensorBoard.
     try:
       self._events_writer_manager.write_event(
-          tf.Event(
+          tf.compat.v1.Event(
               wall_time=0, step=0, file_version=constants.EVENTS_VERSION))
     except IOError as e:
       logger.error(

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
@@ -42,11 +42,13 @@ from tensorboard.backend import application
 from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.debugger import interactive_debugger_plugin
+from tensorboard.util import test_util
 
-tf.compat.v1.disable_v2_behavior()
+
 _SERVER_URL_PREFIX = '/data/plugin/debugger/'
 
 
+@test_util.run_v1_only('Test fails to run and clean up properly; they time out.')
 class InteractiveDebuggerPluginTest(tf.test.TestCase):
 
   def setUp(self):

--- a/tensorboard/plugins/debugger/session_debug_test.py
+++ b/tensorboard/plugins/debugger/session_debug_test.py
@@ -40,8 +40,10 @@ from tensorflow.python import debug as tf_debug  # pylint: disable=wrong-import-
 
 from tensorboard.plugins.debugger import constants
 from tensorboard.plugins.debugger import debugger_server_lib
+from tensorboard.util import test_util
 
 
+@test_util.run_v1_only("Server fails to come up. Requires study.")
 class SessionDebugTestBase(tf.test.TestCase):
 
   def setUp(self):
@@ -83,7 +85,7 @@ class SessionDebugTestBase(tf.test.TestCase):
 
           sess.run(a.initializer, options=run_options)
           return True
-      except tf.errors.FailedPreconditionError:
+      except tf.errors.FailedPreconditionError as exc:
         time.sleep(poll_interval_seconds)
 
     return False

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -84,6 +84,7 @@ py_test(
         ":keras_util",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
+        "//tensorboard/util:test_util",
         "@com_google_protobuf//:protobuf_python",
     ],
 )

--- a/tensorboard/plugins/graph/keras_util_test.py
+++ b/tensorboard/plugins/graph/keras_util_test.py
@@ -33,13 +33,13 @@ class BaseGraphUtilTest(object):
 
     self.assertProtoEquals(
         expected_proto, keras_util.keras_model_to_graph_def(model_config))
-  
+
   def lstm_node_name(self):
-    raise NotImplementedError
+    raise NotImplementedError()
 
   def lstm_keras_class_name(self):
-    raise NotImplementedError
-    
+    raise NotImplementedError()
+
 
   def test_keras_model_to_graph_def_sequential_model(self):
     expected_proto = """

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -100,6 +100,7 @@ py_test(
     deps = [
         ":summary",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/util:tensor_util",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/histogram/summary_test.py
+++ b/tensorboard/plugins/histogram/summary_test.py
@@ -26,6 +26,7 @@ import numpy as np
 import tensorflow as tf
 
 from tensorboard.compat import tf2
+from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.histogram import metadata
 from tensorboard.plugins.histogram import summary
 from tensorboard.util import tensor_util
@@ -138,7 +139,7 @@ class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
     # Map new name to the old name.
     if 'buckets' in kwargs:
       kwargs['bucket_count'] = kwargs.pop('buckets')
-    return tf.Summary.FromString(summary.op(*args, **kwargs).numpy())
+    return summary_pb2.Summary.FromString(summary.op(*args, **kwargs).numpy())
 
   def test_tag(self):
     self.assertEqual('a/histogram_summary',

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -99,6 +99,7 @@ py_test(
         ":summary",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
     ],
 )
 

--- a/tensorboard/plugins/image/summary_test.py
+++ b/tensorboard/plugins/image/summary_test.py
@@ -27,6 +27,7 @@ import six
 import tensorflow as tf
 
 from tensorboard.compat import tf2
+from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.image import metadata
 from tensorboard.plugins.image import summary
 
@@ -161,7 +162,7 @@ class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
     args = list(args)
     # Force first argument to tf.uint8 since the V1 version requires this.
     args[1] = tf.cast(tf.constant(args[1]), tf.uint8)
-    return tf.Summary.FromString(summary.op(*args, **kwargs).numpy())
+    return summary_pb2.Summary.FromString(summary.op(*args, **kwargs).numpy())
 
   def test_tag(self):
     data = np.array(1, np.uint8, ndmin=4)

--- a/tensorboard/plugins/pr_curve/pr_curve_demo.py
+++ b/tensorboard/plugins/pr_curve/pr_curve_demo.py
@@ -183,7 +183,7 @@ def start_runs(
   merged_summary_op = tf.compat.v1.summary.merge_all()
   events_directory = os.path.join(logdir, run_name)
   sess = tf.compat.v1.Session()
-  writer = tf.summary.FileWriter(events_directory, sess.graph)
+  writer = tf.compat.v1.summary.FileWriter(events_directory, sess.graph)
 
   for step in xrange(steps):
     feed_dict = {

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -59,6 +59,7 @@ py_test(
         ":projector_plugin",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -33,6 +33,8 @@ from google.protobuf import text_format
 
 from tensorboard.backend import application
 from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
+from tensorboard.compat.proto import event_pb2
+from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.projector import projector_config_pb2
 from tensorboard.plugins.projector import projector_plugin
@@ -269,10 +271,11 @@ class ProjectorAppTest(tf.test.TestCase):
 
   def _GenerateEventsData(self):
     with test_util.FileWriterCache.get(self.log_dir) as fw:
-      event = tf.Event(
+      event = event_pb2.Event(
           wall_time=1,
           step=1,
-          summary=tf.Summary(value=[tf.Summary.Value(tag='s1', simple_value=0)]))
+          summary=summary_pb2.Summary(
+              value=[summary_pb2.Summary.Value(tag='s1', simple_value=0)]))
       fw.add_event(event)
 
   def _GenerateProjectorTestData(self):
@@ -294,7 +297,8 @@ class ProjectorAppTest(tf.test.TestCase):
     with tf.Graph().as_default():
       sess = tf.compat.v1.Session()
       checkpoint_path = os.path.join(self.log_dir, 'model')
-      tf.compat.v1.get_variable('var1', [1, 2], initializer=tf.constant_initializer(6.0))
+      tf.compat.v1.get_variable('var1',
+                                initializer=tf.constant(np.full([1, 2], 6.0)))
       tf.compat.v1.get_variable('var2', [10, 10])
       tf.compat.v1.get_variable('var3', [100, 100])
       sess.run(tf.compat.v1.global_variables_initializer())

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -39,6 +39,7 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_accumulator",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -36,9 +36,8 @@ from tensorboard.plugins.scalar import scalars_plugin
 from tensorboard.plugins.scalar import summary
 from tensorboard.util import test_util
 
-tf.compat.v1.disable_v2_behavior()
 
-
+@test_util.run_v1_only('Requires contrib for db writer or uses op.Placeholder')
 class ScalarsPluginTest(tf.test.TestCase):
 
   _STEPS = 99

--- a/tensorboard/plugins/scalar/summary_test.py
+++ b/tensorboard/plugins/scalar/summary_test.py
@@ -28,6 +28,7 @@ import six
 import tensorflow as tf
 
 from tensorboard.compat import tf2
+from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.scalar import metadata
 from tensorboard.plugins.scalar import summary
 from tensorboard.util import tensor_util
@@ -117,7 +118,7 @@ class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):
 
 class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
   def scalar(self, *args, **kwargs):
-    return tf.Summary.FromString(summary.op(*args, **kwargs).numpy())
+    return summary_pb2.Summary.FromString(summary.op(*args, **kwargs).numpy())
 
   def test_tag(self):
     self.assertEqual('a/scalar_summary', self.scalar('a', 1).value[0].tag)

--- a/tensorboard/plugins/text/summary_test.py
+++ b/tensorboard/plugins/text/summary_test.py
@@ -28,6 +28,7 @@ import six
 import tensorflow as tf
 
 from tensorboard.compat import tf2
+from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.text import metadata
 from tensorboard.plugins.text import summary
 from tensorboard.util import tensor_util
@@ -135,7 +136,7 @@ class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):
 
 class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
   def text(self, *args, **kwargs):
-    return tf.Summary.FromString(summary.op(*args, **kwargs).numpy())
+    return summary_pb2.Summary.FromString(summary.op(*args, **kwargs).numpy())
 
   def test_tag(self):
     self.assertEqual('a/text_summary', self.text('a', 'foo').value[0].tag)

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -23,6 +23,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":encoder",
+        ":test_util",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",

--- a/tensorboard/util/encoder_test.py
+++ b/tensorboard/util/encoder_test.py
@@ -21,6 +21,7 @@ import six
 import tensorflow as tf
 
 from tensorboard.util import encoder
+from tensorboard.util import test_util
 
 
 class TensorFlowPngEncoderTest(tf.test.TestCase):
@@ -55,6 +56,7 @@ class TensorFlowPngEncoderTest(tf.test.TestCase):
     self._check_png(data)
 
 
+@test_util.run_v1_only('Uses contrib')
 class TensorFlowWavEncoderTest(tf.test.TestCase):
 
   def setUp(self):

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -32,7 +32,6 @@ import threading
 import unittest
 
 import tensorflow as tf
-from tensorflow.python import tf2
 
 from tensorboard import db
 from tensorboard.compat.proto import event_pb2
@@ -304,9 +303,11 @@ def _run_conditionally(guard, name, default_reason=None):
 
   return _impl
 
+_is_tf2 =  tf.__version__.startswith('2.')
 run_v1_only = _run_conditionally(
-    lambda: not tf2.enabled(), name='run_v1_only')
+    lambda: not _is_tf2,
+    name='run_v1_only')
 run_v2_only = _run_conditionally(
-    lambda: tf2.enabled(),
+    lambda: _is_tf2,
     name='run_v2_only',
     default_reason='Test only appropriate for TensorFlow v2')

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -303,6 +303,7 @@ def _run_conditionally(guard, name, default_reason=None):
 
   return _impl
 
+# TODO(#1996): Better detect TF2.0.
 _is_tf2 =  tf.__version__.startswith('2.')
 run_v1_only = _run_conditionally(
     lambda: not _is_tf2,

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -299,7 +299,9 @@ def _run_conditionally(guard, name, reason_required=True):
 
     Args:
       reason: String giving a reason for limiting the test.
-      func: A function or class to be annotated.
+      func: A function or class to be annotated. If `func` is None, this
+          returns a decorator the can be applied to a function. If `func`
+          is not None this returns the decorator applied to `func`.
 
     Returns:
       Returns a decorator that will conditionally skip the decorated test method.

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -280,6 +280,9 @@ def ensure_tb_summary_proto(summary):
 def _run_conditionally(guard, name, default_reason=None):
   """Create a decorator factory that skips a test when guard returns False.
 
+    The factory raises ValueError when default_reason is None and reason is not
+    passed to the factory.
+
     Args:
       guard: A lambda that returns True if a test should be executed.
       name: A human readable name for the decorator for an error message.

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -278,7 +278,7 @@ def ensure_tb_summary_proto(summary):
 
 
 def _run_conditionally(guard, name, default_reason=None):
-  """Creates a decorator that skips a test when guard returns False.
+  """Create a decorator factory that skips a test when guard returns False.
 
     Args:
       guard: A lambda that returns True if a test should be executed.
@@ -291,7 +291,7 @@ def _run_conditionally(guard, name, default_reason=None):
       ValueError when both reason and default_reason are None.
 
     Returns:
-      Returns a decorator.
+      A function that returns a decorator.
     """
 
   def _impl(reason=None):


### PR DESCRIPTION
# Motivation for features / changes
We would like to not regress for TensorFlow v2.

* Technical description of changes
Add an environment variable entry to trigger the build/test against the tf-nightly-2.0-preview.
In case TF2.0 becomes mainstream, until we decide to drop implicit support for TF1, we should test against TF1.

* Screenshots of UI changes
N/a

* Detailed steps to verify changes work correctly (as executed by you)
This PR :)

* Alternate designs / implementations considered
?
