### PR TITLE
Add ability to customize examples for custom AI platform models

### DIFF
--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
@@ -62,6 +62,12 @@ class WitWidgetBase(object):
     self.compare_adjust_prediction_fn = (
       config.get('compare_adjust_prediction')
       if 'compare_adjust_prediction' in config else None)
+    self.adjust_example_fn = (
+      config.get('adjust_example')
+      if 'adjust_example' in config else None)
+    self.compare_adjust_example_fn = (
+      config.get('compare_adjust_example')
+      if 'compare_adjust_example' in config else None)
     if 'custom_predict_fn' in copied_config:
       del copied_config['custom_predict_fn']
     if 'compare_custom_predict_fn' in copied_config:
@@ -70,6 +76,10 @@ class WitWidgetBase(object):
       del copied_config['adjust_prediction']
     if 'compare_adjust_prediction' in copied_config:
       del copied_config['compare_adjust_prediction']
+    if 'adjust_example' in copied_config:
+      del copied_config['adjust_example']
+    if 'compare_adjust_example' in copied_config:
+      del copied_config['compare_adjust_example']
 
     self.set_examples(config['examples'])
     del copied_config['examples']
@@ -265,17 +275,19 @@ class WitWidgetBase(object):
     return self._predict_aip_impl(
       examples, self.config.get('inference_address'),
       self.config.get('model_name'), self.config.get('model_signature'),
-      self.config.get('force_json_input'), self.adjust_prediction_fn)
+      self.config.get('force_json_input'), self.adjust_example_fn,
+      self.adjust_prediction_fn)
 
   def _predict_aip_compare_model(self, examples):
     return self._predict_aip_impl(
       examples, self.config.get('inference_address_2'),
       self.config.get('model_name_2'), self.config.get('model_signature_2'),
       self.config.get('compare_force_json_input'),
+      self.compare_adjust_example_fn,
       self.compare_adjust_prediction_fn)
 
   def _predict_aip_impl(self, examples, project, model, version, force_json,
-                        adjust_prediction):
+                        adjust_example, adjust_prediction):
     """Custom prediction function for running inference through AI Platform."""
     service = googleapiclient.discovery.build('ml', 'v1', cache_discovery=False)
     name = 'projects/{}/models/{}'.format(project, model)
@@ -289,6 +301,11 @@ class WitWidgetBase(object):
       examples_for_predict = [{'b64': base64.b64encode(
         example.SerializeToString()).decode('utf-8') }
         for example in examples]
+
+    # If there is a user-specified input example adjustment to make, make it.
+    if adjust_example:
+      examples_for_predict = [
+        adjust_example(ex) for ex in examples_for_predict]
 
     response = service.projects().predict(
         name=name,

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
@@ -497,7 +497,7 @@ class WitConfigBuilder(object):
 
   def set_ai_platform_model(
     self, project, model, version=None, force_json_input=None,
-    adjust_prediction=None):
+    adjust_prediction=None, adjust_example=None):
     """Sets the model information for a model served by AI Platform.
 
     AI Platform Prediction a Google Cloud serving platform.
@@ -513,6 +513,10 @@ class WitConfigBuilder(object):
       prediction output from the model for a single example and converts it to
       the appopriate format - a regression score or a list of class scores. Only
       necessary if the model doesn't already abide by this format.
+      adjust_example: Optional. If not None then this function takes an example
+      to run prediction on and converts it to the format expected by the model.
+      Necessary for example if the served model expects a single data value to
+      run inference on instead of a list or dict of values.
 
     Returns:
       self, in order to enabled method chaining.
@@ -526,11 +530,13 @@ class WitConfigBuilder(object):
       self.store('force_json_input', True)
     if adjust_prediction:
       self.store('adjust_prediction', adjust_prediction)
+    if adjust_example:
+      self.store('adjust_example', adjust_example)
     return self
 
   def set_compare_ai_platform_model(
     self, project, model, version=None, force_json_input=None,
-    adjust_prediction=None):
+    adjust_prediction=None, adjust_example=None):
     """Sets the model information for a second model served by AI Platform.
 
     AI Platform Prediction a Google Cloud serving platform.
@@ -546,6 +552,10 @@ class WitConfigBuilder(object):
       prediction output from the model for a single example and converts it to
       the appopriate format - a regression score or a list of class scores. Only
       necessary if the model doesn't already abide by this format.
+      adjust_example: Optional. If not None then this function takes an example
+      to run prediction on and converts it to the format expected by the model.
+      Necessary for example if the served model expects a single data value to
+      run inference on instead of a list or dict of values.
 
     Returns:
       self, in order to enabled method chaining.
@@ -559,6 +569,8 @@ class WitConfigBuilder(object):
       self.store('compare_force_json_input', True)
     if adjust_prediction:
       self.store('compare_adjust_prediction', adjust_prediction)
+    if adjust_example:
+      self.store('compare_adjust_example', adjust_example)
     return self
 
   def set_target_feature(self, target):


### PR DESCRIPTION
* Motivation for features / changes

Cloud AI Platform models can have custom prediction code that takes in examples in any format the modeler wants. But WIT requires examples as lists, dicts, or example protos by design. So add the ability to transform examples to the custom format for cloud users that need this capability.

* Technical description of changes

- Add adjust_example function argument to set_ai_platform_model methods, similar to existing adjust_prediction argument.
- Call adjust_example before sending to the model if that argument is passed.

* Screenshots of UI changes

No UI changes.

* Detailed steps to verify changes work correctly (as executed by you)

Ran colab with custom cloud model that needs this capability and verified it works.

