### PR TITLE
docs: update `import_event` in hparams tutorial

### DIFF
--- a/docs/r2/hyperparameter_tuning_with_hparams.ipynb
+++ b/docs/r2/hyperparameter_tuning_with_hparams.ipynb
@@ -298,7 +298,7 @@
         "exp_summary = create_experiment_summary(num_units_list, dropout_rate_list, optimizer_list)\n",
         "root_logdir_writer = tf.summary.create_file_writer(\"logs/hparam_tuning\")\n",
         "with root_logdir_writer.as_default():\n",
-        "  tf.summary.import_event(tf.compat.v1.Event(summary=exp_summary).SerializeToString())"
+        "  tf.summary.experimental.write_raw_pb(exp_summary.SerializeToString(), step=0)"
       ],
       "execution_count": 0,
       "outputs": []
@@ -369,8 +369,8 @@
         "    summary_end = hparams_summary.session_end_pb(api_pb2.STATUS_SUCCESS)\n",
         "      \n",
         "    tf.summary.scalar('accuracy', accuracy, step=1, description=\"The accuracy\")\n",
-        "    tf.summary.import_event(tf.compat.v1.Event(summary=summary_start).SerializeToString())\n",
-        "    tf.summary.import_event(tf.compat.v1.Event(summary=summary_end).SerializeToString())"
+        "    tf.summary.experimental.write_raw_pb(summary_start.SerializeToString(), step=0)\n",
+        "    tf.summary.experimental.write_raw_pb(summary_end.SerializeToString(), step=0)"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
Summary:
Resolves a docs bug noted here:
<https://github.com/tensorflow/tensorboard/pull/2110#issuecomment-485533043>

Test Plan:
Run this notebook in Colab, and observe that the resulting TensorBoard
instance shows both the static configuration (note human-readable
display names) and per-trial values:

![Screenshot proof](https://user-images.githubusercontent.com/4317806/57265005-39131500-702a-11e9-9ad6-1a2095f61514.png)

Then, note that `git grep 'import_event' '*.ipynb'` has no matches as of
this commit, and other uses of `git grep import_event` are fallbacks
only.

wchargin-branch: import-event
