### PR TITLE
Use `rel="noopener"` for `target="_blank"` links

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-initial-dialog.html
@@ -41,6 +41,7 @@ limitations under the License.
               <a
                 href="https://www.tensorflow.org/api_docs/python/tf/Session"
                 target="_blank"
+                rel="noopener noreferrer"
                 >tf.Session</a
               >:
             </div>
@@ -59,12 +60,14 @@ sess.run(my_fetches)
               <a
                 href="https://www.tensorflow.org/programmers_guide/estimators"
                 target="_blank"
+                rel="noopener noreferrer"
                 >Estimator</a
               >
               |
               <a
                 href="https://www.tensorflow.org/api_docs/python/tf/train/MonitoredSession"
                 target="_blank"
+                rel="noopener noreferrer"
                 >MonitoredSession</a
               >:
             </div>
@@ -78,7 +81,10 @@ my_estimator.fit(x=x_data, y=y_data, steps=1000, monitors=[hook])
           </div>
           <div class="code-example-section">
             <div class="code-example-section-title">
-              <a href="https://keras.io/models/model/" target="_blank"
+              <a
+                href="https://keras.io/models/model/"
+                target="_blank"
+                rel="noopener noreferrer"
                 >Keras Model</a
               >:
             </div>

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -1362,6 +1362,7 @@ limitations under the License.
                 target="_blank"
                 class="control"
                 href="https://github.com/tensorflow/tensorboard/tree/master/tensorboard/plugins/interactive_inference/README.md"
+                rel="noopener noreferrer"
               >
                 <paper-icon-button
                   icon="help-outline"

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-app.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-app.html
@@ -61,7 +61,12 @@ limitations under the License.
       <div id="appbar">
         <div>Embedding Projector</div>
         <div class="icons">
-          <a title="Documentation" target="_blank" href="[[documentationLink]]">
+          <a
+            title="Documentation"
+            target="_blank"
+            href="[[documentationLink]]"
+            rel="noopener noreferrer"
+          >
             <paper-icon-button icon="help-outline"></paper-icon-button>
             <paper-tooltip
               position="bottom"
@@ -71,7 +76,12 @@ limitations under the License.
               Open documentation
             </paper-tooltip>
           </a>
-          <a title="Report bug" target="_blank" href="[[bugReportLink]]">
+          <a
+            title="Report bug"
+            target="_blank"
+            href="[[bugReportLink]]"
+            rel="noopener noreferrer"
+          >
             <paper-icon-button icon="bug-report"></paper-icon-button>
             <paper-tooltip
               position="bottom"

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
@@ -568,6 +568,7 @@ limitations under the License.
                 these simple steps. See
                 <a
                   target="_blank"
+                  rel="noopener noreferrer"
                   href="https://www.tensorflow.org/get_started/embedding_viz"
                   >this tutorial</a
                 >
@@ -580,7 +581,10 @@ limitations under the License.
               </p>
               <p>
                 One option is using a
-                <a target="_blank" href="https://gist.github.com/"
+                <a
+                  target="_blank"
+                  href="https://gist.github.com/"
+                  rel="noopener noreferrer"
                   >github gist</a
                 >. If you choose this approach, make sure to link directly to
                 the raw file.
@@ -628,7 +632,11 @@ limitations under the License.
               readonly
             ></paper-input>
             <div id="projector-share-button-container">
-              <a target="_blank" id="projector-share-url-link">
+              <a
+                target="_blank"
+                id="projector-share-url-link"
+                rel="noopener noreferrer"
+              >
                 <paper-button title="Test your shareable URL" class="ink-button"
                   >Test your shareable URL</paper-button
                 >

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.html
@@ -387,7 +387,11 @@ limitations under the License.
           </p>
           <p>
             <iron-icon icon="book" class="book-icon"></iron-icon>
-            <a target="_blank" href="http://distill.pub/2016/misread-tsne/">
+            <a
+              target="_blank"
+              href="http://distill.pub/2016/misread-tsne/"
+              rel="noopener noreferrer"
+            >
               How to use t-SNE effectively.
             </a>
           </p>


### PR DESCRIPTION
Summary:
Links with `target="_blank"` open in a new tab, but by default that new
tab can control the page that opened it via the `window.opener` object.
Using `rel="noopener"` closes this security hole.

Test Plan:
No automated test for now; we tend to catch these in code review, so
this is a backfill. Manual verification:

```
$ git grep -o noopener '*.html' | wc -l
20
$ git grep -o _blank '*.html' | wc -l
20
```

wchargin-branch: rel-noopener
