### PR TITLE
build: use `mirror.tensorflow.org`, now populated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
     printf >"${bazel_checksum_file}" \
         '%s  %s\n' "${BAZEL_SHA256SUM}" "${bazel_binary}" &&
     for url in \
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-linux-x86_64" \
+        "http://mirror.tensorflow.org/github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-linux-x86_64" \
         "https://github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-linux-x86_64" \
     ; do
       if \

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,7 +8,7 @@ http_archive(
     strip_prefix = "bazel-skylib-0.7.0",
     urls = [
         # tag 0.7.0 resolves to commit 6741f733227dc68137512161a5ce6fcf283e3f58 (2019-02-08 18:37:26 +0100)
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/0.7.0.tar.gz",
+        "http://mirror.tensorflow.org/github.com/bazelbuild/bazel-skylib/archive/0.7.0.tar.gz",
         "https://github.com/bazelbuild/bazel-skylib/archive/0.7.0.tar.gz",
     ],
 )
@@ -23,7 +23,7 @@ http_archive(
     sha256 = "f89ca8e91ac53b3c61da356c685bf03e927f23b97b086cc593db8edc088c143f",
     urls = [
         # tag 0.3.1 resolves to commit afa8c4435ed8fd832046dab807ef998a26779ecb (2019-04-03 14:10:32 -0700)
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_webtesting/releases/download/0.3.1/rules_webtesting.tar.gz",
+        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_webtesting/releases/download/0.3.1/rules_webtesting.tar.gz",
         "https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.1/rules_webtesting.tar.gz",
     ],
 )
@@ -41,7 +41,7 @@ http_archive(
     # any release, so we pin to HEAD as of 2019-02-22.
     strip_prefix = "rules_closure-87d24b1df8b62405de8dd059cb604fd9d4b1e395",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/87d24b1df8b62405de8dd059cb604fd9d4b1e395.tar.gz",
+        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_closure/archive/87d24b1df8b62405de8dd059cb604fd9d4b1e395.tar.gz",
         "https://github.com/bazelbuild/rules_closure/archive/87d24b1df8b62405de8dd059cb604fd9d4b1e395.tar.gz",  # 2019-02-22
     ],
 )
@@ -57,7 +57,7 @@ http_archive(
     sha256 = "1086f63c2c9fbea6873e137d08b5711a0493a5b699f258774da97f7672ba939a",
     strip_prefix = "tensorflow-2243bd6ba9b36d43dbd5c0ede313853f187f5dce",
     urls = [
-        "https://mirror.bazel.build/github.com/tensorflow/tensorflow/archive/2243bd6ba9b36d43dbd5c0ede313853f187f5dce.tar.gz",  # 2019-03-26
+        "http://mirror.tensorflow.org/github.com/tensorflow/tensorflow/archive/2243bd6ba9b36d43dbd5c0ede313853f187f5dce.tar.gz",  # 2019-03-26
         "https://github.com/tensorflow/tensorflow/archive/2243bd6ba9b36d43dbd5c0ede313853f187f5dce.tar.gz",
     ],
 )

--- a/tensorboard/tools/import_google_fonts.py
+++ b/tensorboard/tools/import_google_fonts.py
@@ -74,7 +74,7 @@ flags.DEFINE_string('user_agent',
                        'Chrome/62.0.3202.94 '
                        'Safari/537.36',
                        'HTTP User-Agent header to send to Google Fonts')
-flags.DEFINE_string('mirror', 'https://mirror.tensorflow.org/',
+flags.DEFINE_string('mirror', 'http://mirror.tensorflow.org/',
                        'Mirror URL prefix')
 FLAGS = flags.FLAGS
 

--- a/tensorboard/tools/import_google_fonts.py
+++ b/tensorboard/tools/import_google_fonts.py
@@ -74,7 +74,7 @@ flags.DEFINE_string('user_agent',
                        'Chrome/62.0.3202.94 '
                        'Safari/537.36',
                        'HTTP User-Agent header to send to Google Fonts')
-flags.DEFINE_string('mirror', 'https://mirror.bazel.build/',
+flags.DEFINE_string('mirror', 'https://mirror.tensorflow.org/',
                        'Mirror URL prefix')
 FLAGS = flags.FLAGS
 

--- a/third_party/fonts.bzl
+++ b/third_party/fonts.bzl
@@ -24,357 +24,357 @@ def tensorboard_fonts_workspace():
       licenses = ["notice"],  # Apache 2.0
       sha256_urls = {
           "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/google/roboto/ba03b84b90b50afd99f9688059447bc545e5c0e1/LICENSE",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/google/roboto/ba03b84b90b50afd99f9688059447bc545e5c0e1/LICENSE",
               "https://raw.githubusercontent.com/google/roboto/ba03b84b90b50afd99f9688059447bc545e5c0e1/LICENSE",
           ],
           # Roboto (cyrillic)
           "41720926981ffb6dc229f06fc0bbf0f43e45ba032d126726ebee481c2a6559e2": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/uYECMKoHcO9x1wdmbyHIm3-_kf6ByYO6CLYdB4HQE-Y.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/uYECMKoHcO9x1wdmbyHIm3-_kf6ByYO6CLYdB4HQE-Y.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/uYECMKoHcO9x1wdmbyHIm3-_kf6ByYO6CLYdB4HQE-Y.woff2",
           ],
           # Roboto (cyrillic-ext)
           "90a0ad0b48861588a6e33a5905b17e1219ea87ab6f07ccc41e7c2cddf38967a8": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/sTdaA6j0Psb920Vjv-mrzH-_kf6ByYO6CLYdB4HQE-Y.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/sTdaA6j0Psb920Vjv-mrzH-_kf6ByYO6CLYdB4HQE-Y.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/sTdaA6j0Psb920Vjv-mrzH-_kf6ByYO6CLYdB4HQE-Y.woff2",
           ],
           # Roboto (greek)
           "949e287846b0940817e4ea0f65accc4481a46b8733dc12aa0265293a4645c661": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/_VYFx-s824kXq_Ul2BHqYH-_kf6ByYO6CLYdB4HQE-Y.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/_VYFx-s824kXq_Ul2BHqYH-_kf6ByYO6CLYdB4HQE-Y.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/_VYFx-s824kXq_Ul2BHqYH-_kf6ByYO6CLYdB4HQE-Y.woff2",
           ],
           # Roboto (greek-ext)
           "e5b2e29a16d8ef4c5a123b40786af72da589c4aad634eab40d90eef8bb4418aa": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/tnj4SB6DNbdaQnsM8CFqBX-_kf6ByYO6CLYdB4HQE-Y.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/tnj4SB6DNbdaQnsM8CFqBX-_kf6ByYO6CLYdB4HQE-Y.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/tnj4SB6DNbdaQnsM8CFqBX-_kf6ByYO6CLYdB4HQE-Y.woff2",
           ],
           # Roboto (latin)
           "4352380f92ce7f9a4a4a23306b992bed10055dbfffe90987cc72083e583fc280": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/oMMgfZMQthOryQo9n22dcuvvDin1pK8aKteLpeZ5c0A.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/oMMgfZMQthOryQo9n22dcuvvDin1pK8aKteLpeZ5c0A.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/oMMgfZMQthOryQo9n22dcuvvDin1pK8aKteLpeZ5c0A.woff2",
           ],
           # Roboto (latin-ext)
           "80fa23b4804621ce7f16b5c56d524dd90ea09d792622eeac9adf0ee6317b9e3a": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/Ks_cVxiCiwUWVsFWFA3Bjn-_kf6ByYO6CLYdB4HQE-Y.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/Ks_cVxiCiwUWVsFWFA3Bjn-_kf6ByYO6CLYdB4HQE-Y.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/Ks_cVxiCiwUWVsFWFA3Bjn-_kf6ByYO6CLYdB4HQE-Y.woff2",
           ],
           # Roboto (vietnamese)
           "a0a893b2ff1c82d49ac0c09ace71cf8178c0830f6a988103c779b6fc12c0da78": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/NJ4vxlgWwWbEsv18dAhqnn-_kf6ByYO6CLYdB4HQE-Y.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/NJ4vxlgWwWbEsv18dAhqnn-_kf6ByYO6CLYdB4HQE-Y.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/NJ4vxlgWwWbEsv18dAhqnn-_kf6ByYO6CLYdB4HQE-Y.woff2",
           ],
           # Roboto Bold (cyrillic)
           "6082aa2f5aab855120cd58f560f58975579097c484d23cc7854977a529f91bc4": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/isZ-wbCXNKAbnjo6_TwHToX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/isZ-wbCXNKAbnjo6_TwHToX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/isZ-wbCXNKAbnjo6_TwHToX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Bold (cyrillic-ext)
           "616eb767627d16bef2b9be2218bb5f1bbbb97cfbd06c4e5241c8b532b56467aa": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/77FXFjRbGzN4aCrSFhlh3oX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/77FXFjRbGzN4aCrSFhlh3oX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/77FXFjRbGzN4aCrSFhlh3oX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Bold (greek)
           "28959a3f1fea0c7f7feca26f92465f5263f2e8fdec17030e0e7a9e6a8cb321af": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/jSN2CGVDbcVyCnfJfjSdfIX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/jSN2CGVDbcVyCnfJfjSdfIX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/jSN2CGVDbcVyCnfJfjSdfIX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Bold (greek-ext)
           "e94a5635cb68464d332cd374fd57b95913fc5b549f1967fbb73829b2084efd98": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/UX6i4JxQDm3fVTc1CPuwqoX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/UX6i4JxQDm3fVTc1CPuwqoX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/UX6i4JxQDm3fVTc1CPuwqoX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Bold (latin)
           "1be216dbc059d96e288b0c1f399a1a80ee8c65e4c1272dbc4574bd6d23cf45d9": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/d-6IYplOFocCacKzxwXSOJBw1xU1rKptJj_0jans920.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/d-6IYplOFocCacKzxwXSOJBw1xU1rKptJj_0jans920.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/d-6IYplOFocCacKzxwXSOJBw1xU1rKptJj_0jans920.woff2",
           ],
           # Roboto Bold (latin-ext)
           "6c8be972381d4da037f47c33ef1e31b88f0130ded1432730d4d792331f983839": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/97uahxiqZRoncBaCEI3aW4X0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/97uahxiqZRoncBaCEI3aW4X0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/97uahxiqZRoncBaCEI3aW4X0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Bold (vietnamese)
           "5f162f1ca2441cae368e97ed42b56332d7b68b1ffbbf9f7e4b648420667acee5": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/PwZc-YbIL414wB9rB1IAPYX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/PwZc-YbIL414wB9rB1IAPYX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/PwZc-YbIL414wB9rB1IAPYX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Bold Italic (cyrillic)
           "bb4e478b0fe2ae7fbd6369c94d126060ffa697df189d7f3653f23f521f906cd8": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC14sYYdJg5dU2qzJEVSuta0.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC14sYYdJg5dU2qzJEVSuta0.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC14sYYdJg5dU2qzJEVSuta0.woff2",
           ],
           # Roboto Bold Italic (cyrillic-ext)
           "9fc911647b05ecdbadfe6693d6ff306a0a34829999b2055ad2e474e3ad0b778d": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC_ZraR2Tg8w2lzm7kLNL0-w.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC_ZraR2Tg8w2lzm7kLNL0-w.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC_ZraR2Tg8w2lzm7kLNL0-w.woff2",
           ],
           # Roboto Bold Italic (greek)
           "62509e2b63168ae83848cb3f76d2c47177de8618ac918af119cc7ae90c71213b": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcCwt_Rm691LTebKfY2ZkKSmI.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcCwt_Rm691LTebKfY2ZkKSmI.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcCwt_Rm691LTebKfY2ZkKSmI.woff2",
           ],
           # Roboto Bold Italic (greek-ext)
           "07a2e7b4a480176f0f0bc9f7ca757d8467bf41f86e3b1eed374be06ff1b51b56": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC1BW26QxpSj-_ZKm_xT4hWw.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC1BW26QxpSj-_ZKm_xT4hWw.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC1BW26QxpSj-_ZKm_xT4hWw.woff2",
           ],
           # Roboto Bold Italic (latin)
           "556e09ad66d48078d2ea341eff36e93dafdb56fed15e9d92e052a7cb3910e2e9": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC4gp9Q8gbYrhqGlRav_IXfk.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC4gp9Q8gbYrhqGlRav_IXfk.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC4gp9Q8gbYrhqGlRav_IXfk.woff2",
           ],
           # Roboto Bold Italic (latin-ext)
           "5f6115b8655a4e9e0bb6440956b2d7b7d52e90193c6be53731fcf97d1fc45ec3": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC6E8kM4xWR1_1bYURRojRGc.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC6E8kM4xWR1_1bYURRojRGc.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC6E8kM4xWR1_1bYURRojRGc.woff2",
           ],
           # Roboto Bold Italic (vietnamese)
           "b75ce2f4333ea21c1d0aeb0061edcf81b7fffe022a732dae52834a8b62615c5f": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC9DiNsR5a-9Oe_Ivpu8XWlY.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC9DiNsR5a-9Oe_Ivpu8XWlY.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/t6Nd4cfPRhZP44Q5QAjcC9DiNsR5a-9Oe_Ivpu8XWlY.woff2",
           ],
           # Roboto Italic (cyrillic)
           "38602b65e115ae1b267627d5533c2607f446aba939b9ca9143cc4373bd285b83": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/OpXUqTo0UgQQhGj_SFdLWBkAz4rYn47Zy2rvigWQf6w.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/OpXUqTo0UgQQhGj_SFdLWBkAz4rYn47Zy2rvigWQf6w.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/OpXUqTo0UgQQhGj_SFdLWBkAz4rYn47Zy2rvigWQf6w.woff2",
           ],
           # Roboto Italic (cyrillic-ext)
           "d04ce842e235d3e6abfcd37d6598138007f56e391a035167d78edf9088d3035a": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/WxrXJa0C3KdtC7lMafG4dRkAz4rYn47Zy2rvigWQf6w.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/WxrXJa0C3KdtC7lMafG4dRkAz4rYn47Zy2rvigWQf6w.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/WxrXJa0C3KdtC7lMafG4dRkAz4rYn47Zy2rvigWQf6w.woff2",
           ],
           # Roboto Italic (greek)
           "aa9a8db3e6de8124291c3f2fd0bbd0aca8c796f365204d78414536067115be07": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/cDKhRaXnQTOVbaoxwdOr9xkAz4rYn47Zy2rvigWQf6w.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/cDKhRaXnQTOVbaoxwdOr9xkAz4rYn47Zy2rvigWQf6w.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/cDKhRaXnQTOVbaoxwdOr9xkAz4rYn47Zy2rvigWQf6w.woff2",
           ],
           # Roboto Italic (greek-ext)
           "785896def5be5b35967d63f5589ce67fc8d3b452153a37323a4d9b886d828c60": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/1hZf02POANh32k2VkgEoUBkAz4rYn47Zy2rvigWQf6w.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/1hZf02POANh32k2VkgEoUBkAz4rYn47Zy2rvigWQf6w.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/1hZf02POANh32k2VkgEoUBkAz4rYn47Zy2rvigWQf6w.woff2",
           ],
           # Roboto Italic (latin)
           "64565561ddb338a11ffce5b84aa53fa6e8fd203c34208e61eb5602cd08bf527f": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/vPcynSL0qHq_6dX7lKVByXYhjbSpvc47ee6xR_80Hnw.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/vPcynSL0qHq_6dX7lKVByXYhjbSpvc47ee6xR_80Hnw.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/vPcynSL0qHq_6dX7lKVByXYhjbSpvc47ee6xR_80Hnw.woff2",
           ],
           # Roboto Italic (latin-ext)
           "d5b2d7e9efe90feef0c4507d90b2b4e464c6929efd05ad4294d3d5057db57b97": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/vSzulfKSK0LLjjfeaxcREhkAz4rYn47Zy2rvigWQf6w.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/vSzulfKSK0LLjjfeaxcREhkAz4rYn47Zy2rvigWQf6w.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/vSzulfKSK0LLjjfeaxcREhkAz4rYn47Zy2rvigWQf6w.woff2",
           ],
           # Roboto Italic (vietnamese)
           "5d875731e35140f94bc4cb23944d104688d3c6d372833ddae8d22d3aa802beb4": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/K23cxWVTrIFD6DJsEVi07RkAz4rYn47Zy2rvigWQf6w.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/K23cxWVTrIFD6DJsEVi07RkAz4rYn47Zy2rvigWQf6w.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/K23cxWVTrIFD6DJsEVi07RkAz4rYn47Zy2rvigWQf6w.woff2",
           ],
           # Roboto Light (cyrillic)
           "cb94537350a4c593515c0b9066a22f0d74284173b88521c50b894a3179402e46": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/Fl4y0QdOxyyTHEGMXX8kcYX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/Fl4y0QdOxyyTHEGMXX8kcYX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/Fl4y0QdOxyyTHEGMXX8kcYX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Light (cyrillic-ext)
           "66a095c96771a94d2772c7e19a32c6585d4bed3a989faa9e595bb270a2621608": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/0eC6fl06luXEYWpBSJvXCIX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/0eC6fl06luXEYWpBSJvXCIX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/0eC6fl06luXEYWpBSJvXCIX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Light (greek)
           "f0e3a88ae70245bcac12d2640792e50a165ce618d3b5979b735913e582d204f7": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/I3S1wsgSg9YCurV6PUkTOYX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/I3S1wsgSg9YCurV6PUkTOYX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/I3S1wsgSg9YCurV6PUkTOYX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Light (greek-ext)
           "40a162d49fd25da223ea81454616f469270020fc186fe2f109534fb1f72e1bcb": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/-L14Jk06m6pUHB-5mXQQnYX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/-L14Jk06m6pUHB-5mXQQnYX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/-L14Jk06m6pUHB-5mXQQnYX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Light (latin)
           "f7c386915e39d8a925fe10d15744a9da95ac8f90423e12728e7fc3c5e34f4559": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/Hgo13k-tfSpn0qi1SFdUfZBw1xU1rKptJj_0jans920.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/Hgo13k-tfSpn0qi1SFdUfZBw1xU1rKptJj_0jans920.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/Hgo13k-tfSpn0qi1SFdUfZBw1xU1rKptJj_0jans920.woff2",
           ],
           # Roboto Light (latin-ext)
           "bbeeb150a0f72cbd898ba36ed908bb95ef2386d41158c943aa3af4e0c8430639": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/Pru33qjShpZSmG3z6VYwnYX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/Pru33qjShpZSmG3z6VYwnYX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/Pru33qjShpZSmG3z6VYwnYX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Light (vietnamese)
           "5a4e99d1db8c9fd38f6b1c92582c2351cf27075f5ccef89404a8d673fa8e7b26": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/NYDWBdD4gIq26G5XYbHsFIX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/NYDWBdD4gIq26G5XYbHsFIX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/NYDWBdD4gIq26G5XYbHsFIX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Light Italic (cyrillic)
           "4160dc56c5afc7320243a73cdf025d1c64ea19e035b98bad9c170e37c98ee5e2": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at14sYYdJg5dU2qzJEVSuta0.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at14sYYdJg5dU2qzJEVSuta0.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at14sYYdJg5dU2qzJEVSuta0.woff2",
           ],
           # Roboto Light Italic (cyrillic-ext)
           "d95d953cff5e309f22a680e48981070d2cbebf75daba25b078834bf0c4f143e4": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at_ZraR2Tg8w2lzm7kLNL0-w.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at_ZraR2Tg8w2lzm7kLNL0-w.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at_ZraR2Tg8w2lzm7kLNL0-w.woff2",
           ],
           # Roboto Light Italic (greek)
           "8d649207dfd9e6f53614ee7ee8e0865789e38b39244ab1546ee5117ab6f6ed2f": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0atwt_Rm691LTebKfY2ZkKSmI.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0atwt_Rm691LTebKfY2ZkKSmI.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0atwt_Rm691LTebKfY2ZkKSmI.woff2",
           ],
           # Roboto Light Italic (greek-ext)
           "a1153c52da99d21ed2f036e5849c3b2a5d7d3d5913d63ceac983d388288420b4": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at1BW26QxpSj-_ZKm_xT4hWw.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at1BW26QxpSj-_ZKm_xT4hWw.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at1BW26QxpSj-_ZKm_xT4hWw.woff2",
           ],
           # Roboto Light Italic (latin)
           "c4fc2fd6457f67718ccff3434f39a84a83be98defa8e23ac1942580ea53a925e": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at4gp9Q8gbYrhqGlRav_IXfk.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at4gp9Q8gbYrhqGlRav_IXfk.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at4gp9Q8gbYrhqGlRav_IXfk.woff2",
           ],
           # Roboto Light Italic (latin-ext)
           "fd5b96eb1adc32b3fd7823f6a9e3c14122a060d5665091c33d9243f2541b016c": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at6E8kM4xWR1_1bYURRojRGc.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at6E8kM4xWR1_1bYURRojRGc.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at6E8kM4xWR1_1bYURRojRGc.woff2",
           ],
           # Roboto Light Italic (vietnamese)
           "ced9470e7e60d5edeccf4d3a0ab2f57ef653ec9de3097e6950bc06c64157aa5a": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at9DiNsR5a-9Oe_Ivpu8XWlY.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at9DiNsR5a-9Oe_Ivpu8XWlY.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/7m8l7TlFO-S3VkhHuR0at9DiNsR5a-9Oe_Ivpu8XWlY.woff2",
           ],
           # Roboto Medium (cyrillic)
           "74f08a5b16db96fd23eeca2c2e6c354d08a95b3360aa2bb6ea0890517bb10469": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/oHi30kwQWvpCWqAhzHcCSIX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/oHi30kwQWvpCWqAhzHcCSIX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/oHi30kwQWvpCWqAhzHcCSIX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Medium (cyrillic-ext)
           "2aa57d00d0cac3b30aef28a19e9cfea12b45daf9562b4fa623750c8145c0767b": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/ZLqKeelYbATG60EpZBSDy4X0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/ZLqKeelYbATG60EpZBSDy4X0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/ZLqKeelYbATG60EpZBSDy4X0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Medium (greek)
           "b95a36dd1483f97002a0c8aba87106f7fefbd67f22bc25a2bf21352bb4f316ef": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/mx9Uck6uB63VIKFYnEMXrYX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/mx9Uck6uB63VIKFYnEMXrYX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/mx9Uck6uB63VIKFYnEMXrYX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Medium (greek-ext)
           "399cdbc9a94414d94fb15b0386888c6bc8ce4d6140cc3a9a571406a76cf47bb5": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/rGvHdJnr2l75qb0YND9NyIX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/rGvHdJnr2l75qb0YND9NyIX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/rGvHdJnr2l75qb0YND9NyIX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Medium (latin)
           "b79781efede37903be212fcdf63955e41c8649e678b6b83adf824459d240a188": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/RxZJdnzeo3R5zSexge8UUZBw1xU1rKptJj_0jans920.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/RxZJdnzeo3R5zSexge8UUZBw1xU1rKptJj_0jans920.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/RxZJdnzeo3R5zSexge8UUZBw1xU1rKptJj_0jans920.woff2",
           ],
           # Roboto Medium (latin-ext)
           "ba99e38768dd8358450dc363431400b1642c7cd7e5b47830e30aa8ec80fb4790": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/oOeFwZNlrTefzLYmlVV1UIX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/oOeFwZNlrTefzLYmlVV1UIX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/oOeFwZNlrTefzLYmlVV1UIX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Medium (vietnamese)
           "e785fcb2332a43e5f489c0e7457001a93800b459bdf5173cffbb880f350077eb": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/mbmhprMH69Zi6eEPBYVFhYX0hVgzZQUfRDuZrPvH3D8.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/mbmhprMH69Zi6eEPBYVFhYX0hVgzZQUfRDuZrPvH3D8.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/mbmhprMH69Zi6eEPBYVFhYX0hVgzZQUfRDuZrPvH3D8.woff2",
           ],
           # Roboto Medium Italic (cyrillic)
           "e9f24fd84cfbdad488d4f05d97ca2e009af8248044def329f0c78c04e12c32cb": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0V4sYYdJg5dU2qzJEVSuta0.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0V4sYYdJg5dU2qzJEVSuta0.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0V4sYYdJg5dU2qzJEVSuta0.woff2",
           ],
           # Roboto Medium Italic (cyrillic-ext)
           "ecfda0e4317641a395971d71435ad1a3dce0499bccc9bcdcaaebffb714588a4e": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0fZraR2Tg8w2lzm7kLNL0-w.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0fZraR2Tg8w2lzm7kLNL0-w.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0fZraR2Tg8w2lzm7kLNL0-w.woff2",
           ],
           # Roboto Medium Italic (greek)
           "510c1001aa3c1ae574eba6eaa5a404414dd0f5d5cd8c213fe0fac404c1fbbd7c": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0Qt_Rm691LTebKfY2ZkKSmI.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0Qt_Rm691LTebKfY2ZkKSmI.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0Qt_Rm691LTebKfY2ZkKSmI.woff2",
           ],
           # Roboto Medium Italic (greek-ext)
           "e5343e5d46125f688c2f266369983a1f92dbefa8d16f131b09768cdd4a5cebd4": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0VBW26QxpSj-_ZKm_xT4hWw.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0VBW26QxpSj-_ZKm_xT4hWw.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0VBW26QxpSj-_ZKm_xT4hWw.woff2",
           ],
           # Roboto Medium Italic (latin)
           "76d779c16f21b55a95fb182bf7552447ee340d15556e53a99dd789383f6d8c32": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0Ygp9Q8gbYrhqGlRav_IXfk.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0Ygp9Q8gbYrhqGlRav_IXfk.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0Ygp9Q8gbYrhqGlRav_IXfk.woff2",
           ],
           # Roboto Medium Italic (latin-ext)
           "a69b0c33d809b7aac3e9648bfc995bc38cd5e426efeb006dc3b31523f4867f73": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0aE8kM4xWR1_1bYURRojRGc.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0aE8kM4xWR1_1bYURRojRGc.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0aE8kM4xWR1_1bYURRojRGc.woff2",
           ],
           # Roboto Medium Italic (vietnamese)
           "2c94704be76a8ec87995f3427911e50987cfcaa13c5749c770419559fe836509": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0dDiNsR5a-9Oe_Ivpu8XWlY.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0dDiNsR5a-9Oe_Ivpu8XWlY.woff2",
               "https://fonts.gstatic.com/s/roboto/v18/OLffGBTaF0XFOW1gnuHF0dDiNsR5a-9Oe_Ivpu8XWlY.woff2",
           ],
           # Roboto Mono (cyrillic)
           "2c9fae8205ea404d8400b9731423d5f8261788efcb26b651ad1031c70c895824": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY14sYYdJg5dU2qzJEVSuta0.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY14sYYdJg5dU2qzJEVSuta0.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY14sYYdJg5dU2qzJEVSuta0.woff2",
           ],
           # Roboto Mono (cyrillic-ext)
           "671d1df350d3ccfd9a5ebbc9e92810a274d6215a648099f0f6e3e256b2bdae02": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY_ZraR2Tg8w2lzm7kLNL0-w.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY_ZraR2Tg8w2lzm7kLNL0-w.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY_ZraR2Tg8w2lzm7kLNL0-w.woff2",
           ],
           # Roboto Mono (greek)
           "eb84188b287e62e965be53c788b6562554cefcc0a3520f792ba91bb60d40e607": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpYwt_Rm691LTebKfY2ZkKSmI.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpYwt_Rm691LTebKfY2ZkKSmI.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpYwt_Rm691LTebKfY2ZkKSmI.woff2",
           ],
           # Roboto Mono (greek-ext)
           "978a5db5af1654146da5ec93980c273df7010a2d045f1360ac3b9d85bd890299": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY1BW26QxpSj-_ZKm_xT4hWw.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY1BW26QxpSj-_ZKm_xT4hWw.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY1BW26QxpSj-_ZKm_xT4hWw.woff2",
           ],
           # Roboto Mono (latin)
           "ecc28128233f90171df8f8915d60cdc59ff70b9194e1d93061816d3e3cd1f320": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY4gp9Q8gbYrhqGlRav_IXfk.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY4gp9Q8gbYrhqGlRav_IXfk.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY4gp9Q8gbYrhqGlRav_IXfk.woff2",
           ],
           # Roboto Mono (latin-ext)
           "9a7b6e1f38e9a47867ad5c2f403ff4f4477a03bbec300d4e345bf67d5d0da262": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY6E8kM4xWR1_1bYURRojRGc.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY6E8kM4xWR1_1bYURRojRGc.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY6E8kM4xWR1_1bYURRojRGc.woff2",
           ],
           # Roboto Mono (vietnamese)
           "b568a2d630d5924e40b73489cc4a8720fb9fb0249b8117d6d45cfc95d249c1da": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY9DiNsR5a-9Oe_Ivpu8XWlY.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY9DiNsR5a-9Oe_Ivpu8XWlY.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/hMqPNLsu_dywMa4C_DEpY9DiNsR5a-9Oe_Ivpu8XWlY.woff2",
           ],
           # Roboto Mono Bold (cyrillic)
           "656e4cb0b042d18f6b889948f3c9a1f87b70340bd20a38a0d738b0e32a7f00ee": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz1x-M1I1w5OMiqnVF8xBLhU.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz1x-M1I1w5OMiqnVF8xBLhU.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz1x-M1I1w5OMiqnVF8xBLhU.woff2",
           ],
           # Roboto Mono Bold (cyrillic-ext)
           "0d5221a5f914d57a674049b718a37b8f09a0e79647af8b187273f35ab0d8376c": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59FzwXaAXup5mZlfK6xRLrhsco.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59FzwXaAXup5mZlfK6xRLrhsco.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59FzwXaAXup5mZlfK6xRLrhsco.woff2",
           ],
           # Roboto Mono Bold (greek)
           "41553f58ea074adde7eaaefe9b220b49021128f6b68b8be384072c4db430603f": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fzwn6Wqxo-xwxilDXPU8chVU.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fzwn6Wqxo-xwxilDXPU8chVU.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fzwn6Wqxo-xwxilDXPU8chVU.woff2",
           ],
           # Roboto Mono Bold (greek-ext)
           "27798d63b7fadca6c6a2d17ea7673855d44baf75e8172fa9749888898ce04125": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz1T7aJLK6nKpn36IMwTcMMc.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz1T7aJLK6nKpn36IMwTcMMc.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz1T7aJLK6nKpn36IMwTcMMc.woff2",
           ],
           # Roboto Mono Bold (latin)
           "8b827f046df0acf54d80954ae05f0b5e87fdf09bc4c1bf02e8edb0d928e259b7": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz_79_ZuUxCigM2DespTnFaw.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz_79_ZuUxCigM2DespTnFaw.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz_79_ZuUxCigM2DespTnFaw.woff2",
           ],
           # Roboto Mono Bold (latin-ext)
           "b38383e889863e1c25c2334087e6b00835cef283f8448c8b2a2d5d51489d202b": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz4gd9OEPUCN3AdYW0e8tat4.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz4gd9OEPUCN3AdYW0e8tat4.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz4gd9OEPUCN3AdYW0e8tat4.woff2",
           ],
           # Roboto Mono Bold (vietnamese)
           "03b9c55ee9bf53c57c9b9dcb739bc92ada5b97fc81deb5a57e4e8347c4eee8bb": [
-              "https://mirror.bazel.build/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz8bIQSYZnWLaWC9QNCpTK_U.woff2",
+              "http://mirror.tensorflow.org/fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz8bIQSYZnWLaWC9QNCpTK_U.woff2",
               "https://fonts.gstatic.com/s/robotomono/v5/N4duVc9C58uwPiY8_59Fz8bIQSYZnWLaWC9QNCpTK_U.woff2",
           ],
       },

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -38,27 +38,27 @@ def tensorboard_js_workspace():
       licenses = ["notice"],
       sha256_urls_extract_macos = {
           "910395e1e98fb351c62b5702a9deef22aaecf05d6df1d7edc283337542207f3f": [
-              "https://mirror.bazel.build/nodejs.org/dist/v6.9.1/node-v6.9.1-darwin-x64.tar.xz",
+              "http://mirror.tensorflow.org/nodejs.org/dist/v6.9.1/node-v6.9.1-darwin-x64.tar.xz",
               "http://nodejs.org/dist/v6.9.1/node-v6.9.1-darwin-x64.tar.xz",
           ],
       },
       sha256_urls_windows = {
           "1914bfb950be8d576ce9e49c8a0e51c9f2402560fe3c19093e69bc1306a56e9e": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/nodejs/node/v6.9.1/LICENSE",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/nodejs/node/v6.9.1/LICENSE",
               "https://raw.githubusercontent.com/nodejs/node/v6.9.1/LICENSE",
           ],
           "513923b0490ebb7466a56483a62595814ed9d036d6f35476debb0cd606bec526": [
-              "https://mirror.bazel.build/nodejs.org/dist/v6.9.1/win-x64/node.exe",
+              "http://mirror.tensorflow.org/nodejs.org/dist/v6.9.1/win-x64/node.exe",
               "http://nodejs.org/dist/v6.9.1/win-x64/node.exe",
           ],
           "3951aefa4afd6fb836ab06468b1fc2a69fa75bd66ec2f5a0e08c4e32547681e3": [
-              "https://mirror.bazel.build/nodejs.org/dist/v6.9.1/win-x64/node.lib",
+              "http://mirror.tensorflow.org/nodejs.org/dist/v6.9.1/win-x64/node.lib",
               "http://nodejs.org/dist/v6.9.1/win-x64/node.lib",
           ],
       },
       sha256_urls_extract = {
           "d4eb161e4715e11bbef816a6c577974271e2bddae9cf008744627676ff00036a": [
-              "https://mirror.bazel.build/nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x64.tar.xz",
+              "http://mirror.tensorflow.org/nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x64.tar.xz",
               "http://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x64.tar.xz",
           ],
       },
@@ -83,19 +83,19 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # Apache 2.0
       sha256_urls = {
           "a7d00bfd54525bc694b6e32f64c7ebcf5e6b7ae3657be5cc12767bce74654a47": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/Microsoft/TypeScript/v2.7.2/LICENSE.txt",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/Microsoft/TypeScript/v2.7.2/LICENSE.txt",
               "https://raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/LICENSE.txt",
           ],
           "9632bfccde117a8c82690a324bc5c18c3869e9b89ac536fc134ba655d7ec1e98": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/tsc.js",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/tsc.js",
               "https://raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/tsc.js",
           ],
           "529c9f8b45939e0fa80950208bf80452ccb982b460cc25433813c919b67a3b2f": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/lib.es6.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/lib.es6.d.ts",
               "https://raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/lib.es6.d.ts",
           ],
           "f6e6efe57fb9fcf72eed013e2755d04505300f32b78577118ca5dacc85ec852d": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/lib.dom.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/lib.dom.d.ts",
               "https://raw.githubusercontent.com/Microsoft/TypeScript/v2.9.2/lib/lib.dom.d.ts",
           ],
       },
@@ -131,7 +131,7 @@ def tensorboard_js_workspace():
       sha256 = "7a5c785dbcc3ae0daa1fcf4507de6a23bbecdb2bf80460651e4c2b88c1ad7582",
       strip_prefix = "clutz-7f1a3ee9ad9f85a9056084dc039496bbd35e11f6",
       urls = [
-          "https://mirror.bazel.build/github.com/angular/clutz/archive/7f1a3ee9ad9f85a9056084dc039496bbd35e11f6.tar.gz",  # 2017-11-02
+          "http://mirror.tensorflow.org/github.com/angular/clutz/archive/7f1a3ee9ad9f85a9056084dc039496bbd35e11f6.tar.gz",  # 2017-11-02
           "https://github.com/angular/clutz/archive/7f1a3ee9ad9f85a9056084dc039496bbd35e11f6.tar.gz",
       ],
   )
@@ -141,7 +141,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # Apache 2.0
       sha256_urls_extract = {
           "55bdf8dc5d74534b63edbce5f510557a18a2b7aa578938ba300eb65f2da48092": [
-              "https://mirror.bazel.build/github.com/google/closure-compiler/archive/v20180402.tar.gz",
+              "http://mirror.tensorflow.org/github.com/google/closure-compiler/archive/v20180402.tar.gz",
               "https://github.com/google/closure-compiler/archive/v20180402.tar.gz",
           ],
       },
@@ -153,7 +153,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # Apache 2.0
       sha256_urls = {
           "737af73d7b02226e6e1516044a8eb8283376d44f64839979936ca163c00900f4": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/google/closure-compiler/v20180402/contrib/externs/polymer-1.0.js",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/google/closure-compiler/v20180402/contrib/externs/polymer-1.0.js",
               "https://raw.githubusercontent.com/google/closure-compiler/v20180402/contrib/externs/polymer-1.0.js",
           ],
       },
@@ -165,15 +165,15 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "5eb9be209f84c4588f573b9abd8e13c04ce187ad6f40e8b12993d00b1428de54": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/mrdoob/three.js/r77/LICENSE",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/mrdoob/three.js/r77/LICENSE",
               "https://raw.githubusercontent.com/mrdoob/three.js/r77/LICENSE",
           ],
           "881cc79c84c34a1f61f8c8af0ee3f237d83a2eda3868720fdcb47bcacf8da44a": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/mrdoob/three.js/r77/build/three.js",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/mrdoob/three.js/r77/build/three.js",
               "https://raw.githubusercontent.com/mrdoob/three.js/r77/build/three.js",
           ],
           "98b8b5954901025a98033c8bdd65969be1f30b59e11f823ec864253bb72f768d": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/mrdoob/three.js/r77/examples/js/controls/OrbitControls.js",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/mrdoob/three.js/r77/examples/js/controls/OrbitControls.js",
               "https://raw.githubusercontent.com/mrdoob/three.js/r77/examples/js/controls/OrbitControls.js",
           ],
       },
@@ -187,7 +187,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256 = "6c5fa80d0fa9dc4eba634ab042404ff7c162dcb4cfe3473338801aeca0042285",
       urls = [
-          "https://mirror.bazel.build/github.com/lodash/lodash/archive/4.17.5.tar.gz",
+          "http://mirror.tensorflow.org/github.com/lodash/lodash/archive/4.17.5.tar.gz",
           "https://github.com/lodash/lodash/archive/4.17.5.tar.gz",
       ],
       strip_prefix = "lodash-4.17.5",
@@ -202,12 +202,12 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "0e94aada97f12dee6118064add9170484c55022f5d53206ee4407143cd36ddcd": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/sloisel/numeric/v1.2.6/license.txt",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/sloisel/numeric/v1.2.6/license.txt",
               "https://raw.githubusercontent.com/sloisel/numeric/v1.2.6/license.txt",
           ],
           "5dcaba2016fd237091e3a17b0dc272fb21f0e2b15d7628f95a0ad0cd4cdf4020": [
-              "https://mirror.bazel.build/www.numericjs.com/lib/numeric-1.2.6.js",
-              "http://www.numericjs.com/lib/numeric-1.2.6.js",
+              "http://mirror.tensorflow.org/cdnjs.cloudflare.com/ajax/libs/numeric/1.2.6/numeric.js",
+              "https://cdnjs.cloudflare.com/ajax/libs/numeric/1.2.6/numeric.js",
           ],
       },
       rename = {"numeric-1.2.6.js": "numeric.js"},
@@ -219,7 +219,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # Apache License 2.0
       sha256_urls = {
           "85a2ff924f1bf4757976aca22fd0efb045d9b3854f5a4ae838c64e4d11e75005": [
-              "https://mirror.bazel.build/unpkg.com/umap-js@1.0.5/lib/umap-js.min.js",
+              "http://mirror.tensorflow.org/unpkg.com/umap-js@1.0.5/lib/umap-js.min.js",
               "https://unpkg.com/umap-js@1.0.5/lib/umap-js.min.js",
           ],
       },
@@ -234,7 +234,7 @@ def tensorboard_js_workspace():
           # sources directly from git also requires running Node tooling
           # beforehand to generate files. NPM is the only place to get it.
           "08df639782baf9b8cfeeb5fcdfbe3a1ce25b5a916903fc580e201a0a1142a6c4": [
-              "https://mirror.bazel.build/registry.npmjs.org/plottable/-/plottable-3.7.0.tgz",
+              "http://mirror.tensorflow.org/registry.npmjs.org/plottable/-/plottable-3.7.0.tgz",
               "https://registry.npmjs.org/plottable/-/plottable-3.7.0.tgz",
           ],
       },
@@ -246,11 +246,11 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "6a349742a6cb219d5a2fc8d0844f6d89a6efc62e20c664450d884fc7ff2d6015": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/cpettitt/dagre/v0.8.2/LICENSE",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/cpettitt/dagre/v0.8.2/LICENSE",
               "https://raw.githubusercontent.com/cpettitt/dagre/v0.8.2/LICENSE",
           ],
           "43cb4e919196c177c149b63880d262074670af99db6a1e174b25e266da4935a9": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/cpettitt/dagre/v0.8.2/dist/dagre.core.js",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/cpettitt/dagre/v0.8.2/dist/dagre.core.js",
               "https://raw.githubusercontent.com/cpettitt/dagre/v0.8.2/dist/dagre.core.js",
           ],
       },
@@ -261,11 +261,11 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "6a349742a6cb219d5a2fc8d0844f6d89a6efc62e20c664450d884fc7ff2d6015": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/cpettitt/graphlib/v2.1.5/LICENSE",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/cpettitt/graphlib/v2.1.5/LICENSE",
               "https://raw.githubusercontent.com/cpettitt/graphlib/v2.1.5/LICENSE",
           ],
           "ddc33a6aaf955ee24b0e0d30110adf350c65eedc5c0f2c424ca85bc128199a66": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/cpettitt/graphlib/v2.1.5/dist/graphlib.core.js",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/cpettitt/graphlib/v2.1.5/dist/graphlib.core.js",
               "https://raw.githubusercontent.com/cpettitt/graphlib/v2.1.5/dist/graphlib.core.js",
           ],
       },
@@ -277,11 +277,11 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "633f2861a9a862b9cd7967e841e14dd3527912f209d6563595774fa31e3d84cb": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/waylonflinn/weblas/v0.9.0/LICENSE",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/waylonflinn/weblas/v0.9.0/LICENSE",
               "https://raw.githubusercontent.com/waylonflinn/weblas/v0.9.0/LICENSE",
           ],
           "f138fce57f673ca8a633f4aee5ae5b6fcb6ad0de59069a42a74e996fd04d8fcc": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/waylonflinn/weblas/v0.9.0/dist/weblas.js",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/waylonflinn/weblas/v0.9.0/dist/weblas.js",
               "https://raw.githubusercontent.com/waylonflinn/weblas/v0.9.0/dist/weblas.js",
           ],
       },
@@ -293,7 +293,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256_urls_extract = {
           "05a9c2b9c206447be0e26b3a705e7f8df4943df2d063ddc5bf0274f50ec44727": [
-              "https://mirror.bazel.build/github.com/d3/d3/releases/download/v5.7.0/d3.zip",
+              "http://mirror.tensorflow.org/github.com/d3/d3/releases/download/v5.7.0/d3.zip",
               "https://github.com/d3/d3/releases/download/v5.7.0/d3.zip",
           ],
       },
@@ -312,11 +312,11 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256_urls = {
           "f0df289ba9d03d857ad1c2f5918861376b1510b71588ffc60eff5c7a7bfedb09": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/catapult-project/catapult/2f7ee994984f3ebd3dd3dc3e05777bf180ec2ee8/LICENSE",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/catapult-project/catapult/2f7ee994984f3ebd3dd3dc3e05777bf180ec2ee8/LICENSE",
               "https://raw.githubusercontent.com/catapult-project/catapult/2f7ee994984f3ebd3dd3dc3e05777bf180ec2ee8/LICENSE",
           ],
           "b1f0195f305ca66fdb7dae264771f162ae03f04aa642848f15cd871c043e04d1": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/catapult-project/catapult/237aea8b58a37a2991318b6a0db60d84078e5f7e/trace_viewer_full.html",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/catapult-project/catapult/237aea8b58a37a2991318b6a0db60d84078e5f7e/trace_viewer_full.html",
               "https://raw.githubusercontent.com/catapult-project/catapult/237aea8b58a37a2991318b6a0db60d84078e5f7e/trace_viewer_full.html"  # 2017-06-19
           ],
       },
@@ -327,7 +327,7 @@ def tensorboard_js_workspace():
       sha256 = "e3f7b7b3c194c1772d16bdc8b348716c0da59a51daa03ef4503cf06c073caafc",
       strip_prefix = "facets-0.2.1",
       urls = [
-          "http://mirror.bazel.build/github.com/pair-code/facets/archive/0.2.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/pair-code/facets/archive/0.2.1.tar.gz",
           "https://github.com/pair-code/facets/archive/0.2.1.tar.gz",
       ],
   )
@@ -336,7 +336,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # Apache License 2.0
       sha256 = "44fb83628edb77cb8392c165d4d99734750a6fbb00e5391f033962e56f14eba3",
       urls = [
-          "https://mirror.bazel.build/github.com/vaadin/vaadin-split-layout/archive/v1.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/vaadin/vaadin-split-layout/archive/v1.1.0.tar.gz",
           "https://github.com/vaadin/vaadin-split-layout/archive/v1.1.0.tar.gz",
       ],
       srcs = ["vaadin-split-layout.html"],
@@ -353,7 +353,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # Apache License 2.0
       sha256 = "834679bedc1b6bafecac7e7f0e3458d99ace6cddbf154c56631ef6428b787fd1",
       urls = [
-          "https://mirror.bazel.build/github.com/vaadin/vaadin-grid/archive/v3.0.2.tar.gz",
+          "http://mirror.tensorflow.org/github.com/vaadin/vaadin-grid/archive/v3.0.2.tar.gz",
           "https://github.com/vaadin/vaadin-grid/archive/v3.0.2.tar.gz",
       ],
       glob = ["*.html"],
@@ -379,7 +379,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # Apache License 2.0
       sha256 = "1d6a72f401c9d53f68238c617dd43a05cd85ca5aa2e676a5b3c352711448e093",
       urls = [
-          "https://mirror.bazel.build/registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.10.0.tgz",
+          "http://mirror.tensorflow.org/registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.10.0.tgz",
           "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.10.0.tgz",
       ],
       strip_prefix = "package",
@@ -392,7 +392,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256 = "08655255ae810bf4d1cb1642df57658fcce823776d3ba8f4b46f4bbff6c87ece",
       urls = [
-          "https://mirror.bazel.build/registry.npmjs.org/async/-/async-1.5.0.tgz",
+          "http://mirror.tensorflow.org/registry.npmjs.org/async/-/async-1.5.0.tgz",
           "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
       ],
       strip_prefix = "package",
@@ -404,7 +404,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256 = "aca8137bed5bb295bd7173325b7ad604cd2aeb341d739232b4f9f0b26745be90",
       urls = [
-          "https://mirror.bazel.build/registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+          "http://mirror.tensorflow.org/registry.npmjs.org/chai/-/chai-3.5.0.tgz",
           "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       ],
       strip_prefix = "package",
@@ -416,7 +416,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256 = "13ef37a071196a2fba680799b906555d3f0ab61e80a7e8f73f93e77914590dd4",
       urls = [
-          "https://mirror.bazel.build/registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+          "http://mirror.tensorflow.org/registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
           "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
       ],
       suppress = ["strictDependencies"],
@@ -429,7 +429,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "49edb057695fc9019aae992bf7e677a07de7c6ce2bf9f9facde4a245045d1532",
       urls = [
-          "https://mirror.bazel.build/registry.npmjs.org/sinon/-/sinon-1.17.4.tgz",
+          "http://mirror.tensorflow.org/registry.npmjs.org/sinon/-/sinon-1.17.4.tgz",
           "https://registry.npmjs.org/sinon/-/sinon-1.17.4.tgz",
       ],
       strip_prefix = "package/pkg",
@@ -441,7 +441,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "b85fc56f713832960b56fe9269ee4bb2cd41edd2ceb130b0936e5bdbed5dea63",
       urls = [
-          "https://mirror.bazel.build/registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
+          "http://mirror.tensorflow.org/registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
           "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
       ],
       strip_prefix = "package",
@@ -453,7 +453,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "c659e60f7957d9d80c23a7aacc4d71b19c6421a08f91174c0062de369595acae",
       urls = [
-          "https://mirror.bazel.build/registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
+          "http://mirror.tensorflow.org/registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
           "https://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
       ],
       strip_prefix = "package",
@@ -465,7 +465,7 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "9d4ebd4945df8a936916d4d32b7f280f2a3afa35f79e7ca8ad3ed0a42770c537",
       urls = [
-          "https://mirror.bazel.build/registry.npmjs.org/web-component-tester/-/web-component-tester-4.3.6.tgz",
+          "http://mirror.tensorflow.org/registry.npmjs.org/web-component-tester/-/web-component-tester-4.3.6.tgz",
           "https://registry.npmjs.org/web-component-tester/-/web-component-tester-4.3.6.tgz",
       ],
       strip_prefix = "package",
@@ -493,7 +493,7 @@ def tensorboard_js_workspace():
       sha256 = "59d6cfb1187733b71275becfea181fe0aa1f734df5ff77f5850c806bbbf9a0d9",
       strip_prefix = "test-fixture-2.0.1",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/test-fixture/archive/v2.0.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/test-fixture/archive/v2.0.1.tar.gz",
           "https://github.com/PolymerElements/test-fixture/archive/v2.0.1.tar.gz",
       ],
       path = "/test-fixture",
@@ -515,11 +515,11 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "82bf620fbf10af00a83754b7ebadcbcd41af7181e1aa237cdd72a2881d8004fe": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/tensorflow/graphics/be403ab520d129fa2ad99a2dc9ae0102c57a499f/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/array-buffer-data-provider.js",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/tensorflow/graphics/be403ab520d129fa2ad99a2dc9ae0102c57a499f/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/array-buffer-data-provider.js",
               "https://raw.githubusercontent.com/tensorflow/graphics/659021ac8d56c0d13eb0ebfa99786a12d48fbc61/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/array-buffer-data-provider.js",
           ],
           "bc7e983aae707e2d8dc0ca6406e3779e4ad73c537a02bed6d3d3d40180f26904": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/tensorflow/graphics/659021ac8d56c0d13eb0ebfa99786a12d48fbc61/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/mesh-viewer.js",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/tensorflow/graphics/659021ac8d56c0d13eb0ebfa99786a12d48fbc61/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/mesh-viewer.js",
               "https://raw.githubusercontent.com/tensorflow/graphics/659021ac8d56c0d13eb0ebfa99786a12d48fbc61/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/mesh-viewer.js",
           ],
       },

--- a/third_party/polymer.bzl
+++ b/third_party/polymer.bzl
@@ -23,7 +23,7 @@ def tensorboard_polymer_workspace():
       sha256 = "cf0d486e17ed8be8bb4d468564568ba7f1a23f217ed9995df31ca0c7c2a83dc2",
       strip_prefix = "polymer-1.11.3",
       urls = [
-          "https://mirror.bazel.build/github.com/polymer/polymer/archive/v1.11.3.tar.gz",
+          "http://mirror.tensorflow.org/github.com/polymer/polymer/archive/v1.11.3.tar.gz",
           "https://github.com/polymer/polymer/archive/v1.11.3.tar.gz",
       ],
       path = "/polymer",
@@ -40,7 +40,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "c404d453a31082c023457f2635ef4019bfd9e9fbb11c0d186ef55cda15bcab67",
       urls = [
-          "https://mirror.bazel.build/github.com/Polymer/polymer-analyzer/archive/v1.24.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/Polymer/polymer-analyzer/archive/v1.24.1.tar.gz",
           "https://github.com/Polymer/polymer-analyzer/archive/v1.24.1.tar.gz",
       ],
       strip_prefix = "polymer-analyzer-1.24.1",
@@ -58,7 +58,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "355f9a0b0509acbe9abb0aaab4cdd3d8621a56ca55a9bbf696dde9c68a2ff304",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-a11y-announcer/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-a11y-announcer/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/iron-a11y-announcer/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "iron-a11y-announcer-2.1.0",
@@ -72,7 +72,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "0cb94443c5277b2eb022bbf6f64d1573e087ed528f3ad39da40de5d6f51c3af0",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-a11y-keys-behavior/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-a11y-keys-behavior/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/iron-a11y-keys-behavior/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "iron-a11y-keys-behavior-2.1.0",
@@ -86,7 +86,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "80faddb20ac559d04fe32bf4d4652e2cf48bc0bb7567af665ebcabfafd85c557",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-ajax/archive/v2.1.3.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-ajax/archive/v2.1.3.tar.gz",
           "https://github.com/PolymerElements/iron-ajax/archive/v2.1.3.tar.gz",
       ],
       strip_prefix = "iron-ajax-2.1.3",
@@ -106,7 +106,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "a6a20edde3621f6d99d5a1ec9f4ba499d02d9d8d74ddf95e29bf0966fc55e812",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-autogrow-textarea/archive/v2.2.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-autogrow-textarea/archive/v2.2.0.tar.gz",
           "https://github.com/PolymerElements/iron-autogrow-textarea/archive/v2.2.0.tar.gz",
       ],
       strip_prefix = "iron-autogrow-textarea-2.2.0",
@@ -126,7 +126,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "71ecbe6a01bc302cdea01c80bf7b5801e1f570c88cc4ac491591e5cf19fdedfe",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-behaviors/archive/v2.1.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-behaviors/archive/v2.1.1.tar.gz",
           "https://github.com/PolymerElements/iron-behaviors/archive/v2.1.1.tar.gz",
       ],
       strip_prefix = "iron-behaviors-2.1.1",
@@ -146,7 +146,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "3037ede91593eb2880cf2e0c8d0198ae0b5802221e7386578263ab831a058bfc",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-checked-element-behavior/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-checked-element-behavior/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/iron-checked-element-behavior/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "iron-checked-element-behavior-2.1.0",
@@ -164,7 +164,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "d26b9bf200fedc76a9bac54da95e84b5d06b37598fdf99e18c3b943d737aff75",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-component-page/archive/v1.1.9.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-component-page/archive/v1.1.9.tar.gz",
           "https://github.com/PolymerElements/iron-component-page/archive/v1.1.9.tar.gz",
       ],
       strip_prefix = "iron-component-page-1.1.9",
@@ -189,7 +189,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "cad8c568ed26b2c3d67a5c63f53df709591b64b9f2aa724995a2d644a1076fea",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-collapse/archive/v2.2.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-collapse/archive/v2.2.0.tar.gz",
           "https://github.com/PolymerElements/iron-collapse/archive/v2.2.0.tar.gz",
       ],
       strip_prefix = "iron-collapse-2.2.0",
@@ -206,7 +206,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "4e7c148fc35ad1b8d0cf90fca1bc535801513b4ed62953faf37a2d664100a27f",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-demo-helpers/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-demo-helpers/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/iron-demo-helpers/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "iron-demo-helpers-2.1.0",
@@ -232,7 +232,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "5d487c99dd0cf626c800ae8667b0c8c88095f4482a68e837a1d3f58484ca8fb4",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-doc-viewer/archive/v2.0.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-doc-viewer/archive/v2.0.0.tar.gz",
           "https://github.com/PolymerElements/iron-doc-viewer/archive/v2.0.0.tar.gz",
       ],
       strip_prefix = "iron-doc-viewer-2.0.0",
@@ -257,7 +257,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "f265bf731b96eee431d27d1639acfc5b1c76d5aade2bcf395a65fbcdbfae5ef4",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-dropdown/archive/v1.5.6.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-dropdown/archive/v1.5.6.tar.gz",
           "https://github.com/PolymerElements/iron-dropdown/archive/v1.5.6.tar.gz",
       ],
       strip_prefix = "iron-dropdown-1.5.6",
@@ -281,7 +281,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "e0f6ee291103b64ca19e75e42afb0d4dcce87b60b5033a522cd9d2c0260486a7",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-fit-behavior/archive/v2.1.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-fit-behavior/archive/v2.1.1.tar.gz",
           "https://github.com/PolymerElements/iron-fit-behavior/archive/v2.1.1.tar.gz",
       ],
       strip_prefix = "iron-fit-behavior-2.1.1",
@@ -295,7 +295,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "2c147ed1e99870f44aa6e36ff718eee056e49417f64d0ca25caaed781d479ffc",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-flex-layout/archive/v2.0.3.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-flex-layout/archive/v2.0.3.tar.gz",
           "https://github.com/PolymerElements/iron-flex-layout/archive/v2.0.3.tar.gz",
       ],
       strip_prefix = "iron-flex-layout-2.0.3",
@@ -314,7 +314,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "c4541ac5f6c8f2677ab05fde9c5d911af58070e1b97f9d603fe489c40a10c1f0",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-form-element-behavior/archive/v2.1.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-form-element-behavior/archive/v2.1.1.tar.gz",
           "https://github.com/PolymerElements/iron-form-element-behavior/archive/v2.1.1.tar.gz",
       ],
       strip_prefix = "iron-form-element-behavior-2.1.1",
@@ -328,7 +328,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "5030eb65f935ee75bec682e71c6b55a421ff365f9f876f0e920080625fc63694",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-icon/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-icon/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/iron-icon/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "iron-icon-2.1.0",
@@ -346,7 +346,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "779174b4acd9ac8fbbb3e1bf81394db13189f294bd6683c4a0e79f68da8f1911",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-icons/archive/v2.1.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-icons/archive/v2.1.1.tar.gz",
           "https://github.com/PolymerElements/iron-icons/archive/v2.1.1.tar.gz",
       ],
       strip_prefix = "iron-icons-2.1.1",
@@ -375,7 +375,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "31c513ea52648d7b6e716909fea5921272e6244bd560c23571eb2a50e37694de",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-iconset-svg/archive/v2.2.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-iconset-svg/archive/v2.2.0.tar.gz",
           "https://github.com/PolymerElements/iron-iconset-svg/archive/v2.2.0.tar.gz",
       ],
       strip_prefix = "iron-iconset-svg-2.2.0",
@@ -392,7 +392,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "11347e6ba6d73bfddb93e3188e61019c40ef150e03e916a5f8e1c1ac0d3b1f0e",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-image/archive/v1.2.6.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-image/archive/v1.2.6.tar.gz",
           "https://github.com/PolymerElements/iron-image/archive/v1.2.6.tar.gz",
       ],
       strip_prefix = "iron-image-1.2.6",
@@ -409,7 +409,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "e26c49cfa8f013d09d6cc45f6ca76b390ebbe5baea4755d2d0900df083d5ae44",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-input/archive/v1.0.11.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-input/archive/v1.0.11.tar.gz",
           "https://github.com/PolymerElements/iron-input/archive/v1.0.11.tar.gz",
       ],
       strip_prefix = "iron-input-1.0.11",
@@ -427,7 +427,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "02ae4546cd0bd2691cfd4d108be15920047cf0d4478b0e3db7b5b0665d7ab376",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-list/archive/v2.0.14.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-list/archive/v2.0.14.tar.gz",
           "https://github.com/PolymerElements/iron-list/archive/v2.0.14.tar.gz",
       ],
       strip_prefix = "iron-list-2.0.14",
@@ -446,7 +446,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "482c3cad0ad1857fdfeb55d1e22378246379f77e7ac0eb747c248afd87f77146",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-menu-behavior/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-menu-behavior/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/iron-menu-behavior/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "iron-menu-behavior-2.1.0",
@@ -467,7 +467,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "65366ae55474fd058e052aac01f379a5ca3fd8219e0f51cb9e379e2766d607d7",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-meta/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-meta/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/iron-meta/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "iron-meta-2.1.0",
@@ -481,7 +481,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "1f678414a71ab0fe6ed4b8df1f47ed820191073063d3abe8a61d05dff266078f",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-overlay-behavior/archive/v2.3.3.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-overlay-behavior/archive/v2.3.3.tar.gz",
           "https://github.com/PolymerElements/iron-overlay-behavior/archive/v2.3.3.tar.gz",
       ],
       strip_prefix = "iron-overlay-behavior-2.3.3",
@@ -506,7 +506,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "2db73155902d0f24e3ba19ef680ca620c22ebef204e9dacab470aa25677cbc7d",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-pages/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-pages/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/iron-pages/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "iron-pages-2.1.0",
@@ -524,7 +524,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "79c2c1b7f03bf41d7b3a798cbd074419945576add48bfb7c2994f45ac3782fd7",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-range-behavior/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-range-behavior/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/iron-range-behavior/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "iron-range-behavior-2.1.0",
@@ -538,7 +538,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "1bd7875d419a63f3c8d4ca3309b53ecf93d8dddb9703913f5442d04903a89976",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-resizable-behavior/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-resizable-behavior/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/iron-resizable-behavior/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "iron-resizable-behavior-2.1.0",
@@ -552,7 +552,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "9fd59de543198d88e5ca314091954aececf8e5509df6df5bd62232e36886cb58",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-scroll-target-behavior/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-scroll-target-behavior/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/iron-scroll-target-behavior/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "iron-scroll-target-behavior-2.1.0",
@@ -566,7 +566,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "dcd7e180f05c9b66c30eedaee030a30e2f87d997f0de132e08ea4a58d494b01b",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-selector/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-selector/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/iron-selector/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "iron-selector-2.1.0",
@@ -585,7 +585,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "91ad35efdbc9438a41242a4f9aad31284d8749a45968f3a960f4c844c31b3917",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/iron-validatable-behavior/archive/v1.1.2.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-validatable-behavior/archive/v1.1.2.tar.gz",
           "https://github.com/PolymerElements/iron-validatable-behavior/archive/v1.1.2.tar.gz",
       ],
       strip_prefix = "iron-validatable-behavior-1.1.2",
@@ -605,7 +605,7 @@ def tensorboard_polymer_workspace():
       sha256 = "0956488f849c0528d66d5ce28bbfb66e163a7990df2cc5f157a5bf34dcb7dfd2",
       strip_prefix = "iron-validator-behavior-1.0.2",
       urls = [
-          "http://mirror.bazel.build/github.com/PolymerElements/iron-validator-behavior/archive/v1.0.2.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/iron-validator-behavior/archive/v1.0.2.tar.gz",
           "https://github.com/PolymerElements/iron-validator-behavior/archive/v1.0.2.tar.gz",
       ],
       deps = [
@@ -619,7 +619,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # MIT
       sha256 = "dd5a84bdf5a52558a09c2fe948e9be9c4f535901845240f3a60f97f092674aa0",
       urls = [
-          "https://mirror.bazel.build/github.com/chjj/marked/archive/v0.3.2.tar.gz",
+          "http://mirror.tensorflow.org/github.com/chjj/marked/archive/v0.3.2.tar.gz",
           "https://github.com/chjj/marked/archive/v0.3.2.tar.gz",
       ],
       strip_prefix = "marked-0.3.2",
@@ -632,7 +632,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "27abd2ef1cc122d4db32d5308c724e9a4cf9cdb1c224a4409d92cd1f5677e0c1",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/marked-element/archive/v2.4.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/marked-element/archive/v2.4.0.tar.gz",
           "https://github.com/PolymerElements/marked-element/archive/v2.4.0.tar.gz",
       ],
       strip_prefix = "marked-element-2.4.0",
@@ -652,7 +652,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "64dfd4f0603a6670ae2558eb8cae39920c089961bedf8811ddab426fc1e21372",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/neon-animation/archive/v2.2.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/neon-animation/archive/v2.2.1.tar.gz",
           "https://github.com/PolymerElements/neon-animation/archive/v2.2.1.tar.gz",
       ],
       strip_prefix = "neon-animation-2.2.1",
@@ -701,7 +701,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "74090426df1f50d1071095591cf35deb5d645b9116299b2d8e9d538490bd7f32",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-behaviors/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-behaviors/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-behaviors/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-behaviors-2.1.0",
@@ -725,7 +725,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "bcfecab0d28dcc5f7b8dd784d71b3c5a90c645fc984f7f57974211b82eccc31b",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-card/archive/v1.1.6.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-card/archive/v1.1.6.tar.gz",
           "https://github.com/PolymerElements/paper-card/archive/v1.1.6.tar.gz",
       ],
       strip_prefix = "paper-card-1.1.6",
@@ -745,7 +745,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "c3a21e81822f824ab50fe3f36d9fa3f182fefc9884d95ebebd2c3c7878f6dd00",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-button/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-button/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-button/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-button-2.1.0",
@@ -766,7 +766,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "029ccba430b0c9a5ee48f337a5a32b7cdff444bd129b4c4715b27d7bcd48f9e5",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-checkbox/archive/v2.0.3.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-checkbox/archive/v2.0.3.tar.gz",
           "https://github.com/PolymerElements/paper-checkbox/archive/v2.0.3.tar.gz",
       ],
       strip_prefix = "paper-checkbox-2.0.3",
@@ -784,7 +784,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "ddc83d55f98161e8109fa6bfdbc908902c221ff92134b4215ca4765c386b0c97",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-dialog/archive/v2.1.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-dialog/archive/v2.1.1.tar.gz",
           "https://github.com/PolymerElements/paper-dialog/archive/v2.1.1.tar.gz",
       ],
       strip_prefix = "paper-dialog-2.1.1",
@@ -802,7 +802,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "ab218c9b45218042dc30e0a1c053b995683c32b92692165f0514f5b027adff9f",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-dialog-behavior/archive/v1.2.9.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-dialog-behavior/archive/v1.2.9.tar.gz",
           "https://github.com/PolymerElements/paper-dialog-behavior/archive/v1.2.9.tar.gz",
       ],
       strip_prefix = "paper-dialog-behavior-1.2.9",
@@ -825,7 +825,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "e25a40f3bbc7416485e804bdbfcd683d86c2d900cf60951985ef225c482d5fce",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-dialog-scrollable/archive/v2.2.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-dialog-scrollable/archive/v2.2.0.tar.gz",
           "https://github.com/PolymerElements/paper-dialog-scrollable/archive/v2.2.0.tar.gz",
       ],
       strip_prefix = "paper-dialog-scrollable-2.2.0",
@@ -844,7 +844,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "95519f37380476ef6d95119bce6aa6a6271c90a3b83c74f8874e62d601c4d43b",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-dropdown-menu/archive/v1.5.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-dropdown-menu/archive/v1.5.1.tar.gz",
           "https://github.com/PolymerElements/paper-dropdown-menu/archive/v1.5.1.tar.gz",
       ],
       strip_prefix = "paper-dropdown-menu-1.5.1",
@@ -876,7 +876,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "78c76966c5bd92227f02614c3daae7a467118ac40db7ac3ad1a4234a92e30f86",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-header-panel/archive/v1.1.7.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-header-panel/archive/v1.1.7.tar.gz",
           "https://github.com/PolymerElements/paper-header-panel/archive/v1.1.7.tar.gz",
       ],
       strip_prefix = "paper-header-panel-1.1.7",
@@ -893,7 +893,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "3026c61abdfaf9621070c879b9a6dbbdd0236d4453467b54f5672e1c22af4c27",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-icon-button/archive/v2.2.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-icon-button/archive/v2.2.0.tar.gz",
           "https://github.com/PolymerElements/paper-icon-button/archive/v2.2.0.tar.gz",
       ],
       strip_prefix = "paper-icon-button-2.2.0",
@@ -915,7 +915,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "56129da805dd811ad07cafa11ba34071e7ba191093b731d606816763d64c5f55",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-input/archive/v1.2.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-input/archive/v1.2.1.tar.gz",
           "https://github.com/PolymerElements/paper-input/archive/v1.2.1.tar.gz",
       ],
       strip_prefix = "paper-input-1.2.1",
@@ -946,7 +946,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "710dc8ae3d3aad12513de4d111aab3b0bcb31159d9fb73c9ef6d02642df4bce2",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-item/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-item/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-item/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-item-2.1.0",
@@ -971,7 +971,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "294819be85502bef21fe3aa240597f8a60f38d81075acb15ede06ed0867c7832",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-listbox/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-listbox/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-listbox/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-listbox-2.1.0",
@@ -989,7 +989,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "065935ba7946d3f94c61fb536db79658bc87b20d6c44b9914512f496527845fc",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-material/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-material/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-material/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-material-2.1.0",
@@ -1009,7 +1009,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "a3cee220926e315f7412236b3628288774694447c0da4428345f36d0f127ba3b",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-menu/archive/v1.2.2.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-menu/archive/v1.2.2.tar.gz",
           "https://github.com/PolymerElements/paper-menu/archive/v1.2.2.tar.gz",
       ],
       strip_prefix = "paper-menu-1.2.2",
@@ -1034,7 +1034,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "9de3bc8caa1dbad8578013b3455e71894490095bd30cc24f5fc27cfc449942c1",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-menu-button/archive/v1.5.2.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-menu-button/archive/v1.5.2.tar.gz",
           "https://github.com/PolymerElements/paper-menu-button/archive/v1.5.2.tar.gz",
       ],
       strip_prefix = "paper-menu-button-1.5.2",
@@ -1058,7 +1058,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "01557e6385f8ab8fa3fc21fb8eab467ecc3f30a58dc650a6a17032befe427b0c",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-progress/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-progress/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-progress/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-progress-2.1.0",
@@ -1077,7 +1077,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "7dece68725e512273e754821dd30019006bdb31064dcd3287d373de4c06d8c1e",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-radio-button/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-radio-button/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-radio-button/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-radio-button-2.1.0",
@@ -1096,7 +1096,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "d7f83c4ae7b529760c766bfff3a67a198e67e96201029fd68b574a70cbb49360",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-radio-group/archive/v2.2.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-radio-group/archive/v2.2.0.tar.gz",
           "https://github.com/PolymerElements/paper-radio-group/archive/v2.2.0.tar.gz",
       ],
       strip_prefix = "paper-radio-group-2.2.0",
@@ -1116,7 +1116,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "e7a032f1c194e6222b3b4c80e04f28a201c5d12c7e94a33b77f10ab371a19d84",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-ripple/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-ripple/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-ripple/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-ripple-2.1.0",
@@ -1133,7 +1133,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "5d922f348e3058d9b52bbccd8847a6d6c9e39c4282317ecd6acaa90d59c0212f",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-slider/archive/v2.0.6.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-slider/archive/v2.0.6.tar.gz",
           "https://github.com/PolymerElements/paper-slider/archive/v2.0.6.tar.gz",
       ],
       strip_prefix = "paper-slider-2.0.6",
@@ -1157,7 +1157,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "df74ce25bdf16df7f82d4567b0a353073de811f6d3d38df95477b7cefa773688",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-spinner/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-spinner/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-spinner/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-spinner-2.1.0",
@@ -1180,7 +1180,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "37359c72f96f1f3dd90fe7a9ba50d079dc32241de359d5c19c013b564b48bd3f",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-styles/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-styles/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-styles/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-styles-2.1.0",
@@ -1211,7 +1211,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "c09fcd78d1e1c79451c6c12c203ec32c6b36f063f25ad6cdf18da81e33bd9a2d",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-tabs/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-tabs/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-tabs/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-tabs-2.1.0",
@@ -1240,7 +1240,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "d47c0be0387d0f13fa756413f192c4719e1b36c0aa0e2373176733d6224e7001",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-toast/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-toast/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-toast/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-toast-2.1.0",
@@ -1258,7 +1258,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "adf4b41d7e2cfd0d267f62c94506c409be39212e0deadcec7b25526b4d9acd2c",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-toggle-button/archive/v1.3.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-toggle-button/archive/v1.3.0.tar.gz",
           "https://github.com/PolymerElements/paper-toggle-button/archive/v1.3.0.tar.gz",
       ],
       strip_prefix = "paper-toggle-button-1.3.0",
@@ -1277,7 +1277,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "6ce97a7cd55b7aadbe0fbd2c1ef768759e5f8f516645c61a2871018828dccffe",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-toolbar/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-toolbar/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/paper-toolbar/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "paper-toolbar-2.1.0",
@@ -1295,7 +1295,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "07eacd783507d4aad3e5e6e0c128c3816aa7e3149bf8f7dfce525ea5568d0565",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/paper-tooltip/archive/v2.1.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/paper-tooltip/archive/v2.1.1.tar.gz",
           "https://github.com/PolymerElements/paper-tooltip/archive/v2.1.1.tar.gz",
       ],
       strip_prefix = "paper-tooltip-2.1.1",
@@ -1312,7 +1312,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # MIT
       sha256 = "9dc3e68c9f34794a6edb3fc54eb39f4905f1ac6b8e12ecc27836cff1abbccf36",
       urls = [
-          "https://mirror.bazel.build/github.com/PrismJS/prism/archive/v1.13.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PrismJS/prism/archive/v1.13.0.tar.gz",
           "https://github.com/PrismJS/prism/archive/v1.13.0.tar.gz",
       ],
       strip_prefix = "prism-1.13.0",
@@ -1328,7 +1328,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "b7c222f2f9254eae469ef6fa0baa208b376d37b33f7511a4a2471db35bdc40c7",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerElements/prism-element/archive/v2.1.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerElements/prism-element/archive/v2.1.0.tar.gz",
           "https://github.com/PolymerElements/prism-element/archive/v2.1.0.tar.gz",
       ],
       strip_prefix = "prism-element-2.1.0",
@@ -1350,7 +1350,7 @@ def tensorboard_polymer_workspace():
       sha256 = "d83edb667c393efb3e7b40a2c22d439e1d84056be5d36174be6507a45f709daa",
       strip_prefix = "promise-polyfill-1.0.1",
       urls = [
-          "https://mirror.bazel.build/github.com/PolymerLabs/promise-polyfill/archive/v1.0.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/PolymerLabs/promise-polyfill/archive/v1.0.1.tar.gz",
           "https://github.com/PolymerLabs/promise-polyfill/archive/v1.0.1.tar.gz",
       ],
       path = "/promise-polyfill",
@@ -1368,7 +1368,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "f8bd760cbdeba131f6790bd5abe170bcbf7b1755ff58ed16d0b82fa8a7f34a7f",
       urls = [
-          "https://mirror.bazel.build/github.com/web-animations/web-animations-js/archive/2.2.1.tar.gz",
+          "http://mirror.tensorflow.org/github.com/web-animations/web-animations-js/archive/2.2.1.tar.gz",
           "https://github.com/web-animations/web-animations-js/archive/2.2.1.tar.gz",
       ],
       strip_prefix = "web-animations-js-2.2.1",
@@ -1381,7 +1381,7 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "2164e6d07d72d4326865ab7c0acee5493870e1ae5f31e9d22665dff4a4773078",
       urls = [
-          "https://mirror.bazel.build/github.com/webcomponents/webcomponentsjs/archive/v0.7.24.tar.gz",
+          "http://mirror.tensorflow.org/github.com/webcomponents/webcomponentsjs/archive/v0.7.24.tar.gz",
           "https://github.com/webcomponents/webcomponentsjs/archive/v0.7.24.tar.gz",
       ],
       strip_prefix = "webcomponentsjs-0.7.24",

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -24,7 +24,7 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_pythonhosted_markdown",
         urls = [
-            "https://mirror.bazel.build/pypi.python.org/packages/1d/25/3f6d2cb31ec42ca5bd3bfbea99b63892b735d76e26f20dd2dcc34ffe4f0d/Markdown-2.6.8.tar.gz",
+            "http://mirror.tensorflow.org/pypi.python.org/packages/1d/25/3f6d2cb31ec42ca5bd3bfbea99b63892b735d76e26f20dd2dcc34ffe4f0d/Markdown-2.6.8.tar.gz",
             "https://pypi.python.org/packages/1d/25/3f6d2cb31ec42ca5bd3bfbea99b63892b735d76e26f20dd2dcc34ffe4f0d/Markdown-2.6.8.tar.gz",
         ],
         strip_prefix = "Markdown-2.6.8",
@@ -35,7 +35,7 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_pythonhosted_urllib3",
         urls = [
-            "https://mirror.bazel.build/pypi.python.org/packages/cb/34/db09a2f1e27c6ded5dd42afb0e3e2cf6f51ace7d75726385e8a3b1993b17/urllib3-1.25.tar.gz",
+            "http://mirror.tensorflow.org/pypi.python.org/packages/cb/34/db09a2f1e27c6ded5dd42afb0e3e2cf6f51ace7d75726385e8a3b1993b17/urllib3-1.25.tar.gz",
             "https://pypi.python.org/packages/cb/34/db09a2f1e27c6ded5dd42afb0e3e2cf6f51ace7d75726385e8a3b1993b17/urllib3-1.25.tar.gz",
             "https://files.pythonhosted.org/packages/cb/34/db09a2f1e27c6ded5dd42afb0e3e2cf6f51ace7d75726385e8a3b1993b17/urllib3-1.25.tar.gz",
         ],
@@ -47,7 +47,7 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_html5lib",
         urls = [
-            "https://mirror.bazel.build/github.com/html5lib/html5lib-python/archive/0.9999999.tar.gz",
+            "http://mirror.tensorflow.org/github.com/html5lib/html5lib-python/archive/0.9999999.tar.gz",
             "https://github.com/html5lib/html5lib-python/archive/0.9999999.tar.gz",  # identical to 1.0b8
         ],
         sha256 = "184257f98539159a433e2a2197309657ae1283b4c44dbd9c87b2f02ff36adce8",
@@ -58,7 +58,7 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_mozilla_bleach",
         urls = [
-            "https://mirror.bazel.build/github.com/mozilla/bleach/archive/v1.5.tar.gz",
+            "http://mirror.tensorflow.org/github.com/mozilla/bleach/archive/v1.5.tar.gz",
             "https://github.com/mozilla/bleach/archive/v1.5.tar.gz",
         ],
         strip_prefix = "bleach-1.5",
@@ -85,7 +85,7 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_pythonhosted_mock",
         urls = [
-            "https://mirror.bazel.build/files.pythonhosted.org/packages/85/60/ec8c1af81337bab0caba188b218b6758bc94f125f49062f7c5f0647749d2/mock-1.0.0.tar.gz",
+            "http://mirror.tensorflow.org/files.pythonhosted.org/packages/85/60/ec8c1af81337bab0caba188b218b6758bc94f125f49062f7c5f0647749d2/mock-1.0.0.tar.gz",
             "https://files.pythonhosted.org/packages/85/60/ec8c1af81337bab0caba188b218b6758bc94f125f49062f7c5f0647749d2/mock-1.0.0.tar.gz",
         ],
         sha256 = "2d9fbe67001d2e8f02692075257f3c11e1b0194bd838c8ce3f49b31fc6c3f033",
@@ -96,7 +96,7 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_pythonhosted_six",
         urls = [
-            "https://mirror.bazel.build/pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
+            "http://mirror.tensorflow.org/pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
             "http://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
         ],
         sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
@@ -107,7 +107,7 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_python_pypi_portpicker",
         urls = [
-            "https://mirror.bazel.build/pypi.python.org/packages/96/48/0e1f20fdc0b85cc8722284da3c5b80222ae4036ad73210a97d5362beaa6d/portpicker-1.1.1.tar.gz",
+            "http://mirror.tensorflow.org/pypi.python.org/packages/96/48/0e1f20fdc0b85cc8722284da3c5b80222ae4036ad73210a97d5362beaa6d/portpicker-1.1.1.tar.gz",
             "https://pypi.python.org/packages/96/48/0e1f20fdc0b85cc8722284da3c5b80222ae4036ad73210a97d5362beaa6d/portpicker-1.1.1.tar.gz",
         ],
         sha256 = "2f88edf7c6406034d7577846f224aff6e53c5f4250e3294b1904d8db250f27ec",
@@ -118,7 +118,7 @@ def tensorboard_python_workspace():
     http_archive(
         name = "org_tensorflow_serving_api",
         urls = [
-            "https://mirror.bazel.build/files.pythonhosted.org/packages/b5/da/bd60d7b245dbe93f35aded752679124a61bb90154d4698f6f3dba30d75c6/tensorflow_serving_api-1.10.1-py2.py3-none-any.whl",
+            "http://mirror.tensorflow.org/files.pythonhosted.org/packages/b5/da/bd60d7b245dbe93f35aded752679124a61bb90154d4698f6f3dba30d75c6/tensorflow_serving_api-1.10.1-py2.py3-none-any.whl",
             "https://files.pythonhosted.org/packages/b5/da/bd60d7b245dbe93f35aded752679124a61bb90154d4698f6f3dba30d75c6/tensorflow_serving_api-1.10.1-py2.py3-none-any.whl",
         ],
         type = "zip",

--- a/third_party/typings.bzl
+++ b/third_party/typings.bzl
@@ -22,38 +22,38 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "b7da645f6e5555feb7aeede73775da0023ce2257df9c8e76c9159266035a9c0d": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/chai/chai.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/chai/chai.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/chai/chai.d.ts",
           ],
           "a285ca43837c03640134d31fb64a52625f65f4a2890194414d695fbc050b289e": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/5d0f2126c8dac8fce0ff020218aea06607213b0d/google.analytics/ga.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/5d0f2126c8dac8fce0ff020218aea06607213b0d/google.analytics/ga.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/5d0f2126c8dac8fce0ff020218aea06607213b0d/google.analytics/ga.d.ts",
           ],
           # TODO(jart): Upgrade to Lodash v4 typing: Lodash package is broken
           # down into small subpackages with many smaller type files. Loading
           # one type file is no longer enough.
           "e4cd3d5de0eb3bc7b1063b50d336764a0ac82a658b39b5cf90511f489ffdee60": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/efd40e67ff323f7147651bdbef03c03ead7b1675/lodash/lodash.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/efd40e67ff323f7147651bdbef03c03ead7b1675/lodash/lodash.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/efd40e67ff323f7147651bdbef03c03ead7b1675/lodash/lodash.d.ts",
           ],
           "695a03dd2ccb238161d97160b239ab841562710e5c4e42886aefd4ace2ce152e": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/mocha/mocha.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/mocha/mocha.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/mocha/mocha.d.ts",
           ],
           "513ccd9ee1c708881120eeacd56788fc3b3da8e5c6172b20324cebbe858803fe": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/708609e0764daeb5eb64104af7aca50c520c4e6e/sinon/sinon.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/708609e0764daeb5eb64104af7aca50c520c4e6e/sinon/sinon.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/708609e0764daeb5eb64104af7aca50c520c4e6e/sinon/sinon.d.ts",
           ],
           "44eba36339bd1c0792072b7b204ee926fe5ffe1e9e2da916e67ac55548e3668a": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/a872802c0c84ba98ff207d5e673a1fa867c67fd6/polymer/polymer.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/a872802c0c84ba98ff207d5e673a1fa867c67fd6/polymer/polymer.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/a872802c0c84ba98ff207d5e673a1fa867c67fd6/polymer/polymer.d.ts",  # 2016-09-22
           ],
           "7ce67447146eb2b9e9cdaaf8bf45b3209865378022cc8acf86616d3be84f6481": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/8cb9ee3fdfe352cfef672bdfdb5f9c428f915e9f/threejs/three.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/8cb9ee3fdfe352cfef672bdfdb5f9c428f915e9f/threejs/three.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/8cb9ee3fdfe352cfef672bdfdb5f9c428f915e9f/threejs/three.d.ts",  # r74 @ 2016-04-06
           ],
           "691756a6eb455f340c9e834de0d49fff269e7b8c1799c2454465dcd6a4435b80": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/46719185c564694c5583c4b7ad94dbb786ecad46/webcomponents.js/webcomponents.js.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/46719185c564694c5583c4b7ad94dbb786ecad46/webcomponents.js/webcomponents.js.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/46719185c564694c5583c4b7ad94dbb786ecad46/webcomponents.js/webcomponents.js.d.ts",
           ],
       },
@@ -66,7 +66,7 @@ def tensorboard_typings_workspace():
           # TODO(stephanwlee): d3-array is pinned at b6746d. number[] does not
           # cast to d3.ArrayLike<number> for some reason.
           "61e7abb7b1f01fbcb0cab8cf39003392f422566209edd681fbd070eaa84ca000": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/b6746d73a2ddf103c6825449ee2b0953f716d994/types/d3-array/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/b6746d73a2ddf103c6825449ee2b0953f716d994/types/d3-array/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/b6746d73a2ddf103c6825449ee2b0953f716d994/types/d3-array/index.d.ts",  # 2018-08-06
           ],
       },
@@ -77,7 +77,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "6a43110a41bbf3190ef6c515fc8b932086122b7d2fd32e841f4756ba507406c3": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-axis/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-axis/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-axis/index.d.ts",  # 2018-08-06
           ],
       },
@@ -88,7 +88,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "fb5d5bef5af05e086085892946769b9ec8c0f9217876933671038b665a6ec603": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-brush/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-brush/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-brush/index.d.ts",  # 2018-08-06
           ],
       },
@@ -99,7 +99,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "9a06f750a483ae5ce10ceda48c5004cd918c4d803762661dca52eedfd2ed7afd": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-chord/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-chord/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-chord/index.d.ts",  # 2018-08-06
           ],
       },
@@ -110,7 +110,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "8f6ec0925d0ba17efa0dcfea9ab8b3f73114222a569704849e8a169533ea0f95": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-collection/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-collection/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-collection/index.d.ts",  # 2018-08-06
           ],
       },
@@ -121,7 +121,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "83a206846be71cca27273fa5c39544b7d51c9aab8336ae6b5135c6b71a178bbf": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-color/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-color/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-color/index.d.ts",  # 2018-08-06
           ],
       },
@@ -132,7 +132,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "4ddaa6005cfd5fd07df24e8af735d2c1a90d896bd5cacc2f657fe8748ae25af9": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-dispatch/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-dispatch/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-dispatch/index.d.ts",  # 2018-08-06
           ],
       },
@@ -143,7 +143,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "99c4e6872495378bcb768d8cc99551aaee43ba2324fd56282f8f03d81c499975": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-drag/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-drag/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-drag/index.d.ts",  # 2018-08-06
           ],
       },
@@ -154,7 +154,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "5fccc13fc4d3b1c6a434cb277c491ac8d47baed9baba86bdb441ee18ec5bc76e": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-dsv/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-dsv/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-dsv/index.d.ts",  # 2018-08-06
           ],
       },
@@ -165,7 +165,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "d5a9be5316b2d1823a3faa7f75de1e2c2efda5c75f0631b44a0f7b69e11f3a90": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-ease/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-ease/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-ease/index.d.ts",  # 2018-08-06
           ],
       },
@@ -176,7 +176,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "a6941d869584c8f426d5dfbe89ad0f082c104477f81c7d2fe432ccae3cc2ece8": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-force/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-force/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-force/index.d.ts",  # 2018-08-06
           ],
       },
@@ -187,7 +187,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "b5b8cf2707e4c60ea98341e3c5c913f1af2e2bd7c61b90a8329260692fe1f694": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-format/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-format/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-format/index.d.ts",  # 2018-08-06
           ],
       },
@@ -198,7 +198,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "eb527ec61d4a7d81db35f823104fa57cb3def41d72eaa9ce827295d440283206": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-hierarchy/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-hierarchy/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-hierarchy/index.d.ts",  # 2018-08-06
           ],
       },
@@ -209,7 +209,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "e2f3ebafe2b7c6011fe76d19f9e32d8c8b67076b39f7cfa945d543e39f3ef18f": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-interpolate/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-interpolate/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-interpolate/index.d.ts",  # 2018-08-06
           ],
       },
@@ -220,7 +220,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "daad2baf9dd5af11d3c3095c6fb93f7749e581943873b29b6dfc4a6f22d3d6e2": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-path/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-path/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-path/index.d.ts",  # 2018-08-06
           ],
       },
@@ -231,7 +231,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "a76d53d353351cabaaca7f149a57c5ffc7d90c0f181d7f3f40e4a51424289a75": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-polygon/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-polygon/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-polygon/index.d.ts",  # 2018-08-06
           ],
       },
@@ -242,7 +242,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "4ebfae1202903a6d8d2ab52dede7631f2d8d277cbec8107607df7372d19ebbb6": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-quadtree/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-quadtree/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-quadtree/index.d.ts",  # 2018-08-06
           ],
       },
@@ -253,7 +253,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "3d48a2e31ee7b4bc687a6b85b49bcb37e043e0dec4c83fcda8baad27fda7c114": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-queue/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-queue/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-queue/index.d.ts",  # 2018-08-06
           ],
       },
@@ -264,7 +264,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "e30e9105a9c2e11410a452a02e320aebe66a1856e6b9410035ee7b3ad7d80839": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-random/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-random/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-random/index.d.ts",  # 2018-08-06
           ],
       },
@@ -275,7 +275,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "fc2b7c2c05498011eb039825aab76a7916698fb3e7133e278fc92ae529ae99f0": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-request/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-request/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-request/index.d.ts",  # 2018-08-06
           ],
       },
@@ -290,7 +290,7 @@ def tensorboard_typings_workspace():
           # d3-scale into d3-scale and d3-scale-chromatic and deprecates
           # d3.schemeCategory20.
           "58646b85fbbeaa88ff29342e9f1a89cea2d6fa8cb1b5549dc7ec8e9f7e021894": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ff2359e74ce1c539097e47dc586d49d348a94587/types/d3-scale/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ff2359e74ce1c539097e47dc586d49d348a94587/types/d3-scale/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ff2359e74ce1c539097e47dc586d49d348a94587/types/d3-scale/index.d.ts",  # 2018-08-06
           ],
       },
@@ -301,7 +301,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "0e1bf1308ca27649010d5ae91783decd1337bda581b66aaa8be12060110662fa": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-selection/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-selection/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-selection/index.d.ts",  # 2018-08-06
           ],
       },
@@ -312,7 +312,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "47c61d4d8ba88c113fe9f3b37585656c66eddd95262554108a6507674a6c3b3a": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-shape/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-shape/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-shape/index.d.ts",  # 2018-08-06
           ],
       },
@@ -323,7 +323,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "39fb4b2ad57ef393eabd017356f05854a44268a6b98cd2b235c8732fb9989d83": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-time/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-time/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-time/index.d.ts",  # 2018-08-06
           ],
       },
@@ -334,7 +334,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "79021d12162bdd6a850ce4c1a9014b342067db30816f907d4118578c2a59db76": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-timer/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-timer/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-timer/index.d.ts",  # 2018-08-06
           ],
       },
@@ -345,7 +345,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "88e6d462d5a592a2ebbdad7865142160341c93698c50701c4186bcb65a7685a7": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-transition/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-transition/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-transition/index.d.ts",  # 2018-08-06
           ],
       },
@@ -356,7 +356,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "8936e0e6b0f0416c4c08f79e1555869a8553dc04723c4d8fa12990e755f460f5": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-voronoi/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-voronoi/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-voronoi/index.d.ts",  # 2018-08-06
           ],
       },
@@ -367,7 +367,7 @@ def tensorboard_typings_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "65ea463a1297778ebf88e37444722bacd4d33db9a59ac69e78127e1c23670dd3": [
-              "https://mirror.bazel.build/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-zoom/index.d.ts",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-zoom/index.d.ts",
               "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/526dd2e57684fa586452445a181d37369533d02e/types/d3-zoom/index.d.ts",  # 2018-08-06
           ],
       },

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -37,7 +37,7 @@ def tensorboard_workspace():
       strip_prefix = "protobuf-3.6.0/js",
       sha256 = "50a5753995b3142627ac55cfd496cebc418a2e575ca0236e29033c67bd5665f4",
       urls = [
-          "https://mirror.bazel.build/github.com/google/protobuf/archive/v3.6.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/google/protobuf/archive/v3.6.0.tar.gz",
           "https://github.com/google/protobuf/archive/v3.6.0.tar.gz",
       ],
       build_file = "@io_bazel_rules_closure//closure/protobuf:protobuf_js.BUILD",


### PR DESCRIPTION
Summary:
It’s easier for TensorBoard team members to upload files to the
TensorFlow.org mirror than the Bazel mirror. Many of our files were not
mirrored, and fetches from GitHub can be noticeably slow. (For instance,
the Bazel 0.22.0 binary is 1.8–2.0 seconds from the TF mirror and 8.5–12
seconds from GitHub.) As of this commit, all `mirror.bazel.build` URLs
are replaced with `mirror.tensorflow.org` URLs, and all such URLs
contain valid content.

Along the way, I swapped out the defunct numericjs source to a host that
actually still resolves.

On Travis, getting Bazel and running `bazel fetch //tensorboard/...`
typically takes about 44 seconds. Let’s see if this speeds that up.

Test Plan:
Check that Bazel URLs resolve:

```
$ git grep -Pho '(?<=")https?://mirror\.tensorflow\.org/[^"]*' |
> grep -vF '${BAZEL}' | sort | uniq |
> xargs -n 1 -P 32 -- \
> sh -c 'curl -sfL "$1" >/dev/null && echo OK || echo FAIL' unused |
> sort | uniq -c
    231 OK
```

Check that the Travis URL resolves:

```
$ BAZEL=0.22.0
$ curl -sfL "http://mirror.tensorflow.org/github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-linux-x86_64" |
> shasum -a 256
8474ed28ed4998e2f5671ddf3a9a80ae9e484a5de3b8b70c8b654c017c65d363
```

Check that we caught ’em all:

```
$ git grep mirror.bazel | wc -l
0
```

wchargin-branch: mirror-tensorflow-org
