### PR TITLE
uploader: fix export when outdir has no slash

### DIFF
--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -85,7 +85,8 @@ class TensorBoardExporter(object):
     self._api = reader_service_client
     self._outdir = output_directory
     parent_dir = os.path.dirname(self._outdir)
-    _mkdir_p(parent_dir)
+    if parent_dir:
+      _mkdir_p(parent_dir)
     try:
       os.mkdir(self._outdir)
     except OSError as e:


### PR DESCRIPTION
Summary:
Given `export --outdir "${path}"`, we run `makedirs(dirname(path))`. But
this fails when `dirname(path)` is empty, which occurs when `path` has
no directory separator.

Test Plan:
Unit test added: it fails before this change and passes after it.

wchargin-branch: export-no-slash
