### PR TITLE
First step towards doubly exponential smoothing

### DIFF
--- a/tensorboard/components/vz_line_chart/vz-line-chart.ts
+++ b/tensorboard/components/vz_line_chart/vz-line-chart.ts
@@ -1032,6 +1032,7 @@ class LineChart {
     // 1st-order IIR low-pass filter to attenuate the higher-
     // frequency components of the time-series.
     let last = data.length > 0 ? 0 : NaN;
+    let bias = data.length > 0 ? 0 : NaN;
     let numAccum = 0;
 
     const yValues = data.map((d, i) => this.yValueAccessor(d, i, dataset));
@@ -1042,8 +1043,11 @@ class LineChart {
       if (isConstant || !Number.isFinite(nextVal)) {
         d.smoothed = nextVal;
       } else {
-        last = last * smoothingWeight + (1 - smoothingWeight) * nextVal;
+        let old_last = last
+        last = (last + bias) * smoothingWeight + (1 - smoothingWeight) * nextVal;
+        bias = bias * smoothingWeight + (1 - smoothingWeight) * (last - old_last)
         numAccum++;
+
         // The uncorrected moving average is biased towards the initial value.
         // For example, if initialized with `0`, with smoothingWeight `s`, where
         // every data point is `c`, after `t` steps the moving average is


### PR DESCRIPTION
* Motivation for features / changes
The current smoothing function in Tensorboard is based on standard (forward) exponential smoothing. This has the benefit of not alterating past smoothed values with new updates and generally captures constant trends well. However, many scalars in deep-learning exhibit a monotically in/decreasing trend (at least, one hopes). A common approach to allow capturing a (smoothed) trend without sacrificing the first benefit above is to use double exponential smoothing, in which a smoothed bias is also tracked and added to the smoothed value.

* Technical description of changes
This PR provides a first step towards integrating doubly exponential smoothing into Tensorboard's smoothing function, by adding a smoothed bias term. It is a first step towards integrating this and should serve as a conversation starter. If interest exists, I am happy to turn this into a complete change; see comments below.

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered
This PR initially serves as a conversation starter; if interest exists in using this smoothing, several considerations should be discussed before acceptance. This includes:

  - Whether to retain the current bias correction term. This correction assumes constant values and an initial value of zero. At least the first assumption is in conflict with introducing a smoothed bias.
  - Whether the bias should be initialized to a value other than zero. Tying in to the above, it may generally be preferable to treat the first recorded value as special when initializing both smoothed terms. This can be helpful for many common functions, such as n-way classification (where the default value would be 1/n), but may have undesired side-effects (e.g. if the loss on the first step is vastly larger than after a few gradient passes).

