### PR TITLE
extract_pip_package: allow specifying output dir

### DIFF
--- a/tensorboard/pip_package/extract_pip_package.sh
+++ b/tensorboard/pip_package/extract_pip_package.sh
@@ -15,7 +15,30 @@
 
 set -eu
 
-tmpdir="$(mktemp -d)"
-tar xzf "$0.runfiles/org_tensorflow_tensorboard/tensorboard/pip_package/pip_packages.tar.gz" \
-    -C "${tmpdir}"
-find "${tmpdir}" | sort
+usage() {
+    cat <<'EOF'
+usage: extract_pip_package [OUTPUT_DIR]
+
+Extract TensorBoard wheel files into a given directory.
+
+If OUTPUT_DIR is omitted, a temporary directory will be created, and its
+path and contents printed to stdout.
+EOF
+}
+
+tarball="$0.runfiles/org_tensorflow_tensorboard/tensorboard/pip_package/pip_packages.tar.gz"
+
+case $# in
+    0)
+        tmpdir="$(mktemp -d)"
+        tar xzf "${tarball}" -C "${tmpdir}"
+        find "${tmpdir}"
+        ;;
+    1)
+        tar xzf "${tarball}" -C "$1"
+        ;;
+    *)
+        usage >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Test Plan:
Old invocation (still works):

```
$ bazel run //tensorboard/pip_package:extract_pip_package
/tmp/tmp.EqS11sTivI
/tmp/tmp.EqS11sTivI/tensorboard-1.15.0a0-py2-none-any.whl
/tmp/tmp.EqS11sTivI/tensorboard-1.15.0a0-py3-none-any.whl
```

New invocation:

```
$ d="$(mktemp -d)"
$ bazel run //tensorboard/pip_package:extract_pip_package -- "${d}"
$ find "${d}"
/tmp/tmp.2Nr0JszquY
/tmp/tmp.2Nr0JszquY/tensorboard-1.15.0a0-py2-none-any.whl
/tmp/tmp.2Nr0JszquY/tensorboard-1.15.0a0-py3-none-any.whl
```

Failure case:

```
$ bazel run //tensorboard/pip_package:extract_pip_package -- w a t
usage: extract_pip_package [OUTPUT_DIR]

Extract TensorBoard wheel files into a given directory.

If OUTPUT_DIR is omitted, a temporary directory will be created, and its
path and contents printed to stdout.
$ echo $?
1
```

wchargin-branch: extract-specific-dir
