### PR TITLE
build: remove `//tensorboard:tf_contrib_ffmpeg`

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -312,13 +312,6 @@ py_library(
     visibility = ["//visibility:public"],
 )
 
-py_library(
-    name = "tf_contrib_ffmpeg",
-    # This is a dummy rule for the open source world, which indicates
-    # that srcs dereference tf.contrib.ffmpeg.
-    visibility = ["//visibility:public"],
-)
-
 filegroup(
     name = "tf_web_library_default_typings",
     srcs = [

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -78,7 +78,6 @@ py_library(
         ":metadata",
         ":summary_v2",
         "//tensorboard:expect_tensorflow_installed",
-        "//tensorboard:tf_contrib_ffmpeg",
         "//tensorboard/util:encoder",
     ],
 )

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -12,7 +12,6 @@ py_library(
         ":op_evaluator",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
-        "//tensorboard:tf_contrib_ffmpeg",
     ],
 )
 


### PR DESCRIPTION
Summary:
As of #2557, we’ve migrated all users off of `tf.contrib.ffmpeg`, so
this BUILD target can be removed.

Test Plan:
Running `git grep contrib.ffmpeg` yields no results, and the only
mentions of `ffmpeg` are in `beholder/video_writing.py` (which shells
out to `ffmpeg(1)` as a subprocess).

wchargin-branch: remove-ffmpeg
