### PR TITLE
mesh: explictly define public API, for consistency

### DIFF
--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -22,7 +22,7 @@ sh_binary(
         "//tensorboard:version",  # Version module (read by setup.py)
         "//tensorboard/plugins/beholder",  # User-facing beholder API
         "//tensorboard/plugins/hparams",  # User-facing hparams API
-        "//tensorboard/plugins/mesh:summary",  #  User-facing mesh summary API
+        "//tensorboard/plugins/mesh",  #  User-facing mesh API
         "//tensorboard/plugins/projector",  # User-facing projector API
         "//tensorboard/summary:tf_summary",  #  tf.summary API for TF 2.0
     ],

--- a/tensorboard/plugins/mesh/BUILD
+++ b/tensorboard/plugins/mesh/BUILD
@@ -5,6 +5,17 @@ exports_files(["LICENSE"])
 
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
+# Public-facing API, included in Pip package.
+py_library(
+    name = "mesh",
+    srcs = ["__init__.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":summary",
+    ],
+)
+
 py_library(
     name = "metadata",
     srcs = ["metadata.py"],


### PR DESCRIPTION
Summary:
Amends #2205 to be consistent with other plugins.

Test Plan:
Pip package smoke test still passes.

wchargin-branch: mesh-library-target
