### PR TITLE
mesh: fix steps slider

### DIFF
--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-loader.html
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-loader.html
@@ -52,8 +52,8 @@ limitations under the License.
           <paper-slider
             id="steps"
             immediate-value="{{_stepIndex}}"
-            max="[[_getMaxStepIndex(_step)]]"
-            max-markers="[[_getMaxStepIndex(_step)]]"
+            max="[[_getMaxStepIndex(_steps)]]"
+            max-markers="[[_getMaxStepIndex(_steps)]]"
             snaps
             step="1"
             value="{{_stepIndex}}"


### PR DESCRIPTION
Summary:
The steps slider was supposed to be capped at the number of steps, but
in fact was always capped at 100 due to a typo in the Polymer binding.
Fixes #2270.

Test Plan:
Check out #2265 and run the mesh demo to generate test data. Then,
launch TensorBoard with the mesh data and observe that the slider now
goes from 0 to 9 instead of 0 to 100, and that moving along the entire
range of the slider is now useful.

wchargin-branch: mesh-fix-steps
