### PR TITLE
hparams: manually flush writer in graph mode tests

### DIFF
--- a/tensorboard/plugins/hparams/summary_v2_test.py
+++ b/tensorboard/plugins/hparams/summary_v2_test.py
@@ -211,6 +211,7 @@ class HParamsConfigTest(test.TestCase):
           time_created_secs=self.time_created_secs,
       )
       self.assertTrue(sess.run(summ))
+      sess.run(w.flush())
     self._check_logdir(self.logdir)
 
   def test_eager_no_default_writer(self):


### PR DESCRIPTION
Summary:
The test as written may be flaky, according to @nfelt’s comment here:
<https://github.com/tensorflow/tensorboard/pull/2188#discussion_r281431612>

Test Plan:
I couldn’t actually get the previous version of the test to fail (even
with `--runs_per_test=1000`), but it still passes, so that’s nice.

wchargin-branch: hparams-tests-explicit-flush
