### PR TITLE
experimental: plugin lib as ts_library

### DIFF
--- a/tensorboard/components/experimental/plugin_lib/BUILD
+++ b/tensorboard/components/experimental/plugin_lib/BUILD
@@ -5,6 +5,8 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 licenses(["notice"])  # Apache 2.0
 
 # Generating module friendly message.ts.
+# The genrule creates a new version of message.ts that strips `namespace {` and
+# `} // namespace`.
 # TODO(tensorboard-team): tf_ts_library and tf_web_library do not interoperate
 # yet we do have a requirement to make the plugin_lib use tf_ts_library. Remove
 # this when the two can interop or tf_web_library gets deprecated.
@@ -19,6 +21,8 @@ genrule(
     """,
 )
 
+# TODO(psybuzz): create a NPM package when a better requirement comes up using
+# tf_js_binary.
 tf_ts_library(
     name = "plugin_lib",
     srcs = [

--- a/tensorboard/components/experimental/plugin_lib/BUILD
+++ b/tensorboard/components/experimental/plugin_lib/BUILD
@@ -1,32 +1,30 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
-    name = "guest_internals",
+# Generating module friendly message.ts.
+# TODO(tensorboard-team): tf_ts_library and tf_web_library do not interoperate
+# yet we do have a requirement to make the plugin_lib use tf_ts_library. Remove
+# this when the two can interop or tf_web_library gets deprecated.
+genrule(
+    name = "message_lib",
     srcs = [
-        "plugin-guest.ts",
+        "//tensorboard/components/experimental/plugin_util:message.ts",
     ],
-    path = "/tf-plugin-lib",
-    deps = [
-        "//tensorboard/components/experimental/plugin_util:message",
-    ],
+    outs = ["message.ts"],
+    cmd = """
+        cat $< | sed -e "s|^namespace .*||" | sed -e "s|^} // namespace .*||" >$@
+    """,
 )
 
-# TODO(psybuzz): figure out how this tf_web_library can be used to create
-# maybe a NPM package.
-tf_web_library(
+tf_ts_library(
     name = "plugin_lib",
     srcs = [
+        "index.ts",
+        "plugin-guest.ts",
         "runs.ts",
-        "tf-plugin-lib.html",
-    ],
-    path = "/tf-plugin-lib",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":guest_internals",
-        "//tensorboard/components/experimental/plugin_util:message",
+        ":message_lib",
     ],
 )

--- a/tensorboard/components/experimental/plugin_lib/index.ts
+++ b/tensorboard/components/experimental/plugin_lib/index.ts
@@ -1,6 +1,4 @@
-<!--
-@license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
-<link rel="import" href="../tf-plugin-util/message.html" />
-<script src="plugin-guest.js"></script>
+==============================================================================*/
+import * as _runs from './runs';
 
-<script src="runs.js"></script>
+export const runs = _runs;

--- a/tensorboard/components/experimental/plugin_lib/plugin-guest.ts
+++ b/tensorboard/components/experimental/plugin_lib/plugin-guest.ts
@@ -12,44 +12,42 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
-  /**
-   * This code is part of a public bundle provided to plugin authors,
-   * and runs within an IFrame to setup communication with TensorBoard's frame.
-   */
-  if (!window.parent) {
-    throw Error(
-      'The library must run within a TensorBoard iframe-based plugin.'
-    );
-  }
+import {IPC} from './message';
 
-  const channel = new MessageChannel();
-  const ipc = new IPC(channel.port1);
-  channel.port1.start();
+/**
+ * This code is part of a public bundle provided to plugin authors,
+ * and runs within an IFrame to setup communication with TensorBoard's frame.
+ */
+if (!window.parent) {
+  throw Error('The library must run within a TensorBoard iframe-based plugin.');
+}
 
-  const VERSION = 'experimental';
-  window.parent.postMessage(`${VERSION}.bootstrap`, '*', [channel.port2]);
+const channel = new MessageChannel();
+const ipc = new IPC(channel.port1);
+channel.port1.start();
 
-  // Only export for testability.
-  export const _guestIPC = ipc;
+const VERSION = 'experimental';
+window.parent.postMessage(`${VERSION}.bootstrap`, '*', [channel.port2]);
 
-  /**
-   * Sends a message to the parent frame.
-   * @return Promise that resolves with a payload from parent in response to this message.
-   *
-   * @example
-   * const someList = await sendMessage('v1.some.type.parent.understands');
-   * // do fun things with someList.
-   */
-  export const sendMessage = _guestIPC.sendMessage.bind(_guestIPC);
+// Only export for testability.
+export const _guestIPC = ipc;
 
-  /**
-   * Subscribes a callback to a message with particular type.
-   */
-  export const listen = _guestIPC.listen.bind(_guestIPC);
+/**
+ * Sends a message to the parent frame.
+ * @return Promise that resolves with a payload from parent in response to this message.
+ *
+ * @example
+ * const someList = await sendMessage('v1.some.type.parent.understands');
+ * // do fun things with someList.
+ */
+export const sendMessage = _guestIPC.sendMessage.bind(_guestIPC);
 
-  /**
-   * Unsubscribes a callback to a message.
-   */
-  export const unlisten = _guestIPC.unlisten.bind(_guestIPC);
-} // namespace tb_plugin.lib.DO_NOT_USE_INTERNAL
+/**
+ * Subscribes a callback to a message with particular type.
+ */
+export const listen = _guestIPC.listen.bind(_guestIPC);
+
+/**
+ * Unsubscribes a callback to a message.
+ */
+export const unlisten = _guestIPC.unlisten.bind(_guestIPC);

--- a/tensorboard/components/experimental/plugin_lib/plugin-guest.ts
+++ b/tensorboard/components/experimental/plugin_lib/plugin-guest.ts
@@ -19,7 +19,12 @@ import {IPC} from './message';
  * and runs within an IFrame to setup communication with TensorBoard's frame.
  */
 if (!window.parent) {
-  throw Error('The library must run within a TensorBoard iframe-based plugin.');
+  // JSComp hates it when the module throws at the body.
+  setTimeout(() => {
+    throw Error(
+      'The library must run within a TensorBoard iframe-based plugin.'
+    );
+  });
 }
 
 const channel = new MessageChannel();

--- a/tensorboard/components/experimental/plugin_lib/runs.ts
+++ b/tensorboard/components/experimental/plugin_lib/runs.ts
@@ -12,17 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-namespace tb_plugin.lib.runs {
-  export async function getRuns() {
-    return tb_plugin.lib.DO_NOT_USE_INTERNAL.sendMessage(
-      'experimental.GetRuns'
-    );
-  }
+import {sendMessage, listen} from './plugin-guest';
 
-  export function setOnRunsChanged(callback: (runs: string[]) => void | void) {
-    return tb_plugin.lib.DO_NOT_USE_INTERNAL.listen(
-      'experimental.RunsChanged',
-      callback
-    );
-  }
+export async function getRuns() {
+  return sendMessage('experimental.GetRuns');
+}
+
+export function setOnRunsChanged(callback: (runs: string[]) => void | void) {
+  return listen('experimental.RunsChanged', callback);
 }

--- a/tensorboard/components/experimental/plugin_lib/test/BUILD
+++ b/tensorboard/components/experimental/plugin_lib/test/BUILD
@@ -4,6 +4,7 @@ package(
 )
 
 load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library", "tf_js_binary")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -13,17 +14,43 @@ tf_web_test(
     web_library = ":test_web_library",
 )
 
+tf_ts_library(
+    name = "testable_plugin_lib_bundle",
+    srcs = ["testable-plugin-lib.ts"],
+    deps = [
+        "//tensorboard/components/experimental/plugin_lib",
+    ],
+)
+
+tf_js_binary(
+    name = "testable_plugin_bundle",
+    compile = 0,
+    entry_point = "testable-plugin-lib.ts",
+    deps = [
+        ":testable_plugin_lib_bundle",
+    ],
+)
+
+tf_web_library(
+    name = "testable_plugin_lib",
+    testonly = True,
+    srcs = [
+        "testable-iframe.html",
+        "testable_plugin_bundle.js",
+    ],
+    path = "/tf-plugin-lib/test",
+)
+
 tf_web_library(
     name = "test_web_library",
     testonly = True,
     srcs = [
         "test.html",
         "test.ts",
-        "testable-iframe.html",
     ],
     path = "/tf-plugin-lib/test",
     deps = [
-        "//tensorboard/components/experimental/plugin_lib",
+        ":testable_plugin_lib",
         "//tensorboard/components/experimental/plugin_util:plugin_host",
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_imports:web_component_tester",

--- a/tensorboard/components/experimental/plugin_lib/test/test.ts
+++ b/tensorboard/components/experimental/plugin_lib/test/test.ts
@@ -30,6 +30,7 @@ describe('plugin lib integration', () => {
     this.sandbox.server.respondImmediately = true;
     this.iframe = await createIframe();
     this.lib = (this.iframe.contentWindow as any).plugin_lib;
+    this.libInternal = (this.iframe.contentWindow as any).plugin_internal;
   });
 
   afterEach(function() {
@@ -37,7 +38,7 @@ describe('plugin lib integration', () => {
     this.sandbox.restore();
   });
 
-  describe('tb_plugin.lib.run', () => {
+  describe('lib.run', () => {
     describe('#getRuns', () => {
       it('returns list of runs', async function() {
         this.sandbox
@@ -82,7 +83,7 @@ describe('plugin lib integration', () => {
 
         // Await another message to ensure the iframe processed the next message
         // (if any).
-        await this.lib.DO_NOT_USE_INTERNAL.sendMessage('foo');
+        await this.libInternal.sendMessage('foo');
 
         expect(runsChanged).to.not.have.been.called;
       });

--- a/tensorboard/components/experimental/plugin_lib/test/testable-iframe.html
+++ b/tensorboard/components/experimental/plugin_lib/test/testable-iframe.html
@@ -14,7 +14,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<link rel="import" href="../../tf-plugin-lib/tf-plugin-lib.html" />
-<script>
-  window.plugin_lib = tb_plugin.lib;
-</script>
+<script src="testable_plugin_bundle.js"></script>

--- a/tensorboard/components/experimental/plugin_lib/test/testable-plugin-lib.ts
+++ b/tensorboard/components/experimental/plugin_lib/test/testable-plugin-lib.ts
@@ -1,6 +1,4 @@
-<!--
-@license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,9 +11,9 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
-<!DOCTYPE html>
-<link rel="import" href="../../tf-plugin-lib/tf-plugin-lib.html" />
-<script>
-  window.test = tb_plugin.lib.DO_NOT_USE_INTERNAL;
-</script>
+==============================================================================*/
+import * as public_api from '../index';
+import * as plugin_internal from '../plugin-guest.js';
+
+(window as any).plugin_lib = public_api;
+(window as any).plugin_internal = plugin_internal;

--- a/tensorboard/components/experimental/plugin_util/message.ts
+++ b/tensorboard/components/experimental/plugin_util/message.ts
@@ -12,10 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-
 /**
  * This file defines utilities shared by TensorBoard (plugin host) and the
  * dynamic plugin library, used by plugin authors.
+ */
+/**
+ * [1]: Using string to access property prevents JSCompiler mangling and make the
+ * property stable across different versions of a bundle.
  */
 namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
   export type PayloadType =
@@ -65,6 +68,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
 
     private async onMessage(event: MessageEvent) {
       const message = JSON.parse(event.data) as Message;
+      // Please see [1] for reason why we use string to access the property.
       const type = message['type'];
       const id = message['id'];
       const payload = message['payload'];
@@ -94,6 +98,8 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
           replyError = e;
         }
       }
+
+      // Please see [1] for reason why we use string to access the property.
       const replyMessage: Message = {
         ['type']: type,
         ['id']: id,

--- a/tensorboard/components/experimental/plugin_util/message.ts
+++ b/tensorboard/components/experimental/plugin_util/message.ts
@@ -73,7 +73,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
 
       if (isReply) {
         if (!this.responseWaits.has(id)) return;
-        const {resolve, reject} = this.responseWaits.get(id);
+        const {resolve, reject} = this.responseWaits.get(id) as PromiseResolver;
         this.responseWaits.delete(id);
         if (error) {
           reject(new Error(error));
@@ -86,7 +86,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
       let replyPayload = null;
       let replyError = null;
       if (this.listeners.has(type)) {
-        const callback = this.listeners.get(type);
+        const callback = this.listeners.get(type) as MessageCallback;
         try {
           const result = await callback(payload);
           replyPayload = result;

--- a/tensorboard/components/experimental/plugin_util/message.ts
+++ b/tensorboard/components/experimental/plugin_util/message.ts
@@ -70,7 +70,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
       if (message.isReply) {
         if (!this.responseWaits.has(message.id)) return;
         const {id, payload, error} = message;
-        const {resolve, reject} = this.responseWaits.get(id);
+        const {resolve, reject} = this.responseWaits.get(id) as PromiseResolver;
         this.responseWaits.delete(id);
         if (error) {
           reject(new Error(error));
@@ -83,7 +83,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
       let payload = null;
       let error = null;
       if (this.listeners.has(message.type)) {
-        const callback = this.listeners.get(message.type);
+        const callback = this.listeners.get(message.type) as MessageCallback;
         try {
           const result = await callback(message.payload);
           payload = result;

--- a/tensorboard/components/experimental/plugin_util/test/BUILD
+++ b/tensorboard/components/experimental/plugin_util/test/BUILD
@@ -16,13 +16,12 @@ tf_web_test(
 tf_web_library(
     name = "test_web_library",
     srcs = [
-        "iframe.html",
         "plugin-test.ts",
         "tests.html",
     ],
     path = "/tf-plugin-util/test",
     deps = [
-        "//tensorboard/components/experimental/plugin_lib:plugin_lib",
+        "//tensorboard/components/experimental/plugin_lib/test:testable_plugin_lib",
         "//tensorboard/components/experimental/plugin_util:plugin_host",
         "//tensorboard/components/tf_imports:web_component_tester",
     ],

--- a/tensorboard/components/experimental/plugin_util/test/plugin-test.ts
+++ b/tensorboard/components/experimental/plugin_util/test/plugin-test.ts
@@ -38,13 +38,13 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
     });
 
     it('setUp sanity check', function() {
-      expect(this.guestWindow.test)
+      expect(this.guestWindow.plugin_internal)
         .to.have.property('sendMessage')
         .that.is.a('function');
-      expect(this.guestWindow.test)
+      expect(this.guestWindow.plugin_internal)
         .to.have.property('listen')
         .that.is.a('function');
-      expect(this.guestWindow.test)
+      expect(this.guestWindow.plugin_internal)
         .to.have.property('unlisten')
         .that.is.a('function');
     });
@@ -54,9 +54,9 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
         spec: 'host (src) to guest (dest)',
         beforeEachFunc: function() {
           this.destWindow = this.guestWindow;
-          this.destListen = this.guestWindow.test.listen;
-          this.destUnlisten = this.guestWindow.test.unlisten;
-          this.destSendMessage = this.guestWindow.test.sendMessage;
+          this.destListen = this.guestWindow.plugin_internal.listen;
+          this.destUnlisten = this.guestWindow.plugin_internal.unlisten;
+          this.destSendMessage = this.guestWindow.plugin_internal.sendMessage;
           this.srcSendMessage = (type, payload) => {
             return tb_plugin.host
               .broadcast(type, payload)
@@ -75,7 +75,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
               .broadcast(type, payload)
               .then(([result]) => result);
           };
-          this.srcSendMessage = this.guestWindow.test.sendMessage;
+          this.srcSendMessage = this.guestWindow.plugin_internal.sendMessage;
         },
       },
     ].forEach(({spec, beforeEachFunc}) => {

--- a/tensorboard/components/experimental/plugin_util/test/tests.html
+++ b/tensorboard/components/experimental/plugin_util/test/tests.html
@@ -18,6 +18,6 @@ limitations under the License.
 <script vulcanize-noinline src="../../web-component-tester/browser.js"></script>
 
 <template id="iframe-template">
-  <iframe src="./iframe.html"></iframe>
+  <iframe src="../../tf-plugin-lib/test/testable-iframe.html"></iframe>
 </template>
 <script src="plugin-test.js"></script>


### PR DESCRIPTION
we would like to consume the experimental plugin library as a ts_library
(as oppposed to tf_web_library using HTML imports). This change
contains:
1. refactor of lib that uses namespace to module
2. genrule "copy" message.ts due to the build system difficulties

Please turn off the white space changes when reviewing.

supersedes #2727.

This is P1. 

WANT_LGTM=any