### PR TITLE
build: fix lint errors

### DIFF
--- a/tensorboard/defs/hacks.bzl
+++ b/tensorboard/defs/hacks.bzl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Compatibility hacks."""
 
 # TODO(@jart): Merge this file into defs.bzl once that file is sync unified.
 
@@ -20,7 +21,7 @@ def tensorboard_typescript_bundle(
     namespace_srcs,
     namespace_symbol_aliases={},
     namespace_symbol_aliases_public={},
-    **kwargs):
+):
   """Rolls TypeScript ES6 modules into one vanilla source file without imports.
 
   This is a genrule wrapper that concatenates TypeScripts sources inside
@@ -73,8 +74,7 @@ def tensorboard_typescript_bundle(
   cmd.append(") >$@")
   native.genrule(
       name = name,
-      srcs = list(depset(transitive=inputs_depsets)),
+      srcs = depset(transitive=inputs_depsets).to_list(),
       outs = [out],
       cmd = "\n".join(cmd),
-      **kwargs
   )

--- a/tensorboard/defs/vulcanize.bzl
+++ b/tensorboard/defs/vulcanize.bzl
@@ -37,12 +37,12 @@ def _tensorboard_html_binary(ctx):
     ignore_regexs_file_set = depset([ctx.file.path_regexs_for_noinline])
     ignore_regexs_file_path = ctx.file.path_regexs_for_noinline.path
   ctx.action(
-      inputs=list(depset(transitive=[
+      inputs=depset(transitive=[
           manifests,
           files,
           jslibs,
           ignore_regexs_file_set,
-      ])),
+      ]).to_list(),
       outputs=[ctx.outputs.html],
       executable=ctx.executable._Vulcanize,
       arguments=([ctx.attr.compilation_level,

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -227,7 +227,13 @@ def _tf_web_library(ctx):
     ts_typings_paths = depset()
     ts_typings_execroots = depset()
 
-  # export data to parent rules
+  # Export data to parent rules. This uses the legacy, string-based
+  # provider mechanism for compatibility with the base `web_library`
+  # rule from rules_closure: because `tf_web_library`s may depend on
+  # either other `tf_web_library`s or base `web_library`s, the
+  # interfaces ~must be the same.
+  #
+  # buildozer: disable=rule-impl-return
   return struct(
       files=depset(web_srcs + [dummy]),
       exports=unfurl(ctx.attr.exports),

--- a/tensorboard/defs/zipper.bzl
+++ b/tensorboard/defs/zipper.bzl
@@ -24,7 +24,7 @@ def _tensorboard_zip_file(ctx):
     webpaths = depset(transitive=[webpaths, dep.webfiles.webpaths])
     files = depset(transitive=[files, dep.data_runfiles.files])
   ctx.action(
-      inputs=list(depset(transitive=[manifests, files])),
+      inputs=depset(transitive=[manifests, files]).to_list(),
       outputs=[ctx.outputs.zip],
       executable=ctx.executable._Zipper,
       arguments=([ctx.outputs.zip.path] +

--- a/third_party/polymer.bzl
+++ b/third_party/polymer.bzl
@@ -17,6 +17,7 @@
 load("@io_bazel_rules_closure//closure:defs.bzl", "web_library_external")
 
 def tensorboard_polymer_workspace():
+  """Add repositories for Polymer and its standard component library."""
   web_library_external(
       name = "org_polymer",
       licenses = ["notice"],  # BSD-3-Clause

--- a/third_party/typings.bzl
+++ b/third_party/typings.bzl
@@ -17,6 +17,7 @@
 load("@io_bazel_rules_closure//closure:defs.bzl", "filegroup_external")
 
 def tensorboard_typings_workspace():
+  """Add repositories for TypeScript type definitions (`.d.ts` files)."""
   filegroup_external(
       name = "org_definitelytyped",
       licenses = ["notice"],  # MIT

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -26,6 +26,7 @@ load("//third_party:js.bzl", "tensorboard_js_workspace")
 load("//third_party:typings.bzl", "tensorboard_typings_workspace")
 
 def tensorboard_workspace():
+  """Add repositories needed to build TensorBoard."""
   tensorboard_fonts_workspace()
   tensorboard_polymer_workspace()
   tensorboard_python_workspace()


### PR DESCRIPTION
Summary:
Changes in #2267 displeased the Google linter: `list(my_depset)` is
banned because it’s not obvious that this forces iteration, so we switch
to the far clearer `.to_list()` everywhere.

The venerable linter further demands that docstrings be added, even for
drive-by fixes.

Test Plan:
A test import succeeds; all Google-internal tests pass.

wchargin-branch: import-lint
