### PR TITLE
Fixed tf-graph-app to use the new API

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_app/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_app/BUILD
@@ -13,6 +13,7 @@ tf_web_library(
     ],
     path = "/tf-graph-app",
     deps = [
+        "//tensorboard/components/tf_backend",
         "//tensorboard/plugins/graph/tf_graph_board",
         "//tensorboard/plugins/graph/tf_graph_controls",
         "//tensorboard/plugins/graph/tf_graph_loader",
@@ -27,6 +28,7 @@ tensorboard_webcomponent_library(
     srcs = [":tf_graph_app"],
     destdir = "tf-graph-app",
     deps = [
+        "//tensorboard/components/tf_backend:legacy",
         "//tensorboard/plugins/graph/tf_graph_board:legacy",
         "//tensorboard/plugins/graph/tf_graph_controls:legacy",
         "//tensorboard/plugins/graph/tf_graph_loader:legacy",
@@ -35,4 +37,3 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/webcomponentsjs:lib",
     ],
 )
-

--- a/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
+++ b/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
@@ -16,6 +16,7 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-graph-board/tf-graph-board.html">
 <link rel="import" href="../tf-graph-controls/tf-graph-controls.html">
 <link rel="import" href="../tf-graph-loader/tf-graph-loader.html">
@@ -98,7 +99,9 @@ tf-graph-controls {
           selected-node="{{selectedNode}}"
           selected-file="{{selectedFile}}"
       ></tf-graph-controls>
-      <tf-graph-loader id="loader"
+      <tf-graph-loader
+          id="loader"
+          router="[[_router]]"
           out-graph-hierarchy="{{graphHierarchy}}"
           out-graph="{{graph}}"
           out-stats="{{stats}}"
@@ -126,6 +129,7 @@ tf-graph-controls {
 
 <script>
 (function(){
+class NotImplementedError extends Error {}
 
 Polymer({
   is: 'tf-graph-app',
@@ -166,6 +170,35 @@ Polymer({
 
     _renderHierarchy: Object,
     _progress: Object,
+    _router: {
+      type: Object,
+      value: function() {
+        return {
+          pluginRoute: (pluginName, route, params) => {
+            if (this.pbtxtFileLocation) {
+              return this.pbtxtFileLocation;
+            }
+            return tf_backend.getRouter().pluginRoute(
+                pluginName, route, params);
+          },
+          environment: () => {
+            throw new NotImplementedError();
+          },
+          experiments: () => {
+            throw new NotImplementedError();
+          },
+          pluginsListing: () => {
+            throw new NotImplementedError();
+          },
+          runs: () => {
+            throw new NotImplementedError();
+          },
+          runsForExp: () => {
+            throw new NotImplementedError();
+          },
+        };
+      },
+    },
   },
   _updateToolbar: function() {
     this.$$('.container').classList.toggle('no-toolbar', !this.toolbar);
@@ -181,10 +214,20 @@ Polymer({
       // Fetch a pbtxt file. The fetching will be part of the loading sequence.
       this.$.loader.datasets = [{
         // Just name the dataset based on the file location.
-        "name": this.pbtxtFileLocation,
-        "path": this.pbtxtFileLocation,
+        name: this.pbtxtFileLocation,
+        tags: [{
+          tag: null,
+          displayName: this.pbtxtFileLocation,
+          conceptualGraph: false,
+          opGraph: true,
+          profile: false,
+        }],
       }];
-      this.$.loader.set('selectedDataset', 0);
+      this.$.loader.selection = {
+        run: this.pbtxtFileLocation,
+        tag: null,
+        type: tf.graph.SelectionType.OP_GRAPH,
+      };
     } else if (this.pbtxt) {
       // Render the provided pbtxt.
       var blob = new Blob([this.pbtxt]);

--- a/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
+++ b/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
@@ -107,6 +107,8 @@ tf-graph-controls {
           out-stats="{{stats}}"
           progress="{{_progress}}"
           selected-file="[[selectedFile]]"
+          selection="[[_selection]]"
+          datasets="[[_datasets]]"
       ></tf-graph-loader>
     </div>
     <div class="main">
@@ -178,8 +180,7 @@ Polymer({
             if (this.pbtxtFileLocation) {
               return this.pbtxtFileLocation;
             }
-            return tf_backend.getRouter().pluginRoute(
-                pluginName, route, params);
+            throw new NotImplementedError();
           },
           environment: () => {
             throw new NotImplementedError();
@@ -193,12 +194,22 @@ Polymer({
           runs: () => {
             throw new NotImplementedError();
           },
-          runsForExp: () => {
+          runsForExperiment: () => {
             throw new NotImplementedError();
           },
         };
       },
     },
+    _datasets: {
+      // Please refer to tf-graph-dashboard for the Type definition.
+      // The type inforamtion is not exported.
+      type: Object,
+      computed: '_computeDatasets(pbtxtFileLocation)',
+    },
+    _selection: {
+      type: Object,
+      computed: '_computeSelection(pbtxtFileLocation)',
+    }
   },
   _updateToolbar: function() {
     this.$$('.container').classList.toggle('no-toolbar', !this.toolbar);
@@ -209,31 +220,33 @@ Polymer({
   _updateHeight: function() {
     this.$$('.container').style.height = this.height + 'px';
   },
-  _updateGraph: function() {
-    if (this.pbtxtFileLocation) {
-      // Fetch a pbtxt file. The fetching will be part of the loading sequence.
-      this.$.loader.datasets = [{
-        // Just name the dataset based on the file location.
-        name: this.pbtxtFileLocation,
-        tags: [{
-          tag: null,
-          displayName: this.pbtxtFileLocation,
-          conceptualGraph: false,
-          opGraph: true,
-          profile: false,
-        }],
-      }];
-      this.$.loader.selection = {
+  _computeDatasets(pbtxtFileLocation) {
+    return pbtxtFileLocation ? [{
+      // Just name the dataset based on the file location.
+      name: this.pbtxtFileLocation,
+      tags: [{
+        tag: null,
+        displayName: this.pbtxtFileLocation,
+        conceptualGraph: false,
+        opGraph: true,
+        profile: false,
+      }],
+    }] : [];
+  },
+  _computeSelection(pbtxtFileLocation) {
+    return pbtxtFileLocation ? {
         run: this.pbtxtFileLocation,
         tag: null,
         type: tf.graph.SelectionType.OP_GRAPH,
-      };
-    } else if (this.pbtxt) {
+      } : null;
+  },
+  _updateGraph: function() {
+    if (!this.pbtxtFileLocation && this.pbtxt) {
       // Render the provided pbtxt.
       var blob = new Blob([this.pbtxt]);
 
       // TODO(@chihuahua): Find out why we call a private method here and do away with the call.
-      this.$.loader._parseAndConstructHierarchicalGraph(null, blob);
+      this.$.loader._fetchAndConstructHierarchicalGraph(null, blob);
     }
   },
 });

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -846,7 +846,7 @@ Polymer({
       notify: true,
     },
     /**
-     * @type {!Selection}
+     * @type {?Selection}
      */
     selection: {
       type: Object,

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -80,6 +80,7 @@ by default. The user can select a different run from a dropdown menu.
   ></tf-graph-controls>
   <div class="center">
     <tf-graph-loader id="loader"
+          router="[[_router]]"
           datasets="[[_datasets]]"
           selection="[[_selection]]"
           selected-file="[[_selectedFile]]"
@@ -223,6 +224,10 @@ Polymer({
       type: Number,
       value: 500,
       readOnly: true,
+    },
+    _router: {
+      type: Object,
+      value: () => tf_backend.getRouter(),
     },
     runs: Array,
     run: {

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -57,6 +57,12 @@ Polymer({
       type: Object,
       value: () => new tf.graph.op.TpuCompatibilityProvider(),
     },
+
+    /**
+     * @type {!tf_backend.Router}
+     */
+    router: Object,
+
     /**
      * If this optional object is provided, graph logic will override
      * the HierarchyParams it uses to build the graph with properties within
@@ -95,7 +101,7 @@ Polymer({
     },
   },
   observers: [
-    '_selectionChanged(selection, overridingHierarchyParams, compatibilityProvider)',
+    '_selectionChanged(selection, overridingHierarchyParams, compatibilityProvider, router)',
     '_selectedFileChanged(selectedFile, overridingHierarchyParams, compatibilityProvider)',
   ],
   _selectionChanged() {
@@ -113,13 +119,14 @@ Polymer({
       case tf.graph.SelectionType.CONCEPTUAL_GRAPH: {
         // Clear stats about the previous graph.
         this._setOutStats(null);
-        const args = {
+        const params = new URLSearchParams({
           run,
           conceptual: selectionType === tf.graph.SelectionType.CONCEPTUAL_GRAPH,
-        };
-        if (tag) args.tag = tag;
-        const graphPath = tf_backend.addParams(
-            tf_backend.getRouter().pluginRoute('graphs', '/graph'), args);
+        });
+        if (tag) {
+          params.set('tag', tag);
+        }
+        const graphPath = this.router.pluginRoute('graphs', '/graph', params);
         return this._fetchAndConstructHierarchicalGraph(
             graphPath, null, overridingHierarchyParams).then(() => {
               this._graphRunTag = {run, tag};
@@ -145,9 +152,8 @@ Polymer({
               tag: requiredOpGraphTag,
               type: tf.graph.SelectionType.OP_GRAPH,
             }) : Promise.resolve();
-        const metadataPath = tf_backend.addParams(
-            tf_backend.getRouter().pluginRoute('graphs', '/run_metadata'),
-            {tag, run});
+        const metadataPath = this.router.pluginRoute(
+            'graphs', '/run_metadata', new URLSearchParams({tag, run}));
         return maybeFetchGraphPromise
             .then(() => this._readAndParseMetadata(metadataPath));
       }


### PR DESCRIPTION
PR #1853 made changes to support tags in the graph plugin. When making
the change, we broke the tf-graph-app forgetting to update to use the
new API.

Confirmed the fix by:
1. running the demo and uploading a GraphDef pbtxt 
2. running the TensorBoard with dataset that contains op graph, conceptual graph, and profile and uploaded pbtxt manually.

Disclaimer and thoughts:
- Do not exactly understand use case or how tf-graph-app works.
- If tf-graph-app is truly important, there should be a test at least running the demo app.
