### PR TITLE
Change maximum smoothing factor from 1 to 0.999.

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -84,7 +84,7 @@ limitations under the License.
             weight="{{_smoothingWeight}}"
             step="0.001"
             min="0"
-            max="1"
+            max="0.999"
           ></tf-smoothing-input>
         </div>
         <div class="sidebar-section">


### PR DESCRIPTION
1 as a smoothing factor always leads to a constant value of 0 being plotted.
0.999 is the actual highest value you can select for meaningful smoothing.

![1.0 smoothing](https://user-images.githubusercontent.com/11563594/53904366-cb546800-403d-11e9-9981-0510ec7dabf6.png)
![0.999 smoothing](https://user-images.githubusercontent.com/11563594/53904371-cf808580-403d-11e9-863c-8aea35014540.png)

