### PR TITLE
hparams: add hparam writing for non-Keras users

### DIFF
--- a/tensorboard/plugins/hparams/api.py
+++ b/tensorboard/plugins/hparams/api.py
@@ -28,6 +28,8 @@ HParam = summary_v2.HParam
 IntInterval = summary_v2.IntInterval
 Metric = summary_v2.Metric
 RealInterval = summary_v2.RealInterval
+hparams = summary_v2.hparams
+hparams_pb = summary_v2.hparams_pb
 hparams_config = summary_v2.hparams_config
 hparams_config_pb = summary_v2.hparams_config_pb
 

--- a/tensorboard/plugins/hparams/keras.py
+++ b/tensorboard/plugins/hparams/keras.py
@@ -36,12 +36,7 @@ class Callback(tf.keras.callbacks.Callback):
   NOTE: This callback only works in TensorFlow eager mode.
   """
 
-  def __init__(
-      self,
-      writer,
-      hparams,
-      group_name=None,
-  ):
+  def __init__(self, writer, hparams):
     """Create a callback for logging hyperparameters to TensorBoard.
 
     As with the standard `tf.keras.callbacks.TensorBoard` class, each
@@ -51,22 +46,21 @@ class Callback(tf.keras.callbacks.Callback):
       writer: The `SummaryWriter` object to which hparams should be
         written, or a logdir (as a `str`) to be passed to
         `tf.summary.create_file_writer` to create such a writer.
-      logdir: The log directory for this session.
       hparams: A `dict` mapping hyperparameters to the values used in
         this session. Keys should be the names of `HParam` objects used
         in an experiment, or the `HParam` objects themselves. Values
         should be Python `bool`, `int`, `float`, or `string` values,
         depending on the type of the hyperparameter.
-      group_name: The name of the session group containing this session,
-        as a string or `None`. If `None` or empty, the group name is
-        taken to be the session ID.
 
     Raises:
       ValueError: If two entries in `hparams` share the same
         hyperparameter name.
     """
-    self._hparams = _normalize_hparams(hparams)
-    self._group_name = group_name if group_name is not None else ""
+    # Defer creating the actual summary until we write it, so that the
+    # timestamp is correct. But create a "dry-run" first to fail fast in
+    # case the `hparams` are invalid.
+    self._hparams = dict(hparams)
+    summary_v2.hparams_pb(self._hparams)
     if writer is None:
       raise TypeError("writer must be a `SummaryWriter` or `str`, not None")
     elif isinstance(writer, str):
@@ -74,7 +68,7 @@ class Callback(tf.keras.callbacks.Callback):
     else:
       self._writer = writer
 
-  def _write_summary(self, pb, step=None):
+  def _get_writer(self):
     if self._writer is None:
       raise RuntimeError(
           "hparams Keras callback cannot be reused across training sessions"
@@ -83,47 +77,17 @@ class Callback(tf.keras.callbacks.Callback):
       raise RuntimeError(
           "hparams Keras callback only supported in TensorFlow eager mode"
       )
-    raw_pb = pb.SerializeToString()
-    with self._writer.as_default():
-      result = tf.compat.v2.summary.experimental.write_raw_pb(raw_pb, step=step)
+    return self._writer
 
   def on_train_begin(self, logs=None):
     del logs  # unused
-    self._write_summary(
-        summary.session_start_pb(self._hparams, group_name=self._group_name),
-        step=0,
-    )
+    with self._get_writer().as_default():
+      summary_v2.hparams(self._hparams)
 
   def on_train_end(self, logs=None):
     del logs  # unused
-    self._write_summary(
-        summary.session_end_pb(api_pb2.STATUS_SUCCESS),
-        step=0,
-    )
+    with self._get_writer().as_default():
+      pb = summary.session_end_pb(api_pb2.STATUS_SUCCESS)
+      raw_pb = pb.SerializeToString()
+      tf.compat.v2.summary.experimental.write_raw_pb(raw_pb, step=0)
     self._writer = None
-
-
-def _normalize_hparams(hparams):
-  """Normalize a dict keyed by `HParam`s and/or raw strings.
-
-  Args:
-    hparams: A `dict` whose keys are `HParam` objects and/or strings
-      representing hyperparameter names, and whose values are
-      hyperparameter values. No two keys may have the same name.
-
-  Returns:
-    A `dict` whose keys are hyperparameter names (as strings) and whose
-    values are the corresponding hyperparameter values.
-
-  Raises:
-    ValueError: If two entries in `hparams` share the same
-      hyperparameter name.
-  """
-  result = {}
-  for (k, v) in six.iteritems(hparams):
-    if isinstance(k, summary_v2.HParam):
-      k = k.name
-    if k in result:
-      raise ValueError("multiple values specified for hparam %r" % (k,))
-    result[k] = v
-  return result

--- a/tensorboard/plugins/hparams/keras_test.py
+++ b/tensorboard/plugins/hparams/keras_test.py
@@ -56,7 +56,7 @@ class CallbackTest(tf.test.TestCase):
         tf.keras.layers.Dense(1, activation="sigmoid"),
     ])
     self.model.compile(loss="mse", optimizer=self.hparams["optimizer"])
-    self.callback = keras.Callback(writer, self.hparams, group_name="psl27")
+    self.callback = keras.Callback(writer, self.hparams)
 
   def test_eager(self):
     def mock_time():
@@ -99,11 +99,13 @@ class CallbackTest(tf.test.TestCase):
     start_pb.start_time_secs = 1234.5
     end_pb.end_time_secs = 6789.0
 
+    start_pb.group_name = "do_not_care"
+
     expected_start_pb = plugin_data_pb2.SessionStartInfo()
     text_format.Merge(
         """
         start_time_secs: 1234.5
-        group_name: "psl27"
+        group_name: "do_not_care"
         hparams {
           key: "optimizer"
           value {

--- a/tensorboard/plugins/hparams/summary_v2_test.py
+++ b/tensorboard/plugins/hparams/summary_v2_test.py
@@ -43,6 +43,164 @@ from tensorboard.plugins.hparams import summary_v2 as hp
 tf.compat.v1.enable_eager_execution()
 
 
+class HParamsTest(test.TestCase):
+  """Tests for `summary_v2.hparams` and `summary_v2.hparams_pb`."""
+
+  def setUp(self):
+    self.logdir = os.path.join(self.get_temp_dir(), "logs")
+    self.hparams = {
+        hp.HParam("learning_rate", hp.RealInterval(1e-2, 1e-1)): 0.02,
+        hp.HParam("dense_layers", hp.IntInterval(2, 7)): 5,
+        hp.HParam("optimizer", hp.Discrete(["adam", "sgd"])): "adam",
+        hp.HParam("who_knows_what"): "???",
+        hp.HParam(
+            "magic",
+            hp.Discrete([False, True]),
+            display_name="~*~ Magic ~*~",
+            description="descriptive",
+        ): True,
+        "dropout": 0.3,
+    }
+    self.normalized_hparams = {
+        "learning_rate": 0.02,
+        "dense_layers": 5,
+        "optimizer": "adam",
+        "who_knows_what": "???",
+        "magic": True,
+        "dropout": 0.3,
+    }
+    self.start_time_secs = 123.45
+    self.group_name = "big_sha"
+
+    self.expected_session_start_pb = plugin_data_pb2.SessionStartInfo()
+    text_format.Merge(
+        """
+        hparams { key: "learning_rate" value { number_value: 0.02 } }
+        hparams { key: "dense_layers" value { number_value: 5 } }
+        hparams { key: "optimizer" value { string_value: "adam" } }
+        hparams { key: "who_knows_what" value { string_value: "???" } }
+        hparams { key: "magic" value { bool_value: true } }
+        hparams { key: "dropout" value { number_value: 0.3 } }
+        group_name: "big_sha"  # we'll ignore this field when asserting equality
+        """,
+        self.expected_session_start_pb,
+    )
+    self.expected_session_start_pb.start_time_secs = self.start_time_secs
+
+  def _check_summary(self, summary_pb):
+    """Test that a summary contains exactly the expected hparams PB."""
+    values = summary_pb.value
+    self.assertEqual(len(values), 1, values)
+    actual_value = values[0]
+    self.assertEqual(
+        actual_value.metadata.plugin_data.plugin_name,
+        metadata.PLUGIN_NAME,
+    )
+    plugin_content = actual_value.metadata.plugin_data.content
+    info_pb = metadata.parse_session_start_info_plugin_data(plugin_content)
+    # Ignore the `group_name` field; its properties are checked separately.
+    info_pb.group_name = self.expected_session_start_pb.group_name
+    self.assertEqual(info_pb, self.expected_session_start_pb)
+
+  def _check_logdir(self, logdir):
+    """Test that the hparams summary was written to `logdir`."""
+    self._check_summary(_get_unique_summary(self, logdir))
+
+  def test_eager(self):
+    with tf.compat.v2.summary.create_file_writer(self.logdir).as_default():
+      result = hp.hparams(self.hparams, start_time_secs=self.start_time_secs)
+      self.assertTrue(result)
+    self._check_logdir(self.logdir)
+
+  def test_graph_mode(self):
+    with \
+        tf.compat.v1.Graph().as_default(), \
+        tf.compat.v1.Session() as sess, \
+        tf.compat.v2.summary.create_file_writer(self.logdir).as_default() as w:
+      sess.run(w.init())
+      summ = hp.hparams(self.hparams, start_time_secs=self.start_time_secs)
+      self.assertTrue(sess.run(summ))
+    self._check_logdir(self.logdir)
+
+  def test_eager_no_default_writer(self):
+    result = hp.hparams(self.hparams, start_time_secs=self.start_time_secs)
+    self.assertFalse(result)  # no default writer
+
+  def test_pb_contents(self):
+    result = hp.hparams_pb(self.hparams, start_time_secs=self.start_time_secs)
+    self._check_summary(result)
+
+  def test_pb_is_tensorboard_copy_of_proto(self):
+    result = hp.hparams_pb(self.hparams, start_time_secs=self.start_time_secs)
+    self.assertIsInstance(result, summary_pb2.Summary)
+    self.assertNotIsInstance(result, tf.compat.v1.Summary)
+
+  def test_consistency_across_string_key_and_object_key(self):
+    hparams_1 = {
+        hp.HParam("optimizer", hp.Discrete(["adam", "sgd"])): "adam",
+        "learning_rate": 0.02,
+    }
+    hparams_2 = {
+        "optimizer": "adam",
+        hp.HParam("learning_rate", hp.RealInterval(1e-2, 1e-1)): 0.02,
+    }
+    self.assertEqual(
+        hp.hparams_pb(hparams_1, start_time_secs=self.start_time_secs),
+        hp.hparams_pb(hparams_2, start_time_secs=self.start_time_secs),
+    )
+
+  def test_duplicate_hparam_names_across_object_and_string(self):
+    hparams = {
+        "foo": 1,
+        hp.HParam("foo"): 1,
+    }
+    with six.assertRaisesRegex(
+        self, ValueError, "multiple values specified for hparam 'foo'"):
+      hp.hparams_pb(hparams)
+
+  def test_duplicate_hparam_names_from_two_objects(self):
+    hparams = {
+        hp.HParam("foo"): 1,
+        hp.HParam("foo"): 1,
+    }
+    with six.assertRaisesRegex(
+        self, ValueError, "multiple values specified for hparam 'foo'"):
+      hp.hparams_pb(hparams)
+
+  def test_invariant_under_permutation(self):
+    # In particular, the group name should be the same.
+    hparams_1 = {
+        "optimizer": "adam",
+        "learning_rate": 0.02,
+    }
+    hparams_2 = {
+        "learning_rate": 0.02,
+        "optimizer": "adam",
+    }
+    self.assertEqual(
+        hp.hparams_pb(hparams_1, start_time_secs=self.start_time_secs),
+        hp.hparams_pb(hparams_2, start_time_secs=self.start_time_secs),
+    )
+
+  def test_group_name_differs_across_hparams_values(self):
+    hparams_1 = {"foo": 1, "bar": 2, "baz": 4}
+    hparams_2 = {"foo": 1, "bar": 3, "baz": 4}
+    def get_group_name(hparams):
+      summary_pb = hp.hparams_pb(hparams)
+      values = summary_pb.value
+      self.assertEqual(len(values), 1, values)
+      actual_value = values[0]
+      self.assertEqual(
+          actual_value.metadata.plugin_data.plugin_name,
+          metadata.PLUGIN_NAME,
+      )
+      plugin_content = actual_value.metadata.plugin_data.content
+      info = metadata.parse_session_start_info_plugin_data(plugin_content)
+      return info.group_name
+
+    self.assertNotEqual(get_group_name(hparams_1), get_group_name(hparams_2))
+
+
 class HParamsConfigTest(test.TestCase):
   def setUp(self):
     self.logdir = os.path.join(self.get_temp_dir(), "logs")
@@ -146,30 +304,6 @@ class HParamsConfigTest(test.TestCase):
         self.expected_experiment_pb,
     )
 
-  def _get_unique_summary(self, logdir):
-    """Get the unique `Summary` stored in `logdir`.
-
-    Specifically, `logdir` must be a directory containing exactly one
-    entry, which must be an events file of whose events exactly one is a
-    summary. This unique summary will be returned.
-
-    Args:
-      logdir: String path to a logdir.
-
-    Returns:
-      A `summary_pb2.Summary` object.
-    """
-    files = os.listdir(logdir)
-    self.assertEqual(len(files), 1, files)
-    events_file = os.path.join(logdir, files[0])
-    summaries = [
-        event.summary
-        for event in tf.compat.v1.train.summary_iterator(events_file)
-        if event.WhichOneof("what") == "summary"
-    ]
-    self.assertEqual(len(summaries), 1, summaries)
-    return summaries[0]
-
   def _check_summary(self, summary_pb):
     """Test that a summary contains exactly the expected experiment PB."""
     values = summary_pb.value
@@ -187,7 +321,7 @@ class HParamsConfigTest(test.TestCase):
 
   def _check_logdir(self, logdir):
     """Test that the experiment summary was written to `logdir`."""
-    self._check_summary(self._get_unique_summary(logdir))
+    self._check_summary(_get_unique_summary(self, logdir))
 
   def test_eager(self):
     with tf.compat.v2.summary.create_file_writer(self.logdir).as_default():
@@ -237,6 +371,32 @@ class HParamsConfigTest(test.TestCase):
     )
     self.assertIsInstance(result, summary_pb2.Summary)
     self.assertNotIsInstance(result, tf.compat.v1.Summary)
+
+
+def _get_unique_summary(self, logdir):
+  """Get the unique `Summary` stored in `logdir`.
+
+  Specifically, `logdir` must be a directory containing exactly one
+  entry, which must be an events file of whose events exactly one is a
+  summary. This unique summary will be returned.
+
+  Args:
+    self: A `TestCase` object, used for assertions.
+    logdir: String path to a logdir.
+
+  Returns:
+    A `summary_pb2.Summary` object.
+  """
+  files = os.listdir(logdir)
+  self.assertEqual(len(files), 1, files)
+  events_file = os.path.join(logdir, files[0])
+  summaries = [
+      event.summary
+      for event in tf.compat.v1.train.summary_iterator(events_file)
+      if event.WhichOneof("what") == "summary"
+  ]
+  self.assertEqual(len(summaries), 1, summaries)
+  return summaries[0]
 
 
 class IntIntervalTest(test.TestCase):

--- a/tensorboard/plugins/hparams/summary_v2_test.py
+++ b/tensorboard/plugins/hparams/summary_v2_test.py
@@ -120,6 +120,7 @@ class HParamsTest(test.TestCase):
       sess.run(w.init())
       summ = hp.hparams(self.hparams, start_time_secs=self.start_time_secs)
       self.assertTrue(sess.run(summ))
+      sess.run(w.flush())
     self._check_logdir(self.logdir)
 
   def test_eager_no_default_writer(self):


### PR DESCRIPTION
Summary:
This commit adds `hparams` and `hparams_pb`, to write `SessionStartInfo`
summaries for users who do not use the Keras callback.

As with `hparams_config{,_pb}`, this “conceptually” supports notf, but
there is still a transitive dependency through `metadata`.

In the tests, we opt to duplicate some infrastructure code rather than
abstracting over it. Compared to (e.g.) `scalar/summary_test`, our test
matrix has an extra dimension: in addition to “V1 vs. V2” and “op vs.
pb”, we have “`hparams` vs. `hparams_config`”. I couldn’t find an
abstraction whose code reuse outweighed its extra complexity.

These tests caught a bug present in the existing `summary.py` code,
wherein `bool` hparam values are always serialized as `int`s, because in
Python `bool` is a subtype of `int` and so one of the conditionals was
dead. The new code properly emits `bool` hparams, and so is not strictly
“compatible” with the old code.

Test Plan:
Unit tests included. The existing demo uses the Keras callback and so
does not exercise this code.

wchargin-branch: hparams-writing
