### PR TITLE
manager: switch from `datetime` to bare timestamps

### DIFF
--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -394,7 +394,7 @@ def start(arguments, timeout=datetime.timedelta(seconds=60)):
 
   (stdout_fd, stdout_path) = tempfile.mkstemp(prefix=".tensorboard-stdout-")
   (stderr_fd, stderr_path) = tempfile.mkstemp(prefix=".tensorboard-stderr-")
-  start_time = time.time()
+  start_time_seconds = time.time()
   try:
     p = subprocess.Popen(
         ["tensorboard"] + arguments,
@@ -406,8 +406,8 @@ def start(arguments, timeout=datetime.timedelta(seconds=60)):
     os.close(stderr_fd)
 
   poll_interval_seconds = 0.5
-  end_time = start_time + timeout.total_seconds()
-  while time.time() < end_time:
+  end_time_seconds = start_time_seconds + timeout.total_seconds()
+  while time.time() < end_time_seconds:
     time.sleep(poll_interval_seconds)
     subprocess_result = p.poll()
     if subprocess_result is not None:
@@ -417,7 +417,7 @@ def start(arguments, timeout=datetime.timedelta(seconds=60)):
           stderr=_maybe_read_file(stderr_path),
       )
     for info in get_all():
-      if info.pid == p.pid and info.start_time >= start_time:
+      if info.pid == p.pid and info.start_time >= start_time_seconds:
         return StartLaunched(info=info)
   else:
     return StartTimedOut(pid=p.pid)

--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -35,6 +35,10 @@ from tensorboard.util import tb_logging
 
 
 # Type descriptors for `TensorBoardInfo` fields.
+#
+# We represent timestamps as int-seconds-since-epoch rather than
+# datetime objects to work around a bug in Python on Windows. See:
+# https://github.com/tensorflow/tensorboard/issues/2017.
 _FieldType = collections.namedtuple(
     "_FieldType",
     (
@@ -43,13 +47,6 @@ _FieldType = collections.namedtuple(
         "serialize",
         "deserialize",
     ),
-)
-_type_timestamp = _FieldType(
-    serialized_type=int,  # seconds since epoch
-    runtime_type=datetime.datetime,  # microseconds component ignored
-    serialize=lambda dt: int(
-        (dt - datetime.datetime.fromtimestamp(0)).total_seconds()),
-    deserialize=lambda n: datetime.datetime.fromtimestamp(n),
 )
 _type_int = _FieldType(
     serialized_type=int,
@@ -67,7 +64,7 @@ _type_str = _FieldType(
 # Information about a running TensorBoard instance.
 _TENSORBOARD_INFO_FIELDS = collections.OrderedDict((
     ("version", _type_str),
-    ("start_time", _type_timestamp),
+    ("start_time", _type_int),  # seconds since epoch
     ("pid", _type_int),
     ("port", _type_int),
     ("path_prefix", _type_str),  # may be empty
@@ -397,7 +394,7 @@ def start(arguments, timeout=datetime.timedelta(seconds=60)):
 
   (stdout_fd, stdout_path) = tempfile.mkstemp(prefix=".tensorboard-stdout-")
   (stderr_fd, stderr_path) = tempfile.mkstemp(prefix=".tensorboard-stderr-")
-  start_time = datetime.datetime.now()
+  start_time = time.time()
   try:
     p = subprocess.Popen(
         ["tensorboard"] + arguments,
@@ -409,8 +406,8 @@ def start(arguments, timeout=datetime.timedelta(seconds=60)):
     os.close(stderr_fd)
 
   poll_interval_seconds = 0.5
-  end_time = start_time + timeout
-  while datetime.datetime.now() < end_time:
+  end_time = start_time + timeout.total_seconds()
+  while time.time() < end_time:
     time.sleep(poll_interval_seconds)
     subprocess_result = p.poll()
     if subprocess_result is not None:

--- a/tensorboard/manager_test.py
+++ b/tensorboard/manager_test.py
@@ -50,7 +50,7 @@ def _make_info(i=0):
   """
   return manager.TensorBoardInfo(
       version=version.VERSION,
-      start_time=datetime.datetime.fromtimestamp(1548973541 + i),
+      start_time=1548973541 + i,
       port=6060 + i,
       pid=76540 + i,
       path_prefix="/foo",
@@ -71,11 +71,12 @@ class TensorBoardInfoTest(tf.test.TestCase):
     self.assertEqual(also_info, info)
 
   def test_serialization_rejects_bad_types(self):
-    info = _make_info()._replace(start_time=1549061116)  # not a datetime
+    bad_time = datetime.datetime.fromtimestamp(1549061116)  # not an int
+    info = _make_info()._replace(start_time=bad_time)
     with six.assertRaisesRegex(
         self,
         ValueError,
-        "expected 'start_time' of type.*datetime.*, but found: 1549061116"):
+        "expected 'start_time' of type.*int.*, but found: datetime\."):
       manager._info_to_string(info)
 
   def test_serialization_rejects_wrong_version(self):
@@ -291,11 +292,12 @@ class TensorBoardInfoIoTest(tf.test.TestCase):
   def test_write_info_file_rejects_bad_types(self):
     # The particulars of validation are tested more thoroughly in
     # `TensorBoardInfoTest` above.
-    info = _make_info()._replace(start_time=1549061116)
+    bad_time = datetime.datetime.fromtimestamp(1549061116)
+    info = _make_info()._replace(start_time=bad_time)
     with six.assertRaisesRegex(
         self,
         ValueError,
-        "expected 'start_time' of type.*datetime.*, but found: 1549061116"):
+        "expected 'start_time' of type.*int.*, but found: datetime\."):
       manager.write_info_file(info)
     self.assertEqual(self._list_info_dir(), [])
 

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 import datetime
 import shlex
 import sys
+import time
 
 from tensorboard import manager
 
@@ -204,9 +205,8 @@ def _time_delta_from_info(info):
     A human-readable string describing the time since the server
     described by `info` started: e.g., "2 days, 0:48:58".
   """
-  now = datetime.datetime.now()
-  then = info.start_time
-  return str(now.replace(microsecond=0) - then.replace(microsecond=0))
+  delta_seconds = int(time.time()) - info.start_time
+  return str(datetime.timedelta(seconds=delta_seconds))
 
 
 def display(port=None, height=None):

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -34,13 +34,13 @@ from abc import abstractmethod
 import argparse
 import atexit
 from collections import defaultdict
-import datetime
 import errno
 import os
 import signal
 import socket
 import sys
 import threading
+import time
 import inspect
 
 import absl.logging
@@ -262,7 +262,7 @@ class TensorBoard(object):
     server_url = urllib.parse.urlparse(server.get_url())
     info = manager.TensorBoardInfo(
         version=version.VERSION,
-        start_time=datetime.datetime.now(),
+        start_time=int(time.time()),
         port=server_url.port,
         pid=os.getpid(),
         path_prefix=self.flags.path_prefix,


### PR DESCRIPTION
Summary:
Fixes #2017. I’ve spent multiple hours on multiple weekends trying to
figure out how to get Python `datetime`s to properly (a) count seconds
since the epoch and (b) serialize and deserialize properly on all
platforms and all Python versions. I have failed. If nothing else, I can
trust in `int`s.

This is a backward-compatible change: the data format on disk is
unchanged, and the only APIs with incompatible changes were always
explicitly marked as private.

Test Plan:
In addition to running `//tensorboard:manager_e2e_test`, I built a Pip
package and exercised the full notebook workflow in Jupyter (magic
invocation plus `tensorboard.notebook` API) in Python 2 and 3.

wchargin-branch: bare-int-times
