### PR TITLE
core: split magic `--logdir_spec` out from verbatim `--logdir`

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -210,7 +210,6 @@ def TensorBoardWSGIApp(
       db_uri=db_uri,
       flags=flags,
       logdir=flags.logdir,
-      logdir_spec=flags.logdir_spec,
       multiplexer=deprecated_multiplexer,
       assets_zip_provider=assets_zip_provider,
       plugin_name_to_instance=plugin_name_to_instance,

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -141,13 +141,16 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
         event_file_active_filter=_get_event_file_active_filter(flags))
     if flags.generic_data != 'false':
       data_provider = event_data_provider.MultiplexerDataProvider(
-          multiplexer, flags.logdir
+          multiplexer, flags.logdir or flags.logdir_spec
       )
 
   if reload_interval >= 0:
     # We either reload the multiplexer once when TensorBoard starts up, or we
     # continuously reload the multiplexer.
-    path_to_run = parse_event_files_spec(flags.logdir)
+    if flags.logdir:
+      path_to_run = {os.path.expanduser(flags.logdir): None}
+    else:
+      path_to_run = parse_event_files_spec(flags.logdir_spec)
     start_reloading_multiplexer(
         multiplexer, path_to_run, reload_interval, flags.reload_task)
   return TensorBoardWSGIApp(
@@ -207,6 +210,7 @@ def TensorBoardWSGIApp(
       db_uri=db_uri,
       flags=flags,
       logdir=flags.logdir,
+      logdir_spec=flags.logdir_spec,
       multiplexer=deprecated_multiplexer,
       assets_zip_provider=assets_zip_provider,
       plugin_name_to_instance=plugin_name_to_instance,
@@ -425,14 +429,14 @@ class TensorBoardWSGI(object):
     # pylint: enable=too-many-function-args
 
 
-def parse_event_files_spec(logdir):
-  """Parses `logdir` into a map from paths to run group names.
+def parse_event_files_spec(logdir_spec):
+  """Parses `logdir_spec` into a map from paths to run group names.
 
-  The events files flag format is a comma-separated list of path specifications.
-  A path specification either looks like 'group_name:/path/to/directory' or
+  The `--logdir_spec` flag format is a comma-separated list of path
+  specifications. A path spec looks like 'group_name:/path/to/directory' or
   '/path/to/directory'; in the latter case, the group is unnamed. Group names
-  cannot start with a forward slash: /foo:bar/baz will be interpreted as a
-  spec with no name and path '/foo:bar/baz'.
+  cannot start with a forward slash: /foo:bar/baz will be interpreted as a spec
+  with no name and path '/foo:bar/baz'.
 
   Globs are not supported.
 
@@ -445,11 +449,11 @@ def parse_event_files_spec(logdir):
     require any valid runs.
   """
   files = {}
-  if logdir is None:
+  if logdir_spec is None:
     return files
   # Make sure keeping consistent with ParseURI in core/lib/io/path.cc
   uri_pattern = re.compile('[a-zA-Z][0-9a-zA-Z.]*://.*')
-  for specification in logdir.split(','):
+  for specification in logdir_spec.split(','):
     # Check if the spec contains group. A spec start with xyz:// is regarded as
     # URI path spec instead of group spec. If the spec looks like /foo:bar/baz,
     # then we assume it's a path with a colon. If the spec looks like

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -51,6 +51,7 @@ class FakeFlags(object):
   def __init__(
       self,
       logdir,
+      logdir_spec='',
       purge_orphaned_data=True,
       reload_interval=60,
       samples_per_plugin='',
@@ -64,6 +65,7 @@ class FakeFlags(object):
       reload_multifile_inactive_secs=4000,
       generic_data='auto'):
     self.logdir = logdir
+    self.logdir_spec = logdir_spec
     self.purge_orphaned_data = purge_orphaned_data
     self.reload_interval = reload_interval
     self.samples_per_plugin = samples_per_plugin

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -221,6 +221,7 @@ class TBContext(object):
       db_uri=None,
       flags=None,
       logdir=None,
+      logdir_spec=None,
       multiplexer=None,
       plugin_name_to_instance=None,
       window_title=None):
@@ -245,12 +246,12 @@ class TBContext(object):
           function is cheap. The returned connection must only be used by a
           single thread. Things like connection pooling are considered
           implementation details of the provider.
-      db_uri: The string db URI TensorBoard was started with. If this is set,
-          the logdir should be None.
+      db_uri: The string db URI TensorBoard was started with.
       flags: An object of the runtime flags provided to TensorBoard to their
           values.
-      logdir: The string logging directory TensorBoard was started with. If this
-          is set, the db_uri should be None.
+      logdir: The string logging directory TensorBoard was started with.
+      logdir_spec: The value of `--logdir_spec` passed to TensorBoard (see
+          flag-level documentation).
       multiplexer: An EventMultiplexer with underlying TB data. Plugins should
           copy this data over to the database when the db fields are set.
       plugin_name_to_instance: A mapping between plugin name to instance.
@@ -267,6 +268,7 @@ class TBContext(object):
     self.db_uri = db_uri
     self.flags = flags
     self.logdir = logdir
+    self.logdir_spec = logdir_spec
     self.multiplexer = multiplexer
     self.plugin_name_to_instance = plugin_name_to_instance
     self.window_title = window_title

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -221,7 +221,6 @@ class TBContext(object):
       db_uri=None,
       flags=None,
       logdir=None,
-      logdir_spec=None,
       multiplexer=None,
       plugin_name_to_instance=None,
       window_title=None):
@@ -246,12 +245,12 @@ class TBContext(object):
           function is cheap. The returned connection must only be used by a
           single thread. Things like connection pooling are considered
           implementation details of the provider.
-      db_uri: The string db URI TensorBoard was started with.
+      db_uri: The string db URI TensorBoard was started with. If this is set,
+          the logdir should be None.
       flags: An object of the runtime flags provided to TensorBoard to their
           values.
-      logdir: The string logging directory TensorBoard was started with.
-      logdir_spec: The value of `--logdir_spec` passed to TensorBoard (see
-          flag-level documentation).
+      logdir: The string logging directory TensorBoard was started with. If this
+          is set, the db_uri should be None.
       multiplexer: An EventMultiplexer with underlying TB data. Plugins should
           copy this data over to the database when the db fields are set.
       plugin_name_to_instance: A mapping between plugin name to instance.
@@ -268,7 +267,6 @@ class TBContext(object):
     self.db_uri = db_uri
     self.flags = flags
     self.logdir = logdir
-    self.logdir_spec = logdir_spec
     self.multiplexer = multiplexer
     self.plugin_name_to_instance = plugin_name_to_instance
     self.window_title = window_title

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -57,7 +57,8 @@ class CorePlugin(base_plugin.TBPlugin):
     Args:
       context: A base_plugin.TBContext instance.
     """
-    self._logdir = context.logdir or context.logdir_spec
+    logdir_spec = context.flags.logdir_spec if context.flags else ''
+    self._logdir = context.logdir or logdir_spec
     self._db_uri = context.db_uri
     self._window_title = context.window_title
     self._multiplexer = context.multiplexer

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -49,12 +49,14 @@ class FakeFlags(object):
       inspect=False,
       version_tb=False,
       logdir='',
+      logdir_spec='',
       event_file='',
       db='',
       path_prefix=''):
     self.inspect = inspect
     self.version_tb = version_tb
     self.logdir = logdir
+    self.logdir_spec = logdir_spec
     self.event_file = event_file
     self.db = db
     self.path_prefix = path_prefix

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -262,7 +262,7 @@ class TensorBoard(object):
         port=server_url.port,
         pid=os.getpid(),
         path_prefix=self.flags.path_prefix,
-        logdir=self.flags.logdir,
+        logdir=self.flags.logdir or self.flags.logdir_spec,
         db=self.flags.db,
         cache_key=self.cache_key,
     )


### PR DESCRIPTION
Summary:
This introduces a new flag, `--logdir_spec`, whose behavior is the same
as the old behavior of `--logdir`. The `--logdir` flag now specifies a
single log directory, without special treatment for commas and colons,
though it still has the `expanduser` call for compatibility with users
who use the `--logdir=~/...` form rather than `--logdir ~/...`.

I audited all uses of `flags.logdir` and `context.logdir`, and, other
than those changed in this commit, all really should be using `logdir`
rather than `logdir_spec` (i.e., they do not properly parse the logdir
spec, and so were broken before this commit).

Fixes #2615, fixes #1220, and fixes lots of user confusion.

Test Plan:
Run with the following args:

    --logdir ~/data/  # should work as usual
    --logdir=~/data/  # should work as usual
    --logdir ~/data/scalars_demo,~/data/audio_demo  # should be empty
    --logdir ~/data/mnist/lr_1E-03,conv=1,fc=2  # should work now!
    --logdir_spec ~/data/  # should work, but without projector, et al.
    --logdir_spec ~/data/scalars_demo,~/data/audio_demo  # should work

wchargin-branch: logdir-spec
