### PR TITLE
frontend: reinstate registration for conditional plugins

### DIFF
--- a/tensorboard/plugins/beholder/beholder_plugin.py
+++ b/tensorboard/plugins/beholder/beholder_plugin.py
@@ -75,6 +75,8 @@ class BeholderPlugin(base_plugin.TBPlugin):
            tf.io.gfile.exists(info_filename)
 
   def frontend_metadata(self):
+    # TODO(#2338): Keep this in sync with the `registerDashboard` call
+    # on the frontend until that call is removed.
     return super(BeholderPlugin, self).frontend_metadata()._replace(
         element_name='tf-beholder-dashboard',
         remove_dom=True,

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -513,6 +513,14 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
       },
     });
 
+  // TODO(#2338): Remove this, and set up the "no TF" message properly.
+  // Keep this in sync with `frontend_metadata` in `beholder_plugin.py`.
+    tf_tensorboard.registerDashboard({
+      plugin: PLUGIN_NAME,
+      elementName: 'tf-beholder-dashboard',
+      shouldRemoveDom: true,
+    });
+
     })();
   </script>
 </dom-module>

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -513,8 +513,8 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
       },
     });
 
-  // TODO(#2338): Remove this, and set up the "no TF" message properly.
-  // Keep this in sync with `frontend_metadata` in `beholder_plugin.py`.
+    // TODO(#2338): Remove this, and set up the "no TF" message properly.
+    // Keep this in sync with `frontend_metadata` in `beholder_plugin.py`.
     tf_tensorboard.registerDashboard({
       plugin: PLUGIN_NAME,
       elementName: 'tf-beholder-dashboard',

--- a/tensorboard/plugins/debugger/debugger_plugin.py
+++ b/tensorboard/plugins/debugger/debugger_plugin.py
@@ -152,6 +152,8 @@ class DebuggerPlugin(base_plugin.TBPlugin):
             constants.DEBUGGER_PLUGIN_NAME))
 
   def frontend_metadata(self):
+    # TODO(#2338): Keep this in sync with the `registerDashboard` call
+    # on the frontend until that call is removed.
     return super(DebuggerPlugin, self).frontend_metadata()._replace(
         element_name='tf-debugger-dashboard',
     )

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin.py
@@ -160,6 +160,8 @@ class InteractiveDebuggerPlugin(base_plugin.TBPlugin):
     return self._grpc_port is not None
 
   def frontend_metadata(self):
+    # TODO(#2338): Keep this in sync with the `registerDashboard` call
+    # on the frontend until that call is removed.
     return super(InteractiveDebuggerPlugin, self).frontend_metadata()._replace(
         element_name='tf-debugger-dashboard',
     )

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -1426,5 +1426,13 @@ limitations under the License.
           {defaultValue: _DEFAULT_TOP_RIGHT_QUADRANT_HEIGHT}),
     });
 
+    // TODO(#2338): Remove this, and set up the "no debugger enabled"
+    // message properly. Keep this in sync with `frontend_metadata` in
+    // both `debugger_plugin.py` and `interactive_debugger_plugin.py`.
+    tf_tensorboard.registerDashboard({
+      plugin: 'debugger',
+      elementName: 'tf-debugger-dashboard',
+    });
+
   </script>
 </dom-module>

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -84,6 +84,8 @@ class HParamsPlugin(base_plugin.TBPlugin):
         metadata.PLUGIN_NAME))
 
   def frontend_metadata(self):
+    # TODO(#2338): Keep this in sync with the `registerDashboard` call
+    # on the frontend until that call is removed.
     return super(HParamsPlugin, self).frontend_metadata()._replace(
         element_name='tf-hparams-dashboard',
     )

--- a/tensorboard/plugins/hparams/tf_hparams_dashboard/tf-hparams-dashboard.html
+++ b/tensorboard/plugins/hparams/tf_hparams_dashboard/tf-hparams-dashboard.html
@@ -83,6 +83,14 @@ limitations under the License.
       }
     });
 
+    // TODO(#2338): Remove this, and set up a "no TF" message properly.
+    // Keep this in sync with `frontend_metadata` in
+    // `hparams_plugin.py`.
+    tf_tensorboard.registerDashboard({
+      plugin: PLUGIN_NAME,
+      elementName: 'tf-hparams-dashboard'
+    });
+
     })();
   </script>
 </dom-module>

--- a/tensorboard/plugins/interactive_inference/interactive_inference_plugin.py
+++ b/tensorboard/plugins/interactive_inference/interactive_inference_plugin.py
@@ -109,6 +109,8 @@ class InteractiveInferencePlugin(base_plugin.TBPlugin):
     return False
 
   def frontend_metadata(self):
+    # TODO(#2338): Keep this in sync with the `registerDashboard` call
+    # on the frontend until that call is removed.
     return super(InteractiveInferencePlugin, self).frontend_metadata()._replace(
         element_name='tf-interactive-inference-dashboard',
         tab_name='What-If Tool',

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -5819,6 +5819,15 @@ limitations under the License.
        },
     });
 
+    // TODO(#2338): Remove this, and set up a "no TF" message properly.
+    // Keep this in sync with `frontend_metadata` in
+    // `interactive_inference_plugin.py`.
+    tf_tensorboard.registerDashboard({
+      plugin: PLUGIN_NAME,
+      elementName: 'tf-interactive-inference-dashboard',
+      tabName: 'What-If Tool',
+    });
+
     })();
   </script>
 </dom-module>

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -136,6 +136,8 @@ class ProfilePlugin(base_plugin.TBPlugin):
     return self._is_active
 
   def frontend_metadata(self):
+    # TODO(#2338): Keep this in sync with the `registerDashboard` call
+    # on the frontend until that call is removed.
     return super(ProfilePlugin, self).frontend_metadata()._replace(
         element_name='tf-profile-dashboard',
         disable_reload=True,

--- a/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
+++ b/tensorboard/plugins/profile/tf_profile_dashboard/tf-profile-dashboard.html
@@ -496,6 +496,8 @@ profile run can have multiple tools that present the performance profile as diff
       this.set('_isAttached', true);
       // Check if the plugin was created
       this._requestManager
+          // TODO(#2338): The plugins listing is probably not the right
+          // source of truth.
           .request(tf_backend.getRouter().pluginsListing())
           .then(plugins => {
             if (!(PLUGIN_NAME in plugins)) {
@@ -772,6 +774,14 @@ profile run can have multiple tools that present the performance profile as diff
     _isState: function(actualState, candidateState) {
       return actualState === candidateState;
     },
+  });
+
+  // TODO(#2338): Remove this, and set up the "no TF" message properly.
+  // Keep this in sync with `frontend_metadata` in `profile_plugin.py`.
+  tf_tensorboard.registerDashboard({
+    plugin: PLUGIN_NAME,
+    elementName: 'tf-profile-dashboard',
+    isReloadDisabled: true,
   });
 
   })();


### PR DESCRIPTION
Summary:
Plugins whose backends are provided via “loaders” rather than the
plugins themselves may fail to load. We still want to allow those
plugins to display a message in the frontend indicating what must be
done to enable them (e.g., update TensorFlow, start a `tfdbg` debugger),
which requires registering their frontends unconditionally.

This is a short-term hack to retain functionality prior to #2304 (with
the minor change that these plugins will now always appear at the end of
the list). We’ll want to replace this with a better mechanism when time
permits.

Fixes #2338.

Test Plan:
Launch TensorBoard without TensorFlow installed and with no flags other
than `--logdir`. Note that the beholder, debugger, hparams, what-if
tool, and profile dashboards all have valid entries in the “inactive”
dropdown, displaying appropriate help messages.

Verify that of the plugins listed in `default.py`, all those provided
via loaders now have `registerDashboard` statements.

wchargin-branch: register-conditional-plugins
