### PR TITLE
Promote `FrontendMetadata` from `namedtuple` to struct

### DIFF
--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -128,8 +128,7 @@ class FakePlugin(base_plugin.TBPlugin):
     return self._is_active_value
 
   def frontend_metadata(self):
-    base = super(FakePlugin, self).frontend_metadata()
-    return base._replace(
+    return base_plugin.FrontendMetadata(
         element_name=self._element_name_value,
         es_module_path=self._es_module_path_value,
     )

--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
@@ -48,9 +48,7 @@ class ExamplePlugin(base_plugin.TBPlugin):
     }
 
   def frontend_metadata(self):
-    return super(ExamplePlugin, self).frontend_metadata()._replace(
-        es_module_path="/index.js",
-    )
+    return base_plugin.FrontendMetadata(es_module_path="/index.js")
 
   @wrappers.Request.application
   def _serve_js(self, request):

--- a/tensorboard/http_api.md
+++ b/tensorboard/http_api.md
@@ -38,6 +38,8 @@ The `logdir` argument is the path of the directory that contains events files.
 Returns a dict mapping from plugin name to an object that describes a
 plugin, with the following keys:
 
+  - `disable_reload`: Boolean. Whether to disable the reload button and
+    auto-reload timer.
   - `enabled`: Boolean. Indicates whether the plugin is active. A plugin
     might be inactive, for instance, if it lacks relevant data.
   - `loading_mechanism`: One of:

--- a/tensorboard/plugins/BUILD
+++ b/tensorboard/plugins/BUILD
@@ -16,3 +16,15 @@ py_library(
         "@org_pythonhosted_six",
     ],
 )
+
+py_test(
+    name = "base_plugin_test",
+    srcs = ["base_plugin_test.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":base_plugin",
+        "//tensorboard:test",
+        "@org_pythonhosted_six",
+    ],
+)

--- a/tensorboard/plugins/audio/audio_plugin.py
+++ b/tensorboard/plugins/audio/audio_plugin.py
@@ -63,9 +63,7 @@ class AudioPlugin(base_plugin.TBPlugin):
     return bool(self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME))
 
   def frontend_metadata(self):
-    return super(AudioPlugin, self).frontend_metadata()._replace(
-        element_name='tf-audio-dashboard',
-    )
+    return base_plugin.FrontendMetadata(element_name='tf-audio-dashboard')
 
   def _index_impl(self):
     """Return information about the tags in each run.

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -29,38 +29,6 @@ from abc import ABCMeta
 from abc import abstractmethod
 
 
-FrontendMetadata = collections.namedtuple(
-    "FrontendMetadata",
-    (
-        # Name to show in the menu item for this dashboard within the
-        # navigation bar. May differ from the plugin name. For instance,
-        # the tab name should not use underscores to separate words.
-        # Should be a `str` or `None` (defaulting to the `plugin_name`).
-        "tab_name",
-        # ES module to use as an entry point to this plugin. Should be a
-        # `str` that is a key in the result of `get_plugin_apps()`, or
-        # `None` for legacy plugins bundled with TensorBoard as part of
-        # `webfiles.zip`. Mutually exclusive with legacy `element_name`
-        # below.
-        #
-        # TODO(tensorboard-team): Describe the contract/API for the ES
-        # module when it is better defined.
-        "es_module_path",
-        # Whether to disable the reload button and auto-reload timer.
-        # Boolean.
-        "disable_reload",
-        # Whether to remove the plugin DOM when switching to a different
-        # plugin, to trigger the Polymer 'detached' event. Boolean.
-        "remove_dom",
-        # For legacy plugins, name of the custom element defining the
-        # plugin frontend: e.g., `"tf-scalar-dashboard"`. Should be a
-        # `str` or `None` (for iframed plugins). Mutually exclusive with
-        # `es_module_path`.
-        "element_name",
-    ),
-)
-
-
 @six.add_metaclass(ABCMeta)
 class TBPlugin(object):
   """TensorBoard plugin interface.
@@ -124,16 +92,113 @@ class TBPlugin(object):
 
     The base implementation returns a default value. Subclasses should
     override this and specify either an `es_module_path` or (for legacy
-    plugins) an `element_name`, and are encouraged to replace any other
+    plugins) an `element_name`, and are encouraged to set any other
     relevant attributes.
     """
-    return FrontendMetadata(
-        tab_name=None,
-        es_module_path=None,
-        disable_reload=False,
-        remove_dom=False,
-        element_name=None,
-    )
+    return FrontendMetadata()
+
+
+class FrontendMetadata(object):
+  """Metadata required to render a plugin on the frontend.
+
+  Each argument to the constructor is publicly accessible under a field
+  of the same name. See constructor docs for further details.
+  """
+
+  def __init__(
+      self,
+      disable_reload=None,
+      element_name=None,
+      es_module_path=None,
+      remove_dom=None,
+      tab_name=None,
+  ):
+    """Creates a `FrontendMetadata` value.
+
+    The argument list is sorted and may be extended in the future;
+    therefore, callers must pass only named arguments to this
+    constructor.
+
+    Args:
+      disable_reload: Whether to disable the reload button and
+          auto-reload timer. A `bool`; defaults to `False`.
+      element_name: For legacy plugins, name of the custom element
+          defining the plugin frontend: e.g., `"tf-scalar-dashboard"`.
+          A `str` or `None` (for iframed plugins). Mutually exclusive
+          with `es_module_path`.
+      es_module_path: ES module to use as an entry point to this plugin.
+          A `str` that is a key in the result of `get_plugin_apps()`, or
+          `None` for legacy plugins bundled with TensorBoard as part of
+          `webfiles.zip`. Mutually exclusive with legacy `element_name`
+      remove_dom: Whether to remove the plugin DOM when switching to a
+          different plugin, to trigger the Polymer 'detached' event.
+          A `bool`; defaults to `False`.
+      tab_name: Name to show in the menu item for this dashboard within
+          the navigation bar. May differ from the plugin name: for
+          instance, the tab name should not use underscores to separate
+          words. Should be a `str` or `None` (the default; indicates to
+          use the plugin name as the tab name).
+    """
+    self._disable_reload = False if disable_reload is None else disable_reload
+    self._element_name = element_name
+    self._es_module_path = es_module_path
+    self._remove_dom = False if remove_dom is None else remove_dom
+    self._tab_name = tab_name
+
+  @property
+  def disable_reload(self):
+    return self._disable_reload
+
+  @property
+  def element_name(self):
+    return self._element_name
+
+  @property
+  def es_module_path(self):
+    return self._es_module_path
+
+  @property
+  def remove_dom(self):
+    return self._remove_dom
+
+  @property
+  def tab_name(self):
+    return self._tab_name
+
+  def __eq__(self, other):
+    if not isinstance(other, FrontendMetadata):
+      return False
+    if self._disable_reload != other._disable_reload:
+      return False
+    if self._disable_reload != other._disable_reload:
+      return False
+    if self._element_name != other._element_name:
+      return False
+    if self._es_module_path != other._es_module_path:
+      return False
+    if self._remove_dom != other._remove_dom:
+      return False
+    if self._tab_name != other._tab_name:
+      return False
+    return True
+
+  def __hash__(self):
+    return hash((
+        self._disable_reload,
+        self._element_name,
+        self._es_module_path,
+        self._remove_dom,
+        self._tab_name,
+    ))
+
+  def __repr__(self):
+    return "FrontendMetadata(%s)" % ", ".join((
+        "disable_reload=%r" % self._disable_reload,
+        "element_name=%r" % self._element_name,
+        "es_module_path=%r" % self._es_module_path,
+        "remove_dom=%r" % self._remove_dom,
+        "tab_name=%r" % self._tab_name,
+    ))
 
 
 class TBContext(object):

--- a/tensorboard/plugins/base_plugin_test.py
+++ b/tensorboard/plugins/base_plugin_test.py
@@ -1,0 +1,62 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for `tensorboard.plugins.base_plugin`."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorboard import test as tb_test
+from tensorboard.plugins import base_plugin
+
+
+class FrontendMetadataTest(tb_test.TestCase):
+
+  def _create_metadata(self):
+    return base_plugin.FrontendMetadata(
+        disable_reload="my disable_reload",
+        element_name="my element_name",
+        es_module_path="my es_module_path",
+        remove_dom="my remove_dom",
+        tab_name="my tab_name",
+    )
+
+  def test_basics(self):
+    md = self._create_metadata()
+    self.assertEqual(md.disable_reload, "my disable_reload")
+    self.assertEqual(md.element_name, "my element_name")
+    self.assertEqual(md.es_module_path, "my es_module_path")
+    self.assertEqual(md.remove_dom, "my remove_dom")
+    self.assertEqual(md.tab_name, "my tab_name")
+
+  def test_repr(self):
+    repr_ = repr(self._create_metadata())
+    self.assertIn(repr("my disable_reload"), repr_)
+    self.assertIn(repr("my element_name"), repr_)
+    self.assertIn(repr("my es_module_path"), repr_)
+    self.assertIn(repr("my remove_dom"), repr_)
+    self.assertIn(repr("my tab_name"), repr_)
+
+  def test_eq(self):
+    md1 = base_plugin.FrontendMetadata(element_name="foo")
+    md2 = base_plugin.FrontendMetadata(element_name="bar")
+    md3 = base_plugin.FrontendMetadata(element_name="foo")
+    self.assertNotEqual(md1, md2)
+    self.assertNotEqual(md2, md3)
+    self.assertEqual(md3, md1)
+
+
+if __name__ == '__main__':
+  tb_test.main()

--- a/tensorboard/plugins/base_plugin_test.py
+++ b/tensorboard/plugins/base_plugin_test.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,11 +51,21 @@ class FrontendMetadataTest(tb_test.TestCase):
 
   def test_eq(self):
     md1 = base_plugin.FrontendMetadata(element_name="foo")
-    md2 = base_plugin.FrontendMetadata(element_name="bar")
-    md3 = base_plugin.FrontendMetadata(element_name="foo")
-    self.assertNotEqual(md1, md2)
-    self.assertNotEqual(md2, md3)
-    self.assertEqual(md3, md1)
+    md2 = base_plugin.FrontendMetadata(element_name="foo")
+    md3 = base_plugin.FrontendMetadata(element_name="bar")
+    self.assertEqual(md1, md2)
+    self.assertNotEqual(md1, md3)
+    self.assertNotEqual(md1, "hmm")
+
+  def test_hash(self):
+    md1 = base_plugin.FrontendMetadata(element_name="foo")
+    md2 = base_plugin.FrontendMetadata(element_name="foo")
+    md3 = base_plugin.FrontendMetadata(element_name="bar")
+    self.assertEqual(hash(md1), hash(md2))
+    # The next check is technically not required by the `__hash__`
+    # contract, but _should_ pass; failure on this assertion would at
+    # least warrant some scrutiny.
+    self.assertNotEqual(hash(md1), hash(md3))
 
 
 if __name__ == '__main__':

--- a/tensorboard/plugins/beholder/beholder_plugin.py
+++ b/tensorboard/plugins/beholder/beholder_plugin.py
@@ -77,7 +77,7 @@ class BeholderPlugin(base_plugin.TBPlugin):
   def frontend_metadata(self):
     # TODO(#2338): Keep this in sync with the `registerDashboard` call
     # on the frontend until that call is removed.
-    return super(BeholderPlugin, self).frontend_metadata()._replace(
+    return base_plugin.FrontendMetadata(
         element_name='tf-beholder-dashboard',
         remove_dom=True,
     )

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
@@ -108,7 +108,7 @@ class CustomScalarsPlugin(base_plugin.TBPlugin):
     return bool(self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME))
 
   def frontend_metadata(self):
-    return super(CustomScalarsPlugin, self).frontend_metadata()._replace(
+    return base_plugin.FrontendMetadata(
         element_name='tf-custom-scalar-dashboard',
         tab_name='Custom Scalars',
     )

--- a/tensorboard/plugins/debugger/debugger_plugin.py
+++ b/tensorboard/plugins/debugger/debugger_plugin.py
@@ -152,9 +152,7 @@ class DebuggerPlugin(base_plugin.TBPlugin):
             constants.DEBUGGER_PLUGIN_NAME))
 
   def frontend_metadata(self):
-    return super(DebuggerPlugin, self).frontend_metadata()._replace(
-        element_name='tf-debugger-dashboard',
-    )
+    return base_plugin.FrontendMetadata(element_name='tf-debugger-dashboard')
 
   @wrappers.Request.application
   def _serve_health_pills_handler(self, request):

--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -43,8 +43,7 @@ class InactiveDebuggerPlugin(base_plugin.TBPlugin):
     return False
 
   def frontend_metadata(self):
-    return super(InactiveDebuggerPlugin, self).frontend_metadata()._replace(
-        element_name='tf-debugger-dashboard')
+    return base_plugin.FrontendMetadata(element_name='tf-debugger-dashboard')
 
   def get_plugin_apps(self):
     return {

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin.py
@@ -162,9 +162,7 @@ class InteractiveDebuggerPlugin(base_plugin.TBPlugin):
   def frontend_metadata(self):
     # TODO(#2338): Keep this in sync with the `registerDashboard` call
     # on the frontend until that call is removed.
-    return super(InteractiveDebuggerPlugin, self).frontend_metadata()._replace(
-        element_name='tf-debugger-dashboard',
-    )
+    return base_plugin.FrontendMetadata(element_name='tf-debugger-dashboard')
 
   @wrappers.Request.application
   def _serve_ack(self, request):

--- a/tensorboard/plugins/distribution/distributions_plugin.py
+++ b/tensorboard/plugins/distribution/distributions_plugin.py
@@ -69,7 +69,7 @@ class DistributionsPlugin(base_plugin.TBPlugin):
     return self._histograms_plugin.is_active()
 
   def frontend_metadata(self):
-    return super(DistributionsPlugin, self).frontend_metadata()._replace(
+    return base_plugin.FrontendMetadata(
         element_name='tf-distribution-dashboard',
     )
 

--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -72,7 +72,7 @@ class GraphsPlugin(base_plugin.TBPlugin):
     return bool(self._multiplexer and self.info_impl())
 
   def frontend_metadata(self):
-    return super(GraphsPlugin, self).frontend_metadata()._replace(
+    return base_plugin.FrontendMetadata(
         element_name='tf-graph-dashboard',
         # TODO(@chihuahua): Reconcile this setting with Health Pills.
         disable_reload=True,

--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -125,9 +125,7 @@ class HistogramsPlugin(base_plugin.TBPlugin):
     return result
 
   def frontend_metadata(self):
-    return super(HistogramsPlugin, self).frontend_metadata()._replace(
-        element_name='tf-histogram-dashboard',
-    )
+    return base_plugin.FrontendMetadata(element_name='tf-histogram-dashboard')
 
   def histograms_impl(self, tag, run, downsample_to=None):
     """Result of the form `(body, mime_type)`, or `ValueError`.

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -84,9 +84,7 @@ class HParamsPlugin(base_plugin.TBPlugin):
         metadata.PLUGIN_NAME))
 
   def frontend_metadata(self):
-    return super(HParamsPlugin, self).frontend_metadata()._replace(
-        element_name='tf-hparams-dashboard',
-    )
+    return base_plugin.FrontendMetadata(element_name='tf-hparams-dashboard')
 
   # ---- /experiment -----------------------------------------------------------
   @wrappers.Request.application

--- a/tensorboard/plugins/image/images_plugin.py
+++ b/tensorboard/plugins/image/images_plugin.py
@@ -93,9 +93,7 @@ class ImagesPlugin(base_plugin.TBPlugin):
     return bool(self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME))
 
   def frontend_metadata(self):
-    return super(ImagesPlugin, self).frontend_metadata()._replace(
-        element_name='tf-image-dashboard',
-    )
+    return base_plugin.FrontendMetadata(element_name='tf-image-dashboard')
 
   def _index_impl(self):
     if self._db_connection_provider:

--- a/tensorboard/plugins/interactive_inference/interactive_inference_plugin.py
+++ b/tensorboard/plugins/interactive_inference/interactive_inference_plugin.py
@@ -111,7 +111,7 @@ class InteractiveInferencePlugin(base_plugin.TBPlugin):
   def frontend_metadata(self):
     # TODO(#2338): Keep this in sync with the `registerDashboard` call
     # on the frontend until that call is removed.
-    return super(InteractiveInferencePlugin, self).frontend_metadata()._replace(
+    return base_plugin.FrontendMetadata(
         element_name='tf-interactive-inference-dashboard',
         tab_name='What-If Tool',
     )

--- a/tensorboard/plugins/mesh/mesh_plugin.py
+++ b/tensorboard/plugins/mesh/mesh_plugin.py
@@ -145,9 +145,7 @@ class MeshPlugin(base_plugin.TBPlugin):
     return bool(self._multiplexer and any(six.itervalues(all_runs)))
 
   def frontend_metadata(self):
-    return super(MeshPlugin, self).frontend_metadata()._replace(
-        element_name='mesh-dashboard',
-    )
+    return base_plugin.FrontendMetadata(element_name='mesh-dashboard')
 
   def _get_sample(self, tensor_event, sample):
     """Returns a single sample from a batch of samples."""

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin.py
@@ -341,7 +341,7 @@ class PrCurvesPlugin(base_plugin.TBPlugin):
     return any(six.itervalues(all_runs))
 
   def frontend_metadata(self):
-    return super(PrCurvesPlugin, self).frontend_metadata()._replace(
+    return base_plugin.FrontendMetadata(
         element_name='tf-pr-curve-dashboard',
         tab_name='PR Curves',
     )

--- a/tensorboard/plugins/profile/profile_plugin.py
+++ b/tensorboard/plugins/profile/profile_plugin.py
@@ -138,7 +138,7 @@ class ProfilePlugin(base_plugin.TBPlugin):
   def frontend_metadata(self):
     # TODO(#2338): Keep this in sync with the `registerDashboard` call
     # on the frontend until that call is removed.
-    return super(ProfilePlugin, self).frontend_metadata()._replace(
+    return base_plugin.FrontendMetadata(
         element_name='tf-profile-dashboard',
         disable_reload=True,
     )

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -307,7 +307,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
     return False
 
   def frontend_metadata(self):
-    return super(ProjectorPlugin, self).frontend_metadata()._replace(
+    return base_plugin.FrontendMetadata(
         es_module_path='/index.js',
         disable_reload=True,
     )

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -94,9 +94,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
     return bool(self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME))
 
   def frontend_metadata(self):
-    return super(ScalarsPlugin, self).frontend_metadata()._replace(
-        element_name='tf-scalar-dashboard',
-    )
+    return base_plugin.FrontendMetadata(element_name='tf-scalar-dashboard')
 
   def index_impl(self, experiment=None):
     """Return {runName: {tagName: {displayName: ..., description: ...}}}."""

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -215,9 +215,7 @@ class TextPlugin(base_plugin.TBPlugin):
     return bool(self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME))
 
   def frontend_metadata(self):
-    return super(TextPlugin, self).frontend_metadata()._replace(
-        element_name='tf-text-dashboard',
-    )
+    return base_plugin.FrontendMetadata(element_name='tf-text-dashboard')
 
   def index_impl(self):
     mapping = self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME)


### PR DESCRIPTION
Summary:
We used `namedtuple` for `FrontendMetadata` for convenience, but it’s
not actually semantically appropriate. Metadata objects shouldn’t be
iterable, for instance. Using a normal struct also enables us to define
default values, so plugins can drop the `super(…).…._replace` dance.

These APIs are still marked as experimental until 1.15, so this
backward-incompatible change is okay.

Prior discussions:

  - <https://github.com/tensorflow/tensorboard/pull/2529#discussion_r312666985>
  - <https://news.ycombinator.com/item?id=15132670>

Test Plan:
Unit tests for the new struct included; existing tests pass, including
the smoke test, and a manual spot check passes muster.

wchargin-branch: frontend-metadata-struct
