### PR TITLE
fix: update polymer dependency to legacy targets

### DIFF
--- a/tensorboard/components/tf_backend/BUILD
+++ b/tensorboard/components/tf_backend/BUILD
@@ -45,8 +45,8 @@ tensorboard_webcomponent_library(
     srcs = [":tf_backend"],
     destdir = "tf-backend",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/components/vz_sorting:legacy",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/components/tf_card_heading/BUILD
+++ b/tensorboard/components/tf_card_heading/BUILD
@@ -30,10 +30,10 @@ tensorboard_webcomponent_library(
     visibility = ["//visibility:public"],
     destdir = "tf-card-heading",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_markdown_view:legacy",
         "//third_party/javascript/polymer/v1/paper-dialog:lib",
         "//third_party/javascript/polymer/v1/paper-dialog-scrollable:lib",
         "//third_party/javascript/polymer/v1/paper-icon-button:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/components/tf_color_scale/BUILD
+++ b/tensorboard/components/tf_color_scale/BUILD
@@ -28,7 +28,7 @@ tensorboard_webcomponent_library(
     destdir = "tf-color-scale",
     deps = [
         "//tensorboard/components/tf_backend:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/components/tf_dashboard_common/BUILD
+++ b/tensorboard/components/tf_dashboard_common/BUILD
@@ -79,6 +79,7 @@ tensorboard_webcomponent_library(
     srcs = [":tf_dashboard_common"],
     destdir = "tf-dashboard-common",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/components/tf_storage:legacy",
         "//tensorboard/components/vz_sorting:legacy",
@@ -97,6 +98,5 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/paper-spinner:lib",
         "//third_party/javascript/polymer/v1/paper-styles:lib",
         "//third_party/javascript/polymer/v1/paper-toggle-button:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/components/tf_imports/BUILD
+++ b/tensorboard/components/tf_imports/BUILD
@@ -1,5 +1,6 @@
 package(default_visibility = ["//tensorboard:internal"])
 
+load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:hacks.bzl", "tensorboard_typescript_bundle")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
@@ -31,6 +32,19 @@ tf_web_library(
     ],
 )
 
+tensorboard_webcomponent_library(
+    name = "polymer_lib",
+    srcs = [":polymer"],
+    visibility = ["//visibility:public"],
+    destdir = "tf-imports",
+    deps = [
+        ":polymer_externs_lib",
+        "//third_party/javascript/polymer/v1/web-animations-js:other-js",
+        "//third_party/javascript/polymer/v2/polymer:lib",
+        "//third_party/javascript/polymer/v2/webcomponentsjs:lib",
+    ],
+)
+
 tf_web_library(
     name = "polymer_externs",
     srcs = [
@@ -40,6 +54,13 @@ tf_web_library(
     deps = [
         "@org_polymer_externs",
     ],
+)
+
+tensorboard_webcomponent_library(
+    name = "polymer_externs_lib",
+    srcs = [":polymer_externs"],
+    destdir = "tf-imports",
+    deps = ["//third_party/javascript/polymer/v2/polymer:other-js"],
 )
 
 tf_web_library(

--- a/tensorboard/components/tf_line_chart_data_loader/BUILD
+++ b/tensorboard/components/tf_line_chart_data_loader/BUILD
@@ -32,9 +32,9 @@ tensorboard_webcomponent_library(
         "//tensorboard/components/tf_backend:legacy",
         "//tensorboard/components/tf_color_scale:legacy",
         "//tensorboard/components/tf_dashboard_common:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/components/vz_line_chart2:legacy",
         "//third_party/javascript/polymer/v1/paper-spinner:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/components/tf_markdown_view/BUILD
+++ b/tensorboard/components/tf_markdown_view/BUILD
@@ -22,7 +22,7 @@ tensorboard_webcomponent_library(
     visibility = ["//visibility:public"],
     destdir = "tf-markdown-view",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//third_party/javascript/polymer/v1/paper-styles:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/components/tf_storage/BUILD
+++ b/tensorboard/components/tf_storage/BUILD
@@ -26,7 +26,7 @@ tensorboard_webcomponent_library(
     destdir = "tf-storage",
     deps = [
         "//tensorboard/components/tf_globals:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/components/vz_chart_helpers/BUILD
+++ b/tensorboard/components/vz_chart_helpers/BUILD
@@ -31,8 +31,8 @@ tensorboard_webcomponent_library(
     visibility = ["//visibility:public"],
     destdir = "vz-chart-helpers",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/components/vz_sorting:legacy",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/components/vz_line_chart/BUILD
+++ b/tensorboard/components/vz_line_chart/BUILD
@@ -65,7 +65,7 @@ tensorboard_webcomponent_library(
     destdir = "vz-line-chart",
     deps = [
         ":dragZoomInteraction_legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/components/vz_line_chart2/BUILD
+++ b/tensorboard/components/vz_line_chart2/BUILD
@@ -34,9 +34,9 @@ tensorboard_webcomponent_library(
     srcs = [":vz_line_chart2"],
     destdir = "vz-line-chart2",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/components/vz_chart_helpers:legacy",
         "//tensorboard/components/vz_line_chart:dragZoomInteraction_legacy",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/graph/tf_graph/BUILD
+++ b/tensorboard/plugins/graph/tf_graph/BUILD
@@ -34,6 +34,7 @@ tensorboard_webcomponent_library(
     destdir = "tf-graph",
     deps = [
         "//tensorboard/components/tf_dashboard_common:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/plugins/graph/tf_graph_common:legacy",
         "//third_party/javascript/polymer/v1/iron-flex-layout:lib",
         "//third_party/javascript/polymer/v1/iron-icons:lib",
@@ -43,6 +44,5 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/paper-radio-group:lib",
         "//third_party/javascript/polymer/v1/paper-toggle-button:lib",
         "//third_party/javascript/polymer/v1/paper-tooltip:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/graph/tf_graph_app/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_app/BUILD
@@ -24,6 +24,7 @@ tensorboard_webcomponent_library(
     srcs = [":tf_graph_app"],
     destdir = "tf-graph-app",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/plugins/graph/tf_graph_board:legacy",
         "//tensorboard/plugins/graph/tf_graph_controls:legacy",
         "//tensorboard/plugins/graph/tf_graph_loader:legacy",

--- a/tensorboard/plugins/graph/tf_graph_board/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_board/BUILD
@@ -24,10 +24,10 @@ tensorboard_webcomponent_library(
     srcs = [":tf_graph_board"],
     destdir = "tf-graph-board",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/plugins/graph/tf_graph:legacy",
         "//tensorboard/plugins/graph/tf_graph_common:legacy",
         "//tensorboard/plugins/graph/tf_graph_info:legacy",
         "//third_party/javascript/polymer/v1/paper-progress:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/graph/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_common/BUILD
@@ -51,7 +51,7 @@ tensorboard_webcomponent_library(
     destdir = "tf-graph-common",
     deps = [
         "//tensorboard/components/tf_dashboard_common:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/graph/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_controls/BUILD
@@ -35,6 +35,7 @@ tensorboard_webcomponent_library(
     destdir = "tf-graph-controls",
     deps = [
         "//tensorboard/components/tf_dashboard_common:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/plugins/graph/tf_graph_common:legacy",
         "//tensorboard/plugins/graph/tf_graph_node_search:legacy",
         "//third_party/javascript/polymer/v1/paper-button:lib",
@@ -45,6 +46,5 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/paper-radio-group:lib",
         "//third_party/javascript/polymer/v1/paper-toggle-button:lib",
         "//third_party/javascript/polymer/v1/paper-tooltip:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/graph/tf_graph_dashboard/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/BUILD
@@ -31,11 +31,11 @@ tensorboard_webcomponent_library(
     deps = [
         "//tensorboard/components/tf_backend:legacy",
         "//tensorboard/components/tf_dashboard_common:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/vz_sorting:legacy",
         "//tensorboard/plugins/graph/tf_graph:legacy",
         "//tensorboard/plugins/graph/tf_graph_board:legacy",
         "//tensorboard/plugins/graph/tf_graph_controls:legacy",
         "//tensorboard/plugins/graph/tf_graph_loader:legacy_dashboard_loader",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/graph/tf_graph_debugger_data_card/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_debugger_data_card/BUILD
@@ -28,6 +28,7 @@ tensorboard_webcomponent_library(
     destdir = "tf-graph-debugger-data-card",
     deps = [
         "//tensorboard/components/tf_dashboard_common:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/plugins/graph/tf_graph_common:legacy",
         "//third_party/javascript/polymer/v1/iron-collapse:lib",
         "//third_party/javascript/polymer/v1/iron-list:lib",
@@ -36,6 +37,5 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/paper-material:paper-material-html",
         "//third_party/javascript/polymer/v1/paper-slider:lib",
         "//third_party/javascript/polymer/v1/paper-spinner:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/graph/tf_graph_info/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_info/BUILD
@@ -36,6 +36,7 @@ tensorboard_webcomponent_library(
     destdir = "tf-graph-info",
     deps = [
         "//tensorboard/components/tf_dashboard_common:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/plugins/graph/tf_graph_common:legacy",
         "//tensorboard/plugins/graph/tf_graph_debugger_data_card:legacy",
         "//tensorboard/plugins/graph/tf_graph_op_compat_card:legacy",
@@ -46,6 +47,5 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/paper-material:paper-material-html",
         "//third_party/javascript/polymer/v1/paper-slider:lib",
         "//third_party/javascript/polymer/v1/paper-spinner:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/graph/tf_graph_loader/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_loader/BUILD
@@ -24,8 +24,8 @@ tensorboard_webcomponent_library(
     srcs = [":tf_graph_loader"],
     destdir = "tf-graph-loader",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/plugins/graph/tf_graph_common:legacy",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )
 
@@ -51,8 +51,8 @@ tensorboard_webcomponent_library(
     destdir = "tf-graph-loader",
     deps = [
         "//tensorboard/components/tf_backend:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/plugins/graph/tf_graph_common:legacy",
         "//tensorboard/plugins/graph/tf_graph_controls:legacy",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/BUILD
@@ -29,12 +29,12 @@ tensorboard_webcomponent_library(
     destdir = "tf-graph-op-compat-card",
     deps = [
         "//tensorboard/components/tf_dashboard_common:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/plugins/graph/tf_graph_common:legacy",
         "//third_party/javascript/polymer/v1/iron-collapse:lib",
         "//third_party/javascript/polymer/v1/iron-list:lib",
         "//third_party/javascript/polymer/v1/paper-icon-button:lib",
         "//third_party/javascript/polymer/v1/paper-item:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
         "//third_party/tensorboard/plugins/graph/tf_graph_info:tf_graph_icon_legacy",
     ],
 )

--- a/tensorboard/plugins/histogram/vz_histogram_timeseries/BUILD
+++ b/tensorboard/plugins/histogram/vz_histogram_timeseries/BUILD
@@ -34,7 +34,7 @@ tensorboard_webcomponent_library(
     visibility = ["//learning/vis/vz_elements/catalog:__pkg__"],
     destdir = "vz-histogram-timeseries",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/hparams/tf_hparams_google_analytics_tracker/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_google_analytics_tracker/BUILD
@@ -44,6 +44,6 @@ tensorboard_webcomponent_library(
     srcs = [":tf_hparams_google_analytics_tracker"],
     destdir = "tf-hparams-google-analytics-tracker",
     deps = [
-        "//third_party/javascript/polymer/v1/polymer:lib",
+        "//tensorboard/components/tf_imports:polymer_lib",
     ],
 )

--- a/tensorboard/plugins/hparams/tf_hparams_main/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_main/BUILD
@@ -30,10 +30,10 @@ tensorboard_webcomponent_library(
     visibility = ["//tensorboard/plugins/hparams/external_users:whitelist"],
     destdir = "tf-hparams-main",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/plugins/hparams/tf_hparams_google_analytics_tracker:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_query_pane:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_sessions_pane:legacy",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/BUILD
@@ -54,9 +54,9 @@ tensorboard_webcomponent_library(
     srcs = [":tf_hparams_parallel_coords_plot"],
     destdir = "tf-hparams-parallel-coords-plot",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/plugins/hparams/tf_hparams_session_group_values:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_utils:legacy",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_view/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_view/BUILD
@@ -27,11 +27,11 @@ tensorboard_webcomponent_library(
     srcs = [":tf_hparams_parallel_coords_view"],
     destdir = "tf-hparams-parallel-coords-view",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_scale_and_color_controls:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_session_group_details:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_session_group_values:legacy",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/BUILD
@@ -61,6 +61,7 @@ tensorboard_webcomponent_library(
     destdir = "tf-hparams-query-pane",
     deps = [
         "//tensorboard/components/tf_backend:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/plugins/hparams/tf_hparams_utils:legacy",
         "//third_party/javascript/polymer/v1/paper-checkbox:lib",
@@ -68,6 +69,5 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/paper-input:lib",
         "//third_party/javascript/polymer/v1/paper-item:lib",
         "//third_party/javascript/polymer/v1/paper-listbox:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/hparams/tf_hparams_scale_and_color_controls/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_scale_and_color_controls/BUILD
@@ -49,6 +49,7 @@ tensorboard_webcomponent_library(
     srcs = [":tf_hparams_scale_and_color_controls"],
     destdir = "tf-hparams-scale-and-color-controls",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/plugins/hparams/tf_hparams_utils:legacy",
         "//third_party/javascript/polymer/v1/paper-dropdown-menu:lib",
@@ -56,6 +57,5 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/paper-listbox:lib",
         "//third_party/javascript/polymer/v1/paper-radio-button:lib",
         "//third_party/javascript/polymer/v1/paper-radio-group:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot/BUILD
@@ -25,8 +25,8 @@ tensorboard_webcomponent_library(
     srcs = [":tf_hparams_scatter_plot_matrix_plot"],
     destdir = "tf-hparams-scatter-plot-matrix-plot",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/plugins/hparams/tf_hparams_utils:legacy",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_view/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_view/BUILD
@@ -27,11 +27,11 @@ tensorboard_webcomponent_library(
     srcs = [":tf_hparams_scatter_plot_matrix_view"],
     destdir = "tf-hparams-scatter-plot-matrix-view",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/plugins/hparams/tf_hparams_scale_and_color_controls:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_session_group_details:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_session_group_values:legacy",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/hparams/tf_hparams_session_group_details/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_session_group_details/BUILD
@@ -31,10 +31,10 @@ tensorboard_webcomponent_library(
     deps = [
         "//tensorboard/components/tf_backend:legacy",
         "//tensorboard/components/tf_color_scale:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/plugins/hparams/tf_hparams_utils:legacy",
         "//tensorboard/plugins/scalar/tf_scalar_dashboard:tf_scalar_card_legacy",
         "//third_party/javascript/polymer/v1/iron-flex-layout:lib",
         "//third_party/javascript/polymer/v1/iron-resizable-behavior:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/hparams/tf_hparams_session_group_values/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_session_group_values/BUILD
@@ -25,8 +25,8 @@ tensorboard_webcomponent_library(
     visibility = ["//visibility:public"],
     destdir = "tf-hparams-session-group-values",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/plugins/hparams/tf_hparams_table_view:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_utils:legacy",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/hparams/tf_hparams_sessions_pane/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_sessions_pane/BUILD
@@ -32,6 +32,7 @@ tensorboard_webcomponent_library(
     srcs = [":tf_hparams_sessions_pane"],
     destdir = "tf-hparams-sessions-pane",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/plugins/hparams/tf_hparams_parallel_coords_view:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_view:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_table_view:legacy",
@@ -41,6 +42,5 @@ tensorboard_webcomponent_library(
         "//third_party/javascript/polymer/v1/paper-icon-button:lib",
         "//third_party/javascript/polymer/v1/paper-tabs:lib",
         "//third_party/javascript/polymer/v1/paper-toolbar:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/hparams/tf_hparams_table_view/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_table_view/BUILD
@@ -26,9 +26,9 @@ tensorboard_webcomponent_library(
     srcs = [":tf_hparams_table_view"],
     destdir = "tf-hparams-table-view",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
         "//tensorboard/plugins/hparams/tf_hparams_session_group_details:legacy",
         "//tensorboard/plugins/hparams/tf_hparams_utils:legacy",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/profile/tf_profile_common/BUILD
+++ b/tensorboard/plugins/profile/tf_profile_common/BUILD
@@ -22,7 +22,7 @@ tensorboard_webcomponent_library(
     srcs = [":tf_profile_common"],
     destdir = "tf-profile-common",
     deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -68,12 +68,12 @@ tensorboard_webcomponent_library(
     deps = [
         "//tensorboard/components/tf_backend:legacy",
         "//tensorboard/components/tf_card_heading:legacy",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_line_chart_data_loader:legacy",
         "//third_party/javascript/polymer/v1/paper-dropdown-menu:lib",
         "//third_party/javascript/polymer/v1/paper-icon-button:lib",
         "//third_party/javascript/polymer/v1/paper-item:lib",
         "//third_party/javascript/polymer/v1/paper-listbox:lib",
         "//third_party/javascript/polymer/v1/paper-menu-button:lib",
-        "//third_party/javascript/polymer/v1/polymer:lib",
     ],
 )


### PR DESCRIPTION
For the google sync, TensorBoard have the legacy
tensorboard_webcomponent_library targets. Stale dependencies aside, now
in TensorBoard, we depend on tf_imports:polymer instead of the polymer
directly. This change reflects that.