### PR TITLE
program: don’t set default flags on base parser

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -208,6 +208,9 @@ class TensorBoard(object):
     with argparse_util.allow_missing_subcommand():
       flags = base_parser.parse_args(argv[1:])  # Strip binary name from argv.
     if getattr(flags, _SUBCOMMAND_FLAG, None) is None:
+      # Manually assign default value rather than using `set_defaults`
+      # on the base parser to work around Python bug #9351 on old
+      # versions of `argparse`: <https://bugs.python.org/issue9351>
       setattr(flags, _SUBCOMMAND_FLAG, _SERVE_SUBCOMMAND_NAME)
 
     self.cache_key = manager.cache_key(

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -177,7 +177,6 @@ class TensorBoard(object):
         description=('TensorBoard is a suite of web applications for '
                      'inspecting and understanding your TensorFlow runs '
                      'and graphs. https://github.com/tensorflow/tensorboard '))
-    base_parser.set_defaults(**{_SUBCOMMAND_FLAG: _SERVE_SUBCOMMAND_NAME})
     subparsers = base_parser.add_subparsers(
         help="TensorBoard subcommand (defaults to %r)" % _SERVE_SUBCOMMAND_NAME)
 
@@ -208,6 +207,8 @@ class TensorBoard(object):
 
     with argparse_util.allow_missing_subcommand():
       flags = base_parser.parse_args(argv[1:])  # Strip binary name from argv.
+    if getattr(flags, _SUBCOMMAND_FLAG, None) is None:
+      setattr(flags, _SUBCOMMAND_FLAG, _SERVE_SUBCOMMAND_NAME)
 
     self.cache_key = manager.cache_key(
         working_directory=os.getcwd(),


### PR DESCRIPTION
Summary:
With old versions of `argparse`, any `set_defaults` on the base parser
will take precedence over any `set_defaults` on the subparsers. This is
Python [bug #9351][bpo-9351], fixed in [af26c15110b7][fix]. Even though
the versions of argparse bundled with Python 2.7 and 3.5 each include
the fix, we can still avoid this pattern for compatibility.

To see if your Python is affected, run:

```python
import argparse
parser = argparse.ArgumentParser()
parser.set_defaults(test="AFFECTED")
parser.add_subparsers().add_parser("sub").set_defaults(test="OK")
print(parser.parse_args(["sub"]).test)
```

If it prints `AFFECTED`, then this patch affects your Python.

Googlers, see <http://b/143087149> for context.

[bpo-9351]: https://bugs.python.org/issue9351
[fix]: http://github.com/python/cpython/commit/af26c15110b76195e62a06d17e39176d42c0511c

Test Plan:
Running under an old version of `argparse`, existing tests fail before
this change and pass after.

wchargin-branch: program-defaults
