### PR TITLE
cleanup: added doc string to bzl

### DIFF
--- a/tensorboard/defs/vulcanize.bzl
+++ b/tensorboard/defs/vulcanize.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Rule for building the HTML binary using Closure Compiler """
+
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_aspect")

--- a/tensorboard/defs/vulcanize.bzl
+++ b/tensorboard/defs/vulcanize.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Rule for building the HTML binary using Closure Compiler """
+"""Rule for building the HTML binary using Closure Compiler."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 

--- a/tensorboard/defs/zipper.bzl
+++ b/tensorboard/defs/zipper.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Rule for zipping Webfiles. """
+
 load("@io_bazel_rules_closure//closure/private:defs.bzl", "unfurl")
 
 def _tensorboard_zip_file(ctx):

--- a/tensorboard/defs/zipper.bzl
+++ b/tensorboard/defs/zipper.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Rule for zipping Webfiles. """
+"""Rule for zipping Webfiles."""
 
 load("@io_bazel_rules_closure//closure/private:defs.bzl", "unfurl")
 

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-loader.html
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-loader.html
@@ -18,6 +18,7 @@ limitations under the License.
 <link rel="import" href="../tf-card-heading/tf-card-heading.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-imports/tf_graphics_lib.html">
+<link rel="import" href="../tf-imports/threejs.html">
 
 <!--
   Mesh component loads 3D data (point clouds, meshes, etc.) and renders it.

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-loader.html
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-loader.html
@@ -18,7 +18,6 @@ limitations under the License.
 <link rel="import" href="../tf-card-heading/tf-card-heading.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-imports/tf_graphics_lib.html">
-<link rel="import" href="../tf-imports/threejs.html">
 
 <!--
   Mesh component loads 3D data (point clouds, meshes, etc.) and renders it.


### PR DESCRIPTION
As per https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring
we need to add a docstring at the top of the bzl.

This change is not comprehensive as I have not audited all bzl files. 