### PR TITLE
projector: compile the projector HTML binary

### DIFF
--- a/tensorboard/plugins/projector/tf_projector_plugin/BUILD
+++ b/tensorboard/plugins/projector/tf_projector_plugin/BUILD
@@ -17,6 +17,7 @@ tf_web_library(
 
 tensorboard_html_binary(
     name = "projector_binary",
+    compile = True,
     input_path = "/tf-projector/tf-projector-plugin.html",
     output_path = "/tf-projector/projector_binary.html",
     deps = [


### PR DESCRIPTION
Turning this on makes it easier to reliably serve the resulting HTML blob in different contexts.