### PR TITLE
Backport `mock` assertions for Python 2 tests

### DIFF
--- a/tensorboard/tools/whitespace_hygiene_test.py
+++ b/tensorboard/tools/whitespace_hygiene_test.py
@@ -28,8 +28,10 @@ import subprocess
 import sys
 
 
-# Remove files from this list as whitespace errors are fixed.
 exceptions = frozenset([
+    # End-of-line whitespace is semantic in patch files when a line
+    # contains a single space.
+    "third_party/mock_call_assertions.patch",
 ])
 
 

--- a/tensorboard/uploader/exporter_test.py
+++ b/tensorboard/uploader/exporter_test.py
@@ -27,11 +27,9 @@ import grpc_testing
 
 try:
   # python version >= 3.3
-  from unittest import mock
+  from unittest import mock  # pylint: disable=g-import-not-at-top
 except ImportError:
-  # mock==1.0.0 backport lacks `assert_called_once` and friends
-  print("Test disabled in Python 2")
-  exit(0)
+  import mock  # pylint: disable=g-import-not-at-top,unused-import
 
 
 from tensorboard.uploader.proto import export_service_pb2

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -26,11 +26,9 @@ import grpc_testing
 
 try:
   # python version >= 3.3
-  from unittest import mock
+  from unittest import mock  # pylint: disable=g-import-not-at-top
 except ImportError:
-  # mock==1.0.0 backport lacks `assert_called_once` and friends
-  print("Test disabled in Python 2")
-  exit(0)
+  import mock  # pylint: disable=g-import-not-at-top,unused-import
 
 import tensorflow as tf
 

--- a/tensorboard/uploader/util_test.py
+++ b/tensorboard/uploader/util_test.py
@@ -24,11 +24,9 @@ import unittest
 
 try:
   # python version >= 3.3
-  from unittest import mock
+  from unittest import mock  # pylint: disable=g-import-not-at-top
 except ImportError:
-  # mock==1.0.0 backport lacks `assert_called_once` and friends
-  print("Test disabled in Python 2")
-  exit(0)
+  import mock  # pylint: disable=g-import-not-at-top,unused-import
 
 
 from google.protobuf import timestamp_pb2

--- a/third_party/mock_call_assertions.patch
+++ b/third_party/mock_call_assertions.patch
@@ -1,0 +1,59 @@
+--- mock.py	2012-10-07 18:00:10.000000000 +0100
++++ mock.py	2019-10-24 22:19:25.657417082 -0700
+@@ -286,6 +286,12 @@
+     if not _is_instance_mock(mock):
+         return
+ 
++    def assert_called(*args, **kwargs):
++        return mock.assert_called(*args, **kwargs)
++    def assert_not_called(*args, **kwargs):
++        return mock.assert_not_called(*args, **kwargs)
++    def assert_called_once(*args, **kwargs):
++        return mock.assert_called_once(*args, **kwargs)
+     def assert_called_with(*args, **kwargs):
+         return mock.assert_called_with(*args, **kwargs)
+     def assert_called_once_with(*args, **kwargs):
+@@ -318,6 +324,9 @@
+     funcopy.assert_has_calls = assert_has_calls
+     funcopy.assert_any_call = assert_any_call
+     funcopy.reset_mock = reset_mock
++    funcopy.assert_called = assert_called
++    funcopy.assert_not_called = assert_not_called
++    funcopy.assert_called_once = assert_called_once
+ 
+     mock._mock_delegate = funcopy
+ 
+@@ -809,6 +818,33 @@
+         return message % (expected_string, actual_string)
+ 
+ 
++    def assert_not_called(_mock_self):
++        """assert that the mock was never called.
++        """
++        self = _mock_self
++        if self.call_count != 0:
++            msg = ("Expected '%s' to not have been called. Called %s times." %
++                   (self._mock_name or 'mock', self.call_count))
++            raise AssertionError(msg)
++
++    def assert_called(_mock_self):
++        """assert that the mock was called at least once
++        """
++        self = _mock_self
++        if self.call_count == 0:
++            msg = ("Expected '%s' to have been called." %
++                   self._mock_name or 'mock')
++            raise AssertionError(msg)
++
++    def assert_called_once(_mock_self):
++        """assert that the mock was called only once.
++        """
++        self = _mock_self
++        if not self.call_count == 1:
++            msg = ("Expected '%s' to have been called once. Called %s times." %
++                   (self._mock_name or 'mock', self.call_count))
++            raise AssertionError(msg)
++
+     def assert_called_with(_mock_self, *args, **kwargs):
+         """assert that the mock was called with the specified arguments.
+ 

--- a/third_party/python.bzl
+++ b/third_party/python.bzl
@@ -114,6 +114,14 @@ def tensorboard_python_workspace():
         sha256 = "2d9fbe67001d2e8f02692075257f3c11e1b0194bd838c8ce3f49b31fc6c3f033",
         strip_prefix = "mock-1.0.0",
         build_file = str(Label("//third_party:mock.BUILD")),
+        patches = [
+            # `mock==1.0.0` lacks some assertion methods present in
+            # later versions of `mock` (see comment above for why we pin
+            # to this version). Patch created by diffing the pinned
+            # `mock.py` with GitHub head and identifying all the bits
+            # that looked related to the methods in question.
+            "//third_party:mock_call_assertions.patch",
+        ],
     )
 
     http_archive(


### PR DESCRIPTION
Summary:
Some of the `//tensorboard/uploader/...` tests are currently disabled in
Python 2 because our backport of `mock` doesn’t support the required
assertions. We can’t easily upgrade the dependency (see #2132), but we
can backport those assertions. The assertions backported are:

  - `assert_not_called`
  - `assert_called`
  - `assert_called_once`

This patch is the combination of (restrictions of) the following
upstream Git commits:

  - [`c7d6c7dcafd4482626194528b24f174dd15f5f5e`][1] (2014-04-17)
  - [`8882c2fccb9f7d3b8ba2b5534c0dd9d52343725f`][2] (2014-04-17)
  - [`7ca5d3afe293d5e4d769c1cb2dfccb0688ba1292`][3] (2016-03-11)
  - [`07532a75003ec8e871e494f9f1ab8f28fa246f08`][4] (2018-01-19)

I identified those commits by diffing our pinned version of `mock.py`
(the version at upstream commits `b14e284` through `dc1458a`) against
the version of `mock/mock.py` in the current repo, tracing the blame on
the implementation of the relevant assertions, then pruning commits that
relied on other changes not yet patched in (and were [only cosmetic,
anyway][5]).

[1]: https://github.com/testing-cabal/mock/commit/c7d6c7dcafd4482626194528b24f174dd15f5f5e
[2]: https://github.com/testing-cabal/mock/commit/8882c2fccb9f7d3b8ba2b5534c0dd9d52343725f
[3]: https://github.com/testing-cabal/mock/commit/7ca5d3afe293d5e4d769c1cb2dfccb0688ba1292
[4]: https://github.com/testing-cabal/mock/commit/07532a75003ec8e871e494f9f1ab8f28fa246f08
[5]: https://github.com/testing-cabal/mock/commit/57ef3bb5a48ccc549563c42f4a3f1f105ab49c29

Test Plan:
Unit tests pass in Python 2, and are now actually run, too. Changing
`uploader_test.py`’s `test_upload_swallows_rpc_failure` to comment out
the `_upload_once` call causes the subsequent `assert_called_once` to
fail with the correct error message, showing that the assertions are
wired up properly.

wchargin-branch: mock-backport
