### PR TITLE
build: removed bin/genfile prefix in declare_file

### DIFF
--- a/tensorboard/defs/vulcanize.bzl
+++ b/tensorboard/defs/vulcanize.bzl
@@ -14,8 +14,6 @@
 
 """Rule for building the HTML binary using Closure Compiler."""
 
-load("@bazel_skylib//lib:paths.bzl", "paths")
-
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_aspect")
 load("@io_bazel_rules_closure//closure/private:defs.bzl", "collect_js", "unfurl", "long_path")
 
@@ -64,8 +62,7 @@ def _tensorboard_html_binary(ctx):
   manifest_srcs = [struct(path=ctx.outputs.html.path,
                           longpath=long_path(ctx, ctx.outputs.html),
                           webpath=ctx.attr.output_path)]
-  manifest = ctx.actions.declare_file(paths.join(
-      ctx.configuration.bin_dir.path, "%s.pbtxt" % ctx.label.name))
+  manifest = ctx.actions.declare_file("%s.pbtxt" % ctx.label.name)
   ctx.actions.write(
       output=manifest,
       content=struct(
@@ -80,9 +77,8 @@ def _tensorboard_html_binary(ctx):
       manifest=[long_path(ctx, man) for man in manifests.to_list()],
       external_asset=[struct(webpath=k, path=v)
                       for k, v in ctx.attr.external_assets.items()])
-  params_file = ctx.actions.declare_file(paths.join(
-      ctx.configuration.bin_dir.path,
-      "%s_server_params.pbtxt" % ctx.label.name))
+  params_file = ctx.actions.declare_file(
+      "%s_server_params.pbtxt" % ctx.label.name)
   ctx.actions.write(output=params_file, content=params.to_proto())
   ctx.actions.write(
       is_executable=True,

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -113,10 +113,8 @@ def _tf_web_library(ctx):
       execroot.inputs.append(entry)
     elif suffix.endswith(".ts"):
       noext = suffix[:-3]
-      js = ctx.actions.declare_file(paths.join(
-          ctx.genfiles_dir.path, "%s.js" % noext))
-      dts = ctx.actions.declare_file(paths.join(
-          ctx.genfiles_dir.path, "%s.d.ts" % noext))
+      js = ctx.actions.declare_file("%s.js" % noext)
+      dts = ctx.actions.declare_file("%s.d.ts" % noext)
       webpath_js = webpath[:-3] + ".js"
       webpath_dts = webpath[:-3] + ".d.ts"
       _add_webpath(ctx, js, webpath_js, webpaths, new_webpaths, manifest_srcs)

--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -14,8 +14,6 @@
 
 """Same as web_library but supports TypeScript."""
 
-load("@bazel_skylib//lib:paths.bzl", "paths")
-
 load("//third_party:clutz.bzl",
      "DEPRECATED_CLUTZ_ATTRIBUTES",
      "DEPRECATED_CLUTZ_OUTPUTS",
@@ -332,8 +330,7 @@ def _run_webfiles_validator(ctx, srcs, deps, manifest):
   return dummy, manifests
 
 def _new_file(ctx, suffix):
-  return ctx.actions.declare_file(paths.join(
-      ctx.bin_dir.path, "%s%s" % (ctx.label.name, suffix)))
+  return ctx.actions.declare_file("%s%s" % (ctx.label.name, suffix))
 
 def _add_webpath(ctx, src, webpath, webpaths, new_webpaths, manifest_srcs):
   if webpath in new_webpaths:

--- a/third_party/clutz.bzl
+++ b/third_party/clutz.bzl
@@ -14,8 +14,6 @@
 
 """Build definitions for TypeScript from Closure JavaScript libraries."""
 
-load("@bazel_skylib//lib:paths.bzl", "paths")
-
 load("@io_bazel_rules_closure//closure/private:defs.bzl",
      "JS_FILE_TYPE",
      "collect_js",
@@ -51,8 +49,7 @@ def deprecated_extract_dts_from_closure_libraries(ctx):
   js = collect_js(deps, ctx.files._closure_library_base)
   if not js.srcs:
     return None
-  js_typings = ctx.actions.declare_file(paths.join(
-      ctx.bin_dir.path, "%s-js-typings.d.ts" % ctx.label.name))
+  js_typings = ctx.actions.declare_file("%s-js-typings.d.ts" % ctx.label.name)
   # File.extension does not have leading "." whereas JS_FILE_TYPE does.
   clutz_js_externs = [f for f in ctx.files._clutz_externs
                       if '.%s' % f.extension in JS_FILE_TYPE]


### PR DESCRIPTION
Commit 4ba5f51b6d3beb0746ce21d355cef29d918d021d changed ctx.new_file to
ctx.actions.declare_file which is the new way of declaring a file except
the new API behaves a bit differently than the old one.

new_file, as the first argument, took the root directory [1] and
previous to the commit, we passed the bazel genfile path. However,
declare_file no longer take the root path [2] (it generates a new root
path based on whether the rule is genrule or not [3]) and appended the
first argument to the root it generates.

This made TensorBoard have paths like below:
- bazel-out/k8-fastbuild/bin/t/c/tf_backend/bazel-out/k8-fastbuild/bin/backend.js
- bazel-out/k8-fastbuild/bin/t/c/bazel-out/k8-fastbuild/bin/index.pbtxt
- bazel-out/k8-fastbuild/bin/t/c/tf_backend/bazel-out/k8-fastbuild/bin/tf_backend-tsc.json

With the change, above look like below:
- bazel-out/k8-fastbuild/bin/t/c/tf_backend/backend.js
- bazel-out/k8-fastbuild/bin/t/c/index.pbtxt
- bazel-out/k8-fastbuild/bin/t/c/tf_backend/tf_backend-tsc.json


[1]:
https://github.com/bazelbuild/bazel/blob/2a116372382aedbf8a39477e0ea1123903ab5479/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleContext.java#L759-L763
[2]: https://github.com/bazelbuild/bazel/blob/1ace20a6bb7587ae427d5917ffe13fa71d8885e9/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkActionFactory.java#L133
[3]: https://github.com/bazelbuild/bazel/blob/2a116372382aedbf8a39477e0ea1123903ab5479/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java#L621-L623

Looked for every `declare_file` instance and made sure we did not make the mistake.

Related: there were confusions around the difference between bazel-genfiles vs. bazel-bin.
As of 0.25, the Bazel team had merged two concept as there is no tangible difference and
only adds confusion.
https://groups.google.com/forum/#!msg/bazel-dev/5iq7n1soenA/xGM_M1NOCAAJ