### PR TITLE
ci: use latest Pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ before_install:
 
 install:
   - elapsed "install"
+  # Older versions of Pip sometimes resolve specifiers like `tf-nightly`
+  # to versions other than the most recent(!).
+  - pip install -U pip
   # Lint check deps.
   - pip install flake8==3.5.0
   - pip install yamllint==1.5.0


### PR DESCRIPTION
Summary:
CI builds against `tf-nightly` are currently broken, because Travis
elects to install version `1.15.0.dev20190730` even though there are
four more recent releases. Moreover, that version of `tf-nightly`
happens to have a broken `tensorflow_estimator` package.

Upgrading Pip from Travis’s 9.0.1 to current (19.2.1) suffices to
resolve the most recent version.

wchargin-branch: ci-pip-latest
