### PR TITLE
Fix whitespace: this breaks running in jupyter.

### DIFF
--- a/docs/r2/get_started.ipynb
+++ b/docs/r2/get_started.ipynb
@@ -98,7 +98,7 @@
         "!pip install -q tf-nightly-2.0-preview\n",
         "\n",
         "# Load the TensorBoard notebook extension\n",
-        "%load_ext tensorboard.notebook "
+        "%load_ext tensorboard.notebook"
       ],
       "execution_count": 2,
       "outputs": [


### PR DESCRIPTION
 "module `tensorboard.notebook `  not found"

It uses the whole line to determine the module name, including the space.

* Motivation for features / changes

Fix this to work in Jupyter.

* Technical description of changes

Remove bad whitespace.

* Screenshots of UI changes

None.

* Detailed steps to verify changes work correctly (as executed by you)

Run this notebook in OSS jupyter notebook.

* Alternate designs / implementations considered

None
