### PR TITLE
added skip_display argument to start(args_string, skip_display)

### DIFF
--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -120,7 +120,7 @@ def _start_magic(line):
   return start(line)
 
 
-def start(args_string):
+def start(args_string, skip_display=False):
   """Launch and display a TensorBoard instance as if at the command line.
 
   Args:
@@ -128,6 +128,8 @@ def start(args_string):
       interpreted by `shlex.split`: e.g., "--logdir ./logs --port 0".
       Shell metacharacters are not supported: e.g., "--logdir 2>&1" will
       point the logdir at the literal directory named "2>&1".
+    skip_display: (Default: False) When true, does not display the
+      tensorboard window directly in the notebook.
   """
   context = _get_context()
   try:
@@ -155,11 +157,12 @@ def start(args_string):
   start_result = manager.start(parsed_args)
 
   if isinstance(start_result, manager.StartLaunched):
-    _display(
-        port=start_result.info.port,
-        print_message=False,
-        display_handle=handle,
-    )
+    if not skip_display:
+      _display(
+          port=start_result.info.port,
+          print_message=False,
+          display_handle=handle,
+      )
 
   elif isinstance(start_result, manager.StartReused):
     template = (
@@ -172,11 +175,12 @@ def start(args_string):
         delta=_time_delta_from_info(start_result.info),
     )
     print_or_update(message)
-    _display(
-        port=start_result.info.port,
-        print_message=False,
-        display_handle=None,
-    )
+    if not skip_display:
+      _display(
+          port=start_result.info.port,
+          print_message=False,
+          display_handle=None,
+      )
 
   elif isinstance(start_result, manager.StartFailed):
     def format_stream(name, value):


### PR DESCRIPTION
* Motivation for features / changes

As described in Issue #2740 :
Provide an option to make notebooks more beautiful by skipping the in-notebook display (Example: When corporate security policy prevents TensorBoard from being displayed in-notebook).

* Technical description of changes

"skip_display=True" may now be passed into notebook. Display

* Detailed steps to verify changes work correctly (as executed by you)

1. Build and import TensorBoard.
2.  From a Jupyter Notebook run:
`import tensorboard as tensorboard` 
`tensorboard.notebook.start("--logdir ....", skip_display=True)`

* Alternate designs / implementations considered

We should also allow this to be controlled through the "args_string" itself. In the same string that you pass "--logdir", we could create a "--skip-display" flag, this would allow people to set the option through notebook magic as well ("%tensorboard"). If you allow me to, I can create that pull request. 