### PR TITLE
Add node.js target for ppc64le architecture

### DIFF
--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -61,9 +61,15 @@ def tensorboard_js_workspace():
               "http://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x64.tar.xz",
           ],
       },
+      sha256_urls_extract_ppc64le = {
+          "6f6362cba63c20eab4914c2983edd9699c1082792d0a35ef9c54d18b6c488e59": [
+              "http://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-ppc64le.tar.xz",
+          ],
+      },
       strip_prefix = {
           "node-v6.9.1-darwin-x64.tar.xz": "node-v6.9.1-darwin-x64",
           "node-v6.9.1-linux-x64.tar.xz": "node-v6.9.1-linux-x64",
+          "node-v6.9.1-linux-ppc64le.tar.xz": "node-v6.9.1-linux-ppc64le",
       },
       executable = [
           "node",


### PR DESCRIPTION
* Motivation for features / changes
This adds a download target for node.js ppc64le. Support for ppc64le was added in rules_closure with this commit: https://github.com/bazelbuild/rules_closure/commit/87d24b1df8b62405de8dd059cb604fd9d4b1e395
This becomes a simple and safe add to allow building on ppc64 without any patches.

* Technical description of changes
sha256_urls_extract_ppc64le target added to the js.bzl file

* Screenshots of UI changes
No UI Changes

* Detailed steps to verify changes work correctly (as executed by you)
rebuilt Tensorboard; install; start Tensorboard

* Alternate designs / implementations considered
N/A