### PR TITLE
Fix word-break issue on metadata card

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-metadata-card.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-metadata-card.html
@@ -69,7 +69,8 @@ limitations under the License.
 }
     
 .metadata-value {
-  overflow-wrap: break-word;
+  word-wrap: anywhere; /* Firefox only -- word-wrap DNE in Chrome. anywhere DNE in Chrome */
+  word-break: break-word; /* break-word DNE in Firefox */
 }
 </style>
 


### PR DESCRIPTION
Long strings in metadata were incorrectly overflowing the metadata card. Since the element is styled as a table, we need to use word-break rather than overflow-wrap.

**before**
<img width="404" alt="Screen Shot 2019-05-06 at 3 14 42 PM" src="https://user-images.githubusercontent.com/7818584/57258600-c0a05a00-7011-11e9-8dbb-9b03466b252b.png">


**after**
<img width="416" alt="Screen Shot 2019-05-06 at 3 14 50 PM" src="https://user-images.githubusercontent.com/7818584/57258593-bd0cd300-7011-11e9-85d1-96c61c439ad9.png">
