### PR TITLE
Add docstring to tensorboard_js_workspace

### DIFF
--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -19,6 +19,7 @@ load("@io_bazel_rules_closure//closure:defs.bzl", "web_library_external")
 
 
 def tensorboard_js_workspace():
+  """TensorBoard JavaScript dependencies."""
 
   ##############################################################################
   # TensorBoard Build Tools


### PR DESCRIPTION
bzl macros require docstring and missing it would violate the linter.
