### PR TITLE
Fix set examples in jupyter

### DIFF
--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
@@ -85,10 +85,9 @@ class WitWidgetBase(object):
     if 'compare_adjust_attribution' in copied_config:
       del copied_config['compare_adjust_attribution']
 
+    examples = copied_config.pop('examples')
     self.config = copied_config
-    self.set_examples(config['examples'])
-    del copied_config['examples']
-
+    self.set_examples(examples)
 
     # If using AI Platform for prediction, set the correct custom prediction
     # functions.


### PR DESCRIPTION
* Motivation for features / changes

Ensure examples are copied out of the config before we set the config object, to avoid errors in Jupyter notebooks.

* Technical description of changes

Remove examples item from config before setting self.config in order to avoid passing the examples as JSON to the front-end, which can cause parse errors and shouldn't be done.

* Screenshots of UI changes

N/A

* Detailed steps to verify changes work correctly (as executed by you)

Test notebooks in both jupyter and colab to ensure correct initialization and rendering. The regression was only tested in colab which was the cause of this. Moving forward, no PR will only be tested in one environment.

* Alternate designs / implementations considered

N/A
