### PR TITLE
Update protobuf and protobuf_js workspace deps to 3.8.0 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,11 +82,13 @@ install_bazel_dependencies()
 
 http_archive(
     name = "org_tensorflow",
-    sha256 = "9b838466b71f5c53bf9c2015704bd1f431511bf49e363fc7b0af64b00ddf35be",
-    strip_prefix = "tensorflow-dad4197fcf00186df0fe2842228750f484d72b40",
+    # NOTE: when updating this, MAKE SURE to also update the protobuf_js runtime version
+    # in third_party/workspace.bzl to >= the protobuf/protoc version provided by TF.
+    sha256 = "48ddba718da76df56fd4c48b4bbf4f97f254ba269ec4be67f783684c75563ef8",
+    strip_prefix = "tensorflow-2.0.0-rc0",
     urls = [
-        "http://mirror.tensorflow.org/github.com/tensorflow/tensorflow/archive/dad4197fcf00186df0fe2842228750f484d72b40.tar.gz",  # 2019-06-24
-        "https://github.com/tensorflow/tensorflow/archive/dad4197fcf00186df0fe2842228750f484d72b40.tar.gz",
+        "http://mirror.tensorflow.org/github.com/tensorflow/tensorflow/archive/v2.0.0-rc0.tar.gz",  # 2019-08-23
+        "https://github.com/tensorflow/tensorflow/archive/v2.0.0-rc0.tar.gz",
     ],
 )
 

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -39,11 +39,12 @@ def tensorboard_workspace():
 
   http_archive(
       name = "com_google_protobuf_js",
-      strip_prefix = "protobuf-3.6.0/js",
-      sha256 = "50a5753995b3142627ac55cfd496cebc418a2e575ca0236e29033c67bd5665f4",
+      # NOTE: keep the version in sync with the protobuf/protoc version from TF in WORKSPACE.
+      sha256 = "03d2e5ef101aee4c2f6ddcf145d2a04926b9c19e7086944df3842b1b8502b783",
+      strip_prefix = "protobuf-3.8.0/js",
       urls = [
-          "http://mirror.tensorflow.org/github.com/google/protobuf/archive/v3.6.0.tar.gz",
-          "https://github.com/google/protobuf/archive/v3.6.0.tar.gz",
+          "http://mirror.tensorflow.org/github.com/google/protobuf/archive/v3.8.0.tar.gz",
+          "https://github.com/google/protobuf/archive/v3.8.0.tar.gz",
       ],
       build_file = "@io_bazel_rules_closure//closure/protobuf:protobuf_js.BUILD",
   )


### PR DESCRIPTION
This updates our protobuf deps to consistently use protobuf 3.8.0, to fix a version skew issue arising after https://github.com/tensorflow/tensorboard/pull/2609 where the protobuf JS runtime was still on 3.6.0 and thus caused runtime failures when trying to use JSPB messages generated with protoc 3.8.0 (specifically failures that looked like https://github.com/protocolbuffers/protobuf/issues/5930).

Our main protobuf/protoc dep is provided via the TF workspace, so this updates that to 2.0.0-rc0.

cc @jameswex 