### PR TITLE
Confirm that the connection to tensorboard works or change to localhost

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -728,7 +728,7 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
 
     def get_url(self):
         if self._auto_wildcard:
-            display_host = socket.gethostname()
+            display_host = socket.getfqdn()
         else:
             host = self._host
             display_host = (

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -731,7 +731,6 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
         if not self._url:
             if self._auto_wildcard:
                 display_host = socket.getfqdn()
-
                 # Confirm that the connection is open, otherwise change to `localhost`
                 try:
                     socket.create_connection(

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -751,7 +751,7 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
                 self.server_port,
                 self._flags.path_prefix.rstrip("/"),
             )
-        return self._url 
+        return self._url
 
     def print_serving_message(self):
         if self._flags.host is None and not self._flags.bind_all:

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -162,7 +162,6 @@ class TensorBoard(object):
                 raise ValueError("Duplicate subcommand name: %r" % name)
             self.subcommands[name] = subcommand
         self.flags = None
-        self.display_host = None  # Will be set by get_url() below
 
     def configure(self, argv=("",), **kwargs):
         """Configures TensorBoard behavior via flags.
@@ -598,6 +597,7 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
             host = "localhost"
 
         self._host = host
+        self.display_host = None  # Will be set by get_url() below
 
         self._fix_werkzeug_logging()
         try:

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -734,7 +734,9 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
 
                 # Confirm that the connection is open, otherwise change to `localhost`
                 try:
-                    socket.create_connection((self.display_host, self.server_port), timeout = 1)
+                    socket.create_connection(
+                        (self.display_host, self.server_port), timeout=1
+                    )
                 except socket.error as e:
                     self.display_host = "localhost"
 


### PR DESCRIPTION
* Motivation for features / changes

The TensorBoard log told me to go to `http://laptop-name.corp.domain.tld:6006` and that connection failed, but `http://localhost:6006` worked.

* Technical description of changes

I tested the connection to the host with `socket()`, and if it is closed, the host becomes `localhost`.

* Screenshots of UI changes

No UI changes.

* Detailed steps to verify changes work correctly (as executed by you)

I ran `export PYTHONPATH="$PYTHONPATH:$HOME/code/tensorflow:$HOME/code:tensorboard"; python3 tensorboard/program.py`, which threw this unrelated error (and both repos are in sync with upstream):

```
  File "/Users/mmorin/code/tensorboard/tensorboard/data_compat.py", line 24, in <module>
    from tensorboard.compat.proto import summary_pb2
ImportError: cannot import name 'summary_pb2'
```

* Alternate designs / implementations considered

None.