### PR TITLE
Add user friendly message when scroll on chart

### DIFF
--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -207,7 +207,7 @@ export class LineChart {
 
     this.center = new Plottable.Components.Group([
         this.gridlines, xZeroLine, yZeroLine, plot,
-        panZoomLayer, this.tooltipPointsComponent]);
+        this.tooltipPointsComponent, panZoomLayer]);
     this.center.addClass('main');
     this.outer = new Plottable.Components.Table(
         [[this.yAxis, this.center], [null, this.xAxis]]);


### PR DESCRIPTION
Now that we have only enabled scroll zooming when pressing ALT, we
should provide message indicating that the affordance has changed.

Also changed the panning to also work with the ALT key.

![image](https://user-images.githubusercontent.com/2547313/58668232-24eeca80-82ed-11e9-8afb-ac0b12656a08.png)


This change augments #2221.