### PR TITLE
Refactor away TensorBoardWSGIApp in its current form

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -157,42 +157,14 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
       continue
     plugins.append(plugin)
     plugin_name_to_instance[plugin.plugin_name] = plugin
-  return TensorBoardWSGIApp(flags.logdir, plugins, loading_multiplexer,
-                            reload_interval, flags.path_prefix,
-                            flags.reload_task)
 
-
-def TensorBoardWSGIApp(logdir, plugins, multiplexer, reload_interval,
-                       path_prefix='', reload_task='auto'):
-  """Constructs the TensorBoard application.
-
-  Args:
-    logdir: the logdir spec that describes where data will be loaded.
-      may be a directory, or comma,separated list of directories, or colons
-      can be used to provide named directories
-    plugins: A list of base_plugin.TBPlugin subclass instances.
-    multiplexer: The EventMultiplexer with TensorBoard data to serve
-    reload_interval: How often (in seconds) to reload the Multiplexer.
-      Zero means reload just once at startup; negative means never load.
-    path_prefix: A prefix of the path when app isn't served from root.
-    reload_task: Indicates the type of background task to reload with.
-
-  Returns:
-    A WSGI application that implements the TensorBoard backend.
-
-  Raises:
-    ValueError: If something is wrong with the plugin configuration.
-
-  :type plugins: list[base_plugin.TBPlugin]
-  :rtype: TensorBoardWSGI
-  """
-  path_to_run = parse_event_files_spec(logdir)
   if reload_interval >= 0:
     # We either reload the multiplexer once when TensorBoard starts up, or we
     # continuously reload the multiplexer.
-    start_reloading_multiplexer(multiplexer, path_to_run, reload_interval,
-                                reload_task)
-  return TensorBoardWSGI(plugins, path_prefix)
+    path_to_run = parse_event_files_spec(flags.logdir)
+    start_reloading_multiplexer(
+        loading_multiplexer, path_to_run, reload_interval, flags.reload_task)
+  return TensorBoardWSGI(plugins, flags.path_prefix)
 
 
 class TensorBoardWSGI(object):

--- a/tensorboard/plugins/audio/audio_plugin_test.py
+++ b/tensorboard/plugins/audio/audio_plugin_test.py
@@ -92,18 +92,12 @@ class AudioPluginTest(tf.test.TestCase):
         "foo": foo_directory,
         "bar": bar_directory,
     })
+    multiplexer.Reload()
     context = base_plugin.TBContext(
         logdir=self.log_dir, multiplexer=multiplexer)
     self.plugin = audio_plugin.AudioPlugin(context)
-    # Setting a reload interval of -1 disables reloading. We disable reloading
-    # because we seek to block tests from running til after one reload finishes.
-    # This setUp method thus manually reloads the multiplexer. TensorBoard would
-    # otherwise reload in a non-blocking thread.
-    wsgi_app = application.TensorBoardWSGIApp(
-        self.log_dir, [self.plugin], multiplexer, reload_interval=-1,
-        path_prefix='')
+    wsgi_app = application.TensorBoardWSGI([self.plugin])
     self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
-    multiplexer.Reload()
 
   def tearDown(self):
     shutil.rmtree(self.log_dir, ignore_errors=True)

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -302,12 +302,7 @@ class CorePluginTest(tf.test.TestCase):
         multiplexer=self.multiplexer,
         window_title='title foo')
     self.logdir_based_plugin = core_plugin.CorePlugin(context)
-    app = application.TensorBoardWSGIApp(
-        self.logdir,
-        [self.logdir_based_plugin],
-        self.multiplexer,
-        0,
-        path_prefix='')
+    app = application.TensorBoardWSGI([self.logdir_based_plugin])
     self.logdir_based_server = werkzeug_test.Client(app, wrappers.BaseResponse)
 
   def _start_db_based_server(self):

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
@@ -55,21 +55,16 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
     super(InteractiveDebuggerPluginTest, self).setUp()
 
     self._dummy_logdir = tempfile.mkdtemp()
-    self._dummy_multiplexer = event_multiplexer.EventMultiplexer({})
+    dummy_multiplexer = event_multiplexer.EventMultiplexer({})
     self._debugger_port = portpicker.pick_unused_port()
     self._debugger_url = 'grpc://localhost:%d' % self._debugger_port
     context = base_plugin.TBContext(logdir=self._dummy_logdir,
-                                    multiplexer=self._dummy_multiplexer)
+                                    multiplexer=dummy_multiplexer)
     self._debugger_plugin = (
         interactive_debugger_plugin.InteractiveDebuggerPlugin(context))
     self._debugger_plugin.listen(self._debugger_port)
 
-    wsgi_app = application.TensorBoardWSGIApp(
-        self._dummy_logdir,
-        [self._debugger_plugin],
-        self._dummy_multiplexer,
-        reload_interval=0,
-        path_prefix='')
+    wsgi_app = application.TensorBoardWSGI([self._debugger_plugin])
     self._server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
 
   def tearDown(self):

--- a/tensorboard/plugins/image/images_plugin_test.py
+++ b/tensorboard/plugins/image/images_plugin_test.py
@@ -86,17 +86,12 @@ class ImagesPluginTest(tf.test.TestCase):
         "foo": foo_directory,
         "bar": bar_directory,
     })
+    multiplexer.Reload()
     context = base_plugin.TBContext(
         logdir=self.log_dir, multiplexer=multiplexer)
     plugin = images_plugin.ImagesPlugin(context)
-    # Setting a reload interval of -1 disables reloading. We disable reloading
-    # because we seek to block tests from running til after one reload finishes.
-    # This setUp method thus manually reloads the multiplexer. TensorBoard would
-    # otherwise reload in a non-blocking thread.
-    wsgi_app = application.TensorBoardWSGIApp(
-        self.log_dir, [plugin], multiplexer, reload_interval=-1, path_prefix='')
+    wsgi_app = application.TensorBoardWSGI([plugin])
     self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
-    multiplexer.Reload()
     self.routes = plugin.get_plugin_apps()
 
   def tearDown(self):

--- a/tensorboard/plugins/interactive_inference/interactive_inference_plugin_test.py
+++ b/tensorboard/plugins/interactive_inference/interactive_inference_plugin_test.py
@@ -54,11 +54,7 @@ class InferencePluginTest(tf.test.TestCase):
     self.context = base_plugin.TBContext(logdir=self.logdir)
     self.plugin = interactive_inference_plugin.InteractiveInferencePlugin(
         self.context)
-    wsgi_app = application.TensorBoardWSGIApp(
-        self.logdir, [self.plugin],
-        multiplexer=event_multiplexer.EventMultiplexer({}),
-        reload_interval=0,
-        path_prefix='')
+    wsgi_app = application.TensorBoardWSGI([self.plugin])
     self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
 
   def get_fake_example(self, single_int_value=0):

--- a/tensorboard/plugins/mesh/mesh_plugin_test.py
+++ b/tensorboard/plugins/mesh/mesh_plugin_test.py
@@ -129,13 +129,12 @@ class MeshPluginTest(tf.test.TestCase):
     self.context = base_plugin.TBContext(
         logdir=self.log_dir, multiplexer=self.multiplexer)
     self.plugin = mesh_plugin.MeshPlugin(self.context)
-    wsgi_app = application.TensorBoardWSGIApp(
-        self.log_dir, [self.plugin],
-        self.multiplexer,
-        reload_interval=0,
-        path_prefix="")
-    self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+    # Wait until after plugin construction to reload the multiplexer because the
+    # plugin caches data from the multiplexer upon construction and this affects
+    # logic tested later down.
     self.multiplexer.Reload()
+    wsgi_app = application.TensorBoardWSGI([self.plugin])
+    self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
     self.routes = self.plugin.get_plugin_apps()
 
   def tearDown(self):

--- a/tensorboard/plugins/mesh/mesh_plugin_test.py
+++ b/tensorboard/plugins/mesh/mesh_plugin_test.py
@@ -132,6 +132,9 @@ class MeshPluginTest(tf.test.TestCase):
     # Wait until after plugin construction to reload the multiplexer because the
     # plugin caches data from the multiplexer upon construction and this affects
     # logic tested later down.
+    # TODO(https://github.com/tensorflow/tensorboard/issues/2579): Eliminate the
+    # caching of data at construction time and move this Reload() up to just
+    # after the multiplexer is created.
     self.multiplexer.Reload()
     wsgi_app = application.TensorBoardWSGI([self.plugin])
     self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)

--- a/tensorboard/plugins/projector/projector_plugin_test.py
+++ b/tensorboard/plugins/projector/projector_plugin_test.py
@@ -273,9 +273,7 @@ class ProjectorAppTest(tf.test.TestCase):
     context = base_plugin.TBContext(
         logdir=self.log_dir, multiplexer=multiplexer)
     self.plugin = projector_plugin.ProjectorPlugin(context)
-    wsgi_app = application.TensorBoardWSGIApp(
-        self.log_dir, [self.plugin], multiplexer, reload_interval=0,
-        path_prefix='')
+    wsgi_app = application.TensorBoardWSGI([self.plugin])
     self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
 
   def _Get(self, path):


### PR DESCRIPTION
This removes TensorBoardWSGIApp, a thin wrapper over TensorBoardWSGI that launches the reloading thread.  Instead, we move that logic up into `standard_tensorboard_wsgi()` which is the only non-test caller of TensorBoardWSGIApp.

For tests, we update these to use TensorBoardWSGI directly, and add an explicit `multiplexer.Reload()` call where necessary to maintain the previous behavior.

The only usage I know of outside the TB repo is in the TF Lite plugin which I have a PR out to fix in https://github.com/lintian06/tensorflow-lite-plugin/pull/1, but I'm not blocking on that to land.

This addresses core task 1 in https://github.com/tensorflow/tensorboard/issues/2573, and frees up the name TensorBoardWSGIApp to reuse for a new API to come.

