### PR TITLE
add "Rescale all plots" button to global actions

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -118,6 +118,12 @@ limitations under the License.
             </template>
           </template>
           <div class="global-actions">
+              <paper-icon-button
+              id="rescale-all-button"
+              icon="settings-overscan"
+              on-tap="rescale_all"
+              title="Rescale all plots"
+            ></paper-icon-button>
             <paper-icon-button
               id="reload-button"
               class$="[[_getDataRefreshingClass(_refreshing)]]"
@@ -1001,6 +1007,11 @@ limitations under the License.
           if (dashboard && dashboard.reload) dashboard.reload();
         });
         this._lastReloadTime = new Date().toString();
+      },
+
+      rescale_all() {
+        let rescale_buttons = document.querySelectorAll('paper-icon-button[icon="settings-overscan"]');
+        rescale_buttons.forEach((button) => { button.click() });
       },
 
       _reloadData() {


### PR DESCRIPTION
rescales all the scalar graphs on click

* Motivation for features / changes
as models train and data is logged, I have to constantly click the rescale button for each plot, usually 10+ plots for training and validation metrics. This is annoying and takes too long, the plots should be able to rescale together with one click.

* Technical description of changes
Added a button to the global actions panel top right, on click it looks for every rescale button and clicks it
Changes were made only to `components/tf_tensorboard/tf-tensorboard.html`

* Screenshots of UI changes
[https://imgur.com/a/dQIN3Xo](https://imgur.com/a/dQIN3Xo)

* Detailed steps to verify changes work correctly (as executed by you)
Added the change, built using bazel and tf-nightly, ran tb, it worked well

* Alternate designs / implementations considered
Somebody with more knowledge of the repo could probably use a more elegant technique for activating the rescale of each plot, I am not sure where the reference to each plots object/datastructure lives, to call it's rescale function
