### PR TITLE
infra: upgrade three.js to r104 from r77

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizer3DLabels.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizer3DLabels.ts
@@ -284,7 +284,7 @@ export class ScatterPlotVisualizer3DLabels implements ScatterPlotVisualizer {
     }
 
     const colors = this.geometry.getAttribute('color') as THREE.BufferAttribute;
-    colors.array = this.renderColors;
+    (colors as any).setArray(this.renderColors);
 
     const n = pointColors.length / XYZ_ELEMENTS_PER_ENTRY;
     let src = 0;
@@ -331,7 +331,7 @@ export class ScatterPlotVisualizer3DLabels implements ScatterPlotVisualizer {
     this.material.uniforms.texture.value = this.glyphTexture.texture;
     this.material.uniforms.picking.value = true;
     const colors = this.geometry.getAttribute('color') as THREE.BufferAttribute;
-    colors.array = this.pickingColors;
+    (colors as any).setArray(this.pickingColors);
     colors.needsUpdate = true;
   }
 
@@ -346,7 +346,7 @@ export class ScatterPlotVisualizer3DLabels implements ScatterPlotVisualizer {
     this.material.uniforms.texture.value = this.glyphTexture.texture;
     this.material.uniforms.picking.value = false;
     const colors = this.geometry.getAttribute('color') as THREE.BufferAttribute;
-    colors.array = this.renderColors;
+    (colors as any).setArray(this.renderColors);
     colors.needsUpdate = true;
   }
 

--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerPolylines.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerPolylines.ts
@@ -135,7 +135,8 @@ export class ScatterPlotVisualizerPolylines implements ScatterPlotVisualizer {
       this.polylines[i].material.opacity = renderContext.polylineOpacities[i];
       (this.polylines[i].material as THREE.LineBasicMaterial).linewidth =
           renderContext.polylineWidths[i];
-      this.polylineColorBuffer[i].array = renderContext.polylineColors[i];
+      (this.polylineColorBuffer[i] as any)
+          .setArray(renderContext.polylineColors[i]);
       this.polylineColorBuffer[i].needsUpdate = true;
     }
   }

--- a/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerSprites.ts
+++ b/tensorboard/plugins/projector/vz_projector/scatterPlotVisualizerSprites.ts
@@ -38,6 +38,8 @@ const VERTEX_SHADER = `
   uniform float spritesPerRow;
   uniform float spritesPerColumn;
 
+  ${THREE.ShaderChunk[ 'fog_pars_vertex' ]}
+
   void main() {
     // Pass index and color values to fragment shader.
     vColor = color;
@@ -285,11 +287,11 @@ export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
 
     const geometry = new THREE.BufferGeometry();
     geometry.addAttribute(
-        'position', new THREE.BufferAttribute(null, XYZ_NUM_ELEMENTS));
+        'position', new THREE.BufferAttribute(undefined, XYZ_NUM_ELEMENTS));
     geometry.addAttribute(
-        'color', new THREE.BufferAttribute(null, RGB_NUM_ELEMENTS));
+        'color', new THREE.BufferAttribute(undefined, RGB_NUM_ELEMENTS));
     geometry.addAttribute(
-        'scaleFactor', new THREE.BufferAttribute(null, INDEX_NUM_ELEMENTS));
+        'scaleFactor', new THREE.BufferAttribute(undefined, INDEX_NUM_ELEMENTS));
     return geometry;
   }
 
@@ -372,7 +374,8 @@ export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
 
     const positions = (this.points.geometry as THREE.BufferGeometry)
                           .getAttribute('position') as THREE.BufferAttribute;
-    positions.array = newPositions;
+
+    (positions as any).setArray(newPositions);
     positions.needsUpdate = true;
   }
 
@@ -392,13 +395,13 @@ export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
 
     let colors = (this.points.geometry as THREE.BufferGeometry)
                      .getAttribute('color') as THREE.BufferAttribute;
-    colors.array = this.pickingColors;
+    (colors as any).setArray(this.pickingColors);
     colors.needsUpdate = true;
 
     let scaleFactors =
         (this.points.geometry as THREE.BufferGeometry)
             .getAttribute('scaleFactor') as THREE.BufferAttribute;
-    scaleFactors.array = rc.pointScaleFactors;
+    (scaleFactors as any).setArray(rc.pointScaleFactors);
     scaleFactors.needsUpdate = true;
   }
 
@@ -430,13 +433,13 @@ export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
     let colors = (this.points.geometry as THREE.BufferGeometry)
                      .getAttribute('color') as THREE.BufferAttribute;
     this.renderColors = rc.pointColors;
-    colors.array = this.renderColors;
+    (colors as any).setArray(this.renderColors);
     colors.needsUpdate = true;
 
     let scaleFactors =
         (this.points.geometry as THREE.BufferGeometry)
             .getAttribute('scaleFactor') as THREE.BufferAttribute;
-    scaleFactors.array = rc.pointScaleFactors;
+    (scaleFactors as any).setArray(rc.pointScaleFactors);
     scaleFactors.needsUpdate = true;
   }
 

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -165,17 +165,17 @@ def tensorboard_js_workspace():
       # no @license header
       licenses = ["notice"],  # MIT
       sha256_urls = {
-          "5eb9be209f84c4588f573b9abd8e13c04ce187ad6f40e8b12993d00b1428de54": [
-              "http://mirror.tensorflow.org/raw.githubusercontent.com/mrdoob/three.js/r77/LICENSE",
-              "https://raw.githubusercontent.com/mrdoob/three.js/r77/LICENSE",
+          "90f3af9ebfaf34f642b05f3baeeca2c5547d1b8ba6872803990c26804f4067b1": [
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/mrdoob/three.js/r104/LICENSE",
+              "https://raw.githubusercontent.com/mrdoob/three.js/r104/LICENSE",
           ],
-          "881cc79c84c34a1f61f8c8af0ee3f237d83a2eda3868720fdcb47bcacf8da44a": [
-              "http://mirror.tensorflow.org/raw.githubusercontent.com/mrdoob/three.js/r77/build/three.js",
-              "https://raw.githubusercontent.com/mrdoob/three.js/r77/build/three.js",
+          "40873d04d4ace1529c503b10053fe6c09c04e8ba4a1eaacb07a1ea17fa073368": [
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/mrdoob/three.js/r104/build/three.js",
+              "https://raw.githubusercontent.com/mrdoob/three.js/r104/build/three.js",
           ],
-          "98b8b5954901025a98033c8bdd65969be1f30b59e11f823ec864253bb72f768d": [
-              "http://mirror.tensorflow.org/raw.githubusercontent.com/mrdoob/three.js/r77/examples/js/controls/OrbitControls.js",
-              "https://raw.githubusercontent.com/mrdoob/three.js/r77/examples/js/controls/OrbitControls.js",
+          "f495c87a34ac1bf238e245c60e9fed2ec831cefbb9dc29e17b91e24b5ef6559b": [
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/mrdoob/three.js/r104/examples/js/controls/OrbitControls.js",
+              "https://raw.githubusercontent.com/mrdoob/three.js/r104/examples/js/controls/OrbitControls.js",
           ],
       },
   )


### PR DESCRIPTION
### Notable changes:
- Vertex shader require related glsl code block
- other API changes in between
- WebGLRenderer.render no longer takes 4 inputs. Instead, you must set
  renderTarget manually.
- BufferAttribute.prototype.count is important and attribute.array is
  discourage in favor of setArray

### Notable no changes:
- Types are not updated. 
  - DefinitelyType no longer provide the latest
    typing of three in favor TypeScript in three.js repo. For the time
    being, we have decided not to pursue this as downloading the archive
    would fetch unnecessarily large file (examples dir is 300+MB).
  - Types in newer DefinitelyTyped and three.js seem to be incompatible
     with current build system. https://github.com/stephanwlee/tensorboard/commit/daa35e457ed64cbe1cfe871beceb901377e5ec80


### Detailed steps to verify changes work correctly (as executed by you)
Poked around projector, what-if, and mesh plugins thoroughly. 