### PR TITLE
build: make use of tf_ts_library

### DIFF
--- a/tensorboard/components/tf_ng_tensorboard/core/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/core/BUILD
@@ -2,7 +2,7 @@ package(default_visibility = ["//tensorboard:internal"])
 
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 ng_module(
     name = "core",
@@ -21,7 +21,7 @@ ng_module(
     ],
 )
 
-ts_library(
+tf_ts_library(
     name = "test_util",
     testonly = True,
     srcs = ["test_util.ts"],
@@ -30,7 +30,7 @@ ts_library(
     ],
 )
 
-ts_library(
+tf_ts_library(
     name = "core_effects_test_lib",
     testonly = True,
     srcs = [

--- a/tensorboard/components/tf_ng_tensorboard/header/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/header/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -24,7 +24,7 @@ ng_module(
     ],
 )
 
-ts_library(
+tf_ts_library(
     name = "test_lib",
     testonly = True,
     srcs = [

--- a/tensorboard/components/tf_ng_tensorboard/plugins/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/plugins/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -23,7 +23,7 @@ ng_module(
     ],
 )
 
-ts_library(
+tf_ts_library(
     name = "plugins_component_test_lib",
     testonly = True,
     srcs = [

--- a/tensorboard/components/tf_ng_tensorboard/testing/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/testing/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 filegroup(
     name = "test_support_lib",
@@ -11,7 +11,7 @@ filegroup(
     ],
 )
 
-ts_library(
+tf_ts_library(
     name = "initialize_testbed",
     testonly = 1,
     srcs = [

--- a/tensorboard/components/tf_ng_tensorboard/types/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/types/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 # TODO(stephanwlee): move this into shareable place and use it in Polymer-based
 # modules when Angular is ready to be built as part of TensorBoard.
-ts_library(
+tf_ts_library(
     name = "types",
     srcs = [
         "api.ts",


### PR DESCRIPTION
For Google sync, we decided to create a wrapper around ts_library in #2596.

This change applies the fix to all existing `ts_library`s.

WANT_LGTM=any