### PR TITLE
Fix What-If Tool image handling from Polymer 2 update

### DIFF
--- a/tensorboard/components/vz_example_viewer/vz-example-viewer.ts
+++ b/tensorboard/components/vz_example_viewer/vz-example-viewer.ts
@@ -827,12 +827,11 @@ namespace vz_example_viewer {
     },
 
     /**
-     * From an event, finds the feature, value list index and sequence number
-     * that the event corresponds to.
+     * From an element, finds the feature, value list index and sequence number
+     * that the element corresponds to.
      */
-    getDataFromEvent: function(event: Event): DataFromControl {
-      let elem = event.target as HTMLElementWithData;
-      // Get the control that contains the event target. The control will have its
+    getDataFromElem: function(elem: HTMLElementWithData): DataFromControl {
+      // Get the control that contains the target data. The control will have its
       // data-feature attribute set.
       while (elem.dataFeature == null) {
         if (!elem.parentElement) {
@@ -845,6 +844,14 @@ namespace vz_example_viewer {
         valueIndex: elem.dataIndex,
         seqNum: elem.dataSeqNum,
       };
+    },
+
+    /**
+     * From an event, finds the feature, value list index and sequence number
+     * that the event corresponds to.
+     */
+    getDataFromEvent: function(event: Event): DataFromControl {
+      return this.getDataFromElem(event.target);
     },
 
     /** Gets the Feature object corresponding to the provided DataFromControl. */
@@ -1617,7 +1624,7 @@ namespace vz_example_viewer {
         }
       }
       if (inputElem) {
-        inputElem.querySelector('input').click();
+        inputElem.shadowRoot.querySelector('input').click();
       }
     },
 
@@ -1625,11 +1632,12 @@ namespace vz_example_viewer {
     handleFileSelect: function(event: Event, self: any) {
       event.stopPropagation();
       event.preventDefault();
+      const target = event.target;
       const reader = new FileReader();
       const eventAny = event as any;
       const files = eventAny.dataTransfer
         ? eventAny.dataTransfer.files
-        : eventAny.target.files;
+        : eventAny.target.inputElement.inputElement.files;
       if (files.length === 0) {
         return;
       }
@@ -1644,7 +1652,7 @@ namespace vz_example_viewer {
           const encodedImageData = reader.result.substring(index);
           const cc = self.decodedStringToCharCodes(atob(encodedImageData));
 
-          const data = self.getDataFromEvent(event);
+          const data = self.getDataFromElem(target);
           const feat = self.getFeatureFromData(data);
           const values = self.getValueListFromData(data);
           if (feat) {

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-inference-viewer.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-inference-viewer.html
@@ -271,7 +271,7 @@ limitations under the License.
       getMarkerClass: function(index, inferences, modelIndex) {
         return (
           'marker' +
-          (index == inferences.length - 1
+          (inferences != null && index == inferences.length - 1
             ? modelIndex == 0
               ? ' mark-one'
               : ' mark-two'
@@ -281,7 +281,7 @@ limitations under the License.
 
       getRowClass: function(index, inferences, modelIndex) {
         let str = 'row ';
-        if (index == inferences.length - 1) {
+        if (inferences != null && index == inferences.length - 1) {
           str += modelIndex == 0 ? 'dark-row-one' : 'dark-row-two';
         } else {
           str += 'white-row';


### PR DESCRIPTION
* Motivation for features / changes

Polymer 2 update broke a few WIT image-related features.

* Technical description of changes

Update image upload logic to correctly use Polymer2 shadow DOM element targeting and related paper-input updates.
Update inference viewing table component to be able to handle being called before inferences list is set by checking for null. This is due to changes in Polymer2 observer calling.

* Screenshots of UI changes

N/A

* Detailed steps to verify changes work correctly (as executed by you)

Ran WIT image demo and saw now-correct behavior in uploading new images and in duplicating existing examples.