### PR TITLE
scalars: omit empty runs from `/tags` route

### DIFF
--- a/tensorboard/plugins/scalar/http_api.md
+++ b/tensorboard/plugins/scalar/http_api.md
@@ -36,8 +36,7 @@ Here is an example:
       }
     }
 
-Note that runs without any scalar tags are included as keys with value the
-empty dictionary.
+Runs without any scalar tags are omitted from the result.
 
 ## `/data/plugin/scalars/scalars?run=foo&tag=bar`
 

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -115,9 +115,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
         }
       return result
 
-    runs = self._multiplexer.Runs()
-    result = {run: {} for run in runs}
-
+    result = collections.defaultdict(lambda: {})
     mapping = self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME)
     for (run, tag_to_content) in six.iteritems(mapping):
       for (tag, content) in six.iteritems(tag_to_content):

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -156,7 +156,7 @@ class ScalarsPluginTest(tf.test.TestCase):
                 'description': self._HTML_DESCRIPTION,
             },
         },
-        self._RUN_WITH_HISTOGRAM: {},
+        # _RUN_WITH_HISTOGRAM omitted: No scalar data.
     }, self.plugin.index_impl())
 
   def _test_scalars_json(self, run_name, tag_name, should_work=True):


### PR DESCRIPTION
Summary:
This is not a user-facing change, because the runs selector is populated
by the separate `/data/runs` endpoint. As we begin to consider generic
data providers (cf. #2490), it seems superfluous that a “list scalars”
call to a storage layer might be required to include _all_ run names in
the response even if only a few have relevant data and the rest will be
ignored, anyway.

Test Plan:
Tests updated. Manually confirmed that runs like `text_demo` continue to
appear in the scalar dashboard’s run selector even though they have no
scalar data.

wchargin-branch: scalars-omit-empty
