### PR TITLE
ui: fixed graph causing dropdown-menu bug

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -46,6 +46,8 @@ limitations under the License.
           padding: 0;
           color: gray;
         }
+        --iron-icon-width: 15px;
+        --iron-icon-height: 15px;
         --primary-text-color: gray;
         --paper-item-min-height: 30px;
       }

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -39,21 +39,14 @@ limitations under the License.
         flex-direction: column;
         font-size: 12px;
         width: 100%;
+      }
 
-        --paper-font-subhead: {
-          font-size: 14px;
-          color: gray;
-        }
-        --paper-dropdown-menu-icon: {
-          width: 15px;
-          height: 15px;
-        }
-        --paper-dropdown-menu-button: {
-          padding: 0;
-        }
+      paper-dropdown-menu {
         --paper-dropdown-menu-input: {
           padding: 0;
+          color: gray;
         }
+        --primary-text-color: gray;
         --paper-item-min-height: 30px;
       }
 


### PR DESCRIPTION
repro case: https://next.plnkr.co/edit/4MCqtk5HAo3oTOKa

Unclear exactly why it behaves as it does. We can posit that it is a bug
with how shadyCSS handles the mixin and applies one.

While fixing the bug, vetted the CSS rules and removed unnecessary ones
(e.g., ---paper-font-subhead).

Fixes #2403.