### PR TITLE
Rewrite the tf.summary import logic, this time with tests

### DIFF
--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -164,12 +164,12 @@ tb.notebook.start  # don't invoke; just check existence
     import_attr="import tensorflow as tf; a = tf${1}.summary; a.write; a.scalar"
     import_as="import tensorflow${1}.summary as b; b.write; b.scalar"
     import_from="from tensorflow${1} import summary as c; c.write; c.scalar"
-    printf "${import_attr}\n${import_as}\n${import_from}" | python -
-    printf "${import_attr}\n${import_from}\n${import_as}" | python -
-    printf "${import_as}\n${import_attr}\n${import_from}" | python -
-    printf "${import_as}\n${import_from}\n${import_attr}" | python -
-    printf "${import_from}\n${import_attr}\n${import_as}" | python -
-    printf "${import_from}\n${import_as}\n${import_attr}" | python -
+    printf '%s\n' "${import_attr}" "${import_as}" "${import_from}" | python -
+    printf '%s\n' "${import_attr}" "${import_from}" "${import_as}" | python -
+    printf '%s\n' "${import_as}" "${import_attr}" "${import_from}" | python -
+    printf '%s\n' "${import_as}" "${import_from}" "${import_attr}" | python -
+    printf '%s\n' "${import_from}" "${import_attr}" "${import_as}" | python -
+    printf '%s\n' "${import_from}" "${import_as}" "${import_attr}" | python -
   }
   test_tf_summary '.compat.v2'
   is_tf_2() {

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -135,6 +135,8 @@ smoke() {
   pip install -qU pip
   pip install -qU "${smoke_tf}"
   pip install -qU ../dist/*"py${py_major_version}"*.whl >/dev/null
+  pip freeze  # Log the results of pip installation
+
   # Test TensorBoard application
   [ -x ./bin/tensorboard ]  # Ensure pip package included binary
   mkfifo pipe
@@ -145,15 +147,39 @@ smoke() {
   curl -fs "http://localhost:$(cat port)/data/logdir" >logdir.json
   grep 'smokedir' logdir.json
   kill $!
+
   # Test TensorBoard APIs
+  export TF_CPP_MIN_LOG_LEVEL=1  # Suppress spammy TF startup logging.
   python -c "
 import tensorboard as tb
 tb.summary.scalar_pb('test', 42)
 from tensorboard.plugins.projector import visualize_embeddings
 from tensorboard.plugins.beholder import Beholder, BeholderHook
 tb.notebook.start  # don't invoke; just check existence
-import tensorboard.summary._tf.summary as tf_summary
 "
+
+  # Exhaustively test various sequences of importing tf.summary.
+  test_tf_summary() {
+    # First argument is subpath to test, e.g. '' or '.compat.v2'.
+    import_attr="import tensorflow as tf; a = tf${1}.summary; a.write; a.scalar"
+    import_as="import tensorflow${1}.summary as b; b.write; b.scalar"
+    import_from="from tensorflow${1} import summary as c; c.write; c.scalar"
+    printf "${import_attr}\n${import_as}\n${import_from}" | python -
+    printf "${import_attr}\n${import_from}\n${import_as}" | python -
+    printf "${import_as}\n${import_attr}\n${import_from}" | python -
+    printf "${import_as}\n${import_from}\n${import_attr}" | python -
+    printf "${import_from}\n${import_attr}\n${import_as}" | python -
+    printf "${import_from}\n${import_as}\n${import_attr}" | python -
+  }
+  test_tf_summary '.compat.v2'
+  is_tf_2() {
+    python -c "import tensorflow as tf; assert tf.__version__[:2] == '2.'" \
+      >/dev/null 2>&1
+  }
+  if is_tf_2 ; then
+    test_tf_summary ''
+  fi
+
   deactivate
   cd ..
   rm -rf "${smoke_venv}"

--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -18,48 +18,89 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import importlib
-
+# Keep this import outside the function below for internal sync reasons.
 import tensorflow as tf
 
-# Re-export all symbols from the original tf.summary.
-# pylint: disable=wildcard-import,unused-import,g-import-not-at-top
+def reexport_tf_summary():
+  """Re-export all symbols from the original tf.summary.
 
-if getattr(tf, '__version__', '').startswith('2.'):
-  from tensorflow.summary import *
-else:
-  try:
-    # Check if we can directly import tf.compat.v2. We may not be able to if we
-    # reached this import itself while importing tf.compat.v2. Use importlib
-    # to simulate 'import tensorflow.compat.v2' but without binding local names
-    # which are hard to clean up.
-    #
-    # Note that we can't use either of the following internally:
-    #
-    #   import tensorflow.compat.v2 as other
-    #   from tensorflow.compat import v2
-    #
-    # The former raises AttributeError until python 3.7:
-    # <https://bugs.python.org/issue30024>
-    # The latter raises ImportError even when it shouldn't, until python 3.5:
-    # <https://bugs.python.org/issue17636>
-    #
-    # In commemoration of this fiasco, I offer the following haiku:
-    #
-    #   import a module
-    #   it works. but add "as other"
-    #   AttributeError
-    #
-    importlib.import_module('tensorflow.compat.v2')
-  except ImportError:
-    # If that failed, go "under the hood" and attempt to directly import the
-    # module that will become tf.compat.v2.summary.
-    try:
-      from tensorflow._api.v1.compat.v2.summary import *
-    except ImportError:
-      from tensorflow._api.v2.compat.v2.summary import *
-  else:
-    from tensorflow.compat.v2.summary import *
+  This function finds the original tf.summary V2 API and re-exports all the
+  symbols from it within this module as well, so that when this module is
+  patched into the TF API namespace as the new tf.summary, the effect is an
+  overlay that just adds TensorBoard-provided symbols to the module.
+
+  Finding the original tf.summary V2 API module reliably is a challenge, since
+  this code runs *during* the overall TF API import process and depending on
+  the order of imports (which is subject to change), different parts of the API
+  may or may not be defined at the point in time we attempt to access them. This
+  code also may be inserted into two places in the API (tf and tf.compat.v2)
+  and may be re-executed multiple times even for the same place in the API (due
+  to the TF module import system not populating sys.modules properly), so it
+  needs to be robust to many different scenarios.
+
+  The one constraint we can count on is that everywhere this module is loaded
+  (via the component_api_helper mechanism in TF), it's going to be the 'summary'
+  submodule of a larger API package that already has a 'summary' attribute
+  that contains the TF-only summary API symbols we need to re-export. This
+  may either be the original TF-only summary module (the first time we load
+  this module) or a pre-existing copy of this module (if we're re-loading this
+  module again). We don't actually need to differentiate those two cases,
+  because it's okay if we re-import our own TensorBoard-provided symbols; they
+  will just be overwritten later on in this file.
+
+  So given that guarantee, the approach we take is to first attempt to locate
+  a TF V2 API package that already has a 'summary' attribute (most likely this
+  is the parent package into which we're being imported, but not necessarily),
+  and then do the dynamic version of "from tf_api_package.summary import *".
+
+  Lastly, this logic is encapsulated in a function to avoid symbol leakage.
+  """
+  import sys  # pylint: disable=g-import-not-at-top
+
+  # API packages to check for the original V2 summary API, in preference order
+  # to avoid going "under the hood" to the _api packages unless necessary.
+  packages = [
+      'tensorflow',
+      'tensorflow.compat.v2',
+      'tensorflow._api.v2',
+      'tensorflow._api.v2.compat.v2',
+      'tensorflow._api.v1.compat.v2',
+  ]
+  # If we aren't sure we're on V2, don't use tf.summary since it could be V1.
+  # Note there may be false positives since the __version__ attribute may not be
+  # defined at this point in the import process.
+  if not getattr(tf, '__version__', '').startswith('2.'):
+    packages.remove('tensorflow')
+
+  def dynamic_wildcard_import(module):
+    """Implements the logic of "from module import *" for the given module."""
+    symbols = getattr(module, '__all__', None)
+    if symbols is None:
+      symbols = [k for k in module.__dict__.keys() if not k.startswith('_')]
+    globals().update({symbol: getattr(module, symbol) for symbol in symbols})
+
+  notfound = object()  # sentinel value
+  for package_name in packages:
+    package = sys.modules.get(package_name, notfound)
+    if package is notfound:
+      # Either it isn't in this installation at all (e.g. the _api.vX packages
+      # are only in API version X), it isn't imported yet, or it was imported
+      # but not inserted into sys.modules under its user-facing name (for the
+      # non-'_api' packages), at which point we continue down the list to look
+      # "under the hood" for it via its '_api' package name.
+      continue
+    module = getattr(package, 'summary', None)
+    if module is None:
+      # This happens if the package hasn't been fully imported yet. For example,
+      # the 'tensorflow' package won't yet have 'summary' attribute if we are
+      # loading this code via the 'tensorflow.compat...' path and 'compat' is
+      # imported before 'summary' in the 'tensorflow' __init__.py file.
+      continue
+    # Success, we hope. Import all the public symbols into this module.
+    dynamic_wildcard_import(module)
+    return
+
+reexport_tf_summary()
 
 from tensorboard.summary.v2 import audio
 from tensorboard.summary.v2 import histogram
@@ -67,4 +108,4 @@ from tensorboard.summary.v2 import image
 from tensorboard.summary.v2 import scalar
 from tensorboard.summary.v2 import text
 
-del absolute_import, division, print_function, importlib, tf
+del absolute_import, division, print_function, tf, reexport_tf_summary

--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -69,7 +69,7 @@ def reexport_tf_summary():
   # If we aren't sure we're on V2, don't use tf.summary since it could be V1.
   # Note there may be false positives since the __version__ attribute may not be
   # defined at this point in the import process.
-  if not getattr(tf, '__version__', '').startswith('2.'):
+  if not getattr(tf, '__version__', '').startswith('2.'):  # noqa: F821
     packages.remove('tensorflow')
 
   def dynamic_wildcard_import(module):


### PR DESCRIPTION
This rewrite fixes the issue where `import tensorflow.compat.v2.summary as tf_summary` produced a module that included only the tensorboard-defined symbols and none of the TF-defined ones.  See the comments in the rewritten code for the detailed explanation of the new approach.

This PR also adds tests for importing `tf.summary` to our pip package smoke test (which runs on Travis as of #1883), so that there's at least some test coverage for this cross-package import quagmire.

![image](https://user-images.githubusercontent.com/710113/53592783-d6922a00-3b4b-11e9-9450-d681dbc65de0.png)
