### PR TITLE
summary: export v2 symbols as defaults

### DIFF
--- a/tensorboard/pip_package/test_pip_package.sh
+++ b/tensorboard/pip_package/test_pip_package.sh
@@ -183,7 +183,7 @@ hp.hparams_pb({'optimizer': 'adam', 'learning_rate': 0.02})
     # Only test summary scalar, beholder, and mesh summary
     python -c "
 import tensorboard as tb
-tb.summary.scalar_pb('test', 42)
+tb.summary.v1.scalar_pb('test', 42)
 from tensorboard.plugins.beholder import Beholder, BeholderHook
 from tensorboard.plugins.mesh import summary
 "

--- a/tensorboard/pip_package/test_pip_package.sh
+++ b/tensorboard/pip_package/test_pip_package.sh
@@ -184,6 +184,7 @@ hp.hparams_pb({'optimizer': 'adam', 'learning_rate': 0.02})
     python -c "
 import tensorboard as tb
 tb.summary.v1.scalar_pb('test', 42)
+tb.summary.scalar('test v2', 1337)
 from tensorboard.plugins.beholder import Beholder, BeholderHook
 from tensorboard.plugins.mesh import summary
 "

--- a/tensorboard/summary/__init__.py
+++ b/tensorboard/summary/__init__.py
@@ -23,13 +23,13 @@ from __future__ import print_function
 # If the V1 summary API is accessible, load and re-export it here.
 try:
   from tensorboard.summary import v1
-  from tensorboard.summary.v1 import *
 except ImportError:
   pass
 
 # Load the V2 summary API if accessible.
 try:
   from tensorboard.summary import v2
+  from tensorboard.summary.v2 import *
 except ImportError:
   pass
 

--- a/tensorboard/summary/summary_test.py
+++ b/tensorboard/summary/summary_test.py
@@ -69,13 +69,14 @@ class SummaryExportsTest(SummaryExportsBaseTest, unittest.TestCase):
   allowed = frozenset(('v1', 'v2'))
   plugins = frozenset([
     'audio',
-    'custom_scalar',
     'histogram',
     'image',
-    'pr_curve',
     'scalar',
     'text',
   ])
+
+  def test_plugins_export_pb_functions(self):
+    self.skipTest('V2 summary API _pb functions are not finalized yet')
 
 
 class SummaryExportsV1Test(SummaryExportsBaseTest, unittest.TestCase):


### PR DESCRIPTION
This change is for readiness of TensorBoard 2.0 release.
In 2.0, tensorboard.summary should default to v2 symbols.

Fixes #2512 