### PR TITLE
notebook: change default height to 800px

### DIFF
--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -218,7 +218,7 @@ def display(port=None, height=None):
       launched TensorBoard.
     height: The height of the frame into which to render the TensorBoard
       UI, as an `int` number of pixels, or `None` to use a default value
-      (currently 600).
+      (currently 800).
   """
   _display(port=port, height=height, print_message=True, display_handle=None)
 
@@ -235,7 +235,7 @@ def _display(port=None, height=None, print_message=False, display_handle=None):
       render TensorBoard.
   """
   if height is None:
-    height = 600
+    height = 800
 
   if port is None:
     infos = manager.get_all()


### PR DESCRIPTION
Summary:
The previous default height of 600px is okay for some dashboards but
particularly cramped for hparams. Through rigorous testing, we have
determined that 800px is a larger number.

Before and after screenshots of the hparams dashboard:
![Screenshots](https://user-images.githubusercontent.com/4317806/53537097-aac86300-3abd-11e9-8f98-f202a6191ce3.png)

Test Plan:
Build a Pip package, upload it to Colab, run the hparams demo, take
screenshots above.

wchargin-branch: notebook-enlarge-default-height
