### PR TITLE
vulcanize: drop deprecated argument to `TextNode`

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -406,11 +406,7 @@ public final class Vulcanize {
   }
 
   private static Node removeNode(Node node) {
-<<<<<<< HEAD
     return replaceNode(node, new TextNode(""));
-=======
-    return replaceNode(node, new TextNode("", node.baseUri()));
->>>>>>> 237e42c30a2952a72d9ce80adc16ce8541478789
   }
 
   private static Path getWebfile(Webpath path) {

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -277,10 +277,10 @@ public final class Vulcanize {
         if (licenseComment == null) {
           licenseComment = node;
         } else {
-          node = replaceNode(node, new TextNode("", node.baseUri()));
+          node = removeNode(node);
         }
       } else {
-        node = replaceNode(node, new TextNode("", node.baseUri()));
+        node = removeNode(node);
       }
     }
     return node;
@@ -305,7 +305,7 @@ public final class Vulcanize {
       }
       return replaceNode(node, subdocument);
     } else {
-      return replaceNode(node, new TextNode("", node.baseUri()));
+      return removeNode(node);
     }
   }
 
@@ -335,7 +335,7 @@ public final class Vulcanize {
               .removeAttr("jscomp-nocompile");
       if (firstCompiledScript != null) {
         firstCompiledScript.before(newScript);
-        return replaceNode(node, new TextNode("", node.baseUri()));
+        return removeNode(node);
       } else {
         return replaceNode(node, newScript);
       }
@@ -403,6 +403,10 @@ public final class Vulcanize {
   private static Node replaceNode(Node oldNode, Node newNode) {
     oldNode.replaceWith(newNode);
     return newNode;
+  }
+
+  private static Node removeNode(Node node) {
+    return replaceNode(node, new TextNode("", node.baseUri()));
   }
 
   private static Path getWebfile(Webpath path) {

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -406,7 +406,7 @@ public final class Vulcanize {
   }
 
   private static Node removeNode(Node node) {
-    return replaceNode(node, new TextNode("", node.baseUri()));
+    return replaceNode(node, new TextNode(""));
   }
 
   private static Path getWebfile(Webpath path) {


### PR DESCRIPTION
Summary:
The [`TextNode(String, String)` constructor][ctor] is deprecated in
favor of the 1-argument version. The second parameter is unused.

Test Plan:
Built `//tensorboard/components:index.html` before and after this
change, and verified that the two copies are bit-for-bit equivalent.

[ctor]: https://jsoup.org/apidocs/org/jsoup/nodes/TextNode.html#TextNode-java.lang.String-java.lang.String-

wchargin-branch: update-textnode-usage
