### PR TITLE
util: utility for getting resource file

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -151,6 +151,8 @@ py_library(
         "//tensorboard:expect_absl_logging_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_file_inspector",
+        "//tensorboard/util:platform_util",
+        "//tensorboard/util:tb_logging",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -19,6 +19,7 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/compat:tensorflow",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:platform_util",
         "//tensorboard/util:tb_logging",
         "@org_pocoo_werkzeug",
     ],

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -37,6 +37,7 @@ from tensorboard.compat import tf
 from tensorboard.compat import _pywrap_tensorflow
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.projector.projector_config_pb2 import ProjectorConfig
+from tensorboard.util import platform_util
 from tensorboard.util import tb_logging
 
 logger = tb_logging.get_logger()
@@ -485,7 +486,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
   def _serve_file(self, file_path, request):
     """Returns a resource file."""
     res_path = os.path.join(os.path.dirname(__file__), file_path)
-    with open(res_path, 'rb') as read_file:
+    with platform_util.get_resource_as_file(res_path, 'rb') as read_file:
       mimetype = mimetypes.guess_type(file_path)[0]
       return Respond(request, read_file.read(), content_type=mimetype)
 

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -58,6 +58,7 @@ from tensorboard.backend import application
 from tensorboard.backend.event_processing import event_file_inspector as efi
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.core import core_plugin
+from tensorboard.util import platform_util
 from tensorboard.util import tb_logging
 
 
@@ -93,7 +94,7 @@ def get_default_assets_zip_provider():
   if not os.path.exists(path):
     logger.warning('webfiles.zip static assets not found: %s', path)
     return None
-  return lambda: open(path, 'rb')
+  return lambda: platform_util.get_resource_as_file(path, 'rb')
 
 class TensorBoard(object):
   """Class for running TensorBoard.

--- a/tensorboard/util/platform_util.py
+++ b/tensorboard/util/platform_util.py
@@ -23,3 +23,22 @@ from __future__ import print_function
 def readahead_file_path(path, unused_readahead=None):
   """Readahead files not implemented; simply returns given path."""
   return path
+
+
+def get_resource_as_file(name, mode='rb'):
+  """Get the open file object to the named resource.
+
+  Args:
+    name: The name of the resource.
+    mode: The file mode. read_resource only supports 'r', 'rt' and 'rb'.
+  Returns:
+    The open file object to the named resource.
+  Raises:
+    IOError: if the name is not found, or the resource cannot be opened.
+    ValueError: If the mode is not supported.
+  """
+
+  if mode not in ('r', 'rb', 'rt'):
+    raise ValueError('Invalid mode: %r' % mode)
+
+  return open(name, mode)

--- a/tensorboard/util/platform_util_test.py
+++ b/tensorboard/util/platform_util_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2018 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,14 +17,27 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+
 from tensorboard import test as tb_test
 from tensorboard.util import platform_util
 
 
 class PlatformUtilTest(tb_test.TestCase):
 
+  def _write_temp_file(self, body):
+    filename = os.path.join(self.get_temp_dir(), 'foo.txt')
+    with open(filename, 'w') as temp_file:
+      temp_file.write(body)
+    return filename
+
   def test_readahead_file_path(self):
     self.assertEqual('foo/bar', platform_util.readahead_file_path('foo/bar'))
+
+  def test_get_resource_as_file(self):
+    filename = self._write_temp_file('haha😊')
+    with platform_util.get_resource_as_file(filename, 'r') as file:
+      self.assertEqual('haha😊', file.read())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
TensorBoard may want to use a project like google/subpar to create a
self-contained python binary and we need to make sure resources inside
the container to be accessible. This utility creates an abstraction
point for such instances.
