### PR TITLE
Added datatype int64

### DIFF
--- a/tensorboard/plugins/hparams/api.proto
+++ b/tensorboard/plugins/hparams/api.proto
@@ -101,6 +101,7 @@ enum DataType {
   DATA_TYPE_STRING = 1;
   DATA_TYPE_BOOL = 2;
   DATA_TYPE_FLOAT64 = 3;
+  DATA_TYPE_INT64 = 4;
 }
 
 // Represents the closed interval [min_value, max_value] of the real line.


### PR DESCRIPTION
* I came across one comment of @omoindrot in #1998 

* I tried to add int 64 dtpe in api.proto but I am not at all sure about correct way of doing that.

* I added dtpe int64 in the the list of Datatypes in api.proto file present tensorboard/plugins/hparams

* Alternate designs / implementations considered
