### PR TITLE
[graph plugin] Prevent health pills from showing up by default; Fix layout and default

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -407,7 +407,7 @@ limitations under the License.
       </div>
       <template is="dom-if" if="[[healthPillsFeatureEnabled]]">
         <div class="control-holder">
-          <paper-toggle-button checked="{{healthPillsToggledOn}}"
+          <paper-toggle-button checked="{{healthPillsToggledOn}}" class="title"
             >Show health pills</paper-toggle-button
           >
         </div>

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -409,8 +409,7 @@ limitations under the License.
         <div class="control-holder">
           <paper-toggle-button
             checked="{{healthPillsToggledOn}}"
-          ></paper-toggle-button>
-          <div class="title">Show health pills</div>
+          >Show health pills</paper-toggle-button>
         </div>
       </template>
       <div class="control-holder">

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.html
@@ -407,9 +407,9 @@ limitations under the License.
       </div>
       <template is="dom-if" if="[[healthPillsFeatureEnabled]]">
         <div class="control-holder">
-          <paper-toggle-button
-            checked="{{healthPillsToggledOn}}"
-          >Show health pills</paper-toggle-button>
+          <paper-toggle-button checked="{{healthPillsToggledOn}}"
+            >Show health pills</paper-toggle-button
+          >
         </div>
       </template>
       <div class="control-holder">

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -209,7 +209,7 @@ by default. The user can select a different run from a dropdown menu.
       specificHealthPillStep: {type: Number, value: 0},
       healthPillsToggledOn: {
         type: Boolean,
-        value: true,
+        value: false,
         observer: '_healthPillsToggledOnChanged',
       },
       selectedNode: {

--- a/tensorboard/plugins/graph/tf_graph_info/tf-graph-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-graph-info.html
@@ -152,7 +152,11 @@ limitations under the License.
           // So long as there is a mapping (even if empty) from node name to health pills, show the
           // legend and slider. We do that because, even if no health pills exist at the current step,
           // the user may desire to change steps, and the slider must show for the user to do that.
-          return debuggerDataEnabled && nodeNamesToHealthPills;
+          return (
+            debuggerDataEnabled &&
+            nodeNamesToHealthPills &&
+            Object.keys(nodeNamesToHealthPills).length > 0
+          );
         },
         _equals: function(a, b) {
           return a === b;


### PR DESCRIPTION
* Motivation for features / changes
  * Towards fixing https://github.com/tensorflow/tensorboard/issues/2518
  * Fixes https://github.com/tensorflow/tensorboard/issues/2527

* Technical description of changes
  * Check not only the `nodeNamesToHealthPills` variable is truthy, but also that the number of its keys is greater than 0.
  * Correct layout of the "show health pill" toggle.

* Screenshots of UI changes

![image](https://user-images.githubusercontent.com/16824702/62734080-16601600-b9f6-11e9-84b4-466e8d46054e.png)

The health pills no longer show up by default. The layout is fixed.

* Detailed steps to verify changes work correctly (as executed by you)
  * Verified that the health pills don't show up by default with a logdir with graphs in it.

