### PR TITLE
uploader: add license directive to build file

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -1,3 +1,12 @@
+# Description:
+# Uploader for a hosted TensorBoard service
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
 py_library(
     name = "dev_creds",
     srcs = ["dev_creds.py"],


### PR DESCRIPTION
Summary:
The code in question was always Google-owned and licensed as Apache 2.0;
this patch declares that explicitly at the build level.

Test Plan:
Note that this is the same as in (e.g.) `tensorboard/plugins/BUILD`.

wchargin-branch: uploader-license
