### PR TITLE
scalars: document why SVGs are base64-encoded

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -314,9 +314,12 @@ limitations under the License.
       },
       _updateDownloadLink() {
         const svgStr = this.$$('tf-line-chart-data-loader').exportAsSvgString();
-        // https://github.com/tensorflow/tensorboard/pull/1446#issuecomment-436915402
-        // Firefox truncates href to some length for some reason. Using base64
-        // is okay.
+        // The SVG code string may include hash characters, such as an
+        // attribute `clipPath="url(#foo)"`. In such a case, Firefox
+        // will interpret the hash as a fragment specifier (even inside
+        // a data URI), and will truncate the main content at the hash,
+        // yielding an invalid SVG. To prevent this, we base64-encode
+        // the image.
         this.$$('#svgLink').href = `data:image/svg+xml;base64,${btoa(svgStr)}`;
       },
       _runsFromData(data) {

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -315,11 +315,9 @@ limitations under the License.
       _updateDownloadLink() {
         const svgStr = this.$$('tf-line-chart-data-loader').exportAsSvgString();
         // The SVG code string may include hash characters, such as an
-        // attribute `clipPath="url(#foo)"`. In such a case, Firefox
-        // will interpret the hash as a fragment specifier (even inside
-        // a data URI), and will truncate the main content at the hash,
-        // yielding an invalid SVG. To prevent this, we base64-encode
-        // the image.
+        // attribute `clipPath="url(#foo)"`. Thus, we base64-encode the
+        // data so that such a hash is not interpreted as a fragment
+        // specifier, truncating the SVG. (See issue #1874.)
         this.$$('#svgLink').href = `data:image/svg+xml;base64,${btoa(svgStr)}`;
       },
       _runsFromData(data) {


### PR DESCRIPTION
Summary:
This commit amends the comment added in #1601 per my subsequent
investigations. The generated SVG includes hash characters in the
`clip-path` attribute; Firefox interprets these as fragment specifiers,
truncating the SVG. The prior version of the comment speculated that the
issue was related to the length of the SVG, but there’s no evidence that
this is the case.

With this understanding, it’s easy to construct a [simple repro][1] to
confirm this behavior. In Firefox 61, a data-URI describing an SVG image
with a hash character is invalid in both an `img src` and an `a href`;
in Chrome pre-72, it’s fine in both, while Chrome 72 behaves the same as
Firefox. Firefox and Chrome also differ in their handling of newlines in
the non-encoded data-URI; Chrome includes the newlines (except for the
last one), while Firefox strips them.

[1]: https://gist.github.com/wchargin/f644d584ddafb19d003d46084c0f80e5

Test Plan:
No functional change. Inspect the above-linked gist to confirm behavior.

wchargin-branch: svg-url-truncation-comment
