### PR TITLE
Set base URI for plugin iframe

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -806,6 +806,11 @@ limitations under the License.
               this.scopeSubtree(iframe);
               container.appendChild(iframe);
               const subdocument = iframe.contentDocument;
+              const baseUrl = tf_backend.getRouter()
+                  .pluginRoute(selectedDashboard, '/')
+              const base = subdocument.createElement('base');
+              base.href = baseUrl;
+              subdocument.head.appendChild(base);
               const script = subdocument.createElement('script');
               const moduleString = JSON.stringify(loadingMechanism.modulePath);
               script.textContent =


### PR DESCRIPTION
Plugins are developed with a relative to its package in mind. Without
setting the baseURI, the iframe has base path of
http[s]://[TBPATH]/[pathPrefix] which forces all relative paths the
plugin uses require 'data/plugin/[name]/' prefix, which is unnatural.

This change sets the base URI of the plugin iframe to
http[s]://[TBPATH]/[pathPrefix]/data/plugin/[name]/.
