### PR TITLE
Add WIT ability to consume arbitrary prediction-time information

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -5883,7 +5883,11 @@ limitations under the License.
           for (let i = 0; i < extraOutputs.indices.length; i++) {
             const idx = extraOutputs.indices[i];
             const datapoint = Object.assign({}, this.visdata[idx]);
-            for (let modelNum = 0; modelNum < extraOutputs.extra.length; modelNum++) {
+            for (
+              let modelNum = 0;
+              modelNum < extraOutputs.extra.length;
+              modelNum++
+            ) {
               const keys = Object.keys(extraOutputs.extra[modelNum]);
               for (let j = 0; j < keys.length; j++) {
                 const key = keys[j];

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3798,7 +3798,7 @@ limitations under the License.
         refreshSelectedDatapoint_: function() {
           const temp = this.selectedExampleAndInference;
           this.selectedExampleAndInference = null;
-          this.selectedExampleAndInference = temp
+          this.selectedExampleAndInference = temp;
         },
 
         findClosestCounterfactual_: function() {
@@ -5876,15 +5876,19 @@ limitations under the License.
         newExtraOutputs_: function(extraOutputs) {
           // Set attributions from the extra outputs, if available.
           const attributions = [];
-          for (let modelNum = 0; modelNum < extraOutputs.extra.length; modelNum++) {
+          for (
+            let modelNum = 0;
+            modelNum < extraOutputs.extra.length;
+            modelNum++
+          ) {
             if ('attributions' in extraOutputs.extra[modelNum]) {
               attributions.push(extraOutputs.extra[modelNum].attributions);
             }
           }
           if (attributions.length > 0) {
             this.attributions = {
-              'indices': extraOutputs.indices,
-              'attributions': attributions,
+              indices: extraOutputs.indices,
+              attributions: attributions,
             };
           }
 
@@ -5916,15 +5920,17 @@ limitations under the License.
                 if (!Array.isArray(val)) {
                   val = [val];
                 }
-                const isString = val.length > 0 &&
-                    (typeof val[0] == 'string' || val[0] instanceof String);
+                const isString =
+                  val.length > 0 &&
+                  (typeof val[0] == 'string' || val[0] instanceof String);
                 const datapointKey = this.strWithModelName_(key, modelNum);
                 const exampleJsonString = JSON.stringify(
                   this.examplesAndInferences[idx].example
                 );
                 const copiedExample = JSON.parse(exampleJsonString);
-                copiedExample.features.feature[datapointKey] = isString ?
-                    {bytesList: {value: val}} : {floatList: {value: val}};
+                copiedExample.features.feature[datapointKey] = isString
+                  ? {bytesList: {value: val}}
+                  : {floatList: {value: val}};
                 this.examplesAndInferences[idx].example = copiedExample;
               }
             }

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3338,6 +3338,7 @@ limitations under the License.
           // 'attributions' is one of these output data which is parsed into the
           // 'attributions' object defined below as a special case. Any other extra
           // data provided are displayed by WIT with each example.
+          // @type {indices: Array<number>, extra: Array<{Object}>}
           extraOutputs: {
             type: Object,
             observer: 'newExtraOutputs_',

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3266,6 +3266,10 @@ limitations under the License.
             observer: 'newInferences_',
             value: () => ({}),
           },
+          extraOutputs: {
+            type: Object,
+            observer: 'newExtraOutputs_',
+          },
           // Attributions from inference. A dict with two fields: 'indices' and
           // 'attributions'. Indices contains a list of example indices that
           // these new attributions apply to. Attributions contains a list of
@@ -3778,10 +3782,14 @@ limitations under the License.
           } else {
             this.comparedIndices = [];
             this.counterfactualExampleAndInference = null;
-            const temp = this.selectedExampleAndInference;
-            this.selectedExampleAndInference = null;
-            this.selectedExampleAndInference = temp;
+            this.refreshSelectedDatapoint_();
           }
+        },
+
+        refreshSelectedDatapoint_: function() {
+          const temp = this.selectedExampleAndInference;
+          this.selectedExampleAndInference = null;
+          this.selectedExampleAndInference = temp
         },
 
         findClosestCounterfactual_: function() {
@@ -5854,6 +5862,67 @@ limitations under the License.
             }
           }
           this.updatedExample = false;
+        },
+
+        newExtraOutputs_: function(extraOutputs) {
+          // Set attributions from the extra outputs, if available.
+          const attributions = [];
+          for (let i = 0; i < extraOutputs.extra.length; i++) {
+            if ('attributions' in extraOutputs.extra[i]) {
+              attributions.push(extraOutputs.extra[i].attributions);
+            }
+          }
+          if (attributions.length > 0) {
+            this.attributions = {
+              'indices': extraOutputs.indices,
+              'attributions': attributions,
+            };
+          }
+
+          // Add extra output information to datapoints
+          for (let i = 0; i < extraOutputs.indices.length; i++) {
+            const idx = extraOutputs.indices[i];
+            const datapoint = Object.assign({}, this.visdata[idx]);
+            for (let modelNum = 0; modelNum < extraOutputs.extra.length; modelNum++) {
+              const keys = Object.keys(extraOutputs.extra[modelNum]);
+              for (let j = 0; j < keys.length; j++) {
+                const key = keys[j];
+                // Skip attributions as they are handled separately above.
+                if (key == 'attributions') {
+                  continue;
+                }
+                let val = extraOutputs.extra[modelNum][key][i];
+
+                // Update the datapoint with the extra info for use in
+                // Facets Dive.
+                datapoint[datapointKey] = val;
+
+                // Convert the extra output into an array if necessary, for
+                // insertion into tf.Example as a value list, for update of
+                // examplesAndInferences for the example viewer.
+                if (!Array.isArray(val)) {
+                  val = [val];
+                }
+                const isString = val.length > 0 &&
+                    (typeof val[0] == 'string' || val[0] instanceof String);
+                const datapointKey = this.strWithModelName_(key, modelNum);
+                const exampleJsonString = JSON.stringify(
+                  this.examplesAndInferences[idx].example
+                );
+                const copiedExample = JSON.parse(exampleJsonString);
+                copiedExample.features.feature[datapointKey] = isString ?
+                    {bytesList: {value: val}} : {floatList: {value: val}};
+                this.examplesAndInferences[idx].example = copiedExample;
+              }
+            }
+            this.set(`visdata.${idx}`, datapoint);
+          }
+          this.refreshDive_();
+
+          // Update selected datapoint so that if a datapoint is being viewed,
+          // the display is updated with the appropriate extra output.
+          this.computeSelectedExampleAndInference();
+          this.refreshSelectedDatapoint_();
         },
 
         newAttributions_: function(attributions) {

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3338,7 +3338,8 @@ limitations under the License.
           // 'attributions' is one of these output data which is parsed into the
           // 'attributions' object defined below as a special case. Any other extra
           // data provided are displayed by WIT with each example.
-          // @type {indices: Array<number>, extra: Array<{Object}>}
+          // @type {indices: Array<number>,
+          //        extra: Array<{!Object<string, Array<number|string>>}>}
           extraOutputs: {
             type: Object,
             observer: 'newExtraOutputs_',

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -5909,6 +5909,7 @@ limitations under the License.
                   continue;
                 }
                 let val = extraOutputs.extra[modelNum][key][i];
+                const datapointKey = this.strWithModelName_(key, modelNum);
 
                 // Update the datapoint with the extra info for use in
                 // Facets Dive.
@@ -5923,7 +5924,6 @@ limitations under the License.
                 const isString =
                   val.length > 0 &&
                   (typeof val[0] == 'string' || val[0] instanceof String);
-                const datapointKey = this.strWithModelName_(key, modelNum);
                 const exampleJsonString = JSON.stringify(
                   this.examplesAndInferences[idx].example
                 );

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3266,6 +3266,15 @@ limitations under the License.
             observer: 'newInferences_',
             value: () => ({}),
           },
+          // Extra outputs from inference. A dict with two fields: 'indices' and
+          // 'extra'. Indices contains a list of example indices that
+          // these new outputs apply to. Extra contains a list of extra output
+          // objects, one for each model being inferred. The object for each
+          // model is a dict of output data names to lists of the output values
+          // for that data, one entry for each example that was inferred upon.
+          // 'attributions' is one of these output data which is parsed into the
+          // 'attributions' object defined below as a special case. Any other extra
+          // data provided are displayed by WIT with each example.
           extraOutputs: {
             type: Object,
             observer: 'newExtraOutputs_',
@@ -5867,9 +5876,9 @@ limitations under the License.
         newExtraOutputs_: function(extraOutputs) {
           // Set attributions from the extra outputs, if available.
           const attributions = [];
-          for (let i = 0; i < extraOutputs.extra.length; i++) {
-            if ('attributions' in extraOutputs.extra[i]) {
-              attributions.push(extraOutputs.extra[i].attributions);
+          for (let modelNum = 0; modelNum < extraOutputs.extra.length; modelNum++) {
+            if ('attributions' in extraOutputs.extra[modelNum]) {
+              attributions.push(extraOutputs.extra[modelNum].attributions);
             }
           }
           if (attributions.length > 0) {

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
@@ -124,7 +124,7 @@ class WitWidgetBase(object):
     examples_to_infer = [
         self.json_to_proto(self.examples[index]) for index in indices_to_infer]
     infer_objs = []
-    attribution_objs = []
+    extra_output_objs = []
     serving_bundle = inference_utils.ServingBundle(
       self.config.get('inference_address'),
       self.config.get('model_name'),
@@ -137,11 +137,11 @@ class WitWidgetBase(object):
       self.estimator_and_spec.get('estimator'),
       self.estimator_and_spec.get('feature_spec'),
       self.custom_predict_fn)
-    (predictions, attributions) = (
+    (predictions, extra_output) = (
       inference_utils.run_inference_for_inference_results(
         examples_to_infer, serving_bundle))
     infer_objs.append(predictions)
-    attribution_objs.append(attributions)
+    extra_output_objs.append(extra_output)
     if ('inference_address_2' in self.config or
         self.compare_estimator_and_spec.get('estimator') or
         self.compare_custom_predict_fn):
@@ -157,16 +157,16 @@ class WitWidgetBase(object):
         self.compare_estimator_and_spec.get('estimator'),
         self.compare_estimator_and_spec.get('feature_spec'),
         self.compare_custom_predict_fn)
-      (predictions, attributions) = (
+      (predictions, extra_output) = (
         inference_utils.run_inference_for_inference_results(
           examples_to_infer, serving_bundle))
       infer_objs.append(predictions)
-      attribution_objs.append(attributions)
+      extra_output_objs.append(extra_output)
     self.updated_example_indices = set()
     return {
       'inferences': {'indices': indices_to_infer, 'results': infer_objs},
       'label_vocab': self.config.get('label_vocab'),
-      'attributions': attribution_objs}
+      'extra_outputs': extra_output_objs}
 
   def infer_mutants_impl(self, info):
     """Performs mutant inference on specified examples."""

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
@@ -96,8 +96,8 @@ WIT_HTML = """
       window.inferenceCallback = inferences => {{
         wit.labelVocab = inferences.label_vocab;
         wit.inferences = inferences.inferences;
-        wit.attributions = {{indices: wit.inferences.indices,
-                            attributions: inferences.attributions}}
+        wit.extraOutputs = {{indices: wit.inferences.indices,
+                              extra: inferences.extra_outputs}}
       }};
       window.spriteCallback = spriteUrl => {{
         if (!wit.updateSprite) {{

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
@@ -121,7 +121,7 @@ WIT_HTML = """
         wit.labelVocab = inferences.label_vocab;
         wit.inferences = inferences.inferences;
         wit.extraOutputs = {{indices: wit.inferences.indices,
-                              extra: inferences.extra_outputs}};
+                             extra: inferences.extra_outputs}};
       }};
 
       window.distanceCallback = callbackDict => {{

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
@@ -155,9 +155,9 @@ var WITView = widgets.DOMWidgetView.extend({
     const inferences = this.model.get('inferences');
     this.view_.labelVocab = inferences['label_vocab'];
     this.view_.inferences = inferences['inferences'];
-    this.view_.attributions = {
+    this.view_.extraOutputs = {
       indices: this.view_.inferences.indices,
-      attributions: inferences['attributions'],
+      extra: inferences['extra_outputs'],
     };
   },
   eligibleFeaturesChanged: function() {

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
@@ -414,11 +414,11 @@ class WitConfigBuilder(object):
       - For regression: A 1D list of numbers, with a regression score for each
         example being predicted.
 
-    Optionally, if attributions can be returned by the model with each
-    prediction, then this method can return a dict with the key 'predictions'
-    containing the predictions result list described above, and with the key
-    'attributions' containing a list of attributions for each example that was
-    predicted.
+    Optionally, if attributions or other prediction-time information
+    can be returned by the model with each prediction, then this method
+    can return a dict with the key 'predictions' containing the predictions
+    result list described above, and with the key 'attributions' containing
+    a list of attributions for each example that was predicted.
 
     For each example, the attributions list should contain a dict mapping
     input feature names to attribution values for that feature on that example.
@@ -431,6 +431,12 @@ class WitConfigBuilder(object):
         feature values that there are attribution scores for. Index 1 contains
         a list of attribution values for the corresponding feature values in
         the first list.
+
+    This dict can contain any other keys, with their values being a list of
+    prediction-time strings or numbers for each example being predicted. These
+    values will be displayed in WIT as extra information for each example,
+    usable in the same ways by WIT as normal input features (such as for
+    creating plots and slicing performance data).
 
     Args:
       predict_fn: The custom python function which will be used for model
@@ -481,6 +487,12 @@ class WitConfigBuilder(object):
         feature values that there are attribution scores for. Index 1 contains
         a list of attribution values for the corresponding feature values in
         the first list.
+
+    This dict can contain any other keys, with their values being a list of
+    prediction-time strings or numbers for each example being predicted. These
+    values will be displayed in WIT as extra information for each example,
+    usable in the same ways by WIT as normal input features (such as for
+    creating plots and slicing performance data).
 
     Args:
       predict_fn: The custom python function which will be used for model

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
@@ -470,11 +470,11 @@ class WitConfigBuilder(object):
       - For regression: A 1D list of numbers, with a regression score for each
         example being predicted.
 
-    Optionally, if attributions can be returned by the model with each
-    prediction, then this method can return a dict with the key 'predictions'
-    containing the predictions result list described above, and with the key
-    'attributions' containing a list of attributions for each example that was
-    predicted.
+    Optionally, if attributions or other prediction-time information
+    can be returned by the model with each prediction, then this method
+    can return a dict with the key 'predictions' containing the predictions
+    result list described above, and with the key 'attributions' containing
+    a list of attributions for each example that was predicted.
 
     For each example, the attributions list should contain a dict mapping
     input feature names to attribution values for that feature on that example.


### PR DESCRIPTION
* Motivation for features / changes

Previously, when using a custom predict function, WIT could consume attribution information for each example along with the standard prediction outputs. This work extends this so that any prediction-time information can be provided to WIT, beyond just attribution values.

* Technical description of changes

Pass dictionary of extra outputs from custom predict models from python to javascript, instead of just passing attribution information. Attribution information would be inside this dict.

Update python logic to handle this dictionary correctly.

Update javascript logic for notebook mode to pass this extra information to WIT.

Update WIT to consume this information and update its visdata and examplesAndInferences structs with this extra data for each example when provided, for display in Facets Dive and the example viewer.

Extract attributions from this extra output and have WIT consume it in the same way as before.

* Screenshots of UI changes

Showing an extra field named "thingy", set in the code, displayed in the selected example, and used as an axis in the datapoints display to the right:
![extra](https://user-images.githubusercontent.com/15835086/65334579-a74b1500-db90-11e9-8bf8-7d75869f2dbf.png)


* Detailed steps to verify changes work correctly (as executed by you)

Run notebook with attribution to ensure attributions still handled correctly.
Run notebook with extra model output and verify that the extra information is displayed correctly both in the example viewer and Facets Dive.
