### PR TITLE
graph: Fix JSE when switching node selection

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
@@ -489,7 +489,7 @@ limitations under the License.
           return null;
         },
         _getTotalMicros: function(stats) {
-          return stats.getTotalMicros();
+          return stats ? stats.getTotalMicros() : 0;
         },
         _getHasDisplayableNodeStats: function(stats) {
           return tf.graph.util.hasDisplayableNodeStats(stats);


### PR DESCRIPTION
Repro steps:
1. Select a run that has more than one tags
2. Select a tag with RunMetadata
3. Select a node
4. Select the default tag
5. Click nodes around and see JSEs

We have nested dom-ifs to prevent `getTotalMicros` from being called.
However, this is only effective when the DOM is not mounted but this
assumption does not hold after first render (if=true).
