### PR TITLE
proto: support build deps

### DIFF
--- a/tensorboard/defs/BUILD
+++ b/tensorboard/defs/BUILD
@@ -1,5 +1,7 @@
 package(default_visibility = ["//tensorboard:internal"])
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 licenses(["notice"])  # Apache 2.0
 
 filegroup(
@@ -11,6 +13,35 @@ filegroup(
         "clutz.d.ts",
     ],
     visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "tb_proto_library_test",
+    srcs = ["tb_proto_library_test.py"],
+    deps = [
+        ":test_base_py_pb2",
+        ":test_base_py_pb2_grpc",
+        ":test_downstream_py_pb2",
+        ":test_downstream_py_pb2_grpc",
+        "//tensorboard:test",
+    ],
+)
+
+tb_proto_library(
+    name = "test_base",
+    srcs = ["test_base.proto"],
+    has_services = True,
+    testonly = True,
+)
+
+tb_proto_library(
+    name = "test_downstream",
+    srcs = ["test_downstream.proto"],
+    deps = [
+        ":test_base",
+    ],
+    has_services = True,
+    testonly = True,
 )
 
 exports_files(["web_test_python_stub.template.py"])

--- a/tensorboard/defs/tb_proto_library_test.py
+++ b/tensorboard/defs/tb_proto_library_test.py
@@ -1,0 +1,44 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the `tb_proto_library` build macro."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorboard import test as tb_test
+from tensorboard.defs import test_base_pb2
+from tensorboard.defs import test_base_pb2_grpc
+from tensorboard.defs import test_downstream_pb2
+from tensorboard.defs import test_downstream_pb2_grpc
+
+
+class TbProtoLibraryTest(tb_test.TestCase):
+  """Tests for `tb_proto_library`."""
+
+  def tests_with_deps(self):
+    foo = test_base_pb2.Foo()
+    foo.foo = 1
+    bar = test_downstream_pb2.Bar()
+    bar.foo.foo = 1
+    self.assertEqual(foo, bar.foo)
+
+  def test_service_deps(self):
+    self.assertIsInstance(test_base_pb2_grpc.FooServiceServicer, type)
+    self.assertIsInstance(test_downstream_pb2_grpc.BarServiceServicer, type)
+
+
+if __name__ == "__main__":
+  tb_test.main()

--- a/tensorboard/defs/test_base.proto
+++ b/tensorboard/defs/test_base.proto
@@ -1,0 +1,33 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+syntax = "proto3";
+
+message Foo {
+  int32 foo = 1;
+}
+
+service FooService {
+  // Loads some objects.
+  rpc GetFoo(GetFooRequest) returns (GetFooResponse);
+}
+
+message GetFooRequest {
+  int32 count = 1;
+}
+
+message GetFooResponse {
+  repeated Foo foo = 1;
+}

--- a/tensorboard/defs/test_downstream.proto
+++ b/tensorboard/defs/test_downstream.proto
@@ -1,0 +1,36 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+syntax = "proto3";
+
+import "tensorboard/defs/test_base.proto";
+
+message Bar {
+  Foo foo = 1;
+  int32 bar = 2;
+}
+
+service BarService {
+  // Loads some objects.
+  rpc GetBar(GetBarRequest) returns (GetBarResponse);
+}
+
+message GetBarRequest {
+  int32 count = 1;
+}
+
+message GetBarResponse {
+  repeated Bar bar = 1;
+}


### PR DESCRIPTION
Summary:
By happenstance, none of our existing proto definitions need build-level
dependencies (dependencies on proto files from other build targets). But
this is no fundamental restriction. We teach `tb_proto_library` a `deps`
argument, pointing to other `tb_proto_library` macro invocations.

Test Plan:
Unit tests added. After building the Pip package and installing it into
a new virtualenv, we can still use `tensorboard.compat.proto` modules.

wchargin-branch: proto-deps
