### PR TITLE
ng: data loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
     "@types/chai": "^4.1.7",
     "@types/jasmine": "^3.3.16",
     "@types/node": "^12.6.8",
+    "@types/sinon": "^7.0.13",
     "chai": "^4.2.0",
     "prettier": "1.18.2",
+    "sinon": "^7.4.2",
     "typescript": "~3.4.5"
   },
   "dependencies": {

--- a/tensorboard/components/tf_backend/BUILD
+++ b/tensorboard/components/tf_backend/BUILD
@@ -25,9 +25,9 @@ tf_web_library(
     deps = [
         ":type",
         "//tensorboard/components/tf_imports:lodash",
-        "//tensorboard/components/tf_imports:plottable",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/vz_sorting",
+        "//tensorboard/componentsn/tf_imports:plottable",
     ],
 )
 
@@ -47,7 +47,6 @@ tensorboard_webcomponent_library(
     deps = [
         "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
-        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/vz_sorting:legacy",
     ],
 )

--- a/tensorboard/components/tf_backend/BUILD
+++ b/tensorboard/components/tf_backend/BUILD
@@ -47,6 +47,7 @@ tensorboard_webcomponent_library(
     deps = [
         "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/tf_imports_google:lib",
+        "//tensorboard/components/tf_imports:polymer_lib",
         "//tensorboard/components/vz_sorting:legacy",
     ],
 )

--- a/tensorboard/components/tf_backend/BUILD
+++ b/tensorboard/components/tf_backend/BUILD
@@ -25,9 +25,9 @@ tf_web_library(
     deps = [
         ":type",
         "//tensorboard/components/tf_imports:lodash",
+        "//tensorboard/components/tf_imports:plottable",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/vz_sorting",
-        "//tensorboard/componentsn/tf_imports:plottable",
     ],
 )
 

--- a/tensorboard/components/tf_ng_tensorboard/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/BUILD
@@ -75,6 +75,7 @@ ng_module(
         "//tensorboard/components/tf_ng_tensorboard/core",
         "//tensorboard/components/tf_ng_tensorboard/header",
         "//tensorboard/components/tf_ng_tensorboard/plugins",
+        "//tensorboard/components/tf_ng_tensorboard/reloader",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/effects",
@@ -90,5 +91,6 @@ tf_ng_web_test_suite(
         "//tensorboard/components/tf_ng_tensorboard/core:core_effects_test_lib",
         "//tensorboard/components/tf_ng_tensorboard/header:test_lib",
         "//tensorboard/components/tf_ng_tensorboard/plugins:plugins_component_test_lib",
+        "//tensorboard/components/tf_ng_tensorboard/reloader:test_lib",
     ],
 )

--- a/tensorboard/components/tf_ng_tensorboard/app.component.html
+++ b/tensorboard/components/tf_ng_tensorboard/app.component.html
@@ -17,3 +17,4 @@ limitations under the License.
 
 <app-header></app-header>
 <plugins class="plugins"></plugins>
+<reloader></reloader>

--- a/tensorboard/components/tf_ng_tensorboard/app.module.ts
+++ b/tensorboard/components/tf_ng_tensorboard/app.module.ts
@@ -25,6 +25,7 @@ import {PluginsModule} from './plugins/plugins.module';
 import {ROOT_REDUCERS, metaReducers} from './reducers';
 
 import {HeaderModule} from './header/header.module';
+import {ReloaderModule} from './reloader/reloader.module';
 
 @NgModule({
   declarations: [AppComponent],
@@ -34,6 +35,7 @@ import {HeaderModule} from './header/header.module';
     CoreModule,
     HeaderModule,
     PluginsModule,
+    ReloaderModule,
     StoreModule.forRoot(ROOT_REDUCERS, {
       metaReducers,
       runtimeChecks: {

--- a/tensorboard/components/tf_ng_tensorboard/core/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/core/BUILD
@@ -24,15 +24,6 @@ ng_module(
 )
 
 tf_ts_library(
-    name = "test_util",
-    testonly = True,
-    srcs = ["test_util.ts"],
-    deps = [
-        "//tensorboard/components/tf_ng_tensorboard/types",
-    ],
-)
-
-tf_ts_library(
     name = "core_effects_test_lib",
     testonly = True,
     srcs = [
@@ -41,9 +32,9 @@ tf_ts_library(
     tsconfig = "//:tsconfig-test",
     deps = [
         ":core",
-        ":test_util",
         "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_common_http_testing",
         "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_core_testing",
+        "//tensorboard/components/tf_ng_tensorboard/core/testing",
         "//tensorboard/components/tf_ng_tensorboard/types",
         "@npm//@angular/common",
         "@npm//@angular/compiler",
@@ -63,10 +54,12 @@ ng_module(
     ],
     deps = [
         ":core",
-        ":test_util",
+        "//tensorboard/components/tf_ng_tensorboard/core/testing",
         "@npm//@types/chai",
         "@npm//@types/jasmine",
+        "@npm//@types/sinon",
         "@npm//chai",
+        "@npm//sinon",
     ],
 )
 

--- a/tensorboard/components/tf_ng_tensorboard/core/core.actions.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.actions.ts
@@ -29,7 +29,7 @@ export const coreLoaded = createAction('[Core] Loaded');
 export const reload = createAction('[CORE] Reload');
 
 export const pluginsListingRequested = createAction(
-  '[CORE] FETCH_PLUGINS_LISTING_REQUESTED'
+  '[CORE] PluginListing Fetch Requested'
 );
 export const pluginsListingLoaded = createAction(
   '[Core] PluginListing Fetch Successful',
@@ -42,7 +42,7 @@ export const pluginsListingFailed = createAction(
 /**
  * Action for when user wants to enable/disable reload.
  */
-export const toggleReload = createAction('[Core] Reload Toggled ');
+export const toggleReload = createAction('[Core] Reload Toggled');
 
 /**
  * Action for when user wants to change the reload period.

--- a/tensorboard/components/tf_ng_tensorboard/core/core.actions.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.actions.ts
@@ -26,10 +26,10 @@ export const changePlugin = createAction(
 
 export const coreLoaded = createAction('[Core] Loaded');
 
-export const reload = createAction('[CORE] Reload');
+export const reload = createAction('[Core] Reload');
 
 export const pluginsListingRequested = createAction(
-  '[CORE] PluginListing Fetch Requested'
+  '[Core] PluginListing Fetch Requested'
 );
 export const pluginsListingLoaded = createAction(
   '[Core] PluginListing Fetch Successful',

--- a/tensorboard/components/tf_ng_tensorboard/core/core.actions.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.actions.ts
@@ -42,7 +42,7 @@ export const pluginsListingFailed = createAction(
 /**
  * Action for when user wants to enable/disable reload.
  */
-export const toggleReload = createAction('[Core] Reload Toggled');
+export const toggleReloadEnabled = createAction('[Core] Reload Enable Toggled');
 
 /**
  * Action for when user wants to change the reload period.

--- a/tensorboard/components/tf_ng_tensorboard/core/core.actions.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.actions.ts
@@ -26,10 +26,28 @@ export const changePlugin = createAction(
 
 export const coreLoaded = createAction('[Core] Loaded');
 
+export const reload = createAction('[CORE] Reload');
+
+export const pluginsListingRequested = createAction(
+  '[CORE] FETCH_PLUGINS_LISTING_REQUESTED'
+);
 export const pluginsListingLoaded = createAction(
   '[Core] PluginListing Fetch Successful',
   props<{plugins: PluginsListing}>()
 );
 export const pluginsListingFailed = createAction(
   '[Core] PluginListing Fetch Failed'
+);
+
+/**
+ * Action for when user wants to enable/disable reload.
+ */
+export const toggleReload = createAction('[Core] Reload Toggled ');
+
+/**
+ * Action for when user wants to change the reload period.
+ */
+export const changeReloadPeriod = createAction(
+  '[Core] Reload Period Change',
+  props<{periodInMs: number}>()
 );

--- a/tensorboard/components/tf_ng_tensorboard/core/core.reducers.test.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.reducers.test.ts
@@ -162,15 +162,15 @@ describe('core reducer', () => {
     });
   });
 
-  describe('#toggleReload', () => {
+  describe('#toggleReloadEnabled', () => {
     it('toggles reloadEnabled', () => {
       const state1 = createCoreState({reloadEnabled: false});
 
-      const state2 = reducers(state1, actions.toggleReload());
+      const state2 = reducers(state1, actions.toggleReloadEnabled());
 
       expect(state2).to.have.property('reloadEnabled', true);
 
-      const state3 = reducers(state2, actions.toggleReload());
+      const state3 = reducers(state2, actions.toggleReloadEnabled());
 
       expect(state3).to.have.property('reloadEnabled', false);
     });

--- a/tensorboard/components/tf_ng_tensorboard/core/core.reducers.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.reducers.ts
@@ -99,7 +99,7 @@ const reducer = createReducer(
       },
     };
   }),
-  on(actions.toggleReload, (state: CoreState) => {
+  on(actions.toggleReloadEnabled, (state: CoreState) => {
     return {
       ...state,
       reloadEnabled: !state.reloadEnabled,

--- a/tensorboard/components/tf_ng_tensorboard/core/core.reducers.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.reducers.ts
@@ -19,7 +19,11 @@ import {
   on,
   createFeatureSelector,
 } from '@ngrx/store';
-import {PluginId, PluginsListing} from '../types/api';
+import {
+  PluginId,
+  PluginsListing,
+  LoadState as DataLoadState,
+} from '../types/api';
 import * as actions from './core.actions';
 
 // HACK: These imports are for type inference.
@@ -29,18 +33,33 @@ import * as actions from './core.actions';
 
 export const CORE_FEATURE_KEY = 'core';
 
+export interface LoadState {
+  state: DataLoadState;
+  // Time since epoch.
+  lastLoadedTimeInMs: number | null;
+}
+
 export interface CoreState {
   activePlugin: PluginId | null;
   plugins: PluginsListing;
+  pluginsListLoaded: LoadState;
+  reloadPeriodInMs: number;
+  reloadEnabled: boolean;
 }
 
 export interface State {
-  [CORE_FEATURE_KEY]: CoreState;
+  [CORE_FEATURE_KEY]?: CoreState;
 }
 
 const initialState: CoreState = {
   activePlugin: null,
   plugins: {},
+  pluginsListLoaded: {
+    state: DataLoadState.NOT_LOADED,
+    lastLoadedTimeInMs: null,
+  },
+  reloadPeriodInMs: 30000,
+  reloadEnabled: true,
 };
 
 const reducer = createReducer(
@@ -48,11 +67,51 @@ const reducer = createReducer(
   on(actions.changePlugin, (state: CoreState, {plugin}) => {
     return {...state, activePlugin: plugin};
   }),
+  on(actions.pluginsListingRequested, (state: CoreState) => {
+    return {
+      ...state,
+      pluginsListLoaded: {
+        ...state.pluginsListLoaded,
+        state: DataLoadState.LOADING,
+      },
+    };
+  }),
+  on(actions.pluginsListingFailed, (state: CoreState) => {
+    return {
+      ...state,
+      pluginsListLoaded: {
+        ...state.pluginsListLoaded,
+        state: DataLoadState.FAILED,
+      },
+    };
+  }),
   on(actions.pluginsListingLoaded, (state: CoreState, {plugins}) => {
     const [firstPlugin] = Object.keys(plugins);
     let activePlugin =
       state.activePlugin !== null ? state.activePlugin : firstPlugin;
-    return {activePlugin, plugins};
+    return {
+      ...state,
+      activePlugin,
+      plugins,
+      pluginsListLoaded: {
+        state: DataLoadState.LOADED,
+        lastLoadedTimeInMs: Date.now(),
+      },
+    };
+  }),
+  on(actions.toggleReload, (state: CoreState) => {
+    return {
+      ...state,
+      reloadEnabled: !state.reloadEnabled,
+    };
+  }),
+  on(actions.changeReloadPeriod, (state: CoreState, {periodInMs}) => {
+    const nextReloadPeriod =
+      periodInMs > 0 ? periodInMs : state.reloadPeriodInMs;
+    return {
+      ...state,
+      reloadPeriodInMs: nextReloadPeriod,
+    };
   })
 );
 
@@ -62,6 +121,11 @@ export function reducers(state: CoreState, action: Action) {
 
 const selectCoreState = createFeatureSelector<State, CoreState>(
   CORE_FEATURE_KEY
+);
+
+export const getPluginsListLoaded = createSelector(
+  selectCoreState,
+  (state: CoreState): LoadState => state.pluginsListLoaded
 );
 
 export const getActivePlugin = createSelector(
@@ -75,5 +139,19 @@ export const getPlugins = createSelector(
   selectCoreState,
   (state: CoreState): PluginsListing => {
     return state.plugins;
+  }
+);
+
+export const getReloadEnabled = createSelector(
+  selectCoreState,
+  (state: CoreState): boolean => {
+    return state.reloadEnabled;
+  }
+);
+
+export const getReloadPeriodInMs = createSelector(
+  selectCoreState,
+  (state: CoreState): number => {
+    return state.reloadPeriodInMs;
   }
 );

--- a/tensorboard/components/tf_ng_tensorboard/core/core.service.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.service.ts
@@ -15,15 +15,28 @@ limitations under the License.
 import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 
+import {from} from 'rxjs';
+
 import {PluginsListing} from '../types/api';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Injectable()
 export class CoreService {
-  constructor(private readonly http: HttpClient) {}
+  private tfStorage = document.createElement('tf-storage') as any;
+  private tfBackend = (document.createElement('tf-backend') as any).tf_backend;
+
+  constructor(private http: HttpClient) {}
 
   fetchPluginsListing() {
     return this.http.get<PluginsListing>('data/plugins_listing');
+  }
+
+  fetchRuns() {
+    return from(this.tfBackend.runsStore.refresh());
+  }
+
+  fetchEnvironments() {
+    return from(this.tfBackend.environmentStore.refresh());
   }
 }

--- a/tensorboard/components/tf_ng_tensorboard/core/testing/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/core/testing/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+tf_ts_library(
+    name = "testing",
+    testonly = True,
+    srcs = ["index.ts"],
+    deps = [
+        "//tensorboard/components/tf_ng_tensorboard/core",
+        "//tensorboard/components/tf_ng_tensorboard/types",
+    ],
+)

--- a/tensorboard/components/tf_ng_tensorboard/core/testing/index.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/testing/index.ts
@@ -1,0 +1,46 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {PluginMetadata, LoadingMechanismType, LoadState} from '../../types/api';
+import {CoreState, State, CORE_FEATURE_KEY} from '../core.reducers';
+
+export function createPluginMetadata(displayName: string): PluginMetadata {
+  return {
+    disable_reload: false,
+    enabled: true,
+    loading_mechanism: {
+      type: LoadingMechanismType.NONE,
+    },
+    tab_name: displayName,
+    remove_dom: false,
+  };
+}
+
+export function createCoreState(override?: Partial<CoreState>): CoreState {
+  return {
+    activePlugin: null,
+    plugins: {},
+    pluginsListLoaded: {
+      state: LoadState.NOT_LOADED,
+      lastLoadedTimeInMs: null,
+    },
+    reloadPeriodInMs: 30000,
+    reloadEnabled: true,
+    ...override,
+  };
+}
+
+export function createState(coreState: CoreState): State {
+  return {[CORE_FEATURE_KEY]: coreState};
+}

--- a/tensorboard/components/tf_ng_tensorboard/header/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/header/BUILD
@@ -43,7 +43,7 @@ tf_ts_library(
         "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_toolbar",
         "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_platform_browser_animations",
         "//tensorboard/components/tf_ng_tensorboard/core",
-        "//tensorboard/components/tf_ng_tensorboard/core:test_util",
+        "//tensorboard/components/tf_ng_tensorboard/core/testing",
         "@npm//@angular/common",
         "@npm//@angular/compiler",
         "@npm//@angular/core",

--- a/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.test.ts
+++ b/tensorboard/components/tf_ng_tensorboard/header/containers/header.component.test.ts
@@ -25,29 +25,17 @@ import {provideMockStore, MockStore} from '@ngrx/store/testing';
 import {HeaderComponent} from './header.component';
 
 import {changePlugin} from '../../core/core.actions';
-import {State, CoreState, CORE_FEATURE_KEY} from '../../core/core.reducers';
-import {createPluginMetadata} from '../../core/test_util';
+import {State, CoreState} from '../../core/core.reducers';
+import {
+  createPluginMetadata,
+  createState,
+  createCoreState,
+} from '../../core/testing';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('header.component', () => {
   let store: MockStore<State>;
-
-  function createCoreState(): CoreState {
-    return {
-      activePlugin: null,
-      plugins: {
-        foo: createPluginMetadata('Foo Fighter'),
-        bar: createPluginMetadata('Barber'),
-      },
-    };
-  }
-
-  function createInitialState(coreState: CoreState = createCoreState()): State {
-    return {
-      [CORE_FEATURE_KEY]: coreState,
-    };
-  }
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -58,7 +46,16 @@ describe('header.component', () => {
         MatSelectModule,
       ],
       providers: [
-        provideMockStore({initialState: createInitialState()}),
+        provideMockStore({
+          initialState: createState(
+            createCoreState({
+              plugins: {
+                foo: createPluginMetadata('Foo Fighter'),
+                bar: createPluginMetadata('Barber'),
+              },
+            })
+          ),
+        }),
         HeaderComponent,
       ],
       declarations: [HeaderComponent],
@@ -85,15 +82,15 @@ describe('header.component', () => {
     const fixture = TestBed.createComponent(HeaderComponent);
     fixture.detectChanges();
 
-    const coreState = {
-      ...createCoreState(),
-      plugins: {
-        cat: createPluginMetadata('Meow'),
-        dog: createPluginMetadata('Woof'),
-        elephant: createPluginMetadata('Trumpet'),
-      },
-    };
-    const nextState = createInitialState(coreState);
+    const nextState = createState(
+      createCoreState({
+        plugins: {
+          cat: createPluginMetadata('Meow'),
+          dog: createPluginMetadata('Woof'),
+          elephant: createPluginMetadata('Trumpet'),
+        },
+      })
+    );
     store.setState(nextState);
     fixture.detectChanges();
     await fixture.whenStable();
@@ -117,12 +114,17 @@ describe('header.component', () => {
     const fixture = TestBed.createComponent(HeaderComponent);
     fixture.detectChanges();
 
-    const coreState = {
-      ...createCoreState(),
-      activePlugin: 'bar',
-    };
-    const nextState = createInitialState(coreState);
-    store.setState(nextState);
+    store.setState(
+      createState(
+        createCoreState({
+          plugins: {
+            foo: createPluginMetadata('Foo Fighter'),
+            bar: createPluginMetadata('Barber'),
+          },
+          activePlugin: 'bar',
+        })
+      )
+    );
     fixture.detectChanges();
     await fixture.whenStable();
 

--- a/tensorboard/components/tf_ng_tensorboard/plugins/plugins.component.test.ts
+++ b/tensorboard/components/tf_ng_tensorboard/plugins/plugins.component.test.ts
@@ -19,44 +19,47 @@ import {provideMockStore, MockStore} from '@ngrx/store/testing';
 
 import {PluginsComponent} from './plugins.component';
 
-import {PluginId, LoadingMechanismType} from '../types/api';
-import {State, CORE_FEATURE_KEY} from '../core/core.reducers';
+import {PluginId, LoadingMechanismType, LoadState} from '../types/api';
+import {State, CoreState, CORE_FEATURE_KEY} from '../core/core.reducers';
+import {createState, createCoreState} from '../core/testing';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
 describe('plugins.component', () => {
   let store: MockStore<State>;
-  const initialState: State = {
-    [CORE_FEATURE_KEY]: {
-      activePlugin: null,
-      plugins: {
-        bar: {
-          disable_reload: false,
-          enabled: true,
-          loading_mechanism: {
-            type: LoadingMechanismType.CUSTOM_ELEMENT,
-            element_name: 'tb-bar',
-          },
-          tab_name: 'Bar',
-          remove_dom: false,
+  const INITIAL_CORE_STATE: Partial<CoreState> = {
+    plugins: {
+      bar: {
+        disable_reload: false,
+        enabled: true,
+        loading_mechanism: {
+          type: LoadingMechanismType.CUSTOM_ELEMENT,
+          element_name: 'tb-bar',
         },
-        foo: {
-          disable_reload: false,
-          enabled: true,
-          loading_mechanism: {
-            type: LoadingMechanismType.IFRAME,
-            // This will cause 404 as test bundles do not serve
-            // data file in the karma server.
-            module_path: 'random_esmodule.js',
-          },
-          tab_name: 'Bar',
-          remove_dom: false,
+        tab_name: 'Bar',
+        remove_dom: false,
+      },
+      foo: {
+        disable_reload: false,
+        enabled: true,
+        loading_mechanism: {
+          type: LoadingMechanismType.IFRAME,
+          // This will cause 404 as test bundles do not serve
+          // data file in the karma server.
+          module_path: 'random_esmodule.js',
         },
+        tab_name: 'Bar',
+        remove_dom: false,
       },
     },
   };
 
   beforeEach(async () => {
+    const initialState = createState(
+      createCoreState({
+        ...INITIAL_CORE_STATE,
+      })
+    );
     await TestBed.configureTestingModule({
       providers: [provideMockStore({initialState}), PluginsComponent],
       declarations: [PluginsComponent],
@@ -65,13 +68,14 @@ describe('plugins.component', () => {
   });
 
   function setActivePlugin(plugin: PluginId) {
-    store.setState({
-      ...initialState,
-      [CORE_FEATURE_KEY]: {
-        ...initialState[CORE_FEATURE_KEY],
-        activePlugin: plugin,
-      },
-    });
+    store.setState(
+      createState(
+        createCoreState({
+          ...INITIAL_CORE_STATE,
+          activePlugin: plugin,
+        })
+      )
+    );
   }
 
   it('creates no plugin when there is no activePlugin', () => {

--- a/tensorboard/components/tf_ng_tensorboard/reloader/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/reloader/BUILD
@@ -3,21 +3,14 @@ package(default_visibility = ["//tensorboard:internal"])
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
-licenses(["notice"])  # Apache 2.0
-
 ng_module(
-    name = "plugins",
+    name = "reloader",
     srcs = [
-        "plugins.component.ts",
-        "plugins.module.ts",
-    ],
-    assets = [
-        "plugins.component.css",
-        "plugins.component.html",
+        "reloader.component.ts",
+        "reloader.module.ts",
     ],
     deps = [
         "//tensorboard/components/tf_ng_tensorboard/core",
-        "//tensorboard/components/tf_ng_tensorboard/types",
         "@npm//@angular/core",
         "@npm//@ngrx/store",
         "@npm//rxjs",
@@ -25,18 +18,17 @@ ng_module(
 )
 
 tf_ts_library(
-    name = "plugins_component_test_lib",
+    name = "test_lib",
     testonly = True,
     srcs = [
-        "plugins.component.test.ts",
+        "reloader.component.test.ts",
     ],
     tsconfig = "//:tsconfig-test",
     deps = [
-        ":plugins",
+        ":reloader",
         "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_core_testing",
         "//tensorboard/components/tf_ng_tensorboard/core",
         "//tensorboard/components/tf_ng_tensorboard/core/testing",
-        "//tensorboard/components/tf_ng_tensorboard/types",
         "@npm//@angular/common",
         "@npm//@angular/compiler",
         "@npm//@angular/core",

--- a/tensorboard/components/tf_ng_tensorboard/reloader/reloader.component.test.ts
+++ b/tensorboard/components/tf_ng_tensorboard/reloader/reloader.component.test.ts
@@ -1,0 +1,174 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {DebugElement} from '@angular/core';
+import {TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {Store} from '@ngrx/store';
+import {provideMockStore, MockStore} from '@ngrx/store/testing';
+
+import {ReloaderComponent} from './reloader.component';
+
+import {reload} from '../core/core.actions';
+import {
+  State,
+  CoreState,
+  getReloadEnabled,
+  getReloadPeriodInMs,
+} from '../core/core.reducers';
+import {
+  createPluginMetadata,
+  createState,
+  createCoreState,
+} from '../core/testing';
+
+/** @typehack */ import * as _typeHackStore from '@ngrx/store';
+
+describe('reloader.component', () => {
+  let store: MockStore<State>;
+  let dispatchSpy: jasmine.Spy;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [
+        provideMockStore({
+          initialState: createState(
+            createCoreState({
+              reloadPeriodInMs: 5,
+              reloadEnabled: true,
+            })
+          ),
+        }),
+        ReloaderComponent,
+      ],
+      declarations: [ReloaderComponent],
+    }).compileComponents();
+    store = TestBed.get(Store);
+    dispatchSpy = spyOn(store, 'dispatch');
+  });
+
+  it('dispatches reload action every reload period', fakeAsync(() => {
+    store.setState(
+      createState(
+        createCoreState({
+          reloadPeriodInMs: 5,
+          reloadEnabled: true,
+        })
+      )
+    );
+    const fixture = TestBed.createComponent(ReloaderComponent);
+    fixture.detectChanges();
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+
+    tick(5);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).toHaveBeenCalledWith(reload());
+
+    tick(5);
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+    expect(dispatchSpy).toHaveBeenCalledWith(reload());
+
+    // // Manually invoke destruction of the component so we can cleanup the timer.
+    fixture.destroy();
+  }));
+
+  it('disables reload when it is not enabled', fakeAsync(() => {
+    store.setState(
+      createState(
+        createCoreState({
+          reloadPeriodInMs: 5,
+          reloadEnabled: false,
+        })
+      )
+    );
+    const fixture = TestBed.createComponent(ReloaderComponent);
+    fixture.detectChanges();
+
+    tick(10);
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+
+    fixture.destroy();
+  }));
+
+  it('respects reload period', fakeAsync(() => {
+    store.setState(
+      createState(
+        createCoreState({
+          reloadPeriodInMs: 50,
+          reloadEnabled: true,
+        })
+      )
+    );
+    const fixture = TestBed.createComponent(ReloaderComponent);
+    fixture.detectChanges();
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+
+    tick(5);
+    expect(dispatchSpy).not.toHaveBeenCalled();
+
+    tick(45);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).toHaveBeenCalledWith(reload());
+
+    fixture.destroy();
+  }));
+
+  it('only resets timer when store values changes', fakeAsync(() => {
+    store.setState(
+      createState(
+        createCoreState({
+          reloadPeriodInMs: 5,
+          reloadEnabled: true,
+        })
+      )
+    );
+    const fixture = TestBed.createComponent(ReloaderComponent);
+    fixture.detectChanges();
+
+    tick(4);
+    store.setState(
+      createState(
+        createCoreState({
+          reloadPeriodInMs: 5,
+          reloadEnabled: true,
+        })
+      )
+    );
+    fixture.detectChanges();
+    expect(dispatchSpy).not.toHaveBeenCalled();
+
+    tick(1);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+
+    tick(4);
+    store.setState(
+      createState(
+        createCoreState({
+          reloadPeriodInMs: 3,
+          reloadEnabled: true,
+        })
+      )
+    );
+
+    tick(1);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+
+    tick(2);
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+
+    fixture.destroy();
+  }));
+});

--- a/tensorboard/components/tf_ng_tensorboard/reloader/reloader.component.ts
+++ b/tensorboard/components/tf_ng_tensorboard/reloader/reloader.component.ts
@@ -1,0 +1,72 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Component, ChangeDetectionStrategy} from '@angular/core';
+import {Store, select} from '@ngrx/store';
+import {combineLatest} from 'rxjs';
+import {distinctUntilChanged} from 'rxjs/operators';
+
+import {
+  State,
+  getReloadEnabled,
+  getReloadPeriodInMs,
+} from '../core/core.reducers';
+import {reload} from '../core/core.actions';
+
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+
+@Component({
+  selector: 'reloader',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ReloaderComponent {
+  private readonly reloadEnabled$ = this.store.pipe(select(getReloadEnabled));
+  private readonly reloadPeriodInMs$ = this.store.pipe(
+    select(getReloadPeriodInMs)
+  );
+  private reloadTimerId: number | null = null;
+
+  constructor(private store: Store<State>) {}
+
+  ngOnInit() {
+    combineLatest(
+      this.reloadEnabled$.pipe(distinctUntilChanged()),
+      this.reloadPeriodInMs$.pipe(distinctUntilChanged())
+    ).subscribe(([enabled, reloadPeriodInMs]) => {
+      this.cancelLoad();
+      if (enabled) {
+        this.load(reloadPeriodInMs as number);
+      }
+    });
+  }
+
+  private load(reloadPeriodInMs: number) {
+    this.reloadTimerId = setTimeout(() => {
+      this.store.dispatch(reload());
+      this.load(reloadPeriodInMs);
+    }, reloadPeriodInMs);
+  }
+
+  private cancelLoad() {
+    if (this.reloadTimerId !== null) {
+      clearTimeout(this.reloadTimerId);
+    }
+    this.reloadTimerId = null;
+  }
+
+  ngOnDestroy() {
+    this.cancelLoad();
+  }
+}

--- a/tensorboard/components/tf_ng_tensorboard/reloader/reloader.module.ts
+++ b/tensorboard/components/tf_ng_tensorboard/reloader/reloader.module.ts
@@ -12,16 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {PluginMetadata, LoadingMechanismType} from '../types/api';
+import {NgModule} from '@angular/core';
 
-export function createPluginMetadata(displayName: string): PluginMetadata {
-  return {
-    disable_reload: false,
-    enabled: true,
-    loading_mechanism: {
-      type: LoadingMechanismType.NONE,
-    },
-    tab_name: displayName,
-    remove_dom: false,
-  };
-}
+import {ReloaderComponent} from './reloader.component';
+
+@NgModule({
+  declarations: [ReloaderComponent],
+  exports: [ReloaderComponent],
+})
+export class ReloaderModule {}

--- a/tensorboard/components/tf_ng_tensorboard/types/api.ts
+++ b/tensorboard/components/tf_ng_tensorboard/types/api.ts
@@ -12,9 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-export enum ActiveDashboardsLoadState {
+export enum LoadState {
   NOT_LOADED,
   LOADED,
+  LOADING,
   FAILED,
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -390,6 +390,35 @@
     semver "6.2.0"
     semver-intersect "1.4.0"
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.6.0.tgz#ec7670432ae9c8eb710400d112c201a362d83393"
+  integrity sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.1.tgz#52310f2f9bcbc67bdac18c94ad4901b95fde267e"
+  integrity sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
+
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
+  integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
+  dependencies:
+    "@sinonjs/commons" "^1.3.0"
+    array-from "^2.1.1"
+    lodash "^4.17.15"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@types/argparse@1.0.33":
   version "1.0.33"
   resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.33.tgz#2728669427cdd74a99e53c9f457ca2866a37c52d"
@@ -441,6 +470,11 @@
   version "10.14.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.13.tgz#ac786d623860adf39a3f51d629480aacd6a6eec7"
   integrity sha512-yN/FNNW1UYsRR1wwAoyOwqvDuLDtVXnaJTZ898XIw/Q5cCaeVAlVwvsmXLX5PuiScBYwZsZU4JYSHB3TvfdwvQ==
+
+"@types/sinon@^7.0.13":
+  version "7.0.13"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.0.13.tgz#ca039c23a9e27ebea53e0901ef928ea2a1a6d313"
+  integrity sha512-d7c/C/+H/knZ3L8/cxhicHUiTDxdgap0b/aNJfsmLwFu/iOP17mdgbQsbHA3SJmrzsjD0l3UEE5SN4xxuz5ung==
 
 "@types/z-schema@3.16.31":
   version "3.16.31"
@@ -606,6 +640,11 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -1301,6 +1340,11 @@ di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
+
+diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 dom-serialize@^2.2.0:
   version "2.2.1"
@@ -2263,6 +2307,11 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -2408,6 +2457,11 @@ jszip@^3.1.5:
     pako "~1.0.2"
     readable-stream "~2.3.6"
     set-immediate-shim "~1.0.1"
+
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
 
 karma-chrome-launcher@2.2.0:
   version "2.2.0"
@@ -2564,7 +2618,7 @@ lodash.isequal@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
-lodash@^4.16.6, lodash@^4.17.11, lodash@^4.17.14, lodash@~4.17.5:
+lodash@^4.16.6, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@~4.17.5:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -2579,6 +2633,11 @@ log4js@^4.0.0:
     flatted "^2.0.0"
     rfdc "^1.1.4"
     streamroller "^1.0.6"
+
+lolex@^4.1.0, lolex@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
+  integrity sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==
 
 long@^4.0.0:
   version "4.0.0"
@@ -2857,6 +2916,17 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+nise@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.2.tgz#b6d29af10e48b321b307e10e065199338eeb2652"
+  integrity sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==
+  dependencies:
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^4.1.0"
+    path-to-regexp "^1.7.0"
 
 node-fetch-npm@^2.0.2:
   version "2.0.2"
@@ -3268,6 +3338,13 @@ path-parse@^1.0.5, path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -3810,6 +3887,19 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+sinon@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.4.2.tgz#ecd54158fef2fcfbdb231a3fa55140e8cb02ad6c"
+  integrity sha512-pY5RY99DKelU3pjNxcWo6XqeB1S118GBcVIIdDi6V+h6hevn1izcg2xv1hTHW/sViRXU7sUOxt4wTUJ3gsW2CQ==
+  dependencies:
+    "@sinonjs/commons" "^1.4.0"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.3.3"
+    diff "^3.5.0"
+    lolex "^4.2.0"
+    nise "^1.5.2"
+    supports-color "^5.5.0"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -4141,7 +4231,7 @@ supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -4286,7 +4376,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
tf-tensorboard is responsible for loading data for runs, experiments and
trigger reloading. Without this feature, the runStore will be empty and
will not make the tf-runs-selector operable.

This change implements this behavior in Angular in flux way.

