### PR TITLE
hparams: account for proto nondeterminism in tests

### DIFF
--- a/tensorboard/plugins/hparams/summary_v2_test.py
+++ b/tensorboard/plugins/hparams/summary_v2_test.py
@@ -165,7 +165,7 @@ class HParamsTest(test.TestCase):
       self.assertEqual(len(values), 1, values)
       value = values[0]
       raw_content = value.metadata.plugin_data.content
-      value.metadata.plugin_data.content = "<snipped>"
+      value.metadata.plugin_data.content = b"<snipped>"
       content = plugin_data_pb2.HParamsPluginData.FromString(raw_content)
       return (new_summary, content)
 


### PR DESCRIPTION
Summary:
This test seems to be fine in open-source land, but failed 18/32 times
within Google, because the wire format order for maps is undefined:
<https://developers.google.com/protocol-buffers/docs/proto3#maps>

Test Plan:
Within google3, cherry-pick this patch onto <http://cl/247655537>, then
run `:summary_v2_notf_test` with `--runs_per_test=128` to check for
flakiness.

wchargin-branch: hparams-test-deflake
