### PR TITLE
graph: Add default compat-node-title

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
+++ b/tensorboard/plugins/graph/tf_graph_app/tf-graph-app.html
@@ -113,7 +113,6 @@ tf-graph-controls {
           color-by-params="{{colorByParams}}"
           render-hierarchy="{{_renderHierarchy}}"
           selected-node="{{selectedNode}}"
-          compat-node-title="TPU Compatibility"
       ></tf-graph-board>
     </div>
   </div>

--- a/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
+++ b/tensorboard/plugins/graph/tf_graph_board/tf-graph-board.html
@@ -235,7 +235,10 @@ Polymer({
       type: String,
       notify: true,
     },
-    compatNodeTitle: String,
+    compatNodeTitle: {
+      type: String,
+      value: 'TPU Compatibility',
+    },
     // A function with signature EdgeThicknessFunction that computes the
     // thickness of a given edge.
     edgeWidthFunction: Object,

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -108,7 +108,6 @@ by default. The user can select a different run from a dropdown menu.
         render-hierarchy="{{_renderHierarchy}}"
         selected-node="{{_selectedNode}}"
         stats="[[_stats]]"
-        compat-node-title="TPU Compatibility"
     ></tf-graph-board>
   </div>
 </tf-dashboard-layout>


### PR DESCRIPTION
There are many variants of the tf-graph-dashboard. We recently, to
support other type of compatibility check, added a required field of
"compat-node-title" and in the process broke other apps. This change
makes other app behave exactly the same while keeping the
customizability.
