### PR TITLE
[Debugger Plugin] Fix Python unit tests for TF2

### DIFF
--- a/tensorboard/plugins/debugger/debug_graphs_helper_test.py
+++ b/tensorboard/plugins/debugger/debug_graphs_helper_test.py
@@ -86,7 +86,6 @@ class ExtractGatedGrpcDebugOpsTest(tf.test.TestCase):
                          debug_urls=self.debug_server_url)
     return z, run_options
 
-  @test_util.run_v1_only('Ops differ. Similar to [1].')
   def testExtractGatedGrpcTensorsFoundGatedGrpcOps(self):
     with tf.compat.v1.Session() as sess:
       z, run_options = self._createTestGraphAndRunOptions(sess, gated_grpc=True)
@@ -115,7 +114,7 @@ class ExtractGatedGrpcDebugOpsTest(tf.test.TestCase):
       self.assertIn(('d', 0, 'DebugIdentity'), gated_debug_ops)
 
       if not tensorflow_python_tf2.enabled():
-        # Variable reading ops are different in TF1 and TF2.
+        # NOTE(#1705): Variable reading ops are different in TF1 and TF2.
         self.assertIn(('a/read', 0, 'DebugIdentity'), gated_debug_ops)
         self.assertIn(('b/read', 0, 'DebugIdentity'), gated_debug_ops)
         self.assertIn(('c/read', 0, 'DebugIdentity'), gated_debug_ops)
@@ -155,9 +154,6 @@ class ExtractGatedGrpcDebugOpsTest(tf.test.TestCase):
       self.assertEqual([], gated_debug_ops)
 
 
-@test_util.run_v1_only((
-    'Graph creates different op structure in v2. See '
-    'debug_graphs_helper_test.py[1].'))
 class BaseExpandedNodeNameTest(tf.test.TestCase):
 
   def testMaybeBaseExpandedNodeName(self):

--- a/tensorboard/plugins/debugger/debug_graphs_helper_test.py
+++ b/tensorboard/plugins/debugger/debug_graphs_helper_test.py
@@ -37,6 +37,7 @@ from __future__ import print_function
 
 import tensorflow as tf
 from tensorflow.python import debug as tf_debug
+# See discussion on issue #1996 for private module import justification.
 from tensorflow.python import tf2 as tensorflow_python_tf2
 from tensorflow.python.debug.lib import grpc_debug_test_server
 
@@ -112,13 +113,6 @@ class ExtractGatedGrpcDebugOpsTest(tf.test.TestCase):
       self.assertIn(('b', 0, 'DebugIdentity'), gated_debug_ops)
       self.assertIn(('c', 0, 'DebugIdentity'), gated_debug_ops)
       self.assertIn(('d', 0, 'DebugIdentity'), gated_debug_ops)
-
-      if not tensorflow_python_tf2.enabled():
-        # NOTE(#1705): Variable reading ops are different in TF1 and TF2.
-        self.assertIn(('a/read', 0, 'DebugIdentity'), gated_debug_ops)
-        self.assertIn(('b/read', 0, 'DebugIdentity'), gated_debug_ops)
-        self.assertIn(('c/read', 0, 'DebugIdentity'), gated_debug_ops)
-        self.assertIn(('d/read', 0, 'DebugIdentity'), gated_debug_ops)
 
       self.assertIn(('x', 0, 'DebugIdentity'), gated_debug_ops)
       self.assertIn(('y', 0, 'DebugIdentity'), gated_debug_ops)

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
@@ -44,6 +44,7 @@ from tensorboard.plugins import base_plugin
 from tensorboard.plugins.debugger import interactive_debugger_plugin
 from tensorboard.util import test_util
 
+# Debugger Plugin V1 is tied to TF1.x behavior (`tf.Session`s).
 tf = tensorflow.compat.v1
 tf.disable_v2_behavior()
 

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
@@ -33,7 +33,7 @@ import threading
 import numpy as np
 import portpicker  # pylint: disable=import-error
 from six.moves import urllib  # pylint: disable=wrong-import-order
-import tensorflow as tf  # pylint: disable=wrong-import-order
+import tensorflow  # pylint: disable=wrong-import-order
 from tensorflow.python import debug as tf_debug  # pylint: disable=wrong-import-order
 from werkzeug import test as werkzeug_test  # pylint: disable=wrong-import-order
 from werkzeug import wrappers  # pylint: disable=wrong-import-order
@@ -44,11 +44,13 @@ from tensorboard.plugins import base_plugin
 from tensorboard.plugins.debugger import interactive_debugger_plugin
 from tensorboard.util import test_util
 
+tf = tensorflow.compat.v1
+tf.disable_v2_behavior()
+
 
 _SERVER_URL_PREFIX = '/data/plugin/debugger/'
 
 
-@test_util.run_v1_only('Test fails to run and clean up properly; they time out.')
 class InteractiveDebuggerPluginTest(tf.test.TestCase):
 
   def setUp(self):
@@ -116,14 +118,14 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
   def _runSimpleAddMultiplyGraph(self, variable_size=1):
     session_run_results = []
     def session_run_job():
-      with tf.compat.v1.Session() as sess:
+      with tf.Session() as sess:
         a = tf.Variable([10.0] * variable_size, name='a')
         b = tf.Variable([20.0] * variable_size, name='b')
         c = tf.Variable([30.0] * variable_size, name='c')
         x = tf.multiply(a, b, name="x")
         y = tf.add(x, c, name="y")
 
-        sess.run(tf.compat.v1.global_variables_initializer())
+        sess.run(tf.global_variables_initializer())
 
         sess = tf_debug.TensorBoardDebugWrapperSession(sess, self._debugger_url)
         session_run_results.append(sess.run(y))
@@ -134,12 +136,12 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
   def _runMultiStepAssignAddGraph(self, steps):
     session_run_results = []
     def session_run_job():
-      with tf.compat.v1.Session() as sess:
+      with tf.Session() as sess:
         a = tf.Variable(10, dtype=tf.int32, name='a')
         b = tf.Variable(1, dtype=tf.int32, name='b')
-        inc_a = tf.compat.v1.assign_add(a, b, name='inc_a')
+        inc_a = tf.assign_add(a, b, name='inc_a')
 
-        sess.run(tf.compat.v1.global_variables_initializer())
+        sess.run(tf.global_variables_initializer())
 
         sess = tf_debug.TensorBoardDebugWrapperSession(sess, self._debugger_url)
         for _ in range(steps):
@@ -151,15 +153,15 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
   def _runTfGroupGraph(self):
     session_run_results = []
     def session_run_job():
-      with tf.compat.v1.Session() as sess:
+      with tf.Session() as sess:
         a = tf.Variable(10, dtype=tf.int32, name='a')
         b = tf.Variable(20, dtype=tf.int32, name='b')
         d = tf.constant(1, dtype=tf.int32, name='d')
-        inc_a = tf.compat.v1.assign_add(a, d, name='inc_a')
-        inc_b = tf.compat.v1.assign_add(b, d, name='inc_b')
+        inc_a = tf.assign_add(a, d, name='inc_a')
+        inc_b = tf.assign_add(b, d, name='inc_b')
         inc_ab = tf.group([inc_a, inc_b], name="inc_ab")
 
-        sess.run(tf.compat.v1.global_variables_initializer())
+        sess.run(tf.global_variables_initializer())
 
         sess = tf_debug.TensorBoardDebugWrapperSession(sess, self._debugger_url)
         session_run_results.append(sess.run(inc_ab))
@@ -708,7 +710,7 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
   def _runInitializer(self):
     session_run_results = []
     def session_run_job():
-      with tf.compat.v1.Session() as sess:
+      with tf.Session() as sess:
         a = tf.Variable([10.0] * 10, name='a')
         sess = tf_debug.TensorBoardDebugWrapperSession(sess, self._debugger_url)
         # Run the initializer with a debugger-wrapped tf.Session.
@@ -786,7 +788,7 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
   def _runHealthPillNetwork(self):
     session_run_results = []
     def session_run_job():
-      with tf.compat.v1.Session() as sess:
+      with tf.Session() as sess:
         a = tf.Variable(
             [np.nan, np.inf, np.inf, -np.inf, -np.inf, -np.inf, 10, 20, 30],
             dtype=tf.float32, name='a')
@@ -833,11 +835,11 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
   def _runAsciiStringNetwork(self):
     session_run_results = []
     def session_run_job():
-      with tf.compat.v1.Session() as sess:
+      with tf.Session() as sess:
         str1 = tf.Variable('abc', name='str1')
         str2 = tf.Variable('def', name='str2')
         str_concat = tf.add(str1, str2, name='str_concat')
-        sess.run(tf.compat.v1.global_variables_initializer())
+        sess.run(tf.global_variables_initializer())
         sess = tf_debug.TensorBoardDebugWrapperSession(sess, self._debugger_url)
         session_run_results.append(sess.run(str_concat))
     session_run_thread = threading.Thread(target=session_run_job)
@@ -890,11 +892,11 @@ class InteractiveDebuggerPluginTest(tf.test.TestCase):
   def _runBinaryStringNetwork(self):
     session_run_results = []
     def session_run_job():
-      with tf.compat.v1.Session() as sess:
+      with tf.Session() as sess:
         str1 = tf.Variable([b'\x01' * 3, b'\x02' * 3], name='str1')
         str2 = tf.Variable([b'\x03' * 3, b'\x04' * 3], name='str2')
         str_concat = tf.add(str1, str2, name='str_concat')
-        sess.run(tf.compat.v1.global_variables_initializer())
+        sess.run(tf.global_variables_initializer())
         sess = tf_debug.TensorBoardDebugWrapperSession(sess, self._debugger_url)
         session_run_results.append(sess.run(str_concat))
     session_run_thread = threading.Thread(target=session_run_job)

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin_test.py
@@ -33,7 +33,7 @@ import threading
 import numpy as np
 import portpicker  # pylint: disable=import-error
 from six.moves import urllib  # pylint: disable=wrong-import-order
-import tensorflow  # pylint: disable=wrong-import-order
+import tensorflow.compat.v1 as tf  # pylint: disable=wrong-import-order
 from tensorflow.python import debug as tf_debug  # pylint: disable=wrong-import-order
 from werkzeug import test as werkzeug_test  # pylint: disable=wrong-import-order
 from werkzeug import wrappers  # pylint: disable=wrong-import-order
@@ -44,8 +44,8 @@ from tensorboard.plugins import base_plugin
 from tensorboard.plugins.debugger import interactive_debugger_plugin
 from tensorboard.util import test_util
 
-# Debugger Plugin V1 is tied to TF1.x behavior (`tf.Session`s).
-tf = tensorflow.compat.v1
+# These unit tests for Debugger Plugin V1 are tied to TF1.x behavior
+# (`tf.Session`s).
 tf.disable_v2_behavior()
 
 

--- a/tensorboard/plugins/debugger/session_debug_test.py
+++ b/tensorboard/plugins/debugger/session_debug_test.py
@@ -42,6 +42,7 @@ from tensorboard.plugins.debugger import constants
 from tensorboard.plugins.debugger import debugger_server_lib
 from tensorboard.util import test_util
 
+# Debugger Plugin V1 is tied to TF1.x behavior (`tf.Session`s).
 tf = tensorflow.compat.v1
 tf.disable_v2_behavior()
 

--- a/tensorboard/plugins/debugger/session_debug_test.py
+++ b/tensorboard/plugins/debugger/session_debug_test.py
@@ -35,15 +35,15 @@ import time
 
 import numpy as np
 import portpicker  # pylint: disable=import-error
-import tensorflow  # pylint: disable=wrong-import-order
+import tensorflow.compat.v1 as tf  # pylint: disable=wrong-import-order
 from tensorflow.python import debug as tf_debug  # pylint: disable=wrong-import-order
 
 from tensorboard.plugins.debugger import constants
 from tensorboard.plugins.debugger import debugger_server_lib
 from tensorboard.util import test_util
 
-# Debugger Plugin V1 is tied to TF1.x behavior (`tf.Session`s).
-tf = tensorflow.compat.v1
+# These unit tests for Debugger Plugin V1 are tied to TF1.x behavior
+# (`tf.Session`s).
 tf.disable_v2_behavior()
 
 

--- a/tensorboard/plugins/debugger/session_debug_test.py
+++ b/tensorboard/plugins/debugger/session_debug_test.py
@@ -35,30 +35,36 @@ import time
 
 import numpy as np
 import portpicker  # pylint: disable=import-error
-import tensorflow as tf  # pylint: disable=wrong-import-order
+import tensorflow  # pylint: disable=wrong-import-order
 from tensorflow.python import debug as tf_debug  # pylint: disable=wrong-import-order
 
 from tensorboard.plugins.debugger import constants
 from tensorboard.plugins.debugger import debugger_server_lib
 from tensorboard.util import test_util
 
+tf = tensorflow.compat.v1
+tf.disable_v2_behavior()
 
-@test_util.run_v1_only("Server fails to come up. Requires study.")
+
 class SessionDebugTestBase(tf.test.TestCase):
 
   def setUp(self):
+    print("In setUp()")
     self._debugger_data_server_grpc_port = portpicker.pick_unused_port()
     self._debug_url = (
         "grpc://localhost:%d" % self._debugger_data_server_grpc_port)
     self._logdir = tempfile.mkdtemp(prefix="tensorboard_dds_")
 
+    print("tf_debug.__file__ = ")  # DEBUG
+    print(tf_debug.__file__)  # DEBUG
+    # assert False  # DEBUG
     self._debug_data_server = debugger_server_lib.DebuggerDataServer(
         self._debugger_data_server_grpc_port, self._logdir, always_flush=True)
     self._server_thread = threading.Thread(
         target=self._debug_data_server.start_the_debugger_data_receiving_server)
     self._server_thread.start()
 
-    self.assertTrue(self._poll_server_till_success(50, 0.2))
+    self.assertTrue(self._poll_server_till_success(30, 0.2))
 
   def tearDown(self):
     self._debug_data_server.stop_server()
@@ -67,23 +73,26 @@ class SessionDebugTestBase(tf.test.TestCase):
     if os.path.isdir(self._logdir):
       shutil.rmtree(self._logdir)
 
-    tf.compat.v1.reset_default_graph()
+    tf.reset_default_graph()
 
   def _poll_server_till_success(self, max_tries, poll_interval_seconds):
-    for _ in range(max_tries):
+    for i in range(max_tries):
+      print("In _poll_server_till_success() 150: i = %d" % i)  # DEBUG
       try:
-        with tf.compat.v1.Session() as sess:
+        with tf.Session() as sess:
           a_init_val = np.array([42.0])
           a_init = tf.constant(a_init_val, shape=[1], name="a_init")
           a = tf.Variable(a_init, name="a")
+          print("In _poll_server_till_success() 200")  # DEBUG
 
-          run_options = tf.compat.v1.RunOptions(output_partition_graphs=True)
+          run_options = tf.RunOptions(output_partition_graphs=True)
           tf_debug.watch_graph(run_options,
                                sess.graph,
                                debug_ops=["DebugNumericSummary"],
                                debug_urls=[self._debug_url])
 
           sess.run(a.initializer, options=run_options)
+          print("In _poll_server_till_success() 300")  # DEBUG
           return True
       except tf.errors.FailedPreconditionError as exc:
         time.sleep(poll_interval_seconds)
@@ -125,7 +134,7 @@ class SessionDebugTestBase(tf.test.TestCase):
   def _check_health_pills_in_events_file(self,
                                          events_file_path,
                                          debug_key_to_tensors):
-    reader = tf.compat.v1.python_io.tf_record_iterator(events_file_path)
+    reader = tf.python_io.tf_record_iterator(events_file_path)
     event_read = tf.Event()
 
     # The first event in the file should contain the events version, which is
@@ -159,7 +168,7 @@ class SessionDebugTestBase(tf.test.TestCase):
             health_pills[debug_key][i])
 
   def testRunSimpleNetworkoWithInfAndNaNWorks(self):
-    with tf.compat.v1.Session() as sess:
+    with tf.Session() as sess:
       x_init_val = np.array([[2.0], [-1.0]])
       y_init_val = np.array([[0.0], [-0.25]])
       z_init_val = np.array([[0.0, 3.0], [-1.0, 0.0]])
@@ -171,14 +180,14 @@ class SessionDebugTestBase(tf.test.TestCase):
       z_init = tf.constant(z_init_val, shape=[2, 2])
       z = tf.Variable(z_init, name="z")
 
-      u = tf.compat.v1.div(x, y, name="u")  # Produces an Inf.
+      u = tf.div(x, y, name="u")  # Produces an Inf.
       v = tf.matmul(z, u, name="v")  # Produces NaN and Inf.
 
       sess.run(x.initializer)
       sess.run(y.initializer)
       sess.run(z.initializer)
 
-      run_options = tf.compat.v1.RunOptions(output_partition_graphs=True)
+      run_options = tf.RunOptions(output_partition_graphs=True)
       tf_debug.watch_graph(run_options,
                            sess.graph,
                            debug_ops=["DebugNumericSummary"],
@@ -221,18 +230,18 @@ class SessionDebugTestBase(tf.test.TestCase):
     self.assertEqual(0, report[1].pos_inf_event_count)
 
   def testMultipleInt32ValuesOverMultipleRunsAreRecorded(self):
-    with tf.compat.v1.Session() as sess:
+    with tf.Session() as sess:
       x_init_val = np.array([10], dtype=np.int32)
       x_init = tf.constant(x_init_val, shape=[1], name="x_init")
       x = tf.Variable(x_init, name="x")
 
       x_inc_val = np.array([2], dtype=np.int32)
       x_inc = tf.constant(x_inc_val, name="x_inc")
-      inc_x = tf.compat.v1.assign_add(x, x_inc, name="inc_x")
+      inc_x = tf.assign_add(x, x_inc, name="inc_x")
 
       sess.run(x.initializer)
 
-      run_options = tf.compat.v1.RunOptions(output_partition_graphs=True)
+      run_options = tf.RunOptions(output_partition_graphs=True)
       tf_debug.watch_graph(run_options,
                            sess.graph,
                            debug_ops=["DebugNumericSummary"],
@@ -266,7 +275,7 @@ class SessionDebugTestBase(tf.test.TestCase):
     # Before any Session runs, the report ought to be empty.
     self.assertEqual([], self._debug_data_server.numerics_alert_report())
 
-    with tf.compat.v1.Session() as sess:
+    with tf.Session() as sess:
       x_init_val = np.array([[2.0], [-1.0]])
       y_init_val = np.array([[0.0], [-0.25]])
       z_init_val = np.array([[0.0, 3.0], [-1.0, 0.0]])
@@ -278,7 +287,7 @@ class SessionDebugTestBase(tf.test.TestCase):
       z_init = tf.constant(z_init_val, shape=[2, 2])
       z = tf.Variable(z_init, name="z")
 
-      u = tf.compat.v1.div(x, y, name="u")  # Produces an Inf.
+      u = tf.div(x, y, name="u")  # Produces an Inf.
       v = tf.matmul(z, u, name="v")  # Produces NaN and Inf.
 
       sess.run(x.initializer)
@@ -287,7 +296,7 @@ class SessionDebugTestBase(tf.test.TestCase):
 
       run_options_list = []
       for i in range(num_threads):
-        run_options = tf.compat.v1.RunOptions(output_partition_graphs=True)
+        run_options = tf.RunOptions(output_partition_graphs=True)
         # Use different grpc:// URL paths so that each thread opens a separate
         # gRPC stream to the debug data server, simulating multi-worker setting.
         tf_debug.watch_graph(run_options,

--- a/tensorboard/plugins/debugger/session_debug_test.py
+++ b/tensorboard/plugins/debugger/session_debug_test.py
@@ -49,15 +49,11 @@ tf.disable_v2_behavior()
 class SessionDebugTestBase(tf.test.TestCase):
 
   def setUp(self):
-    print("In setUp()")
     self._debugger_data_server_grpc_port = portpicker.pick_unused_port()
     self._debug_url = (
         "grpc://localhost:%d" % self._debugger_data_server_grpc_port)
     self._logdir = tempfile.mkdtemp(prefix="tensorboard_dds_")
 
-    print("tf_debug.__file__ = ")  # DEBUG
-    print(tf_debug.__file__)  # DEBUG
-    # assert False  # DEBUG
     self._debug_data_server = debugger_server_lib.DebuggerDataServer(
         self._debugger_data_server_grpc_port, self._logdir, always_flush=True)
     self._server_thread = threading.Thread(
@@ -77,13 +73,11 @@ class SessionDebugTestBase(tf.test.TestCase):
 
   def _poll_server_till_success(self, max_tries, poll_interval_seconds):
     for i in range(max_tries):
-      print("In _poll_server_till_success() 150: i = %d" % i)  # DEBUG
       try:
         with tf.Session() as sess:
           a_init_val = np.array([42.0])
           a_init = tf.constant(a_init_val, shape=[1], name="a_init")
           a = tf.Variable(a_init, name="a")
-          print("In _poll_server_till_success() 200")  # DEBUG
 
           run_options = tf.RunOptions(output_partition_graphs=True)
           tf_debug.watch_graph(run_options,
@@ -92,7 +86,6 @@ class SessionDebugTestBase(tf.test.TestCase):
                                debug_urls=[self._debug_url])
 
           sess.run(a.initializer, options=run_options)
-          print("In _poll_server_till_success() 300")  # DEBUG
           return True
       except tf.errors.FailedPreconditionError as exc:
         time.sleep(poll_interval_seconds)

--- a/tensorboard/plugins/debugger/session_debug_test.py
+++ b/tensorboard/plugins/debugger/session_debug_test.py
@@ -60,7 +60,7 @@ class SessionDebugTestBase(tf.test.TestCase):
         target=self._debug_data_server.start_the_debugger_data_receiving_server)
     self._server_thread.start()
 
-    self.assertTrue(self._poll_server_till_success(30, 0.2))
+    self.assertTrue(self._poll_server_till_success(50, 0.2))
 
   def tearDown(self):
     self._debug_data_server.stop_server()
@@ -72,7 +72,7 @@ class SessionDebugTestBase(tf.test.TestCase):
     tf.reset_default_graph()
 
   def _poll_server_till_success(self, max_tries, poll_interval_seconds):
-    for i in range(max_tries):
+    for _ in range(max_tries):
       try:
         with tf.Session() as sess:
           a_init_val = np.array([42.0])


### PR DESCRIPTION
* Motivation for features / changes
  * Re. https://github.com/tensorflow/tensorboard/issues/1705
  * Make sure all debugger plugin's python tests pass with TF2

* Technical description of changes
  * In session_debug_test.py and interactive_debugger_plugin_test.py: use tf.compat.v1 and disable_v2_behavior(), as tfdbg (V1) is indeed wedded to the Session::Run() paradigm. 
  * In debug_graphs_helper_test.py: make conditional assertions to fit v2-specific behaviors
