### PR TITLE
[tensor-widget] Render basic tensor info

### DIFF
--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -32,6 +32,7 @@ ts_library(
     srcs = [
         "dtype-utils.ts",
         "health-pill-types.ts",
+        "string-utils.ts",
         "tensor-widget.ts",
         "tensor-widget-impl.ts",
         "types.ts",
@@ -44,6 +45,7 @@ ts_library(
     testonly = True,
     srcs = [
         "dtype-utils-test.ts",
+        "string-utils-test.ts",
     ],
     deps = [
         ":tensor_widget_lib",

--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -32,6 +32,7 @@ ts_library(
     srcs = [
         "dtype-utils.ts",
         "health-pill-types.ts",
+        "shape-utils.ts",
         "string-utils.ts",
         "tensor-widget.ts",
         "tensor-widget-impl.ts",
@@ -45,6 +46,7 @@ ts_library(
     testonly = True,
     srcs = [
         "dtype-utils-test.ts",
+        "shape-utils-test.ts",
         "string-utils-test.ts",
     ],
     deps = [

--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -33,6 +33,7 @@ ts_library(
         "dtype-utils.ts",
         "health-pill-types.ts",
         "tensor-widget.ts",
+        "tensor-widget-impl.ts",
         "types.ts",
         "version.ts",
     ],
@@ -66,6 +67,7 @@ ts_devserver(
     static_files = [
         "demo/demo.css",
         "demo/demo.html",
+        "tensor-widget.css",
     ],
     index_html = "demo/demo.html",
 )

--- a/tensorboard/components/tensor_widget/README.md
+++ b/tensorboard/components/tensor_widget/README.md
@@ -17,8 +17,8 @@ Features
 - The API allows for programmatic interaction with the UI, as well as listening
   to events in the UI.
 
-*This component is in early stage of active development.*
-*Many of its features are still incomplete.*
+_This component is in early stage of active development._
+_Many of its features are still incomplete._
 
 ## Developer workflow
 

--- a/tensorboard/components/tensor_widget/demo/demo.css
+++ b/tensorboard/components/tensor_widget/demo/demo.css
@@ -17,3 +17,12 @@ body {
   margin: 25px;
   font-family: sans-serif;
 }
+
+.tensor {
+  display: inline-block;
+  width: 550px;
+  height: 300px;
+  white-space: nowrap;
+  border: 1px solid rgb(220, 220, 220);
+  margin: 15px;
+}

--- a/tensorboard/components/tensor_widget/demo/demo.css
+++ b/tensorboard/components/tensor_widget/demo/demo.css
@@ -19,10 +19,10 @@ body {
 }
 
 .tensor {
-  display: inline-block;
-  width: 550px;
-  height: 300px;
-  white-space: nowrap;
   border: 1px solid rgb(220, 220, 220);
+  display: inline-block;
+  height: 300px;
   margin: 15px;
+  white-space: nowrap;
+  width: 550px;
 }

--- a/tensorboard/components/tensor_widget/demo/demo.html
+++ b/tensorboard/components/tensor_widget/demo/demo.html
@@ -32,7 +32,10 @@ limitations under the License.
       <span id="tensor-widget-version"></span>
     </p>
 
+    <div id="tensor0" class="tensor"></div>
     <div id="tensor1" class="tensor"></div>
+    <div id="tensor2" class="tensor"></div>
+    <div id="tensor3" class="tensor"></div>
 
     <script src="bundle.js"></script>
     <script>
@@ -47,19 +50,68 @@ limitations under the License.
           tensorWidgetLib.VERSION;
 
         // Render tensor1: a float32 scalar.
-        const tensor1Div = document.getElementById('tensor1');
-        const tensorView1 = {
+        const tensor0Div = document.getElementById('tensor0');
+        // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
+        const tensorView0 = {
           spec: {
             dtype: 'float32',
             shape: [], // A scalar.
           },
         };
+        const tensorWidget0 = tensorWidgetLib.tensorWidget(
+          tensor0Div,
+          tensorView0,
+          {name: 'scalar1'}
+        );
+        tensorWidget0.render();
+
+        // Render tensor1: a 1D int32 tensor.
+        const tensor1Div = document.getElementById('tensor1');
+        // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
+        const tensorView1 = {
+          spec: {
+            dtype: 'int32',
+            shape: [100], // A scalar.
+          },
+        };
         const tensorWidget1 = tensorWidgetLib.tensorWidget(
           tensor1Div,
           tensorView1,
-          {name: 'scalar1'}
+          {name: 'Tensor1DOutputByAnOpWithAVeryLongName:0'}
         );
         tensorWidget1.render();
+
+        // Render tensor2: a 2D uint8 scalar.
+        const tensor2Div = document.getElementById('tensor2');
+        // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
+        const tensorView2 = {
+          spec: {
+            dtype: 'float32',
+            shape: [512, 1024], // A scalar.
+          },
+        };
+        const tensorWidget2 = tensorWidgetLib.tensorWidget(
+          tensor2Div,
+          tensorView2,
+          {name: 'Float32_2D_Tensor:0'}
+        );
+        tensorWidget2.render();
+
+        // Render tensor3: a 3D int32 scalar.
+        const tensor3Div = document.getElementById('tensor3');
+        // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
+        const tensorView3 = {
+          spec: {
+            dtype: 'float32',
+            shape: [64, 32, 50], // A scalar.
+          },
+        };
+        const tensorWidget3 = tensorWidgetLib.tensorWidget(
+          tensor3Div,
+          tensorView3,
+          {name: 'ThreeDimensional:0'}
+        );
+        tensorWidget3.render();
       });
     </script>
   </body>

--- a/tensorboard/components/tensor_widget/demo/demo.html
+++ b/tensorboard/components/tensor_widget/demo/demo.html
@@ -32,6 +32,8 @@ limitations under the License.
       <span id="tensor-widget-version"></span>
     </p>
 
+    <div id="tensor1" class="tensor"></div>
+
     <script src="bundle.js"></script>
     <script>
       // TODO(cais): Find a way to not hard-code the path below and/or cover
@@ -40,8 +42,24 @@ limitations under the License.
         'org_tensorflow_tensorboard/tensorboard/components/tensor_widget/tensor-widget';
 
       require([TENSOR_WIDGET_MODULE_PATH], function(tensorWidgetLib) {
+        // Display the version of the tensor-widget library.
         document.getElementById('tensor-widget-version').textContent =
           tensorWidgetLib.VERSION;
+
+        // Render tensor1: a float32 scalar.
+        const tensor1Div = document.getElementById('tensor1');
+        const tensorView1 = {
+          spec: {
+            dtype: 'float32',
+            shape: [], // A scalar.
+          },
+        };
+        const tensorWidget1 = tensorWidgetLib.tensorWidget(
+          tensor1Div,
+          tensorView1,
+          {name: 'scalar1'}
+        );
+        tensorWidget1.render();
       });
     </script>
   </body>

--- a/tensorboard/components/tensor_widget/demo/demo.html
+++ b/tensorboard/components/tensor_widget/demo/demo.html
@@ -71,7 +71,7 @@ limitations under the License.
         const tensorView1 = {
           spec: {
             dtype: 'int32',
-            shape: [100], // A scalar.
+            shape: [100],
           },
         };
         const tensorWidget1 = tensorWidgetLib.tensorWidget(
@@ -81,13 +81,13 @@ limitations under the License.
         );
         tensorWidget1.render();
 
-        // Render tensor2: a 2D uint8 scalar.
+        // Render tensor2: a 2D float32 scalar.
         const tensor2Div = document.getElementById('tensor2');
         // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
         const tensorView2 = {
           spec: {
             dtype: 'float32',
-            shape: [512, 1024], // A scalar.
+            shape: [512, 1024],
           },
         };
         const tensorWidget2 = tensorWidgetLib.tensorWidget(
@@ -97,20 +97,19 @@ limitations under the License.
         );
         tensorWidget2.render();
 
-        // Render tensor3: a 3D int32 scalar.
+        // Render tensor3: a 3D float32 scalar, without the optional name.
         const tensor3Div = document.getElementById('tensor3');
         // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
         const tensorView3 = {
           spec: {
             dtype: 'float32',
-            shape: [64, 32, 50], // A scalar.
+            shape: [64, 32, 50],
           },
         };
         const tensorWidget3 = tensorWidgetLib.tensorWidget(
           tensor3Div,
-          tensorView3,
-          {name: 'ThreeDimensional:0'}
-        );
+          tensorView3
+        ); // No name.
         tensorWidget3.render();
       });
     </script>

--- a/tensorboard/components/tensor_widget/shape-utils-test.ts
+++ b/tensorboard/components/tensor_widget/shape-utils-test.ts
@@ -1,0 +1,35 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {expect} from 'chai';
+
+import {formatShapeForDisplay} from './shape-utils';
+
+describe('formatShapeForDisplay', () => {
+  it('returns string scalar for []', () => {
+    expect(formatShapeForDisplay([])).to.equal('scalar');
+  });
+
+  it('returns array strings for non-scalar shapes', () => {
+    expect(formatShapeForDisplay([0])).to.equal('[0]');
+    expect(formatShapeForDisplay([12])).to.equal('[12]');
+    expect(formatShapeForDisplay([4, 8])).to.equal('[4,8]');
+    expect(formatShapeForDisplay([1, 32, 8])).to.equal('[1,32,8]');
+    expect(formatShapeForDisplay([8, 32, 32, 128])).to.equal('[8,32,32,128]');
+    expect(formatShapeForDisplay([0, 8, 32, 32, 128])).to.equal(
+      '[0,8,32,32,128]'
+    );
+  });
+});

--- a/tensorboard/components/tensor_widget/shape-utils.ts
+++ b/tensorboard/components/tensor_widget/shape-utils.ts
@@ -1,0 +1,14 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/

--- a/tensorboard/components/tensor_widget/shape-utils.ts
+++ b/tensorboard/components/tensor_widget/shape-utils.ts
@@ -12,3 +12,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+
+/**
+ * Tensor shape utilities for tensor widget.
+ */
+
+/**
+ * Format tensor shape as a string for display.
+ *
+ * The special case of empty shape ([]) is formatted as the more human-readable
+ * name "scalar".
+ *
+ * @param shape
+ * @returns A human-understandable string that describes tensor shape.
+ */
+export function formatShapeForDisplay(shape: ReadonlyArray<number>): string {
+  if (shape.length === 0) {
+    return 'scalar';
+  } else {
+    return `[${shape}]`;
+  }
+}

--- a/tensorboard/components/tensor_widget/string-utils-test.ts
+++ b/tensorboard/components/tensor_widget/string-utils-test.ts
@@ -1,0 +1,55 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {expect} from 'chai';
+
+import {
+  ELLIPSES,
+  formatTensorName,
+  TENSOR_NAME_LENGTH_CUTOFF,
+} from './string-utils';
+
+function stringRepeat(str: string, times: number) {
+  let output = '';
+  for (let i = 0; i < times; ++i) {
+    output += str;
+  }
+  return output;
+}
+
+describe('formatTensorName', () => {
+  it('returns original string for under-limit lengths', () => {
+    expect(formatTensorName('')).to.equal('');
+    expect(formatTensorName('a')).to.equal('a');
+    const onLimitName = stringRepeat('A', TENSOR_NAME_LENGTH_CUTOFF);
+    expect(formatTensorName(onLimitName)).to.equal(onLimitName);
+  });
+
+  it('returns string with ellipses for over-limit lenghts', () => {
+    const longName = stringRepeat('A', TENSOR_NAME_LENGTH_CUTOFF + 10);
+    expect(formatTensorName(longName).length).to.equal(
+      TENSOR_NAME_LENGTH_CUTOFF
+    );
+  });
+});
+
+describe('Constants for formatTensorName', () => {
+  it('TENSOR_NAME_LENGTH_CUTOFF is long-enough positive integer', () => {
+    expect(TENSOR_NAME_LENGTH_CUTOFF).to.be.greaterThan(ELLIPSES.length);
+    expect(Math.floor(TENSOR_NAME_LENGTH_CUTOFF)).to.equal(
+      Math.floor(TENSOR_NAME_LENGTH_CUTOFF)
+    );
+  });
+});

--- a/tensorboard/components/tensor_widget/string-utils-test.ts
+++ b/tensorboard/components/tensor_widget/string-utils-test.ts
@@ -43,6 +43,16 @@ describe('formatTensorName', () => {
       TENSOR_NAME_LENGTH_CUTOFF
     );
   });
+
+  it('includes ellipses, prefix and suffix', () => {
+    const longName = stringRepeat('A', TENSOR_NAME_LENGTH_CUTOFF + 10);
+    const output = formatTensorName(longName);
+    expect(output.indexOf(ELLIPSES)).to.equal(
+      Math.floor(TENSOR_NAME_LENGTH_CUTOFF / 2)
+    );
+    expect(output.slice(0, 1)).to.equal('A');
+    expect(output.slice(output.length - 1, output.length)).to.equal('A');
+  });
 });
 
 describe('Constants for formatTensorName', () => {

--- a/tensorboard/components/tensor_widget/string-utils-test.ts
+++ b/tensorboard/components/tensor_widget/string-utils-test.ts
@@ -37,7 +37,7 @@ describe('formatTensorName', () => {
     expect(formatTensorName(onLimitName)).to.equal(onLimitName);
   });
 
-  it('returns string with ellipses for over-limit lenghts', () => {
+  it('returns string with ellipses for over-limit lengths', () => {
     const longName = stringRepeat('A', TENSOR_NAME_LENGTH_CUTOFF + 10);
     expect(formatTensorName(longName).length).to.equal(
       TENSOR_NAME_LENGTH_CUTOFF

--- a/tensorboard/components/tensor_widget/string-utils.ts
+++ b/tensorboard/components/tensor_widget/string-utils.ts
@@ -23,7 +23,7 @@ export const ELLIPSES = '...';
 /**
  * Format the name of a tensor for display.
  *
- * If the name is longer than `TENSOR_NAME_LENGTH_CUTOFF`. The middle part
+ * If the name is longer than `TENSOR_NAME_LENGTH_CUTOFF`, the middle part
  * of it will be replaced with ellipses.
  *
  * @param tensorName

--- a/tensorboard/components/tensor_widget/string-utils.ts
+++ b/tensorboard/components/tensor_widget/string-utils.ts
@@ -20,17 +20,25 @@ limitations under the License.
 export const TENSOR_NAME_LENGTH_CUTOFF = 20;
 export const ELLIPSES = '...';
 
+/**
+ * Format the name of a tensor for display.
+ *
+ * If the name is longer than `TENSOR_NAME_LENGTH_CUTOFF`. The middle part
+ * of it will be replaced with ellipses.
+ *
+ * @param tensorName
+ * @returns Formated tensor name.
+ */
 export function formatTensorName(tensorName: string): string {
   if (tensorName.length <= TENSOR_NAME_LENGTH_CUTOFF) {
     return tensorName;
   } else {
     const leadLength = Math.floor(TENSOR_NAME_LENGTH_CUTOFF / 2);
-    const trailLength =
-      TENSOR_NAME_LENGTH_CUTOFF - ELLIPSES.length - leadLength;
+    const tailLength = TENSOR_NAME_LENGTH_CUTOFF - ELLIPSES.length - leadLength;
     return (
       tensorName.slice(0, leadLength) +
       ELLIPSES +
-      tensorName.slice(tensorName.length - trailLength, tensorName.length)
+      tensorName.slice(tensorName.length - tailLength, tensorName.length)
     );
   }
 }

--- a/tensorboard/components/tensor_widget/string-utils.ts
+++ b/tensorboard/components/tensor_widget/string-utils.ts
@@ -1,0 +1,36 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/**
+ * String utilities for TensorWidget.
+ */
+
+export const TENSOR_NAME_LENGTH_CUTOFF = 20;
+export const ELLIPSES = '...';
+
+export function formatTensorName(tensorName: string): string {
+  if (tensorName.length <= TENSOR_NAME_LENGTH_CUTOFF) {
+    return tensorName;
+  } else {
+    const leadLength = Math.floor(TENSOR_NAME_LENGTH_CUTOFF / 2);
+    const trailLength =
+      TENSOR_NAME_LENGTH_CUTOFF - ELLIPSES.length - leadLength;
+    return (
+      tensorName.slice(0, leadLength) +
+      ELLIPSES +
+      tensorName.slice(tensorName.length - trailLength, tensorName.length)
+    );
+  }
+}

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -37,12 +37,12 @@ export class TensorWidgetImpl implements TensorWidget {
   }
 
   /**
-   * TODO(cais): Doc string.
+   * Render the tensor widget.
    *
    * This method should be called only once after the instantiation of the
    * `TensorWidget` object, unless the value of the underlying tensor,
    * as seen through `tensorView` has changed after the last `render()`
-   * call.
+   * call, in which case it can be called against to update the display.
    */
   async render() {
     this.rootElement.classList.add('tensor-widget');
@@ -97,7 +97,7 @@ export class TensorWidgetImpl implements TensorWidget {
     this.renderShape();
   }
 
-  /** Render the name in the info subsection. */
+  /** Render the optional name in the info subsection. */
   private renderName() {
     if (this.options.name == null || this.options.name.length === 0) {
       return;

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -43,7 +43,8 @@ export class TensorWidgetImpl implements TensorWidget {
    * This method should be called only once after the instantiation of the
    * `TensorWidget` object, unless the value of the underlying tensor,
    * as seen through `tensorView` has changed after the last `render()`
-   * call, in which case it can be called against to update the display.
+   * call, in which case it can be called again to update the display by
+   * the tensor widget.
    */
   async render() {
     this.rootElement.classList.add('tensor-widget');

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -1,0 +1,159 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {TensorView, TensorWidget, TensorWidgetOptions} from './types';
+
+const DEFAULT_TENSOR_NAME_LENGTH_CUTOFF = 20;
+
+/**
+ * Implementation of TensorWidget.
+ */
+
+/** An implementation of TensorWidget single-tensor view. */
+export class TensorWidgetImpl implements TensorWidget {
+  private options: TensorWidgetOptions;
+
+  // Constituent UI elements.
+  protected headerSection: HTMLDivElement;
+  protected infoSubsection: HTMLDivElement;
+
+  constructor(
+    private readonly rootElement: HTMLDivElement,
+    private readonly tensorView: TensorView,
+    options?: TensorWidgetOptions
+  ) {
+    this.options = options || {};
+  }
+
+  /**
+   * TODO(cais): Doc string.
+   *
+   * This method should be called only once after the instantiation of the
+   * `TensorWidget` object, unless the value of the underlying tensor,
+   * as seen through `tensorView` has changed after the last `render()`
+   * call.
+   */
+  async render() {
+    this.rootElement.classList.add('tensor-widget');
+
+    this.renderHeader();
+    // TODO(cais): Implement and call renderValues();
+  }
+
+  /**
+   * Render the header section of the TensorWidget.
+   *
+   * A TensorWidget has two sections, namely the header and the value sections.
+   * This method is responsible for rendering the former. The latter is rendered
+   * by `renderValues()`.
+   *
+   * The header section itself consists of the following regions:
+   *   - The info subsection, which displays basic information about the tensor,
+   *     including name, dtype and shape. See `renderInfo()`.
+   *   - The health-pill subsection, which displays numeric summary of the tensor's
+   *     eleements. See `renderHealthPill()`.
+   *   - The menu. See `createMenu()`.
+   */
+  private renderHeader() {
+    if (this.headerSection == null) {
+      this.headerSection = document.createElement('div');
+      this.headerSection.classList.add('tensor-widget-header');
+      this.rootElement.appendChild(this.headerSection);
+    }
+    this.renderInfo();
+
+    // TODO(cais): Implement and call renderHealthPill().
+    // TODO(cais): Implement and call createMenu();
+  }
+
+  /**
+   * Render the info subsection of the header section.
+   */
+  private renderInfo() {
+    if (this.infoSubsection == null) {
+      this.infoSubsection = document.createElement('div');
+      this.infoSubsection.classList.add('tensor-widget-info');
+      this.headerSection.appendChild(this.infoSubsection);
+    }
+
+    // Clear the info control.
+    while (this.infoSubsection.firstChild) {
+      this.infoSubsection.removeChild(this.infoSubsection.firstChild);
+    }
+
+    // Create name control.
+    if (this.options.name != null && this.options.name.length > 0) {
+      const nameTagDiv = document.createElement('div');
+      nameTagDiv.classList.add('tensor-widget-tensor-name');
+      const nameLength = this.options.name.length;
+      nameTagDiv.textContent =
+        nameLength > DEFAULT_TENSOR_NAME_LENGTH_CUTOFF
+          ? `...${this.options.name.slice(
+              nameLength - DEFAULT_TENSOR_NAME_LENGTH_CUTOFF,
+              nameLength
+            )}`
+          : this.options.name;
+
+      this.infoSubsection.appendChild(nameTagDiv);
+    }
+
+    this.createDTypeTag();
+    this.createShapeTag();
+  }
+
+  /** Create the dtype tag in the info subsection. */
+  private createDTypeTag() {
+    const dTypeControl = document.createElement('div');
+    dTypeControl.classList.add('tensor-widget-dtype');
+
+    const dTypeLabel = document.createElement('span');
+    dTypeLabel.classList.add('tensor-widget-dtype-label');
+    dTypeLabel.textContent = 'dtype:';
+    dTypeControl.appendChild(dTypeLabel);
+
+    const dTypeValue = document.createElement('span');
+    dTypeValue.textContent = this.tensorView.spec.dtype;
+    dTypeControl.appendChild(dTypeValue);
+
+    this.infoSubsection.appendChild(dTypeControl);
+  }
+
+  /** Create the shape tag in the info subsection. */
+  private createShapeTag() {
+    const shapeTagDiv = document.createElement('div');
+    shapeTagDiv.classList.add('tensor-widget-shape');
+    const shapeTagLabel = document.createElement('div');
+    shapeTagLabel.classList.add('tensor-widget-shape-label');
+    shapeTagLabel.textContent = `shape:`;
+    shapeTagDiv.appendChild(shapeTagLabel);
+    const shapeTagValue = document.createElement('div');
+    shapeTagValue.classList.add('tensor-widget-shape-value');
+    shapeTagValue.textContent = `[${this.tensorView.spec.shape}]`;
+    shapeTagDiv.appendChild(shapeTagValue);
+    this.infoSubsection.appendChild(shapeTagDiv);
+  }
+
+  async scrollHorizontally(index: number) {
+    throw new Error('scrollHorizontally() is not implemented yet.');
+  }
+
+  async scrollVertically(index: number) {
+    throw new Error('scrollVertically() is not implemented yet.');
+  }
+
+  async navigateToIndices(indices: number[]) {
+    throw new Error('navigateToIndices() is not implemented yet.');
+  }
+}

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {TensorView, TensorWidget, TensorWidgetOptions} from './types';
+import {formatShapeForDisplay} from './shape-utils';
 import {formatTensorName} from './string-utils';
 
 /**
@@ -137,7 +138,9 @@ export class TensorWidgetImpl implements TensorWidget {
     shapeTagDiv.appendChild(shapeTagLabel);
     const shapeTagValue = document.createElement('div');
     shapeTagValue.classList.add('tensor-widget-shape-value');
-    shapeTagValue.textContent = `[${this.tensorView.spec.shape}]`;
+    shapeTagValue.textContent = formatShapeForDisplay(
+      this.tensorView.spec.shape
+    );
     shapeTagDiv.appendChild(shapeTagValue);
     this.infoSubsection.appendChild(shapeTagDiv);
   }

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -14,8 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {TensorView, TensorWidget, TensorWidgetOptions} from './types';
-
-const DEFAULT_TENSOR_NAME_LENGTH_CUTOFF = 20;
+import {formatTensorName} from './string-utils';
 
 /**
  * Implementation of TensorWidget.
@@ -93,28 +92,26 @@ export class TensorWidgetImpl implements TensorWidget {
       this.infoSubsection.removeChild(this.infoSubsection.firstChild);
     }
 
-    // Create name control.
-    if (this.options.name != null && this.options.name.length > 0) {
-      const nameTagDiv = document.createElement('div');
-      nameTagDiv.classList.add('tensor-widget-tensor-name');
-      const nameLength = this.options.name.length;
-      nameTagDiv.textContent =
-        nameLength > DEFAULT_TENSOR_NAME_LENGTH_CUTOFF
-          ? `...${this.options.name.slice(
-              nameLength - DEFAULT_TENSOR_NAME_LENGTH_CUTOFF,
-              nameLength
-            )}`
-          : this.options.name;
-
-      this.infoSubsection.appendChild(nameTagDiv);
-    }
-
-    this.createDTypeTag();
-    this.createShapeTag();
+    this.renderName();
+    this.renderDType();
+    this.renderShape();
   }
 
-  /** Create the dtype tag in the info subsection. */
-  private createDTypeTag() {
+  /** Render the name in the info subsection. */
+  private renderName() {
+    if (this.options.name == null || this.options.name.length === 0) {
+      return;
+    }
+    const nameDiv = document.createElement('div');
+    nameDiv.classList.add('tensor-widget-tensor-name');
+    nameDiv.textContent = formatTensorName(this.options.name);
+    // Add a hover text that shows the full name.
+    nameDiv.title = this.options.name;
+    this.infoSubsection.appendChild(nameDiv);
+  }
+
+  /** Render the dtype in the info subsection. */
+  private renderDType() {
     const dTypeControl = document.createElement('div');
     dTypeControl.classList.add('tensor-widget-dtype');
 
@@ -130,8 +127,8 @@ export class TensorWidgetImpl implements TensorWidget {
     this.infoSubsection.appendChild(dTypeControl);
   }
 
-  /** Create the shape tag in the info subsection. */
-  private createShapeTag() {
+  /** Render the shape in the info subsection. */
+  private renderShape() {
     const shapeTagDiv = document.createElement('div');
     shapeTagDiv.classList.add('tensor-widget-shape');
     const shapeTagLabel = document.createElement('div');

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -64,7 +64,7 @@ export class TensorWidgetImpl implements TensorWidget {
    *   - The info subsection, which displays basic information about the tensor,
    *     including name, dtype and shape. See `renderInfo()`.
    *   - The health-pill subsection, which displays numeric summary of the tensor's
-   *     eleements. See `renderHealthPill()`.
+   *     elements. See `renderHealthPill()`.
    *   - The menu. See `createMenu()`.
    */
   private renderHeader() {

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -79,5 +79,4 @@ limitations under the License.
   color: black;
   display: inline-block;
   font-weight: bold;
-  text-decoration: underline;
 }

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -19,17 +19,17 @@ limitations under the License.
 }
 
 .tensor-widget-dtype {
-  position: relative;
-  height: 48px;
-  max-height: 22px;
-  line-height: 22px;
-  display: inline-block;
   align-content: center;
-  vertical-align: middle;
+  color: rgb(60, 60, 60);
+  display: inline-block;
+  font-size: 8pt;
+  height: 48px;
+  line-height: 22px;
+  max-height: 22px;
   padding-left: 14px;
   padding-right: 10px;
-  color: rgb(60, 60, 60);
-  font-size: 8pt;
+  position: relative;
+  vertical-align: middle;
 }
 
 .tensor-widget-dtype-label {

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -1,0 +1,83 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+.tensor-widget {
+  font-family: monospace;
+  font-size: 14px;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  position: relative;
+}
+
+.tensor-widget-dtype {
+  position: relative;
+  height: 48px;
+  max-height: 22px;
+  line-height: 22px;
+  display: inline-block;
+  align-content: center;
+  vertical-align: middle;
+  padding-left: 14px;
+  padding-right: 10px;
+  color: rgb(60, 60, 60);
+  font-size: 8pt;
+}
+
+.tensor-widget-dtype-label {
+  color: rgb(128, 128, 128);
+}
+
+.tensor-widget-header {
+  background-color: rgb(252, 252, 252);
+  box-shadow: 2px 2px 2px #b0b0b0;
+  height: 40px;
+  line-height: 40px;
+  max-height: 40px;
+  position: relative;
+  vertical-align: middle;
+  width: 100%;
+}
+
+.tensor-widget-info {
+  align-content: center;
+  color: rgb(0, 0, 255);
+  display: inline-block;
+  font-size: 8pt;
+  height: 22px;
+  line-height: 22px;
+  margin-left: 8px;
+  max-height: 22px;
+  position: relative;
+  vertical-align: middle;
+}
+
+.tensor-widget-shape {
+  color: rgb(60, 60, 60);
+  display: inline-block;
+  margin-left: 12px;
+}
+
+.tensor-widget-shape-label {
+  color: rgb(128, 128, 128);
+  display: inline-block;
+}
+
+.tensor-widget-shape-value {
+  display: inline-block;
+}
+
+.tensor-widget-tensor-name {
+  color: black;
+  display: inline-block;
+  font-weight: bold;
+  text-decoration: underline;
+}

--- a/tensorboard/components/tensor_widget/tensor-widget.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {TensorWidgetImpl} from './tensor-widget-impl';
 import {TensorWidget, TensorWidgetOptions, TensorView} from './types';
 export {VERSION} from './version';
 
@@ -29,7 +30,5 @@ export function tensorWidget(
   tensor: TensorView,
   options?: TensorWidgetOptions
 ): TensorWidget {
-  throw new Error(
-    'tensorWidget() factory method has not been implemented yet.'
-  );
+  return new TensorWidgetImpl(rootElement, tensor, options);
 }

--- a/tensorboard/components/tensor_widget/tensor-widget.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget.ts
@@ -18,7 +18,7 @@ import {TensorWidget, TensorWidgetOptions, TensorView} from './types';
 export {VERSION} from './version';
 
 /**
- * Create an instance of tensor widiget.
+ * Create an instance of tensor widget.
  * @param rootElement The element in which the tensor widget will be endered.
  * @param tensor The tensor view of which the content is to be rendered
  *   in the tensor widget.


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing tensor widget

* Technical description of changes
  * Add tensor-widget-impl.ts that will hold the core logic that renders the tensor widget.
  * Add the style sheet for TensorWidget: tensor-widget.css
  * Add code that renders the header section and the basic info subsection of it.
  * The basic info subsection includes the following fields:
    * Name (optional)
    * Tensor DType
    * Tensor Shape
  * Add string-utilts.ts to handle the formatting of long tensor names.
  * Add shape-utils.ts. Right now it only has a trivial helper function to format shape strings.
  * Add unit tests for string-utils.ts and shape-utils.ts.
  * Add four tensor widget panels in demo.html.

 * Screenshots of UI changes
![image](https://user-images.githubusercontent.com/16824702/62636305-4aa8d900-b907-11e9-9de3-b4d2a726b5c1.png)

* Detailed steps to verify changes work correctly (as executed by you)
  * Ran `ibazel run tensorboard/components/tensor_widget:dev_server`
  * Ran all tests
