### PR TITLE
Enable WIT usage in JupyterLab/Cloud AI Platform notebooks

### DIFF
--- a/tensorboard/plugins/interactive_inference/README.md
+++ b/tensorboard/plugins/interactive_inference/README.md
@@ -312,7 +312,7 @@ containing:
 ```
 !pip install witwidget
 ```
-For TensorFlow GPU support, use the witwidget-gpu package instead of witwidget.
+For TensorFlow GPU support, use the `witwidget-gpu` package instead of `witwidget`.
 
 Then, use it as seen at the bottom of the
 [What_If_Tool_Notebook_Usage.ipynb notebook](https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/tensorboard/plugins/interactive_inference/What_If_Tool_Notebook_Usage.ipynb).
@@ -324,7 +324,7 @@ Install and enable WIT for JupyterLab by running a cell containing:
 !jupyter labextension install wit-widget
 !jupyter labextension install @jupyter-widgets/jupyterlab-manager
 ```
-For TensorFlow GPU support, use the witwidget-gpu package instead of witwidget.
-Note that you may need to run "!sudo jupyter labextension install..." commands depending on your notebook setup.
+For TensorFlow GPU support, use the `witwidget-gpu` package instead of `witwidget`.
+Note that you may need to run `!sudo jupyter labextension ...` commands depending on your notebook setup.
 
 Use of WIT after installation is the same as with the other notebook installations.

--- a/tensorboard/plugins/interactive_inference/README.md
+++ b/tensorboard/plugins/interactive_inference/README.md
@@ -316,3 +316,15 @@ For TensorFlow GPU support, use the witwidget-gpu package instead of witwidget.
 
 Then, use it as seen at the bottom of the
 [What_If_Tool_Notebook_Usage.ipynb notebook](https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/tensorboard/plugins/interactive_inference/What_If_Tool_Notebook_Usage.ipynb).
+
+### How do I enable it for use in a JupyterLab or Cloud AI Platform notebook?
+Install and enable WIT for JupyterLab by running a cell containing:
+```
+!pip install witwidget
+!jupyter labextension install wit-widget
+!jupyter labextension install @jupyter-widgets/jupyterlab-manager
+```
+For TensorFlow GPU support, use the witwidget-gpu package instead of witwidget.
+Note that you may need to run "!sudo jupyter labextension install..." commands depending on your notebook setup.
+
+Use of WIT after installation is the same as with the other notebook installations.

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/README.md
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/README.md
@@ -1,0 +1,5 @@
+# wit-widget: What-If Tool JupyterLab extension
+
+This npm package is for using the [What-If Tool](https://pair-code.github.io/what-if-tool/) as a JupyterLab extension.
+
+For more information, see the [What-If Tool documentation](https://github.com/tensorflow/tensorboard/blob/master/tensorboard/plugins/interactive_inference/README.md).

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/index.js
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/index.js
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-window.__webpack_public_path__ =
+window.__nbextension_path__ =
   document.querySelector('body').getAttribute('data-base-url') +
   'nbextensions/wit-widget/';
 

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
@@ -44,7 +44,7 @@ var WITView = widgets.DOMWidgetView.extend({
 
     // Adjust WIT html location if running in a jupyter notebook
     // and not in jupyterlab.
-    if (document.querySelector('body').getAttribute('data-base-url') != null) {
+    if (document.body.getAttribute('data-base-url') != null) {
       witHtmlLocation = window.__nbextension_path__ + 'wit_jupyter.html';
     }
 

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
@@ -41,6 +41,13 @@ var WITView = widgets.DOMWidgetView.extend({
     const height = parseInt(
       this.model.attributes.layout.attributes.height, 10) - 20;
     const iframe = document.createElement('iframe');
+
+    // Adjust WIT html location if running in a jupyter notebook
+    // and not in jupyterlab.
+    if (document.querySelector('body').getAttribute('data-base-url') != null) {
+      witHtmlLocation = window.__webpack_public_path__ + 'wit_jupyter.html';
+    }
+
     const src = `<link rel="import" href="${witHtmlLocation}">
     <tf-interactive-inference-dashboard local id="wit"></tf-interactive-inference-dashboard>
     <script>

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+var witHtmlLocation = require('file-loader!./wit_jupyter.html');
 var widgets = require('@jupyter-widgets/base');
 
 // What-If Tool View. Renders the tool and provides communication with the
@@ -40,9 +41,7 @@ var WITView = widgets.DOMWidgetView.extend({
     const height = parseInt(
       this.model.attributes.layout.attributes.height, 10) - 20;
     const iframe = document.createElement('iframe');
-    const templateLocation =
-      window.__webpack_public_path__ + 'wit_jupyter.html';
-    const src = `<link rel="import" href="${templateLocation}">
+    const src = `<link rel="import" href="${witHtmlLocation}">
     <tf-interactive-inference-dashboard local id="wit"></tf-interactive-inference-dashboard>
     <script>
       const wit = document.getElementById('wit');

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
@@ -45,7 +45,7 @@ var WITView = widgets.DOMWidgetView.extend({
     // Adjust WIT html location if running in a jupyter notebook
     // and not in jupyterlab.
     if (document.querySelector('body').getAttribute('data-base-url') != null) {
-      witHtmlLocation = window.__webpack_public_path__ + 'wit_jupyter.html';
+      witHtmlLocation = window.__nbextension_path__ + 'wit_jupyter.html';
     }
 
     const src = `<link rel="import" href="${witHtmlLocation}">

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
@@ -14,7 +14,8 @@
     "jupyterlab-extension"
   ],
   "files": [
-    "dist/*"
+    "dist/*",
+    "lib/*"
   ],
   "scripts": {
     "build": "webpack",

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
@@ -3,7 +3,7 @@
   "description": "What-If Tool jupyter widget",
   "author": "Google LLC",
   "main": "dist/index.js",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license" : "Apache 2.0",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.0.0",
-    "@jupyter-widgets/jupyterlab-manager": "^0.40.0",
+    "@jupyter-widgets/jupyterlab-manager": "0.38.1",
     "file-loader": "^3.0.1"
   },
   "jupyterlab": {

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
@@ -2,12 +2,13 @@
   "name": "wit-widget",
   "description": "What-If Tool jupyter widget",
   "author": "Google LLC",
-  "main": "lib/index.js",
+  "main": "dist/index.js",
+  "version": "0.1.5",
+  "license" : "Apache 2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tensorflow/tensorboard.git"
   },
-  "private": true,
   "keywords": [
     "jupyter",
     "widgets",
@@ -16,8 +17,8 @@
     "jupyterlab-extension"
   ],
   "files": [
-    "lib/**/*.js",
-    "dist/*.js"
+    "lib/*",
+    "dist/*"
   ],
   "scripts": {
     "build": "webpack",
@@ -28,7 +29,9 @@
     "rimraf": "^2.6.1"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^1.0.0"
+    "@jupyter-widgets/base": "^1.0.0",
+    "@jupyter-widgets/jupyterlab-manager": "^0.40.0",
+    "file-loader": "^3.0.1"
   },
   "jupyterlab": {
     "extension": "lib/labplugin"

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
@@ -3,12 +3,9 @@
   "description": "What-If Tool jupyter widget",
   "author": "Google LLC",
   "main": "dist/index.js",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license" : "Apache 2.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/tensorflow/tensorboard.git"
-  },
+  "homepage": "https://github.com/tensorflow/tensorboard/tree/master/tensorboard/plugins/interactive_inference",
   "keywords": [
     "jupyter",
     "widgets",

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
@@ -3,7 +3,7 @@
   "description": "What-If Tool jupyter widget",
   "author": "Google LLC",
   "main": "dist/index.js",
-  "version": "0.1.7",
+  "version": "1.1.0",
   "license" : "Apache 2.0",
   "homepage": "https://github.com/tensorflow/tensorboard/tree/master/tensorboard/plugins/interactive_inference",
   "keywords": [
@@ -14,7 +14,6 @@
     "jupyterlab-extension"
   ],
   "files": [
-    "lib/*",
     "dist/*"
   ],
   "scripts": {
@@ -22,13 +21,13 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "webpack": "^3.5.5",
-    "rimraf": "^2.6.1"
+    "file-loader": "^3.0.1",
+    "rimraf": "^2.6.1",
+    "webpack": "^3.5.5"
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.0.0",
-    "@jupyter-widgets/jupyterlab-manager": "^0.38.1",
-    "file-loader": "^3.0.1"
+    "@jupyter-widgets/jupyterlab-manager": "^0.38.1"
   },
   "jupyterlab": {
     "extension": "lib/labplugin"

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.0.0",
-    "@jupyter-widgets/jupyterlab-manager": "0.38.1",
+    "@jupyter-widgets/jupyterlab-manager": "^0.38.1",
     "file-loader": "^3.0.1"
   },
   "jupyterlab": {

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/webpack.config.js
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/webpack.config.js
@@ -19,7 +19,8 @@ var version = require('./package.json').version;
 // Custom webpack rules are generally the same for all webpack bundles, hence
 // stored in a separate local variable.
 var rules = [
-    { test: /\.css$/, use: ['style-loader', 'css-loader']}
+    { test: /\.css$/, use: ['style-loader', 'css-loader']},
+    { test: /\.(html)$/, use: [{loader: 'file-loader', options: {}}]},
 ]
 
 

--- a/tensorboard/plugins/interactive_inference/witwidget/pip_package/RELEASE.md
+++ b/tensorboard/plugins/interactive_inference/witwidget/pip_package/RELEASE.md
@@ -1,10 +1,12 @@
 # To release a new version of witwidget on PyPI and NPM:
  
-1. Update tensorboard/plugins/interactive_inference/witwidget/version.py (set release version, remove 'dev')
-2. Update version number in tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
+1. Ensure updated version numbers have been merged to the master branch in
+tensorboard/plugins/interactive_inference/witwidget/version.py
+and tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
+2. Clone this repository and checkout the commit that set the new version numbers.
 3. `bazel run tensorboard/plugins/interactive_inference/witwidget/pip_package:build_pip_package`
 4. Upload the whl files created by the previous step to PyPI as per instructions
 at https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives.
-5. Publish the new NPM package through running "npm publish" in the "js/" subdirectory of the package files generated in step 3.
-6. Commit the version changes.
+5. Publish the new NPM package through running `npm publish` in the `js/` subdirectory of the package
+files generated during the build step.
 

--- a/tensorboard/plugins/interactive_inference/witwidget/pip_package/RELEASE.md
+++ b/tensorboard/plugins/interactive_inference/witwidget/pip_package/RELEASE.md
@@ -1,7 +1,10 @@
-# To release a new version of witwidget on PyPI:
+# To release a new version of witwidget on PyPI and NPM:
  
 1. Update tensorboard/plugins/interactive_inference/witwidget/version.py (set release version, remove 'dev')
-2. `bazel run tensorboard/plugins/interactive_inference/witwidget/pip_package:build_pip_package`
-3. Upload the whl files created by the previous step to PyPI as per instructions
+2. Update version number in tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/package.json
+3. `bazel run tensorboard/plugins/interactive_inference/witwidget/pip_package:build_pip_package`
+4. Upload the whl files created by the previous step to PyPI as per instructions
 at https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives.
-4. Commit the version.py change.
+5. Publish the new NPM package through running "npm publish" in the "js/" subdirectory of the package files generated in step 3.
+6. Commit the version changes.
+

--- a/tensorboard/plugins/interactive_inference/witwidget/pip_package/build_pip_package.sh
+++ b/tensorboard/plugins/interactive_inference/witwidget/pip_package/build_pip_package.sh
@@ -40,6 +40,7 @@ mkdir -p js
 pushd js
 
 cp -LR "$plugin_runfile_dir"/witwidget/notebook/jupyter/js/* .
+cp "$plugin_runfile_dir/tf_interactive_inference_dashboard/wit_jupyter.html" lib/
 
 # Install Node dependencies
 npm install


### PR DESCRIPTION
* Motivation for features / changes

Update WitWidget packaging/logic to enable it to work in JupyterLab notebooks, which handle extensions like WitWidget differently than standard Jupyter notebooks. This also enables use in Cloud AI Platform notebooks.

* Technical description of changes

Update packaging code to create correct, public NPM package, as the HTML/JS side of lab extensions are NPM packages.
Update witwidget jupyter js code to handle loading wit_jupyter.html from correct packaged location when running in JupyterLab, while keeping the same initial logic for loading that file when in standard Jupyter, as they are different paths.
Update package building script and webpack config to correctly bundle wit_jupyter.html with the NPM package for the JupyterLab extension.
Update documentation.

* Screenshots of UI changes

No visual changes.

* Detailed steps to verify changes work correctly (as executed by you)

Installed/ran WIT in Cloud AI Platform notebooks (which are JupyterLab notebooks).
Installed/ran WIT in standard Jupyter notebooks to ensure this change didn't break that case.

