### PR TITLE
What-If Tool: simplify inference address documentation

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-inference-panel.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-inference-panel.html
@@ -95,7 +95,7 @@ limitations under the License.
       }
     </style>
     <div class="title">Set up your data and model</div>
-    <paper-input always-float-label label="Inference address (blade address or host:port)"
+    <paper-input always-float-label label="Inference address"
                  placeholder="[[inferenceAddress1]]" value="{{inferenceAddress1}}">
     </paper-input>
     <div class="flex-holder">
@@ -110,7 +110,7 @@ limitations under the License.
       </paper-input>
     </div>
     <div hidden$={{hideModelPane2}}>
-      <paper-input always-float-label label="Inference address (blade address or host:port)"
+      <paper-input always-float-label label="Inference address"
       placeholder="[[inferenceAddress2]]" value="{{inferenceAddress2}}">
       </paper-input>
       <div class="flex-holder">

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -167,7 +167,7 @@ class ServingBundle(object):
   """Light-weight class for holding info to make the inference request.
 
   Attributes:
-    inference_address: A local address or blade address to send inference
+    inference_address: An address (such as "hostname:port") to send inference
       requests to.
     model_name: The Servo model name.
     model_type: One of ['classification', 'regression'].


### PR DESCRIPTION
* Motivation for features / changes

Simplify "inference address" mentions in tool/code to not be misleading.
Documentation on how to set inference address can be found in many places (WIT README, WIT website walkthrough, TB website WIT page, ...).
