### PR TITLE
build: partially fix for Bazel 0.27

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,11 +54,11 @@ closure_repositories(
 
 http_archive(
     name = "org_tensorflow",
-    sha256 = "1086f63c2c9fbea6873e137d08b5711a0493a5b699f258774da97f7672ba939a",
-    strip_prefix = "tensorflow-2243bd6ba9b36d43dbd5c0ede313853f187f5dce",
+    sha256 = "8fd92a6b65330ec23e32ae052eca5cf68e278df677b7e15f36d59e6350f201f0",
+    strip_prefix = "tensorflow-6168f476b52d6d40eeff1823943ed2c0ea28adde",
     urls = [
-        "http://mirror.tensorflow.org/github.com/tensorflow/tensorflow/archive/2243bd6ba9b36d43dbd5c0ede313853f187f5dce.tar.gz",  # 2019-03-26
-        "https://github.com/tensorflow/tensorflow/archive/2243bd6ba9b36d43dbd5c0ede313853f187f5dce.tar.gz",
+        "http://mirror.tensorflow.org/github.com/tensorflow/tensorflow/archive/6168f476b52d6d40eeff1823943ed2c0ea28adde.tar.gz",  # 2019-04-08
+        "https://github.com/tensorflow/tensorflow/archive/6168f476b52d6d40eeff1823943ed2c0ea28adde.tar.gz",
     ],
 )
 

--- a/tensorboard/defs/vulcanize.bzl
+++ b/tensorboard/defs/vulcanize.bzl
@@ -42,9 +42,9 @@ def _tensorboard_html_binary(ctx):
       inputs=depset(transitive=[
           manifests,
           files,
-          jslibs,
           ignore_regexs_file_set,
       ]).to_list(),
+      tools=jslibs,
       outputs=[ctx.outputs.html],
       executable=ctx.executable._Vulcanize,
       arguments=([ctx.attr.compilation_level,

--- a/tensorboard/defs/vulcanize.bzl
+++ b/tensorboard/defs/vulcanize.bzl
@@ -52,8 +52,8 @@ def _tensorboard_html_binary(ctx):
                   ctx.attr.output_path,
                   ctx.outputs.html.path,
                   ignore_regexs_file_path] +
-                 [f.path for f in jslibs] +
-                 [f.path for f in manifests]),
+                 [f.path for f in jslibs.to_list()] +
+                 [f.path for f in manifests.to_list()]),
       progress_message="Vulcanizing %s" % ctx.attr.input_path)
 
   # webfiles manifest
@@ -73,7 +73,7 @@ def _tensorboard_html_binary(ctx):
   params = struct(
       label=str(ctx.label),
       bind="[::]:6006",
-      manifest=[long_path(ctx, man) for man in manifests],
+      manifest=[long_path(ctx, man) for man in manifests.to_list()],
       external_asset=[struct(webpath=k, path=v)
                       for k, v in ctx.attr.external_assets.items()])
   params_file = ctx.new_file(ctx.configuration.bin_dir,

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -170,12 +170,18 @@ def _tf_web_library(ctx):
         [ts_config, er_config],
         transitive=[
             ts_inputs,
+            # TODO(@wchargin): Because `_tsc` is passed as `tools`
+            # below, collecting its runfiles should in principle be
+            # unnecessary, but without this line the two deps of `_tsc`
+            # (`tsc.js` and `@org_nodejs//:bin/node`) are in fact not
+            # included, and so execrooter fails at runtime.
             collect_runfiles([ctx.attr._tsc]),
             ts_typings,
             ts_typings_execroots,
         ],
     )
     ctx.actions.run(
+        tools=ctx.files._tsc,
         inputs=ts_inputs,
         outputs=ts_outputs,
         executable=ctx.executable._execrooter,

--- a/tensorboard/defs/zipper.bzl
+++ b/tensorboard/defs/zipper.bzl
@@ -23,7 +23,7 @@ def _tensorboard_zip_file(ctx):
     manifests = depset(transitive=[manifests, dep.webfiles.manifests])
     webpaths = depset(transitive=[webpaths, dep.webfiles.webpaths])
     files = depset(transitive=[files, dep.data_runfiles.files])
-  ctx.action(
+  ctx.actions.run(
       inputs=depset(transitive=[manifests, files]).to_list(),
       outputs=[ctx.outputs.zip],
       executable=ctx.executable._Zipper,

--- a/tensorboard/defs/zipper.bzl
+++ b/tensorboard/defs/zipper.bzl
@@ -28,8 +28,8 @@ def _tensorboard_zip_file(ctx):
       outputs=[ctx.outputs.zip],
       executable=ctx.executable._Zipper,
       arguments=([ctx.outputs.zip.path] +
-                 [m.path for m in manifests]),
-      progress_message="Zipping %d files" % len(webpaths))
+                 [m.path for m in manifests.to_list()]),
+      progress_message="Zipping %d files" % len(webpaths.to_list()))
   transitive_runfiles = depset()
   for dep in deps:
     transitive_runfiles = depset(transitive=[

--- a/third_party/clutz.bzl
+++ b/third_party/clutz.bzl
@@ -14,6 +14,8 @@
 
 """Build definitions for TypeScript from Closure JavaScript libraries."""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
 load("@io_bazel_rules_closure//closure/private:defs.bzl",
      "JS_FILE_TYPE",
      "collect_js",
@@ -49,7 +51,8 @@ def deprecated_extract_dts_from_closure_libraries(ctx):
   js = collect_js(deps, ctx.files._closure_library_base)
   if not js.srcs:
     return None
-  js_typings = ctx.new_file(ctx.bin_dir, "%s-js-typings.d.ts" % ctx.label.name)
+  js_typings = ctx.actions.declare_file(paths.join(
+      ctx.bin_dir.path, "%s-js-typings.d.ts" % ctx.label.name))
   # File.extension does not have leading "." whereas JS_FILE_TYPE does.
   clutz_js_externs = [f for f in ctx.files._clutz_externs
                       if '.%s' % f.extension in JS_FILE_TYPE]
@@ -60,7 +63,7 @@ def deprecated_extract_dts_from_closure_libraries(ctx):
   if getattr(ctx.attr, "clutz_entry_points", None):
     args.append("--closure_entry_points")
     args.extend(ctx.attr.clutz_entry_points)
-  ctx.action(
+  ctx.actions.run(
       inputs=srcs,
       outputs=[js_typings],
       executable=ctx.executable._clutz,

--- a/third_party/clutz.bzl
+++ b/third_party/clutz.bzl
@@ -55,19 +55,19 @@ def deprecated_extract_dts_from_closure_libraries(ctx):
                       if '.%s' % f.extension in JS_FILE_TYPE]
   srcs = depset(transitive=[depset(clutz_js_externs), js.srcs])
   args = ["-o", js_typings.path]
-  for src in srcs:
+  for src in srcs.to_list():
     args.append(src.path)
   if getattr(ctx.attr, "clutz_entry_points", None):
     args.append("--closure_entry_points")
     args.extend(ctx.attr.clutz_entry_points)
   ctx.action(
-      inputs=list(srcs),
+      inputs=srcs,
       outputs=[js_typings],
       executable=ctx.executable._clutz,
       arguments=args,
       mnemonic="Clutz",
       progress_message="Running Clutz on %d JS files %s" % (
-          len(srcs), ctx.label))
+          len(srcs.to_list()), ctx.label))
   return js_typings
 
 ################################################################################


### PR DESCRIPTION
Summary:
This fixes the new analysis-phase `--incompatible_*` flags:

```
# No longer needed:
--incompatible_depset_is_not_iterable=false \
--incompatible_disable_deprecated_attr_params=false \
--incompatible_new_actions_api=false \
--incompatible_no_support_tools_in_action_inputs=false \
```

The flag `--incompatible_use_python_toolchains=false` is still required
for imports of Python modules defined only in the virtualenv to resolve.
I’m not sure what the right course of action is. The [official
“Migration” discussion][migration] seems to only consider cases where
the problem is caused by Python 2 vs. 3 runtimes, not where a virtualenv
is desired.

[migration]: https://github.com/bazelbuild/bazel/issues/7899

As noted inline in the fourth commit, I do not understand why a
particular hack is required in `web.bzl`.

This makes progress toward #2355.

Test Plan:
You can now successfully run the following on Bazel 0.27.0 (or 0.26.x):

```
flags='
    --incompatible_depset_is_not_iterable=true
    --incompatible_disable_deprecated_attr_params=true
    --incompatible_new_actions_api=true
    --incompatible_no_support_tools_in_action_inputs=true
    --incompatible_use_python_toolchains=false
' &&
bazel build $flags //tensorboard/... &&
bazel test $flags //tensorboard/... &&
bazel run $flags //tensorboard -- --logdir ~/tensorboard_data
```
