### PR TITLE
sync: missing deps on sinon for core test

### DIFF
--- a/tensorboard/components/tf_ng_tensorboard/core/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/core/BUILD
@@ -71,5 +71,6 @@ jasmine_node_test(
     ],
     deps = [
         "@npm//chai",
+        "@npm//sinon",
     ],
 )


### PR DESCRIPTION
core_jasmine_test is missing a dependency on sinon which is not enforced by Bazel rules.
