### PR TITLE
notebook: relocate to `%load_ext tensorboard`

### DIFF
--- a/docs/r2/get_started.ipynb
+++ b/docs/r2/get_started.ipynb
@@ -98,7 +98,7 @@
         "!pip install -q tf-nightly-2.0-preview\n",
         "\n",
         "# Load the TensorBoard notebook extension\n",
-        "%load_ext tensorboard.notebook"
+        "%load_ext tensorboard"
       ],
       "execution_count": 2,
       "outputs": [

--- a/docs/r2/graphs.ipynb
+++ b/docs/r2/graphs.ipynb
@@ -116,7 +116,7 @@
         "# Ensure TensorFlow 2.0 is installed.\n",
         "!pip install -q tf-nightly-2.0-preview\n",
         "# Load the TensorBoard notebook extension.\n",
-        "%load_ext tensorboard.notebook"
+        "%load_ext tensorboard"
       ],
       "execution_count": 0,
       "outputs": []

--- a/docs/r2/hyperparameter_tuning_with_hparams.ipynb
+++ b/docs/r2/hyperparameter_tuning_with_hparams.ipynb
@@ -107,7 +107,7 @@
       "source": [
         "!pip install -q tf-nightly-2.0-preview\n",
         "# Load the TensorBoard notebook extension\n",
-        "%load_ext tensorboard.notebook "
+        "%load_ext tensorboard "
       ],
       "execution_count": 0,
       "outputs": [

--- a/docs/r2/image_summaries.ipynb
+++ b/docs/r2/image_summaries.ipynb
@@ -109,7 +109,7 @@
         "# Ensure TensorFlow 2.0 is installed.\n",
         "!pip install -q tf-nightly-2.0-preview\n",
         "# Load the TensorBoard notebook extension.\n",
-        "%load_ext tensorboard.notebook"
+        "%load_ext tensorboard"
       ],
       "execution_count": 3,
       "outputs": [
@@ -119,8 +119,8 @@
             "\u001b[K    100% |████████████████████████████████| 3.0MB 10.4MB/s \n",
             "\u001b[K    100% |████████████████████████████████| 348kB 15.6MB/s \n",
             "\u001b[K    100% |████████████████████████████████| 61kB 13.0MB/s \n",
-            "\u001b[?25hThe tensorboard.notebook extension is already loaded. To reload it, use:\n",
-            "  %reload_ext tensorboard.notebook\n"
+            "\u001b[?25hThe tensorboard extension is already loaded. To reload it, use:\n",
+            "  %reload_ext tensorboard\n"
           ],
           "name": "stdout"
         }

--- a/docs/r2/scalars_and_keras.ipynb
+++ b/docs/r2/scalars_and_keras.ipynb
@@ -107,7 +107,7 @@
         "# Ensure TensorFlow 2.0 is installed.\n",
         "!pip install -q tf-nightly-2.0-preview\n",
         "# Load the TensorBoard notebook extension.\n",
-        "%load_ext tensorboard.notebook"
+        "%load_ext tensorboard"
       ],
       "execution_count": 0,
       "outputs": []

--- a/docs/r2/tensorboard_in_notebooks.ipynb
+++ b/docs/r2/tensorboard_in_notebooks.ipynb
@@ -114,7 +114,7 @@
       "source": [
         "!pip install -q tf-nightly-2.0-preview\n",
         "# Load the TensorBoard notebook extension\n",
-        "%load_ext tensorboard.notebook "
+        "%load_ext tensorboard "
       ],
       "execution_count": 2,
       "outputs": [

--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -84,4 +84,15 @@ def summary():
   return importlib.import_module('tensorboard.summary')
 
 
+def load_ipython_extension(ipython):
+  """IPython API entry point.
+
+  Only intended to be called by the IPython runtime.
+
+  See:
+    https://ipython.readthedocs.io/en/stable/config/extensions/index.html
+  """
+  notebook._load_ipython_extension(ipython)
+
+
 __version__ = version.VERSION

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -75,12 +75,24 @@ def _get_context():
 
 
 def load_ipython_extension(ipython):
-  """IPython API entry point.
+  """Deprecated: use `%load_ext tensorboard` instead.
 
-  Only intended to be called by the IPython runtime.
+  Raises:
+    RuntimeError: Always.
+  """
+  raise RuntimeError(
+      "Use '%load_ext tensorboard' instead of '%load_ext tensorboard.notebook'."
+  )
 
-  See:
-    https://ipython.readthedocs.io/en/stable/config/extensions/index.html
+
+def _load_ipython_extension(ipython):
+  """Load the TensorBoard notebook extension.
+
+  Intended to be called from `%load_ext tensorboard`. Do not invoke this
+  directly.
+
+  Args:
+    ipython: An `IPython.InteractiveShell` instance.
   """
   _register_magics(ipython)
 


### PR DESCRIPTION
Summary:
“Drop the `.notebook`. It’s cleaner.” (Fixes #1857.)

Using `%load_ext tensorboard.notebook` now gives users a helpful error.

This is a breaking change, which we think is okay because (a) notebook
support was always explicitly marked as “alpha” in release notes and
“experimental” in the code, and (b) notebooks are meant to be run
interactively, so the fix will be easy and immediate.

Test Plan:
Built the Pip package and installed it into a new virtualenv, then
verified that `%load_ext tensorboard.notebook` properly emits an error
message, which directs users to the working `%load_ext tensorboard`:

![Screenshot](https://user-images.githubusercontent.com/4317806/56316051-32217280-610e-11e9-83b9-522b2bad5493.png)

Tested the above with `tf-nightly` and `tf-nightly-2.0-preview`. Also
verified that the `getting_started.ipynb` notebook still works, from
start to finish, within the new virtualenv.

Verified that there are no lingering references to the old endpoint:

```
$ git grep '%load_ext tensorboard.notebook'
tensorboard/notebook.py:      "Use '%load_ext tensorboard' instead of '%load_ext tensorboard.notebook'."
```

wchargin-branch: notebook-extension-at-root
