### PR TITLE
core: avoid extra network request upon run selection

### DIFF
--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
@@ -116,6 +116,7 @@ limitations under the License.
             <tf-category-paginated-view
               category="[[category]]"
               initial-opened="[[_shouldOpen(index)]]"
+              get-category-item-key="[[_getCategoryItemKey]]"
             >
               <template>
                 <tf-pr-curve-card
@@ -194,6 +195,12 @@ limitations under the License.
           type: Array,
           computed:
             '_makeCategories(_runToTagInfo, _selectedRuns, _tagFilter, _categoriesDomReady)',
+        },
+        // Items show multiple runs, so exclude runs from category item keys for
+        // efficient template reuse.
+        _getCategoryItemKey: {
+          type: Function,
+          value: () => (item) => item.tag,
         },
         _requestManager: {
           type: Object,

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -153,6 +153,7 @@ limitations under the License.
             <tf-category-paginated-view
               category="[[category]]"
               initial-opened="[[_shouldOpen(index)]]"
+              get-category-item-key="[[_getCategoryItemKey]]"
             >
               <template>
                 <tf-scalar-card
@@ -263,6 +264,13 @@ limitations under the License.
         _categories: {
           type: Array,
           value: () => [],
+        },
+
+        // Items show multiple runs, so exclude runs from category item keys for
+        // efficient template reuse.
+        _getCategoryItemKey: {
+          type: Function,
+          value: () => (item) => item.tag,
         },
 
         _requestManager: {


### PR DESCRIPTION
* Motivation for features / changes

Changing the selected runs should not cause new network requests, when the data to load is already loaded.  This was not the case in dashboards with category items that show multiple runs (e.g. scalars, pr curves).

* Technical description of changes

To avoid unnecessary network requests, this PR makes some CategoryPaginatedView items keyed by tag, instead of the default tag+runs.  When runs change and tag remains constant, the new scheme lets dom-repeat efficiently reuse a template instance.