### PR TITLE
cleanup: add typing for sinon-chai

### DIFF
--- a/tensorboard/components/tf_backend/test/requestManagerTests.ts
+++ b/tensorboard/components/tf_backend/test/requestManagerTests.ts
@@ -426,8 +426,7 @@ describe('backend', () => {
 
         const response = await rm.fetch('foo');
 
-        // TODO(stephanwlee): Make sure to use sinon-chai when typing is proper.
-        expect(this.stubbedFetch.callCount).to.equal(3);
+        expect(this.stubbedFetch).to.have.been.calledThrice;
         expect(response).to.have.property('ok', false);
         expect(response).to.have.property('status', 500);
         const body = await response.text();

--- a/tensorboard/components/tf_imports/BUILD
+++ b/tensorboard/components/tf_imports/BUILD
@@ -146,6 +146,7 @@ tf_web_library(
         ":chai_typings",
         ":mocha_typings",
         ":sinon_typings",
+        ":sinon_chai_typings",
         "@org_npmjs_registry_web_component_tester",
     ],
 )
@@ -171,6 +172,14 @@ tf_web_library(
     testonly = 1,
     srcs = ["@org_definitelytyped//:sinon.d.ts"],
     path = "/sinonjs",
+    visibility = ["//visibility:private"],
+)
+
+tf_web_library(
+    name = "sinon_chai_typings",
+    testonly = 1,
+    srcs = ["@org_definitelytyped_types_sinon_chai//:index.d.ts"],
+    path = "/sinon_chai",
     visibility = ["//visibility:private"],
 )
 

--- a/third_party/typings.bzl
+++ b/third_party/typings.bzl
@@ -373,3 +373,15 @@ def tensorboard_typings_workspace():
           ],
       },
   )
+
+  filegroup_external(
+      name = "org_definitelytyped_types_sinon_chai",
+      licenses = ["notice"],  # MIT
+      sha256_urls = {
+          "ec72d630fc807ae2cc25d0cf707ed77cca55e08d058f591a9eb4257cd6229d98": [
+              # Version of sinon-chai is tied to that of web-component-tester.
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/b4715b48d6a64a288f4ca6d0d2efcbffb36dd1cf/types/sinon-chai/v2/index.d.ts",
+              "https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/b4715b48d6a64a288f4ca6d0d2efcbffb36dd1cf/types/sinon-chai/v2/index.d.ts",  # 2019-06-05
+          ],
+      },
+  )


### PR DESCRIPTION
sinon-chai comes preinstalled with web-component-tester.
We can make use of it except it misses the typing information.
