### PR TITLE
When turning off counterfactual, correctly update example viewer

### DIFF
--- a/tensorboard/components/vz_example_viewer/vz-example-viewer.ts
+++ b/tensorboard/components/vz_example_viewer/vz-example-viewer.ts
@@ -1354,6 +1354,7 @@ namespace vz_example_viewer {
      */
     createCompareExamplesFromJson: function(json: string) {
       if (!json) {
+        this.compareExample = null;
         return;
       }
       this.compareExample = this.createExamplesFromJsonHelper(json);


### PR DESCRIPTION
* Motivation for features / changes

Currently turning off counterfactual mode doesn't refresh the example viewer display to remove the counterfactual datapoint.

* Detailed steps to verify changes work correctly (as executed by you)

Turned on and off counterfactuals and moved between examples with counterfactuals on and off. Verified correct behavior.

