### PR TITLE
Fix link-breaking typo in docs/r2/graphs.ipynb

### DIFF
--- a/docs/r2/graphs.ipynb
+++ b/docs/r2/graphs.ipynb
@@ -399,7 +399,7 @@
         "\n",
         "The examples so far have described graphs of Keras models, where the graphs have been created by defining Keras layers and calling Model.fit().\n",
         "\n",
-        "You may encounter a situation where you need to use the [`tf.function`](https://www.tensorflow.org/r2/guide/autograph) annotation to [\"autograph\"]((https://www.tensorflow.org/r2/guide/autograph), i.e., transform, a Python computation function into a high-performance TensorFlow graph. For these situations, you use **TensorFlow Summary Trace API** to log autographed functions for visualization in TensorBoard."
+        "You may encounter a situation where you need to use the [`tf.function`](https://www.tensorflow.org/r2/guide/autograph) annotation to [\"autograph\"](https://www.tensorflow.org/r2/guide/autograph), i.e., transform, a Python computation function into a high-performance TensorFlow graph. For these situations, you use **TensorFlow Summary Trace API** to log autographed functions for visualization in TensorBoard."
       ]
     },
     {


### PR DESCRIPTION
The link currently doesn't render correctly; it renders as

```
You may encounter a situation where you need to use the tf.function annotation
to ["autograph"]((https://www.tensorflow.org/r2/guide/autograph), 
```