### PR TITLE
polymer2: fixed plugin dropdown UI issue

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -321,13 +321,11 @@ limitations under the License.
           -webkit-font-smoothing: antialiased;
           font-size: 14px;
           font-weight: 500;
-          text-transform: uppercase;
         }
         --paper-input-container-label: {
           -webkit-font-smoothing: antialiased;
           font-size: 14px;
           font-weight: 500;
-          text-transform: uppercase;
         }
       }
 
@@ -1004,7 +1002,7 @@ limitations under the License.
               type: 'CUSTOM_ELEMENT',
               elementName: legacyMetadata.elementName,
             },
-            tabName: legacyMetadata.tabName,
+            tabName: legacyMetadata.tabName.toUpperCase(),
             disableReload: legacyMetadata.isReloadDisabled || false,
             removeDom: legacyMetadata.removeDom || false,
           };
@@ -1058,7 +1056,7 @@ limitations under the License.
             registry[name] = {
               plugin: name,
               loadingMechanism: loadingMechanism,
-              tabName: backendMetadata.tab_name,
+              tabName: backendMetadata.tab_name.toUpperCase(),
               disableReload: backendMetadata.disable_reload,
               removeDom: backendMetadata.remove_dom,
             };

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -96,7 +96,7 @@ limitations under the License.
               if="[[_inactiveDashboardsExist(_dashboardData, disabledDashboards, _activeDashboards)]]"
             >
               <paper-dropdown-menu
-                label="Inactive"
+                label="INACTIVE"
                 no-label-float
                 noink
                 style="margin-left: 12px"
@@ -337,14 +337,11 @@ limitations under the License.
       }
 
       #inactive-dashboards-menu {
-        --paper-menu-background-color: var(
+        --paper-listbox-background-color: var(
           --tb-toolbar-background-color,
           var(--tb-orange-strong)
         );
-        --paper-menu-color: white;
-        --paper-menu: {
-          text-transform: uppercase;
-        }
+        --paper-listbox-color: white;
       }
 
       .global-actions {


### PR DESCRIPTION
Now that we have real ShadowDom, the input within the paper-input has to
be styled through mulitple layers of webcomponents, correctly. Normally,
we would be using ShadyCSS (CSS mixin did not make it to the spec) and a
mixin API exposed by appropriate WebComponents to achieve that but it is
not viable in this case. Specifically, paper-dropdown-menu allows
styling of paper-input using a mixin but in order to style input within
the paper-input, we need to use another mixin. ShadyCSS explicitly says
the nested mixin is not supported.

Instead of transforming with CSS, we decided to fix the issue by
preprocessing the tabName in JavaScript.

See:
https://github.com/webcomponents/polyfills/tree/master/packages/shadycss#known-issues

Fixes #2446.