### PR TITLE
hparams: Add explicit TF dependency

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -231,6 +231,7 @@ py_test(
         ":metadata",
         ":protos_all_py_pb2",
         ":summary_v2",
+        "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:test",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "@com_google_protobuf//:protobuf_python",


### PR DESCRIPTION
When a Python module imports tensorflow, it needs to explicitly define
dependency to TensorFlow in the BUILD file. This unblocks internally
sync.
