### PR TITLE
Fix comment in export.proto

### DIFF
--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -57,7 +57,7 @@ message StreamExperimentDataRequest {
 // result only contains data for a single tag from a single run. For example if
 // there are five runs and each run had two tags, the RPC will return a stream
 // of at least ten `StreamExperimentDataResponse`s, each one having the
-// scalars for one tag. The values from a single tag may be spit among multiple
+// scalars for one tag. The values from a single tag may be slpit among multiple
 // responses.  Users need to aggregate information from entire stream to get
 // data for the entire experiment. Empty experiments will have zero stream
 // results. Empty runs that doesn't have any tags need not be supported by a

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -57,7 +57,7 @@ message StreamExperimentDataRequest {
 // result only contains data for a single tag from a single run. For example if
 // there are five runs and each run had two tags, the RPC will return a stream
 // of at least ten `StreamExperimentDataResponse`s, each one having the
-// scalars for one tag. The values from a single tag may be slpit among multiple
+// scalars for one tag. The values from a single tag may be split among multiple
 // responses.  Users need to aggregate information from entire stream to get
 // data for the entire experiment. Empty experiments will have zero stream
 // results. Empty runs that doesn't have any tags need not be supported by a

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -54,12 +54,14 @@ message StreamExperimentDataRequest {
 }
 
 // Streams scalars from all the runs and tags in an experiment. Each stream
-// result contains data for a single tag from a single run. For example if there
-// are five runs and each run had two tags, the RPC will return a stream of ten
-// `StreamExperimentDataResponse`s, each one having all the scalars for one tag.
-// Users need to aggregate information from entire stream to get data for the
-// entire experiment. Empty experiments will have zero stream results. Empty
-// runs that doesn't have any tags need not be supported by a hosted service.
+// result only contains data for a single tag from a single run. For example if
+// there are five runs and each run had two tags, the RPC will return a stream
+// of at least ten `StreamExperimentDataResponse`s, each one having the
+// scalars for one tag. The values from a single tag may be spit among multiple
+// responses.  Users need to aggregate information from entire stream to get
+// data for the entire experiment. Empty experiments will have zero stream
+// results. Empty runs that doesn't have any tags need not be supported by a
+// hosted service.
 message StreamExperimentDataResponse {
   // Name of the tag whose data is contained in this response.
   string tag_name = 1;


### PR DESCRIPTION
Export service definition has changed slightly in that all scalars for a given tag are not necessarily all in the same response.  This is to support tags that are too big, for one reason or another, to fit into a single response.

This change updates the comment to reflect the change in understanding.
