### PR TITLE
[tensor-widget] Add TensorWidget demo scaffold

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -87,7 +87,3 @@ tf_workspace()
 # Please add all new dependencies in workspace.bzl.
 load("//third_party:workspace.bzl", "tensorboard_workspace")
 tensorboard_workspace()
-
-# Setup TypeScript toolchain.
-load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
-ts_setup_workspace()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -88,6 +88,6 @@ tf_workspace()
 load("//third_party:workspace.bzl", "tensorboard_workspace")
 tensorboard_workspace()
 
-# Setup TypeScript toolchain
+# Setup TypeScript toolchain.
 load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
 ts_setup_workspace()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -87,3 +87,7 @@ tf_workspace()
 # Please add all new dependencies in workspace.bzl.
 load("//third_party:workspace.bzl", "tensorboard_workspace")
 tensorboard_workspace()
+
+# Setup TypeScript toolchain
+load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
+ts_setup_workspace()

--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -62,6 +62,7 @@ ts_devserver(
     name = "dev_server",
     deps = [":tensor_widget_lib"],
     serving_path = "/bundle.js",
+    entry_module = "tensor-widget",
     static_files = [
         "demo/demo.css",
         "demo/demo.html",

--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -2,7 +2,7 @@ package(default_visibility = ["//tensorboard:internal"])
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("@npm_bazel_typescript//:index.bzl", "ts_devserver", "ts_library")
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
@@ -34,6 +34,7 @@ ts_library(
         "health-pill-types.ts",
         "tensor-widget.ts",
         "types.ts",
+        "version.ts",
     ],
 )
 
@@ -55,4 +56,15 @@ ts_library(
 jasmine_node_test(
     name = "test",
     deps = [":test_lib"],
+)
+
+ts_devserver(
+    name = "dev_server",
+    deps = [":tensor_widget_lib"],
+    serving_path = "/bundle.js",
+    static_files = [
+        "demo/demo.css",
+        "demo/demo.html",
+    ],
+    index_html = "demo/demo.html",
 )

--- a/tensorboard/components/tensor_widget/README.md
+++ b/tensorboard/components/tensor_widget/README.md
@@ -19,3 +19,12 @@ Features
 
 *This component is in early stage of active development.*
 *Many of its features are still incomplete.*
+
+## Developer workflow
+
+### Running the development server
+
+1. Make sure you have installed [ibazel](https://www.npmjs.com/package/@bazel/ibazel)
+2. Run in the root folder of tensorboard: `ibazel run tensorboard/components/tensor_widget:dev_server`
+
+The dev server will track changes to the source files automatically.

--- a/tensorboard/components/tensor_widget/README.md
+++ b/tensorboard/components/tensor_widget/README.md
@@ -25,7 +25,7 @@ Features
 ### Running the development server
 
 1. Make sure you have installed bazel and optionally also
-   [ibazel](https://www.npmjs.com/package/@bazel/ibazel)
+   [ibazel](https://github.com/bazelbuild/bazel-watcher#installation)
 2. Run in the root folder of tensorboard:
 
    ```sh

--- a/tensorboard/components/tensor_widget/README.md
+++ b/tensorboard/components/tensor_widget/README.md
@@ -24,7 +24,19 @@ Features
 
 ### Running the development server
 
-1. Make sure you have installed [ibazel](https://www.npmjs.com/package/@bazel/ibazel)
-2. Run in the root folder of tensorboard: `ibazel run tensorboard/components/tensor_widget:dev_server`
+1. Make sure you have installed bazel and optionally also
+   [ibazel](https://www.npmjs.com/package/@bazel/ibazel)
+2. Run in the root folder of tensorboard:
 
-The dev server will track changes to the source files automatically.
+   ```sh
+   bazel run //tensorboard/components/tensor_widget:dev_server
+   ```
+
+   or using ibazel:
+
+   ```sh
+   ibazel run //tensorboard/components/tensor_widget:dev_server
+   ```
+
+   With ibazel, the dev server will track changes to the source files
+   automatically.

--- a/tensorboard/components/tensor_widget/demo/demo.css
+++ b/tensorboard/components/tensor_widget/demo/demo.css
@@ -1,0 +1,19 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+body {
+  margin: 25px;
+  font-family: sans-serif;
+}

--- a/tensorboard/components/tensor_widget/demo/demo.html
+++ b/tensorboard/components/tensor_widget/demo/demo.html
@@ -34,8 +34,11 @@ limitations under the License.
 
     <script src="bundle.js"></script>
     <script>
+      // TODO(cais): Find a way to not hard-code the path below and/or cover
+      //   it with a test.
       const TENSOR_WIDGET_MODULE_PATH =
         'org_tensorflow_tensorboard/tensorboard/components/tensor_widget/tensor-widget';
+
       require([TENSOR_WIDGET_MODULE_PATH], function(tensorWidgetLib) {
         document.getElementById('tensor-widget-version').textContent =
           tensorWidgetLib.VERSION;

--- a/tensorboard/components/tensor_widget/demo/demo.html
+++ b/tensorboard/components/tensor_widget/demo/demo.html
@@ -38,7 +38,7 @@ limitations under the License.
         'org_tensorflow_tensorboard/tensorboard/components/tensor_widget/tensor-widget';
       require([TENSOR_WIDGET_MODULE_PATH], function(tensorWidgetLib) {
         document.getElementById('tensor-widget-version').textContent =
-          tensorWidgetLib.version;
+          tensorWidgetLib.VERSION;
       });
     </script>
   </body>

--- a/tensorboard/components/tensor_widget/demo/demo.html
+++ b/tensorboard/components/tensor_widget/demo/demo.html
@@ -1,0 +1,45 @@
+<!--
+@license
+Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>TensorWidget Demo</title>
+
+    <link rel="stylesheet" type="text/css" href="demo/demo.css" />
+  </head>
+
+  <body>
+    <h1>TensorWidget Demo</h1>
+    <p>
+      TensorWidget version:
+      <span id="tensor-widget-version"></span>
+    </p>
+
+    <script src="bundle.js"></script>
+    <script>
+      const TENSOR_WIDGET_MODULE_PATH =
+        'org_tensorflow_tensorboard/tensorboard/components/tensor_widget/tensor-widget';
+      require([TENSOR_WIDGET_MODULE_PATH], function(tensorWidgetLib) {
+        document.getElementById('tensor-widget-version').textContent =
+          tensorWidgetLib.version;
+      });
+    </script>
+  </body>
+</html>

--- a/tensorboard/components/tensor_widget/tensor-widget.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget.ts
@@ -14,6 +14,9 @@ limitations under the License.
 ==============================================================================*/
 
 import {TensorWidget, TensorWidgetOptions, TensorView} from './types';
+import {VERSION} from './version';
+
+export const version = VERSION;
 
 /**
  * Create an instance of tensor widiget.

--- a/tensorboard/components/tensor_widget/tensor-widget.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget.ts
@@ -14,9 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {TensorWidget, TensorWidgetOptions, TensorView} from './types';
-import {VERSION} from './version';
-
-export const version = VERSION;
+export {VERSION} from './version';
 
 /**
  * Create an instance of tensor widiget.

--- a/tensorboard/components/tensor_widget/version.ts
+++ b/tensorboard/components/tensor_widget/version.ts
@@ -1,0 +1,16 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export const VERSION = '0.0.0';

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -19,6 +19,7 @@ load("@io_bazel_rules_closure//closure/private:java_import_external.bzl", "java_
 load("@io_bazel_rules_closure//closure:defs.bzl", "filegroup_external")
 load("@io_bazel_rules_closure//closure:defs.bzl", "web_library_external")
 load("@io_bazel_rules_webtesting//web/internal:platform_http_file.bzl", "platform_http_file")
+load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
 load("//third_party:fonts.bzl", "tensorboard_fonts_workspace")
 load("//third_party:polymer.bzl", "tensorboard_polymer_workspace")
 load("//third_party:python.bzl", "tensorboard_python_workspace")
@@ -32,6 +33,9 @@ def tensorboard_workspace():
   tensorboard_python_workspace()
   tensorboard_typings_workspace()
   tensorboard_js_workspace()
+
+  # Set up TypeScript toolchain.
+  ts_setup_workspace()
 
   http_archive(
       name = "com_google_protobuf_js",


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing tensor-widget

* Technical description of changes
  * Add a ts_devserver BUILD target to tensor-widget.
  * Server a demo.html and a demo.css file from the ts_devserver
  * demo.html uses AMD `require()` to load the compiled tensor-widget library
  * Add version.ts both for future versioning and so that we have something to show in the demo page.
  * Update README.md to include instructions on how to run the dev server.

* Screenshots of UI changes
  * 
![image](https://user-images.githubusercontent.com/16824702/62509210-492cc300-b7d8-11e9-8e6d-1812689902e4.png)


* Detailed steps to verify changes work correctly (as executed by you)
  * `ibazel run tensorboard/components/tensor_widget:dev_server`
  * Ran all bazel tests
  * `yarn fix-lint`
