### PR TITLE
build: upgrade `rules_closure` to HEAD

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,13 +36,13 @@ py_repositories()
 
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "075c898cb535437e821c00e6d104060213fc02464876f9f8e088d798caa1e19c",
+    sha256 = "b6936ecc0b5a1ef616b9d7e76694d414aa5605265c11322257a610fb256b1bf7",
     # The changes that we need for Bazel 0.26 compatibility are not in
-    # any release, so we pin to HEAD as of 2019-05-22.
-    strip_prefix = "rules_closure-87b9b7cefe57f9dea04c5e8518862af17cdfba2e",
+    # any release, so we pin to HEAD as of 2019-06-04.
+    strip_prefix = "rules_closure-7434c41542ca9e1b05166d897b90073d1b8b2cf8",
     urls = [
-        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_closure/archive/87b9b7cefe57f9dea04c5e8518862af17cdfba2e.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/87b9b7cefe57f9dea04c5e8518862af17cdfba2e.tar.gz",  # 2019-05-16
+        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_closure/archive/7434c41542ca9e1b05166d897b90073d1b8b2cf8.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/7434c41542ca9e1b05166d897b90073d1b8b2cf8.tar.gz",  # 2019-06-04
     ],
 )
 

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -673,6 +673,7 @@ public final class Vulcanize {
         || uri.contains("//")
         || uri.startsWith("data:")
         || uri.startsWith("javascript:")
+        || uri.startsWith("mailto:")
         // The following are intended to filter out URLs with Polymer variables.
         || (uri.contains("[[") && uri.contains("]]"))
         || (uri.contains("{{") && uri.contains("}}"));


### PR DESCRIPTION
Summary:
This pulls in bazelbuild/rules_closure#383 to fix #2297, and integrates
the same fix into our own `Vulcanize.java` for consistency.

This diff includes a jscompiler upgrade from `v20190325` to `v20190528`.

Test Plan:
The `//tensorboard` target still builds and appears to run fine, with
cursory inspection.

Changing the `href` attribute of the help button in `tf-tensorboard` to
`mailto:xxx@yyy.com` now builds and works properly; prior to this
commit, that failed to build, as described in #2297.

wchargin-branch: rules-closure-mailto-fix
