### PR TITLE
Add option to select which model to use for counterfactual computation

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -2683,18 +2683,6 @@ limitations under the License.
         }
       },
 
-      // nearestCounterfactualDistChanged_: function() {
-      //   if (this.showNearestCounterfactual) {
-      //     this.findClosestCounterfactual_();
-      //   }
-      // },
-
-      // nearestCounterfactualModelChanged_: function() {
-      //   if (this.showNearestCounterfactual) {
-      //     this.findClosestCounterfactual_();
-      //   }
-      // },
-
       findClosestCounterfactual_: function() {
         const selected = this.selected[0];
         const modelInferenceValueStr =

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -190,6 +190,17 @@ limitations under the License.
         }
       }
 
+      .counterfactual-dropdown {
+        display: block;
+        width: 100px;
+        min-width: 100px;
+        padding-right: 10px;
+        --paper-input-container-input: {
+          font-size: 14px;
+          color: #3C4043;
+        }
+      }
+
       .slider-label {
         margin-top: 8px;
       }
@@ -1291,6 +1302,13 @@ limitations under the License.
                               <paper-radio-button name="L1">L1</paper-radio-button>
                               <paper-radio-button name="L2">L2</paper-radio-button>
                             </paper-radio-group>
+                            <paper-dropdown-menu label="Model:" no-label-float class="counterfactual-dropdown">
+                              <paper-listbox class="dropdown-content" selected="{{nearestCounterfactualModel}}">
+                                <template is="dom-repeat" items="[[parsedModelNames]]">
+                                  <paper-item>[[getCounterfactualModelName_(item)]]</paper-item>
+                                </template>
+                              </paper-listbox>
+                            </paper-dropdown-menu>
                             <paper-icon-button icon="info-outline" class="info-icon cf-info-icon no-padding" on-tap="openDialog">
                             </paper-icon-button>
                             <paper-dialog class="dialog-text" horizontal-align="auto" vertical-align="auto">
@@ -2266,6 +2284,12 @@ limitations under the License.
           value: '',
           observer: 'labelFeatureSelected_',
         },
+        // Choose which model is used for counterfactual computation
+        nearestCounterfactualModel: {
+          type: Number,
+          value: 0,
+          observer: 'nearestCounterfactualModelChanged_',
+        },
         // Calculated statistics from the inference results.
         inferenceStats_: {
           type: Array,
@@ -2667,11 +2691,17 @@ limitations under the License.
         }
       },
 
-      // TODO (tolgab) Update for model comparison
+      nearestCounterfactualModelChanged_: function() {
+        if (this.showNearestCounterfactual) {
+          this.findClosestCounterfactual_();
+        }
+      },
+
       findClosestCounterfactual_: function() {
         const selected = this.selected[0];
         const modelInferenceValueStr =
-            this.strWithModelName_(inferenceValueStr, 0);
+            this.strWithModelName_(inferenceValueStr,
+                                   this.nearestCounterfactualModel);
         let closestDist = Number.POSITIVE_INFINITY;
         let closest = -1;
         for (let i = 0; i < this.visdata.length; i++) {
@@ -4005,6 +4035,10 @@ limitations under the License.
           return '<none>';
         }
         return feature;
+      },
+
+      getCounterfactualModelName_: function(modelName) {
+        return 'Model: ' + modelName;
       },
 
       getClassName_: function(cls) {

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -191,10 +191,10 @@ limitations under the License.
       }
 
       .counterfactual-dropdown {
-        display: block;
+        display: inline-block;
         width: 100px;
-        min-width: 100px;
-        padding-right: 10px;
+        min-width: 50px;
+        padding-right: 5px;
         --paper-input-container-input: {
           font-size: 14px;
           color: #3C4043;
@@ -1302,7 +1302,7 @@ limitations under the License.
                               <paper-radio-button name="L1">L1</paper-radio-button>
                               <paper-radio-button name="L2">L2</paper-radio-button>
                             </paper-radio-group>
-                            <paper-dropdown-menu label="Model:" no-label-float class="counterfactual-dropdown">
+                            <paper-dropdown-menu label="Model:" no-label-float class="counterfactual-dropdown" hidden$="[[shouldHideCounterfactualModelSelector_(parsedModelNames)]]">
                               <paper-listbox class="dropdown-content" selected="{{nearestCounterfactualModel}}">
                                 <template is="dom-repeat" items="[[parsedModelNames]]">
                                   <paper-item>[[getCounterfactualModelName_(item)]]</paper-item>
@@ -2896,6 +2896,10 @@ limitations under the License.
 
       shouldShowLabelDropdown_: function(stats) {
         return stats && Object.keys(stats).length > 0;
+      },
+
+      shouldHideCounterfactualModelSelector_: function(modelNames) {
+        return !(modelNames && modelNames.length > 1);
       },
 
       shouldShowOverallPrChart_: function(selectedLabelFeature,

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -1303,7 +1303,7 @@ limitations under the License.
                               <paper-radio-button name="L2">L2</paper-radio-button>
                             </paper-radio-group>
                             <paper-dropdown-menu label="Model:" no-label-float class="counterfactual-dropdown" hidden$="[[shouldHideCounterfactualModelSelector_(parsedModelNames)]]">
-                              <paper-listbox class="dropdown-content" selected="{{nearestCounterfactualModel}}">
+                              <paper-listbox class="dropdown-content" selected="{{nearestCounterfactualModelIndex}}">
                                 <template is="dom-repeat" items="[[parsedModelNames]]">
                                   <paper-item>[[getCounterfactualModelName_(item)]]</paper-item>
                                 </template>
@@ -2285,10 +2285,9 @@ limitations under the License.
           observer: 'labelFeatureSelected_',
         },
         // Choose which model is used for counterfactual computation
-        nearestCounterfactualModel: {
+        nearestCounterfactualModelIndex: {
           type: Number,
           value: 0,
-          observer: 'nearestCounterfactualModelChanged_',
         },
         // Calculated statistics from the inference results.
         inferenceStats_: {
@@ -2452,7 +2451,6 @@ limitations under the License.
         nearestCounterfactualDist: {
           type: String,
           value: "L1",
-          observer: 'nearestCounterfactualDistChanged_',
         },
         visMode: {
           type: String,
@@ -2490,7 +2488,6 @@ limitations under the License.
         showNearestCounterfactual: {
           type: Boolean,
           value: false,
-          observer: 'showNearestCounterfactualChanged_',
         },
         selectedFeatureSort: {
           type: String,
@@ -2553,6 +2550,7 @@ limitations under the License.
 
       observers: [
         'setFacetDistFeatureName(facetDistSwitch, selected)',
+        'nearestCounterfactualStatusChanged_(showNearestCounterfactual, nearestCounterfactualModelIndex, nearestCounterfactualDist)'
       ],
 
       // Required function.
@@ -2673,7 +2671,7 @@ limitations under the License.
             ' distance to datapoint ' + selected[0];
       },
 
-      showNearestCounterfactualChanged_: function(show) {
+      nearestCounterfactualStatusChanged_: function(show) {
         if (show) {
           this.findClosestCounterfactual_();
         } else {
@@ -2685,23 +2683,23 @@ limitations under the License.
         }
       },
 
-      nearestCounterfactualDistChanged_: function() {
-        if (this.showNearestCounterfactual) {
-          this.findClosestCounterfactual_();
-        }
-      },
+      // nearestCounterfactualDistChanged_: function() {
+      //   if (this.showNearestCounterfactual) {
+      //     this.findClosestCounterfactual_();
+      //   }
+      // },
 
-      nearestCounterfactualModelChanged_: function() {
-        if (this.showNearestCounterfactual) {
-          this.findClosestCounterfactual_();
-        }
-      },
+      // nearestCounterfactualModelChanged_: function() {
+      //   if (this.showNearestCounterfactual) {
+      //     this.findClosestCounterfactual_();
+      //   }
+      // },
 
       findClosestCounterfactual_: function() {
         const selected = this.selected[0];
         const modelInferenceValueStr =
             this.strWithModelName_(inferenceValueStr,
-                                   this.nearestCounterfactualModel);
+                                   this.nearestCounterfactualModelIndex);
         let closestDist = Number.POSITIVE_INFINITY;
         let closest = -1;
         for (let i = 0; i < this.visdata.length; i++) {


### PR DESCRIPTION
* Motivation for features / changes
This PR adds the ability to choose which model to use for for counterfactual example computation (Previously, it was computed with respect to first model).

* Technical description of changes
Added a drop-down menu to choose model name in counterfactual settings row. This panel is hidden when there is only one loaded model.

* Screenshots of UI changes

![Screenshot from 2019-05-21 09-47-57](https://user-images.githubusercontent.com/6536229/58116740-08ef7880-7bcb-11e9-8b5f-88137a1ea527.png)

![Screenshot from 2019-05-21 09-48-18](https://user-images.githubusercontent.com/6536229/58116763-1442a400-7bcb-11e9-9926-557d5bc490fb.png)

* Detailed steps to verify changes work correctly (as executed by you)
I ran all demos locally and verified that counterfactuals are computed correctly for the chosen model.

* Alternate designs / implementations considered
