### PR TITLE
build: make ng source sync-able

### DIFF
--- a/tensorboard/components/tf_ng_tensorboard/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/BUILD
@@ -1,8 +1,7 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_karma//:defs.bzl", "ts_web_test_suite")
-load("//tensorboard/defs:defs.bzl", "tf_js_binary")
+load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_web_test_suite")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -11,7 +10,6 @@ tf_web_library(
     name = "tf_ng_tensorboard",
     srcs = [
         ":tf_ng_tensorboard_binary.js",
-        "@npm//:node_modules/zone.js/dist/zone.js",
     ],
     path = "/tf-ng-tensorboard",
     deps = [
@@ -35,6 +33,8 @@ tf_js_binary(
     entry_point = ":main.ts",
     deps = [
         ":ng_main",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_tabs",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_toolbar",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@angular/material",
@@ -71,31 +71,24 @@ ng_module(
         "app.component.html",
     ],
     deps = [
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_platform_browser_animations",
         "//tensorboard/components/tf_ng_tensorboard/core",
         "//tensorboard/components/tf_ng_tensorboard/header",
         "//tensorboard/components/tf_ng_tensorboard/plugins",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
+        "@npm//@ngrx/effects",
         "@npm//@ngrx/store",
     ],
 )
 
 # Karma has overhead of bootstrap/tearDown. Combine as much testcases
 # as possible into one test target and use test sharding to speed up.
-ts_web_test_suite(
+tf_ng_web_test_suite(
     name = "karma_test",
-    srcs = [],
-    bootstrap = [
-        "@npm//:node_modules/zone.js/dist/zone-testing-bundle.js",
-        "@npm//:node_modules/reflect-metadata/Reflect.js",
-    ],
-    runtime_deps = [
-        "//tensorboard/components/tf_ng_tensorboard/testing:initialize_testbed",
-    ],
     deps = [
         "//tensorboard/components/tf_ng_tensorboard/core:core_effects_test_lib",
         "//tensorboard/components/tf_ng_tensorboard/header:test_lib",
         "//tensorboard/components/tf_ng_tensorboard/plugins:plugins_component_test_lib",
-        "//tensorboard/components/tf_ng_tensorboard/testing:test_support_lib",
     ],
 )

--- a/tensorboard/components/tf_ng_tensorboard/angular/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/angular/BUILD
@@ -1,0 +1,62 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+licenses(["notice"])  # Apache 2.0
+
+# This is a dummy rule used as a @angular/common/http dependency.
+# This is not a replacement for @angular/common dependency.
+tf_ts_library(
+    name = "expect_angular_common_http",
+    srcs = [],
+)
+
+# This is a dummy rule used as a @angular/common/testing dependency.
+# This is not a replacement for @angular/common dependency.
+tf_ts_library(
+    name = "expect_angular_common_http_testing",
+    srcs = [],
+)
+
+# This is a dummy rule used as a @angular/core/testing dependency.
+# This is not a replacement for @angular/core dependency.
+tf_ts_library(
+    name = "expect_angular_core_testing",
+    srcs = [],
+    deps = [
+        "@npm//@angular/core",
+    ],
+)
+
+# This is a dummy rule used as a @angular/material/tabs dependency.
+tf_ts_library(
+    name = "expect_angular_material_tabs",
+    srcs = [],
+    deps = [
+        "@npm//@angular/material",
+    ],
+)
+
+# This is a dummy rule used as a @angular/material/toolbar dependency.
+tf_ts_library(
+    name = "expect_angular_material_toolbar",
+    srcs = [],
+    deps = [
+        "@npm//@angular/material",
+    ],
+)
+
+# This is a dummy rule used as a @angular/platform-browser/animations dependency.
+# This is not a replacement for @angular/platform-browser dependency.
+tf_ts_library(
+    name = "expect_angular_platform_browser_animations",
+    srcs = [],
+)
+
+# This is a dummy rule used as a @angular/platform-browser-dynamic/testing dependency.
+# This is not a replacement for @angular/platform-browser-dynamic dependency.
+tf_ts_library(
+    name = "expect_angular_platform_browser_dynamic_testing",
+    srcs = [],
+    deps = ["@npm//@angular/platform-browser-dynamic"],
+)

--- a/tensorboard/components/tf_ng_tensorboard/app.component.ts
+++ b/tensorboard/components/tf_ng_tensorboard/app.component.ts
@@ -17,7 +17,7 @@ import {Store} from '@ngrx/store';
 import {State} from './core/core.reducers';
 import {coreLoaded} from './core/core.actions';
 
-import * as _typeHackRxjs from 'rxjs';
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Component({
   selector: 'tf-ng-tensorboard',

--- a/tensorboard/components/tf_ng_tensorboard/app.module.ts
+++ b/tensorboard/components/tf_ng_tensorboard/app.module.ts
@@ -37,8 +37,6 @@ import {HeaderModule} from './header/header.module';
     StoreModule.forRoot(ROOT_REDUCERS, {
       metaReducers,
       runtimeChecks: {
-        strictStateImmutability: true,
-        strictActionImmutability: true,
         strictStateSerializability: true,
         strictActionSerializability: true,
       },

--- a/tensorboard/components/tf_ng_tensorboard/core/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/core/BUILD
@@ -14,10 +14,12 @@ ng_module(
         "core.service.ts",
     ],
     deps = [
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_common_http",
         "//tensorboard/components/tf_ng_tensorboard/types",
         "@npm//@angular/common",
         "@npm//@ngrx/effects",
         "@npm//@ngrx/store",
+        "@npm//rxjs",
     ],
 )
 
@@ -40,6 +42,8 @@ tf_ts_library(
     deps = [
         ":core",
         ":test_util",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_common_http_testing",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_core_testing",
         "//tensorboard/components/tf_ng_tensorboard/types",
         "@npm//@angular/common",
         "@npm//@angular/compiler",
@@ -60,6 +64,7 @@ ng_module(
     deps = [
         ":core",
         ":test_util",
+        "@npm//@types/chai",
         "@npm//@types/jasmine",
         "@npm//chai",
     ],
@@ -67,7 +72,10 @@ ng_module(
 
 jasmine_node_test(
     name = "core_jasmine_test",
-    deps = [
+    srcs = [
         ":core_reducers_test_lib",
+    ],
+    deps = [
+        "@npm//chai",
     ],
 )

--- a/tensorboard/components/tf_ng_tensorboard/core/core.actions.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.actions.ts
@@ -17,7 +17,7 @@ import {PluginId, PluginsListing} from '../types/api';
 
 // HACK: Below import is for type inference.
 // https://github.com/bazelbuild/rules_nodejs/issues/1013
-import * as _typeHackModels from '@ngrx/store/src/models';
+/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
 
 export const changePlugin = createAction(
   '[Core] Plugin Changed',

--- a/tensorboard/components/tf_ng_tensorboard/core/core.effects.test.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.effects.test.ts
@@ -27,7 +27,7 @@ import {CoreService} from './core.service';
 
 import {createPluginMetadata} from './test_util';
 
-import {PluginsListing, LoadingMechanismType} from '../types/api';
+import {PluginsListing} from '../types/api';
 
 describe('core.effects', () => {
   let httpMock: HttpTestingController;
@@ -55,15 +55,16 @@ describe('core.effects', () => {
     // Assertion/exception in the subscribe does not fail the test.
     // Store the result
     let res = null;
-    const promise = coreEffects.loadPluginsListing$.subscribe((action) => {
-      res = action;
+    coreEffects.loadPluginsListing$.subscribe((action) => {
+      res = action as Action;
     });
     action.next(coreActions.coreLoaded());
     // Flushing the request response invokes above subscription sychronously.
     httpMock.expectOne('data/plugins_listing').flush(pluginsListing);
 
-    expect(res).toEqual(
-      coreActions.pluginsListingLoaded({plugins: pluginsListing})
-    );
+    const expected = coreActions.pluginsListingLoaded({
+      plugins: pluginsListing,
+    });
+    expect(res).toEqual(expected as any);
   });
 });

--- a/tensorboard/components/tf_ng_tensorboard/core/core.effects.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.effects.ts
@@ -16,6 +16,7 @@ import {Injectable} from '@angular/core';
 import {Actions, ofType, createEffect} from '@ngrx/effects';
 import {of} from 'rxjs';
 import {map, flatMap, catchError} from 'rxjs/operators';
+
 import {CoreService} from './core.service';
 import {
   coreLoaded,
@@ -23,11 +24,16 @@ import {
   pluginsListingFailed,
 } from './core.actions';
 
-import * as _typeHackRxjs from 'rxjs';
-import * as _typeHackNgrx from '@ngrx/store/src/models';
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+/** @typehack */ import * as _typeHackNgrx from '@ngrx/store/src/models';
 
 @Injectable()
 export class CoreEffects {
+  /**
+   * Requires to be exported for JSCompiler. JSCompiler, otherwise,
+   * think it is unused property and deadcode eliminate away.
+   */
+  /** @export */
   loadPluginsListing$ = createEffect(() =>
     this.actions$.pipe(
       ofType(coreLoaded),

--- a/tensorboard/components/tf_ng_tensorboard/core/core.reducers.test.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.reducers.test.ts
@@ -16,7 +16,6 @@ import {expect} from 'chai';
 
 import * as actions from './core.actions';
 import {reducers} from './core.reducers';
-import {PluginMetadata, LoadingMechanismType} from '../types/api';
 import {createPluginMetadata} from './test_util';
 
 function createPluginsListing() {

--- a/tensorboard/components/tf_ng_tensorboard/core/core.reducers.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.reducers.ts
@@ -24,13 +24,13 @@ import * as actions from './core.actions';
 
 // HACK: These imports are for type inference.
 // https://github.com/bazelbuild/rules_nodejs/issues/1013
-import * as _typeHackSelector from '@ngrx/store/src/selector';
-import * as _typeHackStore from '@ngrx/store/store';
+/** @typehack */ import * as _typeHackSelector from '@ngrx/store/src/selector';
+/** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
 
 export const CORE_FEATURE_KEY = 'core';
 
 export interface CoreState {
-  activePlugin: PluginId;
+  activePlugin: PluginId | null;
   plugins: PluginsListing;
 }
 
@@ -66,7 +66,7 @@ const selectCoreState = createFeatureSelector<State, CoreState>(
 
 export const getActivePlugin = createSelector(
   selectCoreState,
-  (state: CoreState): PluginId => {
+  (state: CoreState): PluginId | null => {
     return state.activePlugin;
   }
 );

--- a/tensorboard/components/tf_ng_tensorboard/core/core.service.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.service.ts
@@ -17,7 +17,7 @@ import {HttpClient} from '@angular/common/http';
 
 import {PluginsListing} from '../types/api';
 
-import * as _typeHackRxjs from 'rxjs';
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Injectable()
 export class CoreService {

--- a/tensorboard/components/tf_ng_tensorboard/header/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/header/BUILD
@@ -16,11 +16,13 @@ ng_module(
         "containers/header.component.html",
     ],
     deps = [
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_tabs",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_toolbar",
         "//tensorboard/components/tf_ng_tensorboard/core",
         "@npm//@angular/common",
         "@npm//@angular/core",
-        "@npm//@angular/material",
         "@npm//@ngrx/store",
+        "@npm//rxjs",
     ],
 )
 
@@ -33,12 +35,15 @@ tf_ts_library(
     tsconfig = "//:tsconfig-test",
     deps = [
         ":header",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_core_testing",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_tabs",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_toolbar",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_platform_browser_animations",
         "//tensorboard/components/tf_ng_tensorboard/core",
         "//tensorboard/components/tf_ng_tensorboard/core:test_util",
         "@npm//@angular/common",
         "@npm//@angular/compiler",
         "@npm//@angular/core",
-        "@npm//@angular/material",
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/store",
         "@npm//@types/jasmine",

--- a/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.test.ts
+++ b/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.test.ts
@@ -27,7 +27,7 @@ import {changePlugin} from '../../core/core.actions';
 import {State, CoreState, CORE_FEATURE_KEY} from '../../core/core.reducers';
 import {createPluginMetadata} from '../../core/test_util';
 
-import * as _typeHackStore from '@ngrx/store';
+/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('header.component', () => {
   let store: MockStore<State>;

--- a/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.ts
+++ b/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.ts
@@ -19,7 +19,7 @@ import {combineLatest, of} from 'rxjs';
 import {State, getActivePlugin, getPlugins} from '../../core/core.reducers';
 import {changePlugin} from '../../core/core.actions';
 
-import * as _typeHackRxjs from 'rxjs';
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 const selectPlugins = createSelector(
   getPlugins,

--- a/tensorboard/components/tf_ng_tensorboard/plugins/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/plugins/BUILD
@@ -17,6 +17,7 @@ ng_module(
     ],
     deps = [
         "//tensorboard/components/tf_ng_tensorboard/core",
+        "//tensorboard/components/tf_ng_tensorboard/types",
         "@npm//@angular/core",
         "@npm//@ngrx/store",
         "@npm//rxjs",
@@ -32,6 +33,7 @@ tf_ts_library(
     tsconfig = "//:tsconfig-test",
     deps = [
         ":plugins",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_core_testing",
         "//tensorboard/components/tf_ng_tensorboard/core",
         "//tensorboard/components/tf_ng_tensorboard/types",
         "@npm//@angular/common",

--- a/tensorboard/components/tf_ng_tensorboard/plugins/plugins.component.test.ts
+++ b/tensorboard/components/tf_ng_tensorboard/plugins/plugins.component.test.ts
@@ -22,7 +22,7 @@ import {PluginsComponent} from './plugins.component';
 import {PluginId, LoadingMechanismType} from '../types/api';
 import {State, CORE_FEATURE_KEY} from '../core/core.reducers';
 
-import * as _typeHackStore from '@ngrx/store';
+/** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('plugins.component', () => {
   let store: MockStore<State>;

--- a/tensorboard/components/tf_ng_tensorboard/plugins/plugins.component.ts
+++ b/tensorboard/components/tf_ng_tensorboard/plugins/plugins.component.ts
@@ -14,16 +14,17 @@ limitations under the License.
 ==============================================================================*/
 import {Component, ElementRef, ViewChild} from '@angular/core';
 import {Store, select, createSelector} from '@ngrx/store';
-import {State, getPlugins, getActivePlugin} from '../core/core.reducers';
 import {filter} from 'rxjs/operators';
 
-import * as _typeHackRxjs from 'rxjs';
+import {State, getPlugins, getActivePlugin} from '../core/core.reducers';
 import {
   PluginMetadata,
   LoadingMechanismType,
   CustomElementLoadingMechanism,
   IframeLoadingMechanism,
 } from '../types/api';
+
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 interface UiPluginMetadata extends PluginMetadata {
   id: string;
@@ -32,7 +33,7 @@ interface UiPluginMetadata extends PluginMetadata {
 const activePlugin = createSelector(
   getPlugins,
   getActivePlugin,
-  (plugins, id): UiPluginMetadata => {
+  (plugins, id): UiPluginMetadata | null => {
     if (!id || !plugins) return null;
     return Object.assign({id}, plugins[id]);
   }
@@ -57,7 +58,7 @@ export class PluginsComponent {
     // an iframe) when the `activePlugin` changes.
     this.activePlugin$
       .pipe(filter(Boolean))
-      .subscribe((plugin) => this.renderPlugin(plugin));
+      .subscribe((plugin) => this.renderPlugin(plugin as UiPluginMetadata));
   }
 
   private renderPlugin(plugin: UiPluginMetadata) {
@@ -66,7 +67,8 @@ export class PluginsComponent {
     }
 
     if (this.pluginInstances.has(plugin.id)) {
-      this.pluginInstances.get(plugin.id).style.display = null;
+      const instance = this.pluginInstances.get(plugin.id) as HTMLElement;
+      instance.style.display = null;
       return;
     }
 
@@ -90,7 +92,7 @@ export class PluginsComponent {
         const iframePlugin = plugin.loading_mechanism as IframeLoadingMechanism;
         pluginElement = document.createElement('iframe');
         this.pluginsContainer.nativeElement.appendChild(pluginElement);
-        const subdocument = pluginElement.contentDocument;
+        const subdocument = pluginElement.contentDocument as HTMLDocument;
         const script = subdocument.createElement('script');
         const baseHrefString = JSON.stringify(
           new URL(`data/${pluginId}/`, window.location.href)

--- a/tensorboard/components/tf_ng_tensorboard/testing/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/testing/BUILD
@@ -2,6 +2,8 @@ package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
+licenses(["notice"])
+
 filegroup(
     name = "test_support_lib",
     srcs = [
@@ -18,7 +20,7 @@ tf_ts_library(
         "initialize_testbed.ts",
     ],
     deps = [
-        "@npm//@angular/core",
-        "@npm//@angular/platform-browser-dynamic",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_core_testing",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_platform_browser_dynamic_testing",
     ],
 )

--- a/tensorboard/components/tf_ng_tensorboard/types/api.ts
+++ b/tensorboard/components/tf_ng_tensorboard/types/api.ts
@@ -27,27 +27,37 @@ export enum LoadingMechanismType {
 }
 
 export interface CustomElementLoadingMechanism {
+  /** @export */
   type: LoadingMechanismType.CUSTOM_ELEMENT;
+  /** @export */
   element_name: string;
 }
 
 export interface IframeLoadingMechanism {
+  /** @export */
   type: LoadingMechanismType.IFRAME;
+  /** @export */
   module_path: string;
 }
 
 export interface NoLoadingMechanism {
+  /** @export */
   type: LoadingMechanismType.NONE;
 }
 
 export interface PluginMetadata {
+  /** @export */
   disable_reload: boolean;
+  /** @export */
   enabled: boolean;
+  /** @export */
   loading_mechanism:
     | CustomElementLoadingMechanism
     | IframeLoadingMechanism
     | NoLoadingMechanism;
+  /** @export */
   tab_name: string;
+  /** @export */
   remove_dom: boolean;
 }
 

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -14,6 +14,7 @@
 """External-only delegates for various BUILD rules."""
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
+load("@npm_bazel_karma//:defs.bzl", "karma_web_test_suite")
 load("@npm_bazel_typescript//:index.bzl", "ts_config", "ts_devserver", "ts_library")
 
 def tensorboard_webcomponent_library(**kwargs):
@@ -45,3 +46,24 @@ def tf_ts_devserver(**kwargs):
     """TensorBoard wrapper for the rule for a TypeScript dev server."""
 
     ts_devserver(**kwargs)
+
+def tf_ng_web_test_suite(runtime_deps = [], bootstrap = [], deps = [], **kwargs):
+    """TensorBoard wrapper for the rule for a Karma web test suite.
+
+    It has Angular specific configurations that we want as defaults.
+    """
+
+    karma_web_test_suite(
+        srcs = [],
+        bootstrap = bootstrap + [
+            "@npm//:node_modules/zone.js/dist/zone-testing-bundle.js",
+            "@npm//:node_modules/reflect-metadata/Reflect.js",
+        ],
+        runtime_deps = runtime_deps + [
+            "//tensorboard/components/tf_ng_tensorboard/testing:initialize_testbed",
+        ],
+        deps = deps + [
+            "//tensorboard/components/tf_ng_tensorboard/testing:test_support_lib",
+        ],
+        **kwargs
+    )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
-    "inlineSourceMap": true,
-    "moduleResolution": "node",
-    "skipLibCheck": true,
-    "noResolve": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
-    "strictPropertyInitialization": true,
+    "inlineSourceMap": true,
     "lib": ["dom", "es2018"],
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "noResolve": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
     "types": []
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     "noResolve": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "strictPropertyInitialization": true,
     "lib": ["dom", "es2018"],
     "types": []
   }


### PR DESCRIPTION
In this change:
- made tsconfig more strict to roughly reflect internal one
- TypeScript code change to conform to the stricer rule
- created "expected_*" target to denote internal compat dependency graph
- defined missing bazel deps
- the type hacks are annotated for easier migration
- `export` annotation for JSCompiler compatibility.

Corresponding change is cl/266471999.
I have tried `bazel test tensorboard/components/tf_ng_tensorboard/...` both internally and externally after the change.