### PR TITLE
Allow WitWidget example changing

### DIFF
--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
@@ -60,7 +60,7 @@ class WitWidgetBase(object):
     if 'compare_custom_predict_fn' in copied_config:
       del copied_config['compare_custom_predict_fn']
 
-    self._set_examples(config['examples'])
+    self.set_examples(config['examples'])
     del copied_config['examples']
 
     self.config = copied_config
@@ -75,7 +75,13 @@ class WitWidgetBase(object):
     return """
       <link rel="import" href="/nbextensions/wit-widget/wit_jupyter.html">"""
 
-  def _set_examples(self, examples):
+  def set_examples(self, examples):
+    """Sets the examples shown in WIT.
+
+    The examples are initially set by the examples specified in the config
+    builder during construction. This method can change which examples WIT
+    displays.
+    """
     self.examples = [json_format.MessageToJson(ex) for ex in examples]
     self.updated_example_indices = set(range(len(examples)))
 

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
@@ -55,7 +55,6 @@ WIT_HTML = """
   <tf-interactive-inference-dashboard id="wit" local>
   </tf-interactive-inference-dashboard>
   <script>
-    const examples = {examples};
     const id = {id};
     const wit = document.querySelector("#wit");
     wit.parentElement.style.height = '{height}px';
@@ -147,7 +146,7 @@ WIT_HTML = """
       }}
       wit.updateNumberOfModels();
     }};
-    window.updateExamplesCallback = () => {{
+    window.updateExamplesCallback = examples => {{
       if (!wit.updateExampleContents) {{
         requestAnimationFrame(() => window.updateExamplesCallback(examples));
         return;
@@ -156,6 +155,12 @@ WIT_HTML = """
       if (wit.localAtlasUrl) {{
         window.spriteCallback(wit.localAtlasUrl);
       }}
+    }};
+    // BroadcastChannel to allow examples to be updated by a call from an
+    // output cell that isn't the cell hosting the WIT widget.
+    const updateExampleListener = new BroadcastChannel('updateExamples');
+    updateExampleListener.onmessage = msg => {{
+      window.updateExamplesCallback(msg.data);
     }};
   </script>
   """
@@ -179,6 +184,7 @@ class WitWidget(base.WitWidgetBase):
       config_builder: WitConfigBuilder object containing settings for WIT.
       height: Optional height in pixels for WIT to occupy. Defaults to 1000.
     """
+    self._ctor_complete = False
     base.WitWidgetBase.__init__(self, config_builder)
     # Add this instance to the static instance list.
     WitWidget.widgets.append(self)
@@ -186,8 +192,7 @@ class WitWidget(base.WitWidgetBase):
     # Display WIT Polymer element.
     display.display(display.HTML(self._get_element_html()))
     display.display(display.HTML(
-      WIT_HTML.format(
-        examples=json.dumps(self.examples), height=height, id=WitWidget.index)))
+      WIT_HTML.format(height=height, id=WitWidget.index)))
 
     # Increment the static instance WitWidget index counter
     WitWidget.index += 1
@@ -195,12 +200,26 @@ class WitWidget(base.WitWidgetBase):
     # Send the provided config and examples to JS
     output.eval_js("""configCallback('{config}')""".format(
       config=json.dumps(self.config)))
-    output.eval_js('updateExamplesCallback()')
+    output.eval_js("""updateExamplesCallback({examples})""".format(
+      examples=json.dumps(self.examples)))
     self._generate_sprite()
+    self._ctor_complete = True
 
   def _get_element_html(self):
     return """
       <link rel="import" href="/nbextensions/wit-widget/wit_jupyter.html">"""
+
+  def set_examples(self, examples):
+    base.WitWidgetBase.set_examples(self, examples)
+    # If this is called outside of the ctor, use a BroadcastChannel to send
+    # the updated examples to the visualization. Inside of the ctor, no action
+    # is necessary as the ctor handles all communication.
+    if self._ctor_complete:
+      # Use BroadcastChannel to allow this call to be made in a separate colab
+      # cell from the cell that displays WIT.
+      output.eval_js("""(new BroadcastChannel('updateExamples')).postMessage(
+        {examples})""".format(examples=json.dumps(self.examples)))
+      self._generate_sprite()
 
   def infer(self):
     inferences = base.WitWidgetBase.infer_impl(self)

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
@@ -156,7 +156,7 @@ WIT_HTML = """
         window.spriteCallback(wit.localAtlasUrl);
       }}
     }};
-    // BroadcastChannel to allow examples to be updated by a call from an
+    // BroadcastChannel allows examples to be updated by a call from an
     // output cell that isn't the cell hosting the WIT widget.
     const channelName = 'updateExamples' + id;
     const updateExampleListener = new BroadcastChannel(channelName);

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/wit.py
@@ -61,8 +61,8 @@ class WitWidget(widgets.DOMWidget, base.WitWidgetBase):
     # Ensure the visualization takes all available width.
     display(HTML("<style>.container { width:100% !important; }</style>"))
 
-  def _set_examples(self, examples):
-    base.WitWidgetBase._set_examples(self, examples)
+  def set_examples(self, examples):
+    base.WitWidgetBase.set_examples(self, examples)
     self._generate_sprite()
 
   @observe('infer')

--- a/tensorboard/plugins/interactive_inference/witwidget/version.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/version.py
@@ -14,4 +14,4 @@
 
 """Contains the version string."""
 
-VERSION = '1.0.1'
+VERSION = '1.0.2'


### PR DESCRIPTION
* Motivation for features / changes

To support upcoming WIT integrations, made it possible to change the examples being shown by WitWidget through a method call.

* Technical description of changes

- Changed WitWidget private _set_examples method to public set_examples method.
- Changed colab implementation of set_examples to use BroadcastChannel to allow it to be called in a different colab cell than the one that displays WIT. This is necessary because colab sandboxes each output cell in iframes.

* Screenshots of UI changes

N/A

* Detailed steps to verify changes work correctly (as executed by you)

Installed WitWidget with these changes in colab and jupyter and ran test notebook that displayed initial examples, then in another cell, calls set_examples to change which examples are shown. Verified correct behavior in WIT.

