### PR TITLE
program: add subcommand CLI support

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -170,6 +170,7 @@ py_test(
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/plugins/core:core_plugin",
         "@org_pocoo_werkzeug",
+        "@org_pythonhosted_mock",
     ],
 )
 

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -151,6 +151,7 @@ py_library(
         "//tensorboard:expect_absl_logging_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_file_inspector",
+        "//tensorboard/util:argparse_util",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -5,6 +5,23 @@ licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])  # Needed for internal repo.
 
 py_library(
+    name = "argparse_util",
+    srcs = ["argparse_util.py"],
+    srcs_version = "PY2AND3",
+)
+
+py_test(
+    name = "argparse_util_test",
+    size = "small",
+    srcs = ["argparse_util_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":argparse_util",
+        "//tensorboard:test",
+    ],
+)
+
+py_library(
     name = "encoder",
     srcs = ["encoder.py"],
     srcs_version = "PY2AND3",

--- a/tensorboard/util/argparse_util.py
+++ b/tensorboard/util/argparse_util.py
@@ -1,0 +1,63 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Utilities for working with `argparse` in a portable way."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import contextlib
+import gettext
+
+
+@contextlib.contextmanager
+def allow_missing_subcommand():
+  """Make Python 2.7 behave like Python 3 w.r.t. default subcommands.
+
+  The behavior of argparse was changed [1] [2] in Python 3.3. When a
+  parser defines subcommands, it used to be an error for the user to
+  invoke the binary without specifying a subcommand. As of Python 3.3,
+  this is permitted. This monkey patch backports the new behavior to
+  earlier versions of Python.
+
+  This context manager need only be used around `parse_args`; parsers
+  may be constructed and configured outside of the context manager.
+
+  [1]: https://github.com/python/cpython/commit/f97c59aaba2d93e48cbc6d25f7ff9f9c87f8d0b2
+  [2]: https://bugs.python.org/issue16308
+  """
+
+  real_error = argparse.ArgumentParser.error
+
+  # This must exactly match the error message raised by Python 2.7's
+  # `argparse` when no subparser is given. This is `argparse.py:1954` at
+  # Git tag `v2.7.16`.
+  ignored_message = gettext.gettext("too few arguments")
+
+  def error(*args, **kwargs):
+    # Expected signature is `error(self, message)`, but we retain more
+    # flexibility to be forward-compatible with implementation changes.
+    if "message" not in kwargs and len(args) < 2:
+      return real_error(*args, **kwargs)
+    message = kwargs["message"] if "message" in kwargs else args[1]
+    if message == ignored_message:
+      return None
+    else:
+      return real_error(*args, **kwargs)
+
+  argparse.ArgumentParser.error = error
+  yield
+  argparse.ArgumentParser.error = real_error

--- a/tensorboard/util/argparse_util.py
+++ b/tensorboard/util/argparse_util.py
@@ -59,5 +59,7 @@ def allow_missing_subcommand():
       return real_error(*args, **kwargs)
 
   argparse.ArgumentParser.error = error
-  yield
-  argparse.ArgumentParser.error = real_error
+  try:
+    yield
+  finally:
+    argparse.ArgumentParser.error = real_error

--- a/tensorboard/util/argparse_util_test.py
+++ b/tensorboard/util/argparse_util_test.py
@@ -1,0 +1,56 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for `argparse_util`."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+
+from tensorboard import test as tb_test
+from tensorboard.util import argparse_util
+
+
+class AllowMissingSubcommandTest(tb_test.TestCase):
+
+  def test_allows_missing_subcommands(self):
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    subparser = subparsers.add_parser("magic")
+    subparser.set_defaults(chosen="magic")
+    with argparse_util.allow_missing_subcommand():
+      args = parser.parse_args([])
+    self.assertEqual(args, argparse.Namespace())
+
+  def test_allows_provided_subcommands(self):
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    subparser = subparsers.add_parser("magic")
+    subparser.set_defaults(chosen="magic")
+    with argparse_util.allow_missing_subcommand():
+      args = parser.parse_args(["magic"])
+    self.assertEqual(args, argparse.Namespace(chosen="magic"))
+
+  def test_still_complains_on_missing_arguments(self):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("please_provide_me")
+    with argparse_util.allow_missing_subcommand():
+      with self.assertRaises(SystemExit):
+        parser.parse_args([])
+
+
+if __name__ == "__main__":
+  tb_test.main()


### PR DESCRIPTION
Summary:
This commit adds a subcommand interface to support invocations in the
manner of `apt-get install` or `git commit`. All existing invocations
remain valid, and are now also available under the `tensorboard serve`
subcommand. Other subcommands may be injected programmatically. For
instance, we could migrate the existing `tensorboard --inspect` to
`tensorboard inspect`, which makes more sense semantically (as it does
something quite different from starting a web server).

To support both `tensorboard --flags` and `tensorboard serve --flags`,
we require some hacks first to get off the ground at all in Python 2,
and then to have sane error messages without massive flag duplication in
all Python versions. Even recent Python versions don’t have a notion of
a _default_ subcommand, so we need to manually inspect `argv` to
determine what kind of argument parser to construct.

Test Plan:
Unit tests added, and the smoke test for the dynamic plugin (plus the
Pip package test script) serve as integration tests for existing
behavior. It’s important to test this in both Python 2 and Python 3. For
manual testing:

  - Check that the output of `tensorboard --help` still includes all the
    normal flags, and now has a list of subcommands (one item long).
  - Check that the output of `tensorboard serve --help` is just like the
    output of `tensorboard --help`, but without the list of subcommands.
  - Patch a `demo` subcommand into `main.py`, and check that the output
    of `tensorboard demo --help` is just that subcommand’s help (without
    flags to `serve`) and that `tensorboard --help` shows the `demo`
    subcommand.

Finally, note that changing the implementation of the monkey patch to
just `yield; return` causes both `argparse_util_test` and `program_test`
to fail on Python 2 (but not Python 3).

wchargin-branch: subcommands
