### PR TITLE
uploader: include TensorBoard version in RPCs

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -18,6 +18,7 @@ py_library(
     deps = [
         ":util",
         "//tensorboard/uploader/proto:protos_all_py_pb2",
+        "//tensorboard/util:grpc_util",
     ],
 )
 
@@ -32,6 +33,7 @@ py_test(
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/uploader/proto:protos_all_py_pb2",
         "//tensorboard/uploader/proto:protos_all_py_pb2_grpc",
+        "//tensorboard/util:grpc_util",
         "@org_pythonhosted_mock",
     ],
 )

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -53,6 +53,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         "//tensorboard:expect_grpc_installed",
+        "//tensorboard:version",
         "//tensorboard/util:tb_logging",
     ],
 )
@@ -70,7 +71,9 @@ py_test(
         "//tensorboard:expect_futures_installed",
         "//tensorboard:expect_grpc_installed",
         "//tensorboard:test",
+        "//tensorboard:version",
         "@org_pythonhosted_mock",
+        "@org_pythonhosted_six",
     ],
 )
 


### PR DESCRIPTION
Summary:
This will enable servers to detect when clients are using an old version
and send instructions to show the user how to upgrade, especially in the
case of known bugs.

We could implement this with gRPC’s client-side interceptor API, but
that API is loudly disclaimed as experimental, so I’ve gone with the
manual plumbing for now.

Test Plan:
Ran the new uploader with an existing server and verified that it still
works (extra metadata is safely ignored). Verified that a server can
be modified to read this metadata for all three flows (upload, delete,
export). Tested in both Python 2 and Python 3.

wchargin-branch: uploader-version
