### PR TITLE
build: fix JSComp removing methods issue

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -448,6 +448,9 @@ public final class Vulcanize {
     options.setRemoveUnusedPrototypeProperties(false);
     options.setRemoveUnusedPrototypePropertiesInExterns(false);
     options.setRemoveUnusedClassProperties(false);
+    // Prevent Polymer bound method (invisible to JSComp) to be over-optimized.
+    options.setInlineFunctions(CompilerOptions.Reach.NONE);
+    options.setDevirtualizeMethods(false);
 
     // Dependency management.
     options.setClosurePass(true);


### PR DESCRIPTION
There were cases when JSComp removed Polymer bound methods (invisible to
JSComp) away from compiled binary (e.g., inlined into another method).
This change prevents such optimization.

Fixes #2451. Fixes #2447.