### PR TITLE
Properly handle bad requests to plugin data endpoints

### DIFF
--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
@@ -74,12 +74,21 @@ class ExamplePlugin(base_plugin.TBPlugin):
 
   @wrappers.Request.application
   def _serve_greetings(self, request):
-    run = request.args["run"]
-    tag = request.args["tag"]
-    data = [
-        np.asscalar(tensor_util.make_ndarray(event.tensor_proto))
-            .decode("utf-8")
-        for event in self._multiplexer.Tensors(run, tag)
-    ]
+    run = request.args.get("run")
+    tag = request.args.get("tag")
+    if run is None or tag is None:
+      return werkzeug.Response(
+          "Must specify run and tag",
+          content_type="text/plain",
+          code=400,
+      )
+    try:
+      data = [
+          np.asscalar(tensor_util.make_ndarray(event.tensor_proto))
+              .decode("utf-8")
+          for event in self._multiplexer.Tensors(run, tag)
+      ]
+    except KeyError:
+      raise werkzeug.exceptions.BadRequest("Invalid run or tag")
     contents = json.dumps(data, sort_keys=True)
     return werkzeug.Response(contents, content_type="application/json")

--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
@@ -77,11 +77,7 @@ class ExamplePlugin(base_plugin.TBPlugin):
     run = request.args.get("run")
     tag = request.args.get("tag")
     if run is None or tag is None:
-      return werkzeug.Response(
-          "Must specify run and tag",
-          content_type="text/plain",
-          code=400,
-      )
+      raise werkzeug.exceptions.BadRequest("Must specify run and tag")
     try:
       data = [
           np.asscalar(tensor_util.make_ndarray(event.tensor_proto))

--- a/tensorboard/plugins/audio/audio_plugin.py
+++ b/tensorboard/plugins/audio/audio_plugin.py
@@ -140,7 +140,12 @@ class AudioPlugin(base_plugin.TBPlugin):
     sample = int(request.args.get('sample', 0))
 
     events = self._multiplexer.Tensors(run, tag)
-    response = self._audio_response_for_run(events, run, tag, sample)
+    try:
+      response = self._audio_response_for_run(events, run, tag, sample)
+    except KeyError:
+      return http_util.Respond(
+          request, 'Invalid run or tag', 'text/plain', code=400
+      )
     return http_util.Respond(request, response, 'application/json')
 
   def _audio_response_for_run(self, tensor_events, run, tag, sample):
@@ -210,10 +215,15 @@ class AudioPlugin(base_plugin.TBPlugin):
     """Serve encoded audio data."""
     tag = request.args.get('tag')
     run = request.args.get('run')
-    index = int(request.args.get('index'))
-    sample = int(request.args.get('sample', 0))
-    events = self._filter_by_sample(self._multiplexer.Tensors(run, tag), sample)
-    data = tensor_util.make_ndarray(events[index].tensor_proto)[sample, 0]
+    index = int(request.args.get('index', '0'))
+    sample = int(request.args.get('sample', '0'))
+    try:
+      events = self._filter_by_sample(self._multiplexer.Tensors(run, tag), sample)
+      data = tensor_util.make_ndarray(events[index].tensor_proto)[sample, 0]
+    except (KeyError, IndexError):
+      return http_util.Respond(
+          request, 'Invalid run, tag, index, or sample', 'text/plain', code=400
+      )
     mime_type = self._get_mime_type(run, tag)
     return http_util.Respond(request, data, mime_type)
 

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
@@ -125,7 +125,7 @@ class CustomScalarsPlugin(base_plugin.TBPlugin):
           request=request,
           content=str(e),
           content_type='text/plain',
-          code=500)
+          code=400)
     return http_util.Respond(request, body, mime_type)
 
   def download_data_impl(self, run, tag, response_format):
@@ -170,7 +170,6 @@ class CustomScalarsPlugin(base_plugin.TBPlugin):
       payload: Object<string, ScalarEvent[]>,
     }
     """
-    # TODO: return HTTP status code for malformed requests
     tag_regex_string = request.args.get('tag')
     run = request.args.get('run')
     mime_type = 'application/json'
@@ -182,7 +181,7 @@ class CustomScalarsPlugin(base_plugin.TBPlugin):
           request=request,
           content=str(e),
           content_type='text/plain',
-          code=500)
+          code=400)
 
     # Produce the response.
     return http_util.Respond(request, body, mime_type)

--- a/tensorboard/plugins/image/images_plugin.py
+++ b/tensorboard/plugins/image/images_plugin.py
@@ -164,7 +164,12 @@ class ImagesPlugin(base_plugin.TBPlugin):
     tag = request.args.get('tag')
     run = request.args.get('run')
     sample = int(request.args.get('sample', 0))
-    response = self._image_response_for_run(run, tag, sample)
+    try:
+      response = self._image_response_for_run(run, tag, sample)
+    except KeyError:
+      return http_util.Respond(
+          request, 'Invalid run or tag', 'text/plain', code=400
+      )
     return http_util.Respond(request, response, 'application/json')
 
   def _image_response_for_run(self, run, tag, sample):
@@ -325,9 +330,14 @@ class ImagesPlugin(base_plugin.TBPlugin):
     """Serves an individual image."""
     run = request.args.get('run')
     tag = request.args.get('tag')
-    index = int(request.args.get('index'))
-    sample = int(request.args.get('sample', 0))
-    data = self._get_individual_image(run, tag, index, sample)
+    index = int(request.args.get('index', '0'))
+    sample = int(request.args.get('sample', '0'))
+    try:
+      data = self._get_individual_image(run, tag, index, sample)
+    except (KeyError, IndexError):
+      return http_util.Respond(
+          request, 'Invalid run, tag, index, or sample', 'text/plain', code=400
+      )
     image_type = imghdr.what(None, data)
     content_type = _IMGHDR_TO_MIMETYPE.get(image_type, _DEFAULT_IMAGE_MIMETYPE)
     return http_util.Respond(request, data, content_type)

--- a/tensorboard/plugins/mesh/mesh_plugin.py
+++ b/tensorboard/plugins/mesh/mesh_plugin.py
@@ -226,9 +226,12 @@ class MeshPlugin(base_plugin.TBPlugin):
     """
     step = float(request.args.get('step', 0.0))
     tensor_events = self._collect_tensor_events(request, step)
-    content_type = request.args['content_type']
-    content_type = plugin_data_pb2.MeshPluginData.ContentType.Value(
-        content_type)
+    content_type = request.args.get('content_type')
+    try:
+      content_type = plugin_data_pb2.MeshPluginData.ContentType.Value(
+          content_type)
+    except ValueError:
+      return http_util.Respond(request, 'Bad content_type', 'text/plain', 400)
     sample = int(request.args.get('sample', 0))
 
     response = [

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -234,10 +234,14 @@ class ScalarsPlugin(base_plugin.TBPlugin):
   @wrappers.Request.application
   def scalars_route(self, request):
     """Given a tag and single run, return array of ScalarEvents."""
-    # TODO: return HTTP status code for malformed requests
     tag = request.args.get('tag')
     run = request.args.get('run')
     experiment = request.args.get('experiment', '')
     output_format = request.args.get('format')
-    (body, mime_type) = self.scalars_impl(tag, run, experiment, output_format)
+    try:
+      (body, mime_type) = self.scalars_impl(tag, run, experiment, output_format)
+    except KeyError:
+      return http_util.Respond(
+          request, 'Invalid run or tag', 'text/plain', code=400
+      )
     return http_util.Respond(request, body, mime_type)


### PR DESCRIPTION
Summary:
Most\* plugin endpoints for serving actual data have historically tried
to access data from the multiplexer with no validation or error
handling, and as a result would crash and burn (with 500s) given a run
or tag that doesn’t exist. This actually happens fairly commonly: if you
start TensorBoard and interact with the web UI, kill the server while
leaving the browser tab open, and start a new TensorBoard on the same
port but a different log directory, then the old TensorBoard’s refresh
loop will request data from the runs and tags that were previously
available.

These are now properly handled as 400s, not 500s, and they don’t spam
the command line anymore, either. We resolve some TODOs from 2015!

\* Weighted by frequency of use. :-) By raw counts, more plugins behaved
well than ill!

Test Plan:
Visit the following endpoints, and verify that each one responds with a
500 Internal Server Error before this patch, but a 400 Bad Request (with
human-readable message) after this patch:

  - <http://localhost:6006/data/plugin/audio/audio>
  - <http://localhost:6006/data/plugin/audio/individualAudio>
  - <http://localhost:6006/data/plugin/example_basic/greetings?run=&tag=>
  - <http://localhost:6006/data/plugin/images/images>
  - <http://localhost:6006/data/plugin/images/individualImage>
  - <http://localhost:6006/data/plugin/mesh/data?content_type=>
  - <http://localhost:6006/data/plugin/scalars/scalars>

wchargin-branch: keyerror-400
