### PR TITLE
ci: pin TF 1.x nightlies to 2019-08-16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - BAZEL=0.26.1
     - BAZEL_SHA256SUM=6c50e142a0a405d3d8598050d6c1b3920c8cdb82a7ffca6fc067cb474275148f
   matrix:
-    - TF_VERSION_ID=tf-nightly
+    - TF_VERSION_ID=tf-nightly==1.15.0.dev20190816
     - TF_VERSION_ID=tf-nightly-2.0-preview
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 


### PR DESCRIPTION
Summary:
Recent releases of tf-nightly indicate\* that this package will soon
be updated to the TensorFlow 2.0 APIs, and suggest pinning a version.
This commit does that.

\* Via a message printed at `import tensorflow` time.

Test Plan:
Verify that the Travis build specifically instructs Pip to install
version `1.15.0.dev20190816` of the TF 1.x nightlies, while still
floating the TF 2.x nightlies.

wchargin-branch: pin-tf1x
