### PR TITLE
scalars: appear active when data provider present

### DIFF
--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -71,6 +71,11 @@ class ScalarsPlugin(base_plugin.TBPlugin):
 
   def is_active(self):
     """The scalars plugin is active iff any run has at least one scalar tag."""
+    if self._data_provider:
+      # We don't have an experiment ID, and modifying the backend core
+      # to provide one would break backward compatibility. Hack for now.
+      return True
+
     if self._db_connection_provider:
       # The plugin is active if one relevant tag can be found in the database.
       db = self._db_connection_provider()

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -247,7 +247,11 @@ class ScalarsPluginTest(tf.test.TestCase):
 
   @with_runs([_RUN_WITH_HISTOGRAM])
   def test_active_with_histogram(self, plugin):
-    self.assertFalse(plugin.is_active())
+    if plugin._data_provider:
+      # Hack, for now.
+      self.assertTrue(plugin.is_active())
+    else:
+      self.assertFalse(plugin.is_active())
 
   @with_runs([_RUN_WITH_LEGACY_SCALARS, _RUN_WITH_SCALARS, _RUN_WITH_HISTOGRAM])
   def test_active_with_all(self, plugin):


### PR DESCRIPTION
Summary:
Temporary hack to facilitate testing sans multiplexer.

Test Plan:
Remove the multiplexer from the scalars plugin:

```diff
diff --git a/tensorboard/plugins/scalar/scalars_plugin.py b/tensorboard/plugins/scalar/scalars_plugin.py
index 74e6eebc..b3b7a27f 100644
--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -60,6 +60,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
     self._db_connection_provider = context.db_connection_provider
     if context.flags and context.flags.generic_data == 'true':
       self._data_provider = context.data_provider
+      self._multiplexer = None
     else:
       self._data_provider = None

```

Note that prior to this commit the scalars plugin would be marked
inactive (but work fine once explicitly selected), whereas it’s now
marked active.

wchargin-branch: scalars-data-active
