### PR TITLE
Revert "vulcanize: drop deprecated argument to `TextNode` (#2430)"

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -406,7 +406,7 @@ public final class Vulcanize {
   }
 
   private static Node removeNode(Node node) {
-    return replaceNode(node, new TextNode(""));
+    return replaceNode(node, new TextNode("", node.baseUri()));
   }
 
   private static Path getWebfile(Webpath path) {


### PR DESCRIPTION
This reverts commit 22ec90da870ac4b98cb3dd1198358dd54f18a925.

Internal version of jsoup is old and is compatible with the change. 