### PR TITLE
ci: unpin 2019-09-17 estimator nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,13 +70,6 @@ install:
       pip install "absl-py>=0.7.0" \
       && pip install "numpy<2.0,>=1.14.5"
     fi
-  - |
-    # On TF 1.x nightlies, downgrade estimator temporarily.
-    case "${TF_VERSION_ID}" in
-      tf-nightly|tf-nightly==*)
-        pip install tf-estimator-nightly==1.14.0.dev2019091701
-        ;;
-    esac
   # Deps for gfile S3 test.
   - pip install boto3==1.9.86
   - pip install moto==1.3.7


### PR DESCRIPTION
Summary:
This reverts commit e4a70498e833ba50a008db20a48f1444abb2fa84.

Test Plan:
CI suffices.

wchargin-branch: unpin-estimator-20190917-nightly
