### PR TITLE
[debugger plugin] Fix panToNode

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/scene.ts
@@ -201,10 +201,10 @@ module tf.graph.scene {
  *            provided node.
  */
 export function panToNode(nodeName: String, svg, zoomG, d3zoom): boolean {
-  let node = <SVGAElement>d3
-                 .select('[data-name="' + nodeName + '"].' + Class.Node.GROUP)
-                 .node();
+  const node = <SVGAElement>d3
+                   .select(svg).select(`[data-name="${nodeName}"]`).node();
   if (!node) {
+    console.warn(`panToNode() failed for node name "${nodeName}"`);
     return false;
   }
 


### PR DESCRIPTION
* Motivation for features / changes
  * Fixes https://github.com/tensorflow/tensorboard/issues/2455
  * Fixes an issue in graph scene.ts panToNode() method. It fails to find the correct node element. 

* Technical description of changes
  * Fix the logic by which svg node elements are found in panToNode().

* Screenshots of UI changes
  * Now panToNode() works:
    ![image](https://user-images.githubusercontent.com/16824702/61889013-aec4a980-aed2-11e9-8d37-58c0c80195d8.png)

* Detailed steps to verify changes work correctly (as executed by you)
  * Manual verification by using the Debugger Plugin with a Keras Model.fit() call with tfdbg TensorBoardDebugWrapperSession().

* Alternate designs / implementations considered
