### PR TITLE
Fix Fairness optimization dialogs (What-If Tool)

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -2021,25 +2021,24 @@ limitations under the License.
                               The feature that your model is trying to predict.
                               <span class="dialog-link" on-tap="openDialog"
                                 >More.
-                                <paper-dialog
-                                  class="dialog-text"
-                                  horizontal-align="auto"
-                                  vertical-align="auto"
-                                >
-                                  <div class="dialog-title">
-                                    Ground Truth Feature
-                                  </div>
-                                  <div>
-                                    If the datapoints contain a feature that
-                                    represents the ground truth for what the
-                                    model is attempting to predict, then
-                                    selecting that feature here allows the tool
-                                    to investigate the performance of the model
-                                    by comparing the model's results to the
-                                    ground truth feature.
-                                  </div>
-                                </paper-dialog>
                               </span>
+                              <paper-dialog
+                                class="dialog-text"
+                                horizontal-align="auto"
+                                vertical-align="auto"
+                              >
+                                <div class="dialog-title">
+                                  Ground Truth Feature
+                                </div>
+                                <div>
+                                  If the datapoints contain a feature that
+                                  represents the ground truth for what the model
+                                  is attempting to predict, then selecting that
+                                  feature here allows the tool to investigate
+                                  the performance of the model by comparing the
+                                  model's results to the ground truth feature.
+                                </div>
+                              </paper-dialog>
                             </div>
                           </div>
                         </div>
@@ -2066,33 +2065,33 @@ limitations under the License.
                                 negatives. Required for optimization.
                                 <span class="dialog-link" on-tap="openDialog"
                                   >More.
-                                  <paper-dialog
-                                    class="dialog-text"
-                                    horizontal-align="auto"
-                                    vertical-align="auto"
-                                  >
-                                    <div class="dialog-title">
-                                      What is cost ratio?
-                                    </div>
-                                    <div>
-                                      This tells the tool how to optimize the
-                                      classification thresholds when you use the
-                                      optimization strategy controls.
-                                    </div>
-                                    <div>
-                                      1.00 = false positives are equally as
-                                      costly as false negatives.
-                                    </div>
-                                    <div>
-                                      4.00 = false positives are 4 times more
-                                      costly than false negatives
-                                    </div>
-                                    <div>
-                                      0.25 = false negatives are 4 times more
-                                      costly than false positives.
-                                    </div>
-                                  </paper-dialog>
                                 </span>
+                                <paper-dialog
+                                  class="dialog-text"
+                                  horizontal-align="auto"
+                                  vertical-align="auto"
+                                >
+                                  <div class="dialog-title">
+                                    What is cost ratio?
+                                  </div>
+                                  <div>
+                                    This tells the tool how to optimize the
+                                    classification thresholds when you use the
+                                    optimization strategy controls.
+                                  </div>
+                                  <div>
+                                    1.00 = false positives are equally as costly
+                                    as false negatives.
+                                  </div>
+                                  <div>
+                                    4.00 = false positives are 4 times more
+                                    costly than false negatives
+                                  </div>
+                                  <div>
+                                    0.25 = false negatives are 4 times more
+                                    costly than false positives.
+                                  </div>
+                                </paper-dialog>
                               </div>
                             </div>
                           </div>
@@ -3780,7 +3779,7 @@ limitations under the License.
 
         openDialog: function(event) {
           event.stopPropagation();
-          const dialog = event.target.parentElement.parentElement.querySelector(
+          const dialog = event.target.parentElement.querySelector(
             'paper-dialog'
           );
           dialog.open();

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -2302,10 +2302,9 @@ limitations under the License.
                                 slices achieve equal opportunity.
                               </div>
                               <div>
-                                Equal opportunity means that among those
-                                predicted as positive classifications, there is
-                                a similar percentage of correct predictions in
-                                each slice.
+                                Equal opportunity means that a similar fraction
+                                of the real positives is recalled for each slice
+                                (i.e., <i>sensitivity</i> is the same).
                               </div>
                             </paper-dialog>
                           </paper-radio-button>

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -2301,9 +2301,10 @@ limitations under the License.
                                 slices achieve equal opportunity.
                               </div>
                               <div>
-                                Equal opportunity means that a similar fraction
-                                of the real positives is recalled for each slice
-                                (i.e., <i>sensitivity</i> is the same).
+                                Equal opportunity means that among those
+                                datapoints with the positive ground truth label,
+                                there is a similar percentage of positive
+                                predictions in each slice.
                               </div>
                             </paper-dialog>
                           </paper-radio-button>


### PR DESCRIPTION
* Motivation for features / changes
All Fairness optimization info icons were opening the first one (Custom threshold) when clicked.
Also updated description for Equal Opportunity optimisation, which was inaccurate.

* Technical description of changes
Made function `openDialog` open the next sibling to the clicked element.
Also checked that all `paper-dialog` DOMs were positioned where they should, so that this function would work for all cases -- the only two cases I moved would actually work as they were, but we'd rather have positioned in the same way as the others (they were children; we want siblings).

* Screenshots of UI changes
Only actual change is the Equal Opportunity description.
<img width="671" alt="Screenshot 2019-09-24 at 13 54 51" src="https://user-images.githubusercontent.com/6004563/65513284-e9e35900-ded2-11e9-8c69-acd28881c7a8.png">

* Detailed steps to verify changes work correctly (as executed by you)
Open each dialog and confirm it's the one supposed to open:
   - Nearest counterfactual
   - Similarity to selected datapoint
   - Partial Dependence Plots
   - Ground truth
   - Cost ratio
   - Fairness (6 of them)
   - Classification Performance Table
   - Regression Performance Table
   - Exploring Classification Performance
   - ROC curve
   - PR curve

* Alternate designs / implementations considered
N/A