### PR TITLE
Check if tensor value only has 1 shape

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -894,13 +894,20 @@ function extractOutputShapes(attr: Array<{key: string, value: any}>):
   for (let i = 0; i < attr.length; i++) {
     let {key, value} = attr[i];
     if (key === OUTPUT_SHAPES_KEY) {
-      if (!value.list.shape) {
+      let shapes = value.list.shape;
+      if (!shapes) {
         // The OUTPUT_SHAPES_KEY lacks a value. We know nothing about the shape.
         return null;
       }
 
+      if (shapes.length === undefined) {
+        // If a single shape exists, it will have been parsed into an object,
+        // not a list.
+        shapes = [shapes];
+      }
+
       // Map all output tensors into array of numbers denoting their shape.
-      let result = value.list.shape.map(shape => {
+      let result = shapes.map(shape => {
         if (shape.unknown_rank) {
           // This output tensor is of unknown rank. We don't know if it is a
           // scalar, or a tensor, or of what shape it is.


### PR DESCRIPTION
Previously, if a tensor value only has 1 shape, graph plugin logic would
fail to parse the list of shapes because pbtxt-parsing logic does not
differentiate between a field with a single message or a repeated field
containing a single message. This prevented an internal graph from being
parsed (with a console error).

Now, we can verify that the graph is rendered.