### PR TITLE
beholder: use estimator from `tf.estimator`

### DIFF
--- a/tensorboard/plugins/beholder/beholder.py
+++ b/tensorboard/plugins/beholder/beholder.py
@@ -21,7 +21,6 @@ import time
 
 import numpy as np
 import tensorflow as tf
-from tensorflow_estimator import estimator
 
 from tensorboard.plugins.beholder import im_util
 from tensorboard.plugins.beholder.file_system_tools import read_pickle,\
@@ -197,7 +196,7 @@ class Beholder(object):
     return grads, optimizer.apply_gradients(grads_and_vars)
 
 
-class BeholderHook(estimator.SessionRunHook):
+class BeholderHook(tf.estimator.SessionRunHook):
   """SessionRunHook implementation that runs Beholder every step.
 
   Convenient when using tf.train.MonitoredSession:


### PR DESCRIPTION
Summary:
This reverts part of #1911. Tests seem to pass either way (on both
mainline nightly and the 2.0 preview), but the `tf.estimator` form
works better inside Google.

Test Plan:
Running `bazel test //tensorboard/...` passes on both Python 2 and
Python 3, with both tf-nightly-2.0-preview==2.0.0.dev20190312 and the
same version of tf-nightly.

Importing this tree into Google yields a working TensorBoard.

wchargin-branch: beholder-estimator-via-tf
