### PR TITLE
Fix parser when GraphDef is empty

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/parser.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/parser.ts
@@ -145,7 +145,7 @@ export function streamParse(
       };
       file.readAsText(nextChunk);
     }
-    
+
     readChunk('', '', 0);
   });
 }

--- a/tensorboard/plugins/graph/tf_graph_common/test/parser-test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/test/parser-test.ts
@@ -52,6 +52,7 @@ describe('parser', () => {
     // TODO: fail hard on malformed pbtxt.
     // Expected it to fail but our parser currently handles it in
     // unpredictable way...
+    // These specs are describing behavior as implemented.
     describe('malformed cases', () => {
 
       // Then it becomes unpredictable.
@@ -65,13 +66,13 @@ describe('parser', () => {
           const nodes = graph.node;
           assert.isArray(nodes);
           assert.lengthOf(nodes, 1);
-    
+
           assert.equal('Q', nodes[0].name);
           assert.equal('Input', nodes[0].op);
         });
       });
 
-      it('fails to parse a normal node when an empty node appears', () => {
+      it('fails to parse a node when an empty node appears before', () => {
         const pbtxt = tf.graph.test.util.stringToArrayBuffer(`node {}
         node {
           name: "Q"
@@ -81,20 +82,20 @@ describe('parser', () => {
             .then(
               () => assert.fail('Should NOT resolve'),
               () => {
-                // happy!
+                // Expected to fail and reject the promise.
               });
       });
 
-      it('"parses" pbtxt without newlines.', () => {
+      it('parses pbtxt without newlines as errorneously empty', () => {
         const pbtxt = tf.graph.test.util.stringToArrayBuffer(
             `node { name: "Q" op: "Input" } node { name: "A" op: "Input" }`);
         return tf.graph.parser.parseGraphPbTxt(pbtxt).then((graph) => {
           assert.notProperty(graph, 'node');
         });
       });
-    
-    
-      it('parses malformed pbtxt unpredictably', () => {
+
+
+      it('parses malformed pbtxt upto the correct declaration', () => {
         const pbtxt = tf.graph.test.util.stringToArrayBuffer(`node {
           name: "Q"
           op: "Input"
@@ -105,13 +106,13 @@ describe('parser', () => {
           const nodes = graph.node;
           assert.isArray(nodes);
           assert.lengthOf(nodes, 1);
-    
+
           assert.equal('Q', nodes[0].name);
           assert.equal('Input', nodes[0].op);
         });
       });
-    
-      it('parses malformed pbtxt unpredictably v2', () => {
+
+      it('cannot parse when pbtxt is malformed', () => {
         const pbtxt = tf.graph.test.util.stringToArrayBuffer(`node {
           name: "Q"
           op: "Input
@@ -126,7 +127,7 @@ describe('parser', () => {
             .then(
               () => assert.fail('Should NOT resolve'),
               () => {
-                // happy!
+                // Expected to fail and reject the promise.
               });
       });
     });

--- a/tensorboard/plugins/graph/tf_graph_common/test/parser-test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/test/parser-test.ts
@@ -14,10 +14,10 @@ limitations under the License.
 ==============================================================================*/
 
 describe('parser', () => {
-  let assert = chai.assert;
+  const {assert} = chai;
 
-  it('simple pbtxt', done => {
-    let pbtxt = tf.graph.test.util.stringToArrayBuffer(`node {
+  it('parses a simple pbtxt', () => {
+    const pbtxt = tf.graph.test.util.stringToArrayBuffer(`node {
        name: "Q"
        op: "Input"
      }
@@ -31,7 +31,7 @@ describe('parser', () => {
        input: "Q"
        input: "W"
      }`);
-    tf.graph.parser.parseGraphPbTxt(pbtxt).then(graph => {
+    return tf.graph.parser.parseGraphPbTxt(pbtxt).then(graph => {
       let nodes = graph.node;
       assert.isTrue(nodes != null && nodes.length === 3);
 
@@ -45,12 +45,56 @@ describe('parser', () => {
       assert.equal('MatMul', nodes[2].op);
       assert.equal('Q', nodes[2].input[0]);
       assert.equal('W', nodes[2].input[1]);
-
-      done();
     });
   });
 
-  it('stats pbtxt parsing', done => {
+  it('parses an empty pbtxt', () => {
+    const pbtxt = tf.graph.test.util.stringToArrayBuffer(``);
+    return tf.graph.parser.parseGraphPbTxt(pbtxt).then(graph => {
+      assert.notProperty(graph, 'node');
+    });
+  });
+
+  // TODO: fail hard on malformed pbtxt.
+  // Expected it to fail but our parser currently handles it in
+  // unpredictable way...
+  it('parses malformed pbtxt unpredictably', () => {
+    const pbtxt = tf.graph.test.util.stringToArrayBuffer(`node {
+      name: "Q"
+      op: "Input"
+    }
+    node { name: "W" op: "Input" }
+    node { name: "X" op: "MatMul" input: "Q" input: "W" }`);
+    return tf.graph.parser.parseGraphPbTxt(pbtxt).then(graph => {
+      const nodes = graph.node;
+      assert.isArray(nodes);
+      assert.lengthOf(nodes, 1);
+
+      assert.equal('Q', nodes[0].name);
+      assert.equal('Input', nodes[0].op);
+    });
+  });
+
+  it('parses malformed pbtxt unpredictably v2', () => {
+    const pbtxt = tf.graph.test.util.stringToArrayBuffer(`node {
+      name: "Q"
+      op: "Input
+    }
+    node { name: "W" op: "Input"
+    node { name: "X" op: "MatMul" input: "Q" input: "W" }
+    node {
+      name: A"
+      op: "Input"
+    }`);
+    return tf.graph.parser.parseGraphPbTxt(pbtxt)
+        .then(
+          () => assert.fail('Should NOT resolve'),
+          () => {
+            // happy!
+          });
+  });
+
+  it('parses stats pbtxt', () => {
     let statsPbtxt = tf.graph.test.util.stringToArrayBuffer(`step_stats {
       dev_stats {
         device: "cpu"
@@ -66,18 +110,19 @@ describe('parser', () => {
         }
       }
     }`);
-    tf.graph.parser.parseStatsPbTxt(statsPbtxt).then(stepStats => {
+    return tf.graph.parser.parseStatsPbTxt(statsPbtxt).then(stepStats => {
       assert.equal(stepStats.dev_stats.length, 1);
       assert.equal(stepStats.dev_stats[0].device, 'cpu');
       assert.equal(stepStats.dev_stats[0].node_stats.length, 2);
       assert.equal(stepStats.dev_stats[0].node_stats[0].all_start_micros, 10);
       assert.equal(stepStats.dev_stats[0].node_stats[1].node_name, 'Q');
       assert.equal(stepStats.dev_stats[0].node_stats[1].all_end_rel_micros, 4);
-      done();
     });
   });
 
-  it('d3 exists', () => { assert.isTrue(d3 != null); });
+  it('d3 exists', () => {
+    assert.isTrue(d3 != null);
+  });
 
   // TODO(nsthorat): write tests.
 

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -200,8 +200,10 @@ Polymer({
     return tf.graph.parser.fetchAndParseGraphData(path, pbTxtFile, dataTracker)
     .then(function(graph) {
       if (!graph.node) {
-        throw new Error('The graph is empty. Make sure that the graph is ' +
-            'passed to the tf.summary.FileWriter after the graph is defined.');
+        throw new Error('The graph is empty. Tihs can happen when ' +
+            'TensorFlow could not trace any graph. Please refer to ' +
+            'https://github.com/tensorflow/tensorboard/issues/1961 for more ' +
+            'information.');
       }
 
       // Build the flat graph (consists only of Op nodes).
@@ -231,6 +233,9 @@ Polymer({
       };
       var graphTracker = tf.graph.util.getSubtaskTracker(tracker, 20, 'Graph');
       return tf.graph.build(graph, buildParams, graphTracker);
+    }, () => {
+      throw new Error(`This can happen when network connection is bad, GraphDef is malformed, or multiple GraphDefs failed to reconcile.
+Please refer to https://github.com/tensorflow/tensorboard/issues/1929 for GraphDefs combination problems.`)
     })
     .then(function(graph) {
       // Populate compatibile field of OpNode based on whitelist
@@ -249,11 +254,8 @@ Polymer({
     .catch(function(e) {
       // Generic error catch, for errors that happened outside
       // asynchronous tasks.
-      const msg = `Graph visualization failed.
-This can happen when network connection is bad, GraphDef is malformed, or multiple GraphDefs failed to reconcile.
-Please refer to https://github.com/tensorflow/tensorboard/issues/1929 for GraphDefs combination problems.
+      const msg = `Graph visualization failed.\n\n${e}`;
 
-Error:${e}`;
       tracker.reportError(msg, e);
       // Don't swallow the error.
       throw e;

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -200,7 +200,7 @@ Polymer({
     return tf.graph.parser.fetchAndParseGraphData(path, pbTxtFile, dataTracker)
     .then(function(graph) {
       if (!graph.node) {
-        throw new Error('The graph is empty. Tihs can happen when ' +
+        throw new Error('The graph is empty. This can happen when ' +
             'TensorFlow could not trace any graph. Please refer to ' +
             'https://github.com/tensorflow/tensorboard/issues/1961 for more ' +
             'information.');
@@ -234,8 +234,10 @@ Polymer({
       var graphTracker = tf.graph.util.getSubtaskTracker(tracker, 20, 'Graph');
       return tf.graph.build(graph, buildParams, graphTracker);
     }, () => {
-      throw new Error(`This can happen when network connection is bad, GraphDef is malformed, or multiple GraphDefs failed to reconcile.
-Please refer to https://github.com/tensorflow/tensorboard/issues/1929 for GraphDefs combination problems.`)
+      throw new Error('Malformed GraphDef. This can sometimes be caused by a ' + 
+          'bad network connection or difficulty reconciling multiple GraphDefs;' +
+          ' for the latter case, please refer to ' +
+          'https://github.com/tensorflow/tensorboard/issues/1929.');
     })
     .then(function(graph) {
       // Populate compatibile field of OpNode based on whitelist


### PR DESCRIPTION
When GraphDef is empty, due to the bug in streamParse, we failed to
resolve or reject the promise.

Added a test and improved test a bit to add malformed pbtxt case, which
in turn required some additional code changes.


### Screenshot
![image](https://user-images.githubusercontent.com/2547313/53821634-0c0b8e80-3f23-11e9-9292-6d0cdf163828.png)

Will work on further UI improvements in follow up changes.