### PR TITLE
scalars: include experiment ID in download links

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -252,7 +252,12 @@ limitations under the License.
         _downloadUrlFn: {
           type: Function,
           value: function() {
-            return (tag, run) => this.getDataLoadUrl({tag, run});
+            return (tag, run) =>
+              this.getDataLoadUrl({
+                tag,
+                run,
+                experiment: tf_backend.getExperimentId(),
+              });
           },
         },
 


### PR DESCRIPTION
Test Plan:
Visit <http://localhost:6006/?experiment=foo#scalars>, check the “Show
data download links” box, select a run from the dropdown, and verify
that the “CSV” and “JSON” links have `&experiment=foo` query parameters.

wchargin-branch: scalars-xid-download
