### PR TITLE
ui: fix run selector toggle all with many items

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.ts
@@ -37,8 +37,9 @@ namespace tf_dashboard_common {
         computed: 'computeNamesMatchingRegex(names.*, _regex)',
       }, // Runs that match the regex
       selectionState: {
-        // if a name is explicitly enabled, True, if explicitly disabled, False.
-        // if undefined, default value (enable for first k names, disable after).
+        // If a name is explicitly enabled by user gesture, True, if explicitly
+        // disabled, False. If undefined, default value (enable for first k
+        // names, disable after).
         type: Object,
         notify: true,
         value: () => ({}),
@@ -168,28 +169,16 @@ namespace tf_dashboard_common {
       return this.outSelected.indexOf(item) != -1;
     },
     toggleAll: function() {
-      var anyToggledOn = this.namesMatchingRegex.some(
-        (n) => this.selectionState[n]
-      );
-
-      var selectionStateIsDefault =
-        Object.keys(this.selectionState).length == 0;
-
-      var defaultOff =
-        this.namesMatchingRegex.length > this.maxRunsToEnableByDefault;
-      // We have names toggled either if some were explicitly toggled on, or if
-      // we are in the default state, and there are few enough that we default
-      // to toggling on.
-      anyToggledOn = anyToggledOn || (selectionStateIsDefault && !defaultOff);
-
       // If any are toggled on, we turn everything off. Or, if none are toggled
       // on, we turn everything on.
-
-      var newRunsDisabled = {};
-      this.names.forEach(function(n) {
-        newRunsDisabled[n] = !anyToggledOn;
+      const anyToggledOn = this.namesMatchingRegex.some((name) =>
+        this.outSelected.includes(name)
+      );
+      const newSelectionState = {};
+      this.names.forEach((n) => {
+        newSelectionState[n] = !anyToggledOn;
       });
-      this.selectionState = newRunsDisabled;
+      this.selectionState = newSelectionState;
     },
   });
 } // namespace tf_dashboard_common


### PR DESCRIPTION
The run selector has a toggle all runs button.  Before, toggleAll()'s intent is to toggle everything off when the user hasn't interacted with the list and the list is short (<40, everything selected by default).  This logic was broken in [1], which renamed "maxRunsToEnableByDefault" to "maxNamesToEnableByDefault", except for one callsite (causing issue #2614).

This PR fixes the issue and simplifies toggleAll() to rely on "this.outSelected", which already represents the computed selected state.

[1] https://github.com/tensorflow/tensorboard/commit/aacd5cb7ab1076679aa4115191aa3f00e4575f0d