### PR TITLE
Use `six.add_metaclass` for Python 3 compatibility

### DIFF
--- a/tensorboard/backend/event_processing/db_import_multiplexer.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer.py
@@ -241,9 +241,9 @@ class _RunLoader(object):
           run_name=self._run_name)
 
 
+@six.add_metaclass(abc.ABCMeta)
 class _EventSink(object):
   """Abstract sink for batches of serialized tf.Event data."""
-  __metaclass__ = abc.ABCMeta
 
   @abc.abstractmethod
   def write_batch(self, event_batch):

--- a/tensorboard/plugins/BUILD
+++ b/tensorboard/plugins/BUILD
@@ -12,4 +12,7 @@ py_library(
     srcs = ["base_plugin.py"],
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
+    deps = [
+        "@org_pythonhosted_six",
+    ],
 )

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -22,10 +22,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import six
+
 from abc import ABCMeta
 from abc import abstractmethod
 
 
+@six.add_metaclass(ABCMeta)
 class TBPlugin(object):
   """TensorBoard plugin interface.
 
@@ -44,7 +47,6 @@ class TBPlugin(object):
       name must only contain characters among [A-Za-z0-9_.-], and must
       be nonempty, or a ValueError will similarly be thrown.
   """
-  __metaclass__ = ABCMeta
 
   plugin_name = None
 

--- a/tensorboard/plugins/beholder/BUILD
+++ b/tensorboard/plugins/beholder/BUILD
@@ -143,5 +143,6 @@ py_library(
     deps = [
         ":im_util",
         "//tensorboard/util:tb_logging",
+        "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/plugins/beholder/video_writing.py
+++ b/tensorboard/plugins/beholder/video_writing.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import abc
 import os
+import six
 import subprocess
 import time
 
@@ -87,10 +88,9 @@ class VideoWriter(object):
     self.output_index = 0
 
 
+@six.add_metaclass(abc.ABCMeta)
 class VideoOutput(object):
   """Base class for video outputs supported by VideoWriter."""
-
-  __metaclass__ = abc.ABCMeta
 
   # Would add @abc.abstractmethod in python 3.3+
   @classmethod

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -310,9 +310,9 @@ class TensorBoard(object):
     return self.server_class(app, self.flags)
 
 
+@six.add_metaclass(ABCMeta)
 class TensorBoardServer(object):
   """Class for customizing TensorBoard WSGI app serving."""
-  __metaclass__ = ABCMeta
 
   @abstractmethod
   def __init__(self, wsgi_app, flags):


### PR DESCRIPTION
Summary:
Fixes #2121.

Test Plan:

    $ git grep '__metaclass__' | wc -l
    0

wchargin-branch: six-add-metaclass
