### PR TITLE
profile: make help links open in new tabs

### DIFF
--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -48,7 +48,11 @@ profile run can have multiple tools that present the performance profile as diff
     <h3>Profiling isn’t supported in Colab yet.</h3>
     <p>
       Please see
-      <a href="https://github.com/tensorflow/tensorboard/issues/1913">GitHub issue #1913</a>
+      <a
+        href="https://github.com/tensorflow/tensorboard/issues/1913"
+        rel="noopener"
+        target="_blank"
+      >GitHub issue #1913</a>
       for more information.
     </p>
   </div>
@@ -65,21 +69,39 @@ profile run can have multiple tools that present the performance profile as diff
     <p>To collect a profile, you need to run your model on Google Cloud TPUs and
     capture the trace information while your model is running. You may want to
     check out the
-    <a href="https://github.com/tensorflow/tensorboard/blob/1.6/tensorboard/plugins/profile/README.md">README</a>
+    <a
+      href="https://github.com/tensorflow/tensorboard/blob/1.6/tensorboard/plugins/profile/README.md"
+      rel="noopener"
+      target="_blank"
+    >README</a>
     and perhaps the
     <a
-     href="https://cloud.google.com/tpu/docs/cloud-tpu-tools"
+      href="https://cloud.google.com/tpu/docs/cloud-tpu-tools"
+      rel="noopener"
+      target="_blank"
     >tutorial</a> on how to use the
-    <a href="https://pypi.python.org/pypi/cloud-tpu-profiler">cloud-tpu-profiler</a>.
+    <a
+      href="https://pypi.python.org/pypi/cloud-tpu-profiler"
+      rel="noopener"
+      target="_blank"
+    >cloud-tpu-profiler</a>.
     </p>
     <p>
     If you’re new to TPUs, and want to find out how
     to run models, check out the
-    <a href="https://cloud.google.com/tpu/docs/quickstart">Quickstart Using a TPU</a>.
+    <a
+      href="https://cloud.google.com/tpu/docs/quickstart"
+      rel="noopener"
+      target="_blank"
+    >Quickstart Using a TPU</a>.
     </p>
     <p>
     If you think profiling is done properly, please see the page of
-    <a href="https://cloud.google.com/tpu/docs/troubleshooting">Google Cloud TPU Troubleshooting and FAQ</a>
+    <a
+      href="https://cloud.google.com/tpu/docs/troubleshooting"
+      rel="noopener"
+      target="_blank"
+    >Google Cloud TPU Troubleshooting and FAQ</a>
     and consider filing an issue on GitHub.</p>
   </div>
 </template>


### PR DESCRIPTION
Summary:
Not only is opening in new tabs a better user experience, it’s necessary
in notebook contexts so that we don’t try to load the GitHub docs in an
iframe, which would fail because GitHub sets `frame-ancestors 'none'`.
(When I tested #1914 in Colab, I instinctively Ctrl-clicked the link,
thus not hitting this issue.)

Test Plan:
Tested that in both Jupyter and Colab, clicking on a help link before
this change yields a white frame with a “Refused to display…” console
error, while after this change it opens the appropriate link in a new
tab.

Checked statically that each link has `rel="noopener" target="_blank"`:

```shell
$ <./tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html tee \
> >(grep 'href=' | grep -Fcv '<link') \
> >(grep -Fc 'rel="noopener"') \
> >(grep -Fc 'target="_blank"') \
> >/dev/null
6
6
6
```

wchargin-branch: profile-help-in-new-tab
