### PR TITLE
sync: fix the ng_tensorboard deps definition

### DIFF
--- a/tensorboard/components/tf_ng_tensorboard/angular/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/angular/BUILD
@@ -46,6 +46,15 @@ tf_ts_library(
     ],
 )
 
+# This is a dummy rule used as a @angular/material/select dependency.
+tf_ts_library(
+    name = "expect_angular_material_select",
+    srcs = [],
+    deps = [
+        "@npm//@angular/material",
+    ],
+)
+
 # This is a dummy rule used as a @angular/platform-browser/animations dependency.
 # This is not a replacement for @angular/platform-browser dependency.
 tf_ts_library(

--- a/tensorboard/components/tf_ng_tensorboard/header/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/header/BUILD
@@ -16,9 +16,11 @@ ng_module(
         "containers/header.component.html",
     ],
     deps = [
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_select",
         "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_tabs",
         "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_toolbar",
         "//tensorboard/components/tf_ng_tensorboard/core",
+        "//tensorboard/components/tf_ng_tensorboard/types",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@ngrx/store",
@@ -36,6 +38,7 @@ tf_ts_library(
     deps = [
         ":header",
         "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_core_testing",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_select",
         "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_tabs",
         "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_toolbar",
         "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_platform_browser_animations",


### PR DESCRIPTION
- material should have a separate definition.
- strict dependency on the type file.