### PR TITLE
Fix threshold optimizations in WIT

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -5157,7 +5157,8 @@ limitations under the License.
             // above search.
             for (let vIdx = 0; vIdx < values.length; vIdx++) {
               const thresholdsIdx = this.featureValueThresholdsIndexMap[
-                values[vIdx]];
+                values[vIdx]
+              ];
               this.set(
                 'featureValueThresholds.' +
                   thresholdsIdx +
@@ -6099,7 +6100,8 @@ limitations under the License.
               item[feature2]
             );
             thresholds = this.featureValueThresholds[
-              this.featureValueThresholdsIndexMap[key]].threshold;
+              this.featureValueThresholdsIndexMap[key]
+            ].threshold;
           }
           for (let modelNum = 0; modelNum < this.numModels; modelNum++) {
             const nonZeroClassification = this.getClassificationBestNonZero(

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3451,9 +3451,9 @@ limitations under the License.
             type: Array,
             value: () => [],
           },
-          // A map of feature name to the featureValueThresholds items, for quick
+          // A map of feature name to the featureValueThresholds indices, for quick
           // lookup.
-          featureValueThresholdsMap: Object,
+          featureValueThresholdsIndexMap: Object,
           // The default inference label when the classification threshold isn't
           // met.
           defaultInferenceLabel: {
@@ -4382,14 +4382,14 @@ limitations under the License.
                       feature1Value,
                       feature2Value
                     );
-                    thresholdsMap[mapKey] = thresh;
+                    thresholdsMap[mapKey] = thresholds.length - 1;
                   }
                 }
               }
             }
           }
           this.set('featureValueThresholds', thresholds);
-          this.set('featureValueThresholdsMap', thresholdsMap);
+          this.set('featureValueThresholdsIndexMap', thresholdsMap);
           this.refreshInferences_(false);
         },
 
@@ -5156,28 +5156,15 @@ limitations under the License.
             // Set all thresholds to the setting with the lowest cost from the
             // above search.
             for (let vIdx = 0; vIdx < values.length; vIdx++) {
+              const thresholdsIdx = this.featureValueThresholdsIndexMap[
+                values[vIdx]];
               this.set(
-                'featureValueThresholdsMap.' +
-                  values[vIdx] +
+                'featureValueThresholds.' +
+                  thresholdsIdx +
                   '.threshold.' +
                   modelInd +
                   '.threshold',
                 bestThresholds[vIdx] / 100
-              );
-            }
-            // Polymer does not reflect changes if we only update through
-            // featureValueThresholdsMap, this is a quick workaround
-            // until we find the correct way to link
-            for (let i = 0; i < this.featureValueThresholds.length; i++) {
-              const value = this.featureValueThresholds[i].threshold[modelInd]
-                .threshold;
-              this.set(
-                'featureValueThresholds.' +
-                  i +
-                  '.threshold.' +
-                  modelInd +
-                  '.threshold',
-                value
               );
             }
           }
@@ -6111,7 +6098,8 @@ limitations under the License.
               item[feature1],
               item[feature2]
             );
-            thresholds = this.featureValueThresholdsMap[key].threshold;
+            thresholds = this.featureValueThresholds[
+              this.featureValueThresholdsIndexMap[key]].threshold;
           }
           for (let modelNum = 0; modelNum < this.numModels; modelNum++) {
             const nonZeroClassification = this.getClassificationBestNonZero(


### PR DESCRIPTION
* Motivation for features / changes

Polymer2 update broke the updating of threshold sliders in WIT when certain optimization buttons are pressed.

* Technical description of changes

Simplified threshold setting data-binding logic. No longer is there a map and a list to the same threshold information that is data-bound to paper-sliders. Now there is a simple list and the map is still used to quickly find items in the list by slice, but the map contains an index to the list and not the same object as is contained in the list. This fixes the issue where the updates to the slider bound values doesn't always cause the physical slider to update its setting.

* Detailed steps to verify changes work correctly (as executed by you)

Ran through demos apps, sliced performance statistics by a feature, and verified that all threshold optimization buttons now correctly update the sliders, whereas before the sliders would stay stuck in one position even though other information would correctly update.
