### PR TITLE
lib: add a library for cross-frame communication

### DIFF
--- a/tensorboard/components/plugin_util/BUILD
+++ b/tensorboard/components/plugin_util/BUILD
@@ -1,0 +1,39 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_library(
+    name = "plugin_host",
+    srcs = [
+        "plugin-host.html",
+        "plugin-host.ts",
+    ],
+    path = "/tf-plugin",
+    deps = [
+        ":plugin_lib",
+        "//tensorboard/components/tf_backend",
+    ],
+)
+
+tf_web_library(
+    name = "plugin_lib",
+    srcs = [
+        "message.ts",
+    ],
+    path = "/tf-plugin",
+)
+
+tf_web_library(
+    name = "plugin_guest",
+    srcs = [
+        "plugin-guest.html",
+        "plugin-guest.ts",
+    ],
+    path = "/tf-plugin",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":plugin_lib",
+    ],
+)

--- a/tensorboard/components/plugin_util/message.ts
+++ b/tensorboard/components/plugin_util/message.ts
@@ -13,7 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-export type JsonSerializeable = string | number | object;
+export type JsonSerializeable =
+  | string
+  | string[]
+  | number
+  | number[]
+  | object
+  | object[];
 
 export interface Message {
   type: string;

--- a/tensorboard/components/plugin_util/message.ts
+++ b/tensorboard/components/plugin_util/message.ts
@@ -1,0 +1,100 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export interface Message {
+  type: string,
+  id: string,
+  payload: any,
+  error: any,
+}
+
+export type MessageType = string;
+export type MessageCallback = (payload: any) => any;
+
+interface PromiseResolver {
+  resolve: (data: any) => void,
+  reject: (error: Error) => void,
+}
+
+export abstract class IPC {
+  private id = 0;
+  private readonly responseWaits = new Map<string, PromiseResolver>();
+  private readonly listeners = new Map<MessageType, MessageCallback>();
+
+  constructor() {
+    window.addEventListener('message', this._onMessage.bind(this));
+  }
+
+  listen(type: MessageType, callback: MessageCallback) {
+    this.listeners.set(type, callback);
+  }
+
+  unlisten(type: MessageType) {
+    this.listeners.delete(type);
+  }
+
+  private async _onMessage(event: MessageEvent) {
+    const message = JSON.parse(event.data) as Message;
+    const callback = this.listeners.get(message.type);
+
+    if (this.responseWaits.has(message.id)) {
+      const {id, payload, error} = message;
+      const {resolve, reject} = this.responseWaits.get(id);
+      this.responseWaits.delete(id);
+      if (error) {
+        reject(error);
+      } else {
+        resolve(payload);
+      }
+      return;
+    }
+
+    let payload = null;
+    let error = null;
+    if (this.listeners.has(message.type)) {
+      const callback = this.listeners.get(message.type)
+      try {
+        let result = callback(message.payload);
+        if (result instanceof Promise) {
+          result = await result;
+        }
+        payload = result;
+      } catch (e) {
+        error = e;
+      }
+    }
+    const replyMessage: Message = {
+      type: message.type,
+      id: message.id,
+      payload,
+      error,
+    };
+    this.postMessage(event.source, JSON.stringify(replyMessage));
+  }
+
+
+  private postMessage(window: Window, message: string) {
+    window.postMessage(message, '*');
+  }
+
+  protected _sendMessage(window: Window, type: MessageType, payload: any): Promise<any>{
+    const id = `id_${this.id++}`;
+    const message: Message = {type, id, payload, error: null};
+    this.postMessage(window, JSON.stringify(message));
+    return new Promise((resolve, reject) => {
+      this.responseWaits.set(id, {resolve, reject});
+    });
+  }
+}

--- a/tensorboard/components/plugin_util/message.ts
+++ b/tensorboard/components/plugin_util/message.ts
@@ -13,28 +13,36 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+export type JsonSerializeable = string | number | object;
+
 export interface Message {
-  type: string,
-  id: string,
-  payload: any,
-  error: any,
+  type: string;
+  id: string;
+  payload: JsonSerializeable;
+  error: string | null;
 }
 
 export type MessageType = string;
 export type MessageCallback = (payload: any) => any;
 
 interface PromiseResolver {
-  resolve: (data: any) => void,
-  reject: (error: Error) => void,
+  resolve: (data: any) => void;
+  reject: (error: Error) => void;
 }
 
 export abstract class IPC {
+  private idPrefix: string;
   private id = 0;
   private readonly responseWaits = new Map<string, PromiseResolver>();
   private readonly listeners = new Map<MessageType, MessageCallback>();
 
   constructor() {
     window.addEventListener('message', this._onMessage.bind(this));
+    const randomArray = new Uint8Array(16);
+    window.crypto.getRandomValues(randomArray);
+    this.idPrefix = Array.from(randomArray)
+      .map((int: number) => int.toString(16))
+      .join('');
   }
 
   listen(type: MessageType, callback: MessageCallback) {
@@ -46,6 +54,9 @@ export abstract class IPC {
   }
 
   private async _onMessage(event: MessageEvent) {
+    // There are instances where random browser extensions send messages.
+    if (typeof event.data !== 'string') return;
+
     const message = JSON.parse(event.data) as Message;
     const callback = this.listeners.get(message.type);
 
@@ -54,7 +65,7 @@ export abstract class IPC {
       const {resolve, reject} = this.responseWaits.get(id);
       this.responseWaits.delete(id);
       if (error) {
-        reject(error);
+        reject(new Error(error));
       } else {
         resolve(payload);
       }
@@ -64,12 +75,9 @@ export abstract class IPC {
     let payload = null;
     let error = null;
     if (this.listeners.has(message.type)) {
-      const callback = this.listeners.get(message.type)
+      const callback = this.listeners.get(message.type);
       try {
-        let result = callback(message.payload);
-        if (result instanceof Promise) {
-          result = await result;
-        }
+        const result = await callback(message.payload);
         payload = result;
       } catch (e) {
         error = e;
@@ -84,15 +92,18 @@ export abstract class IPC {
     this.postMessage(event.source, JSON.stringify(replyMessage));
   }
 
-
-  private postMessage(window: Window, message: string) {
-    window.postMessage(message, '*');
+  private postMessage(targetWindow: Window, message: string) {
+    targetWindow.postMessage(message, '*');
   }
 
-  protected _sendMessage(window: Window, type: MessageType, payload: any): Promise<any>{
-    const id = `id_${this.id++}`;
+  protected _sendMessage(
+    targetWindow: Window,
+    type: MessageType,
+    payload: any
+  ): Promise<any> {
+    const id = `${this.idPrefix}_${this.id++}`;
     const message: Message = {type, id, payload, error: null};
-    this.postMessage(window, JSON.stringify(message));
+    this.postMessage(targetWindow, JSON.stringify(message));
     return new Promise((resolve, reject) => {
       this.responseWaits.set(id, {resolve, reject});
     });

--- a/tensorboard/components/plugin_util/plugin-guest.html
+++ b/tensorboard/components/plugin_util/plugin-guest.html
@@ -1,0 +1,18 @@
+<!--
+@license
+Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<script src="plugin-guest.js"></script>
+<script src="message.js"></script>

--- a/tensorboard/components/plugin_util/plugin-guest.ts
+++ b/tensorboard/components/plugin_util/plugin-guest.ts
@@ -12,14 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {IPC, Message, MessageType} from './message.js';
+import {IPC, Message, MessageType, PayloadType} from './message.js';
 
 class GuestIPC extends IPC {
   /**
    * payload must be JSON serializable.
    */
-  sendMessage(type: MessageType, payload: any): Promise<any> {
-    return this._sendMessage(window.parent, type, payload);
+  sendMessage(type: MessageType, payload: PayloadType): Promise<PayloadType> {
+    return this.sendMessageToWindow(window.parent, type, payload);
   }
 }
 

--- a/tensorboard/components/plugin_util/plugin-guest.ts
+++ b/tensorboard/components/plugin_util/plugin-guest.ts
@@ -26,6 +26,22 @@ class GuestIPC extends IPC {
 // Only export for testability.
 export const _guestIPC = new GuestIPC();
 
+/**
+ * Sends a message to the parent frame.
+ * @return Promise that resolves with a payload from parent in response to this message.
+ *
+ * @example
+ * const someList = await sendMessage('v1.some.type.parent.understands');
+ * // do fun things with someList.
+ */
 export const sendMessage = _guestIPC.sendMessage.bind(_guestIPC);
+
+/**
+ * Subscribes a callback to a message with particular type.
+ */
 export const listen = _guestIPC.listen.bind(_guestIPC);
+
+/**
+ * Unsubscribes a callback to a message.
+ */
 export const unlisten = _guestIPC.unlisten.bind(_guestIPC);

--- a/tensorboard/components/plugin_util/plugin-guest.ts
+++ b/tensorboard/components/plugin_util/plugin-guest.ts
@@ -1,0 +1,31 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {IPC, Message, MessageType} from './message.js';
+
+class GuestIPC extends IPC {
+  /**
+   * payload must be JSON serializable.
+   */
+  sendMessage(type: MessageType, payload: any): Promise<any> {
+    return this._sendMessage(window.parent, type, payload);
+  }
+}
+
+// Only export for testability.
+export const _guestIPC = new GuestIPC();
+
+export const sendMessage = _guestIPC.sendMessage.bind(_guestIPC);
+export const listen = _guestIPC.listen.bind(_guestIPC);
+export const unlisten = _guestIPC.unlisten.bind(_guestIPC);

--- a/tensorboard/components/plugin_util/plugin-host.html
+++ b/tensorboard/components/plugin_util/plugin-host.html
@@ -1,0 +1,20 @@
+<!--
+@license
+Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<link rel="import" href="../tf-backend/tf-backend.html" />
+
+<script src="message.js"></script>
+<script src="plugin-host.js"></script>

--- a/tensorboard/components/plugin_util/plugin-host.ts
+++ b/tensorboard/components/plugin_util/plugin-host.ts
@@ -32,11 +32,26 @@ const _sendMessage = hostIPC.sendMessage.bind(hostIPC);
 export const sendMessage = _sendMessage;
 export const listen = _listen;
 export const unlisten = _unlisten;
+
 // Export for testability.
 export const _hostIPC = hostIPC;
 
 namespace tf_plugin {
+  /**
+   * Sends a message to the frame specified.
+   * @return Promise that resolves with a payload from frame in response to the message.
+   *
+   * @example
+   * const someList = await sendMessage('v1.some.type.guest.understands');
+   * // do fun things with someList.
+   */
   export const sendMessage = _sendMessage;
+  /**
+   * Subscribes to messages from specified frame of a type specified.
+   */
   export const listen = _listen;
+  /**
+   * Unsubscribes to messages from specified frame of a type specified.
+   */
   export const unlisten = _unlisten;
 } // namespace tf_plugin

--- a/tensorboard/components/plugin_util/plugin-host.ts
+++ b/tensorboard/components/plugin_util/plugin-host.ts
@@ -1,0 +1,52 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {IPC, Message, MessageType} from './message.js';
+
+class HostIPC extends IPC {
+  sendMessage(iframe: HTMLIFrameElement, type: MessageType, payload: any): Promise<any> {
+    return this._sendMessage(iframe.contentWindow, type, payload);
+  }
+}
+
+const hostIPC = new HostIPC();
+const _listen = hostIPC.listen.bind(hostIPC);
+const _unlisten = hostIPC.unlisten.bind(hostIPC);
+
+/**
+ * payload must be JSON serializable.
+ */
+function _sendMessage(
+  iframes: HTMLIFrameElement[],
+  type: MessageType,
+  payload: any,
+): Promise<void> {
+  const sendMessageP = iframes.map((iframe) => {
+    return hostIPC.sendMessage(iframe, type, payload);
+  });
+  return Promise.all(sendMessageP).then(() => {});
+}
+
+export const sendMessage = _sendMessage;
+export const listen = _listen;
+export const unlisten = _unlisten;
+// Export for testability.
+export const _hostIPC = hostIPC;
+
+namespace tf_plugin {
+  export const sendMessage = _sendMessage;
+  export const listen = _listen;
+  export const unlisten = _unlisten;
+}  // namespace tf_plugin
+

--- a/tensorboard/components/plugin_util/plugin-host.ts
+++ b/tensorboard/components/plugin_util/plugin-host.ts
@@ -12,15 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {IPC, Message, MessageType} from './message.js';
+import {IPC, Message, MessageType, PayloadType} from './message.js';
 
 class HostIPC extends IPC {
   sendMessage(
     iframe: HTMLIFrameElement,
     type: MessageType,
-    payload: any
-  ): Promise<any> {
-    return this._sendMessage(iframe.contentWindow, type, payload);
+    payload: PayloadType
+  ): Promise<PayloadType> {
+    return this.sendMessageToWindow(iframe.contentWindow, type, payload);
   }
 }
 

--- a/tensorboard/components/plugin_util/plugin-host.ts
+++ b/tensorboard/components/plugin_util/plugin-host.ts
@@ -15,7 +15,11 @@ limitations under the License.
 import {IPC, Message, MessageType} from './message.js';
 
 class HostIPC extends IPC {
-  sendMessage(iframe: HTMLIFrameElement, type: MessageType, payload: any): Promise<any> {
+  sendMessage(
+    iframe: HTMLIFrameElement,
+    type: MessageType,
+    payload: any
+  ): Promise<any> {
     return this._sendMessage(iframe.contentWindow, type, payload);
   }
 }
@@ -23,20 +27,7 @@ class HostIPC extends IPC {
 const hostIPC = new HostIPC();
 const _listen = hostIPC.listen.bind(hostIPC);
 const _unlisten = hostIPC.unlisten.bind(hostIPC);
-
-/**
- * payload must be JSON serializable.
- */
-function _sendMessage(
-  iframes: HTMLIFrameElement[],
-  type: MessageType,
-  payload: any,
-): Promise<void> {
-  const sendMessageP = iframes.map((iframe) => {
-    return hostIPC.sendMessage(iframe, type, payload);
-  });
-  return Promise.all(sendMessageP).then(() => {});
-}
+const _sendMessage = hostIPC.sendMessage.bind(hostIPC);
 
 export const sendMessage = _sendMessage;
 export const listen = _listen;
@@ -48,5 +39,4 @@ namespace tf_plugin {
   export const sendMessage = _sendMessage;
   export const listen = _listen;
   export const unlisten = _unlisten;
-}  // namespace tf_plugin
-
+} // namespace tf_plugin

--- a/tensorboard/components/plugin_util/test/BUILD
+++ b/tensorboard/components/plugin_util/test/BUILD
@@ -1,0 +1,60 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//tensorboard:internal"],
+)
+
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_test(
+    name = "test",
+    web_library = ":test_web_library",
+    src = "/tf-plugin/test/test_binary.html"
+)
+
+# HACK: specifying tensorboard_html_binary on tf_web_test causes certain
+# environment to throw exception but wrapping tensorbard_html_binary with
+# tf_web_library seems to be okay.
+tf_web_library(
+    name = "test_web_library",
+    srcs = [
+        ":test_binary.html",
+    ],
+    path = "/tf-plugin/test",
+    deps = [
+        ":test_lib",
+        "//tensorboard/components/tf_imports:web_component_tester",
+    ],
+)
+
+tensorboard_html_binary(
+    name = "test_binary",
+    # Disable advanced optimization to prevent check for WebComponentTester
+    # gobals.
+    compilation_level = "SIMPLE",
+    # Requires for compiling `import`s away.
+    compile = True,
+    input_path = "/tf-plugin/test/tests.html",
+    output_path = "/tf-plugin/test/test_binary.html",
+    deps = [
+        ":test_lib",
+    ],
+)
+
+tf_web_library(
+    name = "test_lib",
+    srcs = [
+        "iframe.html",
+        "iframe.ts",
+        "plugin-test.ts",
+        "tests.html",
+    ],
+    path = "/tf-plugin/test",
+    deps = [
+        "//tensorboard/components/plugin_util:plugin_host",
+        "//tensorboard/components/plugin_util:plugin_guest",
+        "//tensorboard/components/tf_imports:web_component_tester",
+    ],
+)

--- a/tensorboard/components/plugin_util/test/iframe.html
+++ b/tensorboard/components/plugin_util/test/iframe.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<!--
+@license
+Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<head>
+<script src="./iframe.js" type="module"></script>
+</head>

--- a/tensorboard/components/plugin_util/test/iframe.html
+++ b/tensorboard/components/plugin_util/test/iframe.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <!--
 @license
 Copyright 2019 The TensorFlow Authors. All Rights Reserved.
@@ -16,5 +16,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <head>
-<script src="./iframe.js" type="module"></script>
+  <script src="./iframe.js" type="module"></script>
 </head>

--- a/tensorboard/components/plugin_util/test/iframe.ts
+++ b/tensorboard/components/plugin_util/test/iframe.ts
@@ -17,4 +17,3 @@ import {sendMessage, listen, unlisten, _guestIPC} from '../plugin-guest.js';
 
 const win = window as any;
 win.test = {sendMessage, listen, unlisten, _guestIPC};
-

--- a/tensorboard/components/plugin_util/test/iframe.ts
+++ b/tensorboard/components/plugin_util/test/iframe.ts
@@ -1,0 +1,20 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {sendMessage, listen, unlisten, _guestIPC} from '../plugin-guest.js';
+
+const win = window as any;
+win.test = {sendMessage, listen, unlisten, _guestIPC};
+

--- a/tensorboard/components/plugin_util/test/plugin-test.ts
+++ b/tensorboard/components/plugin_util/test/plugin-test.ts
@@ -1,0 +1,153 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import * as pluginHost from '../plugin-host.js';
+
+namespace tf_plugin.test {
+
+const {expect} = chai;
+const template = document.getElementById('iframe-template') as HTMLTemplateElement;
+
+describe('plugin-util', () => {
+  beforeEach(function(done) {
+    const iframeFrag = document.importNode(template.content, true);
+    const iframe = iframeFrag.firstElementChild as HTMLIFrameElement;
+    document.body.appendChild(iframe);
+    this.guestFrame = iframe;
+    this.guestWindow = iframe.contentWindow;
+    // Must wait for the JavaScript to be loaded on the child frame.
+    this.guestWindow.addEventListener('load', () => done());
+
+    this.sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    document.body.removeChild(this.guestFrame);
+    this.sandbox.restore();
+  });
+
+  it('setUp sanity check', function() {
+    expect(this.guestWindow.test)
+      .to.have.property('sendMessage').that.is.a('function');
+    expect(this.guestWindow.test)
+      .to.have.property('listen').that.is.a('function');
+    expect(this.guestWindow.test)
+      .to.have.property('unlisten').that.is.a('function');
+  });
+
+  [{
+    spec: 'host (src) to guest (dest)',
+    beforeEachFunc: function() {
+      this.listen = this.guestWindow.test.listen;
+      this.unlisten = this.guestWindow.test.unlisten;
+      this.sendMessage = (type, payload) => {
+        return pluginHost.sendMessage([this.guestFrame], type, payload);
+      };
+      this.getStubDestPostMessage = () => this.sandbox.spy(
+          this.guestWindow.test._guestIPC, 'postMessage');
+    },
+  }, {
+    spec: 'guest (src) to host (dest)',
+    beforeEachFunc: function() {
+      this.listen = pluginHost.listen;
+      this.unlisten = pluginHost.unlisten;
+      this.sendMessage = (type, payload) => {
+        return this.guestWindow.test.sendMessage(type, payload);
+      };
+      this.getStubDestPostMessage = () => this.sandbox.spy(
+          pluginHost._hostIPC, 'postMessage');
+    },
+  }].forEach(({spec, beforeEachFunc}) => {
+    describe(spec, () => {
+      beforeEach(beforeEachFunc);
+
+      beforeEach(function() {
+        this.onMessage = this.sandbox.stub();
+        this.listen('messageType', this.onMessage);
+      });
+
+      it('sends a message to dest', async function() {
+        await this.sendMessage('messageType', 'hello');
+        expect(this.onMessage.callCount).to.equal(1);
+        expect(this.onMessage.firstCall.args).to.deep.equal(['hello']);
+      });
+
+      it('sends a message a random payload not by ref', async function() {
+        const payload = {
+          foo: 'foo',
+          bar: {
+            baz: 'baz',
+          },
+        };
+        await this.sendMessage('messageType', payload);
+        expect(this.onMessage.callCount).to.equal(1);
+
+        expect(this.onMessage.firstCall.args[0]).to.not.equal(payload);
+        expect(this.onMessage.firstCall.args[0]).to.deep.equal(payload);
+      });
+
+
+      it('resolves when dest replies with ack', async function() {
+        const destPostMessage = this.getStubDestPostMessage();
+        const sendMessageP = this.sendMessage('messageType', 'hello');
+
+        expect(this.onMessage.callCount).to.equal(0);
+        expect(destPostMessage.callCount).to.equal(0);
+
+        await sendMessageP;
+        expect(this.onMessage.callCount).to.equal(1);
+        expect(destPostMessage.callCount).to.equal(1);
+        expect(this.onMessage.firstCall.args).to.deep.equal(['hello']);
+      });
+
+      it('triggers, on dest, a cb for the matching type', async function() {
+        const barCb = this.sandbox.stub();
+        this.listen('bar', barCb);
+
+        await this.sendMessage('bar', 'soap');
+
+        expect(this.onMessage.callCount).to.equal(0);
+        expect(barCb.callCount).to.equal(1);
+        expect(barCb.firstCall.args).to.deep.equal(['soap']);
+      });
+
+      it('supports single listener for a type', async function() {
+        const barCb1 = this.sandbox.stub();
+        const barCb2 = this.sandbox.stub();
+        this.listen('bar', barCb1);
+        this.listen('bar', barCb2);
+
+        await this.sendMessage('bar', 'soap');
+
+        expect(barCb1.callCount).to.equal(0);
+        expect(barCb2.callCount).to.equal(1);
+        expect(barCb2.firstCall.args).to.deep.equal(['soap']);
+      });
+
+      it('unregister a callback with unlisten', async function() {
+        const barCb = this.sandbox.stub();
+        this.listen('bar', barCb);
+        await this.sendMessage('bar', 'soap');
+        expect(barCb.callCount).to.equal(1);
+        this.unlisten('bar');
+
+        await this.sendMessage('bar', 'soap');
+
+        expect(barCb.callCount).to.equal(1);
+      });
+    });
+  });
+});
+
+}  // namespace tf_plugin.test

--- a/tensorboard/components/plugin_util/test/plugin-test.ts
+++ b/tensorboard/components/plugin_util/test/plugin-test.ts
@@ -15,139 +15,144 @@ limitations under the License.
 import * as pluginHost from '../plugin-host.js';
 
 namespace tf_plugin.test {
+  const {expect} = chai;
+  const template = document.getElementById(
+    'iframe-template'
+  ) as HTMLTemplateElement;
 
-const {expect} = chai;
-const template = document.getElementById('iframe-template') as HTMLTemplateElement;
+  describe('plugin-util', () => {
+    beforeEach(function(done) {
+      const iframeFrag = document.importNode(template.content, true);
+      const iframe = iframeFrag.firstElementChild as HTMLIFrameElement;
+      document.body.appendChild(iframe);
+      this.guestFrame = iframe;
+      this.guestWindow = iframe.contentWindow;
+      // Must wait for the JavaScript to be loaded on the child frame.
+      this.guestWindow.addEventListener('load', () => done());
 
-describe('plugin-util', () => {
-  beforeEach(function(done) {
-    const iframeFrag = document.importNode(template.content, true);
-    const iframe = iframeFrag.firstElementChild as HTMLIFrameElement;
-    document.body.appendChild(iframe);
-    this.guestFrame = iframe;
-    this.guestWindow = iframe.contentWindow;
-    // Must wait for the JavaScript to be loaded on the child frame.
-    this.guestWindow.addEventListener('load', () => done());
+      this.sandbox = sinon.sandbox.create();
+    });
 
-    this.sandbox = sinon.sandbox.create();
-  });
+    afterEach(function() {
+      document.body.removeChild(this.guestFrame);
+      this.sandbox.restore();
+    });
 
-  afterEach(function () {
-    document.body.removeChild(this.guestFrame);
-    this.sandbox.restore();
-  });
+    it('setUp sanity check', function() {
+      expect(this.guestWindow.test)
+        .to.have.property('sendMessage')
+        .that.is.a('function');
+      expect(this.guestWindow.test)
+        .to.have.property('listen')
+        .that.is.a('function');
+      expect(this.guestWindow.test)
+        .to.have.property('unlisten')
+        .that.is.a('function');
+    });
 
-  it('setUp sanity check', function() {
-    expect(this.guestWindow.test)
-      .to.have.property('sendMessage').that.is.a('function');
-    expect(this.guestWindow.test)
-      .to.have.property('listen').that.is.a('function');
-    expect(this.guestWindow.test)
-      .to.have.property('unlisten').that.is.a('function');
-  });
+    [
+      {
+        spec: 'host (src) to guest (dest)',
+        beforeEachFunc: function() {
+          this.listen = this.guestWindow.test.listen;
+          this.unlisten = this.guestWindow.test.unlisten;
+          this.sendMessage = (type, payload) => {
+            return pluginHost.sendMessage(this.guestFrame, type, payload);
+          };
+          this.getStubDestPostMessage = () =>
+            this.sandbox.spy(this.guestWindow.test._guestIPC, 'postMessage');
+        },
+      },
+      {
+        spec: 'guest (src) to host (dest)',
+        beforeEachFunc: function() {
+          this.listen = pluginHost.listen;
+          this.unlisten = pluginHost.unlisten;
+          this.sendMessage = (type, payload) => {
+            return this.guestWindow.test.sendMessage(type, payload);
+          };
+          this.getStubDestPostMessage = () =>
+            this.sandbox.spy(pluginHost._hostIPC, 'postMessage');
+        },
+      },
+    ].forEach(({spec, beforeEachFunc}) => {
+      describe(spec, () => {
+        beforeEach(beforeEachFunc);
 
-  [{
-    spec: 'host (src) to guest (dest)',
-    beforeEachFunc: function() {
-      this.listen = this.guestWindow.test.listen;
-      this.unlisten = this.guestWindow.test.unlisten;
-      this.sendMessage = (type, payload) => {
-        return pluginHost.sendMessage([this.guestFrame], type, payload);
-      };
-      this.getStubDestPostMessage = () => this.sandbox.spy(
-          this.guestWindow.test._guestIPC, 'postMessage');
-    },
-  }, {
-    spec: 'guest (src) to host (dest)',
-    beforeEachFunc: function() {
-      this.listen = pluginHost.listen;
-      this.unlisten = pluginHost.unlisten;
-      this.sendMessage = (type, payload) => {
-        return this.guestWindow.test.sendMessage(type, payload);
-      };
-      this.getStubDestPostMessage = () => this.sandbox.spy(
-          pluginHost._hostIPC, 'postMessage');
-    },
-  }].forEach(({spec, beforeEachFunc}) => {
-    describe(spec, () => {
-      beforeEach(beforeEachFunc);
+        beforeEach(function() {
+          this.onMessage = this.sandbox.stub();
+          this.listen('messageType', this.onMessage);
+        });
 
-      beforeEach(function() {
-        this.onMessage = this.sandbox.stub();
-        this.listen('messageType', this.onMessage);
-      });
+        it('sends a message to dest', async function() {
+          await this.sendMessage('messageType', 'hello');
+          expect(this.onMessage.callCount).to.equal(1);
+          expect(this.onMessage.firstCall.args).to.deep.equal(['hello']);
+        });
 
-      it('sends a message to dest', async function() {
-        await this.sendMessage('messageType', 'hello');
-        expect(this.onMessage.callCount).to.equal(1);
-        expect(this.onMessage.firstCall.args).to.deep.equal(['hello']);
-      });
+        it('sends a message a random payload not by ref', async function() {
+          const payload = {
+            foo: 'foo',
+            bar: {
+              baz: 'baz',
+            },
+          };
+          await this.sendMessage('messageType', payload);
+          expect(this.onMessage.callCount).to.equal(1);
 
-      it('sends a message a random payload not by ref', async function() {
-        const payload = {
-          foo: 'foo',
-          bar: {
-            baz: 'baz',
-          },
-        };
-        await this.sendMessage('messageType', payload);
-        expect(this.onMessage.callCount).to.equal(1);
+          expect(this.onMessage.firstCall.args[0]).to.not.equal(payload);
+          expect(this.onMessage.firstCall.args[0]).to.deep.equal(payload);
+        });
 
-        expect(this.onMessage.firstCall.args[0]).to.not.equal(payload);
-        expect(this.onMessage.firstCall.args[0]).to.deep.equal(payload);
-      });
+        it('resolves when dest replies with ack', async function() {
+          const destPostMessage = this.getStubDestPostMessage();
+          const sendMessageP = this.sendMessage('messageType', 'hello');
 
+          expect(this.onMessage.callCount).to.equal(0);
+          expect(destPostMessage.callCount).to.equal(0);
 
-      it('resolves when dest replies with ack', async function() {
-        const destPostMessage = this.getStubDestPostMessage();
-        const sendMessageP = this.sendMessage('messageType', 'hello');
+          await sendMessageP;
+          expect(this.onMessage.callCount).to.equal(1);
+          expect(destPostMessage.callCount).to.equal(1);
+          expect(this.onMessage.firstCall.args).to.deep.equal(['hello']);
+        });
 
-        expect(this.onMessage.callCount).to.equal(0);
-        expect(destPostMessage.callCount).to.equal(0);
+        it('triggers, on dest, a cb for the matching type', async function() {
+          const barCb = this.sandbox.stub();
+          this.listen('bar', barCb);
 
-        await sendMessageP;
-        expect(this.onMessage.callCount).to.equal(1);
-        expect(destPostMessage.callCount).to.equal(1);
-        expect(this.onMessage.firstCall.args).to.deep.equal(['hello']);
-      });
+          await this.sendMessage('bar', 'soap');
 
-      it('triggers, on dest, a cb for the matching type', async function() {
-        const barCb = this.sandbox.stub();
-        this.listen('bar', barCb);
+          expect(this.onMessage.callCount).to.equal(0);
+          expect(barCb.callCount).to.equal(1);
+          expect(barCb.firstCall.args).to.deep.equal(['soap']);
+        });
 
-        await this.sendMessage('bar', 'soap');
+        it('supports single listener for a type', async function() {
+          const barCb1 = this.sandbox.stub();
+          const barCb2 = this.sandbox.stub();
+          this.listen('bar', barCb1);
+          this.listen('bar', barCb2);
 
-        expect(this.onMessage.callCount).to.equal(0);
-        expect(barCb.callCount).to.equal(1);
-        expect(barCb.firstCall.args).to.deep.equal(['soap']);
-      });
+          await this.sendMessage('bar', 'soap');
 
-      it('supports single listener for a type', async function() {
-        const barCb1 = this.sandbox.stub();
-        const barCb2 = this.sandbox.stub();
-        this.listen('bar', barCb1);
-        this.listen('bar', barCb2);
+          expect(barCb1.callCount).to.equal(0);
+          expect(barCb2.callCount).to.equal(1);
+          expect(barCb2.firstCall.args).to.deep.equal(['soap']);
+        });
 
-        await this.sendMessage('bar', 'soap');
+        it('unregister a callback with unlisten', async function() {
+          const barCb = this.sandbox.stub();
+          this.listen('bar', barCb);
+          await this.sendMessage('bar', 'soap');
+          expect(barCb.callCount).to.equal(1);
+          this.unlisten('bar');
 
-        expect(barCb1.callCount).to.equal(0);
-        expect(barCb2.callCount).to.equal(1);
-        expect(barCb2.firstCall.args).to.deep.equal(['soap']);
-      });
+          await this.sendMessage('bar', 'soap');
 
-      it('unregister a callback with unlisten', async function() {
-        const barCb = this.sandbox.stub();
-        this.listen('bar', barCb);
-        await this.sendMessage('bar', 'soap');
-        expect(barCb.callCount).to.equal(1);
-        this.unlisten('bar');
-
-        await this.sendMessage('bar', 'soap');
-
-        expect(barCb.callCount).to.equal(1);
+          expect(barCb.callCount).to.equal(1);
+        });
       });
     });
   });
-});
-
-}  // namespace tf_plugin.test
+} // namespace tf_plugin.test

--- a/tensorboard/components/plugin_util/test/tests.html
+++ b/tensorboard/components/plugin_util/test/tests.html
@@ -1,0 +1,23 @@
+<!--
+@license
+Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<link rel="import" href="../plugin-host.html">
+<script vulcanize-noinline src="../../web-component-tester/browser.js"></script>
+
+<template id="iframe-template">
+  <iframe src="./iframe.html"></iframe>
+</template>
+<script src="plugin-test.js" type="module"></script>

--- a/tensorboard/components/plugin_util/test/tests.html
+++ b/tensorboard/components/plugin_util/test/tests.html
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<link rel="import" href="../plugin-host.html">
+<link rel="import" href="../plugin-host.html" />
 <script vulcanize-noinline src="../../web-component-tester/browser.js"></script>
 
 <template id="iframe-template">


### PR DESCRIPTION
TensorBoard, in the near future, will load plugin modules in respective
iframe as was discussed in RFC. This change adds a library that
facilitates communication between main TensorBoard and plugin frames.

