### PR TITLE
rename --version flag to --version_tb to avoid conflict

### DIFF
--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -376,9 +376,12 @@ Example usage:
 
 See tensorboard/backend/event_processing/event_file_inspector.py for more info.\
 ''')
-    
+
+    # This flag has a "_tb" suffix to avoid conflicting with an internal flag
+    # named --version.  Note that due to argparse auto-expansion of unambiguous
+    # flag prefixes, you can still invoke this as `tensorboard --version`.
     parser.add_argument(
-        '--version',
+        '--version_tb',
         action='store_true',
         help='Prints the version of Tensorboard')
 
@@ -464,8 +467,8 @@ flag.\
   def fix_flags(self, flags):
     """Fixes standard TensorBoard CLI flags to parser."""
     FlagsError = base_plugin.FlagsError
-    if flags.version:
-      pass  
+    if flags.version_tb:
+      pass
     elif flags.inspect:
       if flags.logdir and flags.event_file:
         raise FlagsError(

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -47,13 +47,13 @@ class FakeFlags(object):
   def __init__(
       self,
       inspect=False,
-      version=False,
+      version_tb=False,
       logdir='',
       event_file='',
       db='',
       path_prefix=''):
     self.inspect = inspect
-    self.version = version
+    self.version_tb = version_tb
     self.logdir = logdir
     self.event_file = event_file
     self.db = db
@@ -81,8 +81,8 @@ class CorePluginTest(tf.test.TestCase):
 
   def testFlag(self):
     loader = core_plugin.CorePluginLoader()
+    loader.fix_flags(FakeFlags(version_tb=True))
     loader.fix_flags(FakeFlags(inspect=True, logdir='/tmp'))
-    loader.fix_flags(FakeFlags(version=True))
     loader.fix_flags(FakeFlags(inspect=True, event_file='/tmp/event.out'))
     loader.fix_flags(FakeFlags(inspect=False, logdir='/tmp'))
     loader.fix_flags(FakeFlags(inspect=False, db='sqlite:foo'))

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -221,7 +221,7 @@ class TensorBoard(object):
       event_file = os.path.expanduser(self.flags.event_file)
       efi.inspect(self.flags.logdir, event_file, self.flags.tag)
       return 0
-    if self.flags.version:
+    if self.flags.version_tb:
       print(version.VERSION)
       return 0
     try:


### PR DESCRIPTION
The `--version` flag introduced in #2097 unfortunately conflicts with a non-optional Google-internal `--version` flag.  By renaming it `--version_tb` we avoid the conflict, while still allowing the flag to be used like `tensorboard --version` because argparse auto-expands unambiguous flag prefixes.