### PR TITLE
hparams: add Python layer for hparams and metrics

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -95,6 +95,7 @@ py_binary(
     srcs = ["hparams_demo.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":api",
         ":protos_all_py_pb2",
         ":summary",
         "//tensorboard:expect_absl_app_installed",
@@ -102,7 +103,6 @@ py_binary(
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins/scalar:summary",
-        "@com_google_protobuf//:protobuf_python",
         "@org_pythonhosted_six",
     ],
 )
@@ -145,6 +145,38 @@ sh_test(
         ":hparams_util",
     ],
 )
+
+py_library(
+    name = "api",
+    srcs = ["api.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":protos_all_py_pb2",
+        ":summary",
+        "@org_pythonhosted_six",
+    ],
+)
+
+py_test(
+    name = "api_test",
+    srcs = ["api_test.py"],
+    srcs_version = "PY2AND3",
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":api",
+        ":metadata",
+        ":protos_all_py_pb2",
+        "//tensorboard:test",
+        "@com_google_protobuf//:protobuf_python",
+        "@org_pythonhosted_six",
+    ],
+)
+
 
 py_library(
     name = "summary",

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -162,6 +162,7 @@ py_library(
 
 py_test(
     name = "api_test",
+    size = "small",
     srcs = ["api_test.py"],
     srcs_version = "PY2AND3",
     deps = [
@@ -173,7 +174,6 @@ py_test(
         "@org_pythonhosted_six",
     ],
 )
-
 
 py_library(
     name = "summary",

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -164,9 +164,6 @@ py_test(
     name = "api_test",
     srcs = ["api_test.py"],
     srcs_version = "PY2AND3",
-    visibility = [
-        "//visibility:public",
-    ],
     deps = [
         ":api",
         ":metadata",

--- a/tensorboard/plugins/hparams/api.py
+++ b/tensorboard/plugins/hparams/api.py
@@ -282,6 +282,22 @@ class Discrete(Domain):
   """
 
   def __init__(self, values, dtype=None):
+    """Construct a discrete domain.
+
+    Args:
+      values: A iterable of the values in this domain.
+      dtype: The Python data type of values in this domain: one of
+        `int`, `float`, `bool`, or `str`. If `values` is non-empty,
+        `dtype` may be `None`, in which case it will be inferred as the
+        type of the first element of `values`.
+
+    Raises:
+      ValueError: If `values` is empty but no `dtype` is specified.
+      ValueError: If `dtype` or its inferred value is not `int`,
+        `float`, `bool`, or `str`.
+      TypeError: If an element of `values` is not an instance of
+        `dtype`.
+    """
     self._values = list(values)
     if dtype is None:
       if self._values:
@@ -293,7 +309,7 @@ class Discrete(Domain):
     self._dtype = dtype
     for value in self._values:
       if not isinstance(value, self._dtype):
-        raise ValueError(
+        raise TypeError(
             "dtype mismatch: not isinstance(%r, %s)"
             % (value, self._dtype.__name__)
         )

--- a/tensorboard/plugins/hparams/api.py
+++ b/tensorboard/plugins/hparams/api.py
@@ -1,0 +1,378 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Experimental public APIs for the HParams plugin.
+
+These are porcelain on top of `api_pb2` (`api.proto`) and `summary.py`.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import abc
+import time
+
+import six
+
+from tensorboard.plugins.hparams import api_pb2
+from tensorboard.plugins.hparams import summary
+
+
+class Experiment(object):
+  """A top-level experiment description.
+
+  An experiment has a fixed set of hyperparameters and metrics, and
+  consists of multiple sessions. Each session has different associated
+  hyperparameter values and metric values.
+  """
+
+  def __init__(
+      self,
+      hparams,
+      metrics,
+      user=None,
+      description=None,
+      time_created_secs=None,
+  ):
+    """Create an experiment object.
+
+    Args:
+      hparams: A list of `HParam` values.
+      metrics: A list of `Metric` values.
+      user: An optional string denoting the user or group that owns this
+        experiment.
+      description: An optional Markdown string describing this
+        experiment.
+      time_created_secs: The time that this experiment was created, as
+        seconds since epoch. Defaults to the current time.
+    """
+    self._hparams = list(hparams)
+    self._metrics = list(metrics)
+    self._user = user
+    self._description = description
+    if time_created_secs is None:
+      time_created_secs = time.time()
+    self._time_created_secs = time_created_secs
+
+  @property
+  def hparams(self):
+    return list(self._hparams)
+
+  @property
+  def metrics(self):
+    return list(self._metrics)
+
+  @property
+  def user(self):
+    return self._user
+
+  @property
+  def description(self):
+    return self._description
+
+  @property
+  def time_created_secs(self):
+    return self._time_created_secs
+
+  def summary_pb(self):
+    """Create a top-level experiment summary describing this experiment.
+
+    The resulting summary should be written to a log directory that
+    encloses all the individual sessions' log directories.
+
+    Analogous to the low-level `experiment_pb` function in the
+    `hparams.summary` module.
+    """
+    hparam_infos = []
+    for hparam in self._hparams:
+      info = api_pb2.HParamInfo(
+          name=hparam.name,
+          description=hparam.description,
+          display_name=hparam.display_name,
+      )
+      domain = hparam.domain
+      if domain is not None:
+        domain.update_hparam_info(info)
+      hparam_infos.append(info)
+    metric_infos = [metric.as_proto() for metric in self._metrics]
+    return summary.experiment_pb(
+        hparam_infos=hparam_infos,
+        metric_infos=metric_infos,
+        user=self._user,
+        description=self._description,
+        time_created_secs=self._time_created_secs,
+    )
+
+
+class HParam(object):
+  """A hyperparameter in an experiment.
+
+  This class describes a hyperparameter in the abstract. It ranges over
+  a domain of values, but is not bound to any particular value.
+  """
+
+  def __init__(self, name, domain=None, display_name=None, description=None):
+    """Create a hyperparameter object.
+
+    Args:
+      name: A string ID for this hyperparameter, which should be unique
+        within an experiment.
+      domain: An optional `Domain` object describing the values that
+        this hyperparameter can take on.
+      display_name: An optional human-readable display name (`str`).
+      description: An optional Markdown string describing this
+        hyperparameter.
+
+    Raises:
+      ValueError: If `domain` is not a `Domain`.
+    """
+    self._name = name
+    self._domain = domain
+    self._display_name = display_name
+    self._description = description
+    if not isinstance(self._domain, (Domain, type(None))):
+      raise ValueError("not a domain: %r" % (self._domain,))
+
+  def __str__(self):
+    return "<HParam %r: %s>" % (self._name, self._domain)
+
+  def __repr__(self):
+    fields = [
+        ("name", self._name),
+        ("domain", self._domain),
+        ("display_name", self._display_name),
+        ("description", self._description),
+    ]
+    fields_string = ", ".join("%s=%r" % (k, v) for (k, v) in fields)
+    return "HParam(%s)" % fields_string
+
+  @property
+  def name(self):
+    return self._name
+
+  @property
+  def domain(self):
+    return self._domain
+
+  @property
+  def display_name(self):
+    return self._display_name
+
+  @property
+  def description(self):
+    return self._description
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Domain(object):
+  """The domain of a hyperparameter.
+
+  Domains are restricted to values of the simple types `float`, `int`,
+  `str`, and `bool`.
+  """
+
+  @abc.abstractproperty
+  def dtype(self):
+    """Data type of this domain: `float`, `int`, `str`, or `bool`."""
+    pass
+
+  @abc.abstractmethod
+  def update_hparam_info(self, hparam_info):
+    """Update an `HParamInfo` proto to include this domain.
+
+    This should update the `type` field on the proto and exactly one of
+    the `domain` variants on the proto.
+
+    Args:
+      hparam_info: An `api_pb2.HParamInfo` proto to modify.
+    """
+    pass
+
+
+class IntInterval(Domain):
+  """A domain that takes on all integer values in a closed interval."""
+
+  def __init__(self, min_value=None, max_value=None):
+    if not isinstance(min_value, int):
+      raise TypeError("min_value must be an int: %r" % (min_value,))
+    if not isinstance(max_value, int):
+      raise TypeError("max_value must be an int: %r" % (max_value,))
+    if min_value > max_value:
+      raise ValueError("%r > %r" % (min_value, max_value))
+    self._min_value = min_value
+    self._max_value = max_value
+
+  def __str__(self):
+    return "[%s, %s]" % (self._min_value, self._max_value)
+
+  def __repr__(self):
+    return "IntInterval(%r, %r)" % (self._min_value, self._max_value)
+
+  @property
+  def dtype(self):
+    return int
+
+  @property
+  def min_value(self):
+    return self._min_value
+
+  @property
+  def max_value(self):
+    return self._max_value
+
+  def update_hparam_info(self, hparam_info):
+    hparam_info.type = api_pb2.DATA_TYPE_FLOAT64  # TODO(#1998): Add int dtype.
+    hparam_info.domain_interval.min_value = self._min_value
+    hparam_info.domain_interval.max_value = self._max_value
+
+
+class RealInterval(Domain):
+  """A domain that takes on all real values in a closed interval."""
+
+  def __init__(self, min_value=None, max_value=None):
+    if not isinstance(min_value, float):
+      raise TypeError("min_value must be a float: %r" % (min_value,))
+    if not isinstance(max_value, float):
+      raise TypeError("max_value must be a float: %r" % (max_value,))
+    if min_value > max_value:
+      raise ValueError("%r > %r" % (min_value, max_value))
+    self._min_value = min_value
+    self._max_value = max_value
+
+  def __str__(self):
+    return "[%s, %s]" % (self._min_value, self._max_value)
+
+  def __repr__(self):
+    return "RealInterval(%r, %r)" % (self._min_value, self._max_value)
+
+  @property
+  def dtype(self):
+    return float
+
+  @property
+  def min_value(self):
+    return self._min_value
+
+  @property
+  def max_value(self):
+    return self._max_value
+
+  def update_hparam_info(self, hparam_info):
+    hparam_info.type = api_pb2.DATA_TYPE_FLOAT64
+    hparam_info.domain_interval.min_value = self._min_value
+    hparam_info.domain_interval.max_value = self._max_value
+
+
+class Discrete(Domain):
+  """A domain that takes on a fixed set of values.
+
+  These values may be of any (single) domain type.
+  """
+
+  def __init__(self, values, dtype=None):
+    self._values = list(values)
+    if dtype is None:
+      if self._values:
+        dtype = type(self._values[0])
+      else:
+        raise ValueError("Empty domain with no dtype specified")
+    if dtype not in (int, float, bool, str):
+      raise ValueError("Unknown dtype: %r" % (dtype,))
+    self._dtype = dtype
+    for value in self._values:
+      if not isinstance(value, self._dtype):
+        raise ValueError(
+            "dtype mismatch: not isinstance(%r, %s)"
+            % (value, self._dtype.__name__)
+        )
+    self._values.sort()
+
+  def __str__(self):
+    return "{%s}" % (", ".join(repr(x) for x in self._values))
+
+  def __repr__(self):
+    return "Discrete(%r)" % (self._values,)
+
+  @property
+  def dtype(self):
+    return self._dtype
+
+  @property
+  def values(self):
+    return list(self._values)
+
+  def update_hparam_info(self, hparam_info):
+    hparam_info.type = {
+        int: api_pb2.DATA_TYPE_FLOAT64,  # TODO(#1998): Add int dtype.
+        float: api_pb2.DATA_TYPE_FLOAT64,
+        bool: api_pb2.DATA_TYPE_BOOL,
+        str: api_pb2.DATA_TYPE_STRING,
+    }[self._dtype]
+    hparam_info.ClearField("domain_discrete")
+    hparam_info.domain_discrete.extend(self._values)
+
+
+class Metric(object):
+  """A metric in an experiment.
+
+  A metric is a real-valued function of a model. Each metric is
+  associated with a TensorBoard scalar summary, which logs the metric's
+  value as the model trains.
+  """
+  TRAINING = api_pb2.DATASET_TRAINING
+  VALIDATION = api_pb2.DATASET_VALIDATION
+
+  def __init__(
+      self,
+      tag,
+      group=None,
+      display_name=None,
+      description=None,
+      dataset_type=None,
+  ):
+    """
+    Args:
+      tag: The tag name of the scalar summary that corresponds to this
+        metric (as a `str`).
+      group: An optional string listing the subdirectory under the
+        session's log directory containing summaries for this metric.
+        For instance, if summaries for training runs are written to
+        events files in `ROOT_LOGDIR/SESSION_ID/train`, then `group`
+        should be `"train"`. Defaults to the empty string: i.e.,
+        summaries are expected to be written to the session logdir.
+      display_name: An optional human-readable display name.
+      description: An optional Markdown string with a human-readable
+        description of this metric, to appear in TensorBoard.
+      dataset_type: Either `Metric.TRAINING` or `Metric.VALIDATION`, or
+        `None`.
+    """
+    self._tag = tag
+    self._group = group
+    self._display_name = display_name
+    self._description = description
+    self._dataset_type = dataset_type
+    if self._dataset_type not in (None, Metric.TRAINING, Metric.VALIDATION):
+      raise ValueError("invalid dataset type: %r" % (self._dataset_type,))
+
+  def as_proto(self):
+    return api_pb2.MetricInfo(
+        name=api_pb2.MetricName(
+            group=self._group,
+            tag=self._tag,
+        ),
+        display_name=self._display_name,
+        description=self._description,
+        dataset_type=self._dataset_type,
+    )

--- a/tensorboard/plugins/hparams/api.py
+++ b/tensorboard/plugins/hparams/api.py
@@ -205,6 +205,16 @@ class IntInterval(Domain):
   """A domain that takes on all integer values in a closed interval."""
 
   def __init__(self, min_value=None, max_value=None):
+    """Create an `IntInterval`.
+
+    Args:
+      min_value: The lower bound (inclusive) of the interval.
+      max_value: The upper bound (inclusive) of the interval.
+
+    Raises:
+      TypeError: If `min_value` or `max_value` is not an `int`.
+      ValueError: If `min_value > max_value`.
+    """
     if not isinstance(min_value, int):
       raise TypeError("min_value must be an int: %r" % (min_value,))
     if not isinstance(max_value, int):
@@ -242,6 +252,16 @@ class RealInterval(Domain):
   """A domain that takes on all real values in a closed interval."""
 
   def __init__(self, min_value=None, max_value=None):
+    """Create a `RealInterval`.
+
+    Args:
+      min_value: The lower bound (inclusive) of the interval.
+      max_value: The upper bound (inclusive) of the interval.
+
+    Raises:
+      TypeError: If `min_value` or `max_value` is not an `float`.
+      ValueError: If `min_value > max_value`.
+    """
     if not isinstance(min_value, float):
       raise TypeError("min_value must be a float: %r" % (min_value,))
     if not isinstance(max_value, float):

--- a/tensorboard/plugins/hparams/api_test.py
+++ b/tensorboard/plugins/hparams/api_test.py
@@ -236,7 +236,7 @@ class DiscreteTest(test.TestCase):
 
   def test_dtype_mismatch(self):
     with six.assertRaisesRegex(
-        self, ValueError, r"dtype mismatch: not isinstance\(2, str\)"):
+        self, TypeError, r"dtype mismatch: not isinstance\(2, str\)"):
       hp.Discrete(["one", 2])
 
 

--- a/tensorboard/plugins/hparams/api_test.py
+++ b/tensorboard/plugins/hparams/api_test.py
@@ -1,0 +1,244 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import abc
+import collections
+import time
+
+from google.protobuf import text_format
+import six
+
+from tensorboard import test
+from tensorboard.plugins.hparams import api as hp
+from tensorboard.plugins.hparams import api_pb2
+from tensorboard.plugins.hparams import metadata
+
+
+class ExperimentTest(test.TestCase):
+  def test_summary_pb(self):
+    hparams = [
+        hp.HParam("learning_rate", hp.RealInterval(1e-2, 1e-1)),
+        hp.HParam("dense_layers", hp.IntInterval(2, 7)),
+        hp.HParam("optimizer", hp.Discrete(["adam", "sgd"])),
+        hp.HParam("who_knows_what"),
+        hp.HParam(
+            "magic",
+            hp.Discrete([False, True]),
+            display_name="~*~ Magic ~*~",
+            description="descriptive",
+        ),
+    ]
+    metrics = [
+        hp.Metric("samples_per_second"),
+        hp.Metric(group="train", tag="batch_loss", display_name="loss (train)"),
+        hp.Metric(
+            group="validation",
+            tag="epoch_accuracy",
+            display_name="accuracy (val.)",
+            description="Accuracy on the _validation_ dataset.",
+            dataset_type=hp.Metric.VALIDATION,
+        ),
+    ]
+    experiment = hp.Experiment(
+        hparams=hparams,
+        metrics=metrics,
+        user="zalgo",
+        description="nothing to see here; move along",
+        time_created_secs=1555624767,
+    )
+
+    self.assertEqual(experiment.hparams, hparams)
+    self.assertEqual(experiment.metrics, metrics)
+    self.assertEqual(experiment.user, "zalgo"),
+    self.assertEqual(experiment.description, "nothing to see here; move along")
+    self.assertEqual(experiment.time_created_secs, 1555624767)
+
+    expected_experiment_pb = api_pb2.Experiment()
+    text_format.Merge(
+        """
+        description: "nothing to see here; move along"
+        user: "zalgo"
+        time_created_secs: 1555624767.0
+        hparam_infos {
+          name: "learning_rate"
+          type: DATA_TYPE_FLOAT64
+          domain_interval {
+            min_value: 0.01
+            max_value: 0.1
+          }
+        }
+        hparam_infos {
+          name: "dense_layers"
+          type: DATA_TYPE_FLOAT64
+          domain_interval {
+            min_value: 2
+            max_value: 7
+          }
+        }
+        hparam_infos {
+          name: "optimizer"
+          type: DATA_TYPE_STRING
+          domain_discrete {
+            values {
+              string_value: "adam"
+            }
+            values {
+              string_value: "sgd"
+            }
+          }
+        }
+        hparam_infos {
+          name: "who_knows_what"
+        }
+        hparam_infos {
+          name: "magic"
+          type: DATA_TYPE_BOOL
+          display_name: "~*~ Magic ~*~"
+          description: "descriptive"
+          domain_discrete {
+            values {
+              bool_value: false
+            }
+            values {
+              bool_value: true
+            }
+          }
+        }
+        metric_infos {
+          name {
+            tag: "samples_per_second"
+          }
+        }
+        metric_infos {
+          name {
+            group: "train"
+            tag: "batch_loss"
+          }
+          display_name: "loss (train)"
+        }
+        metric_infos {
+          name {
+            group: "validation"
+            tag: "epoch_accuracy"
+          }
+          display_name: "accuracy (val.)"
+          description: "Accuracy on the _validation_ dataset."
+          dataset_type: DATASET_VALIDATION
+        }
+        """,
+        expected_experiment_pb,
+    )
+    actual_summary_pb = experiment.summary_pb()
+    plugin_content = actual_summary_pb.value[0].metadata.plugin_data.content
+    self.assertEqual(
+        metadata.parse_experiment_plugin_data(plugin_content),
+        expected_experiment_pb,
+    )
+
+
+class IntIntervalTest(test.TestCase):
+  def test_simple(self):
+    domain = hp.IntInterval(3, 7)
+    self.assertEqual(domain.min_value, 3)
+    self.assertEqual(domain.max_value, 7)
+    self.assertEqual(domain.dtype, int)
+
+  def test_singleton_domain(self):
+    domain = hp.IntInterval(61, 61)
+    self.assertEqual(domain.min_value, 61)
+    self.assertEqual(domain.max_value, 61)
+    self.assertEqual(domain.dtype, int)
+
+  def test_non_ints(self):
+    with six.assertRaisesRegex(
+        self, TypeError, "min_value must be an int: -inf"):
+      hp.IntInterval(float("-inf"), 0)
+    with six.assertRaisesRegex(
+        self, TypeError, "max_value must be an int: 'eleven'"):
+      hp.IntInterval(7, "eleven")
+
+  def test_backward_endpoints(self):
+    with six.assertRaisesRegex(
+        self, ValueError, "123 > 45"):
+      hp.IntInterval(123, 45)
+
+
+class RealIntervalTest(test.TestCase):
+  def test_simple(self):
+    domain = hp.RealInterval(3.1, 7.7)
+    self.assertEqual(domain.min_value, 3.1)
+    self.assertEqual(domain.max_value, 7.7)
+    self.assertEqual(domain.dtype, float)
+
+  def test_singleton_domain(self):
+    domain = hp.RealInterval(61.318, 61.318)
+    self.assertEqual(domain.min_value, 61.318)
+    self.assertEqual(domain.max_value, 61.318)
+    self.assertEqual(domain.dtype, float)
+
+  def test_infinite_domain(self):
+    inf = float("inf")
+    domain = hp.RealInterval(-inf, inf)
+    self.assertEqual(domain.min_value, -inf)
+    self.assertEqual(domain.max_value, inf)
+    self.assertEqual(domain.dtype, float)
+
+  def test_non_ints(self):
+    with six.assertRaisesRegex(
+        self, TypeError, "min_value must be a float: True"):
+      hp.RealInterval(True, 2.0)
+    with six.assertRaisesRegex(
+        self, TypeError, "max_value must be a float: 'wat'"):
+      hp.RealInterval(1.2, "wat")
+
+  def test_backward_endpoints(self):
+    with six.assertRaisesRegex(
+        self, ValueError, "2.1 > 1.2"):
+      hp.RealInterval(2.1, 1.2)
+
+
+class DiscreteTest(test.TestCase):
+  def test_simple(self):
+    domain = hp.Discrete([1, 2, 5])
+    self.assertEqual(domain.values, [1, 2, 5])
+    self.assertEqual(domain.dtype, int)
+
+  def test_values_sorted(self):
+    domain = hp.Discrete([2, 3, 1])
+    self.assertEqual(domain.values, [1, 2, 3])
+    self.assertEqual(domain.dtype, int)
+
+  def test_empty_with_explicit_dtype(self):
+    domain = hp.Discrete([], dtype=bool)
+    self.assertIs(domain.dtype, bool)
+    self.assertEqual(domain.values, [])
+
+  def test_empty_with_unspecified_dtype(self):
+    with six.assertRaisesRegex(
+        self, ValueError, "Empty domain with no dtype specified"):
+      hp.Discrete([])
+
+  def test_dtype_mismatch(self):
+    with six.assertRaisesRegex(
+        self, ValueError, r"dtype mismatch: not isinstance\(2, str\)"):
+      hp.Discrete(["one", 2])
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorboard/plugins/hparams/hparams_demo.py
+++ b/tensorboard/plugins/hparams/hparams_demo.py
@@ -118,7 +118,7 @@ def model_fn(hparams, seed):
   """Create a Keras model with the given hyperparameters.
 
   Args:
-    hparams: A dict mapping hyperparameter names to values.
+    hparams: A dict mapping hyperparameters in `HPARAMS` to values.
     seed: A hashable object to be used as a random seed (e.g., to
       construct dropout layers in the model).
 
@@ -174,7 +174,7 @@ def run(data, base_logdir, session_id, group_id, hparams):
     session_id: A unique string ID for this session.
     group_id: The string ID of the session group that includes this
       session.
-    hparams: A dict mapping hyperparameter names to values.
+    hparams: A dict mapping hyperparameters in `HPARAMS` to values.
   """
   model = model_fn(hparams=hparams, seed=session_id)
   logdir = os.path.join(base_logdir, session_id)


### PR DESCRIPTION
Summary:
This change introduces `HParam`, `Metric`, and `Experiment` classes,
which represent their proto counterparts in a more Python-friendly way.
It similarly includes a `Domain` class hierarchy, which does not
correspond to a specific proto message, but rather unifies the domain
variants defined on the `HParamInfo` proto.

The design is roughly as in the original sketch of #1998.

The primary benefit of this change is that having first-class domains
enables clients to reuse the domain information for both the experiment
summary and the underlying tuning algorithm. We don’t provide a method
to do this out of the box, because we don’t actually provide any tuners
at this time, but it’s easy to write (e.g.) a `sample_uniform` function
like the one included in this commit. Then, sampling is as easy as

```python
    hparams = {h: sample_uniform(h.domain, rng) for h in HPARAMS}
```

It is also now more convenient to reference hparam values such that
static analysis can detect potential typos, because the `HParam` objects
themselves can be declared as constants and used as keys in a dict.
Writing `hparams["dropuot"]` fails at runtime, but `hparams[HP_DROPUOT]`
fails at lint time.

As a pleasant bonus, hparam definitions are now more compact, fitting
on one line instead of several. The demo code has net fewer lines.

Manual summary writer management is still required. A future change will
introduce a Keras callback to reduce this overhead.

Test Plan:
Some unit tests included, and the demo still works.

wchargin-branch: hparams-structured-api
