### PR TITLE
Fix WIT multiclass confusion matrix

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3176,8 +3176,8 @@ limitations under the License.
                 const modelInferenceValueStr =
                   this.strWithModelName_(inferenceValueStr, modelInd);
                 let count = statsActual[item[modelInferenceValueStr]];
-                allLabels.add(item[modelInferenceValueStr]);
-                allLabels.add(item[modelInferenceValueStr]);
+                allLabels.add(String(item[modelInferenceValueStr]));
+                allLabels.add(String(item[this.selectedLabelFeature]));
                 if (count == null) {
                   statsActual[item[modelInferenceValueStr]] = 1;
                 } else {


### PR DESCRIPTION
* Motivation for features / changes

In certain cases the confusion matrix was missing entries.

* Technical description of changes

Correctly add both the inferred label and the true label to the set of all labels to show in the multiclass confusion matrix, including coercing all labels to strings. 

* Screenshots of UI changes

![fixconfmatrix](https://user-images.githubusercontent.com/15835086/58117622-fece7980-7bcc-11e9-8144-19dc0e76b427.png)
* Detailed steps to verify changes work correctly (as executed by you)

Verified continued correct working in multiclass demo, and verified correct behavior in multiclass colab notebook that displayed this issue.
