### PR TITLE
Fix creation of resnet110

### DIFF
--- a/docs/tensorboard_profiling_keras.ipynb
+++ b/docs/tensorboard_profiling_keras.ipynb
@@ -502,7 +502,7 @@
         "resnet20 = functools.partial(resnet, num_blocks=3)\n",
         "resnet32 = functools.partial(resnet, num_blocks=5)\n",
         "resnet56 = functools.partial(resnet, num_blocks=9)\n",
-        "resnet10 = functools.partial(resnet, num_blocks=110)"
+        "resnet110 = functools.partial(resnet, num_blocks=18)"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
Previous creation of resnet110 used 110 residual blocks and was incorrectly named `resnet10`. Fixing name to resnet110 and using 18 resnet blocks to create a 110 layer network.