### PR TITLE
lazy: check sentinel identity with `is`, not `==`

### DIFF
--- a/tensorboard/lazy.py
+++ b/tensorboard/lazy.py
@@ -85,9 +85,9 @@ def _memoize(f):
   lock = threading.RLock()
   @functools.wraps(f)
   def wrapper(arg):
-    if cache.get(arg, nothing) == nothing:
+    if cache.get(arg, nothing) is nothing:
       with lock:
-        if cache.get(arg, nothing) == nothing:
+        if cache.get(arg, nothing) is nothing:
           cache[arg] = f(arg)
     return cache[arg]
   return wrapper

--- a/tensorboard/lazy_test.py
+++ b/tensorboard/lazy_test.py
@@ -87,6 +87,26 @@ class LazyTest(unittest.TestCase):
     with six.assertRaisesRegex(self, ValueError, expected_message):
       bad.day
 
+  def test_loads_only_once_even_when_result_equal_to_everything(self):
+    # This would fail if the implementation of `_memoize` used `==`
+    # rather than `is` to check for the sentinel value.
+    class EqualToEverything(object):
+      init_count = 0
+
+      def __init__(self):
+        EqualToEverything.init_count += 1
+
+      def __eq__(self, other):
+        return True
+
+    @lazy.lazy_load("foo")
+    def foo():
+      return EqualToEverything()
+
+    dir(foo)
+    dir(foo)
+    self.assertEqual(EqualToEverything.init_count, 1)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tensorboard/lazy_test.py
+++ b/tensorboard/lazy_test.py
@@ -91,21 +91,18 @@ class LazyTest(unittest.TestCase):
     # This would fail if the implementation of `_memoize` used `==`
     # rather than `is` to check for the sentinel value.
     class EqualToEverything(object):
-      init_count = 0
-
-      def __init__(self):
-        EqualToEverything.init_count += 1
-
       def __eq__(self, other):
         return True
 
+    count_box = [0]
     @lazy.lazy_load("foo")
     def foo():
+      count_box[0] += 1
       return EqualToEverything()
 
     dir(foo)
     dir(foo)
-    self.assertEqual(EqualToEverything.init_count, 1)
+    self.assertEqual(count_box[0], 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Summary:
This is not likely to be a problem in practice, but we might as well do
the safe thing when comparing to a sentinel.

Test Plan:
Unit test added, for good measure.

wchargin-branch: lazy-sentinel-is
