### PR TITLE
cleanup: miscellaneous improvements to Vulcanize

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -751,7 +751,7 @@ public final class Vulcanize {
         // that appear inside descendant of a node annotated with `vulcanize-noinline`.  They must
         // resolve from the root because those srcs are rootified.
         Webpath path = Webpath.get("/").resolve(Webpath.get(src)).normalize();
-        sourceContent = new String(Files.readAllBytes(webfiles.get(path)));
+        sourceContent = new String(Files.readAllBytes(webfiles.get(path)), UTF_8);
       }
       String hash = Hashing.sha256().hashString(sourceContent, UTF_8).toString();
       hashes.add(hash);

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -740,7 +740,7 @@ public final class Vulcanize {
   }
 
   private static ArrayList<String> computeScriptShasum(Document document) throws IOException {
-    ArrayList hashes = new ArrayList<String>();
+    ArrayList<String> hashes = new ArrayList<>();
     for (Element script : document.getElementsByTag("script")) {
       String src = script.attr("src");
       String sourceContent;


### PR DESCRIPTION
1. Internal javac complains about untyped ArrayList which seems to be
inferrable from its assignment.
2. specify charset when reading a file content.

merge plan: squash with updated commit message.
