### PR TITLE
[debugger plugin] Temporary solution to avoid double stamping

### DIFF
--- a/tensorboard/plugins/debugger/BUILD
+++ b/tensorboard/plugins/debugger/BUILD
@@ -330,6 +330,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        ":constants",
         ":debugger_plugin",
         ":interactive_debugger_plugin",
         "//tensorboard/plugins:base_plugin",

--- a/tensorboard/plugins/debugger/BUILD
+++ b/tensorboard/plugins/debugger/BUILD
@@ -333,8 +333,10 @@ py_library(
         ":constants",
         ":debugger_plugin",
         ":interactive_debugger_plugin",
+        "//tensorboard/backend:http_util",
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/util:tb_logging",
+        "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/plugins/debugger/debugger_plugin.py
+++ b/tensorboard/plugins/debugger/debugger_plugin.py
@@ -152,8 +152,6 @@ class DebuggerPlugin(base_plugin.TBPlugin):
             constants.DEBUGGER_PLUGIN_NAME))
 
   def frontend_metadata(self):
-    # TODO(#2338): Keep this in sync with the `registerDashboard` call
-    # on the frontend until that call is removed.
     return super(DebuggerPlugin, self).frontend_metadata()._replace(
         element_name='tf-debugger-dashboard',
     )

--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -123,7 +123,8 @@ the interactive Debugger Dashboard. This flag is mutually exclusive with
       noninteractive_plugin.listen(flags.debugger_data_server_grpc_port)
       return noninteractive_plugin
     else:
-      # We always instantiate the interactive Debugger Plugin. If debugger_port
+      # If debugger_data_server_grpc_port flag is not specified, we always
+      # instantiate the interactive Debugger Plugin. If debugger_port
       # is not specified (i.e., defaults to -1), the frontend will display a
       # message indicating that the plugin is not active. It'll also display
       # a command snippet to illustrate how to activate the interactive Debugger

--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -152,19 +152,16 @@ the interactive Debugger Dashboard. This flag is mutually exclusive with
       # pylint: disable=line-too-long,g-import-not-at-top
       from tensorboard.plugins.debugger import interactive_debugger_plugin as interactive_debugger_plugin_lib
       # pylint: enable=line-too-long,g-import-not-at-top
-
-      # If debugger_data_server_grpc_port flag is not specified, we always
-      # instantiate the interactive Debugger Plugin. If debugger_port
-      # is not specified (i.e., defaults to -1), the frontend will display a
-      # message indicating that the plugin is not active. It'll also display
-      # a command snippet to illustrate how to activate the interactive Debugger
-      # Plugin.
       interactive_plugin = (
           interactive_debugger_plugin_lib.InteractiveDebuggerPlugin(context))
-      if flags.debugger_port > 0:
-        logger.info('Starting Interactive Debugger Plugin at gRPC port %d',
-                    flags.debugger_data_server_grpc_port)
-        interactive_plugin.listen(flags.debugger_port)
+      logger.info('Starting Interactive Debugger Plugin at gRPC port %d',
+                  flags.debugger_data_server_grpc_port)
+      interactive_plugin.listen(flags.debugger_port)
       return interactive_plugin
     else:
+      # If neither the debugger_data_server_grpc_port flag or the grpc_port
+      # flag is specified, we instantiate a dummy plugin as a placeholder for
+      # the frontend. The dummy plugin will display a message indicating that
+      # the plugin is not active. It'll also display a command snippet to
+      # illustrate how to activate the interactive Debugger Plugin.
       return InactiveDebuggerPlugin()

--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -92,27 +92,29 @@ the interactive Debugger Dashboard. This flag is mutually exclusive with
       A DebuggerPlugin instance or None if it couldn't be loaded.
     """
     flags = context.flags
-    try:
-      # pylint: disable=g-import-not-at-top,unused-import
-      import tensorflow
-    except ImportError:
-      raise ImportError(
-          'To use the debugger plugin, you need to have TensorFlow installed:\n'
-          '  pip install tensorflow')
-    try:
-      # pylint: disable=line-too-long,g-import-not-at-top
-      from tensorboard.plugins.debugger import debugger_plugin as debugger_plugin_lib
-      from tensorboard.plugins.debugger import interactive_debugger_plugin as interactive_debugger_plugin_lib
-      # pylint: enable=line-too-long,g-import-not-at-top
-    except ImportError as e:
-      e_type, e_value, e_traceback = sys.exc_info()
-      message = e.msg if hasattr(e, 'msg') else e.message  # Handle py2 vs py3
-      if 'grpc' in message:
-        e_value = ImportError(
-            message +
-            '\n\nTo use the debugger plugin, you need to have '
-            'gRPC installed:\n  pip install grpcio')
-      six.reraise(e_type, e_value, e_traceback)
+    if flags.debugger_data_server_grpc_port > 0 or flags.debugger_port > 0:
+      # Verify that the required Python packages are installed.
+      try:
+        # pylint: disable=g-import-not-at-top,unused-import
+        import tensorflow
+      except ImportError:
+        raise ImportError(
+            'To use the debugger plugin, you need to have TensorFlow installed:\n'
+            '  pip install tensorflow')
+      try:
+        # pylint: disable=line-too-long,g-import-not-at-top
+        from tensorboard.plugins.debugger import debugger_plugin as debugger_plugin_lib
+        from tensorboard.plugins.debugger import interactive_debugger_plugin as interactive_debugger_plugin_lib
+        # pylint: enable=line-too-long,g-import-not-at-top
+      except ImportError as e:
+        e_type, e_value, e_traceback = sys.exc_info()
+        message = e.msg if hasattr(e, 'msg') else e.message  # Handle py2 vs py3
+        if 'grpc' in message:
+          e_value = ImportError(
+              message +
+              '\n\nTo use the debugger plugin, you need to have '
+              'gRPC installed:\n  pip install grpcio')
+        six.reraise(e_type, e_value, e_traceback)
 
     if flags.debugger_data_server_grpc_port > 0:
       # debugger_data_server_grpc opens the non-interactive Debugger Plugin,

--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -23,6 +23,8 @@ import sys
 import six
 
 from tensorboard.plugins import base_plugin
+from tensorboard.plugins.debugger import debugger_plugin as debugger_plugin_lib
+from tensorboard.plugins.debugger import interactive_debugger_plugin as interactive_debugger_plugin_lib
 from tensorboard.util import tb_logging
 
 logger = tb_logging.get_logger()
@@ -101,20 +103,6 @@ the interactive Debugger Dashboard. This flag is mutually exclusive with
         raise ImportError(
             'To use the debugger plugin, you need to have TensorFlow installed:\n'
             '  pip install tensorflow')
-      try:
-        # pylint: disable=line-too-long,g-import-not-at-top
-        from tensorboard.plugins.debugger import debugger_plugin as debugger_plugin_lib
-        from tensorboard.plugins.debugger import interactive_debugger_plugin as interactive_debugger_plugin_lib
-        # pylint: enable=line-too-long,g-import-not-at-top
-      except ImportError as e:
-        e_type, e_value, e_traceback = sys.exc_info()
-        message = e.msg if hasattr(e, 'msg') else e.message  # Handle py2 vs py3
-        if 'grpc' in message:
-          e_value = ImportError(
-              message +
-              '\n\nTo use the debugger plugin, you need to have '
-              'gRPC installed:\n  pip install grpcio')
-        six.reraise(e_type, e_value, e_traceback)
 
     if flags.debugger_data_server_grpc_port > 0:
       # debugger_data_server_grpc opens the non-interactive Debugger Plugin,

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -855,14 +855,15 @@ limitations under the License.
         const url = tf_backend.getRouter().pluginRoute(
             'debugger', '/debugger_grpc_host_port');
         this._requestManager.request(url).then(response => {
-          // TODO(cais): If the TDP backend is not activated, display message
+          // TODO(cais): If the Debugger Plugin backend is not activated, display message
           // informing the user of that.
-          this.$.initialDialog.openDialog(response.host, response.port);
-        }).then(() => {
-          // Initiate long-polling.
-          this.long_poll();
-        }).catch(error => {
-          this.$.initialDialog.openDisabledDialog();
+          if (response.port > 0) {
+            this.$.initialDialog.openDialog(response.host, response.port);
+            // Initiate long-polling.
+            this.long_poll();
+          } else {
+            this.$.initialDialog.openDisabledDialog();
+          }
         });
       },
 

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -1436,13 +1436,5 @@ limitations under the License.
           {defaultValue: _DEFAULT_TOP_RIGHT_QUADRANT_HEIGHT}),
     });
 
-    // TODO(#2338): Remove this, and set up the "no debugger enabled"
-    // message properly. Keep this in sync with `frontend_metadata` in
-    // both `debugger_plugin.py` and `interactive_debugger_plugin.py`.
-    tf_tensorboard.registerDashboard({
-      plugin: 'debugger',
-      elementName: 'tf-debugger-dashboard',
-    });
-
   </script>
 </dom-module>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -858,11 +858,11 @@ limitations under the License.
           // TODO(cais): If the TDP backend is not activated, display message
           // informing the user of that.
           this.$.initialDialog.openDialog(response.host, response.port);
-        }).catch(error => {
-          this.$.initialDialog.openDisabledDialog();
         }).then(() => {
           // Initiate long-polling.
           this.long_poll();
+        }).catch(error => {
+          this.$.initialDialog.openDisabledDialog();
         });
       },
 

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
@@ -165,8 +165,6 @@ model.fit(...)
         // TODO(cais): Use markdown; syntax highlight Python code.
         this.set('_host', host);
         this.set('_port', port);
-      } else {
-        throw new Error('Debugger Plugin is not enabled.');
       }
     },
     closeDialog() {

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
@@ -165,6 +165,8 @@ model.fit(...)
         // TODO(cais): Use markdown; syntax highlight Python code.
         this.set('_host', host);
         this.set('_port', port);
+      } else {
+        throw new Error('Debugger Plugin is not enabled.');
       }
     },
     closeDialog() {


### PR DESCRIPTION
* Motivation for features / changes
  * This is a temporary solution to #2437 . It prevents double stamping of tf-debugger-dashboard in DOM, when the plugin is enabled through the command line flag `--debugger_port`.

* Technical description of changes
  * Remove the tf_tensorboard.registerDashboard() call in tf-debugger-dashboard. 
  * In `debugger_plugin_loader.py`, make sure that there is always one plugin returned. This avoids the problem in which the debugger plugin is missing from the dropdown menu when the `--debugger_port` flag is not provided (Thanks to @nfelt and @stephanwlee for the idea).
  * Remove check of grpc import now that grpc is a pip dependency of tensorboard.
  * Simplify the logic of opening the initial dialog and disabled dialog in tf-debugger-dashboard

* Screenshots of UI changes
  * N/A 

* Detailed steps to verify changes work correctly (as executed by you)
  * Manually verified that there is no longer double stamping of tf-debugger-dashboard when the plugin is enabled.
  * Manually verified that the scalar dashboard works correctly with or without the --debugger_port flag.

* Alternate designs / implementations considered
  * As @stephanwlee suggested, there is no easy and thorough solution to this problem. But the plugin loading system in tf-tensorboard will be redone, according to plan.
  * As @wchargin pointed out, we could implement additional "Not support plugin" type frontend support. But that seems to complex to justify the benefit considering the tf-tensorboard redo that will happen. 
  * As discussed in a design doc, we are considering enabling --debugger_port by default (e.g., default to a port such as 6007. When that happens, this will become a non-issue.
