### PR TITLE
Add extra import check for profile plugin

### DIFF
--- a/tensorboard/components/tf_tensorboard/plugin-dialog.html
+++ b/tensorboard/components/tf_tensorboard/plugin-dialog.html
@@ -84,13 +84,20 @@ limitations under the License.
       },
     },
     openNoTensorFlowDialog() {
-      this.set(
-          '_title',
-          'This plugin is disabled without TensorFlow');
-      this.set(
-          '_customMessage',
+      this.openDialog(
+          'This plugin is disabled without TensorFlow',
           'To enable this plugin in TensorBoard, install TensorFlow with '
               + '"pip install tensorflow" or equivalent.');
+    },
+    openOldTensorFlowDialog(version) {
+      this.openDialog(
+          'This plugin is disabled without TensorFlow ' + version,
+          'To enable this plugin in TensorBoard, install TensorFlow '
+              + version + ' or greater with "pip install tensorflow" or equivalent.');
+    },
+    openDialog(title, message) {
+      this.set('_title', title);
+      this.set('_customMessage', message);
       this.$.dialog.open();
     },
     closeDialog() {

--- a/tensorboard/plugins/profile/profile_plugin_loader.py
+++ b/tensorboard/plugins/profile/profile_plugin_loader.py
@@ -51,6 +51,7 @@ through tpu profiler analysis grpc. The grpc channel is not secured.\
     try:
       # pylint: disable=g-import-not-at-top,unused-import
       import tensorflow
+      # Available in TensorFlow 1.14 or later, so do import check
       # pylint: disable=g-import-not-at-top,unused-import
       from tensorflow.python.eager import profiler_client
     except ImportError:

--- a/tensorboard/plugins/profile/profile_plugin_loader.py
+++ b/tensorboard/plugins/profile/profile_plugin_loader.py
@@ -51,6 +51,8 @@ through tpu profiler analysis grpc. The grpc channel is not secured.\
     try:
       # pylint: disable=g-import-not-at-top,unused-import
       import tensorflow
+      # pylint: disable=g-import-not-at-top,unused-import
+      from tensorflow.python.eager import profiler_client
     except ImportError:
       return
     # pylint: disable=g-import-not-at-top

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -445,8 +445,9 @@ profile run can have multiple tools that present the performance profile as diff
           .request(tf_backend.getRouter().pluginsListing())
           .then(plugins => {
             if (!(PLUGIN_NAME in plugins)) {
-              // The plugin was not created
-              this.$.initialDialog.openNoTensorFlowDialog();
+              // The plugin was not created and so either didn't have
+              // TensorFlow or had an old version
+              this.$.initialDialog.openOldTensorFlowDialog('1.14');
               this.set('_isAvailable', false);
             } else {
               // The plugin was created


### PR DESCRIPTION
In testing TensorBoard for PyTorch in Colab I saw an error when running

```
# Install latest version of libraries
!pip install -q torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
!pip install -q tb-nightly

# Start colab TensorBoard instance
%load_ext tensorboard 

%tensorboard --logdir pytorch_logs
```

The error was

```
ERROR: Failed to launch TensorBoard (exited with 1).
Contents of stderr:
Traceback (most recent call last):
  File "/usr/local/bin/tensorboard", line 10, in <module>
    sys.exit(run_main())
  File "/usr/local/lib/python3.6/dist-packages/tensorboard/main.py", line 77, in run_main
    sys.exit(tensorboard.main())
  File "/usr/local/lib/python3.6/dist-packages/tensorboard/program.py", line 228, in main
    server = self._make_server()
  File "/usr/local/lib/python3.6/dist-packages/tensorboard/program.py", line 309, in _make_server
    self.assets_zip_provider)
  File "/usr/local/lib/python3.6/dist-packages/tensorboard/backend/application.py", line 153, in standard_tensorboard_wsgi
    plugin = loader.load(context)
  File "/usr/local/lib/python3.6/dist-packages/tensorboard/plugins/profile/profile_plugin_loader.py", line 57, in load
    from tensorboard.plugins.profile.profile_plugin import ProfilePlugin
  File "/usr/local/lib/python3.6/dist-packages/tensorboard/plugins/profile/profile_plugin.py", line 30, in <module>
    from tensorflow.python.eager import profiler_client
ImportError: cannot import name 'profiler_client'
```

A workaround is to install another version of TensorFlow like

```
!pip install -q tf-nightly-2.0-preview
```

cc @nfelt, @wchargin, @lanpa on this one.