### PR TITLE
infra: fix tomservo and nightly build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -65,6 +65,15 @@ yarn_install(
     name = "npm",
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",
+    # Opt out of symlinking local node_modules folder into bazel internal
+    # directory.  Symlinking is incompatible with our toolchain which often
+    # removes source directory without `bazel clean` which creates broken
+    # symlink into node_modules folder.
+    symlink_node_modules = False,
+    data = [
+        # package.json contains postinstall that requires this file.
+        "//:angular-metadata.tsconfig.json",
+    ],
 )
 
 load("@npm//:install_bazel_dependencies.bzl", "install_bazel_dependencies")


### PR DESCRIPTION
With the symlink_node_modules (default is True), the macro created a
symlink from $PWD/node_modules into bazel internal directory
(e.g., wherever bazel-tensorboard/external/npm/node_modules leads to).
Because we rm -rf the source directory, the node_modules folder gets removed,
creating a broken symlink. This change makes sure npm install does not create
such symlink but instead creates every folder under the bazel internal
directory.
