### PR TITLE
build: allow configuring of extra routes based on experiment id

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -160,8 +160,16 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
       path_to_run = parse_event_files_spec(flags.logdir_spec)
     start_reloading_multiplexer(
         multiplexer, path_to_run, reload_interval, flags.reload_task)
+
+  extra_routes = {
+    '/': {
+        'with_experiment': '/index.html',
+        'without_experiment': '/index.html',
+    },
+  }
   return TensorBoardWSGIApp(
-      flags, plugin_loaders, data_provider, assets_zip_provider, multiplexer)
+      flags, plugin_loaders, data_provider, assets_zip_provider, multiplexer,
+      extra_routes)
 
 
 def _handling_errors(wsgi_app):
@@ -185,7 +193,8 @@ def TensorBoardWSGIApp(
     plugins,
     data_provider=None,
     assets_zip_provider=None,
-    deprecated_multiplexer=None):
+    deprecated_multiplexer=None,
+    extra_routes=None):
   """Constructs a TensorBoard WSGI app from plugins and data providers.
 
   Args:
@@ -199,6 +208,7 @@ def TensorBoardWSGIApp(
     deprecated_multiplexer: Optional `plugin_event_multiplexer.EventMultiplexer`
         to use for any plugins not yet enabled for the DataProvider API.
         Required if the data_provider argument is not passed.
+    extra_routes: See TBContext documentation for more information.
 
   Returns:
     A WSGI application that implements the TensorBoard backend.
@@ -215,6 +225,7 @@ def TensorBoardWSGIApp(
       data_provider=data_provider,
       db_connection_provider=db_connection_provider,
       db_uri=db_uri,
+      extra_routes=extra_routes,
       flags=flags,
       logdir=flags.logdir,
       multiplexer=deprecated_multiplexer,

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -219,6 +219,7 @@ class TBContext(object):
       data_provider=None,
       db_connection_provider=None,
       db_uri=None,
+      extra_routes=None,
       flags=None,
       logdir=None,
       multiplexer=None,
@@ -247,6 +248,10 @@ class TBContext(object):
           implementation details of the provider.
       db_uri: The string db URI TensorBoard was started with. If this is set,
           the logdir should be None.
+      extra_routes: An object that defines extra routes for serving assets. Keys
+          are paths and values are dicts that configure the asset path based on
+          presence of an experiment id. e.g.
+          `{'/': {'with_experiment': '/a', 'without_experiment': '/b'}}`.
       flags: An object of the runtime flags provided to TensorBoard to their
           values.
       logdir: The string logging directory TensorBoard was started with. If this
@@ -265,6 +270,7 @@ class TBContext(object):
     self.data_provider = data_provider
     self.db_connection_provider = db_connection_provider
     self.db_uri = db_uri
+    self.extra_routes = extra_routes
     self.flags = flags
     self.logdir = logdir
     self.multiplexer = multiplexer


### PR DESCRIPTION
* Motivation for features / changes
`core_plugin.py` explicitly registers the route '/' to serve the generated '/index.html' file. This PR replaces the explicit registration with a mechanism for anyone creating a `TensorBoardWSGIApp` to pass in `extra_routes`, letting them configure paths like this.  Doing so makes it easier to serve different assets, depending on whether an `/experiment/foo` is part of the path. 

* Technical description of changes
- Removes explicit '/' --> '/index.html' mapping from core_plugin.py to TensorBoardWSGIApp() callers
- Introduces configurable extra_routes with experimentId-based condition