### PR TITLE
Update TF 2.0 summary_scope()/import_event() usage

### DIFF
--- a/tensorboard/plugins/audio/summary_v2.py
+++ b/tensorboard/plugins/audio/summary_v2.py
@@ -83,7 +83,11 @@ def audio(name,
       description=description,
       encoding=metadata.Encoding.Value('WAV'))
   inputs = [data, sample_rate, max_outputs, step]
-  with tf.summary.summary_scope(
+  # TODO(https://github.com/tensorflow/tensorboard/issues/2109): remove fallback
+  summary_scope = (
+      getattr(tf.summary.experimental, 'summary_scope', None) or
+      tf.summary.summary_scope)
+  with summary_scope(
       name, 'audio_summary', values=inputs) as (tag, _):
     tf.debugging.assert_rank(data, 3)
     tf.debugging.assert_non_negative(max_outputs)

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -68,7 +68,11 @@ def histogram(name, data, step=None, buckets=None, description=None):
   """
   summary_metadata = metadata.create_summary_metadata(
       display_name=None, description=description)
-  with tf.summary.summary_scope(
+  # TODO(https://github.com/tensorflow/tensorboard/issues/2109): remove fallback
+  summary_scope = (
+      getattr(tf.summary.experimental, 'summary_scope', None) or
+      tf.summary.summary_scope)
+  with summary_scope(
       name, 'histogram_summary', values=[data, buckets, step]) as (tag, _):
     tensor = _buckets(data, bucket_count=buckets)
     return tf.summary.write(

--- a/tensorboard/plugins/hparams/hparams_util.py
+++ b/tensorboard/plugins/hparams/hparams_util.py
@@ -176,9 +176,15 @@ def write_summary(summary_pb):
   tf.compat.v1.enable_eager_execution()
   writer = tf.compat.v2.summary.create_file_writer(FLAGS.logdir)
   with writer.as_default():
-    event = tf.compat.v1.Event(summary=summary_pb)
-    tf.compat.v2.summary.import_event(
-        tf.constant(event.SerializeToString(), dtype=tf.string))
+    if hasattr(tf.compat.v2.summary.experimental, "write_raw_pb"):
+      tf.compat.v2.summary.experimental.write_raw_pb(
+          summary_pb.SerializeToString(), step=0)
+    else:
+      # TODO(https://github.com/tensorflow/tensorboard/issues/2109): remove the
+      #   fallback to import_event().
+      event = tf.compat.v1.Event(summary=summary_pb)
+      tf.compat.v2.summary.import_event(
+          tf.constant(event.SerializeToString(), dtype=tf.string))
     # The following may not be required since the context manager may
     # already flush on __exit__, but it doesn't hurt to do it here, as well.
     tf.compat.v2.summary.flush()

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -62,7 +62,11 @@ def image(name,
   """
   summary_metadata = metadata.create_summary_metadata(
       display_name=None, description=description)
-  with tf.summary.summary_scope(
+  # TODO(https://github.com/tensorflow/tensorboard/issues/2109): remove fallback
+  summary_scope = (
+      getattr(tf.summary.experimental, 'summary_scope', None) or
+      tf.summary.summary_scope)
+  with summary_scope(
       name, 'image_summary', values=[data, max_outputs, step]) as (tag, _):
     tf.debugging.assert_rank(data, 4)
     tf.debugging.assert_non_negative(max_outputs)

--- a/tensorboard/plugins/scalar/summary_v2.py
+++ b/tensorboard/plugins/scalar/summary_v2.py
@@ -52,7 +52,11 @@ def scalar(name, data, step=None, description=None):
   """
   summary_metadata = metadata.create_summary_metadata(
       display_name=None, description=description)
-  with tf.summary.summary_scope(
+  # TODO(https://github.com/tensorflow/tensorboard/issues/2109): remove fallback
+  summary_scope = (
+      getattr(tf.summary.experimental, 'summary_scope', None) or
+      tf.summary.summary_scope)
+  with summary_scope(
       name, 'scalar_summary', values=[data, step]) as (tag, _):
     tf.debugging.assert_scalar(data)
     return tf.summary.write(tag=tag,

--- a/tensorboard/plugins/text/summary_v2.py
+++ b/tensorboard/plugins/text/summary_v2.py
@@ -49,7 +49,11 @@ def text(name, data, step=None, description=None):
   """
   summary_metadata = metadata.create_summary_metadata(
       display_name=None, description=description)
-  with tf.summary.summary_scope(
+  # TODO(https://github.com/tensorflow/tensorboard/issues/2109): remove fallback
+  summary_scope = (
+      getattr(tf.summary.experimental, 'summary_scope', None) or
+      tf.summary.summary_scope)
+  with summary_scope(
       name, 'text_summary', values=[data, step]) as (tag, _):
     tf.debugging.assert_type(data, tf.string)
     return tf.summary.write(


### PR DESCRIPTION
This updates TensorBoard's usage of `tf.summary.summary_scope()` and `tf.summary.import_event()` in TF 2.0 in anticipation of a change to those APIs, which moves the functionality under `tf.summary.experimental` and in the case of `import_event()`, also changes it to import `tf.compat.v1.Summary` proto bytes instead of `Event` protos.

Fallback logic is included so we stay compatible with TF versions that don't have this change, including current tf-nightly as of sending this PR.  I've filed https://github.com/tensorflow/tensorboard/issues/2109 to track cleaning up those fallbacks before TF 2.0 final.

Tested by confirming tests pass both before the TF change (as this PR is sent) and after (with the change made locally).  I also manually tested the `hparams_util` helper binary since the current test doesn't actually test its output.