### PR TITLE
Fix datapoint id not displaying correctly for id=0

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -5456,7 +5456,7 @@ limitations under the License.
 
       getSectionTitle: function(title, selectedExampleNum, comparedIndices) {
         let name = title;
-        if (selectedExampleNum != null && selectedExampleNum != '') {
+        if (selectedExampleNum != null && selectedExampleNum !== '') {
           if (comparedIndices != null && comparedIndices.length > 0) {
             name += ' - Datapoints ' + selectedExampleNum + ' and ' + comparedIndices[0];
           }


### PR DESCRIPTION
* Motivation for features / changes
Minor bug fix: Datapoint id title did not populate correctly when id is 0, because 0 == ''" is true.

* Technical description of changes

* Screenshots of UI changes

![old](https://user-images.githubusercontent.com/6536229/57959440-dcd5ae00-78d1-11e9-948e-3684751a88b0.png)

![new](https://user-images.githubusercontent.com/6536229/57959442-df380800-78d1-11e9-8864-b665e6ffcaea.png)

* Detailed steps to verify changes work correctly (as executed by you)
I locally ran the web demos and verified that they work correctly.

* Alternate designs / implementations considered
