### PR TITLE
Use _pywrap_events_writer

### DIFF
--- a/tensorboard/plugins/debugger/debugger_plugin_testlib.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_testlib.py
@@ -25,7 +25,7 @@ import threading
 
 import portpicker  # pylint: disable=import-error
 import tensorflow as tf
-from tensorflow.python import pywrap_tensorflow
+from tensorflow.python import _pywrap_events_writer
 from werkzeug import wrappers
 from werkzeug import test as werkzeug_test
 
@@ -61,7 +61,7 @@ class DebuggerPluginTestBase(tf.test.TestCase):
     self.log_dir = self.get_temp_dir()
     file_prefix = tf.compat.as_bytes(
         os.path.join(self.log_dir, 'events.debugger'))
-    writer = pywrap_tensorflow.EventsWriter(file_prefix)
+    writer = _pywrap_events_writer.EventsWriter(file_prefix)
     device_name = '/job:localhost/replica:0/task:0/cpu:0'
     writer.WriteEvent(
         self._CreateEventWithDebugNumericSummary(
@@ -107,7 +107,7 @@ class DebuggerPluginTestBase(tf.test.TestCase):
     os.mkdir(run_foo_directory)
     file_prefix = tf.compat.as_bytes(
         os.path.join(run_foo_directory, 'events.debugger'))
-    writer = pywrap_tensorflow.EventsWriter(file_prefix)
+    writer = _pywrap_events_writer.EventsWriter(file_prefix)
     writer.WriteEvent(
         self._CreateEventWithDebugNumericSummary(
             device_name=device_name,

--- a/tensorboard/plugins/debugger/debugger_plugin_testlib.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_testlib.py
@@ -25,7 +25,12 @@ import threading
 
 import portpicker  # pylint: disable=import-error
 import tensorflow as tf
-from tensorflow.python import _pywrap_events_writer
+
+# To keep compatibility with both 1.x and 2.x
+try:
+  from tensorflow.python import _pywrap_events_writer as tf_events_writer
+except ImportError:
+  from tensorflow.python import pywrap_tensorflow as tf_events_writer
 from werkzeug import wrappers
 from werkzeug import test as werkzeug_test
 
@@ -61,7 +66,7 @@ class DebuggerPluginTestBase(tf.test.TestCase):
     self.log_dir = self.get_temp_dir()
     file_prefix = tf.compat.as_bytes(
         os.path.join(self.log_dir, 'events.debugger'))
-    writer = _pywrap_events_writer.EventsWriter(file_prefix)
+    writer = tf_events_writer.EventsWriter(file_prefix)
     device_name = '/job:localhost/replica:0/task:0/cpu:0'
     writer.WriteEvent(
         self._CreateEventWithDebugNumericSummary(
@@ -107,7 +112,7 @@ class DebuggerPluginTestBase(tf.test.TestCase):
     os.mkdir(run_foo_directory)
     file_prefix = tf.compat.as_bytes(
         os.path.join(run_foo_directory, 'events.debugger'))
-    writer = _pywrap_events_writer.EventsWriter(file_prefix)
+    writer = tf_events_writer.EventsWriter(file_prefix)
     writer.WriteEvent(
         self._CreateEventWithDebugNumericSummary(
             device_name=device_name,

--- a/tensorboard/plugins/debugger/events_writer_manager.py
+++ b/tensorboard/plugins/debugger/events_writer_manager.py
@@ -27,7 +27,12 @@ import threading
 import time
 
 import tensorflow as tf
-from tensorflow.python import _pywrap_events_writer
+
+# To keep compatibility with both 1.x and 2.x
+try:
+  from tensorflow.python import _pywrap_events_writer as tf_events_writer
+except ImportError:
+  from tensorflow.python import pywrap_tensorflow as tf_events_writer
 from tensorboard.util import tb_logging
 
 logger = tb_logging.get_logger()
@@ -209,7 +214,7 @@ class EventsWriterManager(object):
         os.path.join(directory, DEBUGGER_EVENTS_FILE_STARTING_TEXT),
         time.time(), self._events_file_count)
     logger.info("Creating events file %s", file_path)
-    return _pywrap_events_writer.EventsWriter(tf.compat.as_bytes(file_path))
+    return tf_events_writer.EventsWriter(tf.compat.as_bytes(file_path))
 
   def _fetch_events_files_on_disk(self):
     """Obtains the names of debugger-related events files within the directory.

--- a/tensorboard/plugins/debugger/events_writer_manager.py
+++ b/tensorboard/plugins/debugger/events_writer_manager.py
@@ -27,7 +27,7 @@ import threading
 import time
 
 import tensorflow as tf
-from tensorflow.python import pywrap_tensorflow
+from tensorflow.python import _pywrap_events_writer
 from tensorboard.util import tb_logging
 
 logger = tb_logging.get_logger()
@@ -209,7 +209,7 @@ class EventsWriterManager(object):
         os.path.join(directory, DEBUGGER_EVENTS_FILE_STARTING_TEXT),
         time.time(), self._events_file_count)
     logger.info("Creating events file %s", file_path)
-    return pywrap_tensorflow.EventsWriter(tf.compat.as_bytes(file_path))
+    return _pywrap_events_writer.EventsWriter(tf.compat.as_bytes(file_path))
 
   def _fetch_events_files_on_disk(self):
     """Obtains the names of debugger-related events files within the directory.


### PR DESCRIPTION
Updating the EventsWriter import to _pywrap_events_writer from pywrap_tensorflow.

* Motivation for features / changes
This is part of a larger effort in TensorFlow to break up pywrap_tensorflow and migrate from SWIG to pybind11. Please refer to [this RFC](https://github.com/tensorflow/community/blob/master/rfcs/20190208-pybind11.md) for more information.

* Technical description of changes
Changes the import package to point to the new one. 

* Detailed steps to verify changes work correctly (as executed by you)

This is an example of a pywrap import and how it works. Unfortunately I cannot provide an exact EventsWriter example, because the nightly binary has not been built yet. 

```
In [1]: from tensorflow.python import _pywrap_utils                                                                                                                                                                

In [2]: _pywrap_utils.IsSequence(1)                                                                                                                                                                                
Out[2]: False

In [3]: _pywrap_utils.IsSequence([1])                                                                                                                                                                              
Out[3]: True
```

**NOTE:** Please only submit this PR if you are pulling TensorFlow from `tf-nightly-2.0-preview`. If you are using `tf-nightly`, that has not been updated since 08/21 and is still using old code. 

