### PR TITLE
Create mnist example with embedding projector

### DIFF
--- a/tensorboard/examples/mnist_with_projector.py
+++ b/tensorboard/examples/mnist_with_projector.py
@@ -1,0 +1,249 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""A MNIST classifier with summaries to display TensorBoard Embedding Projector.
+
+It is Convolutional Neural Network for MNIST is built with summaries to demonstrate
+Embedding Projector of TensorBoard.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import numpy as np
+import os
+import sys
+
+import tensorflow as tf
+
+from tensorflow.examples.tutorials.mnist import input_data
+
+FLAGS = None
+
+def train():
+  # Import data
+  mnist = input_data.read_data_sets(FLAGS.data_dir,
+                                    fake_data=FLAGS.fake_data)
+
+  sess = tf.InteractiveSession()
+  # Create a multilayer model.
+
+  # Input placeholders
+  with tf.name_scope('input'):
+    x = tf.placeholder(tf.float32, [None, 784], name='x-input')
+    y_ = tf.placeholder(tf.int64, [None], name='y-input')
+
+  with tf.name_scope('input_reshape'):
+    image_shaped_input = tf.reshape(x, [-1, 28, 28, 1])
+    tf.summary.image('input', image_shaped_input, 10)
+
+  # We can't initialize these variables to 0 - the network will get stuck.
+  def weight_variable(shape):
+    """Create a weight variable with appropriate initialization."""
+    initial = tf.truncated_normal(shape, stddev=0.1)
+    return tf.Variable(initial)
+
+  def bias_variable(shape):
+    """Create a bias variable with appropriate initialization."""
+    initial = tf.constant(0.1, shape=shape)
+    return tf.Variable(initial)
+
+  def variable_summaries(var):
+    """Attach a lot of summaries to a Tensor (for TensorBoard visualization)."""
+    with tf.name_scope('summaries'):
+      mean = tf.reduce_mean(var)
+      tf.summary.scalar('mean', mean)
+      with tf.name_scope('stddev'):
+        stddev = tf.sqrt(tf.reduce_mean(tf.square(var - mean)))
+      tf.summary.scalar('stddev', stddev)
+      tf.summary.scalar('max', tf.reduce_max(var))
+      tf.summary.scalar('min', tf.reduce_min(var))
+      tf.summary.histogram('histogram', var)
+
+  def conv_layer(input_tensor, input_dim, output_dim, layer_name, act=tf.nn.relu):
+    """Reusable code for making a convolutional neural net layer.
+
+    It builds a convolutional layer using the weight and ReLu activation function
+    as standard. Then returns a MaxPooling layer.
+    """
+    # Adding a name scope ensures logical grouping of the layers in the graph.
+    with tf.name_scope(layer_name):
+      # This Variable will hold the state of the weights for the layer
+      with tf.name_scope('weights'):
+        weights = weight_variable([5, 5, input_dim, output_dim])
+        variable_summaries(weights)
+      with tf.name_scope('biases'):
+        biases = bias_variable([output_dim])
+        variable_summaries(biases)
+      with tf.name_scope('conv'):
+        conv = tf.nn.conv2d(input_tensor, weights, strides=[1, 1, 1, 1], padding="SAME")
+      activations = act(conv + biases, name='activation')
+      return tf.nn.max_pool(activations, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding="SAME")
+
+  def fc_layer(input_tensor, input_dim, output_dim, layer_name):
+    """Reusable code for making a fully connected layer."""
+    with tf.name_scope('fc_layer'):
+      # This Variable will hold the state of the weights for the layer
+      with tf.name_scope('weights'):
+        weights = weight_variable([input_dim, output_dim])
+        variable_summaries(weights)
+      with tf.name_scope('biases'):
+        biases = bias_variable([output_dim])
+        variable_summaries(biases)
+      with tf.name_scope('Wx_plus_b'):
+        activations = tf.matmul(input_tensor, weights) + biases
+        tf.summary.histogram('activations', activations)
+      return activations
+
+  # Creates two convolutional layers
+  conv1 = conv_layer(image_shaped_input, 1, 32, 'conv_layer1')
+  conv2 = conv_layer(conv1, 32, 64, 'conv_layer2')
+
+  # Flattened layer
+  flattened = tf.reshape(conv2, [-1, 7 * 7 * 64])
+  
+  # Embedding input and size to project
+  embedding_input = flattened
+  embedding_size = 7*7*64
+
+  y = fc_layer(flattened, 7 * 7 * 64, 10, 'fc_layer')
+
+  with tf.name_scope('cross_entropy'):
+    # The raw formulation of cross-entropy,
+    #
+    # tf.reduce_mean(-tf.reduce_sum(y_ * tf.math.log(tf.softmax(y)),
+    #                               reduction_indices=[1]))
+    #
+    # can be numerically unstable.
+    #
+    # So here we use tf.compat.v1.losses.sparse_softmax_cross_entropy on the
+    # raw logit outputs of the nn_layer above, and then average across
+    # the batch.
+    with tf.name_scope('total'):
+      cross_entropy = tf.losses.sparse_softmax_cross_entropy(
+          labels=y_, logits=y)
+  tf.summary.scalar('cross_entropy', cross_entropy)
+
+  with tf.name_scope('train'):
+    train_step = tf.train.AdamOptimizer(FLAGS.learning_rate).minimize(
+        cross_entropy)
+
+  with tf.name_scope('accuracy'):
+    with tf.name_scope('correct_prediction'):
+      correct_prediction = tf.equal(tf.argmax(y, 1), y_)
+    with tf.name_scope('accuracy'):
+      accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
+  tf.summary.scalar('accuracy', accuracy)
+
+  # Variable assigned with embedding input
+  embedding = tf.Variable(tf.zeros([FLAGS.input_amount, embedding_size]), name="embedding")
+  assigned = embedding.assign(embedding_input)
+  saver = tf.train.Saver()
+
+  # Merge all the summaries and write them out to
+  # /tmp/tensorflow/mnist/logs/mnist_with_summaries (by default)
+  merged = tf.summary.merge_all()
+  train_writer = tf.summary.FileWriter(FLAGS.log_dir + '/train', sess.graph)
+  test_writer = tf.summary.FileWriter(FLAGS.log_dir + '/test')
+  tf.global_variables_initializer().run()
+
+  # Configuration of Embedding Projector  
+  config = tf.contrib.tensorboard.plugins.projector.ProjectorConfig()
+  embedding_config = config.embeddings.add()
+  embedding_config.tensor_name = embedding.name
+  embedding_config.sprite.single_image_dim.extend([28,28])
+  
+  if FLAGS.sprite_path:
+    embedding_config.sprite.image_path = os.path.join(os.getcwd(), FLAGS.sprite_path)
+  
+  if FLAGS.labels_path:
+    embedding_config.metadata_path = os.path.join(os.getcwd(), FLAGS.labels_path)
+  
+  tf.contrib.tensorboard.plugins.projector.visualize_embeddings(test_writer, config)
+
+  # Train the model, and also write summaries.
+  # Every 10th step, measure test-set accuracy, and write test summaries
+  # All other steps, run train_step on training data, & add training summaries
+
+  def feed_dict(train):
+    """Make a TensorFlow feed_dict: maps data onto Tensor placeholders."""
+    if train or FLAGS.fake_data:
+      xs, ys = mnist.train.next_batch(100, fake_data=FLAGS.fake_data)
+    else:
+      xs, ys = mnist.test.images[:FLAGS.input_amount], mnist.test.labels[:FLAGS.input_amount]
+    return {x: xs, y_: ys}
+
+  for i in range(FLAGS.max_steps):
+    if i % 10 == 0:  # Record summaries and test-set accuracy
+      sess.run(assigned, feed_dict=feed_dict(False))
+      saver.save(sess, os.path.join(FLAGS.log_dir, "model.ckpt"), i)
+      summary, acc = sess.run([merged, accuracy], feed_dict=feed_dict(False))
+      test_writer.add_summary(summary, i)
+      print('Accuracy at step %s: %s' % (i, acc))
+    else:  # Record train set summaries, and train
+      if i % 100 == 99:  # Record execution stats
+        run_options = tf.RunOptions(trace_level=tf.RunOptions.FULL_TRACE)
+        run_metadata = tf.RunMetadata()
+        summary, _ = sess.run([merged, train_step],
+                              feed_dict=feed_dict(True),
+                              options=run_options,
+                              run_metadata=run_metadata)
+        train_writer.add_run_metadata(run_metadata, 'step%03d' % i)
+        train_writer.add_summary(summary, i)
+        print('Adding run metadata for', i)
+      else:  # Record a summary
+        summary, _ = sess.run([merged, train_step], feed_dict=feed_dict(True))
+        train_writer.add_summary(summary, i)
+  train_writer.close()
+  test_writer.close()
+
+
+def main(_):
+  if tf.gfile.Exists(FLAGS.log_dir):
+    tf.gfile.DeleteRecursively(FLAGS.log_dir)
+  tf.gfile.MakeDirs(FLAGS.log_dir)
+  with tf.Graph().as_default():
+    train()
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--fake_data', nargs='?', const=True, type=bool,
+                      default=False,
+                      help='If true, uses fake data for unit testing.')
+  parser.add_argument('--max_steps', type=int, default=1000,
+                      help='Number of steps to run trainer.')
+  parser.add_argument('--learning_rate', type=float, default=0.001,
+                      help='Initial learning rate')
+  parser.add_argument('--input_amount', type=int, default=1024,
+                      help='Input amount for classification.')
+  parser.add_argument('--sprite_path', type=str, default="",
+                      help='Sprite path to project on embedding. Width and height must be equal to input amount.')
+  parser.add_argument('--labels_path', type=str, default="",
+                      help='Tsv file with labels to project on embedding. Width and height must be equal to input amount.')
+  parser.add_argument(
+      '--data_dir',
+      type=str,
+      default=os.path.join(os.getenv('TEST_TMPDIR', '/tmp'),
+                           'tensorflow/mnist/input_data'),
+      help='Directory for storing input data')
+  parser.add_argument(
+      '--log_dir',
+      type=str,
+      default=os.path.join(os.getenv('TEST_TMPDIR', '/tmp'),
+                           'tensorflow/mnist/logs/mnist_with_projector'),
+      help='Summaries log directory')
+  FLAGS, unparsed = parser.parse_known_args()
+  tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)


### PR DESCRIPTION
As specified in Tensorboard issue #86, the Embedding Projector does not have a code example. This pull request has a code example of Embedding usage based on [mnist_with_summaries.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py) and [TF Dev Summit 2017 TensorBoard tutorial](https://github.com/martinwicke/tf-dev-summit-tensorboard-tutorial/blob/master/mnist.py). This pull request was opened before in [tensorflow/31348](https://github.com/tensorflow/tensorflow/pull/31348).
 
@MarkDaoust asked me to use `keras.datasets` or `tensorflow_datasets`, but I'm having difficulty to make that change, so I preferred to open the pull request and continue trying to modify the dataset.