### PR TITLE
docs: fix more trailing whitespace in `%load_ext`s

### DIFF
--- a/docs/r2/hyperparameter_tuning_with_hparams.ipynb
+++ b/docs/r2/hyperparameter_tuning_with_hparams.ipynb
@@ -107,7 +107,7 @@
       "source": [
         "!pip install -q tf-nightly-2.0-preview\n",
         "# Load the TensorBoard notebook extension\n",
-        "%load_ext tensorboard "
+        "%load_ext tensorboard"
       ],
       "execution_count": 0,
       "outputs": [

--- a/docs/r2/tensorboard_in_notebooks.ipynb
+++ b/docs/r2/tensorboard_in_notebooks.ipynb
@@ -124,7 +124,7 @@
       "source": [
         "!pip install -q tf-nightly-2.0-preview\n",
         "# Load the TensorBoard notebook extension\n",
-        "%load_ext tensorboard "
+        "%load_ext tensorboard"
       ],
       "execution_count": 2,
       "outputs": [


### PR DESCRIPTION
Summary:
Follow-up to #2118, surfaced in a thread on tensorflow-testing:
<https://groups.google.com/a/tensorflow.org/d/msg/testing/Dh_kAR8omg8/Y5rLELCSAgAJ>

These notebooks work fine in Colab, but apparently break in Jupyter.

Test Plan
Running `git grep 'load_ext.* "'` yielded two matches before this commit
and zero matches after.

wchargin-branch: load-ext-whitespaces
