### PR TITLE
Don't automatically run projection on tab change

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -481,11 +481,7 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
         new Projection('tsne', accessors, dimensionality, dataSet);
     this.projector.setProjection(projection);
 
-    if (!this.dataSet.hasTSNERun) {
-      this.runTSNE();
-    } else {
-      this.projector.notifyProjectionPositionsUpdated();
-    }
+    this.projector.notifyProjectionPositionsUpdated();
   }
 
   private runTSNE() {
@@ -533,11 +529,8 @@ export class ProjectionsPanel extends ProjectionsPanelPolymer {
         new Projection('umap', accessors, dimensionality, dataSet);
     this.projector.setProjection(projection);
 
-    if (!this.dataSet.hasUmapRun) {
-      this.runUmap();
-    } else {
-      this.projector.notifyProjectionPositionsUpdated();
-    }
+
+    this.projector.notifyProjectionPositionsUpdated();
   }
 
   private runUmap() {


### PR DESCRIPTION
It can be really jarring to click the "UMAP" or "t-SNE" tab and have the UX freeze while the projection begins running (computing knn to start). This is particularly problematic in the case of UMAP, where it's impossible to cancel the projection once it starts running. Additionally, it's not possible to set hyperparameters before running the projection.

This PR prevents the automatic running of the projection methods when the corresponding tab is selected (except for PCA, which is automatically run on startup)