### PR TITLE
what-if: upgrade what-if source to be tf 2.0 compatible

### DIFF
--- a/tensorboard/plugins/interactive_inference/utils/BUILD
+++ b/tensorboard/plugins/interactive_inference/utils/BUILD
@@ -29,6 +29,7 @@ py_library(
     deps = [
         ":common_utils",
         ":platform_utils",
+        "//tensorboard:expect_absl_logging_installed",
         "//tensorboard:expect_tensorflow_installed",
         "@org_tensorflow_serving_api",
     ],

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -18,6 +18,8 @@ import collections
 import copy
 import json
 import math
+
+from absl import logging
 import numpy as np
 import tensorflow as tf
 from google.protobuf import json_format
@@ -655,7 +657,7 @@ def get_label_vocab(vocab_path):
       with tf.io.gfile.GFile(vocab_path, 'r') as f:
         return [line.rstrip('\n') for line in f]
     except tf.errors.NotFoundError as err:
-      tf.compat.v1.logging.error('error reading vocab file: %s', err)
+      logging.error('error reading vocab file: %s', err)
   return []
 
 def create_sprite_image(examples):
@@ -693,9 +695,9 @@ def create_sprite_image(examples):
     with tf.compat.v1.Session():
       keys_to_features = {
           image_feature_name:
-              tf.compat.v1.FixedLenFeature((), tf.string, default_value=''),
+              tf.io.FixedLenFeature((), tf.string, default_value=''),
       }
-      parsed = tf.compat.v1.parse_example(examples, keys_to_features)
+      parsed = tf.io.parse_example(examples, keys_to_features)
       images = tf.zeros([1, 1, 1, 1], tf.float32)
       i = tf.constant(0)
       thumbnail_dims = (sprite_thumbnail_dim_px,

--- a/tensorboard/plugins/interactive_inference/witwidget/BUILD
+++ b/tensorboard/plugins/interactive_inference/witwidget/BUILD
@@ -1,5 +1,5 @@
 package(default_visibility = ["//tensorboard:internal"])
- 
+
 licenses(["notice"])  # Apache 2.0
 
 py_library(
@@ -10,6 +10,7 @@ py_library(
     ]),
     srcs_version = "PY2AND3",
     deps = [
+        "//tensorboard:expect_absl_logging_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins/interactive_inference/utils:inference_utils",
         "@com_google_protobuf//:protobuf_python",

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import logging
 import base64
 import json
 import googleapiclient.discovery
@@ -36,7 +37,7 @@ class WitWidgetBase(object):
     Args:
       config_builder: WitConfigBuilder object containing settings for WIT.
     """
-    tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.WARN)
+    logging.set_verbosity(logging.WARN)
     config = config_builder.build()
     copied_config = dict(config)
     self.estimator_and_spec = (

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
@@ -36,7 +36,7 @@ class WitWidgetBase(object):
     Args:
       config_builder: WitConfigBuilder object containing settings for WIT.
     """
-    tf.logging.set_verbosity(tf.logging.WARN)
+    tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.WARN)
     config = config_builder.build()
     copied_config = dict(config)
     self.estimator_and_spec = (

--- a/tensorboard/plugins/interactive_inference/witwidget/pip_package/setup.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/pip_package/setup.py
@@ -43,6 +43,7 @@ if 'witwidget-gpu' in project_name:
   ]
 
 REQUIRED_PACKAGES = [
+    'absl-py >= 0.4',
     'google-api-python-client>=1.7.8',
     'ipywidgets>=7.0.0',
     'jupyter>=1.0,<2',


### PR DESCRIPTION
The utility was using TF v1 only API.

Where necessary, we now use `tf.compat.v1` instead of `tf`.
Also ran the migration script to add keywords to the arguments to some methods.

Report from the migration script:
```
INFO line 673:23: Added keywords to args of function 'tf.shape'
INFO line 713:17: Added keywords to args of function 'tf.cond'
INFO line 718:17: Added keywords to args of function 'tf.while_loop'
INFO line 749:8: Added keywords to args of function 'tf.parse_example'                              
INFO line 749:8: Renamed 'tf.parse_example' to 'tf.io.parse_example'                                                                                                                                    
TensorFlow 2.0 Upgrade Script       
-----------------------------
Converted 1 files             
Detected 0 issues that require attention                    
--------------------------------------------------------------------------------
```

Edit: ran the migration script to the interactive_inference source tree and it made minor changes to notebook/base.py. 

Fixes #2330.

WANT_LGTM=nfelt