### PR TITLE
build: add `:extract_pip_package` for convenience

### DIFF
--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -20,6 +20,12 @@ genrule(
 )
 
 sh_binary(
+    name = "extract_pip_package",
+    srcs = ["extract_pip_package.sh"],
+    data = [":pip_package"],
+)
+
+sh_binary(
     name = "build_pip_package",
     srcs = ["build_pip_package.sh"],
     data = [

--- a/tensorboard/pip_package/extract_pip_package.sh
+++ b/tensorboard/pip_package/extract_pip_package.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+tmpdir="$(mktemp -d)"
+tar xzf "$0.runfiles/org_tensorflow_tensorboard/tensorboard/pip_package/pip_packages.tar.gz" \
+    -C "${tmpdir}"
+find "${tmpdir}" | sort


### PR DESCRIPTION
Summary:
For ad hoc testing, one frequently wants to install a Pip package after
buliding it. A new script extracts the wheels and prints the path to the
enclosing directory (for `xdg-open` to drag-and-drop into Colab) and to
the wheels themselves (to copy-and-paste as a `pip install` argument).

Test Plan:
Run the new binary:

```
$ bazel run //tensorboard/pip_package:extract_pip_package 2>/dev/null
/tmp/tmp.caSTM9Sa7J
/tmp/tmp.caSTM9Sa7J/tensorboard-1.15.0a0-py2-none-any.whl
/tmp/tmp.caSTM9Sa7J/tensorboard-1.15.0a0-py3-none-any.whl
```

wchargin-branch: extract-pip-package
