### PR TITLE
Fix sliced intersection (What-If Tool)

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -4753,7 +4753,11 @@ limitations under the License.
         featureValueThresholdsChanged_: function(featureValueThresholds) {
           const map = {};
           for (let i = 0; i < featureValueThresholds.length; i++) {
-            map[featureValueThresholds[i].value] = i;
+            const key = this.createCombinedValueString_(
+              featureValueThresholds[i].value,
+              featureValueThresholds[i].value2
+            );
+            map[key] = i;
           }
           this.featureValueThresholdsIndexMap = map;
         },
@@ -6854,12 +6858,11 @@ limitations under the License.
         },
 
         createCombinedValueString_: function(val1, val2) {
-          let str = val1 == null ? '' : val1;
-          if (val2 == null || val2 == '') {
+          let str = val1 === undefined || val1 === null ? '' : val1;
+          if (val2 === undefined || val2 === null || val2 === '') {
             return str;
           }
-          str += '/' + val2;
-          return str;
+          return str + '/' + val2;
         },
 
         /**


### PR DESCRIPTION
* Motivation for features / changes

This bug:
<img width="996" alt="Screenshot 2019-10-16 at 21 53 29" src="https://user-images.githubusercontent.com/6004563/66958184-8ecefd00-f05f-11e9-8047-1df336fa3e41.png">


* Technical description of changes

The feature to update `featureValueThresholdsIndexMap` was considering
only the first sliced feature, when it should be using the combined
string.

I also tweaked the function that combines these two values to do strict
comparisons for null and empty strings, because it was considering the
value `0 == ''`, ignoring these values.

* Screenshots of UI changes

<img width="993" alt="Screenshot 2019-10-16 at 21 53 09" src="https://user-images.githubusercontent.com/6004563/66958209-97bfce80-f05f-11e9-988c-94a96e834e33.png">

* Detailed steps to verify changes work correctly (as executed by you)

Slice by two features in the Performance tab and checking that we don't have those `NaN`s.

* Alternate designs / implementations considered

N/A
