### PR TITLE
ci: pin to non-broken nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
     - BAZEL=0.22.0
     - BAZEL_SHA256SUM=8474ed28ed4998e2f5671ddf3a9a80ae9e484a5de3b8b70c8b654c017c65d363
   matrix:
-    - TF_VERSION_ID=tf-nightly
-    - TF_VERSION_ID=tf-nightly-2.0-preview
+    - TF_VERSION_ID=tf-nightly==1.14.1.dev20190606
+    - TF_VERSION_ID=tf-nightly-2.0-preview==2.0.0.dev20190606
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:


### PR DESCRIPTION
Summary:
Due to <https://github.com/tensorflow/tensorflow/issues/29536>.

This unblocks our CI until tomorrow’s nightlies are pushed.

Test Plan:
Fingers crossed.

wchargin-branch: pin-20190606-nightly
