### PR TITLE
Make sure compat PyRecordReader_New reads new data

### DIFF
--- a/tensorboard/compat/tensorflow_stub/io/gfile.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile.py
@@ -335,11 +335,6 @@ class GFile(object):
         self.buff_offset += read_size
         return self.buff[old_buff_offset:old_buff_offset + read_size]
 
-    def seek(self, offset=None):
-        self.buff = None
-        self.buff_offset = offset
-        self.offset = offset
-
     def read(self, n=None):
         result = None
         if self.buff and len(self.buff) > self.buff_offset:

--- a/tensorboard/compat/tensorflow_stub/io/gfile.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile.py
@@ -335,6 +335,11 @@ class GFile(object):
         self.buff_offset += read_size
         return self.buff[old_buff_offset:old_buff_offset + read_size]
 
+    def seek(self, offset=None):
+        self.buff = None
+        self.buff_offset = offset
+        self.offset = offset
+
     def read(self, n=None):
         result = None
         if self.buff and len(self.buff) > self.buff_offset:

--- a/tensorboard/compat/tensorflow_stub/pywrap_tensorflow.py
+++ b/tensorboard/compat/tensorflow_stub/pywrap_tensorflow.py
@@ -164,13 +164,8 @@ def crc32c(data):
 
 
 class PyRecordReader_New:
-    def __init__(
-      self,
-      filename=None,
-      start_offset=0,
-      compression_type=None,
-      status=None
-    ):
+    def __init__(self, filename=None, start_offset=0, compression_type=None,
+                 status=None):
         self.filename = filename
         self.file_handle = None
         self.start_offset = start_offset

--- a/tensorboard/compat/tensorflow_stub/pywrap_tensorflow.py
+++ b/tensorboard/compat/tensorflow_stub/pywrap_tensorflow.py
@@ -166,29 +166,28 @@ def crc32c(data):
 class PyRecordReader_New:
     def __init__(self, filename=None, start_offset=0, compression_type=None,
                  status=None):
+        if filename is None:
+            raise errors.NotFoundError(
+                None, None, 'No filename provided, cannot read Events')
+        if not gfile.exists(filename):
+            raise errors.NotFoundError(
+                None, None,
+                '{} does not point to valid Events file'.format(filename))
+        if start_offset:
+            raise errors.UnimplementedError(
+                None, None, 'start offset not supported by compat reader')
+        if compression_type:
+            # TODO: Handle gzip and zlib compressed files
+            raise errors.UnimplementedError(
+                None, None, 'compression not supported by compat reader')
         self.filename = filename
-        self.file_handle = None
         self.start_offset = start_offset
         self.compression_type = compression_type
         self.status = status
         self.curr_event = None
+        self.file_handle = gfile.GFile(self.filename, 'rb')
 
     def GetNext(self):
-        if self.file_handle is None:
-            if self.filename is None:
-                raise errors.NotFoundError(
-                    None, None, 'No filename provided, cannot read Events')
-            if not gfile.exists(self.filename):
-                raise errors.NotFoundError(
-                    None, None,
-                    '{} does not point to valid Events file'.format(self.filename))
-            if self.compression_type:
-                # TODO: Handle gzip and zlib compressed files
-                raise errors.UnimplementedError(
-                    None, None, 'compression not supported by compat reader')
-            self.file_handle = gfile.GFile(self.filename, 'rb')
-            self.file_handle.seek(self.start_offset)
-
         # Read the header
         self.curr_event = None
         header_str = self.file_handle.read(8)

--- a/tensorboard/compat/tensorflow_stub/pywrap_tensorflow.py
+++ b/tensorboard/compat/tensorflow_stub/pywrap_tensorflow.py
@@ -171,75 +171,69 @@ class PyRecordReader_New:
       compression_type=None,
       status=None
     ):
-        self.event_strs = []
         self.filename = filename
+        self.file_handle = None
         self.start_offset = start_offset
         self.compression_type = compression_type
         self.status = status
-        self.done_reading = False
-        self.index = -1
-
-    def read(self):
-        if self.filename is None:
-            raise errors.NotFoundError(
-                None, None, 'No filename provided, cannot read Events')
-        if not gfile.exists(self.filename):
-            raise errors.NotFoundError(
-                None, None,
-                '{} does not point to valid Events file'.format(self.filename))
-
-        # TODO: Handle gzip and zlib compressed files
-        with gfile.GFile(self.filename, 'rb') as f:
-            f.read(self.start_offset)
-
-            while True:
-                # Read the header
-                header_str = f.read(8)
-                if len(header_str) != 8:
-                    break  # Hit EOF so exit
-                header = struct.unpack('Q', header_str)
-
-                # Read the crc32, which is 4 bytes, and check it against
-                # the crc32 of the header
-                crc_header_str = f.read(4)
-                crc_header = struct.unpack('I', crc_header_str)
-                header_crc_calc = masked_crc32c(header_str)
-                if header_crc_calc != crc_header[0]:
-                    raise errors.DataLossError(
-                        None, None,
-                        '{} failed header crc32 check'.format(self.filename)
-                    )
-
-                # The length of the header tells us how many bytes the Event
-                # string takes
-                header_len = int(header[0])
-                event_str = f.read(header_len)
-
-                event_crc_calc = masked_crc32c(event_str)
-
-                # The next 4 bytes contain the crc32 of the Event string,
-                # which we check for integrity. Sometimes, the last Event
-                # has no crc32, in which case we skip.
-                crc_event_str = f.read(4)
-                if crc_event_str:
-                    crc_event = struct.unpack('I', crc_event_str)
-                    if event_crc_calc != crc_event[0]:
-                        raise errors.DataLossError(
-                            None, None,
-                            '{} failed event crc32 check'.format(self.filename)
-                        )
-                self.event_strs += [event_str]
-
-        self.done_reading = True
+        self.curr_event = None
 
     def GetNext(self):
-        if not self.done_reading:
-            self.read()
+        if self.file_handle is None:
+            if self.filename is None:
+                raise errors.NotFoundError(
+                    None, None, 'No filename provided, cannot read Events')
+            if not gfile.exists(self.filename):
+                raise errors.NotFoundError(
+                    None, None,
+                    '{} does not point to valid Events file'.format(self.filename))
+            if self.compression_type:
+                # TODO: Handle gzip and zlib compressed files
+                raise errors.UnimplementedError(
+                    None, None, 'compression not supported by compat reader')
+            self.file_handle = gfile.GFile(self.filename, 'rb')
+            self.file_handle.seek(self.start_offset)
 
-        if self.index >= len(self.event_strs) - 1:
+        # Read the header
+        self.curr_event = None
+        header_str = self.file_handle.read(8)
+        if len(header_str) != 8:
+            # Hit EOF so raise and exit
             raise errors.OutOfRangeError(None, None, 'No more events to read')
-        else:
-            self.index += 1
+        header = struct.unpack('Q', header_str)
+
+        # Read the crc32, which is 4 bytes, and check it against
+        # the crc32 of the header
+        crc_header_str = self.file_handle.read(4)
+        crc_header = struct.unpack('I', crc_header_str)
+        header_crc_calc = masked_crc32c(header_str)
+        if header_crc_calc != crc_header[0]:
+            raise errors.DataLossError(
+                None, None,
+                '{} failed header crc32 check'.format(self.filename)
+            )
+
+        # The length of the header tells us how many bytes the Event
+        # string takes
+        header_len = int(header[0])
+        event_str = self.file_handle.read(header_len)
+
+        event_crc_calc = masked_crc32c(event_str)
+
+        # The next 4 bytes contain the crc32 of the Event string,
+        # which we check for integrity. Sometimes, the last Event
+        # has no crc32, in which case we skip.
+        crc_event_str = self.file_handle.read(4)
+        if crc_event_str:
+            crc_event = struct.unpack('I', crc_event_str)
+            if event_crc_calc != crc_event[0]:
+                raise errors.DataLossError(
+                    None, None,
+                    '{} failed event crc32 check'.format(self.filename)
+                )
+
+        # Set the current event to be read later by record() call
+        self.curr_event = event_str
 
     def record(self):
-        return self.event_strs[self.index]
+        return self.curr_event

--- a/tensorboard/summary/writer/record_writer_test.py
+++ b/tensorboard/summary/writer/record_writer_test.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 import six
 import os
 from tensorboard.summary.writer.record_writer import RecordWriter
+from tensorboard.compat.tensorflow_stub import errors
 from tensorboard.compat.tensorflow_stub.pywrap_tensorflow import PyRecordReader_New
 from tensorboard import test as tb_test
 
@@ -61,6 +62,21 @@ class RecordWriterTest(tb_test.TestCase):
     for i in range(times_to_test):
       r.GetNext()
       self.assertEqual(r.record(), bytes_to_write)
+
+  def test_record_immediate_read(self):
+    filename = os.path.join(self.get_temp_dir(), "record_immediate_read")
+    bytes_to_write = b"hello world"
+    times_to_test = 10
+    w = RecordWriter(open(filename, 'wb'))
+    r = PyRecordReader_New(filename)
+    with self.assertRaises(errors.OutOfRangeError):
+      r.GetNext()
+    for _ in range(times_to_test):
+      w.write(bytes_to_write)
+      w.flush()
+      r.GetNext()
+      self.assertEqual(r.record(), bytes_to_write)
+    w.close()
 
   def test_expect_bytes_written_bytes_IO(self):
     byte_len = 64

--- a/tensorboard/summary/writer/record_writer_test.py
+++ b/tensorboard/summary/writer/record_writer_test.py
@@ -52,30 +52,28 @@ class RecordWriterTest(tb_test.TestCase):
   def test_record_writer_roundtrip(self):
     filename = os.path.join(self.get_temp_dir(), "record_writer_roundtrip")
     w = RecordWriter(open(filename, 'wb'))
-    bytes_to_write = b"hello world"
-    times_to_test = 50
-    for _ in range(times_to_test):
-      w.write(bytes_to_write)
+    chunks_to_write = [ "hello world{}".format(i).encode() for i in range(10) ]
+    for bytes in chunks_to_write:
+      w.write(bytes)
     w.close()
 
     r = PyRecordReader_New(filename)
-    for i in range(times_to_test):
+    for bytes in chunks_to_write:
       r.GetNext()
-      self.assertEqual(r.record(), bytes_to_write)
+      self.assertEqual(r.record(), bytes)
 
   def test_record_immediate_read(self):
     filename = os.path.join(self.get_temp_dir(), "record_immediate_read")
-    bytes_to_write = b"hello world"
-    times_to_test = 10
+    chunks_to_write = [ "hello world{}".format(i).encode() for i in range(10) ]
     w = RecordWriter(open(filename, 'wb'))
     r = PyRecordReader_New(filename)
     with self.assertRaises(errors.OutOfRangeError):
       r.GetNext()
-    for _ in range(times_to_test):
-      w.write(bytes_to_write)
+    for bytes in chunks_to_write:
+      w.write(bytes)
       w.flush()
       r.GetNext()
-      self.assertEqual(r.record(), bytes_to_write)
+      self.assertEqual(r.record(), bytes)
     w.close()
 
   def test_expect_bytes_written_bytes_IO(self):

--- a/tensorboard/summary/writer/record_writer_test.py
+++ b/tensorboard/summary/writer/record_writer_test.py
@@ -52,7 +52,7 @@ class RecordWriterTest(tb_test.TestCase):
   def test_record_writer_roundtrip(self):
     filename = os.path.join(self.get_temp_dir(), "record_writer_roundtrip")
     w = RecordWriter(open(filename, 'wb'))
-    chunks_to_write = [ "hello world{}".format(i).encode() for i in range(10) ]
+    chunks_to_write = ["hello world{}".format(i).encode() for i in range(10)]
     for bytes in chunks_to_write:
       w.write(bytes)
     w.close()
@@ -64,7 +64,7 @@ class RecordWriterTest(tb_test.TestCase):
 
   def test_record_immediate_read(self):
     filename = os.path.join(self.get_temp_dir(), "record_immediate_read")
-    chunks_to_write = [ "hello world{}".format(i).encode() for i in range(10) ]
+    chunks_to_write = ["hello world{}".format(i).encode() for i in range(10)]
     w = RecordWriter(open(filename, 'wb'))
     r = PyRecordReader_New(filename)
     with self.assertRaises(errors.OutOfRangeError):


### PR DESCRIPTION
This fixes https://github.com/pytorch/pytorch/issues/20477

It looks like our original compat implementation of `PyRecordReader_New` didn't continue to try and read content from a file after it had done the original read. This updates the class to continue to request data from the file and read in new events. Note that this would only be seen in the non-TensorFlow case. Here's a test case:

```
conda create --name notf36 python=3.6
conda activate notf36
pip install --upgrade pip
pip install scipy
conda install -y protobuf
conda install -y absl-py
conda install -y numpy
conda install pytorch-nightly -c pytorch  # For the train.py below
pip install tb-nightly  # For the train.py below
bazel build tensorboard --verbose_failures
./bazel-bin/tensorboard/tensorboard --logdir ../realtime_runs/runs/ --verbosity 2
bazel test //tensorboard/summary/writer:record_writer_test --test_output=errors
```

While the above is running, execute the following `train.py` script located in `../realtime_runs/`:

```
import numpy as np
import time

import torch
from torch.utils.tensorboard import SummaryWriter

writer = SummaryWriter()

for i in range(1000000):
    writer.add_scalar('data/s1', i % 100, i)
    # writer.add_scalar('data/s2', i % 200, i)
    # writer.add_scalars('data/scalar_group', {'xsinx': i * np.sin(i), 'xcosx': i * np.cos(i)})
    writer.flush()

    time.sleep(1)
```

with `python train.py`

With the old code TensorBoard won't update. With the updated code it will as expected.

cc @nfelt, @natalialunova, @wchargin, @lanpa