### PR TITLE
core: implement experimental API for runs

### DIFF
--- a/tensorboard/components/plugin_lib/BUILD
+++ b/tensorboard/components/plugin_lib/BUILD
@@ -1,0 +1,32 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+# TODO(stephanwlee): figure out how this tf_web_library can be used to create
+# maybe a NPM package.
+tf_web_library(
+    name = "plugin_lib",
+    srcs = [
+        "runs.ts",
+        "tf-plugin-lib.html",
+    ],
+    path = "/",
+    deps = [
+        "//tensorboard/components/plugin_util:plugin_guest",
+    ],
+)
+
+tf_web_library(
+    name = "host_impls",
+    srcs = [
+        "runs-host-impl.ts",
+        "tf-plugin-host-impls.html",
+    ],
+    path = "/tf-plugin-lib",
+    deps = [
+        "//tensorboard/components/plugin_util:plugin_host",
+        "//tensorboard/components/tf_backend",
+    ],
+)

--- a/tensorboard/components/plugin_lib/runs-host-impl.ts
+++ b/tensorboard/components/plugin_lib/runs-host-impl.ts
@@ -1,6 +1,4 @@
-<!--
-@license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,11 +11,17 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
-<link rel="import" href="../plugin-host.html" />
-<script vulcanize-noinline src="../../web-component-tester/browser.js"></script>
+==============================================================================*/
+/**
+ * Implements run related plugin APIs.
+ */
+tb.plugin.lib.host.listen('experimental.GetRuns', () => {
+  return tf_backend.runsStore.getRuns();
+});
 
-<template id="iframe-template">
-  <iframe src="./iframe.html"></iframe>
-</template>
-<script src="plugin-test.js"></script>
+tf_backend.runsStore.addListener(() => {
+  return tb.plugin.lib.host.broadcast(
+    'experimental.RunsChange',
+    tf_backend.runsStore.getRuns()
+  );
+});

--- a/tensorboard/components/plugin_lib/runs.ts
+++ b/tensorboard/components/plugin_lib/runs.ts
@@ -12,8 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+namespace tb.plugin.lib.run {
+  export async function getRuns() {
+    return tb.plugin.lib.internal.sendMessage('experimental.GetRuns');
+  }
 
-import {sendMessage, listen, unlisten, _guestIPC} from '../plugin-guest.js';
-
-const win = window as any;
-win.test = {sendMessage, listen, unlisten, _guestIPC};
+  export function addRunsChangeListener(callback: (runs: string[]) => void) {
+    return tb.plugin.lib.internal.listen('experimental.RunsChange', callback);
+  }
+}

--- a/tensorboard/components/plugin_lib/test/BUILD
+++ b/tensorboard/components/plugin_lib/test/BUILD
@@ -1,0 +1,22 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_library(
+    name = "test",
+    testonly = True,
+    srcs = [
+        "test.html",
+        "test.ts",
+        "testable-iframe.html",
+    ],
+    path = "/tf-plugin-lib/test",
+    deps = [
+        "//tensorboard/components/plugin_lib",
+        "//tensorboard/components/plugin_lib:host_impls",
+        "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_imports:web_component_tester",
+    ],
+)

--- a/tensorboard/components/plugin_lib/test/test.html
+++ b/tensorboard/components/plugin_lib/test/test.html
@@ -14,10 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<link rel="import" href="../plugin-host.html" />
-<script vulcanize-noinline src="../../web-component-tester/browser.js"></script>
+<meta charset="utf-8" />
+<script src="../../web-component-tester/browser.js"></script>
 
-<template id="iframe-template">
-  <iframe src="./iframe.html"></iframe>
-</template>
-<script src="plugin-test.js"></script>
+<link rel="import" href="../../tf-backend/tf-backend.html" />
+<link rel="import" href="../tf-plugin-host-impls.html" />
+
+<script src="test.js"></script>

--- a/tensorboard/components/plugin_lib/test/test.ts
+++ b/tensorboard/components/plugin_lib/test/test.ts
@@ -1,0 +1,72 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+async function createIframe(): Promise<HTMLIFrameElement> {
+  return new Promise<HTMLIFrameElement>((resolve) => {
+    const iframe = document.createElement('iframe') as HTMLIFrameElement;
+    document.body.appendChild(iframe);
+    iframe.src = './testable-iframe.html';
+    iframe.onload = () => resolve(iframe);
+  });
+}
+
+describe('plugin lib integration', () => {
+  const {expect} = chai;
+
+  beforeEach(async function() {
+    this.sandbox = sinon.sandbox.create({useFakeServer: true});
+    this.sandbox.server.respondImmediately = true;
+    this.iframe = await createIframe();
+  });
+
+  afterEach(function() {
+    document.body.removeChild(this.iframe);
+    this.sandbox.restore();
+  });
+
+  describe('tb.plugin.lib.run', () => {
+    describe('#getRuns', () => {
+      it('returns list of runs', async function() {
+        this.sandbox
+          .stub(tf_backend.runsStore, 'getRuns')
+          .returns(['foo', 'bar', 'baz']);
+
+        const runs = await (this.iframe.contentWindow as any).getRuns();
+
+        expect(runs).to.deep.equal(['foo', 'bar', 'baz']);
+      });
+    });
+    describe('#addRunsChangeListener', () => {
+      it('lets plugins to subscribe to runs change', async function() {
+        const runsChanged = this.sandbox.stub();
+        const promise = new Promise((resolve) => {
+          (this.iframe.contentWindow as any).addRunsChangeListener(resolve);
+        }).then(runsChanged);
+        this.sandbox.server.respondWith([
+          200,
+          {'Content-Type': 'application/json'},
+          '["foo", "bar"]',
+        ]);
+
+        await tf_backend.runsStore.refresh();
+        await promise;
+
+        expect(runsChanged).to.have.been.calledOnce;
+        expect(runsChanged).to.have.been.calledWith(['foo', 'bar']);
+      });
+    });
+  });
+});
+1;

--- a/tensorboard/components/plugin_lib/test/testable-iframe.html
+++ b/tensorboard/components/plugin_lib/test/testable-iframe.html
@@ -14,10 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<link rel="import" href="../plugin-host.html" />
-<script vulcanize-noinline src="../../web-component-tester/browser.js"></script>
-
-<template id="iframe-template">
-  <iframe src="./iframe.html"></iframe>
-</template>
-<script src="plugin-test.js"></script>
+<link rel="import" href="../../tf-plugin-lib.html" />
+<script>
+  window.getRuns = tb.plugin.lib.run.getRuns;
+  window.addRunsChangeListener = tb.plugin.lib.run.addRunsChangeListener;
+</script>

--- a/tensorboard/components/plugin_lib/tf-plugin-host-impls.html
+++ b/tensorboard/components/plugin_lib/tf-plugin-host-impls.html
@@ -14,10 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<link rel="import" href="../plugin-host.html" />
-<script vulcanize-noinline src="../../web-component-tester/browser.js"></script>
+<link rel="import" href="../tf-backend/tf-backend.html" />
+<link rel="import" href="plugin-host.html" />
 
-<template id="iframe-template">
-  <iframe src="./iframe.html"></iframe>
-</template>
-<script src="plugin-test.js"></script>
+<script src="runs-host-impl.ts"></script>

--- a/tensorboard/components/plugin_lib/tf-plugin-lib.html
+++ b/tensorboard/components/plugin_lib/tf-plugin-lib.html
@@ -14,10 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<link rel="import" href="../plugin-host.html" />
-<script vulcanize-noinline src="../../web-component-tester/browser.js"></script>
+<link rel="import" href="tf-plugin-lib/plugin-guest.html" />
 
-<template id="iframe-template">
-  <iframe src="./iframe.html"></iframe>
-</template>
-<script src="plugin-test.js"></script>
+<script src="runs.js"></script>

--- a/tensorboard/components/plugin_util/BUILD
+++ b/tensorboard/components/plugin_util/BUILD
@@ -5,24 +5,12 @@ load("//tensorboard/defs:web.bzl", "tf_web_library")
 licenses(["notice"])  # Apache 2.0
 
 tf_web_library(
-    name = "plugin_host",
+    name = "message",
     srcs = [
-        "plugin-host.html",
-        "plugin-host.ts",
-    ],
-    path = "/tf-plugin",
-    deps = [
-        ":plugin_lib",
-        "//tensorboard/components/tf_backend",
-    ],
-)
-
-tf_web_library(
-    name = "plugin_lib",
-    srcs = [
+        "message.html",
         "message.ts",
     ],
-    path = "/tf-plugin",
+    path = "/tf-plugin-lib",
 )
 
 tf_web_library(
@@ -31,9 +19,20 @@ tf_web_library(
         "plugin-guest.html",
         "plugin-guest.ts",
     ],
-    path = "/tf-plugin",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":plugin_lib",
+    path = "/tf-plugin-lib",
+    visibility = [
+        "//tensorboard/components/plugin_lib:__subpackages__",
+        "//tensorboard/components/plugin_util/test:__subpackages__",
     ],
+    deps = [":message"],
+)
+
+tf_web_library(
+    name = "plugin_host",
+    srcs = [
+        "plugin-host.html",
+        "plugin-host.ts",
+    ],
+    path = "/tf-plugin-lib",
+    deps = [":message"],
 )

--- a/tensorboard/components/plugin_util/message.html
+++ b/tensorboard/components/plugin_util/message.html
@@ -14,10 +14,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<link rel="import" href="../plugin-host.html" />
-<script vulcanize-noinline src="../../web-component-tester/browser.js"></script>
-
-<template id="iframe-template">
-  <iframe src="./iframe.html"></iframe>
-</template>
-<script src="plugin-test.js"></script>
+<script src="message.js"></script>

--- a/tensorboard/components/plugin_util/message.ts
+++ b/tensorboard/components/plugin_util/message.ts
@@ -12,111 +12,108 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+namespace tb.plugin.lib.internal {
+  /**
+   * This file defines utilities shared by TensorBoard (plugin host) and the
+   * dynamic plugin library, used by plugin authors.
+   */
 
-/**
- * This file defines utilities shared by TensorBoard (plugin host) and the
- * dynamic plugin library, used by plugin authors.
- */
+  export type PayloadType =
+    | null
+    | undefined
+    | string
+    | string[]
+    | boolean
+    | boolean[]
+    | number
+    | number[]
+    | object
+    | object[];
 
-export type PayloadType =
-  | null
-  | undefined
-  | string
-  | string[]
-  | boolean
-  | boolean[]
-  | number
-  | number[]
-  | object
-  | object[];
-
-export interface Message {
-  type: string;
-  id: string;
-  payload: PayloadType;
-  error: string | null;
-  isReply: boolean
-}
-
-export type MessageType = string;
-export type MessageCallback = (payload: any) => any;
-
-interface PromiseResolver {
-  resolve: (data: any) => void;
-  reject: (error: Error) => void;
-}
-
-export class IPC {
-  private id = 0;
-  private readonly responseWaits = new Map<string, PromiseResolver>();
-  private readonly listeners = new Map<MessageType, MessageCallback>();
-  private readonly port: MessagePort;
-
-  constructor(port) {
-    this.port = port;
-    port.addEventListener('message', this.onMessage.bind(this));
+  export interface Message {
+    type: string;
+    id: string;
+    payload: PayloadType;
+    error: string | null;
+    isReply: boolean;
   }
 
-  listen(type: MessageType, callback: MessageCallback) {
-    this.listeners.set(type, callback);
+  export type MessageType = string;
+  export type MessageCallback = (payload: any) => any;
+
+  interface PromiseResolver {
+    resolve: (data: any) => void;
+    reject: (error: Error) => void;
   }
 
-  unlisten(type: MessageType) {
-    this.listeners.delete(type);
-  }
+  export class IPC {
+    private id = 0;
+    private readonly responseWaits = new Map<string, PromiseResolver>();
+    private readonly listeners = new Map<MessageType, MessageCallback>();
+    private readonly port: MessagePort;
 
-  private async onMessage(event: MessageEvent) {
-    const message = JSON.parse(event.data) as Message;
-    const callback = this.listeners.get(message.type);
-
-    if (message.isReply) {
-      if (!this.responseWaits.has(message.id))
-        return;
-      const {id, payload, error} = message;
-      const {resolve, reject} = this.responseWaits.get(id);
-      this.responseWaits.delete(id);
-      if (error) {
-        reject(new Error(error));
-      } else {
-        resolve(payload);
-      }
-      return;
+    constructor(port) {
+      this.port = port;
+      port.addEventListener('message', this.onMessage.bind(this));
     }
 
-    let payload = null;
-    let error = null;
-    if (this.listeners.has(message.type)) {
+    listen(type: MessageType, callback: MessageCallback) {
+      this.listeners.set(type, callback);
+    }
+
+    unlisten(type: MessageType) {
+      this.listeners.delete(type);
+    }
+
+    private async onMessage(event: MessageEvent) {
+      const message = JSON.parse(event.data) as Message;
       const callback = this.listeners.get(message.type);
-      try {
-        const result = await callback(message.payload);
-        payload = result;
-      } catch (e) {
-        error = e;
+
+      if (message.isReply) {
+        if (!this.responseWaits.has(message.id)) return;
+        const {id, payload, error} = message;
+        const {resolve, reject} = this.responseWaits.get(id);
+        this.responseWaits.delete(id);
+        if (error) {
+          reject(new Error(error));
+        } else {
+          resolve(payload);
+        }
+        return;
       }
+
+      let payload = null;
+      let error = null;
+      if (this.listeners.has(message.type)) {
+        const callback = this.listeners.get(message.type);
+        try {
+          const result = await callback(message.payload);
+          payload = result;
+        } catch (e) {
+          error = e;
+        }
+      }
+      const replyMessage: Message = {
+        type: message.type,
+        id: message.id,
+        payload,
+        error,
+        isReply: true,
+      };
+      this.postMessage(replyMessage);
     }
-    const replyMessage: Message = {
-      type: message.type,
-      id: message.id,
-      payload,
-      error,
-      isReply: true,
-    };
-    this.postMessage(replyMessage);
-  }
 
-  private postMessage(message: Message) {
-    this.port.postMessage(JSON.stringify(message));
-  }
+    private postMessage(message: Message) {
+      this.port.postMessage(JSON.stringify(message));
+    }
 
-  sendMessage(
-    type: MessageType,
-    payload: PayloadType,
-  ): Promise<PayloadType> {
-    const id = `${this.id++}`;
-    const message: Message = {type, id, payload, error: null, isReply: false};
-    this.postMessage(message);
-    return new Promise((resolve, reject) => {
-      this.responseWaits.set(id, {resolve, reject});
-    });
+    sendMessage(type: MessageType, payload: PayloadType): Promise<PayloadType> {
+      const id = `${this.id++}`;
+      const message: Message = {type, id, payload, error: null, isReply: false};
+      this.postMessage(message);
+      return new Promise((resolve, reject) => {
+        this.responseWaits.set(id, {resolve, reject});
+      });
+    }
   }
-}
+} // namespace tb.plugin.lib.internal

--- a/tensorboard/components/plugin_util/plugin-guest.html
+++ b/tensorboard/components/plugin_util/plugin-guest.html
@@ -14,5 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<link rel="import" href="message.html" />
+
 <script src="plugin-guest.js"></script>
-<script src="message.js"></script>

--- a/tensorboard/components/plugin_util/plugin-host.html
+++ b/tensorboard/components/plugin_util/plugin-host.html
@@ -14,7 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<link rel="import" href="../tf-backend/tf-backend.html" />
+<link rel="import" href="message.html" />
 
-<script src="message.js"></script>
 <script src="plugin-host.js"></script>

--- a/tensorboard/components/plugin_util/plugin-host.ts
+++ b/tensorboard/components/plugin_util/plugin-host.ts
@@ -12,46 +12,63 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {IPC, Message, MessageType, PayloadType} from './message.js';
+import {IPC, MessageType, PayloadType} from './message.js';
 
-class HostIPC extends IPC {
-  sendMessage(
-    iframe: HTMLIFrameElement,
-    type: MessageType,
-    payload: PayloadType
-  ): Promise<PayloadType> {
-    return this.sendMessageToWindow(iframe.contentWindow, type, payload);
+const portIPCs = new Set<IPC>();
+const VERSION = 'experimental';
+const ipcToFrame = new WeakMap<IPC, HTMLIFrameElement>();
+
+// The initial Window-level listener is needed to bootstrap only.
+// All further communication is done over MessagePorts.
+window.addEventListener('message', (event) => {
+  if (event.data !== `${VERSION}.bootstrap`)
+    return;
+  const port = event.ports[0];
+  if (!port)
+    return;
+  const frame = event.source ? event.source.frameElement : null;
+  if (!frame)
+    return;
+
+  const portIPC = new IPC(port);
+  portIPCs.add(portIPC);
+  ipcToFrame.set(portIPC, frame as HTMLIFrameElement);
+  port.start();
+
+  // TODO: install API.
+});
+
+function _broadcast(
+  type: MessageType,
+  payload: PayloadType
+): Promise<PayloadType[]> {
+  // Clean up disconnected iframes, since they won't respond.
+  for (const ipc of portIPCs) {
+    if (!ipcToFrame.get(ipc).isConnected) {
+      portIPCs.delete(ipc);
+      ipcToFrame.delete(ipc);
+    }
   }
+
+  const ipcs = [...portIPCs];
+  const promises = ipcs.map(ipc => ipc.sendMessage(type, payload));
+  return Promise.all(promises);
 }
 
-const hostIPC = new HostIPC();
-const _listen = hostIPC.listen.bind(hostIPC);
-const _unlisten = hostIPC.unlisten.bind(hostIPC);
-const _sendMessage = hostIPC.sendMessage.bind(hostIPC);
-
-export const sendMessage = _sendMessage;
-export const listen = _listen;
-export const unlisten = _unlisten;
-
-// Export for testability.
-export const _hostIPC = hostIPC;
+export const broadcast = _broadcast;
 
 namespace tf_plugin {
+
   /**
-   * Sends a message to the frame specified.
-   * @return Promise that resolves with a payload from frame in response to the message.
+   * Sends a message to all dynamic plugins. Individual plugins decide whether
+   * or not to listen.
+   * @return Promise that resolves with a list of payloads from each plugin's
+   *         response (or null) to the message.
    *
    * @example
-   * const someList = await sendMessage('v1.some.type.guest.understands');
+   * const someList = await broadcast('some.type.guest.understands');
    * // do fun things with someList.
    */
-  export const sendMessage = _sendMessage;
-  /**
-   * Subscribes to messages from specified frame of a type specified.
-   */
-  export const listen = _listen;
-  /**
-   * Unsubscribes to messages from specified frame of a type specified.
-   */
-  export const unlisten = _unlisten;
+  export const broadcast = _broadcast;
+
 } // namespace tf_plugin

--- a/tensorboard/components/plugin_util/test/BUILD
+++ b/tensorboard/components/plugin_util/test/BUILD
@@ -10,51 +10,50 @@ licenses(["notice"])  # Apache 2.0
 
 tf_web_test(
     name = "test",
+    src = "/tf-plugin/test/test_binary.html",
     web_library = ":test_web_library",
-    src = "/tf-plugin/test/test_binary.html"
 )
 
-# HACK: specifying tensorboard_html_binary on tf_web_test causes certain
-# environment to throw exception but wrapping tensorbard_html_binary with
-# tf_web_library seems to be okay.
+# # HACK: specifying tensorboard_html_binary on tf_web_test causes certain
+# # environment to throw exception but wrapping tensorbard_html_binary with
+# # tf_web_library seems to be okay.
+# tf_web_library(
+#     name = "test_web_library",
+#     srcs = [
+#         ":test_binary.html",
+#     ],
+#     path = "/tf-plugin/test",
+#     deps = [
+#         ":test_lib",
+#         "//tensorboard/components/tf_imports:web_component_tester",
+#     ],
+# )
+
+# tensorboard_html_binary(
+#     name = "test_binary",
+#     # Disable advanced optimization to prevent check for WebComponentTester
+#     # gobals.
+#     compilation_level = "SIMPLE",
+#     # Requires for compiling `import`s away.
+#     compile = True,
+#     input_path = "/tf-plugin/test/tests.html",
+#     output_path = "/tf-plugin/test/test_binary.html",
+#     deps = [
+#         ":test_lib",
+#     ],
+# )
+
 tf_web_library(
     name = "test_web_library",
     srcs = [
-        ":test_binary.html",
-    ],
-    path = "/tf-plugin/test",
-    deps = [
-        ":test_lib",
-        "//tensorboard/components/tf_imports:web_component_tester",
-    ],
-)
-
-tensorboard_html_binary(
-    name = "test_binary",
-    # Disable advanced optimization to prevent check for WebComponentTester
-    # gobals.
-    compilation_level = "SIMPLE",
-    # Requires for compiling `import`s away.
-    compile = True,
-    input_path = "/tf-plugin/test/tests.html",
-    output_path = "/tf-plugin/test/test_binary.html",
-    deps = [
-        ":test_lib",
-    ],
-)
-
-tf_web_library(
-    name = "test_lib",
-    srcs = [
         "iframe.html",
-        "iframe.ts",
         "plugin-test.ts",
         "tests.html",
     ],
-    path = "/tf-plugin/test",
+    path = "/tf-plugin-lib/test",
     deps = [
-        "//tensorboard/components/plugin_util:plugin_host",
         "//tensorboard/components/plugin_util:plugin_guest",
+        "//tensorboard/components/plugin_util:plugin_host",
         "//tensorboard/components/tf_imports:web_component_tester",
     ],
 )

--- a/tensorboard/components/plugin_util/test/iframe.html
+++ b/tensorboard/components/plugin_util/test/iframe.html
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<head>
-  <script src="./iframe.js" type="module"></script>
-</head>
+<link rel="import" href="../plugin-guest.html" />
+<script>
+  window.test = tb.plugin.lib.internal;
+</script>

--- a/tensorboard/components/plugin_util/test/plugin-test.ts
+++ b/tensorboard/components/plugin_util/test/plugin-test.ts
@@ -12,9 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import * as pluginHost from '../plugin-host.js';
 
-namespace tf_plugin.test {
+namespace tb.plugin.lib.host.test {
   const {expect} = chai;
   const template = document.getElementById(
     'iframe-template'
@@ -57,8 +56,8 @@ namespace tf_plugin.test {
           this.destListen = this.guestWindow.test.listen;
           this.destUnlisten = this.guestWindow.test.unlisten;
           this.srcSendMessage = (type, payload) => {
-            return new Promise(async resolve => {
-              const results = await pluginHost.broadcast(type, payload);
+            return new Promise(async (resolve) => {
+              const results = await broadcast(type, payload);
               resolve(results[0]);
             });
           };

--- a/tensorboard/components/plugin_util/test/plugin-test.ts
+++ b/tensorboard/components/plugin_util/test/plugin-test.ts
@@ -57,22 +57,13 @@ namespace tf_plugin.test {
           this.destListen = this.guestWindow.test.listen;
           this.destUnlisten = this.guestWindow.test.unlisten;
           this.srcSendMessage = (type, payload) => {
-            return pluginHost.sendMessage(this.guestFrame, type, payload);
+            return new Promise(async resolve => {
+              const results = await pluginHost.broadcast(type, payload);
+              resolve(results[0]);
+            });
           };
           this.destPostMessageSpy = () =>
             this.sandbox.spy(this.guestWindow.test._guestIPC, 'postMessage');
-        },
-      },
-      {
-        spec: 'guest (src) to host (dest)',
-        beforeEachFunc: function() {
-          this.destListen = pluginHost.listen;
-          this.destUnlisten = pluginHost.unlisten;
-          this.srcSendMessage = (type, payload) => {
-            return this.guestWindow.test.sendMessage(type, payload);
-          };
-          this.destPostMessageSpy = () =>
-            this.sandbox.spy(pluginHost._hostIPC, 'postMessage');
         },
       },
     ].forEach(({spec, beforeEachFunc}) => {


### PR DESCRIPTION
With tb.plugin.lib.run, you can now fetch list of runs and subscribe to
changes.

Do note that this change includes changes to the BUILD where we no
longer use modules for the library. We will revisit this in near future
to make this more usable for non-TB Polymer projects.