### PR TITLE
Various fixes from latest changes

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -6255,7 +6255,10 @@ limitations under the License.
             modelNum < extraOutputs.extra.length;
             modelNum++
           ) {
-            if ('attributions' in extraOutputs.extra[modelNum]) {
+            if (
+              extraOutputs.extra[modelNum] != null &&
+              'attributions' in extraOutputs.extra[modelNum]
+            ) {
               attributions.push(extraOutputs.extra[modelNum].attributions);
             }
           }
@@ -6275,6 +6278,9 @@ limitations under the License.
               modelNum < extraOutputs.extra.length;
               modelNum++
             ) {
+              if (extraOutputs.extra[modelNum] == null) {
+                continue;
+              }
               const keys = Object.keys(extraOutputs.extra[modelNum]);
               for (let j = 0; j < keys.length; j++) {
                 const key = keys[j];

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -1458,7 +1458,7 @@ limitations under the License.
                           >Partial dependence plots</paper-radio-button
                         >
                       </paper-radio-group>
-                      <div class="flex">
+                      <div class="flex-wrap">
                         <div title="Select a datapoint to use this feature">
                           <paper-toggle-button
                             class="counterfactual-toggle"
@@ -3899,13 +3899,13 @@ limitations under the License.
         ready: function() {
           const side = d3.select(this.$.side);
           const center = d3.select(this.$.center);
-          const resizer = d3.select(this.$.resizer);
+          const resizer = this.$.resizer;
           const self = this;
 
           const dragResize = d3.drag().on('drag', () => {
             // Determine resizer position relative to width of the tool.
-            const x = d3.mouse(this.parentNode.parentNode)[0];
-            const width = this.parentNode.parentNode.offsetWidth;
+            const x = d3.mouse(resizer.parentNode.parentNode)[0];
+            const width = resizer.parentNode.parentNode.offsetWidth;
             let perc = (x / width) * 100;
 
             // Side panel will be a minimum of 20% width.
@@ -3920,7 +3920,7 @@ limitations under the License.
             self.$.dive.$.vis._onIronResize();
           });
 
-          resizer.call(dragResize);
+          d3.select(resizer).call(dragResize);
         },
 
         attached: function() {

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -233,6 +233,8 @@ def ensure_not_binary(value):
   try:
     return value.decode() if isinstance(value, binary_type) else value
   except UnicodeDecodeError:
+    # If the value cannot be decoded as a string (such as an encoded image),
+    # then just return the value.
     return value
 
 

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -230,7 +230,10 @@ class ServingBundle(object):
 
 def ensure_not_binary(value):
   """Return non-binary version of value."""
-  return value.decode() if isinstance(value, binary_type) else value
+  try:
+    return value.decode() if isinstance(value, binary_type) else value
+  except UnicodeDecodeError:
+    return value
 
 
 def proto_value_for_feature(example, feature_name):

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils_test.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils_test.py
@@ -81,6 +81,14 @@ class InferenceUtilsTest(tf.test.TestCase):
     self.assertEqual('int64_list', original_feature.feature_type)
     self.assertEqual(1, original_feature.length)
 
+  def test_parse_original_feature_from_example_binary(self):
+    example = tf.train.Example()
+    example.features.feature['img'].bytes_list.value.extend([b'\xef'])
+    original_feature = inference_utils.parse_original_feature_from_example(
+        example, 'img')
+    self.assertEqual('img', original_feature.feature_name)
+    self.assertEqual([b'\xef'], original_feature.original_value)
+
   def test_example_protos_from_path_get_all_in_file(self):
     cns_path = os.path.join(tf.compat.v1.test.get_temp_dir(),
                             'dummy_example')

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
@@ -183,9 +183,9 @@ WIT_HTML = """
           wit.selectedLabelFeature = config['target_feature'];
         }}
         if ('uses_custom_distance_fn' in config) {{
-          wit.customDistanceFunctionSet = 1;
+          wit.customDistanceFunctionSet = true;
         }} else {{
-          wit.customDistanceFunctionSet = 0;
+          wit.customDistanceFunctionSet = false;
         }}
       }};
       window.updateExamplesCallback = examples => {{

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/js/lib/wit.js
@@ -252,9 +252,9 @@ var WITView = widgets.DOMWidgetView.extend({
       this.view_.selectedLabelFeature = config['target_feature'];
     }
     if ('uses_custom_distance_fn' in config) {
-      this.view_.customDistanceFunctionSet = 1;
+      this.view_.customDistanceFunctionSet = true;
     } else {
-      this.view_.customDistanceFunctionSet = 0;
+      this.view_.customDistanceFunctionSet = false;
     }
   },
   spriteChanged: function() {


### PR DESCRIPTION
* Motivation for features / changes

Bashing bugs before witwidget 1.4 launch.

* Technical description of changes

Fixed datapoint editor panel slider to work in all environments (demos were broken) - by explicitly using the correct dom element and also ensuring some content flex-wraps.

Added checks for when extra outputs is null so it doesn't break WIT when that happens.

Allow fallback in PD plot checking when a string can't be decoded as text (for images).

Fixed boolean setting of if custom distance function set, for correct enabling/disabling of L1/L2 radio buttons.

* Detailed steps to verify changes work correctly (as executed by you)

Ran all demos and verified all features work as expected (including PD plots)
Ran notebook demos that show attributions and extra outputs, along with custom distance setting.

