### PR TITLE
Remove --db_import_use_op flag and implementation

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -120,11 +120,6 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
     data_provider = event_data_provider.MultiplexerDataProvider(multiplexer)
   loading_multiplexer = multiplexer
   reload_interval = flags.reload_interval
-  # For db import op mode, prefer reloading in a child process. See
-  # https://github.com/tensorflow/tensorboard/issues/1467
-  reload_task = flags.reload_task
-  if reload_task == 'auto' and flags.db_import and flags.db_import_use_op:
-    reload_task == 'process'
   db_uri = flags.db
   # For DB import mode, create a DB file if we weren't given one.
   if flags.db_import and not flags.db:
@@ -140,8 +135,7 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
     loading_multiplexer = db_import_multiplexer.DbImportMultiplexer(
         db_connection_provider=db_connection_provider,
         purge_orphaned_data=flags.purge_orphaned_data,
-        max_reload_threads=flags.max_reload_threads,
-        use_import_op=flags.db_import_use_op)
+        max_reload_threads=flags.max_reload_threads)
   elif flags.db:
     # DB read-only mode, never load event logs.
     reload_interval = -1
@@ -166,7 +160,7 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
     plugin_name_to_instance[plugin.plugin_name] = plugin
   return TensorBoardWSGIApp(flags.logdir, plugins, loading_multiplexer,
                             reload_interval, flags.path_prefix,
-                            reload_task)
+                            flags.reload_task)
 
 
 def TensorBoardWSGIApp(logdir, plugins, multiplexer, reload_interval,

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -57,7 +57,6 @@ class FakeFlags(object):
       reload_task='auto',
       db='',
       db_import=False,
-      db_import_use_op=False,
       window_title='',
       path_prefix='',
       reload_multifile=False,
@@ -71,7 +70,6 @@ class FakeFlags(object):
     self.reload_task = reload_task
     self.db = db
     self.db_import = db_import
-    self.db_import_use_op = db_import_use_op
     self.window_title = window_title
     self.path_prefix = path_prefix
     self.reload_multifile = reload_multifile

--- a/tensorboard/backend/event_processing/db_import_multiplexer_test.py
+++ b/tensorboard/backend/event_processing/db_import_multiplexer_test.py
@@ -47,8 +47,7 @@ class DbImportMultiplexerTest(tf.test.TestCase):
     self.multiplexer = db_import_multiplexer.DbImportMultiplexer(
         db_connection_provider=self.db_connection_provider,
         purge_orphaned_data=False,
-        max_reload_threads=1,
-        use_import_op=False)
+        max_reload_threads=1)
 
   def _get_runs(self):
     db = self.db_connection_provider()

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -341,15 +341,6 @@ temporary unless --db is also passed to specify a DB path to use.\
 ''')
 
     parser.add_argument(
-        '--db_import_use_op',
-        action='store_true',
-        help='''\
-[experimental] in combination with --db_import, if passed, use TensorFlow's
-import_event() op for importing event data, otherwise use TensorBoard's own
-sqlite ingestion logic.\
-''')
-
-    parser.add_argument(
         '--inspect',
         action='store_true',
         help='''\


### PR DESCRIPTION
This was basically dead code already, since we opted to use a pure-python implementation of the DB writer instead, to avoid the need to launch a subprocess to avoid locking issues in having two SQLite libraries linked into the same process.  Now that the `tf.contrib.summary.create_db_writer()` symbol isn't being ported forward to TF 2.0, it's time to clean this up.

Addresses an item from #1718.