### PR TITLE
[tensor-widget] Add colormap selection and Ctrl/Alt/Shift+wheel zooming

### DIFF
--- a/tensorboard/components/tensor_widget/colormap-test.ts
+++ b/tensorboard/components/tensor_widget/colormap-test.ts
@@ -17,7 +17,7 @@ limitations under the License.
 
 import {expect} from 'chai';
 
-import {GrayscaleColorMap} from './colormap';
+import {GrayscaleColorMap, JetColorMap} from './colormap';
 
 describe('GrayscaleColorMap', () => {
   it('max < min causes constructor error', () => {
@@ -82,4 +82,60 @@ describe('GrayscaleColorMap', () => {
   });
 });
 
-// TODO(cais): Add unit tests for JetColormap.
+describe('JetColormap', () => {
+  it('max < min causes constructor error', () => {
+    const min = 3;
+    const max = 2;
+    expect(() => new JetColorMap({min, max})).to.throw(/max.*<.*min/);
+  });
+
+  it('NaN or Infinity min or max causes constructor error', () => {
+    expect(() => new JetColorMap({min: 0, max: Infinity})).to.throw(
+      /max.*not finite/
+    );
+    expect(() => new JetColorMap({min: 0, max: -Infinity})).to.throw(
+      /max.*not finite/
+    );
+    expect(() => new JetColorMap({min: 0, max: NaN})).to.throw(
+      /max.*not finite/
+    );
+    expect(() => new JetColorMap({min: Infinity, max: 0})).to.throw(
+      /min.*not finite/
+    );
+    expect(() => new JetColorMap({min: -Infinity, max: 0})).to.throw(
+      /min.*not finite/
+    );
+    expect(() => new JetColorMap({min: NaN, max: 0})).to.throw(
+      /min.*not finite/
+    );
+  });
+
+  it('max > min, finite values', () => {
+    const min = 0;
+    const max = 10;
+    const colormap = new JetColorMap({min, max});
+    expect(colormap.getRGB(0)).to.eql([0, 0, 255]);
+    expect(colormap.getRGB(5)).to.eql([127.5, 255, 127.5]);
+    expect(colormap.getRGB(10)).to.eql([255, 0, 0]);
+    // Over-limits.
+    expect(colormap.getRGB(-100)).to.eql([0, 0, 255]);
+    expect(colormap.getRGB(500)).to.eql([255, 0, 0]);
+  });
+
+  it('max > min, non-finite values', () => {
+    const min = 0;
+    const max = 10;
+    const colormap = new JetColorMap({min, max});
+    expect(colormap.getRGB(NaN)).to.eql([255 * 0.25, 255 * 0.25, 255 * 0.25]);
+    expect(colormap.getRGB(-Infinity)).to.eql([
+      255 * 0.5,
+      255 * 0.5,
+      255 * 0.5,
+    ]);
+    expect(colormap.getRGB(Infinity)).to.eql([
+      255 * 0.75,
+      255 * 0.75,
+      255 * 0.75,
+    ]);
+  });
+});

--- a/tensorboard/components/tensor_widget/colormap-test.ts
+++ b/tensorboard/components/tensor_widget/colormap-test.ts
@@ -23,30 +23,34 @@ describe('GrayscaleColorMap', () => {
   it('max < min causes constructor error', () => {
     const min = 3;
     const max = 2;
-    expect(() => new GrayscaleColorMap(min, max)).to.throw(/max.*<.*min/);
+    expect(() => new GrayscaleColorMap({min, max})).to.throw(/max.*<.*min/);
   });
 
   it('NaN or Infinity min or max causes constructor error', () => {
-    expect(() => new GrayscaleColorMap(0, Infinity)).to.throw(
+    expect(() => new GrayscaleColorMap({min: 0, max: Infinity})).to.throw(
       /max.*not finite/
     );
-    expect(() => new GrayscaleColorMap(0, -Infinity)).to.throw(
+    expect(() => new GrayscaleColorMap({min: 0, max: -Infinity})).to.throw(
       /max.*not finite/
     );
-    expect(() => new GrayscaleColorMap(0, NaN)).to.throw(/max.*not finite/);
-    expect(() => new GrayscaleColorMap(Infinity, 0)).to.throw(
+    expect(() => new GrayscaleColorMap({min: 0, max: NaN})).to.throw(
+      /max.*not finite/
+    );
+    expect(() => new GrayscaleColorMap({min: Infinity, max: 0})).to.throw(
       /min.*not finite/
     );
-    expect(() => new GrayscaleColorMap(-Infinity, 0)).to.throw(
+    expect(() => new GrayscaleColorMap({min: -Infinity, max: 0})).to.throw(
       /min.*not finite/
     );
-    expect(() => new GrayscaleColorMap(NaN, 0)).to.throw(/min.*not finite/);
+    expect(() => new GrayscaleColorMap({min: NaN, max: 0})).to.throw(
+      /min.*not finite/
+    );
   });
 
   it('max > min, finite values', () => {
     const min = 0;
     const max = 10;
-    const colormap = new GrayscaleColorMap(min, max);
+    const colormap = new GrayscaleColorMap({min, max});
     expect(colormap.getRGB(0)).to.eql([0, 0, 0]);
     expect(colormap.getRGB(5)).to.eql([127.5, 127.5, 127.5]);
     expect(colormap.getRGB(10)).to.eql([255, 255, 255]);
@@ -58,7 +62,7 @@ describe('GrayscaleColorMap', () => {
   it('max > min, non-finite values', () => {
     const min = 0;
     const max = 10;
-    const colormap = new GrayscaleColorMap(min, max);
+    const colormap = new GrayscaleColorMap({min, max});
     expect(colormap.getRGB(NaN)).to.eql([255, 0, 0]);
     expect(colormap.getRGB(-Infinity)).to.eql([255, 255 / 2, 0]);
     expect(colormap.getRGB(Infinity)).to.eql([0, 0, 255]);
@@ -67,7 +71,7 @@ describe('GrayscaleColorMap', () => {
   it('max === min, non-finite values', () => {
     const min = -3.2;
     const max = -3.2;
-    const colormap = new GrayscaleColorMap(min, max);
+    const colormap = new GrayscaleColorMap({min, max});
     expect(colormap.getRGB(-32)).to.eql([127.5, 127.5, 127.5]);
     expect(colormap.getRGB(-3.2)).to.eql([127.5, 127.5, 127.5]);
     expect(colormap.getRGB(0)).to.eql([127.5, 127.5, 127.5]);

--- a/tensorboard/components/tensor_widget/colormap-test.ts
+++ b/tensorboard/components/tensor_widget/colormap-test.ts
@@ -77,3 +77,5 @@ describe('GrayscaleColorMap', () => {
     expect(colormap.getRGB(Infinity)).to.eql([0, 0, 255]);
   });
 });
+
+// TODO(cais): Add unit tests for JetColormap.

--- a/tensorboard/components/tensor_widget/colormap.ts
+++ b/tensorboard/components/tensor_widget/colormap.ts
@@ -17,6 +17,21 @@ limitations under the License.
 
 const MAX_RGB = 255;
 
+/** Configuration for a colormap. */
+export interface ColorMapConfig {
+  /**
+   * Minimum value that the color map can map to without clipping.
+   * Must be a finite value.
+   */
+  min: number;
+
+  /**
+   * Minimum value that the color map can map to without clipping.
+   * Must be a finite value and be >= `min`.
+   */
+  max: number;
+}
+
 /**
  * Abstract base class for colormap.
  *
@@ -28,15 +43,15 @@ export abstract class ColorMap {
    * @param min Minimum. Must be a finite value.
    * @param max Maximum. Must be finite and >= `min`.
    */
-  constructor(protected readonly min: number, protected readonly max: number) {
-    if (!isFinite(min)) {
-      throw new Error(`min value (${min}) is not finite`);
+  constructor(protected config: ColorMapConfig) {
+    if (!isFinite(config.min)) {
+      throw new Error(`min value (${config.min}) is not finite`);
     }
-    if (!isFinite(max)) {
-      throw new Error(`max value (${max}) is not finite`);
+    if (!isFinite(config.max)) {
+      throw new Error(`max value (${config.max}) is not finite`);
     }
-    if (max < min) {
-      throw new Error(`max (${max}) is < min (${min})`);
+    if (config.max < config.min) {
+      throw new Error(`max (${config.max}) is < min (${config.min})`);
     }
   }
 
@@ -69,13 +84,11 @@ export class GrayscaleColorMap extends ColorMap {
       }
     }
     let relValue =
-      this.min === this.max ? 0.5 : (value - this.min) / (this.max - this.min);
+      this.config.min === this.config.max
+        ? 0.5
+        : (value - this.config.min) / (this.config.max - this.config.min);
     relValue = Math.max(Math.min(relValue, 1), 0);
-    return [
-      MAX_RGB * relValue,
-      MAX_RGB * relValue,
-      MAX_RGB * relValue,
-    ];
+    return [MAX_RGB * relValue, MAX_RGB * relValue, MAX_RGB * relValue];
   }
 }
 
@@ -101,18 +114,20 @@ export class JetColorMap extends ColorMap {
     const lim1 = 0.65;
 
     const relValue =
-      this.min === this.max ? 0.5 : (value - this.min) / (this.max - this.min);
+      this.config.min === this.config.max
+        ? 0.5
+        : (value - this.config.min) / (this.config.max - this.config.min);
     if (relValue <= lim0) {
       // TODO(cais):
-      g = relValue / lim0 * MAX_RGB;
+      g = (relValue / lim0) * MAX_RGB;
       b = MAX_RGB;
     } else if (relValue > lim0 && relValue <= lim1) {
-      r = (relValue - lim0) / (lim1 - lim0) * MAX_RGB;
+      r = ((relValue - lim0) / (lim1 - lim0)) * MAX_RGB;
       g = MAX_RGB;
-      b = (lim1 - relValue) / (lim1 - lim0) * MAX_RGB;
+      b = ((lim1 - relValue) / (lim1 - lim0)) * MAX_RGB;
     } else if (relValue > lim1) {
       r = MAX_RGB;
-      g = (1 - relValue) / (1 - lim1) * MAX_RGB
+      g = ((1 - relValue) / (1 - lim1)) * MAX_RGB;
     }
     return [r, g, b];
   }

--- a/tensorboard/components/tensor_widget/colormap.ts
+++ b/tensorboard/components/tensor_widget/colormap.ts
@@ -101,8 +101,9 @@ export abstract class ColorMap {
     const tickWidth = 8;
     if (value >= this.config.min && value <= this.config.max) {
       // Highlight the relative position of `value` along the color scale.
-      const tickX = (value - this.config.min) /
-          (this.config.max - this.config.min) * canvas.width;
+      const tickX =
+        ((value - this.config.min) / (this.config.max - this.config.min)) *
+        canvas.width;
 
       context.beginPath();
       context.fillStyle = 'rgba(0, 0, 0, 1)';
@@ -146,14 +147,14 @@ export class JetColorMap extends ColorMap {
   getRGB(value: number): [number, number, number] {
     if (isNaN(value)) {
       // NaN.
-      return [MAX_RGB * 0.75, MAX_RGB * 0.75, MAX_RGB * 0.75];
+      return [MAX_RGB * 0.25, MAX_RGB * 0.25, MAX_RGB * 0.25];
     } else if (!isFinite(value)) {
-      if (value > 0) {
-        // +Infinity.
+      if (value < 0) {
+        // -Infinity.
         return [MAX_RGB * 0.5, MAX_RGB * 0.5, MAX_RGB * 0.5];
       } else {
-        // -Infinity.
-        return [MAX_RGB * 0.25, MAX_RGB * 0.25, MAX_RGB * 0.25];
+        // +Infinity.
+        return [MAX_RGB * 0.75, MAX_RGB * 0.75, MAX_RGB * 0.75];
       }
     }
 
@@ -163,10 +164,11 @@ export class JetColorMap extends ColorMap {
     const lim0 = 0.35;
     const lim1 = 0.65;
 
-    const relValue =
+    let relValue =
       this.config.min === this.config.max
         ? 0.5
         : (value - this.config.min) / (this.config.max - this.config.min);
+    relValue = Math.max(Math.min(relValue, 1), 0);
     if (relValue <= lim0) {
       // TODO(cais):
       g = (relValue / lim0) * MAX_RGB;

--- a/tensorboard/components/tensor_widget/colormap.ts
+++ b/tensorboard/components/tensor_widget/colormap.ts
@@ -62,6 +62,56 @@ export abstract class ColorMap {
    *   The range of RGB values is [0, 255].
    */
   abstract getRGB(value: number): [number, number, number];
+
+  /**
+   * Render the colormap as a horizontal scale, while highlighting a specifc
+   * value.
+   *
+   * The value is highlighted if and only if it is `>= this.config.min` and
+   * `<= this.config.max`.
+   *
+   * @param canvas The canvas on which
+   * @param value The number to highlight.
+   */
+  render(canvas: HTMLCanvasElement, value: number) {
+    if (this.config.min === this.config.max) {
+      return;
+    }
+    const context = canvas.getContext('2d');
+    if (context == null) {
+      return;
+    }
+    const steps = 100;
+    const cellWidth = canvas.width / steps;
+    const height = canvas.height;
+    const verticalMargin = 0.2;
+    const barHeight = height * (1 - 2 * verticalMargin);
+    for (let i = 0; i < steps; ++i) {
+      const value =
+        (this.config.max - this.config.min) * (i / steps) + this.config.min;
+      const x = cellWidth * i;
+      const y = height * verticalMargin;
+      const [r, g, b] = this.getRGB(value);
+      context.beginPath();
+      context.fillStyle = `rgba(${r}, ${g}, ${b}, 1)`;
+      context.fillRect(x, y, cellWidth, barHeight);
+      context.stroke();
+    }
+
+    const tickWidth = 8;
+    if (value >= this.config.min && value <= this.config.max) {
+      // Highlight the relative position of `value` along the color scale.
+      const tickX = (value - this.config.min) /
+          (this.config.max - this.config.min) * canvas.width;
+
+      context.beginPath();
+      context.fillStyle = 'rgba(0, 0, 0, 1)';
+      context.moveTo(tickX, verticalMargin * height);
+      context.lineTo(tickX - tickWidth / 2, 0);
+      context.lineTo(tickX + tickWidth / 2, 0);
+      context.fill();
+    }
+  }
 }
 
 /**

--- a/tensorboard/components/tensor_widget/colormap.ts
+++ b/tensorboard/components/tensor_widget/colormap.ts
@@ -68,13 +68,52 @@ export class GrayscaleColorMap extends ColorMap {
         return [MAX_RGB, MAX_RGB / 2, 0];
       }
     }
-    let relativeValue =
+    let relValue =
       this.min === this.max ? 0.5 : (value - this.min) / (this.max - this.min);
-    relativeValue = Math.max(Math.min(relativeValue, 1), 0);
+    relValue = Math.max(Math.min(relValue, 1), 0);
     return [
-      MAX_RGB * relativeValue,
-      MAX_RGB * relativeValue,
-      MAX_RGB * relativeValue,
+      MAX_RGB * relValue,
+      MAX_RGB * relValue,
+      MAX_RGB * relValue,
     ];
+  }
+}
+
+export class JetColorMap extends ColorMap {
+  getRGB(value: number): [number, number, number] {
+    if (isNaN(value)) {
+      // NaN.
+      return [MAX_RGB * 0.75, MAX_RGB * 0.75, MAX_RGB * 0.75];
+    } else if (!isFinite(value)) {
+      if (value > 0) {
+        // +Infinity.
+        return [MAX_RGB * 0.5, MAX_RGB * 0.5, MAX_RGB * 0.5];
+      } else {
+        // -Infinity.
+        return [MAX_RGB * 0.25, MAX_RGB * 0.25, MAX_RGB * 0.25];
+      }
+    }
+
+    let r = 0;
+    let g = 0;
+    let b = 0;
+    const lim0 = 0.35;
+    const lim1 = 0.65;
+
+    const relValue =
+      this.min === this.max ? 0.5 : (value - this.min) / (this.max - this.min);
+    if (relValue <= lim0) {
+      // TODO(cais):
+      g = relValue / lim0 * MAX_RGB;
+      b = MAX_RGB;
+    } else if (relValue > lim0 && relValue <= lim1) {
+      r = (relValue - lim0) / (lim1 - lim0) * MAX_RGB;
+      g = MAX_RGB;
+      b = (lim1 - relValue) / (lim1 - lim0) * MAX_RGB;
+    } else if (relValue > lim1) {
+      r = MAX_RGB;
+      g = (1 - relValue) / (1 - lim1) * MAX_RGB
+    }
+    return [r, g, b];
   }
 }

--- a/tensorboard/components/tensor_widget/colormap.ts
+++ b/tensorboard/components/tensor_widget/colormap.ts
@@ -27,7 +27,10 @@ export interface ColorMapConfig {
 
   /**
    * Minimum value that the color map can map to without clipping.
-   * Must be a finite value and be >= `min`.
+   * Must be a finite value and be `>= min`.
+   *
+   * In the case of `max === min`, all finite values mapped to the
+   * midpoint of the color scale.
    */
   max: number;
 }
@@ -168,9 +171,9 @@ export class JetColorMap extends ColorMap {
       }
     }
 
-    let r = 0;
-    let g = 0;
-    let b = 0;
+    let relR = 0;
+    let relG = 0;
+    let relB = 0;
     const lim0 = 0.35;
     const lim1 = 0.65;
 
@@ -180,16 +183,16 @@ export class JetColorMap extends ColorMap {
         : (value - this.config.min) / (this.config.max - this.config.min);
     relValue = Math.max(Math.min(relValue, 1), 0);
     if (relValue <= lim0) {
-      g = (relValue / lim0) * MAX_RGB;
-      b = MAX_RGB;
+      relG = relValue / lim0;
+      relB = 1;
     } else if (relValue > lim0 && relValue <= lim1) {
-      r = ((relValue - lim0) / (lim1 - lim0)) * MAX_RGB;
-      g = MAX_RGB;
-      b = ((lim1 - relValue) / (lim1 - lim0)) * MAX_RGB;
+      relR = (relValue - lim0) / (lim1 - lim0);
+      relG = 1;
+      relB = (lim1 - relValue) / (lim1 - lim0);
     } else if (relValue > lim1) {
-      r = MAX_RGB;
-      g = ((1 - relValue) / (1 - lim1)) * MAX_RGB;
+      relR = 1;
+      relG = (1 - relValue) / (1 - lim1);
     }
-    return [r, g, b];
+    return [relR * MAX_RGB, relG * MAX_RGB, relB * MAX_RGB];
   }
 }

--- a/tensorboard/components/tensor_widget/colormap.ts
+++ b/tensorboard/components/tensor_widget/colormap.ts
@@ -71,9 +71,9 @@ export abstract class ColorMap {
    * `<= this.config.max`.
    *
    * @param canvas The canvas on which
-   * @param value The number to highlight.
+   * @param value The number to highlight (optional).
    */
-  render(canvas: HTMLCanvasElement, value: number) {
+  render(canvas: HTMLCanvasElement, value?: number) {
     if (this.config.min === this.config.max) {
       return;
     }
@@ -98,19 +98,29 @@ export abstract class ColorMap {
       context.stroke();
     }
 
-    const tickWidth = 8;
-    if (value >= this.config.min && value <= this.config.max) {
-      // Highlight the relative position of `value` along the color scale.
-      const tickX =
-        ((value - this.config.min) / (this.config.max - this.config.min)) *
-        canvas.width;
+    if (value != null) {
+      const tickWidth = 8;
+      if (value >= this.config.min && value <= this.config.max) {
+        // Highlight the relative position of `value` along the color scale.
+        const tickX =
+          ((value - this.config.min) / (this.config.max - this.config.min)) *
+          canvas.width;
 
-      context.beginPath();
-      context.fillStyle = 'rgba(0, 0, 0, 1)';
-      context.moveTo(tickX, verticalMargin * height);
-      context.lineTo(tickX - tickWidth / 2, 0);
-      context.lineTo(tickX + tickWidth / 2, 0);
-      context.fill();
+        // Draw the triangle on the top.
+        context.beginPath();
+        context.fillStyle = 'rgba(0, 0, 0, 1)';
+        context.moveTo(tickX, verticalMargin * height);
+        context.lineTo(tickX - tickWidth / 2, 0);
+        context.lineTo(tickX + tickWidth / 2, 0);
+        context.fill();
+
+        // Draw the triangle on the bottom.
+        context.beginPath();
+        context.moveTo(tickX, (1 - verticalMargin) * height);
+        context.lineTo(tickX - tickWidth / 2, height);
+        context.lineTo(tickX + tickWidth / 2, height);
+        context.fill();
+      }
     }
   }
 }
@@ -170,7 +180,6 @@ export class JetColorMap extends ColorMap {
         : (value - this.config.min) / (this.config.max - this.config.min);
     relValue = Math.max(Math.min(relValue, 1), 0);
     if (relValue <= lim0) {
-      // TODO(cais):
       g = (relValue / lim0) * MAX_RGB;
       b = MAX_RGB;
     } else if (relValue > lim0 && relValue <= lim1) {

--- a/tensorboard/components/tensor_widget/menu.ts
+++ b/tensorboard/components/tensor_widget/menu.ts
@@ -21,6 +21,13 @@ type EventCallback = (event: Event) => void | Promise<void>;
 export interface MenuItemConfig {
   /** Caption displayed on the menu item. */
   caption: string;
+
+  /**
+   * A function that determines whether menu item is currently enabled.
+   *
+   * If not provided, the menu item will always be enabled.
+   */
+  isEnabled?: () => boolean;
 }
 
 /**
@@ -29,13 +36,6 @@ export interface MenuItemConfig {
 export interface SingleActionMenuItemConfig extends MenuItemConfig {
   /** The callback that gets called when the menu item is clicked. */
   callback: EventCallback;
-
-  /**
-   * A function that determines whether menu item is currently enabled.
-   *
-   * If not provided, the menu item will always be enabled.
-   */
-  isEnabled?: () => boolean;
 }
 
 export interface ChoiceMenuItemConfig extends MenuItemConfig {
@@ -267,12 +267,9 @@ export class Menu {
         // This is a single-command item.
         const singleActionConfig = item as SingleActionMenuItemConfig;
         outerItemConfig.onClick = singleActionConfig.callback;
-        if (
-          singleActionConfig.isEnabled != null &&
-          !singleActionConfig.isEnabled()
-        ) {
-          outerItemConfig.disabled = true;
-        }
+      }
+      if (item.isEnabled != null && !item.isEnabled()) {
+        outerItemConfig.disabled = true;
       }
       outerItemConfigs.push(outerItemConfig);
     });

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -69,12 +69,12 @@ enum ValueRenderMode {
  * Implementation of TensorWidget.
  */
 
-/** Color-map look-up table. The keys are meant to be case-insensitive. */
+/** Color-map look-up table. */
 const colorMaps: {
   [colorMapName: string]: new (config: ColorMapConfig) => ColorMap;
 } = {
-  grayscale: GrayscaleColorMap,
-  jet: JetColorMap,
+  Grayscale: GrayscaleColorMap,
+  Jet: JetColorMap,
 };
 
 /** An implementation of TensorWidget single-tensor view. */
@@ -124,6 +124,7 @@ export class TensorWidgetImpl implements TensorWidget {
 
   // Name of color map (takes effect on IMAGE value render mode only).
   protected colorMapName: string = 'Grayscale';
+  protected colorMap: ColorMap | null = null;
 
   // Whether indices should be rendered on ruler ticks on the top and left.
   // Determined dynamically based on the current size of the ticks.
@@ -402,7 +403,15 @@ export class TensorWidgetImpl implements TensorWidget {
       this.rootElement.appendChild(this.valueSection);
 
       this.valueSection.addEventListener('wheel', async (event) => {
-        if (event.ctrlKey && this.valueRenderMode === ValueRenderMode.IMAGE) {
+        let zoomKeyPressed = false;
+        if (this.options.wheelZoomKey == null || this.options.wheelZoomKey === 'ctrl') {
+          zoomKeyPressed = event.ctrlKey;
+        } else if (this.options.wheelZoomKey === 'alt') {
+          zoomKeyPressed = event.altKey;
+        } else if (this.options.wheelZoomKey === 'shift') {
+          zoomKeyPressed = event.shiftKey;
+        }
+        if (zoomKeyPressed && this.valueRenderMode === ValueRenderMode.IMAGE) {
           event.stopPropagation();
           event.preventDefault();
           if (event.deltaY > 0) {
@@ -410,7 +419,6 @@ export class TensorWidgetImpl implements TensorWidget {
           } else {
             this.zoomInOneStepAndRenderValues();
           }
-          console.log(`ctrl + wheel: ${event.deltaY}`); // DEBUG
           return;
         }
 
@@ -842,10 +850,16 @@ export class TensorWidgetImpl implements TensorWidget {
             'missing minimum or maximum values in numeric summary'
         );
       }
-      colorMap = new colorMaps[this.colorMapName.toLowerCase()]({
+      const colorMapConfig: ColorMapConfig = {
         min: minimum as number,
         max: maximum as number,
-      });
+      };
+      if (this.colorMapName in colorMaps) {
+        this.colorMap = new colorMaps[this.colorMapName](colorMapConfig);
+      } else {
+        // Color-map name is not found. Use the default: Grayscale colormap.
+        this.colorMap = new GrayscaleColorMap(colorMapConfig);
+      }
     }
 
     for (let i = 0; i < numRows; ++i) {
@@ -857,7 +871,7 @@ export class TensorWidgetImpl implements TensorWidget {
         ) {
           const value = (values as number[][] | boolean[][] | string[][])[i][j];
           if (valueRenderMode === ValueRenderMode.IMAGE) {
-            const [red, green, blue] = (colorMap as ColorMap).getRGB(
+            const [red, green, blue] = (this.colorMap as ColorMap).getRGB(
               value as number
             );
             valueDiv.style.backgroundColor = `rgb(${red}, ${green}, ${blue})`;
@@ -1045,6 +1059,16 @@ export class TensorWidgetImpl implements TensorWidget {
     this.valueTooltip.style.top = `${top}px`;
     this.valueTooltip.style.left = `${left}px`;
     this.valueTooltip.style.display = 'block';
+
+    // If the current render mode is IMAGE, show the color bar and
+    // indicate the position of the current element along the color-bar scale.
+    if (this.valueRenderMode == ValueRenderMode.IMAGE &&
+        this.colorMap != null) {
+      const colorBarCanvas = document.createElement('canvas');
+      colorBarCanvas.classList.add('tensor-widget-value-tooltip-colorbar');
+      this.valueTooltip.appendChild(colorBarCanvas);
+      this.colorMap.render(colorBarCanvas, parseFloat(detailedValueString));
+    }
   }
 
   private hideValueTooltip() {

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -404,7 +404,10 @@ export class TensorWidgetImpl implements TensorWidget {
 
       this.valueSection.addEventListener('wheel', async (event) => {
         let zoomKeyPressed = false;
-        if (this.options.wheelZoomKey == null || this.options.wheelZoomKey === 'ctrl') {
+        if (
+          this.options.wheelZoomKey == null ||
+          this.options.wheelZoomKey === 'ctrl'
+        ) {
           zoomKeyPressed = event.ctrlKey;
         } else if (this.options.wheelZoomKey === 'alt') {
           zoomKeyPressed = event.altKey;
@@ -1062,8 +1065,10 @@ export class TensorWidgetImpl implements TensorWidget {
 
     // If the current render mode is IMAGE, show the color bar and
     // indicate the position of the current element along the color-bar scale.
-    if (this.valueRenderMode == ValueRenderMode.IMAGE &&
-        this.colorMap != null) {
+    if (
+      this.valueRenderMode == ValueRenderMode.IMAGE &&
+      this.colorMap != null
+    ) {
       const colorBarCanvas = document.createElement('canvas');
       colorBarCanvas.classList.add('tensor-widget-value-tooltip-colorbar');
       this.valueTooltip.appendChild(colorBarCanvas);

--- a/tensorboard/components/tensor_widget/tensor-widget.css
+++ b/tensorboard/components/tensor_widget/tensor-widget.css
@@ -193,6 +193,13 @@ limitations under the License.
   font-size: 13px;
   padding: 5px;
   position: absolute;
+  user-select: none;
+  width: 240px;
+}
+
+.tensor-widget-value-tooltip-colorbar {
+  height: 24px;
+  width: 95%;
 }
 
 .tensor-widget-value-tooltip-indices {

--- a/tensorboard/components/tensor_widget/types.ts
+++ b/tensorboard/components/tensor_widget/types.ts
@@ -185,6 +185,14 @@ export interface TensorWidgetOptions {
    */
   decimalPlaces?: number;
 
+  /**
+   * Whether to use the Alt, Ctrl or Shift key with the mouse for zooming under
+   * the image value-rendering mode.
+   *
+   * Defaults to Ctrl key ('ctrl').
+   */
+  wheelZoomKey?: 'alt' | 'ctrl' | 'shift';
+
   /** TODO(cais): Add support for custom tensor renderers. */
 }
 

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-tensor-value-view.html
@@ -342,7 +342,8 @@ limitations under the License.
             if (this.tensorWidget == null) {
               this.tensorWidget = tensor_widget.tensorWidget(
                 this.$$('#tensor-widget'),
-                tensorView
+                tensorView,
+                {wheelZoomKey: 'alt'}
               );
             }
             this.tensorWidget.render();


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing TensorWidget

* Technical description of changes
  * Support Ctrl/Alt/Shift + mouse wheel zooming
  * Add an optional field to TensorWidgetOptions: wheelZoomKey to allow specifying whether alt, ctrl or shift key activates wheel zooming.
  * Add jet colormap
  * Add colormap selection menu
  * Added a color bar in the value tooltip that indicates where the currently pointed-to value is within the color scale.

* Screenshots of UI changes
  * ![image](https://user-images.githubusercontent.com/16824702/66793119-dbc0a100-eeb0-11e9-950d-a72c2599062c.png)
  * ![image](https://user-images.githubusercontent.com/16824702/66793166-04e13180-eeb1-11e9-83d3-123802de1247.png)
  * ![image](https://user-images.githubusercontent.com/16824702/66793021-5b01a500-eeb0-11e9-9abd-4c90401106b5.png)
  * ![image](https://user-images.githubusercontent.com/16824702/66793103-b338a700-eeb0-11e9-86a6-f8d351d88acf.png)