### PR TITLE
Configure oauth for uploader client and make it required

### DIFF
--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -46,6 +46,26 @@ OPENID_CONNECT_SCOPES = (
 )
 
 
+# The client "secret" is public by design for installed apps. See
+# https://developers.google.com/identity/protocols/OAuth2?csw=1#installed
+OAUTH_CLIENT_CONFIG = b"""
+{
+  "installed": {
+    "client_id": "373649185512-8v619h5kft38l4456nm2dj4ubeqsrvh6.apps.googleusercontent.com",
+    "project_id": "hosted-tensorboard-prod",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_secret": "pOyAuU2yq2arsM98Bw5hwYtr",
+    "redirect_uris": [
+      "urn:ietf:wg:oauth:2.0:oob",
+      "http://localhost"
+    ]
+  }
+}
+"""
+
+
 # Components of the relative path (within the user settings directory) at which
 # to store TensorBoard uploader credentials.
 TENSORBOARD_CREDENTIALS_FILEPATH_PARTS = [

--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -52,21 +52,6 @@ TENSORBOARD_CREDENTIALS_FILEPATH_PARTS = [
     "tensorboard", "credentials", "uploader-creds.json"]
 
 
-def application_default_credentials():
-  """Returns the active Application Default Credentials.
-
-  Returns:
-    google.auth.credentials.Credentials: the current credentials.
-
-  Raises:
-    google.auth.exceptions.DefaultCredentialsError:
-        If no credentials were found, or if the credentials found were invalid.
-  """
-  credentials, project_id = google.auth.default(scopes=OPENID_CONNECT_SCOPES)
-  del project_id  # unused
-  return credentials
-
-
 class CredentialsStore(object):
   """Private file store for a `google.oauth2.credentials.Credentials`."""
 

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -198,7 +198,7 @@ def _run(flags):
   credentials = store.read_credentials()
   if not credentials:
     _prompt_for_user_ack(intent)
-    client_config = json.loads(dev_creds.DEV_OAUTH_CLIENT_CONFIG)
+    client_config = json.loads(auth.OAUTH_CLIENT_CONFIG)
     flow = auth.build_installed_app_flow(client_config)
     credentials = flow.run(force_console=flags.auth_force_console)
     sys.stderr.write('\n')  # Extra newline after auth flow messages.


### PR DESCRIPTION
Removes `--auth_type` argument that doesn't work anyway to avoid confusion, and adds an OAuth client configuration.

See internal b/143329558.