### PR TITLE
Fix long type not found for json input in python3

### DIFF
--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -22,7 +22,7 @@ import numpy as np
 import tensorflow as tf
 from google.protobuf import json_format
 from six import iteritems
-from six import string_types
+from six import string_types, integer_types
 from six.moves import zip  # pylint: disable=redefined-builtin
 
 from tensorboard.plugins.interactive_inference.utils import common_utils

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -155,7 +155,7 @@ class MutantFeatureValue(object):
           'unexpected type: {}'.format(type(original_feature)))
     self.original_feature = original_feature
 
-    if index is not None and not isinstance(index, int):
+    if index is not None and not isinstance(index, integer_types):
       raise ValueError(
           'index should be None or int, but had unexpected type: {}'.format(
               type(index)))

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
@@ -16,6 +16,7 @@
 import sys
 import tensorflow as tf
 from numbers import Number
+from six import integer_types
 
 
 def _is_colab():
@@ -488,7 +489,7 @@ class WitConfigBuilder(object):
     return tf_examples
 
   def _add_single_feature(self, feat, value, ex):
-    if isinstance(value, (int, long)):
+    if isinstance(value, integer_types):
       ex.features.feature[feat].int64_list.value.append(value)
     elif isinstance(value, Number):
       ex.features.feature[feat].float_list.value.append(value)


### PR DESCRIPTION
* Motivation for features / changes
long type does not exist in python 3, changed type testing to six.integer types from long to prevent errors when wit is used with json inputs.

* Technical description of changes

* Screenshots of UI changes
None
* Detailed steps to verify changes work correctly (as executed by you)
Tested cloud xgboost model with python 3 kernel in colab.
* Alternate designs / implementations considered
None