### PR TITLE
Travis CI: Do not hardcore trusty because it is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
* Motivation for features / changes
Travis CI has switch to [Xenial as the default distro](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) because [Trusty reached the end of its five-year LTS window in April 2019](https://ubuntu.com/blog/ubuntu-14-04-trusty-tahr).

* Technical description of changes

Remove the hardcoding of the Trusty distro.

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)

Execute test steps locally and on a branch in Travis CI.

* Alternate designs / implementations considered

Also see #2292