### PR TITLE
hparams: remove `Experiment` from public API docs

### DIFF
--- a/tensorboard/plugins/hparams/api.py
+++ b/tensorboard/plugins/hparams/api.py
@@ -49,8 +49,8 @@ directly:
 ...   sess.run(w.flush())
 
 To control how hyperparameters and metrics appear in the TensorBoard UI,
-you can define `HParam` and `Metric` objects and collect them in an
-`Experiment`:
+you can define `HParam` and `Metric` objects, and write an experiment
+summary to the top-level log directory:
 
 >>> HP_OPTIMIZER = hp.HParam("optimizer")
 >>> HP_FC_DROPOUT = hp.HParam(
@@ -60,20 +60,19 @@ you can define `HParam` and `Metric` objects and collect them in an
 ... )
 >>> HP_NEURONS = hp.HParam("neurons", description="Neurons per dense layer")
 >>>
->>> experiment = hp.Experiment(
-...     hparams=[
-...         HP_OPTIMIZER,
-...         HP_FC_DROPOUT,
-...         HP_NEURONS,
-...     ],
-...     metrics=[
-...         hp.Metric("xent", group="validation", display_name="cross-entropy"),
-...         hp.Metric("f1", group="validation", display_name="F&#x2081; score"),
-...         hp.Metric("loss", group="train", display_name="training loss"),
-...     ],
-... )
 >>> with tf.summary.create_file_writer(base_logdir).as_default():
-...   hp.hparams_config(experiment)  # write experiment summary
+...   hp.hparams_config(
+...       hparams=[
+...           HP_OPTIMIZER,
+...           HP_FC_DROPOUT,
+...           HP_NEURONS,
+...       ],
+...       metrics=[
+...           hp.Metric("xent", group="validation", display_name="cross-entropy"),
+...           hp.Metric("f1", group="validation", display_name="F&#x2081; score"),
+...           hp.Metric("loss", group="train", display_name="training loss"),
+...       ],
+...   )
 
 You can continue to pass a string-keyed dict to the Keras callback or
 the `hparams` function, or you can use `HParam` objects as the keys. The


### PR DESCRIPTION
Summary:
This was an error; the `Experiment` symbol never existed in the final
version of the public APIs. (It existed in earlier drafts, but was
removed for the sake of simplicity.)

Thanks to @tfboyd for reporting this.

Test Plan:
Note that this now matches the invocation in the demo that can actually
be run:

https://github.com/tensorflow/tensorboard/blob/9335e0d3a271293919822aa8a689e9ef04cd6ff8/tensorboard/plugins/hparams/hparams_demo.py#L215-L216

wchargin-branch: hparams-no-experiment
