### PR TITLE
Bump `grpcio` version to 1.24.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
   - pip install yamllint==1.17.0
   # TensorBoard deps.
   - pip install futures==3.1.1
-  - pip install grpcio==1.6.3
+  - pip install grpcio==1.24.3
   - pip install grpcio-testing==1.24.3
   - pip install 'google-auth >= 1.6.3, < 2'
   - pip install 'google-auth-oauthlib >= 0.4.1, < 0.5'

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -26,7 +26,7 @@ REQUIRED_PACKAGES = [
     'absl-py >= 0.4',
     # futures is a backport of the python 3.2+ concurrent.futures module
     'futures >= 3.1.1; python_version < "3"',
-    'grpcio >= 1.6.3',
+    'grpcio >= 1.24.3',
     'google-auth >= 1.6.3, < 2',
     'google-auth-oauthlib >= 0.4.1, < 0.5',
     'markdown >= 2.6.8',


### PR DESCRIPTION
Summary:
We depend on `grpc.local_server_credentials`, which was added in 1.24.0.
Installing the Pip package into a fresh virtualenv generally picks this
up, because the `grpcio >= 1.6.3` will install the latest version, but
that won’t suffice for virtualenvs that already have an old version
installed. We now explicitly depend on `1.24.3`.

Travis wasn’t seeing this problem because the `grpcio-testing` dep pulls
in a matching version of `grpcio`.

Test Plan:
Create a new virtualenv and install `grpcio==1.16.0` (e.g.) into it.
Then, install the TensorBoard Pip package. Run

```
python -c 'import grpc; print(grpc.local_server_credentials)'
```

and note that this now passes instead of failing with `AttributeError`.

wchargin-branch: grpcio-1.24.3
