### PR TITLE
Fix `TFRecordCompressionType` test failures

### DIFF
--- a/tensorboard/plugins/interactive_inference/utils/platform_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/platform_utils.py
@@ -128,9 +128,9 @@ def example_protos_from_path(path,
 
   filenames = filepath_to_filepath_list(path)
   compression_types = [
-      tf.io.TFRecordCompressionType.NONE,
-      tf.io.TFRecordCompressionType.GZIP,
-      tf.io.TFRecordCompressionType.ZLIB,
+      '',  # no compression (distinct from `None`!)
+      'GZIP',
+      'ZLIB',
   ]
   current_compression_idx = 0
   current_file_index = 0


### PR DESCRIPTION
Summary:
tensorflow/tensorflow#26676 removed `tf.io.TFRecordCompressionType`,
which our tests used; `tf-nightly-2.0-preview==2.0.0.dev20190319` was
the first version without this symbol.

Fixes #2035.

Test Plan:
All tests pass on `tf-nightly-2.0-preview==2.0.0.dev20190321` and also
on `tf-nightly==1.14.1.dev20190321`.

wchargin-branch: fix-tf26676-failures
