### PR TITLE
proto: enable compiling gRPC services

### DIFF
--- a/tensorboard/defs/protos.bzl
+++ b/tensorboard/defs/protos.bzl
@@ -14,14 +14,20 @@
 
 load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
 
-def tb_proto_library(name, srcs=None, visibility=None, testonly=None):
-  py_proto_library(
-      name = name + "_py_pb2",
-      srcs = srcs,
-      srcs_version = "PY2AND3",
-      deps = ["@com_google_protobuf//:protobuf_python"],
-      protoc = "@com_google_protobuf//:protoc",
-      visibility = visibility,
-      default_runtime = "@com_google_protobuf//:protobuf_python",
-      testonly = testonly,
-  )
+def tb_proto_library(
+        name,
+        srcs = None,
+        visibility = None,
+        testonly = None,
+        has_services = False):
+    py_proto_library(
+        name = name + "_py_pb2",
+        srcs = srcs,
+        srcs_version = "PY2AND3",
+        use_grpc_plugin = has_services,
+        deps = ["@com_google_protobuf//:protobuf_python"],
+        protoc = "@com_google_protobuf//:protoc",
+        visibility = visibility,
+        default_runtime = "@com_google_protobuf//:protobuf_python",
+        testonly = testonly,
+    )


### PR DESCRIPTION
Summary:
This commit teaches `tb_proto_library` a new `has_services` flag. When
set, the proto library will be compiled with gRPC service support, and
an additional `*_py_pb2_grpc` `py_library` target will be created.

The `py_proto_library` macro provided by the protobuf build rules no
longer suits our purpose, as it can only create one `*_py_pb2` build
target that includes both the `*_pb2` and `*_pb2_grpc` Python modules.
This is inconsistent with TensorFlow and some Google internal rules. We
now directly use `proto_gen` rather than using `py_proto_library`. This
is fine: that macro is marked as unstable because its interface may
change, and our goal is precisely to change the interface.

Test Plan:
Run

```
bazel query --output=build \
    'filter(".*protos_all.*", //tensorboard/...:all)'
```

and note that the output is identical before and after this change, so
existing protos will be unchanged.

Then, add a simple service to `tensorboard/plugins/hparams/api.proto`:

```proto
service TestService {
  rpc ListSesssionGroups(ListSessionGroupsRequest)
      returns (ListSessionGroupsResponse);
}
```

Build the Pip package and install it into a new virtualenv. Try to
import `tensorboard.plugins.hparams.api_pb2_grpc`, but note that
this fails. Then, add `has_services = True` to the hparams `BUILD` file,
and rebuild and reinstall the Pip package. The import should still fail.
Finally, add a `:protos_all_py_pb2_grpc` dep to `:hparams_plugin`, and
try once more. The import should now work, and the imported module
should have a `TestServiceStub` attribute.

wchargin-branch: proto-grpc
