### PR TITLE
csp: make it globally configurable

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -38,6 +38,7 @@ from tensorboard.compat import tf
 # instead use a configurable via some kind of assets provider which would
 # hold configurations for the CSP.
 DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST = []
+DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC = True
 
 _EXTRACT_MIMETYPE_PATTERN = re.compile(r'^[^;\s]*')
 _EXTRACT_CHARSET_PATTERN = re.compile(r'charset=([-_0-9A-Za-z]+)')
@@ -187,10 +188,12 @@ def Respond(request,
 
       # TODO(stephanwlee): remove `'strict dynamic'` when dynamic plugin
       # resources can be hashed upfront.
-      script_srcs = '{domains} strict-dynamic {shas}'.format(
-          domains=' '.join(whitelist_domains),
-          shas=whitelist_hashes,
-      )
+      script_srcs_fragments = [
+        ' '.join(whitelist_domains),
+        'strict-dynamic' if DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC else '',
+        whitelist_hashes
+      ]
+      script_srcs = ' '.join([frag for frag in script_srcs_fragments if frag])
     else:
       script_srcs = "'none'"
 

--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -37,8 +37,11 @@ from tensorboard.compat import tf
 # TODO(stephanwlee): Refactor this to not use the module variable but
 # instead use a configurable via some kind of assets provider which would
 # hold configurations for the CSP.
-DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST = []
-DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC = True
+def DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST():
+  return []
+
+def DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC():
+  return True
 
 _EXTRACT_MIMETYPE_PATTERN = re.compile(r'^[^;\s]*')
 _EXTRACT_CHARSET_PATTERN = re.compile(r'charset=([-_0-9A-Za-z]+)')
@@ -176,7 +179,7 @@ def Respond(request,
           ["'sha256-{}'".format(sha256) for sha256 in csp_scripts_sha256s])
 
       whitelist_domains = []
-      for domain in DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST:
+      for domain in DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST():
         url = urlparse.urlparse(domain)
         if not url.scheme == 'https' or not url.netloc:
           raise ValueError('Expected all whitelist to be a https URL: %s' % domain)
@@ -190,7 +193,7 @@ def Respond(request,
       # resources can be hashed upfront.
       script_srcs_fragments = [
         ' '.join(whitelist_domains),
-        'strict-dynamic' if DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC else '',
+        'strict-dynamic' if DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC() else '',
         whitelist_hashes
       ]
       script_srcs = ' '.join([frag for frag in script_srcs_fragments if frag])

--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -37,8 +37,8 @@ from tensorboard.compat import tf
 # TODO(stephanwlee): Refactor this to not use the module variable but
 # instead use a configurable via some kind of assets provider which would
 # hold configurations for the CSP.
-DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST = lambda: []
-DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC = lambda: True
+DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST = []
+DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC = True
 
 _EXTRACT_MIMETYPE_PATTERN = re.compile(r'^[^;\s]*')
 _EXTRACT_CHARSET_PATTERN = re.compile(r'charset=([-_0-9A-Za-z]+)')
@@ -176,7 +176,7 @@ def Respond(request,
           ["'sha256-{}'".format(sha256) for sha256 in csp_scripts_sha256s])
 
       whitelist_domains = []
-      for domain in DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST():
+      for domain in DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST:
         url = urlparse.urlparse(domain)
         if not url.scheme == 'https' or not url.netloc:
           raise ValueError('Expected all whitelist to be a https URL: %s' % domain)
@@ -190,7 +190,7 @@ def Respond(request,
       # resources can be hashed upfront.
       script_srcs_fragments = [
         ' '.join(whitelist_domains),
-        'strict-dynamic' if DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC() else '',
+        'strict-dynamic' if DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC else '',
         whitelist_hashes
       ]
       script_srcs = ' '.join([frag for frag in script_srcs_fragments if frag])

--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -37,11 +37,8 @@ from tensorboard.compat import tf
 # TODO(stephanwlee): Refactor this to not use the module variable but
 # instead use a configurable via some kind of assets provider which would
 # hold configurations for the CSP.
-def DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST():
-  return []
-
-def DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC():
-  return True
+DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST = lambda: []
+DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC = lambda: True
 
 _EXTRACT_MIMETYPE_PATTERN = re.compile(r'^[^;\s]*')
 _EXTRACT_CHARSET_PATTERN = re.compile(r'charset=([-_0-9A-Za-z]+)')

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -208,9 +208,8 @@ class RespondTest(tb_test.TestCase):
     )
     self.assertEqual(r.headers.get('Content-Security-Policy'), expected_csp)
 
-  @mock.patch.object(http_util, 'DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC')
-  def testCsp_disableStrictDynamic(self, mock_strict_dynamic):
-    mock_strict_dynamic.return_value = False
+  @mock.patch.object(http_util, 'DO_NOT_USE_CSP_SCRIPT_HASHES_STRICT_DYNAMIC', False)
+  def testCsp_disableStrictDynamic(self):
     q = wrappers.Request(wtest.EnvironBuilder().get_environ())
     r = http_util.Respond(
         q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcdefghi'])
@@ -221,9 +220,9 @@ class RespondTest(tb_test.TestCase):
     )
     self.assertEqual(r.headers.get('Content-Security-Policy'), expected_csp)
 
-  @mock.patch.object(http_util, 'DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST')
-  def testCsp_globalDomainWhiteList(self, mock_domain_whitelist):
-    mock_domain_whitelist.return_value = ['https://tensorflow.org']
+  @mock.patch.object(http_util, 'DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST',
+    ['https://tensorflow.org'])
+  def testCsp_globalDomainWhiteList(self):
     q = wrappers.Request(wtest.EnvironBuilder().get_environ())
     r = http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
     expected_csp = (
@@ -233,36 +232,40 @@ class RespondTest(tb_test.TestCase):
     )
     self.assertEqual(r.headers.get('Content-Security-Policy'), expected_csp)
 
-  @mock.patch.object(http_util, 'DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST')
-  def testCsp_badGlobalDomainWhiteList(self, mock_domain_whitelist):
+  def testCsp_badGlobalDomainWhiteList(self):
     q = wrappers.Request(wtest.EnvironBuilder().get_environ())
 
-    mock_domain_whitelist.return_value = ['http://tensorflow.org']
-    with self.assertRaisesRegex(
-        ValueError, '^Expected all whitelist to be a https URL'):
-      http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
+    with mock.patch.object(http_util, 'DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST',
+        ['http://tensorflow.org']):
+      with self.assertRaisesRegex(
+          ValueError, '^Expected all whitelist to be a https URL'):
+        http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
 
-    mock_domain_whitelist.return_value = ['https://tensorflow.org/']
-    with self.assertRaisesRegex(
-        ValueError, '^Expected whitelist domain to not have a path:'):
-      http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
+    with mock.patch.object(http_util, 'DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST',
+        ['https://tensorflow.org/']):
+      with self.assertRaisesRegex(
+          ValueError, '^Expected whitelist domain to not have a path:'):
+        http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
 
-    mock_domain_whitelist.return_value = ['https://tensorflow.org/foo/bar']
-    with self.assertRaisesRegex(
-        ValueError, '^Expected whitelist domain to not have a path:'):
-      http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
+    with mock.patch.object(http_util, 'DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST',
+        ['https://tensorflow.org/foo/bar']):
+      with self.assertRaisesRegex(
+          ValueError, '^Expected whitelist domain to not have a path:'):
+        http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
 
     # Cannot grant more trust to a script from a remote source.
-    mock_domain_whitelist.return_value = ['strict-dynamic https://tensorflow.org/']
-    with self.assertRaisesRegex(
-        ValueError, '^Expected all whitelist to be a https URL'):
-      http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
+    with mock.patch.object(http_util, 'DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST',
+        ['strict-dynamic https://tensorflow.org/']):
+      with self.assertRaisesRegex(
+          ValueError, '^Expected all whitelist to be a https URL'):
+        http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
 
     # Attempt to terminate the script-src to specify a new one that allows ALL!
-    mock_domain_whitelist.return_value = ['https://tensorflow.org;script-src *']
-    with self.assertRaisesRegex(
-        ValueError, '^Expected whitelist domain to not contain ";"'):
-      http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
+    with mock.patch.object(http_util, 'DO_NOT_USE_CSP_SCRIPT_DOMAINS_WHITELIST',
+        ['https://tensorflow.org;script-src *']):
+      with self.assertRaisesRegex(
+          ValueError, '^Expected whitelist domain to not contain ";"'):
+        http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
 
 
 def _gzip(bs):

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -113,7 +113,8 @@ class CorePlugin(base_plugin.TBPlugin):
             # TODO(stephanwlee): devise a way to omit font-roboto/roboto.html from
             # the assets zip file.
             if checksum_path in zip_.namelist():
-              shasums = zip_.read(checksum_path).splitlines(False)
+              lines = zip_.read(checksum_path).splitlines(False);
+              shasums = [hash.decode('utf8') for hash in lines]
             else:
               shasums = None
 


### PR DESCRIPTION
This is a temporary measure to unblock a high priority item. In the
ideal world, we would want some kind of global CSP configuration that
would also know about all static contents in the application.
