### PR TITLE
ng: make mat-icon configuration modular

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -263,7 +263,10 @@ tf_web_library(
         "//tensorboard/components:index.html",
         "//tensorboard/components:trace_viewer_index.html",
     ] + select({
-        "//tensorboard:dev_build": ["//tensorboard/components:ng_index"],
+        "//tensorboard:dev_build": [
+            "//tensorboard/components:ng_index",
+            "//tensorboard/components/tf_ng_tensorboard:svg_bundle",
+        ],
         "//conditions:default": [],
     }),
     path = "/",

--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -80,6 +80,7 @@ tf_web_library(
         ":ng_polymer_lib_binary",
         "//tensorboard/components/tf_ng_tensorboard",
         "//tensorboard/components/tf_ng_tensorboard:material_theme",
+        "//tensorboard/components/tf_ng_tensorboard:svg_bundle",
     ],
 )
 

--- a/tensorboard/components/tf_ng_tensorboard/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/BUILD
@@ -77,6 +77,7 @@ ng_module(
     srcs = [
         "app.component.ts",
         "app.module.ts",
+        "mat_icon.module.ts",
         "reducers.ts",
     ],
     assets = [

--- a/tensorboard/components/tf_ng_tensorboard/BUILD
+++ b/tensorboard/components/tf_ng_tensorboard/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_web_test_suite", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ng_web_test_suite", "tf_ts_library", "tf_svg_bundle")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 licenses(["notice"])  # Apache 2.0
@@ -85,6 +85,7 @@ ng_module(
     ],
     deps = [
         ":config",
+        "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_material_icon",
         "//tensorboard/components/tf_ng_tensorboard/angular:expect_angular_platform_browser_animations",
         "//tensorboard/components/tf_ng_tensorboard/core",
         "//tensorboard/components/tf_ng_tensorboard/header",
@@ -108,4 +109,12 @@ tf_ng_web_test_suite(
         "//tensorboard/components/tf_ng_tensorboard/reloader:test_lib",
         "//tensorboard/components/tf_ng_tensorboard/settings:test_lib",
     ],
+)
+
+tf_svg_bundle(
+    name = "svg_bundle",
+    srcs = [
+        "@com_google_material_design_icon//:ic_settings_24px.svg"
+    ],
+    output_name = "icon_bundle.svg",
 )

--- a/tensorboard/components/tf_ng_tensorboard/app.module.ts
+++ b/tensorboard/components/tf_ng_tensorboard/app.module.ts
@@ -12,9 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {BrowserModule} from '@angular/platform-browser';
+import {BrowserModule, DomSanitizer} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {NgModule} from '@angular/core';
+import {MatIconModule, MatIconRegistry} from '@angular/material/icon';
 import {StoreModule} from '@ngrx/store';
 import {EffectsModule} from '@ngrx/effects';
 
@@ -27,6 +28,8 @@ import {ROOT_REDUCERS, metaReducers} from './reducers';
 import {HeaderModule} from './header/header.module';
 import {ReloaderModule} from './reloader/reloader.module';
 
+const SVG_PATH = './icon_bundle.svg';
+
 @NgModule({
   declarations: [AppComponent],
   imports: [
@@ -36,6 +39,7 @@ import {ReloaderModule} from './reloader/reloader.module';
     HeaderModule,
     PluginsModule,
     ReloaderModule,
+    MatIconModule,
     StoreModule.forRoot(ROOT_REDUCERS, {
       metaReducers,
       runtimeChecks: {
@@ -48,4 +52,15 @@ import {ReloaderModule} from './reloader/reloader.module';
   providers: [],
   bootstrap: [AppComponent],
 })
-export class AppModule {}
+export class AppModule {
+  constructor(
+    private domSanitizer: DomSanitizer,
+    iconRegistry: MatIconRegistry
+  ) {
+    iconRegistry.addSvgIconSet(this.getIconUrl());
+  }
+
+  private getIconUrl() {
+    return this.domSanitizer.bypassSecurityTrustResourceUrl(SVG_PATH);
+  }
+}

--- a/tensorboard/components/tf_ng_tensorboard/app.module.ts
+++ b/tensorboard/components/tf_ng_tensorboard/app.module.ts
@@ -15,7 +15,6 @@ limitations under the License.
 import {BrowserModule, DomSanitizer} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {NgModule} from '@angular/core';
-import {MatIconModule, MatIconRegistry} from '@angular/material/icon';
 import {StoreModule} from '@ngrx/store';
 import {EffectsModule} from '@ngrx/effects';
 
@@ -27,6 +26,7 @@ import {ROOT_REDUCERS, metaReducers} from './reducers';
 
 import {HeaderModule} from './header/header.module';
 import {ReloaderModule} from './reloader/reloader.module';
+import {MatIconModule} from './mat_icon.module';
 
 const SVG_PATH = './icon_bundle.svg';
 
@@ -37,9 +37,9 @@ const SVG_PATH = './icon_bundle.svg';
     BrowserAnimationsModule,
     CoreModule,
     HeaderModule,
+    MatIconModule,
     PluginsModule,
     ReloaderModule,
-    MatIconModule,
     StoreModule.forRoot(ROOT_REDUCERS, {
       metaReducers,
       runtimeChecks: {
@@ -52,15 +52,4 @@ const SVG_PATH = './icon_bundle.svg';
   providers: [],
   bootstrap: [AppComponent],
 })
-export class AppModule {
-  constructor(
-    private domSanitizer: DomSanitizer,
-    iconRegistry: MatIconRegistry
-  ) {
-    iconRegistry.addSvgIconSet(this.getIconUrl());
-  }
-
-  private getIconUrl() {
-    return this.domSanitizer.bypassSecurityTrustResourceUrl(SVG_PATH);
-  }
-}
+export class AppModule {}

--- a/tensorboard/components/tf_ng_tensorboard/mat_icon.module.ts
+++ b/tensorboard/components/tf_ng_tensorboard/mat_icon.module.ts
@@ -1,0 +1,32 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {DomSanitizer} from '@angular/platform-browser';
+import {NgModule} from '@angular/core';
+import {
+  MatIconModule as NgMatIconModule,
+  MatIconRegistry,
+} from '@angular/material/icon';
+
+const SVG_PATH = './icon_bundle.svg';
+
+@NgModule({
+  imports: [NgMatIconModule],
+})
+export class MatIconModule {
+  constructor(domSanitizer: DomSanitizer, iconRegistry: MatIconRegistry) {
+    const url = domSanitizer.bypassSecurityTrustResourceUrl(SVG_PATH);
+    iconRegistry.addSvgIconSet(url);
+  }
+}

--- a/tensorboard/components/tf_ng_tensorboard/settings/settings_button.component.ts
+++ b/tensorboard/components/tf_ng_tensorboard/settings/settings_button.component.ts
@@ -21,7 +21,7 @@ import {SettingsDialogComponent} from './dialog.component';
   selector: 'settings-button',
   template: `
     <button mat-button (click)="openDialog()">
-      <mat-icon>more_vert</mat-icon>
+      <mat-icon svgIcon="ic_settings_24px"></mat-icon>
     </button>
   `,
 })

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -67,3 +67,15 @@ def tf_ng_web_test_suite(runtime_deps = [], bootstrap = [], deps = [], **kwargs)
         ],
         **kwargs
     )
+
+def tf_svg_bundle(name, srcs, output_name):
+    native.genrule(
+        name = name,
+        srcs = srcs,
+        outs = [output_name],
+        cmd = "$(execpath //tensorboard/tools:mat_bundle_icon_svg) $@ $(SRCS)",
+        tools = [
+            "//tensorboard/tools:mat_bundle_icon_svg",
+        ],
+    )
+

--- a/tensorboard/tools/BUILD
+++ b/tensorboard/tools/BUILD
@@ -5,3 +5,12 @@ py_binary(
     srcs = ["import_google_fonts.py"],
     deps = ["//tensorboard:expect_tensorflow_installed"],
 )
+
+sh_binary(
+    name = "mat_bundle_icon_svg",
+    srcs = ["mat_bundle_icon_svg.sh"],
+    visibility = [
+        "//tensorboard:internal",
+    ],
+)
+

--- a/tensorboard/tools/mat_bundle_icon_svg.sh
+++ b/tensorboard/tools/mat_bundle_icon_svg.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Exposes input SVGs as definitions with filename, without extension, as the
+# ids.
+# Usage: mat_bundle_icon_svg.sh [output.svg] [in_1.svg] [in_2.svg] ...
+
+OUTPUT_PATH=$1
+shift
+
+PREAMBLE='<svg><defs>'
+POSTAMBLE='</defs></svg>'
+
+echo $PREAMBLE > $OUTPUT_PATH
+for file in "$@"; do
+  svg_id="$(basename $file | sed 's|\.svg$||g')"
+  cat $file | sed "s|<svg|<svg id=\"$svg_id\"|g" >> $OUTPUT_PATH
+done
+
+echo $POSTAMBLE >> $OUTPUT_PATH

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -529,3 +529,15 @@ def tensorboard_js_workspace():
           ],
       },
   )
+
+  filegroup_external(
+      name = "com_google_material_design_icon",
+      licenses = ["notice"],  # Apache 2.0
+      sha256_urls = {
+          "d0872fb94037822164c8cea43a2ebeafdd1b664ff0fdc9387f0e1e1a7ee74628": [
+              "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/3.0.1/action/svg/production/ic_settings_24px.svg",
+              "https://raw.githubusercontent.com/google/material-design-icons/3.0.1/action/svg/production/ic_settings_24px.svg"
+          ],
+      },
+  )
+


### PR DESCRIPTION
This allows for a different implementation of the sanitizier. 