### PR TITLE
mesh: update tf-graphics dep to 2019-07-30

### DIFF
--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -505,12 +505,12 @@ def tensorboard_js_workspace():
       licenses = ["notice"],  # MIT
       sha256_urls = {
           "76ebbb763969cad7f66fadf24d97a8beec6b6e9c64da568139ad739a1c46ba14": [
-              "http://mirror.tensorflow.org/raw.githubusercontent.com/tensorflow/graphics/ad9dce1aa09d2922304b14e11a2fa1c4652189b5/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/array-buffer-data-provider.js",
-              "https://raw.githubusercontent.com/tensorflow/graphics/ad9dce1aa09d2922304b14e11a2fa1c4652189b5/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/array-buffer-data-provider.js",
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/tensorflow/graphics/fa0fc3496d86f0235d614a5f9a27257a1898cae2/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/array-buffer-data-provider.js",
+              "https://raw.githubusercontent.com/tensorflow/graphics/fa0fc3496d86f0235d614a5f9a27257a1898cae2/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/array-buffer-data-provider.js",
           ],
-          "caa00bdd80fe10b481f34b34df1b8688316ed8e8a6aaa49ddf9e5e6ac7f202e4": [
-              "http://mirror.tensorflow.org/raw.githubusercontent.com/tensorflow/graphics/ad9dce1aa09d2922304b14e11a2fa1c4652189b5/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/mesh-viewer.js",
-              "https://raw.githubusercontent.com/tensorflow/graphics/ad9dce1aa09d2922304b14e11a2fa1c4652189b5/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/mesh-viewer.js",
+          "0e25af04903d91bb4471d2abc6035ed35c1681993a269feff32ba404a7d9bb9f": [
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/tensorflow/graphics/fa0fc3496d86f0235d614a5f9a27257a1898cae2/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/mesh-viewer.js",
+              "https://raw.githubusercontent.com/tensorflow/graphics/fa0fc3496d86f0235d614a5f9a27257a1898cae2/tensorflow_graphics/tensorboard/mesh_visualizer/tf_mesh_dashboard/mesh-viewer.js",
           ],
       },
   )


### PR DESCRIPTION
Summary:
This fixes a “Cannot read property 'forEach' of undefined” error, as
reported in #2324.

Test Plan:
Run the following script to generate test data:

```python
import tensorflow as tf
from tensorboard.plugins.mesh import summary as mesh_summary

points = tf.random.normal([1, 20, 3], 0, 1)

meshes_summary = mesh_summary.op("new_points", vertices=points)

writer = tf.summary.FileWriter("logs")

with tf.Session() as sess:
    summaries = sess.run(meshes_summary)
    writer.add_summary(summaries)
```

Then, launch TensorBoard pointing at `./logs`, and observe that the mesh
plugin successfully loads and renders without console errors, though the
point clouds are still hard to see:

![Screenshot of mesh plugin rendering point clouds][screenshot]

[screenshot]: https://user-images.githubusercontent.com/4317806/62171802-0f921e80-b2e5-11e9-9609-5a212aad9db9.png

wchargin-branch: tf-graphics-20190730
