### PR TITLE
Aggregate numeric values when slicing (What-If Tool)

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3263,6 +3263,11 @@ limitations under the License.
             type: String,
           },
           maxInferenceEntriesPerRun: Number,
+          // Number of buckets When aggregating numeric features.
+          numBuckets: {
+            type: Number,
+            value: 10,
+          },
 
           // Inferences from servo.
           inferences: {
@@ -6097,22 +6102,25 @@ limitations under the License.
          * Whether values of this feature should be aggregated in bucket slices.
          */
         shouldBeAggregated_: function(feature) {
-          const maxUniqueValueSlices = 10; // TODO: Move this to a variable.
           return (
             this.distanceStats_[feature] &&
             this.distanceStats_[feature].isNumeric &&
-            this.stats[feature].uniqueCount > maxUniqueValueSlices
+            // No point in aggregating if less unique values than buckets.
+            this.stats[feature].uniqueCount > this.numBuckets
           );
         },
 
+        /**
+         * Calculate edges between buckets for aggregating numeric features.
+         * We do this beforehand to round numbers and avoid ugly interval labels.
+         */
         calculateFeatureBucketEdges_: function() {
-          const numBuckets = 10; // TODO: Move this to a variable.
           this.featureBucketEdges_ = {};
           for (const feature of Object.keys(this.distanceStats_)) {
             if (this.shouldBeAggregated_(feature)) {
               const min = this.stats[feature].numberMin;
               const max = this.stats[feature].numberMax;
-              const len = (max - min) / numBuckets;
+              const len = (max - min) / this.numBuckets;
               const stdDev = this.distanceStats_[feature].stdDev;
               function round(val) {
                 // Round to a precision near the magnitude of standard deviation.
@@ -6121,7 +6129,7 @@ limitations under the License.
               }
               const bucketEdges = [];
               bucketEdges.push(min);
-              for (let i = 1; i < numBuckets; i++) {
+              for (let i = 1; i < this.numBuckets; i++) {
                 bucketEdges.push(round(min + i * len));
               }
               bucketEdges.push(max);

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3213,6 +3213,10 @@ limitations under the License.
       }
     }
 
+    function deepClone(obj) {
+      return JSON.parse(JSON.stringify(obj));
+    }
+
     (function() {
       const PLUGIN_NAME = 'whatif';
 
@@ -4156,17 +4160,10 @@ limitations under the License.
               );
               const key = this.createCombinedValueString_(key1, key2);
               if (!(key in thresholdsMap)) {
-                // Deep copy thresholds for each facet
-                const modelThresholds = [];
-                for (let i = 0; i < this.overallThresholds.length; i++) {
-                  modelThresholds.push({
-                    threshold: this.overallThresholds[i].threshold,
-                  });
-                }
                 thresholdsMap[key] = {
                   value: key1,
                   value2: key2,
-                  threshold: modelThresholds,
+                  threshold: deepClone(this.overallThresholds),
                   opened: false,
                 };
               }

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -4123,6 +4123,17 @@ limitations under the License.
         },
 
         /**
+         * Get the key to which this example belongs when the dataset is sliced by the given feature(s).
+         */
+        getSliceKey_: function(example, feature1, feature2) {
+          // TODO: Aggregate numeric keys into buckets.
+          return this.createCombinedValueString_(
+            example[feature1],
+            example[feature2]
+          );
+        },
+
+        /**
          * Creates a list of all feature values of the selected breakdown feature
          * or feature crosses if two breakdown features are selected, and gets
          * inference stats per breakdown.
@@ -4193,6 +4204,7 @@ limitations under the License.
                       opened: false,
                     };
                     thresholds.push(thresh);
+                    // TODO: Make this coincide with the getSliceKey_
                     const mapKey = this.createCombinedValueString_(
                       feature1Value,
                       feature2Value
@@ -4277,9 +4289,10 @@ limitations under the License.
                   const item = this.visdata[i];
                   let facetedStats = null;
                   if (this.selectedBreakdownFeature != '') {
-                    const facetKey = this.createCombinedValueString_(
-                      item[this.selectedBreakdownFeature],
-                      item[this.selectedSecondBreakdownFeature]
+                    const facetKey = this.getSliceKey_(
+                      item,
+                      this.selectedBreakdownFeature,
+                      this.selectedSecondBreakdownFeature
                     );
                     facetedStats = inferenceStats.faceted[facetKey];
                     if (!facetedStats) {
@@ -4356,9 +4369,10 @@ limitations under the License.
                   const item = this.visdata[i];
                   let facetedStats = null;
                   if (this.selectedBreakdownFeature != '') {
-                    const facetKey = this.createCombinedValueString_(
-                      item[this.selectedBreakdownFeature],
-                      item[this.selectedSecondBreakdownFeature]
+                    const facetKey = this.getSliceKey_(
+                      item,
+                      this.selectedBreakdownFeature,
+                      this.selectedSecondBreakdownFeature
                     );
                     facetedStats = inferenceStats.faceted[facetKey];
                     if (!facetedStats) {
@@ -4412,9 +4426,10 @@ limitations under the License.
                   const item = this.visdata[i];
                   let facetedStats = null;
                   if (this.selectedBreakdownFeature != '') {
-                    const facetKey = this.createCombinedValueString_(
-                      item[this.selectedBreakdownFeature],
-                      item[this.selectedSecondBreakdownFeature]
+                    const facetKey = this.getSliceKey_(
+                      item,
+                      this.selectedBreakdownFeature,
+                      this.selectedSecondBreakdownFeature
                     );
                     facetedStats = inferenceStats.faceted[facetKey];
                     if (!facetedStats) {
@@ -5922,9 +5937,10 @@ limitations under the License.
           // case), then get the appropriate threshold for this item's value for
           // that feature. Otherwise the overall threshold will be used.
           if (feature1.length !== 0) {
-            let key = this.createCombinedValueString_(
-              item[feature1],
-              item[feature2]
+            let key = this.getSliceKey_(
+              item,
+              this.selectedBreakdownFeature,
+              this.selectedSecondBreakdownFeature
             );
             thresholds = this.featureValueThresholdsMap[key].threshold;
           }

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3263,7 +3263,7 @@ limitations under the License.
             type: String,
           },
           maxInferenceEntriesPerRun: Number,
-          // Number of buckets When aggregating numeric features.
+          // Number of buckets when aggregating numeric features.
           numBuckets: {
             type: Number,
             value: 10,
@@ -4191,6 +4191,7 @@ limitations under the License.
             }.bind(this)
           );
           const thresholds = Object.values(thresholdsMap);
+          this.set('selectedFeatureSort', 'Alphabetical');
           this.set('featureValueThresholds', thresholds);
           this.set('featureValueThresholdsMap', thresholdsMap);
           this.refreshInferences_(false);
@@ -4552,9 +4553,13 @@ limitations under the License.
                 );
               }
             } else if (this.selectedFeatureSort == 'Alphabetical') {
-              return this.getPrintableValue_(a).localeCompare(
-                this.getPrintableValue_(b)
-              );
+              const aValue = this.getPrintableValue_(a);
+              const bValue = this.getPrintableValue_(b);
+              // Handle numeric intervals
+              if (aValue[0] === '[' && bValue[0] === '[') {
+                return Number.parseFloat(aValue.substring(1)) - Number.parseFloat(bValue.substring(1));
+              }
+              return aValue.localeCompare(bValue);
             } else if (this.selectedFeatureSort == 'Accuracy') {
               if (
                 this.isBinaryClassification_(this.modelType, this.multiClass)
@@ -4606,6 +4611,10 @@ limitations under the License.
             if (this.selectedFeatureSort == 'Count') {
               return b.count - a.count;
             } else if (this.selectedFeatureSort == 'Alphabetical') {
+              // Handle numeric intervals
+              if (a.name[0] === '[' && b.name[0] === '[') {
+                return Number.parseFloat(a.name.substring(1)) - Number.parseFloat(b.name.substring(1));
+              }
               return a.name.localeCompare(b.name);
             } else if (this.selectedFeatureSort == 'Mean error') {
               return b.meanError - a.meanError;

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3647,6 +3647,7 @@ limitations under the License.
             type: Boolean,
             value: true,
           },
+          featureBucketEdges_: Object,
         },
 
         observers: [
@@ -4130,10 +4131,25 @@ limitations under the License.
          * Get the key to which this example belongs when the dataset is sliced by the given feature(s).
          */
         getSliceKey_: function(example, feature1, feature2) {
-          // TODO: Aggregate numeric keys into buckets.
+          const bucketEdges = this.featureBucketEdges_;
+          function maybeAggregate(feature) {
+            const edges = bucketEdges[feature];
+            if (edges) {
+              for (let i = 1; i < edges.length; i++) {
+                if (
+                  example[feature] < edges[i] ||
+                  (example[feature] === edges[i] && i === edges.length - 1)
+                ) {
+                  const right = i < edges.length - 1 ? ')' : ']';
+                  return '[' + edges[i - 1] + ', ' + edges[i] + right;
+                }
+              }
+            }
+            return example[feature];
+          }
           return this.createCombinedValueString_(
-            example[feature1],
-            example[feature2]
+            maybeAggregate(feature1),
+            maybeAggregate(feature2)
           );
         },
 
@@ -6023,6 +6039,7 @@ limitations under the License.
             {name: '', data: temp},
           ]);
           this.calculateDistanceStats_(this.$.overview.protoInput.toObject());
+          this.calculateFeatureBucketEdges_();
           const tempSelected = this.$.dive.selectedData;
           this.$.dive.selectedData = [];
           this.$.dive.selectedData = tempSelected;
@@ -6053,7 +6070,7 @@ limitations under the License.
             const featureStats = statsProto.datasetsList[0].featuresList[i];
             const feature = featureStats.name;
             this.distanceStats_[feature] = {
-              isNumeric: featureStats.numStats != null
+              isNumeric: featureStats.numStats != null,
             };
             if (this.distanceStats_[feature].isNumeric) {
               // For numeric features, store standard deviation.
@@ -6072,6 +6089,43 @@ limitations under the License.
                 probSameValue += probEntry * probEntry;
               }
               this.distanceStats_[feature].probSameValue = probSameValue;
+            }
+          }
+        },
+
+        /**
+         * Whether values of this feature should be aggregated in bucket slices.
+         */
+        shouldBeAggregated_: function(feature) {
+          const maxUniqueValueSlices = 10; // TODO: Move this to a variable.
+          return (
+            this.distanceStats_[feature] &&
+            this.distanceStats_[feature].isNumeric &&
+            this.stats[feature].uniqueCount > maxUniqueValueSlices
+          );
+        },
+
+        calculateFeatureBucketEdges_: function() {
+          const numBuckets = 10; // TODO: Move this to a variable.
+          this.featureBucketEdges_ = {};
+          for (const feature of Object.keys(this.distanceStats_)) {
+            if (this.shouldBeAggregated_(feature)) {
+              const min = this.stats[feature].numberMin;
+              const max = this.stats[feature].numberMax;
+              const len = (max - min) / numBuckets;
+              const stdDev = this.distanceStats_[feature].stdDev;
+              function round(val) {
+                // Round to a precision near the magnitude of standard deviation.
+                const precision = -Math.floor(Math.log10(stdDev));
+                return Math.round(val * 10 ** precision) / 10 ** precision;
+              }
+              const bucketEdges = [];
+              bucketEdges.push(min);
+              for (let i = 1; i < numBuckets; i++) {
+                bucketEdges.push(round(min + i * len));
+              }
+              bucketEdges.push(max);
+              this.featureBucketEdges_[feature] = bucketEdges;
             }
           }
         },

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -4143,78 +4143,36 @@ limitations under the License.
           // back to custom (default).
           this.resetOptimizationSelected_();
 
-          const feature1 = this.selectedBreakdownFeature;
-          if (feature1 == '') {
-            this.selectedSecondBreakdownFeature = '';
-          }
-          const feature2 = this.selectedSecondBreakdownFeature;
-          const thresholds = [];
           const thresholdsMap = {};
-          if (feature1.length !== 0) {
-            let feature1Values = this.stats[feature1].valueHash;
-            // Only breakdown performance by features that don't contain fully-
-            // unique values per example.
-            if (
-              this.stats[feature1].totalCount !=
-              this.examplesAndInferences.length
-            ) {
-              feature1Values = Object.assign({}, feature1Values, {
-                undefined: '',
-              });
-            }
-            let feature2Values = {undefined: ''};
-            if (feature2.length != 0) {
-              feature2Values = this.stats[feature2].valueHash;
-              if (
-                this.stats[feature2].totalCount !=
-                this.examplesAndInferences.length
-              ) {
-                feature2Values = Object.assign({}, feature2Values, {
-                  undefined: '',
-                });
-              }
-            }
-
-            // For the selected feature, set up a dict of each feature value in
-            // the dataset to the threshold. Add this to a list (for display
-            // purposes) and create a map of feature value to entry in that list.
-            for (var key1 in feature1Values) {
-              if (feature1Values.hasOwnProperty(key1)) {
-                for (var key2 in feature2Values) {
-                  if (feature2Values.hasOwnProperty(key2)) {
-                    const feature1Value =
-                      key1 == 'undefined'
-                        ? undefined
-                        : this.stats[feature1].valueHash[key1].value;
-                    const feature2Value =
-                      key2 == 'undefined'
-                        ? undefined
-                        : this.stats[feature2].valueHash[key2].value;
-                    // Deep copy thresholds for each facet
-                    const modelThresholds = [];
-                    for (let i = 0; i < this.overallThresholds.length; i++) {
-                      modelThresholds.push({
-                        threshold: this.overallThresholds[i].threshold,
-                      });
-                    }
-                    const thresh = {
-                      value: feature1Value,
-                      value2: feature2Value,
-                      threshold: modelThresholds,
-                      opened: false,
-                    };
-                    thresholds.push(thresh);
-                    // TODO: Make this coincide with the getSliceKey_
-                    const mapKey = this.createCombinedValueString_(
-                      feature1Value,
-                      feature2Value
-                    );
-                    thresholdsMap[mapKey] = thresh;
-                  }
+          this.visdata.forEach(
+            function(item) {
+              const key1 = this.getSliceKey_(
+                item,
+                this.selectedBreakdownFeature
+              );
+              const key2 = this.getSliceKey_(
+                item,
+                this.selectedSecondBreakdownFeature
+              );
+              const key = this.createCombinedValueString_(key1, key2);
+              if (!(key in thresholdsMap)) {
+                // Deep copy thresholds for each facet
+                const modelThresholds = [];
+                for (let i = 0; i < this.overallThresholds.length; i++) {
+                  modelThresholds.push({
+                    threshold: this.overallThresholds[i].threshold,
+                  });
                 }
+                thresholdsMap[key] = {
+                  value: key1,
+                  value2: key2,
+                  threshold: modelThresholds,
+                  opened: false,
+                };
               }
-            }
-          }
+            }.bind(this)
+          );
+          const thresholds = Object.values(thresholdsMap);
           this.set('featureValueThresholds', thresholds);
           this.set('featureValueThresholdsMap', thresholdsMap);
           this.refreshInferences_(false);

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3849,7 +3849,7 @@ limitations under the License.
             const maxLength = Math.max(aVals.length, bVals.length);
             let featureTotalDist = 0;
             for (let i = 0; i < maxLength; i++) {
-              if (this.distanceStats_[feat].stdDev != null) {
+              if (this.distanceStats_[feat].isNumeric) {
                 featureTotalDist += this.getNumericDist(
                   aVals[i],
                   bVals[i],
@@ -6081,8 +6081,10 @@ limitations under the License.
           ) {
             const featureStats = statsProto.datasetsList[0].featuresList[i];
             const feature = featureStats.name;
-            this.distanceStats_[feature] = {};
-            if (featureStats.numStats) {
+            this.distanceStats_[feature] = {
+              isNumeric: featureStats.numStats != null
+            };
+            if (this.distanceStats_[feature].isNumeric) {
               // For numeric features, store standard deviation.
               this.distanceStats_[feature].stdDev =
                 featureStats.numStats.stdDev;


### PR DESCRIPTION
* Motivation for features / changes

When slicing by a numeric feature, aggregate values in intervals instead of creating a slice for each different value.

* Technical description of changes

The current implementation creates one slice for each different value of the feature. This might result in a huge number of slices that become unmanageable (imagine a slicing by features like "age" or "salary", which can have hundreds of unique values).
To work around this issue, we aggregate the values into buckets (like a histogram), then show aggregated statistics and performance results for each bucket.
Nothing changes for categorical features.

* Screenshots of UI changes

![Screenshot from 2019-09-18 17-54-25](https://user-images.githubusercontent.com/6004563/65169376-4f03fe00-da3e-11e9-80d9-ea35ca621fb5.png)

* Detailed steps to verify changes work correctly (as executed by you)

For both _multi_ and _age_ demos, wait for data to load and then:
1. Open the Performance tab
1. Slice by different features and check that:
   * Categorical features behave just like before (compare with demos in prod at https://pair-code.github.io/what-if-tool)
   * Numeric features with up to 10 unique values also remain the same
   * Numeric features with more than 10 unique values are aggregated in buckets, and results are coherent with the correct totals.

* Alternate designs / implementations considered

I opted for the equally-sized intervals (as opposed to the equally-populated ones, for example), mainly because they should be simpler to understand and because one of comparative columns is precisely the number of examples in each slice. The number of slices is controlled by a variable that could become a setting if needed.
As for notations, I also considered other a simple `a — b`, but the mathematical intervals are particularly precise and seem to be accessible enough.
Finally, generating the bucket edges beforehand was important to make the values look ok, since we would oftentimes get things like _[17.43333333333, 20]_ printed otherwise. I tried to simply calculate them ad hoc, but having consistent and simple display turned out to be more complex than expected.

cc @jameswex and @tolga-b 