### PR TITLE
Download umap-js from unpkg rather than github

### DIFF
--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -218,8 +218,8 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # Apache License 2.0
       sha256_urls = {
           "85a2ff924f1bf4757976aca22fd0efb045d9b3854f5a4ae838c64e4d11e75005": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/PAIR-code/umap-js/1.0.5/lib/umap-js.min.js",
-              "https://raw.githubusercontent.com/PAIR-code/umap-js/1.0.5/lib/umap-js.min.js",
+              "https://mirror.bazel.build/unpkg.com/umap-js@1.0.5/lib/umap-js.min.js",
+              "https://unpkg.com/umap-js@1.0.5/lib/umap-js.min.js",
           ],
       },
   )


### PR DESCRIPTION
I'd like to stop pushing the compiled JS to github and instead maintain it on npm. This PR changes the BUILD rule to point to unpkg (a CDN for npm packages) rather than github static content to pull down the same minified JS.