### PR TITLE
hparams: add `api` and `summary_v2` to Pip package

### DIFF
--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -21,6 +21,7 @@ sh_binary(
         "//tensorboard:lib",  # User-facing overall TensorBoard API
         "//tensorboard:version",  # Version module (read by setup.py)
         "//tensorboard/plugins/beholder",  # User-facing beholder API
+        "//tensorboard/plugins/hparams",  # User-facing hparams API
         "//tensorboard/plugins/projector",  # User-facing projector API
         "//tensorboard/summary:tf_summary",  #  tf.summary API for TF 2.0
     ],

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -10,6 +10,19 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 exports_files(["LICENSE"])
 
+# Public-facing API, included in Pip package.
+py_library(
+    name = "hparams",
+    srcs = ["__init__.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":api",
+        ":summary",
+        ":summary_v2",
+    ],
+)
+
 py_library(
     name = "hparams_plugin",
     srcs = [
@@ -23,12 +36,9 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
-        ":api",
         ":error",
         ":metadata",
         ":protos_all_py_pb2",
-        ":summary",
-        ":summary_v2",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/compat:tensorflow",

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -23,10 +23,12 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        ":api",
         ":error",
         ":metadata",
         ":protos_all_py_pb2",
         ":summary",
+        ":summary_v2",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/compat:tensorflow",


### PR DESCRIPTION
Summary:
Previously, `hparams.summary` was available via a “fake” dependency of
`:hparams_plugin`. We replace that fake dependency with a “public API”
target, as used by Beholder and the projector.

Test Plan:
Cherry-pick #2188, then:

```
$ bazel run //tensorboard/pip_package:build_pip_package -- --no-smoke
$ PATH_TO_PY3_WHEEL=...  # last line of command output
$ cd "$(mktemp -d)"
$ virtualenv -q -p python3.5 ./ve
$ . ./ve/bin/activate
(ve) $ pip install -q tf-nightly-2.0-preview
(ve) $ pip uninstall -q -y tb-nightly
(ve) $ pip install "${PATH_TO_PY3_WHEEL}"
(ve) $ python
>>> from tensorboard.plugins.hparams import api
>>> from tensorboard.plugins.hparams import plugin_data_pb2
>>> pb = api.hparams_pb({"optimizer": "adam", "magic": True})
>>> content = pb.value[0].metadata.plugin_data.content
>>> plugin_data_pb2.HParamsPluginData.FromString(content)
session_start_info {
  hparams {
    key: "magic"
    value {
      bool_value: true
    }
  }
  hparams {
    key: "optimizer"
    value {
      string_value: "adam"
    }
  }
  group_name: "18497c833ee7276fd662fe139cf96f01d33ed8a6a5a4f7b0999b3b5db9f706a6"
  start_time_secs: 1556910144.4714012
}
```

Also verified that none of the `srcs` of `:hparams_plugin` directly
import `hparams.summary`.

wchargin-branch: hparams-api-in-pip
