### PR TITLE
Fixed incorrect runs-selector rendering

### DIFF
--- a/tensorboard/components/tf_dashboard_common/dashboard-style.html
+++ b/tensorboard/components/tf_dashboard_common/dashboard-style.html
@@ -23,6 +23,10 @@ limitations under the License.
   <template>
     <style include="iron-flex"></style>
     <style>
+      :host {
+        --sidebar-vertical-padding: 15px;
+      }
+
       .sidebar {
         box-sizing: border-box;
         display: flex;
@@ -35,8 +39,11 @@ limitations under the License.
       }
 
       tf-runs-selector {
-        flex-shrink: 1;
         flex-grow: 1;
+        flex-shrink: 1;
+        max-height: calc(100% - var(--sidebar-vertical-padding) * 2);
+        overflow: hidden;
+        position: absolute;
       }
 
       .search-input {
@@ -45,7 +52,8 @@ limitations under the License.
 
       .sidebar-section {
         border-top: solid 1px rgba(0, 0, 0, .12);
-        padding: 15px 0 15px 30px;
+        padding: var(--sidebar-vertical-padding) 0 var(--sidebar-vertical-padding) 30px;
+        position: relative;
       }
 
       .sidebar-section:first-of-type {

--- a/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.html
+++ b/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.html
@@ -93,12 +93,12 @@ handle these situations gracefully.
       display: flex;
       flex-direction: column;
       height: 100%;
+      overflow: hidden;
     }
     #outer-container {
       overflow-y: auto;
       overflow-x: hidden;
       width: 100%;
-      height: 0; /* Quirk to make firefox add scrolling instead of expand div */
       flex-grow: 1;
       flex-shrink: 1;
       word-wrap: break-word;

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -71,10 +71,10 @@ Properties out:
     </template>
     <style>
       :host {
+        box-sizing: border-box;
         display: flex;
         flex-direction: column;
         padding-bottom: 10px;
-        box-sizing: border-box;
       }
       #top-text {
         width: 100%;
@@ -88,6 +88,7 @@ Properties out:
         display: flex;
         flex-grow: 1;
         flex-shrink: 1;
+        overflow: hidden;
       }
       .x-button {
         font-size: 13px;


### PR DESCRIPTION
Nature of the bug:
Sidebar tf-runs-selector is a bit trickier in term of layout: its height
depends both on number/size of the content (# of runs) and size of the
viewport (show scrollbar if it does not fit in the sidebar).

To confine the size of the tf-runs-selector w.r.t the height of its
container (whose height is not defined by content but its sibling sizes
which are computed by respective descendents), we need to make each flex
container `overflow: hidden`. `overflow: hidden` makes child and
child-flex-container compute height w.r.t, the flex-container with
`overflow: hidden`.

When run numbers are low, we make tf-runs-selector's height computed
w.r.t. descendent heights by not putting `height: 100%`.

Confirmed the change both on Chrome 75 and Firefox 66.
