### PR TITLE
Extensible plugin infrastructural changes

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -192,6 +192,19 @@ py_library(
     ],
 )
 
+py_test(
+    name = "default_test",
+    size = "small",
+    srcs = ["default_test.py"],
+    srcs_version = "PY2AND3",
+    tags = ["support_notf"],
+    deps = [
+        ":default",
+        ":test",
+        "//tensorboard/plugins/scalar:scalars_plugin",
+    ],
+)
+
 py_library(
     name = "version",
     srcs = ["version.py"],

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -171,6 +171,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        "//tensorboard:expect_pkg_resources_installed",
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/plugins/audio:audio_plugin",
         "//tensorboard/plugins/beholder:beholder_plugin_loader",
@@ -201,7 +202,9 @@ py_test(
     deps = [
         ":default",
         ":test",
-        "//tensorboard/plugins/scalar:scalars_plugin",
+        "//tensorboard:expect_pkg_resources_installed",
+        "//tensorboard/plugins:base_plugin",
+        "@org_pythonhosted_mock",
     ],
 )
 
@@ -282,6 +285,14 @@ py_library(
     # This is a dummy rule used as a absl-py dependency in open-source.
     # We expect absl-py to already be installed on the system, e.g. via
     # `pip install absl-py`
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "expect_pkg_resources_installed",
+    # This is a dummy rule used as a pkg-resources dependency in open-source.
+    # We expect pkg-resources to already be installed on the system, e.g., via
+    # `pip install setuptools`.
     visibility = ["//visibility:public"],
 )
 

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -277,9 +277,14 @@ class TensorBoardWSGI(object):
     response = {}
     for plugin in self._plugins:
       start = time.time()
+      module_path = None
+      if plugin.es_module_path() is not None:
+        module_path = (self._path_prefix + DATA_PREFIX + PLUGIN_PREFIX + '/' +
+                       plugin.plugin_name + plugin.es_module_path())
+
       response[plugin.plugin_name] = {
           'enabled': plugin.is_active(),
-          'es_module_path': plugin.es_module_path() or '',
+          'es_module_path': module_path,
       }
       elapsed = time.time() - start
       logger.info(

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -277,7 +277,10 @@ class TensorBoardWSGI(object):
     response = {}
     for plugin in self._plugins:
       start = time.time()
-      response[plugin.plugin_name] = plugin.is_active()
+      response[plugin.plugin_name] = {
+          'enabled': plugin.is_active(),
+          'es_module_path': plugin.es_module_path() or '',
+      }
       elapsed = time.time() - start
       logger.info(
           'Plugin listing: is_active() for %s took %0.3f seconds',

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -817,8 +817,11 @@ limitations under the License.
         return this._dashboardData
             .map((d) => d.plugin)
             .filter((dashboardName) => {
-                return this._pluginsListing[dashboardName] &&
-                    this._pluginsListing[dashboardName].enabled;
+                const maybeMetadata = this._pluginsListing[dashboardName];
+                if (typeof maybeMetadata === 'boolean') {
+                  return maybeMetadata;
+                }
+                return this._pluginsListing[dashboardName].enabled;
             });
       },
 

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -817,11 +817,15 @@ limitations under the License.
         return this._dashboardData
             .map((d) => d.plugin)
             .filter((dashboardName) => {
+                // TODO(stephanwlee): Remove boolean code path when releasing
+                // 2.0.
+                // PluginsListing can be an object whose key is name of the
+                // plugin and value is a boolean indicating whether if it is
+                // enabled. This is deprecated but we will maintain backwards
+                // compatibility for some time.
                 const maybeMetadata = this._pluginsListing[dashboardName];
-                if (typeof maybeMetadata === 'boolean') {
-                  return maybeMetadata;
-                }
-                return this._pluginsListing[dashboardName].enabled;
+                if (typeof maybeMetadata === 'boolean') return maybeMetadata;
+                return maybeMetadata && maybeMetadata.enabled;
             });
       },
 

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -465,17 +465,18 @@ limitations under the License.
           value: _.values(tf_tensorboard.dashboardRegistry),
         },
 
+        _pluginsListing: {
+          type: Object,
+          value: () => ({}),
+        },
+
         /**
-         * The set of currently active dashboards. `null` if not yet fetched.
-         *
-         * TODO(@wchargin): Consider templating in an initial value for
-         * this property.
-         *
+         * The set of currently active dashboards.
          * @type {Array<string>?}
          */
         _activeDashboards: {
           type: Array,
-          value: null,
+          computed: '_computeActiveDashboard(_dashboardData, _pluginsListing)'
         },
 
         /** @type {tf_tensorboard.ActiveDashboardsLoadState} */
@@ -812,15 +813,22 @@ limitations under the License.
         this._lastReloadTime = new Date().toString();
       },
 
-      _fetchActiveDashboards() {
+      _computeActiveDashboard() {
+        return this._dashboardData
+            .map((d) => d.plugin)
+            .filter((dashboardName) => {
+                return this._pluginsListing[dashboardName] &&
+                    this._pluginsListing[dashboardName].enabled;
+            });
+      },
+
+      _fetchPluginsListing() {
         this._canceller.cancelAll();
-        const updateActiveDashboards = this._canceller.cancellable(result => {
+        const updatePluginsListing = this._canceller.cancellable(result => {
           if (result.cancelled) {
             return;
           }
-          const activePlugins = result.value;
-          this._activeDashboards = this._dashboardData.map(
-              d => d.plugin).filter(p => activePlugins[p]);
+          this._pluginsListing = result.value;
           this._activeDashboardsLoadState = tf_tensorboard.ActiveDashboardsLoadState.LOADED;
         });
         const onFailure = () => {
@@ -834,7 +842,7 @@ limitations under the License.
         };
         return this._requestManager
           .request(tf_backend.getRouter().pluginsListing())
-          .then(updateActiveDashboards, onFailure);
+          .then(updatePluginsListing, onFailure);
       },
 
       _computeActiveDashboardsNotLoaded(state) {
@@ -878,7 +886,7 @@ limitations under the License.
       _reloadData() {
         this._refreshing = true;
         return Promise.all([
-          this._fetchActiveDashboards(),
+          this._fetchPluginsListing(),
           tf_backend.environmentStore.refresh(),
           tf_backend.runsStore.refresh(),
           tf_backend.experimentsStore.refresh(),

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -95,22 +95,19 @@ def get_plugins():
 def get_dynamic_plugins():
   """Returns a list specifying TensorBoard's dynamically loaded plugins.
 
-	A dynamic TensorBoard plugin is specified using entry_points [1]. This will be
-  the de facto mechanism to load plugins and there no longer will be a concept
-  of the first-party plugins as depicted above in `get_plugins`.
+  A dynamic TensorBoard plugin is specified using entry_points [1] and it is
+  the primary way to integrate plugin whose code does not reside in TensorBoard
+  repository.
 
   This list can be passed to the `tensorboard.program.TensorBoard` API.
 
   Returns:
-		a list of base_plugin.TBPlugin
+    list of base_plugin.TBLoader or base_plugin.TBPlugin.
 
   [1]: https://packaging.python.org/specifications/entry-points/
   """
-  dynamic_plugins = [
-      entry_point.load()
-      for entry_point
-      in pkg_resources.iter_entry_points('tensorboard_plugins')]
-
   return [
-      get_plugin()[2]
-      for get_plugin in dynamic_plugins]
+      entry_point.load()
+      for entry_point in pkg_resources.iter_entry_points('tensorboard_plugins')
+  ]
+

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 
 import logging
 import os
+import pkg_resources
 
 from tensorboard.compat import tf
 from tensorboard.plugins import base_plugin
@@ -86,4 +87,30 @@ def get_plugins():
 
   :rtype: list[Union[base_plugin.TBLoader, Type[base_plugin.TBPlugin]]]
   """
+
   return _PLUGINS[:]
+
+# TODO(stephanwlee): Combine with get_plugins when concept of first-party
+# plugins is undone.
+def get_dynamic_plugins():
+  """Returns a list specifying TensorBoard's dynamically loaded plugins.
+
+	A dynamic TensorBoard plugin is specified using entry_points [1]. This will be
+  the de facto mechanism to load plugins and there no longer will be a concept
+  of the first-party plugins as depicted above in `get_plugins`.
+
+  This list can be passed to the `tensorboard.program.TensorBoard` API.
+
+  Returns:
+		a list of base_plugin.TBPlugin
+
+  [1]: https://packaging.python.org/specifications/entry-points/
+  """
+  dynamic_plugins = [
+      entry_point.load()
+      for entry_point
+      in pkg_resources.iter_entry_points('tensorboard_plugins')]
+
+  return [
+      get_plugin()[2]
+      for get_plugin in dynamic_plugins]

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -90,14 +90,12 @@ def get_plugins():
 
   return _PLUGINS[:]
 
-# TODO(stephanwlee): Combine with get_plugins when concept of first-party
-# plugins is undone.
+
 def get_dynamic_plugins():
   """Returns a list specifying TensorBoard's dynamically loaded plugins.
 
   A dynamic TensorBoard plugin is specified using entry_points [1] and it is
-  the primary way to integrate plugin whose code does not reside in TensorBoard
-  repository.
+  the robust way to integrate plugins into TensorBoard.
 
   This list can be passed to the `tensorboard.program.TensorBoard` API.
 

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ from __future__ import print_function
 
 import logging
 import os
+
 import pkg_resources
 
 from tensorboard.compat import tf
@@ -108,4 +109,3 @@ def get_dynamic_plugins():
       entry_point.load()
       for entry_point in pkg_resources.iter_entry_points('tensorboard_plugins')
   ]
-

--- a/tensorboard/default_test.py
+++ b/tensorboard/default_test.py
@@ -40,14 +40,14 @@ class FakePlugin(base_plugin.TBPlugin):
 class FakeEntryPoint(pkg_resources.EntryPoint):
   """EntryPoint class that fake loads FakePlugin."""
 
-  @staticmethod
-  def create():
+  @classmethod
+  def create(cls):
     """Creates an instance of FakeEntryPoint.
 
     Returns:
       instance of FakeEntryPoint
     """
-    return FakeEntryPoint('foo', 'bar')
+    return cls('foo', 'bar')
 
   def load(self):
     """Returns FakePlugin instead of resolving module.

--- a/tensorboard/default_test.py
+++ b/tensorboard/default_test.py
@@ -1,0 +1,87 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Collection of first-party plugins.
+
+This module exists to isolate tensorboard.program from the potentially
+heavyweight build dependencies for first-party plugins. This way people
+doing custom builds of TensorBoard have the option to only pay for the
+dependencies they want.
+
+This module also grants the flexibility to those doing custom builds, to
+automatically inherit the centrally-maintained list of standard plugins,
+for less repetition.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+  # python version >= 3.3
+  from unittest import mock  # pylint: disable=g-import-not-at-top
+except ImportError:
+  import mock  # pylint: disable=g-import-not-at-top,unused-import
+
+import pkg_resources
+
+from tensorboard import default
+from tensorboard.plugins import base_plugin
+from tensorboard import test
+
+
+class FakePlugin(base_plugin.TBPlugin):
+  """FakePlugin for testing."""
+
+  plugin_name = 'fake'
+
+
+class FakeEntryPoint(pkg_resources.EntryPoint):
+  """EntryPoint class that fake loads FakePlugin."""
+
+  @staticmethod
+  def create():
+    """Creates an instance off FakeEntryPoint.
+
+    Returns:
+      instance of FakeEntryPoint
+    """
+    return FakeEntryPoint('foo', 'bar')
+
+
+  def load(self):
+    """Returns FakePlugin instead of resolving module.
+
+    Returns:
+      FakePlugin
+    """
+    return FakePlugin
+
+
+
+class DefaultTest(test.TestCase):
+
+  @mock.patch.object(pkg_resources, 'iter_entry_points')
+  def test_get_dynamic_plugin(self, mock_iter_entry_points):
+    mock_iter_entry_points.return_value = [FakeEntryPoint.create()]
+
+    actual_plugins = default.get_dynamic_plugins()
+
+    mock_iter_entry_points.assert_called_with('tensorboard_plugins')
+    self.assertEquals(actual_plugins, [FakePlugin])
+
+
+if __name__ == "__main__":
+  test.main()
+

--- a/tensorboard/default_test.py
+++ b/tensorboard/default_test.py
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Collection of first-party plugins.
-
-This module exists to isolate tensorboard.program from the potentially
-heavyweight build dependencies for first-party plugins. This way people
-doing custom builds of TensorBoard have the option to only pay for the
-dependencies they want.
-
-This module also grants the flexibility to those doing custom builds, to
-automatically inherit the centrally-maintained list of standard plugins,
-for less repetition.
-"""
+"""Unit tests for `tensorboard.default`."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -52,13 +42,12 @@ class FakeEntryPoint(pkg_resources.EntryPoint):
 
   @staticmethod
   def create():
-    """Creates an instance off FakeEntryPoint.
+    """Creates an instance of FakeEntryPoint.
 
     Returns:
       instance of FakeEntryPoint
     """
     return FakeEntryPoint('foo', 'bar')
-
 
   def load(self):
     """Returns FakePlugin instead of resolving module.
@@ -67,7 +56,6 @@ class FakeEntryPoint(pkg_resources.EntryPoint):
       FakePlugin
     """
     return FakePlugin
-
 
 
 class DefaultTest(test.TestCase):
@@ -79,9 +67,8 @@ class DefaultTest(test.TestCase):
     actual_plugins = default.get_dynamic_plugins()
 
     mock_iter_entry_points.assert_called_with('tensorboard_plugins')
-    self.assertEquals(actual_plugins, [FakePlugin])
+    self.assertEqual(actual_plugins, [FakePlugin])
 
 
 if __name__ == "__main__":
   test.main()
-

--- a/tensorboard/http_api.md
+++ b/tensorboard/http_api.md
@@ -55,7 +55,11 @@ Example response:
     {
       "scalars": {
         "enabled": true,
-        "es_module_path": "/data/plugin/scalars/plugins/main.js"
+        "es_module_path": null
+      },
+      "my_shiny_plugin": {
+        "enabled": true,
+        "es_module_path": "/data/plugin/my_shiny_plugin/main.js"
       }
     }
 

--- a/tensorboard/http_api.md
+++ b/tensorboard/http_api.md
@@ -35,7 +35,8 @@ The `logdir` argument is the path of the directory that contains events files.
 
 ## `data/plugins_listing`
 
-Returns a dict mapping from plugin name to an object that describes a plugin.
+Returns a dict mapping from plugin name to an object that describes a
+plugin.
 
 The object contains a property `enabled`, a boolean indicating whether
 the plugin is active. A plugin might be inactive, for instance, if it
@@ -44,17 +45,17 @@ frontend to hide or deprioritize inactive plugins so that the user can
 focus on the plugins that have data. Note that inactive plugins may
 still be rendered if the user explicitly requests this.
 
-Another property `es_module_path` is an optional one that describes a path to
-the main JavaScript plugin module that will be loaded onto an iframe. For "v1"
-plugins whose JavaScript source is incorporated into webfiles.zip, the field is
-empty.
+Another property `es_module_path` is an optional one that describes a
+path to the main JavaScript plugin module that will be loaded onto an
+iframe. For "v1" plugins whose JavaScript source is incorporated into
+webfiles.zip, the field is empty.
 
 Example response:
 
     {
       "scalars": {
         "enabled": true,
-        "es_module_path": "/scalars/plugins/main.js"
+        "es_module_path": "/data/plugin/scalars/plugins/main.js"
       }
     }
 

--- a/tensorboard/http_api.md
+++ b/tensorboard/http_api.md
@@ -48,7 +48,7 @@ still be rendered if the user explicitly requests this.
 Another property `es_module_path` is an optional one that describes a
 path to the main JavaScript plugin module that will be loaded onto an
 iframe. For "v1" plugins whose JavaScript source is incorporated into
-webfiles.zip, the field is empty.
+webfiles.zip, the field is null.
 
 Example response:
 

--- a/tensorboard/http_api.md
+++ b/tensorboard/http_api.md
@@ -35,12 +35,29 @@ The `logdir` argument is the path of the directory that contains events files.
 
 ## `data/plugins_listing`
 
-Returns a dict mapping from plugin name to a boolean indicating whether
+Returns a dict mapping from plugin name to an object that describes a plugin.
+
+The object contains a property `enabled`, a boolean indicating whether
 the plugin is active. A plugin might be inactive, for instance, if it
 lacks relevant data. Every plugin has a key. This route allows the
 frontend to hide or deprioritize inactive plugins so that the user can
 focus on the plugins that have data. Note that inactive plugins may
 still be rendered if the user explicitly requests this.
+
+Another property `es_module_path` is an optional one that describes a path to
+the main JavaScript plugin module that will be loaded onto an iframe. For "v1"
+plugins whose JavaScript source is incorporated into webfiles.zip, the field is
+empty.
+
+Example response:
+
+    {
+      "scalars": {
+        "enabled": true,
+        "es_module_path": "/scalars/plugins/main.js"
+      }
+    }
+
 
 ## `data/runs`
 

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -54,8 +54,9 @@ def run_main():
     print("TensorFlow installation not found - running with reduced feature set.",
           file=sys.stderr)
 
-  tensorboard = program.TensorBoard(default.get_plugins(),
-                                    program.get_default_assets_zip_provider())
+  tensorboard = program.TensorBoard(
+			default.get_plugins() + default.get_dynamic_plugins(),
+			program.get_default_assets_zip_provider())
   try:
     from absl import app
     # Import this to check that app.run() will accept the flags_parser argument.

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -55,8 +55,8 @@ def run_main():
           file=sys.stderr)
 
   tensorboard = program.TensorBoard(
-			default.get_plugins() + default.get_dynamic_plugins(),
-			program.get_default_assets_zip_provider())
+      default.get_plugins() + default.get_dynamic_plugins(),
+      program.get_default_assets_zip_provider())
   try:
     from absl import app
     # Import this to check that app.run() will accept the flags_parser argument.

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -30,6 +30,7 @@ REQUIRED_PACKAGES = [
     'markdown >= 2.6.8',
     'numpy >= 1.12.0',
     'protobuf >= 3.6.0',
+    'setuptools >= 41.0.0',
     'six >= 1.10.0',
     'werkzeug >= 0.11.15',
     # python3 specifically requires wheel 0.26

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -75,6 +75,18 @@ class TBPlugin(object):
     """
     raise NotImplementedError()
 
+  def es_module_path(self):
+    """Returns one of the keys in get_plugin_apps that is an entry ES module.
+
+    For a plugin that is loaded onto an iframe, a frontend entry point has to be
+    specified. For a plugin that is bundled with TensorBoard as part of
+    webfiles.zip, return None.
+
+    Returns:
+      A key in the get_plugins_apps.
+    """
+    return None
+
 
 class TBContext(object):
   """Magic container of information passed from TensorBoard core to plugins.

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -78,12 +78,15 @@ class TBPlugin(object):
   def es_module_path(self):
     """Returns one of the keys in get_plugin_apps that is an entry ES module.
 
-    For a plugin that is loaded onto an iframe, a frontend entry point has to be
+    For a plugin that is loaded into an iframe, a frontend entry point has to be
     specified. For a plugin that is bundled with TensorBoard as part of
     webfiles.zip, return None.
 
+    TODO(tensorboard-team): describe the contract/API for the ES module when
+    it is better defined.
+
     Returns:
-      A key in the get_plugins_apps.
+      A key in the result of `get_plugin_apps()`, or None.
     """
     return None
 


### PR DESCRIPTION
This is the change based on https://github.com/tensorflow/community/pull/90.

The change makes two improvements:
1.  allow dynamic plugins (as spec in the RFC; uses entry_points to discover) to be loaded
2. change `plugins_listing` contract to include metadata about plugins including their respective FE entry point.

Notes on default_test: tried to get this tested end-to-end but setuptools was a bit cumbersome to test. For specifically, `setuptools.setup` cannot be invoked programmatically and it can lead to bad side-effects when not cleaned up properly.