### PR TITLE
Fix invisible selector box

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/scatterPlotRectangleSelector.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotRectangleSelector.ts
@@ -68,7 +68,7 @@ export class ScatterPlotRectangleSelector {
 
   onMouseDown(offsetX: number, offsetY: number) {
     this.isMouseDown = true;
-    this.rectElement.style.display = 'block';
+    this.svgElement.style.display = 'block';
 
     this.startCoordinates = [offsetX, offsetY];
     this.lastBoundingBox = {
@@ -100,7 +100,7 @@ export class ScatterPlotRectangleSelector {
 
   onMouseUp() {
     this.isMouseDown = false;
-    this.rectElement.style.display = 'none';
+    this.svgElement.style.display = 'none';
     this.rectElement.setAttribute('width', '0');
     this.rectElement.setAttribute('height', '0');
     this.selectionCallback(this.lastBoundingBox);


### PR DESCRIPTION
For some reason the selector bounding box has disappeared in the embedding projector. This PR fixes it, making it visible again.

Fixes #2195.