### PR TITLE
cleanup: fixed few typos.

### DIFF
--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/axes.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/axes.ts
@@ -18,7 +18,7 @@ limitations under the License.
 namespace tf.hparams.parallel_coords_plot {
 
 /**
- * The scale types a column can have. These correspond to the values of 
+ * The scale types a column can have. These correspond to the values of
  * options.columns[].scale. See the comments in
  * tf-hparam-scale-and-color-controls.html for more details on the various
  * scale types.
@@ -30,18 +30,18 @@ export enum ScaleType {
   NON_NUMERIC = "NON_NUMERIC"
 }
 
-/** 
+/**
  * An AxisBrushFilter is essentially a function indicating whether a given
  * value in the domain of the axis is inside the current axis brush selection.
  */
 interface AxisBrushFilter {
-  /** The function represented by the filter. Should return true if 
-   * 'value' is in the current brush selection for the axis. 
+  /** The function represented by the filter. Should return true if
+   * 'value' is in the current brush selection for the axis.
    */
   isPassing(value: any): boolean;
 }
 
-/** 
+/**
  * An AlwaysPassingBrushFilter returns 'true' for any value. It is used
  * to represent the case when an Axis does not have an active brush selection.
  */
@@ -51,14 +51,14 @@ class AlwaysPassingBrushFilter implements AxisBrushFilter {
   }
 }
 
-/** 
+/**
  * An IntervalBrushFilter returns 'true' if the given (numeric) value lies
  * in a given interval specified on construction . It's used to represent
  * brush filters for Axis with linear, logarithmic or quantile scales.
  */
 class IntervalBrushFilter implements AxisBrushFilter {
   /** Constructs the filter. The interval used is defined by lower, and upper.
-   * If lowerOpen (resp. upperOpen) is true, the interval will be open in 
+   * If lowerOpen (resp. upperOpen) is true, the interval will be open in
    * its lower (resp. upper) end, otherwise it will be closed.
    */
   public constructor(lower: number,
@@ -109,20 +109,20 @@ class SetBrushFilter implements AxisBrushFilter {
 /**
  * Represents a single Axis. An axis does not know its horizontal location in
  * the SVG; instead the axes locations are managed by the AxesCollection class.
- * An axis represents a single column (metric or haparam). It stores a scale 
- * type and a D3 scale that maps values in the axis domain (column values) 
- * to y-coordinates in the SVG. Additionally, an axis stores a 
- * D3-brush-selection which is a 2-element numeric array of the form 
+ * An axis represents a single column (metric or haparam). It stores a scale
+ * type and a D3 scale that maps values in the axis domain (column values)
+ * to y-coordinates in the SVG. Additionally, an axis stores a
+ * D3-brush-selection which is a 2-element numeric array of the form
  * [lower, upper] containing the upper and lower y-coordinates of the current
  * brush selection. If no brush selection exists, the brush selection stored is
  * null.
- * Finally, an axis can be visible (displayed) or invisible (which will be 
+ * Finally, an axis can be visible (displayed) or invisible (which will be
  * set based on the user's settings for the corresponding column). An invisible
- * axis need not have its scale or scale-type populated. 
+ * axis need not have its scale or scale-type populated.
  */
 export class Axis {
   /**
-   * Constructs an axis representing the column indexed by 'colIndex' with 
+   * Constructs an axis representing the column indexed by 'colIndex' with
    * respect to 'schema'. Needs an InteractionManager instance so that it can
    * call its event handlers upon receiving events from the DOM.
    */
@@ -147,7 +147,7 @@ export class Axis {
   public yScale(): any {
     return this._yScale;
   }
-  
+
   public scaleType(): ScaleType | null {
     return this._scaleType;
   }
@@ -166,9 +166,9 @@ export class Axis {
       this.brushSelection(), this.scaleType(), this.yScale());
   }
 
-  /** 
+  /**
    * Sets the domain and scale type for the axis. The current brush selection
-   * is preserved. 
+   * is preserved.
    */
   public setDomainAndScale(domainValues: any[], scaleType: ScaleType) {
     this._scaleType = scaleType;
@@ -246,10 +246,10 @@ export class Axis {
       .extent([[-8, 0], [8, this._svgProps.height + 1]])
       /* Define the brush event handlers. D3 will call these both when
          the user moves the brush selection and when we change the brush
-         selection programmatically using d3Brush.move(). We'd like to 
+         selection programmatically using d3Brush.move(). We'd like to
          avoid calling the interactionManager in the latter case; thus,
-         we call _isInteractiveD3Event() to find out if the event was fired 
-         due to a programmetic change of the brush selection , and if so, 
+         we call _isInteractiveD3Event() to find out if the event was fired
+         due to a programmetic change of the brush selection , and if so,
          ignore the event. */
       .on("start", () => {
         if (!_isInteractiveD3Event(d3.event)) {
@@ -281,7 +281,7 @@ export class Axis {
       .append("g")
       .classed("brush", true);
     brushG.call(d3Brush);
-    
+
     // Set the brush selection programmatically.
     // We need to cast brushG to 'any' here since TypeScript doesn't realize
     // the brushG is a <g> selection and complains.
@@ -293,7 +293,7 @@ export class Axis {
   }
 
   /**
-   * @returns the brush filter for the given selection using the current
+   * @return the brush filter for the given selection using the current
    * scale.
    */
   private _buildBrushFilter(brushSelection: d3.BrushSelection,
@@ -349,8 +349,8 @@ export class Axis {
 
 /**
  * Manages the collection of axes shown in the plot. Has methods that handle
- * dragging an axis and contains the logic for re-ordering the axes 
- * during dragging. 
+ * dragging an axis and contains the logic for re-ordering the axes
+ * during dragging.
  */
 export class AxesCollection {
   public constructor(svgProps: SVGProperties, schema: tf.hparams.Schema,
@@ -367,7 +367,7 @@ export class AxesCollection {
   }
 
   /**
-   * Updates all axes based on the given 'options' (see the comments in 
+   * Updates all axes based on the given 'options' (see the comments in
    * tf-hparams-scale-and-color-controls.html) and sessionGroups. SessionGroups
    * are used to update the domain (and thus scale) of the axes. The 'options'
    * object control which axes are visible.
@@ -392,10 +392,10 @@ export class AxesCollection {
       if (!visibleColIndices.has(axis.colIndex())) {
         axis.setDisplayed(false);
       }
-    });  
+    });
 
     this._updateStationaryAxesPositions(visibleColIndices);
-    
+
     // Update the DOM.
     this._parentsSel = this._parentsSel
       .data(Array.from(visibleColIndices), /*key=*/ (colIndex => colIndex));
@@ -414,19 +414,19 @@ export class AxesCollection {
       });
   }
 
-  /** 
+  /**
    * Executes mapFunction on each visible axis. Returns an array containing the
    * result from each invocation. The function is invoked on the axes ordered
-   * by their increasing xPosition. 
+   * by their increasing xPosition.
    */
   public mapVisibleAxes<T>(mapFunction: (xPosition, axis)=>T): T[] {
     return this._stationaryAxesPositions.domain().map(
       colIndex => mapFunction(this.getAxisPosition(colIndex),
                               this._axes[colIndex]));
   }
-  
+
   /**
-   * @returns true if the given predicate returns true on every visible axis,
+   * @return true if the given predicate returns true on every visible axis,
    *     false otherwise. Note that the predicate will only be evaluated until
    *     the first time it returns false.
    */
@@ -443,11 +443,11 @@ export class AxesCollection {
 
   /* Axis dragging.
    * To drag an axis, call: dragStart(), followed by one or more drag() calls
-   * followed by a single call to dragEnd(). 
+   * followed by a single call to dragEnd().
    * At most one axis can be dragged at any given time.
-   * Each axis (whether dragged or not) has an associated "stationary" 
+   * Each axis (whether dragged or not) has an associated "stationary"
    * position which is its (x-coordinate) position when it is not being dragged.
-   * The actual position of an axis is either its associated stationary 
+   * The actual position of an axis is either its associated stationary
    * position if its not dragged or its currently dragged position. This class
    * maintains the invariant that the axes' stationary positions match the order
    * of their actual position by re-assigning stationary positions to axes when
@@ -490,16 +490,16 @@ export class AxesCollection {
   }
 
   /**
-   * Sets the domain of 'stationaryAxesPositions' to be precisely the given 
+   * Sets the domain of 'stationaryAxesPositions' to be precisely the given
    * visibleColIndices, but preserves the order of the column indices that
-   * are already in the domain. Essentially, this method removes indices in 
-   * the domain that are not in visibleColIndices and then appends indices in 
-   * visibleColIndices that are not currently in the domain. Thus, indices in 
+   * are already in the domain. Essentially, this method removes indices in
+   * the domain that are not in visibleColIndices and then appends indices in
+   * visibleColIndices that are not currently in the domain. Thus, indices in
    * visibleColIndices that are already in stationaryAxesPositions
    * will maintain their order in stationaryAxesPositions and will precede
    * the new elements.
    *
-   * This reassigns stationary positions to axes so that the only visible 
+   * This reassigns stationary positions to axes so that the only visible
    * axes are the ones with column indices in 'visibleColIndices', but preserves
    * the order of axes indexed by visibleColIndices that are already visible.
    */
@@ -510,14 +510,14 @@ export class AxesCollection {
       ...visibleDomain, ...Array.from(visibleColIndices)]));
     this._stationaryAxesPositions.domain(newDomain);
   }
-  
+
   private _updateAxesPositionsInDOM(selectionOrTransition) {
     selectionOrTransition.attr("transform",
                                colIndex =>
                                tf.hparams.utils.translateStr(
                                  this.getAxisPosition(colIndex)));
   }
-  
+
   private _createAxes(interactionManager: InteractionManager): Axis[] {
     return d3.range(tf.hparams.utils.numColumns(this._schema)).map(
       colIndex => new Axis(
@@ -528,15 +528,15 @@ export class AxesCollection {
   private _svgProps: SVGProperties;
   private _schema: tf.hparams.Schema;
   private _axes: Axis[];
-  /** 
-   * The current assignment of stationary positions to axes. 
+  /**
+   * The current assignment of stationary positions to axes.
    * The axis representing column i has an associated stationary position
    * _stationaryAxesPositions(i).
    */
   private _stationaryAxesPositions: any /* D3 point scale */;
   private _draggedAxis: Axis | null;
   private _draggedAxisPosition: number | null;
-  private _parentsSel: any;  
+  private _parentsSel: any;
 }
 
 function _isInteractiveD3Event(d3Event: any) {

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/interaction_manager.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/interaction_manager.ts
@@ -13,12 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-/* Defines the InteractionManager class and related classes. 
-   This is the main entry point to the parallel coordinates implementation. 
+/* Defines the InteractionManager class and related classes.
+   This is the main entry point to the parallel coordinates implementation.
 */
 
 namespace tf.hparams.parallel_coords_plot {
-  
+
 /**
  * Denotes the callback function type that InteractionManager uses to
  * notify a consumer that either the peaked or selected session group has
@@ -28,8 +28,8 @@ namespace tf.hparams.parallel_coords_plot {
  */
 type SessionGroupCallback = (SessionGroup: tf.hparams.SessionGroup) => void;
 
-/** 
- * Stores some global properties such as width and height of the SVG element 
+/**
+ * Stores some global properties such as width and height of the SVG element
  * used for rendering the parallel coordinates plot. Also contains the top-level
  * DOM <g> element underwhich the plot will be rendered.
  */
@@ -46,9 +46,8 @@ export class SVGProperties {
     // to "100%" so that it takes up the full area of its parent, but use
     // "min-width" and "min-height", so that if the parent is too small
     // the svg won't shrink down (it will overflow with scroll bars).
-    // If the parent is larger than the minimum size, we use the its
-    // preserveAspectRatio attr to scale the contents to fit the larger
-    // size.
+    // If the parent is larger than the minimum size, we use its
+    // preserveAspectRatio attr to scale the contents to fit the larger size.
     this.svg = d3.select(svg);
     const margin = {top: 30, right: 10, bottom: 10, left: 10};
     const COL_WIDTH = 100;
@@ -85,7 +84,7 @@ export class SVGProperties {
  *    manager = new InteractionManager(svgProps, schema, peakedSessionChangedCB,
  *                                     selectedSessionChangedCB);
  *    ...
- *    // Notify manager of new options or session groups: 
+ *    // Notify manager of new options or session groups:
  *    manager.onOptionsOrSessionGroupsChanged(newOptions, newSessionGroups)
  *    ...
  *    // This will be called when peaked session changed:
@@ -114,12 +113,12 @@ export class InteractionManager {
       })
       .on("mouseleave", () => this.onMouseLeave());
   }
- 
+
   public onDragStart(colIndex: number) {
     this._axesCollection.dragStart(colIndex);
     this._linesCollection.hideBackgroundLines();
   }
-  
+
   public onDrag(newX: number) {
     this._axesCollection.drag(newX);
     this._linesCollection.recomputeControlPoints(LineType.FOREGROUND);
@@ -141,7 +140,7 @@ export class InteractionManager {
       newBrushSelection);
     this._linesCollection.recomputeForegroundLinesVisibility();
   }
-  
+
   public onMouseMoved(newX:number, newY:number) {
     this._linesCollection.updatePeakedSessionGroup(
       this._linesCollection.findClosestSessionGroup(newX, newY));
@@ -177,7 +176,7 @@ export class InteractionManager {
     const oldPeakedSessionGroupHandle =
       this._linesCollection.peakedSessionGroupHandle();
     const oldSelectedSessionGroupHandle =
-      this._linesCollection.selectedSessionGroupHandle();  
+      this._linesCollection.selectedSessionGroupHandle();
     this._linesCollection.redraw(
       newSessionGroups,
       newOptions.colorByColumnIndex !== undefined
@@ -186,7 +185,7 @@ export class InteractionManager {
       newOptions.minColor,
       newOptions.maxColor);
     // A redraw may change the selected / peaked session group. So call the
-    // apropriate callbacks if needed.
+    // appropriate callbacks if needed.
     if (!oldPeakedSessionGroupHandle.equalsTo(
       this._linesCollection.peakedSessionGroupHandle())) {
       this._peakedSessionGroupChangedCB(
@@ -202,7 +201,7 @@ export class InteractionManager {
   public schema() : tf.hparams.Schema {
     return this._schema;
   }
-  
+
   private _svgProps: SVGProperties;
   private _schema: tf.hparams.Schema;
   private _peakedSessionGroupChangedCB: SessionGroupCallback;

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/lines.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/lines.ts
@@ -16,17 +16,17 @@ limitations under the License.
 /* Defines classes for managing the collection of lines in the parallel
    coordinates plot.
  */
-   
+
 namespace tf.hparams.parallel_coords_plot {
 
-/** 
+/**
  * Represents the line 'type'. Either a foreground or a background line.
  * Each session group is drawn as two identical piecewise linear curves (which
  * we call "lines" here) drawn one on top of the other.
- * The background line is gray, and the foreground line drawn on top is 
- * typically colored according to the color-by column. Foreground lines are 
+ * The background line is gray, and the foreground line drawn on top is
+ * typically colored according to the color-by column. Foreground lines are
  * only displayed for the lines that satisfy the brush filter of each axis.
- * 
+ *
  * Note that we could have used just one line and set its color according to
  * whether it satisfies the brush filters of the axes. However, with this
  * strategy, if the line density is large, gray lines may overlap non
@@ -38,9 +38,9 @@ export enum LineType {
 }
 
 /**
- * A handle to a representation of a session group in the 'LinesCollection' 
- * class below. The handle can also be "null" -- meaning it references no 
- * session group (similar to a "null pointer"), in which case the 
+ * A handle to a representation of a session group in the 'LinesCollection'
+ * class below. The handle can also be "null" -- meaning it references no
+ * session group (similar to a "null pointer"), in which case the
  * 'sessionGroup()' method returns null.
  *
  * Note: we use this class rather than a simple SessionGroup object so that we
@@ -48,10 +48,10 @@ export enum LineType {
  * instead the (foreground) <path> element is stored in the handle.
  */
 export class SessionGroupHandle {
-  /** 
+  /**
    * Constructs a session group handle from a D3 selection of the path
    * element representing the sessionGroup. This should only be called by the
-   * 'LinesCollection' class below. If sessionGroupSel is empty or undefined, a 
+   * 'LinesCollection' class below. If sessionGroupSel is empty or undefined, a
    * "null" handle will be constructed.
    */
   public constructor(sessionGroupSel?: any) {
@@ -62,8 +62,8 @@ export class SessionGroupHandle {
     this._sessionGroupSel = sessionGroupSel;
   }
 
-  /** 
-   * @returns the sessionGroup object this handle references or null if
+  /**
+   * @return the sessionGroup object this handle references or null if
    * this is a "null" reference.
    */
   public sessionGroup(): tf.hparams.SessionGroup | null {
@@ -76,9 +76,9 @@ export class SessionGroupHandle {
     return this.sessionGroup() === null;
   }
 
-  /** 
+  /**
    * Should only be called by the 'LinesCollection' class below.
-   * @returns the d3-selection given on construction.
+   * @return the d3-selection given on construction.
    */
   public selection(): any {
     return this._sessionGroupSel;
@@ -86,7 +86,7 @@ export class SessionGroupHandle {
 
   /**
    * Compares this handle to 'otherHandle' and returns true if both are null
-   * or both are not null and they reference equal session groups. 
+   * or both are not null and they reference equal session groups.
    * Session group equality is determined by their names.
    */
   public equalsTo(otherHandle: SessionGroupHandle): boolean {
@@ -101,7 +101,7 @@ export class SessionGroupHandle {
 
   private _sessionGroupSel: any /* D3 selection */
 };
-  
+
 /**
  * Manages the lines representing the session groups. Each session group is
  * represented by two <path> elements with the same control points: a foreground
@@ -109,15 +109,15 @@ export class SessionGroupHandle {
  * background line (it succeeds it in document order). The foreground line is
  * colored based on the value  of the 'color-by' column (specified in options),
  * whereas the background line is gray. The foreground line is displayed only
- * if the session group passes the current axes brush filters. This way, only 
- * session groups that pass the current brush filters will be represented by 
- * colored lines, and the other session groups will be represented by gray 
- * lines. 
+ * if the session group passes the current axes brush filters. This way, only
+ * session groups that pass the current brush filters will be represented by
+ * colored lines, and the other session groups will be represented by gray
+ * lines.
  *
- * Note that we could have represented each session group with a single line 
- * with a color that depends on whether the session group passed the brush 
- * filters. However, this would have required us to re-order the DOM to avoid 
- * rendering gray lines on top of colored lines (which would look bad, 
+ * Note that we could have represented each session group with a single line
+ * with a color that depends on whether the session group passed the brush
+ * filters. However, this would have required us to re-order the DOM to avoid
+ * rendering gray lines on top of colored lines (which would look bad,
  * especially if the density of lines is large).
  *
  * This class also stores two SessionGroupHandles: peakedSessionGroupHandle and
@@ -150,7 +150,7 @@ export class LinesCollection {
   }
 
   /**
-   * @returns a SessionGroupHandle referencing the given sessionGroup. If the
+   * @return a SessionGroupHandle referencing the given sessionGroup. If the
    * given sessionGroup is null or undefined returns a "null" handle.
    */
   public getSessionGroupHandle(sessionGroup: tf.hparams.SessionGroup) {
@@ -160,7 +160,7 @@ export class LinesCollection {
     return new SessionGroupHandle(
       this._fgPathsSel.filter(sg => sg.name === sessionGroup.name));
   }
-  
+
   public hideBackgroundLines() {
     this._bgPathsSel.attr("visibility", "hidden");
   }
@@ -178,13 +178,13 @@ export class LinesCollection {
   }
 
   /**
-   * Recomputes the control points of the lines with the given 'type' 
-   * (foreground or background) to correspond to the current state of the 
+   * Recomputes the control points of the lines with the given 'type'
+   * (foreground or background) to correspond to the current state of the
    * axesCollection.
    *
    * @param lineType - The type of lines to update.
-   * @param transitionDuration - The lines will be transitioned (animated) to 
-   *     their new state. This specifies the duration of that transition. 0 
+   * @param transitionDuration - The lines will be transitioned (animated) to
+   *     their new state. This specifies the duration of that transition. 0
    *     means no animation.
    */
   public recomputeControlPoints(lineType: LineType, transitionDuration = 0) {
@@ -209,13 +209,13 @@ export class LinesCollection {
   }
 erez
   /**
-   * Rerenders the foreground lines so that their visibility matches the 
+   * Rerenders the foreground lines so that their visibility matches the
    * current brush filters.
    */
   public recomputeForegroundLinesVisibility() {
     this._fgPathsSel.classed(
       "invisible-path",
-      sessionGroup => 
+      sessionGroup =>
         !this._axesCollection.allVisibleAxesSatisfy(
           (xPosition, axis)=>
             axis.brushFilter().isPassing(
@@ -228,7 +228,7 @@ erez
   /**
    * Sets the coloring scheme of the (visible) foreground lines.
    * A foreground line will be colored by a color corresponding to the value
-   * of the column indexed by colorByColumnIndex in the session group 
+   * of the column indexed by colorByColumnIndex in the session group
    * represented by the line. The color corresponding to a value is
    * interpolated between minColor and maxColor.
    */
@@ -282,9 +282,9 @@ erez
 
   /**
    * Returns a handle referencing the closest session group to a given point
-   * in the SVG or a null handle if the closest session group is 
+   * in the SVG or a null handle if the closest session group is
    * too far away.
-   */ 
+   */
   public findClosestSessionGroup(x: number, y:number): SessionGroupHandle {
     const axesPositions = this._axesCollection.mapVisibleAxes<number>(
       (xPosition, axis) => xPosition);
@@ -298,7 +298,7 @@ erez
     }
     return new SessionGroupHandle(d3.select(closestFgPath));
   }
-  
+
   private _createLineColorFunction(
     colorByColumnIndex: number | null,
     minColor: string,
@@ -315,24 +315,25 @@ erez
     return sessionGroup => colorScale(tf.hparams.utils.columnValueByIndex(
       this._schema, sessionGroup, colorByColumnIndex));
   }
-  
+
   private _recomputePathSelection(currentPathSel: any /* d3 selection */) {
     currentPathSel = currentPathSel
       .data(this._sessionGroups, /*key=*/ (sessionGroup=>sessionGroup.name));
     currentPathSel.exit().remove();
     return currentPathSel.enter().append("path").merge(currentPathSel);
   }
-  
+
   /** Sets the controlPoints property of 'pathElement' to the control-points
    * array of the given sessionGroup with respect to the current state of
-   * the axesCollection. 
+   * the axesCollection.
    */
   private _setControlPointsProperty(pathElement: any,
                                     sessionGroup: tf.hparams.SessionGroup) {
     pathElement.controlPoints = this._computeControlPoints(sessionGroup);
   }
 
-  /** @returns an array of 2-tuples--each representing a control point for
+  /**
+   * @return an array of 2-tuples--each representing a control point for
    * a line representing the given 'sessionGroup'. The control points are
    * computed with respect to the current state of the axesCollection.
    */


### PR DESCRIPTION
Common typo catcher caught few things in our recent PR #2223.
Closure type system annotates return type with "@return" instead of
"@returns".

Other extraneous whitespace changes are VIM removing all trailing whitespaces
throughout the file. 