### PR TITLE
Use isinstance rather than type to support CorePlugin subclass

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -248,7 +248,7 @@ class TensorBoardWSGI(object):
       try:
         plugin_apps = plugin.get_plugin_apps()
       except Exception as e:  # pylint: disable=broad-except
-        if type(plugin) is core_plugin.CorePlugin:  # pylint: disable=unidiomatic-typecheck
+        if isinstance(plugin, core_plugin.CorePlugin):  # pylint: disable=unidiomatic-typecheck
           raise
         logger.warn('Plugin %s failed. Exception: %s',
                            plugin.plugin_name, str(e))
@@ -258,7 +258,7 @@ class TensorBoardWSGI(object):
           raise ValueError('Plugin named %r handles invalid route %r: '
                            'route does not start with a slash' %
                            (plugin.plugin_name, route))
-        if type(plugin) is core_plugin.CorePlugin:  # pylint: disable=unidiomatic-typecheck
+        if isinstance(plugin, core_plugin.CorePlugin):  # pylint: disable=unidiomatic-typecheck
           path = self._path_prefix + route
         else:
           path = (self._path_prefix + DATA_PREFIX + PLUGIN_PREFIX + '/' +


### PR DESCRIPTION
# Motivation for features / changes

Was unable to subclass CorePlugin so we could update the log directory path via a URL class.

# Technical description of changes

Use isinstance instead of type.

cc @nfelt