### PR TITLE
plugins: add initializer on base plugin class

### DIFF
--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -67,7 +67,7 @@ class TBPlugin(object):
 
   Every plugin must extend from this class.
 
-  Subclasses must have a trivial constructor that takes a TBContext
+  Subclasses should have a trivial constructor that takes a TBContext
   argument. Any operation that might throw an exception should either be
   done lazily or made safe with a TBLoader subclass, so the plugin won't
   negatively impact the rest of TensorBoard.
@@ -82,6 +82,17 @@ class TBPlugin(object):
   """
 
   plugin_name = None
+
+  def __init__(self, context):
+    """Initializes this plugin.
+
+    The default implementation does nothing. Subclasses are encouraged
+    to override this and save any necessary fields from the `context`.
+
+    Args:
+      context: A `base_plugin.TBContext` object.
+    """
+    pass
 
   @abstractmethod
   def get_plugin_apps(self):


### PR DESCRIPTION
Summary:
Prior to this change, defining a (possibly dynamically loaded) plugin
without this initializer would yield the rather inscrutable error

```
  File "/VIRTUAL_ENV/tensorboard/plugins/base_plugin.py", line 253, in load
    return self._plugin_class(context)
TypeError: object() takes no parameters
```

whose stack trace does not contain the offending plugin code at all.
(The error is because initializers are effectively inherited in Python.)

Test Plan:
Cherry-pick #2354, delete its example plugin’s `__init__`, and note that
the example still works. (You’ll have to build TensorBoard’s Pip package
and install it into a virtualenv.)

wchargin-branch: plugin-empty-initializer
