### PR TITLE
hparams: add (mostly-)notf `hparams_config_pb`

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -214,9 +214,10 @@ py_library(
         "//visibility:public",
     ],
     deps = [
+        ":metadata",
         ":protos_all_py_pb2",
-        ":summary",
-        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/compat",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
         "@org_pythonhosted_six",
     ],
 )
@@ -230,8 +231,8 @@ py_test(
         ":metadata",
         ":protos_all_py_pb2",
         ":summary_v2",
-        "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:test",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
         "@com_google_protobuf//:protobuf_python",
         "@org_pythonhosted_mock",
         "@org_pythonhosted_six",

--- a/tensorboard/plugins/hparams/summary_v2.py
+++ b/tensorboard/plugins/hparams/summary_v2.py
@@ -61,7 +61,7 @@ def hparams_config(hparams, metrics, time_created_secs=None):
 
 
 def hparams_config_pb(hparams, metrics, time_created_secs=None):
-  # NOTE: Keep docs in sync with `hparams_config_pb` below.
+  # NOTE: Keep docs in sync with `hparams_config` above.
   """Create a top-level experiment configuration.
 
   This configuration describes the hyperparameters and metrics that will


### PR DESCRIPTION
Summary:
We reimplement `hparams_config` in terms of a new `hparams_config_pb`,
which has no direct dependencies on TensorFlow. The `metadata` module
unfortunately still emits TensorFlow protos, so there is still a
transitive dependency.

Note that this duplicates a small bit of logic from `summary`. We don’t
reimplement `summary` in terms of `summary_v2`, because we intentionally
provide a smaller API in `summary_v2` (e.g., we omit experiment name and
owner, which are unused). It is thus not possible to implement the full
functionality of `summary` in terms of `summary_v2`.

Test Plan:
Existing unit tests suffice for coverage, and also updated to test the
new endpoint explicitly.

wchargin-branch: hparams-config-pb
