### PR TITLE
add user-friendly docstring for TB-provided tf.summary module

### DIFF
--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -12,7 +12,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""TensorFlow component package for providing tf.summary from TensorBoard."""
+
+# NOTE: This module exists to provide the `tf.summary` module in the TensorFlow
+# API using symbols defined in TensorBoard. This works via a mechanism within
+# TensorFlow's API construction logic called "component_api_helper" that imports
+# an arbitrary module and inserts it into the TF APIs as a "component API". That
+# logic is specifically hardcoded to look for this exact tensorboard module.
+#
+# This note is in a comment, not the module docstring, because the module
+# docstring below is what users will see as the tf.summary docstring and in the
+# generated API documentation, and this is just an implementation detail.
+
+"""
+Operations for writing summary data, for use in analysis and visualization.
+
+The tf.summary module provides APIs for writing summary data. This data can be
+visualized in TensorBoard, the visualization toolkit that comes with TensorFlow.
+See the [TensorBoard website](https://www.tensorflow.org/tensorboard) for more
+detailed tutorials about how to use these APIs, or some quick examples below.
+
+Example usage with eager execution, the default in TF 2.0:
+
+```python
+writer = tf.summary.create_file_writer("/tmp/mylogs")
+with writer.as_default():
+  for step in range(100):
+    # other model code would go here
+    tf.summary.scalar("metric", 0.5, step=step)
+    writer.flush()
+```
+
+Example usage with `tf.function` graph execution:
+
+```python
+writer = tf.summary.create_file_writer("/tmp/mylogs")
+
+@tf.function
+def my_func(metric, step):
+  # other model code would go here
+  with writer.as_default():
+    tf.summary.scalar("metric", metric, step=step)
+
+for step in range(100):
+  my_func(0.5, step)
+  writer.flush()
+```
+
+Example usage with legacy TF 1.x graph execution:
+
+```python
+with tf.compat.v1.Graph().as_default():
+  step = tf.Variable(0, dtype=tf.int64)
+  step_update = step.assign_add(1)
+  writer = tf.summary.create_file_writer("/tmp/mylogs")
+  with writer.as_default():
+    tf.summary.scalar("metric", 0.5, step=step)
+  all_summary_ops = tf.compat.v1.all_v2_summary_ops()
+  writer_flush = writer.flush()
+
+  sess = tf.compat.v1.Session()
+  sess.run([writer.init(), step.initializer])
+  for i in range(100):
+    sess.run(step_update)
+    sess.run(all_summary_ops)
+    sess.run(writer_flush)
+```
+
+"""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -26,7 +26,7 @@
 """
 Operations for writing summary data, for use in analysis and visualization.
 
-The tf.summary module provides APIs for writing summary data. This data can be
+The `tf.summary` module provides APIs for writing summary data. This data can be
 visualized in TensorBoard, the visualization toolkit that comes with TensorFlow.
 See the [TensorBoard website](https://www.tensorflow.org/tensorboard) for more
 detailed tutorials about how to use these APIs, or some quick examples below.
@@ -38,7 +38,7 @@ writer = tf.summary.create_file_writer("/tmp/mylogs")
 with writer.as_default():
   for step in range(100):
     # other model code would go here
-    tf.summary.scalar("metric", 0.5, step=step)
+    tf.summary.scalar("my_metric", 0.5, step=step)
     writer.flush()
 ```
 
@@ -48,13 +48,13 @@ Example usage with `tf.function` graph execution:
 writer = tf.summary.create_file_writer("/tmp/mylogs")
 
 @tf.function
-def my_func(metric, step):
+def my_func(step):
   # other model code would go here
   with writer.as_default():
-    tf.summary.scalar("metric", metric, step=step)
+    tf.summary.scalar("my_metric", 0.5, step=step)
 
 for step in range(100):
-  my_func(0.5, step)
+  my_func(step)
   writer.flush()
 ```
 
@@ -66,15 +66,15 @@ with tf.compat.v1.Graph().as_default():
   step_update = step.assign_add(1)
   writer = tf.summary.create_file_writer("/tmp/mylogs")
   with writer.as_default():
-    tf.summary.scalar("metric", 0.5, step=step)
-  all_summary_ops = tf.compat.v1.all_v2_summary_ops()
+    tf.summary.scalar("my_metric", 0.5, step=step)
+  all_summary_ops = tf.compat.v1.summary.all_v2_summary_ops()
   writer_flush = writer.flush()
 
   sess = tf.compat.v1.Session()
   sess.run([writer.init(), step.initializer])
   for i in range(100):
-    sess.run(step_update)
     sess.run(all_summary_ops)
+    sess.run(step_update)
     sess.run(writer_flush)
 ```
 


### PR DESCRIPTION
This adds a friendlier docstring to the `_tf/summary` module that TF 2.0 re-exports as `tf.summary`, which is also the source for the [tf.summary generated API documentation](https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/summary).  I've included minimal API usage examples for all three expected execution contexts, and verified that all three can be executed properly with the latest tf-nightly-2.0-preview [1].

The comments about the component module implementation details I've moved into an actual comment so they don't appear in the API docs.

[1] ok, this is not quite true yet for the third example, but it should hopefully be true tomorrow, and I'll hold off on merging until then.