### PR TITLE
Add ml service name and version for CAIP

### DIFF
--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
@@ -360,7 +360,8 @@ class WitWidgetBase(object):
       examples, self.config.get('inference_address'),
       self.config.get('model_name'), self.config.get('model_signature'),
       self.config.get('force_json_input'), self.adjust_example_fn,
-      self.adjust_prediction_fn, self.adjust_attribution_fn)
+      self.adjust_prediction_fn, self.adjust_attribution_fn,
+      self.config.get('aip_service_name'), self.config.get('aip_service_version'))
 
   def _predict_aip_compare_model(self, examples):
     return self._predict_aip_impl(
@@ -369,16 +370,20 @@ class WitWidgetBase(object):
       self.config.get('compare_force_json_input'),
       self.compare_adjust_example_fn,
       self.compare_adjust_prediction_fn,
-      self.compare_adjust_attribution_fn)
+      self.compare_adjust_attribution_fn,
+      self.config.get('compare_aip_service_name'),
+      self.config.get('compare_aip_service_version'))
 
   def _predict_aip_impl(self, examples, project, model, version, force_json,
-                        adjust_example, adjust_prediction, adjust_attribution):
+                        adjust_example, adjust_prediction, adjust_attribution,
+                        service_name, service_version):
     """Custom prediction function for running inference through AI Platform."""
 
     # Set up environment for GCP call for specified project.
     os.environ['GOOGLE_CLOUD_PROJECT'] = project
 
-    service = googleapiclient.discovery.build('ml', 'v1', cache_discovery=False)
+    service = googleapiclient.discovery.build(
+      service_name, service_version, cache_discovery=False)
     name = 'projects/{}/models/{}'.format(project, model)
     if version is not None:
       name += '/versions/{}'.format(version)

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
@@ -531,7 +531,8 @@ class WitConfigBuilder(object):
 
   def set_ai_platform_model(
     self, project, model, version=None, force_json_input=None,
-    adjust_prediction=None, adjust_example=None, adjust_attribution=None):
+    adjust_prediction=None, adjust_example=None, adjust_attribution=None,
+    service_name='ml', service_version='v1'):
     """Sets the model information for a model served by AI Platform.
 
     AI Platform Prediction a Google Cloud serving platform.
@@ -556,6 +557,10 @@ class WitConfigBuilder(object):
       example and converts it to the format expected by the tool, which is a
       dictionary of input feature names to attribution scores. Usually necessary
       if making use of adjust_example and the model returns attribution results.
+      service_name: Optional. Name of the AI Platform Prediction service. Defaults
+      to 'ml'.
+      service_version: Optional. Version of the AI Platform Prediction service. Defaults
+      to 'v1'.
 
     Returns:
       self, in order to enabled method chaining.
@@ -563,6 +568,8 @@ class WitConfigBuilder(object):
     self.set_inference_address(project)
     self.set_model_name(model)
     self.store('use_aip', True)
+    self.store('aip_service_name', service_name)
+    self.store('aip_service_version', service_version)
     if version is not None:
       self.set_model_signature(version)
     if force_json_input:
@@ -577,7 +584,8 @@ class WitConfigBuilder(object):
 
   def set_compare_ai_platform_model(
     self, project, model, version=None, force_json_input=None,
-    adjust_prediction=None, adjust_example=None, adjust_attribution=None):
+    adjust_prediction=None, adjust_example=None, adjust_attribution=None,
+    service_name='ml', service_version='v1'):
     """Sets the model information for a second model served by AI Platform.
 
     AI Platform Prediction a Google Cloud serving platform.
@@ -602,6 +610,10 @@ class WitConfigBuilder(object):
       example and converts it to the format expected by the tool, which is a
       dictionary of input feature names to attribution scores. Usually necessary
       if making use of adjust_example and the model returns attribution results.
+      service_name: Optional. Name of the AI Platform Prediction service. Defaults
+      to 'ml'.
+      service_version: Optional. Version of the AI Platform Prediction service. Defaults
+      to 'v1'.
 
     Returns:
       self, in order to enabled method chaining.
@@ -609,6 +621,8 @@ class WitConfigBuilder(object):
     self.set_compare_inference_address(project)
     self.set_compare_model_name(model)
     self.store('compare_use_aip', True)
+    self.store('compare_aip_service_name', service_name)
+    self.store('compare_aip_service_version', service_version)
     if version is not None:
       self.set_compare_model_signature(version)
     if force_json_input:


### PR DESCRIPTION
* Motivation for features / changes

WitWidget cloud users need a way to override the cloud service and service version to send requests to.

* Technical description of changes

Added parameters for service name and version to cloud setup functions, defaulting those parameters to the correct default server.

* Detailed steps to verify changes work correctly (as executed by you)

Ran against default server models and a non-default server model.

