### PR TITLE
graph: sync parser config to proto counterpart

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/parser.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/parser.ts
@@ -156,23 +156,45 @@ export function streamParse(
  * to be repeated. This list is used in parsing time to convert repeated
  * attributes into arrays even when the attribute only shows up once in the
  * object.
+ * Repeated fields have to be in sync with graph.proto and all of its
+ * dependencies.
+ * See https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/framework/graph.proto
  */
 const GRAPH_REPEATED_FIELDS: {[attrPath: string]: boolean} = {
   'library.function': true,
   'library.function.node_def': true,
+  'library.function.node_def.input': true,
+  'library.function.node_def.attr': true,
+  'library.function.node_def.attr.value.list.b': true,
+  'library.function.node_def.attr.value.list.f': true,
+  'library.function.node_def.attr.value.list.func': true,
+  'library.function.node_def.attr.value.list.i': true,
+  'library.function.node_def.attr.value.list.s': true,
+  'library.function.node_def.attr.value.list.shape': true,
+  'library.function.node_def.attr.value.list.shape.dim': true,
+  'library.function.node_def.attr.value.list.tensor': true,
+  'library.function.node_def.attr.value.list.type': true,
+  'library.function.node_def.attr.value.shape.dim': true,
+  'library.function.node_def.attr.value.tensor.string_val': true,
+  'library.function.node_def.attr.value.tensor.tensor_shape.dim': true,
   'library.function.signature.input_arg': true,
   'library.function.signature.output_arg': true,
   'library.versions': true,
   'node': true,
   'node.input': true,
   'node.attr': true,
+  'node.attr.value.list.b': true,
+  'node.attr.value.list.f': true,
+  'node.attr.value.list.func': true,
+  'node.attr.value.list.i': true,
+  'node.attr.value.list.s': true,
+  'node.attr.value.list.shape': true,
+  'node.attr.value.list.shape.dim': true,
+  'node.attr.value.list.tensor': true,
   'node.attr.value.list.type': true,
   'node.attr.value.shape.dim': true,
   'node.attr.value.tensor.string_val': true,
   'node.attr.value.tensor.tensor_shape.dim': true,
-  'node.attr.value.list.shape': true,
-  'node.attr.value.list.shape.dim': true,
-  'node.attr.value.list.s': true
 };
 
 const METADATA_REPEATED_FIELDS: {[attrPath: string]: boolean} = {

--- a/tensorboard/plugins/graph/tf_graph_common/test/parser-test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/test/parser-test.ts
@@ -107,24 +107,24 @@ describe('parser', () => {
             .that.is.an('array')
             .and.that.has.length(1);
 
-        const first_func = graph.library.function[0];
+        const firstFunc = graph.library.function[0];
 
-        expect(first_func).to.have.property('signature')
+        expect(firstFunc).to.have.property('signature')
             .that.has.property('name', 'foo');
 
-        expect(first_func).to.have.property('node_def')
+        expect(firstFunc).to.have.property('node_def')
             .that.is.an('array')
             .and.that.has.length(2);
 
-        expect(first_func.node_def[0]).to.have.property('name', 'NoOp');
-        expect(first_func.node_def[0]).to.not.have.property('input');
-        expect(first_func.node_def[0]).to.have.property('attr')
+        expect(firstFunc.node_def[0]).to.have.property('name', 'NoOp');
+        expect(firstFunc.node_def[0]).to.not.have.property('input');
+        expect(firstFunc.node_def[0]).to.have.property('attr')
             .that.deep.equal([{key: '_output_shapes', value: {list: {}}}]);
 
-        expect(first_func.node_def[1]).to.have.property('name', 'Identity');
-        expect(first_func.node_def[1]).to.have.property('input')
+        expect(firstFunc.node_def[1]).to.have.property('name', 'Identity');
+        expect(firstFunc.node_def[1]).to.have.property('input')
             .that.deep.equal(['placeholder_1', '^NoOp']);
-        expect(first_func.node_def[1]).to.have.property('attr')
+        expect(firstFunc.node_def[1]).to.have.property('attr')
             .that.deep.equal([
                 {key: 'T', value: {type: 'DT_BOOL'}},
                 {key: '_output_shapes', value: {list: {shape: [{}]}}}

--- a/tensorboard/plugins/graph/tf_graph_common/test/parser-test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/test/parser-test.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 describe('parser', () => {
-  const {assert} = chai;
+  const {assert, expect} = chai;
 
   describe('parsing GraphDef pbtxt', () => {
     it('parses a simple pbtxt', () => {
@@ -46,6 +46,89 @@ describe('parser', () => {
         assert.equal('MatMul', nodes[2].op);
         assert.equal('Q', nodes[2].input[0]);
         assert.equal('W', nodes[2].input[1]);
+      });
+    });
+
+    it('parses function def library', () => {
+      const pbtxt = tf.graph.test.util.stringToArrayBuffer(`library {
+        function {
+          signature {
+            name: "foo"
+            input_arg {
+              name: "placeholder_1"
+              type: DT_INT32
+            }
+            input_arg {
+              name: "placeholder_2"
+              type: DT_BOOL
+            }
+            output_arg {
+              name: "identity"
+              type: DT_BOOL
+            }
+          }
+          node_def {
+            name: "NoOp"
+            op: "NoOp"
+            attr {
+              key: "_output_shapes"
+              value {
+                list {
+                }
+              }
+            }
+          }
+          node_def {
+            name: "Identity"
+            op: "Identity"
+            input: "placeholder_1"
+            input: "^NoOp"
+            attr {
+              key: "T"
+              value {
+                type: DT_BOOL
+              }
+            }
+            attr {
+              key: "_output_shapes"
+              value {
+                list {
+                  shape {
+                  }
+                }
+              }
+            }
+          }
+        }
+      }`);
+      return tf.graph.parser.parseGraphPbTxt(pbtxt).then(graph => {
+        expect(graph).to.have.property('library')
+            .that.has.property('function')
+            .that.is.an('array')
+            .and.that.has.length(1);
+
+        const first_func = graph.library.function[0];
+
+        expect(first_func).to.have.property('signature')
+            .that.has.property('name', 'foo');
+
+        expect(first_func).to.have.property('node_def')
+            .that.is.an('array')
+            .and.that.has.length(2);
+
+        expect(first_func.node_def[0]).to.have.property('name', 'NoOp');
+        expect(first_func.node_def[0]).to.not.have.property('input');
+        expect(first_func.node_def[0]).to.have.property('attr')
+            .that.deep.equal([{key: '_output_shapes', value: {list: {}}}]);
+
+        expect(first_func.node_def[1]).to.have.property('name', 'Identity');
+        expect(first_func.node_def[1]).to.have.property('input')
+            .that.deep.equal(['placeholder_1', '^NoOp']);
+        expect(first_func.node_def[1]).to.have.property('attr')
+            .that.deep.equal([
+                {key: 'T', value: {type: 'DT_BOOL'}},
+                {key: '_output_shapes', value: {list: {shape: [{}]}}}
+            ]);
       });
     });
 


### PR DESCRIPTION
A repeated field in Graph proto definition requires an entry in the
parser.ts to parse the text proto correctly. It was not only missing
entries for FunctionDefLibrary but also missed ones for few properties.

Do note that we did not encounter issues because we do not make use of
most of the properties.

Fixes #2062