### PR TITLE
Polymer 2: pr-curve: fix the basic functionalities

### DIFF
--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
@@ -62,7 +62,6 @@ limitations under the License.
           <tf-runs-selector selected-runs="{{_selectedRuns}}">
           </tf-runs-selector>
         </div>
-       </div>
       </div>
       <div class="center" slot="center">
         <template is="dom-if" if="[[_dataNotFound]]">
@@ -137,8 +136,14 @@ limitations under the License.
         type: String,
         value: 'step',
       },
-      _selectedRuns: Array,
-      _runToTagInfo: Object,
+      _selectedRuns: {
+        type: Array,
+        value: () => [],
+      },
+      _runToTagInfo: {
+        type: Object,
+        value: () => ({}),
+      },
       // The steps that the step slider for each run should use.
       _runToAvailableTimeEntries: {
         type: Object, // map<run: string, steps: number[]>

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
@@ -141,9 +141,7 @@ limitations under the License.
       if (isNaN(val)) {
         delete newRunToStepIndex[run];
       } else {
-        Object.assign(newRunToStepIndex, {
-          [run]: event.target.immediateValue,
-        });
+        newRunToStepIndex[run] = event.target.immediateValue;
       }
       this._runToStepIndex = newRunToStepIndex;
     },
@@ -158,9 +156,7 @@ limitations under the License.
         if (!_.isNumber(newRunToStepIndex[run])) {
           // This run had previously lacked a slider. Initially set the slider
           // for the run to point to the last step.
-          Object.assign(newRunToStepIndex, {
-            [run]: entries.length - 1,
-          });
+          newRunToStepIndex[run] = entries.length - 1;
         }
       });
       this._runToStepIndex = newRunToStepIndex;

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
@@ -136,8 +136,8 @@ limitations under the License.
       const run = event.target.dataset.run;
       const val = event.target.immediateValue;
       const newRunToStepIndex = Object.assign({}, this._runToStepIndex);
-      // slider emits changed event before it goes away with a immediateValue
-      // of NaN.
+      // Slider emits a changed event before it goes away with an
+      // immediateValue of NaN.
       if (isNaN(val)) {
         delete newRunToStepIndex[run];
       } else {

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
@@ -32,7 +32,7 @@ limitations under the License.
           </div>
         </div>
         <div class="step-display-container">
-          [[_computeTimeTextForRun(runToAvailableTimeEntries, _runToStepIndex.*, run, timeDisplayType)]]
+          [[_computeTimeTextForRun(runToAvailableTimeEntries, _runToStepIndex, run, timeDisplayType)]]
         </div>
         <paper-slider
           data-run$="[[run]]"
@@ -40,7 +40,7 @@ limitations under the License.
           type="number"
           min=0
           max="[[_computeMaxStepIndexForRun(runToAvailableTimeEntries, run)]]"
-          value="[[_getStep(_runToStepIndex.*, run)]]"
+          value="[[_getStep(_runToStepIndex, run)]]"
           on-immediate-value-changed="_sliderValueChanged"
         ></paper-slider>
       </div>
@@ -84,7 +84,7 @@ limitations under the License.
       runToStep: {
         type: Object,
         notify: true,
-        computed: "_computeRunToStep(runToAvailableTimeEntries, _runToStepIndex.*)",
+        computed: "_computeRunToStep(runToAvailableTimeEntries, _runToStepIndex)",
       },
       timeDisplayType: String,
       // A mapping between run and slider index.
@@ -104,8 +104,8 @@ limitations under the License.
       return tf_color_scale.runsColorScale(run);
     },
     _computeTimeTextForRun(
-        runToAvailableTimeEntries, runToStepIndexChanged, run, timeDisplayType) {
-      const stepIndex = this._runToStepIndex[run];
+        runToAvailableTimeEntries, runToStepIndex, run, timeDisplayType) {
+      const stepIndex = runToStepIndex[run];
       if (!_.isNumber(stepIndex)) {
         // The step is not known yet.
         return '';
@@ -134,7 +134,18 @@ limitations under the License.
     },
     _sliderValueChanged(event) {
       const run = event.target.dataset.run;
-      this.set(`_runToStepIndex.${run}`, event.target.immediateValue);
+      const val = event.target.immediateValue;
+      const newRunToStepIndex = Object.assign({}, this._runToStepIndex);
+      // slider emits changed event before it goes away with a immediateValue
+      // of NaN.
+      if (isNaN(val)) {
+        delete newRunToStepIndex[run];
+      } else {
+        Object.assign(newRunToStepIndex, {
+          [run]: event.target.immediateValue,
+        });
+      }
+      this._runToStepIndex = newRunToStepIndex;
     },
     _computeMaxStepIndexForRun(runToAvailableTimeEntries, run) {
       const entries = runToAvailableTimeEntries[run];
@@ -142,21 +153,25 @@ limitations under the License.
     },
     _updateStepsForNewRuns(runToAvailableTimeEntries) {
       // The mapping from run to available time entries just changed.
+      const newRunToStepIndex = Object.assign({}, this._runToStepIndex);
       _.forOwn(runToAvailableTimeEntries, (entries, run) => {
-        if (!_.isNumber(this._runToStepIndex[run])) {
+        if (!_.isNumber(newRunToStepIndex[run])) {
           // This run had previously lacked a slider. Initially set the slider
           // for the run to point to the last step.
-          this.set(`_runToStepIndex.${run}`, entries.length - 1);
+          Object.assign(newRunToStepIndex, {
+            [run]: entries.length - 1,
+          });
         }
       });
+      this._runToStepIndex = newRunToStepIndex;
     },
     _getStep(runToStepIndex, run) {
       if (!this._runToStepIndex) return 0;
       return this._runToStepIndex[run];
     },
-    _computeRunToStep(runToAvailableTimeEntries, runToStepIndexChanged) {
+    _computeRunToStep(runToAvailableTimeEntries, runToStepIndex) {
       const runToStep = {};
-      _.forOwn(this._runToStepIndex, (index, run) => {
+      _.forOwn(runToStepIndex, (index, run) => {
         const entries = runToAvailableTimeEntries[run];
         if (!entries) {
           return;

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.html
@@ -32,15 +32,17 @@ limitations under the License.
           </div>
         </div>
         <div class="step-display-container">
-          [[_computeTimeTextForRun(runToAvailableTimeEntries, _runToStepIndex, run, timeDisplayType)]]
+          [[_computeTimeTextForRun(runToAvailableTimeEntries, _runToStepIndex.*, run, timeDisplayType)]]
         </div>
         <paper-slider
-            data-run$="[[run]]"
-            step="1"
-            type="number"
-            min=0
-            max="[[_computeMaxStepIndexForRun(runToAvailableTimeEntries, run)]]"
-            ></paper-slider>
+          data-run$="[[run]]"
+          step="1"
+          type="number"
+          min=0
+          max="[[_computeMaxStepIndexForRun(runToAvailableTimeEntries, run)]]"
+          value="[[_getStep(_runToStepIndex.*, run)]]"
+          on-immediate-value-changed="_sliderValueChanged"
+        ></paper-slider>
       </div>
     </template>
     <style>
@@ -82,7 +84,7 @@ limitations under the License.
       runToStep: {
         type: Object,
         notify: true,
-        computed: "_computeRunToStep(runToAvailableTimeEntries, _runToStepIndex)",
+        computed: "_computeRunToStep(runToAvailableTimeEntries, _runToStepIndex.*)",
       },
       timeDisplayType: String,
       // A mapping between run and slider index.
@@ -95,19 +97,15 @@ limitations under the License.
         computed: "_computeRunsWithSliders(runs, runToAvailableTimeEntries)",
       },
     },
-    listeners: {
-      "value-change": "_sliderValueChanged",
-      "immediate-value-change": "_sliderValueChanged",
-    },
     observers: [
-      "_updateStepsForNewRuns(runs, runToAvailableTimeEntries, _runToStepIndex)",
+      "_updateStepsForNewRuns(runToAvailableTimeEntries)",
     ],
     _computeColorForRun(run) {
       return tf_color_scale.runsColorScale(run);
     },
     _computeTimeTextForRun(
-        runToAvailableTimeEntries, runToStepIndex, run, timeDisplayType) {
-      const stepIndex = runToStepIndex[run];
+        runToAvailableTimeEntries, runToStepIndexChanged, run, timeDisplayType) {
+      const stepIndex = this._runToStepIndex[run];
       if (!_.isNumber(stepIndex)) {
         // The step is not known yet.
         return '';
@@ -136,56 +134,29 @@ limitations under the License.
     },
     _sliderValueChanged(event) {
       const run = event.target.dataset.run;
-      const newRunToStepIndex = _.clone(this._runToStepIndex);
-      newRunToStepIndex[run] = event.target.immediateValue;
-      this.set('_runToStepIndex', newRunToStepIndex);
+      this.set(`_runToStepIndex.${run}`, event.target.immediateValue);
     },
     _computeMaxStepIndexForRun(runToAvailableTimeEntries, run) {
       const entries = runToAvailableTimeEntries[run];
       return entries && entries.length ? entries.length - 1 : 0;
     },
-    _updateStepsForNewRuns(runs, runToAvailableTimeEntries, runToStepIndex) {
+    _updateStepsForNewRuns(runToAvailableTimeEntries) {
       // The mapping from run to available time entries just changed.
-      const newRunToStepIndex = {};
-      let runAdded = false;
       _.forOwn(runToAvailableTimeEntries, (entries, run) => {
-        if (!_.isNumber(runToStepIndex[run])) {
+        if (!_.isNumber(this._runToStepIndex[run])) {
           // This run had previously lacked a slider. Initially set the slider
           // for the run to point to the last step.
-          newRunToStepIndex[run] = entries.length - 1;
-          runAdded = true;
-        } else {
-          // The step for this run did not change.
-          newRunToStepIndex[run] = runToStepIndex[run];
+          this.set(`_runToStepIndex.${run}`, entries.length - 1);
         }
       });
-
-      // We only update the run to step index mapping if it changed. Otherwise,
-      // we enter an infinite loop and hit the max stack size for recursion.
-      if (runAdded) {
-        this.set('_runToStepIndex', newRunToStepIndex);
-      }
-
-      // Set the values of all the sliders. They are not 2-way bound, so we must
-      // actually set them. We asynchronously update the sliders because we
-      // should only update sliders after the dom-repeat finishes rendering. We
-      // update sliders even if no run was added because the `runs` array might
-      // have changed despite how `runToAvailableTimeEntries` did not.
-      this.async(() => {
-        this._updateSliders(newRunToStepIndex);
-      });
     },
-    _updateSliders(runToStepIndex) {
-      // When selected runs change, make sure any new sliders point to the
-      // correct step.
-      const sliders = this.querySelectorAll('paper-slider');
-      for (let i = 0; i < sliders.length; i++) {
-        sliders[i].value = runToStepIndex[sliders[i].dataset.run];
-      }
+    _getStep(runToStepIndex, run) {
+      if (!this._runToStepIndex) return 0;
+      return this._runToStepIndex[run];
     },
-    _computeRunToStep(runToAvailableTimeEntries, runToStepIndex) {
+    _computeRunToStep(runToAvailableTimeEntries, runToStepIndexChanged) {
       const runToStep = {};
-      _.forOwn(runToStepIndex, (index, run) => {
+      _.forOwn(this._runToStepIndex, (index, run) => {
         const entries = runToAvailableTimeEntries[run];
         if (!entries) {
           return;


### PR DESCRIPTION
Problem 1: the DOM structure
Problem 2: tf-pr-curve-steps-selector broke because its usage of
querySelector. It uses an internal state, `runsToStepIndex`, to record
run to stepIndex (note the distinction from just step) map. It was
manually setting the value to the paper-sliders and listened to the
changed event via listeners. Something in Polymer 2 broke. Instead,
now, we use data-binding to update the value of the paper-slider
Polymer way.

stepIndex vs. step: when there are tons of data, due to our reservoir
sampling, there can be only a subset of the steps. Say we have steps
[0, 4, 10, 1000] for a run foo. When the steps are rendered, it has to
translated to indices since the paper-slider does not supporting an enum.
`runToStepIndex` stores slider index which gets translated to real
`step` via `runToAvailableTimeEntries`.
