### PR TITLE
Fix issue where we werent initializing knn properly

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/data.ts
+++ b/tensorboard/plugins/projector/vz_projector/data.ts
@@ -390,7 +390,8 @@ export class DataSet {
       );
 
       // Initialize UMAP and return the number of epochs.
-      return this.umap.initializeFit(X, knnIndices, knnDistances);
+      this.umap.setPrecomputedKNN(knnIndices, knnDistances);
+      return this.umap.initializeFit(X);
     }, UMAP_MSG_ID);
     
     // Now, iterate through all epoch batches of the UMAP optimization, updating

--- a/tensorboard/plugins/projector/vz_projector/umap.d.ts
+++ b/tensorboard/plugins/projector/vz_projector/umap.d.ts
@@ -31,7 +31,8 @@ interface UMAP {
     new(params?: UMAPParameters): UMAP;
     fit(X: Vectors): number[][];
     fitAsync(X: Vectors, callback?: (epochNumber: number) => void | boolean): Promise<number[][]>;
-    initializeFit(X: Vectors, knnIndices?: number[][], knnDistances?: number[][]): number;
+    initializeFit(X: Vectors): number;
+    setPrecomputedKNN(knnIndices: number[][], knnDistances: number[][]): void;
     step(): number;
     getEmbedding(): number[][];
 }


### PR DESCRIPTION
While debugging the standalone projector app, we discovered a bug caused by the divergence between the umap-js and the `umap.d.ts` typings that we maintain in this repo. This bug caused an error when initializing very small datasets. This PR fixes the incorrect usage of `umap.initializeFit` and updates the types to match the library.