### PR TITLE
ui: add expand arrow to category paginated view

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,44 @@
+# Release 2.0.0
+
+The 2.0 minor series tracks TensorFlow 2.0.
+
+## Breaking changes
+
+- TensorBoard now serves on localhost only by default to avoid unintentional
+  overexposure. To expose TensorBoard to the network, either use a proxy, bind
+  to a specific hostname or IP address by using the `--host` flag, or explicitly
+  enable the previous behavior of binding on all network interfaces by passing
+  the flag `--bind_all`. See PR #2589.
+
+- The `--logdir` flag no longer supports passing multiple comma-delimited paths,
+  which means that it now *supports* paths containing literal comma and colon
+  characters, like `./logs/m=10,n=20,lr=0.001` or `./logs/run_12:30:15`. To
+  mimic the old behavior, prefer using a tree of symlinks as it works with more
+  plugins, but as a fallback the flag `--logdir_spec` exposes the old behavior.
+  See PR #2664.
+
+- Projector plugin `visualize_embeddings()` API now takes `logdir` as its first
+  parameter rather than `writer` (which only supported TF 1.x summary writers).
+  For backwards compatibility TF 1.x writers will still be accepted, but passing
+  the logdir explicitly is preferred since it works without any dependency on
+  TF 1.x or 2.x summary writing. See PR #2665.
+
+- The namespace `tensorboard.summary.*` now aliases the summary API symbols in
+  `tensorboard.summary.v2.*` rather than those in `tensorboard.summary.v1.*`.
+  The old symbols can still be accessed under the `.v1` names. Note that the
+  new v2 API symbols are exposed in TF 2.0 as the new `tf.summary.*` API and
+  this is normally how they should be used. See PR #2670.
+
+## Features
+
+- Smarter log directory polling can be used by passing `--reload_multifile=true`
+  to poll all "active" event files in a directory rather than only the last one.
+  This avoids problems where data written to the non-last file never appears.
+  See PR #1867 for details, including how to adjust the "active" threshold.
+
+- What-If Tool now can sort PD plots by interestingness (#2461)
+
+
 # Release 1.15.0
 
 The 1.15 minor series tracks TensorFlow 1.15.

--- a/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
+++ b/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
@@ -14,6 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<link rel="import" href="../iron-icon/iron-icon.html" />
 <link rel="import" href="../iron-collapse/iron-collapse.html" />
 <link rel="import" href="../paper-button/paper-button.html" />
 <link rel="import" href="../paper-input/paper-input.html" />
@@ -53,7 +54,7 @@ limitations under the License.
             </template>
             <template is="dom-if" if="[[!_isCompositeSearch(category)]]">
               <span class="light">Tags matching /</span>
-              <span class="category-name">[[category.name]]</span>
+              <span class="category-name" title=[[category.name]]>[[category.name]]</span>
               <span class="light">/</span>
               <template is="dom-if" if="[[_isUniversalSearchQuery]]">
                 <span> (all tags)</span>
@@ -64,10 +65,13 @@ limitations under the License.
             </template>
           </template>
           <template is="dom-if" if="[[!_isSearchResults]]">
-            <span class="category-name">[[category.name]]</span>
+            <span class="category-name" title=[[category.name]]>[[category.name]]</span>
           </template>
         </span>
-        <span class="count"><span>[[_count]]</span></span>
+        <span class="count">
+          <span>[[_count]]</span>
+          <iron-icon icon="expand-more" class="expand-arrow"></iron-icon>
+        </span>
       </button>
       <!-- TODO(stephanwlee): investigate further. For some reason,
         transitionend that the iron-collapse relies on sometimes does not
@@ -154,6 +158,9 @@ limitations under the License.
         line-height: 1;
         box-shadow: 0 1px 5px rgba(0, 0, 0, 0.2);
         padding: 10px 15px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
       }
 
       .heading::-moz-focus-inner {
@@ -165,9 +172,16 @@ limitations under the License.
         border-bottom-right-radius: 0 !important;
       }
 
+      [open-button] .expand-arrow {
+        transform: rotateZ(180deg);
+      }
+
       .name {
         display: inline-flex;
-        float: left;
+        padding: 2px 0;
+        white-space: pre;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .light {
@@ -176,13 +190,16 @@ limitations under the License.
 
       .category-name {
         white-space: pre;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .count {
-        float: right;
-        margin-right: 5px;
+        margin: 0 5px;
         font-size: 12px;
         color: var(--paper-grey-500);
+        display: flex;
+        align-items: center;
       }
 
       .heading::-moz-focus-inner {
@@ -198,11 +215,6 @@ limitations under the License.
         border-top: none;
         border: 1px solid #dedede;
         padding: 15px;
-      }
-
-      .name {
-        display: inline-flex;
-        float: left;
       }
 
       .light {

--- a/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
+++ b/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
@@ -69,7 +69,9 @@ limitations under the License.
           </template>
         </span>
         <span class="count">
-          <span>[[_count]]</span>
+          <template is="dom-if" if="[[_hasMultiple]]">
+            <span>[[_count]]</span>
+          </template>
           <iron-icon icon="expand-more" class="expand-arrow"></iron-icon>
         </span>
       </button>
@@ -294,9 +296,9 @@ limitations under the License.
           type: Number,
           computed: '_computeCount(category.items.*)',
         },
-        _arrowIconType: {
-          type: String,
-          computed: '_computeArrowIconType(opened)',
+        _hasMultiple: {
+          type: Number,
+          computed: '_computeHasMultiple(_count)',
         },
         _paneRendered: {
           type: Boolean,
@@ -410,8 +412,8 @@ limitations under the License.
         return this.category.items.length;
       },
 
-      _computeArrowIconType() {
-        return this.opened ? 'expand-more' : 'chevron-right';
+      _computeHasMultiple() {
+        return this._count > 1;
       },
 
       _togglePane() {

--- a/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
+++ b/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
@@ -54,7 +54,9 @@ limitations under the License.
             </template>
             <template is="dom-if" if="[[!_isCompositeSearch(category)]]">
               <span class="light">Tags matching /</span>
-              <span class="category-name" title=[[category.name]]>[[category.name]]</span>
+              <span class="category-name" title="[[category.name]]"
+                >[[category.name]]</span
+              >
               <span class="light">/</span>
               <template is="dom-if" if="[[_isUniversalSearchQuery]]">
                 <span> (all tags)</span>
@@ -65,7 +67,9 @@ limitations under the License.
             </template>
           </template>
           <template is="dom-if" if="[[!_isSearchResults]]">
-            <span class="category-name" title=[[category.name]]>[[category.name]]</span>
+            <span class="category-name" title="[[category.name]]"
+              >[[category.name]]</span
+            >
           </template>
         </span>
         <span class="count">

--- a/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
+++ b/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
@@ -54,7 +54,7 @@ limitations under the License.
             </template>
             <template is="dom-if" if="[[!_isCompositeSearch(category)]]">
               <span class="light">Tags matching /</span>
-              <span class="category-name" title="[[category.name]]"
+              <span class="category-name" title$="[[category.name]]"
                 >[[category.name]]</span
               >
               <span class="light">/</span>
@@ -67,7 +67,7 @@ limitations under the License.
             </template>
           </template>
           <template is="dom-if" if="[[!_isSearchResults]]">
-            <span class="category-name" title="[[category.name]]"
+            <span class="category-name" title$="[[category.name]]"
               >[[category.name]]</span
             >
           </template>
@@ -184,10 +184,7 @@ limitations under the License.
 
       .name {
         display: inline-flex;
-        padding: 2px 0;
-        white-space: pre;
         overflow: hidden;
-        text-overflow: ellipsis;
       }
 
       .light {
@@ -198,6 +195,7 @@ limitations under the License.
         white-space: pre;
         overflow: hidden;
         text-overflow: ellipsis;
+        padding: 2px 0;
       }
 
       .count {
@@ -206,6 +204,7 @@ limitations under the License.
         color: var(--paper-grey-500);
         display: flex;
         align-items: center;
+        flex: none;
       }
 
       .heading::-moz-focus-inner {
@@ -301,7 +300,7 @@ limitations under the License.
           computed: '_computeCount(category.items.*)',
         },
         _hasMultiple: {
-          type: Number,
+          type: Boolean,
           computed: '_computeHasMultiple(_count)',
         },
         _paneRendered: {


### PR DESCRIPTION
* Motivation for features / changes
The UI could make it clearer when sections in a category-paginated-view are expanded/collapsed at first glance, and indicate that expansion is an affordance.

* Technical description of changes
  - Adds an iron-icon to the right of the section heading count that is '>' when collapsed, 'v' when opened
  -  Truncates long section names to prevent overflow
  -  Gives section name text a tooltip when hovered
  -  Only show count if there are multiple items

* Screenshots of UI changes
![image](https://user-images.githubusercontent.com/2322480/65995423-5669d500-e44a-11e9-91ed-fca8c7009276.png)
![image](https://user-images.githubusercontent.com/2322480/65998529-51a81f80-e450-11e9-84d3-b4955b27e901.png)

