### PR TITLE
test: skip V1-only tests under TF2 behavior

### DIFF
--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -27,6 +27,8 @@ import threading
 import unittest
 
 import tensorflow as tf
+# See discussion on issue #1996 for private module import justification.
+from tensorflow.python import tf2 as tensorflow_python_tf2
 
 from tensorboard.compat.proto import event_pb2
 from tensorboard.compat.proto import graph_pb2
@@ -158,16 +160,10 @@ def _run_conditionally(guard, name, default_reason=None):
 
   return _impl
 
-# Logic from `tensorflow.python.tf2`, assuming that `enable_v2_behavior`
-# has not been manually called (which we have no way to check).
-_is_tf2 = (
-    tf.__version__.startswith('2.')
-    or os.getenv('TF2_BEHAVIOR', '0') != '0'
-)
 run_v1_only = _run_conditionally(
-    lambda: not _is_tf2,
+    lambda: not tensorflow_python_tf2.enabled(),
     name='run_v1_only')
 run_v2_only = _run_conditionally(
-    lambda: _is_tf2,
+    lambda: tensorflow_python_tf2.enabled(),
     name='run_v2_only',
     default_reason='Test only appropriate for TensorFlow v2')

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
 import threading
 import unittest
 

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
 import threading
 import unittest
 
@@ -157,8 +158,12 @@ def _run_conditionally(guard, name, default_reason=None):
 
   return _impl
 
-# TODO(#1996): Better detect TF2.0.
-_is_tf2 =  tf.__version__.startswith('2.')
+# Logic from `tensorflow.python.tf2`, assuming that `enable_v2_behavior`
+# has not been manually called (which we have no way to check).
+_is_tf2 = (
+    tf.__version__.startswith('2.')
+    or os.getenv('TF2_BEHAVIOR', '0') != '0'
+)
 run_v1_only = _run_conditionally(
     lambda: not _is_tf2,
     name='run_v1_only')


### PR DESCRIPTION
Summary:
When the `TF2_BEHAVIOR` environment variable is set, TensorFlow behaves
as if `tf.compat.v1.enable_v2_behavior()` were invoked. In such a case,
we should not run V1-only tests.

We elect to test this by importing a private TensorFlow module rather
than reading the environment variable directly. Both are undocumented,
but the module import will give us a hard failure if it is changed,
while the environment variable will silently change behavior.

This fixes some Google-internal issues (see <http://cl/247294725>). It
should be a no-op externally; we do not set this environment variable.

Resolves #1996.

Test Plan:
Count the number of skipped tests before and after this change:

```
tests="$(bazel query "
    tests(rdeps(
        //tensorboard/...,
        set($(git grep -l run_v._only)) - //tensorboard/util:test_util.py
    ))
")" &&
bazel test ${tests} --test_output=all 2>&1 |
    sed -n -e 's/.*(skipped=\([0-9]\+\)).*/\1/p' |
    awk '{ c += $1 } END { print c }'
```

On TF 2.0, it prints `166` both before and after this change; on TF 1.x,
it prints `21` both before and after this change.

wchargin-branch: respect-tf2-behavior
