### PR TITLE
core: increase frontend active request limit

### DIFF
--- a/tensorboard/components/tf_backend/requestManager.ts
+++ b/tensorboard/components/tf_backend/requestManager.ts
@@ -104,7 +104,7 @@ namespace tf_backend {
     private _nActiveRequests: number;
     private _nSimultaneousRequests: number;
 
-    constructor(nSimultaneousRequests = 10, maxRetries = 3) {
+    constructor(nSimultaneousRequests = 1000, maxRetries = 3) {
       this._queue = [];
       this._nActiveRequests = 0;
       this._nSimultaneousRequests = nSimultaneousRequests;


### PR DESCRIPTION
* Motivation for features / changes
   - The simultaneous request limit is not needed, since modern browsers have their own internal connection limit scheme.  (although we need to keep the parameter for BaseStore, which assumes we can only make 1 request at a time).

* Technical description of changes
  - Increases simultaneous request limit

WANT_LGTM=stephan