### PR TITLE
analytics: send pathname on pageview event

### DIFF
--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -744,7 +744,9 @@ limitations under the License.
         const pluginString = selectedDashboard || '';
         tf_storage.setString(tf_storage.TAB, pluginString);
         // Record this dashboard selection as a page view.
-        ga('set', 'page', '/' + pluginString);
+        let pathname = window.location.pathname;
+        pathname += pathname.endsWith('/') ? pluginString : '/' + pluginString;
+        ga('set', 'page', pathname);
         ga('send', 'pageview');
       },
 


### PR DESCRIPTION
Notice: this change only applies when Google Analytics is enabled which,
in OSS, it is not.

This change allows path like /experiment/abc to be logged as
/experiment/abc/scalar.

Do note that, according to [Google Analytics API doc](https://developers.google.com/analytics/devguides/collection/analyticsjs/pages), `ga('set', 'page',
arg)` is a way of modifying page url often to sanitize PII from the
path. This impacts all subsequent events like pageview or others.
