### PR TITLE
diagnose: use non-deprecated `logging.warning`

### DIFF
--- a/tensorboard/tools/diagnose_tensorboard.py
+++ b/tensorboard/tools/diagnose_tensorboard.py
@@ -194,9 +194,9 @@ def installed_packages():
     for package in actual:
       logging.info("installed: %s", packages[package])
     if len(actual) == 0:
-      logging.warn("no installation among: %s", sorted(family))
+      logging.warning("no installation among: %s", sorted(family))
     elif len(actual) > 1:
-      logging.warn("conflicting installations: %s", sorted(actual))
+      logging.warning("conflicting installations: %s", sorted(actual))
       found_conflict = True
 
   if found_conflict:


### PR DESCRIPTION
Summary:
It appears that this has been deprecated since at least Python 3.5, and
Python 3.7 warns about it.

Test Plan:
Running `python3.7 tensorboard/tools/diagnose_tensorboard.py` without
TensorFlow prior to this commit would emit a warning:

```
tensorboard/tools/diagnose_tensorboard.py:197: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
```

As of this commit, that warning no longer appears. There are no other
occurrences of `.warn(?!ing)` in this file.

wchargin-branch: diagnose-warning
