### PR TITLE
ci: pin to non-broken estimator nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,13 @@ install:
       pip install "absl-py>=0.7.0" \
       && pip install "numpy<2.0,>=1.14.5"
     fi
+  - |
+    # On TF 1.x nightlies, downgrade estimator temporarily.
+    case "${TF_VERSION_ID}" in
+      tf-nightly|tf-nightly==*)
+        pip install tf-estimator-nightly==1.14.0.dev2019091701
+        ;;
+    esac
   # Deps for gfile S3 test.
   - pip install boto3==1.9.86
   - pip install moto==1.3.7


### PR DESCRIPTION
Summary:
Due to <https://github.com/tensorflow/tensorflow/issues/32621>.

This unblocks our CI until tomorrow’s nightlies are pushed.

Test Plan:
Ran this 5-line shell command (with `pip install` changed to `echo) once
with `TF_VERSION_ID` set to each value from the `env` section, and noted
that in all cases it succeeds and that it only prints output in the
correct case.

wchargin-branch: pin-estimator-20190917-nightly
