### PR TITLE
core: fix double requests in data loader

### DIFF
--- a/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
@@ -129,9 +129,9 @@ namespace tf_dashboard_common {
     },
 
     created() {
-      this._loadData = _.debounce(this._loadDataImpl, 100, {
+      this._loadData = _.throttle(this._loadDataImpl, 100, {
         leading: true,
-        trailing: true,
+        trailing: false,
       });
     },
 

--- a/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
@@ -162,10 +162,18 @@ namespace tf_dashboard_common {
             return !this._inflightOrLoadedData.has(name);
           })
           .map((datum) => {
-            const name = this.getDataLoadName(datum);
-            this._inflightOrLoadedData.add(name);
+            const cacheKey = this.getDataLoadName(datum);
+            this._inflightOrLoadedData.add(cacheKey);
             return this.requestData(datum).then((value) => {
-              this.loadDataCallback(this, datum, value);
+              // dataToLoad can change while the request in-flight and it may
+              // not be no longer required (loadDataCallback can be an expensive
+              // proess so we would like to omit it if possible).
+              const isDataRequiredNow = this.dataToLoad.find(
+                (datum) => this.getDataLoadName(datum) === cacheKey
+              );
+              if (isDataRequiredNow) {
+                this.loadDataCallback(this, datum, value);
+              }
             });
           });
 


### PR DESCRIPTION
* Motivation for features / changes
   - Loading the scalars dashboard results in 2x network requests against data/plugin/scalars/scalars.  It turns out that our [data-loader](https://github.com/tensorflow/tensorboard/blob/418fb939fbf2505f31096eb233896733b4641354/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts#L133) fires on both leading and trailing, so 2 calls to loadData() within 100ms will trigger 2 invocations.

   - Also, the simultaneous request limit is not needed, since modern browsers have their own internal connection limit scheme.  (although we need to keep the parameter for BaseStore, which assumes we can only make 1 request at a time).

* Technical description of changes

  - Removes the leading call (trailing is true by default)
  - Increases simultaneous request limit
  - Removes the Polymer async/cancelAsync

WANT_LGTM=stephan