### PR TITLE
ui: fix help animation for line chart

### DIFF
--- a/tensorboard/components/vz_line_chart2/panZoomDragLayer.html
+++ b/tensorboard/components/vz_line_chart2/panZoomDragLayer.html
@@ -29,7 +29,7 @@ limitations under the License.
         animation-delay: 1s;
         animation-duration: 1s;
         animation-name: fade-out;
-        background: rgba(30, 30, 30, .6);
+        background: rgba(30, 30, 30, 0.6);
         bottom: 0;
         color: #fff;
         display: flex;

--- a/tensorboard/components/vz_line_chart2/panZoomDragLayer.html
+++ b/tensorboard/components/vz_line_chart2/panZoomDragLayer.html
@@ -20,3 +20,42 @@ limitations under the License.
 <link rel="import" href="../vz-line-chart/dragZoomInteraction.html" />
 
 <script src="panZoomDragLayer.js"></script>
+
+<dom-module id="vz-pan-zoom-style">
+  <template>
+    <style>
+      .help {
+        align-items: center;
+        animation-delay: 1s;
+        animation-duration: 1s;
+        animation-name: fade-out;
+        background: rgba(30, 30, 30, .6);
+        bottom: 0;
+        color: #fff;
+        display: flex;
+        justify-content: center;
+        left: 0;
+        opacity: 1;
+        padding: 20px;
+        pointer-events: none;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+
+      .help > span {
+        white-space: normal;
+      }
+
+      @keyframes fade-out {
+        0% {
+          opacity: 1;
+        }
+
+        100% {
+          opacity: 0;
+        }
+      }
+    </style>
+  </template>
+</dom-module>

--- a/tensorboard/components/vz_line_chart2/panZoomDragLayer.ts
+++ b/tensorboard/components/vz_line_chart2/panZoomDragLayer.ts
@@ -94,34 +94,11 @@ namespace vz_line_chart2 {
 
       const helpContainer = this.element();
       if (!helpContainer.select('.help').empty()) return;
-      // If the style gets crazy, use CSS and custom-dom API.
-      const help = helpContainer
-        .append('div')
-        .classed('help', true)
-        .style('background', 'rgba(30, 30, 30, .6)')
-        .style('color', '#fff')
-        .style('pointer-events', 'none')
-        .style('opacity', 1)
-        .style('position', 'absolute')
-        .style('top', 0)
-        .style('bottom', 0)
-        .style('left', 0)
-        .style('right', 0)
-        .style('display', 'flex')
-        .style('justify-content', 'center')
-        .style('padding', '20px')
-        .style('align-items', 'center');
 
-      const fade = d3.transition().duration(2500);
-      help
-        .transition(fade)
-        .style('opacity', 0)
-        .remove();
-
-      help
-        .append('span')
-        .text('Alt + Scroll to Zoom')
-        .style('white-space', 'normal');
+      const help = helpContainer.append('div').classed('help', true);
+      help.append('span').text('Alt + Scroll to Zoom');
+      // Please see vz-pan-zoom-style for the definition of the animation.
+      help.on('animationend', () => void help.remove());
     }
 
     static isPanKey(event: MouseEvent): boolean {

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.html
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.html
@@ -41,6 +41,7 @@ such as different X scales (linear and temporal), tooltips and smoothing.
       content-component-name="vz-line-chart-tooltip"
     ></vz-chart-tooltip>
     <style include="plottable-style"></style>
+    <style include="vz-pan-zoom-style"></style>
     <style>
       :host {
         -moz-user-select: none;


### PR DESCRIPTION
With the Polymer change, d3 transition started to misbehave. Because we
were not happy with the frame-rate of the d3.transition, we decided to
refactor the code to use pure CSS for the animation instead.

Empirically, the animation looks a lot smoother. 