### PR TITLE
manager: launch `TENSORBOARD_BINARY` if available

### DIFF
--- a/tensorboard/manager.py
+++ b/tensorboard/manager.py
@@ -397,9 +397,10 @@ def start(arguments, timeout=datetime.timedelta(seconds=60)):
   (stdout_fd, stdout_path) = tempfile.mkstemp(prefix=".tensorboard-stdout-")
   (stderr_fd, stderr_path) = tempfile.mkstemp(prefix=".tensorboard-stderr-")
   start_time_seconds = time.time()
+  tensorboard_binary = os.environ.get("TENSORBOARD_BINARY", "tensorboard")
   try:
     p = subprocess.Popen(
-        ["tensorboard"] + arguments,
+        [tensorboard_binary] + arguments,
         stdout=stdout_fd,
         stderr=stderr_fd,
     )


### PR DESCRIPTION
Summary:
This enables specifying the TensorBoard binary with an environment
variable. Callers previously needed to set up a `PATH` with a custom
binary; this is simpler and less intrusive.

(Googlers, see comments on <http://cl/236333099> for context.)

Test Plan:
The newly added test fails before this change and passes after it.

wchargin-branch: tensorboard-binary
