### PR TITLE
Fix with long words in projector metadata card

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-metadata-card.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-metadata-card.html
@@ -46,6 +46,7 @@ limitations under the License.
   line-height: 24px;
   padding: 12px 12px 8px;
   width: 230px;
+  word-break: break-word;
 }
 
 #metadata-table {
@@ -65,6 +66,10 @@ limitations under the License.
   display: table-cell;
   font-size: 12px;
   padding: 3px 3px;
+}
+    
+.metadata-value {
+  word-break: break-word;
 }
 </style>
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-metadata-card.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-metadata-card.html
@@ -46,7 +46,7 @@ limitations under the License.
   line-height: 24px;
   padding: 12px 12px 8px;
   width: 230px;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 #metadata-table {
@@ -69,7 +69,7 @@ limitations under the License.
 }
     
 .metadata-value {
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 </style>
 


### PR DESCRIPTION
* Motivation for features / changes
Bug with long strings presentation in metadata card. 

* Technical description of changes
Only two css classes were changed. 

* Screenshots of UI changes
Before fix:
![image](https://user-images.githubusercontent.com/501780/54463744-22b4af80-4785-11e9-9529-e3e1c0347eed.png)

After fix:
![image](https://user-images.githubusercontent.com/501780/54463722-0c0e5880-4785-11e9-9463-6baf9578b321.png)

* Detailed steps to verify changes work correctly (as executed by you)
Just put long strings in metadata
