### PR TITLE
Add TensorFlow full name in op profile details card.

### DIFF
--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-details.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-details.html
@@ -121,8 +121,12 @@ tf-op-bar {
           <tf-op-bar value="[[_memoryUtilization(node)]]"></tf-op-bar>
         </div>
         <div hidden="[[!node.xla.expression]]">
-          <b>Expression: </b>
+          <b>XLA Expression: </b>
           <code class="expression">[[node.xla.expression]]</code>
+        </div>
+        <div hidden="[[!node.xla.provenance]]">
+          <b>TensorFlow Name: </b>
+          <code class="expression">[[node.xla.provenance]]</code>
         </div>
         <div class="unavailable" hidden="[[!_fused(node)]]">
           Performance information for individual fused operations is not available.


### PR DESCRIPTION
* Motivation for features / changes
External customer requested to add full TensorFlow name in the details card.
* Technical description of changes
The node.xla.provenance has the full name, it is just we didn't show it.
* Screenshots of UI changes
![op_profile_tensorflow_name](https://user-images.githubusercontent.com/3082188/56534719-156eab80-650f-11e9-9923-6facb6f6ed6f.png)

* Detailed steps to verify changes work correctly (as executed by you)
```sh
bazel run tensorboard/plugins/profile:profile_demo
bazel run tensorboard:tensorboard -- --logdir=/tmp/profile_demo
# and go to localhost:6006/#profile
```

![op_profile_tensorflow_name_demo](https://user-images.githubusercontent.com/3082188/56535038-b9f0ed80-650f-11e9-8629-56d77e105f47.png)

* Alternate designs / implementations considered
N/A