### PR TITLE
docs: fix invalid json

### DIFF
--- a/docs/tensorboard_in_notebooks.ipynb
+++ b/docs/tensorboard_in_notebooks.ipynb
@@ -145,7 +145,7 @@
         "  # %tensorflow_version only exists in Colab.\n",
         "  %tensorflow_version 2.x\n",
         "except Exception:\n",
-        "  pass\n"
+        "  pass\n",
         "\n",
         "# Load the TensorBoard notebook extension\n",
         "%load_ext tensorboard"


### PR DESCRIPTION
Confirmed that all ipynb have valid JSON by running below.

```sh
find docs -iname "*.ipynb" | xargs jq . 1>/dev/null
echo $?
```

WANT_LGTM=any