### PR TITLE
Fix mesh visualizer

### DIFF
--- a/tensorboard/plugins/mesh_visualizer/tf_mesh_dashboard/mesh-loader.js
+++ b/tensorboard/plugins/mesh_visualizer/tf_mesh_dashboard/mesh-loader.js
@@ -139,7 +139,7 @@ Polymer({
    * Function to call when component must be reloaded.
    */
   reload: function() {
-    if (!this.active) {
+    if (!this.active || !this.isAttached) {
       return;
     }
     this.set('_isMeshLoading', true);

--- a/tensorboard/plugins/mesh_visualizer/tf_mesh_dashboard/mesh-loader.js
+++ b/tensorboard/plugins/mesh_visualizer/tf_mesh_dashboard/mesh-loader.js
@@ -108,7 +108,7 @@ Polymer({
   },
 
   observers: [
-    'reload(run, tag)',
+    'reload(run, tag, active, _dataProvider)',
     '_updateScene(_currentStep)',
     '_updateView(selectedView)'
   ],
@@ -139,7 +139,7 @@ Polymer({
    * Function to call when component must be reloaded.
    */
   reload: function() {
-    if (!this.active || !this.isAttached) {
+    if (!this.active || !this._dataProvider) {
       return;
     }
     this.set('_isMeshLoading', true);

--- a/tensorboard/plugins/mesh_visualizer/tf_mesh_dashboard/tf-mesh-dashboard.html
+++ b/tensorboard/plugins/mesh_visualizer/tf_mesh_dashboard/tf-mesh-dashboard.html
@@ -25,6 +25,7 @@ limitations under the License.
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
 <link rel="import" href="../tf-runs-selector/tf-runs-selector.html">
 <link rel="import" href="../tf-tensorboard/registry.html">
+<link rel="import" href="tf-mesh-loader.html">
 
 <!--
   A frontend that displays a set of tf-mesh-loaders.
@@ -33,10 +34,7 @@ limitations under the License.
   <template>
     <tf-dashboard-layout>
       <div class="sidebar all-controls">
-        <div class="sidebar-section">
-          <tf-runs-selector selected-runs="{{_selectedRuns}}">
-          </tf-runs-selector>
-        </div>
+
         <div class="sidebar-section view-control">
             <h3 class="title">Point of view</h3>
             <div>
@@ -54,14 +52,18 @@ limitations under the License.
                 <paper-tooltip animation-delay="0" for="user-radio-button" position="right" offset="0">
                   Keep current camera position and zoom level.
                 </paper-tooltip>
-                <paper-radio-button id="user-radio-button" name="share">
+                <paper-radio-button id="share-radio-button" name="share">
                   Share viewpoint
                 </paper-radio-button>
-                <paper-tooltip animation-delay="0" for="user-radio-button" position="right" offset="0">
+                <paper-tooltip animation-delay="0" for="share-radio-button" position="right" offset="0">
                   Share viewpoint among all cameras.
                 </paper-tooltip>
               </paper-radio-group>
             </div>
+        </div>
+        <div class="sidebar-section runs-selector">
+          <tf-runs-selector selected-runs="{{_selectedRuns}}">
+          </tf-runs-selector>
         </div>
       </div>
       <div class="center">
@@ -134,6 +136,14 @@ limitations under the License.
         font-weight: normal;
         font-size: 14px;
         margin-bottom: 5px;
+      }
+
+      .runs-selector {
+        flex-grow: 1;
+      }
+
+      tf-runs-selector {
+        display: flex;
       }
 
       .view-control {


### PR DESCRIPTION
There were two problems:
1. dataProvider is not available until component is attached
2. missing dependency to tf-mesh-loader in mesh-dashboard

One minor feature improvements:
- Runs selector now appears below the Point of view section and it now
  spans the entire view height.

![image](https://user-images.githubusercontent.com/2547313/57256969-f55de280-700c-11e9-9d4c-d57fed5b4c48.png)

+cc @podlipensky