### PR TITLE
add new test for exporting TB symbols under tf.summary

### DIFF
--- a/tensorboard/summary/BUILD
+++ b/tensorboard/summary/BUILD
@@ -52,6 +52,19 @@ py_library(
     ],
 )
 
+py_test(
+    name = "summary_test",
+    size = "small",
+    srcs = ["summary_test.py"],
+    srcs_version = "PY2AND3",
+    tags = ["support_notf"],
+    deps = [
+        ":summary",
+        ":summary_v1",
+        ":summary_v2",
+    ],
+)
+
 # This library provides a _tf.summary package with summary API symbols from
 # TensorBoard, meant to be overlayed into TensorFlow's namespace as tf.summary.
 #
@@ -77,14 +90,12 @@ py_library(
 )
 
 py_test(
-    name = "summary_test",
+    name = "tf_summary_test",
     size = "small",
-    srcs = ["summary_test.py"],
+    srcs = ["tf_summary_test.py"],
     srcs_version = "PY2AND3",
-    tags = ["support_notf"],
     deps = [
-        ":summary",
-        ":summary_v1",
-        ":summary_v2",
+        ":tf_summary",
+        "//tensorboard:expect_tensorflow_installed",
     ],
 )

--- a/tensorboard/summary/tf_summary_test.py
+++ b/tensorboard/summary/tf_summary_test.py
@@ -1,0 +1,55 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Integration test for exporting TB symbols under the `tf.summary` API.
+
+This checks the integration between TF and TB to verify that the mechanism we
+use to export TensorBoard symbols as part of the `tf.summary` API works.
+
+We also test this at an even higher level (and with many different import
+sequences) via our pip package build script. But that script is run only in
+our external CI, whereas this python test can run anywhere our normal tests run.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+import sys
+import unittest
+
+class TfSummaryExportTest(unittest.TestCase):
+
+  def test_tf_summary_export(self):
+    # Check as a precondition that TF wasn't already imported.
+    self.assertEqual('notfound', sys.modules.get('tensorflow', 'notfound'))
+    import tensorflow as tf
+    if not tf.__version__.startswith('2.'):
+      if hasattr(tf, 'compat') and hasattr(tf.compat, 'v2'):
+        tf = tf.compat.v2
+      else:
+        self.skipTest('TF v2 summary API not available')
+    # Check that tf.summary contains both TB-provided and TF-provided symbols.
+    expected_symbols = frozenset(
+        ['scalar', 'image', 'audio', 'histogram', 'text']
+        + ['write', 'create_file_writer', 'SummaryWriter'])
+    self.assertLessEqual(expected_symbols, frozenset(dir(tf.summary)))
+    # Ensure we can deference symbols as well.
+    print(tf.summary.scalar)
+    print(tf.summary.write)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tensorboard/summary/tf_summary_test.py
+++ b/tensorboard/summary/tf_summary_test.py
@@ -26,14 +26,18 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
 import sys
 import unittest
+
 
 class TfSummaryExportTest(unittest.TestCase):
 
   def test_tf_summary_export(self):
-    # Check as a precondition that TF wasn't already imported.
+    # Ensure that TF wasn't already imported, since we want this test to cover
+    # the entire flow of "import tensorflow; use tf.summary" and if TF was in
+    # fact already imported that reduces the comprehensiveness of the test.
+    # This means this test has to be kept in its own file and that no other
+    # test methods in this file should import tensorflow.
     self.assertEqual('notfound', sys.modules.get('tensorflow', 'notfound'))
     import tensorflow as tf
     if not tf.__version__.startswith('2.'):
@@ -46,7 +50,7 @@ class TfSummaryExportTest(unittest.TestCase):
         ['scalar', 'image', 'audio', 'histogram', 'text']
         + ['write', 'create_file_writer', 'SummaryWriter'])
     self.assertLessEqual(expected_symbols, frozenset(dir(tf.summary)))
-    # Ensure we can deference symbols as well.
+    # Ensure we can dereference symbols as well.
     print(tf.summary.scalar)
     print(tf.summary.write)
 


### PR DESCRIPTION
This adds a new python-based integration test that for TF 2.0, the Tensorboard-provided symbols are successfully exported under `tf.summary`.  We already have tests for this in build_pip_package.sh, but that only runs regularly in our Travis CI, whereas this python test easily can run wherever our python tests run, including our internal CI (which I verified with a test sync).

This should help avoid issues like https://github.com/tensorflow/tensorflow/issues/28027.