### PR TITLE
sec: Enable CSP and disallow random script tags

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -60,6 +60,8 @@ _JSON_MIMETYPES = set([
     'application/json+protobuf',
 ])
 
+# Do not support xhtml for now.
+_HTML_MIMETYPE = 'text/html'
 
 def Respond(request,
             content,
@@ -67,7 +69,8 @@ def Respond(request,
             code=200,
             expires=0,
             content_encoding=None,
-            encoding='utf-8'):
+            encoding='utf-8',
+            csp_scripts_sha256s=None):
   """Construct a werkzeug Response.
 
   Responses are transmitted to the browser with compression if: a) the browser
@@ -103,6 +106,9 @@ def Respond(request,
     expires: Second duration for browser caching.
     content_encoding: Encoding if content is already encoded, e.g. 'gzip'.
     encoding: Input charset if content parameter has byte strings.
+    csp_scripts_sha256s: List of base64 serialized sha256 of whitelisted script
+      elements for script-src of the Content-Security-Policy. It is only be used
+      when the content_type is text/html.
 
   Returns:
     A werkzeug Response object (a WSGI application).
@@ -157,6 +163,22 @@ def Respond(request,
   else:
     headers.append(('Expires', '0'))
     headers.append(('Cache-Control', 'no-cache, must-revalidate'))
+  if mimetype == _HTML_MIMETYPE and csp_scripts_sha256s:
+    # The quotes need to be single quotes per csp requirement.
+    script_srcs = ' '.join(
+        ["'sha256-{}'".format(sha256) for sha256 in csp_scripts_sha256s])
+    csp_string = ';'.join([
+            "default-src 'self'",
+            # data uri used by favicon
+            "img-src 'self' data:",
+            # gstatic: used by google-chart
+            # inline styles: Polymer templates + d3 uses inline styles.
+            "style-src https://www.gstatic.com data: 'unsafe-inline'",
+            # TODO(stephanwlee): remove `'strict dynamic'` when dynamic plugin
+            # resources can be hashed upfront.
+            "script-src 'strict-dynamic' %s" % script_srcs,
+        ])
+    headers.append(('Content-Security-Policy', csp_string))
 
   if request.method == 'HEAD':
     content = None

--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -165,10 +165,9 @@ def Respond(request,
     headers.append(('Expires', '0'))
     headers.append(('Cache-Control', 'no-cache, must-revalidate'))
   if mimetype == _HTML_MIMETYPE:
-    # The quotes need to be single quotes per csp requirement.
     if csp_scripts_sha256s:
       whitelist_hashes = ' '.join(
-        ["'sha256-{}'".format(sha256) for sha256 in csp_scripts_sha256s])
+          ["'sha256-{}'".format(sha256) for sha256 in csp_scripts_sha256s])
       # TODO(stephanwlee): remove `'strict dynamic'` when dynamic plugin
       # resources can be hashed upfront.
       script_srcs = 'strict-dynamic %s' % whitelist_hashes

--- a/tensorboard/defs/vulcanize.bzl
+++ b/tensorboard/defs/vulcanize.bzl
@@ -22,8 +22,8 @@ def _tensorboard_html_binary(ctx):
 
   The rule outputs a HTML that resolves all HTML import statements into one
   document. When compile option is on, it compiles all script sources with
-  JSCompiler and combines them into one script element. The rule also outputs
-  name.html.scripts_sha256 file that contains sha256 hash, in hex, of all
+  JSCompiler and combines script elements. The rule also outputs
+  [name].html.scripts_sha256 file that contains sha256 hash, in base64, of all
   script elements (sources inside element and content of JavaScript src they
   point at). The hashes are delimited by newline.
   """

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.hash.Hashing;
+import com.google.common.io.BaseEncoding;
 import com.google.javascript.jscomp.BasicErrorManager;
 import com.google.javascript.jscomp.CheckLevel;
 import com.google.javascript.jscomp.CompilationLevel;
@@ -793,13 +794,14 @@ public final class Vulcanize {
         }
         sourceContent = new String(Files.readAllBytes(webfiles.get(webpath)), UTF_8);
       }
-      String hash = Hashing.sha256().hashString(sourceContent, UTF_8).toString();
+      String hash = BaseEncoding.base64().encode(
+          Hashing.sha256().hashString(sourceContent, UTF_8).asBytes());
       hashes.add(hash);
     }
     return hashes;
   }
 
-  // Writes sha256 of script tags in hex in the document.
+  // Writes sha256 of script tags in base64 in the document.
   private static void writeShasum(Document document, Path output) throws FileNotFoundException, IOException {
     String hashes = Joiner.on("\n").join(computeScriptShasum(document));
     Files.write(

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -110,14 +110,15 @@ class CorePlugin(base_plugin.TBPlugin):
 
           if os.path.splitext(path)[1] == '.html':
             checksum_path = os.path.join(SHASUM_DIR, path + SHASUM_FILE_SUFFIX)
-            shasum = None
             # TODO(stephanwlee): devise a way to omit font-roboto/roboto.html from
             # the assets zip file.
             if checksum_path in zip_.namelist():
-              shasum = zip_.read(checksum_path).splitlines(False)
+              shasums = zip_.read(checksum_path).splitlines(False)
+            else:
+              shasums = None
 
             wsgi_app = functools.partial(
-                self._serve_html, shasum, gzipped_asset_bytes)
+                self._serve_html, shasums, gzipped_asset_bytes)
           else:
             wsgi_app = functools.partial(
                 self._serve_asset, path, gzipped_asset_bytes)

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import codecs
 import collections
 import functools
 import gzip

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -157,7 +157,7 @@ class CorePlugin(base_plugin.TBPlugin):
         gzipped_asset_bytes,
         'text/html',
         content_encoding='gzip',
-        csp_scripts_sha256s=shasums
+        csp_scripts_sha256s=shasums,
     )
 
   @wrappers.Request.application


### PR DESCRIPTION
For our HTML-based resources, we now apply the CSP so we do not load
unknown image, styles, and scripts.

Design choice made:
- the CSP is applied at the http_util with one API to configure the hash
  part so no response can set the CSP to "unsafe" and make entire
  application unsafe. e.g., dynamic resource is served with "unsafe" and
  the unsafe script tag gets loaded which now has access to the parent
  frame and exfiltrate.

Future work:
- Turn `'strict-dynamic'` off
- Apply CSP to the projector_binary.html.
- CSP needs to work better with the dynamic plugin. One possibility is
  to modify our API so the plugins can define static resources which can
  be shasumed by TensorBoard.
- Above logic can introduce more complexity to the core_plugin. We
  should consider creating richer asset_provider API so it can mediate
  with serving.

tests:
- [x] caused CSP violation to see how browser react (on localhost, too)
- [x] loaded application with CSP
- [x] loaded projector plugin
- [x] set compile=False and confirmed the application working with 420
hashes.
- [x] google_charts loaded properly
- [x] firefox