### PR TITLE
ci: swap `tf-nightly-2.0-preview` to `tf-nightly`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - BAZEL_SHA256SUM=6c50e142a0a405d3d8598050d6c1b3920c8cdb82a7ffca6fc067cb474275148f
   matrix:
     - TF_VERSION_ID=tf-nightly==1.15.0.dev20190816
-    - TF_VERSION_ID=tf-nightly-2.0-preview
+    - TF_VERSION_ID=tf-nightly
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:

--- a/tensorboard/examples/plugins/example_basic/smoke_test.sh
+++ b/tensorboard/examples/plugins/example_basic/smoke_test.sh
@@ -45,7 +45,7 @@ pip install -qU wheel 'setuptools>=36.2.0'
 [ -f ./example-plugin/dist/*.whl ]  # just one wheel
 
 py_major_version="$(python -c 'import sys; print(sys.version_info[0])')"
-pip install tf-nightly-2.0-preview  # TODO(@wchargin): Other versions, too?
+pip install tf-nightly  # TODO(@wchargin): Other versions, too?
 pip uninstall -y tensorboard tb-nightly  # drop conflicting packages
 pip install ./tensorboard-wheels/*py"${py_major_version}"*.whl
 pip install ./example-plugin/dist/*.whl

--- a/tensorboard/pip_package/test_pip_package.sh
+++ b/tensorboard/pip_package/test_pip_package.sh
@@ -27,9 +27,9 @@ Options:
   --all-pythons: Test on both Python 2 and Python 3. This is the default.
   --default-python-only: Test only using the stock "python" binary.
   --tf-version VERSION: Test against the provided version of TensorFlow,
-      given as a Pip package specifier like "tf-nightly-2.0-preview" or
-      "tensorflow==2.0.0a0". If empty, will test without installing
-      TensorFlow. Defaults to "tf-nightly".
+      given as a Pip package specifier like "tensorflow==2.0.0a0" or
+      "tf-nightly". If empty, will test without installing TensorFlow.
+      Defaults to "tf-nightly".
 EOF
 }
 


### PR DESCRIPTION
Summary:
As of 2019-10-03, the `tf-nightly` package includes TensorFlow 2.x, and
the `tf-nightly-2.0-preview` package is not expected to be updated.

Test Plan:
Further occurrences of `git grep tf-nightly-2.0-preview` are in
notebooks, which should be updated separately, and the diagnosis script,
which is correct as is.

wchargin-branch: remove-tf2p
