### PR TITLE
tf-runs-selector: make it take up parent's width.

### DIFF
--- a/tensorboard/components/tf_dashboard_common/dashboard-style.html
+++ b/tensorboard/components/tf_dashboard_common/dashboard-style.html
@@ -25,6 +25,7 @@ limitations under the License.
     <style>
       :host {
         --sidebar-vertical-padding: 15px;
+        --sidebar-left-padding: 30px;
       }
 
       .sidebar {
@@ -41,9 +42,11 @@ limitations under the License.
       tf-runs-selector {
         flex-grow: 1;
         flex-shrink: 1;
+        left: var(--sidebar-left-padding);
         max-height: calc(100% - var(--sidebar-vertical-padding) * 2);
         overflow: hidden;
         position: absolute;
+        right: 0;
       }
 
       .search-input {
@@ -52,7 +55,7 @@ limitations under the License.
 
       .sidebar-section {
         border-top: solid 1px rgba(0, 0, 0, .12);
-        padding: var(--sidebar-vertical-padding) 0 var(--sidebar-vertical-padding) 30px;
+        padding: var(--sidebar-vertical-padding) 0 var(--sidebar-vertical-padding) var(--sidebar-left-padding);
         position: relative;
       }
 


### PR DESCRIPTION
Especially when name of the run is short and size of the window is large,
tf-runs-selector was not taking up the size of the parent width. This bug
was quite subtle for our demo/test data because data location string was
long enough to make the tf-runs-selector take up wider width. By manually
removing the data location string (length of run names do not matter), we
were able to reproduce the bug. 

This change makes tf-runs-selector take up the width of the parent.
Because we use position relative-absolute trick, we have to consider the
size of the parent's (or relative container) padding.

Fixes #2358.

