### PR TITLE
program: initialize server objects exactly once

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -422,7 +422,7 @@ def with_port_scanning(cls):
 
 
 @with_port_scanning
-class WerkzeugServer(serving.ThreadedWSGIServer):
+class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
   """Implementation of TensorBoardServer using the Werkzeug dev server."""
 
   # ThreadedWSGIServer handles this in werkzeug 0.12+ but we allow 0.11.x.


### PR DESCRIPTION
Summary:
This resolves a piece of technical debt that was convenient but not
robust to implementation changes in Werkzeug and the Python standard
library. When searching for ports, instead of calling superclass
initializers multiple times until they succeed, we create new server
objects (each with a single port) multiple times until one is
successfully initialized. Each object’s initializer chain is invoked
only once.

The mechanism provides a `with_port_scanning` factory that is agnostic
to the actual server implementation.

This commit is easier to review when ignoring whitespace changes.

Test Plan:
Spawn 11 TensorBoard processes without specifying a port; e.g.:

```
$ bazel build //tensorboard
$ for in in {1..11}; do
> ./bazel-bin/tensorboard/tensorboard --logdir /tmp/whatever &
> done; sleep 2
```

Observe that the first ten bind to successive ports, and that the last
one gives “TensorBoard could not bind to any port around 6006 (tried 10
times)”).

Then, run

```
./bazel-bin/tensorboard/tensorboard --logdir /tmp/whatever --port 6006
```

to see that you still get the “could not bind to port 6006, it was
already in use” error.

Finally, you can use `jobs -p | xargs kill` to kill all extant jobs.

wchargin-branch: program-single-init
