### PR TITLE
Add inference error messages in WIT notebook mode

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/BUILD
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/BUILD
@@ -36,6 +36,7 @@ tf_web_library(
         "@org_polymer_paper_spinner",
         "@org_polymer_paper_styles",
         "@org_polymer_paper_tabs",
+        "@org_polymer_paper_toast",
         "@org_polymer_paper_toggle_button",
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_dashboard_common",

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -4470,7 +4470,8 @@ limitations under the License.
           // TODO(jwexler): Support attributions from multiple models.
           // For now, we only display attribution from the first model, if WIT
           // is loaded with two models.
-          const attribs = attributions.attributions[0][i];
+          const attribs = attributions.attributions[0] == null ? {} :
+              attributions.attributions[0][i];
           const keys = Object.keys(attribs);
           for (let j = 0; j < keys.length; j++) {
             // If the attributions for a key is a 2D array then treat the first

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -1502,7 +1502,7 @@ limitations under the License.
                     <div id="noexamples" class="noexamples info-text">
                       Datapoints and their inference results will be displayed here.
                     </div>
-                    <paper-spinner-lite id="spinner" hidden active></paper-spinner-lite>
+                    <paper-spinner-lite id="spinner" hidden="[[spinnerHidden_]]" active></paper-spinner-lite>
                     <div class="feature-container-holder" id="partialplotholder">
                       <div class="pd-plots-header">
                         <div class="flex">
@@ -2652,7 +2652,12 @@ limitations under the License.
         allConfMatrixLabels: {
           type: Array,
           value: () => ([]),
-        }
+        },
+        // Controls if the loading spinner is hidden from view.
+        spinnerHidden_: {
+          type: Boolean,
+          value: true,
+        },
       },
 
       observers: [
@@ -4308,7 +4313,7 @@ limitations under the License.
       },
 
       newInferences_: function() {
-        this.$.spinner.hidden = true;
+        this.spinnerHidden_ = true;
         this.updateInferences_(true);
         requestAnimationFrame(() => this.updateInferenceStats_(true));
       },
@@ -4587,16 +4592,16 @@ limitations under the License.
                              'use_predict': this.usePredictApi,
                              'predict_output_tensor': this.predictOutputTensor,
                              'predict_input_tensor': this.predictInputTensor};
-        this.$.spinner.hidden = false;
+        this.spinnerHidden_ = false;
         if (!this.local) {
           const url = this.makeUrl_('/data/plugin/whatif/infer',
               inferParams);
           const inferContents = result => {
-            this.$.spinner.hidden = true;
+            this.spinnerHidden_ = true;
             this.labelVocab = /** @type {!Array} */ (JSON.parse(result.value.vocab));
             this.inferences = /** @type {!Object} */ (JSON.parse(result.value.inferences));
           };
-          this.makeAsyncRequest_(url, inferContents, null);
+          this.makeAsyncRequest_(url, inferContents, null, 'Model inference');
         }
         this.fire('infer-examples', inferParams);
       },
@@ -4680,7 +4685,8 @@ limitations under the License.
           var url = this.makeUrl_('/data/plugin/whatif/update_example', null);
 
           this.makeAsyncRequest_(url, null, {'example': exampleJson,
-                                              'index': index});
+                                             'index': index},
+                                 'Datapoint update');
         }
       },
 
@@ -4708,20 +4714,20 @@ limitations under the License.
         console.error(msg);
       },
 
-      handleError_: function(errorStr) {
+      handleError: function(errorStr) {
         this.showToast_(errorStr);
         this.exampleStatusStr = errorStr;
-        this.$.spinner.hidden = true;
+        this.spinnerHidden_ = true;
       },
 
       makeAsyncRequest_: function(
-          url, thenDoFn, postData, errorFn = () => {}) {
+          url, thenDoFn, postData, requestStr, errorFn = () => {}) {
         const wrapperFn = this._canceller.cancellable(result => {
           if (result.cancelled) {
             return;
           }
           if (result.value && result.value.error){
-            this.handleError_(result.value.error);
+            this.handleError(result.value.error);
             if (errorFn != null) {
               errorFn();
             }
@@ -4731,7 +4737,7 @@ limitations under the License.
         });
         this._requestManager.request(url, postData).then(wrapperFn)
             .catch(reason => {
-              this.handleError_('Request failed: ' + reason);
+              this.handleError(requestStr + ' failed: ' + reason);
               if (errorFn != null) {
                 errorFn();
               }
@@ -4841,7 +4847,7 @@ limitations under the License.
       updateExampleContents: function(examples, hasSprite) {
         this.exampleStatusStr = examples.length + ' datapoints loaded';
         this.$.noexamples.style.display = 'none';
-        this.$.spinner.hidden = true;
+        this.spinnerHidden_ = true;
         this.examplesAndInferences = examples.map(function(ex) {
           const example = JSON.parse(ex);
           return {example: example, changed: false, orig: JSON.parse(ex)};});
@@ -4914,8 +4920,8 @@ limitations under the License.
             result.value.examples, result.value.sprite);
         };
         this.exampleStatusStr = 'Loading datapoints...'
-        this.makeAsyncRequest_(url, updateExampleContents, null);
-        this.$.spinner.hidden = false;
+        this.makeAsyncRequest_(url, updateExampleContents, null, 'Datapoint load');
+        this.spinnerHidden_ = false;
       },
 
       updateSprite: function() {
@@ -4969,7 +4975,7 @@ limitations under the License.
           };
           const url = this.makeUrl_('/data/plugin/whatif/duplicate_example',
             {'index': duplicatedIndex});
-          this.makeAsyncRequest_(url, refreshDiveAfterDuplicate, null);
+          this.makeAsyncRequest_(url, refreshDiveAfterDuplicate, null, 'Datapoint duplication');
         } else {
           this.refreshDive_();
         }
@@ -5004,7 +5010,7 @@ limitations under the License.
           };
           const url = this.makeUrl_('/data/plugin/whatif/delete_example',
             {'index': deletedIndex});
-          this.makeAsyncRequest_(url, refreshDiveAfterDelete, null);
+          this.makeAsyncRequest_(url, refreshDiveAfterDelete, null, 'Datapoint delete');
         } else {
           this.refreshDive_();
         }
@@ -5462,7 +5468,7 @@ limitations under the License.
           }
           this.makeAsyncRequest_(
             url, chartMakerCallback.bind(this), null,
-            chartErrorCallback.bind(this));
+            'Plot creation', chartErrorCallback.bind(this));
         } else {
           this.fire('infer-mutants', urlParams);
         }
@@ -5652,7 +5658,7 @@ limitations under the License.
           const setEligibleFields = result => {
             this.set('partialDepPlotEligibleFeatures', result.value);
           };
-          this.makeAsyncRequest_(url, setEligibleFields, null);
+          this.makeAsyncRequest_(url, setEligibleFields, null, 'Plot setup');
         } else {
           this.fire('get-eligible-features');
         }

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -35,6 +35,7 @@ limitations under the License.
 <link rel="import" href="../paper-spinner/paper-spinner-lite.html">
 <link rel="import" href="../paper-tabs/paper-tab.html">
 <link rel="import" href="../paper-tabs/paper-tabs.html">
+<link rel="import" href="../paper-toast/paper-toast.html">
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../tf-backend/tf-backend.html">
 <link rel="import" href="../tf-dashboard-common/dashboard-style.html">
@@ -4438,6 +4439,9 @@ limitations under the License.
               : this.strWithModelName_(inferenceValueStr, 0);
           if (this.isRegression_(this.modelType)) {
             this.$.dive.horizontalPosition = this.strWithModelName_(inferenceValueStr, 0);
+            if (this.numModels > 1) {
+              this.$.dive.verticalPosition = this.strWithModelName_(inferenceValueStr, 1);
+            }
           }
           else if (this.isBinaryClassification_(this.modelType, this.multiClass)) {
             if (this.numModels == 1) {
@@ -4704,6 +4708,12 @@ limitations under the License.
         console.error(msg);
       },
 
+      handleError_: function(errorStr) {
+        this.showToast_(errorStr);
+        this.exampleStatusStr = errorStr;
+        this.$.spinner.hidden = true;
+      },
+
       makeAsyncRequest_: function(
           url, thenDoFn, postData, errorFn = () => {}) {
         const wrapperFn = this._canceller.cancellable(result => {
@@ -4711,9 +4721,7 @@ limitations under the License.
             return;
           }
           if (result.value && result.value.error){
-            // show toast with the error
-            this.showToast_(result.value.error);
-            this.$.spinner.hidden = true;
+            this.handleError_(result.value.error);
             if (errorFn != null) {
               errorFn();
             }
@@ -4723,9 +4731,7 @@ limitations under the License.
         });
         this._requestManager.request(url, postData).then(wrapperFn)
             .catch(reason => {
-              this.exampleStatusStr = 'Request failed';
-              this.showToast_('Request failed: ' + reason);
-              this.$.spinner.hidden = true;
+              this.handleError_('Request failed: ' + reason);
               if (errorFn != null) {
                 errorFn();
               }
@@ -5398,16 +5404,6 @@ limitations under the License.
           return null;
         }
         return {step: origValue, scalar: origInferenceScore};
-      },
-
-      showToast: function(msg) {
-        const toast = document.createElement('paper-toast');
-        document.body.appendChild(toast);
-        toast.text = msg;
-        toast.show();
-
-        // Also, log to console.
-        console.error(msg);
       },
 
       deletePdPlotSpinner: function(featureName) {

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -4602,7 +4602,7 @@ limitations under the License.
             this.labelVocab = /** @type {!Array} */ (JSON.parse(result.value.vocab));
             this.inferences = /** @type {!Object} */ (JSON.parse(result.value.inferences));
           };
-          this.makeAsyncRequest_(url, inferContents, null, 'Model inference');
+          this.makeAsyncRequest_(url, inferContents, null, 'model inference');
         }
         this.fire('infer-examples', inferParams);
       },
@@ -4687,7 +4687,7 @@ limitations under the License.
 
           this.makeAsyncRequest_(url, null, {'example': exampleJson,
                                              'index': index},
-                                 'Datapoint update');
+                                 'datapoint update');
         }
       },
 
@@ -4722,7 +4722,7 @@ limitations under the License.
       },
 
       makeAsyncRequest_: function(
-          url, thenDoFn, postData, requestStr, errorFn = () => {}) {
+          url, thenDoFn, postData, readableRequestName, errorFn = () => {}) {
         const wrapperFn = this._canceller.cancellable(result => {
           if (result.cancelled) {
             return;
@@ -4738,7 +4738,8 @@ limitations under the License.
         });
         this._requestManager.request(url, postData).then(wrapperFn)
             .catch(reason => {
-              this.handleError(requestStr + ' failed: ' + reason);
+              this.handleError(
+                  `Request for ${readableRequestName} failed: ${reason}`);
               if (errorFn != null) {
                 errorFn();
               }
@@ -4921,7 +4922,7 @@ limitations under the License.
             result.value.examples, result.value.sprite);
         };
         this.exampleStatusStr = 'Loading datapoints...'
-        this.makeAsyncRequest_(url, updateExampleContents, null, 'Datapoint load');
+        this.makeAsyncRequest_(url, updateExampleContents, null, 'datapoint load');
         this.spinnerHidden_ = false;
       },
 
@@ -4976,7 +4977,7 @@ limitations under the License.
           };
           const url = this.makeUrl_('/data/plugin/whatif/duplicate_example',
             {'index': duplicatedIndex});
-          this.makeAsyncRequest_(url, refreshDiveAfterDuplicate, null, 'Datapoint duplication');
+          this.makeAsyncRequest_(url, refreshDiveAfterDuplicate, null, 'datapoint duplication');
         } else {
           this.refreshDive_();
         }
@@ -5011,7 +5012,7 @@ limitations under the License.
           };
           const url = this.makeUrl_('/data/plugin/whatif/delete_example',
             {'index': deletedIndex});
-          this.makeAsyncRequest_(url, refreshDiveAfterDelete, null, 'Datapoint delete');
+          this.makeAsyncRequest_(url, refreshDiveAfterDelete, null, 'datapoint delete');
         } else {
           this.refreshDive_();
         }
@@ -5469,7 +5470,7 @@ limitations under the License.
           }
           this.makeAsyncRequest_(
             url, chartMakerCallback.bind(this), null,
-            'Plot creation', chartErrorCallback.bind(this));
+            'plot creation', chartErrorCallback.bind(this));
         } else {
           this.fire('infer-mutants', urlParams);
         }
@@ -5659,7 +5660,7 @@ limitations under the License.
           const setEligibleFields = result => {
             this.set('partialDepPlotEligibleFeatures', result.value);
           };
-          this.makeAsyncRequest_(url, setEligibleFields, null, 'Plot setup');
+          this.makeAsyncRequest_(url, setEligibleFields, null, 'plot setup');
         } else {
           this.fire('get-eligible-features');
         }

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
@@ -91,14 +91,13 @@ WIT_HTML = """
       // Javascript callbacks called by python code to communicate with WIT
       // Polymer element.
       window.backendError = errorStr => {{
-        wit.handleError_(errorStr);
+        wit.handleError(errorStr);
       }};
       window.inferenceCallback = inferences => {{
-        const parsedInferences = JSON.parse(inferences);
-        wit.labelVocab = parsedInferences.label_vocab;
-        wit.inferences = parsedInferences.inferences;
+        wit.labelVocab = inferences.label_vocab;
+        wit.inferences = inferences.inferences;
         wit.attributions = {{indices: wit.inferences.indices,
-                            attributions: parsedInferences.attributions}}
+                            attributions: inferences.attributions}}
       }};
       window.spriteCallback = spriteUrl => {{
         if (!wit.updateSprite) {{
@@ -238,10 +237,9 @@ class WitWidget(base.WitWidgetBase):
   def infer(self):
     try:
       inferences = base.WitWidgetBase.infer_impl(self)
-      output.eval_js("""inferenceCallback('{inferences}')""".format(
+      output.eval_js("""inferenceCallback({inferences})""".format(
         inferences=json.dumps(inferences)))
     except Exception as e:
-      error_str = str(e)
       output.eval_js("""backendError('{error}')""".format(
         error=json.dumps(str(e))))
 

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
@@ -200,16 +200,16 @@ class WitWidget(base.WitWidgetBase):
     # Display WIT Polymer element.
     display.display(display.HTML(self._get_element_html()))
     display.display(display.HTML(
-      WIT_HTML.format(height=height, id=self.id)))
+        WIT_HTML.format(height=height, id=self.id)))
 
     # Increment the static instance WitWidget index counter
     WitWidget.index += 1
 
     # Send the provided config and examples to JS
     output.eval_js("""configCallback({config})""".format(
-      config=json.dumps(self.config)))
+        config=json.dumps(self.config)))
     output.eval_js("""updateExamplesCallback({examples})""".format(
-      examples=json.dumps(self.examples)))
+        examples=json.dumps(self.examples)))
     self._generate_sprite()
     self._ctor_complete = True
 
@@ -227,23 +227,23 @@ class WitWidget(base.WitWidgetBase):
       # cell from the cell that displays WIT.
       channel_name = 'updateExamples{}'.format(self.id)
       output.eval_js("""(new BroadcastChannel('{channel_name}')).postMessage(
-        {examples})""".format(
-          examples=json.dumps(self.examples), channel_name=channel_name))
+          {examples})""".format(
+              examples=json.dumps(self.examples), channel_name=channel_name))
       self._generate_sprite()
 
   def infer(self):
     try:
       inferences = base.WitWidgetBase.infer_impl(self)
       output.eval_js("""inferenceCallback({inferences})""".format(
-        inferences=json.dumps(inferences)))
+          inferences=json.dumps(inferences)))
     except Exception as e:
       output.eval_js("""backendError({error})""".format(
-        error=json.dumps({'msg': str(e)})))
+          error=json.dumps({'msg': str(e)})))
 
   def delete_example(self, index):
     self.examples.pop(index)
     self.updated_example_indices = set([
-      i if i < index else i - 1 for i in self.updated_example_indices])
+        i if i < index else i - 1 for i in self.updated_example_indices])
     self._generate_sprite()
 
   def update_example(self, index, example):
@@ -259,16 +259,16 @@ class WitWidget(base.WitWidgetBase):
   def get_eligible_features(self):
     features_list = base.WitWidgetBase.get_eligible_features_impl(self)
     output.eval_js("""eligibleFeaturesCallback({features_list})""".format(
-      features_list=json.dumps(features_list)))
+        features_list=json.dumps(features_list)))
 
   def infer_mutants(self, info):
     try:
       json_mapping = base.WitWidgetBase.infer_mutants_impl(self, info)
       output.eval_js("""inferMutantsCallback({json_mapping})""".format(
-        json_mapping=json.dumps(json_mapping)))
+          json_mapping=json.dumps(json_mapping)))
     except Exception as e:
       output.eval_js("""backendError({error})""".format(
-        error=json.dumps({'msg': str(e)})))
+          error=json.dumps({'msg': str(e)})))
 
   def _generate_sprite(self):
     sprite = base.WitWidgetBase.create_sprite(self)

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
@@ -32,7 +32,7 @@ var WITView = widgets.DOMWidgetView.extend({
         this.eligibleFeaturesChanged, this);
     this.model.on('change:mutant_charts', this.mutantChartsChanged, this);
     this.model.on('change:sprite', this.spriteChanged, this);
-    this.model.on('change:error_str', this.backendError, this);
+    this.model.on('change:error', this.backendError, this);
   },
 
   /**
@@ -231,8 +231,8 @@ var WITView = widgets.DOMWidgetView.extend({
     this.view_.updateSprite();
   },
   backendError: function() {
-    const errorStr = this.model.get('error_str');
-    this.view_.handleError_(errorStr);
+    const error = this.model.get('error');
+    this.view_.handleError_(error['msg']);
   },
 });
 

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
@@ -232,7 +232,7 @@ var WITView = widgets.DOMWidgetView.extend({
   },
   backendError: function() {
     const error = this.model.get('error');
-    this.view_.handleError_(error['msg']);
+    this.view_.handleError(error['msg']);
   },
 });
 

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
@@ -32,6 +32,7 @@ var WITView = widgets.DOMWidgetView.extend({
         this.eligibleFeaturesChanged, this);
     this.model.on('change:mutant_charts', this.mutantChartsChanged, this);
     this.model.on('change:sprite', this.spriteChanged, this);
+    this.model.on('change:error_str', this.backendError, this);
   },
 
   /**
@@ -228,6 +229,10 @@ var WITView = widgets.DOMWidgetView.extend({
     this.view_.hasSprite = true;
     this.view_.localAtlasUrl = spriteUrl;
     this.view_.updateSprite();
+  },
+  backendError: function() {
+    const errorStr = this.model.get('error_str');
+    this.view_.handleError_(errorStr);
   },
 });
 

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/wit.py
@@ -47,6 +47,7 @@ class WitWidget(widgets.DOMWidget, base.WitWidgetBase):
   mutant_charts = Dict([]).tag(sync=True)
   mutant_charts_counter = Int(0)
   sprite = Unicode('').tag(sync=True)
+  error_str = Unicode('').tag(sync=True)
 
   def __init__(self, config_builder, height=1000):
     """Constructor for Jupyter notebook WitWidget.
@@ -67,7 +68,10 @@ class WitWidget(widgets.DOMWidget, base.WitWidgetBase):
 
   @observe('infer')
   def _infer(self, change):
-    self.inferences = base.WitWidgetBase.infer_impl(self)
+    try:
+      self.inferences = base.WitWidgetBase.infer_impl(self)
+    except Exception as e:
+      self.error_str = str(e)
 
   # Observer callbacks for changes from javascript.
   @observe('get_eligible_features')
@@ -78,10 +82,13 @@ class WitWidget(widgets.DOMWidget, base.WitWidgetBase):
   @observe('infer_mutants')
   def _infer_mutants(self, change):
     info = self.infer_mutants
-    json_mapping = base.WitWidgetBase.infer_mutants_impl(self, info)
-    json_mapping['counter'] = self.mutant_charts_counter
-    self.mutant_charts_counter += 1
-    self.mutant_charts = json_mapping
+    try:
+      json_mapping = base.WitWidgetBase.infer_mutants_impl(self, info)
+      json_mapping['counter'] = self.mutant_charts_counter
+      self.mutant_charts_counter += 1
+      self.mutant_charts = json_mapping
+    except Exception as e:
+      self.error_str = str(e)
 
   @observe('update_example')
   def _update_example(self, change):


### PR DESCRIPTION
* Motivation for features / changes

If a model fails to run inference in WitWidget, no error is currently displayed so the user has no idea why WIT isn't working correctly. This change adds in proper error handling.

* Technical description of changes

Updated jupyter and colab witwidget code so that if inference throws any python error, it is properly caught and sent to the frontend.
The frontend now displays that inference error in a toast and in the status message.
Also fixed a small bug where when comparing 2 regression models, the initial Facets Dive view doesn't compare the two models.

* Screenshots of UI changes

![errorwit](https://user-images.githubusercontent.com/15835086/60831278-372f1480-a187-11e9-9179-8bf2d798c651.png)

* Detailed steps to verify changes work correctly (as executed by you)

Ran colab and jupyter notebooks with and without inference errors to see that the error message in both cases gets to the user.
Ran a two-model regression notebook to see proper default Dive display.
