### PR TITLE
Handle large mutliclass better in WIT

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -1017,6 +1017,10 @@ limitations under the License.
         margin-left: 30px;
       }
 
+      .scroll-x {
+        overflow-x: auto;
+      }
+
       .perf-table-clickable {
         cursor: pointer;
       }
@@ -2081,7 +2085,7 @@ limitations under the License.
                           </div>
                         </div>
                         <iron-collapse opened="{{featureValueThreshold.opened}}">
-                          <div class="perf-table-entry-expanded flex-row-reverse">
+                          <div class="perf-table-entry-expanded flex-row-reverse scroll-x">
                             <div>
                               <template is="dom-if" if="[[shouldShowFeaturePrCharts_(selectedLabelFeature, selectedBreakdownFeature, inferences)]]">
                                 <div class="conf-matrix-holder">
@@ -2124,7 +2128,7 @@ limitations under the License.
                             </div>
                           </div>
                         </div>
-                        <div class="perf-table-entry-expanded flex-row-reverse">
+                        <div class="perf-table-entry-expanded flex-row-reverse scroll-x">
                           <template is="dom-if" if="[[shouldShowOverallPrChart_(selectedLabelFeature, selectedBreakdownFeature, inferences)]]">
                             <div class="conf-matrix-holder">
                               <div class="conf-text">Confusion matrix</div>
@@ -5032,10 +5036,39 @@ limitations under the License.
        */
       addChart: function(chartType, featureName, data){
         let chart;
+        let dataToChart = data;
+
+        // If multiclass and there are more inferred classes than the set
+        // number of classes to display, then filter the classes to display
+        // in the chart down to the top scoring classes.
+        if (this.isMultiClass_(this.modelType, this.multiClass)) {
+          dataToChart = [];
+          for (let modelIdx = 0; modelIdx < data.length; modelIdx++) {
+            let modelDataToChart = {};
+            if (Object.keys(data[modelIdx]).length >
+                parseInt(this.maxInferenceEntriesPerRun)) {
+              const exampleId = this.selected &&
+                this.selected.length > 0 ? this.selected[0] : 0;
+              // Get the class labels of the top scoring classes from the most
+              // recent inference.
+              const labels = this.examplesAndInferences[exampleId].inferences[
+                this.examplesAndInferences[exampleId].inferences.length - 1][
+                  modelIdx].slice(0, this.maxInferenceEntriesPerRun);
+              for (let labelIdx = 0; labelIdx < labels.length; labelIdx++) {
+                const label = labels[labelIdx].label;
+                modelDataToChart[label] = data[modelIdx][label];
+              }
+            } else {
+              modelDataToChart = data[modelIdx];
+            }
+            dataToChart.push(modelDataToChart);
+          }
+        }
+
         if (chartType == 'numeric'){
-          chart = this.makeLineChart(featureName, data);
+          chart = this.makeLineChart(featureName, dataToChart);
         } else if (chartType == 'categorical'){
-          chart = this.makeBarChart(featureName, data);
+          chart = this.makeBarChart(featureName, dataToChart);
         } else {
           console.error('Unknown chartType: ' + chartType);
         }

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -5046,14 +5046,16 @@ limitations under the License.
           for (let modelIdx = 0; modelIdx < data.length; modelIdx++) {
             let modelDataToChart = {};
             if (Object.keys(data[modelIdx]).length >
-                parseInt(this.maxInferenceEntriesPerRun)) {
+                Number(this.maxInferenceEntriesPerRun)) {
               const exampleId = this.selected &&
                 this.selected.length > 0 ? this.selected[0] : 0;
               // Get the class labels of the top scoring classes from the most
               // recent inference.
-              const labels = this.examplesAndInferences[exampleId].inferences[
-                this.examplesAndInferences[exampleId].inferences.length - 1][
-                  modelIdx].slice(0, this.maxInferenceEntriesPerRun);
+              const currentExample = this.examplesAndInferences[exampleId];
+              const lastInference = currentExample.inferences[
+                currentExample.inferences.length - 1];
+              const labels = lastInference[modelIdx].slice(
+                0, this.maxInferenceEntriesPerRun);
               for (let labelIdx = 0; labelIdx < labels.length; labelIdx++) {
                 const label = labels[labelIdx].label;
                 modelDataToChart[label] = data[modelIdx][label];


### PR DESCRIPTION
* Motivation for features / changes

Models with many classes (like 100) have display issues in WIT

* Technical description of changes

Only show top N classes in PD plots, just like we already do in inference panel
Correctly scroll large confusion matrices instead of overflowing into area where it can't be viewed

* Screenshots of UI changes
![100conf](https://user-images.githubusercontent.com/15835086/60108246-5022d900-9736-11e9-9656-b7de61e722f8.png)

![100pdp](https://user-images.githubusercontent.com/15835086/60108270-56b15080-9736-11e9-8c2d-9952615973b1.png)


* Detailed steps to verify changes work correctly (as executed by you)

Ran all demos to see no regressions
Ran a demo with 100 classes to verify better visuals

