### PR TITLE
added images to nearest neighbors list

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
@@ -227,10 +227,11 @@ limitations under the License.
         flex-direction: column;
       }
 
-      .results, .nn, .nn-list {
+      .results,
+      .nn,
+      .nn-list {
         flex: 1 0 100px;
       }
-
     </style>
     <div class="container">
       <div class="buttons">
@@ -293,17 +294,25 @@ limitations under the License.
             </div>
           </div>
           <div class="neighbor-image-controls">
-            <paper-checkbox id="neighbor-images-checkbox" class="no-images-available" checked="{{showNeighborImages}}">
-             show images
-             <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
-             <paper-tooltip
-               position="bottom"
-               animation-delay="0"
-               fit-to-visible-bounds
-             >
-               If image data is available, show the images of the nearest neighbors.
-             </paper-tooltip>
-           </paper-checkbox>
+            <paper-checkbox
+              id="neighbor-images-checkbox"
+              class="no-images-available"
+              checked="{{showNeighborImages}}"
+            >
+              show images
+              <paper-icon-button
+                icon="help"
+                class="help-icon"
+              ></paper-icon-button>
+              <paper-tooltip
+                position="bottom"
+                animation-delay="0"
+                fit-to-visible-bounds
+              >
+                If image data is available, show the images of the nearest
+                neighbors.
+              </paper-tooltip>
+            </paper-checkbox>
           </div>
         </div>
         <p>Nearest points in the original space:</p>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
@@ -127,7 +127,6 @@ limitations under the License.
       .nn-list .neighbor-image,
       .metadata-list .metadata-image {
         width: 100%;
-        display: None;
       }
 
       .nn-list.nn-img-show .neighbor-image,
@@ -160,10 +159,6 @@ limitations under the License.
       .neighbor-image-controls {
         display: flex;
         padding: 0.8em 0.1em;
-      }
-
-      .no-images-available {
-        display: None;
       }
 
       .options a {
@@ -294,25 +289,25 @@ limitations under the License.
             </div>
           </div>
           <div class="neighbor-image-controls">
-            <paper-checkbox
-              id="neighbor-images-checkbox"
-              class="no-images-available"
-              checked="{{showNeighborImages}}"
-            >
-              show images
-              <paper-icon-button
-                icon="help"
-                class="help-icon"
-              ></paper-icon-button>
-              <paper-tooltip
-                position="bottom"
-                animation-delay="0"
-                fit-to-visible-bounds
-              >
-                If image data is available, show the images of the nearest
-                neighbors.
-              </paper-tooltip>
-            </paper-checkbox>
+            <template is="dom-if" if="[[spriteImagesAvailable]]">
+                <paper-checkbox
+                  id="neighbor-images-checkbox"
+                  checked="{{showNeighborImages}}"
+                >
+                  show images
+                  <paper-icon-button
+                    icon="help"
+                    class="help-icon"
+                  ></paper-icon-button>
+                  <paper-tooltip
+                    position="bottom"
+                    animation-delay="0"
+                    fit-to-visible-bounds
+                  >
+                    Show the images of the nearest neighbors.
+                  </paper-tooltip>
+                </paper-checkbox>
+            </template>
           </div>
         </div>
         <p>Nearest points in the original space:</p>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
@@ -290,23 +290,23 @@ limitations under the License.
           </div>
           <div class="neighbor-image-controls">
             <template is="dom-if" if="[[spriteImagesAvailable]]">
-                <paper-checkbox
-                  id="neighbor-images-checkbox"
-                  checked="{{showNeighborImages}}"
+              <paper-checkbox
+                id="neighbor-images-checkbox"
+                checked="{{showNeighborImages}}"
+              >
+                show images
+                <paper-icon-button
+                  icon="help"
+                  class="help-icon"
+                ></paper-icon-button>
+                <paper-tooltip
+                  position="bottom"
+                  animation-delay="0"
+                  fit-to-visible-bounds
                 >
-                  show images
-                  <paper-icon-button
-                    icon="help"
-                    class="help-icon"
-                  ></paper-icon-button>
-                  <paper-tooltip
-                    position="bottom"
-                    animation-delay="0"
-                    fit-to-visible-bounds
-                  >
-                    Show the images of the nearest neighbors.
-                  </paper-tooltip>
-                </paper-checkbox>
+                  Show the images of the nearest neighbors.
+                </paper-tooltip>
+              </paper-checkbox>
             </template>
           </div>
         </div>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
@@ -124,6 +124,17 @@ limitations under the License.
         border-left: 1px solid rgba(0, 0, 0, 0.15);
       }
 
+      .nn-list .neighbor-image,
+      .metadata-list .metadata-image {
+        width: 100%;
+        display: None;
+      }
+
+      .nn-list.nn-img-show .neighbor-image,
+      .metadata-list.nn-img-show .metadata-image {
+        display: block;
+      }
+
       .nn-list .neighbor-link:hover,
       .metadata-list .metadata-link:hover {
         cursor: pointer;
@@ -146,6 +157,15 @@ limitations under the License.
         float: right;
       }
 
+      .neighbor-image-controls {
+        display: flex;
+        padding: 0.8em 0.1em;
+      }
+
+      .no-images-available {
+        display: None;
+      }
+
       .options a {
         color: #727272;
         font-size: 13px;
@@ -158,7 +178,7 @@ limitations under the License.
       }
 
       .neighbors {
-        margin-bottom: 30px;
+        margin-bottom: 15px;
       }
 
       .neighbors-options {
@@ -206,6 +226,11 @@ limitations under the License.
         display: flex;
         flex-direction: column;
       }
+
+      .results, .nn, .nn-list {
+        flex: 1 0 100px;
+      }
+
     </style>
     <div class="container">
       <div class="buttons">
@@ -266,6 +291,19 @@ limitations under the License.
               <a class="selected cosine" href="javascript:void(0);">COSINE</a>
               <a class="euclidean" href="javascript:void(0);">EUCLIDEAN</a>
             </div>
+          </div>
+          <div class="neighbor-image-controls">
+            <paper-checkbox id="neighbor-images-checkbox" class="no-images-available" checked="{{showNeighborImages}}">
+             show images
+             <paper-icon-button icon="help" class="help-icon"></paper-icon-button>
+             <paper-tooltip
+               position="bottom"
+               animation-delay="0"
+               fit-to-visible-bounds
+             >
+               If image data is available, show the images of the nearest neighbors.
+             </paper-tooltip>
+           </paper-checkbox>
           </div>
         </div>
         <p>Nearest points in the original space:</p>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.html
@@ -124,13 +124,13 @@ limitations under the License.
         border-left: 1px solid rgba(0, 0, 0, 0.15);
       }
 
-      .nn-list .neighbor-image,
-      .metadata-list .metadata-image {
+      .nn-list .sprite-image,
+      .metadata-list .sprite-image {
         width: 100%;
       }
 
-      .nn-list.nn-img-show .neighbor-image,
-      .metadata-list.nn-img-show .metadata-image {
+      .nn-list.nn-img-show .sprite-image,
+      .metadata-list.nn-img-show .sprite-image {
         display: block;
       }
 
@@ -290,10 +290,7 @@ limitations under the License.
           </div>
           <div class="neighbor-image-controls">
             <template is="dom-if" if="[[spriteImagesAvailable]]">
-              <paper-checkbox
-                id="neighbor-images-checkbox"
-                checked="{{showNeighborImages}}"
-              >
+              <paper-checkbox checked="{{showNeighborImages}}">
                 show images
                 <paper-icon-button
                   icon="help"

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
@@ -31,11 +31,11 @@ namespace vz_projector {
   });
 
   export type spriteMetadata = {
-    imagePath?: string,
-    singleImageDim?: number[],
-    aspectRatio?: number,
-    nCols?: number,
-  }
+    imagePath?: string;
+    singleImageDim?: number[];
+    aspectRatio?: number;
+    nCols?: number;
+  };
 
   export class InspectorPanel extends InspectorPanelPolymer {
     distFunc: DistanceFunction;
@@ -69,7 +69,9 @@ namespace vz_projector {
       this.limitMessage = this.$$('.limit-msg') as HTMLDivElement;
       this.searchBox = this.$$('#search-box') as ProjectorInput;
       this.displayContexts = [];
-      this.neighborImagesCheckbox = this.$$('#neighbor-images-checkbox') as HTMLInputElement
+      this.neighborImagesCheckbox = this.$$(
+        '#neighbor-images-checkbox'
+      ) as HTMLInputElement;
       this.setShowNeighborImages(this.neighborImagesCheckbox.checked);
     }
 
@@ -119,20 +121,27 @@ namespace vz_projector {
         return stats.name;
       });
 
-
-      if(spriteAndMetadata.spriteMetadata && spriteAndMetadata.spriteMetadata.imagePath) {
-        const [spriteWidth, spriteHeight] = spriteAndMetadata.spriteMetadata.singleImageDim;
+      if (
+        spriteAndMetadata.spriteMetadata &&
+        spriteAndMetadata.spriteMetadata.imagePath
+      ) {
+        const [
+          spriteWidth,
+          spriteHeight,
+        ] = spriteAndMetadata.spriteMetadata.singleImageDim;
         this.spriteMeta = {
           imagePath: spriteAndMetadata.spriteImage.src,
           aspectRatio: spriteWidth / spriteHeight,
           nCols: Math.floor(spriteAndMetadata.spriteImage.width / spriteWidth),
           singleImageDim: [spriteWidth, spriteHeight],
         };
-      }
-      else {
+      } else {
         this.spriteMeta = {};
       }
-      this.neighborImagesCheckbox.classList.toggle('no-images-available', !this.spriteMeta.imagePath)
+      this.neighborImagesCheckbox.classList.toggle(
+        'no-images-available',
+        !this.spriteMeta.imagePath
+      );
 
       if (
         this.selectedMetadataField == null ||
@@ -155,7 +164,7 @@ namespace vz_projector {
       this.enableResetFilterButton(false);
     }
 
-    setShowNeighborImages(show: boolean, selector='.nn-list') {
+    setShowNeighborImages(show: boolean, selector = '.nn-list') {
       this.showNeighborImages = show;
       const cls = 'nn-img-show';
       // NOTE: selector used so we could easily move to metadata-info
@@ -319,10 +328,10 @@ namespace vz_projector {
       const minDist = neighbors.length > 0 ? neighbors[0].dist : 0;
 
       const spriteImagePath = this.spriteMeta.imagePath;
-      if(spriteImagePath) {
-        var { aspectRatio, nCols } = this.spriteMeta;
+      if (spriteImagePath) {
+        var {aspectRatio, nCols} = this.spriteMeta;
         var paddingBottom = 100 / aspectRatio + '%';
-        var backgroundSize = (`${nCols * 100}% ${nCols * 100}%`);
+        var backgroundSize = `${nCols * 100}% ${nCols * 100}%`;
       }
 
       for (let i = 0; i < neighbors.length; i++) {
@@ -331,16 +340,20 @@ namespace vz_projector {
         const neighborElement = document.createElement('div');
         neighborElement.className = 'neighbor';
 
-        if(spriteImagePath) {
+        if (spriteImagePath) {
           var neighborElementImage = document.createElement('div');
           neighborElementImage.className = 'neighbor-image';
           neighborElementImage.style.backgroundImage = `url(${spriteImagePath})`;
           neighborElementImage.style.paddingBottom = paddingBottom;
 
           neighborElementImage.style.backgroundSize = backgroundSize;
-          const [ row, col ] = [ Math.floor(neighbor.index / nCols), neighbor.index % nCols ];
-          neighborElementImage.style.backgroundPosition = (
-            `${col / (nCols - 1) * 100}% ${row / (nCols - 1) * 100}%`);
+          const [row, col] = [
+            Math.floor(neighbor.index / nCols),
+            neighbor.index % nCols,
+          ];
+          neighborElementImage.style.backgroundPosition = `${(col /
+            (nCols - 1)) *
+            100}% ${(row / (nCols - 1)) * 100}%`;
         }
 
         const neighborElementLink = document.createElement('a');
@@ -387,7 +400,7 @@ namespace vz_projector {
           barElement.appendChild(tickElement);
         }
 
-        if(spriteImagePath) {
+        if (spriteImagePath) {
           neighborElement.appendChild(neighborElementImage);
         }
         neighborElementLink.appendChild(labelValueElement);

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
@@ -30,12 +30,12 @@ namespace vz_projector {
       showNeighborImages: {
         type: Boolean,
         value: true,
-        observer: '_updateNeighborsList',
+        observer: '_refreshNeighborsList',
       },
       spriteImagesAvailable: {
         type: Boolean,
         value: true,
-        observer: '_updateNeighborsList',
+        observer: '_refreshNeighborsList',
       },
     },
   });
@@ -169,12 +169,8 @@ namespace vz_projector {
       this.enableResetFilterButton(false);
     }
 
-    _updateNeighborsList() {
+    _refreshNeighborsList() {
       this.updateNeighborsList();
-    }
-
-    checkSpriteImagesAvailable() {
-      return !!this.spriteMeta.imagePath;
     }
 
     metadataEditorContext(enabled: boolean, metadataColumn: string) {
@@ -366,7 +362,7 @@ namespace vz_projector {
       const minDist = neighbors.length > 0 ? neighbors[0].dist : 0;
 
       if (this.spriteImagesAvailable && this.showNeighborImages) {
-        var image_renderer = this.spriteImageRenderer();
+        var imageRenderer = this.spriteImageRenderer();
       }
 
       for (let i = 0; i < neighbors.length; i++) {
@@ -420,7 +416,7 @@ namespace vz_projector {
         }
 
         if (this.spriteImagesAvailable && this.showNeighborImages) {
-          const neighborElementImage = image_renderer(neighbor);
+          const neighborElementImage = imageRenderer(neighbor);
           neighborElement.appendChild(neighborElementImage);
         }
 

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-inspector-panel.ts
@@ -132,7 +132,6 @@ namespace vz_projector {
         spriteAndMetadata.spriteMetadata &&
         spriteAndMetadata.spriteMetadata.imagePath
       ) {
-
         const [
           spriteWidth,
           spriteHeight,
@@ -171,7 +170,7 @@ namespace vz_projector {
     }
 
     _updateNeighborsList() {
-      if(this.projector) {
+      if (this.projector) {
         const neighbors = this.projector.dataSet.findNeighbors(
           this.selectedPointIndices[0],
           this.distFunc,
@@ -364,9 +363,10 @@ namespace vz_projector {
             Math.floor(neighbor.index / nCols),
             neighbor.index % nCols,
           ];
-          neighborElementImage.style.backgroundPosition = (
-            `${(col / (nCols - 1)) * 100}%
-             ${(row / (nCols - 1)) * 100}%`);
+          neighborElementImage.style.backgroundPosition = `${(col /
+            (nCols - 1)) *
+            100}%
+             ${(row / (nCols - 1)) * 100}%`;
         }
 
         const neighborElementLink = document.createElement('a');


### PR DESCRIPTION
* Motivation for features / changes

This is in reference to something in #2492. I'm working with image data (audio spectrograms, tbe) and I'm trying to visualize them with the embedding projector, but due to the transparency in the sprite textures and them just being small, it makes it difficult to actually make sense of and visualize neighboring points. So I wanted to add some view that allows us to see the images larger, more organized, without the shaders.

* Technical description of changes

I added the sprite images over each item in the nearest neighbor list (that pops up when you select a point).
I also added a checkbox to toggle this feature which will only be shown if a sprite image file is available.
It uses css background-image/position to load the image, and uses the singleImageDim to calculate and give the div the proper aspect ratio.

Sometimes it takes a second to show the images. I would have thought it would be cached from when it was loaded for THREE.js, but it's only a second so it's not too bad. 

One solution could be lazy loading the divs (see [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)), which I considered doing. It's not yet supported for Internet Explorer 8, (which like, why haven't ppl downloaded chrome or firefox or something, anything else.. 😝) so I figured I'd hold off before tying in the polyfill and all that.

I also fixed a bug where the nearest neighbors list wasn't scrolling (that was a problem before I started) - I just added flex params to the containers that needed it.

* Screenshots of UI changes

![image](https://user-images.githubusercontent.com/6741720/62971619-4a657d80-bde0-11e9-84d2-f7b9f56b8bf6.png)

* Detailed steps to verify changes work correctly (as executed by you)

Create a tensorboard run where you send your embeddings to the projector. My `projector_config.pbtxt` looks like this:
```
# projector_config.pbtxt
embeddings {
  tensor_name: "nat_embedding:0"
  metadata_path: "meta.txt"
  sprite {
    image_path: "sprite.png"
    single_image_dim: 256
    single_image_dim: 256
  }
}
```

Open the embedding projector and click on a point. This should open up the nearest neighbors panel, where you should see your sprites visible 🌈

* Alternate designs / implementations considered

 I still find it difficult to browse the images without zooming out far because they are all vertical and you can only look at a couple at a time, so having some way to expanding to multiple columns would be helpful. The two ways that I could see it working would be:
    - have the panel be expandable (drag the edge)
    - add a modal popup that shows some 6/8/12 column grid which could give us 20-50 on a page depending on how you like your zoom.

There are a few more things that I think we could do:
 - `metadata-info` is a very similar panel, but I haven't duplicated the code to have it handle both. Seeing as they are very similar, I think a good move could be to combine `updateNeighborsList` and `metadataEditorContext` using more general class names, because they are almost the same interface.
 - add an option to use a metadata column to provide "full scale" image links in the case where the sprites are too small. The big concern with this is that we'd definitely need to add lazy loading for this and potentially also decrease the default number of nearest neighbors.