### PR TITLE
ng: remove tf_web_library target

### DIFF
--- a/tensorboard/components/tf_ng_tensorboard/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/BUILD
@@ -2,21 +2,9 @@ package(default_visibility = ["//tensorboard:internal"])
 
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_js_binary")
-load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
-    name = "tf_ng_tensorboard",
-    srcs = [
-        ":tf_ng_tensorboard_binary.js",
-        "@npm//:node_modules/zone.js/dist/zone.js",
-    ],
-    path = "/tf-ng-tensorboard",
-    deps = [
-        ":tf_ng_tensorboard_binary",
-    ],
-)
 
 tf_js_binary(
     name = "tf_ng_tensorboard_binary",


### PR DESCRIPTION
This change removes the tf_web_library target from the
tf_ng_tensorboard to unblock google sync process.

Generally speaking, tf_web_library is an impediment in general to our
building/development cycle so we should reconsider using the
tf_web_library for angular source at all. We are currently thinking that
Angular source can depend on Polymer but Polymer cannot depend on
Angular.
