### PR TITLE
uploader: add TensorBoard.dev branding

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -1,5 +1,5 @@
 # Description:
-# Uploader for a hosted TensorBoard service
+# Uploader for TensorBoard.dev
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Downloads experiment data from a hosted Tensorboard service."""
+"""Downloads experiment data from TensorBoard.dev."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -42,7 +42,7 @@ _MAX_INT64 = 2**63 - 1
 
 
 class TensorBoardExporter(object):
-  """Exports all of the user's experiment data from a hosted service.
+  """Exports all of the user's experiment data from TensorBoard.dev.
 
   Data is exported into a directory, with one file per experiment. Each
   experiment file is a sequence of time series, represented as a stream

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -5,7 +5,7 @@ package tensorboard.service;
 import "google/protobuf/timestamp.proto";
 import "tensorboard/compat/proto/summary.proto";
 
-// Service for exporting data from a hosted service.
+// Service for exporting data from TensorBoard.dev.
 service TensorBoardExporterService {
   // Stream the experiment_id of all the experiments owned by the caller.
   rpc StreamExperiments(StreamExperimentsRequest)
@@ -16,7 +16,7 @@ service TensorBoardExporterService {
 }
 
 // Request to stream the experiment_id of all the experiments owned by the
-// caller from a hosted service.
+// caller from TensorBoard.dev.
 message StreamExperimentsRequest {
   // Timestamp to get a consistent snapshot of the data in the database.
   // This is useful when making multiple read RPCs and needing the data to be
@@ -32,7 +32,7 @@ message StreamExperimentsRequest {
   // TODO(@karthikv2k): Support pagination.
 }
 
-// Streams experiment IDs returned from a hosted service.
+// Streams experiment IDs returned from TensorBoard.dev.
 message StreamExperimentsResponse {
   // List of experiment IDs for the experiments owned by the user. The entire
   // list of experiments owned by the user is streamed in batches and each batch
@@ -59,7 +59,7 @@ message StreamExperimentDataRequest {
 // `StreamExperimentDataResponse`s, each one having all the scalars for one tag.
 // Users need to aggregate information from entire stream to get data for the
 // entire experiment. Empty experiments will have zero stream results. Empty
-// runs that doesn't have any tags need not be supported by a hosted service.
+// runs that doesn't have any tags need not be supported by TensorBoard.dev.
 message StreamExperimentDataResponse {
   // Name of the tag whose data is contained in this response.
   string tag_name = 1;

--- a/tensorboard/uploader/proto/write_service.proto
+++ b/tensorboard/uploader/proto/write_service.proto
@@ -5,7 +5,7 @@ package tensorboard.service;
 import "tensorboard/uploader/proto/scalar.proto";
 import "tensorboard/compat/proto/summary.proto";
 
-// Service for writing data to a hosted service.
+// Service for writing data to TensorBoard.dev.
 service TensorBoardWriterService {
   // Request for a new location to write TensorBoard readable events.
   rpc CreateExperiment(CreateExperimentRequest)
@@ -18,7 +18,7 @@ service TensorBoardWriterService {
   // Request that unreachable data be purged. Used only for testing;
   // disabled in production.
   rpc PurgeData(PurgeDataRequest) returns (PurgeDataResponse) {}
-  // Request additional data be stored in a hosted service.
+  // Request additional data be stored in TensorBoard.dev.
   rpc WriteScalar(WriteScalarRequest) returns (WriteScalarResponse) {}
   // Request that the calling user and all their data be permanently deleted.
   // Used for testing purposes.

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Uploads a TensorBoard logdir to a hosted service."""
+"""Uploads a TensorBoard logdir to TensorBoard.dev."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -62,7 +62,7 @@ logger = tb_logging.get_logger()
 
 
 class TensorBoardUploader(object):
-  """Uploads a TensorBoard logdir to a hosted service."""
+  """Uploads a TensorBoard logdir to TensorBoard.dev."""
 
   def __init__(self, writer_client, logdir, rate_limiter=None):
     """Constructs a TensorBoardUploader.

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -49,7 +49,7 @@ _MESSAGE_TOS = u"""\
 Your use of this service is subject to Google's Terms of Service
 <https://policies.google.com/terms> and Privacy Policy
 <https://policies.google.com/privacy>, and TensorBoard.dev's Terms of Service
-<https://tensorboard.dev/policy/terms>.
+<https://tensorboard.dev/policy/terms.html>.
 
 This notice will not be shown again while you are logged into the uploader.
 To log out, run `tensorboard dev auth revoke`.

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Main program for the TensorBoard hosted service uploader."""
+"""Main program for the TensorBoard.dev uploader."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -48,7 +48,8 @@ _FLAGS = None
 _MESSAGE_TOS = u"""\
 Your use of this service is subject to Google's Terms of Service
 <https://policies.google.com/terms> and Privacy Policy
-<https://policies.google.com/privacy>.
+<https://policies.google.com/privacy>, and TensorBoard.dev's Terms of Service
+<https://tensorboard.dev/policy/terms>.
 
 This notice will not be shown again while you are logged into the uploader.
 To log out, run `tensorboard dev auth revoke`.
@@ -108,7 +109,7 @@ def _define_flags(parser):
       '--console rather than a browser redirect to localhost.')
 
   upload = subparsers.add_parser(
-      'upload', help='upload an experiment to a hosted service')
+      'upload', help='upload an experiment to TensorBoard.dev')
   upload.set_defaults(**{_SUBCOMMAND_FLAG: _SUBCOMMAND_KEY_UPLOAD})
   upload.add_argument(
       '--logdir',
@@ -170,7 +171,7 @@ def _parse_flags(argv=('',)):
   """
   parser = argparse_flags.ArgumentParser(
       prog='uploader',
-      description=('Upload your TensorBoard experiments to a hosted service'))
+      description=('Upload your TensorBoard experiments to TensorBoard.dev'))
   _define_flags(parser)
   arg0 = argv[0] if argv else ''
   global _FLAGS
@@ -274,9 +275,14 @@ class _DeleteExperimentIntent(_Intent):
   """The user intends to delete an experiment."""
 
   _MESSAGE_TEMPLATE = textwrap.dedent(u"""\
-      This will delete the experiment with the following ID:
+      This will delete the experiment on https://tensorboard.dev with the
+      following experiment ID:
 
       {experiment_id}
+
+      You have chosen to delete an experiment. All experiments uploaded
+      to TensorBoard.dev are publicly visible. Do not upload sensitive
+      data.
   """)
 
   def __init__(self, experiment_id):
@@ -310,9 +316,13 @@ class _UploadIntent(_Intent):
   """The user intends to upload an experiment from the given logdir."""
 
   _MESSAGE_TEMPLATE = textwrap.dedent(u"""\
-      This will upload your TensorBoard logs from the following directory:
+      This will upload your TensorBoard logs to https://tensorboard.dev/ from
+      the following directory:
 
       {logdir}
+
+      This TensorBoard will be visible to everyone. Do not upload sensitive
+      data.
   """)
 
   def __init__(self, logdir):
@@ -346,10 +356,14 @@ class _ExportIntent(_Intent):
   """The user intends to download all their experiment data."""
 
   _MESSAGE_TEMPLATE = textwrap.dedent(u"""\
-      This will download all your experiment data and save it to the
-      following directory:
+      This will download all your experiment data from https://tensorboard.dev
+      and save it to the following directory:
 
       {output_dir}
+
+      Downloading your experiment data does not delete it from the
+      service. All experiments uploaded to TensorBoard.dev are publicly
+      visible. Do not upload sensitive data.
   """)
 
   def __init__(self, output_dir):
@@ -447,7 +461,7 @@ class UploaderSubcommand(program.TensorBoardSubcommand):
     return _run(flags)
 
   def help(self):
-    return 'upload data to a hosted service'
+    return 'upload data to TensorBoard.dev'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Summary:
This includes the Terms of Service link in the consent screen, as well
as the explicit disclaimer that all uploaded data is publicly visible.
It also patches the help text (`tensorboard -h`, `tensorboard dev -h`).

Test Plan:
Running `git grep "a hosted"` (…service) no longer returns any results.

wchargin-branch: tensorboard.dev
