### PR TITLE
Fix graph-loading for tf-graph-app and tf-debugger

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
+++ b/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
@@ -92,7 +92,6 @@ tf-graph-controls {
     <div class="side">
       <tf-graph-controls
           color-by-params="[[colorByParams]]"
-          stats="[[stats]]"
           color-by="{{colorBy}}"
           render-hierarchy="[[_renderHierarchy]]"
           selected-node="{{selectedNode}}"
@@ -101,7 +100,6 @@ tf-graph-controls {
       <tf-graph-loader id="loader"
           out-graph-hierarchy="{{graphHierarchy}}"
           out-graph="{{graph}}"
-          out-stats="{{stats}}"
           progress="{{_progress}}"
           selected-file="[[selectedFile]]"
       ></tf-graph-loader>
@@ -110,7 +108,6 @@ tf-graph-controls {
       <tf-graph-board id="graphboard"
           graph-hierarchy="[[graphHierarchy]]"
           graph="[[graph]]"
-          stats="[[stats]]"
           progress="[[_progress]]"
           color-by="[[colorBy]]"
           color-by-params="{{colorByParams}}"
@@ -130,8 +127,6 @@ tf-graph-controls {
 Polymer({
   is: 'tf-graph-app',
   properties: {
-    stats: Object,
-
     // To use tf-graph-app, specify one of these 2 properties. Provide either
     // 1. The path to a pbtxt file to load (pbtxtFileLocation). This option nicely makes the
     //    progress bar include the time it takes to load the file across the network. The path could
@@ -190,7 +185,7 @@ Polymer({
       var blob = new Blob([this.pbtxt]);
 
       // TODO(@chihuahua): Find out why we call a private method here and do away with the call.
-      this.$.loader._fetchAndConstructHierarchicalGraph(null, blob);
+      this.$.loader._parseAndConstructHierarchicalGraph(null, blob);
     }
   },
 });

--- a/tensorboard/plugins/graph/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_common/BUILD
@@ -17,6 +17,7 @@ tf_web_library(
         "graph.ts",
         "hierarchy.ts",
         "layout.ts",
+        "loader.ts",
         "minimap.ts",
         "node.ts",
         "op.ts",

--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -1020,6 +1020,30 @@ function addEdgeToGraph(
   });
 }
 
+export const DefaultBuildParams: BuildParams = {
+  enableEmbedding: true,
+  inEmbeddingTypes: ['Const'],
+  outEmbeddingTypes: ['^[a-zA-Z]+Summary$'],
+  // This is the whitelist of inputs on op types that are considered
+  // reference edges. "Assign 0" indicates that the first input to
+  // an OpNode with operation type "Assign" is a reference edge.
+  refEdges: {
+    'Assign 0': true,
+    'AssignAdd 0': true,
+    'AssignSub 0': true,
+    'assign 0': true,
+    'assign_add 0': true,
+    'assign_sub 0': true,
+    'count_up_to 0': true,
+    'ScatterAdd 0': true,
+    'ScatterSub 0': true,
+    'ScatterUpdate 0': true,
+    'scatter_add 0': true,
+    'scatter_sub 0': true,
+    'scatter_update 0': true,
+  },
+};
+
 export function build(
     graphDef: tf.graph.proto.GraphDef, params: BuildParams,
     tracker: ProgressTracker): Promise<SlimGraph> {

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -416,12 +416,20 @@ export interface HierarchyParams {
   useGeneralizedSeriesPatterns: boolean;
 }
 
+export const DefaultHierarchyParams = {
+  verifyTemplate: true,
+  seriesNodeMinSize: 5,
+  seriesMap: {},
+  rankDirection: 'BT',
+  useGeneralizedSeriesPatterns: false,
+};
+
 /**
  * @param graph The raw graph.
  * @param params Parameters used when building a hierarchy.
  */
 export function build(graph: tf.graph.SlimGraph, params: HierarchyParams,
-    tracker: ProgressTracker): Promise<Hierarchy|void> {
+    tracker: ProgressTracker): Promise<Hierarchy> {
   let h = new HierarchyImpl({'rankdir': params.rankDirection});
   let seriesNames: { [name: string]: string } = {};
   return tf.graph.util

--- a/tensorboard/plugins/graph/tf_graph_common/loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/loader.ts
@@ -1,0 +1,69 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+module tf.graph.loader {
+  export type GraphAndHierarchy = {
+    graph: SlimGraph,
+    graphHierarchy: hierarchy.Hierarchy;
+  };
+
+  export function fetchAndConstructHierarchicalGraph(
+      tracker: tf.graph.util.Tracker,
+      remotePath: string|null,
+      pbTxtFile: Blob|null,
+      compatibilityProvider: op.CompatibilityProvider =
+          new op.TpuCompatibilityProvider(),
+      hierarchyParams: hierarchy.HierarchyParams =
+          hierarchy.DefaultHierarchyParams,
+  ): Promise<GraphAndHierarchy> {
+    const dataTracker = util.getSubtaskTracker(tracker, 30, 'Data');
+    const graphTracker = util.getSubtaskTracker(tracker, 20, 'Graph');
+    const hierarchyTracker = util.getSubtaskTracker(
+        tracker, 50, 'Namespace hierarchy');
+
+    return parser.fetchAndParseGraphData(remotePath, pbTxtFile, dataTracker)
+      .then(function(graph) {
+        if (!graph.node) {
+          throw new Error('The graph is empty. This can happen when ' +
+            'TensorFlow could not trace any graph. Please refer to ' +
+            'https://github.com/tensorflow/tensorboard/issues/1961 for more ' +
+            'information.');
+        }
+
+        return build(graph, DefaultBuildParams, graphTracker);
+      }, () => {
+        throw new Error('Malformed GraphDef. This can sometimes be caused by ' +
+          'a bad network connection or difficulty reconciling multiple ' +
+          'GraphDefs; for the latter case, please refer to ' +
+          'https://github.com/tensorflow/tensorboard/issues/1929.');
+      })
+      .then(async (graph) => {
+        // Populate compatibile field of OpNode based on whitelist
+        op.checkOpsForCompatibility(graph, compatibilityProvider);
+        const graphHierarchy = await hierarchy.build(
+            graph, hierarchyParams, hierarchyTracker);
+        return {graph, graphHierarchy};
+      })
+      .catch((e) => {
+        // Generic error catch, for errors that happened outside
+        // asynchronous tasks.
+        const msg = `Graph visualization failed.\n\n${e}`;
+
+        tracker.reportError(msg, e);
+        // Don't swallow the error.
+        throw e;
+      });
+  }
+
+}  // module tf.graph.loader

--- a/tensorboard/plugins/graph/tf_graph_common/tf-graph-common.html
+++ b/tensorboard/plugins/graph/tf_graph_common/tf-graph-common.html
@@ -20,20 +20,21 @@ limitations under the License.
 <link rel="import" href="../tf-imports/graphlib.html">
 <link rel="import" href="../tf-imports/lodash.html">
 
+<script src="annotation.js"></script>
 <script src="colors.js"></script>
 <script src="common.js"></script>
+<script src="contextmenu.js"></script>
+<script src="edge.js"></script>
 <script src="externs.js"></script>
 <script src="graph.js"></script>
 <script src="hierarchy.js"></script>
 <script src="layout.js"></script>
+<script src="loader.js"></script>
+<script src="node.js"></script>
 <script src="op.js"></script>
 <script src="parser.js"></script>
 <script src="proto.js"></script>
 <script src="render.js"></script>
-<script src="annotation.js"></script>
-<script src="contextmenu.js"></script>
-<script src="edge.js"></script>
-<script src="node.js"></script>
 <script src="scene.js"></script>
 <script src="template.js"></script>
 <script src="util.js"></script>

--- a/tensorboard/plugins/graph/tf_graph_common/util.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/util.ts
@@ -36,6 +36,12 @@ module tf.graph.util {
     return result;
   }
 
+  export type Tracker = {
+    setMessage: (msg: string) => void;
+    updateProgress: (value: number) => void;
+    reportError: (msg: string, error: Error) => void;
+  };
+
   /**
    * Creates a tracker that sets the progress property of the
    * provided polymer component. The provided component must have
@@ -43,7 +49,7 @@ module tf.graph.util {
    * property is an object with a numerical 'value' property and a
    * string 'msg' property.
    */
-  export function getTracker(polymerComponent: any) {
+  export function getTracker(polymerComponent: any): Tracker {
     return {
       setMessage: function(msg) {
         polymerComponent.set(

--- a/tensorboard/plugins/graph/tf_graph_dashboard/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/BUILD
@@ -20,7 +20,7 @@ tf_web_library(
         "//tensorboard/plugins/graph/tf_graph",
         "//tensorboard/plugins/graph/tf_graph_board",
         "//tensorboard/plugins/graph/tf_graph_controls",
-        "//tensorboard/plugins/graph/tf_graph_loader",
+        "//tensorboard/plugins/graph/tf_graph_loader:tf_graph_dashboard_loader",
     ],
 )
 
@@ -35,7 +35,7 @@ tensorboard_webcomponent_library(
         "//tensorboard/plugins/graph/tf_graph:legacy",
         "//tensorboard/plugins/graph/tf_graph_board:legacy",
         "//tensorboard/plugins/graph/tf_graph_controls:legacy",
-        "//tensorboard/plugins/graph/tf_graph_loader:legacy",
+        "//tensorboard/plugins/graph/tf_graph_loader:legacy_dashboard_loader",
         "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -20,7 +20,7 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-graph-board/tf-graph-board.html">
 <link rel="import" href="../tf-graph-controls/tf-graph-controls.html">
-<link rel="import" href="../tf-graph-loader/tf-graph-loader.html">
+<link rel="import" href="../tf-graph-loader/tf-graph-dashboard-loader.html">
 <link rel="import" href="../tf-storage/tf-storage.html">
 <link rel="import" href="../tf-tensorboard/registry.html">
 <link rel="import" href="../vz-sorting/vz-sorting.html">
@@ -79,7 +79,7 @@ by default. The user can select a different run from a dropdown menu.
         health-pills-toggled-on="{{healthPillsToggledOn}}"
   ></tf-graph-controls>
   <div class="center">
-    <tf-graph-loader id="loader"
+    <tf-graph-dashboard-loader id="loader"
           datasets="[[_datasets]]"
           selection="[[_selection]]"
           selected-file="[[_selectedFile]]"
@@ -89,7 +89,7 @@ by default. The user can select a different run from a dropdown menu.
           progress="{{_progress}}"
           hierarchy-params="[[_hierarchyParams]]"
           compatibility-provider="[[_compatibilityProvider]]"
-    ></tf-graph-loader>
+    ></tf-graph-dashboard-loader>
     <tf-graph-board id="graphboard"
         devices-for-stats="[[_devicesForStats]]"
         color-by="[[_colorBy]]"

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -87,7 +87,7 @@ by default. The user can select a different run from a dropdown menu.
           out-graph="{{_graph}}"
           out-stats="{{_stats}}"
           progress="{{_progress}}"
-          out-hierarchy-params="{{_hierarchyParams}}"
+          hierarchy-params="[[_hierarchyParams]]"
           compatibility-provider="[[_compatibilityProvider]]"
     ></tf-graph-loader>
     <tf-graph-board id="graphboard"
@@ -238,7 +238,11 @@ Polymer({
     _selection: {
       type: Object,
     },
-    _compatibilityProvider: Object
+    _compatibilityProvider: Object,
+    _hierarchyParams: {
+      type: Object,
+      value: () => tf.graph.hierarchy.DefaultHierarchyParams,
+    },
   },
   listeners: {
     'node-toggle-expand': '_handleNodeToggleExpand',

--- a/tensorboard/plugins/graph/tf_graph_loader/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_loader/BUILD
@@ -6,6 +6,29 @@ load("//tensorboard/defs:web.bzl", "tf_web_library")
 licenses(["notice"])  # Apache 2.0
 
 tf_web_library(
+    name = "tf_graph_loader",
+    srcs = [
+        "tf-graph-loader.html",
+        "tf-graph-loader.ts",
+    ],
+    path = "/tf-graph-loader",
+    deps = [
+        "//tensorboard/plugins/graph/tf_graph_common",
+        "//tensorboard/components/tf_imports:polymer",
+    ],
+)
+
+tensorboard_webcomponent_library(
+    name = "legacy",
+    srcs = [":tf_graph_loader"],
+    destdir = "tf-graph-loader",
+    deps = [
+        "//tensorboard/plugins/graph/tf_graph_common:legacy",
+        "//third_party/javascript/polymer/v1/polymer:lib",
+    ],
+)
+
+tf_web_library(
     name = "tf_graph_dashboard_loader",
     srcs = [
         "tf-graph-dashboard-loader.html",
@@ -22,7 +45,7 @@ tf_web_library(
 
 tensorboard_webcomponent_library(
     name = "legacy_dashboard_loader",
-    srcs = [":tf_graph_loader"],
+    srcs = [":tf_graph_dashboard_loader"],
     destdir = "tf-graph-loader",
     deps = [
         "//tensorboard/components/tf_backend:legacy",

--- a/tensorboard/plugins/graph/tf_graph_loader/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_loader/BUILD
@@ -6,10 +6,10 @@ load("//tensorboard/defs:web.bzl", "tf_web_library")
 licenses(["notice"])  # Apache 2.0
 
 tf_web_library(
-    name = "tf_graph_loader",
+    name = "tf_graph_dashboard_loader",
     srcs = [
-        "tf-graph-loader.html",
-        "tf-graph-loader.ts",
+        "tf-graph-dashboard-loader.html",
+        "tf-graph-dashboard-loader.ts",
     ],
     path = "/tf-graph-loader",
     deps = [
@@ -21,7 +21,7 @@ tf_web_library(
 )
 
 tensorboard_webcomponent_library(
-    name = "legacy",
+    name = "legacy_dashboard_loader",
     srcs = [":tf_graph_loader"],
     destdir = "tf-graph-loader",
     deps = [

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.html
@@ -28,8 +28,8 @@ capable of loading an op graph. Another difference is that the loader takes
 `selection` from the tf-graph-controls as an input as opposed to URL path of an
 data endpoint.
 -->
-<dom-module id="tf-graph-loader">
+<dom-module id="tf-graph-dashboard-loader">
 </dom-module>
 
-<script src="tf-graph-loader.js"></script>
+<script src="tf-graph-dashboard-loader.js"></script>
 

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.ts
@@ -20,7 +20,7 @@ interface GraphRunTag {
 }
 
 Polymer({
-  is: 'tf-graph-loader',
+  is: 'tf-graph-dashboard-loader',
 
   properties: {
     datasets: Array,

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -1,0 +1,26 @@
+<!--
+@license
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../tf-graph-common/tf-graph-common.html">
+
+<dom-module id="tf-graph-loader">
+</dom-module>
+
+<script src="tf-graph-loader.js"></script>
+
+

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.html
@@ -20,7 +20,13 @@ limitations under the License.
 <link rel="import" href="../tf-graph-common/tf-graph-common.html">
 
 <!--
-An element which provides a filter parsing for pbtxt to graph output.
+Data loader for tf-graph-dashboard.
+
+The loader loads op graph, conceptual graphs, and RunMetadata associated with an
+op graph which is the major difference from the tf-graph-loader which is only
+capable of loading an op graph. Another difference is that the loader takes
+`selection` from the tf-graph-controls as an input as opposed to URL path of an
+data endpoint.
 -->
 <dom-module id="tf-graph-loader">
 </dom-module>

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.ts
@@ -45,16 +45,9 @@ Polymer({
       type: Object,
       value: () => new tf.graph.op.TpuCompatibilityProvider(),
     },
-    /**
-     * If this optional object is provided, graph logic will override
-     * the HierarchyParams it uses to build the graph with properties within
-     * this object. For possible properties that this object can have, please
-     * see documentation on the HierarchyParams TypeScript interface.
-     * @type {Object}
-     */
-    overridingHierarchyParams: {
+    hierarchyParams: {
       type: Object,
-      value: () => ({})
+      value: () => tf.graph.hierarchy.DefaultHierarchyParams,
     },
     outGraphHierarchy: {
       type: Object,
@@ -66,25 +59,20 @@ Polymer({
       readOnly: true, //readonly so outsider can't change this via binding
       notify: true
     },
-    /**
-     * @type {?GraphRunTag}
-     */
-    _graphRunTag: Object,
-    outHierarchyParams: {
-      type: Object,
-      readOnly: true,
-      notify: true
-    },
     /** @type {Object} */
     outStats: {
       type: Object,
       readOnly: true, // This property produces data.
       notify: true
     },
+    /**
+     * @type {?GraphRunTag}
+     */
+    _graphRunTag: Object,
   },
   observers: [
-    '_selectionChanged(selection, overridingHierarchyParams, compatibilityProvider)',
-    '_selectedFileChanged(selectedFile, overridingHierarchyParams, compatibilityProvider)',
+    '_selectionChanged(selection, compatibilityProvider)',
+    '_selectedFileChanged(selectedFile, compatibilityProvider)',
   ],
   _selectionChanged(): void {
     // selection can change a lot within a microtask.
@@ -95,7 +83,6 @@ Polymer({
   },
   _load: function(selection: tf.graph.controls.Selection): Promise<void> {
     const {run, tag, type: selectionType} = selection;
-    const {overridingHierarchyParams} = this;
 
     switch (selectionType) {
       case tf.graph.SelectionType.OP_GRAPH:
@@ -110,10 +97,9 @@ Polymer({
         if (tag) params.set('tag', tag);
         const graphPath =
             tf_backend.getRouter().pluginRoute('graphs', '/graph', params);
-        return this._fetchAndConstructHierarchicalGraph(
-            graphPath, null, overridingHierarchyParams).then(() => {
-              this._graphRunTag = {run, tag};
-            });
+        return this._fetchAndConstructHierarchicalGraph(graphPath).then(() => {
+          this._graphRunTag = {run, tag};
+        })
       }
       case tf.graph.SelectionType.PROFILE: {
         const {tags} = this.datasets.find(({name}) => name === run);
@@ -151,7 +137,7 @@ Polymer({
     // Reset the progress bar to 0.
     this.set('progress', {
       value: 0,
-      msg: ''
+      msg: '',
     });
     var tracker = tf.graph.util.getTracker(this);
     tf.graph.parser.fetchAndParseMetadata(path, tracker)
@@ -159,100 +145,26 @@ Polymer({
           this._setOutStats(stats);
         });
   },
-  _fetchAndConstructHierarchicalGraph: function(
-      path: (string|null), pbTxtFile?: Blob,
-      overridingHierarchyParams?: {}): Promise<void> {
+  _fetchAndConstructHierarchicalGraph: async function(
+      path: (string|null), pbTxtFile?: Blob): Promise<void> {
     // Reset the progress bar to 0.
     this.set('progress', {
       value: 0,
-      msg: ''
+      msg: '',
     });
-    var tracker = tf.graph.util.getTracker(this);
-    var hierarchyParams = {
-      verifyTemplate: true,
-      // If a set of numbered op nodes has at least this number of nodes
-      // then group them into a series node.
-      seriesNodeMinSize: 5,
-      // A map of series node names to series grouping settings, to indicate
-      // if a series is to be rendered as grouped or ungrouped.
-      // Starts out empty which allows the renderer to decide which series
-      // are initially rendered grouped and which aren't.
-      seriesMap: {},
-      rankDirection: 'BT',
-      useGeneralizedSeriesPatterns: false,
-    };
-    _.forOwn(overridingHierarchyParams, (value, key) => {
-      hierarchyParams[key] = value;
-    });
-    this._setOutHierarchyParams(hierarchyParams);
-    var dataTracker = tf.graph.util.getSubtaskTracker(tracker, 30, 'Data');
-    return tf.graph.parser.fetchAndParseGraphData(path, pbTxtFile, dataTracker)
-    .then(function(graph) {
-      if (!graph.node) {
-        throw new Error('The graph is empty. This can happen when ' +
-            'TensorFlow could not trace any graph. Please refer to ' +
-            'https://github.com/tensorflow/tensorboard/issues/1961 for more ' +
-            'information.');
-      }
-
-      // Build the flat graph (consists only of Op nodes).
-
-      // This is the whitelist of inputs on op types that are considered
-      // reference edges. "Assign 0" indicates that the first input to
-      // an OpNode with operation type "Assign" is a reference edge.
-      var refEdges = {};
-      refEdges["Assign 0"] = true;
-      refEdges["AssignAdd 0"] = true;
-      refEdges["AssignSub 0"] = true;
-      refEdges["assign 0"] = true;
-      refEdges["assign_add 0"] = true;
-      refEdges["assign_sub 0"] = true;
-      refEdges["count_up_to 0"] = true;
-      refEdges["ScatterAdd 0"] = true;
-      refEdges["ScatterSub 0"] = true;
-      refEdges["ScatterUpdate 0"] = true;
-      refEdges["scatter_add 0"] = true;
-      refEdges["scatter_sub 0"] = true;
-      refEdges["scatter_update 0"] = true;
-      var buildParams = {
-        enableEmbedding: true,
-        inEmbeddingTypes: ['Const'],
-        outEmbeddingTypes: ['^[a-zA-Z]+Summary$'],
-        refEdges: refEdges
-      };
-      var graphTracker = tf.graph.util.getSubtaskTracker(tracker, 20, 'Graph');
-      return tf.graph.build(graph, buildParams, graphTracker);
-    }, () => {
-      throw new Error('Malformed GraphDef. This can sometimes be caused by a ' +
-          'bad network connection or difficulty reconciling multiple GraphDefs;' +
-          ' for the latter case, please refer to ' +
-          'https://github.com/tensorflow/tensorboard/issues/1929.');
-    })
-    .then((graph) => {
-      // Populate compatibile field of OpNode based on whitelist
-      tf.graph.op.checkOpsForCompatibility(graph, this.compatibilityProvider);
-
+    const tracker = tf.graph.util.getTracker(this);
+    return tf.graph.loader.fetchAndConstructHierarchicalGraph(
+      tracker,
+      path,
+      pbTxtFile,
+      this.compatibilityProvider,
+      this.hierarchyParams,
+    ).then(({graph, graphHierarchy}) => {
       this._setOutGraph(graph);
-      var hierarchyTracker = tf.graph.util.getSubtaskTracker(tracker, 50,
-          'Namespace hierarchy');
-      return tf.graph.hierarchy.build(graph, hierarchyParams, hierarchyTracker);
-    })
-    .then((graphHierarchy) => {
-      // Update the properties which notify the parent with the
-      // graph hierarchy and whether the data has live stats or not.
       this._setOutGraphHierarchy(graphHierarchy);
-    })
-    .catch((e) => {
-      // Generic error catch, for errors that happened outside
-      // asynchronous tasks.
-      const msg = `Graph visualization failed.\n\n${e}`;
-
-      tracker.reportError(msg, e);
-      // Don't swallow the error.
-      throw e;
     });
   },
-  _selectedFileChanged: function(e: Event|null, overridingHierarchyParams: {}): void {
+  _selectedFileChanged: function(e: Event|null): void {
     if (!e) {
       return;
     }
@@ -266,8 +178,7 @@ Polymer({
     // selects the same file, we'll re-read it.
     target.value = '';
 
-    this._fetchAndConstructHierarchicalGraph(
-        null, file, overridingHierarchyParams);
+    this._fetchAndConstructHierarchicalGraph(null, file);
   },
 });
 

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.ts
@@ -78,10 +78,10 @@ Polymer({
     this.debounce('load', () => {
       const dataset = this.datasets[this.selectedData];
       if (!dataset) return;
-      this._fetchAndConstructHierarchicalGraph(dataset.path);
+      this._parseAndConstructHierarchicalGraph(dataset.path);
     });
   },
-  _fetchAndConstructHierarchicalGraph(
+  _parseAndConstructHierarchicalGraph(
       path: (string|null), pbTxtFile?: Blob): void {
     const {
       overridingHierarchyParams,
@@ -120,7 +120,7 @@ Polymer({
     // selects the same file, we'll re-read it.
     target.value = '';
 
-    this._fetchAndConstructHierarchicalGraph(null, file);
+    this._parseAndConstructHierarchicalGraph(null, file);
   },
 });
 

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.ts
@@ -1,0 +1,127 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace tf.graph.loader {
+
+Polymer({
+  is: 'tf-graph-loader',
+
+  properties: {
+    /**
+     * @type {Array<{name: string, path: string}>}
+     */
+    datasets: Array,
+    selectedData: {
+      type: Number,
+      value: 0,
+    },
+    selectedFile: Object,
+    compatibilityProvider: {
+      type: Object,
+      value: () => new tf.graph.op.TpuCompatibilityProvider(),
+    },
+    /**
+     * If this optional object is provided, graph logic will override
+     * the HierarchyParams it uses to build the graph with properties within
+     * this object. For possible properties that this object can have, please
+     * see documentation on the HierarchyParams TypeScript interface.
+     * @type {Object}
+     */
+    overridingHierarchyParams: {
+      type: Object,
+      value: () => ({})
+    },
+    /**
+     * @type {{value: number, msg: string}}
+     *
+     * A number between 0 and 100 denoting the % of progress
+     * for the progress bar and the displayed message.
+     */
+    progress: {
+      type: Object,
+      notify: true,
+    },
+    outGraphHierarchy: {
+      type: Object,
+      readOnly: true, //readonly so outsider can't change this via binding
+      notify: true
+    },
+    outGraph: {
+      type: Object,
+      readOnly: true, //readonly so outsider can't change this via binding
+      notify: true
+    },
+    outHierarchyParams: {
+      type: Object,
+      readOnly: true,
+      notify: true
+    },
+  },
+  observers: [
+    '_loadData(datasets, selectedData, overridingHierarchyParams, compatibilityProvider)',
+    '_loadFile(selectedFile, overridingHierarchyParams, compatibilityProvider)',
+  ],
+  _loadData(): void {
+    // Input can change a lot within a microtask.
+    // Don't fetch too much too fast and introduce race condition.
+    this.debounce('load', () => {
+      const dataset = this.datasets[this.selectedData];
+      if (!dataset) return;
+      this._fetchAndConstructHierarchicalGraph(dataset.path);
+    });
+  },
+  _fetchAndConstructHierarchicalGraph(
+      path: (string|null), pbTxtFile?: Blob): void {
+    const {
+      overridingHierarchyParams,
+      compatibilityProvider,
+    } = this;
+    // Reset the progress bar to 0.
+    this.progress = {value: 0, msg: ''};
+    const tracker = tf.graph.util.getTracker(this);
+    const hierarchyParams = Object.assign(
+        {},
+        tf.graph.hierarchy.DefaultHierarchyParams,
+        overridingHierarchyParams);
+    tf.graph.loader.fetchAndConstructHierarchicalGraph(
+      tracker,
+      path,
+      pbTxtFile,
+      compatibilityProvider,
+      hierarchyParams,
+    ).then(({graph, graphHierarchy}) => {
+      this._setOutHierarchyParams(hierarchyParams);
+      this._setOutGraph(graph);
+      this._setOutGraphHierarchy(graphHierarchy);
+    });
+  },
+  _loadFile(e: Event|null): void {
+    if (!e) {
+      return;
+    }
+    const target = (e.target as HTMLInputElement);
+    const file = target.files[0];
+    if (!file) {
+      return;
+    }
+
+    // Clear out the value of the file chooser. This ensures that if the user
+    // selects the same file, we'll re-read it.
+    target.value = '';
+
+    this._fetchAndConstructHierarchicalGraph(null, file);
+  },
+});
+
+}  // namespace tf.graph.loader


### PR DESCRIPTION
tf-graph-control, being inside graph plugin, changed recently to work
better with other graph components like tf-graph-controls. More
specifically, the problem happen because the tf-graph-loader was
refactored to take `selection` as the primary input to the loader and
it used run & type of graph selected by user to fetch appropriate data.
This contrasts with previous input `datasets` which took a `path` as an
input which loader used to fetch the data from. tf-graph-app and
tf-debugger-dashboard plugin were using the datasets prop to pass in
the special endpoint where the data lives.

Before describing refactor, we should define what the tf-graph-loader
should be. The loader is a UI-less functional component (renders no DOM;
uses lifecycle method and props to provide some functionality) that is
capable of fetching various informations like graph, conceptual graph,
and profile info (RunMetadata). We have recently introduce more
complexity to it.

Interestingly, all tf-graph variants (internal to Google too) does not
make use of any other data type other than the graph and there is almost
no reason to use the tf-graph-loader. The graph utilities provide an
ability to fetch and parse GraphDef, create SlimGraph, and create a
hierarchy with ease. The core values the tf-graph-loader provides are
1. error handling and 2. progress tracker (uses Polymer API). By
reusing the component, one can provide some consistency there.

There were few ways to refactor this:
1. Behavior (mixin)
2. tf-graph-dashboard can have specialized wrapper that converts
`selection` into the old `datasets`.
3. Put bulk of fetch+parse+graph_building to util and have specialized
graph loaders

To stephanwlee, option 2 was unfavorable because the tf-graph-loader
becomes needlessly complex with different control flow depending on type
of data requested when it was only used/required by tf-graph-dashboard.
Instead, we chose to go with the option 3. Instead of inadvertently breaking
others due to dependency on tf-graph-* components, for our velocity, we
believe all variants of graph should use utility method without reusing the 
components. 