### PR TITLE
Enable more tests in notf case for Travis CI

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -77,11 +77,11 @@ py_test(
     srcs = ["manager_test.py"],
     srcs_version = "PY2AND3",
     visibility = ["//tensorboard:internal"],
+    tags = ["support_notf"],
     deps = [
         ":manager",
         ":version",
         "//tensorboard/util:tb_logging",
-        "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],
 )
@@ -138,10 +138,10 @@ py_test(
     size = "small",
     srcs = ["program_test.py"],
     srcs_version = "PY2AND3",
+    tags = ["support_notf"],
     deps = [
         ":default",
         ":program",
-        "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/plugins/core:core_plugin",
         "@org_pocoo_werkzeug",
@@ -343,9 +343,9 @@ py_test(
     size = "small",
     srcs = ["plugin_util_test.py"],
     srcs_version = "PY2AND3",
+    tags = ["support_notf"],
     deps = [
         ":plugin_util",
-        "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -348,6 +348,7 @@ py_test(
     tags = ["support_notf"],
     deps = [
         ":plugin_util",
+        "//tensorboard/util:test_case",
         "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -80,9 +80,9 @@ py_test(
     tags = ["support_notf"],
     deps = [
         ":manager",
+        ":test",
         ":version",
         "//tensorboard/util:tb_logging",
-        "//tensorboard/util:test_case",
         "@org_pythonhosted_six",
     ],
 )
@@ -143,10 +143,21 @@ py_test(
     deps = [
         ":default",
         ":program",
+        ":test",
         "//tensorboard/backend:application",
         "//tensorboard/plugins/core:core_plugin",
-        "//tensorboard/util:test_case",
         "@org_pocoo_werkzeug",
+    ],
+)
+
+py_library(
+    name = "test",
+    testonly = 1,
+    srcs = ["test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        "//tensorboard/util:tb_logging",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -348,7 +359,7 @@ py_test(
     tags = ["support_notf"],
     deps = [
         ":plugin_util",
-        "//tensorboard/util:test_case",
+        ":test",
         "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -82,6 +82,7 @@ py_test(
         ":manager",
         ":version",
         "//tensorboard/util:tb_logging",
+        "//tensorboard/util:test_case",
         "@org_pythonhosted_six",
     ],
 )
@@ -144,6 +145,7 @@ py_test(
         ":program",
         "//tensorboard/backend:application",
         "//tensorboard/plugins/core:core_plugin",
+        "//tensorboard/util:test_case",
         "@org_pocoo_werkzeug",
     ],
 )

--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -28,7 +28,7 @@ py_test(
     tags = ["support_notf"],
     deps = [
         ":http_util",
-        "//tensorboard/util:test_case",
+        "//tensorboard:test",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],
@@ -52,7 +52,7 @@ py_test(
     tags = ["support_notf"],
     deps = [
         ":json_util",
-        "//tensorboard/util:test_case",
+        "//tensorboard:test",
     ],
 )
 
@@ -86,9 +86,9 @@ py_test(
     tags = ["support_notf"],
     deps = [
         ":application",
+        "//tensorboard:test",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
-        "//tensorboard/util:test_case",
         "@org_pocoo_werkzeug",
     ],
 )

--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -25,9 +25,9 @@ py_test(
     size = "small",
     srcs = ["http_util_test.py"],
     srcs_version = "PY2AND3",
+    tags = ["support_notf"],
     deps = [
         ":http_util",
-        "//tensorboard:expect_tensorflow_installed",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],
@@ -48,9 +48,9 @@ py_test(
     size = "small",
     srcs = ["json_util_test.py"],
     srcs_version = "PY2AND3",
+    tags = ["support_notf"],
     deps = [
         ":json_util",
-        "//tensorboard:expect_tensorflow_installed",
     ],
 )
 
@@ -81,9 +81,9 @@ py_test(
     size = "small",
     srcs = ["application_test.py"],
     srcs_version = "PY2AND3",
+    tags = ["support_notf"],
     deps = [
         ":application",
-        "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
         "@org_pocoo_werkzeug",

--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -28,6 +28,7 @@ py_test(
     tags = ["support_notf"],
     deps = [
         ":http_util",
+        "//tensorboard/util:test_case",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],
@@ -51,6 +52,7 @@ py_test(
     tags = ["support_notf"],
     deps = [
         ":json_util",
+        "//tensorboard/util:test_case",
     ],
 )
 
@@ -86,6 +88,7 @@ py_test(
         ":application",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:test_case",
         "@org_pocoo_werkzeug",
     ],
 )

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -39,10 +39,10 @@ except ImportError:
 from werkzeug import test as werkzeug_test
 from werkzeug import wrappers
 
+from tensorboard import test as tb_test
 from tensorboard.backend import application
 from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
 from tensorboard.plugins import base_plugin
-from tensorboard.util import test_case
 
 
 class FakeFlags(object):
@@ -117,7 +117,7 @@ class FakePlugin(base_plugin.TBPlugin):
     return self._is_active_value
 
 
-class ApplicationTest(test_case.TestCase):
+class ApplicationTest(tb_test.TestCase):
   def setUp(self):
     plugins = [
         FakePlugin(
@@ -150,7 +150,7 @@ class ApplicationTest(test_case.TestCase):
     self.assertEqual(parsed_object, {'foo': True, 'bar': False})
 
 
-class ApplicationBaseUrlTest(test_case.TestCase):
+class ApplicationBaseUrlTest(tb_test.TestCase):
   path_prefix = '/test'
   def setUp(self):
     plugins = [
@@ -190,7 +190,7 @@ class ApplicationBaseUrlTest(test_case.TestCase):
     self.assertEqual(parsed_object, {'foo': True, 'bar': False})
 
 
-class ApplicationPluginNameTest(test_case.TestCase):
+class ApplicationPluginNameTest(tb_test.TestCase):
 
   def _test(self, name, should_be_okay):
     temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
@@ -232,7 +232,7 @@ class ApplicationPluginNameTest(test_case.TestCase):
     self._test('Scalar-Dashboard_3000.1', True)
 
 
-class ApplicationPluginRouteTest(test_case.TestCase):
+class ApplicationPluginRouteTest(tb_test.TestCase):
 
   def _test(self, route, should_be_okay):
     temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
@@ -265,7 +265,7 @@ class ApplicationPluginRouteTest(test_case.TestCase):
     self._test('runaway', False)
 
 
-class ParseEventFilesSpecTest(test_case.TestCase):
+class ParseEventFilesSpecTest(tb_test.TestCase):
 
   def assertPlatformSpecificLogdirParsing(self, pathObj, logdir, expected):
     """
@@ -386,7 +386,7 @@ class ParseEventFilesSpecTest(test_case.TestCase):
           ntpath, 'A:C:\\foo\\path', {'C:\\foo\\path': 'A'})
 
 
-class TensorBoardPluginsTest(test_case.TestCase):
+class TensorBoardPluginsTest(tb_test.TestCase):
 
   def setUp(self):
     self.context = None
@@ -435,7 +435,7 @@ class TensorBoardPluginsTest(test_case.TestCase):
     self.assertEqual('bar', mapping['bar'].plugin_name)
 
 
-class ApplicationConstructionTest(test_case.TestCase):
+class ApplicationConstructionTest(tb_test.TestCase):
 
   def testExceptions(self):
     logdir = '/fake/foo'
@@ -461,7 +461,7 @@ class ApplicationConstructionTest(test_case.TestCase):
       application.TensorBoardWSGIApp(logdir, plugins, multiplexer, 0, '')
 
 
-class DbTest(test_case.TestCase):
+class DbTest(tb_test.TestCase):
 
   def testSqliteDb(self):
     db_uri = 'sqlite:' + os.path.join(self.get_temp_dir(), 'db')
@@ -526,4 +526,4 @@ class DbTest(test_case.TestCase):
 
 
 if __name__ == '__main__':
-  test_case.main()
+  tb_test.main()

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -438,7 +438,7 @@ class TensorBoardPluginsTest(unittest.TestCase):
   def testNameToPluginMapping(self):
     # The mapping from plugin name to instance should include both plugins.
     mapping = self.context.plugin_name_to_instance
-    self.assertItemsEqual(['foo', 'bar'], list(mapping.keys()))
+    six.assertCountEqual(self, ['foo', 'bar'], list(mapping.keys()))
     self.assertEqual('foo', mapping['foo'].plugin_name)
     self.assertEqual('bar', mapping['bar'].plugin_name)
 

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -29,7 +29,7 @@ import socket
 import tempfile
 
 import six
-import tensorflow as tf
+import unittest
 
 try:
   # python version >= 3.3
@@ -117,7 +117,7 @@ class FakePlugin(base_plugin.TBPlugin):
     return self._is_active_value
 
 
-class ApplicationTest(tf.test.TestCase):
+class ApplicationTest(unittest.TestCase):
   def setUp(self):
     plugins = [
         FakePlugin(
@@ -150,7 +150,7 @@ class ApplicationTest(tf.test.TestCase):
     self.assertEqual(parsed_object, {'foo': True, 'bar': False})
 
 
-class ApplicationBaseUrlTest(tf.test.TestCase):
+class ApplicationBaseUrlTest(unittest.TestCase):
   path_prefix = '/test'
   def setUp(self):
     plugins = [
@@ -190,11 +190,14 @@ class ApplicationBaseUrlTest(tf.test.TestCase):
     self.assertEqual(parsed_object, {'foo': True, 'bar': False})
 
 
-class ApplicationPluginNameTest(tf.test.TestCase):
+class ApplicationPluginNameTest(unittest.TestCase):
+
+  def setUp(self):
+    self.temp_dir = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, self.temp_dir)
 
   def _test(self, name, should_be_okay):
-    temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
-    self.addCleanup(shutil.rmtree, temp_dir)
+    temp_dir = tempfile.mkdtemp(prefix=self.temp_dir)
     multiplexer = event_multiplexer.EventMultiplexer(
         size_guidance=application.DEFAULT_SIZE_GUIDANCE,
         purge_orphaned_data=True)
@@ -232,11 +235,14 @@ class ApplicationPluginNameTest(tf.test.TestCase):
     self._test('Scalar-Dashboard_3000.1', True)
 
 
-class ApplicationPluginRouteTest(tf.test.TestCase):
+class ApplicationPluginRouteTest(unittest.TestCase):
+
+  def setUp(self):
+    self.temp_dir = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, self.temp_dir)
 
   def _test(self, route, should_be_okay):
-    temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())
-    self.addCleanup(shutil.rmtree, temp_dir)
+    temp_dir = tempfile.mkdtemp(prefix=self.temp_dir)
     multiplexer = event_multiplexer.EventMultiplexer(
         size_guidance=application.DEFAULT_SIZE_GUIDANCE,
         purge_orphaned_data=True)
@@ -265,7 +271,7 @@ class ApplicationPluginRouteTest(tf.test.TestCase):
     self._test('runaway', False)
 
 
-class ParseEventFilesSpecTest(tf.test.TestCase):
+class ParseEventFilesSpecTest(unittest.TestCase):
 
   def assertPlatformSpecificLogdirParsing(self, pathObj, logdir, expected):
     """
@@ -386,14 +392,16 @@ class ParseEventFilesSpecTest(tf.test.TestCase):
           ntpath, 'A:C:\\foo\\path', {'C:\\foo\\path': 'A'})
 
 
-class TensorBoardPluginsTest(tf.test.TestCase):
+class TensorBoardPluginsTest(unittest.TestCase):
 
   def setUp(self):
     self.context = None
+    self.temp_dir = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, self.temp_dir)
     dummy_assets_zip_provider = lambda: None
     # The application should have added routes for both plugins.
     self.app = application.standard_tensorboard_wsgi(
-        FakeFlags(logdir=self.get_temp_dir()),
+        FakeFlags(logdir=self.temp_dir),
         [
           base_plugin.BasicLoader(functools.partial(
               FakePlugin,
@@ -435,7 +443,7 @@ class TensorBoardPluginsTest(tf.test.TestCase):
     self.assertEqual('bar', mapping['bar'].plugin_name)
 
 
-class ApplicationConstructionTest(tf.test.TestCase):
+class ApplicationConstructionTest(unittest.TestCase):
 
   def testExceptions(self):
     logdir = '/fake/foo'
@@ -461,10 +469,14 @@ class ApplicationConstructionTest(tf.test.TestCase):
       application.TensorBoardWSGIApp(logdir, plugins, multiplexer, 0, '')
 
 
-class DbTest(tf.test.TestCase):
+class DbTest(unittest.TestCase):
+
+  def setUp(self):
+    self.temp_dir = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, self.temp_dir)
 
   def testSqliteDb(self):
-    db_uri = 'sqlite:' + os.path.join(self.get_temp_dir(), 'db')
+    db_uri = 'sqlite:' + os.path.join(self.temp_dir, 'db')
     db_module, db_connection_provider = application.get_database_info(db_uri)
     self.assertTrue(hasattr(db_module, 'Date'))
     with contextlib.closing(db_connection_provider()) as conn:
@@ -479,7 +491,7 @@ class DbTest(tf.test.TestCase):
         self.assertEqual(('justine',), c.fetchone())
 
   def testTransactionRollback(self):
-    db_uri = 'sqlite:' + os.path.join(self.get_temp_dir(), 'db')
+    db_uri = 'sqlite:' + os.path.join(self.temp_dir, 'db')
     _, db_connection_provider = application.get_database_info(db_uri)
     with contextlib.closing(db_connection_provider()) as conn:
       with conn:
@@ -498,7 +510,7 @@ class DbTest(tf.test.TestCase):
 
   def testTransactionRollback_doesntDoAnythingIfIsolationLevelIsNone(self):
     # NOTE: This is a terrible idea. Don't do this.
-    db_uri = ('sqlite:' + os.path.join(self.get_temp_dir(), 'db') +
+    db_uri = ('sqlite:' + os.path.join(self.temp_dir, 'db') +
               '?isolation_level=null')
     _, db_connection_provider = application.get_database_info(db_uri)
     with contextlib.closing(db_connection_provider()) as conn:
@@ -526,4 +538,4 @@ class DbTest(tf.test.TestCase):
 
 
 if __name__ == '__main__':
-  tf.test.main()
+  unittest.main()

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -26,11 +26,12 @@ import struct
 import six
 from werkzeug import test as wtest
 from werkzeug import wrappers
+
+from tensorboard import test as tb_test
 from tensorboard.backend import http_util
-from tensorboard.util import test_case
 
 
-class RespondTest(test_case.TestCase):
+class RespondTest(tb_test.TestCase):
 
   def testHelloWorld(self):
     q = wrappers.Request(wtest.EnvironBuilder().get_environ())
@@ -197,4 +198,4 @@ def _bitflip(bs):
                   for i in range(len(bs)))
 
 if __name__ == '__main__':
-  test_case.main()
+  tb_test.main()

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -24,13 +24,13 @@ import gzip
 import struct
 
 import six
-import unittest
 from werkzeug import test as wtest
 from werkzeug import wrappers
 from tensorboard.backend import http_util
+from tensorboard.util import test_case
 
 
-class RespondTest(unittest.TestCase):
+class RespondTest(test_case.TestCase):
 
   def testHelloWorld(self):
     q = wrappers.Request(wtest.EnvironBuilder().get_environ())
@@ -197,4 +197,4 @@ def _bitflip(bs):
                   for i in range(len(bs)))
 
 if __name__ == '__main__':
-  unittest.main()
+  test_case.main()

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -24,13 +24,13 @@ import gzip
 import struct
 
 import six
-import tensorflow as tf
+import unittest
 from werkzeug import test as wtest
 from werkzeug import wrappers
 from tensorboard.backend import http_util
 
 
-class RespondTest(tf.test.TestCase):
+class RespondTest(unittest.TestCase):
 
   def testHelloWorld(self):
     q = wrappers.Request(wtest.EnvironBuilder().get_environ())
@@ -197,4 +197,4 @@ def _bitflip(bs):
                   for i in range(len(bs)))
 
 if __name__ == '__main__':
-  tf.test.main()
+  unittest.main()

--- a/tensorboard/backend/json_util_test.py
+++ b/tensorboard/backend/json_util_test.py
@@ -17,15 +17,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import unittest
-
-
 from tensorboard.backend import json_util
+from tensorboard.util import test_case
 
 _INFINITY = float('inf')
 
 
-class FloatWrapperTest(unittest.TestCase):
+class FloatWrapperTest(test_case.TestCase):
 
   def _assertWrapsAs(self, to_wrap, expected):
     """Asserts that |to_wrap| becomes |expected| when wrapped."""
@@ -63,4 +61,4 @@ class FloatWrapperTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  test_case.main()

--- a/tensorboard/backend/json_util_test.py
+++ b/tensorboard/backend/json_util_test.py
@@ -17,13 +17,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from tensorboard import test as tb_test
 from tensorboard.backend import json_util
-from tensorboard.util import test_case
 
 _INFINITY = float('inf')
 
 
-class FloatWrapperTest(test_case.TestCase):
+class FloatWrapperTest(tb_test.TestCase):
 
   def _assertWrapsAs(self, to_wrap, expected):
     """Asserts that |to_wrap| becomes |expected| when wrapped."""
@@ -61,4 +61,4 @@ class FloatWrapperTest(test_case.TestCase):
 
 
 if __name__ == '__main__':
-  test_case.main()
+  tb_test.main()

--- a/tensorboard/backend/json_util_test.py
+++ b/tensorboard/backend/json_util_test.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import unittest
 
 
 from tensorboard.backend import json_util
@@ -25,7 +25,7 @@ from tensorboard.backend import json_util
 _INFINITY = float('inf')
 
 
-class FloatWrapperTest(tf.test.TestCase):
+class FloatWrapperTest(unittest.TestCase):
 
   def _assertWrapsAs(self, to_wrap, expected):
     """Asserts that |to_wrap| becomes |expected| when wrapped."""
@@ -63,4 +63,4 @@ class FloatWrapperTest(tf.test.TestCase):
 
 
 if __name__ == '__main__':
-  tf.test.main()
+  unittest.main()

--- a/tensorboard/manager_test.py
+++ b/tensorboard/manager_test.py
@@ -23,7 +23,6 @@ import errno
 import json
 import os
 import re
-import shutil
 import tempfile
 
 import six

--- a/tensorboard/manager_test.py
+++ b/tensorboard/manager_test.py
@@ -265,9 +265,6 @@ class TensorBoardInfoIoTest(test_case.TestCase):
     tempfile.tempdir = None  # force `gettempdir` to reinitialize from env
     self.info_dir = manager._get_info_dir()  # ensure that directory exists
 
-  def tearDown(self):
-    tempfile.tempdir = None  # force `gettempdir` to reinitialize from env
-
   def _list_info_dir(self):
     return os.listdir(self.info_dir)
 

--- a/tensorboard/manager_test.py
+++ b/tensorboard/manager_test.py
@@ -330,19 +330,19 @@ class TensorBoardInfoIoTest(unittest.TestCase):
     def remove_info(i):
       with mock.patch("os.getpid", lambda: 76540 + i):
         manager.remove_info_file()
-    self.assertItemsEqual(manager.get_all(), [])
+    six.assertCountEqual(self, manager.get_all(), [])
     add_info(1)
-    self.assertItemsEqual(manager.get_all(), [_make_info(1)])
+    six.assertCountEqual(self, manager.get_all(), [_make_info(1)])
     add_info(2)
-    self.assertItemsEqual(manager.get_all(), [_make_info(1), _make_info(2)])
+    six.assertCountEqual(self, manager.get_all(), [_make_info(1), _make_info(2)])
     remove_info(1)
-    self.assertItemsEqual(manager.get_all(), [_make_info(2)])
+    six.assertCountEqual(self, manager.get_all(), [_make_info(2)])
     add_info(3)
-    self.assertItemsEqual(manager.get_all(), [_make_info(2), _make_info(3)])
+    six.assertCountEqual(self, manager.get_all(), [_make_info(2), _make_info(3)])
     remove_info(3)
-    self.assertItemsEqual(manager.get_all(), [_make_info(2)])
+    six.assertCountEqual(self, manager.get_all(), [_make_info(2)])
     remove_info(2)
-    self.assertItemsEqual(manager.get_all(), [])
+    six.assertCountEqual(self, manager.get_all(), [])
 
   def test_get_all_ignores_bad_files(self):
     with open(os.path.join(self.info_dir, "pid-1234.info"), "w") as outfile:

--- a/tensorboard/manager_test.py
+++ b/tensorboard/manager_test.py
@@ -34,9 +34,9 @@ except ImportError:
   import mock  # pylint: disable=g-import-not-at-top,unused-import
 
 from tensorboard import manager
+from tensorboard import test as tb_test
 from tensorboard import version
 from tensorboard.util import tb_logging
-from tensorboard.util import test_case
 
 
 def _make_info(i=0):
@@ -60,7 +60,7 @@ def _make_info(i=0):
   )
 
 
-class TensorBoardInfoTest(test_case.TestCase):
+class TensorBoardInfoTest(tb_test.TestCase):
   """Unit tests for TensorBoardInfo typechecking and serialization."""
 
   def test_roundtrip_serialization(self):
@@ -168,7 +168,7 @@ class TensorBoardInfoTest(test_case.TestCase):
     self.assertEqual(manager.data_source_from_info(info), "db sqlite:~/bar")
 
 
-class CacheKeyTest(test_case.TestCase):
+class CacheKeyTest(tb_test.TestCase):
   """Unit tests for `manager.cache_key`."""
 
   def test_result_is_str(self):
@@ -254,7 +254,7 @@ class CacheKeyTest(test_case.TestCase):
     self.assertEqual(with_list, with_tuple)
 
 
-class TensorBoardInfoIoTest(test_case.TestCase):
+class TensorBoardInfoIoTest(tb_test.TestCase):
   """Tests for `write_info_file`, `remove_info_file`, and `get_all`."""
 
   def setUp(self):
@@ -352,4 +352,4 @@ class TensorBoardInfoIoTest(test_case.TestCase):
 
 
 if __name__ == "__main__":
-  test_case.main()
+  tb_test.main()

--- a/tensorboard/plugin_util_test.py
+++ b/tensorboard/plugin_util_test.py
@@ -19,12 +19,12 @@ from __future__ import print_function
 import textwrap
 
 import six
-import tensorflow as tf
+import unittest
 
 from tensorboard import plugin_util
 
 
-class MarkdownToSafeHTMLTest(tf.test.TestCase):
+class MarkdownToSafeHTMLTest(unittest.TestCase):
 
   def _test(self, markdown_string, expected):
     actual = plugin_util.markdown_to_safe_html(markdown_string)
@@ -124,4 +124,4 @@ class MarkdownToSafeHTMLTest(tf.test.TestCase):
 
 
 if __name__ == '__main__':
-  tf.test.main()
+  unittest.main()

--- a/tensorboard/plugin_util_test.py
+++ b/tensorboard/plugin_util_test.py
@@ -21,10 +21,10 @@ import textwrap
 import six
 
 from tensorboard import plugin_util
-from tensorboard.util import test_case
+from tensorboard import test as tb_test
 
 
-class MarkdownToSafeHTMLTest(test_case.TestCase):
+class MarkdownToSafeHTMLTest(tb_test.TestCase):
 
   def _test(self, markdown_string, expected):
     actual = plugin_util.markdown_to_safe_html(markdown_string)
@@ -124,4 +124,4 @@ class MarkdownToSafeHTMLTest(test_case.TestCase):
 
 
 if __name__ == '__main__':
-  test_case.main()
+  tb_test.main()

--- a/tensorboard/plugin_util_test.py
+++ b/tensorboard/plugin_util_test.py
@@ -19,12 +19,12 @@ from __future__ import print_function
 import textwrap
 
 import six
-import unittest
 
 from tensorboard import plugin_util
+from tensorboard.util import test_case
 
 
-class MarkdownToSafeHTMLTest(unittest.TestCase):
+class MarkdownToSafeHTMLTest(test_case.TestCase):
 
   def _test(self, markdown_string, expected):
     actual = plugin_util.markdown_to_safe_html(markdown_string)
@@ -124,4 +124,4 @@ class MarkdownToSafeHTMLTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  test_case.main()

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -21,13 +21,13 @@ from __future__ import print_function
 import argparse
 
 import six
-import unittest
 
 from tensorboard import program
 from tensorboard.plugins.core import core_plugin
+from tensorboard.util import test_case
 
 
-class TensorBoardTest(unittest.TestCase):
+class TensorBoardTest(test_case.TestCase):
   """Tests the TensorBoard program."""
 
   def testConfigure(self):
@@ -40,7 +40,7 @@ class TensorBoardTest(unittest.TestCase):
       tb.configure(foo='bar')
 
 
-class WerkzeugServerTest(unittest.TestCase):
+class WerkzeugServerTest(test_case.TestCase):
   """Tests the default Werkzeug implementation of TensorBoardServer.
 
   Mostly useful for IPv4/IPv6 testing. This test should run with only IPv4, only
@@ -87,4 +87,4 @@ class WerkzeugServerTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  test_case.main()

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -34,7 +34,7 @@ class TensorBoardTest(unittest.TestCase):
     # Many useful flags are defined under the core plugin.
     tb = program.TensorBoard(plugins=[core_plugin.CorePluginLoader()])
     tb.configure(logdir='foo')
-    self.assertTrue(tb.flags.logdir.startswith('foo'))
+    self.assertStartsWith(tb.flags.logdir, 'foo')
 
     with six.assertRaisesRegex(self, ValueError, 'Unknown TensorBoard flag'):
       tb.configure(foo='bar')
@@ -61,7 +61,7 @@ class WerkzeugServerTest(unittest.TestCase):
     server = program.WerkzeugServer(
         self._StubApplication(),
         self.make_flags(host='', port=0, path_prefix=''))
-    self.assertTrue(server.get_url().startswith('http://'))
+    self.assertStartsWith(server.get_url(), 'http://')
 
   def testSpecifiedHost(self):
     one_passed = False
@@ -69,7 +69,7 @@ class WerkzeugServerTest(unittest.TestCase):
       server = program.WerkzeugServer(
           self._StubApplication(),
           self.make_flags(host='127.0.0.1', port=0, path_prefix=''))
-      self.assertTrue(server.get_url().startswith('http://127.0.0.1:'))
+      self.assertStartsWith(server.get_url(), 'http://127.0.0.1:')
       one_passed = True
     except program.TensorBoardServerException:
       # IPv4 is not supported
@@ -78,7 +78,7 @@ class WerkzeugServerTest(unittest.TestCase):
       server = program.WerkzeugServer(
           self._StubApplication(),
           self.make_flags(host='::1', port=0, path_prefix=''))
-      self.assertTrue(server.get_url().startswith('http://[::1]:'))
+      self.assertStartsWith(server.get_url(), 'http://[::1]:')
       one_passed = True
     except program.TensorBoardServerException:
       # IPv6 is not supported

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -23,11 +23,11 @@ import argparse
 import six
 
 from tensorboard import program
+from tensorboard import test as tb_test
 from tensorboard.plugins.core import core_plugin
-from tensorboard.util import test_case
 
 
-class TensorBoardTest(test_case.TestCase):
+class TensorBoardTest(tb_test.TestCase):
   """Tests the TensorBoard program."""
 
   def testConfigure(self):
@@ -40,7 +40,7 @@ class TensorBoardTest(test_case.TestCase):
       tb.configure(foo='bar')
 
 
-class WerkzeugServerTest(test_case.TestCase):
+class WerkzeugServerTest(tb_test.TestCase):
   """Tests the default Werkzeug implementation of TensorBoardServer.
 
   Mostly useful for IPv4/IPv6 testing. This test should run with only IPv4, only
@@ -87,4 +87,4 @@ class WerkzeugServerTest(test_case.TestCase):
 
 
 if __name__ == '__main__':
-  test_case.main()
+  tb_test.main()

--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -21,26 +21,26 @@ from __future__ import print_function
 import argparse
 
 import six
-import tensorflow as tf
+import unittest
 
 from tensorboard import program
 from tensorboard.plugins.core import core_plugin
 
 
-class TensorBoardTest(tf.test.TestCase):
+class TensorBoardTest(unittest.TestCase):
   """Tests the TensorBoard program."""
 
   def testConfigure(self):
     # Many useful flags are defined under the core plugin.
     tb = program.TensorBoard(plugins=[core_plugin.CorePluginLoader()])
     tb.configure(logdir='foo')
-    self.assertStartsWith(tb.flags.logdir, 'foo')
+    self.assertTrue(tb.flags.logdir.startswith('foo'))
 
     with six.assertRaisesRegex(self, ValueError, 'Unknown TensorBoard flag'):
       tb.configure(foo='bar')
 
 
-class WerkzeugServerTest(tf.test.TestCase):
+class WerkzeugServerTest(unittest.TestCase):
   """Tests the default Werkzeug implementation of TensorBoardServer.
 
   Mostly useful for IPv4/IPv6 testing. This test should run with only IPv4, only
@@ -61,7 +61,7 @@ class WerkzeugServerTest(tf.test.TestCase):
     server = program.WerkzeugServer(
         self._StubApplication(),
         self.make_flags(host='', port=0, path_prefix=''))
-    self.assertStartsWith(server.get_url(), 'http://')
+    self.assertTrue(server.get_url().startswith('http://'))
 
   def testSpecifiedHost(self):
     one_passed = False
@@ -69,7 +69,7 @@ class WerkzeugServerTest(tf.test.TestCase):
       server = program.WerkzeugServer(
           self._StubApplication(),
           self.make_flags(host='127.0.0.1', port=0, path_prefix=''))
-      self.assertStartsWith(server.get_url(), 'http://127.0.0.1:')
+      self.assertTrue(server.get_url().startswith('http://127.0.0.1:'))
       one_passed = True
     except program.TensorBoardServerException:
       # IPv4 is not supported
@@ -78,7 +78,7 @@ class WerkzeugServerTest(tf.test.TestCase):
       server = program.WerkzeugServer(
           self._StubApplication(),
           self.make_flags(host='::1', port=0, path_prefix=''))
-      self.assertStartsWith(server.get_url(), 'http://[::1]:')
+      self.assertTrue(server.get_url().startswith('http://[::1]:'))
       one_passed = True
     except program.TensorBoardServerException:
       # IPv6 is not supported
@@ -87,4 +87,4 @@ class WerkzeugServerTest(tf.test.TestCase):
 
 
 if __name__ == '__main__':
-  tf.test.main()
+  unittest.main()

--- a/tensorboard/test.py
+++ b/tensorboard/test.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""TensorBoard test case helper module.
+"""TensorBoard test module.
 
-This module provides a TensorBoard base test class with some of the
-niceties of tf.test.TestCase, while only requiring standard unittest
-be installed.
+This module provides a TensorBoard base test class and main function
+with some of the niceties of tf.test, while only requiring standard
+unittest be installed.
 """
 
 from __future__ import absolute_import
@@ -26,6 +26,7 @@ from __future__ import print_function
 import atexit
 import os
 import shutil
+import six
 import tempfile
 import unittest
 
@@ -74,10 +75,7 @@ class TestCase(unittest.TestCase):
 
     Same as assertCountEqual in Python 3 with unittest.TestCase.
     """
-    if hasattr(self, 'assertCountEqual'):
-        self.assertCountEqual(actual, expected, msg)
-    else:
-        super(TestCase, self).assertItemsEqual(actual, expected, msg)
+    return six.assertCountEqual(super(TestCase, self), actual, expected, msg)
 
   def assertStartsWith(self, actual, expected_start, msg=None):
     """Test that string actual starts with string expected_start."""

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -64,7 +64,7 @@ py_test(
     tags = ["support_notf"],
     deps = [
         ":platform_util",
-        ":test_case",
+        "//tensorboard:test",
     ],
 )
 
@@ -81,16 +81,6 @@ py_library(
     deps = [
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/compat/tensorflow_stub",
-    ],
-)
-
-py_library(
-    name = "test_case",
-    testonly = 1,
-    srcs = ["test_case.py"],
-    srcs_version = "PY2AND3",
-    deps = [
-        ":tb_logging",
     ],
 )
 

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -91,7 +91,6 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":tb_logging",
-        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -61,9 +61,9 @@ py_test(
     size = "small",
     srcs = ["platform_util_test.py"],
     srcs_version = "PY2AND3",
+    tags = ["support_notf"],
     deps = [
         ":platform_util",
-        "//tensorboard:expect_tensorflow_installed",
     ],
 )
 

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -64,6 +64,7 @@ py_test(
     tags = ["support_notf"],
     deps = [
         ":platform_util",
+        ":test_case",
     ],
 )
 
@@ -80,6 +81,17 @@ py_library(
     deps = [
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/compat/tensorflow_stub",
+    ],
+)
+
+py_library(
+    name = "test_case",
+    testonly = 1,
+    srcs = ["test_case.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":tb_logging",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/util/platform_util_test.py
+++ b/tensorboard/util/platform_util_test.py
@@ -16,15 +16,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from tensorboard import test as tb_test
 from tensorboard.util import platform_util
-from tensorboard.util import test_case
 
 
-class PlatformUtilTest(test_case.TestCase):
+class PlatformUtilTest(tb_test.TestCase):
 
   def test_readahead_file_path(self):
     self.assertEqual('foo/bar', platform_util.readahead_file_path('foo/bar'))
 
 
 if __name__ == '__main__':
-  test_case.main()
+  tb_test.main()

--- a/tensorboard/util/platform_util_test.py
+++ b/tensorboard/util/platform_util_test.py
@@ -16,16 +16,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import unittest
-
 from tensorboard.util import platform_util
+from tensorboard.util import test_case
 
 
-class PlatformUtilTest(unittest.TestCase):
+class PlatformUtilTest(test_case.TestCase):
 
   def test_readahead_file_path(self):
     self.assertEqual('foo/bar', platform_util.readahead_file_path('foo/bar'))
 
 
 if __name__ == '__main__':
-  unittest.main()
+  test_case.main()

--- a/tensorboard/util/platform_util_test.py
+++ b/tensorboard/util/platform_util_test.py
@@ -16,16 +16,16 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
+import unittest
 
 from tensorboard.util import platform_util
 
 
-class PlatformUtilTest(tf.test.TestCase):
+class PlatformUtilTest(unittest.TestCase):
 
   def test_readahead_file_path(self):
     self.assertEqual('foo/bar', platform_util.readahead_file_path('foo/bar'))
 
 
 if __name__ == '__main__':
-  tf.test.main()
+  unittest.main()

--- a/tensorboard/util/test_case.py
+++ b/tensorboard/util/test_case.py
@@ -1,0 +1,111 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TensorBoard test case helper module.
+
+This module provides a TensorBoard base test class with some of the
+niceties of tf.test.TestCase, while only requiring standard unittest
+be installed.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import atexit
+import os
+import shutil
+import six
+import tempfile
+import unittest
+
+from tensorboard.util import tb_logging
+
+
+logger = tb_logging.get_logger()
+
+_temp_dir = None
+
+
+def get_temp_dir():
+  """Return a temporary directory for tests to use."""
+  global _temp_dir
+  if not _temp_dir:
+    if os.environ.get('TEST_TMPDIR'):
+      temp_dir = tempfile.mkdtemp(prefix=os.environ['TEST_TMPDIR'])
+    else:
+      temp_dir = tempfile.mkdtemp()
+
+    def delete_temp_dir(dirname=temp_dir):
+      try:
+        shutil.rmtree(dirname)
+      except OSError as e:
+        logger.error('Error removing %s: %s', dirname, e)
+
+    atexit.register(delete_temp_dir)
+    _temp_dir = temp_dir
+
+  return _temp_dir
+
+
+class TestCase(unittest.TestCase):
+  """TensorBoard base test class.
+  This class can lazily create a temporary directory for tests to use.
+  """
+
+  def __init__(self, method='runTest'):
+    super(TestCase, self).__init__(method)
+    self._method = method
+    self._tempdir = None
+
+  def setUp(self):
+    super(TestCase, self).setUp()
+
+  def tearDown(self):
+    super(TestCase, self).tearDown()
+
+  def assertItemsEqual(self, actual, expected, msg=None):
+    """Test that sequence first contains the same elements as second,
+    regardless of their order.
+
+    Same as assertCountEqual in Python 3 with unittest.TestCase."""
+    six.assertCountEqual(self, actual, expected, msg)
+
+  def assertStartsWith(self, actual, expected_start, msg=None):
+    """Test that string first starts with string second."""
+    if not actual.startswith(expected_start):
+      if msg is None:
+        msg = '{} does not start with {}'.format(actual, expected_start)
+      raise AssertionError(msg)
+
+  def get_temp_dir(self):
+    """Returns a unique temporary directory for the test to use.
+    If you call this method multiple times during in a test, it will return the
+    same folder. However, across different runs the directories will be
+    different. This will ensure that across different runs tests will not be
+    able to pollute each others environment.
+    If you need multiple unique directories within a single test, you should
+    use tempfile.mkdtemp as follows:
+      tempfile.mkdtemp(dir=self.get_temp_dir()):
+    Returns:
+      string, the path to the unique temporary directory created for this test.
+    """
+    if not self._tempdir:
+      self._tempdir = tempfile.mkdtemp(dir=get_temp_dir())
+    return self._tempdir
+
+
+def main(*args, **kwargs):
+  """Pass args and kwargs through to unittest main"""
+  return unittest.main(*args, **kwargs)

--- a/tensorboard/util/test_case.py
+++ b/tensorboard/util/test_case.py
@@ -80,7 +80,10 @@ class TestCase(unittest.TestCase):
     regardless of their order.
 
     Same as assertCountEqual in Python 3 with unittest.TestCase."""
-    six.assertCountEqual(self, actual, expected, msg)
+    if hasattr(self, 'assertCountEqual'):
+        self.assertCountEqual(actual, expected, msg)
+    else:
+        super(TestCase, self).assertItemsEqual(actual, expected, msg)
 
   def assertStartsWith(self, actual, expected_start, msg=None):
     """Test that string first starts with string second."""

--- a/tensorboard/util/test_case.py
+++ b/tensorboard/util/test_case.py
@@ -26,7 +26,6 @@ from __future__ import print_function
 import atexit
 import os
 import shutil
-import six
 import tempfile
 import unittest
 

--- a/tensorboard/util/test_case.py
+++ b/tensorboard/util/test_case.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -60,39 +60,35 @@ def get_temp_dir():
 
 class TestCase(unittest.TestCase):
   """TensorBoard base test class.
+
   This class can lazily create a temporary directory for tests to use.
   """
 
-  def __init__(self, method='runTest'):
-    super(TestCase, self).__init__(method)
-    self._method = method
+  def __init__(self, methodName='runTest'):
+    super(TestCase, self).__init__(methodName)
     self._tempdir = None
 
-  def setUp(self):
-    super(TestCase, self).setUp()
-
-  def tearDown(self):
-    super(TestCase, self).tearDown()
-
   def assertItemsEqual(self, actual, expected, msg=None):
-    """Test that sequence first contains the same elements as second,
+    """Test that sequence actual contains the same elements as expected,
     regardless of their order.
 
-    Same as assertCountEqual in Python 3 with unittest.TestCase."""
+    Same as assertCountEqual in Python 3 with unittest.TestCase.
+    """
     if hasattr(self, 'assertCountEqual'):
         self.assertCountEqual(actual, expected, msg)
     else:
         super(TestCase, self).assertItemsEqual(actual, expected, msg)
 
   def assertStartsWith(self, actual, expected_start, msg=None):
-    """Test that string first starts with string second."""
+    """Test that string actual starts with string expected_start."""
     if not actual.startswith(expected_start):
-      if msg is None:
-        msg = '{} does not start with {}'.format(actual, expected_start)
-      raise AssertionError(msg)
+      fail_msg = '%r does not start with %r' % (actual, expected_start)
+      fail_msg += ' : %r' % (msg) if msg else ''
+      self.fail(fail_msg)
 
   def get_temp_dir(self):
     """Returns a unique temporary directory for the test to use.
+
     If you call this method multiple times during in a test, it will return the
     same folder. However, across different runs the directories will be
     different. This will ensure that across different runs tests will not be
@@ -100,6 +96,7 @@ class TestCase(unittest.TestCase):
     If you need multiple unique directories within a single test, you should
     use tempfile.mkdtemp as follows:
       tempfile.mkdtemp(dir=self.get_temp_dir()):
+
     Returns:
       string, the path to the unique temporary directory created for this test.
     """


### PR DESCRIPTION
Continuation of work for #2027 and ultimately removing the TENSORBOARD_NO_TF=1 environment variable.

Pulled out of https://github.com/tensorflow/tensorboard/pull/2075 and still need to fix some Python 3 vs 2 issues.

Tested with

```
bazel test //tensorboard:manager_test --test_output=errors
bazel test //tensorboard/backend:application_test --test_output=errors
```