### PR TITLE
[draft] generic data providers

### DIFF
--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -64,6 +64,7 @@ py_library(
     deps = [
         ":http_util",
         "//tensorboard:expect_sqlite3_installed",
+        "//tensorboard/backend/event_processing:data_provider",
         "//tensorboard/backend/event_processing:db_import_multiplexer",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/backend/event_processing:event_multiplexer",

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -40,6 +40,7 @@ from werkzeug import wrappers
 
 from tensorboard.backend import http_util
 from tensorboard.backend.event_processing import db_import_multiplexer
+from tensorboard.backend.event_processing import data_provider as event_data_provider  # pylint: disable=line-too-long
 from tensorboard.backend.event_processing import plugin_event_accumulator as event_accumulator  # pylint: disable=line-too-long
 from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
 from tensorboard.plugins import base_plugin
@@ -141,7 +142,13 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
     # DB read-only mode, never load event logs.
     reload_interval = -1
   plugin_name_to_instance = {}
+  data_provider = None
+  if flags.generic_data:
+    if not flags.logdir:
+      raise base_plugin.FlagsError('--generic_data requires --logdir')
+    data_provider = event_data_provider.MultiplexerDataProvider(multiplexer)
   context = base_plugin.TBContext(
+      data_provider=data_provider,
       db_module=db_module,
       db_connection_provider=db_connection_provider,
       db_uri=db_uri,

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -61,7 +61,8 @@ class FakeFlags(object):
       window_title='',
       path_prefix='',
       reload_multifile=False,
-      reload_multifile_inactive_secs=4000):
+      reload_multifile_inactive_secs=4000,
+      generic_data=False):
     self.logdir = logdir
     self.purge_orphaned_data = purge_orphaned_data
     self.reload_interval = reload_interval
@@ -75,6 +76,7 @@ class FakeFlags(object):
     self.path_prefix = path_prefix
     self.reload_multifile = reload_multifile
     self.reload_multifile_inactive_secs = reload_multifile_inactive_secs
+    self.generic_data = generic_data
 
 
 class FakePlugin(base_plugin.TBPlugin):

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -31,6 +31,17 @@ py_test(
 )
 
 py_library(
+    name = "data_provider",
+    srcs = ["data_provider.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        "//tensorboard/data:provider",
+        "//tensorboard/util:tensor_util",
+        "@org_pythonhosted_six",
+    ],
+)
+
+py_library(
     name = "directory_loader",
     srcs = ["directory_loader.py"],
     srcs_version = "PY2AND3",

--- a/tensorboard/backend/event_processing/data_provider.py
+++ b/tensorboard/backend/event_processing/data_provider.py
@@ -1,0 +1,76 @@
+import six
+
+from tensorboard.data import provider
+from tensorboard.util import tensor_util
+
+class MultiplexerDataProvider(provider.DataProvider):
+  def __init__(self, multiplexer):
+    """Trivial initializer.
+
+    Args:
+      multiplexer: A `plugin_event_multiplexer.EventMultiplexer` (note:
+        not a boring old `event_multiplexer.EventMultiplexer`).
+    """
+    self._multiplexer = multiplexer
+
+  def list_scalars(
+      self,
+      experiment_id,
+      owner_plugin,
+      run_tag_filter=None,
+  ):
+    del experiment_id  # ignored for now
+    run_tag_content = self._multiplexer.PluginRunToTagToContent(owner_plugin)
+    result = {}
+    for (run, tag_to_content) in six.iteritems(run_tag_content):
+      result_for_run = {}
+      for tag in tag_to_content:
+        if run_tag_filter is not None and not run_tag_filter.test(run, tag):
+          continue
+        result[run] = result_for_run
+        highest_step_event = max(
+            self._multiplexer.Tensors(run, tag),
+            key=lambda event: event.step,
+        )
+        result_for_run[tag] = provider.ScalarMetadata(
+            max_step=highest_step_event.step,
+            corresponding_wall_time=highest_step_event.wall_time,
+            summary_metadata=self._multiplexer.SummaryMetadata(run, tag),
+        )
+    return result
+
+  def read_scalars(
+      self,
+      experiment_id,
+      owner_plugin,
+      downsample_to=None,
+      run_tag_filter=None,
+      step_filter=None,
+  ):
+    del experiment_id  # ignored for now
+    index = self._multiplexer.PluginRunToTagToContent(owner_plugin)
+    result = {}
+    if step_filter is None:
+      step_filter = provider.StepFilter(lower_bound=0, upper_bound=-1)
+    for run in run_tag_filter.runs:
+      result_for_run = {}
+      for tag in run_tag_filter.tags:
+        if tag not in index.get(run, {}):
+          continue
+        result[run] = result_for_run
+        all_events = self._multiplexer.Tensors(run, tag)
+        max_step = max(all_events, key=lambda event: event.step).step
+        (lower_bound, upper_bound) = step_filter.resolve(max_step)
+        events = [e for e in all_events if lower_bound <= e.step <= upper_bound]
+        del all_events
+        result_for_run[tag] = [self._convert_scalar_event(e) for e in events]
+        # TODO: Downsampling not used. We could downsample on top of the
+        # existing sampling, which would be nice for testing.
+    return result
+
+  def _convert_scalar_event(self, event):
+    return provider.ScalarDatum(
+        step=event.step,
+        wall_time=event.wall_time, 
+        value=tensor_util.make_ndarray(event.tensor_proto).item(),
+    )

--- a/tensorboard/data/BUILD
+++ b/tensorboard/data/BUILD
@@ -1,0 +1,13 @@
+# Description:
+# Experimental framework for generic TensorBoard data providers.
+
+package(default_visibility = ["//tensorboard:internal"])
+
+py_library(
+    name = "provider",
+    srcs = ["provider.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@org_pythonhosted_six",
+    ],
+)

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -1,0 +1,204 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Experimental framework for generic TensorBoard data providers."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import abc
+import collections
+
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class DataProvider(object):
+  @abc.abstractmethod
+  def list_scalars(
+      self,
+      experiment_id,
+      owner_plugin,
+      run_tag_filter=None,
+  ):
+    """List metadata about scalar time series.
+
+    Args:
+      experiment_id: ID of enclosing experiment.
+      owner_plugin: String name of the TensorBoard plugin that created
+        the data to be queried. Required.
+      run_tag_filter: Optional `RunTagFilter` value. If provided, a time
+        series will only be included in the result if its run and tag
+        both pass this filter. If omitted, all time series will be
+        included.
+
+    The result will only contain keys for run-tag combinations that
+    actually exist, which may not include all entries in the
+    `run_tag_filter`.
+
+    Returns:
+      A nested map `d` such that `d[run][tag]` is a `ScalarMetadata`
+      value.
+    """
+    pass
+
+  @abc.abstractmethod
+  def read_scalars(
+      self,
+      experiment_id,
+      owner_plugin,
+      downsample_to=None,
+      run_tag_filter=None,
+      step_filter=None,
+  ):
+    """Read values from scalar time series.
+
+    Args:
+      experiment_id: ID of enclosing experiment.
+      owner_plugin: String name of the TensorBoard plugin that created
+        the data to be queried. Required.
+      downsample_to: Integer number of steps to which to downsample the
+        results (e.g., `1000`). Required.
+      run_tag_filter: Optional `RunTagFilter` value. If provided, a time
+        series will only be included in the result if its run and tag
+        both pass this filter. If `None`, all time series will be
+        included.
+      step_filter: Optional `StepFilter` value. If `None`, the entire
+        range of steps may be included.
+
+    The result will only contain keys for run-tag combinations that
+    actually exist, which may not include all entries in the
+    `run_tag_filter`.
+
+    Returns:
+      A nested map `d` such that `d[run][tag]` is a list of
+      `ScalarDatum` values sorted by step.
+    """
+    pass
+
+  def list_tensors(self):
+    """Not yet specified."""
+    pass
+
+  def read_tensors(self):
+    """Not yet specified."""
+    pass
+
+  def list_blob_sequences(self):
+    """Not yet specified."""
+    pass
+
+  def read_blob_sequences(self):
+    """Not yet specified."""
+    pass
+
+  def list_atemporal_blobs(self):
+    """Not yet specified."""
+    pass
+
+  def read_atemporal_blobs(self):
+    """Not yet specified."""
+    pass
+
+
+_ScalarMetadata = collections.namedtuple(
+    "ScalarMetadata",
+    ("max_step", "corresponding_wall_time", "summary_metadata"),
+)
+class ScalarMetadata(_ScalarMetadata):
+  """Metadata about a scalar time series for a particular run and tag.
+
+  Attributes:
+    max_step: The largest step for this scalar time series; an integer.
+    corresponding_wall_time: The wall time of the datum with the largest
+      step in this time series, as `float` seconds since epoch.
+    summary_metadata: A `summary_pb2.SummaryMetadata` value.
+  """
+  pass
+
+
+_ScalarDatum = collections.namedtuple(
+    "ScalarDatum", ("step", "wall_time", "value")
+)
+class ScalarDatum(_ScalarDatum):
+  """A single datum in a scalar time series for a run and tag.
+
+  Attributes:
+    step: The global step at which this datum occurred; an integer. This
+      is a unique key among data of this time series.
+    wall_time: The real-world time at which this datum occurred, as
+      `float` seconds since epoch.
+    value: The scalar value for this datum; a `float`.
+  """
+  pass
+
+
+class RunTagFilter(object):
+  """Filters data by run and tag names."""
+
+  def __init__(self, runs, tags):
+    """Construct a `RunTagFilter`.
+
+    A time series passes this filter if both its run *and* its tag are
+    included in the corresponding whitelists.
+
+    Order and multiplicity are ignored; `runs` and `tags` are treated as
+    sets.
+
+    Args:
+      runs: Collection of run names, as strings.
+      tags: Collection of tag names, as strings.
+    """
+    self._runs = frozenset(runs)
+    self._tags = frozenset(tags)
+
+  @property
+  def runs(self):
+    return self._runs
+
+  @property
+  def tags(self):
+    return self._tags
+
+
+class StepFilter(object):
+  """Filters data in a time series by step."""
+
+  def __init__(self, min_step, max_step):
+    """Construct a `StepFilter`.
+
+    Negative values for `min_step` or `max_step` indicate indices from
+    the end of the array, as with Python slicing semantics.
+
+    It is valid for `max_step` to be smaller than `min_step`; in this
+    case, if `min_step` and `max_step` are of the same sign, no data
+    will pass this filter.
+
+    Args:
+      min_step: The minimum step value permitted by this filter,
+        inclusive. Integer.
+      max_step: The maximum step value permitted by this filter,
+        inclusive. Integer.
+    """
+    self._min_step = min_step
+    self._max_step = max_step
+
+  @property
+  def min_step(self):
+    return self._min_step
+
+  @property
+  def max_step(self):
+    return self._max_step

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -151,6 +151,7 @@ class TBContext(object):
   def __init__(
       self,
       assets_zip_provider=None,
+      data_provider=None,
       db_connection_provider=None,
       db_module=None,
       db_uri=None,
@@ -171,6 +172,8 @@ class TBContext(object):
           handle this function returns must be closed. It is assumed that you
           will pass this file handle to zipfile.ZipFile. This zip file should
           also have been created by the tensorboard_zip_file build rule.
+      data_provider: Instance of `tensorboard.data.provider.DataProvider`, or
+          `None`.
       db_connection_provider: Function taking no arguments that returns a
           PEP-249 database Connection object, or None if multiplexer should be
           used instead. The returned value must be closed, and is safe to use in
@@ -198,6 +201,7 @@ class TBContext(object):
       window_title: A string specifying the window title.
     """
     self.assets_zip_provider = assets_zip_provider
+    self.data_provider = data_provider
     self.db_connection_provider = db_connection_provider
     self.db_module = db_module
     self.db_uri = db_uri

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -483,6 +483,18 @@ it receives new data at least once per hour)\
 ''')
 
     parser.add_argument(
+        '--generic_data',
+        # Custom str-to-bool converter since regular bool() doesn't work.
+        type=lambda v: {'true': True, 'false': False}.get(v.lower(), v),
+        choices=[True, False],
+        default=False,
+        help='''\
+[experimental] Use generic data provider infrastructure. Only compatible
+with `--logdir` loading for now.
+''')
+
+
+    parser.add_argument(
         '--samples_per_plugin',
         type=str,
         default='',

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -16,6 +16,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        "//tensorboard/data:provider",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -33,6 +33,7 @@ import numpy as np
 from tensorboard import plugin_util
 from tensorboard.backend import http_util
 from tensorboard.compat import tf
+from tensorboard.data import provider
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.scalar import metadata
 from tensorboard.util import tensor_util
@@ -57,6 +58,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
     """
     self._multiplexer = context.multiplexer
     self._db_connection_provider = context.db_connection_provider
+    self._data_provider = context.data_provider
 
   def get_plugin_apps(self):
     return {
@@ -90,6 +92,22 @@ class ScalarsPlugin(base_plugin.TBPlugin):
 
   def index_impl(self):
     """Return {runName: {tagName: {displayName: ..., description: ...}}}."""
+    if self._data_provider:
+      mapping = self._data_provider.list_scalars(
+          experiment_id=None,  # experiment support not yet implemented
+          owner_plugin=metadata.PLUGIN_NAME,
+      )
+      result = {run: {} for run in mapping}
+      for (run, tag_to_content) in six.iteritems(mapping):
+        for (tag, metadatum) in six.iteritems(tag_to_content):
+          sm = metadatum.summary_metadata
+          descr = plugin_util.markdown_to_safe_html(sm.summary_description)
+          result[run][tag] = {
+              'displayName': sm.display_name,
+              'description': descr,
+          }
+      return result
+
     if self._db_connection_provider:
       # Read tags from the database.
       db = self._db_connection_provider()
@@ -131,7 +149,19 @@ class ScalarsPlugin(base_plugin.TBPlugin):
 
   def scalars_impl(self, tag, run, experiment, output_format):
     """Result of the form `(body, mime_type)`."""
-    if self._db_connection_provider:
+    if self._data_provider:
+      all_scalars = self._data_provider.read_scalars(
+          experiment_id=None,  # experiment support not yet implemented
+          owner_plugin=metadata.PLUGIN_NAME,
+          downsample_to=1000,
+          run_tag_filter=provider.RunTagFilter(runs=[run], tags=[tag]),
+          step_filter=None,  # also the default
+      )
+      scalars = all_scalars.get(run, {}).get(tag, None)
+      if scalars is None:
+        raise ValueError('No scalar data for run=%r, tag=%r' % (run, tag))
+      values = [(x.wall_time, x.step, x.value) for x in scalars]
+    elif self._db_connection_provider:
       db = self._db_connection_provider()
       # We select for steps greater than -1 because the writer inserts
       # placeholder rows en masse. The check for step filters out those rows.


### PR DESCRIPTION
Initial implementation; scalars only; much hack.

One small manual test plan—applying

```diff
diff --git a/tensorboard/plugins/scalar/scalars_plugin.py b/tensorboard/plugins/scalar/scalars_plugin.py
index 66e4e20a..fb4a39e6 100644
--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -155,7 +155,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
           owner_plugin=metadata.PLUGIN_NAME,
           downsample_to=1000,
           run_tag_filter=provider.RunTagFilter(runs=[run], tags=[tag]),
-          step_filter=None,  # also the default
+          step_filter=provider.StepFilter(lower_bound=400, upper_bound=-500),
       )
       scalars = all_scalars.get(run, {}).get(tag, None)
       if scalars is None:
```

and loading an experiment with steps 0 through 2000 properly limits the
window to steps 400 through 1500:

![Screenshot of scalar chart with step-axis from 400 to 1.5k][ss]

[ss]: https://user-images.githubusercontent.com/4317806/62401168-dcdf6480-b536-11e9-9830-eebd0f819237.png
