### PR TITLE
data load: prevent JSE when canceling async

### DIFF
--- a/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
@@ -132,8 +132,10 @@ namespace tf_dashboard_common {
     reset() {
       // https://github.com/tensorflow/tensorboard/issues/1499
       // Cannot use the observer to observe `loadKey` changes directly.
-      this.cancelAsync(this._loadDataAsync);
-      this._loadDataAsync = null;
+      if (this._loadDataAsync != null) {
+        this.cancelAsync(this._loadDataAsync);
+        this._loadDataAsync = null;
+      }
       if (this._canceller) this._canceller.cancelAll();
       if (this._dataLoadState) this._dataLoadState.clear();
       if (this.isAttached) this._loadData();
@@ -158,8 +160,10 @@ namespace tf_dashboard_common {
       // t=10: unmount
       // t=20: request for 'a' resolves but we do not change the loadState
       // because we do not want to set one if, instead, it was resetted at t=10.
-      this.cancelAsync(this._loadDataAsync);
-      this._loadDataAsync = null;
+      if (this._loadDataAsync != null) {
+        this.cancelAsync(this._loadDataAsync);
+        this._loadDataAsync = null;
+      }
     },
 
     _loadDataIfActive() {
@@ -200,33 +204,43 @@ namespace tf_dashboard_common {
               );
             });
 
-          return Promise.all(promises).then(
-            this._canceller.cancellable((result) => {
-              // It was resetted. Do not notify of the data load.
-              if (!result.cancelled) {
-                const keysFetched = result.value;
-                const fetched = new Set(keysFetched);
-                const shouldNotify = this.dataToLoad.some((datum) =>
-                  fetched.has(this.getDataLoadName(datum))
-                );
+          return Promise.all(promises)
+            .then(
+              this._canceller.cancellable((result) => {
+                // It was resetted. Do not notify of the data load.
+                if (!result.cancelled) {
+                  const keysFetched = result.value;
+                  const fetched = new Set(keysFetched);
+                  const shouldNotify = this.dataToLoad.some((datum) =>
+                    fetched.has(this.getDataLoadName(datum))
+                  );
 
-                if (shouldNotify) {
-                  this.onLoadFinish();
+                  if (shouldNotify) {
+                    this.onLoadFinish();
+                  }
                 }
-              }
 
-              const isDataFetchPending = Array.from(
-                this._dataLoadState.values()
-              ).some((loadState) => loadState === LoadState.LOADING);
+                const isDataFetchPending = Array.from(
+                  this._dataLoadState.values()
+                ).some((loadState) => loadState === LoadState.LOADING);
 
-              if (!isDataFetchPending) {
-                // Read-only property have a special setter.
-                this._setDataLoading(false);
-              }
-
-              this._loadDataAsync = null;
-            })
-          );
+                if (!isDataFetchPending) {
+                  // Read-only property have a special setter.
+                  this._setDataLoading(false);
+                }
+              }),
+              // TODO(stephanwlee): remove me when we can use  Promise.prototype.finally
+              // instead
+              () => {}
+            )
+            .then(
+              this._canceller.cancellable(({cancelled}) => {
+                if (cancelled) {
+                  return;
+                }
+                this._loadDataAsync = null;
+              })
+            );
         })
       );
     },

--- a/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
@@ -111,6 +111,11 @@ namespace tf_dashboard_common {
         type: Object,
         value: () => new tf_backend.Canceller(),
       },
+
+      _loadDataAsync: {
+        type: Number,
+        value: null,
+      },
     },
 
     observers: ['_dataToLoadChanged(isAttached, dataToLoad.*)'],
@@ -128,6 +133,7 @@ namespace tf_dashboard_common {
       // https://github.com/tensorflow/tensorboard/issues/1499
       // Cannot use the observer to observe `loadKey` changes directly.
       this.cancelAsync(this._loadDataAsync);
+      this._loadDataAsync = null;
       if (this._canceller) this._canceller.cancelAll();
       if (this._dataLoadState) this._dataLoadState.clear();
       if (this.isAttached) this._loadData();
@@ -153,6 +159,7 @@ namespace tf_dashboard_common {
       // t=20: request for 'a' resolves but we do not change the loadState
       // because we do not want to set one if, instead, it was resetted at t=10.
       this.cancelAsync(this._loadDataAsync);
+      this._loadDataAsync = null;
     },
 
     _loadDataIfActive() {
@@ -216,6 +223,8 @@ namespace tf_dashboard_common {
                 // Read-only property have a special setter.
                 this._setDataLoading(false);
               }
+
+              this._loadDataAsync = null;
             })
           );
         })


### PR DESCRIPTION
Polymer.prototype.async without a wait time defaults to next microtask.
Polymer implemented custom microtask scheduling which is not impervious
to some edge case.

Polymer has some internal counter for the microtasks and the `async`
call returns (contrived for illustration) `currentMicroTaskCounter + i`.
When canelling the async, it checks whether the handle is in between
`currentMicroTaskCounter` and `currentMicroTaskCounter` + [numAsyncs]
and it expects callback to exist when it is in between. The problem
happened when a handle is cancelled twice (our `reset` method gets
called more than once in a microtask for hparams) as it cannot find a
callback for the handle.

reference: https://github.com/Polymer/polymer/blob/dc20feca22ed6915eb67a6df2a8475ceba295de7/lib/utils/async.js#L198-L204

simpler repro:
```ts
const handle = this.async(() => {});
this.cancelAsync(handle);
this.cancelAsync(handle); // throws the error.
```