### PR TITLE
ng: fix the dev CSP issue

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -259,15 +259,15 @@ tf_web_library(
     srcs = [
         "//tensorboard/components:index.html",
         "//tensorboard/components:trace_viewer_index.html",
-    ],
+    ] + select({
+        "//tensorboard:dev_build": ["//tensorboard/components:ng_index"],
+        "//conditions:default": [],
+    }),
     path = "/",
     deps = [
         ":html_assets_shasums",
         "@com_google_fonts_roboto",
-    ] + select({
-        "//tensorboard:dev_build": ["//tensorboard/components:ng_tensorboard"],
-        "//conditions:default": [],
-    }),
+    ],
 )
 
 tf_web_library(
@@ -275,7 +275,12 @@ tf_web_library(
     srcs = [
         "//tensorboard/components:index.html.scripts_sha256",
         "//tensorboard/components:trace_viewer_index.html.scripts_sha256",
-    ],
+    ] + select({
+        "//tensorboard:dev_build": [
+            "//tensorboard/components:ng_index.html.scripts_sha256",
+        ],
+        "//conditions:default": [],
+    }),
     path = "/_shasums",
 )
 

--- a/tensorboard/components/tf_backend/tf-backend-polymer.ts
+++ b/tensorboard/components/tf_backend/tf-backend-polymer.ts
@@ -17,6 +17,7 @@ namespace tf_backend {
   // tf-ng-tensorboard by exposing otherwise mangled smybols.
   Polymer({
     is: 'tf-backend',
+    _template: null, // strictTemplatePolicy requires a template (even a null one).
     tf_backend: tf_backend,
   });
 } // namespace tf_backend

--- a/tensorboard/components/tf_storage/tf-storage-polymer.ts
+++ b/tensorboard/components/tf_storage/tf-storage-polymer.ts
@@ -17,6 +17,7 @@ namespace tf_storage {
   // tf-ng-tensorboard by exposing otherwise mangled smybols.
   Polymer({
     is: 'tf-storage',
+    _template: null, // strictTemplatePolicy requires a template (even a null one).
     tf_storage: tf_storage,
   });
 } // namespace tf_storage


### PR DESCRIPTION
TensorBoard now enforces very strict CSP and this did have a negative
impact on our tf-ng-tensorboard dev mode. Previously, TensorBoard was
able to skip the Vulcanization step of tf_ng_tensorboard because we were
using rollup bundle anyways. This skipping did improve the incremental
build speed of the Angular app. However, now that CSP infrastructure
is built on top of the Vulcanization tooling (or rather, requires shasum
of all script tags to be computed ahead of time), we are now Vulcanizing
AFTER rollup.

We have longer term plans to improve our CSP/assets story which should
improve this.
