### PR TITLE
uploader: parse JSON from Unicode for Python 3.5

### DIFF
--- a/tensorboard/uploader/auth.py
+++ b/tensorboard/uploader/auth.py
@@ -48,7 +48,7 @@ OPENID_CONNECT_SCOPES = (
 
 # The client "secret" is public by design for installed apps. See
 # https://developers.google.com/identity/protocols/OAuth2?csw=1#installed
-OAUTH_CLIENT_CONFIG = b"""
+OAUTH_CLIENT_CONFIG = u"""
 {
   "installed": {
     "client_id": "373649185512-8v619h5kft38l4456nm2dj4ubeqsrvh6.apps.googleusercontent.com",

--- a/tensorboard/uploader/dev_creds.py
+++ b/tensorboard/uploader/dev_creds.py
@@ -19,11 +19,11 @@ from __future__ import division
 from __future__ import print_function
 
 
-DEV_SSL_CERT = b"""
+DEV_SSL_CERT = u"""
 """
 
-DEV_SSL_CERT_KEY = b"""
+DEV_SSL_CERT_KEY = u"""
 """
 
-DEV_OAUTH_CLIENT_CONFIG = b"""
+DEV_OAUTH_CLIENT_CONFIG = u"""
 """


### PR DESCRIPTION
Summary:
In versions of Python 3 prior to Python 3.6, `json.dumps` must take a
Unicode string as argument. (This was relaxed in [bpo-17909].)

[bpo-17909]: https://bugs.python.org/issue17909

Test Plan:
In a Python 3.5 virtualenv, run `tensorboard dev auth revoke`, then run
`tensorboard dev upload --logdir /tmp/whatever`. Note that the OAuth
flow now works properly rather than failing with a `TypeError`. Note
that the only other use of `json.loads` under `tensorboard/uploader/` is
in `exporter_test.py`, and that test passes on Python 3.5.

wchargin-branch: uploader-oauth-unicode