### PR TITLE
fix tooltip position

### DIFF
--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -768,8 +768,8 @@ def run_inference(examples, serving_bundle):
     attributions = None
     # If the custom prediction function returned a dict, then parse out the
     # prediction scores and the attributions. If it is just a list, then the
-    # results are just the prediction results without attributions.
-    if not isinstance(values, list):
+    # results are the prediction results without attributions.
+    if isinstance(values, dict):
       attributions = values['attributions']
       values = values['predictions']
     return (common_utils.convert_prediction_values(values, serving_bundle),

--- a/tensorboard/plugins/interactive_inference/witwidget/version.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/version.py
@@ -14,4 +14,4 @@
 
 """Contains the version string."""
 
-VERSION = '1.0.2'
+VERSION = '1.1'

--- a/tensorboard/plugins/profile/pod_viewer/topology_graph/topology-graph.ts
+++ b/tensorboard/plugins/profile/pod_viewer/topology_graph/topology-graph.ts
@@ -356,8 +356,8 @@ Polymer({
 
             // Update the tooltip position and value
             d3.select(parent.$.tooltip)
-                .style('left', d3.select(this).attr('x') + 'px')
-                .style('top', d3.select(this).attr('y') + 'px')
+                .style('left', (~~d3.select(this).attr('x') + 50) + 'px')
+                .style('top', (~~d3.select(this).attr('y') + 200) + 'px')
                 .select('#value')
                 .text(parent._getToolTipText(d));
             d3.select(parent.$.tooltip).classed('hidden', false);

--- a/tensorboard/plugins/profile/pod_viewer/topology_graph/topology-graph.ts
+++ b/tensorboard/plugins/profile/pod_viewer/topology_graph/topology-graph.ts
@@ -356,8 +356,8 @@ Polymer({
 
             // Update the tooltip position and value
             d3.select(parent.$.tooltip)
-                .style('left', d3.event.pageX + 10 + 'px')
-                .style('top', d3.event.pageY - 10 + 'px')
+                .style('left', d3.select(this).attr('x') + 'px')
+                .style('top', d3.select(this).attr('y') + 'px')
                 .select('#value')
                 .text(parent._getToolTipText(d));
             d3.select(parent.$.tooltip).classed('hidden', false);

--- a/tensorboard/plugins/profile/pod_viewer/topology_graph/topology-graph.ts
+++ b/tensorboard/plugins/profile/pod_viewer/topology_graph/topology-graph.ts
@@ -356,8 +356,8 @@ Polymer({
 
             // Update the tooltip position and value
             d3.select(parent.$.tooltip)
-                .style('left', (~~d3.select(this).attr('x') + 50) + 'px')
-                .style('top', (~~d3.select(this).attr('y') + 200) + 'px')
+                .style('left', Number(d3.select(this).attr('x')) + 50 + 'px')
+                .style('top', Number(d3.select(this).attr('y')) + 200 + 'px')
                 .select('#value')
                 .text(parent._getToolTipText(d));
             d3.select(parent.$.tooltip).classed('hidden', false);


### PR DESCRIPTION
* Motivation for features / changes
The tooltip displayed when hovering on image of a pod is positioned suboptimally, this PR position the tooltip better. #2284 
* Technical description of changes

* Screenshots of UI changes
![pod_viewer_new3](https://user-images.githubusercontent.com/3082188/58595344-2eacfb00-8225-11e9-9eba-7cca5d0e4951.png)



* Detailed steps to verify changes work correctly (as executed by you)
bazel run tensorboard:tensorboard -- --logdir=gs://cloud-tpu-tools
* Alternate designs / implementations considered
