### PR TITLE
hparams: fix demo Unicode handling in Python 3

### DIFF
--- a/tensorboard/plugins/hparams/hparams_demo.py
+++ b/tensorboard/plugins/hparams/hparams_demo.py
@@ -84,7 +84,7 @@ def init_temperature_list():
 
 def fingerprint(string):
   m = hashlib.md5()
-  m.update(string)
+  m.update(string.encode('utf-8'))
   return m.hexdigest()
 
 
@@ -233,9 +233,9 @@ def run_all(logdir, verbose=False):
   for initial_temperature in TEMPERATURE_LIST:
     for ambient_temperature in TEMPERATURE_LIST:
       for material in HEAT_COEFFICIENTS:
-        hparams = {'initial_temperature': initial_temperature,
-                   'ambient_temperature': ambient_temperature,
-                   'material': material}
+        hparams = {u'initial_temperature': initial_temperature,
+                   u'ambient_temperature': ambient_temperature,
+                   u'material': material}
         hparam_str = str(hparams)
         group_name = fingerprint(hparam_str)
         for repeat_idx in xrange(2):


### PR DESCRIPTION
Summary:
Fixes #1564. Supersedes #1565 by using Unicode strings in both Python
versions, rather than using bare literals and only sometimes explicitly
encoding them.

Test Plan:
Running `bazel run //tensorboard/plugins/hparams:hparams_demo` now
passes in both Python 2 and Python 3, whereas prior to this commit it
passed in Python 2 but failed with “TypeError: Unicode-objects must be
encoded before hashing” in Python 3.

wchargin-branch: hparams-demo-unicode
