### PR TITLE
Add `SECURITY.md` with disclosure instructions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# TensorBoard Security
+
+Please refer to [TensorFlow’s security model and guidelines][tf-security].
+
+To report any security related issues, please email `security@tensorflow.org`
+[as described in TensorFlow’s `SECURITY.md`][email]. Consult that document for
+details, including an encryption key for especially sensitive disclosures.
+
+[email]: https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md#reporting-vulnerabilities
+[tf-security]: https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md


### PR DESCRIPTION
Summary:
We don’t have much to say on top of TensorFlow’s existing `SECURITY.md`,
so we link to that and explicitly provide a disclosure email for
passersby. Links are intentionally to `master` rather than permalinks.

Test Plan:
Preview the Markdown on GitHub and click both links; verify that they
work.

wchargin-branch: security-md
