### PR TITLE
core: add x-content-type-options: nosniff

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -147,6 +147,7 @@ def Respond(request,
 
   headers = []
   headers.append(('Content-Length', str(content_length)))
+  headers.append(('X-Content-Type-Options', 'nosniff'))
   if content_encoding:
     headers.append(('Content-Encoding', content_encoding))
   if expires > 0:


### PR DESCRIPTION
This prevents browsers from guessing correct mimetype and make it follow
the content-type given by the server. Please read [1] for more information.

There was no functional regression from the change.

[1]: http://go/mdn/HTTP/Basics_of_HTTP/MIME_types#MIME_sniffing