### PR TITLE
docs: describe PATH requirements for Jupyter

### DIFF
--- a/docs/r2/tensorboard_in_notebooks.ipynb
+++ b/docs/r2/tensorboard_in_notebooks.ipynb
@@ -77,7 +77,14 @@
       },
       "cell_type": "markdown",
       "source": [
-        "TensorBoard can be used directly within notebook experiences such as [Colab](https://colab.research.google.com/) and [Jupyter](https://jupyter.org/). This can be helpful for sharing results, integrating TensorBoard into existing workflows, and using TensorBoard without installing anything locally."
+        "TensorBoard can be used directly within notebook experiences such as [Colab](https://colab.research.google.com/) and [Jupyter](https://jupyter.org/). This can be helpful for sharing results, integrating TensorBoard into existing workflows, and using TensorBoard without installing anything locally.\n",
+        "\n",
+        "**For Jupyter users:** If you’ve installed Jupyter and TensorBoard into\n",
+        "the same virtualenv, then you should be good to go. If you’re using a\n",
+        "more complicated setup, like a global Jupyter installation with a custom\n",
+        "kernelspec, then you must ensure that the `tensorboard` binary is on\n",
+        "your `PATH` inside the Jupyter notebook context by prepending your\n",
+        "virtualenv’s `bin` directory to `os.environ[\"PATH\"]`."
       ]
     },
     {

--- a/docs/r2/tensorboard_in_notebooks.ipynb
+++ b/docs/r2/tensorboard_in_notebooks.ipynb
@@ -81,10 +81,13 @@
         "\n",
         "**For Jupyter users:** If you’ve installed Jupyter and TensorBoard into\n",
         "the same virtualenv, then you should be good to go. If you’re using a\n",
-        "more complicated setup, like a global Jupyter installation with a custom\n",
-        "kernelspec, then you must ensure that the `tensorboard` binary is on\n",
-        "your `PATH` inside the Jupyter notebook context by prepending your\n",
-        "virtualenv’s `bin` directory to `os.environ[\"PATH\"]`."
+        "more complicated setup, like a global Jupyter installation and kernels\n",
+        "for different Conda/virtualenv environments, then you must ensure that\n",
+        "the `tensorboard` binary is on your `PATH` inside the Jupyter notebook\n",
+        "context. One way to do this is to modify the `kernel_spec` to prepend\n",
+        "the environment’s `bin` directory to `PATH`, [as described here][1].\n",
+        "\n",
+        "[1]: https://github.com/ipython/ipykernel/issues/395#issuecomment-479787997\n"
       ]
     },
     {

--- a/docs/r2/tensorboard_in_notebooks.ipynb
+++ b/docs/r2/tensorboard_in_notebooks.ipynb
@@ -77,17 +77,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "TensorBoard can be used directly within notebook experiences such as [Colab](https://colab.research.google.com/) and [Jupyter](https://jupyter.org/). This can be helpful for sharing results, integrating TensorBoard into existing workflows, and using TensorBoard without installing anything locally.\n",
-        "\n",
-        "**For Jupyter users:** If you’ve installed Jupyter and TensorBoard into\n",
-        "the same virtualenv, then you should be good to go. If you’re using a\n",
-        "more complicated setup, like a global Jupyter installation and kernels\n",
-        "for different Conda/virtualenv environments, then you must ensure that\n",
-        "the `tensorboard` binary is on your `PATH` inside the Jupyter notebook\n",
-        "context. One way to do this is to modify the `kernel_spec` to prepend\n",
-        "the environment’s `bin` directory to `PATH`, [as described here][1].\n",
-        "\n",
-        "[1]: https://github.com/ipython/ipykernel/issues/395#issuecomment-479787997\n"
+        "TensorBoard can be used directly within notebook experiences such as [Colab](https://colab.research.google.com/) and [Jupyter](https://jupyter.org/). This can be helpful for sharing results, integrating TensorBoard into existing workflows, and using TensorBoard without installing anything locally."
       ]
     },
     {
@@ -107,7 +97,17 @@
       },
       "cell_type": "markdown",
       "source": [
-        "Start by installing TF 2.0 and loading the TensorBoard notebook extension:"
+        "Start by installing TF 2.0 and loading the TensorBoard notebook extension:\n",
+        "\n",
+        "**For Jupyter users:** If you’ve installed Jupyter and TensorBoard into\n",
+        "the same virtualenv, then you should be good to go. If you’re using a\n",
+        "more complicated setup, like a global Jupyter installation and kernels\n",
+        "for different Conda/virtualenv environments, then you must ensure that\n",
+        "the `tensorboard` binary is on your `PATH` inside the Jupyter notebook\n",
+        "context. One way to do this is to modify the `kernel_spec` to prepend\n",
+        "the environment’s `bin` directory to `PATH`, [as described here][1].\n",
+        "\n",
+        "[1]: https://github.com/ipython/ipykernel/issues/395#issuecomment-479787997\n"
       ]
     },
     {


### PR DESCRIPTION
Summary:
Closes tensorflow/tensorflow#27304, wherein a user noted difficulty
using the TensorBoard notebook extensions with Jupyter installed as a
user-level site package rather than in the virtualenv.

Test Plan:
Uploaded this notebook to Colab; the Markdown renders properly:

![Screenshot of rendered Markdown](https://user-images.githubusercontent.com/4317806/56541384-6935c080-6520-11e9-8259-e60a28819c24.png)

wchargin-branch: docs-jupyter-path
