### PR TITLE
Add separate non-TensorFlow test run in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ install:
   - pip install yamllint==1.5.0
   - |
     # Install TensorFlow if requested
-    if [ ! -z "${TF_VERSION_ID}" ]; then
+    if [ -n "${TF_VERSION_ID}" ]; then
       pip install -I "${TF_VERSION_ID}"
     else
       # Requirements typically found through TensorFlow

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,8 +111,8 @@ install:
       pip install -I "${TF_VERSION_ID}"
     else
       # Requirements typically found through TensorFlow
-      pip install absl-py>=0.7.0
-      pip install numpy<2.0,>=1.14.5
+      pip install "absl-py>=0.7.0"
+      pip install "numpy<2.0,>=1.14.5"
     fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
   matrix:
     - TF_VERSION_ID=tf-nightly
     - TF_VERSION_ID=tf-nightly-2.0-preview
+    - TF_VERSION_ID= # Do not install TensorFlow in this case
 
 cache:
   directories:
@@ -104,7 +105,11 @@ install:
   - pip install mock==2.0.0
   - pip install moto==1.3.7
   - pip install yamllint==1.5.0
-  - pip install -I "${TF_VERSION_ID}"
+  - |
+    # Install TensorFlow if requested
+    if [ ! -z "${TF_VERSION_ID}" ]; then
+      pip install -I "${TF_VERSION_ID}"
+    fi
 
 before_script:
   # fail the build if there are Python syntax errors or undefined names
@@ -127,7 +132,13 @@ script:
   # Note: bazel test implies fetch+build, but this gives us timing.
   - bazel fetch //tensorboard/...
   - bazel build //tensorboard/...
-  - bazel test //tensorboard/...
+  - |
+    # Limit tests without TensorFlow
+    if [ -z "${TF_VERSION_ID}" ]; then
+      bazel test //tensorboard/... --test_tag_filters=support_notf
+    else
+      bazel test //tensorboard/...
+    fi
   # Run manual S3 test
   - bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test
   - bazel run //tensorboard/pip_package:build_pip_package -- --tf-version "${TF_VERSION_ID}" --smoke

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,12 +137,13 @@ script:
   - bazel fetch //tensorboard/...
   - bazel build //tensorboard/...
   - |
-    # Limit tests without TensorFlow
+    # When TensorFlow is not installed, run a restricted subset of tests.
     if [ -z "${TF_VERSION_ID}" ]; then
-      bazel test //tensorboard/... --test_tag_filters=support_notf
+      test_tag_filters=support_notf
     else
-      bazel test //tensorboard/...
+      test_tag_filters=
     fi
+  - bazel test //tensorboard/... --test_tag_filters="${test_tag_filters}"
   # Run manual S3 test
   - bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test
   - bazel run //tensorboard/pip_package:build_pip_package -- --tf-version "${TF_VERSION_ID}" --smoke

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
   matrix:
     - TF_VERSION_ID=tf-nightly
     - TF_VERSION_ID=tf-nightly-2.0-preview
-    - TF_VERSION_ID= # Do not install TensorFlow in this case
+    - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:
   directories:
@@ -109,6 +109,10 @@ install:
     # Install TensorFlow if requested
     if [ ! -z "${TF_VERSION_ID}" ]; then
       pip install -I "${TF_VERSION_ID}"
+    else
+      # Requirements typically found through TensorFlow
+      pip install absl-py>=0.7.0
+      pip install numpy<2.0,>=1.14.5
     fi
 
 before_script:

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -52,6 +52,7 @@ py_test(
     srcs = ["lib_test.py"],
     srcs_version = "PY2AND3",
     visibility = ["//tensorboard:internal"],
+    tags = ["support_notf"],
     deps = [
         ":lib",
         "@org_pythonhosted_six",
@@ -366,6 +367,7 @@ py_test(
     srcs = ["lazy_test.py"],
     srcs_version = "PY2AND3",
     size = "small",
+    tags = ["support_notf"],
     deps = [
         ":lazy",
         "@org_pythonhosted_six",

--- a/tensorboard/compat/tensorflow_stub/BUILD
+++ b/tensorboard/compat/tensorflow_stub/BUILD
@@ -31,6 +31,7 @@ py_test(
     size = "small",
     srcs = ["io/gfile_test.py"],
     srcs_version = "PY2AND3",
+    tags = ["support_notf"],
     deps = [
         ":tensorflow_stub",
     ],

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -161,14 +161,14 @@ smoke() {
   python -c "
 import tensorboard as tb
 assert tb.__version__ == tb.version.VERSION
-tb.summary.scalar_pb('test', 42)
 from tensorboard.plugins.projector import visualize_embeddings
 tb.notebook.start  # don't invoke; just check existence
 "
   if [ -n "${smoke_tf}" ]; then
-    # Only test beholder with TF
+    # Only test summary scalar and beholder with TF
     python -c "
 import tensorboard as tb
+tb.summary.scalar_pb('test', 42)
 from tensorboard.plugins.beholder import Beholder, BeholderHook
 "
   fi

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -127,6 +127,7 @@ smoke() {
   printf '\n\n%70s\n' | tr ' ' '='
   if [ -z "${smoke_tf}" ]; then
     echo "Smoke testing with ${smoke_python} and no tensorflow..."
+    export TENSORBOARD_NO_TF=1
   else
     echo "Smoke testing with ${smoke_python} and ${smoke_tf}..."
   fi

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -174,8 +174,7 @@ from tensorboard.plugins.beholder import Beholder, BeholderHook
   fi
 
   if [ -n "${smoke_tf}" ]; then
-    # Exhaustively test various sequences of importing tf.summary
-    # but only with TF
+    # Exhaustively test various sequences of importing tf.summary.
     test_tf_summary() {
       # First argument is subpath to test, e.g. '' or '.compat.v2'.
       import_attr="import tensorflow as tf; a = tf${1}.summary; a.write; a.scalar"

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -138,7 +138,7 @@ smoke() {
   . bin/activate
   pip install -qU pip
 
-  if [ ! -z "${smoke_tf}" ]; then
+  if [ -n "${smoke_tf}" ]; then
     pip install -qU "${smoke_tf}"
   fi
   pip install -qU ../dist/*"py${py_major_version}"*.whl >/dev/null
@@ -167,10 +167,7 @@ tb.notebook.start  # don't invoke; just check existence
 "
 
   # Check if we are testing with or without tf
-  is_tf() {
-    python -c "import tensorflow as tf" >/dev/null 2>&1
-  }
-  if is_tf ; then
+  if [ -n "${smoke_tf}" ]; then
     # Exhaustively test various sequences of importing tf.summary.
     test_tf_summary() {
       # First argument is subpath to test, e.g. '' or '.compat.v2'.

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -163,13 +163,19 @@ import tensorboard as tb
 assert tb.__version__ == tb.version.VERSION
 tb.summary.scalar_pb('test', 42)
 from tensorboard.plugins.projector import visualize_embeddings
-from tensorboard.plugins.beholder import Beholder, BeholderHook
 tb.notebook.start  # don't invoke; just check existence
 "
-
-  # Check if we are testing with or without tf
   if [ -n "${smoke_tf}" ]; then
-    # Exhaustively test various sequences of importing tf.summary.
+    # Only test beholder with TF
+    python -c "
+import tensorboard as tb
+from tensorboard.plugins.beholder import Beholder, BeholderHook
+"
+  fi
+
+  if [ -n "${smoke_tf}" ]; then
+    # Exhaustively test various sequences of importing tf.summary
+    # but only with TF
     test_tf_summary() {
       # First argument is subpath to test, e.g. '' or '.compat.v2'.
       import_attr="import tensorflow as tf; a = tf${1}.summary; a.write; a.scalar"

--- a/tensorboard/summary/BUILD
+++ b/tensorboard/summary/BUILD
@@ -81,6 +81,7 @@ py_test(
     size = "small",
     srcs = ["summary_test.py"],
     srcs_version = "PY2AND3",
+    tags = ["support_notf"],
     deps = [
         ":summary",
         ":summary_v1",


### PR DESCRIPTION
Continuation of work for https://github.com/tensorflow/tensorboard/issues/2027 and ultimately removing the `TENSORBOARD_NO_TF=1` environment variable.

Plugins tests aren't run yet, but this confirms that build and limited tests run without TensorFlow installed.