### PR TITLE
Show "capture profile" button in the profile plugin even if there is no profile data.

### DIFF
--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -45,11 +45,6 @@ profile run can have multiple tools that present the performance profile as diff
 -->
 
 <dom-module id="tf-profile-dashboard">
-  <style>
-.profile-btn {
-  width: 160px;
-}
-  </style>
 <template>
 <template is="dom-if" if="[[_isState(_topLevelState, 'IN_COLAB')]]">
   <div style="max-width: 540px; margin: 80px auto 0 auto;">
@@ -99,21 +94,22 @@ profile run can have multiple tools that present the performance profile as diff
   <div style="max-width: 540px; margin: 80px auto 0 auto;">
     <h3>No profile data was found.</h3>
 
-    <paper-button class="profile-btn" raised on-tap="_openCaptureProfileDialog">Capture Profile</paper-button>
+    <paper-button raised on-tap="_openCaptureProfileDialog">Capture Profile</paper-button>
 
-    <p>If you have a model running on a Google Cloud TPU or a GPU, you may be
+    <p>If you have a model running on CPU, GPU, or Google Cloud TPU, you may be
         able to use the above button to capture a profile.
+    <p>If you’re a CPU or GPU user, please use the IP address option. You may want to check out the
+        <a href="https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/docs/r2/tensorboard_profiling_keras.ipynb" rel="noopener" target="_blank">tutorial</a> on how to
+        start a TensorFlow profiler server and profile a Keras model on a GPU.
     <p>If you're a TPU user, please use the TPU name option and you may want to check out the
-           <a href="https://cloud.google.com/tpu/docs/cloud-tpu-tools"
-               rel="noopener" target="_blank">tutorial</a>
-           on how to interpreting the profiling results.
-    <p>If you’re a GPU user, please use the IP address option and you may want to check out the
-    <a href="https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/docs/r2/tensorboard_profiling_keras.ipynb" rel="noopenr" target="_blank">tutorial</a> on how to profile a Keras model on a GPU.
+        <a href="https://cloud.google.com/tpu/docs/cloud-tpu-tools"
+            rel="noopener" target="_blank">tutorial</a>
+        on how to interpreting the profiling results.
     <p>If you think profiling is done properly, please see the page of
         <a href="https://cloud.google.com/tpu/docs/troubleshooting"
             rel="noopener"
             target="_blank">Google Cloud TPU Troubleshooting and FAQ</a>
-        and consider filing an issue on GitHub.
+        and consider filing an issue on GitHub.</p>
   </div>
 </template>
 <template is="dom-if" if="[[_isState(_topLevelState, 'ACTIVE')]]">
@@ -121,7 +117,7 @@ profile run can have multiple tools that present the performance profile as diff
   <div class="sidebar">
     <div class="allcontrols">
       <div class="sidebar-section">
-        <paper-button class="profile-btn" raised
+        <paper-button raised
                       on-tap="_openCaptureProfileDialog">Capture Profile</paper-button>
       </div>
       <div class="sidebar-section">

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -107,7 +107,8 @@ profile run can have multiple tools that present the performance profile as diff
            <a href="https://cloud.google.com/tpu/docs/cloud-tpu-tools"
                rel="noopener" target="_blank">tutorial</a>
            on how to interpreting the profiling results.
-    <p>If you’re a GPU user, please use the IP address option.
+    <p>If you’re a GPU user, please use the IP address option and you may want to check out the
+    <a href="https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/docs/r2/tensorboard_profiling_keras.ipynb" rel="noopenr" target="_blank">tutorial</a> on how to profile a Keras model on a GPU.
     <p>If you think profiling is done properly, please see the page of
         <a href="https://cloud.google.com/tpu/docs/troubleshooting"
             rel="noopener"

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -45,6 +45,11 @@ profile run can have multiple tools that present the performance profile as diff
 -->
 
 <dom-module id="tf-profile-dashboard">
+  <style>
+.profile-btn {
+  width: 160px;
+}
+  </style>
 <template>
 <template is="dom-if" if="[[_isState(_topLevelState, 'IN_COLAB')]]">
   <div style="max-width: 540px; margin: 80px auto 0 auto;">
@@ -93,43 +98,21 @@ profile run can have multiple tools that present the performance profile as diff
 <template is="dom-if" if="[[_isState(_topLevelState, 'DATA_NOT_FOUND')]]">
   <div style="max-width: 540px; margin: 80px auto 0 auto;">
     <h3>No profile data was found.</h3>
-    <p>To collect a profile, you need to run your model on Google Cloud TPUs and
-    capture the trace information while your model is running. You may want to
-    check out the
-    <a
-      href="https://github.com/tensorflow/tensorboard/blob/1.6/tensorboard/plugins/profile/README.md"
-      rel="noopener"
-      target="_blank"
-    >README</a>
-    and perhaps the
-    <a
-      href="https://cloud.google.com/tpu/docs/cloud-tpu-tools"
-      rel="noopener"
-      target="_blank"
-    >tutorial</a> on how to use the
-    <a
-      href="https://pypi.python.org/pypi/cloud-tpu-profiler"
-      rel="noopener"
-      target="_blank"
-    >cloud-tpu-profiler</a>.
-    </p>
-    <p>
-    If you’re new to TPUs, and want to find out how
-    to run models, check out the
-    <a
-      href="https://cloud.google.com/tpu/docs/quickstart"
-      rel="noopener"
-      target="_blank"
-    >Quickstart Using a TPU</a>.
-    </p>
-    <p>
-    If you think profiling is done properly, please see the page of
-    <a
-      href="https://cloud.google.com/tpu/docs/troubleshooting"
-      rel="noopener"
-      target="_blank"
-    >Google Cloud TPU Troubleshooting and FAQ</a>
-    and consider filing an issue on GitHub.</p>
+
+    <paper-button class="profile-btn" raised on-tap="_openCaptureProfileDialog">Capture Profile</paper-button>
+
+    <p>If you have a model running on a Google Cloud TPU or a GPU, you may be
+        able to use the above button to capture a profile.
+    <p>If you're a TPU user, please use the TPU name option and you may want to check out the
+           <a href="https://cloud.google.com/tpu/docs/cloud-tpu-tools"
+               rel="noopener" target="_blank">tutorial</a>
+           on how to interpreting the profiling results.
+    <p>If you’re a GPU user, please use the IP address option.
+    <p>If you think profiling is done properly, please see the page of
+        <a href="https://cloud.google.com/tpu/docs/troubleshooting"
+            rel="noopener"
+            target="_blank">Google Cloud TPU Troubleshooting and FAQ</a>
+        and consider filing an issue on GitHub.
   </div>
 </template>
 <template is="dom-if" if="[[_isState(_topLevelState, 'ACTIVE')]]">
@@ -137,7 +120,7 @@ profile run can have multiple tools that present the performance profile as diff
   <div class="sidebar">
     <div class="allcontrols">
       <div class="sidebar-section">
-        <paper-button raised
+        <paper-button class="profile-btn" raised
                       on-tap="_openCaptureProfileDialog">Capture Profile</paper-button>
       </div>
       <div class="sidebar-section">


### PR DESCRIPTION
* Motivation for features / changes
https://github.com/tensorflow/tensorboard/issues/2090
* Technical description of changes
Show the capture profile button when no data is found. Modify the FAQs to both TPU and CPU/GPU.
* Screenshots of UI changes
Before:
![no_profile_data_found_old](https://user-images.githubusercontent.com/3082188/56753171-d7f06500-673e-11e9-9344-917b383db251.png)
After:
![no_profile_data_found_gpu2](https://user-images.githubusercontent.com/3082188/56759698-6c15f880-674e-11e9-9420-190920eca3b4.png)

* Detailed steps to verify changes work correctly (as executed by you)
bazel run tensorboard:tensorboard -- logdir=.
http://localhost:6006/#profile
* Alternate designs / implementations considered

