### PR TITLE
cleanup: use http_util.Respond

### DIFF
--- a/tensorboard/plugins/beholder/beholder_plugin.py
+++ b/tensorboard/plugins/beholder/beholder_plugin.py
@@ -186,9 +186,10 @@ class BeholderPlugin(base_plugin.TBPlugin):
     # Thanks to Miguel Grinberg for this technique:
     # https://blog.miguelgrinberg.com/post/video-streaming-with-flask
     mimetype = 'multipart/x-mixed-replace; boundary=frame'
-    return wrappers.Response(response=self._frame_generator(),
-                             status=200,
-                             mimetype=mimetype)
+    return http_util.Respond(request,
+                             self._frame_generator(),
+                             mimetype,
+                             code=200)
 
   @wrappers.Request.application
   def _serve_ping(self, request): # pylint: disable=unused-argument

--- a/tensorboard/plugins/debugger/interactive_debugger_plugin.py
+++ b/tensorboard/plugins/debugger/interactive_debugger_plugin.py
@@ -334,4 +334,4 @@ class InteractiveDebuggerPlugin(base_plugin.TBPlugin):
       return http_util.Respond(request, response, response_encoding)
     else:
       response = {'error': 'Invalid mode for source_code endpoint: %s' % mode}
-      return http_util.Response(request, response, response_encoding, 500)
+      return http_util.Respond(request, response, response_encoding, 500)


### PR DESCRIPTION
http_util.Respond, instead of werzeug.wrapper.Response attempts to
provide good defaults and require parameters to help make TensorBoard
more secure. This change converts few usage of Response to Respond.
