### PR TITLE
Unblock the sync

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -6,7 +6,7 @@ package(default_visibility = [":internal"])
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:zipper.bzl", "tensorboard_zip_file")
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])  # Needed for internal repo.
 

--- a/tensorboard/components/tf_ng_tensorboard/core/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/core/BUILD
@@ -55,6 +55,7 @@ ng_module(
     deps = [
         ":core",
         "//tensorboard/components/tf_ng_tensorboard/core/testing",
+        "//tensorboard/components/tf_ng_tensorboard/types",
         "@npm//@types/chai",
         "@npm//@types/jasmine",
         "@npm//@types/sinon",

--- a/tensorboard/components/tf_ng_tensorboard/core/core.reducers.test.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.reducers.test.ts
@@ -96,7 +96,10 @@ describe('core reducer', () => {
   });
 
   describe('#pluginsListingLoaded', () => {
-    let clock: sinon.SinonFakeTimers;
+    // type definition of sinon differs in google3 and it cannot be strongly
+    // typed.
+    // TODO(stephanwlee): prefer to use jasmine from now on.
+    let clock: any;
 
     beforeEach(() => {
       clock = sinon.useFakeTimers(1000);

--- a/tensorboard/components/tf_ng_tensorboard/core/core.reducers.ts
+++ b/tensorboard/components/tf_ng_tensorboard/core/core.reducers.ts
@@ -64,55 +64,73 @@ const initialState: CoreState = {
 
 const reducer = createReducer(
   initialState,
-  on(actions.changePlugin, (state: CoreState, {plugin}) => {
-    return {...state, activePlugin: plugin};
-  }),
-  on(actions.pluginsListingRequested, (state: CoreState) => {
-    return {
-      ...state,
-      pluginsListLoaded: {
-        ...state.pluginsListLoaded,
-        state: DataLoadState.LOADING,
-      },
-    };
-  }),
-  on(actions.pluginsListingFailed, (state: CoreState) => {
-    return {
-      ...state,
-      pluginsListLoaded: {
-        ...state.pluginsListLoaded,
-        state: DataLoadState.FAILED,
-      },
-    };
-  }),
-  on(actions.pluginsListingLoaded, (state: CoreState, {plugins}) => {
-    const [firstPlugin] = Object.keys(plugins);
-    let activePlugin =
-      state.activePlugin !== null ? state.activePlugin : firstPlugin;
-    return {
-      ...state,
-      activePlugin,
-      plugins,
-      pluginsListLoaded: {
-        state: DataLoadState.LOADED,
-        lastLoadedTimeInMs: Date.now(),
-      },
-    };
-  }),
-  on(actions.toggleReloadEnabled, (state: CoreState) => {
-    return {
-      ...state,
-      reloadEnabled: !state.reloadEnabled,
-    };
-  }),
-  on(actions.changeReloadPeriod, (state: CoreState, {periodInMs}) => {
-    const nextReloadPeriod =
-      periodInMs > 0 ? periodInMs : state.reloadPeriodInMs;
-    return {
-      ...state,
-      reloadPeriodInMs: nextReloadPeriod,
-    };
-  })
+  on(
+    actions.changePlugin,
+    (state: CoreState, {plugin}): CoreState => {
+      return {...state, activePlugin: plugin};
+    }
+  ),
+  on(
+    actions.pluginsListingRequested,
+    (state: CoreState): CoreState => {
+      return {
+        ...state,
+        pluginsListLoaded: {
+          ...state.pluginsListLoaded,
+          state: DataLoadState.LOADING,
+        },
+      };
+    }
+  ),
+  on(
+    actions.pluginsListingFailed,
+    (state: CoreState): CoreState => {
+      return {
+        ...state,
+        pluginsListLoaded: {
+          ...state.pluginsListLoaded,
+          state: DataLoadState.FAILED,
+        },
+      };
+    }
+  ),
+  on(
+    actions.pluginsListingLoaded,
+    (state: CoreState, {plugins}): CoreState => {
+      const [firstPlugin] = Object.keys(plugins);
+      let activePlugin =
+        state.activePlugin !== null ? state.activePlugin : firstPlugin;
+      return {
+        ...state,
+        activePlugin,
+        plugins,
+        pluginsListLoaded: {
+          state: DataLoadState.LOADED,
+          lastLoadedTimeInMs: Date.now(),
+        },
+      };
+    }
+  ),
+  on(
+    actions.toggleReloadEnabled,
+    (state: CoreState): CoreState => {
+      return {
+        ...state,
+        reloadEnabled: !state.reloadEnabled,
+      };
+    }
+  ),
+  on(
+    actions.changeReloadPeriod,
+    (state: CoreState, {periodInMs}): CoreState => {
+      const nextReloadPeriod =
+        periodInMs > 0 ? periodInMs : state.reloadPeriodInMs;
+      return {
+        ...state,
+        reloadPeriodInMs: nextReloadPeriod,
+      };
+    }
+  )
 );
 
 export function reducers(state: CoreState, action: Action) {


### PR DESCRIPTION
sync: unblock by fixing typing on the Angular code 
1. Although it looks perfectly fine, internal TSC fails to correctly
infer return type of the reducer. We now specify the return type
2. Strict deps on typing/api.
3. Sinon type definition differs and it cannot be correctly typed unless
we convert `sinon.Sinon` to `Sinon.Sinon` which seem very brittle.
Typing to `any` and have a policy to now use jasmine.

sync: remove comment after license as per conformance check

merge plan: squash with two commit messages combined.
