### PR TITLE
Graph plugin: show graph fetch error properly

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
@@ -87,8 +87,9 @@ Example
 }
 
 #progress-msg {
-  width: 400px;
   margin-bottom: 5px;
+  white-space: pre-wrap;
+  width: 400px;
 }
 
 paper-progress {

--- a/tensorboard/plugins/graph/tf_graph_common/parser.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/parser.ts
@@ -43,8 +43,9 @@ export function fetchPbTxt(filepath: string): Promise<ArrayBuffer> {
       // Fetch does not reject for 400+.
       if (res.ok) {
         res.arrayBuffer().then(resolve, reject);
+      } else {
+        res.text().then(reject, reject);
       }
-      res.text().then(reject, reject);
     });
   });
 }
@@ -79,7 +80,7 @@ export function fetchAndParseMetadata(path: string, tracker: ProgressTracker) {
 export function fetchAndParseGraphData(path: string, pbTxtFile: Blob,
     tracker: ProgressTracker) {
   return tf.graph.util
-      .runTask(
+      .runAsyncPromiseTask(
           'Reading graph pbtxt', 40,
           () => {
             if (pbTxtFile) {
@@ -95,7 +96,7 @@ export function fetchAndParseGraphData(path: string, pbTxtFile: Blob,
           },
           tracker)
       .then((arrayBuffer: ArrayBuffer) => {
-        return tf.graph.util.runTask('Parsing graph.pbtxt', 60, () => {
+        return tf.graph.util.runAsyncPromiseTask('Parsing graph.pbtxt', 60, () => {
           return parseGraphPbTxt(arrayBuffer);
         }, tracker);
       });

--- a/tensorboard/plugins/graph/tf_graph_common/parser.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/parser.ts
@@ -38,15 +38,14 @@ function parseValue(value: string): string|number|boolean {
  * Fetches a text file and returns a promise of the result.
  */
 export function fetchPbTxt(filepath: string): Promise<ArrayBuffer> {
-  return new Promise<ArrayBuffer>(function(resolve, reject) {
-    const request = new XMLHttpRequest();
-    request.open('GET', filepath);
-    request.responseType = 'arraybuffer';
-
-    request.onerror = () => reject(request.status);
-    request.onload = () => resolve(request.response);
-
-    request.send(null);
+  return new Promise((resolve, reject) => {
+    fetch(filepath).then(res => {
+      // Fetch does not reject for 400+.
+      if (res.ok) {
+        res.arrayBuffer().then(resolve, reject);
+      }
+      res.text().then(reject, reject);
+    });
   });
 }
 

--- a/tensorboard/plugins/graph/tf_graph_common/parser.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/parser.ts
@@ -39,7 +39,7 @@ function parseValue(value: string): string|number|boolean {
  */
 export function fetchPbTxt(filepath: string): Promise<ArrayBuffer> {
   return new Promise((resolve, reject) => {
-    fetch(filepath).then(res => {
+    fetch(filepath).then((res) => {
       // Fetch does not reject for 400+.
       if (res.ok) {
         res.arrayBuffer().then(resolve, reject);

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -249,7 +249,12 @@ Polymer({
     .catch(function(e) {
       // Generic error catch, for errors that happened outside
       // asynchronous tasks.
-      tracker.reportError("Graph visualization failed: " + e, e);
+      const msg = `Graph visualization failed.
+This can happen when network connection is bad, GraphDef is malformed, or multiple GraphDefs failed to reconcile.
+Please refer to https://github.com/tensorflow/tensorboard/issues/1929 for GraphDefs combination problems.
+
+Error:${e}`;
+      tracker.reportError(msg, e);
       // Don't swallow the error.
       throw e;
     });


### PR DESCRIPTION
Few issues:
1. fetchPbTxt or XMLHTTPRequest invokes `onload` even in case of error.
2. Promise handling was weird
3. Graph plugin try/catched and returned None instead of letting the
   route handle the error by responding with 400.

Test changes to catch these issues will come in follow up changes.

* Screenshots of UI changes
![image](https://user-images.githubusercontent.com/2547313/53610929-a5cce780-3b81-11e9-9791-7689e2f267a4.png)
