### PR TITLE
lib: export `version` and define `__version__`

### DIFF
--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -20,6 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorboard import lazy
+from tensorboard import version
 
 
 # Please be careful when changing the structure of this file.
@@ -81,3 +82,6 @@ def program():
 def summary():
   import importlib  # pylint: disable=g-import-not-at-top
   return importlib.import_module('tensorboard.summary')
+
+
+__version__ = version.VERSION

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -152,6 +152,7 @@ smoke() {
   export TF_CPP_MIN_LOG_LEVEL=1  # Suppress spammy TF startup logging.
   python -c "
 import tensorboard as tb
+assert tb.__version__ == tb.version.VERSION
 tb.summary.scalar_pb('test', 42)
 from tensorboard.plugins.projector import visualize_embeddings
 from tensorboard.plugins.beholder import Beholder, BeholderHook


### PR DESCRIPTION
Summary:
Resolves #2020. The `__version__` attribute meets the specifications set
forth in [PEP 396].

[PEP 396]: https://www.python.org/dev/peps/pep-0396/

Test Plan:
The newly modified smoke test still passes; manually verified that the
new `__version__` attribute has the right value.

wchargin-branch: export-version
