### PR TITLE
use tf.audio for encode/decode_wav if available

### DIFF
--- a/tensorboard/plugins/audio/summary_v2.py
+++ b/tensorboard/plugins/audio/summary_v2.py
@@ -71,8 +71,10 @@ def audio(name,
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
-  # TODO(nickfelt): get encode_wav() exported in the public API.
-  from tensorflow.python.ops import gen_audio_ops
+  audio_ops = getattr(tf, 'audio', None)
+  if audio_ops is None:
+    # Fallback for older versions of TF without tf.audio.
+    from tensorflow.python.ops import gen_audio_ops as audio_ops
 
   if encoding is None:
     encoding = 'wav'
@@ -92,7 +94,7 @@ def audio(name,
     tf.debugging.assert_rank(data, 3)
     tf.debugging.assert_non_negative(max_outputs)
     limited_audio = data[:max_outputs]
-    encode_fn = functools.partial(gen_audio_ops.encode_wav,
+    encode_fn = functools.partial(audio_ops.encode_wav,
                                   sample_rate=sample_rate)
     encoded_audio = tf.map_fn(encode_fn, limited_audio,
                               dtype=tf.string,


### PR DESCRIPTION
TF's upcoming 1.14 release (and current nightlies) expose a `tf.audio` module with `encode_wav()` and `decode_wav()`, so when these are available we can use the symbols from there instead of `gen_audio_ops` which is not part of the public API, and which was used only as an interim fix for TF 2.0 compatibility since the old solution (`tf.contrib.ffmpeg.encode_audio`) is not present in TF 2.0 at all.

See https://github.com/tensorflow/tensorboard/issues/1705 for migrating other parts of the APIs/tests off of `tf.contrib.ffmpeg.encode_audio` which remains to be done.

Tested by running `summary_test` against both `tf-nightly` and TF 1.13, which lacks `tf.audio`.