### PR TITLE
[profile] make trace viewer respect --path_prefix

### DIFF
--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -404,7 +404,7 @@ profile run can have multiple tools that present the performance profile as diff
       // The endpoint that serves trace viewer app.
       traceViewerBaseUrl: {
         type: String,
-        value: "/trace_viewer_index.html",
+        value: "trace_viewer_index.html",
       },
       _profilerServiceAddress: String,
       _profilerServiceAddressType: {
@@ -641,10 +641,6 @@ profile run can have multiple tools that present the performance profile as diff
             {tag: toolName,
              run: datasetName,
              host: hostName});
-        // Make the trace data url relative to the root.
-        if (trace_data_url[0] != '/') {
-          trace_data_url = '/' + trace_data_url;
-        }
         // Pass the URL of trace data via GET parameter to the iframed trace
         // viewer app.
         var is_streaming = toolName.endsWith('@');


### PR DESCRIPTION
Fixes #2263.

The trace viewer logic was hardcoded to use absolute paths (relative to the hostname), which doesn't work when `--path_prefix` is set.  As far as I can tell there is no particular reason why the trace viewer shouldn't use relative path names like the rest of TensorBoard, and the code that forced the absolute path has been around since the profile plugin was introduced, so I suspect it's just outdated.

Tested by running `tensorboard --path_prefix /mypath/` and then putting nginx in front of it as follows:

```sh
echo 'events {} http { access_log stdout; error_log stderr; server { listen 8080; server_name localhost; proxy_buffering off; location /mypath/ { proxy_pass http://localhost:6006; }}}' > /tmp/nginx.conf && sudo nginx -g 'daemon off;' -/tmp/nginx.conf
```

Confirmed that the previously broken trace viewer now loads demo data correctly when accessed via `http://localhost:8080/mypath/`.  I also ran tensorboard without a path prefix and confirmed the trace viewer still loads correctly in that case as well.
