### PR TITLE
cleanup: express explicit dependency on threejs

### DIFF
--- a/tensorboard/components/tf_imports/tf_graphics_lib.html
+++ b/tensorboard/components/tf_imports/tf_graphics_lib.html
@@ -14,5 +14,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+<!--
+  mesh-viewer.js has dependency on threejs. Because TensorFlow graphics do not
+  have an entry html, we have to define library dependency here.
+-->
+<link rel="import" href="threejs.html">
+
 <script src="array-buffer-data-provider.js"></script>
 <script src="mesh-viewer.js"></script>

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/BUILD
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/BUILD
@@ -23,6 +23,7 @@ tf_web_library(
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_imports:tf_graphics_lib",
+        "//tensorboard/components/tf_imports:threejs",
         "//tensorboard/components/tf_paginated_view",
         "//tensorboard/components/tf_runs_selector",
         "//tensorboard/components/tf_tensorboard:registry",

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-loader.html
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-loader.html
@@ -18,6 +18,7 @@ limitations under the License.
 <link rel="import" href="../tf-card-heading/tf-card-heading.html">
 <link rel="import" href="../tf-color-scale/tf-color-scale.html">
 <link rel="import" href="../tf-imports/tf_graphics_lib.html">
+<link rel="import" href="../tf-imports/threejs.html">
 
 <!--
   Mesh component loads 3D data (point clouds, meshes, etc.) and renders it.


### PR DESCRIPTION
tf_mesh_dashboard did not explicitly define dependency on threejs and
implicitly relying on other plugins loading the threejs before its
resource is loaded on the Vulcanized HTML binary. Now that projector,
another user of the threejs, is now dynamically loaded, this pattern
becomes a lot more brittle.

WANT_LGTM=any
This unblocks internal sync.
