### PR TITLE
Release 1.13.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,12 @@
+# Release 1.13.1
+
+## Bug fixes
+- #1895 - Fix `strftime`-related launch error on Windows (PR #1900)
+- #1794 - Fix What-If Tool loading examples without inference (PR #1898)
+- #1914 - Disable the profile dashboard inside Colab, where it doesn’t work
+- #1945 - Fix profile dashboard loading behavior
+
+
 # Release 1.13.0
 
 The 1.13 minor series tracks TensorFlow 1.13.

--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -47,7 +47,8 @@ _FieldType = collections.namedtuple(
 _type_timestamp = _FieldType(
     serialized_type=int,  # seconds since epoch
     runtime_type=datetime.datetime,  # microseconds component ignored
-    serialize=lambda dt: int(dt.strftime("%s")),
+    serialize=lambda dt: int(
+        (dt - datetime.datetime.fromtimestamp(0)).total_seconds()),
     deserialize=lambda n: datetime.datetime.fromtimestamp(n),
 )
 _type_int = _FieldType(

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3729,7 +3729,7 @@ limitations under the License.
         this.$.dive.atlasUrl = '';
         this.$.dive.imageFieldName = '';
         this.hasSprite = hasSprite;
-        this.updateSprite();
+        this.refreshDive_();
         if (!this.shouldDisableInferButton_(
             this.examplesAndInferences, this.modelName, this.inferenceAddress,
             this.updatedExample)) {

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -48,7 +48,11 @@ profile run can have multiple tools that present the performance profile as diff
     <h3>Profiling isn’t supported in Colab yet.</h3>
     <p>
       Please see
-      <a href="https://github.com/tensorflow/tensorboard/issues/1913">GitHub issue #1913</a>
+      <a
+        href="https://github.com/tensorflow/tensorboard/issues/1913"
+        rel="noopener"
+        target="_blank"
+      >GitHub issue #1913</a>
       for more information.
     </p>
   </div>
@@ -65,21 +69,39 @@ profile run can have multiple tools that present the performance profile as diff
     <p>To collect a profile, you need to run your model on Google Cloud TPUs and
     capture the trace information while your model is running. You may want to
     check out the
-    <a href="https://github.com/tensorflow/tensorboard/blob/1.6/tensorboard/plugins/profile/README.md">README</a>
+    <a
+      href="https://github.com/tensorflow/tensorboard/blob/1.6/tensorboard/plugins/profile/README.md"
+      rel="noopener"
+      target="_blank"
+    >README</a>
     and perhaps the
     <a
-     href="https://cloud.google.com/tpu/docs/cloud-tpu-tools"
+      href="https://cloud.google.com/tpu/docs/cloud-tpu-tools"
+      rel="noopener"
+      target="_blank"
     >tutorial</a> on how to use the
-    <a href="https://pypi.python.org/pypi/cloud-tpu-profiler">cloud-tpu-profiler</a>.
+    <a
+      href="https://pypi.python.org/pypi/cloud-tpu-profiler"
+      rel="noopener"
+      target="_blank"
+    >cloud-tpu-profiler</a>.
     </p>
     <p>
     If you’re new to TPUs, and want to find out how
     to run models, check out the
-    <a href="https://cloud.google.com/tpu/docs/quickstart">Quickstart Using a TPU</a>.
+    <a
+      href="https://cloud.google.com/tpu/docs/quickstart"
+      rel="noopener"
+      target="_blank"
+    >Quickstart Using a TPU</a>.
     </p>
     <p>
     If you think profiling is done properly, please see the page of
-    <a href="https://cloud.google.com/tpu/docs/troubleshooting">Google Cloud TPU Troubleshooting and FAQ</a>
+    <a
+      href="https://cloud.google.com/tpu/docs/troubleshooting"
+      rel="noopener"
+      target="_blank"
+    >Google Cloud TPU Troubleshooting and FAQ</a>
     and consider filing an issue on GitHub.</p>
   </div>
 </template>

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -43,13 +43,23 @@ profile run can have multiple tools that present the performance profile as diff
 
 <dom-module id="tf-profile-dashboard">
 <template>
-<template is="dom-if" if="[[_isNotComplete(progress)]]">
+<template is="dom-if" if="[[_isState(_topLevelState, 'IN_COLAB')]]">
+  <div style="max-width: 540px; margin: 80px auto 0 auto;">
+    <h3>Profiling isn’t supported in Colab yet.</h3>
+    <p>
+      Please see
+      <a href="https://github.com/tensorflow/tensorboard/issues/1913">GitHub issue #1913</a>
+      for more information.
+    </p>
+  </div>
+</template>
+<template is="dom-if" if="[[_isState(_topLevelState, 'LOADING')]]">
   <div id="progress-bar">
     <div id="progress-msg">[[progress.msg]]</div>
     <paper-progress value="[[progress.value]]"></paper-progress>
   </div>
 </template>
-<template is="dom-if" if="[[_dataNotFound]]">
+<template is="dom-if" if="[[_isState(_topLevelState, 'DATA_NOT_FOUND')]]">
   <div style="max-width: 540px; margin: 80px auto 0 auto;">
     <h3>No profile data was found.</h3>
     <p>To collect a profile, you need to run your model on Google Cloud TPUs and
@@ -73,7 +83,7 @@ profile run can have multiple tools that present the performance profile as diff
     and consider filing an issue on GitHub.</p>
   </div>
 </template>
-<template is="dom-if" if="[[!_dataNotFound]]">
+<template is="dom-if" if="[[_isState(_topLevelState, 'ACTIVE')]]">
   <tf-dashboard-layout>
   <div class="sidebar">
     <div class="allcontrols">
@@ -209,6 +219,35 @@ profile run can have multiple tools that present the performance profile as diff
 <script>
   "use strict";
 
+  /**
+   * The main state of the profile dashboard (as distinct from any
+   * subtool states).
+   *
+   * @enum {string}
+   */
+  const TopLevelState = {
+    /**
+     * Indicates that we are in a Colab notebook environment. The
+     * profile dashboard does not work well in Colab; the trace viewer
+     * does not work at all. If in Colab, we'll show only an explanatory
+     * message.
+     */
+    "IN_COLAB": "IN_COLAB",
+    /**
+     * Indicates that there are no runs with profile data.
+     */
+    "DATA_NOT_FOUND": "DATA_NOT_FOUND",
+    /**
+     * Indicates that we're loading data. This may be the case on the
+     * initial load or when the user switches tools.
+     */
+    "LOADING": "LOADING",
+    /**
+     * Indicates that a tool is active (data has finished loading).
+     */
+    "ACTIVE": "ACTIVE",
+  };
+
   Polymer({
     is: "tf-profile-dashboard",
     properties: {
@@ -234,6 +273,17 @@ profile run can have multiple tools that present the performance profile as diff
       _activeHostsList: {
         type: Array,
         observer: '_activeHostsChanged'
+      },
+      _inColab: {
+        type: Boolean,
+        value: () => !!(window.TENSORBOARD_ENV || {}).IN_COLAB,
+        readOnly: true,
+      },
+      /** @type {TopLevelState} */
+      _topLevelState: {
+        type: String,
+        computed: '_computeTopLevelState(_inColab, _dataNotFound, progress)',
+        readOnly: true,
       },
       /**
        * @type {{value: number, msg: string}}
@@ -326,10 +376,6 @@ profile run can have multiple tools that present the performance profile as diff
     },
     detached: function() {
       this.set('_isAttached', false);
-    },
-    /** True if the progress is not complete yet (< 100 %). */
-    _isNotComplete: function(progress) {
-      return !this._dataNotFound && progress.value < 100;
     },
     _maybeInitializeDashboard: function(isAttached) {
       if (this._initialized || !isAttached) {
@@ -533,6 +579,24 @@ profile run can have multiple tools that present the performance profile as diff
       if (host == "") return "default";
       // Otherwise, remove the seperator, e.g. "host1_" => "host1".
       return host.slice(0, -1);
+    },
+    _computeTopLevelState: function(inColab, dataNotFound, progress) {
+      if (inColab)
+        return "IN_COLAB";
+      if (dataNotFound)
+        return "DATA_NOT_FOUND";
+      if (!progress || progress.value < 100)
+        return "LOADING";
+      return "ACTIVE";
+    },
+    /**
+     * Check whether the two given states are equal.
+     *
+     * @param {TopLevelState} topLevelState
+     * @param {TopLevelState} candidateState
+     */
+    _isState: function(actualState, candidateState) {
+      return actualState === candidateState;
     },
   });
 

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -425,17 +425,13 @@ profile run can have multiple tools that present the performance profile as diff
             'Processing datasets', 70, () => {
               return new Promise(function(resolve, reject) {
                 parent._processRunToTool(runToTool);
-                return Promise.resolve(null);
+                resolve(null);
               });
             }, tracker);
       })
       .then(() => {
         return tf.profile.util.runTask(
-            'Done', 10, () => {
-              return new Promise(function(resolve, reject) {
-                return Promise.resolve(null);
-              });
-            }, tracker);
+            'Done', 10, () => null, tracker);
       });
     },
     _processRunToTool: function(runToTool) {

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '1.13.0'
+VERSION = '1.13.1'


### PR DESCRIPTION
**Merge this pull request ONLY via rebase, NOT via squash or merge-commit.**

This PR cherry-picks #1898, #1900, #1914, #1922, and #1945 on top of the
1.13 tracking branch to form 1.13.1, per our plan in #1906.

Tested in Python 3 on Windows and in Python 2 on Linux: TensorBoard
starts, and the profile dashboard works (all tools) and is disabled if
you set `window.TENSORBOARD_ENV = {IN_COLAB: true}`, in which case the
help link opens in a new tab.
