### PR TITLE
Add PR curves and F1 score to WIT

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -221,9 +221,9 @@ limitations under the License.
       }
 
       .pr-line-chart {
-        margin: 6px;
+        margin: 0;
         height: 200px;
-        width: 300px;
+        width: 280px;
         display: inline-block;
       }
 
@@ -536,16 +536,41 @@ limitations under the License.
         font-weight: 500;
       }
 
-      .roc-holder {
+      .curves-holder {
+        display: flex;
+        flex-wrap: wrap;
+        margin-top: 20px;
+        position: relative;
+      }
+
+      .curve-holder {
         width: 300px;
         height: 235px;
-        margin-top: 20px;
         margin-bottom: 20px;
-        margin-right: 50px;
+        margin-right: 20px;
         position: relative;
       }
 
       .roc-x-label {
+        position: absolute;
+        bottom: 0;
+        left: 120px;
+        font-size: 12px;
+        color: #5f6368;
+        padding: 0px;
+      }
+
+      .roc-y-label {
+        position: absolute;
+        left: -34px;
+        bottom: 110px;
+        transform: rotate(270deg);
+        font-size: 12px;
+        color: #5f6368;
+        padding: 0px;
+      }
+
+      .pr-x-label {
         position: absolute;
         bottom: 0;
         left: 140px;
@@ -554,9 +579,9 @@ limitations under the License.
         padding: 0px;
       }
 
-      .roc-y-label {
+      .pr-y-label {
         position: absolute;
-        left: -30px;
+        left: -14px;
         bottom: 110px;
         transform: rotate(270deg);
         font-size: 12px;
@@ -876,6 +901,7 @@ limitations under the License.
       .roc-text {
         color: #3C4043;
         font-size: 16px;
+        margin-left: 44px;
       }
 
       .conf-text {
@@ -1109,6 +1135,11 @@ limitations under the License.
       }
       .perf-table-acc {
         width: 15%;
+        text-align: right;
+        margin-right: 20px;
+      }
+      .perf-table-f1 {
+        width: 10%;
         text-align: right;
         margin-right: 20px;
       }
@@ -1771,6 +1802,7 @@ limitations under the License.
                       <div class="perf-table-fp">False Positives (%)</div>
                       <div class="perf-table-fn">False Negatives (%)</div>
                       <div class="perf-table-acc">Accuracy (%)</div>
+                      <div class="perf-table-f1">F1</div>
                     </div>
                     <div class="perf-table-entries-holder">
                       <template is="dom-repeat" items="[[featureValueThresholds]]" as="featureValueThreshold">
@@ -1808,6 +1840,11 @@ limitations under the License.
                                   <div class="perf-table-num-entry">[[getAccuracyModelIndex(inferenceStats_, featureValueThreshold.threshold, index, featureValueThreshold)]]</div>
                                 </template>
                               </div>
+                              <div class="perf-table-f1 perf-table-clickable" on-tap="togglePerfRow">
+                                <template is="dom-repeat" items="{{featureValueThreshold.threshold}}">
+                                  <div class="perf-table-num-entry">[[getF1ModelIndex(inferenceStats_, featureValueThreshold.threshold, index, featureValueThreshold)]]</div>
+                                </template>
+                              </div>
                             </div>
                         </div>
                         <iron-collapse opened="{{featureValueThreshold.opened}}">
@@ -1824,23 +1861,43 @@ limitations under the License.
                                   </tf-confusion-matrix>
                                 </template>
                               </div>
-                              <div class="roc-holder">
-                                <div class="roc-text">ROC curve
-                                  <paper-icon-button icon="info-outline" class="info-icon threshold-info-icon no-padding" on-tap="openDialog">
-                                  </paper-icon-button>
-                                  <paper-dialog class="dialog-text" horizontal-align="right" vertical-align="bottom">
-                                    <div class="dialog-title">ROC curve</div>
-                                    <div>A receiver operating characteristic (ROC) curve plots the true positive rate (TPR) against the
-                                      false positive rate (FPR) at various classification thresholds.
-                                    </div>
-                                  </paper-dialog>
+                              <div class="curves-holder">
+                                <div class="curve-holder">
+                                  <div class="roc-text">ROC curve
+                                    <paper-icon-button icon="info-outline" class="info-icon threshold-info-icon no-padding" on-tap="openDialog">
+                                    </paper-icon-button>
+                                    <paper-dialog class="dialog-text" horizontal-align="right" vertical-align="bottom">
+                                      <div class="dialog-title">ROC curve</div>
+                                      <div>A receiver operating characteristic (ROC) curve plots the true positive rate (TPR) against the
+                                        false positive rate (FPR) at various classification thresholds.
+                                      </div>
+                                    </paper-dialog>
+                                  </div>
+                                  <div class="roc-x-label">False positive rate</div>
+                                  <div class="roc-y-label">True positive rate</div>
+                                  <vz-line-chart id="[[getRocChartId(index)]]" class="pr-line-chart"
+                                      x-axis-formatter="[[getSimpleAxisFormatter(axisPrecision)]]"
+                                      y-axis-formatter="[[getSimpleAxisFormatter(axisPrecision)]]">
+                                  </vz-line-chart>
                                 </div>
-                                <div class="roc-x-label">False positive rate</div>
-                                <div class="roc-y-label">True positive rate</div>
-                                <vz-line-chart id="[[getPrChartId(index)]]" class="pr-line-chart"
-                                    x-axis-formatter="[[getSimpleAxisFormatter(axisPrecision)]]"
-                                    y-axis-formatter="[[getSimpleAxisFormatter(axisPrecision)]]">
-                                </vz-line-chart>
+                                <div class="curve-holder">
+                                  <div class="roc-text">PR curve
+                                    <paper-icon-button icon="info-outline" class="info-icon threshold-info-icon no-padding" on-tap="openDialog">
+                                    </paper-icon-button>
+                                    <paper-dialog class="dialog-text" horizontal-align="right" vertical-align="bottom">
+                                      <div class="dialog-title">PR curve</div>
+                                      <div>A precision-recall (PR) curve plots precision against
+                                        recall at various classification thresholds.
+                                      </div>
+                                    </paper-dialog>
+                                  </div>
+                                  <div class="pr-x-label">Recall</div>
+                                  <div class="pr-y-label">Precision</div>
+                                  <vz-line-chart id="[[getPrChartId(index)]]" class="pr-line-chart"
+                                      x-axis-formatter="[[getSimpleAxisFormatter(axisPrecision)]]"
+                                      y-axis-formatter="[[getSimpleAxisFormatter(axisPrecision)]]">
+                                  </vz-line-chart>
+                                </div>
                               </div>
                             </template>
                           </div>
@@ -1881,6 +1938,11 @@ limitations under the License.
                                 <div class="perf-table-num-entry">[[getAccuracyModelIndex(inferenceStats_, overallThresholds, index)]]</div>
                               </template>
                             </div>
+                            <div class="perf-table-f1">
+                              <template is="dom-repeat" items="{{overallThresholds}}">
+                                <div class="perf-table-num-entry">[[getF1ModelIndex(inferenceStats_, overallThresholds, index)]]</div>
+                              </template>
+                            </div>
                           </div>
                         </div>
                         <div class="perf-table-entry-expanded flex-row-reverse">
@@ -1896,23 +1958,43 @@ limitations under the License.
                                 </tf-confusion-matrix>
                               </template>
                             </div>
-                            <div class="roc-holder">
-                              <div class="roc-text">ROC curve
-                                <paper-icon-button icon="info-outline" class="info-icon threshold-info-icon no-padding" on-tap="openDialog">
-                                </paper-icon-button>
-                                <paper-dialog class="dialog-text" horizontal-align="right" vertical-align="bottom">
-                                  <div class="dialog-title">ROC curve</div>
-                                  <div>A receiver operating characteristic (ROC) curve plots the true positive rate (TPR) against the
-                                    false positive rate (FPR) at various classification thresholds.
-                                  </div>
-                                </paper-dialog>
+                            <div class="curves-holder">
+                              <div class="curve-holder">
+                                <div class="roc-text">ROC curve
+                                  <paper-icon-button icon="info-outline" class="info-icon threshold-info-icon no-padding" on-tap="openDialog">
+                                  </paper-icon-button>
+                                  <paper-dialog class="dialog-text" horizontal-align="right" vertical-align="bottom">
+                                    <div class="dialog-title">ROC curve</div>
+                                    <div>A receiver operating characteristic (ROC) curve plots the true positive rate (TPR) against the
+                                      false positive rate (FPR) at various classification thresholds.
+                                    </div>
+                                  </paper-dialog>
+                                </div>
+                                <div class="roc-x-label">False positive rate</div>
+                                <div class="roc-y-label">True positive rate</div>
+                                <vz-line-chart id="rocchart" class="pr-line-chart"
+                                    x-axis-formatter="[[getSimpleAxisFormatter(axisPrecision)]]"
+                                    y-axis-formatter="[[getSimpleAxisFormatter(axisPrecision)]]">
+                                </vz-line-chart>
                               </div>
-                              <div class="roc-x-label">False positive rate</div>
-                              <div class="roc-y-label">True positive rate</div>
-                              <vz-line-chart id="prchart" class="pr-line-chart"
-                                  x-axis-formatter="[[getSimpleAxisFormatter(axisPrecision)]]"
-                                  y-axis-formatter="[[getSimpleAxisFormatter(axisPrecision)]]">
-                              </vz-line-chart>
+                              <div class="curve-holder">
+                                <div class="roc-text">PR curve
+                                  <paper-icon-button icon="info-outline" class="info-icon threshold-info-icon no-padding" on-tap="openDialog">
+                                  </paper-icon-button>
+                                  <paper-dialog class="dialog-text" horizontal-align="right" vertical-align="bottom">
+                                    <div class="dialog-title">PR curve</div>
+                                    <div>A precision-recall (PR) curve plots precision against
+                                      recall at various classification thresholds.
+                                    </div>
+                                  </paper-dialog>
+                                </div>
+                                <div class="pr-x-label">Recall</div>
+                                <div class="pr-y-label">Precision</div>
+                                <vz-line-chart id="prchart" class="pr-line-chart"
+                                    x-axis-formatter="[[getSimpleAxisFormatter(axisPrecision)]]"
+                                    y-axis-formatter="[[getSimpleAxisFormatter(axisPrecision)]]">
+                                </vz-line-chart>
+                              </div>
                             </div>
                           </template>
                         </div>
@@ -3262,11 +3344,18 @@ limitations under the License.
               plotStats.push(inferenceStats.faceted[key]);
               plotThresholds.push(modelThresholds[modelInd].threshold)
             }
-            this.plotPr(
+            this.plotChart(
+              this.$$('#' + this.getRocChartId(i)),
+              plotStats,
+              plotThresholds,
+              regenInferenceStats,
+              true);
+            this.plotChart(
               this.$$('#' + this.getPrChartId(i)),
               plotStats,
               plotThresholds,
-              regenInferenceStats);
+              regenInferenceStats,
+              false);
           }
           const plotStats = [];
           const plotThresholds = [];
@@ -3275,9 +3364,12 @@ limitations under the License.
             plotStats.push(this.inferenceStats_[modelInd].thresholds);
             plotThresholds.push(this.overallThresholds[modelInd].threshold);
           }
-          this.plotPr(
+          this.plotChart(
+            this.$$('#rocchart'), plotStats,
+            plotThresholds, regenInferenceStats, true);
+          this.plotChart(
             this.$$('#prchart'), plotStats,
-            plotThresholds, regenInferenceStats);
+            plotThresholds, regenInferenceStats, false);
         }
         this.updateCorrectness_();
       },
@@ -3377,16 +3469,20 @@ limitations under the License.
       },
 
       /**
-       * Plots a PR purve given data to plot.
+       * Plots a PR or ROC purve given data to plot.
        * thresholdstats and thresholds are arrays, indexed by model number
        */
-      plotPr: function(chart, thresholdStats, thresholds,
-                       regenInferenceStats) {
+      plotChart: function(chart, thresholdStats, thresholds,
+                       regenInferenceStats, isRoc) {
         if (!thresholdStats || !thresholdStats[0] || !chart) {
           return;
         }
         const visibleCharts = [];
         const seriesColors = [];
+        const xAxis = isRoc ? 'FPR' : 'TPR';
+        const yAxis = isRoc ? 'TPR' : 'PPV';
+        const xAxisLabel = isRoc ? 'FPR' : 'Recall';
+        const yAxisLabel = isRoc ? 'TPR' : 'Precision';
         for (let modelInd = 0; modelInd < thresholdStats.length; modelInd++) {
           let currentThresholdData = null;
           const data = thresholdStats[modelInd].map((thresh, i) => {
@@ -3394,14 +3490,14 @@ limitations under the License.
             // current threshold
             if (i - thresholds[modelInd] * 100 < 0.5) {
               currentThresholdData = {
-                'step': thresh['FPR'],
-                'scalar': thresh['TPR'],
+                'step': thresh[xAxis],
+                'scalar': thresh[yAxis],
                 'threshold': i / 100
               };
             }
             return {
-              'step': thresh['FPR'],
-              'scalar': thresh['TPR'],
+              'step': thresh[xAxis],
+              'scalar': thresh[yAxis],
               'threshold': i / 100
             };
           }).reverse();
@@ -3429,15 +3525,17 @@ limitations under the License.
                 },
             },
             {
-                title: 'TPR',
+                title: yAxisLabel,
                 evaluate: function (d) {
-                  return percentageFormatter(d.datum.scalar);
+                  return isRoc ? percentageFormatter(d.datum.scalar) :
+                    valueFormatter(d.datum.scalar);
                 },
             },
             {
-                title: 'FPR',
+                title: xAxisLabel,
                 evaluate: function (d) {
-                  return percentageFormatter(d.datum.step);
+                  return isRoc ? percentageFormatter(d.datum.step) :
+                    valueFormatter(d.datum.step);
                 },
             },
           ];
@@ -3462,7 +3560,7 @@ limitations under the License.
       },
 
       /**
-       * Calculates TPR and FPR given binary confusion matrix counts.
+       * Calculates TPR, FPR, and PPV given binary confusion matrix counts.
        */
       calcThresholdStats: function(stats) {
         for (let i = 0; i < stats.length; i++) {
@@ -3477,6 +3575,12 @@ limitations under the License.
               stats[i]['FP'] / (stats[i]['FP'] + stats[i]['TN']);
           } else {
             stats[i]['FPR'] = 0;
+          }
+          if (stats[i]['TP'] + stats[i]['FP'] > 0) {
+            stats[i]['PPV'] =
+              stats[i]['TP'] / (stats[i]['TP'] + stats[i]['FP']);
+          } else {
+            stats[i]['PPV'] = 0;
           }
         }
       },
@@ -3780,6 +3884,34 @@ limitations under the License.
       },
 
       /**
+       * Returns the F1 score for a given confusion matrix
+       * from the threshold selected, model index, and facet to view.
+       */
+       getF1ModelIndex: function(inferenceStats, thresholds, modelInd, item) {
+        // TODO(jameswex): This unnecessarily recalculates confusion matrix.
+        // Can speed this up.
+        const formatter = d3.format(",.2f");
+        const confCounts = this.getConfusionCountsModelIndex(
+          inferenceStats, thresholds, modelInd, item);
+        if (Object.keys(confCounts).length == 0) {
+          return 0;
+        }
+        if (confCounts['Yes']['Yes'] == 0) {
+          if (confCounts['No']['Yes'] != 0 || confCounts['Yes']['No'] != 0) {
+            return formatter(0);
+          } else {
+            return formatter(1);
+          }
+        }
+        const precision = confCounts['Yes']['Yes'] /
+          (confCounts['Yes']['Yes'] + confCounts['No']['Yes']);
+        const recall = confCounts['Yes']['Yes'] /
+          (confCounts['Yes']['Yes'] + confCounts['Yes']['No']);
+        return formatter(
+          2 * (precision * recall) / (precision + recall));
+      },
+
+      /**
        * Returns the number of examples in a given facet.
        */
       getFeatureValueCount: function(inferenceStats, thresholds, item) {
@@ -3969,6 +4101,10 @@ limitations under the License.
               }
               return a + total;
             }, 0), null);
+      },
+
+      getRocChartId: function(index) {
+        return 'rocchart' + index;
       },
 
       getPrChartId: function(index) {

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -562,7 +562,7 @@ limitations under the License.
 
       .roc-y-label {
         position: absolute;
-        left: -34px;
+        left: -36px;
         bottom: 110px;
         transform: rotate(270deg);
         font-size: 12px;

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3896,17 +3896,18 @@ limitations under the License.
         if (Object.keys(confCounts).length == 0) {
           return 0;
         }
-        if (confCounts['Yes']['Yes'] == 0) {
-          if (confCounts['No']['Yes'] != 0 || confCounts['Yes']['No'] != 0) {
+        const truePositives = confCounts['Yes']['Yes'];
+        const falsePositives = confCounts['No']['Yes'];
+        const falseNegatives = confCounts['Yes']['No'];
+        if (truePositives == 0) {
+          if (falsePositives != 0 || falseNegatives != 0) {
             return formatter(0);
           } else {
             return formatter(1);
           }
         }
-        const precision = confCounts['Yes']['Yes'] /
-          (confCounts['Yes']['Yes'] + confCounts['No']['Yes']);
-        const recall = confCounts['Yes']['Yes'] /
-          (confCounts['Yes']['Yes'] + confCounts['Yes']['No']);
+        const precision = truePositives / (truePositives + falsePositives);
+        const recall = truePositives / (truePositives + falseNegatives);
         return formatter(
           2 * (precision * recall) / (precision + recall));
       },


### PR DESCRIPTION
* Motivation for features / changes

Per user requests, adding PR curves and F1 score to performance tab of WIT for binary classification models.

* Technical description of changes

- Adjust chart generation code to handle both PR curves and existing ROC curves
- Change visuals to handle both charts side by side
- Add calculation of precision (positive predictive value) in order to support PR curve.
- Add calculation of F1 score
- Add row in performance table for F1 score

* Screenshots of UI changes

![pr](https://user-images.githubusercontent.com/15835086/58196695-e035b480-7c98-11e9-88c5-637e8440607a.png)

* Detailed steps to verify changes work correctly (as executed by you)

Ran binary classification demos (single and multimodel) to visualize change and ensure correctness.