### PR TITLE
manager: improve error messages for exec failures

### DIFF
--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -21,8 +21,10 @@ from __future__ import division
 from __future__ import print_function
 
 import datetime
+import errno
 import shlex
 import sys
+import textwrap
 import time
 
 from tensorboard import manager
@@ -190,6 +192,28 @@ def start(args_string):
         )
     )
     print_or_update(message)
+
+  elif isinstance(start_result, manager.StartExecFailed):
+    the_tensorboard_binary = (
+        "%r (set by the `TENSORBOARD_BINARY` environment variable)"
+            % (start_result.explicit_binary,)
+        if start_result.explicit_binary is not None
+        else "`tensorboard`"
+    )
+    if start_result.os_error.errno == errno.ENOENT:
+      message = (
+          "ERROR: Could not find %s. Please ensure that your PATH contains "
+          "an executable `tensorboard` program, or explicitly specify the path "
+          "to a TensorBoard binary by setting the `TENSORBOARD_BINARY` "
+          "environment variable."
+          % (the_tensorboard_binary,)
+      )
+    else:
+      message = (
+          "ERROR: Failed to start %s: %s"
+          % (the_tensorboard_binary, start_result.os_error)
+      )
+    print_or_update(textwrap.fill(message))
 
   elif isinstance(start_result, manager.StartTimedOut):
     message = (


### PR DESCRIPTION
Summary:
This gives users a more explicit error message for common configuration
errors, like virtualenvs with `--system-site-packages` that mix and
match packages and binaries across environments.

Test Plan:
Automated tests cover changes to `manager.py`. For notebook changes,
build the Pip package, and install it and `IPython` to a new virtualenv.
From an IPython shell, run through all the cases:

```
In [1]: %load_ext tensorboard
In [2]: import os
In [3]: os.environ["PATH"] = ""
In [4]: %tensorboard --logdir logs
Launching TensorBoard...
ERROR: Could not find `tensorboard`. Please ensure that your PATH
contains an executable `tensorboard` program, or explicitly specify
the path to a TensorBoard binary by setting the `TENSORBOARD_BINARY`
environment variable.
In [5]: os.environ["TENSORBOARD_BINARY"] = "/not/likely"
In [6]: %tensorboard --logdir logs
Launching TensorBoard...
ERROR: Could not find '/not/likely' (set by the `TENSORBOARD_BINARY`
environment variable). Please ensure that your PATH contains an
executable `tensorboard` program, or explicitly specify the path to a
TensorBoard binary by setting the `TENSORBOARD_BINARY` environment
variable.
In [7]: os.environ["TENSORBOARD_BINARY"] = "."  # EACCES
In [8]: %tensorboard --logdir logs
Launching TensorBoard...
ERROR: Failed to start '.' (set by the `TENSORBOARD_BINARY`
environment variable): [Errno 13] Permission denied: '.'
```

wchargin-branch: manager-execfailed
