### PR TITLE
infra: use base.setAttribute instead .href

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -809,6 +809,9 @@ limitations under the License.
               const pluginBasePath = tf_backend.getRouter()
                   .pluginRoute(selectedDashboard, '/')
               const base = subdocument.createElement('base');
+              // TODO(stephanwlee): Use sanitized URL when setting the href.
+              // setAttribute is a bypass for the security conformance which we
+              // have no way to address.
               base.setAttribute(
                   'href',
                   String(new URL(pluginBasePath, window.location.href)));

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -806,10 +806,12 @@ limitations under the License.
               this.scopeSubtree(iframe);
               container.appendChild(iframe);
               const subdocument = iframe.contentDocument;
-              const baseUrl = tf_backend.getRouter()
+              const pluginBasePath = tf_backend.getRouter()
                   .pluginRoute(selectedDashboard, '/')
               const base = subdocument.createElement('base');
-              base.href = baseUrl;
+              base.setAttribute(
+                  'href',
+                  String(new URL(pluginBasePath, window.location.href)));
               subdocument.head.appendChild(base);
               const script = subdocument.createElement('script');
               const moduleString = JSON.stringify(loadingMechanism.modulePath);


### PR DESCRIPTION
Closure security conformance test guard against almost all instances of
setting .href. Since we will not be using the goog.safe APIs for now, we
will be using setAttribute instead.

Confirm the change with an example plugin.