### PR TITLE
Metaclass syntax is not py3k-compatible #2121

### DIFF
--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -44,12 +44,11 @@ class TBPlugin(object):
       name must only contain characters among [A-Za-z0-9_.-], and must
       be nonempty, or a ValueError will similarly be thrown.
   """
-  __metaclass__ = ABCMeta
-
+  
   plugin_name = None
 
-  @abstractmethod
-  def get_plugin_apps(self):
+  @six.add_metaclass
+  def get_plugin_apps(self, metaclass=ABCMeta):
     """Returns a set of WSGI applications that the plugin implements.
 
     Each application gets registered with the tensorboard app and is served
@@ -61,8 +60,8 @@ class TBPlugin(object):
     """
     raise NotImplementedError()
 
-  @abstractmethod
-  def is_active(self):
+  @six.add_metaclass
+  def is_active(self, metaclass=ABCMeta):
     """Determines whether this plugin is active.
 
     A plugin may not be active for instance if it lacks relevant data. If a

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -308,10 +308,9 @@ class TensorBoard(object):
 
 class TensorBoardServer(object):
   """Class for customizing TensorBoard WSGI app serving."""
-  __metaclass__ = ABCMeta
 
-  @abstractmethod
-  def __init__(self, wsgi_app, flags):
+  @six.add_metaclass
+  def __init__(self, wsgi_app, flags, metaclass=ABCMeta):
     """Create a flag-configured HTTP server for TensorBoard's WSGI app.
 
     Args:
@@ -320,13 +319,13 @@ class TensorBoardServer(object):
     """
     raise NotImplementedError()
 
-  @abstractmethod
-  def serve_forever(self):
+  @six.add_metaclass
+  def serve_forever(self, metaclass=ABCMeta):
     """Blocking call to start serving the TensorBoard server."""
     raise NotImplementedError()
 
-  @abstractmethod
-  def get_url(self):
+  @six.add_metaclass
+  def get_url(self, metaclass=ABCMeta):
     """Returns a URL at which this server should be reachable."""
     raise NotImplementedError()
 


### PR DESCRIPTION
@nfelt, @wchargin Sorry, I was not able do any tests as my this laptop is not supporting anything as it is not my working laptop . Also I edited only 2 out of 4 files mentioned in issue #2121. PLease can anybody check whether these changes are relevant? 