### PR TITLE
Improve error handling for exporting large experiments

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -17,6 +17,7 @@ py_library(
     srcs = ["exporter.py"],
     deps = [
         ":util",
+        "//tensorboard:expect_grpc_installed",
         "//tensorboard/uploader/proto:protos_all_py_pb2",
         "//tensorboard/util:grpc_util",
     ],
@@ -28,6 +29,7 @@ py_test(
     deps = [
         ":exporter_lib",
         ":test_util",
+        "//tensorboard:expect_grpc_installed",
         "//tensorboard:expect_grpc_testing_installed",
         "//tensorboard:test",
         "//tensorboard/compat/proto:protos_all_py_pb2",

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import base64
 import errno
+import grpc
 import json
 import os
 import string
@@ -39,7 +40,6 @@ _FILENAME_SAFE_CHARS = frozenset(string.ascii_letters + string.digits + "-_")
 
 # Maximum value of a signed 64-bit integer.
 _MAX_INT64 = 2**63 - 1
-
 
 class TensorBoardExporter(object):
   """Exports all of the user's experiment data from a hosted service.
@@ -110,13 +110,19 @@ class TensorBoardExporter(object):
       read_time = time.time()
     for experiment_id in self._request_experiment_ids(read_time):
       filepath = _scalars_filepath(self._outdir, experiment_id)
-      with _open_excl(filepath) as outfile:
-        data = self._request_scalar_data(experiment_id, read_time)
-        for block in data:
-          json.dump(block, outfile, sort_keys=True)
-          outfile.write("\n")
-          outfile.flush()
-      yield experiment_id
+      try:
+        with _open_excl(filepath) as outfile:
+          data = self._request_scalar_data(experiment_id, read_time)
+          for block in data:
+            json.dump(block, outfile, sort_keys=True)
+            outfile.write("\n")
+            outfile.flush()
+        yield experiment_id
+      except grpc.RpcError as e:
+        if e.code() == grpc.StatusCode.CANCELLED:
+          raise GrpcTimeoutException(experiment_id)
+        else:
+          raise(e)
 
   def _request_experiment_ids(self, read_time):
     """Yields all of the calling user's experiment IDs, as strings."""
@@ -165,6 +171,10 @@ class OutputFileExistsError(ValueError):
   # Like Python 3's `__builtins__.FileExistsError`.
   pass
 
+class GrpcTimeoutException(Exception):
+  def __init__(self, experiment_id):
+    super(GrpcTimeoutException, self).__init__(experiment_id)
+    self.experiment_id = experiment_id
 
 def _scalars_filepath(base_dir, experiment_id):
   """Gets file path in which to store scalars for the given experiment."""

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -122,7 +122,7 @@ class TensorBoardExporter(object):
         if e.code() == grpc.StatusCode.CANCELLED:
           raise GrpcTimeoutException(experiment_id)
         else:
-          raise(e)
+          raise
 
   def _request_experiment_ids(self, read_time):
     """Yields all of the calling user's experiment IDs, as strings."""

--- a/tensorboard/uploader/exporter_test.py
+++ b/tensorboard/uploader/exporter_test.py
@@ -239,7 +239,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
     def stream_experiments(request, **kwargs):
       del request  # unused
       yield export_service_pb2.StreamExperimentsResponse(
-          experiment_ids = [experiment_id])
+          experiment_ids=[experiment_id])
 
     def stream_experiment_data(request, **kwargs):
       del request  # unused

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -367,9 +367,15 @@ class _ExportIntent(_Intent):
       msg = 'Output directory already exists: %r' % outdir
       raise base_plugin.FlagsError(msg)
     num_experiments = 0
-    for experiment_id in exporter.export():
-      num_experiments += 1
-      print('Downloaded experiment %s' % experiment_id)
+    try:
+      for experiment_id in exporter.export():
+        num_experiments += 1
+        print('Downloaded experiment %s' % experiment_id)
+    except exporter_lib.NewExceptionType as e:
+      print(
+        '\nUploader has failed because of an internal error.  Please reach '
+        'out via e-mail to tensorboard.dev-support@google.com to get help '
+        'completing your export of experiment %s.' % e.experiment_id)
     print('Done. Downloaded %d experiments to: %s' % (num_experiments, outdir))
 
 

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -371,9 +371,9 @@ class _ExportIntent(_Intent):
       for experiment_id in exporter.export():
         num_experiments += 1
         print('Downloaded experiment %s' % experiment_id)
-    except exporter_lib.NewExceptionType as e:
+    except exporter_lib.GrpcTimeoutException as e:
       print(
-        '\nUploader has failed because of an internal error.  Please reach '
+        '\nUploader has failed because of a timeout error.  Please reach '
         'out via e-mail to tensorboard.dev-support@google.com to get help '
         'completing your export of experiment %s.' % e.experiment_id)
     print('Done. Downloaded %d experiments to: %s' % (num_experiments, outdir))


### PR DESCRIPTION
Large experiments sometimes fail to export due to grpc timeouts.  This change clarifies the situation to the user.

Tested:
  Adds unit tests for grpc.CANCELLED case.
