### PR TITLE
ng: introduce ngrx and create basic usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,15 @@
     "typescript": "~3.4.5"
   },
   "dependencies": {
-    "@angular/animations": "^8.1.2",
+    "@angular/animations": "^8.2.2",
+    "@angular/cdk": "^8.1.3",
     "@angular/common": "^8.1.2",
     "@angular/core": "^8.1.2",
+    "@angular/forms": "^8.2.2",
+    "@angular/material": "^8.1.3",
     "@angular/platform-browser": "^8.1.3",
     "@angular/router": "^8.1.2",
+    "@ngrx/store": "^8.2.0",
     "rxjs": "^6.5.2",
     "zone.js": "^0.9.1"
   }

--- a/tensorboard/components/tf_ng_tensorboard/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/BUILD
@@ -2,9 +2,31 @@ package(default_visibility = ["//tensorboard:internal"])
 
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_js_binary")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
 
+tf_web_library(
+    name = "tf_ng_tensorboard",
+    srcs = [
+        ":tf_ng_tensorboard_binary.js",
+        "@npm//:node_modules/zone.js/dist/zone.js",
+    ],
+    path = "/tf-ng-tensorboard",
+    deps = [
+        ":tf_ng_tensorboard_binary",
+    ],
+)
+
+# TODO(stephanwlee): move this to root level
+tf_web_library(
+    name = "material_theme",
+    srcs = [
+        "@npm//:node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
+    ],
+    path = "/@angular",
+    strip_prefix = "node_modules/@angular/material/prebuilt-themes",
+)
 
 tf_js_binary(
     name = "tf_ng_tensorboard_binary",
@@ -14,8 +36,9 @@ tf_js_binary(
         ":ng_main",
         "@npm//@angular/common",
         "@npm//@angular/core",
+        "@npm//@angular/material",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/router",
+        "@npm//@ngrx/store",
         "@npm//rxjs",
         "@npm//zone.js",
     ],
@@ -40,15 +63,17 @@ ng_module(
     srcs = [
         "app.component.ts",
         "app.module.ts",
-        "app-routing.module.ts",
+        "reducers.ts",
     ],
     assets = [
         "app.component.css",
         "app.component.html",
     ],
     deps = [
+        "//tensorboard/components/tf_ng_tensorboard/core",
+        "//tensorboard/components/tf_ng_tensorboard/header",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
-        "@npm//@angular/router",
+        "@npm//@ngrx/store",
     ],
 )

--- a/tensorboard/components/tf_ng_tensorboard/app.component.html
+++ b/tensorboard/components/tf_ng_tensorboard/app.component.html
@@ -15,5 +15,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <div>
-  Angular TensorBoard
+  <app-header></app-header>
 </div>

--- a/tensorboard/components/tf_ng_tensorboard/app.component.ts
+++ b/tensorboard/components/tf_ng_tensorboard/app.component.ts
@@ -30,6 +30,6 @@ export class AppComponent {
     // TODO(stephanwlee): Instead of hardcoding it, consider reading it off of the
     // tf_dashboard.registry. It is current infeasible unless Angular source is also
     // compiled with JSCompiler.
-    this.store.dispatch(changePlugin({plugin: 'meowth'}));
+    this.store.dispatch(changePlugin({plugin: 'Core'}));
   }
 }

--- a/tensorboard/components/tf_ng_tensorboard/app.module.ts
+++ b/tensorboard/components/tf_ng_tensorboard/app.module.ts
@@ -13,14 +13,33 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {BrowserModule} from '@angular/platform-browser';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {NgModule} from '@angular/core';
+import {StoreModule} from '@ngrx/store';
 
-import {AppRoutingModule} from './app-routing.module';
 import {AppComponent} from './app.component';
+import {CoreModule} from './core/core.module';
+import {ROOT_REDUCERS, metaReducers} from './reducers';
+
+import {HeaderModule} from './header/header.module';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, AppRoutingModule],
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    CoreModule,
+    HeaderModule,
+    StoreModule.forRoot(ROOT_REDUCERS, {
+      metaReducers,
+      runtimeChecks: {
+        strictStateImmutability: true,
+        strictActionImmutability: true,
+        strictStateSerializability: true,
+        strictActionSerializability: true,
+      },
+    }),
+  ],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/tensorboard/components/tf_ng_tensorboard/core/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/core/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+ng_module(
+    name = "core",
+    srcs = [
+        "core.actions.ts",
+        "core.module.ts",
+        "core.reducers.ts",
+    ],
+    deps = [
+        "//tensorboard/components/tf_ng_tensorboard/types",
+        "@npm//@ngrx/store",
+    ],
+)

--- a/tensorboard/components/tf_ng_tensorboard/core/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/core/BUILD
@@ -1,6 +1,7 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 
 ng_module(
     name = "core",
@@ -12,5 +13,25 @@ ng_module(
     deps = [
         "//tensorboard/components/tf_ng_tensorboard/types",
         "@npm//@ngrx/store",
+    ],
+)
+
+ng_module(
+    name = "core_test_lib",
+    testonly = True,
+    srcs = [
+        "core.reducers.test.ts",
+    ],
+    deps = [
+        ":core",
+        "@npm//@types/jasmine",
+        "@npm//chai",
+    ],
+)
+
+jasmine_node_test(
+    name = "core_jasmine_test",
+    deps = [
+        ":core_test_lib",
     ],
 )

--- a/tensorboard/components/tf_ng_tensorboard/core/core.actions.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.actions.ts
@@ -12,17 +12,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {enableProdMode} from '@angular/core';
-import {platformBrowser} from '@angular/platform-browser';
-import {AppModuleNgFactory} from './app.module.ngfactory';
-import 'zone.js/dist/zone.js'; // Angular runtime dep
+import {createAction, props} from '@ngrx/store';
+import {PluginId} from '../types/api';
 
-// TODO(stephanwlee): Create dev mode and conditionally enable this.
-enableProdMode();
+// HACK: Below import is for type inference.
+// https://github.com/bazelbuild/rules_nodejs/issues/1013
+import * as _typeHackModels from '@ngrx/store/src/models';
 
-// Bootstrap needs to happen after body is ready but we cannot reliably
-// controls the order in which script gets loaded (Vulcanization inlines
-// the script in <head>).
-window.addEventListener('DOMContentLoaded', () => {
-  platformBrowser().bootstrapModuleFactory(AppModuleNgFactory);
-});
+type ChangePluginProps = {plugin: PluginId};
+
+export const changePlugin = createAction(
+  'CHANGE_PLUGIN',
+  props<ChangePluginProps>()
+);

--- a/tensorboard/components/tf_ng_tensorboard/core/core.module.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.module.ts
@@ -12,17 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {enableProdMode} from '@angular/core';
-import {platformBrowser} from '@angular/platform-browser';
-import {AppModuleNgFactory} from './app.module.ngfactory';
-import 'zone.js/dist/zone.js'; // Angular runtime dep
+import {NgModule} from '@angular/core';
+import {StoreModule} from '@ngrx/store';
 
-// TODO(stephanwlee): Create dev mode and conditionally enable this.
-enableProdMode();
+import {CORE_FEATURE_KEY, reducers} from './core.reducers';
 
-// Bootstrap needs to happen after body is ready but we cannot reliably
-// controls the order in which script gets loaded (Vulcanization inlines
-// the script in <head>).
-window.addEventListener('DOMContentLoaded', () => {
-  platformBrowser().bootstrapModuleFactory(AppModuleNgFactory);
-});
+@NgModule({
+  imports: [StoreModule.forFeature(CORE_FEATURE_KEY, reducers)],
+})
+export class CoreModule {}

--- a/tensorboard/components/tf_ng_tensorboard/core/core.reducers.test.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.reducers.test.ts
@@ -12,14 +12,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {createAction, props} from '@ngrx/store';
-import {PluginId} from '../types/api';
+import {expect} from 'chai';
 
-// HACK: Below import is for type inference.
-// https://github.com/bazelbuild/rules_nodejs/issues/1013
-import * as _typeHackModels from '@ngrx/store/src/models';
+import * as actions from './core.actions';
+import {reducers} from './core.reducers';
 
-export const changePlugin = createAction(
-  'CHANGE_PLUGIN',
-  props<{plugin: PluginId}>()
-);
+describe('core reducer', () => {
+  describe('#changePlugin', () => {
+    it('sets activePlugin to the one in action payload', () => {
+      const state = {activePlugin: 'foo'};
+      const nextState = reducers(state, actions.changePlugin({plugin: 'bar'}));
+
+      expect(nextState).to.have.property('activePlugin', 'bar');
+    });
+  });
+});

--- a/tensorboard/components/tf_ng_tensorboard/core/core.reducers.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.reducers.ts
@@ -1,0 +1,64 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  Action,
+  createSelector,
+  createReducer,
+  on,
+  createFeatureSelector,
+} from '@ngrx/store';
+import {PluginId} from '../types/api';
+import * as actions from './core.actions';
+
+// HACK: These imports are for type inference.
+// https://github.com/bazelbuild/rules_nodejs/issues/1013
+import * as _typeHackSelector from '@ngrx/store/src/selector';
+import * as _typeHackStore from '@ngrx/store/store';
+
+export const CORE_FEATURE_KEY = 'core';
+
+export interface CoreState {
+  activePlugin: PluginId;
+}
+
+export interface State {
+  [CORE_FEATURE_KEY]: CoreState;
+}
+
+const initialState = {};
+
+const reducer = createReducer(
+  initialState,
+  on(actions.changePlugin, (state: CoreState, {plugin}) => {
+    return {
+      activePlugin: plugin,
+    };
+  })
+);
+
+export function reducers(state: CoreState, action: Action) {
+  return reducer(state, action);
+}
+
+const selectCoreState = createFeatureSelector<State, CoreState>(
+  CORE_FEATURE_KEY
+);
+
+export const getActivePlugin = createSelector(
+  selectCoreState,
+  (state: CoreState): PluginId => {
+    return state.activePlugin;
+  }
+);

--- a/tensorboard/components/tf_ng_tensorboard/header/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/header/BUILD
@@ -1,0 +1,24 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+licenses(["notice"])  # Apache 2.0
+
+ng_module(
+    name = "header",
+    srcs = [
+        "containers/header.component.ts",
+        "header.module.ts",
+    ],
+    assets = [
+        "containers/header.component.css",
+        "containers/header.component.html",
+    ],
+    deps = [
+        "//tensorboard/components/tf_ng_tensorboard/core",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@angular/material",
+        "@npm//@ngrx/store",
+    ],
+)

--- a/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.css
+++ b/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.css
@@ -12,17 +12,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {enableProdMode} from '@angular/core';
-import {platformBrowser} from '@angular/platform-browser';
-import {AppModuleNgFactory} from './app.module.ngfactory';
-import 'zone.js/dist/zone.js'; // Angular runtime dep
-
-// TODO(stephanwlee): Create dev mode and conditionally enable this.
-enableProdMode();
-
-// Bootstrap needs to happen after body is ready but we cannot reliably
-// controls the order in which script gets loaded (Vulcanization inlines
-// the script in <head>).
-window.addEventListener('DOMContentLoaded', () => {
-  platformBrowser().bootstrapModuleFactory(AppModuleNgFactory);
-});

--- a/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.html
+++ b/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.html
@@ -18,7 +18,7 @@ limitations under the License.
   <span>TensorBoard</span>
   <mat-tab-group>
     <mat-tab label="{{ activePlugin$ | async }}"></mat-tab>
-    <mat-tab label=" Siamese"></mat-tab>
+    <mat-tab label="Siamese"></mat-tab>
     <mat-tab label="Persian"></mat-tab>
   </mat-tab-group>
 </mat-toolbar>

--- a/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.html
+++ b/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.html
@@ -1,4 +1,6 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+<!--
+@license
+Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -11,14 +13,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
-import {NgModule} from '@angular/core';
-import {Routes, RouterModule} from '@angular/router';
-
-const routes: Routes = [];
-
-@NgModule({
-  imports: [RouterModule],
-  exports: [RouterModule],
-})
-export class AppRoutingModule {}
+-->
+<mat-toolbar>
+  <span>TensorBoard</span>
+  <mat-tab-group>
+    <mat-tab label="{{ activePlugin$ | async }}"></mat-tab>
+    <mat-tab label=" Siamese"></mat-tab>
+    <mat-tab label="Persian"></mat-tab>
+  </mat-tab-group>
+</mat-toolbar>

--- a/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.ts
+++ b/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.ts
@@ -14,22 +14,17 @@ limitations under the License.
 ==============================================================================*/
 import {Component} from '@angular/core';
 import {Store, select} from '@ngrx/store';
-import {State, getActivePlugin} from './core/core.reducers';
-import {changePlugin} from './core/core.actions';
-import {PluginId} from './types/api';
+
+import {State, getActivePlugin} from '../../core/core.reducers';
+
+import * as _typeHackRxjs from 'rxjs';
 
 @Component({
-  selector: 'tf-ng-tensorboard',
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css'],
+  selector: 'app-header',
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.css'],
 })
-export class AppComponent {
+export class HeaderComponent {
+  activePlugin$ = this.store.pipe(select(getActivePlugin));
   constructor(private store: Store<State>) {}
-
-  ngOnInit() {
-    // TODO(stephanwlee): Instead of hardcoding it, consider reading it off of the
-    // tf_dashboard.registry. It is current infeasible unless Angular source is also
-    // compiled with JSCompiler.
-    this.store.dispatch(changePlugin({plugin: 'meowth'}));
-  }
 }

--- a/tensorboard/components/tf_ng_tensorboard/header/header.module.ts
+++ b/tensorboard/components/tf_ng_tensorboard/header/header.module.ts
@@ -12,17 +12,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {enableProdMode} from '@angular/core';
-import {platformBrowser} from '@angular/platform-browser';
-import {AppModuleNgFactory} from './app.module.ngfactory';
-import 'zone.js/dist/zone.js'; // Angular runtime dep
+import {NgModule} from '@angular/core';
+// Uses `async` pipe.
+import {CommonModule} from '@angular/common';
 
-// TODO(stephanwlee): Create dev mode and conditionally enable this.
-enableProdMode();
+import {MatTabsModule} from '@angular/material/tabs';
+import {MatToolbarModule} from '@angular/material/toolbar';
 
-// Bootstrap needs to happen after body is ready but we cannot reliably
-// controls the order in which script gets loaded (Vulcanization inlines
-// the script in <head>).
-window.addEventListener('DOMContentLoaded', () => {
-  platformBrowser().bootstrapModuleFactory(AppModuleNgFactory);
-});
+import {HeaderComponent} from './containers/header.component';
+import {CoreModule} from '../core/core.module';
+
+@NgModule({
+  declarations: [HeaderComponent],
+  exports: [HeaderComponent],
+  providers: [],
+  imports: [MatToolbarModule, MatTabsModule, CommonModule, CoreModule],
+})
+export class HeaderModule {}

--- a/tensorboard/components/tf_ng_tensorboard/reducers.ts
+++ b/tensorboard/components/tf_ng_tensorboard/reducers.ts
@@ -1,0 +1,46 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {InjectionToken} from '@angular/core';
+import {
+  Action,
+  ActionReducer,
+  ActionReducerMap,
+  MetaReducer,
+} from '@ngrx/store';
+
+export interface State {}
+
+// console.log all actions
+export function logger(reducer: ActionReducer<any>): ActionReducer<any> {
+  return (state, action) => {
+    const result = reducer(state, action);
+    console.groupCollapsed(action.type);
+    console.log('prev state', state);
+    console.log('action', action);
+    console.log('next state', result);
+    console.groupEnd();
+
+    return result;
+  };
+}
+
+// TODO(stephanwlee): Create dev mode and conditionally enable this.
+export const metaReducers: MetaReducer<any>[] = false ? [logger] : [];
+
+export const ROOT_REDUCERS = new InjectionToken<
+  ActionReducerMap<State, Action>
+>('Root reducers token', {
+  factory: () => ({}),
+});

--- a/tensorboard/components/tf_ng_tensorboard/types/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/types/BUILD
@@ -1,0 +1,12 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+
+# TODO(stephanwlee): move this into shareable place and use it in Polymer-based
+# modules when Angular is ready to be built as part of TensorBoard.
+ts_library(
+    name = "types",
+    srcs = [
+        "api.ts",
+    ],
+)

--- a/tensorboard/components/tf_ng_tensorboard/types/api.ts
+++ b/tensorboard/components/tf_ng_tensorboard/types/api.ts
@@ -47,9 +47,11 @@ export interface Dashboard {
   /**
    * Whether or not tf-tensorboard reload functionality should be disabled.
    *
-   * If true, then: 1) the reload button in the top right corner of the
-   * TensorBoard UI will be shaded out; and 2) the timer that triggers the
-   * reload() method to be called every few seconds will be disabled.
+   * If true, then:
+   *   1. the reload button in the top right corner of the TensorBoard UI
+   *      will be shaded out
+   *   2. the timer that triggers the reload() method to be called every few
+   *      seconds will be disabled.
    */
   isReloadDisabled: boolean;
 }

--- a/tensorboard/components/tf_ng_tensorboard/types/api.ts
+++ b/tensorboard/components/tf_ng_tensorboard/types/api.ts
@@ -1,0 +1,55 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+export enum ActiveDashboardsLoadState {
+  NOT_LOADED,
+  LOADED,
+  FAILED,
+}
+
+export type PluginId = string;
+
+/** Registration for a plugin dashboard UI. */
+export interface Dashboard {
+  /**
+   * Name of the element for the dashboard (excluding the angle brackets on
+   * either side). For instance, tf-scalar-dashboard. Used to select the
+   * correct dashboard when a user enters it.
+   */
+  elementName: string;
+
+  /**
+   * The name of the plugin associated with this dashboard. This string must
+   * match the PLUGIN_NAME specified by the backend of the plugin. Each plugin
+   * can be associated with no more than 1 plugin - this also means that each
+   * dashboard has a unique plugin field.
+   */
+  plugin: PluginId;
+
+  /**
+   * The string to show in the menu item for this dashboard within the
+   * navigation bar. That tab name may differ from the plugin name. For
+   * instance, the tab name should not use underscores to separate words.
+   */
+  tabName: string;
+
+  /**
+   * Whether or not tf-tensorboard reload functionality should be disabled.
+   *
+   * If true, then: 1) the reload button in the top right corner of the
+   * TensorBoard UI will be shaded out; and 2) the timer that triggers the
+   * reload() method to be called every few seconds will be disabled.
+   */
+  isReloadDisabled: boolean;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,10 +48,10 @@
     "@angular-devkit/core" "8.1.2"
     rxjs "6.4.0"
 
-"@angular/animations@^8.1.2":
-  version "8.1.2"
-  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-8.1.2.tgz#2e4fec78a9345d9f1d93e9d464911c71f8c80046"
-  integrity sha512-szR5qzRe6vS1qrPhV2p5fMp5vQxT2SaljXGs3Xgt2Tl23om0XVNcqK0I8NNuK/ehuJ5LXQ1fJHniGcmN2aUw0g==
+"@angular/animations@^8.2.2":
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-8.2.2.tgz#9e4162d242302f9b480cd967c7dccf4b07cdf435"
+  integrity sha512-vOfZGMDnP5/n4MIxZqT49nVc305EYpRK+bz68hJmZd2QkTxQA+8j84xr4jfIC6zUWdyQqZhwWEF5Lqqy7G155g==
   dependencies:
     tslib "^1.9.0"
 
@@ -69,6 +69,15 @@
     semver "^5.6.0"
     shelljs "0.8.2"
     tsickle "^0.35.0"
+
+"@angular/cdk@^8.1.3":
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-8.1.3.tgz#c791b4ae950bd015c4f618204e4f974e2dd64254"
+  integrity sha512-+DOS6x05/nNdnoRmEi3bgQxKym34PeCRGD6dimdw0l7ZgM57qhlaBWo0dXB7QSyR9E44uVT91e4h8ye+/ne1DQ==
+  dependencies:
+    tslib "^1.7.1"
+  optionalDependencies:
+    parse5 "^5.0.0"
 
 "@angular/cli@^8.1.2":
   version "8.1.2"
@@ -130,6 +139,20 @@
   integrity sha512-Gm/UIUnIkeah39vxi4enVH/CUcPZOgGDyw4RNagw4pH8dTP8V0RUz8uteOr3DS+Eh49BcHkrT2oU5MBZSZ3lvw==
   dependencies:
     tslib "^1.9.0"
+
+"@angular/forms@^8.2.2":
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-8.2.2.tgz#8e06255942615b6d4b550f645d5e647d600f84c1"
+  integrity sha512-2PTTKWP+GoHRLf3S3HKzn5QJtCMMRaMmcTrbR10hgUmDPdMeULGNZG3OacV8rRbRv4TDtXoqbKp0NRFQ7xsofQ==
+  dependencies:
+    tslib "^1.9.0"
+
+"@angular/material@^8.1.3":
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/@angular/material/-/material-8.1.3.tgz#1e65a6e02196348413cb073da3255771116c7618"
+  integrity sha512-qZVWrJ/EO1y0lJCy7pe536RlYiih3p3fQzj7tgus7JdOpspyF+zBLzn8gNrdAFACXpVWwq2kLorieoR3BB47ZQ==
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/platform-browser@^8.1.3":
   version "8.1.3"
@@ -250,6 +273,11 @@
   version "0.12.10"
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.10.tgz#c0e2c875c24a21da6d345d09189f5df4a1801d82"
   integrity sha512-tsog/HTdM88/WyR0Jz7XWTI0ghbJkt9soFXnQJrINDyaTGzbCoJjRttaW/IY5eAp4eqDyfg++jq6o+byEDOkIQ==
+
+"@ngrx/store@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@ngrx/store/-/store-8.2.0.tgz#8374fa803babdbf2a599240a8e546fa726d83edd"
+  integrity sha512-RTmg7WstMhxEIWxtcK1dC4i/3OQeS11ilosQjmZyiRcbRQzvBMZqQzNdpwb5yL6rEQ19Cka/QEWm2sd2USzHeA==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -2599,6 +2627,11 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse5@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
+  integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
+
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -3439,7 +3472,7 @@ tsickle@^0.35.0:
     mkdirp "^0.5.1"
     source-map "^0.7.3"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
This change introduces ngrx, a state management, to our angular shell.
The usage of ngrx is very limited. Soon, it will be expanded to make XHR
to fetch list of plugins and properly render the header.

It looks like this:
![image](https://user-images.githubusercontent.com/2547313/63142021-de7c4400-bf9c-11e9-9d0c-1f15f4ece967.png)

Note that the folder structure was largely inspired by https://github.com/ngrx/platform/tree/master/projects/example-app but is prone to change based on team consensus. 