### PR TITLE
mesh: remove obsolete installation instructions

### DIFF
--- a/tensorboard/plugins/mesh/README.md
+++ b/tensorboard/plugins/mesh/README.md
@@ -104,37 +104,3 @@ Here is a snippet of how to build and run the demo application:
 ```
 bazel run tensorboard/plugins/mesh:mesh_demo -- --mesh_path=path/to/ply/file
 ```
-
-## How to install
-
-The mesh plugin isn’t yet part of stable TensorBoard, so you’ll need to
-install the latest TensorBoard nightly build to use it.
-
-### Colab
-
-```
-!pip install -q -U tb-nightly
-```
-
-Then load TensorBoard extension and run it, similar to how you would do it in the Terminal:
-
-```
-%load_ext tensorboard
-%tensorboard --logdir=/path/to/logs
-```
-
-Please consult the [example Colab notebook](https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/tensorboard/plugins/mesh/Mesh_Plugin_Tensorboard.ipynb) for more details.
-
-### Terminal
-
-If you want to run TensorBoard nightly build locally, first you need to install it:
-
-```shell
-pip install tf-nightly
-```
-
-Then just run it:
-
-```shell
-tensorboard --logdir path/to/logs
-```


### PR DESCRIPTION
Summary:
The mesh plugin has been available by default since TensorBoard 1.14,
and requires no extra setup or nightly packages locally or in Colab.

Test Plan:
Note that `from tensorboard.plugins.mesh import summary` works in a new
Colab notebook, in a TensorFlow 2.0.0 install, and in a TensorBoard 1.15
install.

wchargin-branch: mesh-install
