### PR TITLE
Update WIT attribution colors

### DIFF
--- a/tensorboard/components/vz_example_viewer/vz-example-viewer.ts
+++ b/tensorboard/components/vz_example_viewer/vz-example-viewer.ts
@@ -83,10 +83,7 @@ namespace vz_example_viewer {
   const FLOAT_FEATURE_NAME = 'float';
   const BASE_64_IMAGE_ENCODING_PREFIX = 'base64,';
   const CHANGE_CALLBACK_TIMER_DELAY_MS = 1000;
-  // Colors for the saliency color scale.
-  const posSaliencyColor = '#007B83';
-  const negSaliencyColor = '#FF847C';
-  const neutralSaliencyColor = '#fff';
+  const noAttributionColor = '#fff';
   const defaultTextColor = '#3c4043';
   const lightTextColor = '#fff';
 
@@ -434,18 +431,18 @@ namespace vz_example_viewer {
     _useLightColor(saliency) {
       const percentile = (saliency - this.minSal) / (this.maxSal - this.minSal);
       if (this.minSal < 0 && this.maxSal > 0) {
-        return percentile < 0.1 || percentile > 0.8;
+        return percentile < 0.3 || percentile > 0.7;
       } else if (this.minSal < 0) {
-        return percentile < 0.1;
+        return percentile < 0.6;
       } else {
-        return percentile > 0.8;
+        return percentile > 0.4;
       }
     },
 
     _haveSaliencyImpl: function() {
       // Reset all value pills to default settings.
       this.selectAll('.value-pill')
-        .style('background', neutralSaliencyColor)
+        .style('background', noAttributionColor)
         .attr('title', '')
         .style('color', defaultTextColor);
 
@@ -474,7 +471,7 @@ namespace vz_example_viewer {
         this.selectAll(`.${this.sanitizeFeature(feat.name)}.value-pill`)
           .style(
             'background',
-            this.showSaliency ? colorFn : () => neutralSaliencyColor
+            this.showSaliency ? colorFn : () => noAttributionColor
           )
           .attr(
             'title',
@@ -504,7 +501,7 @@ namespace vz_example_viewer {
             'background',
             this.showSaliency
               ? () => this.getColorForSaliency(mostExtremeSal)
-              : () => neutralSaliencyColor
+              : () => noAttributionColor
           );
         }
       }
@@ -1897,7 +1894,7 @@ namespace vz_example_viewer {
     /** Returns the color to display for a given saliency value. */
     getColorForSaliency: function(salVal: number) {
       if (!this.showSaliencyForValue(salVal)) {
-        return neutralSaliencyColor;
+        return noAttributionColor;
       } else {
         return this.colors(salVal);
       }
@@ -1953,7 +1950,7 @@ namespace vz_example_viewer {
           IMG_SALIENCY_MAX_COLOR_RATIO * ratioToSaliencyExtreme;
 
         const {r, g, b} = d3.rgb(
-          salVal > 0 ? posSaliencyColor : negSaliencyColor
+          salVal > 0 ? this.colors(this.maxSal) : this.colors(this.minSal)
         );
         d[i] = d[i] * (1 - blendRatio) + r * blendRatio;
         d[i + 1] = d[i + 1] * (1 - blendRatio) + g * blendRatio;

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -3373,9 +3373,11 @@ limitations under the License.
     const attributionSparseValueSuffix = '_values';
 
     // Colors for the attribution color scale.
-    const posAttributionColor = '#007B83';
-    const negAttributionColor = '#FF847C';
-    const neutralAttributionColor = '#fff';
+    const posAttributionHighColor = '#3D7078';
+    const posAttributionLowColor = '#6A9EA7';
+    const neutralAttributionColor = '#FFD8C3';
+    const negAttributionLowColor = '#C7696E';
+    const negAttributionHighColor = '#943A43';
     const COLOR_INTERPOLATOR = d3.interpolateRgb;
     const LEGEND_WIDTH_PX = 160;
     const LEGEND_HEIGHT_PX = 8;
@@ -6403,13 +6405,17 @@ limitations under the License.
           let attributionColorRange = [];
           if (this.minAttribution < 0) {
             attributionDomain.push(this.minAttribution);
-            attributionColorRange.push(negAttributionColor);
+            attributionColorRange.push(negAttributionHighColor);
+            attributionDomain.push(this.minAttribution / 2);
+            attributionColorRange.push(negAttributionLowColor);
           }
           attributionDomain.push(0);
           attributionColorRange.push(neutralAttributionColor);
           if (this.maxAttribution > 0) {
+            attributionDomain.push(this.maxAttribution / 2);
+            attributionColorRange.push(posAttributionLowColor);
             attributionDomain.push(this.maxAttribution);
-            attributionColorRange.push(posAttributionColor);
+            attributionColorRange.push(posAttributionHighColor);
           }
 
           this.attributionColorScale = d3
@@ -6451,7 +6457,7 @@ limitations under the License.
           // Set 3 ticks on the legend, handling all positive, all negative,
           // or a mix of both.
           const ticks = [];
-          if (attributionColorRange.length == 3) {
+          if (attributionColorRange.length == 5) {
             ticks.push(this.minAttribution / 2);
             ticks.push(0);
             ticks.push(this.maxAttribution / 2);


### PR DESCRIPTION
* Motivation for features / changes

Updating WIT attribution color scales per mocks

* Technical description of changes

Changed colors and to a 5 color scale for better blending along the gradient.
Removed the duplication of the colors in vz-example-viewer.
Updated at what value the feature value text changes to white due to the background color for attribution.

* Screenshots of UI changes

![attrcolors](https://user-images.githubusercontent.com/15835086/65776657-91010400-e110-11e9-86dd-f5a130cc985b.png)

* Detailed steps to verify changes work correctly (as executed by you)

Ran attribution WIT notebook with attributions with different domains ( all negative, all positive, mix of both) and ensured color and text color looked correct and matched mocks.
