### PR TITLE
cleanup: import werkzeug test

### DIFF
--- a/tensorboard/backend/empty_path_redirect_test.py
+++ b/tensorboard/backend/empty_path_redirect_test.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import json
 
 import werkzeug
+from werkzeug import test as werkzeug_test
 
 from tensorboard import test as tb_test
 from tensorboard.backend import empty_path_redirect
@@ -35,7 +36,7 @@ class EmptyPathRedirectMiddlewareTest(tb_test.TestCase):
     app = empty_path_redirect.EmptyPathRedirectMiddleware(app)
     app = self._lax_strip_foo_middleware(app)
     self.app = app
-    self.server = werkzeug.test.Client(self.app, werkzeug.BaseResponse)
+    self.server = werkzeug_test.Client(self.app, werkzeug.BaseResponse)
 
   def _lax_strip_foo_middleware(self, app):
     """Strips a `/foo` prefix if it exists; no-op otherwise."""

--- a/tensorboard/backend/experiment_id_test.py
+++ b/tensorboard/backend/experiment_id_test.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import json
 
 import werkzeug
+from werkzeug import test as werkzeug_test
 
 from tensorboard import test as tb_test
 from tensorboard.backend import experiment_id
@@ -32,7 +33,7 @@ class ExperimentIdMiddlewareTest(tb_test.TestCase):
   def setUp(self):
     super(ExperimentIdMiddlewareTest, self).setUp()
     self.app = experiment_id.ExperimentIdMiddleware(self._echo_app)
-    self.server = werkzeug.test.Client(self.app, werkzeug.BaseResponse)
+    self.server = werkzeug_test.Client(self.app, werkzeug.BaseResponse)
 
   def _echo_app(self, environ, start_response):
     # https://www.python.org/dev/peps/pep-0333/#environ-variables

--- a/tensorboard/backend/path_prefix_test.py
+++ b/tensorboard/backend/path_prefix_test.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import json
 
 import werkzeug
+from werkzeug import test as werkzeug_test
 
 from tensorboard import errors
 from tensorboard import test as tb_test
@@ -62,7 +63,7 @@ class PathPrefixMiddlewareTest(tb_test.TestCase):
 
   def test_empty_path_prefix(self):
     app = path_prefix.PathPrefixMiddleware(self._echo_app, "")
-    server = werkzeug.test.Client(app, werkzeug.BaseResponse)
+    server = werkzeug_test.Client(app, werkzeug.BaseResponse)
 
     with self.subTest("at empty"):
       self._assert_ok(server.get(""), path="", script="")
@@ -76,7 +77,7 @@ class PathPrefixMiddlewareTest(tb_test.TestCase):
 
   def test_nonempty_path_prefix(self):
     app = path_prefix.PathPrefixMiddleware(self._echo_app, "/pfx")
-    server = werkzeug.test.Client(app, werkzeug.BaseResponse)
+    server = werkzeug_test.Client(app, werkzeug.BaseResponse)
 
     with self.subTest("at root"):
       response = server.get("/pfx")
@@ -102,7 +103,7 @@ class PathPrefixMiddlewareTest(tb_test.TestCase):
     app = self._echo_app
     app = path_prefix.PathPrefixMiddleware(app, "/bar")
     app = path_prefix.PathPrefixMiddleware(app, "/foo")
-    server = werkzeug.test.Client(app, werkzeug.BaseResponse)
+    server = werkzeug_test.Client(app, werkzeug.BaseResponse)
 
     response = server.get("/foo/bar/baz/quux")
     self._assert_ok(response, path="/baz/quux", script="/foo/bar")


### PR DESCRIPTION
werkzeug internally do not have `test` module.

This unblocks the sync.