### PR TITLE
build: use `tf.test.main` for `hparams:api_test`

### DIFF
--- a/tensorboard/plugins/hparams/api_test.py
+++ b/tensorboard/plugins/hparams/api_test.py
@@ -252,7 +252,7 @@ class DiscreteTest(test.TestCase):
       hp.Discrete(["one", 2])
 
 
-class KerasCallbackTest(test.TestCase):
+class KerasCallbackTest(tf.test.TestCase):
 
   def setUp(self):
     super(KerasCallbackTest, self).setUp()
@@ -399,4 +399,4 @@ class KerasCallbackTest(test.TestCase):
 
 
 if __name__ == "__main__":
-  test.main()
+  tf.test.main()


### PR DESCRIPTION
Summary:
This test case already contains actual TensorFlow code. Within Google,
such tests must be run via `tf.test.main()` or `absltest.main()`, and
the TensorFlow-specific code should be in a `tf.test.TestCase` as well
(though this is not strictly required).

Test Plan:
Verified that this patch fixes a test that’s broken when syncing into
Google3.

wchargin-branch: tf-test-api-test
