### PR TITLE
Improve memory viewer and tf-op-profile tool. 

### DIFF
--- a/tensorboard/plugins/profile/memory_viewer/memory_usage/memory-usage.ts
+++ b/tensorboard/plugins/profile/memory_viewer/memory_usage/memory-usage.ts
@@ -94,7 +94,31 @@ namespace memory_viewer_usage {
       }
       this.initBuffers_(bufferAssignment);
       this.initAllocations_(bufferAssignment);
-      this.findPeakMemoryUsage_(bufferAssignment);
+      const trace = this.getHbmHeapTrace_(bufferAssignment);
+      if (!trace) {
+        console.error('Missing hbm heap simulator trace.');
+        return;
+      }
+      this.findPeakMemoryUsage_(trace);
+    }
+
+    /**
+     * From a list of heap simulator traces, identify the one uses the HBM
+     * memory space.
+     */
+    private getHbmHeapTrace_(bufferAssignment) {
+      const kHbmColor = 0;
+      for (const trace of bufferAssignment.heapSimulatorTraces) {
+        for (const event of trace.events) {
+          if (!event.bufferId) continue;
+          const buffer = this.idToBuffer_[event.bufferId];
+          if (!buffer) continue;
+          if (buffer.color != kHbmColor) break;
+          // This heap simulator trace is for hbm.
+          return trace;
+        }
+      }
+      return null;
     }
 
     /**
@@ -219,9 +243,9 @@ namespace memory_viewer_usage {
     }
 
     /**
-     * Finds the peak memory usage from the `bufferAssignment`.
+     * Finds the peak memory usage from the `heapSimulatorTrace`.
      */
-    private findPeakMemoryUsage_(bufferAssignment) {
+    private findPeakMemoryUsage_(heapSimulatorTrace) {
       let heapSizes: number[] = [];
       let unpaddedHeapSizes: number[] = [];
       let logicalBuffers: number[] = [];
@@ -233,7 +257,7 @@ namespace memory_viewer_usage {
       // Unpadded size at peak.
       let unpaddedPeakHeapSizeBytes = 0;
       let peakHeapSizePosition = 0;
-      for (const event of bufferAssignment.heapSimulatorTraces[0].events) {
+      for (const event of heapSimulatorTrace.events) {
         heapSizes.push(memory_viewer_utils.bytesToMiB(heapSizeBytes));
         unpaddedHeapSizes.push(
           memory_viewer_utils.bytesToMiB(unpaddedHeapSizeBytes)
@@ -253,6 +277,7 @@ namespace memory_viewer_usage {
         }
         switch (event.kind.toString()) {
           case 'ALLOC':
+          case 'SHARE_WITH':
             logicalBuffers.push(eventId);
             heapSizeBytes += buffer.size;
 
@@ -281,12 +306,6 @@ namespace memory_viewer_usage {
             if (heapSizeBytes < 0) {
               console.error('heap_size_bytes < 0');
             }
-            break;
-          case 'SHARE_WITH':
-            // Nothing to do, but note we've seen the shared thing.
-            this.unSeenLogicalBuffers_.delete(
-              parseInt(event.shareWithCanonicalId, 10)
-            );
             break;
           default:
             console.log('ERROR: unknown heap event kind:', event);

--- a/tensorboard/plugins/profile/memory_viewer/memory_usage/memory-usage.ts
+++ b/tensorboard/plugins/profile/memory_viewer/memory_usage/memory-usage.ts
@@ -107,6 +107,7 @@ namespace memory_viewer_usage {
      * memory space.
      */
     private getHbmHeapTrace_(bufferAssignment) {
+      // XLA memory space colors and Hbm memory space is colored to 0.
       const kHbmColor = 0;
       for (const trace of bufferAssignment.heapSimulatorTraces) {
         for (const event of trace.events) {

--- a/tensorboard/plugins/profile/memory_viewer/memory_usage/memory-usage.ts
+++ b/tensorboard/plugins/profile/memory_viewer/memory_usage/memory-usage.ts
@@ -107,7 +107,8 @@ namespace memory_viewer_usage {
      * memory space.
      */
     private getHbmHeapTrace_(bufferAssignment) {
-      // XLA memory space colors and Hbm memory space is colored to 0.
+      // The color here indicates the XLA memory space color assigned to each
+      // logical buffer by graph coloring pass.
       const kHbmColor = 0;
       for (const trace of bufferAssignment.heapSimulatorTraces) {
         for (const event of trace.events) {

--- a/tensorboard/plugins/profile/memory_viewer/xla/logical-buffer.ts
+++ b/tensorboard/plugins/profile/memory_viewer/xla/logical-buffer.ts
@@ -18,6 +18,7 @@ namespace memory_viewer_xla_lb {
   export class LogicalBuffer {
     id: number;
     size: number;
+    color: number;
     computationName: string | undefined = '';
     instructionName: string | undefined = '';
     shapeIndex: number[] = [];
@@ -25,6 +26,7 @@ namespace memory_viewer_xla_lb {
     constructor(buffer) {
       this.id = parseInt(buffer.id, 10);
       this.size = parseInt(buffer.size, 10);
+      this.color = parseInt(buffer.color, 10);
       this.initBufferLocation_(buffer.definedAt);
     }
 

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-details.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-details.html
@@ -19,7 +19,7 @@ You may obtain a copy of the License at
 <link rel="import" href="utils.html" />
 
 <!--
-  tf-op-bar shows a small % utilization bar, colored using flameColor.
+  tf-op-bar shows two small % utilization bars, colored using flameColor.
 -->
 <dom-module id="tf-op-bar">
   <template>
@@ -36,15 +36,15 @@ You may obtain a copy of the License at
     Polymer({
       is: 'tf-op-bar',
       properties: {
-        value: {
-          type: Number,
-          notify: true,
-          observer: '_updateValue',
-        },
+        value: { type: Number, },
+        color: { type: String, },
       },
+      observers: [
+        '_updateValue(value, color)',
+      ],
       _percent: tf_op_profile.percent,
-      _updateValue: function(value) {
-        const color = tf_op_profile.flameColor(value);
+      _updateValue: function(value, color) {
+        if (!color) return;
         const length = tf_op_profile.percent(value);
         this.style.background = `linear-gradient(to right, ${color} ${length}, #ccc ${length})`;
       },
@@ -126,11 +126,18 @@ You may obtain a copy of the License at
       <div class="card-content">
         <div hidden="[[!_hasFlops(node)]]">
           <b>FLOPS utilization: </b>
-          <tf-op-bar value="[[_utilization(node)]]"></tf-op-bar>
+          <tf-op-bar color="[[_flopsColor(node)]]" value="[[_utilization(node)]]"></tf-op-bar>
         </div>
         <div hidden="[[!_hasMemoryUtilization(node)]]">
-          <b>Memory utilization: </b>
-          <tf-op-bar value="[[_memoryUtilization(node)]]"></tf-op-bar>
+          <b>Memory bandwidth utilization: </b>
+          <tf-op-bar color="[[_bwColor(node)]]" value="[[_memoryUtilization(node)]]"></tf-op-bar>
+        </div>
+        <div class="unavailable" hidden="[[!_fused(node)]]">
+          Performance information for individual fused operations is not
+          available.
+        </div>
+        <div class="unavailable" hidden="[[!node.category]]">
+          Select items within this category for performance details.
         </div>
         <div hidden="[[!node.xla.expression]]">
           <b>XLA Expression: </b>
@@ -139,13 +146,6 @@ You may obtain a copy of the License at
         <div hidden="[[!node.xla.provenance]]">
           <b>TensorFlow Name: </b>
           <code class="expression">[[node.xla.provenance]]</code>
-        </div>
-        <div class="unavailable" hidden="[[!_fused(node)]]">
-          Performance information for individual fused operations is not
-          available.
-        </div>
-        <div class="unavailable" hidden="[[!node.category]]">
-          Select items within this category for performance details.
         </div>
         <div hidden="[[!node.xla.layout]]">
           <b>Layout: </b>
@@ -197,7 +197,7 @@ You may obtain a copy of the License at
         return 'Unknown';
       },
       _fused: function(node) {
-        return node && node.xla && !node.metrics;
+        return node && node.xla && !(node.metrics && node.metrics.time);
       },
       _dimensionColor: function(dim) {
         if (!dim || !dim.alignment) return null;
@@ -217,6 +217,12 @@ You may obtain a copy of the License at
         var mulSuffix = mul == 1 ? '' : ': ' + mul + ' × ' + dim.alignment;
         if (dim.size % dim.alignment == 0) return 'Exact fit' + mulSuffix;
         return 'Pad to ' + mul * dim.alignment + mulSuffix;
+      },
+      _flopsColor: function(node) {
+        return tf_op_profile.flopsColor(tf_op_profile.utilization(node));
+      },
+      _bwColor: function(node) {
+        return tf_op_profile.bwColor(tf_op_profile.memoryUtilization(node));
       },
     });
   </script>

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-details.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-details.html
@@ -36,12 +36,10 @@ You may obtain a copy of the License at
     Polymer({
       is: 'tf-op-bar',
       properties: {
-        value: { type: Number, },
-        color: { type: String, },
+        value: {type: Number},
+        color: {type: String},
       },
-      observers: [
-        '_updateValue(value, color)',
-      ],
+      observers: ['_updateValue(value, color)'],
       _percent: tf_op_profile.percent,
       _updateValue: function(value, color) {
         if (!color) return;
@@ -126,11 +124,17 @@ You may obtain a copy of the License at
       <div class="card-content">
         <div hidden="[[!_hasFlops(node)]]">
           <b>FLOPS utilization: </b>
-          <tf-op-bar color="[[_flopsColor(node)]]" value="[[_utilization(node)]]"></tf-op-bar>
+          <tf-op-bar
+            color="[[_flopsColor(node)]]"
+            value="[[_utilization(node)]]"
+          ></tf-op-bar>
         </div>
         <div hidden="[[!_hasMemoryUtilization(node)]]">
           <b>Memory bandwidth utilization: </b>
-          <tf-op-bar color="[[_bwColor(node)]]" value="[[_memoryUtilization(node)]]"></tf-op-bar>
+          <tf-op-bar
+            color="[[_bwColor(node)]]"
+            value="[[_memoryUtilization(node)]]"
+          ></tf-op-bar>
         </div>
         <div class="unavailable" hidden="[[!_fused(node)]]">
           Performance information for individual fused operations is not

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
@@ -79,9 +79,12 @@ You may obtain a copy of the License at
       <h3>
         Overall TPU FLOPS utilization is
         <span style$="color:[[_flopsColor(_root)]]">
-          [[_utilizationPercent(_root)]]</span>
-        , memory bandwidth utilization is <span style$="color:[[_bwColor(_root)]]">
-        [[_memoryUtilizationPercent(_root)]]</span>
+          [[_utilizationPercent(_root)]]</span
+        >
+        , memory bandwidth utilization is
+        <span style$="color:[[_bwColor(_root)]]">
+          [[_memoryUtilizationPercent(_root)]]</span
+        >
       </h3>
       <div id="description">
         <p>
@@ -91,8 +94,8 @@ You may obtain a copy of the License at
         </p>
         <p>
           "Idle" represents the portion of the total execution time on device
-          that is idle. Wasted time is defined by
-          RuntimeFraction * (1 - max(FlopsUtilization, MemoryUtilization)).
+          that is idle. Wasted time is defined by RuntimeFraction * (1 -
+          max(FlopsUtilization, MemoryUtilization)).
         </p>
       </div>
       <div id="control">
@@ -122,9 +125,11 @@ You may obtain a copy of the License at
           </paper-slider
           >ops</span
         >
-        <span class="controlRowRight">&nbsp;
-          <paper-toggle-button checked={{byWaste}}>
-          </paper-toggle-button>Sort by wasted time</span>
+        <span class="controlRowRight"
+          >&nbsp;
+          <paper-toggle-button checked="{{byWaste}}"> </paper-toggle-button>Sort
+          by wasted time</span
+        >
         <span class="controlRowRight"
           >off&nbsp;
           <paper-toggle-button checked="{{showP90}}"> </paper-toggle-button>Top

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
@@ -76,12 +76,13 @@ You may obtain a copy of the License at
       }
     </style>
     <div class="tf-op-profile">
-      <h4>
+      <h3>
         Overall TPU FLOPS utilization is
-        <span style$="color:[[_textColor(_root)]]">
-          [[_utilizationPercent(_root)]]</span
-        >
-      </h4>
+        <span style$="color:[[_flopsColor(_root)]]">
+          [[_utilizationPercent(_root)]]</span>
+        , memory bandwidth utilization is <span style$="color:[[_bwColor(_root)]]">
+        [[_memoryUtilizationPercent(_root)]]</span>
+      </h3>
       <div id="description">
         <p>
           Modifying your model's architecture, data dimensions, and improving
@@ -90,7 +91,8 @@ You may obtain a copy of the License at
         </p>
         <p>
           "Idle" represents the portion of the total execution time on device
-          that is idle.
+          that is idle. Wasted time is defined by
+          RuntimeFraction * (1 - max(FlopsUtilization, MemoryUtilization)).
         </p>
       </div>
       <div id="control">
@@ -101,8 +103,11 @@ You may obtain a copy of the License at
         >
         <!--
           paper-slider sets how many child nodes to show for each category.
-          If paper-toggle-button is checked, then only children in top 90th
-          percentile of time spent are listed.
+          If P90 paper-toggle-button is checked, then only children in top 90th
+          percentile of time spent are listed. If byWaste paper-toggle-button is
+          checked, then the children by be sorted by wasted time, that is
+          defined by the following equation:
+          RuntimeFraction * (1 - max(FlopsUtilization, MemoryUtilization)).
         -->
         <span class="controlRowLeft"
           >Show top
@@ -117,6 +122,9 @@ You may obtain a copy of the License at
           </paper-slider
           >ops</span
         >
+        <span class="controlRowRight">&nbsp;
+          <paper-toggle-button checked={{byWaste}}>
+          </paper-toggle-button>Sort by wasted time</span>
         <span class="controlRowRight"
           >off&nbsp;
           <paper-toggle-button checked="{{showP90}}"> </paper-toggle-button>Top
@@ -126,6 +134,7 @@ You may obtain a copy of the License at
       <tf-op-table
         root-node="[[_root]]"
         active="{{active}}"
+        by-waste="{{byWaste}}"
         show-p90="{{showP90}}"
         children-count="{{childrenCount}}"
       >
@@ -165,6 +174,11 @@ You may obtain a copy of the License at
           value: false,
           notify: true,
         },
+        byWaste: {
+          type: Boolean,
+          value: false,
+          notify: true,
+        },
         childrenCount: {
           type: Number,
           value: 10,
@@ -191,11 +205,17 @@ You may obtain a copy of the License at
       _utilizationPercent: function(node) {
         return tf_op_profile.percent(tf_op_profile.utilization(node));
       },
+      _memoryUtilizationPercent: function(node) {
+        return tf_op_profile.percent(tf_op_profile.memoryUtilization(node));
+      },
       _hasFlops: function(node) {
         return node.metrics.flops > 0;
       },
-      _textColor: function(node) {
-        return tf_op_profile.flameColor(tf_op_profile.utilization(node), 0.7);
+      _flopsColor: function(node) {
+        return tf_op_profile.flopsColor(tf_op_profile.utilization(node));
+      },
+      _bwColor: function(node) {
+        return tf_op_profile.bwColor(tf_op_profile.memoryUtilization(node));
       },
     });
   </script>

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-profile.html
@@ -94,8 +94,11 @@ You may obtain a copy of the License at
         </p>
         <p>
           "Idle" represents the portion of the total execution time on device
-          that is idle. Wasted time is defined by RuntimeFraction * (1 -
-          max(FlopsUtilization, MemoryUtilization)).
+          that is idle. Wasted time is defined by
+          <code
+            >RuntimeFraction * (1 - max(FlopsUtilization,
+            MemoryUtilization))</code
+          >.
         </p>
       </div>
       <div id="control">

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-table.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-table.html
@@ -405,7 +405,8 @@ limitations under the License.
           return 0;
         }
         return (a, b) => {
-            return tf_op_profile.timeWasted(b) - tf_op_profile.timeWasted(a)};
+          return tf_op_profile.timeWasted(b) - tf_op_profile.timeWasted(a);
+        };
       },
     });
   </script>

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-table.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-table.html
@@ -264,7 +264,7 @@ limitations under the License.
       <template
         is="dom-repeat"
         items="{{_getKChildren(node, childrenCount, showP90, level)}}"
-        sort="{{_sort(byWaste)}}"
+        sort="[[_sort(byWaste)]]"
       >
         <tf-op-table-entry
           node="[[item]]"

--- a/tensorboard/plugins/profile/tf_op_profile/tf-op-table.html
+++ b/tensorboard/plugins/profile/tf_op_profile/tf-op-table.html
@@ -22,6 +22,7 @@ limitations under the License.
   <template>
     <style>
       #time,
+      #wasted,
       #utilization {
         width: 60px;
       }
@@ -81,6 +82,7 @@ limitations under the License.
     </style>
     <div id="header">
       <span id="time">Time</span>
+      <span id="wasted">Wasted</span>
       <span id="name">Name</span>
       <span id="provenance">TensorFlow Op</span>
       <span id="utilization">FLOPS</span>
@@ -91,6 +93,7 @@ limitations under the License.
       header-click="[[_onHeaderClick]]"
       children-count="{{childrenCount}}"
       show-p90="{{showP90}}"
+      by-waste="{{byWaste}}"
       expanded="true"
     >
     </tf-op-table-entry>
@@ -109,6 +112,11 @@ limitations under the License.
           notify: true,
         },
         showP90: {
+          type: Boolean,
+          value: false,
+          notify: true,
+        },
+        byWaste: {
           type: Boolean,
           value: false,
           notify: true,
@@ -206,11 +214,12 @@ limitations under the License.
         font-family: monospace;
       }
       #time,
+      #wasted,
       #utilization {
         font-size: smaller;
       }
       /* Utilization has a background color, so it stretches to fill the row.
-   Its text is in an inner div that remains vertically centered. */
+         Its text is in an inner div that remains vertically centered. */
       #utilization {
         align-self: stretch;
       }
@@ -233,6 +242,7 @@ limitations under the License.
     >
       <div id="bar" style$="width:{{_barWidth(node)}}"></div>
       <span id="time">{{_percent(node)}}</span>
+      <span id="wasted">{{_timeWasted(node)}}</span>
       <span id="name" style$="padding-left:[[level]]em;">
         <span id="disclosure">
           <span hidden="[[!node.children.length]]">
@@ -254,11 +264,13 @@ limitations under the License.
       <template
         is="dom-repeat"
         items="{{_getKChildren(node, childrenCount, showP90, level)}}"
+        sort="{{_sort(byWaste)}}"
       >
         <tf-op-table-entry
           node="[[item]]"
           children-count="{{childrenCount}}"
           show-p90="{{showP90}}"
+          by-waste="{{byWaste}}"
           level="{{_nextLevel(level)}}"
           header-hover="{{headerHover}}"
           header-click="{{headerClick}}"
@@ -329,6 +341,9 @@ limitations under the License.
           ? tf_op_profile.percent(node.metrics.time)
           : '';
       },
+      _timeWasted: function(node) {
+        return tf_op_profile.percent(tf_op_profile.timeWasted(node));
+      },
       _provenance: function(node) {
         return node.xla && node.xla.provenance
           ? node.xla.provenance.replace(/^.*\//, '')
@@ -354,9 +369,9 @@ limitations under the License.
         this.classList.toggle('selected', v);
       },
       /*
-    Returns top K children for the node. If p90 is true, then only children
-    fallen in the top 90th percentile in time are returned.
-  */
+       Returns top K children for the node. If p90 is true, then only children
+       fallen in the top 90th percentile in time are returned.
+      */
       _getKChildren: function(node, k, p90, level) {
         if (p90 && node.children.length > 0 && node.children[0].metrics) {
           var tot = 0,
@@ -379,6 +394,18 @@ limitations under the License.
       },
       _getPaddingLeft: function(level) {
         return level + 5;
+      },
+      /*
+       If byWaste is true, sort the children by wasted time in descending order.
+       The wasted time is defined by the following equation:
+       RuntimeFraction * (1 - max(FlopsUtilization, MemoryUtilization))
+      */
+      _sort: function(byWaste) {
+        if (!byWaste) {
+          return 0;
+        }
+        return (a, b) => {
+            return tf_op_profile.timeWasted(b) - tf_op_profile.timeWasted(a)};
       },
     });
   </script>

--- a/tensorboard/plugins/profile/tf_op_profile/utils.ts
+++ b/tensorboard/plugins/profile/tf_op_profile/utils.ts
@@ -49,6 +49,14 @@ namespace tf_op_profile {
       : rgba(2 * (1 - fraction) * brightness, brightness, 0, opacity);
   }
 
+  export function flopsColor(fraction: number) {
+    return flameColor(fraction, 0.7);
+  }
+
+  export function bwColor(fraction: number) {
+    return flameColor(1 - fraction, 0.7);
+  }
+
   export function utilization(node: any) {
     // NaN indicates undefined utilization for fused operations (we can't measure
     // performance inside a fusion). It could also indicate operations with zero
@@ -79,5 +87,10 @@ namespace tf_op_profile {
       : fraction < 0.00001
       ? '0.00%'
       : (fraction * 100).toPrecision(2) + '%';
+  }
+  export function timeWasted(node: any) {
+    if (!node || !node.metrics) return 0 / 0;
+    return node.metrics.time *
+        (1 - Math.max(utilization(node), memoryUtilization(node)));
   }
 } // namespace tf_op_profile

--- a/tensorboard/plugins/profile/tf_op_profile/utils.ts
+++ b/tensorboard/plugins/profile/tf_op_profile/utils.ts
@@ -90,7 +90,9 @@ namespace tf_op_profile {
   }
   export function timeWasted(node: any) {
     if (!node || !node.metrics) return 0 / 0;
-    return node.metrics.time *
-        (1 - Math.max(utilization(node), memoryUtilization(node)));
+    return (
+      node.metrics.time *
+      (1 - Math.max(utilization(node), memoryUtilization(node)))
+    );
   }
 } // namespace tf_op_profile

--- a/tensorboard/plugins/profile/tf_op_profile/utils.ts
+++ b/tensorboard/plugins/profile/tf_op_profile/utils.ts
@@ -58,17 +58,17 @@ namespace tf_op_profile {
   }
 
   export function utilization(node: any) {
-    // NaN indicates undefined utilization for fused operations (we can't measure
-    // performance inside a fusion). It could also indicate operations with zero
-    // time, but they currently don't appear in the profile.
-    if (!node || !node.metrics || !node.metrics.time) return 0 / 0;
+    // NaN indicates undefined utilization for fused operations (we can't
+    // measure performance inside a fusion). It could also indicate operations
+    // with zero time, but they currently don't appear in the profile.
+    if (!node || !node.metrics || !node.metrics.time) return NaN;
     return node.metrics.flops / node.metrics.time;
   }
 
   export function memoryUtilization(node: any) {
-    // NaN indicates undefined memory utilization (the profile was collected from
-    // older versions of profiler).
-    if (!node || !node.metrics || !node.metrics.memoryBandwidth) return 0 / 0;
+    // NaN indicates undefined memory utilization (the profile was collected
+    // from older versions of profiler).
+    if (!node || !node.metrics || !node.metrics.memoryBandwidth) return NaN;
     return node.metrics.memoryBandwidth;
   }
 
@@ -89,7 +89,7 @@ namespace tf_op_profile {
       : (fraction * 100).toPrecision(2) + '%';
   }
   export function timeWasted(node: any) {
-    if (!node || !node.metrics) return 0 / 0;
+    if (!node || !node.metrics) return NaN;
     return (
       node.metrics.time *
       (1 - Math.max(utilization(node), memoryUtilization(node)))


### PR DESCRIPTION
* Motivation for features / changes
Add bug fixes and feature requests that have been made internally but are not in Github repository.
* Technical description of changes
Memory viewer:
1)  Identify hbm heapSimulatorTrace from logical buffer color.
2)  Fix a bug that XLA made changes to heap simulator proto to have must alias support. 'SHARE_WITH' type allocation now needs to be taken into account in heap simulator.
Op Profile:
1) Add wasted time and sort by wasted time in the table.
2) Add memory bandwidth utilization to the header and make its color higher is red (bad) and lower is green (good).
3) Move unavailable info upper to where performance info is in the op details card.

* Screenshots of UI changes
![op_profile_demo](https://user-images.githubusercontent.com/3082188/62722104-89e83000-b9c2-11e9-9628-e06729d1e475.png)

(No change to memory viewer UI, only bug fixes.)

* Detailed steps to verify changes work correctly (as executed by you)
tensorboard --logdir=gs://cloud-tpu-tools
Run: 2019-08-02_23:38:56 op_profile and memory viewer tool.

* Alternate designs / implementations considered
