### PR TITLE
Use `raise_exception_on_not_ok_status` from V1

### DIFF
--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -38,7 +38,7 @@ class RawEventFileLoader(object):
       raise ValueError('A file path is required')
     file_path = platform_util.readahead_file_path(file_path)
     logger.debug('Opening a record reader pointing at %s', file_path)
-    with tf.errors.raise_exception_on_not_ok_status() as status:
+    with tf.compat.v1.errors.raise_exception_on_not_ok_status() as status:
       self._reader = _pywrap_tensorflow.PyRecordReader_New(
           tf.compat.as_bytes(file_path), 0, tf.compat.as_bytes(''), status)
     # Store it for logging purposes.
@@ -65,7 +65,7 @@ class RawEventFileLoader(object):
     while True:
       try:
         if legacy_get_next:
-          with tf.errors.raise_exception_on_not_ok_status() as status:
+          with tf.compat.v1.errors.raise_exception_on_not_ok_status() as status:
             self._reader.GetNext(status)
         else:
           self._reader.GetNext()

--- a/tensorboard/compat/tensorflow_stub/__init__.py
+++ b/tensorboard/compat/tensorflow_stub/__init__.py
@@ -35,5 +35,7 @@ from . import io  # noqa
 from . import pywrap_tensorflow  # noqa
 from . import tensor_shape  # noqa
 
+compat.v1.errors = errors
+
 # Set a fake __version__ to help distinguish this as our own stub API.
 __version__ = 'stub'


### PR DESCRIPTION
Summary:
Fixes #2115 in response to:
<https://github.com/tensorflow/tensorflow/commit/ea3f474c5ff94152f72b5417eff2046111bb77e3>

The other two symbols deprecated in that commit are not used by
TensorBoard.

We alias `compat.v1.errors = errors` from the TensorFlow stub so that
notf tests can continue to work.

Test Plan:
All Bazel tests pass in `tf-nightly-2.0-preview==2.0.0.dev20190416`, and
the Pip package smoke test also passes.

wchargin-branch: fix-tf-status-handling
