### PR TITLE
Add popup dialog for plugins that require TensorFlow

### DIFF
--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -47,6 +47,19 @@ tf_web_library(
 )
 
 tf_web_library(
+    name = "plugin_dialog",
+    srcs = [
+        "plugin-dialog.html",
+    ],
+    path = "/tf-tensorboard",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorboard/components/tf_imports:lodash",
+        "//tensorboard/components/tf_imports:polymer",
+    ],
+)
+
+tf_web_library(
     name = "default_plugins",
     srcs = ["default-plugins.html"],
     path = "/tf-tensorboard",

--- a/tensorboard/components/tf_tensorboard/plugin-dialog.html
+++ b/tensorboard/components/tf_tensorboard/plugin-dialog.html
@@ -1,0 +1,104 @@
+<!--
+@license
+Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-imports/lodash.html">
+
+
+<dom-module id="tf-plugin-dialog">
+  <template>
+    <!-- We use a custom backdrop to avoid occluding the TensorBoard navbar. -->
+    <template is="dom-if" if="[[_open]]">
+      <div id="dashboard-backdrop"></div>
+    </template>
+    <paper-dialog id="dialog"
+                  modal
+                  opened="{{_open}}"
+                  with-backdrop="[[_useNativeBackdrop]]">
+      <h2 id='dialog-title'>[[_title]]</h2>
+      <div class="custom-message">[[_customMessage]]</div>
+    </paper-dialog>
+  </template>
+  <style>
+    /** We rely on a separate `_hidden` property instead of directly making use
+        of the `_open` attribute because this CSS specification may strangely
+        affect other elements throughout TensorBoard. See #899. */
+    #dashboard-backdrop {
+      background: rgba(0, 0, 0, 0.6);
+      width: 100%;
+      height: 100%;
+    }
+
+    #dialog-title {
+      padding-bottom: 15px;
+    }
+
+    .custom-message {
+      margin-top: 0;
+      margin-bottom: 15px;
+    }
+  </style>
+  <script>
+
+  Polymer({
+    is: "tf-plugin-dialog",
+    properties: {
+      _title: {
+        type: String,
+        value: null,
+      },
+      _customMessage: {
+        type: String,
+        value: null,
+      },
+      _open: {
+        type: Boolean,
+      },
+      _hidden: {
+        type: Boolean,
+        computed: '_computeHidden(_open)',
+        reflectToAttribute: true,  // for CSS
+      },
+      // Suppress the native paper-dialog backdrop. We use a custom one. We make
+      // the dialog reference this bound property instead of directly setting
+      // the attribute to the string "false" in the HTML because Polymer
+      // unfortunately parses "false" as a true-ey value (a non-empty string).
+      _useNativeBackdrop: {
+        type: Boolean,
+        value: false,
+        readOnly: true,
+      },
+    },
+    openNoTensorFlowDialog() {
+      this.set(
+          '_title',
+          'This plugin is disabled without TensorFlow');
+      this.set(
+          '_customMessage',
+          'To enable this plugin in TensorBoard, install TensorFlow with '
+              + '"pip install tf-nightly" or equivalent.');
+      this.$.dialog.open();
+    },
+    closeDialog() {
+      this.$.dialog.close();
+    },
+    _computeHidden(open) {
+      return !open;
+    },
+  });
+  </script>
+</dom-module>

--- a/tensorboard/components/tf_tensorboard/plugin-dialog.html
+++ b/tensorboard/components/tf_tensorboard/plugin-dialog.html
@@ -90,7 +90,7 @@ limitations under the License.
       this.set(
           '_customMessage',
           'To enable this plugin in TensorBoard, install TensorFlow with '
-              + '"pip install tf-nightly" or equivalent.');
+              + '"pip install tensorflow" or equivalent.');
       this.$.dialog.open();
     },
     closeDialog() {

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -51,7 +51,8 @@ def run_main():
   program.setup_environment()
 
   if getattr(tf, '__version__', 'stub') == 'stub':
-    logger.warn("TensorFlow installation not found - running with reduced feature set.")
+    print("TensorFlow installation not found - running with reduced feature set.",
+          file=sys.stderr)
 
   tensorboard = program.TensorBoard(default.get_plugins(),
                                     program.get_default_assets_zip_provider())

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -51,12 +51,6 @@ def run_main():
   program.setup_environment()
 
   if getattr(tf, '__version__', 'stub') == 'stub':
-    # Unless the user has explicitly requested running without TensorFlow by setting the
-    # TENSORBOARD_NO_TF environment variable, we check for TensorFlow here so that if it's
-    # missing we generate a clear and immediate error rather than partial functionality.
-    # TODO(#2027): Remove environment check once we have placeholder UI
-    if os.getenv('TENSORBOARD_NO_TF') is None:
-      import tensorflow  # pylint: disable=unused-import
     logger.warn("TensorFlow installation not found - running with reduced feature set.")
 
   tensorboard = program.TensorBoard(default.get_plugins(),

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/BUILD
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/BUILD
@@ -22,6 +22,7 @@ tf_web_library(
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_runs_selector",
+        "//tensorboard/components/tf_tensorboard:plugin_dialog",
         "//tensorboard/components/tf_tensorboard:registry",
         "@org_polymer_paper_button",
         "@org_polymer_paper_dialog",

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -23,12 +23,14 @@ limitations under the License.
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-dashboard-common/dashboard-style.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
+<link rel="import" href="../tf-tensorboard/plugin-dialog.html">
 <link rel="import" href="../tf-tensorboard/registry.html">
 <link rel="import" href="tf-beholder-video.html">
 <link rel="import" href="tf-beholder-info.html">
 
 <dom-module id="tf-beholder-dashboard">
   <template>
+    <tf-plugin-dialog id="initialDialog"></tf-plugin-dialog>
     <tf-dashboard-layout>
       <div class="sidebar">
         <template is="dom-if" if="[[_controls_disabled]]">
@@ -346,6 +348,13 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
           value: () => new tf_backend.RequestManager(10, 0),
         },
 
+        _canceller: {
+          type: Object,
+          value: () => new tf_backend.Canceller(),
+        },
+
+        _isAttached: Boolean,
+
         _values: {
           type: String,
           value: 'trainable_variables',
@@ -476,17 +485,39 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
         this.$.record_button.classList.toggle('is-recording')
       },
 
+      attached: function() {
+        // Check if the plugin was created
+        this._requestManager
+            .request(tf_backend.getRouter().pluginsListing())
+            .then(this._canceller.cancellable(result => {
+              if (result.cancelled) {
+                return;
+              }
+              if (!('beholder' in result.value)) {
+                // The plugin was not created
+                this.$.initialDialog.openNoTensorFlowDialog();
+                this.set('_isAttached', false);
+              } else {
+                // The plugin was created
+                this.$.initialDialog.closeDialog();
+                this.set('_isAttached', true);
+              }
+            }));
+      },
+
       ready() {
         this.reload()
       },
 
       reload() {
-        const url = tf_backend.getRouter().pluginRoute(PLUGIN_NAME, '/is-active');
+        if (this._isAttached) {
+          const url = tf_backend.getRouter().pluginRoute(PLUGIN_NAME, '/is-active');
 
-        this._requestManager.request(url).then(response => {
-          this.set('_is_active', response['is_active']);
-          this.set('_controls_disabled', !response['is_config_writable']);
-        })
+          this._requestManager.request(url).then(response => {
+            this.set('_is_active', response['is_active']);
+            this.set('_controls_disabled', !response['is_config_writable']);
+          })
+        }
       },
     });
     })();

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -336,7 +336,7 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
     "use strict";
     (function() {
 
-    const PLUGIN_NAME = 'beholder'
+    const PLUGIN_NAME = 'beholder';
 
     Polymer({
       is: 'tf-beholder-dashboard',
@@ -348,12 +348,7 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
           value: () => new tf_backend.RequestManager(10, 0),
         },
 
-        _canceller: {
-          type: Object,
-          value: () => new tf_backend.Canceller(),
-        },
-
-        _isAttached: Boolean,
+        _isAvailable: Boolean,
 
         _values: {
           type: String,
@@ -489,20 +484,17 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
         // Check if the plugin was created
         this._requestManager
             .request(tf_backend.getRouter().pluginsListing())
-            .then(this._canceller.cancellable(result => {
-              if (result.cancelled) {
-                return;
-              }
-              if (!('beholder' in result.value)) {
+            .then(plugins => {
+              if (!(PLUGIN_NAME in plugins)) {
                 // The plugin was not created
                 this.$.initialDialog.openNoTensorFlowDialog();
-                this.set('_isAttached', false);
+                this.set('_isAvailable', false);
               } else {
                 // The plugin was created
                 this.$.initialDialog.closeDialog();
-                this.set('_isAttached', true);
+                this.set('_isAvailable', true);
               }
-            }));
+            });
       },
 
       ready() {
@@ -510,7 +502,7 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
       },
 
       reload() {
-        if (this._isAttached) {
+        if (this._isAvailable) {
           const url = tf_backend.getRouter().pluginRoute(PLUGIN_NAME, '/is-active');
 
           this._requestManager.request(url).then(response => {
@@ -520,12 +512,13 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
         }
       },
     });
-    })();
 
     tf_tensorboard.registerDashboard({
-      plugin: 'beholder',
+      plugin: PLUGIN_NAME,
       elementName: 'tf-beholder-dashboard',
       shouldRemoveDom: true,
     });
+
+    })();
   </script>
 </dom-module>

--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -99,8 +99,9 @@ the interactive Debugger Dashboard. This flag is mutually exclusive with
       # pylint: disable=g-import-not-at-top,unused-import
       import tensorflow
     except ImportError:
-      raise ImportError('To use the debugger plugin, you need to have '
-          ' TensorFlow installed:\n  pip install tensorflow')
+      raise ImportError(
+          'To use the debugger plugin, you need to have TensorFlow installed:\n'
+          '  pip install tensorflow')
     try:
       # pylint: disable=line-too-long,g-import-not-at-top
       from tensorboard.plugins.debugger import debugger_plugin as debugger_plugin_lib

--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -99,7 +99,8 @@ the interactive Debugger Dashboard. This flag is mutually exclusive with
       # pylint: disable=g-import-not-at-top,unused-import
       import tensorflow
     except ImportError:
-      return None
+      raise ImportError('To use the debugger plugin, you need to have '
+          ' TensorFlow installed:\n  pip install tensorflow')
     try:
       # pylint: disable=line-too-long,g-import-not-at-top
       from tensorboard.plugins.debugger import debugger_plugin as debugger_plugin_lib

--- a/tensorboard/plugins/hparams/tf_hparams_dashboard/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_dashboard/BUILD
@@ -12,7 +12,9 @@ tf_web_library(
     path = "/tf-hparams-dashboard",
     visibility = ["//visibility:public"],
     deps = [
+        "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_tensorboard:plugin_dialog",
         "//tensorboard/plugins/hparams/tf_hparams_backend",
         "//tensorboard/plugins/hparams/tf_hparams_main",
     ],

--- a/tensorboard/plugins/hparams/tf_hparams_dashboard/tf-hparams-dashboard.html
+++ b/tensorboard/plugins/hparams/tf_hparams_dashboard/tf-hparams-dashboard.html
@@ -34,6 +34,10 @@ limitations under the License.
   </template>
   <script>
     'use strict';
+    (function() {
+
+    const PLUGIN_NAME = 'hparams';
+
     Polymer({
       is: 'tf-hparams-dashboard',
       properties: {
@@ -42,7 +46,7 @@ limitations under the License.
           value: () => {
             return new tf.hparams.Backend(
                 /* apiUrl= */ tf_backend.getRouter().pluginRoute(
-                    /* pluginName= */ 'hparams',
+                    /* pluginName= */ PLUGIN_NAME,
                     /* route= */ ''),
                 new tf_backend.RequestManager(),
                 /* Use GETs if we're running in colab (due to b/126387106).
@@ -51,45 +55,40 @@ limitations under the License.
             )
           }
         },
-        _canceller: {
-          type: Object,
-          value: () => new tf_backend.Canceller(),
-        },
-        _isAttached: Boolean
+        _isAvailable: Boolean
       },
 
-      // This is called by the tensorboard web framework on attaching plugin.
       attached: function() {
         // Check if the plugin was created
         this._backend._requestManager
             .request(tf_backend.getRouter().pluginsListing())
-            .then(this._canceller.cancellable(result => {
-              if (result.cancelled) {
-                return;
-              }
-              if (!('hparams' in result.value)) {
+            .then(plugins => {
+              if (!(PLUGIN_NAME in plugins)) {
                 // The plugin was not created
                 this.$.initialDialog.openNoTensorFlowDialog();
-                this.set('_isAttached', false);
+                this.set('_isAvailable', false);
               } else {
                 // The plugin was created
                 this.$.initialDialog.closeDialog();
-                this.set('_isAttached', true);
+                this.set('_isAvailable', true);
               }
-            }));
+            });
       },
 
       // This is called by the tensorboard web framework to refresh the plugin.
       reload() {
-        if (this._isAttached) {
+        if (this._isAvailable) {
             this.$["hparams-main"].reload();
         }
       }
     });
+
     // Register the plugin main element with Tensorboard.
     tf_tensorboard.registerDashboard({
-      plugin: 'hparams',
+      plugin: PLUGIN_NAME,
       elementName: 'tf-hparams-dashboard'
     });
+
+    })();
   </script>
 </dom-module>

--- a/tensorboard/plugins/hparams/tf_hparams_dashboard/tf-hparams-dashboard.html
+++ b/tensorboard/plugins/hparams/tf_hparams_dashboard/tf-hparams-dashboard.html
@@ -16,13 +16,16 @@ limitations under the License.
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-hparams-main/tf-hparams-main.html">
 <link rel="import" href="../tf-hparams-backend/tf-hparams-backend.html">
+<link rel="import" href="../tf-tensorboard/plugin-dialog.html">
 
 <dom-module id="tf-hparams-dashboard">
   <template>
     <!-- Tensorboard does not specify an experimentName. Currently it only
          supports one experiment per invocation. -->
+    <tf-plugin-dialog id="initialDialog"></tf-plugin-dialog>
     <tf-hparams-main
       id="hparams-main"
       backend="[[_backend]]"
@@ -47,12 +50,40 @@ limitations under the License.
                 /* useHttpGet= */ !!(window.TENSORBOARD_ENV || {}).IN_COLAB,
             )
           }
-        }
+        },
+        _canceller: {
+          type: Object,
+          value: () => new tf_backend.Canceller(),
+        },
+        _isAttached: Boolean
+      },
+
+      // This is called by the tensorboard web framework on attaching plugin.
+      attached: function() {
+        // Check if the plugin was created
+        this._backend._requestManager
+            .request(tf_backend.getRouter().pluginsListing())
+            .then(this._canceller.cancellable(result => {
+              if (result.cancelled) {
+                return;
+              }
+              if (!('hparams' in result.value)) {
+                // The plugin was not created
+                this.$.initialDialog.openNoTensorFlowDialog();
+                this.set('_isAttached', false);
+              } else {
+                // The plugin was created
+                this.$.initialDialog.closeDialog();
+                this.set('_isAttached', true);
+              }
+            }));
       },
 
       // This is called by the tensorboard web framework to refresh the plugin.
       reload() {
-        this.$["hparams-main"].reload();
+        if (this._isAttached) {
+            this.$["hparams-main"].reload();
+        }
       }
     });
     // Register the plugin main element with Tensorboard.

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/BUILD
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/BUILD
@@ -41,6 +41,7 @@ tf_web_library(
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_storage",
+        "//tensorboard/components/tf_tensorboard:plugin_dialog",
         "//tensorboard/components/tf_tensorboard:registry",
     ],
 )

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -42,6 +42,7 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/tf-option-selector.html">
 <link rel="import" href="../tf-storage/tf-storage.html">
 <link rel="import" href="./tf-inference-panel.html">
+<link rel="import" href="../tf-tensorboard/plugin-dialog.html">
 <link rel="import" href="../tf-tensorboard/registry.html">
 <link rel="import" href="../vz-bar-chart/vz-bar-chart.html">
 <link rel="import" href="../vz-line-chart/vz-line-chart.html">
@@ -1181,6 +1182,7 @@ limitations under the License.
         --paper-toggle-button-label-color: #3C4043;
       }
     </style>
+    <tf-plugin-dialog id="initialDialog"></tf-plugin-dialog>
     <paper-dialog id="inferencesettings" class="inference-settings" opened="[[!local]]">
       <tf-inference-panel
           inference-address="{{inferenceAddress}}"
@@ -2133,7 +2135,7 @@ limitations under the License.
       properties: {
 
         // TensorBoard plugin standard.
-        requestManager: {
+        _requestManager: {
           type: Object,
           value: () => new tf_backend.RequestManager(),
         },
@@ -2553,7 +2555,23 @@ limitations under the License.
           self.$.dive.$.vis._onIronResize();
         });
 
-        resizer.call(dragResize);
+        // Check if the plugin was created
+        this._requestManager
+            .request(tf_backend.getRouter().pluginsListing())
+            .then(this._canceller.cancellable(result => {
+              if (result.cancelled) {
+                return;
+              }
+              if (!('whatif' in result.value)) {
+                // The plugin was not created
+                this.$.inferencesettings.close();
+                this.$.initialDialog.openNoTensorFlowDialog();
+              } else {
+                // The plugin was created
+                this.$.initialDialog.closeDialog();
+                resizer.call(dragResize);
+              }
+            }));
       },
 
       settingsClicked_: function() {
@@ -4447,7 +4465,7 @@ limitations under the License.
             thenDoFn(result);
           }
         });
-        this.requestManager.request(url, postData).then(wrapperFn)
+        this._requestManager.request(url, postData).then(wrapperFn)
             .catch(reason => {
               this.exampleStatusStr = 'Request failed';
               this.showToast_('Request failed: ' + reason);

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -2571,6 +2571,9 @@ limitations under the License.
                 // The plugin was not created
                 this.$.inferencesettings.close();
                 this.$.initialDialog.openNoTensorFlowDialog();
+              } else {
+                // The plugin was created
+                this.$.initialDialog.closeDialog();
               }
             });
       },

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -2559,6 +2559,10 @@ limitations under the License.
           self.$.dive.$.vis._onIronResize();
         });
 
+        resizer.call(dragResize);
+      },
+
+      attached: function() {
         // Check if the plugin was created
         this._requestManager
             .request(tf_backend.getRouter().pluginsListing())
@@ -2567,10 +2571,6 @@ limitations under the License.
                 // The plugin was not created
                 this.$.inferencesettings.close();
                 this.$.initialDialog.openNoTensorFlowDialog();
-              } else {
-                // The plugin was created
-                this.$.initialDialog.closeDialog();
-                resizer.call(dragResize);
               }
             });
       },

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -2130,6 +2130,10 @@ limitations under the License.
       }
     }
 
+    (function() {
+
+    const PLUGIN_NAME = 'whatif';
+
     Polymer({
       is: "tf-interactive-inference-dashboard",
       properties: {
@@ -2558,11 +2562,8 @@ limitations under the License.
         // Check if the plugin was created
         this._requestManager
             .request(tf_backend.getRouter().pluginsListing())
-            .then(this._canceller.cancellable(result => {
-              if (result.cancelled) {
-                return;
-              }
-              if (!('whatif' in result.value)) {
+            .then(plugins => {
+              if (!(PLUGIN_NAME in plugins)) {
                 // The plugin was not created
                 this.$.inferencesettings.close();
                 this.$.initialDialog.openNoTensorFlowDialog();
@@ -2571,7 +2572,7 @@ limitations under the License.
                 this.$.initialDialog.closeDialog();
                 resizer.call(dragResize);
               }
-            }));
+            });
       },
 
       settingsClicked_: function() {
@@ -5568,10 +5569,11 @@ limitations under the License.
     });
 
     tf_tensorboard.registerDashboard({
-      plugin: 'whatif',
+      plugin: PLUGIN_NAME,
       elementName: 'tf-interactive-inference-dashboard',
       tabName: 'What-If Tool',
     });
 
+    })();
   </script>
 </dom-module>

--- a/tensorboard/plugins/profile/tf_profile_dashboard/BUILD
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/BUILD
@@ -12,6 +12,7 @@ tf_web_library(
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_dashboard_common",
+        "//tensorboard/components/tf_tensorboard:plugin_dialog",
         "//tensorboard/components/tf_tensorboard:registry",
         "//tensorboard/components/vz_sorting",
         "//tensorboard/plugins/graph/tf_graph_controls",

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -302,6 +302,10 @@ profile run can have multiple tools that present the performance profile as diff
     "ACTIVE": "ACTIVE",
   };
 
+  (function() {
+
+  const PLUGIN_NAME = 'profile';
+
   Polymer({
     is: "tf-profile-dashboard",
     properties: {
@@ -309,11 +313,7 @@ profile run can have multiple tools that present the performance profile as diff
         type: Object,
         value: () => new tf_backend.RequestManager(),
       },
-      _canceller: {
-        type: Object,
-        value: () => new tf_backend.Canceller(),
-      },
-      _isAttached: Boolean,
+      _isAvailable: Boolean,
       // Whether this dashboard is initialized. This dashboard should only be
       // initialized once.
       _initialized: Boolean,
@@ -434,7 +434,7 @@ profile run can have multiple tools that present the performance profile as diff
     ready: function() {
     },
     observers: [
-      '_maybeInitializeDashboard(_isAttached)',
+      '_maybeInitializeDashboard(_isAttached, _isAvailable)',
       '_maybeUpdateData(_selectedHostName)',
       '_maybeUpdateActiveHosts(_selectedDatasetName, _selectedToolName)',
     ],
@@ -442,23 +442,20 @@ profile run can have multiple tools that present the performance profile as diff
       // Check if the plugin was created
       this._requestManager
           .request(tf_backend.getRouter().pluginsListing())
-          .then(this._canceller.cancellable(result => {
-            if (result.cancelled) {
-              return;
-            }
-            if (!('profile' in result.value)) {
+          .then(plugins => {
+            if (!(PLUGIN_NAME in plugins)) {
               // The plugin was not created
               this.$.initialDialog.openNoTensorFlowDialog();
-              this.set('_isAttached', false);
+              this.set('_isAvailable', false);
             } else {
               // The plugin was created
               this.$.initialDialog.closeDialog();
-              this.set('_isAttached', true);
+              this.set('_isAvailable', true);
             }
-          }));
+          });
     },
     detached: function() {
-      this.set('_isAttached', false);
+      this.set('_isAvailable', false);
     },
     _openCaptureProfileDialog: function() {
       this.$.captureProfileDialog.open();
@@ -484,8 +481,8 @@ profile run can have multiple tools that present the performance profile as diff
       this.$.toast.text = text;
       this.$.toast.open();
     },
-    _maybeInitializeDashboard: function(isAttached) {
-      if (this._initialized || !isAttached) {
+    _maybeInitializeDashboard: function(isAttached, isAvailable) {
+      if (this._initialized || !isAttached || !isAvailable) {
         // Either this dashboard is already initialized ... or we are not yet
         // ready to initialize.
         return;
@@ -704,10 +701,11 @@ profile run can have multiple tools that present the performance profile as diff
   });
 
   tf_tensorboard.registerDashboard({
-    plugin: 'profile',
+    plugin: PLUGIN_NAME,
     elementName: 'tf-profile-dashboard',
     isReloadDisabled: true,
   });
 
+  })();
 </script>
 </dom-module>

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -33,6 +33,7 @@ limitations under the License.
 <link rel="import" href="../memory-viewer/memory-viewer-dashboard.html">
 <link rel="import" href="../google-chart/google-chart-demo.html">
 <link rel="import" href="../tf-tensorboard/registry.html">
+<link rel="import" href="../tf-tensorboard/plugin-dialog.html">
 <link rel="import" href="../vz-sorting/vz-sorting.html">
 
 <!--
@@ -60,6 +61,7 @@ profile run can have multiple tools that present the performance profile as diff
   </div>
 </template>
 <paper-toast id="toast" text="" always-on-top></paper-toast>
+<tf-plugin-dialog id="initialDialog"></tf-plugin-dialog>
 <paper-dialog id="captureProfileDialog" modal>
   <paper-input label="Profiler Service URL or TPU name"
                always-float-label
@@ -307,6 +309,10 @@ profile run can have multiple tools that present the performance profile as diff
         type: Object,
         value: () => new tf_backend.RequestManager(),
       },
+      _canceller: {
+        type: Object,
+        value: () => new tf_backend.Canceller(),
+      },
       _isAttached: Boolean,
       // Whether this dashboard is initialized. This dashboard should only be
       // initialized once.
@@ -433,7 +439,23 @@ profile run can have multiple tools that present the performance profile as diff
       '_maybeUpdateActiveHosts(_selectedDatasetName, _selectedToolName)',
     ],
     attached: function() {
-      this.set('_isAttached', true);
+      // Check if the plugin was created
+      this._requestManager
+          .request(tf_backend.getRouter().pluginsListing())
+          .then(this._canceller.cancellable(result => {
+            if (result.cancelled) {
+              return;
+            }
+            if (!('profile' in result.value)) {
+              // The plugin was not created
+              this.$.initialDialog.openNoTensorFlowDialog();
+              this.set('_isAttached', false);
+            } else {
+              // The plugin was created
+              this.$.initialDialog.closeDialog();
+              this.set('_isAttached', true);
+            }
+          }));
     },
     detached: function() {
       this.set('_isAttached', false);

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -313,6 +313,7 @@ profile run can have multiple tools that present the performance profile as diff
         type: Object,
         value: () => new tf_backend.RequestManager(),
       },
+      _isAttached: Boolean,
       _isAvailable: Boolean,
       // Whether this dashboard is initialized. This dashboard should only be
       // initialized once.
@@ -439,6 +440,7 @@ profile run can have multiple tools that present the performance profile as diff
       '_maybeUpdateActiveHosts(_selectedDatasetName, _selectedToolName)',
     ],
     attached: function() {
+      this.set('_isAttached', true);
       // Check if the plugin was created
       this._requestManager
           .request(tf_backend.getRouter().pluginsListing())
@@ -455,7 +457,7 @@ profile run can have multiple tools that present the performance profile as diff
           });
     },
     detached: function() {
-      this.set('_isAvailable', false);
+      this.set('_isAttached', false);
     },
     _openCaptureProfileDialog: function() {
       this.$.captureProfileDialog.open();


### PR DESCRIPTION
Adding a popup dialog for when plugins are not created. Note that this is different from being "inactive", which can be due to data, etc.

Fixes #2027 

Everything should be good to go and I've tested on my Mac with the following:

```
conda create --name tfpy36 python=3.6
conda activate tfpy36
pip install --upgrade pip
pip install tf-nightly-2.0-preview
conda install protobuf
conda install absl-py
conda install numpy
bazel build tensorboard
./bazel-bin/tensorboard/tensorboard --logdir ~/local/sample_runs/runs
# Navigate to the hparams tab and verify a popup is NOT shown

conda create --name notf python=2.7
conda activate notf
pip install --upgrade pip
pip install scipy
conda install protobuf
conda install absl-py
conda install numpy
bazel build tensorboard
./bazel-bin/tensorboard/tensorboard --logdir ~/local/sample_runs/runs
# Navigate to the hparams tab and verify a popup is shown
```

cc @lanpa, @nfelt 