### PR TITLE
ui: fix downloader links before run selection

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-downloader.html
+++ b/tensorboard/components/tf_dashboard_common/tf-downloader.html
@@ -33,14 +33,16 @@ limitations under the License.
         </template>
       </paper-listbox>
     </paper-dropdown-menu>
-    <a download="[[_csvName(tag, _run)]]" href="[[_csvUrl(tag, _run, urlFn)]]"
-      >CSV</a
-    ><!--
-    --><a
-      download="[[_jsonName(tag, _run)]]"
-      href="[[_jsonUrl(tag, _run, urlFn)]]"
-      >JSON</a
-    >
+    <template is="dom-if" if="[[_run]]">
+      <a download="[[_csvName(tag, _run)]]" href="[[_csvUrl(tag, _run, urlFn)]]"
+        >CSV</a
+      ><!--
+      --><a
+        download="[[_jsonName(tag, _run)]]"
+        href="[[_jsonUrl(tag, _run, urlFn)]]"
+        >JSON</a
+      >
+    </template>
     <style>
       :host {
         display: flex;
@@ -69,7 +71,10 @@ limitations under the License.
     Polymer({
       is: 'tf-downloader',
       properties: {
-        _run: String,
+        _run: {
+          type: String,
+          value: '',
+        },
         runs: Array, // Array<string>
         tag: String,
         // Clients pass `urlFn: (tag: string, run: string) => string`,
@@ -80,15 +85,19 @@ limitations under the License.
         urlFn: Function,
       },
       _csvUrl(tag, run, urlFn) {
+        if (!run) return '';
         return tf_backend.addParams(urlFn(tag, run), {format: 'csv'});
       },
       _jsonUrl(tag, run, urlFn) {
+        if (!run) return '';
         return urlFn(tag, run);
       },
       _csvName(tag, run) {
+        if (!run) return '';
         return `run-${run}-tag-${tag}.csv`;
       },
       _jsonName(tag, run) {
+        if (!run) return '';
         return `run-${run}-tag-${tag}.json`;
       },
     });

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -92,7 +92,10 @@ public final class Vulcanize {
   private static final ImmutableSet<String> EXTRA_JSDOC_TAGS =
       ImmutableSet.of("attribute", "hero", "group", "required");
 
-  private static final Pattern WEBPATH_PATTERN = Pattern.compile("//~~WEBPATH~~([^\n]+)");
+  private static final Pattern SCRIPT_DELIMITER_PATTERN =
+      Pattern.compile("//# sourceURL=build:/([^\n]+)");
+
+  private static final String SCRIPT_DELIMITER = "//# sourceURL=build:/%name%";
 
   private static final Parser parser = Parser.htmlParser();
   private static final Map<Webpath, Path> webfiles = new HashMap<>();
@@ -440,7 +443,7 @@ public final class Vulcanize {
 
     // So we can chop JS binary back up into the original script tags.
     options.setPrintInputDelimiter(true);
-    options.setInputDelimiter("//~~WEBPATH~~%name%");
+    options.setInputDelimiter(SCRIPT_DELIMITER);
 
     // Optimizations that are too advanced for us right now.
     options.setPropertyRenaming(PropertyRenamingPolicy.OFF);
@@ -556,7 +559,7 @@ public final class Vulcanize {
     // Split apart the JS blob and put it back in the original <script> locations.
     Deque<Map.Entry<Webpath, Node>> tags = new ArrayDeque<>();
     tags.addAll(sourceTags.entrySet());
-    Matcher matcher = WEBPATH_PATTERN.matcher(jsBlob);
+    Matcher matcher = SCRIPT_DELIMITER_PATTERN.matcher(jsBlob);
     verify(matcher.find(), "Nothing found in compiled JS blob!");
     Webpath path = Webpath.get(matcher.group(1));
     int start = 0;


### PR DESCRIPTION
Before the user selects a run via the downloader dropdown, the "CSV", "JSON" links used to have an href with the word "undefined" in the middle.

In this CL, we
- only builds an href if a run is selected
- only show the download links if a run is selected