### PR TITLE
diagnose: wrap diagnostics in `<details>` element

### DIFF
--- a/tensorboard/tools/diagnose_tensorboard.py
+++ b/tensorboard/tools/diagnose_tensorboard.py
@@ -404,6 +404,10 @@ def main():
   print("### Diagnostics")
   print()
 
+  print("<details>")
+  print("<summary>Diagnostics output</summary>")
+  print()
+
   markdown_code_fence = "``````"  # seems likely to be sufficient
   print(markdown_code_fence)
   suggestions = []
@@ -418,7 +422,7 @@ def main():
       pass
   print(markdown_code_fence)
   print()
-  print("End of diagnostics.")
+  print("</details>")
 
   for suggestion in suggestions:
     print()


### PR DESCRIPTION
Summary:
The output of `pip freeze` in particular can be multiple pages long. We
do want this output, but we don’t want to scroll through it.

Test Plan:
Run the diagnosis script and copy the output into a GitHub comment box
to preview the rendered Markdown. Note that it’s now compact—

![screenshot of rendered diagnostics output with `<details>` element][1]

—and that you can click the “Diagnostics output” to expand the full
contents.

[1]: https://user-images.githubusercontent.com/4317806/59795069-465d2980-928f-11e9-893c-d8c62d99d592.png

wchargin-branch: diagnostics-details
