### PR TITLE
Update urllib3 for CVE-2019-11324

### DIFF
--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -35,12 +35,12 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_pythonhosted_urllib3",
         urls = [
-            "https://mirror.bazel.build/pypi.python.org/packages/b1/53/37d82ab391393565f2f831b8eedbffd57db5a718216f82f1a8b4d381a1c1/urllib3-1.24.1.tar.gz",
-            "https://pypi.python.org/packages/b1/53/37d82ab391393565f2f831b8eedbffd57db5a718216f82f1a8b4d381a1c1/urllib3-1.24.1.tar.gz",
-            "https://files.pythonhosted.org/packages/b1/53/37d82ab391393565f2f831b8eedbffd57db5a718216f82f1a8b4d381a1c1/urllib3-1.24.1.tar.gz",
+            "https://mirror.bazel.build/pypi.python.org/packages/cb/34/db09a2f1e27c6ded5dd42afb0e3e2cf6f51ace7d75726385e8a3b1993b17/urllib3-1.25.tar.gz",
+            "https://pypi.python.org/packages/cb/34/db09a2f1e27c6ded5dd42afb0e3e2cf6f51ace7d75726385e8a3b1993b17/urllib3-1.25.tar.gz",
+            "https://files.pythonhosted.org/packages/cb/34/db09a2f1e27c6ded5dd42afb0e3e2cf6f51ace7d75726385e8a3b1993b17/urllib3-1.25.tar.gz",
         ],
-        sha256 = "de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22",
-        strip_prefix = "urllib3-1.24.1/src",
+        sha256 = "f03eeb431c77b88cf8747d47e94233a91d0e0fdae1cf09e0b21405a885700266",
+        strip_prefix = "urllib3-1.25/src",
         build_file = str(Label("//third_party:urllib3.BUILD")),
     )
 


### PR DESCRIPTION
* Motivation for features / changes
Security Vulnerability
Urllib3 version 1.24.1 and earlier have an issue with certificate handling. Details in:
https://nvd.nist.gov/vuln/detail/CVE-2019-11324

This Pull Request updates urllib3 to the latest version (1.25). No other changes.

* Technical description of changes
Update the effected package (urllib3) to the latest version, which contains the fix

* Screenshots of UI changes
no UI changes

* Detailed steps to verify changes work correctly (as executed by you)
Updated .bzl file, rebuilt, started TensorBoard

* Alternate designs / implementations considered
N/A