### PR TITLE
application: fix default flag value in test stub

### DIFF
--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -62,7 +62,7 @@ class FakeFlags(object):
       path_prefix='',
       reload_multifile=False,
       reload_multifile_inactive_secs=4000,
-      generic_data=frozenset()):
+      generic_data='auto'):
     self.logdir = logdir
     self.purge_orphaned_data = purge_orphaned_data
     self.reload_interval = reload_interval


### PR DESCRIPTION
Summary:
This doesn’t actually end up mattering, but the default value for each
flag should be a valid member of that flag’s domain. This is a hold-over
from a previous formulation of `--generic_data`.

Test Plan:
That tests pass suffices.

wchargin-branch: fix-test-default-flag
