### PR TITLE
test: use `absltest` for `tensorboard.test`

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -159,6 +159,7 @@ py_library(
     srcs = ["test.py"],
     srcs_version = "PY2AND3",
     deps = [
+        "//tensorboard:expect_absl_testing_absltest_installed",
         "//tensorboard/util:tb_logging",
         "@org_pythonhosted_six",
     ],
@@ -282,6 +283,14 @@ py_library(
 
 py_library(
     name = "expect_absl_logging_installed",
+    # This is a dummy rule used as a absl-py dependency in open-source.
+    # We expect absl-py to already be installed on the system, e.g. via
+    # `pip install absl-py`
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "expect_absl_testing_absltest_installed",
     # This is a dummy rule used as a absl-py dependency in open-source.
     # We expect absl-py to already be installed on the system, e.g. via
     # `pip install absl-py`


### PR DESCRIPTION
Summary:
Within Google, tests that call certain functions must be run via either
`tf.test` or `absltest`. When possible, we’d like to use `absltest` so
that the tests can be run in notf settings. Thus, we change the backing
implementation of `tensorboard.test` from `unittest` to `absltest`.

We retain the `tensorboard.test` layer to add the `get_temp_dir` method,
which is provided by `tf.test` but not `absltest`, and which our tests
often expect to use.

This has the side benefit that we get lots of assertions for free,
including `assertStartsWith`, `assertEndsWith`, and `assertLen`, as well
as fancy ones like `assertSequenceAlmostEqual` and `assertUrlEqual`.
(Unfortunately, we still lack `tf.test`’s `assertProtoEquals`.)

Test Plan:
Existing tests pass. Googlers, see <http://cl/251757823>.

wchargin-branch: tb-test-absltest
