### PR TITLE
data: add `list_runs` API call and implementation

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -36,6 +36,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         "//tensorboard/data:provider",
+        "//tensorboard/util:tb_logging",
         "//tensorboard/util:tensor_util",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/backend/event_processing/data_provider.py
+++ b/tensorboard/backend/event_processing/data_provider.py
@@ -51,18 +51,18 @@ class MultiplexerDataProvider(provider.DataProvider):
     try:
       return self._multiplexer.FirstEventTimestamp(run_name)
     except ValueError as e:
-      logger.warn(
-          "Unable to get first event timestamp for run %s: %s", run_name, e
-      )
-      # Put runs without a timestamp at the end.
-      return float("inf")
+      return None
 
   def list_runs(self, experiment_id):
     del experiment_id  # ignored for now
-    return sorted(
-        self._multiplexer.Runs(),
-        key=lambda run: (self._get_first_event_timestamp(run), run),
-    )
+    return [
+        provider.Run(
+            run_id=run,  # use names as IDs
+            run_name=run,
+            start_time=self._get_first_event_timestamp(run),
+        )
+        for run in self._multiplexer.Runs()
+    ]
 
   def list_scalars(self, experiment_id, plugin_name, run_tag_filter=None):
     del experiment_id  # ignored for now

--- a/tensorboard/backend/event_processing/data_provider.py
+++ b/tensorboard/backend/event_processing/data_provider.py
@@ -21,7 +21,11 @@ from __future__ import print_function
 import six
 
 from tensorboard.data import provider
+from tensorboard.util import tb_logging
 from tensorboard.util import tensor_util
+
+
+logger = tb_logging.get_logger()
 
 
 class MultiplexerDataProvider(provider.DataProvider):
@@ -42,6 +46,23 @@ class MultiplexerDataProvider(provider.DataProvider):
     if tags is not None and tag not in tags:
       return False
     return True
+
+  def _get_first_event_timestamp(self, run_name):
+    try:
+      return self._multiplexer.FirstEventTimestamp(run_name)
+    except ValueError as e:
+      logger.warn(
+          "Unable to get first event timestamp for run %s: %s", run_name, e
+      )
+      # Put runs without a timestamp at the end.
+      return float("inf")
+
+  def list_runs(self, experiment_id):
+    del experiment_id  # ignored for now
+    return sorted(
+        self._multiplexer.Runs(),
+        key=lambda run: (self._get_first_event_timestamp(run), run),
+    )
 
   def list_scalars(self, experiment_id, plugin_name, run_tag_filter=None):
     del experiment_id  # ignored for now

--- a/tensorboard/backend/event_processing/data_provider_test.py
+++ b/tensorboard/backend/event_processing/data_provider_test.py
@@ -77,6 +77,32 @@ class MultiplexerDataProviderTest(tf.test.TestCase):
   def create_provider(self):
     return data_provider.MultiplexerDataProvider(self.create_multiplexer())
 
+  def test_list_runs(self):
+    # We can't control the timestamps of events written to disk (without
+    # manually reading the tfrecords, modifying the data, and writing
+    # them back out), so we provide a fake multiplexer instead.
+    class FakeMultiplexer(object):
+      def Runs(self):
+        return ["second_2", "first", "no_time", "second_1"]
+
+      def FirstEventTimestamp(multiplexer, run):
+        self.assertIn(run, multiplexer.Runs())
+        result = {
+            "second_2": 2.0,
+            "first": 1.5,
+            "no_time": None,
+            "second_1": 2.0,  # tie: should sort lexicographically
+        }[run]
+        if result is None:
+          raise ValueError("No event timestep could be found")
+        else:
+          return result
+
+    multiplexer = FakeMultiplexer()
+    provider = data_provider.MultiplexerDataProvider(multiplexer)
+    result = provider.list_runs(experiment_id="unused")
+    self.assertEqual(result, ["first", "second_1", "second_2", "no_time"])
+
   def test_list_scalars_all(self):
     provider = self.create_provider()
     result = provider.list_scalars(

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -151,6 +151,9 @@ class Run(object):
       return False
     return True
 
+  def __hash__(self):
+    return hash((self._run_id, self._run_name, self._start_time))
+
   def __repr__(self):
     return "Run(%s)" % ", ".join((
         "run_id=%r" % (self._run_id,),

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -37,18 +37,11 @@ class DataProvider(object):
   def list_runs(self, experiment_id):
     """List all runs within an experiment.
 
-    The returned sequence should be sorted by run start time (i.e., the
-    time of the first event in each run), so that as new runs are
-    created under a running TensorBoard the list of runs is append-only,
-    and thus each run's time series color stays constant over time. In
-    case two runs have the same start time, their relative order should
-    be tie-broken deterministically (e.g., by run name).
-
     Args:
       experiment_id: ID of enclosing experiment.
 
     Returns:
-      A sequence of distinct run names, sorted as described above.
+      A collection of `Run` values.
     """
     pass
 
@@ -115,6 +108,55 @@ class DataProvider(object):
   def read_blob_sequences(self):
     """Not yet specified."""
     pass
+
+
+class Run(object):
+  """Metadata about a run.
+
+  Attributes:
+    run_id: A unique opaque string identifier for this run.
+    run_name: A user-facing name for this run (as a `str`).
+    start_time: The wall time of the earliest recorded event in this
+      run, as `float` seconds since epoch, or `None` if this run has no
+      recorded events.
+  """
+
+  __slots__ = ("_run_id", "_run_name", "_start_time")
+
+  def __init__(self, run_id, run_name, start_time):
+    self._run_id = run_id
+    self._run_name = run_name
+    self._start_time = start_time
+
+  @property
+  def run_id(self):
+    return self._run_id
+
+  @property
+  def run_name(self):
+    return self._run_name
+
+  @property
+  def start_time(self):
+    return self._start_time
+
+  def __eq__(self, other):
+    if not isinstance(other, Run):
+      return False
+    if self._run_id != other._run_id:
+      return False
+    if self._run_name != other._run_name:
+      return False
+    if self._start_time != other._start_time:
+      return False
+    return True
+
+  def __repr__(self):
+    return "Run(%s)" % ", ".join((
+        "run_id=%r" % (self._run_id,),
+        "run_name=%r" % (self._run_name,),
+        "start_time=%r" % (self._start_time,),
+    ))
 
 
 class ScalarTimeSeries(object):

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -34,6 +34,25 @@ class DataProvider(object):
   """
 
   @abc.abstractmethod
+  def list_runs(self, experiment_id):
+    """List all runs within an experiment.
+
+    The returned sequence should be sorted by run start time (i.e., the
+    time of the first event in each run), so that as new runs are
+    created under a running TensorBoard the list of runs is append-only,
+    and thus each run's time series color stays constant over time. In
+    case two runs have the same start time, their relative order should
+    be tie-broken deterministically (e.g., by run name).
+
+    Args:
+      experiment_id: ID of enclosing experiment.
+
+    Returns:
+      A sequence of distinct run names, sorted as described above.
+    """
+    pass
+
+  @abc.abstractmethod
   def list_scalars(self, experiment_id, plugin_name, run_tag_filter=None):
     """List metadata about scalar time series.
 

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -154,9 +154,15 @@ class CorePlugin(base_plugin.TBPlugin):
     last, and then ties are broken by sorting on the run name.
     """
     if self._data_provider:
-      # We pass `experiment_id=None` because experiment support is not
-      # yet implemented.
-      run_names = list(self._data_provider.list_runs(experiment_id=None))
+      runs = sorted(
+          # (`experiment_id=None` as experiment support is not yet implemented)
+          self._data_provider.list_runs(experiment_id=None),
+          key=lambda run: (
+              run.start_time if run.start_time is not None else float('inf'),
+              run.run_name,
+          )
+      )
+      run_names = [run.run_name for run in runs]
     elif self._db_connection_provider:
       db = self._db_connection_provider()
       cursor = db.execute('''

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -63,6 +63,10 @@ class CorePlugin(base_plugin.TBPlugin):
     self._multiplexer = context.multiplexer
     self._db_connection_provider = context.db_connection_provider
     self._assets_zip_provider = context.assets_zip_provider
+    if context.flags and context.flags.generic_data == 'true':
+      self._data_provider = context.data_provider
+    else:
+      self._data_provider = None
 
   def is_active(self):
     return True
@@ -149,7 +153,11 @@ class CorePlugin(base_plugin.TBPlugin):
     Sort order is by started time (aka first event time) with empty times sorted
     last, and then ties are broken by sorting on the run name.
     """
-    if self._db_connection_provider:
+    if self._data_provider:
+      # We pass `experiment_id=None` because experiment support is not
+      # yet implemented.
+      run_names = list(self._data_provider.list_runs(experiment_id=None))
+    elif self._db_connection_provider:
       db = self._db_connection_provider()
       cursor = db.execute('''
         SELECT


### PR DESCRIPTION
Summary:
The `list_scalars` and `read_scalars` API calls aren’t sufficient for a
fully end-to-end demo with a custom data provider implementation,
because the frontend gets the list of runs to display from `/data/runs`.
This commit adds a corresponding API call and wires it up to the client.

Test Plan:
Unit tests included. To manually verify that the new APIs are being
called, patch the `MultiplexerDataProvider` to include some bogus value:

```diff
diff --git a/tensorboard/backend/event_processing/data_provider.py b/tensorboard/backend/event_processing/data_provider.py
index ef602320..20e43800 100644
--- a/tensorboard/backend/event_processing/data_provider.py
+++ b/tensorboard/backend/event_processing/data_provider.py
@@ -55,7 +55,7 @@ class MultiplexerDataProvider(provider.DataProvider):

   def list_runs(self, experiment_id):
     del experiment_id  # ignored for now
-    return [
+    return [provider.Run("wat", "wot", 0.123)] + [
         provider.Run(
             run_id=run,  # use names as IDs
             run_name=run,
```

…then verify that the frontend displays the (real) runs in the same
order with and without `--generic_data=true`.

wchargin-branch: data-list-runs
