### PR TITLE
Fix tabs left margin (What-If Tool)

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -662,7 +662,6 @@ limitations under the License.
       .main-bottom-bar {
         height: 52px;
         min-height: 52px;
-        margin-left: 44px;
         flex-grow: 0;
         display: flex;
         /* box-shadow: 0 2px 5px grey;


### PR DESCRIPTION
* Motivation for features / changes

This left margin was added by mistake in #2755.

* Technical description of changes

Simply delete the line added by mistake.

* Screenshots of UI changes

Moving tabs back to where they were:
<img width="265" alt="Screenshot 2019-10-11 at 19 38 37" src="https://user-images.githubusercontent.com/6004563/66676158-c05e5780-ec5e-11e9-964a-517edd24dc57.png">

* Detailed steps to verify changes work correctly (as executed by you)

Open demo and verify that tabs are in the same position as in `master`.

* Alternate designs / implementations considered
N/A