### PR TITLE
Allow passing TBPlugin/TBLoader subclasses to TensorBoardWSGIApp

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -149,6 +149,7 @@ py_test(
         ":program",
         ":test",
         "//tensorboard/backend:application",
+        "//tensorboard/plugins:base_plugin",
         "//tensorboard/plugins/core:core_plugin",
         "@org_pocoo_werkzeug",
     ],

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -160,7 +160,8 @@ def TensorBoardWSGIApp(
 
   Args:
     flags: An argparse.Namespace containing TensorBoard CLI flags.
-    plugins: A list of TBLoader subclasses for the plugins to load.
+    plugins: A list of plugins, which can be provided as TBPlugin subclasses
+        or TBLoader instances or subclasses.
     assets_zip_provider: See TBContext documentation for more information.
     data_provider: Instance of `tensorboard.data.provider.DataProvider`. May
         be `None` if `flags.generic_data` is set to `"false"` in which case
@@ -191,7 +192,8 @@ def TensorBoardWSGIApp(
       plugin_name_to_instance=plugin_name_to_instance,
       window_title=flags.window_title)
   tbplugins = []
-  for loader in plugins:
+  for plugin_spec in plugins:
+    loader = make_plugin_loader(plugin_spec)
     plugin = loader.load(context)
     if plugin is None:
       continue
@@ -601,3 +603,22 @@ class _DbModeMultiplexer(event_multiplexer.EventMultiplexer):
   def Reload(self):
     """Unsupported."""
     raise NotImplementedError()
+
+
+def make_plugin_loader(plugin):
+  """Returns a plugin loader for the given plugin.
+
+  Args:
+    plugin: A TBPlugin subclass, or a TBLoader instance or subclass.
+
+  Returns:
+    A TBLoader for the given plugin.
+  """
+  if isinstance(plugin, base_plugin.TBLoader):
+    return plugin
+  if isinstance(plugin, type):
+    if issubclass(plugin, base_plugin.TBLoader):
+      return plugin()
+    if issubclass(plugin, base_plugin.TBPlugin):
+      return base_plugin.BasicLoader(plugin)
+  raise TypeError("Not a TBLoader or TBPlugin subclass: %r" % (plugin,))

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -614,11 +614,11 @@ def make_plugin_loader(plugin_spec):
   Returns:
     A TBLoader for the given plugin.
   """
-  if isinstance(plugin, base_plugin.TBLoader):
-    return plugin
-  if isinstance(plugin, type):
-    if issubclass(plugin, base_plugin.TBLoader):
-      return plugin()
-    if issubclass(plugin, base_plugin.TBPlugin):
-      return base_plugin.BasicLoader(plugin)
-  raise TypeError("Not a TBLoader or TBPlugin subclass: %r" % (plugin,))
+  if isinstance(plugin_spec, base_plugin.TBLoader):
+    return plugin_spec
+  if isinstance(plugin_spec, type):
+    if issubclass(plugin_spec, base_plugin.TBLoader):
+      return plugin_spec()
+    if issubclass(plugin_spec, base_plugin.TBPlugin):
+      return base_plugin.BasicLoader(plugin_spec)
+  raise TypeError("Not a TBLoader or TBPlugin subclass: %r" % (plugin_spec,))

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -605,11 +605,11 @@ class _DbModeMultiplexer(event_multiplexer.EventMultiplexer):
     raise NotImplementedError()
 
 
-def make_plugin_loader(plugin):
+def make_plugin_loader(plugin_spec):
   """Returns a plugin loader for the given plugin.
 
   Args:
-    plugin: A TBPlugin subclass, or a TBLoader instance or subclass.
+    plugin_spec: A TBPlugin subclass, or a TBLoader instance or subclass.
 
   Returns:
     A TBLoader for the given plugin.

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -60,20 +60,20 @@ logger = logging.getLogger(__name__)
 # Ordering matters. The order in which these lines appear determines the
 # ordering of tabs in TensorBoard's GUI.
 _PLUGINS = [
-    core_plugin.CorePluginLoader(),
+    core_plugin.CorePluginLoader,
     scalars_plugin.ScalarsPlugin,
     custom_scalars_plugin.CustomScalarsPlugin,
     images_plugin.ImagesPlugin,
     audio_plugin.AudioPlugin,
-    debugger_plugin_loader.DebuggerPluginLoader(),
+    debugger_plugin_loader.DebuggerPluginLoader,
     graphs_plugin.GraphsPlugin,
     distributions_plugin.DistributionsPlugin,
     histograms_plugin.HistogramsPlugin,
     text_plugin.TextPlugin,
     pr_curves_plugin.PrCurvesPlugin,
-    profile_plugin_loader.ProfilePluginLoader(),
-    beholder_plugin_loader.BeholderPluginLoader(),
-    interactive_inference_plugin_loader.InteractiveInferencePluginLoader(),
+    profile_plugin_loader.ProfilePluginLoader,
+    beholder_plugin_loader.BeholderPluginLoader,
+    interactive_inference_plugin_loader.InteractiveInferencePluginLoader,
     hparams_plugin.HParamsPlugin,
     mesh_plugin.MeshPlugin,
 ]

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -257,10 +257,10 @@ class BasicLoader(TBLoader):
 
     :param plugin_class: :class:`TBPlugin`
     """
-    self._plugin_class = plugin_class
+    self.plugin_class = plugin_class
 
   def load(self, context):
-    return self._plugin_class(context)
+    return self.plugin_class(context)
 
 
 class FlagsError(ValueError):

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -118,14 +118,17 @@ class TensorBoard(object):
     """Creates new instance.
 
     Args:
-      plugins: A list of TensorBoard plugins to load, as TBLoader instances or
-        TBPlugin classes. If not specified, defaults to first-party plugins.
+      plugin: A list of TensorBoard plugins to load, as TBPlugin classes or
+        TBLoader instances or classes. If not specified, defaults to first-party
+        plugins.
       assets_zip_provider: Delegates to TBContext or uses default if None.
       server_class: An optional factory for a `TensorBoardServer` to use
         for serving the TensorBoard WSGI app. If provided, its callable
         signature should match that of `TensorBoardServer.__init__`.
 
-    :type plugins: list[Union[base_plugin.TBLoader, Type[base_plugin.TBPlugin]]]
+    :type plugins: list[Union[base_plugin.TBLoader,
+                              Type[base_plugin.TBLoader],
+                              Type[base_plugin.TBPlugin]]]
     :type assets_zip_provider: () -> file
     :type server_class: class
     """
@@ -136,13 +139,7 @@ class TensorBoard(object):
       assets_zip_provider = get_default_assets_zip_provider()
     if server_class is None:
       server_class = create_port_scanning_werkzeug_server
-    def make_loader(plugin):
-      if isinstance(plugin, base_plugin.TBLoader):
-        return plugin
-      if issubclass(plugin, base_plugin.TBPlugin):
-        return base_plugin.BasicLoader(plugin)
-      raise ValueError("Not a TBLoader or TBPlugin subclass: %s" % plugin)
-    self.plugin_loaders = [make_loader(p) for p in plugins]
+    self.plugin_loaders = [application.make_plugin_loader(p) for p in plugins]
     self.assets_zip_provider = assets_zip_provider
     self.server_class = server_class
     self.flags = None

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -125,12 +125,6 @@ class TensorBoard(object):
       server_class: An optional factory for a `TensorBoardServer` to use
         for serving the TensorBoard WSGI app. If provided, its callable
         signature should match that of `TensorBoardServer.__init__`.
-
-    :type plugins: list[Union[base_plugin.TBLoader,
-                              Type[base_plugin.TBLoader],
-                              Type[base_plugin.TBPlugin]]]
-    :type assets_zip_provider: () -> file
-    :type server_class: class
     """
     if plugins is None:
       from tensorboard import default


### PR DESCRIPTION
This is a follow up to #2576 that makes the new `TensorBoardWSGIApp()` entry point accept types besides TBLoader instances for its `plugins` argument, namely it also accepts a `TBPlugin` subclass (which it will wrap in a `BasicLoader`) or a `TBLoader` subclass (which it will instantiate with no arguments to get an instance).

I moved the existing helper in `program.TensorBoard()` into `application.py` for this, which means that API also has gained the ability to take a `TBLoader` class (and a better error if passing in invalid types).

Lastly, I've streamlined the plugin list in `default.py` to just use bare `TBLoader` subclasses, which liberates 10 parentheses to be used for nobler purposes.