### PR TITLE
Making session group detail reset after data change

### DIFF
--- a/tensorboard/plugins/hparams/tf_hparams_session_group_details/tf-hparams-session-group-details.html
+++ b/tensorboard/plugins/hparams/tf_hparams_session_group_details/tf-hparams-session-group-details.html
@@ -202,6 +202,14 @@ clicks on a row in table-view or a curve in parallel-coords view.
           this._sessionGroupNameHash = tf.hparams.utils.hashOfString(
               this.sessionGroup.name);
         }
+        // Reset each scalar-card by prodding 'tag'.
+        // We do this so the card will reset its domain on the next load.
+        Polymer.dom(this.root).querySelectorAll('tf-scalar-card').forEach(
+            c => {
+              const tag = c.get("tag");
+              c.set("tag", "");
+              c.set("tag", tag);
+            });
       },
 
       _haveMetrics() {


### PR DESCRIPTION
This is needed to solve b/111691396 as well as make the UI more deterministic which aids integration tests (without this, occaisonally and non-predictably the charts do not reset).