### PR TITLE
scalar: use ObjectURL for SVG link for durability

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -316,7 +316,7 @@ limitations under the License.
       },
       _updateDownloadLink() {
         const svgStr = this.$$('tf-line-chart-data-loader').exportAsSvgString();
-        const bytes = new Uint8Array(svgStr.length).map((_, i) => svgStr.charCodeAt(i));
+        const bytes = new TextEncoder().encode(svgStr);
         const blob = new Blob([bytes], {type: 'image/svg+xml'});
         this.$$('#svgLink').setAttribute('href', URL.createObjectURL(blob));
       },

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -316,13 +316,6 @@ limitations under the License.
       },
       _updateDownloadLink() {
         const svgStr = this.$$('tf-line-chart-data-loader').exportAsSvgString();
-<<<<<<< HEAD
-        // The SVG code string may include hash characters, such as an
-        // attribute `clipPath="url(#foo)"`. Thus, we base64-encode the
-        // data so that such a hash is not interpreted as a fragment
-        // specifier, truncating the SVG. (See issue #1874.)
-        this.$$('#svgLink').href = `data:image/svg+xml;base64,${btoa(svgStr)}`;
-=======
         const bytes = new Uint8Array(svgStr.length).map((_, i) => svgStr.charCodeAt(i));
         const blob = new Blob([bytes], {type: 'image/svg+xml'});
         this.$$('#svgLink').setAttribute('href', URL.createObjectURL(blob));
@@ -330,7 +323,6 @@ limitations under the License.
       _removeDownloadLink() {
         URL.revokeObjectURL(this.$$('#svgLink').href);
         this.$$('#svgLink').removeAttribute('href');
->>>>>>> scalar: use ObjectURL for SVG link for durability
       },
       _runsFromData(data) {
         return data.map((datum) => datum.run);

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -80,7 +80,9 @@ limitations under the License.
       title="Fit domain to data"
     ></paper-icon-button>
     <template is="dom-if" if="[[showDownloadLinks]]">
-      <paper-menu-button on-paper-dropdown-open="_updateDownloadLink">
+      <paper-menu-button
+          on-paper-dropdown-open="_updateDownloadLink"
+          on-paper-dropdown-close="_removeDownloadLink">
         <paper-icon-button
           class="dropdown-trigger"
           slot="dropdown-trigger"
@@ -314,11 +316,21 @@ limitations under the License.
       },
       _updateDownloadLink() {
         const svgStr = this.$$('tf-line-chart-data-loader').exportAsSvgString();
+<<<<<<< HEAD
         // The SVG code string may include hash characters, such as an
         // attribute `clipPath="url(#foo)"`. Thus, we base64-encode the
         // data so that such a hash is not interpreted as a fragment
         // specifier, truncating the SVG. (See issue #1874.)
         this.$$('#svgLink').href = `data:image/svg+xml;base64,${btoa(svgStr)}`;
+=======
+        const bytes = new Uint8Array(svgStr.length).map((_, i) => svgStr.charCodeAt(i));
+        const blob = new Blob([bytes], {type: 'image/svg+xml'});
+        this.$$('#svgLink').setAttribute('href', URL.createObjectURL(blob));
+      },
+      _removeDownloadLink() {
+        URL.revokeObjectURL(this.$$('#svgLink').href);
+        this.$$('#svgLink').removeAttribute('href');
+>>>>>>> scalar: use ObjectURL for SVG link for durability
       },
       _runsFromData(data) {
         return data.map((datum) => datum.run);


### PR DESCRIPTION
Data uri in the link for download has given us some trouble with
encoding and length limitations. We want to use the ObjectURL like
PR #1610 that is more durable to aforementioned limitations.

Tested this on Chrome 72 & 74, Firefox 65, and Safari.