### PR TITLE
profile: fix loading progress behavior

### DIFF
--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -425,17 +425,13 @@ profile run can have multiple tools that present the performance profile as diff
             'Processing datasets', 70, () => {
               return new Promise(function(resolve, reject) {
                 parent._processRunToTool(runToTool);
-                return Promise.resolve(null);
+                resolve(null);
               });
             }, tracker);
       })
       .then(() => {
         return tf.profile.util.runTask(
-            'Done', 10, () => {
-              return new Promise(function(resolve, reject) {
-                return Promise.resolve(null);
-              });
-            }, tracker);
+            'Done', 10, () => null, tracker);
       });
     },
     _processRunToTool: function(runToTool) {


### PR DESCRIPTION
Summary:
The profile dashboard had an existing bug that was revealed by #1914:
the loading progress bar never actually finishes. Prior to #1914, you
could actually see the loading bar if you made your window narrow
enough:
![Screenshot of a zombie progress bar](https://user-images.githubusercontent.com/4317806/53674700-95317580-3c44-11e9-924f-82f6dc8d5f18.png)

This was because the prior version of the dashboard rendered the main
tool irrespective of whether the data had actually finished loading. As
of #1914, the “loading” and “active” states are mutually exclusive, so
instead of just having a zombie progress bar we actually block the view.

The cause of the bug is a promise that never resolves. (The executor
provided to the `Promise` constructor’s return value is ignored; only
the `resolve` and `reject` callbacks can fulfill a promise.)

This was not caught while testing #1914 because it cannot be reproduced
with the demo data present at that commit; with that more complete set
of data, there are other code paths that clobber the progress value to
100% (which is really a separate issue, but that’s not important right
now), such as `_maybeUpdateData`.

Test Plan:
Regenerate profile plugin demo data if you haven’t done so since #1942,
then launch TensorBoard:

```
$ rm -rf /tmp/profile_demo/
$ bazel run //tensorboard/plugins/profile:profile_demo
$ bazel run //tensorboard -- --logdir /tmp/profile_demo
```

The trace viewer should be displayed (prior to this commit, it wasn’t).

wchargin-branch: profile-broken-promises
