### PR TITLE
ng: render inactive plugins

### DIFF
--- a/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.css
+++ b/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.css
@@ -29,9 +29,33 @@ mat-tab-group {
   flex: 0 0 auto;
 }
 
-.mat-tab-group {
+.plugins {
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  font-size: 14px;
+  height: 100%;
+  overflow: hidden;
+}
+
+mat-tab-group {
   flex: 1 1 auto;
   overflow: hidden;
+}
+
+mat-form-field {
+  flex: 0 0;
+  /* visually center align with _text_ of the select to the center. */
+  margin-top: 5px;
+  /* default width is 180px */
+  width: 130px;
+}
+
+mat-label,
+mat-select,
+mat-option {
+  font-weight: 500;
+  text-transform: uppercase;
 }
 
 /deep/ .tb-toolbar .mat-tab-header,
@@ -41,5 +65,15 @@ mat-tab-group {
 }
 
 /deep/ .tb-toolbar .mat-tab-label {
+  min-width: 48px; /* default is 160px which is too big for us */
+  padding: 0 12px; /* default is 24px */
   text-transform: uppercase;
+}
+
+/deep/ .tb-toolbar mat-tab-group .mat-tab-header-pagination-disabled {
+  visibility: hidden;
+}
+
+/deep/ .tb-toolbar .mat-tab-disabled {
+  display: none;
 }

--- a/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.html
+++ b/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.html
@@ -16,13 +16,37 @@ limitations under the License.
 -->
 <mat-toolbar class="tb-toolbar">
   <span class="brand">TensorBoard</span>
-  <mat-tab-group
-    [selectedIndex]="activePluginIndex$ | async"
-    (selectedIndexChange)="onPluginSelectionChanged($event)"
-  >
-    <mat-tab *ngFor="let plugin of plugins$ | async" [label]="plugin.tab_name">
-    </mat-tab>
-  </mat-tab-group>
+  <span class="plugins">
+    <mat-tab-group
+      [selectedIndex]="activePluginIndex$ | async"
+      (selectedTabChange)="onPluginSelectionChanged($event)"
+      animationDuration="100ms"
+    >
+      <mat-tab
+        *ngFor="let plugin of plugins$ | async"
+        [label]="plugin.tab_name"
+        [disabled]="!plugin.enabled"
+      >
+      </mat-tab>
+    </mat-tab-group>
+    <mat-form-field
+      floatLabel="never"
+      *ngIf="(disabledPlugins$ | async)?.length > 0"
+    >
+      <mat-label>Inactive</mat-label>
+      <mat-select
+        [value]="activePlugin$ | async"
+        (selectionChange)="onDisabledPluginSelectionChanged($event)"
+      >
+        <mat-option
+          *ngFor="let plugin of disabledPlugins$ | async"
+          [value]="plugin.id"
+        >
+          {{ plugin.tab_name }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </span>
   <span class="settings">
     settings go here
   </span>

--- a/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.test.ts
+++ b/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.test.ts
@@ -16,6 +16,7 @@ import {DebugElement} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {MatTabsModule} from '@angular/material/tabs';
 import {MatToolbarModule} from '@angular/material/toolbar';
+import {MatSelectModule} from '@angular/material/select';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Store} from '@ngrx/store';
@@ -50,7 +51,12 @@ describe('header.component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MatTabsModule, MatToolbarModule, NoopAnimationsModule],
+      imports: [
+        MatTabsModule,
+        MatToolbarModule,
+        NoopAnimationsModule,
+        MatSelectModule,
+      ],
       providers: [
         provideMockStore({initialState: createInitialState()}),
         HeaderComponent,

--- a/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.ts
+++ b/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.ts
@@ -13,29 +13,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Component} from '@angular/core';
+import {MatTabChangeEvent} from '@angular/material/tabs';
+import {MatSelectChange} from '@angular/material/select';
 import {Store, select, createSelector} from '@ngrx/store';
 import {combineLatest, of} from 'rxjs';
 
 import {State, getActivePlugin, getPlugins} from '../../core/core.reducers';
 import {changePlugin} from '../../core/core.actions';
 
+import {PluginMetadata, PluginId} from '../../types/api';
+
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
+
+interface UiPluginMetadata extends PluginMetadata {
+  id: PluginId;
+}
 
 const selectPlugins = createSelector(
   getPlugins,
-  (listing) =>
+  (listing): UiPluginMetadata[] =>
     Object.keys(listing).map((key) =>
       Object.assign({}, {id: key}, listing[key])
     )
 );
 
+const selectDisabledPlugins = createSelector(
+  selectPlugins,
+  (plugins): UiPluginMetadata[] => plugins.filter((plugin) => !plugin.enabled)
+);
+
 const selectActivePluginIndex = createSelector(
-  getPlugins,
+  selectPlugins,
   getActivePlugin,
   (plugins, activePlugin) => {
-    return Object.keys(plugins).findIndex(
-      (pluginId) => pluginId === activePlugin
-    );
+    return plugins.findIndex((plugin) => plugin.id === activePlugin);
   }
 );
 
@@ -45,15 +56,23 @@ const selectActivePluginIndex = createSelector(
   styleUrls: ['./header.component.css'],
 })
 export class HeaderComponent {
-  activePluginIndex$ = this.store.pipe(select(selectActivePluginIndex));
-  plugins$ = this.store.pipe(select(selectPlugins));
+  readonly activePlugin$ = this.store.pipe(select(getActivePlugin));
+  readonly activePluginIndex$ = this.store.pipe(
+    select(selectActivePluginIndex)
+  );
+  readonly plugins$ = this.store.pipe(select(selectPlugins));
+  readonly disabledPlugins$ = this.store.pipe(select(selectDisabledPlugins));
 
-  constructor(private store: Store<State>) {}
+  constructor(private readonly store: Store<State>) {}
 
-  onPluginSelectionChanged(index: number) {
+  onPluginSelectionChanged({index}: MatTabChangeEvent) {
     const index$ = of(index);
     combineLatest(this.plugins$, index$).subscribe(([plugins, index]) => {
       this.store.dispatch(changePlugin({plugin: plugins[index].id}));
     });
+  }
+
+  onDisabledPluginSelectionChanged(selectChangeEvent: MatSelectChange) {
+    this.store.dispatch(changePlugin({plugin: selectChangeEvent.value}));
   }
 }

--- a/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.ts
+++ b/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.ts
@@ -29,7 +29,7 @@ interface UiPluginMetadata extends PluginMetadata {
   id: PluginId;
 }
 
-const selectPlugins = createSelector(
+const getUiPlugins = createSelector(
   getPlugins,
   (listing): UiPluginMetadata[] =>
     Object.keys(listing).map((key) =>
@@ -37,13 +37,13 @@ const selectPlugins = createSelector(
     )
 );
 
-const selectDisabledPlugins = createSelector(
-  selectPlugins,
+const getDisabledPlugins = createSelector(
+  getUiPlugins,
   (plugins): UiPluginMetadata[] => plugins.filter((plugin) => !plugin.enabled)
 );
 
-const selectActivePluginIndex = createSelector(
-  selectPlugins,
+const getActivePluginIndex = createSelector(
+  getUiPlugins,
   getActivePlugin,
   (plugins, activePlugin) => {
     return plugins.findIndex((plugin) => plugin.id === activePlugin);
@@ -57,11 +57,9 @@ const selectActivePluginIndex = createSelector(
 })
 export class HeaderComponent {
   readonly activePlugin$ = this.store.pipe(select(getActivePlugin));
-  readonly activePluginIndex$ = this.store.pipe(
-    select(selectActivePluginIndex)
-  );
-  readonly plugins$ = this.store.pipe(select(selectPlugins));
-  readonly disabledPlugins$ = this.store.pipe(select(selectDisabledPlugins));
+  readonly activePluginIndex$ = this.store.pipe(select(getActivePluginIndex));
+  readonly plugins$ = this.store.pipe(select(getUiPlugins));
+  readonly disabledPlugins$ = this.store.pipe(select(getDisabledPlugins));
 
   constructor(private readonly store: Store<State>) {}
 

--- a/tensorboard/components/tf_ng_tensorboard/header/header.module.ts
+++ b/tensorboard/components/tf_ng_tensorboard/header/header.module.ts
@@ -18,6 +18,7 @@ import {CommonModule} from '@angular/common';
 
 import {MatTabsModule} from '@angular/material/tabs';
 import {MatToolbarModule} from '@angular/material/toolbar';
+import {MatSelectModule} from '@angular/material/select';
 
 import {HeaderComponent} from './containers/header.component';
 import {CoreModule} from '../core/core.module';
@@ -26,6 +27,12 @@ import {CoreModule} from '../core/core.module';
   declarations: [HeaderComponent],
   exports: [HeaderComponent],
   providers: [],
-  imports: [MatToolbarModule, MatTabsModule, CommonModule, CoreModule],
+  imports: [
+    MatToolbarModule,
+    MatTabsModule,
+    MatSelectModule,
+    CommonModule,
+    CoreModule,
+  ],
 })
 export class HeaderModule {}


### PR DESCRIPTION
Inactive plugins are supposed to show up in the dropdown list.
This change renders the inactive plugins correctly.

Screenshot:
![image](https://user-images.githubusercontent.com/2547313/64438908-c66c8180-d07d-11e9-885a-82ae005cf00f.png)
