### PR TITLE
build: use `tf.test.main` for `mesh:demo_utils_test`

### DIFF
--- a/tensorboard/plugins/mesh/BUILD
+++ b/tensorboard/plugins/mesh/BUILD
@@ -145,6 +145,7 @@ py_test(
     srcs = ["demo_utils_test.py"],
     data = [
         ":test_data",
+        "//tensorboard/compat:tensorflow",
     ],
     srcs_version = "PY2AND3",
     deps = [

--- a/tensorboard/plugins/mesh/demo_utils_test.py
+++ b/tensorboard/plugins/mesh/demo_utils_test.py
@@ -20,10 +20,13 @@ from __future__ import print_function
 
 import os
 import unittest
+
+import tensorflow as tf
+
 from tensorboard.plugins.mesh import demo_utils
 
 
-class TestPLYReader(unittest.TestCase):
+class TestPLYReader(tf.test.TestCase):
   def test_parse_vertex(self):
     """Tests vertex coordinate and color parsing."""
     # Vertex 3D coordinates with RGBA color.
@@ -56,4 +59,4 @@ class TestPLYReader(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  tf.test.main()


### PR DESCRIPTION
Summary:
This test case already contains actual TensorFlow code, via the `GFile`
use in the code under test. Within Google, such tests must be run via
`tf.test.main()` or `absltest.main()`, and the TensorFlow-specific code
should be in a `tf.test.TestCase` as well (though this is not strictly
required).

Test Plan:
Verified that this patch fixes a test that’s broken when syncing into
Google3.

wchargin-branch: tf-test-mesh-test
