### PR TITLE
Add median stats to What-If Tool regression performance stats table

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3507,7 +3507,7 @@ limitations under the License.
             return b.medianError - a.medianError;
           } else if (this.selectedFeatureSort == 'Median absolute error') {
             return b.medianAbsError - a.medianAbsError;
-          } else {
+          } else if (this.selectedFeatureSort == 'Median squared error') {
             return b.medianSquaredError - a.medianSquaredError;
           }
         });

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -2172,8 +2172,11 @@ limitations under the License.
                       <div class="perf-table-val">Feature Value</div>
                       <div class="perf-table-count">Count</div>
                       <div class="perf-table-error">Mean error</div>
+                      <div class="perf-table-error">Median error</div>
                       <div class="perf-table-error">Mean absolute error</div>
+                      <div class="perf-table-error">Median absolute error</div>
                       <div class="perf-table-sq-error">Mean squared error</div>
+                      <div class="perf-table-sq-error">Median squared error</div>
                     </div>
                     <div class="perf-table-entries-holder">
                       <template is="dom-repeat" items="[[regressionEntries_]]">
@@ -2188,10 +2191,19 @@ limitations under the License.
                               [[formatError(item.meanError)]]
                             </div>
                             <div class="perf-table-error perf-table-num-entry perf-table-text-entry">
+                              [[formatError(item.medianError)]]
+                            </div>
+                            <div class="perf-table-error perf-table-num-entry perf-table-text-entry">
                               [[formatError(item.meanAbsError)]]
                             </div>
                             <div class="perf-table-sq-error perf-table-num-entry perf-table-text-entry">
+                              [[formatError(item.medianAbsError)]]
+                            </div>
+                            <div class="perf-table-error perf-table-num-entry perf-table-text-entry">
                               [[formatError(item.meanSquaredError)]]
+                            </div>
+                            <div class="perf-table-sq-error perf-table-num-entry perf-table-text-entry">
+                              [[formatError(item.medianSquaredError)]]
                             </div>
                           </div>
                         </div>
@@ -3491,19 +3503,39 @@ limitations under the License.
             return b.meanAbsError - a.meanAbsError;
           } else if (this.selectedFeatureSort == 'Mean squared error') {
             return b.meanSquaredError - a.meanSquaredError;
+          } else if (this.selectedFeatureSort == 'Median error') {
+            return b.medianError - a.medianError;
+          } else if (this.selectedFeatureSort == 'Median absolute error') {
+            return b.medianAbsError - a.medianAbsError;
+          } else {
+            return b.medianSquaredError - a.medianSquaredError;
           }
         });
       },
 
       fillInRegressionStats: function(regressionStats, name) {
         // From initial regression stats having regression error per example,
-        // calculate mean error, mean abs error, and mean squared error.
+        // calculate error statistics.
         function mean(data) {
           const sum = data.reduce((sum, value) => {
             return sum + value;
           }, 0);
 
           return sum / data.length;
+        }
+        function median(sortedData) {
+          if (sortedData.length == 0) {
+            return NaN;
+          }
+          const midIndex = sortedData.length / 2;
+          if (sortedData.length == 1) {
+            return sortedData[0];
+          } else if (sortedData.length % 2 == 0) {
+            return sortedData[midIndex];
+          } else {
+            return (sortedData[Math.floor(midIndex)] +
+                    sortedData[Math.ceil(midIndex)]) / 2;
+          }
         }
 
         const absErrors = regressionStats.errors.map(err => Math.abs(err));
@@ -3514,6 +3546,9 @@ limitations under the License.
           meanError: mean(regressionStats.errors),
           meanAbsError: mean(absErrors),
           meanSquaredError: mean(squaredErrors),
+          medianError: median(regressionStats.errors.sort((a, b) => a - b)),
+          medianAbsError: median(absErrors.sort((a, b) => a - b)),
+          medianSquaredError: median(squaredErrors.sort((a, b) => a - b)),
           count: regressionStats.errors.length
         };
       },
@@ -5811,7 +5846,9 @@ limitations under the License.
           sorts = sorts.concat(['Accuracy']);
         } else {
           sorts = sorts.concat(
-            ['Mean error', 'Mean absolute error', 'Mean squared error']);
+            ['Mean error', 'Median error', 'Mean absolute error',
+             'Median absolute error', 'Mean squared error',
+             'Median squared error']);
         }
         return sorts;
       },

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3523,10 +3523,11 @@ limitations under the License.
 
           return sum / data.length;
         }
-        function median(sortedData) {
-          if (sortedData.length == 0) {
+        function median(data) {
+          if (data.length == 0) {
             return NaN;
           }
+          const sortedData = data.sort((a, b) => a - b);
           const midIndex = sortedData.length / 2;
           if (sortedData.length == 1) {
             return sortedData[0];
@@ -3546,9 +3547,9 @@ limitations under the License.
           meanError: mean(regressionStats.errors),
           meanAbsError: mean(absErrors),
           meanSquaredError: mean(squaredErrors),
-          medianError: median(regressionStats.errors.sort((a, b) => a - b)),
-          medianAbsError: median(absErrors.sort((a, b) => a - b)),
-          medianSquaredError: median(squaredErrors.sort((a, b) => a - b)),
+          medianError: median(regressionStats.errors),
+          medianAbsError: median(absErrors),
+          medianSquaredError: median(squaredErrors),
           count: regressionStats.errors.length
         };
       },


### PR DESCRIPTION
* Motivation for features / changes

Users asked for median error stats in addition to current mean error stats

* Technical description of changes

Added calculation of, and display of, median error, median absolute error, and median squared error to the regression performance table.

* Screenshots of UI changes

![medians](https://user-images.githubusercontent.com/15835086/61384844-64627d80-a87f-11e9-9207-61ade70ccf8e.png)

* Detailed steps to verify changes work correctly (as executed by you)

Ran regression demo and viewed performance stats in total and broken down into slices. Verified correct median numbers and that sorting by those new columns worked.
