### PR TITLE
Fix StopIteration issue in Python 3.7 (PEP 479)

### DIFF
--- a/tensorboard/backend/event_processing/directory_watcher.py
+++ b/tensorboard/backend/event_processing/directory_watcher.py
@@ -107,6 +107,10 @@ class DirectoryWatcher(object):
     # If the loader exists, check it for a value.
     if not self._loader:
       self._InitializeLoader()
+    
+    # If it still doesn't exist, there is no data
+    if not self._loader:
+      return
 
     while True:
       # Yield all the new events in the path we're currently loading from.
@@ -167,7 +171,7 @@ class DirectoryWatcher(object):
     if path:
       self._SetPath(path)
     else:
-      raise StopIteration
+      return
 
   def _SetPath(self, path):
     """Sets the current path to watch for new events.

--- a/tensorboard/backend/event_processing/directory_watcher.py
+++ b/tensorboard/backend/event_processing/directory_watcher.py
@@ -170,8 +170,6 @@ class DirectoryWatcher(object):
     path = self._GetNextPath()
     if path:
       self._SetPath(path)
-    else:
-      return
 
   def _SetPath(self, path):
     """Sets the current path to watch for new events.

--- a/tensorboard/backend/event_processing/directory_watcher.py
+++ b/tensorboard/backend/event_processing/directory_watcher.py
@@ -107,7 +107,7 @@ class DirectoryWatcher(object):
     # If the loader exists, check it for a value.
     if not self._loader:
       self._InitializeLoader()
-    
+
     # If it still doesn't exist, there is no data
     if not self._loader:
       return


### PR DESCRIPTION
The handling of the StopIteration exception within generators changed in Python 3.7 (PEP 479). 
 This broke our handling of empty log directories, causing one test to fail: `directory_watcher_test:TestEmptyDirectory()`.

The backwards-compatible fix is explained at https://www.python.org/dev/peps/pep-0479/#writing-backwards-and-forwards-compatible-code.

This is the only instance of this issue in TensorBoard that causes a test failure.  My reading of the few other appearances of `StopIteration` is that they are legitimate (either catching it, or raising it in a `__next__` method).