### PR TITLE
test: ensure that build URLs are valid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,8 @@ before_script:
   - tensorboard/tools/license_test.sh
   # Make sure that IPython notebooks have valid Markdown.
   - tensorboard/tools/docs_list_format_test.sh
+  # Make sure that build URLs are valid.
+  - tensorboard/tools/mirror_urls_test.sh
 
 # Commands in this section should only fail if it's our fault. Travis will
 # categorize them as 'failed', rather than 'error' for other sections.

--- a/tensorboard/tools/mirror_urls_test.sh
+++ b/tensorboard/tools/mirror_urls_test.sh
@@ -43,7 +43,7 @@ check_urls_resolve() {
     check_cmd='curl -sfL "$1" >/dev/null || printf "%s\n" "$1"'
     # shellcheck disable=SC2016
     git grep -Pho '(?<=")https?://mirror\.tensorflow\.org/[^"]*' \
-        | grep -vF '${BAZEL}' \
+        | grep -vF '${version}' \
         | sort \
         | uniq \
         | xargs -n 1 -P 32 -- sh -c "${check_cmd}" unused \

--- a/tensorboard/tools/mirror_urls_test.sh
+++ b/tensorboard/tools/mirror_urls_test.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Check that all TensorFlow build mirror URLs resolve, and that we're
+# not using any legacy Bazel mirror URLs.
+#
+# This does not check that every URL in a build/workspace file is
+# properly mirrored.
+#
+# This test requires an Internet connection.
+
+set -eu
+
+if ! [ -f WORKSPACE ]; then
+    printf >&2 'fatal: no WORKSPACE file found (are you at TensorBoard root?)\n'
+    exit 2
+fi
+
+unresolved_urls_file=
+bazel_urls_file=
+cleanup() {
+    rm "${unresolved_urls_file}" || true
+    rm "${bazel_urls_file}" || true
+}
+trap cleanup EXIT
+
+check_urls_resolve() {
+    unresolved_urls_file="$(mktemp)"
+    # shellcheck disable=SC2016
+    check_cmd='curl -sfL "$1" >/dev/null || printf "%s\n" "$1"'
+    # shellcheck disable=SC2016
+    git grep -Pho '(?<=")https?://mirror\.tensorflow\.org/[^"]*' \
+        | grep -vF '${BAZEL}' \
+        | sort \
+        | uniq \
+        | xargs -n 1 -P 32 -- sh -c "${check_cmd}" unused \
+        | sort \
+        >"${unresolved_urls_file}"
+    # NOTE: The above use of `xargs -P` with a single output stream is
+    # technically subject to race conditions involving interleaving
+    # output. This is unlikely to occur in practice, and if it does
+    # occur the exit status of this test will still be correct; only the
+    # list of URLs may potentially be mangled.
+
+    if ! [ -s "${unresolved_urls_file}" ]; then
+        return 0
+    fi
+
+    printf '%s\n' 'The following URLs are not properly mirrored:'
+    cat "${unresolved_urls_file}"
+    printf '%s\n' \
+        'Googlers, see http://b/133880558 for further instructions.' \
+        '' \
+        ;
+    return 1
+}
+
+check_no_bazel_urls() {
+    bazel_urls_file="$(mktemp)"
+    git grep -Hn 'https\?://mirror\.bazel\.build\S*' \
+        | sort \
+        >"${bazel_urls_file}"
+    if ! [ -s "${bazel_urls_file}" ]; then
+        return 0
+    fi
+    printf '%s\n' 'The following URLs point to the legacy Bazel mirror:'
+    cat "${bazel_urls_file}"
+    printf '%s\n' \
+        'Please update them to use http://mirror.tensorflow.org/ instead.' \
+        '' \
+        ;
+    return 1
+}
+
+main() {
+    failed=0
+    check_urls_resolve || failed=1
+    check_no_bazel_urls || failed=1
+    return "${failed}"
+}
+
+main "$@"

--- a/tensorboard/tools/mirror_urls_test.sh
+++ b/tensorboard/tools/mirror_urls_test.sh
@@ -70,7 +70,7 @@ check_urls_resolve() {
 
 check_no_bazel_urls() {
     bazel_urls_file="$(mktemp)"
-    git grep -Hn 'https\?://mirror\.bazel\.build\S*' \
+    git grep -Hn 'https\?://mirror\.bazel\.build' \
         | sort \
         >"${bazel_urls_file}"
     if ! [ -s "${bazel_urls_file}" ]; then

--- a/tensorboard/tools/mirror_urls_test.sh
+++ b/tensorboard/tools/mirror_urls_test.sh
@@ -42,8 +42,13 @@ check_urls_resolve() {
     # shellcheck disable=SC2016
     check_cmd='curl -sfL "$1" >/dev/null || printf "%s\n" "$1"'
     # shellcheck disable=SC2016
-    git grep -Pho '(?<=")https?://mirror\.tensorflow\.org/[^"]*' \
-        | grep -vF '${version}' \
+    exclude='${version}'  # as in `ci/download_bazel.sh`
+    # We use `git-grep` to efficiently get an initial result set, then
+    # filter it down with GNU `grep` separately, because `git-grep` only
+    # learned `-o` in Git v2.19; Travis uses v2.15.1.
+    git grep -Ph '(?<=")https?://mirror\.tensorflow\.org/[^"]*' \
+        | grep -o 'https\?://mirror\.tensorflow\.org/[^"]*' \
+        | grep -vF -- "${exclude}" \
         | sort \
         | uniq \
         | xargs -n 1 -P 32 -- sh -c "${check_cmd}" unused \


### PR DESCRIPTION
Summary:
This tests that URLs point to the TensorFlow mirror (as opposed to the
Bazel mirror) and that they resolve to valid archives.

Test Plan:
Run `./tensorboard/tools/mirror_urls_test.sh`, and note that it passes
with no output. Then apply the following patch to add some bad URLs:

```diff
diff --git a/WORKSPACE b/WORKSPACE
index 3943b0cf..d3975dfe 100644
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,9 @@ http_archive(
     urls = [
         # tag 0.7.0 resolves to commit 6741f733227dc68137512161a5ce6fcf283e3f58 (2019-02-08 18:37:26 +0100)
         "http://mirror.tensorflow.org/github.com/bazelbuild/bazel-skylib/archive/0.7.0.tar.gz",
+        "http://mirror.tensorflow.org/example.com/nonexistent.txt",
+        "http://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/0.7.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/0.7.0.tar.gz",
         "https://github.com/bazelbuild/bazel-skylib/archive/0.7.0.tar.gz",
     ],
 )
```

Re-run the test, and note that it fails with exit code 1 and this text:

```
The following URLs are not properly mirrored:
  - http://mirror.tensorflow.org/example.com/nonexistent.txt
Please comment on your PR asking a TensorBoard core team member
to mirror these URLs per instructions in http://b/133880558.

The following URLs point to the legacy Bazel mirror:
WORKSPACE:13:        "http://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/0.7.0.tar.gz",
WORKSPACE:14:        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/0.7.0.tar.gz",
Please update them to use http://mirror.tensorflow.org/ instead.

```

Tested on Git v2.15.1, which is what Travis uses.

wchargin-branch: mirror-urls-test