### PR TITLE
Make audio-related functionality and tests TF 2.x–compatible

### DIFF
--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -108,7 +108,6 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/util:tensor_util",
-        "//tensorboard/util:test_util",
     ],
 )
 

--- a/tensorboard/plugins/audio/audio_plugin_test.py
+++ b/tensorboard/plugins/audio/audio_plugin_test.py
@@ -39,7 +39,6 @@ from tensorboard.plugins.audio import summary
 from tensorboard.util import test_util
 
 
-@test_util.run_v1_only('Uses tf.contrib in setUp via audio.summary')
 class AudioPluginTest(tf.test.TestCase):
 
   def setUp(self):
@@ -51,40 +50,42 @@ class AudioPluginTest(tf.test.TestCase):
 
     # Create old-style audio summaries for run "foo".
     tf.compat.v1.reset_default_graph()
-    sess = tf.compat.v1.Session()
-    placeholder = tf.compat.v1.placeholder(tf.float32)
-    tf.compat.v1.summary.audio(name="baz", tensor=placeholder, sample_rate=44100)
-    merged_summary_op = tf.compat.v1.summary.merge_all()
-    foo_directory = os.path.join(self.log_dir, "foo")
-    with test_util.FileWriterCache.get(foo_directory) as writer:
-      writer.add_graph(sess.graph)
-      for step in xrange(2):
-        # The floats (sample data) range from -1 to 1.
-        writer.add_summary(sess.run(merged_summary_op, feed_dict={
-            placeholder: numpy.random.rand(42, 22050) * 2 - 1
-        }), global_step=step)
+    with tf.compat.v1.Graph().as_default():
+      sess = tf.compat.v1.Session()
+      placeholder = tf.compat.v1.placeholder(tf.float32)
+      tf.compat.v1.summary.audio(name="baz", tensor=placeholder, sample_rate=44100)
+      merged_summary_op = tf.compat.v1.summary.merge_all()
+      foo_directory = os.path.join(self.log_dir, "foo")
+      with test_util.FileWriterCache.get(foo_directory) as writer:
+        writer.add_graph(sess.graph)
+        for step in xrange(2):
+          # The floats (sample data) range from -1 to 1.
+          writer.add_summary(sess.run(merged_summary_op, feed_dict={
+              placeholder: numpy.random.rand(42, 22050) * 2 - 1
+          }), global_step=step)
 
     # Create new-style audio summaries for run "bar".
     tf.compat.v1.reset_default_graph()
-    sess = tf.compat.v1.Session()
-    audio_placeholder = tf.compat.v1.placeholder(tf.float32)
-    labels_placeholder = tf.compat.v1.placeholder(tf.string)
-    summary.op("quux", audio_placeholder, sample_rate=44100,
-               labels=labels_placeholder,
-               description="how do you pronounce that, anyway?")
-    merged_summary_op = tf.compat.v1.summary.merge_all()
-    bar_directory = os.path.join(self.log_dir, "bar")
-    with test_util.FileWriterCache.get(bar_directory) as writer:
-      writer.add_graph(sess.graph)
-      for step in xrange(2):
-        # The floats (sample data) range from -1 to 1.
-        writer.add_summary(sess.run(merged_summary_op, feed_dict={
-            audio_placeholder: numpy.random.rand(42, 11025, 1) * 2 - 1,
-            labels_placeholder: [
-                tf.compat.as_bytes('step **%s**, sample %s' % (step, sample))
-                for sample in xrange(42)
-            ],
-        }), global_step=step)
+    with tf.compat.v1.Graph().as_default():
+      sess = tf.compat.v1.Session()
+      audio_placeholder = tf.compat.v1.placeholder(tf.float32)
+      labels_placeholder = tf.compat.v1.placeholder(tf.string)
+      summary.op("quux", audio_placeholder, sample_rate=44100,
+                 labels=labels_placeholder,
+                 description="how do you pronounce that, anyway?")
+      merged_summary_op = tf.compat.v1.summary.merge_all()
+      bar_directory = os.path.join(self.log_dir, "bar")
+      with test_util.FileWriterCache.get(bar_directory) as writer:
+        writer.add_graph(sess.graph)
+        for step in xrange(2):
+          # The floats (sample data) range from -1 to 1.
+          writer.add_summary(sess.run(merged_summary_op, feed_dict={
+              audio_placeholder: numpy.random.rand(42, 11025, 1) * 2 - 1,
+              labels_placeholder: [
+                  tf.compat.as_bytes('step **%s**, sample %s' % (step, sample))
+                  for sample in xrange(42)
+              ],
+          }), global_step=step)
 
     # Start a server with the plugin.
     multiplexer = event_multiplexer.EventMultiplexer({

--- a/tensorboard/plugins/audio/summary.py
+++ b/tensorboard/plugins/audio/summary.py
@@ -91,7 +91,6 @@ def op(name,
   file format explicitly.
   """
   # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
-  import tensorflow  # for contrib
   import tensorflow.compat.v1 as tf
 
   if display_name is None:
@@ -101,9 +100,7 @@ def op(name,
 
   if encoding == 'wav':
     encoding = metadata.Encoding.Value('WAV')
-    encoder = functools.partial(tensorflow.contrib.ffmpeg.encode_audio,
-                                samples_per_second=sample_rate,
-                                file_format='wav')
+    encoder = functools.partial(tf.audio.encode_wav, sample_rate=sample_rate)
   else:
     raise ValueError('Unknown encoding: %r' % encoding)
 

--- a/tensorboard/plugins/audio/summary_test.py
+++ b/tensorboard/plugins/audio/summary_test.py
@@ -30,7 +30,6 @@ from tensorboard.compat import tf2
 from tensorboard.plugins.audio import metadata
 from tensorboard.plugins.audio import summary
 from tensorboard.util import tensor_util
-from tensorboard.util import test_util
 
 
 try:
@@ -149,7 +148,6 @@ class SummaryBaseTest(object):
       self.audio('k488', data, 44100, encoding='pptx')
 
 
-@test_util.run_v1_only('Uses tf.contrib')
 class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):
   def setUp(self):
     super(SummaryV1PbTest, self).setUp()
@@ -168,13 +166,12 @@ class SummaryV1PbTest(SummaryBaseTest, tf.test.TestCase):
     self.skipTest('summary V1 pb does not actually enforce this')
 
 
-@test_util.run_v1_only('Uses tf.contrib')
 class SummaryV1OpTest(SummaryBaseTest, tf.test.TestCase):
   def setUp(self):
     super(SummaryV1OpTest, self).setUp()
 
   def audio(self, *args, **kwargs):
-    return tf.Summary.FromString(summary.op(*args, **kwargs).numpy())
+    return tf.compat.v1.Summary.FromString(summary.op(*args, **kwargs).numpy())
 
   def test_tag(self):
     data = np.array(1, np.float32, ndmin=3)

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -23,7 +23,6 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":encoder",
-        ":test_util",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_six",

--- a/tensorboard/util/encoder.py
+++ b/tensorboard/util/encoder.py
@@ -84,16 +84,14 @@ class _TensorFlowWavEncoder(op_evaluator.PersistentOpEvaluator):
 
   def initialize_graph(self):
     # TODO(nickfelt): remove on-demand imports once dep situation is fixed.
-    import tensorflow  # for contrib
     import tensorflow.compat.v1 as tf
     self._audio_placeholder = tf.placeholder(
         dtype=tf.float32, name='image_to_encode')
     self._samples_per_second_placeholder = tf.placeholder(
         dtype=tf.int32, name='samples_per_second')
-    self._encode_op = tensorflow.contrib.ffmpeg.encode_audio(
+    self._encode_op = tf.audio.encode_wav(
         self._audio_placeholder,
-        file_format='wav',
-        samples_per_second=self._samples_per_second_placeholder)
+        sample_rate=self._samples_per_second_placeholder)
 
   def run(self, audio, samples_per_second):  # pylint: disable=arguments-differ
     if not isinstance(audio, np.ndarray):

--- a/tensorboard/util/encoder_test.py
+++ b/tensorboard/util/encoder_test.py
@@ -21,7 +21,6 @@ import six
 import tensorflow as tf
 
 from tensorboard.util import encoder
-from tensorboard.util import test_util
 
 
 class TensorFlowPngEncoderTest(tf.test.TestCase):
@@ -56,7 +55,6 @@ class TensorFlowPngEncoderTest(tf.test.TestCase):
     self._check_png(data)
 
 
-@test_util.run_v1_only('Uses contrib')
 class TensorFlowWavEncoderTest(tf.test.TestCase):
 
   def setUp(self):


### PR DESCRIPTION
Summary:
These tests used `tf.contrib.ffmpeg.encode_audio`, but they can actually
just use `tf.audio.encode_wav`, which has existed since TensorFlow 1.14.
This also makes the encoder itself TF 2.x–compatible.

Makes progress toward #1705.

Test Plan:
Tests pass in both TF 1.x and TF 2.x, and the `run_v1_only` decorators
have been removed:

```
$ git grep run_v1_only '*encoder*_test.py' '*audio*_test.py' | wc -l
0
```

wchargin-branch: audio-tf2x
