### PR TITLE
Fix slicing buckets in WIT

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -6740,12 +6740,13 @@ limitations under the License.
         calculateBucketEdges_: function(feature, numBuckets) {
           if (
             !this.isNumericFeature_(feature) ||
-            // No point in aggregating if less unique values than buckets.
-            this.stats[feature].uniqueCount < numBuckets ||
+            // No point in aggregating if not more unique values than buckets.
+            this.stats[feature].uniqueCount <= numBuckets ||
             // Already done.
             (this.featureBucketEdges_[feature] &&
               this.featureBucketEdges_[feature].length == numBuckets + 1)
           ) {
+            delete this.featureBucketEdges_[feature];
             return;
           }
           const min = this.stats[feature].numberMin;


### PR DESCRIPTION
* Motivation for features / changes

Slicing by numeric features didn't always give the right result.

* Technical description of changes

If number of buckets >= number of unique values, don't do ranges, slice by unique values.
In this case, make sure to delete bucket range information.

* Detailed steps to verify changes work correctly (as executed by you)

Test in demo crossing the unique value threshold in both directions.