### PR TITLE
Travis CI: Do not hardcore trusty because it is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
Trusty is beyond its normal support date so do not hardcode it in .travis.yml. @nfelt Your review please?

* Motivation for features / changes

* Technical description of changes

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
