### PR TITLE
sec: disable strictTemplatePolicy on TB and enable on projector

### DIFF
--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -11,7 +11,6 @@ tf_web_library(
     path = "/",
     deps = [
         ":analytics",
-        ":security",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_tensorboard",
         "//tensorboard/components/tf_tensorboard:default_plugins",

--- a/tensorboard/components/tensorboard.html
+++ b/tensorboard/components/tensorboard.html
@@ -28,7 +28,9 @@ limitations under the License.
 />
 
 <!-- Configures polymer and requires to be loaded at the top. -->
-<link rel="import" href="security.html" />
+<!-- TODO(stephanwlee): Hparams (vaadin-grid) cannot support strictTemplatePolciy. Figure out
+how to enable it back. -->
+<!-- <link rel="import" href="security.html" /> -->
 
 <link rel="import" href="analytics.html" />
 <link rel="import" href="tf-imports/polymer.html" />

--- a/tensorboard/plugins/projector/tf_projector_plugin/BUILD
+++ b/tensorboard/plugins/projector/tf_projector_plugin/BUILD
@@ -32,6 +32,7 @@ tf_web_library(
     ],
     path = "/tf-projector",
     deps = [
+        "//tensorboard/components:security",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/plugins/projector/vz_projector",
         "@com_google_fonts_roboto",

--- a/tensorboard/plugins/projector/tf_projector_plugin/tf-projector-plugin.html
+++ b/tensorboard/plugins/projector/tf_projector_plugin/tf-projector-plugin.html
@@ -14,6 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<!-- Configures polymer and requires to be loaded at the top. -->
+<link rel="import" href="../security.html" />
 <link rel="import" href="../tf-imports/polymer.html" />
 <link rel="import" href="../font-roboto/roboto.html" />
 <link rel="import" href="../vz-projector/vz-projector-dashboard.html" />


### PR DESCRIPTION
The strictTemplatePolicy caused regression on hparams dashboard as
vaadingrid was not happy about it.

This change disables the policy for TensorBoard but enables the policy
on one of our dynamic plugin, projector, which is okay with it.
