### PR TITLE
Use tensorboard.compat for tf in projector plugin

### DIFF
--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -32,7 +32,7 @@ py_library(
     deps = [
         ":projector_plugin",
         ":protos_all_py_pb2",
-        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/compat:tensorflow",
     ],
 )
 

--- a/tensorboard/plugins/projector/__init__.py
+++ b/tensorboard/plugins/projector/__init__.py
@@ -28,7 +28,7 @@ from __future__ import print_function
 import os
 
 from google.protobuf import text_format as _text_format
-import tensorflow as tf
+from tensorboard.compat import tf2 as tf
 from tensorboard.plugins.projector import projector_plugin as _projector_plugin
 from tensorboard.plugins.projector.projector_config_pb2 import EmbeddingInfo
 from tensorboard.plugins.projector.projector_config_pb2 import SpriteMetadata

--- a/tensorboard/plugins/projector/__init__.py
+++ b/tensorboard/plugins/projector/__init__.py
@@ -28,7 +28,7 @@ from __future__ import print_function
 import os
 
 from google.protobuf import text_format as _text_format
-from tensorboard.compat import tf2 as tf
+from tensorboard.compat import tf
 from tensorboard.plugins.projector import projector_plugin as _projector_plugin
 from tensorboard.plugins.projector.projector_config_pb2 import EmbeddingInfo
 from tensorboard.plugins.projector.projector_config_pb2 import SpriteMetadata


### PR DESCRIPTION
Not sure how I missed this, but we need to use `tensorboard.compat` for the TensorFlow dependency in the projector plugin. Saw this failure when attempting to use internally.

cc @nfelt @wchargin 