### PR TITLE
profile: update demo data to include trace-only run

### DIFF
--- a/tensorboard/plugins/profile/profile_demo.py
+++ b/tensorboard/plugins/profile/profile_demo.py
@@ -81,14 +81,16 @@ def dump_data(logdir):
         proto = trace_events_pb2.Trace()
         text_format.Merge(profile_demo_data.TRACES[run], proto)
         f.write(proto.SerializeToString())
-    shutil.copyfile('tensorboard/plugins/profile/profile_demo.op_profile.json',
-                    os.path.join(run_dir, 'op_profile.json'))
-    shutil.copyfile(
-        'tensorboard/plugins/profile/profile_demo.memory_viewer.json',
-        os.path.join(run_dir, 'memory_viewer.json'))
-    shutil.copyfile(
-        'tensorboard/plugins/profile/profile_demo.google_chart_demo.json',
-        os.path.join(run_dir, 'google_chart_demo.json'))
+
+    if run not in profile_demo_data.TRACE_ONLY:
+      shutil.copyfile('tensorboard/plugins/profile/profile_demo.op_profile.json',
+                      os.path.join(run_dir, 'op_profile.json'))
+      shutil.copyfile(
+          'tensorboard/plugins/profile/profile_demo.memory_viewer.json',
+          os.path.join(run_dir, 'memory_viewer.json'))
+      shutil.copyfile(
+          'tensorboard/plugins/profile/profile_demo.google_chart_demo.json',
+          os.path.join(run_dir, 'google_chart_demo.json'))
 
   # Unsupported tool data should not be displayed.
   run_dir = os.path.join(plugin_logdir, 'empty')

--- a/tensorboard/plugins/profile/profile_demo_data.py
+++ b/tensorboard/plugins/profile/profile_demo_data.py
@@ -20,6 +20,8 @@ from __future__ import print_function
 
 RUNS = ['foo', 'bar']
 
+TRACE_ONLY = ['foo']
+
 
 TRACES = {}
 


### PR DESCRIPTION
Summary:
We make this change because we have a bug in profile plugin that will be
triggered if logdir only contains trace data.


Test Plan:
Remove any old profile demo data, then regenerate the data and launch
TensorBoard:

```
$ rm -rf /tmp/profile_demo/
$ bazel run //tensorboard/plugins/profile:profile_demo
$ bazel run //tensorboard -- --logdir /tmp/profile_demo
```

Prior to this commit, this would have _appeared_ to work; now, it hangs
on the “Processing datasets” screen. Fix to come shortly.
