### PR TITLE
Fix retracing warnings in the range loop.

### DIFF
--- a/docs/migrate.ipynb
+++ b/docs/migrate.ipynb
@@ -89,7 +89,10 @@
         "colab": {}
       },
       "source": [
-        "!pip install tf-nightly-2.0-preview"
+        "try:\n",
+        "  %tensorflow_version 2.x\n",
+        "except:\n",
+        "  pass"
       ],
       "execution_count": 1,
       "outputs": [
@@ -239,7 +242,7 @@
         "    # other model code would go here\n",
         "    tf.summary.scalar(\"my_metric\", 0.5, step=step)\n",
         "\n",
-        "for step in range(100):\n",
+        "for step in tf.range(100, dtype=tf.int64):\n",
         "  my_func(step)\n",
         "  writer.flush()"
       ],


### PR DESCRIPTION
-Use colab's `%tensorflow_version` to skip the 60s install time (this is standard for tensorflow notebooks now).

-Use `tf.range` instead of `range` to prevent function retracing+warnings.