### PR TITLE
build: add sourceURL to map scripts in devtools

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -92,7 +92,10 @@ public final class Vulcanize {
   private static final ImmutableSet<String> EXTRA_JSDOC_TAGS =
       ImmutableSet.of("attribute", "hero", "group", "required");
 
-  private static final Pattern WEBPATH_PATTERN = Pattern.compile("//~~WEBPATH~~([^\n]+)");
+  private static final Pattern SCRIPT_DELIMITER_PATTERN =
+      Pattern.compile("//# sourceURL=build:/([^\n]+)");
+
+  private static final String SCRIPT_DELIMITER = "//# sourceURL=build:/%name%";
 
   private static final Parser parser = Parser.htmlParser();
   private static final Map<Webpath, Path> webfiles = new HashMap<>();
@@ -440,7 +443,7 @@ public final class Vulcanize {
 
     // So we can chop JS binary back up into the original script tags.
     options.setPrintInputDelimiter(true);
-    options.setInputDelimiter("//~~WEBPATH~~%name%");
+    options.setInputDelimiter(SCRIPT_DELIMITER);
 
     // Optimizations that are too advanced for us right now.
     options.setPropertyRenaming(PropertyRenamingPolicy.OFF);
@@ -556,7 +559,7 @@ public final class Vulcanize {
     // Split apart the JS blob and put it back in the original <script> locations.
     Deque<Map.Entry<Webpath, Node>> tags = new ArrayDeque<>();
     tags.addAll(sourceTags.entrySet());
-    Matcher matcher = WEBPATH_PATTERN.matcher(jsBlob);
+    Matcher matcher = SCRIPT_DELIMITER_PATTERN.matcher(jsBlob);
     verify(matcher.find(), "Nothing found in compiled JS blob!");
     Webpath path = Webpath.get(matcher.group(1));
     int start = 0;


### PR DESCRIPTION
Before, opening DevTools on Tensorboard showed the single vulcanized html in Sources panel.

In this CL, adding sourceURL lets browser devtools know where a script really came from.  This lets you do things like open a script by name (e.g. DevTools Sources panel > Cmd+P > "run-selector") and have debugging-by-file ([breaks](https://bugs.chromium.org/p/chromium/issues/detail?id=1003497) with pretty-print, sadly).

![image](https://user-images.githubusercontent.com/2322480/64829789-9728a980-d582-11e9-9ebf-7f3fc2ae9bdc.png)

Note:
- preserving whitespace would be nice, but none of the Closure flags I tried worked
- grouping all the "iron-" elements into a folder would be nice, but is a bit more work