### PR TITLE
core: move ES module path into `FrontendMetadata`

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -292,7 +292,7 @@ class TensorBoardWSGI(object):
         plugin_metadata['tab_name'] = plugin.plugin_name
       plugin_metadata['enabled'] = is_active
 
-      es_module_handler = plugin.es_module_path()
+      es_module_handler = plugin_metadata.pop('es_module_path')
       element_name = plugin_metadata.pop('element_name')
       if element_name is not None and es_module_handler is not None:
         logger.error(

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -124,16 +124,10 @@ class FakePlugin(base_plugin.TBPlugin):
 
   def frontend_metadata(self):
     base = super(FakePlugin, self).frontend_metadata()
-    return base._replace(element_name=self._element_name_value)
-
-  def es_module_path(self):
-    """Returns a path to plugin frontend entry.
-
-    Returns:
-      A string that corresponds to a key of routes_mapping. For non-dynamic
-      plugins, it returns None.
-    """
-    return self._es_module_path_value
+    return base._replace(
+        element_name=self._element_name_value,
+        es_module_path=self._es_module_path_value,
+    )
 
 
 class ApplicationTest(tb_test.TestCase):

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -37,6 +37,12 @@ FrontendMetadata = collections.namedtuple(
         # the tab name should not use underscores to separate words.
         # Should be a `str` or `None` (defaulting to the `plugin_name`).
         "tab_name",
+        # ES module to use as an entry point to this plugin. Should be a
+        # `str` that is a key in the result of `get_plugin_apps()`, or
+        # `None` for legacy plugins bundled with TensorBoard as part of
+        # `webfiles.zip`. Mutually exclusive with legacy `element_name`
+        # below.
+        "es_module_path",
         # Whether to disable the reload button and auto-reload timer.
         # Boolean.
         "disable_reload",
@@ -50,7 +56,8 @@ FrontendMetadata = collections.namedtuple(
         "use_data_selector",
         # For legacy plugins, name of the custom element defining the
         # plugin frontend: e.g., `"tf-scalar-dashboard"`. Should be a
-        # `str` or `None` (for iframed plugins).
+        # `str` or `None` (for iframed plugins). Mutually exclusive with
+        # `es_module_path`.
         "element_name",
     ),
 )
@@ -106,32 +113,19 @@ class TBPlugin(object):
   def frontend_metadata(self):
     """Defines how the plugin will be displayed on the frontend.
 
-    The base implementation returns a default value. Subclasses are
-    encouraged to override this method and replace any attributes on the
-    result.
+    The base implementation returns a default value. Subclasses should
+    override this and specify either an `es_module_path` or (for legacy
+    plugins) an `element_name`, and are encouraged to replace any other
+    relevant attributes.
     """
     return FrontendMetadata(
         tab_name=None,
+        es_module_path=None,
         disable_reload=False,
         remove_dom=False,
         use_data_selector=False,
         element_name=None,
     )
-
-  def es_module_path(self):
-    """Returns one of the keys in get_plugin_apps that is an entry ES module.
-
-    For a plugin that is loaded into an iframe, a frontend entry point has to be
-    specified. For a plugin that is bundled with TensorBoard as part of
-    webfiles.zip, return None.
-
-    TODO(tensorboard-team): describe the contract/API for the ES module when
-    it is better defined.
-
-    Returns:
-      A key in the result of `get_plugin_apps()`, or None.
-    """
-    return None
 
 
 class TBContext(object):

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -42,6 +42,9 @@ FrontendMetadata = collections.namedtuple(
         # `None` for legacy plugins bundled with TensorBoard as part of
         # `webfiles.zip`. Mutually exclusive with legacy `element_name`
         # below.
+        #
+        # TODO(tensorboard-team): Describe the contract/API for the ES
+        # module when it is better defined.
         "es_module_path",
         # Whether to disable the reload button and auto-reload timer.
         # Boolean.


### PR DESCRIPTION
Summary:
The two loading mechanisms are now specified in the same data object, so
switching from one to the other requires only a single change.

The HTTP API and the frontend are unchanged.

Test Plan:
Modify the scalar plugin’s `frontend_metadata` to use an ES module path:

```diff
diff --git a/tensorboard/plugins/scalar/scalars_plugin.py b/tensorboard/plugins/scalar/scalars_plugin.py
index 1b864a74..2e06c86a 100644
--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -85,7 +85,8 @@ class ScalarsPlugin(base_plugin.TBPlugin):

   def frontend_metadata(self):
     return super(ScalarsPlugin, self).frontend_metadata()._replace(
-        element_name='tf-scalar-dashboard',
+        #element_name='tf-scalar-dashboard',
+        es_module_path='/magic.js',
         use_data_selector=True,
     )
```

Then, launch TensorBoard and note that the `plugins_listing` response
contains the right values for both the scalar and image plugins.

wchargin-branch: es-module-metadata
