### PR TITLE
Fix counterfactual model dropdown

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -1448,7 +1448,7 @@ limitations under the License.
                             hidden$="[[shouldHideCounterfactualModelSelector_(parsedModelNames)]]"
                           >
                             <paper-listbox
-                              class="dropdown-content"
+                              slot="dropdown-content"
                               selected="{{nearestCounterfactualModelIndex}}"
                             >
                               <template


### PR DESCRIPTION
* Motivation for features / changes

Dropdown for model selection for counterfactual was broken on polymer2 update.

* Technical description of changes

Fix slot="dropdown-content" to match all other dropdowns

* Detailed steps to verify changes work correctly (as executed by you)

Test dropdown functionality in multi-model demo.

