### PR TITLE
replace deprecated tf.compat.v1.train.checkpoint_exists()

### DIFF
--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -406,9 +406,9 @@ class ProjectorPlugin(base_plugin.TBPlugin):
         if ckpt_path:
           config.model_checkpoint_path = ckpt_path
 
-      # Sanity check for the checkpoint file.
+      # Sanity check for the checkpoint file existing.
       if (config.model_checkpoint_path and _using_tf() and
-          not tf.compat.v1.train.checkpoint_exists(config.model_checkpoint_path)):
+          not tf.io.gfile.glob(config.model_checkpoint_path + '*')):
         logger.warn('Checkpoint file "%s" not found',
                            config.model_checkpoint_path)
         continue


### PR DESCRIPTION
Further progress on #1718 - TF now issues deprecation warnings for compat v1 usage, and this is the last one that is triggered just from running the `tensorboard` binary (using TB V1 summary APIs also triggers them, but that's less of an issue).