### PR TITLE
profile: standardize tutorial style

### DIFF
--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -39,7 +39,7 @@ upper_tabs:
         path: /tensorboard/r2/hyperparameter_tuning_with_hparams
       - title: "What-If Tool"
         path: /tensorboard/r2/what_if_tool
-      - title: "Profiling Tool"
+      - title: "Profiling tool"
         path: /tensorboard/r2/tensorboard_profiling_keras
       - title: "TensorBoard in notebooks"
         path: /tensorboard/r2/tensorboard_in_notebooks

--- a/docs/r2/tensorboard_profiling_keras.ipynb
+++ b/docs/r2/tensorboard_profiling_keras.ipynb
@@ -91,9 +91,9 @@
       "source": [
         "\n",
         "## Overview\n",
-        "Performance is critical for machine learning. TensorFlow has a built-in profiler that allows you to record runtime of each ops with very little effort. Then you can visualize the profile result in TensorBoard's **Profile Plugin**. This tutorial focuses on GPU but the Profile Plugin can also be used with TPUs by following the [Cloud TPU Tools](https://cloud.google.com/tpu/docs/cloud-tpu-tools).\n",
+        "Performance is critical for machine learning. TensorFlow has a built-in profiler that allows you to record runtime of each ops with very little effort. Then you can visualize the profile result in TensorBoard's *Profile Plugin*. This tutorial focuses on GPU but the Profile Plugin can also be used with TPUs by following the [Cloud TPU Tools](https://cloud.google.com/tpu/docs/cloud-tpu-tools).\n",
         "\n",
-        "This tutorial presents very basic examples to help you learn how to enable profiler when developing your Keras model. You will learn how to use the Keras TensorBoard callback to visualize profile result. **Profiler APIs** and **Profiler Server** mentioned in **Other ways for profiling** allow you to profile non-Keras TensorFlow job."
+        "This tutorial presents very basic examples to help you learn how to enable profiler when developing your Keras model. You will learn how to use the Keras TensorBoard callback to visualize profile result. *Profiler APIs* and *Profiler Server* mentioned in “Other ways for profiling” allow you to profile non-Keras TensorFlow job."
       ]
     },
     {
@@ -108,7 +108,7 @@
         "\n",
         "*   Install latest [TensorBoard](https://www.tensorflow.org/tensorboard) on your local machine.\n",
         "\n",
-        "*   Select **GPU** in the Accelerator drop-down in Notebook Settings (Assuming you run this notebook on Colab).\n",
+        "*   Select “GPU” in the Accelerator drop-down in Notebook Settings (Assuming you run this notebook on Colab).\n",
         "\n",
         ">![Notebook Settings](https://github.com/tensorflow/tensorboard/blob/master/docs/r2/images/profiler-notebook-settings.png?raw=1\\)\n",
         "\n"
@@ -610,7 +610,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "When creating TensorBoard callback, you can specify the batch num you want to profile. By default, TensorFlow will profile the second batch, because many one time graph optimizations run on the first batch. You can modify it by setting **profile_batch**. You can also turn off profiling by setting it to 0.\n",
+        "When creating TensorBoard callback, you can specify the batch num you want to profile. By default, TensorFlow will profile the second batch, because many one time graph optimizations run on the first batch. You can modify it by setting `profile_batch`. You can also turn off profiling by setting it to 0.\n",
         "\n",
         "This time, you will profile on the third batch."
       ]
@@ -765,7 +765,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "Download **logdir.tar.gz** by right-clicking it in **Files** tab.\n",
+        "Download `logdir.tar.gz` by right-clicking it in “Files” tab.\n",
         "\n",
         "![Download](https://github.com/tensorflow/tensorboard/blob/master/docs/r2/images/profiler-download-logdir.png?raw=1\\)\n",
         "\n",
@@ -788,7 +788,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "Open a new tab in your Chrome browser and navigate to [localhost:6006](http://localhost:6006) and then click **Profile** tab. You may see the profile result like this:\n",
+        "Open a new tab in your Chrome browser and navigate to [localhost:6006](http://localhost:6006) and then click “Profile” tab. You may see the profile result like this:\n",
         "\n",
         "![Trace View](https://github.com/tensorflow/tensorboard/blob/master/docs/r2/images/profiler-trace-viewer.png?raw=1\\)\n",
         "\n",
@@ -805,22 +805,22 @@
         "## Trace Viewer\n",
         "Once you click the profile tab, you will see Trace Viewer. The page displays a timeline of different events that happened on the CPU and the accelerator during the collection period.\n",
         "\n",
-        "The Trace Viewer shows multiple **event groups** on the vertical axis. Each event group has multiple horizontal **tracks**, filled with trace events. The **track** is basically an event timeline for events executed on a thread or a GPU stream. Individual events are the colored, rectangular blocks on the timeline tracks. Time moves from left to right.\n",
+        "The Trace Viewer shows multiple *event groups* on the vertical axis. Each event group has multiple horizontal *tracks*, filled with trace events. The *track* is basically an event timeline for events executed on a thread or a GPU stream. Individual events are the colored, rectangular blocks on the timeline tracks. Time moves from left to right.\n",
         "\n",
-        "You can navigate through the result using **w** (zoom in), **s** (zoom out), **a** (scroll left), **d** (scroll right).\n",
+        "You can navigate through the result using `w` (zoom in), `s` (zoom out), `a` (scroll left), `d` (scroll right).\n",
         "\n",
-        "A single rectangle represents a **trace event**: when it began, and when it ended. To study an individual rectangle, you can click on it after selecting the mouse cursor icon in the floating tool bar. This will display information about the rectangle, such as its Start time and Duration.\n",
+        "A single rectangle represents a *trace event*: when it began, and when it ended. To study an individual rectangle, you can click on it after selecting the mouse cursor icon in the floating tool bar. This will display information about the rectangle, such as its Start time and Duration.\n",
         "\n",
-        "In addition to clicking, you can drag the mouse to select a rectangle covering a group of trace events. This will give you a list of events that intersect that rectangle and summarize them for you. The **m** key can be used to measure the time duration of the selected events.\n",
+        "In addition to clicking, you can drag the mouse to select a rectangle covering a group of trace events. This will give you a list of events that intersect that rectangle and summarize them for you. The `m` key can be used to measure the time duration of the selected events.\n",
         "\n",
         "![List of Events](https://github.com/tensorflow/tensorboard/blob/master/docs/r2/images/profiler-trace-viewer-select.png?raw=1\\)\n",
         "\n",
         "The trace events are collected from three sources:\n",
         "\n",
         "\n",
-        "*   **CPU**: CPU events are under event group named **/host:CPU**. Each track represents a thread on CPU. E.g. input pipeline events, GPU op scheduling events, CPU ops execution events, etc.\n",
-        "*   **GPU**: GPU events are under event groups prefixed by **/device:GPU:***.  Except **stream:all**, each event group represents one stream on GPU. **stream::all** aggregates all events on one GPU. E.g. Memory copy events, Kernel execution events, etc.\n",
-        "*   **TensorFlow Runtime**: Runtime events are under event groups prefixed by **/job:***. Runtime events represent the TensorFlow ops invoked by python program. E.g. tf.function execution events, etc.\n",
+        "*   **CPU:** CPU events are under event group named `/host:CPU`. Each track represents a thread on CPU. E.g. input pipeline events, GPU op scheduling events, CPU ops execution events, etc.\n",
+        "*   **GPU:** GPU events are under event groups prefixed by `/device:GPU:`.  Except `stream:all`, each event group represents one stream on GPU. `stream::all` aggregates all events on one GPU. E.g. Memory copy events, Kernel execution events, etc.\n",
+        "*   **TensorFlow Runtime:** Runtime events are under event groups prefixed by `/job:`. Runtime events represent the TensorFlow ops invoked by python program. E.g. tf.function execution events, etc.\n",
         "\n",
         "\n",
         "\n",
@@ -850,7 +850,7 @@
         "\n",
         "![Runtime](https://github.com/tensorflow/tensorboard/blob/master/docs/r2/images/profiler-blocking-runtime.png?raw=1\\)\n",
         "\n",
-        "In TensorFlow runtime, there is a big block named **Iterator::GetNextSync**, which is a blocking call to get the next batch from data input pipeline. And it blocks the training step. So if you could prepare the input data for step **s** in **s-1** step, you can probably train this model faster.\n",
+        "In TensorFlow runtime, there is a big block named `Iterator::GetNextSync`, which is a blocking call to get the next batch from data input pipeline. And it blocks the training step. So if you could prepare the input data for step `s` in `s-1` step, you can probably train this model faster.\n",
         "\n",
         "You can achieve it by using [tf.data.prefetch](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#prefetch)."
       ]
@@ -946,7 +946,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "Woohoo! You have just improvd training performance from **~235ms/step** to **~200ms/step**.  "
+        "Woohoo! You have just improvd training performance from *~235ms/step* to *~200ms/step*.  "
       ]
     },
     {
@@ -970,11 +970,11 @@
       "cell_type": "markdown",
       "source": [
         "\n",
-        "Download **logs** directory again to see the new profile result in TensorBoard.\n",
+        "Download `logs` directory again to see the new profile result in TensorBoard.\n",
         "\n",
         "![TF Runtime](https://github.com/tensorflow/tensorboard/blob/master/docs/r2/images/profiler-prefetch-runtime.png?raw=1\\)\n",
         "\n",
-        "The big **Iterator::GetNextSync** block is not there anymore.\n",
+        "The big `Iterator::GetNextSync` block is not there anymore.\n",
         "\n",
         "Good job!\n",
         "\n",
@@ -998,9 +998,9 @@
       "cell_type": "markdown",
       "source": [
         "## Other ways for profiling\n",
-        "In addition to TensorBoard callback, TensorFlow also provides two additional way to trigger profiler manually: **Profiler APIs** and **Profiler Service**.\n",
+        "In addition to TensorBoard callback, TensorFlow also provides two additional way to trigger profiler manually: *Profiler APIs* and *Profiler Service*.\n",
         "\n",
-        "**NOTE**: Please don't run multiple profilers at the same time. If you want to use either Profiler APIs or Profiler Service with TensorBoard callback, ensure the **profile_batch** parameter is set to 0.\n",
+        "**Note:** Please don't run multiple profilers at the same time. If you want to use either Profiler APIs or Profiler Service with TensorBoard callback, ensure the `profile_batch` parameter is set to 0.\n",
         "\n",
         "\n",
         "\n",
@@ -1075,7 +1075,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "Then you can send profiling request to profiler server to perform on-demand profiling on TensorBoard by clicking **CAPTURE PROFILE** button:\n",
+        "Then you can send profiling request to profiler server to perform on-demand profiling on TensorBoard by clicking the “Capture Profile” button:\n",
         "\n",
         "![CAPTURE PROFILE](https://github.com/tensorflow/tensorboard/blob/master/docs/r2/images/profiler-capture.png?raw=1\\)\n",
         "\n",

--- a/docs/r2/tensorboard_profiling_keras.ipynb
+++ b/docs/r2/tensorboard_profiling_keras.ipynb
@@ -1000,7 +1000,7 @@
         "## Other ways for profiling\n",
         "In addition to TensorBoard callback, TensorFlow also provides two additional way to trigger profiler manually: *Profiler APIs* and *Profiler Service*.\n",
         "\n",
-        "**Note:** Please don't run multiple profilers at the same time. If you want to use either Profiler APIs or Profiler Service with TensorBoard callback, ensure the `profile_batch` parameter is set to 0.\n",
+        "Note: Please don't run multiple profilers at the same time. If you want to use either Profiler APIs or Profiler Service with TensorBoard callback, ensure the `profile_batch` parameter is set to 0.\n",
         "\n",
         "\n",
         "\n",


### PR DESCRIPTION
Summary:
Per @lamberta via [the Google dev docs style guide][guide], we should
use sentence case for titles and headers, and “prefer italics instead
bold for emphasis” because “bold style tends to conflict with the
h3/h4/h5 styles that devsite uses when skimming the page”.

This commit replaces strong emphasis with emphasis, quotations, or code
spans, as appropriate. Strong emphasis is retained for description list
items and a `**NOTE**:` specifier (changed to `**Note:**` for
consistency with [the same guide][guide]).

This commit is easier to review with `--word-diff`.

[guide]: https://developers.google.com/style/capitalization

Test Plan:
Check that all remaining `**`-sequences are intended:

```
$ grep -F '**' docs/r2/tensorboard_profiling_keras.ipynb | cut -c -40
        "*   **CPU**: CPU events are und
        "*   **GPU**: GPU events are und
        "*   **TensorFlow Runtime**: Run
        "**NOTE**: Please don't run mult
```

wchargin-branch: profile-unembolden
