### PR TITLE
[tensor-widget] Add support for hierarchical menu and image view of tensor values

### DIFF
--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -47,6 +47,7 @@ tf_ts_library(
     srcs = [
         "dtype-utils.ts",
         "health-pill-types.ts",
+        "menu.ts",
         "selection.ts",
         "shape-utils.ts",
         "slicing-control.ts",

--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -45,6 +45,7 @@ tf_ts_library(
 tf_ts_library(
     name = "tensor_widget_lib",
     srcs = [
+        "colormap.ts",
         "dtype-utils.ts",
         "health-pill-types.ts",
         "menu.ts",
@@ -64,6 +65,7 @@ tf_ts_library(
     name = "test_lib",
     testonly = True,
     srcs = [
+        "colormap-test.ts",
         "dtype-utils-test.ts",
         "selection-test.ts",
         "shape-utils-test.ts",

--- a/tensorboard/components/tensor_widget/colormap-test.ts
+++ b/tensorboard/components/tensor_widget/colormap-test.ts
@@ -1,0 +1,79 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/** Unit tests for colormaps. */
+
+import {expect} from 'chai';
+
+import {GrayscaleColorMap} from './colormap';
+
+describe('GrayscaleColorMap', () => {
+  it('max < min causes constructor error', () => {
+    const min = 3;
+    const max = 2;
+    expect(() => new GrayscaleColorMap(min, max)).to.throw(/max.*<.*min/);
+  });
+
+  it('NaN or Infinity min or max causes constructor error', () => {
+    expect(() => new GrayscaleColorMap(0, Infinity)).to.throw(
+      /max.*not finite/
+    );
+    expect(() => new GrayscaleColorMap(0, -Infinity)).to.throw(
+      /max.*not finite/
+    );
+    expect(() => new GrayscaleColorMap(0, NaN)).to.throw(/max.*not finite/);
+    expect(() => new GrayscaleColorMap(Infinity, 0)).to.throw(
+      /min.*not finite/
+    );
+    expect(() => new GrayscaleColorMap(-Infinity, 0)).to.throw(
+      /min.*not finite/
+    );
+    expect(() => new GrayscaleColorMap(NaN, 0)).to.throw(/min.*not finite/);
+  });
+
+  it('max > min, finite values', () => {
+    const min = 0;
+    const max = 10;
+    const colormap = new GrayscaleColorMap(min, max);
+    expect(colormap.getRGB(0)).to.eql([0, 0, 0]);
+    expect(colormap.getRGB(5)).to.eql([127.5, 127.5, 127.5]);
+    expect(colormap.getRGB(10)).to.eql([255, 255, 255]);
+    // Over-limits.
+    expect(colormap.getRGB(-100)).to.eql([0, 0, 0]);
+    expect(colormap.getRGB(500)).to.eql([255, 255, 255]);
+  });
+
+  it('max > min, non-finite values', () => {
+    const min = 0;
+    const max = 10;
+    const colormap = new GrayscaleColorMap(min, max);
+    expect(colormap.getRGB(NaN)).to.eql([255, 0, 0]);
+    expect(colormap.getRGB(-Infinity)).to.eql([255, 255 / 2, 0]);
+    expect(colormap.getRGB(Infinity)).to.eql([0, 0, 255]);
+  });
+
+  it('max === min, non-finite values', () => {
+    const min = -3.2;
+    const max = -3.2;
+    const colormap = new GrayscaleColorMap(min, max);
+    expect(colormap.getRGB(-32)).to.eql([127.5, 127.5, 127.5]);
+    expect(colormap.getRGB(-3.2)).to.eql([127.5, 127.5, 127.5]);
+    expect(colormap.getRGB(0)).to.eql([127.5, 127.5, 127.5]);
+    expect(colormap.getRGB(32)).to.eql([127.5, 127.5, 127.5]);
+    expect(colormap.getRGB(NaN)).to.eql([255, 0, 0]);
+    expect(colormap.getRGB(-Infinity)).to.eql([255, 255 / 2, 0]);
+    expect(colormap.getRGB(Infinity)).to.eql([0, 0, 255]);
+  });
+});

--- a/tensorboard/components/tensor_widget/colormap.ts
+++ b/tensorboard/components/tensor_widget/colormap.ts
@@ -20,7 +20,7 @@ const MAX_RGB = 255;
 /**
  * Abstract base class for colormap.
  *
- * A colormap maps a numeric value onto an RGB color.
+ * A colormap maps a numeric value to an RGB color.
  */
 export abstract class ColorMap {
   /**
@@ -42,9 +42,9 @@ export abstract class ColorMap {
 
   /**
    * Get the RGB value based on element value.
-   * @param value The element value to be mapped onto RGB color values.
-   * @returns RGB color values represented as a length-3 number array.
-   *   The range of RGB values is 0 - 255.
+   * @param value The element value to be mapped to RGB color value.
+   * @returns RGB color value represented as a length-3 number array.
+   *   The range of RGB values is [0, 255].
    */
   abstract getRGB(value: number): [number, number, number];
 }
@@ -54,6 +54,8 @@ export abstract class ColorMap {
  */
 export class GrayscaleColorMap extends ColorMap {
   getRGB(value: number): [number, number, number] {
+    // This color scheme for pathological values matches tfdbg v1's Health Pills
+    // feature.
     if (isNaN(value)) {
       // NaN.
       return [MAX_RGB, 0, 0];

--- a/tensorboard/components/tensor_widget/colormap.ts
+++ b/tensorboard/components/tensor_widget/colormap.ts
@@ -17,7 +17,17 @@ limitations under the License.
 
 const MAX_RGB = 255;
 
+/**
+ * Abstract base class for colormap.
+ *
+ * A colormap maps a numeric value onto an RGB color.
+ */
 export abstract class ColorMap {
+  /**
+   * Constructor of ColorMap.
+   * @param min Minimum. Must be a finite value.
+   * @param max Maximum. Must be finite and >= `min`.
+   */
   constructor(protected readonly min: number, protected readonly max: number) {
     if (!isFinite(min)) {
       throw new Error(`min value (${min}) is not finite`);
@@ -30,9 +40,18 @@ export abstract class ColorMap {
     }
   }
 
+  /**
+   * Get the RGB value based on element value.
+   * @param value The element value to be mapped onto RGB color values.
+   * @returns RGB color values represented as a length-3 number array.
+   *   The range of RGB values is 0 - 255.
+   */
   abstract getRGB(value: number): [number, number, number];
 }
 
+/**
+ * A grayscale color map implementation.
+ */
 export class GrayscaleColorMap extends ColorMap {
   getRGB(value: number): [number, number, number] {
     if (isNaN(value)) {

--- a/tensorboard/components/tensor_widget/colormap.ts
+++ b/tensorboard/components/tensor_widget/colormap.ts
@@ -1,0 +1,59 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/** Colormap used to display numeric values */
+
+const MAX_RGB = 255;
+
+export abstract class ColorMap {
+  constructor(protected readonly min: number, protected readonly max: number) {
+    if (!isFinite(min)) {
+      throw new Error(`min value (${min}) is not finite`);
+    }
+    if (!isFinite(max)) {
+      throw new Error(`max value (${max}) is not finite`);
+    }
+    if (max < min) {
+      throw new Error(`max (${max}) is < min (${min})`);
+    }
+  }
+
+  abstract getRGB(value: number): [number, number, number];
+}
+
+export class GrayscaleColorMap extends ColorMap {
+  getRGB(value: number): [number, number, number] {
+    if (isNaN(value)) {
+      // NaN.
+      return [MAX_RGB, 0, 0];
+    } else if (!isFinite(value)) {
+      if (value > 0) {
+        // +Infinity.
+        return [0, 0, MAX_RGB];
+      } else {
+        // -Infinity.
+        return [MAX_RGB, MAX_RGB / 2, 0];
+      }
+    }
+    let relativeValue =
+      this.min === this.max ? 0.5 : (value - this.min) / (this.max - this.min);
+    relativeValue = Math.max(Math.min(relativeValue, 1), 0);
+    return [
+      MAX_RGB * relativeValue,
+      MAX_RGB * relativeValue,
+      MAX_RGB * relativeValue,
+    ];
+  }
+}

--- a/tensorboard/components/tensor_widget/demo/demo.html
+++ b/tensorboard/components/tensor_widget/demo/demo.html
@@ -42,7 +42,7 @@ limitations under the License.
     <div id="tensor6" class="tensor"></div>
     <div id="tensor7" class="tensor"></div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/tensorflow/1.2.7/tf.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tensorflow/1.2.9/tf.min.js"></script>
     <script src="bundle.js"></script>
     <script>
       const DEMO_MODULE_PATH =

--- a/tensorboard/components/tensor_widget/demo/demo.ts
+++ b/tensorboard/components/tensor_widget/demo/demo.ts
@@ -179,13 +179,26 @@ export function tensorToTensorView(x: any): tensorWidget.TensorView {
       const numericSummary: BaseTensorNumericSummary = {
         elementCount: x.size,
       };
-      if (x.dtype === 'float32' || x.dtype === 'int32') {
-        (numericSummary as BooleanOrNumericTensorNumericSummary).minimum = x
-          .min()
-          .arraySync();
-        (numericSummary as BooleanOrNumericTensorNumericSummary).maximum = x
-          .max()
-          .arraySync();
+      if (x.dtype === 'float32' || x.dtype === 'int32' || x.dtype == 'bool') {
+        // This is not an efficient way to compute the maximum and minimum of
+        // finite values in a tensor. But it is okay as this is just a demo.
+        const data = x.dataSync() as Float32Array;
+        let minimum = Infinity;
+        let maximum = -Infinity;
+        for (let i = 0; i < data.length; ++i) {
+          const value = data[i];
+          if (!isFinite(value)) {
+            continue;
+          }
+          if (value < minimum) {
+            minimum = value;
+          }
+          if (value > maximum) {
+            maximum = value;
+          }
+        }
+        (numericSummary as BooleanOrNumericTensorNumericSummary).minimum = minimum;
+        (numericSummary as BooleanOrNumericTensorNumericSummary).maximum = maximum;
       }
       // TODO(cais): Take care of boolean dtype.
       return numericSummary;

--- a/tensorboard/components/tensor_widget/demo/demo.ts
+++ b/tensorboard/components/tensor_widget/demo/demo.ts
@@ -177,15 +177,15 @@ export function tensorToTensorView(x: any): tensorWidget.TensorView {
     },
     getNumericSummary: async () => {
       const numericSummary: BaseTensorNumericSummary = {
-        elementCount: x.size(),
+        elementCount: x.size,
       };
       if (x.dtype === 'float32' || x.dtype === 'int32') {
         (numericSummary as BooleanOrNumericTensorNumericSummary).minimum = x
           .min()
-          .dataSync();
+          .arraySync();
         (numericSummary as BooleanOrNumericTensorNumericSummary).maximum = x
           .max()
-          .dataSync();
+          .arraySync();
       }
       // TODO(cais): Take care of boolean dtype.
       return numericSummary;

--- a/tensorboard/components/tensor_widget/demo/demo.ts
+++ b/tensorboard/components/tensor_widget/demo/demo.ts
@@ -15,6 +15,10 @@ limitations under the License.
 
 import * as tensorWidget from '../tensor-widget';
 import {TensorViewSlicingSpec, TensorView} from '../types';
+import {
+  BaseTensorNumericSummary,
+  BooleanOrNumericTensorNumericSummary,
+} from '../health-pill-types';
 
 // TODO(cais): Find a way to import tfjs-core here, instead of depending on
 // a global variable.
@@ -171,9 +175,20 @@ export function tensorToTensorView(x: any): tensorWidget.TensorView {
       // TODO(cais): Check memory leak.
       return retval;
     },
-    getHealthPill: async () => {
-      // return calculateHealthPill(x);
-      throw new Error('Not implemented yet.');
+    getNumericSummary: async () => {
+      const numericSummary: BaseTensorNumericSummary = {
+        elementCount: x.size(),
+      };
+      if (x.dtype === 'float32' || x.dtype === 'int32') {
+        (numericSummary as BooleanOrNumericTensorNumericSummary).minimum = x
+          .min()
+          .dataSync();
+        (numericSummary as BooleanOrNumericTensorNumericSummary).maximum = x
+          .max()
+          .dataSync();
+      }
+      // TODO(cais): Take care of boolean dtype.
+      return numericSummary;
     },
   };
 }

--- a/tensorboard/components/tensor_widget/demo/demo.ts
+++ b/tensorboard/components/tensor_widget/demo/demo.ts
@@ -176,9 +176,6 @@ export function tensorToTensorView(x: any): tensorWidget.TensorView {
       return retval;
     },
     getNumericSummary: async () => {
-      const numericSummary: BaseTensorNumericSummary = {
-        elementCount: x.size,
-      };
       if (x.dtype === 'float32' || x.dtype === 'int32' || x.dtype == 'bool') {
         // This is not an efficient way to compute the maximum and minimum of
         // finite values in a tensor. But it is okay as this is just a demo.
@@ -197,11 +194,14 @@ export function tensorToTensorView(x: any): tensorWidget.TensorView {
             maximum = value;
           }
         }
-        (numericSummary as BooleanOrNumericTensorNumericSummary).minimum = minimum;
-        (numericSummary as BooleanOrNumericTensorNumericSummary).maximum = maximum;
+        return {
+          elementCount: x.size,
+          minimum,
+          maximum,
+        };
+      } else {
+        return {elementCount: x.size};
       }
-      // TODO(cais): Take care of boolean dtype.
-      return numericSummary;
     },
   };
 }

--- a/tensorboard/components/tensor_widget/health-pill-types.ts
+++ b/tensorboard/components/tensor_widget/health-pill-types.ts
@@ -39,5 +39,5 @@ export interface BooleanOrNumericTensorNumericSummary
   maximum: number | boolean;
 }
 
-// TODO(cais): Add sub-interfaces of `BaseTensorHealthPill` for other tensor
+// TODO(cais): Add sub-interfaces of `BaseTensorNumericSummary` for other tensor
 // dtypes.

--- a/tensorboard/components/tensor_widget/health-pill-types.ts
+++ b/tensorboard/components/tensor_widget/health-pill-types.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 /**
- * Health pill: A summary of a tensor's element values.
+ * A summary of a tensor's element values.
  *
  * It contains information such as
  * - the distribution of the tensor's values among different value categories
@@ -25,9 +25,18 @@ limitations under the License.
  * This base health-pill interface is general enough for all tensor
  * data types, including boolean, integer, float and string.
  */
-export interface BaseTensorHealthPill {
+export interface BaseTensorNumericSummary {
   /** Number of elements in the tensor. */
   elementCount: number;
+}
+
+export interface BooleanOrNumericTensorNumericSummary
+  extends BaseTensorNumericSummary {
+  /** Minimum of all finite values. */
+  minimum: number | boolean;
+
+  /** Maximum of all finite values. */
+  maximum: number | boolean;
 }
 
 // TODO(cais): Add sub-interfaces of `BaseTensorHealthPill` for other tensor

--- a/tensorboard/components/tensor_widget/menu.ts
+++ b/tensorboard/components/tensor_widget/menu.ts
@@ -90,6 +90,9 @@ class FlatMenu {
   private isShown: boolean = false;
   private dropdown: HTMLDivElement;
 
+  // Callback function for clicking outside the menu item.
+  private blurHideFunction: (() => void) | null = null;
+
   /**
    * Constructor of FlatMenu.
    * @param parentElement The parent element that the root UI element of this
@@ -100,9 +103,6 @@ class FlatMenu {
     this.dropdown.classList.add('tensor-widget-dim-dropdown');
     this.dropdown.style.position = 'fixed';
     this.dropdown.style.display = 'none';
-    this.dropdown.addEventListener('mouseleave', () => {
-      this.hide();
-    });
     parentElement.appendChild(this.dropdown);
   }
 
@@ -122,8 +122,9 @@ class FlatMenu {
         menuItem.classList.add('tensor-widget-dim-dropdown-menu-item-disabled');
         return;
       }
-
       menuItem.addEventListener('click', (event) => {
+        event.stopPropagation();
+        this.dropdown.click();
         if (itemConfig.onClick !== null) {
           itemConfig.onClick(event);
         }
@@ -161,6 +162,15 @@ class FlatMenu {
     this.dropdown.style.top = (top - topOffset).toFixed(1) + 'px';
     this.dropdown.style.left = (left - leftOffset).toFixed(1) + 'px';
     this.isShown = true;
+
+    this.blurHideFunction = () => {
+      this.hide();
+    };
+    setTimeout(
+      () =>
+        window.addEventListener('click', this.blurHideFunction as () => void),
+      50
+    );
   }
 
   /** Hide this FlatMenu: Remove it from screen display. */
@@ -170,6 +180,9 @@ class FlatMenu {
       this.dropdown.removeChild(this.dropdown.firstChild);
     }
     this.isShown = false;
+    if (this.blurHideFunction != null) {
+      window.removeEventListener('click', this.blurHideFunction);
+    }
   }
 
   /** Whether this FlatMenu is being shown currently. */

--- a/tensorboard/components/tensor_widget/menu.ts
+++ b/tensorboard/components/tensor_widget/menu.ts
@@ -13,12 +13,55 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+type Callback = () => void | Promise<void>;
+type HoverCallback = (event: Event) => void | Promise<void>;
+
+/**
+ * The base interface for a menu item.
+ */
 export interface MenuItemConfig {
   /** Caption displayed on the menu item. */
   caption: string;
+}
 
-  /** Click callback for the menu item. */
-  onClick: () => void | Promise<void>;
+/**
+ * A menu item which when clicked, triggers a single action.
+ */
+export interface SingleActionMenuItemConfig extends MenuItemConfig {
+  /** The callback that gets called when the menu item is clicked. */
+  callback: Callback;
+}
+
+export interface ChoiceMenuItemConfig extends MenuItemConfig {
+  /** All possible options. */
+  options: string[];
+
+  /** The default selection from `options`, a 0-based index. */
+  defaultSelection: number;
+
+  /**
+   * The callback that gets called when the selection has changed.
+   *
+   * The `currentSelection` argument is the 0-based index for the currently
+   * selected option.
+   */
+  callback: (currentSelection: number) => void | Promise<void>;
+}
+
+/**
+ * A menu item that supports a binary toggle state.
+ */
+export interface ToggleMenuItemConfig extends MenuItemConfig {
+  /** The default state of the menu item. */
+  defaultState: boolean;
+
+  /**
+   * The callback that gets called when the toggle state has changed.
+   *
+   * The `currentState` argument is a boolean indicating whether the
+   * toggle menu item is activated (`true`) or not (`false`).
+   */
+  callback: (currentState: boolean) => void | Promise<void>;
 }
 
 export interface MenuConfig {
@@ -27,15 +70,77 @@ export interface MenuConfig {
 }
 
 /**
+ * Helper class: A menu item without hierarchy.
+ */
+class FlatMenu {
+  private isShown: boolean = false;
+  private dropdown: HTMLDivElement;
+  // TODO(cais): Tie in the arg lengths.
+  constructor(parentElement: HTMLDivElement) {
+    this.dropdown = document.createElement('div');
+    this.dropdown.classList.add('tensor-widget-dim-dropdown');
+    this.dropdown.style.position = 'fixed';
+    this.dropdown.style.display = 'none';
+    parentElement.appendChild(this.dropdown);
+  }
+
+  show(
+    top: number,
+    left: number,
+    captions: string[],
+    onHoverCallbacks: Array<HoverCallback | null>
+  ) {
+    captions.forEach((caption, i) => {
+      const menuItem = document.createElement('div');
+      menuItem.classList.add('tensor-widget-dim-dropdown-menu-item');
+      menuItem.textContent = caption;
+      this.dropdown.appendChild(menuItem);
+      const onHover = onHoverCallbacks[i];
+      if (onHover !== null) {
+        menuItem.addEventListener('mouseover', onHover);
+        // TODO(cais): Add mouseexit callback.
+      }
+    });
+    this.dropdown.style.display = 'block';
+    this.dropdown.style.top = top + 'px';
+    this.dropdown.style.left = left + 'px';
+    const actualRect = this.dropdown.getBoundingClientRect();
+    const topOffset = actualRect.top - top;
+    const leftOffset = actualRect.left - left;
+    this.dropdown.style.top = (top - topOffset).toFixed(1) + 'px';
+    this.dropdown.style.left = (left - leftOffset).toFixed(1) + 'px';
+    this.isShown = true;
+  }
+
+  hide() {
+    this.dropdown.style.display = 'none';
+    while (this.dropdown.firstChild) {
+      this.dropdown.removeChild(this.dropdown.firstChild);
+    }
+    this.isShown = false;
+  }
+
+  shown() {
+    return this.isShown;
+  }
+}
+
+/**
  * A class for menu that supports configurable items and callbacks.
  */
 export class Menu {
+  private baseFlatMenu: FlatMenu;
+
   /**
    * Constructor for the Menu class.
    *
    * @param config Configuration for the menu.
    */
-  constructor(private readonly config: MenuConfig) {
+  constructor(
+    private readonly config: MenuConfig,
+    private readonly parentElement: HTMLDivElement
+  ) {
+    this.baseFlatMenu = new FlatMenu(parentElement);
   }
 
   /**
@@ -45,11 +150,36 @@ export class Menu {
    * @param left The left coordinate for the top-left corner of the menu.
    */
   show(top: number, left: number) {
-
+    const captions: string[] = this.config.items.map((item) => item.caption);
+    const onHovers: Array<HoverCallback | null> = this.config.items.map(
+      (item) => {
+        if ((item as ChoiceMenuItemConfig).options != null) {
+          // TODO(cais): Check to make sure it's not empty?
+          return (event) => {
+            const captions = (item as ChoiceMenuItemConfig).options;
+            const optionsFlatMenu = new FlatMenu(this.parentElement);
+            console.log(captions);
+            console.log(event.srcElement);
+            const box = (event.srcElement as HTMLDivElement).getBoundingClientRect();
+            const top = box.top;
+            const left = box.right;
+            const onHovers = captions.map((caption) => null);
+            optionsFlatMenu.show(top, left, captions, onHovers);
+          };
+        } else {
+          return null;
+        }
+      }
+    );
+    this.baseFlatMenu.show(top, left, captions, onHovers);
   }
 
   /** Hide the menu. */
   hide() {
+    this.baseFlatMenu.hide();
+  }
 
+  shown(): boolean {
+    return this.baseFlatMenu.shown();
   }
 }

--- a/tensorboard/components/tensor_widget/menu.ts
+++ b/tensorboard/components/tensor_widget/menu.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-type Callback = () => void | Promise<void>;
 type EventCallback = (event: Event) => void | Promise<void>;
 
 /**
@@ -29,7 +28,7 @@ export interface MenuItemConfig {
  */
 export interface SingleActionMenuItemConfig extends MenuItemConfig {
   /** The callback that gets called when the menu item is clicked. */
-  callback: Callback;
+  callback: EventCallback;
 }
 
 export interface ChoiceMenuItemConfig extends MenuItemConfig {
@@ -53,9 +52,8 @@ export interface MenuConfig {
   items: MenuItemConfig[];
 }
 
-
 interface FlatMenuItemConfig {
-  caption: string,
+  caption: string;
   onClick: EventCallback | null;
   onHover: EventCallback | null;
 }
@@ -78,11 +76,7 @@ class FlatMenu {
     parentElement.appendChild(this.dropdown);
   }
 
-  show(
-    top: number,
-    left: number,
-    itemConfigs: FlatMenuItemConfig[]
-  ) {
+  show(top: number, left: number, itemConfigs: FlatMenuItemConfig[]) {
     itemConfigs.forEach((itemConfig, i) => {
       const menuItem = document.createElement('div');
       menuItem.classList.add('tensor-widget-dim-dropdown-menu-item');
@@ -202,7 +196,7 @@ export class Menu {
                   choiceConfig.callback(k);
                 }
               },
-              onHover: null
+              onHover: null,
             });
           });
           const optionsFlatMenu = new FlatMenu(parent);

--- a/tensorboard/components/tensor_widget/menu.ts
+++ b/tensorboard/components/tensor_widget/menu.ts
@@ -29,6 +29,13 @@ export interface MenuItemConfig {
 export interface SingleActionMenuItemConfig extends MenuItemConfig {
   /** The callback that gets called when the menu item is clicked. */
   callback: EventCallback;
+
+  /**
+   * A function that determines whether menu item is currently enabled.
+   *
+   * If not provided, the menu item will always be enabled.
+   */
+  isEnabled?: () => boolean;
 }
 
 export interface ChoiceMenuItemConfig extends MenuItemConfig {
@@ -64,6 +71,13 @@ interface FlatMenuItemConfig {
 
   /** The hover callback for the item. */
   onHover: EventCallback | null;
+
+  /**
+   * Whether the item is disabled.
+   *
+   * If not specified, treated as `false` (not disabled).
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -104,6 +118,11 @@ class FlatMenu {
       menuItem.classList.add('tensor-widget-dim-dropdown-menu-item');
       menuItem.textContent = itemConfig.caption;
       this.dropdown.appendChild(menuItem);
+      if (itemConfig.disabled) {
+        menuItem.classList.add('tensor-widget-dim-dropdown-menu-item-disabled');
+        return;
+      }
+
       menuItem.addEventListener('click', (event) => {
         if (itemConfig.onClick !== null) {
           itemConfig.onClick(event);
@@ -233,7 +252,14 @@ export class Menu {
         };
       } else {
         // This is a single-command item.
-        outerItemConfig.onClick = (item as SingleActionMenuItemConfig).callback;
+        const singleActionConfig = item as SingleActionMenuItemConfig;
+        outerItemConfig.onClick = singleActionConfig.callback;
+        if (
+          singleActionConfig.isEnabled != null &&
+          !singleActionConfig.isEnabled()
+        ) {
+          outerItemConfig.disabled = true;
+        }
       }
       outerItemConfigs.push(outerItemConfig);
     });

--- a/tensorboard/components/tensor_widget/menu.ts
+++ b/tensorboard/components/tensor_widget/menu.ts
@@ -52,19 +52,35 @@ export interface MenuConfig {
   items: MenuItemConfig[];
 }
 
+/**
+ * The configuration of an item of a FlatMenu.
+ */
 interface FlatMenuItemConfig {
+  /** Caption of the FlatMenu item. */
   caption: string;
+
+  /** The click callback for the item. */
   onClick: EventCallback | null;
+
+  /** The hover callback for the item. */
   onHover: EventCallback | null;
 }
 
 /**
  * Helper class: A menu item without hierarchy.
+ *
+ * A FlatMenu doesn't support hierarchy. The `Menu` class below, which supports
+ * menus with hierarchy, is built by composing this helper class.
  */
 class FlatMenu {
   private isShown: boolean = false;
   private dropdown: HTMLDivElement;
-  // TODO(cais): Tie in the arg lengths.
+
+  /**
+   * Constructor of FlatMenu.
+   * @param parentElement The parent element that the root UI element of this
+   *   FlatMenu will be appended to as a child.
+   */
   constructor(parentElement: HTMLDivElement) {
     this.dropdown = document.createElement('div');
     this.dropdown.classList.add('tensor-widget-dim-dropdown');
@@ -76,6 +92,12 @@ class FlatMenu {
     parentElement.appendChild(this.dropdown);
   }
 
+  /**
+   * Show the FlatMenu item.
+   * @param top The top coordinate for the FlatMenu.
+   * @param left The left coordinate for the FlatMenu.
+   * @param itemConfigs Configuration of the menu items.
+   */
   show(top: number, left: number, itemConfigs: FlatMenuItemConfig[]) {
     itemConfigs.forEach((itemConfig, i) => {
       const menuItem = document.createElement('div');
@@ -122,6 +144,7 @@ class FlatMenu {
     this.isShown = true;
   }
 
+  /** Hide this FlatMenu: Remove it from screen display. */
   hide() {
     this.dropdown.style.display = 'none';
     while (this.dropdown.firstChild) {
@@ -130,6 +153,7 @@ class FlatMenu {
     this.isShown = false;
   }
 
+  /** Whether this FlatMenu is being shown currently. */
   shown() {
     return this.isShown;
   }
@@ -137,6 +161,8 @@ class FlatMenu {
 
 /**
  * A class for menu that supports configurable items and callbacks.
+ *
+ * Hierarchy is supported.
  */
 export class Menu {
   private baseFlatMenu: FlatMenu;
@@ -214,11 +240,12 @@ export class Menu {
     this.baseFlatMenu.show(top, left, outerItemConfigs);
   }
 
-  /** Hide the menu. */
+  /** Hide the menu: Remove it from display. */
   hide() {
     this.baseFlatMenu.hide();
   }
 
+  /** Whether this Menu is being shown currently. */
   shown(): boolean {
     return this.baseFlatMenu.shown();
   }

--- a/tensorboard/components/tensor_widget/menu.ts
+++ b/tensorboard/components/tensor_widget/menu.ts
@@ -1,0 +1,55 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export interface MenuItemConfig {
+  /** Caption displayed on the menu item. */
+  caption: string;
+
+  /** Click callback for the menu item. */
+  onClick: () => void | Promise<void>;
+}
+
+export interface MenuConfig {
+  /** An ordered list of items that comprise the menu. */
+  items: MenuItemConfig[];
+}
+
+/**
+ * A class for menu that supports configurable items and callbacks.
+ */
+export class Menu {
+  /**
+   * Constructor for the Menu class.
+   *
+   * @param config Configuration for the menu.
+   */
+  constructor(private readonly config: MenuConfig) {
+  }
+
+  /**
+   * Show the menu.
+   *
+   * @param top The top coordinate for the top-left corner of the menu.
+   * @param left The left coordinate for the top-left corner of the menu.
+   */
+  show(top: number, left: number) {
+
+  }
+
+  /** Hide the menu. */
+  hide() {
+
+  }
+}

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -57,7 +57,7 @@ type ValueClass = 'numeric' | 'boolean' | 'string';
 
 enum ValueRenderMode {
   TEXT = 1,
-  IMAGE = 2
+  IMAGE = 2,
 }
 
 /**

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -55,6 +55,11 @@ const DETAILED_VALUE_ATTR_KEY = 'detailed-value';
 
 type ValueClass = 'numeric' | 'boolean' | 'string';
 
+enum ValueRenderMode {
+  TEXT = 1,
+  IMAGE = 2
+}
+
 /**
  * Implementation of TensorWidget.
  */
@@ -102,7 +107,7 @@ export class TensorWidgetImpl implements TensorWidget {
   private menu: Menu | null = null;
 
   // Value render mode.
-  protected valueRenderMode: 'text' | 'image';
+  protected valueRenderMode: ValueRenderMode;
 
   // Size of each cell used to display the tensor value under the 'image' mode.
   protected imageCellSize = 12;
@@ -117,7 +122,7 @@ export class TensorWidgetImpl implements TensorWidget {
     this.options = options || {};
     this.slicingSpec = getDefaultSlicingSpec(this.tensorView.spec.shape);
     this.rank = this.tensorView.spec.shape.length;
-    this.valueRenderMode = 'text';
+    this.valueRenderMode = ValueRenderMode.TEXT;
   }
 
   /**
@@ -271,10 +276,10 @@ export class TensorWidgetImpl implements TensorWidget {
         defaultSelection: 0,
         callback: (currentMode: number) => {
           if (currentMode === 0) {
-            this.valueRenderMode = 'text';
+            this.valueRenderMode = ValueRenderMode.TEXT;
             this.renderValues();
           } else {
-            this.valueRenderMode = 'image';
+            this.valueRenderMode = ValueRenderMode.IMAGE;
             this.tensorView.getNumericSummary().then((numericSummary) => {
               this.numericSummary = numericSummary;
               this.renderValues();
@@ -289,7 +294,7 @@ export class TensorWidgetImpl implements TensorWidget {
           this.imageCellSize *= zoomStepRatio;
           this.renderValues();
         },
-        isEnabled: () => this.valueRenderMode === 'image',
+        isEnabled: () => this.valueRenderMode === ValueRenderMode.IMAGE,
       } as SingleActionMenuItemConfig);
       this.menuConfig.items.push({
         caption: 'Zoom out (Image mode only)',
@@ -297,7 +302,7 @@ export class TensorWidgetImpl implements TensorWidget {
           this.imageCellSize /= zoomStepRatio;
           this.renderValues();
         },
-        isEnabled: () => this.valueRenderMode === 'image',
+        isEnabled: () => this.valueRenderMode === ValueRenderMode.IMAGE,
       } as SingleActionMenuItemConfig);
     }
     if (this.menuConfig !== null && this.menuConfig.items.length > 0) {
@@ -519,7 +524,7 @@ export class TensorWidgetImpl implements TensorWidget {
     for (let i = 0; i < maxNumCols; ++i) {
       const tick = document.createElement('div');
       tick.classList.add('tensor-widget-top-ruler-tick');
-      if (this.valueRenderMode === 'image') {
+      if (this.valueRenderMode === ValueRenderMode.IMAGE) {
         tick.style.width = `${this.imageCellSize}px`;
       }
       this.topRuler.appendChild(tick);
@@ -573,7 +578,7 @@ export class TensorWidgetImpl implements TensorWidget {
     for (let i = 0; i < maxNumRows; ++i) {
       const row = document.createElement('div');
       row.classList.add('tensor-widget-value-row');
-      if (this.valueRenderMode === 'image') {
+      if (this.valueRenderMode === ValueRenderMode.IMAGE) {
         row.style.height = `${this.imageCellSize}px`;
         row.style.lineHeight = `${this.imageCellSize}px`;
       }
@@ -582,7 +587,7 @@ export class TensorWidgetImpl implements TensorWidget {
 
       const tick = document.createElement('div');
       tick.classList.add('tensor-widget-top-ruler-tick');
-      if (this.valueRenderMode === 'image') {
+      if (this.valueRenderMode === ValueRenderMode.IMAGE) {
         tick.style.height = `${this.imageCellSize}px`;
         tick.style.lineHeight = `${this.imageCellSize}px`;
       }
@@ -632,7 +637,7 @@ export class TensorWidgetImpl implements TensorWidget {
       for (let j = 0; j < numCols; ++j) {
         const valueDiv = document.createElement('div');
         valueDiv.classList.add('tensor-widget-value-div');
-        if (this.valueRenderMode === 'image') {
+        if (this.valueRenderMode === ValueRenderMode.IMAGE) {
           valueDiv.style.width = `${this.imageCellSize}px`;
           valueDiv.style.height = `${this.imageCellSize}px`;
           valueDiv.style.lineHeight = `${this.imageCellSize}px`;
@@ -706,7 +711,7 @@ export class TensorWidgetImpl implements TensorWidget {
           throw new Error(`Missing horizontal range for ${this.rank}D tensor.`);
         }
         const colIndex = this.slicingSpec.horizontalRange[0] + i;
-        if (this.valueRenderMode === 'text') {
+        if (this.valueRenderMode === ValueRenderMode.TEXT) {
           if (colIndex < numCols) {
             this.topRulerTicks[i].textContent = `${colIndex}`;
           } else {
@@ -732,7 +737,7 @@ export class TensorWidgetImpl implements TensorWidget {
           throw new Error(`Missing vertcial range for ${this.rank}D tensor.`);
         }
         const rowIndex = this.slicingSpec.verticalRange[0] + i;
-        if (this.valueRenderMode === 'text') {
+        if (this.valueRenderMode === ValueRenderMode.TEXT) {
           if (rowIndex < numRows) {
             this.leftRulerTicks[i].textContent = `${rowIndex}`;
           } else {
@@ -763,7 +768,7 @@ export class TensorWidgetImpl implements TensorWidget {
 
     let colorMap: ColorMap | null = null;
     const valueRenderMode = this.valueRenderMode;
-    if (valueRenderMode === 'image') {
+    if (valueRenderMode === ValueRenderMode.IMAGE) {
       if (this.numericSummary == null) {
         throw new Error(
           'Failed to render image representation of tensor due to ' +
@@ -789,7 +794,7 @@ export class TensorWidgetImpl implements TensorWidget {
           j < (values as number[][])[i].length
         ) {
           const value = (values as number[][] | boolean[][] | string[][])[i][j];
-          if (valueRenderMode === 'image') {
+          if (valueRenderMode === ValueRenderMode.IMAGE) {
             const [red, green, blue] = (colorMap as ColorMap).getRGB(
               value as number
             );

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -109,6 +109,10 @@ export class TensorWidgetImpl implements TensorWidget {
   // Value render mode.
   protected valueRenderMode: ValueRenderMode;
 
+  // Whether indices should be rendered on ruler ticks on the top and left.
+  // Determined dynamically based on the current size of the ticks.
+  protected showIndicesOnTicks: boolean = false;
+
   // Size of each cell used to display the tensor value under the 'image' mode.
   protected imageCellSize = 12;
 
@@ -706,12 +710,24 @@ export class TensorWidgetImpl implements TensorWidget {
       const numCols = this.tensorView.spec.shape[
         this.slicingSpec.viewingDims[1]
       ];
+
+      this.showIndicesOnTicks = false;
+      if (this.topRulerTicks.length > 0) {
+        const tickBox = this.topRulerTicks[0].getBoundingClientRect();
+        const tickWidth = tickBox.right - tickBox.left;
+        const dimSize = this.tensorView.spec.shape[
+          this.slicingSpec.viewingDims[0]
+        ];
+        this.showIndicesOnTicks =
+          tickWidth > 8 * Math.ceil(Math.log(dimSize) / Math.LN10);
+      }
+
       for (let i = 0; i < this.topRulerTicks.length; ++i) {
         if (this.slicingSpec.horizontalRange === null) {
           throw new Error(`Missing horizontal range for ${this.rank}D tensor.`);
         }
         const colIndex = this.slicingSpec.horizontalRange[0] + i;
-        if (this.valueRenderMode === ValueRenderMode.TEXT) {
+        if (this.showIndicesOnTicks) {
           if (colIndex < numCols) {
             this.topRulerTicks[i].textContent = `${colIndex}`;
           } else {
@@ -737,7 +753,7 @@ export class TensorWidgetImpl implements TensorWidget {
           throw new Error(`Missing vertcial range for ${this.rank}D tensor.`);
         }
         const rowIndex = this.slicingSpec.verticalRange[0] + i;
-        if (this.valueRenderMode === ValueRenderMode.TEXT) {
+        if (this.showIndicesOnTicks) {
           if (rowIndex < numRows) {
             this.leftRulerTicks[i].textContent = `${rowIndex}`;
           } else {

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -265,7 +265,6 @@ export class TensorWidgetImpl implements TensorWidget {
         options: ['Text', 'Image'],
         defaultSelection: 0,
         callback: (currentMode: number) => {
-          console.log(`Display mode changed: ${currentMode}`);
           if (currentMode === 0) {
             this.valueRenderMode = 'text';
             this.renderValues();
@@ -561,6 +560,10 @@ export class TensorWidgetImpl implements TensorWidget {
 
       const tick = document.createElement('div');
       tick.classList.add('tensor-widget-top-ruler-tick');
+      if (this.valueRenderMode === 'image') {
+        tick.style.height = `${this.imageCellSize}px`;
+        tick.style.lineHeight = `${this.imageCellSize}px`;
+      }
       row.appendChild(tick);
       this.leftRulerTicks.push(tick);
       if (tick.getBoundingClientRect().bottom >= rootElementBottom) {

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -773,7 +773,7 @@ export class TensorWidgetImpl implements TensorWidget {
             );
             valueDiv.style.backgroundColor = `rgb(${red}, ${green}, ${blue})`;
           } else {
-            // valueRenderMode: 'text'
+            // Here, valueRenderMode is 'text'.
             if (valueClass === 'numeric') {
               // TODO(cais): Once health pills are available, use the min/max
               // values to determine the number of decimal places.

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -1011,6 +1011,10 @@ export class TensorWidgetImpl implements TensorWidget {
     await this.renderValueDivs();
   }
 
+  /**
+   * Determine if indices should be displayed on ruler ticks given
+   * the current tick sizes.
+   */
   private calculateShowIndicesOnRulerTicks() {
     if (this.rank >= 2) {
       const tickBox = this.topRulerTicks[0].getBoundingClientRect();

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -19,7 +19,12 @@ import {
   isIntegerDType,
   isStringDType,
 } from './dtype-utils';
-import {ChoiceMenuItemConfig, Menu, MenuConfig} from './menu';
+import {
+  ChoiceMenuItemConfig,
+  Menu,
+  MenuConfig,
+  SingleActionMenuItemConfig,
+} from './menu';
 import {TensorElementSelection} from './selection';
 import {
   formatShapeForDisplay,
@@ -277,12 +282,29 @@ export class TensorWidgetImpl implements TensorWidget {
           }
         },
       } as ChoiceMenuItemConfig);
+      const zoomStepRatio = 1.2;
+      this.menuConfig.items.push({
+        caption: 'Zoom in (Image mode only)',
+        callback: (event) => {
+          this.imageCellSize *= zoomStepRatio;
+          this.renderValues();
+        },
+        isEnabled: () => this.valueRenderMode === 'image',
+      } as SingleActionMenuItemConfig);
+      this.menuConfig.items.push({
+        caption: 'Zoom out (Image mode only)',
+        callback: (event) => {
+          this.imageCellSize /= zoomStepRatio;
+          this.renderValues();
+        },
+        isEnabled: () => this.valueRenderMode === 'image',
+      } as SingleActionMenuItemConfig);
     }
-    if (this.menuConfig !== null) {
+    if (this.menuConfig !== null && this.menuConfig.items.length > 0) {
       this.menu = new Menu(this.menuConfig, this
         .headerSection as HTMLDivElement);
+      this.renderMenuThumb();
     }
-    this.renderMenuThumb();
   }
 
   /** Render the thumb that when clicked, toggles the menu display state. */

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -286,7 +286,6 @@ export class TensorWidgetImpl implements TensorWidget {
         const rect = (this.menuThumb as HTMLDivElement).getBoundingClientRect();
         const top = rect.bottom;
         const left = rect.left;
-        console.log(`top = ${top}, left = ${left}`);
         this.menu.show(top, left);
       }
     });

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -144,9 +144,9 @@ export class TensorWidgetImpl implements TensorWidget {
       this.headerSection.classList.add('tensor-widget-header');
       this.rootElement.appendChild(this.headerSection);
     }
+    this.createMenu();
     this.renderInfo();
     // TODO(cais): Implement and call renderHealthPill().
-    this.createMenu();
   }
 
   /**

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -114,7 +114,7 @@ export class TensorWidgetImpl implements TensorWidget {
   protected showIndicesOnTicks: boolean = false;
 
   // Size of each cell used to display the tensor value under the 'image' mode.
-  protected imageCellSize = 12;
+  protected imageCellSize = 16;
 
   protected numericSummary: BaseTensorNumericSummary | null = null;
 
@@ -711,17 +711,6 @@ export class TensorWidgetImpl implements TensorWidget {
         this.slicingSpec.viewingDims[1]
       ];
 
-      this.showIndicesOnTicks = false;
-      if (this.topRulerTicks.length > 0) {
-        const tickBox = this.topRulerTicks[0].getBoundingClientRect();
-        const tickWidth = tickBox.right - tickBox.left;
-        const dimSize = this.tensorView.spec.shape[
-          this.slicingSpec.viewingDims[0]
-        ];
-        this.showIndicesOnTicks =
-          tickWidth > 8 * Math.ceil(Math.log(dimSize) / Math.LN10);
-      }
-
       for (let i = 0; i < this.topRulerTicks.length; ++i) {
         if (this.slicingSpec.horizontalRange === null) {
           throw new Error(`Missing horizontal range for ${this.rank}D tensor.`);
@@ -1015,9 +1004,30 @@ export class TensorWidgetImpl implements TensorWidget {
     if (this.slicingControl != null) {
       this.slicingControl.setSlicingSpec(this.slicingSpec);
     }
+    // Determine if indices should be rendered on ruler ticks.
+    this.calculateShowIndicesOnRulerTicks();
     this.renderTopRuler();
     this.renderLeftRuler();
     await this.renderValueDivs();
+  }
+
+  private calculateShowIndicesOnRulerTicks() {
+    if (this.rank >= 2) {
+      const tickBox = this.topRulerTicks[0].getBoundingClientRect();
+      const tickWidth = tickBox.right - tickBox.left;
+      const dimSize = this.tensorView.spec.shape[
+        this.slicingSpec.viewingDims[0]
+      ];
+      this.showIndicesOnTicks =
+        tickWidth > 9 * Math.ceil(Math.log(dimSize) / Math.LN10);
+    } else if (this.rank === 1) {
+      const tickBox = this.leftRulerTicks[0].getBoundingClientRect();
+      const tickHeight = tickBox.bottom - tickBox.top;
+      this.showIndicesOnTicks = tickHeight > 16;
+    } else {
+      // rank is 0.
+      this.showIndicesOnTicks = false;
+    }
   }
 
   /**

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -110,6 +110,21 @@ limitations under the License.
   vertical-align: middle;
 }
 
+.tensor-widget-menu-thumb {
+  color: rgb(32, 33, 36);
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 16px;
+  float: right;
+  left: -10px;
+  position: relative;
+  user-select: none;
+}
+
+.tensor-widget-menu-thumb:hover {
+  color: rgb(227, 116, 0);
+}
+
 .tensor-widget-shape {
   color: rgb(60, 60, 60);
   display: inline-block;

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -61,11 +61,11 @@ limitations under the License.
   border-bottom: 1px solid rgb(180, 180, 180);
   font-size: 12px;
   padding: 3px;
+  user-select: none;
 }
 
 .tensor-widget-dim-dropdown-menu-item-active {
   background-color: rgb(100, 180, 255);
-  color: rgb(255, 255, 255);
 }
 
 .tensor-widget-dtype {

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -113,10 +113,10 @@ limitations under the License.
 .tensor-widget-menu-thumb {
   color: rgb(32, 33, 36);
   cursor: pointer;
+  display: inline-block;
   font-weight: bold;
   font-size: 16px;
-  float: right;
-  left: -10px;
+  margin-left: 10px;
   position: relative;
   user-select: none;
 }

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -68,6 +68,10 @@ limitations under the License.
   background-color: rgb(100, 180, 255);
 }
 
+.tensor-widget-dim-dropdown-menu-item-disabled {
+  color: rgb(128, 128, 128);
+}
+
 .tensor-widget-dtype {
   align-content: center;
   color: rgb(60, 60, 60);

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -117,6 +117,7 @@ limitations under the License.
   font-weight: bold;
   font-size: 16px;
   margin-left: 10px;
+  margin-right: 5px;
   position: relative;
   user-select: none;
 }

--- a/tensorboard/components/tensor_widget/types.ts
+++ b/tensorboard/components/tensor_widget/types.ts
@@ -57,7 +57,7 @@ export interface TensorView {
    */
   view: (slicingSpec: TensorViewSlicingSpec) => Promise<SlicedValues>;
 
-  /** Get the health pill of the underlying tensor. */
+  /** Get the numeric summary of the underlying tensor. */
   getNumericSummary: () => Promise<BaseTensorNumericSummary>;
 }
 

--- a/tensorboard/components/tensor_widget/types.ts
+++ b/tensorboard/components/tensor_widget/types.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {BaseTensorHealthPill} from './health-pill-types';
+import {BaseTensorNumericSummary} from './health-pill-types';
 
 export type Shape = ReadonlyArray<number>;
 
@@ -58,7 +58,7 @@ export interface TensorView {
   view: (slicingSpec: TensorViewSlicingSpec) => Promise<SlicedValues>;
 
   /** Get the health pill of the underlying tensor. */
-  getHealthPill: () => Promise<BaseTensorHealthPill>;
+  getNumericSummary: () => Promise<BaseTensorNumericSummary>;
 }
 
 /**

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -178,6 +178,7 @@ limitations under the License.
               id="tensorValueMultiView"
               continue-to-callback="[[_createContinueToCallback()]]"
               tensor-name-clicked="[[_createNodeClickedHandler()]]"
+              get-health-pill="[[_createGetHealthPill()]]"
             >
             </tf-tensor-value-multi-view>
           </template>

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-multi-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-multi-view.html
@@ -52,6 +52,8 @@ limitations under the License.
           type: Number,
           value: 0,
         },
+
+        getHealthPill: Function,
       },
 
       addView(view) {
@@ -61,6 +63,8 @@ limitations under the License.
         viewCard.viewId = view.viewId;
         viewCard.tensorName = view.tensorName;
         viewCard.debugOp = view.debugOp;
+        viewCard.deviceName = view.deviceName;
+        viewCard.maybeBaseExpandedNodeName = view.maybeBaseExpandedNodeName;
         viewCard.dtype = view.dtype;
         viewCard.shape = view.shape;
         viewCard.slicing = view.slicing;
@@ -80,6 +84,7 @@ limitations under the License.
             view.maybeBaseExpandedNodeName
           );
         };
+        viewCard.getHealthPill = this.getHealthPill;
         multiViewContainer.appendChild(viewCard);
         viewCard.refresh();
       },

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
@@ -192,6 +192,9 @@ limitations under the License.
 
         tensorName: String,
         debugOp: String,
+        deviceName: String,
+        maybeBaseExpandedNodeName: String,
+
         slicing: String,
         timeIndices: String,
 
@@ -203,6 +206,7 @@ limitations under the License.
         tensorNameCallback: Object,
 
         tensorWidget: Object,
+        getHealthPill: Function,
 
         _isTensorValueScalar: {
           type: Boolean,
@@ -305,6 +309,31 @@ limitations under the License.
                     }
                   })
                   .catch((err) => reject(err));
+              });
+            },
+            getNumericSummary: async () => {
+              return new Promise((resolve, reject) => {
+                const watch_key = this.tensorName + ':' + this.debugOp;
+                this.getHealthPill(
+                  watch_key,
+                  this.deviceName,
+                  this.maybeBaseExpandedNodeName,
+                  (healthPill) => {
+                    if (healthPill == null) {
+                      reject(
+                        `Failed to get health pill for watch key ${watch_key}`
+                      );
+                    } else {
+                      resolve({
+                        // See health_pill_calc.py for more details of the tfdbg v1
+                        // health-pill (numeric-summary) format.
+                        elementCount: healthPill[1],
+                        minimum: healthPill[8],
+                        maximum: healthPill[9],
+                      });
+                    }
+                  }
+                );
               });
             },
           };


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing TensorWidget

* Technical description of changes
  * Add menu.ts: Include `FlatMenu` and `Menu` classes.
  * Add a default menu item to TensorWdigetImpl, one that allows user to switch between text and image representations of numeric tensors.
  * Add colormap.ts: Include the base class `ColorMap` and a basic implementation `GrayscaleColorMap`. The latter is used for image rendering of numeric and boolean tensor values.
  * Add minimum and maximum values to `BooleanOrNumericTensorNumericSummary`
  * Rename terminology: health pill --> numeric summary
  * Update demo.ts.

* Screenshots of UI changes
![image](https://user-images.githubusercontent.com/16824702/66248925-c56d5500-e6fa-11e9-8752-9bd076b3eb55.png)

![image](https://user-images.githubusercontent.com/16824702/66248929-d5853480-e6fa-11e9-9168-6095332d10a2.png)

![image](https://user-images.githubusercontent.com/16824702/66248919-b4244880-e6fa-11e9-8a54-88aa560ed80d.png)

![image](https://user-images.githubusercontent.com/16824702/66248936-ea61c800-e6fa-11e9-889b-df08431d6421.png)


