### PR TITLE
Improve the performance and scalability of pod viewer

### DIFF
--- a/tensorboard/plugins/profile/pod_viewer/details_card/details-card.html
+++ b/tensorboard/plugins/profile/pod_viewer/details_card/details-card.html
@@ -57,9 +57,6 @@ paper-card {
     <paper-card id="card" heading="[[_name]]" hidden="[[!_name]]" elevation="2">
       <template is="dom-repeat" items=[[nodes]] as="node">
         <div class="card-content info">
-          <div hidden="[[!_isChannel(node)]]">
-            <p>Replica Id: <span class="value">[[node.replicaId]]</span></p>
-          </div>
           <div hidden="[[_isStep(node)]]">
             <p>Data Transferred: <span class="value">[[_sizeMiB(node.dataSize)]] MiB</span></p>
             <p>Latency: <span class="value">[[_format(node.durationUs)]] µs</span></p>
@@ -68,8 +65,6 @@ paper-card {
           </div>
           <div hidden="[[!_isChannel(node)]]">
             <p>Send Delay: <span class="value">[[_format(node.sendDelayUs)]] µs</span></p>
-            <p>From: <span class="value">Chip[[_chipId(node.srcCoreId)]], Core[[_nodeId(node.srcCoreId)]]</span></p>
-            <p>To: <span class="value">Chip[[_chipId(node.dstCoreId)]], Core[[_nodeId(node.dstCoreId)]]</span></p>
             <p>Hlo Names: </p>
             <code class="code-style">
               <template is="dom-repeat" items=[[node.hloNames]]>

--- a/tensorboard/plugins/profile/pod_viewer/details_card/details-card.ts
+++ b/tensorboard/plugins/profile/pod_viewer/details_card/details-card.ts
@@ -32,7 +32,8 @@ Polymer({
         {key: 'lowFlopsComputeUs', label: 'Low flops compute'},
         {key: 'hostInfeedDurationUs', label: 'Infeed'},
         {key: 'hostOutfeedDurationUs', label: 'Outfeed'},
-        {key: 'crsDurationUs', label: 'All reduce'},
+        {key: 'allReduceComputeDurationUs', label: 'AllReduce compute'},
+        {key: 'allReduceSyncDurationUs', label: 'AllReduce sync'},
         {key: 'sendDurationUs', label: 'Send'},
         {key: 'recvDurationUs', label: 'Recv'},
       ],
@@ -114,7 +115,7 @@ Polymer({
       function(node: undefined|podviewer.proto.PodStatsRecord,
           key: undefined|string): string|undefined {
     if (!key || !node) return;
-    return this._format(node[key]);
+    return this._format(node[key] ? node[key] : 0);
   },
   /**
    * Return a the percentage of a specific breakdown.
@@ -122,7 +123,7 @@ Polymer({
   _getStepBreakdownPct:
       function(node: undefined|podviewer.proto.PodStatsRecord,
           key: undefined|string): string|undefined {
-    if (!key || !node || !node.totalDurationUs) return;
+    if (!key || !node || !node.totalDurationUs || !node[key]) return;
     return (node[key] / node.totalDurationUs * 100).toFixed(2) + '%';
   },
 });

--- a/tensorboard/plugins/profile/pod_viewer/pod_viewer_common/proto.ts
+++ b/tensorboard/plugins/profile/pod_viewer/pod_viewer_common/proto.ts
@@ -98,11 +98,10 @@ module podviewer.proto {
     sendDurationUs: number;
     /** The time spent on recv operations. */
     recvDurationUs: number;
-    /**
-     * The time spent on all-reduce in micro-seconds
-     * (used to be cross-replica-sum).
-     */
-    crsDurationUs: number;
+    /** The time spent on actual all-reduce compute in micro-seconds. */
+    allReduceComputeDurationUs: number;
+    /** The time spent on all-reduce synchronization in micro-seconds. */
+    allReduceSyncDurationUs: number;
     /** bottleneck out of the above mentioned metrics. */
     bottleneck: string;
   }
@@ -135,10 +134,10 @@ module podviewer.proto {
   export interface ChannelInfo {
     /** Id of the channel. */
     channelId: number;
-    /** Core id of the send op. */
-    srcCoreId: number;
-    /** Core id of the recv op. */
-    dstCoreId: number;
+    /** Core ids of the send ops. */
+    srcCoreIds: Array<number>;
+    /** Core ids of the recv ops. */
+    dstCoreIds: Array<number>;
     /** Byte size of the data transferred. */
     dataSize: number;
     /**
@@ -158,8 +157,6 @@ module podviewer.proto {
      * op, the delay is zero.
      */
     sendDelayUs: number;
-    /** The replica_id of the program executing the send and recv ops. */
-    replicaId: number;
   }
 
   /** Data input to the pod viewer tool. */

--- a/tensorboard/plugins/profile/pod_viewer/pod_viewer_dashboard/pod-viewer-dashboard.html
+++ b/tensorboard/plugins/profile/pod_viewer/pod_viewer_dashboard/pod-viewer-dashboard.html
@@ -103,7 +103,7 @@ paper-slider {
       <div id="topo-graph">
         <topology-graph run-environment=[[_runEnvironment]]
             data=[[_podStatsMap]] metrics=[[_stepBreakdownLayers]]
-            active-bar=[[activeBar]] selected-channel={{selectedChannel}}>
+            active-bar=[[activeBar]]>
         </topology-graph>
       </div>
       <div id="channel-bars" class="bar-chart" hidden="[[!_channelDb]]">

--- a/tensorboard/plugins/profile/pod_viewer/pod_viewer_dashboard/pod-viewer-dashboard.ts
+++ b/tensorboard/plugins/profile/pod_viewer/pod_viewer_dashboard/pod-viewer-dashboard.ts
@@ -66,7 +66,8 @@ Polymer({
         {key: 'lowFlopsComputeUs', label: 'Low flops compute'},
         {key: 'hostInfeedDurationUs', label: 'Infeed'},
         {key: 'hostOutfeedDurationUs', label: 'Outfeed'},
-        {key: 'crsDurationUs', label: 'All reduce'},
+        {key: 'allReduceComputeDurationUs', label: 'AllReduce compute'},
+        {key: 'allReduceSyncDurationUs', label: 'AllReduce sync'},
         {key: 'sendDurationUs', label: 'Send'},
         {key: 'recvDurationUs', label: 'Recv'},
       ],
@@ -162,8 +163,10 @@ Polymer({
         if (j == 1) {
           continue;
         }
+        const duration = val[layers[j].key];
+        if (!duration) continue;
         // Skip the lowFlopsComputeUs.
-        val['lowFlopsComputeUs'] -= val[layers[j].key];
+        val['lowFlopsComputeUs'] -= duration;
       }
     }
    return podStatsMap;

--- a/tensorboard/plugins/profile/pod_viewer/pod_viewer_dashboard/pod-viewer-dashboard.ts
+++ b/tensorboard/plugins/profile/pod_viewer/pod_viewer_dashboard/pod-viewer-dashboard.ts
@@ -29,11 +29,6 @@ Polymer({
       type: Array,
       notify: true,
     },
-    selectedChannel: {
-      type: Array,
-      notify: true,
-      observer: '_selectedChannelChanged',
-    },
     activeBar: {
       type: Object,
       notify: true,
@@ -206,14 +201,6 @@ Polymer({
   _dataChanged(newData: podviewer.proto.PodViewerInputData) {
     if (!newData) return;
     this.curStepId = 0;
-  },
-  /**
-   * Updates the input of the details card when selected channel changed.
-   */
-  _selectedChannelChanged(newChannel: Array<podviewer.proto.ChannelInfo>) {
-    if (newChannel) {
-      this.activeDetails = newChannel;
-    }
   },
   /**
    * The active bar could be one of the PodStatsRecord, ChannelInfo or

--- a/tensorboard/plugins/profile/pod_viewer/pod_viewer_dashboard/pod-viewer-dashboard.ts
+++ b/tensorboard/plugins/profile/pod_viewer/pod_viewer_dashboard/pod-viewer-dashboard.ts
@@ -159,10 +159,12 @@ Polymer({
         if (j == 1) {
           continue;
         }
-        const duration = val[layers[j].key];
-        if (!duration) continue;
+        // Input missing a field, set it to 0.
+        if (!val[layers[j].key]) {
+           val[layers[j].key] = 0;
+        }
         // Skip the lowFlopsComputeUs.
-        val['lowFlopsComputeUs'] -= duration;
+        val['lowFlopsComputeUs'] -= val[layers[j].key];
       }
     }
    return podStatsMap;

--- a/tensorboard/plugins/profile/pod_viewer/pod_viewer_dashboard/pod-viewer-dashboard.ts
+++ b/tensorboard/plugins/profile/pod_viewer/pod_viewer_dashboard/pod-viewer-dashboard.ts
@@ -125,6 +125,7 @@ Polymer({
   _computeRunEnvironment(
       data: podviewer.proto.PodViewerInputData|undefined|null):
           podviewer.proto.RunEnvironment {
+    if (!data) return;
     return data.runEnvironment;
   },
   _computeMaxStepId(podStatsMaps: Array<podviewer.proto.PodStatsMap>): number {

--- a/tensorboard/plugins/profile/pod_viewer/stack_bar_chart/stack-bar-chart.ts
+++ b/tensorboard/plugins/profile/pod_viewer/stack_bar_chart/stack-bar-chart.ts
@@ -161,6 +161,7 @@ Polymer({
 
     let legendEnter = legend.enter().append('g');
     legendEnter.append('rect')
+        .attr('x', YAXIS_TO_LEGEND)
         .attr('width', ICON_SIZE)
         .attr('height', ICON_SIZE);
     legendEnter.append('text')
@@ -175,8 +176,8 @@ Polymer({
                 LABELS_PER_LANE) + ',' +
                     Math.floor(i / LABELS_PER_LANE) * LEGEND_HEIGHT + ')'
         );
-    legend.selectAll('rect').attr('fill', (d, i) => colorScale(i));
-    legend.selectAll('text').text((d) => d);
+    legend.select('rect').attr('fill', (d, i) => colorScale(i));
+    legend.select('text').text((d) => d);
   },
   /**
    * Redraw the stack bar chart.

--- a/tensorboard/plugins/profile/pod_viewer/stack_bar_chart/stack-bar-chart.ts
+++ b/tensorboard/plugins/profile/pod_viewer/stack_bar_chart/stack-bar-chart.ts
@@ -117,13 +117,8 @@ Polymer({
         .selectAll('rect').data((d) => d);
     rects.enter().append('rect').merge(rects)
         .attr('width', xScale.bandwidth())
-        .attr('y', (d) => yScale(d[1]) ? yScale(d[1]) : 0)
-        .attr('height',
-            (d) => {
-              // For backward compatibility, old traces may have h undefeind.
-              const h = yScale(d[0]) - yScale(d[1]);
-              return h ? h : 0;
-            })
+        .attr('y', (d) => yScale(d[1]))
+        .attr('height', (d) => yScale(d[0]) - yScale(d[1]))
         .attr('x', (d, i) => xScale(parent.xDomainFunc(d.data)))
         .on('mouseover',
             function(d) {
@@ -170,12 +165,12 @@ Polymer({
         .attr('dy', LEGEND_TEXT_SIZE)
    
     legend = legendEnter.merge(legend);
-    legend.attr('transform',
-        (d, i) => 'translate(' + (i * LEGEND_WIDTH -
-            Math.floor(i / LABELS_PER_LANE) * LEGEND_WIDTH *
-                LABELS_PER_LANE) + ',' +
-                    Math.floor(i / LABELS_PER_LANE) * LEGEND_HEIGHT + ')'
-        );
+    legend.attr('transform', (d, i) => {
+      const x = i * LEGEND_WIDTH - Math.floor(i / LABELS_PER_LANE) *
+                      LEGEND_WIDTH * LABELS_PER_LANE;
+      const y = Math.floor(i / LABELS_PER_LANE) * LEGEND_HEIGHT;
+      return `translate(${x}, ${y})`;
+    });
     legend.select('rect').attr('fill', (d, i) => colorScale(i));
     legend.select('text').text((d) => d);
   },

--- a/tensorboard/plugins/profile/pod_viewer/stack_bar_chart/stack-bar-chart.ts
+++ b/tensorboard/plugins/profile/pod_viewer/stack_bar_chart/stack-bar-chart.ts
@@ -28,6 +28,7 @@ const LEGEND_TEXT_HEIGHT = 9.5;
 const LEGEND_TEXT_SIZE = '0.32em';
 
 const FONT_SIZE = 14;
+const TRANSITION_DURATION = 1000;
 
 Polymer({
   is: 'stack-bar-chart',
@@ -57,9 +58,6 @@ Polymer({
     if (!data.length || !this.isAttached || this.stackLayers.length == 0) {
       return;
     }
-    d3.select(this.$.chart).selectAll('g > *').remove();
-    d3.select(this.$.chart).select('svg').remove();
-    d3.select(this.$.chart).select('.svg-container').remove();
     const stackKey = this.stackLayers.map((d) => d.key);
     const stackLabel = this.stackLayers.map((d) => d.label);
     const height = SVG_HEIGHT - SVG_MARGIN.top - SVG_MARGIN.bottom;
@@ -68,13 +66,26 @@ Polymer({
     let yScale = d3.scaleLinear().range([height, 0]);
     let colorScale = d3.scaleOrdinal<number, string>(d3.schemeCategory10)
                        .domain([0, 19]);
-    let svg = d3.select(this.$.chart).append('svg')
-        .attr('width', Math.max(SVG_MIN_WIDTH,
-            xScaleRange + SVG_MARGIN.left + SVG_MARGIN.right))
-        .attr('height', SVG_HEIGHT)
-        .append('g')
-        .attr('transform',
-            'translate(' + SVG_MARGIN.left + ',' + SVG_MARGIN.top + ')');
+    let svg = d3.select(this.$.chart).select('svg');
+    if (svg.empty()) {
+      svg = d3.select(this.$.chart).append('svg')
+          .attr('width', Math.max(SVG_MIN_WIDTH,
+              xScaleRange + SVG_MARGIN.left + SVG_MARGIN.right))
+          .attr('height', SVG_HEIGHT)
+          .append('g')
+          .attr('transform',
+              'translate(' + SVG_MARGIN.left + ',' + SVG_MARGIN.top + ')');
+      // Draw x-axis.
+      svg.append('g')
+          .attr('class', 'x axis')
+          .style('font-size', FONT_SIZE)
+          .attr('transform', 'translate(0,' + (height + 5) + ')');
+      // Draw y-axis.
+      svg.append('g')
+          .attr('class', 'y axis')
+          .style('font-size', FONT_SIZE)
+          .attr('transform', 'translate(0,0)');
+    }
     let stack = d3.stack().keys(stackKey).order(d3.stackOrderNone)
         .offset(d3.stackOffsetNone);
     const layers = stack(data);
@@ -83,7 +94,15 @@ Polymer({
         .nice();
     this.drawLayers(svg, layers, xScale, yScale, colorScale);
     this.drawAxes(svg, xScale, yScale, height);
-    this.drawLegend(svg, stackLabel, colorScale);
+    let legend = d3.select(this.$.chart).select('.legend');
+    if (legend.empty()) {
+      legend = svg.append('g')
+          .attr('class', 'legend')
+          .attr('font-family', 'sans-serif')
+          .attr('font-size', FONT_SIZE)
+          .attr('text-anchor', 'start')
+    }
+    this.drawLegend(legend, stackLabel, colorScale);
   },
   /**
    * Draw the layers for all the bars.
@@ -91,16 +110,17 @@ Polymer({
   drawLayers: function(svg: any, layers: any, xScale: any, yScale: any,
                        colorScale: any) {
     let parent = this;
+    // Update layer for each metric across all cores, and rect for each core.
     let layer = svg.selectAll('.layer').data(layers);
-    layer.enter().append('g').merge(layer)
-        .attr('class', 'layer')
+    let rects = layer.enter().append('g').attr('class', 'layer').merge(layer)
         .style('fill', (d, i) => colorScale(i))
-        .selectAll('rect').data((d) => d)
-        .enter().append('rect')
+        .selectAll('rect').data((d) => d);
+    rects.enter().append('rect').merge(rects)
         .attr('width', xScale.bandwidth())
         .attr('y', (d) => yScale(d[1]) ? yScale(d[1]) : 0)
         .attr('height',
             (d) => {
+              // For backward compatibility, old traces may have h undefeind.
               const h = yScale(d[0]) - yScale(d[1]);
               return h ? h : 0;
             })
@@ -114,53 +134,49 @@ Polymer({
             function(d) {
               d3.select(this).style('opacity', 1.0);
               parent.activeBar = null;
-            });
+            })
+        .transition()
+        .duration(TRANSITION_DURATION);
+    layer.exit().remove();
   },
   /**
    * Draw the axes of the chart.
    */
   drawAxes: function(svg: any, xScale: any, yScale: any, height: number) {
-    svg.append('g')
-        .attr('class', 'axis axis--x')
-        .style('font-size', FONT_SIZE)
-        .attr('transform', 'translate(0,' + (height + 5) + ')')
+    svg.select('.x.axis')
+        .transition()
+        .duration(TRANSITION_DURATION)     
         .call(d3.axisBottom(xScale));
-    svg.append('g')
-        .attr('class', 'axis axis--y')
-        .style('font-size', FONT_SIZE)
-        .attr('transform', 'translate(0,0)')
+    svg.select('.y.axis')
+        .transition()
+        .duration(TRANSITION_DURATION)
         .call(d3.axisLeft(yScale));
   },
   /**
    * Draw the legends of the chart.
    */
-  drawLegend: function(svg: any, labels: Array<string>, colorScale: any) {
-    let legend = svg.append('g')
-        .attr('font-family', 'sans-serif')
-        .attr('font-size', FONT_SIZE)
-        .attr('text-anchor', 'start')
-        .selectAll('g')
-        .data(labels.slice());
-    let legendG = legend.enter().append('g').merge(legend)
-        .attr('transform',
-            (d, i) => 'translate(' +
-                (i * LEGEND_WIDTH -
-                    Math.floor(i / LABELS_PER_LANE) * LEGEND_WIDTH *
-                        LABELS_PER_LANE) + ',' +
-                            Math.floor(i / LABELS_PER_LANE) *
-                                LEGEND_HEIGHT + ')'
-        );
+  drawLegend: function(selection: any, labels: Array<string>, colorScale: any) {
+    let legend = selection.selectAll('g').data(labels.slice());
+    legend.exit().remove();
 
-    legendG.append('rect')
-        .attr('x', YAXIS_TO_LEGEND)
+    let legendEnter = legend.enter().append('g');
+    legendEnter.append('rect')
         .attr('width', ICON_SIZE)
-        .attr('height', ICON_SIZE)
-        .attr('fill', (d, i) => colorScale(i));
-    legendG.append('text')
+        .attr('height', ICON_SIZE);
+    legendEnter.append('text')
         .attr('x', YAXIS_TO_LEGEND + LEGEND_MARGIN + ICON_SIZE)
         .attr('y', LEGEND_TEXT_HEIGHT)
         .attr('dy', LEGEND_TEXT_SIZE)
-        .text((d) => d);
+   
+    legend = legendEnter.merge(legend);
+    legend.attr('transform',
+        (d, i) => 'translate(' + (i * LEGEND_WIDTH -
+            Math.floor(i / LABELS_PER_LANE) * LEGEND_WIDTH *
+                LABELS_PER_LANE) + ',' +
+                    Math.floor(i / LABELS_PER_LANE) * LEGEND_HEIGHT + ')'
+        );
+    legend.selectAll('rect').attr('fill', (d, i) => colorScale(i));
+    legend.selectAll('text').text((d) => d);
   },
   /**
    * Redraw the stack bar chart.

--- a/tensorboard/plugins/profile/pod_viewer/stack_bar_chart/stack-bar-chart.ts
+++ b/tensorboard/plugins/profile/pod_viewer/stack_bar_chart/stack-bar-chart.ts
@@ -98,8 +98,12 @@ Polymer({
         .selectAll('rect').data((d) => d)
         .enter().append('rect')
         .attr('width', xScale.bandwidth())
-        .attr('y', (d) => yScale(d[1]))
-        .attr('height', (d) => yScale(d[0]) - yScale(d[1]))
+        .attr('y', (d) => yScale(d[1]) ? yScale(d[1]) : 0)
+        .attr('height',
+            (d) => {
+              const h = yScale(d[0]) - yScale(d[1]);
+              return h ? h : 0;
+            })
         .attr('x', (d, i) => xScale(parent.xDomainFunc(d.data)))
         .on('mouseover',
             function(d) {

--- a/tensorboard/plugins/profile/pod_viewer/topology_graph/BUILD
+++ b/tensorboard/plugins/profile/pod_viewer/topology_graph/BUILD
@@ -21,6 +21,5 @@ tf_web_library(
         "@org_polymer_paper_listbox",
         "@org_polymer_paper_menu",
         "@org_polymer_paper_menu_button",
-        "@org_polymer_paper_slider",
     ],
 )

--- a/tensorboard/plugins/profile/pod_viewer/topology_graph/topology-graph.html
+++ b/tensorboard/plugins/profile/pod_viewer/topology_graph/topology-graph.html
@@ -24,7 +24,6 @@ limitations under the License.
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../paper-item/paper-item.html">
 <link rel="import" href="../paper-listbox/paper-listbox.html">
-<link rel="import" href="../paper-slider/paper-slider.html">
 <link rel="import" href="pod-viewer-common.html">
 
 <dom-module id='topology-graph'>
@@ -170,13 +169,6 @@ paper-slider {
             </template>
           </paper-listbox>
         </paper-menu-button>
-        <div hidden="[[!_maxChannelId]]">
-          <span class="control-row-left metrics-label">Please select a channel id
-            <paper-slider min=[[_minChannelId]] max=[[_maxChannelId]]
-                snaps step="1" value="{{selectedChannelId}}" editable>
-            </paper-slider>
-          </span>
-        </div>
       </div>
       <div id="tpgraph"></div>
       <div id="tooltip" class="hidden">

--- a/tensorboard/plugins/profile/pod_viewer/topology_graph/topology-graph.ts
+++ b/tensorboard/plugins/profile/pod_viewer/topology_graph/topology-graph.ts
@@ -463,8 +463,8 @@ Polymer({
    * @return Path in svg format.
    */
   linkToPath: function(link: podviewer.proto.ChannelInfo): string {
-    const src = this.coreIdToPos(link.srcCoreId);
-    const dst = this.coreIdToPos(link.dstCoreId);
+    const src = this.coreIdToPos(link.srcCoreIds[0]);
+    const dst = this.coreIdToPos(link.dstCoreIds[0]);
     const path = 'M ' + src.x + ' ' + src.y + 'L ' + dst.x + ' ' + dst.y;
     return path;
   },

--- a/tensorboard/plugins/profile/pod_viewer/topology_graph/topology-graph.ts
+++ b/tensorboard/plugins/profile/pod_viewer/topology_graph/topology-graph.ts
@@ -16,6 +16,8 @@ const MAIN_COLORS = [
   '#ffffd9', '#edf8b1', '#c7e9b4', '#7fcdbb', '#41b6c4', '#1d91c0',
   '#225ea8', '#253494', '#081d58'
 ];
+const COLOR_SCALE =
+    d3.scaleQuantile<string>().domain([0, 1.0]).range(MAIN_COLORS);
 const SVG_WIDTH = 1620;
 const SVG_MARGIN = {top: 50, right: 0, bottom: 100, left: 30};
 
@@ -26,6 +28,8 @@ const HOST_TO_HOST_MARGIN = 10;
 
 const HOST_Y_STRIDE = 2;
 const NODES_PER_CHIP = 2;
+
+const TRANSITION_DURATION = 1000;
 
 interface Position {
   x: number,
@@ -46,7 +50,7 @@ interface TopoData {
   rid: number,
   /** Host name. */
   host: string,
-  /** Values of the selected metric. */
+  /** Values of the node. */
   values: Array<number>,
   /** Step total duration. */
   total: number,
@@ -59,6 +63,9 @@ interface HostData {
   /** Index on y-dimension. */
   ydim: number,
 };
+
+/** Src and dest ids of a link. */
+type SrcDestIds = [number, number];
 
 Polymer({
   is: 'topology-graph',
@@ -121,12 +128,6 @@ Polymer({
     _gSVG: {
       type: Object,
     },
-    _gLink: {
-      type: Object,
-    },
-    _colorScale: {
-      type: Object,
-    }
   },
   observers: ['drawTopology(_topoData, runEnvironment)'],
   /**
@@ -179,51 +180,51 @@ Polymer({
    * Main function to draw topology graph based on TPU topology.
    */
   topologyGraph: function(data: Array<TopoData>) {
-    d3.select(this.$.tpgraph).selectAll('g > *').remove();
-    d3.select(this.$.tpgraph).select('svg').remove();
-    d3.select(this.$.tpgraph).select('.svg-container').remove();
     this._hostGridWidth = this.getHostGridSize(this._hostXStride);
     this._hostGridHeight = this.getHostGridSize(HOST_Y_STRIDE);
     this._nodeGridWidth = CHIP_GRID_SIZE / NODES_PER_CHIP;
     this._nodeGridHeight = CHIP_GRID_SIZE;
     const hostXDim = this._xDimension / this._hostXStride;
     const hostYDim = this._yDimension / HOST_Y_STRIDE;
-    this._colorScale =
-        d3.scaleQuantile<string>().domain([0, 1.0]).range(MAIN_COLORS);
     const chipXDims = Array.from(Array(this._xDimension).keys());
     const chipYDims = Array.from(Array(this._yDimension).keys());
-    let svg = d3.select(this.$.tpgraph)
-        .append('svg')
-        .attr('width', SVG_WIDTH)
-        .attr('height', hostYDim * this._hostGridHeight
-            + SVG_MARGIN.bottom + SVG_MARGIN.top)
-        .append('g')
-        .attr('transform',
-            'translate(' + SVG_MARGIN.left + ',' + SVG_MARGIN.top + ')');
+    if (!this._gSVG) {
+      this._gSVG = d3.select(this.$.tpgraph)
+          .append('svg')
+          .attr('width', SVG_WIDTH)
+          .attr('height', hostYDim * this._hostGridHeight
+              + SVG_MARGIN.bottom + SVG_MARGIN.top)
+          .append('g')
+          .attr('transform',
+              'translate(' + SVG_MARGIN.left + ',' + SVG_MARGIN.top + ')');
+
+      // Creates a group for all rects.
+      this._gSVG.append('svg:g').classed('graph', true);
+      // Creates separate group for links, so that the z-index remains in the right order.
+      this._gSVG.append('svg:g').classed('link', true);
+
+      // Add a svg:defs for the arrow head.
+      this._gSVG.append('svg:defs').append('svg:marker')
+          .attr('id', 'arrow')
+          .attr('viewBox', '0 -5 10 10')
+          .attr('markerWidth', 5)
+          .attr('markerHeight', 5)
+          .attr('orient', 'auto')
+          .append('svg:path')
+          .style('stroke', 'red')
+          .style('fill', 'red')
+          .attr('d', 'M0,-5L10,0L0,5');
+    }
+    let svg = this._gSVG.select('.graph');
     const hostData = this.createHostData(hostXDim, hostYDim);
     this.drawHostCards(
         svg, hostData, this._hostGridWidth, this._hostGridHeight);
-    this.drawNodeCards(svg, data, this._colorScale);
-
-    // Creates separate groups, so that the z-index remains in the right order.
-    this._gLink = svg.append('svg:g').classed('link', true);
-
-    // Add a svg:defs for the arrow head.
-    svg.append('svg:defs').append('svg:marker')
-        .attr('id', 'arrow')
-        .attr('viewBox', '0 -5 10 10')
-        .attr('markerWidth', 5)
-        .attr('markerHeight', 5)
-        .attr('orient', 'auto')
-        .append('svg:path')
-        .style('stroke', 'red')
-        .style('fill', 'red')
-        .attr('d', 'M0,-5L10,0L0,5');
+    this.drawNodeCards(svg, data, COLOR_SCALE);
     this.drawLabels(svg, chipXDims, chipYDims);
     const legendYLoc =
         this._hostGridHeight * Math.ceil(this._yDimension / HOST_Y_STRIDE) +
         HOST_TO_HOST_MARGIN;
-    this.drawLegend(svg, legendYLoc, this._colorScale);
+    this.drawLegend(svg, legendYLoc, COLOR_SCALE);
   },
   /**
    * Returns the size of host grid, including the host card size and the margin
@@ -272,7 +273,7 @@ Polymer({
    */
   drawLabels: function(svg: any, xdims: number[], ydims: number[]) {
     // Draw label on x axis.
-    let xLabel = svg.selectAll('.xLabel').data(xdims);
+    let xLabel = svg.selectAll('.x-label').data(xdims);
     xLabel.enter().append('text').merge(xLabel)
         .text((d) => d)
         .attr('x', (d, i) => this.getChipXLoc(
@@ -281,10 +282,13 @@ Polymer({
         .attr('y', 0)
         .style('text-anchor', 'middle')
         .attr('transform', 'translate(' + CHIP_GRID_SIZE / 2 + ', -6)')
-        .attr('class', 'axis');
+        .attr('class', 'x-label')
+        .transition()
+        .duration(TRANSITION_DURATION);
+    xLabel.exit().remove();
 
     // Draw label on y axis.
-    let yLabel = svg.selectAll('.yLabel').data(ydims);
+    let yLabel = svg.selectAll('.y-label').data(ydims);
     yLabel.enter().append('text').merge(yLabel)
         .text((d) => d)
         .attr('x', 0)
@@ -292,19 +296,22 @@ Polymer({
                        Math.floor(i / HOST_Y_STRIDE), i % HOST_Y_STRIDE))
         .style('text-anchor', 'middle')
         .attr('transform', 'translate(-12,' + CHIP_GRID_SIZE / 2 + ')')
-        .attr('class', 'axis');
+        .attr('class', 'y-label')
+        .transition()
+        .duration(TRANSITION_DURATION);
+    yLabel.exit().remove();
   },
   /**
    * Draw the UI of host cards.
    */
   drawHostCards: function(svg, data, gridWidth: number, gridHeight: number) {
-    let cards = svg.selectAll('.xdim').data(data, (d) => d.xdim);
+    let cards = svg.selectAll('.host').data(data);
     cards.enter().append('rect').merge(cards)
         .attr('x', (d) => d.xdim * gridWidth)
         .attr('y', (d) => d.ydim * gridHeight)
         .attr('rx', 4 * gridWidth / gridHeight)
         .attr('ry', 4)
-        .attr('class', 'hour bordered')
+        .attr('class', 'host bordered')
         .attr('width', gridWidth - HOST_TO_HOST_MARGIN)
         .attr('height', gridHeight - HOST_TO_HOST_MARGIN)
         .attr('border', 1)
@@ -312,14 +319,14 @@ Polymer({
         .style('stroke', 'black')
         .style('stroke-width', 1)
         .transition()
-        .duration(1000);
+        .duration(TRANSITION_DURATION);
     cards.exit().remove();
   },
   /**
    * Draw the UI of node cards.
    */
   drawNodeCards: function(svg: any, data: Array<TopoData>, colorScale: any) {
-    let cards = svg.selectAll('.xdim').data(data, (d) => d.xdim);
+    let cards = svg.selectAll('.node').data(data);
     let parent = this;
     let metricIdx = Math.max(this.selectedMetricIdx, 0);
     cards.enter().append('rect').merge(cards)
@@ -336,7 +343,7 @@ Polymer({
         })
         .attr('rx', 4 / NODES_PER_CHIP)
         .attr('ry', 4)
-        .attr('class', 'hour bordered')
+        .attr('class', 'node bordered')
         .attr('width', this._nodeGridWidth)
         .attr('height', this._nodeGridHeight)
         .attr('border', 1)
@@ -358,29 +365,28 @@ Polymer({
         .on('mouseout', function() {
             d3.select(this).classed('cell-hover', false).style('opacity', 1.0);
             d3.select(parent.$.tooltip).classed('hidden', true);
-        });
+        })
+        .transition()
+        .duration(TRANSITION_DURATION)
     cards.exit().remove();
   },
   /**
    * Draw the UI of chip to chip links.
    */
-  drawLinks: function(linkData: Array<podviewer.proto.ChannelInfo>) {
-    if (!linkData || linkData.length == 0 || !this._gLink) {
+  drawLinks: function(svg: any, linkData: Array<SrcDestIds>) {
+    if (!linkData || !linkData.length || !svg) {
       return;
     }
-
-    // Handle links;
-    let links = this._gLink.selectAll('.link').data(linkData);
-
-    // attach the arrow from defs
+    let links = svg.select('.link').selectAll('path').data(linkData);
+    
+    // Draw a link from each srcCoreId to each dstCoreId,
+    // with an arrow from defs attached.
     links.enter().append('svg:path').merge(links)
-        .attr('id', (d) => 'cid' + d.channelId)
         .attr('stroke-width', 2)
         .attr('stroke', 'red')
         .attr('fill', 'none')
         .attr('marker-end', 'url(#arrow)')
-        .style('visibility', 'hidden')
-        .attr('d', (d) => this.linkToPath(d));
+        .attr('d', (d) => this.linkToPath(d[0], d[1]));
 
     // Handle deleted links.
     links.exit().remove();
@@ -408,9 +414,10 @@ Polymer({
    * Returns the svg path given the src and dst core and node id.
    * @return Path in svg format.
    */
-  linkToPath: function(link: podviewer.proto.ChannelInfo): string {
-    const src = this.coreIdToPos(link.srcCoreIds[0]);
-    const dst = this.coreIdToPos(link.dstCoreIds[0]);
+  linkToPath: function(srcCoreId: number|undefined,
+                       dstCoreId: number|undefined): string {
+    const src = this.coreIdToPos(srcCoreId ? srcCoreId : 0);
+    const dst = this.coreIdToPos(dstCoreId ? dstCoreId : 0);
     const path = 'M ' + src.x + ' ' + src.y + 'L ' + dst.x + ' ' + dst.y;
     return path;
   },
@@ -442,19 +449,22 @@ Polymer({
     const legendElementWidth = CHIP_GRID_SIZE * 2;
     let legend = svg.selectAll('.legend').data(
         [0].concat(colorScale.quantiles()), (d) => d);
-    let legendG = legend.enter().append('g').merge(legend)
-                      .attr('class', 'legend');
-    legendG.append('rect')
-        .attr('x', (d, i) => legendElementWidth * i)
-        .attr('y', height)
+    legend.exit().remove();
+
+    let legendEnter = legend.enter().append('g').attr('class', 'legend');
+    legendEnter.append('rect')
         .attr('width', legendElementWidth)
         .attr('height', CHIP_GRID_SIZE)
+        .merge(legend.select('rect'))
+        .attr('x', (d, i) => legendElementWidth * i)
+        .attr('y', height)
         .style('fill', (d, i) => MAIN_COLORS[i]);
-    legendG.append('text')
+
+    legendEnter.append('text')
+        .merge(legend.select('text'))
         .text((d) => '\u2265 0.' + Math.round(d * 10))
         .attr('x', (d, i) => legendElementWidth * i)
         .attr('y', height + CHIP_GRID_SIZE * 2);
-    legend.exit().remove();
   },
   /**
    * Redraws the graph when the data to be rendered changed.
@@ -466,7 +476,6 @@ Polymer({
       return;
     }
     this.topologyGraph(topoData);
-    this.drawLinks(this.data.channelDb);
   },
   attached: function() {
     this.drawTopology(this._topoData, this.runEnvironment);
@@ -477,7 +486,7 @@ Polymer({
   _selectedMetricIdxChanged: function(newIdx: number) {
     if (newIdx < 0) return;
     d3.select(this.$.tpgraph).selectAll('.node').style('fill',
-        (d) => this._colorScale(d['values'][newIdx] / d['total']));
+        (d) => COLOR_SCALE(d['values'][newIdx] / d['total']));
   },
   /**
    * Updates the topology color coding or selected channel id when the
@@ -497,8 +506,10 @@ Polymer({
         }
       }
       this.selectedMetricIdx = -1;
-    } else if (newData.channelId) {
-      this.selectedChannelId = newData.channelId;
+    } else if (newData.srcCoreIds) {
+      const links = newData.srcCoreIds.map(
+          (src, i) => [src, newData.dstCoreIds[i]]);
+      this.drawLinks(this._gSVG, links);
     }
   },
   /**


### PR DESCRIPTION
* Motivation for features / changes
When loading a large trace (~50MB), pod viewer takes a long time to render (>30s) and crashes the browser when changing the step or metric id. This change improves the logic and reduces the rendering and scripting time to ~1s. 

* Technical description of changes
1) Previously send recv links are saved for each replica, which doesn't scale for a 4-way spatial partitioning model on a tpu v3-2048 pod which have 512 replicas. In data processing (c++), we instead only save aggregated stats across all replicas to reduce the result json size. Instead of srcCoreId and dstCoreId for each replica, we save a list of srcCoreIds  and dstCoreIds of all replicas for each channel.
proto.ts reflects this changes.
2) There's another proto change that deprecates crsDurationUs and replace with allReduceComputeDurationUs and allReduceSyncDurationUs.
3) Changed details-card.ts, details-card.html and pod-viewer-dashboard.ts to ensure backward compatibility of those proto changes.
4)  Improve TopologyGraph scalability
     a. Change the _computeTopoData to not be triggered by changes in selectedMetricIdx. When selectedMetricIdx changes, we will only change the color of the cards (instead of redrawing).
     b. Remove the channel selection in topology-graph. The user can hover over the channel bars and select for the channel.
     c. Instead of drawing all the links at the beginning and change the visibility (this creates too many dom elements and causes browser to crash), this change only draws the links that with the selected channel id.
5) Fix the merge and updates of d3 (Selection was not on the right elements), and avoid redrawing stack-bar-chart and topology-graph from scratch. 

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)
bazel run :tensorboard -- --logdir=gs://cloud-tpu-tools-df
Select test run, and pod viewer tool. Under the 'new' host is the new trace, and others are old traces.

* Alternate designs / implementations considered
