### PR TITLE
ci: pin TF 1.x to 1.15.0rc3, not nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - BAZEL=0.26.1
     - BAZEL_SHA256SUM=6c50e142a0a405d3d8598050d6c1b3920c8cdb82a7ffca6fc067cb474275148f
   matrix:
-    - TF_VERSION_ID=tf-nightly==1.15.0.dev20190816
+    - TF_VERSION_ID=tensorflow==1.15.0rc3
     - TF_VERSION_ID=tf-nightly
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 


### PR DESCRIPTION
Summary:
There are no more 1.x nightlies, so this is actually a more recent
version of TensorFlow. In particular, it pins `gast==0.2.2`, which will
probably unblock #2639.

Test Plan:
In a new virtualenv, after running `pip install tensorflow==1.15.0rc3`,
the `//tensorboard/plugins/mesh:summary_v2_test` test passes.

wchargin-branch: pin-tf-1.15.0rc3
