### PR TITLE
[tensor-widget] Add slicing control to support 3D+ tensors

### DIFF
--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -33,6 +33,7 @@ ts_library(
         "dtype-utils.ts",
         "health-pill-types.ts",
         "shape-utils.ts",
+        "slicing-control.ts",
         "string-utils.ts",
         "tensor-widget.ts",
         "tensor-widget-impl.ts",

--- a/tensorboard/components/tensor_widget/demo/demo.html
+++ b/tensorboard/components/tensor_widget/demo/demo.html
@@ -37,6 +37,7 @@ limitations under the License.
     <div id="tensor2" class="tensor"></div>
     <div id="tensor3" class="tensor"></div>
     <div id="tensor4" class="tensor"></div>
+    <div id="tensor5" class="tensor"></div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tensorflow/1.2.7/tf.min.js"></script>
     <script src="bundle.js"></script>

--- a/tensorboard/components/tensor_widget/demo/demo.ts
+++ b/tensorboard/components/tensor_widget/demo/demo.ts
@@ -118,7 +118,7 @@ function demo() {
     tensorWidget.VERSION;
 
   /////////////////////////////////////////////////////////////
-  // Render tensor0: a float32 scalar.
+  // float32 scalar.
   const tensorDiv0 = document.getElementById('tensor0') as HTMLDivElement;
   // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
   const tensorView0 = tensorToTensorView(tf.scalar(28));
@@ -128,7 +128,7 @@ function demo() {
   tensorWidget0.render();
 
   /////////////////////////////////////////////////////////////
-  // Render tensor1: a 1D int32 tensor.
+  // 1D int32 tensor.
   const tensorDiv1 = document.getElementById('tensor1') as HTMLDivElement;
   // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
   const tensorView1 = tensorToTensorView(
@@ -140,7 +140,7 @@ function demo() {
   tensorWidget1.render();
 
   /////////////////////////////////////////////////////////////
-  // Render tensor2: a 2D float32 scalar.
+  // 2D float32 scalar.
   const tensor2Div = document.getElementById('tensor2') as HTMLDivElement;
   const tensorView2 = tensorToTensorView(tf.randomNormal([128, 64]));
   const tensorWidget2 = tensorWidget.tensorWidget(tensor2Div, tensorView2, {
@@ -149,7 +149,7 @@ function demo() {
   tensorWidget2.render();
 
   /////////////////////////////////////////////////////////////
-  // Render tensor3: a 2D float32 scalar with NaN and Infinities in it.
+  // 2D float32 scalar with NaN and Infinities in it.
   const tensorDiv3 = document.getElementById('tensor3') as HTMLDivElement;
   const tensorView3 = tensorToTensorView(
     tf.tensor2d([[NaN, -Infinity], [Infinity, 0]])
@@ -161,9 +161,8 @@ function demo() {
   tensorWidget3.render();
 
   /////////////////////////////////////////////////////////////
-  // Render tensor4: a 3D float32 scalar, without the optional name.
+  // 3D float32 scalar, without the optional name.
   const tensorDiv4 = document.getElementById('tensor4') as HTMLDivElement;
-  // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
   const tensorView4 = tensorToTensorView(
     tf.linspace(0, (64 * 32 * 50 - 1) / 100, 64 * 32 * 50).reshape([64, 32, 50])
   );
@@ -171,15 +170,16 @@ function demo() {
   tensorWidget4.render();
 
   /////////////////////////////////////////////////////////////
-  // Render tensor4: a 3D float32 scalar, without the optional name.
+  // 4D float32 scalar, without the optional name.
   const tensorDiv5 = document.getElementById('tensor5') as HTMLDivElement;
-  // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
   const tensorView5 = tensorToTensorView(
     tf
       .linspace(0, (2 * 4 * 15 * 20 - 1) / 100, 2 * 4 * 15 * 20)
       .reshape([2, 4, 15, 20])
   );
-  const tensorWidget5 = tensorWidget.tensorWidget(tensorDiv5, tensorView5); // No name.
+  const tensorWidget5 = tensorWidget.tensorWidget(tensorDiv5, tensorView5, {
+    name: 'FourDimensionalTensor',
+  });
   tensorWidget5.render();
 }
 

--- a/tensorboard/components/tensor_widget/demo/demo.ts
+++ b/tensorboard/components/tensor_widget/demo/demo.ts
@@ -164,12 +164,9 @@ function demo() {
   // Render tensor4: a 3D float32 scalar, without the optional name.
   const tensorDiv4 = document.getElementById('tensor4') as HTMLDivElement;
   // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
-  const tensorView4: any = {
-    spec: {
-      dtype: 'float32',
-      shape: [64, 32, 50],
-    },
-  };
+  const tensorView4 =  tensorToTensorView(
+    tf.linspace(0, (64 * 32 * 50 - 1) / 100, 64 * 32 * 50)
+    .reshape([64, 32, 50]));
   const tensorWidget4 = tensorWidget.tensorWidget(tensorDiv4, tensorView4); // No name.
   tensorWidget4.render();
 }

--- a/tensorboard/components/tensor_widget/demo/demo.ts
+++ b/tensorboard/components/tensor_widget/demo/demo.ts
@@ -169,6 +169,16 @@ function demo() {
     .reshape([64, 32, 50]));
   const tensorWidget4 = tensorWidget.tensorWidget(tensorDiv4, tensorView4); // No name.
   tensorWidget4.render();
+
+  /////////////////////////////////////////////////////////////
+  // Render tensor4: a 3D float32 scalar, without the optional name.
+  const tensorDiv5 = document.getElementById('tensor5') as HTMLDivElement;
+  // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
+  const tensorView5 =  tensorToTensorView(
+    tf.linspace(0, (2 * 4 * 15 * 20 - 1) / 100, 2 * 4 * 15 * 20)
+    .reshape([2, 4, 15, 20]));
+  const tensorWidget5 = tensorWidget.tensorWidget(tensorDiv5, tensorView5); // No name.
+  tensorWidget5.render();
 }
 
 demo();

--- a/tensorboard/components/tensor_widget/demo/demo.ts
+++ b/tensorboard/components/tensor_widget/demo/demo.ts
@@ -164,9 +164,9 @@ function demo() {
   // Render tensor4: a 3D float32 scalar, without the optional name.
   const tensorDiv4 = document.getElementById('tensor4') as HTMLDivElement;
   // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
-  const tensorView4 =  tensorToTensorView(
-    tf.linspace(0, (64 * 32 * 50 - 1) / 100, 64 * 32 * 50)
-    .reshape([64, 32, 50]));
+  const tensorView4 = tensorToTensorView(
+    tf.linspace(0, (64 * 32 * 50 - 1) / 100, 64 * 32 * 50).reshape([64, 32, 50])
+  );
   const tensorWidget4 = tensorWidget.tensorWidget(tensorDiv4, tensorView4); // No name.
   tensorWidget4.render();
 
@@ -174,9 +174,11 @@ function demo() {
   // Render tensor4: a 3D float32 scalar, without the optional name.
   const tensorDiv5 = document.getElementById('tensor5') as HTMLDivElement;
   // TODO(cais): Replace this with a TensorFlow.js-based TensorView.
-  const tensorView5 =  tensorToTensorView(
-    tf.linspace(0, (2 * 4 * 15 * 20 - 1) / 100, 2 * 4 * 15 * 20)
-    .reshape([2, 4, 15, 20]));
+  const tensorView5 = tensorToTensorView(
+    tf
+      .linspace(0, (2 * 4 * 15 * 20 - 1) / 100, 2 * 4 * 15 * 20)
+      .reshape([2, 4, 15, 20])
+  );
   const tensorWidget5 = tensorWidget.tensorWidget(tensorDiv5, tensorView5); // No name.
   tensorWidget5.render();
 }

--- a/tensorboard/components/tensor_widget/shape-utils-test.ts
+++ b/tensorboard/components/tensor_widget/shape-utils-test.ts
@@ -15,7 +15,12 @@ limitations under the License.
 
 import {expect} from 'chai';
 
-import {formatShapeForDisplay, getDefaultSlicingSpec} from './shape-utils';
+import {
+  formatShapeForDisplay,
+  getDefaultSlicingSpec,
+  dimensionsDiffer,
+} from './shape-utils';
+import {TensorViewSlicingSpec} from './types';
 
 describe('formatShapeForDisplay', () => {
   it('returns string scalar for []', () => {
@@ -114,5 +119,109 @@ describe('getDefaultSlicingSpec', () => {
       verticalRange: null,
       horizontalRange: null,
     });
+  });
+});
+
+describe('dimensionsDiffer', () => {
+  it('Different orders in slicing dimensions are ignored', () => {
+    const spec0: TensorViewSlicingSpec = {
+      slicingDimsAndIndices: [
+        {
+          dim: 0,
+          index: 0,
+        },
+        {
+          dim: 1,
+          index: 0,
+        },
+      ],
+      viewingDims: [2, 3],
+      verticalRange: null,
+      horizontalRange: null,
+    };
+    const spec1: TensorViewSlicingSpec = {
+      slicingDimsAndIndices: [
+        {
+          dim: 1,
+          index: 0,
+        },
+        {
+          dim: 0,
+          index: 0,
+        },
+      ],
+      viewingDims: [2, 3],
+      verticalRange: null,
+      horizontalRange: null,
+    };
+    expect(dimensionsDiffer(spec0, spec1)).to.be.false;
+  });
+
+  it('Different slicing indices are ignored', () => {
+    const spec0: TensorViewSlicingSpec = {
+      slicingDimsAndIndices: [
+        {
+          dim: 0,
+          index: 8,
+        },
+        {
+          dim: 1,
+          index: 0,
+        },
+      ],
+      viewingDims: [2, 3],
+      verticalRange: null,
+      horizontalRange: null,
+    };
+    const spec1: TensorViewSlicingSpec = {
+      slicingDimsAndIndices: [
+        {
+          dim: 0,
+          index: 0,
+        },
+        {
+          dim: 1,
+          index: 9,
+        },
+      ],
+      viewingDims: [2, 3],
+      verticalRange: null,
+      horizontalRange: null,
+    };
+    expect(dimensionsDiffer(spec0, spec1)).to.be.false;
+  });
+
+  it('Differen slicing and viewing dimensions are captured', () => {
+    const spec0: TensorViewSlicingSpec = {
+      slicingDimsAndIndices: [
+        {
+          dim: 0,
+          index: 0,
+        },
+        {
+          dim: 3,
+          index: 0,
+        },
+      ],
+      viewingDims: [1, 2],
+      verticalRange: null,
+      horizontalRange: null,
+    };
+    const spec1: TensorViewSlicingSpec = {
+      slicingDimsAndIndices: [
+        {
+          dim: 0,
+          index: 0,
+        },
+        {
+          dim: 1,
+          index: 0,
+        },
+      ],
+      viewingDims: [2, 3],
+      verticalRange: null,
+      horizontalRange: null,
+    };
+    expect(dimensionsDiffer(spec0, spec1)).to.be.true;
   });
 });

--- a/tensorboard/components/tensor_widget/shape-utils-test.ts
+++ b/tensorboard/components/tensor_widget/shape-utils-test.ts
@@ -18,7 +18,7 @@ import {expect} from 'chai';
 import {
   formatShapeForDisplay,
   getDefaultSlicingSpec,
-  dimensionsDiffer,
+  areSlicingSpecsCompatible,
 } from './shape-utils';
 import {TensorViewSlicingSpec} from './types';
 
@@ -154,7 +154,7 @@ describe('dimensionsDiffer', () => {
       verticalRange: null,
       horizontalRange: null,
     };
-    expect(dimensionsDiffer(spec0, spec1)).to.be.false;
+    expect(areSlicingSpecsCompatible(spec0, spec1)).to.be.true;
   });
 
   it('Different slicing indices are ignored', () => {
@@ -188,10 +188,10 @@ describe('dimensionsDiffer', () => {
       verticalRange: null,
       horizontalRange: null,
     };
-    expect(dimensionsDiffer(spec0, spec1)).to.be.false;
+    expect(areSlicingSpecsCompatible(spec0, spec1)).to.be.true;
   });
 
-  it('Differen slicing and viewing dimensions are captured', () => {
+  it('Different slicing and viewing dimensions are captured', () => {
     const spec0: TensorViewSlicingSpec = {
       slicingDimsAndIndices: [
         {
@@ -222,6 +222,6 @@ describe('dimensionsDiffer', () => {
       verticalRange: null,
       horizontalRange: null,
     };
-    expect(dimensionsDiffer(spec0, spec1)).to.be.true;
+    expect(areSlicingSpecsCompatible(spec0, spec1)).to.be.false;
   });
 });

--- a/tensorboard/components/tensor_widget/shape-utils.ts
+++ b/tensorboard/components/tensor_widget/shape-utils.ts
@@ -80,3 +80,30 @@ export function getDefaultSlicingSpec(shape: Shape): TensorViewSlicingSpec {
   }
   return slicingSpec;
 }
+
+/**
+ * Check if two slicing specs involve different dimension arrangements.
+ *
+ * Note that the slicing indicies in the slicing dimensions are ignored.
+ *
+ * @param spec0
+ * @param spec1
+ * @return TODO(cais): Finish doc string.
+ */
+export function dimensionsDiffer(
+  spec0: TensorViewSlicingSpec, spec1: TensorViewSlicingSpec): boolean {
+  if (spec0.viewingDims[0] !== spec1.viewingDims[0]) {
+    return true;
+  } else if (spec0.viewingDims[1] !== spec1.viewingDims[1]) {
+    return true;
+  } else {
+    // Check the slicing dimension.
+    const slicingDims0 =
+      spec0.slicingDimsAndIndices.map(dimAndIndex => dimAndIndex.dim);
+    slicingDims0.sort();
+    const slicingDims1 =
+      spec0.slicingDimsAndIndices.map(dimAndIndex => dimAndIndex.dim);
+    slicingDims1.sort();
+    return JSON.stringify(slicingDims0) !== JSON.stringify(slicingDims1);
+  }
+}

--- a/tensorboard/components/tensor_widget/shape-utils.ts
+++ b/tensorboard/components/tensor_widget/shape-utils.ts
@@ -88,21 +88,26 @@ export function getDefaultSlicingSpec(shape: Shape): TensorViewSlicingSpec {
  *
  * @param spec0
  * @param spec1
- * @return TODO(cais): Finish doc string.
+ * @return `true` if and only if the slicing dimensions and/or the viewing
+ *   dimensions differ between the `spec0` and `spec1`.
  */
 export function dimensionsDiffer(
-  spec0: TensorViewSlicingSpec, spec1: TensorViewSlicingSpec): boolean {
+  spec0: TensorViewSlicingSpec,
+  spec1: TensorViewSlicingSpec
+): boolean {
   if (spec0.viewingDims[0] !== spec1.viewingDims[0]) {
     return true;
   } else if (spec0.viewingDims[1] !== spec1.viewingDims[1]) {
     return true;
   } else {
     // Check the slicing dimension.
-    const slicingDims0 =
-      spec0.slicingDimsAndIndices.map(dimAndIndex => dimAndIndex.dim);
+    const slicingDims0 = spec0.slicingDimsAndIndices.map(
+      (dimAndIndex) => dimAndIndex.dim
+    );
     slicingDims0.sort();
-    const slicingDims1 =
-      spec0.slicingDimsAndIndices.map(dimAndIndex => dimAndIndex.dim);
+    const slicingDims1 = spec0.slicingDimsAndIndices.map(
+      (dimAndIndex) => dimAndIndex.dim
+    );
     slicingDims1.sort();
     return JSON.stringify(slicingDims0) !== JSON.stringify(slicingDims1);
   }

--- a/tensorboard/components/tensor_widget/shape-utils.ts
+++ b/tensorboard/components/tensor_widget/shape-utils.ts
@@ -85,7 +85,7 @@ export function getDefaultSlicingSpec(shape: Shape): TensorViewSlicingSpec {
  * Check if two slicing specs involve the compatible dimension arrangements.
  *
  * "Compatible dimension arrangement" means the same dimensions are used
- * for viewing and the same dimensions are used for slcing.
+ * for viewing and the same dimensions are used for slicing.
  *
  * Note that the slicing indicies in the slicing dimensions are ignored.
  * So are the ordering of the slicing dimensions.

--- a/tensorboard/components/tensor_widget/shape-utils.ts
+++ b/tensorboard/components/tensor_widget/shape-utils.ts
@@ -82,23 +82,27 @@ export function getDefaultSlicingSpec(shape: Shape): TensorViewSlicingSpec {
 }
 
 /**
- * Check if two slicing specs involve different dimension arrangements.
+ * Check if two slicing specs involve the compatible dimension arrangements.
+ *
+ * "Compatible dimension arrangement" means the same dimensions are used
+ * for viewing and the same dimensions are used for slcing.
  *
  * Note that the slicing indicies in the slicing dimensions are ignored.
+ * So are the ordering of the slicing dimensions.
  *
  * @param spec0
  * @param spec1
- * @return `true` if and only if the slicing dimensions and/or the viewing
- *   dimensions differ between the `spec0` and `spec1`.
+ * @return `true` if and only if the slicing dimensions and the viewing
+ *   dimensions are compatible between `spec0` and `spec1`.
  */
-export function dimensionsDiffer(
+export function areSlicingSpecsCompatible(
   spec0: TensorViewSlicingSpec,
   spec1: TensorViewSlicingSpec
 ): boolean {
   if (spec0.viewingDims[0] !== spec1.viewingDims[0]) {
-    return true;
+    return false;
   } else if (spec0.viewingDims[1] !== spec1.viewingDims[1]) {
-    return true;
+    return false;
   } else {
     // Check the slicing dimension.
     const slicingDims0 = spec0.slicingDimsAndIndices.map(
@@ -109,6 +113,6 @@ export function dimensionsDiffer(
       (dimAndIndex) => dimAndIndex.dim
     );
     slicingDims1.sort();
-    return JSON.stringify(slicingDims0) !== JSON.stringify(slicingDims1);
+    return JSON.stringify(slicingDims0) === JSON.stringify(slicingDims1);
   }
 }

--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -20,8 +20,12 @@ export type OnSlicingSpecChangeCallback = (
 ) => void;
 
 /**
- * UI control for selecting which dimensions to slicing down to 1 and which
- * to view. Used for tensors with rank (dimensionality) 3 or higher.
+ * UI control for
+ * - selecting which dimensions to slicing down to 1 and which to view
+ *   as a 2D data table.
+ * - which index to select within each sliced dimension.
+ *
+ * Used for tensors with rank (dimensionality) 3 or higher.
  */
 export class SlicingControl {
   private rank: number;
@@ -43,16 +47,21 @@ export class SlicingControl {
   private dimControlsListenerAttached: boolean[];
 
   /**
+   * Constructor of SlicingControl.
    *
-   * @param rootDiv
+   * @param rootDiv The div element in which all the UI components will be
+   *   rendered.
    * @param shape Shape of the tensor.
-   * @param initialSlicingSpec The initial slicing spec of the dimension.
-   *   DimensionControl will not mutate this object.
+   * @param onSlicngSpecChange User specified callback for slicing spec changes
+   *   triggered by user interactions with this SlicingControl. The callback
+   *   will be invoked for changes in:
+   *   - which dimensions are used for slicing and which for viewing
+   *   - the selected index within a slicing dimension.
    */
   constructor(
     private readonly rootDiv: HTMLDivElement,
     private readonly shape: Shape,
-    private readonly onSlicngSpecChange: OnSlicingSpecChangeCallback
+    private readonly onSlicngSpecChange?: OnSlicingSpecChangeCallback
   ) {
     this.rank = this.shape.length;
     if (this.rank < 3) {
@@ -65,6 +74,12 @@ export class SlicingControl {
     this.createComponents();
   }
 
+  /**
+   * Create all UI components of this SlicingControl.
+   *
+   * The detailed contents of the components are not filled in. Those are filled
+   * in when the `render()` method is called.
+   */
   private createComponents() {
     // Clear the dim group.
     while (this.rootDiv.firstChild) {
@@ -113,7 +128,7 @@ export class SlicingControl {
   }
 
   /**
-   * Re-render the slicing control according to the current slicing spec
+   * Re-render the slicing control according to the current slicing spec.
    */
   render(slicingSpec?: TensorViewSlicingSpec) {
     if (slicingSpec != null) {
@@ -177,7 +192,7 @@ export class SlicingControl {
           });
 
           // When defocusing (blurring) from the dim input, it changes back into
-          // a div.
+          // a static div.
           dimInput.addEventListener('blur', () => {
             dimInput.style.display = 'none';
             dimControl.style.display = 'inline-block';
@@ -294,6 +309,20 @@ export class SlicingControl {
     }
   }
 
+  /**
+   * Set the slicing spec externally.
+   *
+   * This will trigger a re-rendering of the SlicingControl's UI components,
+   * which will reflect the input slicing spec's value.
+   *
+   * @param slicingSpec The externally-set slicing spec. It will not be mutated
+   *   by SlicingControl.
+   */
+  setSlicingSpec(slicingSpec: TensorViewSlicingSpec) {
+    this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
+    this.render(this.slicingSpec);
+  }
+
   private clearAllDropdowns() {
     this.dropdowns.forEach((dropdown) => {
       if (dropdown != null) {
@@ -302,10 +331,5 @@ export class SlicingControl {
         }
       }
     });
-  }
-
-  setSlicingSpec(slicingSpec: TensorViewSlicingSpec) {
-    this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
-    this.render(this.slicingSpec);
   }
 }

--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -1,0 +1,87 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Shape, TensorViewSlicingSpec} from "./types";
+
+export type OnSlicingSpecChangeCallback = (slicingSpec: TensorViewSlicingSpec) => void;
+
+/**
+ * UI control for selecting which dimensions to slicing down to 1 and which
+ * to view. Used for tensors with rank (dimensionality) 3 or higher.
+ */
+export class SlicingControl {
+  private rank: number;
+
+  // The current slicing spec.
+  private slicingSpec: TensorViewSlicingSpec;
+
+  // Constituent UI components.
+  private dimGroup: HTMLDivElement;
+
+  /**
+   *
+   * @param rootDiv
+   * @param shape Shape of the tensor.
+   * @param initialSlicingSpec The initial slicing spec of the dimension.
+   *   DimensionControl will not mutate this object.
+   */
+  constructor(private readonly rootDiv: HTMLDivElement,
+              private readonly shape: Shape,
+              readonly initialSlicingSpec: TensorViewSlicingSpec,
+              private readonly onSlcingSpecChange: OnSlicingSpecChangeCallback) {
+    this.rank = this.shape.length;
+    if (this.rank < 3) {
+      throw new Error(
+          `Dimension control is not applicable to tensor shapes less than ` +
+          `3D: received ${this.rank}D tensor shape: ` +
+          `${JSON.stringify(this.shape)}.`);
+    }
+    this.rootDiv.classList.add('tensor-widget-slicing-control');
+    this.slicingSpec = JSON.parse(JSON.stringify(initialSlicingSpec));
+  }
+
+  render() {
+    if (this.dimGroup == null) {
+      this.dimGroup = document.createElement('div');
+      this.dimGroup.classList.add('tensor-widget-dim-group');
+      this.rootDiv.appendChild(this.dimGroup);
+    }
+
+    // Clean the dim group.
+    while (this.dimGroup.firstChild) {
+      this.dimGroup.removeChild(this.dimGroup.firstChild);
+    }
+
+    const slicingDims = this.slicingSpec.slicingDimsAndIndices.map(
+      dimAndIndex => dimAndIndex.dim);
+    const slicingIndices = this.slicingSpec.slicingDimsAndIndices.map(
+        dimAndIndex => dimAndIndex.index);
+    for (let i = 0; i < this.rank; ++i) {
+      const dimControl = document.createElement('div');
+      if (slicingDims.indexOf(i) !== -1) {
+        // This is a dimension being sliced down to a size of 1.
+      } else if (this.slicingSpec.viewingDims[0] === i) {
+        // This is a dimension being viewed as the vertical (rows) dimension.
+        dimControl.textContent = '↕:';
+        dimControl.classList.add('tensor-widget-dim-viewed');
+      } else if (this.slicingSpec.viewingDims[1] === i) {
+        // This is a dimension being viewed as the horizontal (columns)
+        // dimension.
+        dimControl.textContent = '↔:';
+        dimControl.classList.add('tensor-widget-dim-viewed');
+      }
+    }
+  }
+}

--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -198,7 +198,9 @@ export class SlicingControl {
             ) {
               // Reject invalid value.
               dimInput.value = String(
-                this.slicingSpec.slicingDimsAndIndices[slicingDims.indexOf(i)].index);
+                this.slicingSpec.slicingDimsAndIndices[slicingDims.indexOf(i)]
+                  .index
+              );
               return;
             }
             this.slicingSpec.slicingDimsAndIndices[

--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -273,15 +273,18 @@ export class SlicingControl {
       (dimAndIndex) => dimAndIndex.dim
     );
     for (let i = 0; i < this.rank; ++i) {
-      // Create "Swap with" menu items only with slicing dimensions.
+      // Create "Swap with" menu items only with slicing dimensions, i.e., not
+      // with viewing dimensions.
       if (slicingDims.indexOf(i) === -1) {
         continue;
       }
-      // Do not allow the second (columns) viewing dimension to be before
+      // Also, do not allow the second (columns) viewing dimension to be before
       // the first one.
       if (
-        dim === this.slicingSpec.viewingDims[1] &&
-        i < this.slicingSpec.viewingDims[0]
+        (dim === this.slicingSpec.viewingDims[1] &&
+          i <= this.slicingSpec.viewingDims[0]) ||
+        (dim == this.slicingSpec.viewingDims[0] &&
+          i >= this.slicingSpec.viewingDims[1])
       ) {
         continue;
       }

--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -37,6 +37,8 @@ export class SlicingControl {
   private dimControls: HTMLDivElement[];
   // Input elements for selecting the slices in sliced dimensions.
   private dimInputs: HTMLInputElement[];
+  // Displayed commas.
+  private commas: HTMLDivElement[];
   // Dropdown mini-menus to allow swapping a viewed dimension with another
   // dimension.
   private dropdowns: HTMLDivElement[];
@@ -86,6 +88,7 @@ export class SlicingControl {
     }
     this.dimControls = [];
     this.dimInputs = [];
+    this.commas = [];
     this.dropdowns = [];
     this.dimControlsListenerAttached = [];
 
@@ -98,6 +101,7 @@ export class SlicingControl {
     for (let i = 0; i < this.rank; ++i) {
       const dimControl = document.createElement('div');
       dimControl.classList.add('tensor-widget-dim');
+      dimControl.title = `Dimension ${i}: size=${this.shape[i]}`;
       this.rootDiv.appendChild(dimControl);
       this.dimControls.push(dimControl);
 
@@ -110,6 +114,15 @@ export class SlicingControl {
       dimInput.style.display = 'none';
       this.rootDiv.appendChild(dimInput);
       this.dimInputs.push(dimInput);
+
+      if (i < this.rank - 1) {
+        // Render a comma
+        const comma = document.createElement('div');
+        comma.classList.add('tensor-widget-dim-comma');
+        comma.textContent = ',';
+        this.rootDiv.appendChild(comma);
+        this.commas.push(comma);
+      }
 
       const dropdown = document.createElement('div');
       dropdown.classList.add('tensor-widget-dim-dropdown');

--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -155,7 +155,7 @@ export class SlicingControl {
       if (slicingDims.indexOf(i) !== -1) {
         // This is a dimension being sliced down to a size of 1.
         const currentIndex = slicingIndices[slicingDims.indexOf(i)];
-        dimControl.textContent = `${currentIndex}/${dimSize}`;
+        dimControl.textContent = `${currentIndex}`;
 
         dimInput.classList.add('tensor-widget-dim');
         dimInput.type = 'number';
@@ -187,7 +187,7 @@ export class SlicingControl {
             this.slicingSpec.slicingDimsAndIndices[
               slicingDims.indexOf(i)
             ].index = newIndex;
-            dimControl.textContent = `${newIndex}/${dimSize}`;
+            dimControl.textContent = `${newIndex}`;
             this.onSlicngSpecChange(this.slicingSpec);
           });
 
@@ -204,14 +204,14 @@ export class SlicingControl {
         if (this.slicingSpec.viewingDims[0] === i) {
           // This is a dimension being viewed as the vertical (rows) dimension.
           dimControl.textContent =
-            `Rows: ${this.slicingSpec.verticalRange[0]}:` +
-            `${this.slicingSpec.verticalRange[1]}/${dimSize}`;
+            `🡙: ${this.slicingSpec.verticalRange[0]}:` +
+            `${this.slicingSpec.verticalRange[1]}`;
         } else {
           // This is a dimension being viewed as the horizontal (columns)
           // dimension.
           dimControl.textContent =
-            `Cols: ${this.slicingSpec.horizontalRange[0]}:` +
-            `${this.slicingSpec.horizontalRange[1]}/${dimSize}`;
+            `🡘: ${this.slicingSpec.horizontalRange[0]}:` +
+            `${this.slicingSpec.horizontalRange[1]}`;
         }
         dimControl.classList.add('tensor-widget-dim');
         if (!this.dimControlsListenerAttached[i]) {

--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -53,7 +53,7 @@ export class SlicingControl {
    * @param rootDiv The div element in which all the UI components will be
    *   rendered.
    * @param shape Shape of the tensor.
-   * @param onSlicngSpecChange User specified callback for slicing spec changes
+   * @param onSlicingSpecChange User specified callback for slicing spec changes
    *   triggered by user interactions with this SlicingControl. The callback
    *   will be invoked for changes in:
    *   - which dimensions are used for slicing and which for viewing
@@ -62,7 +62,7 @@ export class SlicingControl {
   constructor(
     private readonly rootDiv: HTMLDivElement,
     private readonly shape: Shape,
-    private readonly onSlicngSpecChange?: OnSlicingSpecChangeCallback
+    private readonly onSlicingSpecChange?: OnSlicingSpecChangeCallback
   ) {
     this.rank = this.shape.length;
     if (this.rank < 3) {
@@ -171,13 +171,13 @@ export class SlicingControl {
       if (slicingDims.indexOf(i) !== -1) {
         // This is a dimension being sliced down to a size of 1.
         const currentIndex = slicingIndices[slicingDims.indexOf(i)];
-        dimControl.textContent = `${currentIndex}`;
+        dimControl.textContent = String(currentIndex);
 
         dimInput.classList.add('tensor-widget-dim');
         dimInput.type = 'number';
         dimInput.min = '0';
-        dimInput.max = `${dimSize - 1}`;
-        dimInput.value = `${currentIndex}`;
+        dimInput.max = String(dimSize - 1);
+        dimInput.value = String(currentIndex);
 
         // When the dim control is clicked, it becomes a number input.
         if (!this.dimControlsListenerAttached[i]) {
@@ -197,14 +197,15 @@ export class SlicingControl {
               Math.floor(dimSize) != dimSize
             ) {
               // Reject invalid value.
-              dimInput.value = `${this.slicingSpec.slicingDimsAndIndices[slicingDims.indexOf(i)].index}`;
+              dimInput.value = String(
+                this.slicingSpec.slicingDimsAndIndices[slicingDims.indexOf(i)].index);
               return;
             }
             this.slicingSpec.slicingDimsAndIndices[
               slicingDims.indexOf(i)
             ].index = newIndex;
-            dimControl.textContent = `${newIndex}`;
-            this.onSlicngSpecChange(this.slicingSpec);
+            dimControl.textContent = String(newIndex);
+            this.onSlicingSpecChange(this.slicingSpec);
           });
 
           // When defocusing (blurring) from the dim input, it changes back into
@@ -308,8 +309,8 @@ export class SlicingControl {
         };
         this.slicingSpec.verticalRange = null;
         this.slicingSpec.horizontalRange = null;
-        if (this.onSlicngSpecChange) {
-          this.onSlicngSpecChange(this.slicingSpec);
+        if (this.onSlicingSpecChange) {
+          this.onSlicingSpecChange(this.slicingSpec);
         }
       });
     }

--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -13,9 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Shape, TensorViewSlicingSpec} from "./types";
+import {Shape, TensorViewSlicingSpec} from './types';
 
-export type OnSlicingSpecChangeCallback = (slicingSpec: TensorViewSlicingSpec) => void;
+export type OnSlicingSpecChangeCallback = (
+  slicingSpec: TensorViewSlicingSpec
+) => void;
 
 /**
  * UI control for selecting which dimensions to slicing down to 1 and which
@@ -47,19 +49,21 @@ export class SlicingControl {
    * @param initialSlicingSpec The initial slicing spec of the dimension.
    *   DimensionControl will not mutate this object.
    */
-  constructor(private readonly rootDiv: HTMLDivElement,
-              private readonly shape: Shape,
-              private readonly onSlicngSpecChange: OnSlicingSpecChangeCallback) {
+  constructor(
+    private readonly rootDiv: HTMLDivElement,
+    private readonly shape: Shape,
+    private readonly onSlicngSpecChange: OnSlicingSpecChangeCallback
+  ) {
     this.rank = this.shape.length;
     if (this.rank < 3) {
       throw new Error(
-          `Dimension control is not applicable to tensor shapes less than ` +
+        `Dimension control is not applicable to tensor shapes less than ` +
           `3D: received ${this.rank}D tensor shape: ` +
-          `${JSON.stringify(this.shape)}.`);
+          `${JSON.stringify(this.shape)}.`
+      );
     }
     this.createComponents();
   }
-
 
   private createComponents() {
     // Clear the dim group.
@@ -117,9 +121,11 @@ export class SlicingControl {
     }
 
     const slicingDims = this.slicingSpec.slicingDimsAndIndices.map(
-      dimAndIndex => dimAndIndex.dim);
+      (dimAndIndex) => dimAndIndex.dim
+    );
     const slicingIndices = this.slicingSpec.slicingDimsAndIndices.map(
-      dimAndIndex => dimAndIndex.index);
+      (dimAndIndex) => dimAndIndex.index
+    );
     for (let i = 0; i < this.rank; ++i) {
       const dimControl = this.dimControls[i];
       const dimInput = this.dimInputs[i];
@@ -147,21 +153,25 @@ export class SlicingControl {
           dimControl.addEventListener('click', () => {
             this.clearAllDropdowns();
             dimControl.style.display = 'none';
-            dimInput.style.display = 'inline-block' ;
+            dimInput.style.display = 'inline-block';
           });
 
           // Set change callback for the dim input.
-          dimInput.addEventListener('change',  () => {
+          dimInput.addEventListener('change', () => {
             const newIndex = parseInt(dimInput.value, 10);
-            if (!isFinite(newIndex) || newIndex < 0 || newIndex >= dimSize ||
-                Math.floor(dimSize) != dimSize) {
+            if (
+              !isFinite(newIndex) ||
+              newIndex < 0 ||
+              newIndex >= dimSize ||
+              Math.floor(dimSize) != dimSize
+            ) {
               // Reject invalid value.
-              dimInput.value =
-                `${this.slicingSpec.slicingDimsAndIndices[slicingDims.indexOf(i)].index}`;
+              dimInput.value = `${this.slicingSpec.slicingDimsAndIndices[slicingDims.indexOf(i)].index}`;
               return;
             }
-            this.slicingSpec.slicingDimsAndIndices[slicingDims.indexOf(i)].index =
-              newIndex;
+            this.slicingSpec.slicingDimsAndIndices[
+              slicingDims.indexOf(i)
+            ].index = newIndex;
             dimControl.textContent = `${newIndex}/${dimSize}`;
             this.onSlicngSpecChange(this.slicingSpec);
           });
@@ -179,13 +189,13 @@ export class SlicingControl {
         if (this.slicingSpec.viewingDims[0] === i) {
           // This is a dimension being viewed as the vertical (rows) dimension.
           dimControl.textContent =
-            `Rows: ${this.slicingSpec.verticalRange[0]}-` +
+            `Rows: ${this.slicingSpec.verticalRange[0]}:` +
             `${this.slicingSpec.verticalRange[1]}/${dimSize}`;
         } else {
           // This is a dimension being viewed as the horizontal (columns)
           // dimension.
           dimControl.textContent =
-            `Cols: ${this.slicingSpec.horizontalRange[0]}-` +
+            `Cols: ${this.slicingSpec.horizontalRange[0]}:` +
             `${this.slicingSpec.horizontalRange[1]}/${dimSize}`;
         }
         dimControl.classList.add('tensor-widget-dim');
@@ -203,18 +213,31 @@ export class SlicingControl {
   }
 
   /**
-   * TODO(cais): Doc string.
+   * Render items in a viewing dimension's dropdown menu.
+   *
+   * The rendering is based on what dimension swappings are possible.
+   * The dropdown menu will be shown if it is non-empty after the menu items are
+   * populated.
+   *
    * @param dropdown
-   * @param dim
+   * @param top The top coordinate of the menu.
+   * @param left The left coordinate of the menu.
+   * @param dim The dimension that the viewing dimension belongs to. E.g., `0`
+   *   for the first dimension.
    */
   private renderDropdownMenuItems(
-    dropdown: HTMLDivElement, top: number, left: number, dim: number) {
+    dropdown: HTMLDivElement,
+    top: number,
+    left: number,
+    dim: number
+  ) {
     // Clear all dropdown menus. Make sure that at any moment, only one dropdown
     // menu is open.
     this.clearAllDropdowns();
 
     const slicingDims = this.slicingSpec.slicingDimsAndIndices.map(
-      dimAndIndex => dimAndIndex.dim);
+      (dimAndIndex) => dimAndIndex.dim
+    );
     for (let i = 0; i < this.rank; ++i) {
       // Create "Swap with" menu items only with slicing dimensions.
       if (slicingDims.indexOf(i) === -1) {
@@ -222,9 +245,11 @@ export class SlicingControl {
       }
       // Do not allow the second (columns) viewing dimension to be before
       // the first one.
-      if (dim === this.slicingSpec.viewingDims[1] &&
-          i < this.slicingSpec.viewingDims[0]) {
-        continue
+      if (
+        dim === this.slicingSpec.viewingDims[1] &&
+        i < this.slicingSpec.viewingDims[0]
+      ) {
+        continue;
       }
 
       const menuItem = document.createElement('div');
@@ -235,7 +260,9 @@ export class SlicingControl {
         menuItem.classList.add('tensor-widget-dim-dropdown-menu-item-active');
       });
       menuItem.addEventListener('mouseleave', () => {
-        menuItem.classList.remove('tensor-widget-dim-dropdown-menu-item-active');
+        menuItem.classList.remove(
+          'tensor-widget-dim-dropdown-menu-item-active'
+        );
       });
 
       const isFirstViewingDim = this.slicingSpec.viewingDims[0] === dim;
@@ -244,7 +271,7 @@ export class SlicingControl {
         this.slicingSpec.viewingDims[isFirstViewingDim ? 0 : 1] = i;
         this.slicingSpec.slicingDimsAndIndices[k] = {
           dim,
-          index: 0
+          index: 0,
         };
         this.slicingSpec.verticalRange = null;
         this.slicingSpec.horizontalRange = null;
@@ -268,7 +295,7 @@ export class SlicingControl {
   }
 
   private clearAllDropdowns() {
-    this.dropdowns.forEach(dropdown => {
+    this.dropdowns.forEach((dropdown) => {
       if (dropdown != null) {
         while (dropdown.firstChild) {
           dropdown.removeChild(dropdown.firstChild);
@@ -278,9 +305,6 @@ export class SlicingControl {
   }
 
   setSlicingSpec(slicingSpec: TensorViewSlicingSpec) {
-    // TODO(cais): See if there is a change in slicingDimsAndIndices and
-    // if there is any change in viewingDims, and if so, call createComponents()
-    // before calling render().
     this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
     this.render(this.slicingSpec);
   }

--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -62,7 +62,7 @@ export class SlicingControl {
 
 
   private createComponents() {
-    // Clean the dim group.
+    // Clear the dim group.
     while (this.rootDiv.firstChild) {
       this.rootDiv.removeChild(this.rootDiv.firstChild);
     }
@@ -208,15 +208,10 @@ export class SlicingControl {
    * @param dim
    */
   private renderDropdownMenuItems(
-    dropdown: HTMLDivElement,  top: number, left: number, dim: number) {
+    dropdown: HTMLDivElement, top: number, left: number, dim: number) {
     // Clear all dropdown menus. Make sure that at any moment, only one dropdown
     // menu is open.
     this.clearAllDropdowns();
-
-    dropdown.style.position = 'fixed';
-    dropdown.style.top = `${top}px`;
-    dropdown.style.left = `${left}px`;
-    dropdown.style.display = 'block';
 
     const slicingDims = this.slicingSpec.slicingDimsAndIndices.map(
       dimAndIndex => dimAndIndex.dim);
@@ -224,6 +219,12 @@ export class SlicingControl {
       // Create "Swap with" menu items only with slicing dimensions.
       if (slicingDims.indexOf(i) === -1) {
         continue;
+      }
+      // Do not allow the second (columns) viewing dimension to be before
+      // the first one.
+      if (dim === this.slicingSpec.viewingDims[1] &&
+          i < this.slicingSpec.viewingDims[0]) {
+        continue
       }
 
       const menuItem = document.createElement('div');
@@ -256,6 +257,14 @@ export class SlicingControl {
     dropdown.addEventListener('mouseleave', () => {
       dropdown.style.display = 'none';
     });
+
+    // Show the dropdown menu if and only if it is non-empty.
+    if (dropdown.firstChild) {
+      dropdown.style.position = 'fixed';
+      dropdown.style.top = `${top}px`;
+      dropdown.style.left = `${left}px`;
+      dropdown.style.display = 'block';
+    }
   }
 
   private clearAllDropdowns() {
@@ -273,7 +282,6 @@ export class SlicingControl {
     // if there is any change in viewingDims, and if so, call createComponents()
     // before calling render().
     this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
-    console.log('Calling render:', JSON.stringify(this.slicingSpec));  // DEBUG
     this.render(this.slicingSpec);
   }
 }

--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -34,7 +34,6 @@ export class SlicingControl {
   private slicingSpec: TensorViewSlicingSpec;
 
   // Constituent UI components.
-  // private rootDiv: HTMLDivElement;
   private dimControls: HTMLDivElement[];
   // Input elements for selecting the slices in sliced dimensions.
   private dimInputs: HTMLInputElement[];
@@ -125,6 +124,10 @@ export class SlicingControl {
     this.bracketDivs[1].textContent = ']';
     this.bracketDivs[1].classList.add('tensor-widget-dim-brackets');
     this.rootDiv.appendChild(this.bracketDivs[1]);
+
+    this.rootDiv.addEventListener('mouseleave', () => {
+      this.clearAllDropdowns();
+    });
   }
 
   /**
@@ -204,13 +207,13 @@ export class SlicingControl {
         if (this.slicingSpec.viewingDims[0] === i) {
           // This is a dimension being viewed as the vertical (rows) dimension.
           dimControl.textContent =
-            `🡙: ${this.slicingSpec.verticalRange[0]}:` +
+            `🡙 ${this.slicingSpec.verticalRange[0]}:` +
             `${this.slicingSpec.verticalRange[1]}`;
         } else {
           // This is a dimension being viewed as the horizontal (columns)
           // dimension.
           dimControl.textContent =
-            `🡘: ${this.slicingSpec.horizontalRange[0]}:` +
+            `🡘 ${this.slicingSpec.horizontalRange[0]}:` +
             `${this.slicingSpec.horizontalRange[1]}`;
         }
         dimControl.classList.add('tensor-widget-dim');
@@ -273,11 +276,13 @@ export class SlicingControl {
       dropdown.appendChild(menuItem);
       menuItem.addEventListener('mouseenter', () => {
         menuItem.classList.add('tensor-widget-dim-dropdown-menu-item-active');
+        this.dimControls[i].classList.add('tensor-widget-dim-highlighted');
       });
       menuItem.addEventListener('mouseleave', () => {
         menuItem.classList.remove(
           'tensor-widget-dim-dropdown-menu-item-active'
         );
+        this.dimControls[i].classList.remove('tensor-widget-dim-highlighted');
       });
 
       const isFirstViewingDim = this.slicingSpec.viewingDims[0] === dim;
@@ -329,6 +334,7 @@ export class SlicingControl {
         while (dropdown.firstChild) {
           dropdown.removeChild(dropdown.firstChild);
         }
+        dropdown.style.display = 'none';
       }
     });
   }

--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -106,9 +106,9 @@ export class SlicingControl {
         continue;
       }
 
+      const dimSize = this.shape[i];
       if (slicingDims.indexOf(i) !== -1) {
         // This is a dimension being sliced down to a size of 1.
-        const dimSize = this.shape[i];
         const currentIndex = slicingIndices[slicingDims.indexOf(i)];
         dimControl.textContent = `${currentIndex}/${dimSize}`;
 
@@ -127,7 +127,8 @@ export class SlicingControl {
         // Set change callback for the dim input.
         dimInput.addEventListener('change',  () => {
           const newIndex = parseInt(dimInput.value, 10);
-          if (newIndex < 0 || newIndex >= dimSize || Math.floor(dimSize) != dimSize) {
+          if (!isFinite(newIndex) || newIndex < 0 || newIndex >= dimSize ||
+              Math.floor(dimSize) != dimSize) {
             // Reject invalid value.
             dimInput.value =
               `${this.slicingSpec.slicingDimsAndIndices[slicingDims.indexOf(i)].index}`;
@@ -150,14 +151,14 @@ export class SlicingControl {
         // This is a dimension being viewed as the vertical (rows) dimension.
         dimControl.textContent =
           `Rows: ${this.slicingSpec.verticalRange[0]}-` +
-          `${this.slicingSpec.verticalRange[1]}`;
+          `${this.slicingSpec.verticalRange[1]}/${dimSize}`;
         dimControl.classList.add('tensor-widget-dim');
       } else if (this.slicingSpec.viewingDims[1] === i) {
         // This is a dimension being viewed as the horizontal (columns)
         // dimension.
         dimControl.textContent =
           `Cols: ${this.slicingSpec.horizontalRange[0]}-` +
-          `${this.slicingSpec.horizontalRange[1]}`;
+          `${this.slicingSpec.horizontalRange[1]}/${dimSize}`;
         dimControl.classList.add('tensor-widget-dim');
       }
       // this.rootDiv.appendChild(dimControl);

--- a/tensorboard/components/tensor_widget/slicing-control.ts
+++ b/tensorboard/components/tensor_widget/slicing-control.ts
@@ -30,6 +30,8 @@ export class SlicingControl {
   // Constituent UI components.
   // private rootDiv: HTMLDivElement;
   private dimControls: HTMLDivElement[];
+  private dimInputs: HTMLInputElement[];
+  private bracketDivs: [HTMLDivElement, HTMLDivElement] = [null, null];
 
   /**
    *
@@ -48,42 +50,73 @@ export class SlicingControl {
           `3D: received ${this.rank}D tensor shape: ` +
           `${JSON.stringify(this.shape)}.`);
     }
-  }
-
-  render(slcingSpec: TensorViewSlicingSpec) {
-    this.slicingSpec = JSON.parse(JSON.stringify(slcingSpec));
-    // if (this.rootDiv == null) {
-    //   this.rootDiv.appendChild(this.rootDiv);
-    // }
 
     // Clean the dim group.
     while (this.rootDiv.firstChild) {
       this.rootDiv.removeChild(this.rootDiv.firstChild);
     }
     this.dimControls = [];
+    this.dimInputs = [];
+
+    // Create the div elements for the brackets and the dim controls.
+    this.bracketDivs[0] = document.createElement('div');
+    this.bracketDivs[0].textContent = '[';
+    this.bracketDivs[0].classList.add('tensor-widget-dim-brackets');
+    this.rootDiv.appendChild(this.bracketDivs[0]);
+
+    for (let i = 0; i < this.rank; ++i) {
+      const dimControl = document.createElement('div');
+      dimControl.classList.add('tensor-widget-dim');
+      this.rootDiv.appendChild(dimControl);
+      this.dimControls.push(dimControl);
+
+      const dimInput = document.createElement('input');
+      dimInput.classList.add('tensor-widget-dim');
+      // The dim input is initially hidden, and will be shown when the dim
+      // control is clicked.
+      dimInput.style.display = 'none';
+      this.rootDiv.appendChild(dimInput);
+      this.dimInputs.push(dimInput);
+    }
+
+    this.bracketDivs[1] = document.createElement('div');
+    this.bracketDivs[1].textContent = ']';
+    this.bracketDivs[1].classList.add('tensor-widget-dim-brackets');
+    this.rootDiv.appendChild(this.bracketDivs[1]);
+  }
+
+  /**
+   * Re-render the slicing control according to the current slicing spec
+   */
+  render(slicingSpec?: TensorViewSlicingSpec) {
+    if (slicingSpec != null) {
+      this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
+    }
 
     const slicingDims = this.slicingSpec.slicingDimsAndIndices.map(
       dimAndIndex => dimAndIndex.dim);
     const slicingIndices = this.slicingSpec.slicingDimsAndIndices.map(
       dimAndIndex => dimAndIndex.index);
     for (let i = 0; i < this.rank; ++i) {
-      const dimControl = document.createElement('div');
+      const dimControl = this.dimControls[i];
+      const dimInput = this.dimInputs[i];
+      if (dimInput.style.display !== 'none') {
+        // This dimension is currently being adjusted for slicing index. Skip
+        // rendering.
+        continue;
+      }
+
       if (slicingDims.indexOf(i) !== -1) {
         // This is a dimension being sliced down to a size of 1.
         const dimSize = this.shape[i];
         const currentIndex = slicingIndices[slicingDims.indexOf(i)];
         dimControl.textContent = `${currentIndex}/${dimSize}`;
-        dimControl.classList.add('tensor-widget-dim');
 
-        const dimInput = document.createElement('input');
         dimInput.classList.add('tensor-widget-dim');
         dimInput.type = 'number';
         dimInput.min = '0';
         dimInput.max = `${dimSize - 1}`;
         dimInput.value = `${currentIndex}`;
-        dimInput.style.width = '5';
-        dimInput.style.display = 'none';
-        this.rootDiv.appendChild(dimInput);
 
         // When the dim control is clicked, it becomes a number input.
         dimControl.addEventListener('click', () => {
@@ -111,23 +144,28 @@ export class SlicingControl {
         dimInput.addEventListener('blur', () => {
           dimInput.style.display = 'none';
           dimControl.style.display = 'inline-block';
-          // TODO(cais): Update the number.
-          // this.drawDimControl('top');
-          // this.drawDimControl('left');
         });
 
       } else if (this.slicingSpec.viewingDims[0] === i) {
         // This is a dimension being viewed as the vertical (rows) dimension.
-        dimControl.textContent = '↕:';
+        dimControl.textContent =
+          `Rows: ${this.slicingSpec.verticalRange[0]}-` +
+          `${this.slicingSpec.verticalRange[1]}`;
         dimControl.classList.add('tensor-widget-dim');
       } else if (this.slicingSpec.viewingDims[1] === i) {
         // This is a dimension being viewed as the horizontal (columns)
         // dimension.
-        dimControl.textContent = '↔:';
+        dimControl.textContent =
+          `Cols: ${this.slicingSpec.horizontalRange[0]}-` +
+          `${this.slicingSpec.horizontalRange[1]}`;
         dimControl.classList.add('tensor-widget-dim');
       }
-      this.rootDiv.appendChild(dimControl);
-      this.dimControls.push(dimControl);
+      // this.rootDiv.appendChild(dimControl);
     }
+  }
+
+  setSlicingSpec(slicingSpec: TensorViewSlicingSpec) {
+    this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
+    this.render(this.slicingSpec);
   }
 }

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -14,7 +14,11 @@ limitations under the License.
 ==============================================================================*/
 
 import {isIntegerDType, isFloatDType} from './dtype-utils';
-import {formatShapeForDisplay, getDefaultSlicingSpec, dimensionsDiffer} from './shape-utils';
+import {
+  formatShapeForDisplay,
+  getDefaultSlicingSpec,
+  dimensionsDiffer,
+} from './shape-utils';
 import {SlicingControl} from './slicing-control';
 import {formatTensorName, numericValueToString} from './string-utils';
 import {
@@ -209,8 +213,6 @@ export class TensorWidgetImpl implements TensorWidget {
     }
 
     this.clearValueSection();
-
-    // TODO(cais): Move this out of the else branch.
     this.createTopRuler();
     this.createLeftRuler();
     this.createValueDivs();
@@ -218,12 +220,10 @@ export class TensorWidgetImpl implements TensorWidget {
 
     if (this.rank > 2) {
       this.slicingControl = new SlicingControl(
-        this.slicingSpecRoot, this.tensorView.spec.shape,
+        this.slicingSpecRoot,
+        this.tensorView.spec.shape,
         async (slicingSpec: TensorViewSlicingSpec) => {
           if (dimensionsDiffer(this.slicingSpec, slicingSpec)) {
-            console.log('Slicing dimensions differ!!!');  // DEBUG
-            console.log('slicing spec changed:',
-              JSON.stringify(slicingSpec));  // DEBUG
             this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
             // The dimension arrangement has changed in the slicing spec.
             // The rulers and value divs must be re-created. This is why
@@ -233,7 +233,8 @@ export class TensorWidgetImpl implements TensorWidget {
             this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
             await this.renderRulersAndValueDivs();
           }
-        });
+        }
+      );
       this.slicingControl.render(this.slicingSpec);
     }
   }
@@ -302,7 +303,6 @@ export class TensorWidgetImpl implements TensorWidget {
         // The tick has gone out of the right bound of the tensor widget.
         if (this.rank >= 2) {
           this.slicingSpec.horizontalRange[1] = i + 1;
-          console.log(`Set this.slicingSpec.horizontalRange to ${this.slicingSpec.horizontalRange[1]}`);  // DEBUG
           this.colsCutoff = true;
         }
         break;
@@ -482,9 +482,7 @@ export class TensorWidgetImpl implements TensorWidget {
    */
   private async renderRulersAndValueDivs() {
     if (this.slicingControl != null) {
-      console.log('*** Calling setSlicingSpec():', JSON.stringify(this.slicingSpec)); // DEBUG
       this.slicingControl.setSlicingSpec(this.slicingSpec);
-      console.log('*** DONE calling setSlicingSpec()');  // DEBUG
     }
     this.renderTopRuler();
     this.renderLeftRuler();

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -218,9 +218,6 @@ export class TensorWidgetImpl implements TensorWidget {
       this.slicingControl = new SlicingControl(
         this.slicingSpecRoot, this.tensorView.spec.shape,
         async (slicingSpec: TensorViewSlicingSpec) => {
-          // TODO(cais): Implement.
-          console.log(`New slicing spec:`,
-            JSON.stringify(slicingSpec.slicingDimsAndIndices));
           this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
           await this.renderRulersAndValueDivs();
         });
@@ -372,7 +369,6 @@ export class TensorWidgetImpl implements TensorWidget {
    */
   private renderTopRuler() {
     if (this.rank >= 2) {
-      console.log(`renderTopRuler():`, this.slicingSpec);  // DEBUG
       const numCols = this.tensorView.spec.shape[
         this.slicingSpec.viewingDims[1]
       ];
@@ -463,6 +459,9 @@ export class TensorWidgetImpl implements TensorWidget {
    * based on the current slicing spec.
    */
   private async renderRulersAndValueDivs() {
+    if (this.slicingControl != null) {
+      this.slicingControl.setSlicingSpec(this.slicingSpec);
+    }
     this.renderTopRuler();
     this.renderLeftRuler();
     await this.renderValueDivs();

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -187,7 +187,7 @@ export class TensorWidgetImpl implements TensorWidget {
    * Fill in the content of the value divs given the current slicing spec.
    */
   private async renderValues() {
-    if (this.rank > 2 &&  this.slicingSpecRoot == null) {
+    if (this.rank > 2 && this.slicingSpecRoot == null) {
       this.slicingSpecRoot = document.createElement('div');
       this.slicingSpecRoot.classList.add('tensor-widget-slicing-group');
       this.rootElement.appendChild(this.slicingSpecRoot);
@@ -216,7 +216,7 @@ export class TensorWidgetImpl implements TensorWidget {
     this.createValueDivs();
     await this.renderRulersAndValueDivs();
 
-    if (this.rank > 2 && this.slicingControl == null) {
+    if (this.rank > 2) {
       this.slicingControl = new SlicingControl(
         this.slicingSpecRoot, this.tensorView.spec.shape,
         async (slicingSpec: TensorViewSlicingSpec) => {

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -36,6 +36,7 @@ export class TensorWidgetImpl implements TensorWidget {
   // Constituent UI elements.
   protected headerSection: HTMLDivElement;
   protected infoSubsection: HTMLDivElement;
+  protected slicingSpecRoot: HTMLDivElement;
   protected valueSection: HTMLDivElement;
   protected topRuler: HTMLDivElement;
   protected baseRulerTick: HTMLDivElement;
@@ -43,6 +44,9 @@ export class TensorWidgetImpl implements TensorWidget {
   protected leftRulerTicks: HTMLDivElement[];
   protected valueRows: HTMLDivElement[];
   protected valueDivs: HTMLDivElement[][];
+
+  // The UI slicing control used by 3D+ tensors.
+  protected slicingControl: SlicingControl;
 
   // Whether the height of the root element is insufficient to display
   // all the rows (vertical dimension under currrent slicing) at once.
@@ -183,6 +187,12 @@ export class TensorWidgetImpl implements TensorWidget {
    * Fill in the content of the value divs given the current slicing spec.
    */
   private async renderValues() {
+    if (this.rank > 2) {
+      this.slicingSpecRoot = document.createElement('div');
+      this.slicingSpecRoot.classList.add('tensor-widget-slicing-group');
+      this.rootElement.appendChild(this.slicingSpecRoot);
+    }
+
     if (this.valueSection == null) {
       this.valueSection = document.createElement('div');
       this.valueSection.classList.add('tensor-widget-value-section');
@@ -197,12 +207,24 @@ export class TensorWidgetImpl implements TensorWidget {
         await this.scrollUpOrDown(event.deltaY > 0 ? 'down' : 'up');
       });
     }
-    // TOOD(cais): Remove this check once 2D+ tensors are supported.
-    if (this.rank <= 2) {
-      this.createTopRuler();
-      this.createLeftRuler();
-      this.createValueDivs();
-      await this.renderRulersAndValueDivs();
+
+    // TODO(cais): Move this out of the else branch.
+    this.createTopRuler();
+    this.createLeftRuler();
+    this.createValueDivs();
+    await this.renderRulersAndValueDivs();
+
+    if (this.rank > 2) {  // TODO(cais): Remove.
+      this.slicingControl = new SlicingControl(
+        this.slicingSpecRoot, this.tensorView.spec.shape,
+        async (slicingSpec: TensorViewSlicingSpec) => {
+          // TODO(cais): Implement.
+          console.log(`New slicing spec:`,
+            JSON.stringify(slicingSpec.slicingDimsAndIndices));
+          this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
+          await this.renderRulersAndValueDivs();
+        });
+      this.slicingControl.render(this.slicingSpec);
     }
   }
 
@@ -236,13 +258,6 @@ export class TensorWidgetImpl implements TensorWidget {
     this.baseRulerTick = document.createElement('div');
     this.baseRulerTick.classList.add('tensor-widget-top-ruler-tick');
     this.topRuler.appendChild(this.baseRulerTick);
-
-    // TODO(cais): Handle 3D+ cases.
-    if (this.rank > 2) {
-      throw new Error(
-        `Support for ${this.rank}D tensor is not implemented yet.`
-      );
-    }
 
     // Whether the number of columns to render on the screen is to be
     // determined, e.g., when the `render` method is called for the first time.
@@ -357,6 +372,7 @@ export class TensorWidgetImpl implements TensorWidget {
    */
   private renderTopRuler() {
     if (this.rank >= 2) {
+      console.log(`renderTopRuler():`, this.slicingSpec);  // DEBUG
       const numCols = this.tensorView.spec.shape[
         this.slicingSpec.viewingDims[1]
       ];

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -15,6 +15,7 @@ limitations under the License.
 
 import {isIntegerDType, isFloatDType} from './dtype-utils';
 import {formatShapeForDisplay, getDefaultSlicingSpec} from './shape-utils';
+import {SlicingControl} from './slicing-control';
 import {formatTensorName, numericValueToString} from './string-utils';
 import {
   TensorView,

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {isIntegerDType, isFloatDType} from './dtype-utils';
-import {formatShapeForDisplay, getDefaultSlicingSpec} from './shape-utils';
+import {formatShapeForDisplay, getDefaultSlicingSpec, dimensionsDiffer} from './shape-utils';
 import {SlicingControl} from './slicing-control';
 import {formatTensorName, numericValueToString} from './string-utils';
 import {
@@ -218,6 +218,19 @@ export class TensorWidgetImpl implements TensorWidget {
       this.slicingControl = new SlicingControl(
         this.slicingSpecRoot, this.tensorView.spec.shape,
         async (slicingSpec: TensorViewSlicingSpec) => {
+          if (dimensionsDiffer(this.slicingSpec, slicingSpec)) {
+            console.log('Slicing dimensions differ!!!');  // DEBUG
+            console.log('slicing spec changed:',
+              JSON.stringify(slicingSpec));  // DEBUG
+            this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
+            await this.render();
+            // console.log('Calling createTopRuler()');  // DEBUG
+            // this.createTopRuler();
+            // console.log('Calling createLeftRuler()');  // DEBUG
+            // this.createLeftRuler();
+            // console.log('Calling createValueDivs()');  // DEBUG
+            // this.createValueDivs();
+          }
           this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
           await this.renderRulersAndValueDivs();
         });
@@ -460,6 +473,7 @@ export class TensorWidgetImpl implements TensorWidget {
    */
   private async renderRulersAndValueDivs() {
     if (this.slicingControl != null) {
+      console.log('Calling setSlicingSpec():', JSON.stringify(this.slicingSpec)); // DEBUG
       this.slicingControl.setSlicingSpec(this.slicingSpec);
     }
     this.renderTopRuler();

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -17,7 +17,7 @@ import {isIntegerDType, isFloatDType} from './dtype-utils';
 import {
   formatShapeForDisplay,
   getDefaultSlicingSpec,
-  dimensionsDiffer,
+  areSlicingSpecsCompatible,
 } from './shape-utils';
 import {SlicingControl} from './slicing-control';
 import {formatTensorName, numericValueToString} from './string-utils';
@@ -223,7 +223,7 @@ export class TensorWidgetImpl implements TensorWidget {
         this.slicingSpecRoot,
         this.tensorView.spec.shape,
         async (slicingSpec: TensorViewSlicingSpec) => {
-          if (dimensionsDiffer(this.slicingSpec, slicingSpec)) {
+          if (!areSlicingSpecsCompatible(this.slicingSpec, slicingSpec)) {
             this.slicingSpec = JSON.parse(JSON.stringify(slicingSpec));
             // The dimension arrangement has changed in the slicing spec.
             // The rulers and value divs must be re-created. This is why

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -29,6 +29,14 @@ limitations under the License.
   padding: 2px;
 }
 
+.tensor-widget-dim-comma {
+  color: rgb(128, 128, 128);
+  display: inline-block;
+  font-size: 12px;
+  height: 14px;
+  line-height: 14px;
+}
+
 .tensor-widget-dim-highlighted {
   border: 1px solid rgb(100, 180, 255);
   font-weight: bold;

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -18,6 +18,15 @@ limitations under the License.
   position: relative;
 }
 
+.tensor-widget-dim {
+  border: 1px solid rgb(160, 160, 160);
+  display:inline-block;
+  font-size: 12px;
+  margin-left: 15px;
+  margin-right: 15px;
+  padding: 2px;
+}
+
 .tensor-widget-dtype {
   align-content: center;
   color: rgb(60, 60, 60);
@@ -73,6 +82,15 @@ limitations under the License.
 
 .tensor-widget-shape-value {
   display: inline-block;
+}
+
+.tensor-widget-slicing-group {
+  background-color: rgb(250, 250, 250);
+  border-bottom: 1px solid rgb(190, 190, 190);
+  display: block;
+  text-align: center;
+  padding-bottom: 5px;
+  padding-top: 5px;
 }
 
 .tensor-widget-tensor-name {

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -22,6 +22,8 @@ limitations under the License.
   border: 1px solid rgb(160, 160, 160);
   display: inline-block;
   font-size: 12px;
+  height: 14px;
+  line-height: 14px;
   margin-left: 15px;
   margin-right: 15px;
   padding: 2px;

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -20,11 +20,15 @@ limitations under the License.
 
 .tensor-widget-dim {
   border: 1px solid rgb(160, 160, 160);
-  display:inline-block;
+  display: inline-block;
   font-size: 12px;
   margin-left: 15px;
   margin-right: 15px;
   padding: 2px;
+}
+
+.tensor-widget-dim-brackets {
+  display: inline-block;
 }
 
 .tensor-widget-dtype {
@@ -88,6 +92,7 @@ limitations under the License.
   background-color: rgb(250, 250, 250);
   border-bottom: 1px solid rgb(190, 190, 190);
   display: block;
+  height: 18px;
   text-align: center;
   padding-bottom: 5px;
   padding-top: 5px;

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -28,7 +28,29 @@ limitations under the License.
 }
 
 .tensor-widget-dim-brackets {
+  color: rgb(128, 128, 128);
   display: inline-block;
+  font-size: 8pt;
+}
+
+.tensor-widget-dim-dropdown {
+  background-color: rgb(255, 255, 255);
+  border: 1px solid rgb(128, 128, 128);
+  box-shadow: 2px 2px 2px #b0b0b0;
+  cursor: pointer;
+  width: 180px;
+  z-index: 1000;
+}
+
+.tensor-widget-dim-dropdown-menu-item {
+  border-bottom: 1px solid rgb(180, 180, 180);
+  font-size: 12px;
+  padding: 3px;
+}
+
+.tensor-widget-dim-dropdown-menu-item-active {
+  background-color: rgb(100, 180, 255);
+  color: rgb(255, 255, 255);
 }
 
 .tensor-widget-dtype {

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -29,6 +29,11 @@ limitations under the License.
   padding: 2px;
 }
 
+.tensor-widget-dim-highlighted {
+  border: 1px solid rgb(100, 180, 255);
+  font-weight: bold;
+}
+
 .tensor-widget-dim-brackets {
   color: rgb(128, 128, 128);
   display: inline-block;


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing TensorWidget

* Technical description of changes
  * Add a slicing control UI, included in the newly created file silcing-control.ts
  * This UI allows the user to  move between slices and to flexibly change which dimensions of a 3D+ tensor are sliced and which are viewed in the value table.
  * The dimension selection is supported by an ad hoc dropdown menu.

* Screenshots of UI changes
![image](https://user-images.githubusercontent.com/16824702/63184491-43bb4e00-c00c-11e9-879f-28d817415018.png)

The dropdown menu for swapping a viewing dimension with a slicing one:
![image](https://user-images.githubusercontent.com/16824702/63186411-30f74800-c011-11e9-86d0-e1bc9e856aef.png)

The div for a slicing dimension becomes a number input box when clicked.
![image](https://user-images.githubusercontent.com/16824702/63186441-44a2ae80-c011-11e9-9950-47e9909ccc90.png)

- Co-author: @bileschi 