### PR TITLE
Make profile plugin use EventMultiplexer to find data in subdirectories

### DIFF
--- a/tensorboard/backend/event_processing/plugin_asset_util.py
+++ b/tensorboard/backend/event_processing/plugin_asset_util.py
@@ -49,7 +49,7 @@ def ListPlugins(logdir):
   """
   plugins_dir = os.path.join(logdir, _PLUGINS_DIR)
   try:
-    entries = tf.io.gfile.listdir(plugin_dir)
+    entries = tf.io.gfile.listdir(plugins_dir)
   except tf.errors.NotFoundError:
     return []
   # Strip trailing slashes, which listdir() includes for some filesystems

--- a/tensorboard/backend/event_processing/plugin_asset_util.py
+++ b/tensorboard/backend/event_processing/plugin_asset_util.py
@@ -48,10 +48,14 @@ def ListPlugins(logdir):
     a list of plugin names, as strings
   """
   plugins_dir = os.path.join(logdir, _PLUGINS_DIR)
-  if not tf.io.gfile.isdir(plugins_dir):
+  try:
+    entries = tf.io.gfile.listdir(plugin_dir)
+  except tf.errors.NotFoundError:
     return []
-  entries = tf.io.gfile.listdir(plugins_dir)
-  return [x for x in entries if _IsDirectory(plugins_dir, x)]
+  # Strip trailing slashes, which listdir() includes for some filesystems
+  # for subdirectories, after using them to bypass IsDirectory().
+  return [x.rstrip('/') for x in entries
+          if x.endswith('/') or _IsDirectory(plugins_dir, x)]
 
 
 def ListAssets(logdir, plugin_name):
@@ -67,10 +71,11 @@ def ListAssets(logdir, plugin_name):
     didn't register) an empty list is returned.
   """
   plugin_dir = PluginDirectory(logdir, plugin_name)
-  if not tf.io.gfile.isdir(plugin_dir):
+  try:
+    # Strip trailing slashes, which listdir() includes for some filesystems.
+    return [x.rstrip('/') for x in tf.io.gfile.listdir(plugin_dir)]
+  except tf.errors.NotFoundError:
     return []
-  entries = tf.io.gfile.listdir(plugin_dir)
-  return [x for x in entries if not _IsDirectory(plugin_dir, x)]
 
 
 def RetrieveAsset(logdir, plugin_name, asset_name):

--- a/tensorboard/plugins/profile/BUILD
+++ b/tensorboard/plugins/profile/BUILD
@@ -30,6 +30,7 @@ py_library(
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/util:tb_logging",
         "@org_pocoo_werkzeug",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/plugins/profile/BUILD
+++ b/tensorboard/plugins/profile/BUILD
@@ -42,6 +42,7 @@ py_test(
         ":profile_plugin",
         ":protos_all_py_pb2",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/backend/event_processing:plugin_asset_util",
         "//tensorboard/plugins:base_plugin",
     ],

--- a/tensorboard/plugins/profile/profile_demo.py
+++ b/tensorboard/plugins/profile/profile_demo.py
@@ -37,8 +37,18 @@ from tensorboard.plugins.profile import profile_demo_data
 from tensorboard.plugins.profile import profile_plugin
 from tensorboard.plugins.profile import trace_events_pb2
 
+
+tf.compat.v1.enable_eager_execution()
+
+
 # Directory into which to write tensorboard data.
 LOGDIR = '/tmp/profile_demo'
+
+
+# Suffix for the empty eventfile to write. Should be kept in sync with TF
+# profiler kProfileEmptySuffix constant defined in:
+#   tensorflow/core/profiler/rpc/client/capture_profile.cc.
+EVENT_FILE_SUFFIX = '.profile-empty'
 
 
 def _maybe_create_directory(directory):
@@ -48,8 +58,17 @@ def _maybe_create_directory(directory):
     print('Directory %s already exists.' %directory)
 
 
+def write_empty_event_file(logdir):
+  w = tf.compat.v2.summary.create_file_writer(
+      logdir, filename_suffix=EVENT_FILE_SUFFIX)
+  w.close()
+
+
 def dump_data(logdir):
   """Dumps plugin data to the log directory."""
+  # Create a tfevents file in the logdir so it is detected as a run.
+  write_empty_event_file(logdir)
+
   plugin_logdir = plugin_asset_util.PluginDirectory(
       logdir, profile_plugin.ProfilePlugin.plugin_name)
   _maybe_create_directory(plugin_logdir)

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -38,7 +38,6 @@ logger = tb_logging.get_logger()
 PLUGIN_NAME = 'profile'
 
 # HTTP routes
-LOGDIR_ROUTE = '/logdir'
 DATA_ROUTE = '/data'
 TOOLS_ROUTE = '/tools'
 HOSTS_ROUTE = '/hosts'
@@ -106,11 +105,6 @@ class ProfilePlugin(base_plugin.TBPlugin):
         self.logdir, ProfilePlugin.plugin_name)
     self.stub = None
     self.master_tpu_unsecure_channel = context.flags.master_tpu_unsecure_channel
-
-  @wrappers.Request.application
-  def logdir_route(self, request):
-    return http_util.Respond(request, {'logdir': self.plugin_logdir},
-                             'application/json')
 
   def _run_dir(self, run):
     run_dir = os.path.join(self.plugin_logdir, run)
@@ -329,7 +323,6 @@ class ProfilePlugin(base_plugin.TBPlugin):
 
   def get_plugin_apps(self):
     return {
-        LOGDIR_ROUTE: self.logdir_route,
         TOOLS_ROUTE: self.tools_route,
         HOSTS_ROUTE: self.hosts_route,
         DATA_ROUTE: self.data_route,

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -281,7 +281,8 @@ class ProfilePlugin(base_plugin.TBPlugin):
         else:
           frontend_run = '/'.join([tb_run_name, profile_run])
         profile_run_dir = os.path.join(tb_plugin_dir, profile_run)
-        yield frontend_run, self._get_active_tools(profile_run_dir)
+        if tf.io.gfile.isdir(profile_run_dir):
+          yield frontend_run, self._get_active_tools(profile_run_dir)
 
   def _get_active_tools(self, profile_run_dir):
     tools = []

--- a/tensorboard/plugins/profile/profile_plugin_test.py
+++ b/tensorboard/plugins/profile/profile_plugin_test.py
@@ -161,7 +161,7 @@ class ProfilePluginTest(tf.test.TestCase):
     runs = dict(self.plugin.generate_run_to_tools())
     # Expect runs for the logdir root, 'a', and 'b/c' but not for 'b'
     # because it doesn't contain a tfevents file.
-    expected = RUN_TO_TOOLS.keys()
+    expected = list(RUN_TO_TOOLS.keys())
     expected.extend('a/' + run for run in RUN_TO_TOOLS.keys())
     expected.extend('b/c/' + run for run in RUN_TO_TOOLS.keys())
     self.assertItemsEqual(runs.keys(), expected)

--- a/tensorboard/plugins/profile/profile_plugin_test.py
+++ b/tensorboard/plugins/profile/profile_plugin_test.py
@@ -25,9 +25,13 @@ import tensorflow as tf
 from werkzeug import Request
 
 from tensorboard.backend.event_processing import plugin_asset_util
+from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.profile import profile_plugin
 from tensorboard.plugins.profile import trace_events_pb2
+
+
+tf.compat.v1.enable_eager_execution()
 
 
 class FakeFlags(object):
@@ -39,63 +43,128 @@ class FakeFlags(object):
     self.master_tpu_unsecure_channel = master_tpu_unsecure_channel
 
 
+RUN_TO_TOOLS = {
+    'foo': ['trace_viewer'],
+    'bar': ['unsupported'],
+    'baz': ['trace_viewer'],
+    'empty': [],
+}
+
+
+RUN_TO_HOSTS = {
+    'foo': ['host0', 'host1'],
+    'bar': ['host1'],
+    'baz': ['host2'],
+    'empty': [],
+}
+
+
+EXPECTED_TRACE_DATA = dict(
+    displayTimeUnit='ns',
+    metadata={'highres-ticks': True},
+    traceEvents=[
+        dict(
+            ph='M',
+            pid=0,
+            name='process_name',
+            args=dict(name='foo')),
+        dict(
+            ph='M',
+            pid=0,
+            name='process_sort_index',
+            args=dict(sort_index=0)),
+        dict(),
+    ],
+)
+
+
+# Suffix for the empty eventfile to write. Should be kept in sync with TF
+# profiler kProfileEmptySuffix constant defined in:
+#   tensorflow/core/profiler/rpc/client/capture_profile.cc.
+EVENT_FILE_SUFFIX = '.profile-empty'
+
+
+def generate_testdata(logdir):
+  plugin_logdir = plugin_asset_util.PluginDirectory(
+      logdir, profile_plugin.ProfilePlugin.plugin_name)
+  os.makedirs(plugin_logdir)
+  for run in RUN_TO_TOOLS:
+    run_dir = os.path.join(plugin_logdir, run)
+    os.mkdir(run_dir)
+    for tool in RUN_TO_TOOLS[run]:
+      if tool not in profile_plugin.TOOLS:
+        continue
+      for host in RUN_TO_HOSTS[run]:
+        file_name = host + profile_plugin.TOOLS[tool]
+        tool_file = os.path.join(run_dir, file_name)
+        if tool == 'trace_viewer':
+          trace = trace_events_pb2.Trace()
+          trace.devices[0].name = run
+          data = trace.SerializeToString()
+        else:
+          data = tool
+        with open(tool_file, 'wb') as f:
+          f.write(data)
+  with open(os.path.join(plugin_logdir, 'noise'), 'w') as f:
+    f.write('Not a dir, not a run.')
+
+
+def write_empty_event_file(logdir):
+  w = tf.compat.v2.summary.create_file_writer(
+      logdir, filename_suffix=EVENT_FILE_SUFFIX)
+  w.close()
+
+
 class ProfilePluginTest(tf.test.TestCase):
 
   def setUp(self):
-    # Populate the log directory with runs and traces.
     self.logdir = self.get_temp_dir()
-    plugin_logdir = plugin_asset_util.PluginDirectory(
-        self.logdir, profile_plugin.ProfilePlugin.plugin_name)
-    os.makedirs(plugin_logdir)
-    self.run_to_tools = {
-        'foo': ['trace_viewer'],
-        'bar': ['unsupported'],
-        'baz': ['trace_viewer'],
-        'empty': [],
-    }
-    self.run_to_hosts = {
-        'foo': ['host0', 'host1'],
-        'bar': ['host1'],
-        'baz': ['host2'],
-        'empty': [],
-    }
-    for run in self.run_to_tools:
-      run_dir = os.path.join(plugin_logdir, run)
-      os.mkdir(run_dir)
-      for tool in self.run_to_tools[run]:
-        if tool not in profile_plugin.TOOLS:
-          continue
-        for host in self.run_to_hosts[run]:
-          file_name = host + profile_plugin.TOOLS[tool]
-          tool_file = os.path.join(run_dir, file_name)
-          if tool == 'trace_viewer':
-            trace = trace_events_pb2.Trace()
-            trace.devices[0].name = run
-            data = trace.SerializeToString()
-          else:
-            data = tool
-          with open(tool_file, 'wb') as f:
-            f.write(data)
-    with open(os.path.join(plugin_logdir, 'noise'), 'w') as f:
-      f.write('Not a dir, not a run.')
-
-    # The profiler plugin does not use the multiplexer, so we do not bother to
-    # construct a meaningful one right now. In fact, the profiler plugin does
-    # not use this context object in general. Its constructor has to accept it
-    # though, and it may use the context in the future.
+    self.multiplexer = event_multiplexer.EventMultiplexer()
+    self.multiplexer.AddRunsFromDirectory(self.logdir)
     context = base_plugin.TBContext(
         logdir=self.logdir,
-        multiplexer=None,
+        multiplexer=self.multiplexer,
         flags=FakeFlags(self.logdir))
     self.plugin = profile_plugin.ProfilePlugin(context)
     self.apps = self.plugin.get_plugin_apps()
 
-  def testRuns(self):
-    runs = self.plugin.index_impl()
-    self.assertItemsEqual(runs.keys(), self.run_to_tools.keys())
-    self.assertItemsEqual(runs['foo'], self.run_to_tools['foo'])
+  def testRuns_logdirWithoutEventFile(self):
+    generate_testdata(self.logdir)
+    self.multiplexer.Reload()
+    runs = dict(self.plugin.generate_run_to_tools())
+    self.assertItemsEqual(runs.keys(), RUN_TO_TOOLS.keys())
+    self.assertItemsEqual(runs['foo'], RUN_TO_TOOLS['foo'])
     self.assertItemsEqual(runs['bar'], [])
     self.assertItemsEqual(runs['empty'], [])
+
+  def testRuns_logdirWithEventFIle(self):
+    write_empty_event_file(self.logdir)
+    generate_testdata(self.logdir)
+    self.multiplexer.Reload()
+    runs = dict(self.plugin.generate_run_to_tools())
+    self.assertItemsEqual(runs.keys(), RUN_TO_TOOLS.keys())
+
+  def testRuns_withSubdirectories(self):
+    subdir_a = os.path.join(self.logdir, 'a')
+    subdir_b = os.path.join(self.logdir, 'b')
+    subdir_b_c = os.path.join(subdir_b, 'c')
+    generate_testdata(self.logdir)
+    generate_testdata(subdir_a)
+    generate_testdata(subdir_b)
+    generate_testdata(subdir_b_c)
+    write_empty_event_file(self.logdir)
+    write_empty_event_file(subdir_a)
+    # Skip writing an event file for subdir_b
+    write_empty_event_file(subdir_b_c)
+    self.multiplexer.AddRunsFromDirectory(self.logdir)
+    self.multiplexer.Reload()
+    runs = dict(self.plugin.generate_run_to_tools())
+    # Expect runs for the logdir root, 'a', and 'b/c' but not for 'b'
+    # because it doesn't contain a tfevents file.
+    expected = RUN_TO_TOOLS.keys()
+    expected.extend('a/' + run for run in RUN_TO_TOOLS.keys())
+    expected.extend('b/c/' + run for run in RUN_TO_TOOLS.keys())
+    self.assertItemsEqual(runs.keys(), expected)
 
   def makeRequest(self, run, tag, host):
     req = Request({})
@@ -103,28 +172,30 @@ class ProfilePluginTest(tf.test.TestCase):
     return req
 
   def testHosts(self):
+    generate_testdata(self.logdir)
+    subdir_a = os.path.join(self.logdir, 'a')
+    generate_testdata(subdir_a)
+    write_empty_event_file(subdir_a)
+    self.multiplexer.AddRunsFromDirectory(self.logdir)
+    self.multiplexer.Reload()
     hosts = self.plugin.host_impl('foo', 'trace_viewer')
     self.assertItemsEqual(['host0', 'host1'], sorted(hosts))
+    hosts_a = self.plugin.host_impl('a/foo', 'trace_viewer')
+    self.assertItemsEqual(['host0', 'host1'], sorted(hosts_a))
 
   def testData(self):
+    generate_testdata(self.logdir)
+    subdir_a = os.path.join(self.logdir, 'a')
+    generate_testdata(subdir_a)
+    write_empty_event_file(subdir_a)
+    self.multiplexer.AddRunsFromDirectory(self.logdir)
+    self.multiplexer.Reload()
     trace = json.loads(self.plugin.data_impl(
         self.makeRequest('foo', 'trace_viewer', 'host0')))
-    self.assertEqual(trace,
-                     dict(
-                         displayTimeUnit='ns',
-                         metadata={'highres-ticks': True},
-                         traceEvents=[
-                             dict(
-                                 ph='M',
-                                 pid=0,
-                                 name='process_name',
-                                 args=dict(name='foo')),
-                             dict(
-                                 ph='M',
-                                 pid=0,
-                                 name='process_sort_index',
-                                 args=dict(sort_index=0)), {}
-                         ]))
+    self.assertEqual(trace, EXPECTED_TRACE_DATA)
+    trace_a = json.loads(self.plugin.data_impl(
+        self.makeRequest('a/foo', 'trace_viewer', 'host0')))
+    self.assertEqual(trace_a, EXPECTED_TRACE_DATA)
 
     # Invalid tool/run.
     self.assertEqual(None, self.plugin.data_impl(
@@ -135,8 +206,46 @@ class ProfilePluginTest(tf.test.TestCase):
         self.makeRequest('bar', 'unsupported', 'host1')))
     self.assertEqual(None, self.plugin.data_impl(
         self.makeRequest('empty', 'trace_viewer', '')))
+    self.assertEqual(None, self.plugin.data_impl(
+        self.makeRequest('a', 'trace_viewer', '')))
 
   def testActive(self):
+    def wait_for_thread():
+      with self.plugin._is_active_lock:
+        pass
+    # Launch thread to check if active.
+    self.plugin.is_active()
+    wait_for_thread()
+    # Should be false since there's no data yet.
+    self.assertFalse(self.plugin.is_active())
+    wait_for_thread()
+    generate_testdata(self.logdir)
+    self.multiplexer.Reload()
+    # Launch a new thread to check if active.
+    self.plugin.is_active()
+    wait_for_thread()
+    # Now that there's data, this should be active.
+    self.assertTrue(self.plugin.is_active())
+
+  def testActive_subdirectoryOnly(self):
+    def wait_for_thread():
+      with self.plugin._is_active_lock:
+        pass
+    # Launch thread to check if active.
+    self.plugin.is_active()
+    wait_for_thread()
+    # Should be false since there's no data yet.
+    self.assertFalse(self.plugin.is_active())
+    wait_for_thread()
+    subdir_a = os.path.join(self.logdir, 'a')
+    generate_testdata(subdir_a)
+    write_empty_event_file(subdir_a)
+    self.multiplexer.AddRunsFromDirectory(self.logdir)
+    self.multiplexer.Reload()
+    # Launch a new thread to check if active.
+    self.plugin.is_active()
+    wait_for_thread()
+    # Now that there's data, this should be active.
     self.assertTrue(self.plugin.is_active())
 
 


### PR DESCRIPTION
This fixes #500 by making the profile plugin use EventMultiplexer's plugin assets handling logic to find profile plugin data in arbitrarily deep logdir subdirectories, *as long as those subdirectories contain at least one tfevents file*.  It's an alternative to PR #1360.

The plugin assets system is deprecated, but the profile plugin data already matches the format expected by that system, and we don't have a better way yet to manage large blobs of plugin-specific data that are too big or unwieldy to want to shove into event files.

One complication here is that the profile plugin has a particular complex plugin assets usage pattern in its `plugins/profile` subdirectories.  Each such directory can itself contain multiple "runs" in the profile plugin terminology - not to be confused with TensorBoard "runs" which are any subdirectories within the logdir root that contain `tfevents` files.  So a given TensorBoard run may contain many profile plugin runs.  This previously wasn't a huge concern because the profile plugin had no real concept of TensorBoard runs, since it only used the logdir root run (aka the `.` run).  I distinguish these in the new code as "TB/TensorBoard runs" versus "profile runs".

To work around this limitation without frontend changes, this borrows the notion from #1360 of including both the TensorBoard run and the profile run in the "run" concept passed around by the profile plugin frontend (and used in URL parameters to query the plugin backend), which the new code calls a "frontend run" or just "run".  I tweaked the logic from #1360 so that instead of including the entire directory path, we just include the part below the logdir, and we omit the `plugins/profile` intermediate path components.  This generates more concise and user-friendly run names.  The long term solution should probably be refactoring the frontend so that it exposes the TensorBoard runs directly in their own selection menu, and then within a given TensorBoard run, exposes the existing drop-down for a "profile run".

I've taken some pains to make the `is_active()` implementation fairly efficient (since this blocks overall TensorBoard loading, and was the primary concern with the independent traversal approach from #1360).  The main `generate_run_to_tools()` logic is in a generator form so that `is_active()` can short-circuit and return early once we've found an active run.  However, querying the EventMultiplexer for plugin assets still hits every single run directory, which is slow; we should attempt to do this on the main reload background thread and cache it so this lookup can be fast.