### PR TITLE
uploader: fix `auth revoke` help suggestion

### DIFF
--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -51,7 +51,7 @@ Your use of this service is subject to Google's Terms of Service
 <https://policies.google.com/privacy>.
 
 This notice will not be shown again while you are logged into the uploader.
-To log out, rerun this command with the --auth_revoke flag.
+To log out, run `tensorboard dev auth revoke`.
 """
 
 


### PR DESCRIPTION
Summary:
The correct invocation is `auth revoke`, not `--auth_revoke`, which was
a vestige of a previous formulation.

wchargin-branch: uploader-auth-revoke-text
