### PR TITLE
build: add `.bazelrc` to disable Python toolchains

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,5 @@
-common --incompatible_use_python_toolchains=false
+# For compatibility with Bazel 0.27 through 0.29. See:
+# <https://github.com/tensorflow/tensorboard/issues/2355>
+aquery --incompatible_use_python_toolchains=false
+build --incompatible_use_python_toolchains=false
+test --incompatible_use_python_toolchains=false

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+common --incompatible_use_python_toolchains=false


### PR DESCRIPTION
Summary:
This expands our forward-compatibility window to at least 0.29.0rc4 by
opting out of the `--incompatible_use_python_toolchains` flag whose
default was flipped in 0.27.0 (see #2355).

Fixes #2534.

Test Plan:
On Bazel 0.29.0rc4, verify that `//tensorboard` fetches, builds, and
runs correctly and that all tests pass, without the need to manually
specify any flags to Bazel.

wchargin-branch: bazelrc-toolchains
