### PR TITLE
core: always gate data selector behind query param

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -730,18 +730,19 @@ limitations under the License.
           return;
         }
         const dashboard = tf_tensorboard.dashboardRegistry[selectedDashboard];
+        const useDataSelector = tf_globals.getEnableDataSelector() && dashboard.useDataSelector;
         // Use .children, not .childNodes, to avoid counting comment nodes.
         if (container.children.length === 0) {
           const component = document.createElement(dashboard.elementName);
           component.id = 'dashboard';  // used in `_selectedDashboardComponent`
-          if (dashboard.useDataSelector) {
+          if (useDataSelector) {
             this.cancelDebouncer('updateDataSelection');
             component.dataSelection = this._dataSelection;
           }
           container.appendChild(component);
         }
         this.set('_isReloadDisabled', dashboard.isReloadDisabled);
-        this.set('_isDataSelectorEnabled', dashboard.useDataSelector);
+        this.set('_isDataSelectorEnabled', useDataSelector);
       },
 
       /**
@@ -777,7 +778,7 @@ limitations under the License.
 
         const selectedDashboard = this._selectedDashboard;
         const dashboard = tf_tensorboard.dashboardRegistry[selectedDashboard];
-        if (dashboard.useDataSelector) {
+        if (tf_globals.getEnableDataSelector() && dashboard.useDataSelector) {
           this.debounce('updateDataSelection', () => {
             component.dataSelection = this._dataSelection;
           }, DATA_SELECTION_CHANGE_DEBOUNCE_MS);

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -271,7 +271,7 @@ limitations under the License.
 
         useDataSelector: {
           type: Boolean,
-          value: USE_DATA_SELECTOR,
+          computed: '_computeUseDataSelector(dataSelection)',
         },
       },
       behaviors: [
@@ -289,6 +289,9 @@ limitations under the License.
           '_ignoreYOutliers', {defaultValue: true, useLocalStorage: true}),
       _computeSmoothingEnabled(_smoothingWeight) {
         return _smoothingWeight > 0;
+      },
+      _computeUseDataSelector(dataSelection) {
+        return dataSelection != null;
       },
 
       _getCategoryKey(category) {
@@ -363,7 +366,7 @@ limitations under the License.
       _updateCategories(
           runToTagInfo, selectedRuns, tagFilter, categoriesDomReady) {
         let categories;
-        const usesDataSelection = this.useDataSelector && this.dataSelection;
+        const usesDataSelection = this.dataSelection != null;
         if (usesDataSelection && this.dataSelection.selections.length == 0) {
           categories = [];
         } else if (usesDataSelection &&
@@ -425,7 +428,7 @@ limitations under the License.
     tf_tensorboard.registerDashboard({
       plugin: PLUGIN_NAME,
       elementName: 'tf-scalar-dashboard',
-      useDataSelector: USE_DATA_SELECTOR,
+      useDataSelector: true,
     });
 
   </script>


### PR DESCRIPTION
Summary:
We’d like to serve dashboard registration metadata from the backend, as
will be the case for dynamically loaded plugins. This is straightforward
except for the scalar plugin’s `useDataSelector` bit, which depends on
the query parameter. This patch changes moves the query parameter gating
from the scalar plugin to the core frontend.

Test Plan:
Verify that the following behavior is the same before and after this
change: (a) when the URL has no query parameters, neither the scalars
dashboard nor the images dashboard shows a data selector; and (b) when
the URL has `?EnableDataSelector`, the scalars dashboard has a data
selector and no run selector, while the images dashboard has a run
selector and no data selector.

wchargin-branch: top-level-data-selector-flag
