### PR TITLE
Zoom with mouse wheel only when alt key is pressed

### DIFF
--- a/tensorboard/components/vz_line_chart2/panZoomDragLayer.ts
+++ b/tensorboard/components/vz_line_chart2/panZoomDragLayer.ts
@@ -34,7 +34,8 @@ export class PanZoomDragLayer extends Plottable.Components.Group {
    * When not pressing alt-key, it behaves like DragZoomLayer -- dragging a
    * region zooms the area under the gray box and double clicking resets the
    * zoom. When pressing alt-key, it lets user pan around while having mousedown
-   * on the chart and let user zoom-in/out of cursor when scroll.
+   * on the chart and let user zoom-in/out of cursor when scroll with alt key
+   * pressed.
    */
   constructor(
       xScale: Plottable.QuantitativeScale<number|{valueOf(): number}>,
@@ -46,6 +47,7 @@ export class PanZoomDragLayer extends Plottable.Components.Group {
     this.panZoom.dragInteraction().mouseFilter((event: MouseEvent) => {
       return PanZoomDragLayer.isPanKey(event) && event.button === 0;
     });
+    this.panZoom.wheelFilter((event) => event.altKey);
     this.panZoom.attachTo(this);
 
     this.dragZoomLayer = new vz_line_chart.DragZoomLayer(


### PR DESCRIPTION
Default mouse wheel to zoom is rather obnoxious since large area of the
TensorBoard is zoomable area.

Note that preferably we'd want to provide some tooltip or help to make
this feature discoverable but simple hack using `HTMLElement.title` felt very 
disturbing and poor. We, in later time, might want to consider doing what
Google Map does on mobile (when scroll event happens inside the zoomable
area, it shows shows a transparent splash describing how to zoom). Note that
none of these solutions are friendly to the screen reader softwares.

Fixes #2214.

