### PR TITLE
cleanup: deprecate vulcanize-noinline

### DIFF
--- a/tensorboard/components/experimental/plugin_util/test/tests.html
+++ b/tensorboard/components/experimental/plugin_util/test/tests.html
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <link rel="import" href="../plugin-host.html" />
-<script vulcanize-noinline src="../../web-component-tester/browser.js"></script>
+<script src="../../web-component-tester/browser.js"></script>
 
 <template id="iframe-template">
   <iframe src="./iframe.html"></iframe>

--- a/tensorboard/components/vz_sorting/test/tests.html
+++ b/tensorboard/components/vz_sorting/test/tests.html
@@ -17,7 +17,7 @@ limitations under the License.
 -->
 
 <meta charset="utf-8" />
-<script vulcanize-noinline src="../../web-component-tester/browser.js"></script>
+<script src="../../web-component-tester/browser.js"></script>
 <link rel="import" href="../vz-sorting.html" />
 <body>
   <script src="sortingTests.js"></script>

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -258,7 +258,7 @@ public final class Vulcanize {
           break;
         }
       }
-      if (!getAttrTransitive(node, "vulcanize-noinline").isPresent() && !ignoreFile) {
+      if (!ignoreFile) {
         if (isExternalCssNode(node)
             && !shouldIgnoreUri(href)) {
           node = visitStylesheet(node);
@@ -775,9 +775,8 @@ public final class Vulcanize {
       if (src.isEmpty()) {
         sourceContent = script.html();
       } else {
-        // script element that remains are the ones with src that is absolute, annotated with
-        // `jscomp-ignore`, or appear inside descendant of a node annotated with
-        // `vulcanize-noinline`. They must resolve from the root because those srcs are rootified.
+        // script element that remains are the ones with src that is absolute or annotated with
+        // `jscomp-ignore`. They must resolve from the root because those srcs are rootified.
         Webpath webpathSrc = Webpath.get(src);
         Webpath webpath = Webpath.get("/").resolve(Webpath.get(src)).normalize();
         if (isAbsolutePath(webpathSrc)) {


### PR DESCRIPTION
All usages of vulcanize-noinline can be replaced with jscomp-ignore so
we decided to deprecate the very similar magical attribute,
vulcanize-noinline.
