### PR TITLE
infra: add basic JSON linter for ipynbs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,12 +4,20 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["tsconfig.json"])
 
-
 ts_config(
     name = "tsconfig-test",
     src = "tsconfig-test.json",
-    deps = [":tsconfig.json"],
     visibility = [
-	"//tensorboard:internal",
+        "//tensorboard:internal",
     ],
+    deps = [":tsconfig.json"],
+)
+
+sh_test(
+    name = "docs_test",
+    size = "small",
+    srcs = ["docs_test.sh"],
+    data = glob([
+        "docs/*.ipynb",
+    ]),
 )

--- a/docs_test.sh
+++ b/docs_test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+exit_code=0
+
+DOCS_DIR="${TEST_SRCDIR}/org_tensorflow_tensorboard/docs/"
+ipynbs="$(find $DOCS_DIR -iname *.ipynb)"
+bad_files=()
+
+# Check whether ipynb have the right JSON format.
+for ipynb in $ipynbs; do
+  jq . "$ipynb" >/dev/null 2>&1
+  code=$?
+
+  if [[ code -gt 0 ]]; then
+    bad_files+=("$ipynb")
+  fi
+
+  exit_code=$((exit_code + $code))
+done
+
+printf '%s\n' "${bad_files[@]}"
+exit $exit_code


### PR DESCRIPTION
Recently, TensorBoard had malformed ipynb that should not have made
it into the repo. This is a basic check. It does not guarantee the correctness
of the notebook.

Note that the test is not placed inside docs folder as it would require
another set of configuration changes to the docs generation.

However, I can be convinced that it is the right thing to do.