### PR TITLE
Remove deprecated usage of name_scope

### DIFF
--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -88,7 +88,7 @@ def _buckets(data, bucket_count=None):
   """
   if bucket_count is None:
     bucket_count = DEFAULT_BUCKET_COUNT
-  with tf.name_scope('buckets', values=[data, bucket_count]):
+  with tf.name_scope('buckets'):
     tf.debugging.assert_scalar(bucket_count)
     tf.debugging.assert_type(bucket_count, tf.int32)
     data = tf.reshape(data, shape=[-1])  # flatten


### PR DESCRIPTION
We will change v2 name_scope to only have a name argument, no more values (since that makes no sense without a Graph and all). Hence this usage would break.
