### PR TITLE
[WIP] Added missing instructions on building pip package

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,6 +20,12 @@ You can build and run TensorBoard via Bazel (from within the TensorFlow nightly 
 (tf)$ bazel run //tensorboard -- --logdir /path/to/logs
 ```
 
+To build the pip package, you will need to evoke the following command:
+
+```sh
+(tf)$ bazel run //tensorboard/pip_package:build_pip_package
+```
+
 To generate fake log data for a plugin, run its demo script. For instance, this command generates fake scalar data in `/tmp/scalars_demo`:
 
 ```sh


### PR DESCRIPTION
* Motivation for features / changes

There is no included instruction for building a pip package from source although it is supposed to be trivial. Including these instructions will make new contributors' experience easier if they want to test or distribute their build in a pip package.

I have referenced the [BUILD file](https://github.com/tensorflow/tensorboard/blob/master/tensorboard/pip_package/BUILD) and added basic instruction into `DEVELOPMENT.md`. 

However, while the build succeeds and does not give any errors, the `.whl` file itself is actually nowhere to be found. 

Apologies for not realizing this before opening the PR, I'll just close it first.

* Technical description of changes

Added instruction into `DEVELOPMENT.md`

* Screenshots of UI changes

NIL

* Detailed steps to verify changes work correctly (as executed by you)

Only changes to markdown in `DEVELOPMENT.md`. No code changes.

* Alternate designs / implementations considered
