### PR TITLE
ci: upgrade flake8 and yamllint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ install:
   # to versions other than the most recent(!).
   - pip install -U pip
   # Lint check deps.
-  - pip install flake8==3.5.0
-  - pip install yamllint==1.5.0
+  - pip install flake8==3.7.8
+  - pip install yamllint==1.17.0
   # TensorBoard deps.
   - pip install futures==3.1.1
   - pip install grpcio==1.6.3
@@ -78,8 +78,9 @@ install:
 before_script:
   - elapsed "before_script"
   # Do a fail-fast check for Python syntax errors or undefined names.
+  # See: http://flake8.pycqa.org/en/3.7.8/user/error-codes.html
   # Use the comment '# noqa: <error code>' to suppress.
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   # Lint frontend code
   - yarn lint
   # Lint .yaml docs files. Use '# yamllint disable-line rule:foo' to suppress.

--- a/tensorboard/compat/tensorflow_stub/io/gfile_s3_test.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile_s3_test.py
@@ -354,7 +354,7 @@ class GFileTest(unittest.TestCase):
         for file_name in file_names:
             # Add an end slash
             path = top_directory + '/' + file_name
-            if file_name is 'model.ckpt':
+            if file_name == 'model.ckpt':
                 content = ckpt_content
             else:
                 content = ''

--- a/tensorboard/plugins/interactive_inference/interactive_inference_plugin.py
+++ b/tensorboard/plugins/interactive_inference/interactive_inference_plugin.py
@@ -79,7 +79,7 @@ class InteractiveInferencePlugin(base_plugin.TBPlugin):
     self._logdir = context.logdir
     self._has_auth_group = (context.flags and
                             'authorized_groups' in context.flags and
-                            context.flags.authorized_groups is not '')
+                            context.flags.authorized_groups != '')
 
   def get_plugin_apps(self):
     """Obtains a mapping between routes and handlers. Stores the logdir.


### PR DESCRIPTION
Like #2654 but without the distro change from Trusty to Xenial in order to make it easier to review these improvements separately from the complexities of changing the distro.

* Motivation for features / changes

Both flake8 and yamllint have progressively added new tests and some new flake8 tests have been found to have a positive effect on runtime safety.

* Technical description of changes

1. Upgrade flake8 and yamllint to current versions.
2. Add more flake8 tests
3. Fix two instances of __use ==/!= to compare str, bytes, and int literals__ because identity is not the same thing as equality in Python. These instances will raise __SyntaxWarnings__ on Python 3.8 so best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)

Execute test steps locally and on a branch in Travis CI.
* Alternate designs / implementations considered