### PR TITLE
hparams: avoid TensorFlow dependency in summary_v2

### DIFF
--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -163,6 +163,8 @@ import tensorboard as tb
 assert tb.__version__ == tb.version.VERSION
 from tensorboard.plugins.projector import visualize_embeddings
 tb.notebook.start  # don't invoke; just check existence
+from tensorboard.plugins.hparams import summary_v2 as hp
+hp.hparams_pb({'optimizer': 'adam', 'learning_rate': 0.02})
 "
   if [ -n "${smoke_tf}" ]; then
     # Only test summary scalar, beholder, and mesh summary

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -252,6 +252,26 @@ py_test(
     ],
 )
 
+py_test(
+    name = "summary_v2_notf_test",
+    size = "small",
+    srcs = ["summary_v2_test.py"],
+    main = "summary_v2_test.py",
+    srcs_version = "PY2AND3",
+    tags = ["support_notf"],
+    deps = [
+        ":metadata",
+        ":protos_all_py_pb2",
+        ":summary_v2",
+        "//tensorboard:test",
+        "//tensorboard/compat:no_tensorflow",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
+        "@com_google_protobuf//:protobuf_python",
+        "@org_pythonhosted_mock",
+        "@org_pythonhosted_six",
+    ],
+)
+
 py_library(
     name = "summary",
     srcs = ["summary.py"],

--- a/tensorboard/plugins/hparams/metadata.py
+++ b/tensorboard/plugins/hparams/metadata.py
@@ -18,8 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import tensorflow as tf
-
+from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.hparams import error
 from tensorboard.plugins.hparams import plugin_data_pb2
 
@@ -50,8 +49,8 @@ def create_summary_metadata(hparams_plugin_data_pb):
   content = plugin_data_pb2.HParamsPluginData()
   content.CopyFrom(hparams_plugin_data_pb)
   content.version = PLUGIN_DATA_VERSION
-  return tf.compat.v1.SummaryMetadata(
-      plugin_data=tf.compat.v1.SummaryMetadata.PluginData(
+  return summary_pb2.SummaryMetadata(
+      plugin_data=summary_pb2.SummaryMetadata.PluginData(
           plugin_name=PLUGIN_NAME, content=content.SerializeToString()))
 
 

--- a/tensorboard/plugins/hparams/summary.py
+++ b/tensorboard/plugins/hparams/summary.py
@@ -184,7 +184,8 @@ def _summary(tag, hparams_plugin_data):
     hparams_plugin_data: The HParamsPluginData message to use.
   """
   summary = tf.compat.v1.Summary()
-  summary.value.add(
-      tag=tag,
-      metadata=metadata.create_summary_metadata(hparams_plugin_data))
+  tb_metadata = metadata.create_summary_metadata(hparams_plugin_data)
+  raw_metadata = tb_metadata.SerializeToString()
+  tf_metadata = tf.compat.v1.SummaryMetadata.FromString(raw_metadata)
+  summary.value.add(tag=tag, metadata=tf_metadata)
   return summary

--- a/tensorboard/plugins/hparams/summary_v2.py
+++ b/tensorboard/plugins/hparams/summary_v2.py
@@ -236,11 +236,8 @@ def _summary_pb(tag, hparams_plugin_data):
     A TensorBoard `summary_pb2.Summary` message.
   """
   summary = summary_pb2.Summary()
-  tf_metadata = metadata.create_summary_metadata(hparams_plugin_data)
-  tb_metadata = summary_pb2.SummaryMetadata.FromString(
-      tf_metadata.SerializeToString()
-  )
-  summary.value.add(tag=tag, metadata=tb_metadata)
+  summary_metadata = metadata.create_summary_metadata(hparams_plugin_data)
+  summary.value.add(tag=tag, metadata=summary_metadata)
   return summary
 
 

--- a/tensorboard/plugins/hparams/summary_v2_test.py
+++ b/tensorboard/plugins/hparams/summary_v2_test.py
@@ -21,10 +21,10 @@ import abc
 import collections
 import os
 import time
+import unittest
 
 from google.protobuf import text_format
 import six
-import tensorflow as tf
 
 try:
   # python version >= 3.3
@@ -33,6 +33,7 @@ except ImportError:
   import mock  # pylint: disable=g-import-not-at-top,unused-import
 
 from tensorboard import test
+from tensorboard.compat import tf
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.hparams import api_pb2
 from tensorboard.plugins.hparams import metadata
@@ -40,7 +41,15 @@ from tensorboard.plugins.hparams import plugin_data_pb2
 from tensorboard.plugins.hparams import summary_v2 as hp
 
 
-tf.compat.v1.enable_eager_execution()
+if tf.__version__ == "stub":
+  tf = None
+
+
+if tf is not None:
+  tf.compat.v1.enable_eager_execution()
+
+
+requires_tf = unittest.skipIf(tf is None, "Requires TensorFlow.")
 
 
 class HParamsTest(test.TestCase):
@@ -106,12 +115,14 @@ class HParamsTest(test.TestCase):
     """Test that the hparams summary was written to `logdir`."""
     self._check_summary(_get_unique_summary(self, logdir))
 
+  @requires_tf
   def test_eager(self):
     with tf.compat.v2.summary.create_file_writer(self.logdir).as_default():
       result = hp.hparams(self.hparams, start_time_secs=self.start_time_secs)
       self.assertTrue(result)
     self._check_logdir(self.logdir)
 
+  @requires_tf
   def test_graph_mode(self):
     with \
         tf.compat.v1.Graph().as_default(), \
@@ -123,6 +134,7 @@ class HParamsTest(test.TestCase):
       sess.run(w.flush())
     self._check_logdir(self.logdir)
 
+  @requires_tf
   def test_eager_no_default_writer(self):
     result = hp.hparams(self.hparams, start_time_secs=self.start_time_secs)
     self.assertFalse(result)  # no default writer
@@ -134,7 +146,8 @@ class HParamsTest(test.TestCase):
   def test_pb_is_tensorboard_copy_of_proto(self):
     result = hp.hparams_pb(self.hparams, start_time_secs=self.start_time_secs)
     self.assertIsInstance(result, summary_pb2.Summary)
-    self.assertNotIsInstance(result, tf.compat.v1.Summary)
+    if tf is not None:
+      self.assertNotIsInstance(result, tf.compat.v1.Summary)
 
   def test_consistency_across_string_key_and_object_key(self):
     hparams_1 = {
@@ -324,6 +337,7 @@ class HParamsConfigTest(test.TestCase):
     """Test that the experiment summary was written to `logdir`."""
     self._check_summary(_get_unique_summary(self, logdir))
 
+  @requires_tf
   def test_eager(self):
     with tf.compat.v2.summary.create_file_writer(self.logdir).as_default():
       result = hp.hparams_config(
@@ -334,6 +348,7 @@ class HParamsConfigTest(test.TestCase):
       self.assertTrue(result)
     self._check_logdir(self.logdir)
 
+  @requires_tf
   def test_graph_mode(self):
     with \
         tf.compat.v1.Graph().as_default(), \
@@ -348,6 +363,7 @@ class HParamsConfigTest(test.TestCase):
       self.assertTrue(sess.run(summ))
     self._check_logdir(self.logdir)
 
+  @requires_tf
   def test_eager_no_default_writer(self):
     result = hp.hparams_config(
         hparams=self.hparams,
@@ -371,7 +387,8 @@ class HParamsConfigTest(test.TestCase):
         time_created_secs=self.time_created_secs,
     )
     self.assertIsInstance(result, summary_pb2.Summary)
-    self.assertNotIsInstance(result, tf.compat.v1.Summary)
+    if tf is not None:
+      self.assertNotIsInstance(result, tf.compat.v1.Summary)
 
 
 def _get_unique_summary(self, logdir):
@@ -489,4 +506,7 @@ class DiscreteTest(test.TestCase):
 
 
 if __name__ == "__main__":
-  tf.test.main()
+  if tf is not None:
+    tf.test.main()
+  else:
+    test.main()


### PR DESCRIPTION
Summary:
This changes the private `metadata` module to emit TensorBoard protos
instead of TensorFlow protos, removing its dependency on TensorFlow. Its
two clients are updated: we add a reinterpret-cast to one and remove the
cast from the other.

Test Plan:
A new test target runs with `//tensorboard/compat:no_tensorflow`.
Verified that this passes in a virtualenv that actually does not have
TensorFlow installed, skipping only the expected six tests. Smoke test
updated for notf builds; the new smoke test fails before this change.

wchargin-branch: hparams-notf
