### PR TITLE
Add more options for TPU profiling

### DIFF
--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -427,11 +427,11 @@ class ProfilePlugin(base_plugin.TBPlugin):
   @wrappers.Request.application
   def capture_route(self, request):
     service_addr = request.args.get('service_addr')
-    duration = int(request.args.get('duration'))
+    duration = int(request.args.get('duration', '1000'))
     is_tpu_name = request.args.get('is_tpu_name') == 'true'
     worker_list = request.args.get('worker_list')
     include_dataset_ops = request.args.get('include_dataset_ops') == 'true'
-    num_tracing_attempts = int(request.args.get('num_retry')) + 1
+    num_tracing_attempts = int(request.args.get('num_retry', '0')) + 1
 
     if is_tpu_name:
       try:
@@ -455,7 +455,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
       self.master_tpu_unsecure_channel = master_ip
     try:
       profiler_client.start_tracing(service_addr, self.logdir, duration,
-          worker_list, include_dataset_ops, num_tracing_attempts);
+          worker_list, include_dataset_ops, num_tracing_attempts)
       return http_util.Respond(
           request, {'result': 'Capture profile successfully. Please refresh.'},
           'application/json')

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -431,7 +431,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
     is_tpu_name = request.args.get('is_tpu_name') == 'true'
     worker_list = request.args.get('worker_list')
     include_dataset_ops = request.args.get('include_dataset_ops') == 'true'
-    num_tracing_attempts = int(request.args.get('num_tracing_attempts'))
+    num_tracing_attempts = int(request.args.get('num_retry')) + 1
 
     if is_tpu_name:
       try:

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -73,14 +73,14 @@ def process_raw_trace(raw_trace):
   trace.ParseFromString(raw_trace)
   return ''.join(trace_events_json.TraceEventsJsonStream(trace))
 
-def get_workers_list(cluster_resolver):
+def get_worker_list(cluster_resolver):
   """Parses TPU workers list from the cluster resolver."""
   cluster_spec = cluster_resolver.cluster_spec()
   task_indices = cluster_spec.task_indices('worker')
-  workers_list = [
+  worker_list = [
       cluster_spec.task_address('worker', i).split(':')[0] for i in task_indices
   ]
-  return ','.join(workers_list)
+  return ','.join(worker_list)
 
 class ProfilePlugin(base_plugin.TBPlugin):
   """Profile Plugin for TensorBoard."""
@@ -427,18 +427,16 @@ class ProfilePlugin(base_plugin.TBPlugin):
   @wrappers.Request.application
   def capture_route(self, request):
     service_addr = request.args.get('service_addr')
-    try:
-      duration = int(request.args.get('duration'))
-    except TypeError:
-      # Returns code=200 to show error message in UI.
-      return http_util.Respond(request, {'error': 'invalid duration.'},
-                               'application/json', code=200)
+    duration = int(request.args.get('duration'))
     is_tpu_name = request.args.get('is_tpu_name') == 'true'
-    workers_list = ''
+    worker_list = request.args.get('worker_list')
+    include_dataset_ops = request.args.get('include_dataset_ops') == 'true'
+    num_tracing_attempts = int(request.args.get('num_tracing_attempts'))
+
     if is_tpu_name:
       try:
         tpu_cluster_resolver = (
-            tf.distribute.cluster_resolver.TPUClusterResolver([service_addr]))
+            tf.distribute.cluster_resolver.TPUClusterResolver(service_addr))
         master_grpc_addr = tpu_cluster_resolver.get_master()
       except (ImportError, RuntimeError) as err:
         return http_util.Respond(request, {'error': err.message},
@@ -447,7 +445,8 @@ class ProfilePlugin(base_plugin.TBPlugin):
         return http_util.Respond(request,
             {'error': 'no TPUs with the specified names exist.'},
              'application/json', code=200)
-      workers_list = get_workers_list(tpu_cluster_resolver)
+      if not worker_list:
+        worker_list = get_worker_list(tpu_cluster_resolver)
       # TPU cluster resolver always returns port 8470. Replace it with 8466
       # on which profiler service is running.
       master_ip = master_grpc_addr.replace('grpc://', '').replace(':8470', '')
@@ -455,8 +454,8 @@ class ProfilePlugin(base_plugin.TBPlugin):
       # Set the master TPU for streaming trace viewer.
       self.master_tpu_unsecure_channel = master_ip
     try:
-      profiler_client.start_tracing(service_addr, self.logdir,
-                                    duration, workers_list);
+      profiler_client.start_tracing(service_addr, self.logdir, duration,
+          worker_list, include_dataset_ops, num_tracing_attempts);
       return http_util.Respond(
           request, {'result': 'Capture profile successfully. Please refresh.'},
           'application/json')

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -70,7 +70,9 @@ profile run can have multiple tools that present the performance profile as diff
   <paper-input label="Profiler Service URL or TPU name"
                always-float-label
                placeholder="localhost:6009"
-               value="{{_profilerServiceAddress}}"></paper-input>
+               value="{{_profilerServiceAddress}}"
+               auto-validate
+               required></paper-input>
   <label id="profiler-address-type-label">Address Type:</label>
   <paper-radio-group selected="{{_profilerServiceAddressType}}"
                      aria-labelledby="profiler-address-type-label">
@@ -81,11 +83,34 @@ profile run can have multiple tools that present the performance profile as diff
                always-float-label
                type="number"
                min=1
+               max=600000
+               auto-validate
+               pattern="[0-9]+"
+               error-message="Input is not an integer between 1 to 600000"
+               required
                value="{{_profileDuration}}"></paper-input>
+  <div hidden="{{!_shouldShowTpuOptions(_profilerServiceAddressType)}}">
+    <paper-checkbox checked="{{_profileIncludeDatasetOps}}">Trace dataset ops</paper-checkbox>
+    <paper-input label="Automatically retry N times when no trace event is collected"
+                 always-float-label
+                 type="number"
+                 min=1
+                 max=100
+                 auto-validate
+                 pattern="[0-9]+"
+                 error-message="Input is not an integer between 1 to 100"
+                 required
+                 value="{{_profileNumTracingAttempts}}"></paper-input>
+    <paper-input label="Subset of worker TPUs to profile (optional)"
+                 always-float-label
+                 placeholder="List of IPs, e.g. 10.4.1.2,10.4.1.3"
+                 value="{{_profileWorkerList}}"></paper-input>
+  </div>
   <div class="buttons">
     <paper-button dialog-confirm raised
                   on-tap="_captureProfile"
-                  disabled$="[[_shouldDisableCaptureProfileButton(profilerServiceAddress, _profileDuration)]]">Capture</paper-button>
+                  disabled$="[[_shouldDisableCaptureProfileButton(_profilerServiceAddress, _profileDuration, _profileNumTracingAttempts)]]">
+        Capture</paper-button>
     <paper-button dialog-confirm>Close</paper-button>
   </div>
 </paper-dialog>
@@ -388,6 +413,17 @@ profile run can have multiple tools that present the performance profile as diff
         type: Number,
         value: 1000,
       },
+      _profileNumTracingAttempts: {
+        type: Number,
+        value: 3,
+      },
+      _profileWorkerList: {
+        type: String,
+      },
+      _profileIncludeDatasetOps: {
+        type: Boolean,
+        value: true,
+      },
       // The URL for the trace data being display.
       _traceDataUrl: {
         type: String,
@@ -478,17 +514,25 @@ profile run can have multiple tools that present the performance profile as diff
     _openCaptureProfileDialog: function() {
       this.$.captureProfileDialog.open();
     },
-    _shouldDisableCaptureProfileButton: function(profilerServiceAddress, profileDuration) {
-      return !profilerServiceAddress || profileDuration <= 0;
+    _shouldDisableCaptureProfileButton: function(
+        profilerServiceAddress, profileDuration, numTracingAttempts) {
+      return !profilerServiceAddress || profileDuration <= 0
+          || numTracingAttempts <=0;
+    },
+    _shouldShowTpuOptions: function(profilerServiceAddressType) {
+      return profilerServiceAddressType == 'tpu-name';
     },
     _captureProfile: function() {
       this._capturingProfile = true;
       const captureProfileUrl = tf_backend.addParams(
           tf_backend.getRouter().pluginRoute('profile', '/capture_profile'),
           {
-            service_addr: this._profilerServiceAddress,
+            service_addr: this._profilerServiceAddress.trim(),
             is_tpu_name: this._profilerServiceAddressType == 'tpu-name',
             duration: this._profileDuration,
+            worker_list: this._profileWorkerList,
+            include_dataset_ops: this._profileIncludeDatasetOps,
+            num_tracing_attempts: this._profileNumTracingAttempts,
           });
       this._requestManager.request(captureProfileUrl).then((json) => {
 	this._capturingProfile = false;

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -89,18 +89,20 @@ profile run can have multiple tools that present the performance profile as diff
                error-message="Input is not an integer between 1 to 600000"
                required
                value="{{_profileDuration}}"></paper-input>
+
+  <paper-input label="Automatically retry N times when no trace event is collected"
+               always-float-label
+               type="number"
+               min=0
+               max=100
+               auto-validate
+               pattern="[0-9]+"
+               error-message="Input is not an integer between 0 to 100"
+               required
+               value="{{_profileNumRetry}}"></paper-input>
+
   <div hidden="{{!_shouldShowTpuOptions(_profilerServiceAddressType)}}">
     <paper-checkbox checked="{{_profileIncludeDatasetOps}}">Trace dataset ops</paper-checkbox>
-    <paper-input label="Automatically retry N times when no trace event is collected"
-                 always-float-label
-                 type="number"
-                 min=1
-                 max=100
-                 auto-validate
-                 pattern="[0-9]+"
-                 error-message="Input is not an integer between 1 to 100"
-                 required
-                 value="{{_profileNumTracingAttempts}}"></paper-input>
     <paper-input label="Subset of worker TPUs to profile (optional)"
                  always-float-label
                  placeholder="List of IPs, e.g. 10.4.1.2,10.4.1.3"
@@ -109,7 +111,7 @@ profile run can have multiple tools that present the performance profile as diff
   <div class="buttons">
     <paper-button dialog-confirm raised
                   on-tap="_captureProfile"
-                  disabled$="[[_shouldDisableCaptureProfileButton(_profilerServiceAddress, _profileDuration, _profileNumTracingAttempts)]]">
+                  disabled$="[[_shouldDisableCaptureProfileButton(_profilerServiceAddress, _profileDuration, _profileNumRetry)]]">
         Capture</paper-button>
     <paper-button dialog-confirm>Close</paper-button>
   </div>
@@ -413,7 +415,7 @@ profile run can have multiple tools that present the performance profile as diff
         type: Number,
         value: 1000,
       },
-      _profileNumTracingAttempts: {
+      _profileNumRetry: {
         type: Number,
         value: 3,
       },
@@ -515,9 +517,9 @@ profile run can have multiple tools that present the performance profile as diff
       this.$.captureProfileDialog.open();
     },
     _shouldDisableCaptureProfileButton: function(
-        profilerServiceAddress, profileDuration, numTracingAttempts) {
+        profilerServiceAddress, profileDuration, numRetry) {
       return !profilerServiceAddress || profileDuration <= 0
-          || numTracingAttempts <=0;
+          || numRetry === "";
     },
     _shouldShowTpuOptions: function(profilerServiceAddressType) {
       return profilerServiceAddressType == 'tpu-name';
@@ -532,7 +534,7 @@ profile run can have multiple tools that present the performance profile as diff
             duration: this._profileDuration,
             worker_list: this._profileWorkerList,
             include_dataset_ops: this._profileIncludeDatasetOps,
-            num_tracing_attempts: this._profileNumTracingAttempts,
+            num_retry: this._profileNumRetry,
           });
       this._requestManager.request(captureProfileUrl).then((json) => {
 	this._capturingProfile = false;

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -412,11 +412,11 @@ profile run can have multiple tools that present the performance profile as diff
         value: "ip-address",
       },
       _profileDuration: {
-        type: Number,
+        type: String,
         value: 1000,
       },
       _profileNumRetry: {
-        type: Number,
+        type: String,
         value: 3,
       },
       _profileWorkerList: {
@@ -518,7 +518,7 @@ profile run can have multiple tools that present the performance profile as diff
     },
     _shouldDisableCaptureProfileButton: function(
         profilerServiceAddress, profileDuration, numRetry) {
-      return !profilerServiceAddress || profileDuration <= 0
+      return !profilerServiceAddress || profileDuration === ""
           || numRetry === "";
     },
     _shouldShowTpuOptions: function(profilerServiceAddressType) {

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -413,11 +413,11 @@ profile run can have multiple tools that present the performance profile as diff
       },
       _profileDuration: {
         type: String,
-        value: 1000,
+        value: "1000",
       },
       _profileNumRetry: {
         type: String,
-        value: 3,
+        value: "3",
       },
       _profileWorkerList: {
         type: String,


### PR DESCRIPTION
* Motivation for features / changes
StartTracing API has more options to config how to profile a model. Add that to the capture profile pop up.
* Technical description of changes
1) Add work_list, num_tracing_attempts and include_dataset_ops to the pop up.
2) Trim the string of the ProfilerServiceAddress to remove leading and trailing spaces.
3) Add auto-validate to the input field.
4) Fix a bug that the "_profilerServiceAddress" should be passed into the shouldDisableCaptureProfileButton instead of the "profilerServiceAddress".

* Screenshots of UI changes
![capture_profile_button](https://user-images.githubusercontent.com/3082188/58140077-7b278380-7bf2-11e9-98fc-3831a634a892.png)

* Detailed steps to verify changes work correctly (as executed by you)
bazel run tensorboard/plugins/profile:profile_demo
bazel run tensorboard:tensorboard -- --logdir=/tmp/profile_demo
* Alternate designs / implementations considered
