### PR TITLE
build: make tensor_widget build with JSComp

### DIFF
--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -21,8 +21,22 @@ tf_web_library(
 
 tf_js_binary(
     name = "tensor_widget_binary",
+    srcs = [
+        "externs.js",
+    ],
     compile = 1,
-    entry_point = ":tensor-widget.ts",
+    entry_point = ":tensor-widget-interop.ts",
+    deps = [
+        ":tensor_widget_binary_lib",
+    ],
+)
+
+tf_ts_library(
+    name = "tensor_widget_binary_lib",
+    srcs = [
+        "tensor-widget-interop.ts",
+    ],
+    tsconfig = ":tsconfig",
     deps = [
         ":tensor_widget_lib",
     ],

--- a/tensorboard/components/tensor_widget/externs.js
+++ b/tensorboard/components/tensor_widget/externs.js
@@ -1,0 +1,26 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * @externs Externs for TensorWidget for interoperability.
+ */
+
+/** @type {!Object} */
+var tensor_widget = {};
+
+/** @type {!Function} */
+tensor_widget.tensorWidget;
+
+/** @type {!string} */
+tensor_widget.VERSION;

--- a/tensorboard/components/tensor_widget/tensor-widget-interop.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-interop.ts
@@ -1,0 +1,18 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import * as tensorWidget from './tensor-widget';
+
+// Prevent JSComp to mangle the exported name.
+(window as any)['tensor_widget'] = tensorWidget;

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/externs.js
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/externs.js
@@ -33,6 +33,7 @@
 /** @type {!Object} */ var tf;
 /** @type {!Function|undefined} */ var ga;
 /** @type {!Function|undefined} */ var KeyframeEffect;
+/** @type {!Object} */ var tensor_widget;
 
 /**
  * Some weird webcomponents-lite.js thing.

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
@@ -311,7 +311,7 @@ limitations under the License.
 
           setTimeout(() => {
             if (this.tensorWidget == null) {
-              this.tensorWidget = tensor_widget_binary.tensorWidget(
+              this.tensorWidget = tensor_widget.tensorWidget(
                 this.$$('#tensor-widget'),
                 tensorView
               );


### PR DESCRIPTION
The name, tensor_widget_binary, is unique to rollup_bundle; could not
figure out how to disable such global export in the bundler yet. As
such, we need to explicitly export a module to a global variable.

The externs file was introduced so the exported names are not mangle and
can remain stable.

Internal POC can be found here: cl/268757810
