### PR TITLE
ci: print `pip freeze` output, for debugging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ install:
   - pip install moto==1.3.7
   # Workaround for https://github.com/travis-ci/travis-ci/issues/7940
   - sudo rm -f /etc/boto.cfg
+  - pip freeze  # print installed distributions, for debugging purposes
   - elapsed "install (done)"
 
 before_script:


### PR DESCRIPTION
Summary:
This was removed in #2278, but is actually pretty helpful.

wchargin-branch: ci-pip-freeze
