### PR TITLE
Improve travis.yml config for faster CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ env:
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:
+  # Reuse the pip cache directory across build machines.
   pip: true
+  # Cache directories for Bazel. See ci/bazelrc for details.
   directories:
     - $HOME/.cache/tb-bazel-repo
     - $HOME/.cache/tb-bazel-disk
@@ -35,7 +37,7 @@ cache:
 # If inline scripts get too long, Travis surprisingly prints them twice.
 
 before_install:
-  - elapsed() { TZ=UTC printf "Time %(%T)T %s\n" "$SECONDS" "$@"; }
+  - elapsed() { TZ=UTC printf "Time %(%T)T %s\n" "$SECONDS" "$1"; }
   - elapsed "before_install"
   - ci/download_bazel.sh "${BAZEL}" "${BAZEL_SHA256SUM}" ~/bazel
   - sudo mv ~/bazel /usr/local/bin/bazel
@@ -49,7 +51,7 @@ install:
   - pip install yamllint==1.5.0
   # TensorBoard deps.
   - pip install futures==3.1.1
-  - pip install grpcio==1.0
+  - pip install grpcio==1.6.3
   # Uninstall older Travis numpy to avoid upgrade-in-place issues.
   - pip uninstall -y numpy
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
 dist: trusty
-sudo: required
-
 language: python
 python:
   - "2.7"
   - "3.6"
-
-os:
-  - linux
 
 branches:
   only:
@@ -29,8 +24,10 @@ env:
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:
+  pip: true
   directories:
-    - $HOME/.bazel-output-base
+    - $HOME/.cache/tb-bazel-repo
+    - $HOME/.cache/tb-bazel-disk
 
 # Each bullet point is displayed in the Travis log as one collapsed line, which
 # indicates how long it took. Travis will check the return code at the end. We
@@ -38,88 +35,44 @@ cache:
 # If inline scripts get too long, Travis surprisingly prints them twice.
 
 before_install:
-  # Travis pre-installs an old version of numpy. We uninstall it to
-  # reduce the potential for strange behavior when upgrading in-place
-  # for TensorFlow's numpy dependency.
-  - pip uninstall -y numpy
-  - pip freeze  # print installed distributions, for debugging purposes
-  - |
-    # Download Bazel
-    bazel_binary="$(mktemp)" &&
-    bazel_checksum_file="$(mktemp)" &&
-    printf >"${bazel_checksum_file}" \
-        '%s  %s\n' "${BAZEL_SHA256SUM}" "${bazel_binary}" &&
-    for url in \
-        "http://mirror.tensorflow.org/github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-linux-x86_64" \
-        "https://github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-linux-x86_64" \
-    ; do
-      if \
-          wget -t 3 -O "${bazel_binary}" "${url}" &&
-          shasum -a 256 --check "${bazel_checksum_file}"; then
-        break
-      else
-        rm -f "${bazel_binary}"
-      fi
-    done &&
-    rm "${bazel_checksum_file}" &&
-    [ -f "${bazel_binary}" ]
-  - chmod +x "${bazel_binary}"
-  - sudo mv "${bazel_binary}" /usr/local/bin/bazel
-
-  # Fix Boto and Travis issue https://github.com/travis-ci/travis-ci/issues/7940
-  - sudo rm -f /etc/boto.cfg
-
-  # Storing build artifacts in this directory helps Travis cache them. This
-  # will sometimes cut latency in half, when we're lucky.
-  - echo "startup --output_base=${HOME}/.bazel-output-base" >>~/.bazelrc
-
-  # Travis Trusty Sudo GCE VMs have 2 cores and 7.5 GB RAM. These settings
-  # help Bazel go faster and not OOM the system.
-  - echo "startup --host_jvm_args=-Xms500m" >>~/.bazelrc
-  - echo "startup --host_jvm_args=-Xmx500m" >>~/.bazelrc
-  - echo "startup --host_jvm_args=-XX:-UseParallelGC" >>~/.bazelrc
-  - echo "build --local_resources=400,2,1.0" >>~/.bazelrc
-  - echo "build --worker_max_instances=2" >>~/.bazelrc
-
-  # Make Bazel as strict as possible, so TensorBoard will build correctly
-  # for users, regardless of their Bazel configuration.
-  - echo "build --worker_verbose" >>~/.bazelrc
-  - echo "build --worker_sandboxing" >>~/.bazelrc
-  - echo "build --spawn_strategy=sandboxed" >>~/.bazelrc
-  - echo "build --genrule_strategy=sandboxed" >>~/.bazelrc
-  - echo "test --test_verbose_timeout_warnings" >>~/.bazelrc
-
-  # It's helpful to see the errors on failure.
-  - echo "build --verbose_failures" >>~/.bazelrc
-  - echo "test --test_output=errors" >>~/.bazelrc
-
-  # We need to pass the PATH from our virtualenv down into our tests,
-  # which is non-hermetic and so disabled by default in Bazel 0.21.0+.
-  - echo "test --action_env=PATH" >>~/.bazelrc
+  - elapsed() { TZ=UTC printf "Time %(%T)T %s\n" "$SECONDS" "$@"; }
+  - elapsed "before_install"
+  - ci/download_bazel.sh "${BAZEL}" "${BAZEL_SHA256SUM}" ~/bazel
+  - sudo mv ~/bazel /usr/local/bin/bazel
+  - cp ci/bazelrc ~/.bazelrc
+  - elapsed "before_install (done)"
 
 install:
-  - pip install boto3==1.9.86
+  - elapsed "install"
+  # Lint check deps.
   - pip install flake8==3.5.0
-  - pip install futures==3.1.1
-  - pip install grpcio==1.6.3
-  - pip install moto==1.3.7
   - pip install yamllint==1.5.0
+  # TensorBoard deps.
+  - pip install futures==3.1.1
+  - pip install grpcio==1.0
+  # Uninstall older Travis numpy to avoid upgrade-in-place issues.
+  - pip uninstall -y numpy
   - |
     # Install TensorFlow if requested
     if [ -n "${TF_VERSION_ID}" ]; then
       pip install -I "${TF_VERSION_ID}"
     else
-      # Requirements typically found through TensorFlow
-      pip install "absl-py>=0.7.0"
-      pip install "numpy<2.0,>=1.14.5"
+      # Requirements typically found through TensorFlow.
+      pip install "absl-py>=0.7.0" \
+      && pip install "numpy<2.0,>=1.14.5"
     fi
+  # Deps for gfile S3 test.
+  - pip install boto3==1.9.86
+  - pip install moto==1.3.7
+  # Workaround for https://github.com/travis-ci/travis-ci/issues/7940
+  - sudo rm -f /etc/boto.cfg
+  - elapsed "install (done)"
 
 before_script:
-  # fail the build if there are Python syntax errors or undefined names
+  - elapsed "before_script"
+  # Do a fail-fast check for Python syntax errors or undefined names.
+  # Use the comment '# noqa: <error code>' to suppress.
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  # a comment of '# noqa' or better yet '# noqa: <error code>' added to the code to silence flake8
-  - flake8 . --count --exit-zero --ignore=E111,E114 --max-complexity=10 --max-line-length=127 --statistics
   # Lint .yaml docs files. Use '# yamllint disable-line rule:foo' to suppress.
   - yamllint -c docs/.yamllint docs docs/.yamllint
   # Make sure we aren't accidentally including work-in-progress code.
@@ -128,42 +81,31 @@ before_script:
   - tensorboard/tools/license_test.sh
   # Make sure that IPython notebooks have valid Markdown.
   - tensorboard/tools/docs_list_format_test.sh
+  - elapsed "before_script (done)"
 
 # Commands in this section should only fail if it's our fault. Travis will
 # categorize them as 'failed', rather than 'error' for other sections.
 script:
+  - elapsed "script"
   # Note: bazel test implies fetch+build, but this gives us timing.
-  - bazel fetch //tensorboard/...
-  - bazel build //tensorboard/...
+  - elapsed && bazel fetch //tensorboard/...
+  - elapsed && bazel build //tensorboard/...
   - |
-    # When TensorFlow is not installed, run a restricted subset of tests.
-    if [ -z "${TF_VERSION_ID}" ]; then
-      test_tag_filters=support_notf
+    # Run tests (only a restricted subset if TensorFlow is not installed).
+    elapsed && if [ -n "${TF_VERSION_ID}" ]; then
+      bazel test //tensorboard/...
     else
-      test_tag_filters=
+      bazel test //tensorboard/... --test_tag_filters=support_notf
     fi
-  - bazel test //tensorboard/... --test_tag_filters="${test_tag_filters}"
+  - elapsed && bazel run //tensorboard/pip_package:build_pip_package -- --tf-version "${TF_VERSION_ID}" --smoke
   # Run manual S3 test
-  - bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test
-  - bazel run //tensorboard/pip_package:build_pip_package -- --tf-version "${TF_VERSION_ID}" --smoke
+  - elapsed && bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test
+  - elapsed "script (done)"
 
 after_script:
   # Bazel launches daemons unless --batch is used.
+  - elapsed "after_script"
   - bazel shutdown
-
-before_cache:
-  - |
-    # Scrub tiny build artifacts not worth caching.
-    find "${HOME}/.bazel-output-base" \
-      -name \*.runfiles -print0 \
-      -or -name \*.tar.gz -print0 \
-      -or -name \*-execroot.json -print0 \
-      -or -name \*-tsc.json -print0 \
-      -or -name \*-params.pbtxt -print0 \
-      -or -name \*-args.txt -print0 \
-      -or -name \*.runfiles_manifest -print0 \
-      -or -name \*.server_params.pbtxt -print0 \
-      | xargs -0 rm -rf
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,15 @@ before_script:
   - tensorboard/tools/license_test.sh
   # Make sure that IPython notebooks have valid Markdown.
   - tensorboard/tools/docs_list_format_test.sh
+  - |
+    # Specify subset of tests to run depending on TF installation config.
+    # We condition the value of --test_tag_filters so that we can run the
+    # bazel test command unconditionally which produces nicer log output.
+    if [ -z "${TF_VERSION_ID}" ]; then
+      test_tag_filters=support_notf
+    else
+      test_tag_filters=
+    fi
   - elapsed "before_script (done)"
 
 # Commands in this section should only fail if it's our fault. Travis will
@@ -90,13 +99,7 @@ script:
   # Note: bazel test implies fetch+build, but this gives us timing.
   - elapsed && bazel fetch //tensorboard/...
   - elapsed && bazel build //tensorboard/...
-  - |
-    # Run tests (only a restricted subset if TensorFlow is not installed).
-    elapsed && if [ -n "${TF_VERSION_ID}" ]; then
-      bazel test //tensorboard/...
-    else
-      bazel test //tensorboard/... --test_tag_filters=support_notf
-    fi
+  - elapsed && bazel test //tensorboard/... --test_tag_filters="${test_tag_filters}"
   - elapsed && bazel run //tensorboard/pip_package:build_pip_package -- --tf-version "${TF_VERSION_ID}" --smoke
   # Run manual S3 test
   - elapsed && bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test

--- a/ci/bazelrc
+++ b/ci/bazelrc
@@ -1,0 +1,34 @@
+# Limit resources since Travis Trusty GCE VMs have 2 cores and 7.5 GB RAM.
+build --local_resources=4000,2,1.0
+build --worker_max_instances=2
+
+# Ensure sandboxing is on to increase hermeticity.
+build --spawn_strategy=sandboxed
+build --worker_sandboxing
+
+# Ensure the PATH env var from our virtualenv propagates into tests, which is
+# no longer on by default in Bazel 0.21.0 and possibly again in the future.
+# We set this flag for "build" since "test" inherits it, but if we don't set
+# it for build too, this causes a rebuild at test time, and if we set it for
+# both we hit https://github.com/bazelbuild/bazel/issues/8237.
+#
+# See also:
+# https://github.com/bazelbuild/bazel/issues/7095 (protobuf PATH sensitivity)
+# https://github.com/bazelbuild/bazel/issues/7026 (future of action_env)
+build --action_env=PATH
+
+# Set up caching on local disk so incremental builds are faster.
+# See https://bazel.build/designs/2016/09/30/repository-cache.html
+build --repository_cache=~/.cache/tb-bazel-repo
+fetch --repository_cache=~/.cache/tb-bazel-repo
+query --repository_cache=~/.cache/tb-bazel-repo
+# See https://docs.bazel.build/versions/master/remote-caching.html#disk-cache
+build --disk_cache=~/.cache/tb-bazel-disk
+
+# Log more information to help with debugging, and disable curses output which
+# just adds more clutter to the log. (Travis spoofs an interactive terminal.)
+common --curses=no
+build --verbose_failures
+build --worker_verbose
+test --test_output=errors
+test --test_verbose_timeout_warnings

--- a/ci/download_bazel.sh
+++ b/ci/download_bazel.sh
@@ -24,7 +24,7 @@ die() {
 }
 
 if [ "$#" -ne 3 ]; then
-  die "Usage: ${0} <version> <sha256sum> <destination-file>"
+  die "Usage: $0 <version> <sha256sum> <destination-file>"
 fi
 
 version="$1"
@@ -33,7 +33,7 @@ dest="$3"
 
 temp_dest="$(mktemp)"
 
-mirror_url="https://mirror.bazel.build/github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-linux-x86_64"
+mirror_url="http://mirror.tensorflow.org/github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-linux-x86_64"
 github_url="https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-linux-x86_64"
 
 for url in "${mirror_url}" "${github_url}"; do

--- a/ci/download_bazel.sh
+++ b/ci/download_bazel.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Script to download Bazel binary directly onto a build machine.
+
+set -e
+
+die() {
+  printf >&2 "%s\n" "$1"
+  exit 1
+}
+
+if [ "$#" -ne 3 ]; then
+  die "Usage: ${0} <version> <sha256sum> <destination-file>"
+fi
+
+version="$1"
+checksum="$2"
+dest="$3"
+
+temp_dest="$(mktemp)"
+
+mirror_url="https://mirror.bazel.build/github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-linux-x86_64"
+github_url="https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-linux-x86_64"
+
+for url in "${mirror_url}" "${github_url}"; do
+  wget -t 3 -O "${temp_dest}" "${url}" \
+    && printf "%s  %s\n" "${checksum}" "${temp_dest}" | shasum -a 256 --check \
+    || { rm -f "${temp_dest}"; continue; }
+  mv "${temp_dest}" "${dest}"
+  break
+done
+
+[ -f "${dest}" ]
+chmod +x "${dest}"
+ls -l "${dest}"


### PR DESCRIPTION
This streamlines and improves our .travis.yml configuration and caching behavior in hopes of reducing our painfully slow Travis builds.  In my testing so far this drops the total time to execute by ~30% (so from 50m total across 3 machines to more like 35m), by shaving a little over 2 minutes off of each of the 6 jobs in our test matrix.

Here's the list of changes I implemented that I felt overall improved speed (or were mixed, but seemed like better practice):
- changed caching approach to use Bazel's properly designed caching APIs
  - repository caching for `bazel fetch` results
  - remote caching API for build results/artifacts, using local disk backend
  - **con:** fetch is slower (60ish seconds instead of 15) - not entirely sure why, but perhaps it doesn't cache all the downloaded results of fetch (some indication of this on https://github.com/bazelbuild/bazel/issues/6869). We may be able to tweak fetching behavior to improve this.
  - **con:** build is slower (90ish seconds instead of 60) - I think with the new caching we're rebuilding more things, e.g. now there are a bunch of closure warnings. We may be able to improve this by restructuring some of our build rules to be more cacheable, or generally speeding up the build.
  - **pro:** fetch/store operations for cache are much faster (60s fetch + 140s store reduced to 15s fetch + 60-75s store), which basically makes up for the above slowdowns
  - **pro:** no more need for hacky code to manually "prune" the output directory
- added caching for pip packages
  - **pro:** pip installs are perhaps 30% or so faster, which also speeds up the smoke test (I'm not sure why they aren't even faster than this; I think sometimes incorrectly skip the cache or in some cases the packages run setup.py operations that still take time)
  - **pro:** less at the whim of pypi latency; less uninteresting logging of package downloads
  - **con:** some extra time to fetch/store cache but not much (maybe 15s)
- removed warning-only flake8 run
  - **pro:** 10 seconds saved for every build job
  - **con:** no notice of warnings, but we never looked at this routinely anyway
- changed bazel --action_env=PATH to apply to build+test, not just test
  - **pro:** can re-use package analysis from build step in test step, saving a few seconds

And then I did some cleanup:

- factored out bazel settings into a `ci/bazelrc` file
- factored out bazel downloading logic into `ci/download_bazel.sh` and streamlined it slightly
- added bazelrc `common --curses=no` to suppress attempted progress bar spam
- removed aggressive use of bazel --host_jvm_args that I didn't see justification for
- removed redundant travis.yml config elements like sudo and os (Fixes #2113)
- slightly reworked some other misc travis steps for clarity

Finally I added some simple instrumentation showing the elapsed time since the shell started at various points during the job, which makes it a bit easier to get a sense of where the slow parts are without having to sum up the time taken by many individual commands (also, the travis time indicators are slightly flaky and don't always get parsed correctly by the fancy UI).

-----

I was originally hoping for a bigger speedup by combining all the testing for the different TF versions into a single job, since then we could reuse the build step and avoid rebuilding each time.  The problem I ran into was that bazel test result caching falls apart at that point - I wasn't aware of a simple way to tell bazel to treat each run of the tests as a separate set of cacheable test results (rather than re-using the same cache, which due to the non-hermeticity could fail to rerun tests that need to be rerun).  Trying to work around this via cache munging would erase a lot of the benefits of the simplification above, and that approach was already much more complicated than what I have here.  

Down the road, I think further improvements could be:
- making the actual fetch and build steps faster / caching them more effectively
- figuring out a way to incorporate the TF version into Bazel's hermeticized understanding of the world so that it caches test results for different TF versions differently, but somehow still re-uses the build outputs (I have no idea how to do this but maybe we could ask the Bazel team)
- reducing our TF-dependent tests to a smaller set, and then only running a much more limited set of tests against each TF version we test against (though of course once we bump versions to 2.0 we could stop testing against TF 1.x)
- waiting for Python 2 to finally die in 2020 and then no longer running those tests either


