### PR TITLE
Fix PD plots in py3

### DIFF
--- a/tensorboard/plugins/interactive_inference/utils/BUILD
+++ b/tensorboard/plugins/interactive_inference/utils/BUILD
@@ -31,6 +31,7 @@ py_library(
         ":platform_utils",
         "//tensorboard:expect_absl_logging_installed",
         "//tensorboard:expect_tensorflow_installed",
+        "@org_pythonhosted_six",
         "@org_tensorflow_serving_api",
     ],
 )
@@ -55,6 +56,7 @@ py_test(
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "@org_pythonhosted_mock",
+        "@org_pythonhosted_six",
         "@org_tensorflow_serving_api",
     ],
 )

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -125,7 +125,8 @@ class OriginalFeatureList(object):
   def __init__(self, feature_name, original_value, feature_type):
     """Inits OriginalFeatureList."""
     self.feature_name = feature_name
-    self.original_value = [ensure_not_binary(v) for v in original_value]
+    self.original_value = [
+      ensure_not_binary(value) for value in original_value]
     self.feature_type = feature_type
 
     # Derived attributes.

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -26,7 +26,6 @@ import numpy as np
 import tensorflow as tf
 from google.protobuf import json_format
 from six import binary_type, string_types, integer_types
-from six import ensure_binary, ensure_str
 from six import iteritems
 from six.moves import zip  # pylint: disable=redefined-builtin
 
@@ -165,7 +164,7 @@ class MutantFeatureValue(object):
           'index should be None or int, but had unexpected type: {}'.format(
               type(index)))
     self.index = index
-    self.mutant_value = (ensure_binary(mutant_value)
+    self.mutant_value = (mutant_value.encode()
         if isinstance(mutant_value, string_types) else mutant_value)
 
 
@@ -230,7 +229,7 @@ class ServingBundle(object):
 
 def ensure_not_binary(value):
   """Return non-binary version of value."""
-  return ensure_str(value) if isinstance(value, binary_type) else value
+  return value.decode() if isinstance(value, binary_type) else value
 
 
 def proto_value_for_feature(example, feature_name):

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -130,9 +130,6 @@ class OriginalFeatureList(object):
       for v in original_value]
     self.feature_type = feature_type
 
-    #if feature_type == 'bytes_list':
-    #  self.original_value = [v.decode('utf-8') for v in self.original_value]
-
     # Derived attributes.
     self.length = sum(1 for _ in original_value)
 
@@ -172,10 +169,6 @@ class MutantFeatureValue(object):
     self.mutant_value = (
       mutant_value.encode()
       if isinstance(mutant_value, string_types) else mutant_value)
-    #if self.original_feature.feature_type == 'bytes_list':
-    #  print('encoding mutant')
-    #  self.mutant_value = self.mutant_value.encode()
-    #  print(self.mutant_value)
 
 
 class ServingBundle(object):
@@ -449,13 +442,10 @@ def make_mutant_tuples(example_protos, original_feature, index_to_mutate,
           new_values = list(feature_list)
           new_values[index_to_mutate] = mutant_feature.mutant_value
 
-        print('new values')
-        print(new_values)
         del feature_list[:]
         feature_list.extend(new_values)
         mutant_examples.append(copied_example)
-      except (ValueError, IndexError) as e:
-        print(e)
+      except (ValueError, IndexError):
         # If the mutant value can't be set, still add the example to the
         # mutant_example even though no change was made. This is necessary to
         # allow for computation of global PD plots when not all examples have
@@ -495,7 +485,6 @@ def mutant_charts_for_feature(example_protos, feature_name, serving_bundles,
 
     charts = []
     for serving_bundle in serving_bundles:
-      print(mutant_examples)
       (inference_result_proto, _) = run_inference(
         mutant_examples, serving_bundle)
       charts.append(make_json_formatted_for_single_chart(
@@ -595,7 +584,6 @@ def make_json_formatted_for_single_chart(mutant_features,
           y_label: sum(y_list) / float(len(y_list))
         })
       return_series[key].sort(key=lambda p: p[x_label])
-    print(return_series)
     return return_series
 
   elif isinstance(inference_result_proto, regression_pb2.RegressionResponse):

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils_test.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils_test.py
@@ -177,7 +177,7 @@ class InferenceUtilsTest(tf.test.TestCase):
         examples[0: 3], top_k=1)
     self.assertDictEqual({
         'non_numeric': {
-            'samples': [b'cat']
+            'samples': ['cat']
         }
     }, data)
 
@@ -186,7 +186,7 @@ class InferenceUtilsTest(tf.test.TestCase):
         examples[0: 20], top_k=2)
     self.assertDictEqual({
         'non_numeric': {
-            'samples': [b'pony', b'cow']
+            'samples': ['pony', 'cow']
         }
     }, data)
 

--- a/tensorboard/plugins/interactive_inference/witwidget/pip_package/setup.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/pip_package/setup.py
@@ -47,7 +47,7 @@ REQUIRED_PACKAGES = [
     'google-api-python-client>=1.7.8',
     'ipywidgets>=7.0.0',
     'jupyter>=1.0,<2',
-    'six>1.12.0',
+    'six>=1.12.0',
 ] + _TF_REQ
 
 def get_readme():

--- a/tensorboard/plugins/interactive_inference/witwidget/pip_package/setup.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/pip_package/setup.py
@@ -47,6 +47,7 @@ REQUIRED_PACKAGES = [
     'google-api-python-client>=1.7.8',
     'ipywidgets>=7.0.0',
     'jupyter>=1.0,<2',
+    'six>1.12.0',
 ] + _TF_REQ
 
 def get_readme():


### PR DESCRIPTION
* Motivation for features / changes
PD plots didn't work at all in notebook mode with py3 kernels.

* Technical description of changes

Ensure string feature values used in PD plot generation are sent to JS as strings for json serialization, not as bytes, to avoid failing serialization.
Correctly use the bytes when running in py3 as that is what tf.Example expects for bytes_list, whereas in py2 it functions on strings.
Make use of six.bytes_type and encode and decode functions to correctly handle this.

* Detailed steps to verify changes work correctly (as executed by you)

Ran notebooks in py2 and py3 with this change and verified that PD plots are shown correctly (with correct values as well) for both numeric and categorical features.

