### PR TITLE
program: add direct `absl.flags` Bazel pseudodep

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -147,6 +147,7 @@ py_library(
     deps = [
         ":manager",
         ":version",
+        "//tensorboard:expect_absl_flags_installed",
         "//tensorboard:expect_absl_logging_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_file_inspector",


### PR DESCRIPTION
Summary:
Now that the `absl` dependency is unconditional, we should express it in
the build file, even though this is a no-op in open source. (I meant to
include this in #2758, but forgot to amend it into the commit.)

Test Plan:
None.

wchargin-branch: absl-always-dep
