### PR TITLE
docs: fix list rendering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,8 @@ before_script:
   - tensorboard/tools/do_not_submit_test.sh
   # Make sure all necessary files have the license information.
   - tensorboard/tools/license_test.sh
+  # Make sure that IPython notebooks have valid Markdown.
+  - tensorboard/tools/docs_list_format_test.sh
 
 # Commands in this section should only fail if it's our fault. Travis will
 # categorize them as 'failed', rather than 'error' for other sections.

--- a/docs/r2/graphs.ipynb
+++ b/docs/r2/graphs.ipynb
@@ -410,9 +410,10 @@
       "cell_type": "markdown",
       "source": [
         "To use the Sumary Trace API:\n",
+        "\n",
         "*   Define and annotate a function with `tf.function`\n",
         "*   Use `tf.summary.trace_on()` immediately before your function call site.\n",
-        "    *    Add profile information (memory, CPU time) to graph by passing `profiler=True`\n",
+        "*    Add profile information (memory, CPU time) to graph by passing `profiler=True`\n",
         "*   With a Summary file writer, call `tf.summary.trace_export()` to save the log data\n",
         "\n",
         "You can then use TensorBoard to see how your function behaves.\n"

--- a/docs/r2/hyperparameter_tuning_with_hparams.ipynb
+++ b/docs/r2/hyperparameter_tuning_with_hparams.ipynb
@@ -82,6 +82,7 @@
         "The HParams dashboard in TensorBoard provides several tools to help with this process of identifying the best experiment or most promising sets of hyperparameters. \n",
         "\n",
         "This tutorial will focus on the following steps:\n",
+        "\n",
         "1. Experiment setup and HParams summary\n",
         "2. Adapt TensorFlow runs to log hyperparameters and metrics\n",
         "3. Start runs and log them all under one parent directory\n",
@@ -507,6 +508,7 @@
       "cell_type": "markdown",
       "source": [
         "The left pane of the dashboard provides filtering capabilities that are active across all the views in the HParams dashboard:\n",
+        "\n",
         "- Filter which hyperparameters/metrics are shown in the dashboard\n",
         "- Filter which hyperparameter/metrics values are shown in the dashboard\n",
         "- Filter on run status (running, success, ...)\n",
@@ -522,6 +524,7 @@
       "cell_type": "markdown",
       "source": [
         "The HParams dashboard has three different views, with various useful information:\n",
+        "\n",
         "* The **Table View** lists the runs, their hyperparameters, and their metrics.\n",
         "* The **Parallel Coordinates View** shows each run as a line going through an axis for each hyperparemeter and metric. Click and drag the mouse on any axis to mark a region which will highlight only the runs that pass through it. This can be useful for identifying which groups of hyperparameters are most important. The axes themselves can be re-ordered by dragging them.\n",
         "* The **Scatter Plot View** shows plots comparing each hyperparameter/metric with each metric. This can help identify correlations. Click and drag to select a region in a specific plot and highlight those sessions across the other plots. \n",

--- a/tensorboard/tools/docs_list_format_test.sh
+++ b/tensorboard/tools/docs_list_format_test.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Check that any Markdown lists in IPython notebooks are preceded by a
+# blank line, which is required for the Google-internal docs processor
+# to interpret them as lists.
+
+set -e
+
+if ! [ -f WORKSPACE ]; then
+    printf >&2 'fatal: no WORKSPACE file found (are you at TensorBoard root?)\n'
+    exit 2
+fi
+
+git ls-files -z '*.ipynb' |
+xargs -0 awk '
+    { is_list = /"([-*]|[0-9]+\.) / }
+    is_list && !last_list && !last_blank {
+        printf "%s:%s:%s\n", FILENAME, FNR, $0;
+        status = 1;
+    }
+    { last_blank = /"\\n",/; last_list = is_list }
+    END { exit status }
+' 

--- a/tensorboard/tools/docs_list_format_test.sh
+++ b/tensorboard/tools/docs_list_format_test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Summary:
The Google-internal Markdown processor, which renders our docs site,
requires that lists be preceded by a blank line. This is [nonstandard],
so the previews shown in GitHub and even Colab itself look fine, but the
docs site does not:

![Example of a botched ordered list][ex-ol]

![Example of a botched unordered list][ex-ul]

This patch fixes up our notebooks to accommodate to the stricter style.

Test Plan:
Regression test added. Before this change, running the new test outputs

```
docs/r2/graphs.ipynb:413:        "*   Define and annotate a function with `tf.function`\n",
docs/r2/graphs.ipynb:416:        "*   With a Summary file writer, call `tf.summary.trace_export()` to save the log data\n",
docs/r2/hyperparameter_tuning_with_hparams.ipynb:85:        "1. Experiment setup and HParams summary\n",
docs/r2/hyperparameter_tuning_with_hparams.ipynb:510:        "- Filter which hyperparameters/metrics are shown in the dashboard\n",
docs/r2/hyperparameter_tuning_with_hparams.ipynb:525:        "* The **Table View** lists the runs, their hyperparameters, and their metrics.\n",
```

and exits 123. After this change, it outputs nothing and exits 0.

[ex-ol]: https://user-images.githubusercontent.com/4317806/54706565-75cb9100-4afc-11e9-81a3-b91ab1f96087.png
[ex-ul]: https://user-images.githubusercontent.com/4317806/54706613-90056f00-4afc-11e9-9cb6-84f83470bf29.png
[nonstandard]: https://spec.commonmark.org/dingus/?text=No%20newline%20after%20me%0A*%20and%20yet%20a%20fine%20list%20here

wchargin-branch: docs-newline
