### PR TITLE
hparams: expose `hparams_config_pb` from `api`

### DIFF
--- a/tensorboard/plugins/hparams/api.py
+++ b/tensorboard/plugins/hparams/api.py
@@ -29,6 +29,7 @@ IntInterval = summary_v2.IntInterval
 Metric = summary_v2.Metric
 RealInterval = summary_v2.RealInterval
 hparams_config = summary_v2.hparams_config
+hparams_config_pb = summary_v2.hparams_config_pb
 
 KerasCallback = keras.Callback
 


### PR DESCRIPTION
Summary:
This should have been in #2174.

Test Plan:
That unit tests pass is sufficient. We don’t have demos that exercise
this endpoint. (The implementation is tested in `summary_v2_test`.)

wchargin-branch: hparams-config-pb-export
