### PR TITLE
Add project include file for banner

### DIFF
--- a/docs/_project.yaml
+++ b/docs/_project.yaml
@@ -5,3 +5,4 @@ description: "TensorFlow's visualization toolkit"
 hide_from_products_list: true
 content_license: cc3-apache2
 buganizer_id: 141521
+include: /_project_included.yaml


### PR DESCRIPTION
This adds an announcement banner to the site: go/tfo-stage/tensorboard

The included `_project_included.yaml` lives in the main tf.org directory (which this directory gets imported into). (see: cl/236066165)