### PR TITLE
core: allow frame_ancestors configuration from CLI

### DIFF
--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -64,6 +64,7 @@ py_library(
     deps = [
         ":empty_path_redirect",
         ":experiment_id",
+        ":frame_ancestors",
         ":http_util",
         ":path_prefix",
         "//tensorboard:errors",
@@ -132,6 +133,28 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":experiment_id",
+        "//tensorboard:test",
+        "@org_pocoo_werkzeug",
+    ],
+)
+
+py_library(
+    name = "frame_ancestors",
+    srcs = ["frame_ancestors.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        "@org_pocoo_werkzeug",
+    ],
+)
+
+py_test(
+    name = "frame_ancestors_test",
+    size = "small",
+    srcs = ["frame_ancestors_test.py"],
+    srcs_version = "PY2AND3",
+    tags = ["support_notf"],
+    deps = [
+        ":frame_ancestors",
         "//tensorboard:test",
         "@org_pocoo_werkzeug",
     ],

--- a/tensorboard/backend/frame_ancestors.py
+++ b/tensorboard/backend/frame_ancestors.py
@@ -1,0 +1,90 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Internal path prefix support for TensorBoard.
+
+Using a path prefix of `/foo/bar` enables TensorBoard to serve from
+`http://localhost:6006/foo/bar/` rather than `http://localhost:6006/`.
+See the `--path_prefix` flag docs for more details.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import functools
+
+import werkzeug
+
+
+class FrameAncestorsMiddleware(object):
+  """WSGI middleware for adding Content-Secuity-Policy for frame-ancestors.
+
+  All requests to this middleware must begin with the specified path
+  prefix (otherwise, a 404 will be returned immediately). Requests will
+  be forwarded to the underlying application with the path prefix
+  stripped and appended to `SCRIPT_NAME` (see the WSGI spec, PEP 3333,
+  for details).
+  """
+
+  def __init__(self, application, frame_ancestors_flag):
+    """Initializes this middleware.
+
+    Args:
+      application: The WSGI application to wrap (see PEP 3333).
+      path_prefix: A string path prefix to be stripped from incoming
+        requests. If empty, this middleware is a no-op. If non-empty,
+        the path prefix must start with a slash and not end with one
+        (e.g., "/tensorboard").
+    """
+    self._application = application
+    self._flag = frame_ancestors_flag
+
+  def __call__(self, environ, start_response):
+    @functools.wraps(start_response)
+    def new_start_response(status, headers):
+      return start_response(status, self._headers_with_maybe_csp(headers))
+
+    return self._application(environ, new_start_response)
+
+  def _headers_with_maybe_csp(self, headers):
+    """Add a Content-Security-Policy facilitating Colab output frames.
+    This is intended for use with the `google.colab.kernel.proxyPort`
+    JavaScript function available from within a Colab output frame.
+    If the headers already include an explicit CSP, they are returned
+    unchanged.
+    Args:
+      headers: A list of WSGI headers (key-value tuples of `str`s).
+    Returns:
+      A new list of WSGI headers; the original is unchanged.
+    """
+    # Do not attach CSP for non-HTMLs
+    headers = werkzeug.Headers(headers)
+    if not headers.get('Content-Type', type=str).startswith('text/html'):
+      return headers.to_wsgi_list()
+
+    flag = self._flag
+    if flag == 'unsafe' or flag == 'notebook':
+      allowed = '*'
+    elif flag == 'colab':
+      allowed = ' '.join([
+          'https://*.googleusercontent.com',
+          'https://*.google.com',
+      ])
+    else:
+      allowed = "'none'"
+
+    headers.add_header('Content-Security-Policy', 'frame-ancestors %s;' % allowed)
+
+    return headers.to_wsgi_list()

--- a/tensorboard/backend/frame_ancestors_test.py
+++ b/tensorboard/backend/frame_ancestors_test.py
@@ -1,0 +1,82 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for `tensorboard.backend.frame_ancestors`."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import json
+
+import werkzeug
+from werkzeug import test as werkzeug_test
+
+from tensorboard import test as tb_test
+from tensorboard.backend import frame_ancestors
+
+
+class FrameAncestorsTest(tb_test.TestCase):
+  """Tests for `FrameAncestorsMiddleware`."""
+
+  def _bootstrap(self, flag):
+    app = frame_ancestors.FrameAncestorsMiddleware(self._echo_app, flag)
+    return werkzeug_test.Client(app, werkzeug.BaseResponse)
+
+  def _echo_app(self, environ, start_response):
+    path = environ.get("PATH_INFO", "")
+    if path == "html":
+      start_response("200 OK", [("Content-Type", "text/html")])
+      return "<b>hello</b>world"
+    if path == "json":
+      start_response("200 OK", [("Content-Type", "application/json")])
+      return '{"hello": "world"}'
+    start_response("404 NOT FOUND", [("Content-Type", "text/plain")])
+    return "meow"
+
+  def _assert_frame_ancestors(self, response, expected_frame_ancestors):
+    csp = response.headers.get("Content-Security-Policy", None)
+    if expected_frame_ancestors is None:
+      self.assertEqual(csp, None)
+    else:
+      self.assertEqual(csp, "frame-ancestors %s;" % expected_frame_ancestors)
+
+  def test_html_response(self):
+    response = self._bootstrap("unsafe").get("html")
+    self._assert_frame_ancestors(response, "*")
+
+  def test_flag(self):
+    response = self._bootstrap("none").get("html")
+    self._assert_frame_ancestors(response, "'none'")
+
+    response = self._bootstrap("colab").get("html")
+    self._assert_frame_ancestors(
+        response, "https://*.googleusercontent.com https://*.google.com")
+
+    response = self._bootstrap("notebook").get("html")
+    self._assert_frame_ancestors(response, "*")
+
+    response = self._bootstrap("unsafe").get("html")
+    self._assert_frame_ancestors(response, "*")
+
+  def test_non_htmls(self):
+    response = self._bootstrap("none").get("json")
+    self._assert_frame_ancestors(response, None)
+
+    response = self._bootstrap("none").get("")
+    self._assert_frame_ancestors(response, None)
+
+
+if __name__ == "__main__":
+  tb_test.main()

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -151,6 +151,7 @@ def start(args_string):
     else:
       handle.update(IPython.display.Pretty(message))
 
+  args_string='%s %s' % (_get_context_default_args(), args_string)
   parsed_args = shlex.split(args_string, comments=True, posix=True)
   start_result = manager.start(parsed_args)
 
@@ -314,6 +315,15 @@ def _display(port=None, height=None, print_message=False, display_handle=None):
       _CONTEXT_NONE: _display_cli,
   }[_get_context()]
   return fn(port=port, height=height, display_handle=display_handle)
+
+
+def _get_context_default_args():
+  context = _get_context()
+  if context == _CONTEXT_COLAB:
+    return '--frame_ancestors=colab'
+  if context == _CONTEXT_IPYTHON:
+    return '--frame_ancestors=notebook'
+  return ''
 
 
 def _display_colab(port, height, display_handle):

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -583,6 +583,25 @@ keeps 500 scalars and all images. Most users should not need to set this
 flag.\
 ''')
 
+    # TODO(stephanwlee): change the default to none at TB 3.0.
+    parser.add_argument(
+        '--frame_ancestors',
+        metavar='TYPE',
+        type=str,
+        choices=['none', 'colab', 'notebook', 'unsafe'],
+        default='unsafe',
+        help='''\
+[experimental] Controls whether TensorBoard can be rendered inside an iframe.
+frame-ancestors is an item in Content-Security-Policy that tells browser whether
+a document can be rendered inside an iframe under a host. (default:
+%(default)s). Possible configurations are:
+'none': disallows any site from rendering TensorBoard inside an iframe.
+'colab': only can be rendered inside Colab notebook.
+'notebook': preset for Jupyter like notebooks.
+'unsafe': allow any site from embedding TensorBoard.\
+''')
+
+
   def fix_flags(self, flags):
     """Fixes standard TensorBoard CLI flags to parser."""
     FlagsError = base_plugin.FlagsError


### PR DESCRIPTION
Now, with --frame_ancestors, one can change the frame-ancestors
Content-Security-Policy to one of four configurations. The
configurations are:

- none: does not allow TensorBoard to be iframed
- colab: CSP for colab only
- notebook: CSP for notebook environments like Jupyter
- unsafe: allow any sites from embedding TensorBoard

The default for now is `unsafe` since that is current behavior as of
TB 2.0.

Do note that notebook one is the same as unsafe for now because in
context of, at least, Jupyter, localhost:[port] document loads
TensorBoard in an iframe that is running at localhost:6006. Because for
CSP keyword like "self" has to match both host-uri and the port, it does
not work for us. Moreover, it is, depending on Jupyter configuration,
naturally to run one on "ip" which would make the address not
guess-able. Until we have a better solution, we will have the "unsafe"
behavior for the notebook configuration.

Inspirations from #2397.
