### PR TITLE
Fix cloud model usage with JSON input

### DIFF
--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
@@ -100,12 +100,13 @@ class WitWidgetBase(object):
     # function, then convert examples to JSON before sending to the
     # custom predict function.
     if self.config.get('uses_json_input'):
-      if self.custom_predict_fn is not None:
+      if self.custom_predict_fn is not None and not self.config.get('use_aip'):
         user_predict = self.custom_predict_fn
         def wrapped_custom_predict_fn(examples):
           return user_predict(self._json_from_tf_examples(examples))
         self.custom_predict_fn = wrapped_custom_predict_fn
-      if self.compare_custom_predict_fn is not None:
+      if (self.compare_custom_predict_fn is not None and
+          not self.config.get('compare_use_aip')):
         compare_user_predict = self.compare_custom_predict_fn
         def wrapped_compare_custom_predict_fn(examples):
           return compare_user_predict(self._json_from_tf_examples(examples))


### PR DESCRIPTION
* Motivation for features / changes

Fix cloud model usage with JSON input, broken in 1.4.1

* Technical description of changes

Do not auto-convert examples before passing to custom predict fn, if the custom predict fn is for CAIP, as that has its own example handling logic.

* Screenshots of UI changes

N/A

* Detailed steps to verify changes work correctly (as executed by you)

Test normal custom predict fn and cloud AI model with JSON input and ensure both work.
