### PR TITLE
What-If Tool: Fix error message overflow issue

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -159,6 +159,7 @@ limitations under the License.
 
       .settings-button {
         margin-top: 4px;
+        min-width: 40px;
       }
 
       .button {
@@ -400,6 +401,7 @@ limitations under the License.
       .datapoint-right-controls-holder {
         display: flex;
         flex-direction: row-reverse;
+        overflow: hidden;
       }
 
       .tf-category-pane {
@@ -736,6 +738,7 @@ limitations under the License.
         color: #5F6368;
         white-space: nowrap;
         overflow: hidden;
+        text-overflow: ellipsis;
         padding-top: 16px;
       }
 

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -159,7 +159,10 @@ limitations under the License.
 
       .settings-button {
         margin-top: 4px;
-        min-width: 40px;
+      }
+
+      .datapoint-right-controls-holder .control {
+        flex-shrink: 0;
       }
 
       .button {
@@ -1306,10 +1309,10 @@ limitations under the License.
                   </paper-tabs>
                 </div>
                 <div class="datapoint-right-controls-holder">
-                  <a target="_blank" href="https://github.com/tensorflow/tensorboard/tree/master/tensorboard/plugins/interactive_inference/README.md">
+                  <a target="_blank" class="control" href="https://github.com/tensorflow/tensorboard/tree/master/tensorboard/plugins/interactive_inference/README.md">
                     <paper-icon-button icon="help-outline" class="settings-button" title="What-If Tool documentation"></paper-icon-button>
                   </a>
-                  <paper-icon-button icon="settings" on-tap="settingsClicked_" class="settings-button" title="What-If Tool settings" disabled$="[[local]]"></paper-icon-button>
+                  <paper-icon-button icon="settings" on-tap="settingsClicked_" class="settings-button control" title="What-If Tool settings" disabled$="[[local]]"></paper-icon-button>
                   <div class="example-status">[[exampleStatusStr]]</div>
                 </div>
               </div>

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -742,7 +742,7 @@ limitations under the License.
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        padding-top: 16px;
+        padding-top: 20px;
       }
 
       .example-id-label {


### PR DESCRIPTION
* Motivation for features / changes

Long WIT error messages caused text overflow, hiding some controls.

* Technical description of changes

Added correct CSS rules to avoid overflow issue and to ellipsis the status string. The full error string is already shown in a toast as well.

* Screenshots of UI changes

Fixed:
![overflow](https://user-images.githubusercontent.com/15835086/61901029-d9236080-aeec-11e9-9728-28f85ae1d1d1.png)

* Detailed steps to verify changes work correctly (as executed by you)

Ran demo app, added fake very long error message, verified correct visual behavior (and incorrect behavior before fix).

