### PR TITLE
Revert "scalar: use ObjectURL for SVG link for durability (#1979)"

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -80,9 +80,7 @@ limitations under the License.
       title="Fit domain to data"
     ></paper-icon-button>
     <template is="dom-if" if="[[showDownloadLinks]]">
-      <paper-menu-button
-          on-paper-dropdown-open="_updateDownloadLink"
-          on-paper-dropdown-close="_removeDownloadLink">
+      <paper-menu-button on-paper-dropdown-open="_updateDownloadLink">
         <paper-icon-button
           class="dropdown-trigger"
           slot="dropdown-trigger"
@@ -316,13 +314,11 @@ limitations under the License.
       },
       _updateDownloadLink() {
         const svgStr = this.$$('tf-line-chart-data-loader').exportAsSvgString();
-        const bytes = new TextEncoder().encode(svgStr);
-        const blob = new Blob([bytes], {type: 'image/svg+xml'});
-        this.$$('#svgLink').setAttribute('href', URL.createObjectURL(blob));
-      },
-      _removeDownloadLink() {
-        URL.revokeObjectURL(this.$$('#svgLink').href);
-        this.$$('#svgLink').removeAttribute('href');
+        // The SVG code string may include hash characters, such as an
+        // attribute `clipPath="url(#foo)"`. Thus, we base64-encode the
+        // data so that such a hash is not interpreted as a fragment
+        // specifier, truncating the SVG. (See issue #1874.)
+        this.$$('#svgLink').href = `data:image/svg+xml;base64,${btoa(svgStr)}`;
       },
       _runsFromData(data) {
         return data.map((datum) => datum.run);


### PR DESCRIPTION
Summary:
This reverts commit e46bab98da5b2369d96721758c50c01b23a2ec83.

A Google-internal check objects to that PR on the grounds that object
URLs can induce XSS vulnerabilities. Googlers, see <http://b/128425516>.

Test Plan:
Downloading the chart still works, in both Chrome 72 and Firefox
60.5.1esr.

wchargin-branch: revert-1979
