### PR TITLE
Added public visibility to binary HParams targets

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -94,7 +94,6 @@ py_binary(
     name = "hparams_demo",
     srcs = ["hparams_demo.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//visibility:public"],
     deps = [
         ":protos_all_py_pb2",
         ":summary",

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -94,6 +94,7 @@ py_binary(
     name = "hparams_demo",
     srcs = ["hparams_demo.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":protos_all_py_pb2",
         ":summary",
@@ -109,6 +110,7 @@ py_binary(
     name = "hparams_util",
     srcs = ["hparams_util.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":protos_all_py_pb2",
         ":summary",


### PR DESCRIPTION
Needed to allow "packaging" these public binaries from other BUILD packages.  
@wchargin please take a look.
Thanks!