### PR TITLE
Move What-If Tool into an iframe in Jupyter widget

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -72,6 +72,7 @@ limitations under the License.
     </style>
     <style>
       :host {
+        font-family: 'Roboto', 'Noto', sans-serif;
         --paper-tab-ink: var(--tb-orange-dark);
         --wit-color-gray300: #DADCE0;
       }
@@ -2932,6 +2933,15 @@ limitations under the License.
           overallThresholds.push({threshold: 0.5})
         }
         this.set('overallThresholds', overallThresholds);
+
+        // If inference can be performed automatically at this point, due to
+        // examples already being set, and now the model being set, then
+        // cause inference to run.
+        if (!this.shouldDisableInferButton_(
+            this.examplesAndInferences, this.modelName, this.inferenceAddress,
+            this.updatedExample)) {
+          this.inferClicked_();
+        }
       },
 
       isComputedKeyStr_: function(feature) {


### PR DESCRIPTION
* Motivation for features / changes

In order for WitWidget to live in a Jupyter notebook without interfering with other widgets that also use Polymer, we need to load it inside an iframe. Otherwise for examples the TFMA visualizations and WitWidget cannot live in the same notebook without failing, due to their vulcanized HTML files for their widgets both containing polymer dependencies (since the browser will fail on the loading of those deps a second time).

* Technical description of changes

Moved WIT HTML element and its vulcanized dependency to inside an iframe.
Updated wit.js code to ensure WIT is fully loaded inside iframe before trying to use it.
Update WIT element to use correct font, as without this, inside iframe it reverts to default browser fonts.
Update WIT element to auto-infer when a model is set, if examples have already been loaded. Previously this only happened if a model was set and THEN examples were set. But it should auto-infer when these are set in either order.

* Screenshots of UI changes

No visual changes, but included screenshot of WIT loading inside iframe in Jupyter

![witiframe](https://user-images.githubusercontent.com/15835086/57397324-6c74b180-719a-11e9-88f9-f8aba551344c.png)

* Detailed steps to verify changes work correctly (as executed by you)

pip build/install with this PR. Run WIT inside Jupyter notebook with model/data, ensure all functionality and visual correctness.