### PR TITLE
graph: provide built-binary for legacy target

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_app/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_app/BUILD
@@ -2,6 +2,7 @@ package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -19,14 +20,17 @@ tf_web_library(
     ],
 )
 
+tensorboard_html_binary(
+    name = "binary",
+    compile = True,
+    input_path = "/tf-graph-app/tf-graph-app.html",
+    output_path = "/tf-graph-app/binary.html",
+    deps = [":tf_graph_app"],
+)
+
 tensorboard_webcomponent_library(
     name = "legacy",
-    srcs = [":tf_graph_app"],
+    srcs = [":binary"],
     destdir = "tf-graph-app",
-    deps = [
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/plugins/graph/tf_graph_board:legacy",
-        "//tensorboard/plugins/graph/tf_graph_controls:legacy",
-        "//tensorboard/plugins/graph/tf_graph_loader:legacy",
-    ],
 )
+


### PR DESCRIPTION
Internal build requires the built binary.