### PR TITLE
Wrap rollup_bundle around tf_js_binary for interop

### DIFF
--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -1,9 +1,8 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
+load("//tensorboard/defs:defs.bzl", "tf_js_binary")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 load("@npm_bazel_typescript//:index.bzl", "ts_devserver", "ts_library")
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -19,8 +18,9 @@ tf_web_library(
     ],
 )
 
-rollup_bundle(
+tf_js_binary(
     name = "tensor_widget_binary",
+    compile = 1,
     entry_point = ":tensor-widget.ts",
     deps = [
         ":tensor_widget_lib",
@@ -44,13 +44,13 @@ ts_library(
     srcs = [
         "dtype-utils-test.ts",
     ],
+    tsconfig = "//:tsconfig-test",
     deps = [
         ":tensor_widget_lib",
         "@npm//@types/chai",
         "@npm//@types/jasmine",
         "@npm//chai",
     ],
-    tsconfig = "//:tsconfig-test",
 )
 
 jasmine_node_test(
@@ -60,12 +60,12 @@ jasmine_node_test(
 
 ts_devserver(
     name = "dev_server",
-    deps = [":tensor_widget_lib"],
-    serving_path = "/bundle.js",
     entry_module = "tensor-widget",
+    index_html = "demo/demo.html",
+    serving_path = "/bundle.js",
     static_files = [
         "demo/demo.css",
         "demo/demo.html",
     ],
-    index_html = "demo/demo.html",
+    deps = [":tensor_widget_lib"],
 )

--- a/tensorboard/components/tf_ng_tensorboard/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/BUILD
@@ -1,11 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_js_binary")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
-
 
 tf_web_library(
     name = "tf_ng_tensorboard",
@@ -15,12 +14,13 @@ tf_web_library(
     ],
     path = "/tf-ng-tensorboard",
     deps = [
-        ":tf_ng_tensorboard_binary"
+        ":tf_ng_tensorboard_binary",
     ],
 )
 
-rollup_bundle(
+tf_js_binary(
     name = "tf_ng_tensorboard_binary",
+    compile = 1,
     entry_point = ":main.ts",
     deps = [
         ":ng_main",
@@ -36,13 +36,13 @@ rollup_bundle(
 ng_module(
     name = "ng_main",
     srcs = [
-        "main.ts"
+        "main.ts",
     ],
     deps = [
         ":app",
         "@npm//@angular/core",
-        "@npm//@angular/router",
         "@npm//@angular/platform-browser",
+        "@npm//@angular/router",
         "@npm//zone.js",
     ],
 )
@@ -50,9 +50,9 @@ ng_module(
 ng_module(
     name = "app",
     srcs = [
-        "app-routing.module.ts",
-        "app.module.ts",
         "app.component.ts",
+        "app.module.ts",
+        "app-routing.module.ts",
     ],
     assets = [
         "app.component.css",
@@ -60,7 +60,7 @@ ng_module(
     ],
     deps = [
         "@npm//@angular/core",
-        "@npm//@angular/router",
         "@npm//@angular/platform-browser",
+        "@npm//@angular/router",
     ],
 )

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -11,7 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
 
 def tensorboard_webcomponent_library(**kwargs):
-  """Rules referencing this will be deleted from the codebase soon."""
-  pass
+    """Rules referencing this will be deleted from the codebase soon."""
+    pass
+
+def tf_js_binary(compile, **kwargs):
+    """Rules for creating a JavaScript bundle.
+
+    Please refer to https://bazelbuild.github.io/rules_nodejs/Built-ins.html#rollup_bundle
+    for more details.
+    """
+
+    # `compile` option is used internally but is not used by rollup_bundle.
+    # Discard it.
+    rollup_bundle(**kwargs)


### PR DESCRIPTION
In order to sync the latest change that includes rollup_bundle into
Google, we need to make a wrapper that change some behavior internally.

Extraenous changes are auto formatter (buildifier plugin) acting up.