### PR TITLE
csp: fix bugs and properly treat projector

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -204,9 +204,7 @@ def Respond(request,
     script_srcs = _create_csp_string(*frags)
 
     csp_string = ';'.join([
-        "default-src 'none'",
-        "base-uri 'self'",
-        "connect-src 'self'",
+        "default-src 'self'",
         'font-src %s' % _create_csp_string(
             "'self'",
             *_CSP_FONT_DOMAINS_WHITELIST

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -192,7 +192,7 @@ class RespondTest(tb_test.TestCase):
     r = http_util.Respond(
         q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcdefghi'])
     expected_csp = (
-        "default-src 'none';base-uri 'self';connect-src 'self';font-src 'self';"
+        "default-src 'self';font-src 'self';"
         "frame-src 'self';img-src 'self' data:;object-src 'none';"
         "style-src https://www.gstatic.com data: 'unsafe-inline';"
         "script-src 'strict-dynamic' 'unsafe-eval' 'sha256-abcdefghi'"
@@ -203,7 +203,7 @@ class RespondTest(tb_test.TestCase):
     q = wrappers.Request(wtest.EnvironBuilder().get_environ())
     r = http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=None)
     expected_csp = (
-        "default-src 'none';base-uri 'self';connect-src 'self';font-src 'self';"
+        "default-src 'self';font-src 'self';"
         "frame-src 'self';img-src 'self' data:;object-src 'none';"
         "style-src https://www.gstatic.com data: 'unsafe-inline';"
         "script-src 'none'"
@@ -216,7 +216,7 @@ class RespondTest(tb_test.TestCase):
     r = http_util.Respond(
         q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcdefghi'])
     expected_csp = (
-        "default-src 'none';base-uri 'self';connect-src 'self';font-src 'self';"
+        "default-src 'self';font-src 'self';"
         "frame-src 'self';img-src 'self' data:;object-src 'none';"
         "style-src https://www.gstatic.com data: 'unsafe-inline';"
         "script-src 'unsafe-eval' 'sha256-abcdefghi'"
@@ -229,7 +229,7 @@ class RespondTest(tb_test.TestCase):
     r = http_util.Respond(
         q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcdefghi'])
     expected_csp = (
-        "default-src 'none';base-uri 'self';connect-src 'self';font-src 'self';"
+        "default-src 'self';font-src 'self';"
         "frame-src 'self';img-src 'self' data:;object-src 'none';"
         "style-src https://www.gstatic.com data: 'unsafe-inline';"
         "script-src 'strict-dynamic' 'sha256-abcdefghi'"
@@ -244,7 +244,7 @@ class RespondTest(tb_test.TestCase):
     q = wrappers.Request(wtest.EnvironBuilder().get_environ())
     r = http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
     expected_csp = (
-        "default-src 'none';base-uri 'self';connect-src 'self';font-src 'self';"
+        "default-src 'self';font-src 'self';"
         "frame-src 'self';img-src 'self' data: https://example.com;object-src 'none';"
         "style-src https://www.gstatic.com data: 'unsafe-inline' https://googol.com;"
         "script-src https://tensorflow.org/tensorboard 'strict-dynamic' 'unsafe-eval' "

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -73,6 +73,7 @@ setup(
         'tensorboard.plugins.projector': [
             'tf_projector_plugin/index.js',
             'tf_projector_plugin/projector_binary.html',
+            'tf_projector_plugin/projector_binary.html.scripts_sha256',
         ],
     },
     # Disallow python 3.0 and 3.1 which lack a 'futures' module (see above).

--- a/tensorboard/plugins/projector/tf_projector_plugin/BUILD
+++ b/tensorboard/plugins/projector/tf_projector_plugin/BUILD
@@ -10,6 +10,7 @@ tf_web_library(
     srcs = [
         # Keep this in sync with pip_package/setup.py
         ":projector_binary.html",
+        ":projector_binary.html.scripts_sha256",
         "index.js",
     ],
     path = "/tf-projector",


### PR DESCRIPTION
With enabling CSP on TensorBoard, we have broken projector in few ways.
Because we enforce CSP for all text/html response, we need to have
proper sha256s for all scripts including ones for the projector. Several
fixes are:

1. strict-dynamic -> 'strict-dynamic'
2. 'frame-src' is now set for `iframe src="..."`
3. script hashes are piped in for projector
4. `unsafe-eval` because of numericjs [1].

[1]:
https://github.com/sloisel/numeric/blob/656fa1254be540f428710738ca9c1539625777f1/src/numeric.js#L576-L585

Confession: tested projector before applying stricter rules on _all_ `text/html` before :\. Tested on projector now.
