### PR TITLE
core: expose backend and storage as Polymer

### DIFF
--- a/tensorboard/components/tf_backend/BUILD
+++ b/tensorboard/components/tf_backend/BUILD
@@ -17,6 +17,7 @@ tf_web_library(
         "router.ts",
         "runsStore.ts",
         "tf-backend.html",
+        "tf-backend.ts",
         "urlPathHelpers.ts",
     ],
     path = "/tf-backend",
@@ -25,6 +26,7 @@ tf_web_library(
         ":type",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:plottable",
+        "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/vz_sorting",
     ],
 )

--- a/tensorboard/components/tf_backend/tf-backend.html
+++ b/tensorboard/components/tf_backend/tf-backend.html
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<link rel="import" href="../tf-imports/polymer.html" />
 <link rel="import" href="../tf-imports/lodash.html" />
 <link rel="import" href="../vz-sorting/vz-sorting.html" />
 
@@ -27,3 +28,7 @@ limitations under the License.
 <script src="runsStore.js"></script>
 <script src="backend.js"></script>
 <script src="canceller.js"></script>
+
+<dom-module id="tf-backend">
+  <script src="tf-backend.js"></script>
+</dom-module>

--- a/tensorboard/components/tf_backend/tf-backend.ts
+++ b/tensorboard/components/tf_backend/tf-backend.ts
@@ -1,6 +1,4 @@
-<!--
-@license
-Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,14 +11,14 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
-
-<link rel="import" href="../tf-globals/tf-globals.html" />
-<link rel="import" href="../tf-imports/lodash.html" />
-
-<script src="listeners.js"></script>
-<script src="storage.js"></script>
-
-<dom-module id="tf-storage">
-  <script src="tf-storage.js"></script>
-</dom-module>
+==============================================================================*/
+namespace tf_backend {
+  // HACK: this Polymer component allows stores to be accessible from
+  // tf-ng-tensorboard by exposing otherwise mangled smybols.
+  Polymer({
+    is: 'tf-backend',
+    environmentStore: tf_backend.environmentStore,
+    experimentsStore: tf_backend.experimentsStore,
+    runsStore: tf_backend.runsStore,
+  });
+} // namespace tf_backend

--- a/tensorboard/components/tf_storage/BUILD
+++ b/tensorboard/components/tf_storage/BUILD
@@ -11,6 +11,7 @@ tf_web_library(
         "listeners.ts",
         "storage.ts",
         "tf-storage.html",
+        "tf-storage.ts",
     ],
     path = "/tf-storage",
     visibility = ["//visibility:public"],

--- a/tensorboard/components/tf_storage/tf-storage.ts
+++ b/tensorboard/components/tf_storage/tf-storage.ts
@@ -1,0 +1,50 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace tf_storage {
+  // HACK: this Polymer component allows stores to be accessible from
+  // tf-ng-tensorboard by exposing otherwise mangled smybols.
+  Polymer({
+    is: 'tf-storage',
+
+    DISAMBIGUATOR: tf_storage.DISAMBIGUATOR,
+    TAB: tf_storage.TAB,
+
+    getString: tf_storage.getString,
+    setString: tf_storage.setString,
+    getStringInitializer: tf_storage.getStringInitializer,
+    getStringObserver: tf_storage.getStringObserver,
+    disposeStringBinding: tf_storage.disposeStringBinding,
+
+    getBoolean: tf_storage.getBoolean,
+    setBoolean: tf_storage.setBoolean,
+    getBooleanInitializer: tf_storage.getBooleanInitializer,
+    getBooleanObserver: tf_storage.getBooleanObserver,
+    disposeBooleanBinding: tf_storage.disposeBooleanBinding,
+
+    getNumber: tf_storage.getNumber,
+    setNumber: tf_storage.setNumber,
+    getNumberInitializer: tf_storage.getNumberInitializer,
+    getNumberObserver: tf_storage.getNumberObserver,
+    disposeNumberBinding: tf_storage.disposeNumberBinding,
+
+    getObject: tf_storage.getObject,
+    setObject: tf_storage.setObject,
+    getObjectInitializer: tf_storage.getObjectInitializer,
+    getObjectObserver: tf_storage.getObjectObserver,
+    disposeObjectBinding: tf_storage.disposeObjectBinding,
+
+    // Export more symbols if they are truly needed.
+  });
+} // namespace tf_storage


### PR DESCRIPTION
This change contains a hack that should improve developer experience
by allowing Angular app to wrap Polymer code.

In order for the Angular app to be useful, we need to cross the
JSCompiler and rollup boundary where symbols are separtely mangled.
By exposing as property in the Polymer element, we can make the symbol
more stable.
