### PR TITLE
Fix WIT textarea border issue

### DIFF
--- a/tensorboard/components/vz_example_viewer/vz-example-viewer.html
+++ b/tensorboard/components/vz_example_viewer/vz-example-viewer.html
@@ -106,7 +106,11 @@ limitations under the License.
       }
 
       iron-autogrow-textarea {
+        border: 1px solid #FFFFFF;
+        border-radius: 4px;
         font-size: 14px;
+        -moz-appearance: none;
+        -webkit-appearance: none;
         --iron-autogrow-textarea: {
           color: #3C4043;
         }
@@ -127,27 +131,23 @@ limitations under the License.
 
       .value-pill {
         text-align: left;
-        border-radius: 4px;
         margin: 4px;
         padding: 4px 8px;
-        border: 1px solid #FFFFFF;
         color: #3C4043;
       }
 
       .value-pill:hover {
-        background:#f8f9fa;
+        background: #f8f9fa;
       }
 
       .value-pill[focused] {
         border: 1px solid #ffeb3b;
-        background:#f8f9fa;
+        background: #f8f9fa;
       }
 
       .value-compare {
         text-align: left;
-        border-radius: 4px;
         padding: 4px 8px;
-        border: 1px solid #FFFFFF;
       }
 
       .value-pill-stacked {

--- a/tensorboard/components/vz_example_viewer/vz-example-viewer.ts
+++ b/tensorboard/components/vz_example_viewer/vz-example-viewer.ts
@@ -841,7 +841,6 @@ Polymer({
 
   onInputBlur: function(event: Event) {
     this.showDeleteValueButton = false;
-    const inputControl = event.target as HTMLInputElement;
   },
 
   /**


### PR DESCRIPTION
* Motivation for features / changes

WIT's example viewer textarea's had incorrect border styling.

* Technical description of changes

Added css rules to not use the -appearance rules for textareas and instead allow our custom styling
Reorganized existing rules around these elements to be a little simpler

* Screenshots of UI changes
![KpLS84vsueC](https://user-images.githubusercontent.com/15835086/57034182-e2b66880-6c1c-11e9-843e-3566294229f0.png)

* Detailed steps to verify changes work correctly (as executed by you)

Ran demos, saw correct visuals
