### PR TITLE
hparams: mark public APIs as stable

### DIFF
--- a/tensorboard/plugins/hparams/api.py
+++ b/tensorboard/plugins/hparams/api.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Experimental public APIs for the HParams plugin.
+"""Public APIs for the HParams plugin.
 
 This module supports a spectrum of use cases, depending on how much
 structure you want. In the simplest case, you can simply collect your


### PR DESCRIPTION
Summary:
Active development of these APIs has completed, and they were published
in the 1.14 release notes. Closes #1998.

wchargin-branch: hparams-public-api
