### PR TITLE
 vulc: jscomp-ignored script in topological order

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -110,7 +110,6 @@ public final class Vulcanize {
   private static final Multimap<Webpath, String> suppressions = HashMultimap.create();
   private static CompilationLevel compilationLevel;
   private static Webpath outputPath;
-  private static Node firstCompiledScript;
   private static Node firstScript;
   private static Node licenseComment;
   private static int insideDemoSnippet;
@@ -343,16 +342,8 @@ public final class Vulcanize {
               .removeAttr("src")
               .removeAttr("jscomp-minify")
               .removeAttr("jscomp-nocompile");
-      if (firstCompiledScript != null) {
-        firstCompiledScript.before(newScript);
-        return removeNode(node);
-      } else {
-        return replaceNode(node, newScript);
-      }
+      return replaceNode(node, newScript);
     } else {
-      if (firstCompiledScript == null) {
-        firstCompiledScript = node;
-      }
       sourcesFromScriptTags.put(path, script);
       sourceTags.put(path, node);
       Optional<String> suppress = getAttrTransitive(node, "jscomp-suppress");


### PR DESCRIPTION
For jscomp-ignored script, we took a special treatment to place it
before the first script tag we found. Not sure why it is done that way
but it does not seem to cause functional regression.

This change allows us to place a script tag before loading polymer
binary (which is jscomp-ignored) so we can enable the Polymer's
strictTemplatePolicy.

test: clicked around 12 plugins and verified that nothing was borked.


