### PR TITLE
core: update polymer2 externs

### DIFF
--- a/tensorboard/components/tf_imports/BUILD
+++ b/tensorboard/components/tf_imports/BUILD
@@ -17,6 +17,7 @@ tf_web_library(
     name = "polymer",
     srcs = [
         "polymer.html",
+        "polymer-externs.html",
         "@org_definitelytyped//:polymer.d.ts"
     ],
     path = "/tf-imports",
@@ -27,19 +28,6 @@ tf_web_library(
         "@org_polymer",
         "@org_polymer_web_animations_js",
         "@org_polymer_webcomponentsjs",
-    ],
-)
-
-tf_web_library(
-    name = "polymer-externs",
-    srcs = [
-        "polymer-externs.html",
-    ],
-    path = "/polymer",
-    visibility = ["//visibility:public"],
-    exports = ["@org_polymer"],
-    deps = [
-        "@org_polymer",
     ],
 )
 

--- a/tensorboard/components/tf_imports/BUILD
+++ b/tensorboard/components/tf_imports/BUILD
@@ -17,17 +17,28 @@ tf_web_library(
     name = "polymer",
     srcs = [
         "polymer.html",
-        "polymer-externs.html",
         "@org_definitelytyped//:polymer.d.ts"
     ],
     path = "/tf-imports",
     visibility = ["//visibility:public"],
     exports = ["@org_polymer"],
     deps = [
+        ":polymer_externs",
         ":webcomponentsjs",
         "@org_polymer",
         "@org_polymer_web_animations_js",
         "@org_polymer_webcomponentsjs",
+    ],
+)
+
+tf_web_library(
+    name = "polymer_externs",
+    srcs = [
+        "polymer-externs.html",
+    ],
+    path = "/tf-imports",
+    deps = [
+        "@org_polymer_externs",
     ],
 )
 

--- a/tensorboard/components/tf_imports/BUILD
+++ b/tensorboard/components/tf_imports/BUILD
@@ -31,6 +31,19 @@ tf_web_library(
 )
 
 tf_web_library(
+    name = "polymer-externs",
+    srcs = [
+        "polymer-externs.html",
+    ],
+    path = "/polymer",
+    visibility = ["//visibility:public"],
+    exports = ["@org_polymer"],
+    deps = [
+        "@org_polymer",
+    ],
+)
+
+tf_web_library(
     name = "lodash",
     srcs = [
         "lodash.html",

--- a/tensorboard/components/tf_imports/polymer-externs.html
+++ b/tensorboard/components/tf_imports/polymer-externs.html
@@ -1,0 +1,4 @@
+<script src="externs/closure-types.js"></script>
+<script src="externs/polymer-externs.js"></script>
+<script src="externs/polymer-internal-shared-types.js"></script>
+<script src="externs/webcomponents-externs.js"></script>

--- a/tensorboard/components/tf_imports/polymer-externs.html
+++ b/tensorboard/components/tf_imports/polymer-externs.html
@@ -1,4 +1,4 @@
-<script src="externs/closure-types.js"></script>
-<script src="externs/polymer-externs.js"></script>
-<script src="externs/polymer-internal-shared-types.js"></script>
-<script src="externs/webcomponents-externs.js"></script>
+<script jscomp-externs src="../polymer/externs/closure-types.js"></script>
+<script jscomp-externs src="../polymer/externs/polymer-externs.js"></script>
+<script jscomp-externs src="../polymer/externs/polymer-internal-shared-types.js"></script>
+<script jscomp-externs src="../polymer/externs/webcomponents-externs.js"></script>

--- a/tensorboard/components/tf_imports/polymer.html
+++ b/tensorboard/components/tf_imports/polymer.html
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<link rel="import" href="polymer-externs.html">
+
 <script src="../web-animations-js/web-animations-next-lite.min.js"></script>
 <!-- NOTE: Instruct Vulcanize to add the source without using JSCompiler.
 Without this, because of [1], JSCompiler omits the source from the output

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
@@ -41,7 +41,6 @@ filegroup(
         # Ordering probably matters
         "//third_party:jspbfix",
         "@com_google_javascript_closure_compiler_externs",
-        "//tensorboard/components/tf_imports:polymer-externs",
         "externs.js",
         "@com_google_javascript_closure_library//:closure/goog/base.js",
         "@com_google_javascript_closure_library//:closure/goog/deps.js",

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
@@ -41,7 +41,7 @@ filegroup(
         # Ordering probably matters
         "//third_party:jspbfix",
         "@com_google_javascript_closure_compiler_externs",
-        "@com_google_javascript_closure_compiler_externs_polymer",
+        "//tensorboard/components/tf_imports:polymer-externs",
         "externs.js",
         "@com_google_javascript_closure_library//:closure/goog/base.js",
         "@com_google_javascript_closure_library//:closure/goog/deps.js",

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -100,7 +100,7 @@ public final class Vulcanize {
   private static final Set<String> legalese = new HashSet<>();
   private static final List<String> licenses = new ArrayList<>();
   private static final List<Webpath> stack = new ArrayList<>();
-  private static final List<SourceFile> externs = new ArrayList<>();
+  private static final Map<String, SourceFile> externs = new LinkedHashMap<>();
   private static final List<SourceFile> sourcesFromJsLibraries = new ArrayList<>();
   private static final Map<Webpath, String> sourcesFromScriptTags = new LinkedHashMap<>();
   private static final Map<Webpath, Node> sourceTags = new LinkedHashMap<>();
@@ -138,7 +138,7 @@ public final class Vulcanize {
         String code = new String(Files.readAllBytes(Paths.get(args[i])), UTF_8);
         SourceFile sourceFile = SourceFile.fromCode(args[i], code);
         if (code.contains("@externs")) {
-          externs.add(sourceFile);
+          externs.put(args[i], sourceFile);
         } else {
           sourcesFromJsLibraries.add(sourceFile);
         }
@@ -323,9 +323,9 @@ public final class Vulcanize {
     boolean wantsMinify = getAttrTransitive(node, "jscomp-minify").isPresent();
 
     if (node.hasAttr("jscomp-externs")) {
-      Path filePath = getWebfile(path);
-      SourceFile sourceFile = SourceFile.fromCode(path.toString(), script);
-      externs.add(sourceFile);
+      String filePath = getWebfile(path).toString();
+      SourceFile sourceFile = SourceFile.fromCode(filePath, script);
+      externs.put(filePath, sourceFile);
       // Remove script tag of extern since it is not needed at the run time.
       return replaceNode(node, new TextNode("", node.baseUri()));
     } else if (node.attr("src").endsWith(".min.js")
@@ -498,6 +498,13 @@ public final class Vulcanize {
               //             https://github.com/google/closure-compiler/pull/1959
               return CheckLevel.OFF;
             }
+            if (error.sourceName.endsWith("externs/webcomponents-externs.js")) {
+              // TODO(stephanwlee): Figure out why above externs cause variable
+              // declare issue. Seems to do with usage of `let` in Polymer 2.x
+              // branch.
+              // Ref: #2425.
+              return CheckLevel.WARNING;
+            }
             if (IGNORE_PATHS_PATTERN.matcher(error.sourceName).matches()) {
               return CheckLevel.OFF;
             }
@@ -528,10 +535,12 @@ public final class Vulcanize {
       sauce.add(SourceFile.fromCode(source.getKey().toString(), source.getValue()));
     }
 
+    List<SourceFile> externsList = new ArrayList<>(externs.values());
+
     // Compile everything into a single script.
     Compiler compiler = new Compiler();
     compiler.disableThreads();
-    Result result = compiler.compile(externs, sauce, options);
+    Result result = compiler.compile(externsList, sauce, options);
     if (!result.success) {
       System.exit(1);
     }

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -149,7 +149,18 @@ public final class Vulcanize {
       }
       Webfiles manifest = loadWebfilesPbtxt(Paths.get(args[i]));
       for (WebfilesSource src : manifest.getSrcList()) {
-        webfiles.put(Webpath.get(src.getWebpath()), Paths.get(src.getPath()));
+        String webpath = src.getWebpath();
+        Path srcPath = Paths.get(src.getPath());
+
+        webfiles.put(Webpath.get(webpath), srcPath);
+
+        if (webpath.startsWith("/polymer/externs")) {
+          String code = new String(Files.readAllBytes(srcPath), UTF_8);
+          SourceFile sourceFile = SourceFile.fromCode(webpath, code);
+          if (code.contains("@externs")) {
+            externs.add(sourceFile);
+          }
+        }
       }
     }
     stack.add(inputPath);
@@ -453,7 +464,7 @@ public final class Vulcanize {
     options.setDependencyOptions(com.google.javascript.jscomp.DependencyOptions.sortOnly());
 
     // Polymer pass.
-    options.setPolymerVersion(1);
+    options.setPolymerVersion(2);
 
     // Debug flags.
     if (testOnly) {

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -150,17 +150,6 @@ def tensorboard_js_workspace():
   )
 
   filegroup_external(
-      name = "com_google_javascript_closure_compiler_externs_polymer",
-      licenses = ["notice"],  # Apache 2.0
-      sha256_urls = {
-          "a537215a0981b2fdd8cb1d12a0ef9f38398f62a5be7885e39de305fa4bd98f54": [
-              "http://mirror.tensorflow.org/raw.githubusercontent.com/google/closure-compiler/v20190121/contrib/externs/polymer-1.0.js",
-              "https://raw.githubusercontent.com/google/closure-compiler/v20190121/contrib/externs/polymer-1.0.js",
-          ],
-      },
-  )
-
-  filegroup_external(
       name = "org_threejs",
       # no @license header
       licenses = ["notice"],  # MIT

--- a/third_party/polymer.bzl
+++ b/third_party/polymer.bzl
@@ -22,16 +22,13 @@ def tensorboard_polymer_workspace():
       licenses = ["notice"],  # BSD-3-Clause
       sha256 = "604dbbb0bc90d833abfc24cbe67e98c628c50ee28a828b8d97551c2732b8e3ba",
       strip_prefix = "polymer-2.7.0",
+      # IMPORTANT: Keep this in sync with @org_polymer_externs
       urls = [
           "http://mirror.tensorflow.org/github.com/polymer/polymer/archive/v2.7.0.tar.gz",
           "https://github.com/polymer/polymer/archive/v2.7.0.tar.gz",
       ],
       path = "/polymer",
       srcs = [
-          "externs/closure-types.js",
-          "externs/polymer-externs.js",
-          "externs/polymer-internal-shared-types.js",
-          "externs/webcomponents-externs.js",
           "lib/elements/array-selector.html",
           "lib/elements/custom-style.html",
           "lib/elements/dom-bind.html",
@@ -78,6 +75,24 @@ def tensorboard_polymer_workspace():
           "polymer.html",
       ],
       deps = ["@org_webcomponents_shadycss"],
+  )
+
+  web_library_external(
+      name = "org_polymer_externs",
+      licenses = ["notice"],  # BSD-3-Clause
+      sha256 = "604dbbb0bc90d833abfc24cbe67e98c628c50ee28a828b8d97551c2732b8e3ba",
+      strip_prefix = "polymer-2.7.0",
+      urls = [
+          "http://mirror.tensorflow.org/github.com/polymer/polymer/archive/v2.7.0.tar.gz",
+          "https://github.com/polymer/polymer/archive/v2.7.0.tar.gz",
+      ],
+      path = "/polymer",
+      srcs = [
+          "externs/closure-types.js",
+          "externs/polymer-externs.js",
+          "externs/polymer-internal-shared-types.js",
+          "externs/webcomponents-externs.js",
+      ],
   )
 
   web_library_external(

--- a/third_party/polymer.bzl
+++ b/third_party/polymer.bzl
@@ -31,6 +31,7 @@ def tensorboard_polymer_workspace():
           "externs/closure-types.js",
           "externs/polymer-externs.js",
           "externs/polymer-internal-shared-types.js",
+          "externs/webcomponents-externs.js",
           "lib/elements/array-selector.html",
           "lib/elements/custom-style.html",
           "lib/elements/dom-bind.html",


### PR DESCRIPTION
### Nature of the change

With the Polymer upgrade, the extern files for JSCompiler is supplied by the Polymer project. We would like to upgrade the type information for better Polymer2 compatibility.

#### About the change in Vulcanize.java
For other externs, in vulcanize/BUILD, we were passing them as files to Vulcanize.java. However, due to the internal restrictions, we can only pass them as a tf_web_library which Vulcanize.java takes as a webfile.pbtxt. Now that externs exist in the webfile.pbtxt, we need to account for that when loading all externs.


Merge plan: squash into polymer2 branch.