### PR TITLE
build: fix nondeterministic `tsc` error

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/test/hierarchy-test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/test/hierarchy-test.ts
@@ -12,9 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-const {expect} = chai;
-
 describe('hierarchy', () => {
+  const {expect} = chai;
+
   beforeEach(function() {
     const pbtxt = tf.graph.test.util.stringToArrayBuffer(`
       node {


### PR DESCRIPTION
Summary:
This fixes the following `tsc` error:

```
../../../../../../../../../../../../../../tmp/tmpMOk7do/tf-graph-common/test/hierarchy-test.ts(15,8): error TS2451: Cannot redeclare block-scoped variable 'expect'.
Target //tensorboard/plugins/graph/tf_graph_common/test:test_web_library failed to build
```

The error does not always appear. I can reproduce it on `bf227471` on
Linux after running `bazel clean --expunge` with Bazel 0.26.1, Python
3.6, and `tf-nightly-2.0-preview==2.0.0.dev20190814`, but @stephanwlee
can’t reproduce it with those same configurations.  We don’t know why
this happens, and we don’t know why I’m just seeing it now.

Test Plan:
Check that all `const {expect} = chai;` bindings are now within a scope
brace of some kind:

```
$ git grep -h -B 1 'const {expect}'
namespace tf_backend {
  const {expect} = chai;
--
namespace tf_paginated_view {
  const {expect} = chai;
--
namespace vz_line_chart2 {
  const {expect} = chai;
--
describe('hierarchy', () => {
  const {expect} = chai;
```

wchargin-branch: tsc-redeclare-expect
