### PR TITLE
diagnose: warn about `tensorflow-tensorboard`

### DIFF
--- a/tensorboard/tools/diagnose_tensorboard.py
+++ b/tensorboard/tools/diagnose_tensorboard.py
@@ -172,6 +172,7 @@ def installed_packages():
       frozenset([
           u"tensorboard",
           u"tb-nightly",
+          u"tensorflow-tensorboard",
       ]),
       frozenset([
           u"tensorflow",


### PR DESCRIPTION
Summary:
We teach the diagnosis script that the `tensorflow-tensorboard` PyPI
package provides a `tensorboard` module, and thus must not coexist with
either `tensorboard` or `tb-nightly`.

The `tensorflow-tensorboard` package is a legacy artifact, used only by
versions of TensorBoard prior to 1.6.0. It should usually not be
installed, unless one specifically wants to use old versions of both
TensorBoard and TensorFlow.

Test Plan:
Create a virtualenv, and install into it `tensorflow==1.14.0` (and thus
`tensorboard==1.14.0`) and `tensorflow-tensorboard==1.5.1`. Note that
running `tensorboard --logdir .` fails. Running the diagnosis script
prior to this commit turned up no action items. As of this commit, it
detects the problem and prints an action item with suggested invocations
that do solve the issue.

wchargin-branch: diagnose-tftb
