### PR TITLE
tf-tensorboard: fix inactive menu hiding

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -742,7 +742,7 @@ limitations under the License.
           workingSet.delete(d.plugin);
         });
         activeDashboards.forEach((d) => {
-          workingSet.delete(d.plugin);
+          workingSet.delete(d);
         });
         return workingSet.size > 0;
       },


### PR DESCRIPTION
Summary:
The “inactive” dropdown is supposed to be hidden when no plugins are
inactive, but a silent type error caused this logic to be incorrect.
(The `activeDashboards` list has plugin names, not plugins.)

Test Plan:
Apply the following patch to “uninstall” all plugins except for scalars:

```diff
diff --git a/tensorboard/components/tf_tensorboard/default-plugins.html b/tensorboard/components/tf_tensorboard/default-plugins.html
index 307b65ac..e0497827 100644
--- a/tensorboard/components/tf_tensorboard/default-plugins.html
+++ b/tensorboard/components/tf_tensorboard/default-plugins.html
@@ -22,6 +22,7 @@ limitations under the License.
   and is later instantiated dynamically with `document.createElement`.
 -->
 <link rel="import" href="../tf-scalar-dashboard/tf-scalar-dashboard.html" />
+<!--
 <link
   rel="import"
   href="../tf-custom-scalar-dashboard/tf-custom-scalar-dashboard.html"
@@ -48,3 +49,4 @@ limitations under the License.
 />
 <link rel="import" href="../tf-hparams-dashboard/tf-hparams-dashboard.html" />
 <link rel="import" href="../tf-mesh-dashboard/tf-mesh-dashboard.html" />
+-->
diff --git a/tensorboard/default.py b/tensorboard/default.py
index 41f66546..2ffbe1d3 100644
--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -62,6 +62,8 @@ logger = logging.getLogger(__name__)
 _PLUGINS = [
     core_plugin.CorePluginLoader,
     scalars_plugin.ScalarsPlugin,
+]
+_UNUSED = [
     custom_scalars_plugin.CustomScalarsPlugin,
     images_plugin.ImagesPlugin,
     audio_plugin.AudioPlugin,
@@ -105,6 +107,7 @@ def get_dynamic_plugins():

   [1]: https://packaging.python.org/specifications/entry-points/
   """
+  return []
   return [
       entry_point.load()
       for entry_point in pkg_resources.iter_entry_points('tensorboard_plugins')
```

Then launch TensorBoard pointing to a directory with scalars, and note
that the inactive menu is hidden; relaunch pointing to an empty logdir,
and note that the inactive menu appears.

wchargin-branch: inactive-hide
