### PR TITLE
Fix dynamic plugin bootstrap sequence in Firefox

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -892,18 +892,23 @@ limitations under the License.
         const pluginBasePath = tf_backend
           .getRouter()
           .pluginRoute(selectedDashboard, '/');
-        const base = subdocument.createElement('base');
-        // TODO(stephanwlee): Use sanitized URL when setting the href.
-        // setAttribute is a bypass for the security conformance which we
-        // have no way to address.
-        base.setAttribute(
-          'href',
-          String(new URL(pluginBasePath, window.location.href))
-        );
-        subdocument.head.appendChild(base);
         const script = subdocument.createElement('script');
+        const baseHrefString = JSON.stringify(
+          new URL(pluginBasePath, window.location.href)
+        );
         const moduleString = JSON.stringify(loadingMechanism.modulePath);
-        script.textContent = `import(${moduleString}).then((m) => void m.render());`;
+        script.textContent = [
+          // `setTimeout(..., 0)` and the late `<base>` configuration
+          // (in the inline script rather than the host) are needed to
+          // work around a Firefox bug:
+          // https://github.com/tensorflow/tensorboard/issues/2536
+          `setTimeout(() => {\n`,
+          `  const base = document.createElement("base");\n`,
+          `  base.setAttribute("href", ${baseHrefString});\n`,
+          `  document.head.appendChild(base);\n`,
+          `  import(${moduleString}).then((m) => void m.render());\n`,
+          `}, 0);\n`,
+        ].join('');
         subdocument.body.appendChild(script);
       },
 


### PR DESCRIPTION
Summary:
We initialize dynamic plugins by creating a new iframe and injecting
into it a `script` element with `import("path/to/index.js")`. This does
not work in Firefox, throwing what appears to be an internal error:
<https://bugzilla.mozilla.org/show_bug.cgi?id=1573262>

@stephanwlee had the idea to try wrapping the contents of the inner
frame’s script with `setTimeout(…, 0)`, which worked! It turns out that
we have to move the `baseURI` initialization into that deferred context,
too.

Fixes #2536.

Test Plan:
Launch TensorBoard and navigate to `/#projector`. Confirm that the
projector plugin loads properly in both Chrome 76 and Firefox 68. The
vanilla JS `example_basic` plugin also works in both now, too.

Co-authored-by: Stephan Lee <stephanwlee@gmail.com>
wchargin-branch: dynamic-plugin-firefox
