### PR TITLE
Load projector plugin dynamically

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -24,6 +24,7 @@ py_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":default",
+        ":dynamic_plugins",
         ":program",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins:base_plugin",
@@ -187,10 +188,16 @@ py_library(
         "//tensorboard/plugins/interactive_inference:interactive_inference_plugin_loader",
         "//tensorboard/plugins/pr_curve:pr_curves_plugin",
         "//tensorboard/plugins/profile:profile_plugin_loader",
-        "//tensorboard/plugins/projector:projector_plugin",
         "//tensorboard/plugins/scalar:scalars_plugin",
         "//tensorboard/plugins/text:text_plugin",
         "//tensorboard/plugins/mesh:mesh_plugin",
+    ],
+)
+
+py_library(
+    name = "dynamic_plugins",
+    deps = [
+        "//tensorboard/plugins/projector:projector_plugin",
     ],
 )
 

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -77,7 +77,6 @@ tf_web_library(
         "//tensorboard/plugins/mesh/tf_mesh_dashboard",
         "//tensorboard/plugins/pr_curve/tf_pr_curve_dashboard",
         "//tensorboard/plugins/profile/tf_profile_dashboard",
-        "//tensorboard/plugins/projector/vz_projector",
         "//tensorboard/plugins/scalar/tf_scalar_dashboard",
         "//tensorboard/plugins/text/tf_text_dashboard",
     ],

--- a/tensorboard/components/tf_tensorboard/default-plugins.html
+++ b/tensorboard/components/tf_tensorboard/default-plugins.html
@@ -29,7 +29,6 @@ limitations under the License.
 <link rel="import" href="../tf-graph-dashboard/tf-graph-dashboard.html">
 <link rel="import" href="../tf-distribution-dashboard/tf-distribution-dashboard.html">
 <link rel="import" href="../tf-histogram-dashboard/tf-histogram-dashboard.html">
-<link rel="import" href="../vz-projector/vz-projector-dashboard.html">
 <link rel="import" href="../tf-text-dashboard/tf-text-dashboard.html">
 <link rel="import" href="../tf-pr-curve-dashboard/tf-pr-curve-dashboard.html">
 <link rel="import" href="../tf-profile-dashboard/tf-profile-dashboard.html">

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -50,7 +50,6 @@ from tensorboard.plugins.interactive_inference import (
 )
 from tensorboard.plugins.pr_curve import pr_curves_plugin
 from tensorboard.plugins.profile import profile_plugin_loader
-from tensorboard.plugins.projector import projector_plugin
 from tensorboard.plugins.scalar import scalars_plugin
 from tensorboard.plugins.text import text_plugin
 from tensorboard.plugins.mesh import mesh_plugin
@@ -70,7 +69,6 @@ _PLUGINS = [
     graphs_plugin.GraphsPlugin,
     distributions_plugin.DistributionsPlugin,
     histograms_plugin.HistogramsPlugin,
-    projector_plugin.ProjectorPlugin,
     text_plugin.TextPlugin,
     pr_curves_plugin.PrCurvesPlugin,
     profile_plugin_loader.ProfilePluginLoader(),

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -158,6 +158,8 @@ smoke() {
   curl -fs "http://localhost:$(cat port)/data/plugin/projector/runs" >projector_runs.json
   # logdir does not contain any checkpoints and thus an empty runs.
   grep '\[\]' projector_runs.json
+  curl -fs "http://localhost:$(cat port)/data/plugin/projector/projector_binary.html" >projector_binary.html
+  grep '<vz-projector-dashboard' projector_binary.html
   kill $!
 
   # Test TensorBoard APIs

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -155,6 +155,9 @@ smoke() {
   grep '<tf-tensorboard' index.html
   curl -fs "http://localhost:$(cat port)/data/logdir" >logdir.json
   grep 'smokedir' logdir.json
+  curl -fs "http://localhost:$(cat port)/data/plugin/projector/runs" >projector_runs.json
+  # logdir does not contain any checkpoints and thus an empty runs.
+  grep '\[\]' projector_runs.json
   kill $!
 
   # Test TensorBoard APIs

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -58,6 +58,9 @@ setup(
     packages=find_packages(),
     entry_points={
         'console_scripts': CONSOLE_SCRIPTS,
+        'tensorboard_plugins': [
+            'projector_plugin=tensorboard.plugins.projector.projector_plugin:ProjectorPlugin',
+        ],
     },
     package_data={
         'tensorboard': [
@@ -65,6 +68,10 @@ setup(
         ],
         'tensorboard.plugins.beholder': [
             'resources/*',
+        ],
+        'tensorboard.plugins.projector': [
+            'tf_projector_plugin/index.js',
+            'tf_projector_plugin/projector_binary.html',
         ],
     },
     # Disallow python 3.0 and 3.1 which lack a 'futures' module (see above).

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -59,7 +59,7 @@ setup(
     entry_points={
         'console_scripts': CONSOLE_SCRIPTS,
         'tensorboard_plugins': [
-            'projector_plugin=tensorboard.plugins.projector.projector_plugin:ProjectorPlugin',
+            'projector = tensorboard.plugins.projector.projector_plugin:ProjectorPlugin',
         ],
     },
     package_data={
@@ -69,6 +69,7 @@ setup(
         'tensorboard.plugins.beholder': [
             'resources/*',
         ],
+        # Must keep this in sync with tf_projector_plugin:projector_assets
         'tensorboard.plugins.projector': [
             'tf_projector_plugin/index.js',
             'tf_projector_plugin/projector_binary.html',

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -22,6 +22,9 @@ py_library(
         "//tensorboard/util:tb_logging",
         "@org_pocoo_werkzeug",
     ],
+    data = [
+        "//tensorboard/plugins/projector/tf_projector_plugin:projector_assets",
+    ],
 )
 
 py_library(

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -19,8 +19,10 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import functools
 import imghdr
 import math
+import mimetypes
 import os
 import threading
 
@@ -260,7 +262,12 @@ class ProjectorPlugin(base_plugin.TBPlugin):
         TENSOR_ROUTE: self._serve_tensor,
         METADATA_ROUTE: self._serve_metadata,
         BOOKMARKS_ROUTE: self._serve_bookmarks,
-        SPRITE_IMAGE_ROUTE: self._serve_sprite_image
+        SPRITE_IMAGE_ROUTE: self._serve_sprite_image,
+        '/index.js':
+            functools.partial(self._serve_file, 'tf_projector_plugin/index.js'),
+        '/projector_binary.html':
+            functools.partial(
+                self._serve_file, 'tf_projector_plugin/projector_binary.html'),
     }
     return self._handlers
 
@@ -298,7 +305,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
 
   def frontend_metadata(self):
     return super(ProjectorPlugin, self).frontend_metadata()._replace(
-        element_name='vz-projector-dashboard',
+        es_module_path="/index.js",
         disable_reload=True,
     )
 
@@ -470,6 +477,14 @@ class ProjectorPlugin(base_plugin.TBPlugin):
       assets_dir = os.path.join(self.run_paths[run], _PLUGINS_DIR, _PLUGIN_NAME)
       assets_path_pair = (run, os.path.abspath(assets_dir))
       run_path_pairs.append(assets_path_pair)
+
+  @wrappers.Request.application
+  def _serve_file(self, file_path, request):
+    """Returns a resource file."""
+    res_path = os.path.join(os.path.dirname(__file__), file_path)
+    with open(res_path, 'rb') as read_file:
+      mimetype = mimetypes.guess_type(file_path)[0]
+      return Respond(request, read_file.read(), content_type=mimetype)
 
   @wrappers.Request.application
   def _serve_runs(self, request):

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -264,10 +264,13 @@ class ProjectorPlugin(base_plugin.TBPlugin):
         BOOKMARKS_ROUTE: self._serve_bookmarks,
         SPRITE_IMAGE_ROUTE: self._serve_sprite_image,
         '/index.js':
-            functools.partial(self._serve_file, 'tf_projector_plugin/index.js'),
+            functools.partial(
+                self._serve_file,
+                os.path.join('tf_projector_plugin', 'index.js')),
         '/projector_binary.html':
             functools.partial(
-                self._serve_file, 'tf_projector_plugin/projector_binary.html'),
+                self._serve_file,
+                os.path.join('tf_projector_plugin', 'projector_binary.html')),
     }
     return self._handlers
 
@@ -305,7 +308,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
 
   def frontend_metadata(self):
     return super(ProjectorPlugin, self).frontend_metadata()._replace(
-        es_module_path="/index.js",
+        es_module_path='/index.js',
         disable_reload=True,
     )
 

--- a/tensorboard/plugins/projector/tf_projector_plugin/BUILD
+++ b/tensorboard/plugins/projector/tf_projector_plugin/BUILD
@@ -8,8 +8,9 @@ licenses(["notice"])  # Apache 2.0
 tf_web_library(
     name = "projector_assets",
     srcs = [
+        # Keep this in sync with pip_package/setup.py
         ":projector_binary.html",
-        "index.js"
+        "index.js",
     ],
     path = "/tf-projector",
 )

--- a/tensorboard/plugins/projector/tf_projector_plugin/BUILD
+++ b/tensorboard/plugins/projector/tf_projector_plugin/BUILD
@@ -1,0 +1,36 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_library(
+    name = "projector_assets",
+    srcs = [
+        ":projector_binary.html",
+        "index.js"
+    ],
+    path = "/tf-projector",
+)
+
+tensorboard_html_binary(
+    name = "projector_binary",
+    input_path = "/tf-projector/tf-projector-plugin.html",
+    output_path = "/tf-projector/projector_binary.html",
+    deps = [
+        ":tf_projector_plugin",
+    ],
+)
+
+tf_web_library(
+    name = "tf_projector_plugin",
+    srcs = [
+        "tf-projector-plugin.html",
+    ],
+    path = "/tf-projector",
+    deps = [
+        "//tensorboard/plugins/projector/vz_projector",
+        "@com_google_fonts_roboto",
+    ],
+)

--- a/tensorboard/plugins/projector/tf_projector_plugin/index.js
+++ b/tensorboard/plugins/projector/tf_projector_plugin/index.js
@@ -2,7 +2,9 @@ export function render() {
   const style = document.createElement('style');
   style.innerText = `
 html,
-body {
+body,
+iframe {
+  border: 0;
   height: 100%;
   margin: 0;
   width: 100%;
@@ -11,10 +13,5 @@ body {
 
   const iframe = document.createElement('iframe');
   iframe.src = './projector_binary.html';
-  Object.assign(iframe.style, {
-    border: 0,
-    height: '100%',
-    width: '100%',
-  });
   document.body.appendChild(iframe);
 }

--- a/tensorboard/plugins/projector/tf_projector_plugin/index.js
+++ b/tensorboard/plugins/projector/tf_projector_plugin/index.js
@@ -1,0 +1,20 @@
+export function render() {
+  const style = document.createElement('style');
+  style.innerText = `
+html,
+body {
+  height: 100%;
+  margin: 0;
+  width: 100%;
+}`;
+  document.head.appendChild(style);
+
+  const iframe = document.createElement('iframe');
+  iframe.src = './projector_binary.html';
+  Object.assign(iframe.style, {
+    border: 0,
+    height: '100%',
+    width: '100%',
+  });
+  document.body.appendChild(iframe);
+}

--- a/tensorboard/plugins/projector/tf_projector_plugin/index.js
+++ b/tensorboard/plugins/projector/tf_projector_plugin/index.js
@@ -1,3 +1,17 @@
+// Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export function render() {
   const style = document.createElement('style');
   style.innerText = `

--- a/tensorboard/plugins/projector/tf_projector_plugin/tf-projector-plugin.html
+++ b/tensorboard/plugins/projector/tf_projector_plugin/tf-projector-plugin.html
@@ -1,3 +1,19 @@
+<!--
+@license
+Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <link rel="import" href="../font-roboto/roboto.html">
 <link rel="import" href="../vz-projector/vz-projector-dashboard.html">
 

--- a/tensorboard/plugins/projector/tf_projector_plugin/tf-projector-plugin.html
+++ b/tensorboard/plugins/projector/tf_projector_plugin/tf-projector-plugin.html
@@ -14,4 +14,3 @@ body {
 <body>
   <vz-projector-dashboard></vz-projector-dashboard>
 </body>
-

--- a/tensorboard/plugins/projector/tf_projector_plugin/tf-projector-plugin.html
+++ b/tensorboard/plugins/projector/tf_projector_plugin/tf-projector-plugin.html
@@ -1,0 +1,17 @@
+<link rel="import" href="../font-roboto/roboto.html">
+<link rel="import" href="../vz-projector/vz-projector-dashboard.html">
+
+<style>
+html,
+body {
+  height: 100%;
+  margin: 0;
+  width: 100%;
+  font-family: Roboto, sans-serif;
+}
+</style>
+
+<body>
+  <vz-projector-dashboard></vz-projector-dashboard>
+</body>
+

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.html
@@ -69,7 +69,7 @@ Polymer({
     dataNotFound: Boolean,
     _routePrefix: {
       type: String,
-      value: () => tf_backend.getRouter().pluginRoute('projector', ''),
+      value: '.',
     },
     // Whether this dashboard is initialized. This dashboard should only be initialized once.
     _initialized: Boolean,


### PR DESCRIPTION
Build projector frontend code as a separate binary and loaded that as a
soruce (not from webfiles) in projector_plugin.

Made changes to our pip packaging to include the projector FE binaries.
Made changes to tensorboard dependencies to make local development easy.

Tested:
  - local dev by running `pip setup.py develop` in source tree A then
    running TensorBoard in source tree B
  - tested pip package building and running TensorBoard
