### PR TITLE
beholder: fix image resizing

### DIFF
--- a/tensorboard/plugins/beholder/BUILD
+++ b/tensorboard/plugins/beholder/BUILD
@@ -27,6 +27,19 @@ py_library(
     ],
 )
 
+py_test(
+    name = "beholder_test",
+    srcs = ["beholder_test.py"],
+    size = "small",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":beholder",
+        "//tensorboard/util:test_util",
+        "//tensorboard:expect_numpy_installed",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
 py_library(
     name = "beholder_plugin",
     srcs = ["beholder_plugin.py"],

--- a/tensorboard/plugins/beholder/beholder_test.py
+++ b/tensorboard/plugins/beholder/beholder_test.py
@@ -1,0 +1,53 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for some very basic Beholder functionality."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+from tensorboard.plugins import beholder
+from tensorboard.util import test_util
+import tensorflow as tf
+
+
+class BeholderTest(tf.test.TestCase):
+
+  def setUp(self):
+    self._current_time_seconds = 1554232353
+
+  def advance_time(self, delta_seconds):
+    self._current_time_seconds += delta_seconds
+
+  def get_time(self):
+    return self._current_time_seconds
+
+  @test_util.run_v1_only("Requires sessions")
+  def test_update(self):
+    with tf.test.mock.patch("time.time", self.get_time):
+      b = beholder.Beholder(self.get_temp_dir())
+      array = np.array([[0, 1], [1, 0]])
+      with tf.Session() as sess:
+        v = tf.Variable([0, 0], trainable=True)
+        sess.run(tf.global_variables_initializer())
+        # Beholder only updates if at least one frame has passed. The
+        # default FPS value is 10, but in any case 100 seconds ought to
+        # do it.
+        self.advance_time(delta_seconds=100)
+        b.update(session=sess, arrays=[array])
+
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/tensorboard/plugins/beholder/im_util.py
+++ b/tensorboard/plugins/beholder/im_util.py
@@ -119,9 +119,10 @@ class Resizer(op_evaluator.PersistentOpEvaluator):
   def initialize_graph(self):
     self._image_placeholder = tf.compat.v1.placeholder(dtype=tf.float32)
     self._size_placeholder = tf.compat.v1.placeholder(dtype=tf.int32)
-    self._resize_op = tf.image.resize(self._image_placeholder,
-                                      self._size_placeholder,
-                                      method=tf.image.ResizeMethod.NEAREST_NEIGHBOR)
+    self._resize_op = tf.compat.v1.image.resize_nearest_neighbor(
+        self._image_placeholder,
+        self._size_placeholder,
+    )
 
   # pylint: disable=arguments-differ
   def run(self, image, height, width):


### PR DESCRIPTION
Summary:
This reverts part of #1734 to fix #2073. A change to the TensorFlow APIs
added a static shape requirement, but Beholder’s image resizer operates
on images whose size is not statically known.

Test code adapted from @comzyh’s MWE in #2073—thanks!

Test Plan:
Added a unit test, which has the correct pass/fail behavior on current
`tf-nightly` and TensorFlow 1.13.1. The test does not run in TF 2.0,
because Beholder depends on sessions.

wchargin-branch: fix-2073
