### PR TITLE
Polymer 2: fix all the tests

### DIFF
--- a/tensorboard/components/tf_backend/test/tests.html
+++ b/tensorboard/components/tf_backend/test/tests.html
@@ -19,7 +19,7 @@ limitations under the License.
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="../../polymer/polymer.html">
   <link rel="import" href="../tf-backend.html">

--- a/tensorboard/components/tf_categorization_utils/test/tests.html
+++ b/tensorboard/components/tf_categorization_utils/test/tests.html
@@ -17,7 +17,7 @@ limitations under the License.
 -->
 
 <meta charset="utf-8">
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <script src="../../web-component-tester/browser.js"></script>
 <link rel="import" href="../tf-categorization-utils.html">
 <body>

--- a/tensorboard/components/tf_color_scale/test/tests.html
+++ b/tensorboard/components/tf_color_scale/test/tests.html
@@ -18,7 +18,7 @@ limitations under the License.
 
 <meta charset="utf-8">
 <script src="../../web-component-tester/browser.js"></script>
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../tf-color-scale.html">
 <body>
 <script src="colorScaleTests.js"></script>

--- a/tensorboard/components/tf_data_selector/test/tests.html
+++ b/tensorboard/components/tf_data_selector/test/tests.html
@@ -18,7 +18,7 @@ limitations under the License.
 
 <meta charset="utf-8">
 <script src="../../web-component-tester/browser.js"></script>
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../storage-utils.html">
 <body>
 <script src="storage-utils-test.js"></script>

--- a/tensorboard/components/tf_paginated_view/test/categoryPaginatedViewTests.ts
+++ b/tensorboard/components/tf_paginated_view/test/categoryPaginatedViewTests.ts
@@ -47,6 +47,15 @@ function flushAllP(): Promise<[void, void]> {
 describe('tf-paginated-view tests', () => {
   let view: any;
 
+  /**
+   * Returns stamped template item.
+   */
+  function getItem(id: string): HTMLElement {
+    return view.$.view.querySelector(`#${id}`);
+  }
+  /**
+   * Returns element inside shadowRoot of tf-category-paginated-view.
+   */
   function querySelector(cssSelector: string): HTMLElement {
     return view.$.view.root.querySelector(cssSelector);
   }
@@ -66,49 +75,49 @@ describe('tf-paginated-view tests', () => {
   });
 
   it('renders a page', () => {
-    expect(querySelector('#id0')).to.be.not.null;
-    expect(querySelector('#id1')).to.be.not.null;
+    expect(getItem('id0')).to.be.not.null;
+    expect(getItem('id1')).to.be.not.null;
 
     // 2-4 should be in another page.
-    expect(querySelector('#id2')).to.be.null;
+    expect(getItem('id2')).to.be.null;
   });
 
   it('responds to ancestor prop change that is bound on template', () => {
-    expect(querySelector('#id0').getAttribute('number')).to.equal('42');
+    expect(getItem('id0').getAttribute('number')).to.equal('42');
 
     view.randomNumber = 7;
-    expect(querySelector('#id0').getAttribute('number')).to.equal('7');
+    expect(getItem('id0').getAttribute('number')).to.equal('7');
   });
 
   it('navigates to next page when clicked on a button', async () => {
     // Sanity check
-    expect(querySelector('#id2')).to.be.null;
-    expect(querySelector('#id4')).to.be.null;
+    expect(getItem('id2')).to.be.null;
+    expect(getItem('id4')).to.be.null;
     expect(querySelector('paper-input')).to.have.property('value', '1');
 
     await goNext();
 
-    expect(querySelector('#id1')).to.be.null;
-    expect(querySelector('#id2')).to.be.not.null;
-    expect(querySelector('#id3')).to.be.not.null;
-    expect(querySelector('#id4')).to.be.null;
+    expect(getItem('id1')).to.be.null;
+    expect(getItem('id2')).to.be.not.null;
+    expect(getItem('id3')).to.be.not.null;
+    expect(getItem('id4')).to.be.null;
     expect(querySelector('paper-input')).to.have.property('value', '2');
 
     await goNext();
 
-    expect(querySelector('#id3')).to.be.null;
-    expect(querySelector('#id4')).to.be.not.null;
+    expect(getItem('id3')).to.be.null;
+    expect(getItem('id4')).to.be.not.null;
     expect(querySelector('paper-input')).to.have.property('value', '3');
   });
 
   it('reacts to limit change', () => {
     // 2-4 should be in another page, initially.
-    expect(querySelector('#id2')).to.be.null;
+    expect(getItem('id2')).to.be.null;
 
     view._limit = 4;
-    expect(querySelector('#id2')).to.be.not.null;
-    expect(querySelector('#id3')).to.be.not.null;
-    expect(querySelector('#id4')).to.be.null;
+    expect(getItem('id2')).to.be.not.null;
+    expect(getItem('id3')).to.be.not.null;
+    expect(getItem('id4')).to.be.null;
   });
 
   it('reacts to category update', async () => {
@@ -118,24 +127,24 @@ describe('tf-paginated-view tests', () => {
       {items: view.category.items.slice().reverse()},
     );
     await flushAllP();
-    expect(querySelector('#id4')).to.be.not.null;
-    expect(querySelector('#id3')).to.be.not.null;
+    expect(getItem('id4')).to.be.not.null;
+    expect(getItem('id3')).to.be.not.null;
   });
 
   it('reacts to items update', async () => {
     // Mutate the property of category in Polymeric way.
     view.set('category.items', view.category.items.slice().reverse());
     await flushAllP();
-    expect(querySelector('#id4')).to.be.not.null;
-    expect(querySelector('#id3')).to.be.not.null;
+    expect(getItem('id4')).to.be.not.null;
+    expect(getItem('id3')).to.be.not.null;
   });
 
   it('handles shrinking the number of pages', async () => {
     view.category = createCategory(1);
     await flushAllP();
 
-    expect(querySelector('#id0')).to.be.not.null;
-    expect(querySelector('#id1')).to.be.null;
+    expect(getItem('id0')).to.be.not.null;
+    expect(getItem('id1')).to.be.null;
     expect(_getPageCount()).to.equal(1);
   });
 

--- a/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
+++ b/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
@@ -19,6 +19,7 @@ limitations under the License.
 <link rel="import" href="../paper-input/paper-input.html">
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="tf-dom-repeat.html">
+<link rel="import" href="tf-paginated-view-store.html">
 
 <!--
   tf-category-paginated-view takes a category and renders subset of its items

--- a/tensorboard/components/tf_storage/test/tests.html
+++ b/tensorboard/components/tf_storage/test/tests.html
@@ -17,7 +17,7 @@ limitations under the License.
 -->
 
 <meta charset="utf-8">
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <script src="../../web-component-tester/browser.js"></script>
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../tf-storage.html">

--- a/tensorboard/components/tf_tensorboard/test/tensorboardTests.html
+++ b/tensorboard/components/tf_tensorboard/test/tensorboardTests.html
@@ -19,7 +19,7 @@ limitations under the License.
 <html>
 <head>
   <link rel="import" href="../../polymer/polymer.html">
-  <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="../tf-tensorboard.html">
   <link rel="stylesheet" type="text/css" href="../../../lib/css/global.css">

--- a/tensorboard/components/vz_line_chart2/test/tests.html
+++ b/tensorboard/components/vz_line_chart2/test/tests.html
@@ -17,7 +17,7 @@ limitations under the License.
 -->
 
 <meta charset="utf-8">
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <script src="../../web-component-tester/browser.js"></script>
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../tf-imports/plottable.html">

--- a/tensorboard/plugins/distribution/vz_distribution_chart/index.html
+++ b/tensorboard/plugins/distribution/vz_distribution_chart/index.html
@@ -21,7 +21,7 @@ limitations under the License.
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>vz-distribution chart demo</title>
-    <script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="vz-distribution-chart.html">
     <link rel="import" href="../iron-demo-helpers/demo-snippet.html">
     <link rel="import" href="../paper-styles/typography.html">

--- a/tensorboard/plugins/graph/tf_graph/demo/index.html
+++ b/tensorboard/plugins/graph/tf_graph/demo/index.html
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../tf-graph.html">
 <link rel="import" href="../../tf-graph-common/tf-graph-common.html">
 <link rel="import" href="../../tf-graph-loader/tf-graph-loader.html">

--- a/tensorboard/plugins/graph/tf_graph_board/demo/index.html
+++ b/tensorboard/plugins/graph/tf_graph_board/demo/index.html
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../tf-graph-board.html">
 <link rel="import" href="../../tf-graph-common/tf-graph-common.html">
 <link rel="import" href="../../tf-graph-loader/tf-graph-loader.html">

--- a/tensorboard/plugins/graph/tf_graph_common/test/index.html
+++ b/tensorboard/plugins/graph/tf_graph_common/test/index.html
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <meta charset="utf-8">
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <script src="../../web-component-tester/browser.js"></script>
 <link rel="import" href="../tf-graph-common.html">
 <body>

--- a/tensorboard/plugins/graph/tf_graph_controls/demo/index.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/demo/index.html
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../tf-graph-controls.html">
 <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
 <title>TF Graph Controls Demo</title>

--- a/tensorboard/plugins/graph/tf_graph_debugger_data_card/demo/index.html
+++ b/tensorboard/plugins/graph/tf_graph_debugger_data_card/demo/index.html
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../tf-graph-debugger-data-card.html">
 <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
 <title>TF Graph Info Demo</title>

--- a/tensorboard/plugins/graph/tf_graph_info/demo/index.html
+++ b/tensorboard/plugins/graph/tf_graph_info/demo/index.html
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../tf-graph-info.html">
 <link rel="import" href="../../tf-graph-common/tf-graph-common.html">
 <link rel="import" href="../../tf-graph-loader/tf-graph-loader.html">

--- a/tensorboard/plugins/graph/tf_graph_loader/demo/index.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/demo/index.html
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../tf-graph-loader.html">
 <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
 <title>TF Graph Loader Demo</title>

--- a/tensorboard/plugins/graph/tf_graph_loader/test/index.html
+++ b/tensorboard/plugins/graph/tf_graph_loader/test/index.html
@@ -19,7 +19,7 @@ limitations under the License.
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="../tf-graph-loader.html">
 </head>

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/test/tests.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/test/tests.html
@@ -19,7 +19,7 @@ limitations under the License.
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../../../webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../../../web-component-tester/browser.js"></script>
   <link rel="import" href="../tf-histogram-core.html">
 </head>

--- a/tensorboard/plugins/histogram/vz_histogram_timeseries/index.html
+++ b/tensorboard/plugins/histogram/vz_histogram_timeseries/index.html
@@ -21,7 +21,7 @@ limitations under the License.
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>vz-histogram-timeseries demo</title>
-    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="vz-histogram-timeseries.html">
     <link rel="import" href="../iron-demo-helpers/demo-snippet.html">
     <link rel="import" href="../paper-styles/typography.html">

--- a/tensorboard/plugins/hparams/tf_hparams_google_analytics_tracker/test/tf-hparams-google-analytics-tracker-test.html
+++ b/tensorboard/plugins/hparams/tf_hparams_google_analytics_tracker/test/tf-hparams-google-analytics-tracker-test.html
@@ -23,7 +23,7 @@ limitations under the License.
 <html>
   <head>
     <meta charset="utf-8">
-    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
     <link rel="import" href="../tf-hparams-google-analytics-tracker.html">
   </head>

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/test/tf-hparams-parallel-coords-plot-test.html
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/test/tf-hparams-parallel-coords-plot-test.html
@@ -19,7 +19,7 @@ limitations under the License.
 <html>
   <head>
     <meta charset="utf-8">
-    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
     <link rel="import" href="../../tf-hparams-parallel-coords-plot/tf-hparams-parallel-coords-plot.html">
     <link rel="import" href="../../tf-hparams-parallel-coords-plot/utils.html">

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/test/tf-hparams-query-pane-test.html
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/test/tf-hparams-query-pane-test.html
@@ -19,7 +19,7 @@ limitations under the License.
 <html>
   <head>
     <meta charset="utf-8">
-    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
     <link rel="import" href="../tf-hparams-query-pane.html">
     <link rel="import" href="../../tf-hparams-backend/tf-hparams-backend.html">

--- a/tensorboard/plugins/hparams/tf_hparams_scale_and_color_controls/test/tf-hparams-scale-and-color-controls-test.html
+++ b/tensorboard/plugins/hparams/tf_hparams_scale_and_color_controls/test/tf-hparams-scale-and-color-controls-test.html
@@ -19,7 +19,7 @@ limitations under the License.
 <html>
   <head>
     <meta charset="utf-8">
-    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
     <link rel="import" href="../tf-hparams-scale-and-color-controls.html">
   </head>

--- a/tensorboard/plugins/hparams/tf_hparams_utils/test/tf-hparams-utils-test.html
+++ b/tensorboard/plugins/hparams/tf_hparams_utils/test/tf-hparams-utils-test.html
@@ -19,7 +19,7 @@ limitations under the License.
 <html>
   <head>
     <meta charset="utf-8">
-    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
     <link rel="../../tf-imports/d3.html">
     <link rel="import" href="../tf-hparams-utils.html">

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/demo/BUILD
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/demo/BUILD
@@ -18,7 +18,7 @@ tf_web_library(
         "//tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_imports:webcomponentsjs",
-         "@org_polymer_web_animations_js",
+        "@org_polymer_web_animations_js",
     ],
 )
 
@@ -44,7 +44,7 @@ tf_web_library(
         "//tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_imports:webcomponentsjs",
-         "@org_polymer_web_animations_js",
+        "@org_polymer_web_animations_js",
     ],
 )
 
@@ -70,7 +70,7 @@ tf_web_library(
         "//tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_imports:webcomponentsjs",
-         "@org_polymer_web_animations_js",
+        "@org_polymer_web_animations_js",
     ],
 )
 
@@ -96,7 +96,7 @@ tf_web_library(
         "//tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_imports:webcomponentsjs",
-         "@org_polymer_web_animations_js",
+        "@org_polymer_web_animations_js",
     ],
 )
 
@@ -123,7 +123,7 @@ tf_web_library(
         "//tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_imports:webcomponentsjs",
-         "@org_polymer_web_animations_js",
+        "@org_polymer_web_animations_js",
     ],
 )
 

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/demo/tf-interactive-inference-age-demo.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/demo/tf-interactive-inference-age-demo.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 
 <script src="../web-animations-js/web-animations-next-lite.min.js"></script>
-<script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="tf-interactive-inference-dashboard.html">
 <script src="tf.min.js"></script>

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/demo/tf-interactive-inference-demo.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/demo/tf-interactive-inference-demo.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 
 <script src="../web-animations-js/web-animations-next-lite.min.js"></script>
-<script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="tf-interactive-inference-dashboard.html">
 <script src="tf.min.js"></script>

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/demo/tf-interactive-inference-image-demo.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/demo/tf-interactive-inference-image-demo.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 
 <script src="../web-animations-js/web-animations-next-lite.min.js"></script>
-<script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="tf-interactive-inference-dashboard.html">
 <script src="tf.min.js"></script>

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/demo/tf-interactive-inference-iris-demo.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/demo/tf-interactive-inference-iris-demo.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 
 <script src="../web-animations-js/web-animations-next-lite.min.js"></script>
-<script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="tf-interactive-inference-dashboard.html">
 <script src="tf.min.js"></script>

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/demo/tf-interactive-inference-multi-demo.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/demo/tf-interactive-inference-multi-demo.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 
 <script src="../web-animations-js/web-animations-next-lite.min.js"></script>
-<script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="tf-interactive-inference-dashboard.html">
 <script src="tf.min.js"></script>
@@ -47,8 +47,8 @@ limitations under the License.
         labelVocab: {type: Array, value: ['<=50k', '>50k']},
       },
       ready: async function() {
-	this.$.dash.modelName = "1, 2";
-	this.$.dash.inferenceAddress = "demo1, demo2";
+        this.$.dash.modelName = "1, 2";
+        this.$.dash.inferenceAddress = "demo1, demo2";
         this.$.dash.updateNumberOfModels();
         this.means = {
           'age': 38.64358543876172,

--- a/tensorboard/plugins/projector/vz_projector/standalone.html
+++ b/tensorboard/plugins/projector/vz_projector/standalone.html
@@ -28,7 +28,7 @@ limitations under the License.
   <!-- This script is stripped during vulcanization, available only during development. It provides
        polyfill for debugging/testing in non-Chrome browsers.
   -->
-  <script src="webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="vz-projector/vz-projector-app.html">
   <link rel="import" href="iron-icons/iron-icons.html">
   <link rel="import" href="paper-icon-button/paper-icon-button.html">

--- a/tensorboard/plugins/projector/vz_projector/test/tests.html
+++ b/tensorboard/plugins/projector/vz_projector/test/tests.html
@@ -18,7 +18,7 @@ limitations under the License.
 
 <meta charset="utf-8">
 <script src="../../web-component-tester/browser.js"></script>
-<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="../bundle.html">
 <body>
 <script src="assert.js"></script>


### PR DESCRIPTION
We no longer load `webcomponents-lite.min.js`. Update the reference.

Confirmed the change by running `bazel test tensorboard/components/... tensorboard/plugins/...` on a branch that integrates changes from pending PRs.

After this change, `bazel test tensorboard/...` builds and passes.