### PR TITLE
program_test: bind to all interfaces

### DIFF
--- a/tensorboard/program_test.py
+++ b/tensorboard/program_test.py
@@ -73,7 +73,8 @@ class WerkzeugServerTest(tb_test.TestCase):
 
   def make_flags(self, **kwargs):
     flags = argparse.Namespace()
-    kwargs.setdefault('bind_all', False)
+    kwargs.setdefault('host', None)
+    kwargs.setdefault('bind_all', kwargs['host'] is None)
     for k, v in six.iteritems(kwargs):
       setattr(flags, k, v)
     return flags
@@ -82,19 +83,19 @@ class WerkzeugServerTest(tb_test.TestCase):
     # Test that we can bind to all interfaces without throwing an error
     server = program.WerkzeugServer(
         self._StubApplication(),
-        self.make_flags(host='', port=0, path_prefix=''))
+        self.make_flags(port=0, path_prefix=''))
     self.assertStartsWith(server.get_url(), 'http://')
 
   def testPathPrefixSlash(self):
     #Test that checks the path prefix ends with one trailing slash
     server = program.WerkzeugServer(
         self._StubApplication(),
-        self.make_flags(host='', port=0, path_prefix='/test'))
+        self.make_flags(port=0, path_prefix='/test'))
     self.assertEndsWith(server.get_url(), '/test/')
 
     server = program.WerkzeugServer(
         self._StubApplication(),
-        self.make_flags(host='', port=0, path_prefix='/test/'))
+        self.make_flags(port=0, path_prefix='/test/'))
     self.assertEndsWith(server.get_url(), '/test/')
 
   def testSpecifiedHost(self):


### PR DESCRIPTION
Summary:
These tests are currently broken on IPv6-only systems. While it’s valid
to open a _socket_ that binds to `("localhost", 0)` even if the system
only supports IPv6, it’s not valid to start a _Werkzeug server_ with
host `localhost`, because Werkzeug detects `localhost` as an IPv4
address and will open an `AF_INET` socket, causing catastrophe.

This restores the test behavior prior to #2589, which IMHO isn’t great,
but unbreaks these tests on IPv6-only systems.

Test Plan:
This test still works on my dual-IPv4/IPv6 machine, and now also works
on an IPv6-only machine where previously it failed with `EAFNOSUPPORT`.

wchargin-branch: program-test-bind-all
