### PR TITLE
profile: fix trace viewer

### DIFF
--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -32,7 +32,6 @@ tf_web_library(
     srcs = ["trace_viewer.html"],
     path = "/",
     deps = [
-        "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_trace_viewer",
     ],
 )

--- a/tensorboard/components/trace_viewer.html
+++ b/tensorboard/components/trace_viewer.html
@@ -20,11 +20,11 @@ limitations under the License.
 <html>
   <head>
     <title>Trace Viewer</title>
-    <link rel="import" href="tf-imports/polymer.html" />
+    <!-- Note that trace_viewer_full is bundled with a Polymer (1.8.1)-->
     <link
       rel="import"
       href="tf-trace-viewer/tf-trace-viewer.html"
-      jscomp-nocompile="true"
+      jscomp-nocompile
     />
     <style>
       body {


### PR DESCRIPTION
TensorBoard depends on Chromium Catapult projector by downloading its
Vulcanized source (it comes from [1] which is quite dated but there is
no good replacement). The bundle comes with a Polymer version v1.8.1 (
search for `Polymer.version="` in [1]) and it is incompatible with
tf-imports/polymer.html.

[1]:
https://raw.githubusercontent.com/catapult-project/catapult/vulcanized_traceviewer/trace_viewer_full.html

Fixes #2491.