### PR TITLE
Fix streaming trace viewer and improve error message

### DIFF
--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -143,7 +143,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
     if self.master_tpu_unsecure_channel and self.logdir.startswith('gs://'):
       if self.stub is None:
         import grpc
-        from tensorflow.contrib.tpu.profiler import tpu_profiler_analysis_pb2_grpc # pylint: disable=line-too-long
+        from tensorflow.python.tpu.profiler import profiler_analysis_pb2_grpc # pylint: disable=line-too-long
         # Workaround the grpc's 4MB message limitation.
         gigabyte = 1024 * 1024 * 1024
         options = [('grpc.max_message_length', gigabyte),
@@ -151,8 +151,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
                    ('grpc.max_receive_message_length', gigabyte)]
         tpu_profiler_port = self.master_tpu_unsecure_channel + ':8466'
         channel = grpc.insecure_channel(tpu_profiler_port, options)
-        self.stub = tpu_profiler_analysis_pb2_grpc.TPUProfileAnalysisStub(
-            channel)
+        self.stub = profiler_analysis_pb2_grpc.ProfileAnalysisStub(channel)
 
   def _run_dir(self, run):
     """Helper that maps a frontend run name to a profile "run" directory.
@@ -378,10 +377,10 @@ class ProfilePlugin(base_plugin.TBPlugin):
 
     self.start_grpc_stub_if_necessary()
     if tool == 'trace_viewer@' and self.stub is not None:
-      from tensorflow.contrib.tpu.profiler import tpu_profiler_analysis_pb2
-      grpc_request = tpu_profiler_analysis_pb2.ProfileSessionDataRequest()
-      grpc_request.repository_root = run_dir
-      grpc_request.session_id = profile_run[:-1]
+      from tensorflow.core.profiler import profiler_analysis_pb2
+      grpc_request = profiler_analysis_pb2.ProfileSessionDataRequest()
+      grpc_request.repository_root = os.path.dirname(run_dir)
+      grpc_request.session_id = profile_run
       grpc_request.tool_name = 'trace_viewer'
       # Remove the trailing dot if present
       grpc_request.host_name = host.rstrip('.')
@@ -431,26 +430,39 @@ class ProfilePlugin(base_plugin.TBPlugin):
     try:
       duration = int(request.args.get('duration'))
     except TypeError:
-      return http_util.Respond(request, 'Invalid duration',
-                               'text/plain', code=400)
+      # Returns code=200 to show error message in UI.
+      return http_util.Respond(request, {'error': 'invalid duration.'},
+                               'application/json', code=200)
     is_tpu_name = request.args.get('is_tpu_name') == 'true'
     workers_list = ''
     if is_tpu_name:
-      tpu_cluster_resolver = (
-          tf.distribute.cluster_resolver.TPUClusterResolver([service_addr]))
-      service_addr = tpu_cluster_resolver.get_master()
+      try:
+        tpu_cluster_resolver = (
+            tf.distribute.cluster_resolver.TPUClusterResolver([service_addr]))
+        master_grpc_addr = tpu_cluster_resolver.get_master()
+      except (ImportError, RuntimeError) as err:
+        return http_util.Respond(request, {'error': err.message},
+                                 'application/json', code=200)
+      except (ValueError, TypeError):
+        return http_util.Respond(request,
+            {'error': 'no TPUs with the specified names exist.'},
+             'application/json', code=200)
       workers_list = get_workers_list(tpu_cluster_resolver)
       # TPU cluster resolver always returns port 8470. Replace it with 8466
       # on which profiler service is running.
-      service_addr = service_addr.replace('grpc://', '').replace(':8470', ':8466')
+      master_ip = master_grpc_addr.replace('grpc://', '').replace(':8470', '')
+      service_addr = master_ip + ':8466'
+      # Set the master TPU for streaming trace viewer.
+      self.master_tpu_unsecure_channel = master_ip
     try:
-      profiler_client.start_tracing(service_addr, self.logdir, duration, workers_list);
+      profiler_client.start_tracing(service_addr, self.logdir,
+                                    duration, workers_list);
       return http_util.Respond(
-          request, {'result': 'Capture profile successfully. Please refresh'},
+          request, {'result': 'Capture profile successfully. Please refresh.'},
           'application/json')
     except tf.errors.UnavailableError:
-      return http_util.Respond(request, 'Empty trace result',
-                               'text/plain', code=404)
+      return http_util.Respond(request, {'error': 'empty trace result.'},
+                                         'application/json', code=200)
 
   def get_plugin_apps(self):
     return {

--- a/tensorboard/plugins/profile/tf_profile_dashboard/BUILD
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/BUILD
@@ -29,6 +29,7 @@ tf_web_library(
         "@org_polymer_paper_menu",
         "@org_polymer_paper_progress",
         "@org_polymer_paper_radio_group",
+	"@org_polymer_paper_spinner",
         "@org_polymer_paper_toast",
     ],
 )

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -22,6 +22,7 @@ limitations under the License.
 <link rel="import" href="../paper-progress/paper-progress.html">
 <link rel="import" href="../paper-radio-group/paper-radio-group.html">
 <link rel="import" href="../paper-toast/paper-toast.html">
+<link rel="import" href="../paper-spinner/paper-spinner.html">
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-dashboard-common/tf-dashboard-layout.html">
@@ -61,7 +62,9 @@ profile run can have multiple tools that present the performance profile as diff
     </p>
   </div>
 </template>
-<paper-toast id="toast" text="" always-on-top></paper-toast>
+<paper-toast id="toast" duration="0" text="" always-on-top>
+  <paper-button onclick="toast.toggle()" class="yellow-button">Close now!</paper-button>
+</paper-toast>
 <tf-plugin-dialog id="initialDialog"></tf-plugin-dialog>
 <paper-dialog id="captureProfileDialog" modal>
   <paper-input label="Profiler Service URL or TPU name"
@@ -97,6 +100,7 @@ profile run can have multiple tools that present the performance profile as diff
     <h3>No profile data was found.</h3>
 
     <paper-button raised on-tap="_openCaptureProfileDialog">Capture Profile</paper-button>
+    <paper-spinner class="capture-spinner" active="[[_capturingProfile]]"></paper-spinner>
 
     <p>If you have a model running on CPU, GPU, or Google Cloud TPU, you may be
         able to use the above button to capture a profile.
@@ -119,8 +123,8 @@ profile run can have multiple tools that present the performance profile as diff
   <div class="sidebar">
     <div class="allcontrols">
       <div class="sidebar-section">
-        <paper-button raised
-                      on-tap="_openCaptureProfileDialog">Capture Profile</paper-button>
+        <paper-button raised on-tap="_openCaptureProfileDialog">Capture Profile</paper-button>
+	<paper-spinner class="capture-spinner" active="[[_capturingProfile]]"></paper-spinner>
       </div>
       <div class="sidebar-section">
         <div class="title">Runs <span class="counter">([[_datasets.length]])</span></div>
@@ -259,6 +263,14 @@ profile run can have multiple tools that present the performance profile as diff
   details-card {
     width: 100%;
     will-change: transform;
+  }
+  .yellow-button {
+    color: #eeff41;
+    text-transform: none;
+  }
+  .capture-spinner {
+    padding-left: 5px;
+    vertical-align: middle;
   }
 </style>
 
@@ -428,6 +440,10 @@ profile run can have multiple tools that present the performance profile as diff
       _activePodDetails: {
         type: Array,
       },
+      _capturingProfile: {
+	type: Boolean,
+	value: false,
+      },
     },
     reload: function() {
     },
@@ -466,6 +482,7 @@ profile run can have multiple tools that present the performance profile as diff
       return !profilerServiceAddress || profileDuration <= 0;
     },
     _captureProfile: function() {
+      this._capturingProfile = true;
       const captureProfileUrl = tf_backend.addParams(
           tf_backend.getRouter().pluginRoute('profile', '/capture_profile'),
           {
@@ -474,8 +491,17 @@ profile run can have multiple tools that present the performance profile as diff
             duration: this._profileDuration,
           });
       this._requestManager.request(captureProfileUrl).then((json) => {
-        this._showToast(json.result);
+	this._capturingProfile = false;
+        if (json.error != null) {
+	  // Profiling API specific error.
+	  this._showToast(
+	      'Failed to capture profile: ' + json.error);
+	  return;
+        }
+        this._showToast(json.result);	
       }).catch((error) => {
+	this._capturingProfile = false;
+	// Network error.
         this._showToast("Failed to capture profile: " + error);
       });
     },


### PR DESCRIPTION
* Motivation for features / changes
tpu_profiler_analysis.proto has been moved from tensorflow/contrib to tensorflow/core/profiler and renamed to profiler_analysis.proto. Therefore, need to update the module import here.
The error message when capturing a profile is lost when responding with error code 400. Change to return a json error message with error code 200, so that it can be shown in the UI.
Also add a spinner when capturing profile. 

* Technical description of changes

* Screenshots of UI changes
![loading](https://user-images.githubusercontent.com/3082188/57335891-ec3a4780-70d8-11e9-98e2-42046703a100.png)
![error_message](https://user-images.githubusercontent.com/3082188/57335970-2d325c00-70d9-11e9-88fa-1d5d4b0f1981.png)


* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
