### PR TITLE
core: stabilize and use `plugin_metadata`

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -23,6 +23,7 @@ from __future__ import division
 from __future__ import print_function
 
 import atexit
+import collections
 import json
 import os
 import re
@@ -274,7 +275,7 @@ class TensorBoardWSGI(object):
     Returns:
       A werkzeug.Response object.
     """
-    response = {}
+    response = collections.OrderedDict()
     for plugin in self._plugins:
       start = time.time()
       is_active = plugin.is_active()
@@ -310,9 +311,8 @@ class TensorBoardWSGI(object):
             ]),
         }
       else:
-        # As a compatibility measure (for plugins that we don't control,
-        # and for incremental migration of core plugins), we'll pull it
-        # from the frontend registry for now.
+        # As a compatibility measure (for plugins that we don't
+        # control), we'll pull it from the frontend registry for now.
         loading_mechanism = {
             'type': 'NONE',
         }

--- a/tensorboard/backend/json_util.py
+++ b/tensorboard/backend/json_util.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
 import math
 
 from tensorboard.compat import tf
@@ -69,6 +70,9 @@ def Cleanse(obj, encoding='utf-8'):
   elif isinstance(obj, set):
     return [Cleanse(i, encoding) for i in sorted(obj)]
   elif isinstance(obj, dict):
-    return {Cleanse(k, encoding): Cleanse(v, encoding) for k, v in obj.items()}
+    return collections.OrderedDict(
+        (Cleanse(k, encoding), Cleanse(v, encoding))
+        for k, v in obj.items()
+    )
   else:
     return obj

--- a/tensorboard/backend/json_util_test.py
+++ b/tensorboard/backend/json_util_test.py
@@ -17,13 +17,16 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
+import string
+
 from tensorboard import test as tb_test
 from tensorboard.backend import json_util
 
 _INFINITY = float('inf')
 
 
-class FloatWrapperTest(tb_test.TestCase):
+class CleanseTest(tb_test.TestCase):
 
   def _assertWrapsAs(self, to_wrap, expected):
     """Asserts that |to_wrap| becomes |expected| when wrapped."""
@@ -49,6 +52,15 @@ class FloatWrapperTest(tb_test.TestCase):
 
   def testWrapsRecursively(self):
     self._assertWrapsAs({'x': [_INFINITY]}, {'x': ['Infinity']})
+
+  def testOrderedDict_preservesOrder(self):
+    # dict iteration order is not specified prior to Python 3.7, and is
+    # observably different from insertion order in CPython 2.7.
+    od = collections.OrderedDict()
+    for c in string.ascii_lowercase:
+      od[c] = c
+    self.assertEqual(len(od), 26, od)
+    self.assertEqual(list(od), list(json_util.Cleanse(od)))
 
   def testTuple_turnsIntoList(self):
     self.assertEqual(json_util.Cleanse(('a', 'b')), ['a', 'b'])

--- a/tensorboard/components/tf_tensorboard/default-plugins.html
+++ b/tensorboard/components/tf_tensorboard/default-plugins.html
@@ -18,12 +18,8 @@ limitations under the License.
 <!--
   Load dashboards into UI for all first-party TensorBoard plugins.
 
-  Each dashboard calls the registerDashboard() function to tell
-  <tf-tensorboard> that it exists, so it can be loaded dynamically via
-  document.createElement().
-
-  Ordering matters. The order in which these lines appear determines the
-  ordering of tabs in TensorBoard's GUI.
+  Each dashboard registers itself onto the global CustomElementRegistry,
+  and is later instantiated dynamically with `document.createElement`.
 -->
 <link rel="import" href="../tf-scalar-dashboard/tf-scalar-dashboard.html">
 <link rel="import" href="../tf-custom-scalar-dashboard/tf-custom-scalar-dashboard.html">

--- a/tensorboard/components/tf_tensorboard/registry.ts
+++ b/tensorboard/components/tf_tensorboard/registry.ts
@@ -80,7 +80,12 @@ export type DashboardRegistry = {[key: string]: Dashboard};
 export let dashboardRegistry : DashboardRegistry = {};
 
 /**
- * Registers Dashboard for plugin into TensorBoard frontend.
+ * For legacy plugins, registers Dashboard for plugin into TensorBoard frontend.
+ *
+ * New plugins should implement the `frontend_metadata` method on the
+ * corresponding Python plugin to provide this information instead.
+ *
+ * For legacy plugins:
  *
  * This function should be called after the Polymer custom element is defined.
  * It's what allows the tf-tensorboard component to dynamically load it as a

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -387,10 +387,6 @@ limitations under the License.
   </template>
   <script src="autoReloadBehavior.js"></script>
   <script>
-    if (_.isEmpty(tf_tensorboard.dashboardRegistry)) {
-      throw new Error('HTML import plugin dashboards *before* tf-tensorboard');
-    }
-
     /**
      * @typedef {{
      *   plugin: string,
@@ -555,7 +551,7 @@ limitations under the License.
         _showNoSuchDashboardMessage: {
           type: Boolean,
           computed:
-            '_computeShowNoSuchDashboardMessage(_dashboardData, _selectedDashboard)',
+            '_computeShowNoSuchDashboardMessage(_activeDashboardsLoaded, _dashboardRegistry, _selectedDashboard)',
         },
 
         /**
@@ -571,13 +567,12 @@ limitations under the License.
         _dashboardToMaybeRemove: String,
 
         /*
-         * Will be set to `true` once our DOM is ready: in particular,
-         * once each dashboard has a `<div>` into which we can render its
-         * Polymer component root.
+         * Once the dashboard container for dashboard `d` is stamped,
+         * key `d` of this object will be set to `true`.
          */
         _dashboardContainersStamped: {
-          type: Boolean,
-          value: false,
+          type: Object,
+          value: () => ({}),
         },
         _isReloadDisabled: {
           type: Boolean,
@@ -764,7 +759,7 @@ limitations under the License.
           activeDashboards,
           selectedDashboard,
       ) {
-        if (!containersStamped || !activeDashboards || !selectedDashboard) {
+        if (!activeDashboards || !selectedDashboard || !containersStamped[selectedDashboard]) {
           return;
         }
         const previous = this._dashboardToMaybeRemove;
@@ -824,10 +819,6 @@ limitations under the License.
        * `null` is returned.
        */
       _selectedDashboardComponent() {
-        if (!this._dashboardContainersStamped) {
-          throw new Error(
-            'There is no "selected dashboard" before containers are stamped.');
-        }
         const selectedDashboard = this._selectedDashboard;
         var dashboard = this.$$(
           `.dashboard-container[data-dashboard=${selectedDashboard}] #dashboard`);
@@ -835,9 +826,6 @@ limitations under the License.
       },
 
       _updateDataSelection(dashboardRegistry) {
-        // The dashboard is not ready yet until it stamped the containers.
-        if (!this._dashboardContainersStamped) return;
-
         this.cancelDebouncer('updateDataSelection');
 
         const component = this._selectedDashboardComponent();
@@ -873,7 +861,11 @@ limitations under the License.
         const dashboardsTemplate = this.$$('#dashboards-template');
         const onDomChange = () => {
           // This will trigger an observer that kicks off everything.
-          this._dashboardContainersStamped = true;
+          const dashboardContainersStamped = {};
+          for (const container of this.querySelectorAll('.dashboard-container')) {
+            dashboardContainersStamped[container.dataset.dashboard] = true;
+          }
+          this._dashboardContainersStamped = dashboardContainersStamped;
         };
         dashboardsTemplate.addEventListener(
           'dom-change', onDomChange, /*useCapture=*/false);
@@ -972,7 +964,17 @@ limitations under the License.
             };
           }
         }
-        return registry;
+
+        // Reorder to list all values from the `/data/plugins_listing`
+        // response first and in their listed order.
+        const orderedRegistry = {};
+        for (const plugin of Object.keys(pluginsListing)) {
+          if (registry[plugin]) {
+            orderedRegistry[plugin] = registry[plugin];
+          }
+        }
+        Object.assign(orderedRegistry, registry);
+        return orderedRegistry;
       },
 
       _computeDashboardData(dashboardRegistry) {
@@ -1016,9 +1018,8 @@ limitations under the License.
           && activeDashboards.length === 0
           && selectedDashboard == null);
       },
-      _computeShowNoSuchDashboardMessage(dashboards, selectedDashboard) {
-        return !!selectedDashboard &&
-               !dashboards.some(d => d.plugin === selectedDashboard);
+      _computeShowNoSuchDashboardMessage(loaded, registry, selectedDashboard) {
+        return loaded && !!selectedDashboard && registry[selectedDashboard] == null;
       },
 
       _updateRouter(router) {

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -58,22 +58,24 @@ from tensorboard.plugins.mesh import mesh_plugin
 
 logger = logging.getLogger(__name__)
 
+# Ordering matters. The order in which these lines appear determines the
+# ordering of tabs in TensorBoard's GUI.
 _PLUGINS = [
     core_plugin.CorePluginLoader(),
-    beholder_plugin_loader.BeholderPluginLoader(),
     scalars_plugin.ScalarsPlugin,
     custom_scalars_plugin.CustomScalarsPlugin,
     images_plugin.ImagesPlugin,
     audio_plugin.AudioPlugin,
+    debugger_plugin_loader.DebuggerPluginLoader(),
     graphs_plugin.GraphsPlugin,
     distributions_plugin.DistributionsPlugin,
     histograms_plugin.HistogramsPlugin,
-    pr_curves_plugin.PrCurvesPlugin,
     projector_plugin.ProjectorPlugin,
     text_plugin.TextPlugin,
-    interactive_inference_plugin_loader.InteractiveInferencePluginLoader(),
+    pr_curves_plugin.PrCurvesPlugin,
     profile_plugin_loader.ProfilePluginLoader(),
-    debugger_plugin_loader.DebuggerPluginLoader(),
+    beholder_plugin_loader.BeholderPluginLoader(),
+    interactive_inference_plugin_loader.InteractiveInferencePluginLoader(),
     hparams_plugin_loader.HParamsPluginLoader(),
     mesh_plugin.MeshPlugin,
 ]

--- a/tensorboard/plugins/audio/audio_plugin.py
+++ b/tensorboard/plugins/audio/audio_plugin.py
@@ -62,6 +62,11 @@ class AudioPlugin(base_plugin.TBPlugin):
       return False
     return bool(self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME))
 
+  def frontend_metadata(self):
+    return super(AudioPlugin, self).frontend_metadata()._replace(
+        element_name='tf-audio-dashboard',
+    )
+
   def _index_impl(self):
     """Return information about the tags in each run.
 

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
@@ -176,10 +176,5 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
       },
     });
 
-    tf_tensorboard.registerDashboard({
-      plugin: 'audio',
-      elementName: 'tf-audio-dashboard',
-    });
-
   </script>
 </dom-module>

--- a/tensorboard/plugins/beholder/beholder_plugin.py
+++ b/tensorboard/plugins/beholder/beholder_plugin.py
@@ -74,6 +74,12 @@ class BeholderPlugin(base_plugin.TBPlugin):
     return tf.io.gfile.exists(summary_filename) and\
            tf.io.gfile.exists(info_filename)
 
+  def frontend_metadata(self):
+    return super(BeholderPlugin, self).frontend_metadata()._replace(
+        element_name='tf-beholder-dashboard',
+        remove_dom=True,
+    )
+
   def is_config_writable(self):
     try:
       if not tf.io.gfile.exists(self.PLUGIN_LOGDIR):

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -513,12 +513,6 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
       },
     });
 
-    tf_tensorboard.registerDashboard({
-      plugin: PLUGIN_NAME,
-      elementName: 'tf-beholder-dashboard',
-      shouldRemoveDom: true,
-    });
-
     })();
   </script>
 </dom-module>

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
@@ -107,6 +107,12 @@ class CustomScalarsPlugin(base_plugin.TBPlugin):
     # This plugin is active if any run has a layout.
     return bool(self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME))
 
+  def frontend_metadata(self):
+    return super(CustomScalarsPlugin, self).frontend_metadata()._replace(
+        element_name='tf-custom-scalar-dashboard',
+        tab_name='Custom Scalars',
+    )
+
   @wrappers.Request.application
   def download_data_route(self, request):
     run = request.args.get('run')

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
@@ -384,11 +384,5 @@ writer.add_summary(layout_summary)
         }
       },
     });
-
-    tf_tensorboard.registerDashboard({
-      plugin: 'custom_scalars',
-      elementName: 'tf-custom-scalar-dashboard',
-      tabName: 'Custom Scalars',
-    });
   </script>
 </dom-module>

--- a/tensorboard/plugins/debugger/debugger_plugin.py
+++ b/tensorboard/plugins/debugger/debugger_plugin.py
@@ -151,6 +151,11 @@ class DebuggerPlugin(base_plugin.TBPlugin):
         self._event_multiplexer.PluginRunToTagToContent(
             constants.DEBUGGER_PLUGIN_NAME))
 
+  def frontend_metadata(self):
+    return super(DebuggerPlugin, self).frontend_metadata()._replace(
+        element_name='tf-debugger-dashboard',
+    )
+
   @wrappers.Request.application
   def _serve_health_pills_handler(self, request):
     """A (wrapped) werkzeug handler for serving health pills.

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin.py
@@ -159,6 +159,11 @@ class InteractiveDebuggerPlugin(base_plugin.TBPlugin):
     """
     return self._grpc_port is not None
 
+  def frontend_metadata(self):
+    return super(InteractiveDebuggerPlugin, self).frontend_metadata()._replace(
+        element_name='tf-debugger-dashboard',
+    )
+
   @wrappers.Request.application
   def _serve_ack(self, request):
     # Send client acknowledgement. `True` is just used as a dummy value.

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -1426,10 +1426,5 @@ limitations under the License.
           {defaultValue: _DEFAULT_TOP_RIGHT_QUADRANT_HEIGHT}),
     });
 
-    tf_tensorboard.registerDashboard({
-      plugin: 'debugger',
-      elementName: 'tf-debugger-dashboard',
-    });
-
   </script>
 </dom-module>

--- a/tensorboard/plugins/distribution/distributions_plugin.py
+++ b/tensorboard/plugins/distribution/distributions_plugin.py
@@ -68,6 +68,11 @@ class DistributionsPlugin(base_plugin.TBPlugin):
     """
     return self._histograms_plugin.is_active()
 
+  def frontend_metadata(self):
+    return super(DistributionsPlugin, self).frontend_metadata()._replace(
+        element_name='tf-distribution-dashboard',
+    )
+
   def distributions_impl(self, tag, run):
     """Result of the form `(body, mime_type)`, or `ValueError`."""
     (histograms, mime_type) = self._histograms_plugin.histograms_impl(

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
@@ -196,10 +196,5 @@ limitations under the License.
       },
     });
 
-    tf_tensorboard.registerDashboard({
-      plugin: 'distributions',
-      elementName: 'tf-distribution-dashboard',
-    });
-
   </script>
 </dom-module>

--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -71,6 +71,13 @@ class GraphsPlugin(base_plugin.TBPlugin):
     """The graphs plugin is active iff any run has a graph."""
     return bool(self._multiplexer and self.info_impl())
 
+  def frontend_metadata(self):
+    return super(GraphsPlugin, self).frontend_metadata()._replace(
+        element_name='tf-graph-dashboard',
+        # TODO(@chihuahua): Reconcile this setting with Health Pills.
+        disable_reload=True,
+    )
+
   def info_impl(self):
     """Returns a dict of all runs and tags and their data availabilities."""
     result = {}

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -508,11 +508,4 @@ Polymer({
   },
 });
 
-tf_tensorboard.registerDashboard({
-  plugin: 'graphs',
-  elementName: 'tf-graph-dashboard',
-  // TODO(@chihuahua): Reconcile this setting with Health Pills.
-  isReloadDisabled: true,
-});
-
 </script>

--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -124,6 +124,11 @@ class HistogramsPlugin(base_plugin.TBPlugin):
 
     return result
 
+  def frontend_metadata(self):
+    return super(HistogramsPlugin, self).frontend_metadata()._replace(
+        element_name='tf-histogram-dashboard',
+    )
+
   def histograms_impl(self, tag, run, downsample_to=None):
     """Result of the form `(body, mime_type)`, or `ValueError`.
 

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -229,10 +229,5 @@ limitations under the License.
       },
     });
 
-    tf_tensorboard.registerDashboard({
-      plugin: 'histograms',
-      elementName: 'tf-histogram-dashboard',
-    });
-
   </script>
 </dom-module>

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -83,6 +83,11 @@ class HParamsPlugin(base_plugin.TBPlugin):
     return bool(self._context.multiplexer.PluginRunToTagToContent(
         metadata.PLUGIN_NAME))
 
+  def frontend_metadata(self):
+    return super(HParamsPlugin, self).frontend_metadata()._replace(
+        element_name='tf-hparams-dashboard',
+    )
+
   # ---- /experiment -----------------------------------------------------------
   @wrappers.Request.application
   def get_experiment_route(self, request):

--- a/tensorboard/plugins/hparams/tf_hparams_dashboard/tf-hparams-dashboard.html
+++ b/tensorboard/plugins/hparams/tf_hparams_dashboard/tf-hparams-dashboard.html
@@ -83,12 +83,6 @@ limitations under the License.
       }
     });
 
-    // Register the plugin main element with Tensorboard.
-    tf_tensorboard.registerDashboard({
-      plugin: PLUGIN_NAME,
-      elementName: 'tf-hparams-dashboard'
-    });
-
     })();
   </script>
 </dom-module>

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
@@ -312,11 +312,5 @@ TensorFlow run.
         return runToTagInfo[run][tag];
       },
     });
-
-    tf_tensorboard.registerDashboard({
-      plugin: 'images',
-      elementName: 'tf-image-dashboard',
-    });
-
   </script>
 </dom-module>

--- a/tensorboard/plugins/interactive_inference/interactive_inference_plugin.py
+++ b/tensorboard/plugins/interactive_inference/interactive_inference_plugin.py
@@ -108,6 +108,12 @@ class InteractiveInferencePlugin(base_plugin.TBPlugin):
     # TODO(jameswex): Maybe enable if config flags were specified?
     return False
 
+  def frontend_metadata(self):
+    return super(InteractiveInferencePlugin, self).frontend_metadata()._replace(
+        element_name='tf-interactive-inference-dashboard',
+        tab_name='What-If Tool',
+    )
+
   def generate_sprite(self, example_strings):
     # Generate a sprite image for the examples if the examples contain the
     # standard encoded image feature.

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -5819,12 +5819,6 @@ limitations under the License.
        },
     });
 
-    tf_tensorboard.registerDashboard({
-      plugin: PLUGIN_NAME,
-      elementName: 'tf-interactive-inference-dashboard',
-      tabName: 'What-If Tool',
-    });
-
     })();
   </script>
 </dom-module>

--- a/tensorboard/plugins/mesh/mesh_plugin.py
+++ b/tensorboard/plugins/mesh/mesh_plugin.py
@@ -142,6 +142,11 @@ class MeshPlugin(base_plugin.TBPlugin):
     # to the plugin.
     return bool(self._multiplexer and any(six.itervalues(all_runs)))
 
+  def frontend_metadata(self):
+    return super(MeshPlugin, self).frontend_metadata()._replace(
+        element_name='mesh-dashboard',
+    )
+
   def _get_sample(self, tensor_event, sample):
     """Returns a single sample from a batch of samples."""
     data = tensor_util.make_ndarray(tensor_event.tensor_proto)

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-dashboard.html
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-dashboard.html
@@ -272,11 +272,6 @@ limitations under the License.
         }
       });  // End of Polymer constructor call.
 
-      tf_tensorboard.registerDashboard({
-        plugin: 'mesh',
-        elementName: 'mesh-dashboard',
-      });
-
     })();  // End of anonymous namespace.
   </script>
 </dom-module>

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin.py
@@ -340,6 +340,12 @@ class PrCurvesPlugin(base_plugin.TBPlugin):
     # The plugin is active if any of the runs has a tag relevant to the plugin.
     return any(six.itervalues(all_runs))
 
+  def frontend_metadata(self):
+    return super(PrCurvesPlugin, self).frontend_metadata()._replace(
+        element_name='tf-pr-curve-dashboard',
+        tab_name='PR Curves',
+    )
+
   def _process_tensor_event(self, event, thresholds):
     """Converts a TensorEvent into a dict that encapsulates information on it.
 

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
@@ -261,11 +261,5 @@ limitations under the License.
     },
   });
 
-  tf_tensorboard.registerDashboard({
-    plugin: 'pr_curves',
-    elementName: 'tf-pr-curve-dashboard',
-    tabName: 'PR Curves',
-  });
-
   </script>
 </dom-module>

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -135,6 +135,12 @@ class ProfilePlugin(base_plugin.TBPlugin):
         new_thread.start()
     return self._is_active
 
+  def frontend_metadata(self):
+    return super(ProfilePlugin, self).frontend_metadata()._replace(
+        element_name='tf-profile-dashboard',
+        disable_reload=True,
+    )
+
   def start_grpc_stub_if_necessary(self):
     # We will enable streaming trace viewer on two conditions:
     # 1. user specify the flags master_tpu_unsecure_channel to the ip address of

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -774,12 +774,6 @@ profile run can have multiple tools that present the performance profile as diff
     },
   });
 
-  tf_tensorboard.registerDashboard({
-    plugin: PLUGIN_NAME,
-    elementName: 'tf-profile-dashboard',
-    isReloadDisabled: true,
-  });
-
   })();
 </script>
 </dom-module>

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -296,6 +296,12 @@ class ProjectorPlugin(base_plugin.TBPlugin):
     new_thread.start()
     return False
 
+  def frontend_metadata(self):
+    return super(ProjectorPlugin, self).frontend_metadata()._replace(
+        element_name='vz-projector-dashboard',
+        disable_reload=True,
+    )
+
   def _determine_is_active(self):
     """Determines whether the plugin is active.
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.html
@@ -97,11 +97,5 @@ Polymer({
   },
 });
 
-tf_tensorboard.registerDashboard({
-  plugin: 'projector',
-  elementName: 'vz-projector-dashboard',
-  isReloadDisabled: true,
-});
-
 </script>
 </dom-module>

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -85,8 +85,8 @@ class ScalarsPlugin(base_plugin.TBPlugin):
 
   def frontend_metadata(self):
     return super(ScalarsPlugin, self).frontend_metadata()._replace(
-        use_data_selector=True,
         element_name='tf-scalar-dashboard',
+        use_data_selector=True,
     )
 
   def index_impl(self):

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -425,11 +425,5 @@ limitations under the License.
       },
     });
 
-    tf_tensorboard.registerDashboard({
-      plugin: PLUGIN_NAME,
-      elementName: 'tf-scalar-dashboard',
-      useDataSelector: true,
-    });
-
   </script>
 </dom-module>

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -249,6 +249,11 @@ class TextPlugin(base_plugin.TBPlugin):
 
     return False
 
+  def frontend_metadata(self):
+    return super(TextPlugin, self).frontend_metadata()._replace(
+        element_name='tf-text-dashboard',
+    )
+
   def _maybe_launch_index_impl_thread(self):
     """Attempts to launch a thread to compute index_impl().
 

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
@@ -157,10 +157,5 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
       },
     });
 
-    tf_tensorboard.registerDashboard({
-      plugin: 'text',
-      elementName: 'tf-text-dashboard',
-    });
-
   </script>
 </dom-module>


### PR DESCRIPTION
Summary:
This patch switches first-party plugins from calling `registerDashboard`
on the frontend to implementing `plugin_metadata` on the backend.

This requires reworking the “dashboard containers stamped” logic, whose
purpose is to introduce a Polymer data dependency from the `dom-repeat`
stamping state to the dashboard rendering. Previously, all containers
were stamped simultaneously, but this may no longer be the case; we must
instead track exactly which containers have been stamped.

Plugin ordering was also previously defined implicitly on the frontend;
we shift that ordering to the backend.

Test Plan:
Check that basic functionality still works (dashboards display as
intended and in the correct order). Click through every dashboard to
verify that the proper web component is rendered. Verify that navigating
to `/#wat` displays a “no such dashboard” message, but navigating to
`/#scalars` shows no such message even before the plugins listing loads.
Verify that TensorBoard works properly when pointed at an empty logdir.

Then, check that all plugins were migrated (except for the core plugin,
which has no frontend):

```
$ git grep -l registerDashboard
tensorboard/components/tf_tensorboard/registry.ts
$ comm -3 \
> <(git grep -l 'class .*TBPlugin' ':!*test.py' | sort) \
> <(git grep -l 'def frontend_metadata' ':!*test.py' | sort) \
> ;
tensorboard/plugins/core/core_plugin.py
```

wchargin-branch: core-use-pluginmetadata
