### PR TITLE
Enable WitWidget for AI Platform including xgboost models

### DIFF
--- a/tensorboard/plugins/interactive_inference/README.md
+++ b/tensorboard/plugins/interactive_inference/README.md
@@ -61,8 +61,8 @@ that takes TensorFlow Example or SequenceExample protos
 (data points) as inputs directly in a jupyter or colab notebook.
 
 Additionally, the What-If Tool can analyze
-[CMLE-hosted](https://cloud.google.com/ml-engine/) classification or
-regresssion models that take TensorFlow Example protos, SequenceExample protos,
+[AI Platform Prediction-hosted](https://cloud.google.com/ml-engine/) classification
+or regresssion models that take TensorFlow Example protos, SequenceExample protos,
 or raw JSON objects as inputs.
 
 You can also use What-If Tool with a custom prediction function that takes
@@ -272,8 +272,8 @@ The model to be used for inference by the tool can be specified in many ways:
   object that is provided through the `set_estimator_and_feature_spec` method.
   In this case the inference will be done inside the notebook using the
   provided estimator.
-- As a model hosted by [CMLE](https://cloud.google.com/ml-engine/) through the
-  `set_cmle_model` method.
+- As a model hosted by [AI Platform Prediction](https://cloud.google.com/ml-engine/)
+  through the`set_ai_platform_model` method.
 - As a custom prediction function provided through `set_custom_predict_fn` method.
   In this case WIT will directly call the function for inference.
 - As an endpoint for a model being served by [TensorFlow Serving](https://github.com/tensorflow/serving),

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
@@ -56,20 +56,20 @@ class WitWidgetBase(object):
     self.compare_custom_predict_fn = (
       config.get('compare_custom_predict_fn')
       if 'compare_custom_predict_fn' in config else None)
-    self.adjust_fn = (
+    self.adjust_prediction_fn = (
       config.get('adjust_prediction')
       if 'adjust_prediction' in config else None)
-    self.compare_adjust_fn = (
-      config.get('adjust_prediction_2')
-      if 'adjust_prediction_2' in config else None)
+    self.compare_adjust_prediction_fn = (
+      config.get('compare_adjust_prediction')
+      if 'compare_adjust_prediction' in config else None)
     if 'custom_predict_fn' in copied_config:
       del copied_config['custom_predict_fn']
     if 'compare_custom_predict_fn' in copied_config:
       del copied_config['compare_custom_predict_fn']
     if 'adjust_prediction' in copied_config:
       del copied_config['adjust_prediction']
-    if 'adjust_prediction' in copied_config:
-      del copied_config['adjust_prediction_2']
+    if 'compare_adjust_prediction' in copied_config:
+      del copied_config['compare_adjust_prediction']
 
     self._set_examples(config['examples'])
     del copied_config['examples']
@@ -80,7 +80,7 @@ class WitWidgetBase(object):
     # functions.
     if self.config.get('use_aip'):
       self.custom_predict_fn = self._predict_aip_model
-    if self.config.get('use_aip_2'):
+    if self.config.get('compare_use_aip'):
       self.compare_custom_predict_fn = self._predict_aip_compare_model
 
   def _get_element_html(self):
@@ -259,13 +259,14 @@ class WitWidgetBase(object):
     return self._predict_aip_impl(
       examples, self.config.get('inference_address'),
       self.config.get('model_name'), self.config.get('model_signature'),
-      self.config.get('force_json_input'), self.adjust_fn)
+      self.config.get('force_json_input'), self.adjust_prediction_fn)
 
   def _predict_aip_compare_model(self, examples):
     return self._predict_aip_impl(
       examples, self.config.get('inference_address_2'),
       self.config.get('model_name_2'), self.config.get('model_signature_2'),
-      self.config.get('force_json_input_2'), self.compare_adjust_fn)
+      self.config.get('compare_force_json_input'),
+      self.compare_adjust_prediction_fn)
 
   def _predict_aip_impl(self, examples, project, model, version, force_json,
                         adjust_prediction):

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
@@ -490,7 +490,8 @@ class WitConfigBuilder(object):
     return tf_examples
 
   def set_ai_platform_model(
-    self, project, model, version=None, force_json_input=None):
+    self, project, model, version=None, force_json_input=None,
+    adjust_prediction=None):
     """Sets the model information for a model served by AI Platform.
 
     AI Platform Prediction a Google Cloud serving platform.
@@ -502,6 +503,10 @@ class WitConfigBuilder(object):
       force_json_input: Optional. If True and examples are provided as
       tf.Example protos, convert them to raw JSON objects before sending them
       for inference to this model.
+      adjust_prediction: Optional. If not None then this function takes the
+      prediction output from the model for a single example and converts it to
+      the appopriate format - a regression score or a list of class scores. Only
+      necessary if the model doesn't already abide by this format.
 
     Returns:
       self, in order to enabled method chaining.
@@ -513,10 +518,13 @@ class WitConfigBuilder(object):
       self.set_model_signature(version)
     if force_json_input:
       self.store('force_json_input', True)
+    if adjust_prediction:
+      self.store('adjust_prediction', adjust_prediction)
     return self
 
   def set_compare_ai_platform_model(
-    self, project, model, version=None, force_json_input=None):
+    self, project, model, version=None, force_json_input=None,
+    adjust_prediction=None):
     """Sets the model information for a second model served by AI Platform.
 
     AI Platform Prediction a Google Cloud serving platform.
@@ -528,6 +536,10 @@ class WitConfigBuilder(object):
       force_json_input: Optional. If True and examples are provided as
       tf.Example protos, convert them to raw JSON objects before sending them
       for inference to this model.
+      adjust_prediction: Optional. If not None then this function takes the
+      prediction output from the model for a single example and converts it to
+      the appopriate format - a regression score or a list of class scores. Only
+      necessary if the model doesn't already abide by this format.
 
     Returns:
       self, in order to enabled method chaining.
@@ -539,6 +551,8 @@ class WitConfigBuilder(object):
       self.set_compare_model_signature(version)
     if force_json_input:
       self.store('force_json_input_2', True)
+    if adjust_prediction:
+      self.store('adjust_prediction_2', adjust_prediction)
     return self
 
   def set_target_feature(self, target):

--- a/tensorboard/plugins/interactive_inference/witwidget/version.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/version.py
@@ -14,4 +14,4 @@
 
 """Contains the version string."""
 
-VERSION = '1.0.1'
+VERSION = '1.0.2'

--- a/tensorboard/plugins/interactive_inference/witwidget/version.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/version.py
@@ -14,4 +14,4 @@
 
 """Contains the version string."""
 
-VERSION = '1.0.2'
+VERSION = '1.0.1'


### PR DESCRIPTION
* Motivation for features / changes

Continuing work on CMLE mode for WitWidget, which has been rebranded to AI Platform by Cloud. Added support for xgboost models in AI Platform as well.

* Technical description of changes

Rename CMLE to AI Platform serving
Allow examples to be provided as JSON lists (which is true for xgboost models), not just JSON dicts.
Allow separate provided of feature names for display when examples are provided as flat lists.
Add better prediction result parsing logic for AI Platform use-case, handling more models out of the box.
Add ability for user to specify custom prediction adjustment function for when the AI Platform model returns results in a format that is unknown to WIT.

* Screenshots of UI changes
N/A

* Detailed steps to verify changes work correctly (as executed by you)

Verified changes with two AI Platform models in a colab, including one that uses a custom prediction adjustment function.

* Alternate designs / implementations considered
