### PR TITLE
uploader: link to `/policy/terms/`, not `terms.html`

### DIFF
--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -49,7 +49,7 @@ _MESSAGE_TOS = u"""\
 Your use of this service is subject to Google's Terms of Service
 <https://policies.google.com/terms> and Privacy Policy
 <https://policies.google.com/privacy>, and TensorBoard.dev's Terms of Service
-<https://tensorboard.dev/policy/terms.html>.
+<https://tensorboard.dev/policy/terms/>.
 
 This notice will not be shown again while you are logged into the uploader.
 To log out, run `tensorboard dev auth revoke`.


### PR DESCRIPTION
Summary:
We’ll have a redirect in place, but we’d prefer that this be the
canonical path.

wchargin-branch: uploader-terms-slash
