### PR TITLE
graph: bring keras_util.py up to date with TF

### DIFF
--- a/tensorboard/plugins/graph/keras_util.py
+++ b/tensorboard/plugins/graph/keras_util.py
@@ -156,7 +156,7 @@ def _update_dicts(name_scope,
   elif is_parent_functional_model and not is_functional_model:
     # Sequential model can take only one input. Make sure inbound to the
     # model is linked to the first layer in the Sequential model.
-    prev_node_name = _scoped_name(name_scope, inbound_nodes[0][0])
+    prev_node_name = _scoped_name(name_scope, inbound_nodes[0][0][0])
   elif not is_parent_functional_model and prev_node_name and is_functional_model:
     assert len(input_layers) == 1, (
         'Cannot have multi-input Functional model when parent model '


### PR DESCRIPTION
Summary:
Fixes #2051. This cherry-picks part of Google-internal cl/239834276 to
fix a change made in TensorFlow 90f1ed7cd3ae167b60c1b0acc6f45af454c8d592
that first appeared in the 20190323 nightly.

Test Plan:
Running `bazel test //tensorboard/plugins/graph:keras_util_test` fails
before this patch but passes after it, on tf-nightly-20190325-py2.7.

wchargin-branch: fix-2051
