### PR TITLE
feat: enable scrolling when added large image

### DIFF
--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -113,7 +113,7 @@ future for loading older images.
         height: auto;
         position: relative;
         margin: 0 15px 40px 0;
-        overflow-y: auto;
+        overflow-x: auto;
       }
 
       /** When actual size shown is on, use the actual image width. */

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -113,6 +113,7 @@ future for loading older images.
         height: auto;
         position: relative;
         margin: 0 15px 40px 0;
+        overflow-y: scroll;
       }
 
       /** When actual size shown is on, use the actual image width. */

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.html
@@ -113,7 +113,7 @@ future for loading older images.
         height: auto;
         position: relative;
         margin: 0 15px 40px 0;
-        overflow-y: scroll;
+        overflow-y: auto;
       }
 
       /** When actual size shown is on, use the actual image width. */


### PR DESCRIPTION
* Motivation for features / changes

In my case the image is too big I suppose it's 1920x640.
![image](https://user-images.githubusercontent.com/10709657/56845078-0a8c9000-68ee-11e9-85f8-8d56669420a6.png)
After clicking:
![image](https://user-images.githubusercontent.com/10709657/56845081-1d06c980-68ee-11e9-90b7-58e7245e3abb.png)

* Technical description of changes

I let it scroll.

* Screenshots of UI changes

![image](https://user-images.githubusercontent.com/10709657/56845097-432c6980-68ee-11e9-92ff-ee30bb42b120.png)

But it's not that visually pleasing totally.

![image](https://user-images.githubusercontent.com/10709657/56845101-53dcdf80-68ee-11e9-8df4-5c839630ce97.png)

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered

I'm not sure how to make it more beautiful, but the current fix works perfectly for me. Hope it helps.
