### PR TITLE
proto: sync to TensorFlow v1.15.0-rc0

### DIFF
--- a/tensorboard/compat/proto/config.proto
+++ b/tensorboard/compat/proto/config.proto
@@ -7,7 +7,7 @@ option java_outer_classname = "ConfigProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
 
-// add go_package externally with copybara
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf";
 import "tensorboard/compat/proto/cost_graph.proto";
 import "tensorboard/compat/proto/graph.proto";
 import "tensorboard/compat/proto/step_stats.proto";
@@ -327,6 +327,32 @@ message RPCOptions {
   // If compression_algorithm is set, the compression level to be used.
   // From 0 (no compression), up to 3.
   int32 compression_level = 3;
+
+  // Setting cache_rpc_response to true will enable sender side caching of
+  // response for RecvTensorAsync and RecvBufAsync to allow receiver to retry
+  // requests . This is only necessary when the network fabric is experiencing a
+  // significant error rate.  Without it we'll fail a step on an network error,
+  // while with it we'll be able to complete long steps (like complex
+  // initializations) in the face of some network errors during RecvTensor.
+  bool cache_rpc_response = 4;
+
+  // Disables TCP connection sharing when opening a new RPC channel.
+  bool disable_session_connection_sharing = 5;
+}
+
+// Metadata about the session.
+//
+// This can be used by the runtime and the Ops for debugging, monitoring, etc.
+//
+// The (name, version) tuple is expected to be a unique identifier for
+// sessions within the same process.
+//
+// NOTE: This is currently used and propagated only by the direct session.
+message SessionMetadata {
+  string name = 1;
+
+  // The version is optional. If set, needs to be >= 0.
+  int64 version = 2;
 }
 
 // Session configuration parameters.
@@ -498,6 +524,22 @@ message ConfigProto {
     // This is helpful when a worker wants to partition a graph
     // (for example during a PartitionedCallOp).
     bool share_cluster_devices_in_session = 10;
+
+    // Metadata about the session.
+    //
+    // If set, this can be used by the runtime and the Ops for debugging,
+    // monitoring, etc.
+    //
+    // NOTE: This is currently used and propagated only by the direct session.
+    SessionMetadata session_metadata = 11;
+
+    // If true, the session may treat the graph as being static for optimization
+    // purposes.
+    //
+    // If this option is set to true when a session is created, the full
+    // GraphDef must be passed in a single call to Session::Create(), and
+    // Session::Extend() may not be supported.
+    bool optimize_for_static_graph = 12;
   };
 
   Experimental experimental = 16;

--- a/tensorboard/compat/proto/debug.proto
+++ b/tensorboard/compat/proto/debug.proto
@@ -10,13 +10,15 @@ option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobu
 // Option for watching a node in TensorFlow Debugger (tfdbg).
 message DebugTensorWatch {
   // Name of the node to watch.
+  // Use "*" for wildcard. But note: currently, regex is not supported in
+  // general.
   string node_name = 1;
 
   // Output slot to watch.
-  // The semantics of output_slot == -1 is that the node is only watched for
-  // completion, but not for any output tensors. See NodeCompletionCallback
-  // in debug_gateway.h.
-  // TODO(cais): Implement this semantics.
+  // The semantics of output_slot == -1 is that all outputs of the node
+  // will be watched (i.e., a wildcard).
+  // Other negative values of output_slot are invalid and will lead to
+  // errors currently.
   int32 output_slot = 2;
 
   // Name(s) of the debugging op(s).

--- a/tensorboard/compat/proto/meta_graph.proto
+++ b/tensorboard/compat/proto/meta_graph.proto
@@ -14,6 +14,7 @@ import "tensorboard/compat/proto/tensor_shape.proto";
 import "tensorboard/compat/proto/types.proto";
 import "tensorboard/compat/proto/saved_object_graph.proto";
 import "tensorboard/compat/proto/saver.proto";
+import "tensorboard/compat/proto/struct.proto";
 
 // NOTE: This protocol buffer is evolving, and will go through revisions in the
 // coming months.
@@ -225,6 +226,15 @@ message TensorInfo {
     string dense_shape_tensor_name = 3;
   }
 
+  // Generic encoding for composite tensors.
+  message CompositeTensor {
+    // The serialized TypeSpec for the composite tensor.
+    TypeSpecProto type_spec = 1;
+
+    // A TensorInfo for each flattened component tensor.
+    repeated TensorInfo components = 2;
+  }
+
   oneof encoding {
     // For dense `Tensor`s, the name of the tensor in the graph.
     string name = 1;
@@ -233,6 +243,8 @@ message TensorInfo {
     // uses only the COO encoding.  This is supported and documented in the
     // SparseTensor Python class.
     CooSparse coo_sparse = 4;
+    // Generic encoding for CompositeTensors.
+    CompositeTensor composite_tensor = 5;
   }
   DataType dtype = 2;
   // The static shape should be recorded here, to the extent that it can

--- a/tensorboard/compat/proto/node_def.proto
+++ b/tensorboard/compat/proto/node_def.proto
@@ -11,7 +11,7 @@ import "tensorboard/compat/proto/attr_value.proto";
 message NodeDef {
   // The name given to this operator. Used for naming inputs,
   // logging, visualization, etc.  Unique within a single GraphDef.
-  // Must match the regexp "[A-Za-z0-9.][A-Za-z0-9_./]*".
+  // Must match the regexp "[A-Za-z0-9.][A-Za-z0-9_>./]*".
   string name = 1;
 
   // The operation name.  There may be custom parameters in attrs.
@@ -70,6 +70,15 @@ message NodeDef {
     // be {A, B}. This information can be used to map errors originating at the
     // current node to some top level source code.
     repeated string original_node_names = 1;
+
+    // This is intended to store the list of names of the functions from the
+    // original graph that this node was derived. For example if this node, say
+    // C, was result of a fusion of node A in function FA and node B in function
+    // FB, then `original_funcs` would be {FA, FB}. If the node is in the top
+    // level graph, the `original_func` is empty. This information, with the
+    // `original_node_names` can be used to map errors originating at the
+    // current ndoe to some top level source code.
+    repeated string original_func_names = 2;
   };
 
   // This stores debug information associated with the node.

--- a/tensorboard/compat/proto/op_def.proto
+++ b/tensorboard/compat/proto/op_def.proto
@@ -14,7 +14,7 @@ import "tensorboard/compat/proto/types.proto";
 // LINT.IfChange
 message OpDef {
   // Op names starting with an underscore are reserved for internal use.
-  // Names should be CamelCase and match the regexp "[A-Z][a-zA-Z0-9_]*".
+  // Names should be CamelCase and match the regexp "[A-Z][a-zA-Z0-9>_]*".
   string name = 1;
 
   // For describing inputs and outputs.

--- a/tensorboard/compat/proto/resource_handle.proto
+++ b/tensorboard/compat/proto/resource_handle.proto
@@ -7,6 +7,9 @@ option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
 option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
 
+import "tensorboard/compat/proto/tensor_shape.proto";
+import "tensorboard/compat/proto/types.proto";
+
 // Protocol buffer representing a handle to a tensorflow resource. Handles are
 // not valid across executions, but can be serialized back and forth from within
 // a single run.
@@ -27,4 +30,13 @@ message ResourceHandleProto {
   // For debug-only, the name of the type pointed to by this handle, if
   // available.
   string maybe_type_name = 5;
+
+  // Protocol buffer representing a pair of (data type, tensor shape).
+  message DtypeAndShape {
+    DataType dtype = 1;
+    TensorShapeProto shape = 2;
+  }
+
+  // Data types and shapes for the underlying resource.
+  repeated DtypeAndShape dtypes_and_shapes = 6;
 };

--- a/tensorboard/compat/proto/rewriter_config.proto
+++ b/tensorboard/compat/proto/rewriter_config.proto
@@ -7,7 +7,7 @@ option java_outer_classname = "RewriterConfigProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
 
-// add go_package externally with copybara
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf";
 
 import "tensorboard/compat/proto/attr_value.proto";
 import "tensorboard/compat/proto/verifier_config.proto";

--- a/tensorboard/compat/proto/saved_object_graph.proto
+++ b/tensorboard/compat/proto/saved_object_graph.proto
@@ -74,6 +74,8 @@ message SavedUserObject {
   string identifier = 1;
   // Version information from the producer of this SavedUserObject.
   VersionDef version = 2;
+  // Initialization-related metadata.
+  string metadata = 3;
 }
 
 // A SavedAsset points to an asset in the MetaGraph.

--- a/tensorboard/compat/proto/struct.proto
+++ b/tensorboard/compat/proto/struct.proto
@@ -56,6 +56,8 @@ message StructuredValue {
     tensorboard.DataType tensor_dtype_value = 32;
     // Represents a value for tf.TensorSpec.
     TensorSpecProto tensor_spec_value = 33;
+    // Represents a value for tf.TypeSpec.
+    TypeSpecProto type_spec_value = 34;
 
     // Represents a list of `Value`.
     ListValue list_value = 51;
@@ -104,4 +106,29 @@ message TensorSpecProto {
   string name = 1;
   tensorboard.TensorShapeProto shape = 2;
   tensorboard.DataType dtype = 3;
-};
+}
+
+// Represents a tf.TypeSpec
+message TypeSpecProto {
+  enum TypeSpecClass {
+    UNKNOWN = 0;
+    SPARSE_TENSOR_SPEC = 1;   // tf.SparseTensorSpec
+    INDEXED_SLICES_SPEC = 2;  // tf.IndexedSlicesSpec
+    RAGGED_TENSOR_SPEC = 3;   // tf.RaggedTensorSpec
+    TENSOR_ARRAY_SPEC = 4;    // tf.TensorArraySpec
+    DATA_DATASET_SPEC = 5;    // tf.data.DatasetSpec
+    DATA_ITERATOR_SPEC = 6;   // IteratorSpec from data/ops/iterator_ops.py
+    OPTIONAL_SPEC = 7;        // tf.OptionalSpec
+    PER_REPLICA_SPEC = 8;     // PerReplicaSpec from distribute/values.py
+  }
+  TypeSpecClass type_spec_class = 1;
+
+  // The value returned by TypeSpec._serialize().
+  StructuredValue type_state = 2;
+
+  // This is currently redundant with the type_spec_class enum, and is only
+  // used for error reporting.  In particular, if you use an older binary to
+  // load a newer model, and the model uses a TypeSpecClass that the older
+  // binary doesn't support, then this lets us display a useful error message.
+  string type_spec_class_name = 3;
+}

--- a/tensorboard/compat/proto/types.proto
+++ b/tensorboard/compat/proto/types.proto
@@ -67,7 +67,7 @@ enum DataType {
   DT_UINT64_REF = 123;
 }
 // LINT.ThenChange(
-//    https://www.tensorflow.org/code/tensorflow/c/c_api.h,
+//    https://www.tensorflow.org/code/tensorflow/c/tf_datatype.h,
 //    https://www.tensorflow.org/code/tensorflow/go/tensor.go,
 //    https://www.tensorflow.org/code/tensorboard/compat/proto/tensor.cc,
 //    https://www.tensorflow.org/code/tensorboard/compat/proto/types.h,

--- a/tensorboard/compat/proto/variable.proto
+++ b/tensorboard/compat/proto/variable.proto
@@ -7,7 +7,7 @@ option java_outer_classname = "VariableProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
 
-// add go_package externally with copybara
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
 
 // Indicates when a distributed variable will be synced.
 enum VariableSynchronization {

--- a/tensorboard/compat/proto/verifier_config.proto
+++ b/tensorboard/compat/proto/verifier_config.proto
@@ -5,7 +5,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "VerifierConfigProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-// add go_package externally with copybara
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf";
 
 // The config for graph verifiers.
 message VerifierConfig {


### PR DESCRIPTION
Summary:
These are synced to TensorFlow tag `v1.15.0-rc0`, which resolves to
a0163a0a727c9c7af5ac976debd5e28d42275b8c.

There are no new protos or new `import` dependencies, so the existing
build rules and tests suffice.

Test Plan:
Running `bazel test //tensorboard/compat/proto:proto_test` now passes in
a virtualenv with `tensorflow==1.15.0rc0` installed. This is the same as
current TF 1.x nightlies, which are frozen, but _not_ the same as
current TF 2.x nightlies, due to changes in HEAD.

wchargin-branch: proto-sync-v1.15.0-rc0
