### PR TITLE
build_pip_package: print build log on failure

### DIFF
--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -52,13 +52,9 @@ main() {
   trap cleanup EXIT
 
   log_file="${workdir}/log"
-  suppress_log() {
-    rm "${workdir}/log" || true
-  }
-
-  build 3>&1 4>&2 1>"${log_file}" 2>&1
+  build >"${log_file}" 2>&1
   exit_code=$?
-  if [ "${exit_code}" -ne 0 ] && [ -f "${log_file}" ]; then
+  if [ "${exit_code}" -ne 0 ]; then
     cat "${log_file}" >&2
   fi
   return "${exit_code}"
@@ -127,8 +123,7 @@ build() (
       ;;
     *)
       if ! [ -d "${output}" ]; then
-        printf >&4 'fatal: no such output directory: %s\n' "${output}"
-        suppress_log
+        printf >&2 'fatal: no such output directory: %s\n' "${output}"
         return 1
       fi
       mv "${workdir}"/dist/*.whl "${output}"


### PR DESCRIPTION
Summary:
We don’t use `set -x` indiscriminately because build tool output appears
in Bazel logs, and that would be a lot of spam. But we should print
output on failures, to clarify the cause of issues like #2458.

The original version of #2363 had this functionality in the BUILD rule
itself, but @nfelt found that the multiple layers of escaping made this
a bit hard to read (fair enough), so we now include the relevant
functionality in `build_pip_package.sh`.

Recommend ignoring whitespace for reading this patch.

Test Plan:
Building `//tensorboard/pip_package` on a machine with no `virtualenv`
binary now prints:

```
ERROR: /home/wchargin/tensorboard/tensorboard/pip_package/BUILD:8:1: Executing genrule //tensorboard/pip_package:pip_package failed (Exit 127) bash failed: error executing command /bin/bash -c ... (remaining 1 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
++ uname
+ [ Linux = Darwin ]
+ sedi=sed -i
+ command -v virtualenv
Target //tensorboard/pip_package:pip_package failed to build
Use --verbose_failures to see the command lines of failed build steps.
FAILED: Build did NOT complete successfully
```

which is pretty clear that the problem is that `virtualenv` is not
installed. After installing `virtualenv`, the build completes
successfully with no output, as desired.

wchargin-branch: pip-package-error-handling
