### PR TITLE
uploader: set default endpoint to production

### DIFF
--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -92,7 +92,7 @@ def _define_flags(parser):
   parser.add_argument(
       '--endpoint',
       type=str,
-      default='localhost:10000',
+      default='api.tensorboard.dev:443',
       help='URL for the API server accepting write requests.')
 
   parser.add_argument(


### PR DESCRIPTION
Test Plan:
Build the Pip package and install it into a new virtualenv. Using the
new package, revoke auth (`tensorboard dev auth revoke`), then upload an
experiment. Note that the correct Terms of Service and Privacy Policy
documents are clearly displayed in the consent prompt.

wchargin-branch: uploader-prod
