### PR TITLE
example_basic: bump smoke test to moderate timeout

### DIFF
--- a/tensorboard/examples/plugins/example_basic/BUILD
+++ b/tensorboard/examples/plugins/example_basic/BUILD
@@ -12,7 +12,7 @@ licenses(["notice"])  # Apache 2.0
 sh_test(
     name = "smoke_test",
     size = "large",
-    timeout = "short",
+    timeout = "moderate",
     srcs = ["smoke_test.sh"],
     # Don't just `glob(["**"])` because `setup.py` creates artifacts
     # like wheels and a `tensorboard_plugin_example.egg-info` directory,


### PR DESCRIPTION
Summary:
This has timed out a few times on CI, and I’ve never seen it actually
hang, so bumping the timeout seems appropriate. See:
<https://github.com/tensorflow/tensorboard/pull/2500#discussion_r311094558>

Test Plan:
The test still passes, so the `BUILD` file is valid.

wchargin-branch: example-smoke-moderate
