### PR TITLE
Remove unused TBContext.db_module field

### DIFF
--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -692,14 +692,15 @@ class DbTest(tb_test.TestCase):
 
   def testSqliteDb(self):
     db_uri = 'sqlite:' + os.path.join(self.get_temp_dir(), 'db')
-    db_module, db_connection_provider = application.get_database_info(db_uri)
-    self.assertTrue(hasattr(db_module, 'Date'))
+    db_connection_provider = application.create_sqlite_connection_provider(
+        db_uri)
     with contextlib.closing(db_connection_provider()) as conn:
       with conn:
         with contextlib.closing(conn.cursor()) as c:
           c.execute('create table peeps (name text)')
           c.execute('insert into peeps (name) values (?)', ('justine',))
-    _, db_connection_provider = application.get_database_info(db_uri)
+    db_connection_provider = application.create_sqlite_connection_provider(
+        db_uri)
     with contextlib.closing(db_connection_provider()) as conn:
       with contextlib.closing(conn.cursor()) as c:
         c.execute('select name from peeps')
@@ -707,7 +708,8 @@ class DbTest(tb_test.TestCase):
 
   def testTransactionRollback(self):
     db_uri = 'sqlite:' + os.path.join(self.get_temp_dir(), 'db')
-    _, db_connection_provider = application.get_database_info(db_uri)
+    db_connection_provider = application.create_sqlite_connection_provider(
+        db_uri)
     with contextlib.closing(db_connection_provider()) as conn:
       with conn:
         with contextlib.closing(conn.cursor()) as c:
@@ -727,7 +729,8 @@ class DbTest(tb_test.TestCase):
     # NOTE: This is a terrible idea. Don't do this.
     db_uri = ('sqlite:' + os.path.join(self.get_temp_dir(), 'db') +
               '?isolation_level=null')
-    _, db_connection_provider = application.get_database_info(db_uri)
+    db_connection_provider = application.create_sqlite_connection_provider(
+        db_uri)
     with contextlib.closing(db_connection_provider()) as conn:
       with conn:
         with contextlib.closing(conn.cursor()) as c:

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -153,7 +153,6 @@ class TBContext(object):
       assets_zip_provider=None,
       data_provider=None,
       db_connection_provider=None,
-      db_module=None,
       db_uri=None,
       flags=None,
       logdir=None,
@@ -181,9 +180,6 @@ class TBContext(object):
           function is cheap. The returned connection must only be used by a
           single thread. Things like connection pooling are considered
           implementation details of the provider.
-      db_module: A PEP-249 DB Module, e.g. sqlite3. This is useful for accessing
-          things like date time constructors. This value will be None if we are
-          not in SQL mode and multiplexer should be used instead.
       db_uri: The string db URI TensorBoard was started with. If this is set,
           the logdir should be None.
       flags: An object of the runtime flags provided to TensorBoard to their
@@ -203,7 +199,6 @@ class TBContext(object):
     self.assets_zip_provider = assets_zip_provider
     self.data_provider = data_provider
     self.db_connection_provider = db_connection_provider
-    self.db_module = db_module
     self.db_uri = db_uri
     self.flags = flags
     self.logdir = logdir

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -311,11 +311,10 @@ class CorePluginTest(tf.test.TestCase):
     self.logdir_based_server = werkzeug_test.Client(app, wrappers.BaseResponse)
 
   def _start_db_based_server(self):
-    db_module, db_connection_provider = application.get_database_info(
+    db_connection_provider = application.create_sqlite_connection_provider(
         self.db_uri)
     context = base_plugin.TBContext(
         assets_zip_provider=get_test_assets_zip_provider(),
-        db_module=db_module,
         db_connection_provider=db_connection_provider,
         db_uri=self.db_uri,
         window_title='title foo')

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -79,10 +79,9 @@ class ScalarsPluginTest(tf.test.TestCase):
   def set_up_db(self):
     self.db_path = os.path.join(self.get_temp_dir(), 'db.db')
     self.db_uri = 'sqlite:' + self.db_path
-    db_module, db_connection_provider = application.get_database_info(
+    db_connection_provider = application.create_sqlite_connection_provider(
         self.db_uri)
     context = base_plugin.TBContext(
-        db_module=db_module,
         db_connection_provider=db_connection_provider,
         db_uri=self.db_uri)
     self.core_plugin = core_plugin.CorePlugin(context)


### PR DESCRIPTION
This field is unused today and has no planned future use, since we only support `sqlite3` and aren't planning on extended support via this mechanism.  Removing it simplifies later refactoring.