### PR TITLE
Plot inference evolution (What-If Tool)

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -1795,6 +1795,7 @@ limitations under the License.
                             </tf-inference-viewer>
                           </template>
                         </div>
+                        <div id="inferenceEvolution"></div>
                       </iron-collapse>
                     </div>
                   </div>
@@ -3684,6 +3685,7 @@ limitations under the License.
           /** @type {?Object} */
           selectedExampleAndInference: {
             type: Object,
+            observer: 'plotInferenceEvolution',
           },
           // The closest counterfatual example to the currently selected item,
           // if one is found through the counterfactual button.
@@ -6347,6 +6349,7 @@ limitations under the License.
           this.loadingBarHidden_ = true;
           this.updateInferences_(true);
           requestAnimationFrame(() => this.updateInferenceStats_(true));
+          this.plotInferenceEvolution();
         },
 
         refreshInferencesNoRegen_: function() {
@@ -7348,6 +7351,45 @@ limitations under the License.
           }
         },
 
+        plotInferenceEvolution: function() {
+          const container = Polymer.dom(this.$$('#inferenceEvolution'));
+          while (container.firstChild) {
+            container.removeChild(container.firstChild);
+          }
+          const example = this.selectedExampleAndInference;
+          if (
+            !example ||
+            !example.inferences ||
+            example.inferences.length < 2
+          ) {
+            return;
+          }
+          const inferences = example.inferences;
+          const data = [];
+          for (let i = 0; i < inferences.length; i++) {
+            const inference = inferences[i];
+            for (let modelInd = 0; modelInd < inference.length; modelInd++) {
+              const modelInference = inference[modelInd];
+              for (
+                let labelInd = 0;
+                labelInd < modelInference.length;
+                labelInd++
+              ) {
+                const value = modelInference[labelInd].score;
+                if (!data[modelInd]) {
+                  data[modelInd] = {};
+                }
+                if (!data[modelInd][labelInd]) {
+                  data[modelInd][labelInd] = [{}];
+                }
+                data[modelInd][labelInd].push({step: i, scalar: value});
+              }
+            }
+          }
+          const chart = this.makeLineChart('Run', data, true);
+          container.appendChild(chart);
+        },
+
         getExamples_: function() {
           var url = this.makeUrl_('/data/plugin/whatif/examples_from_path', {
             examples_path: this.examplesPath,
@@ -7563,7 +7605,7 @@ limitations under the License.
           }
 
           if (chartType == 'numeric') {
-            chart = this.makeLineChart(featureName, dataToChart);
+            chart = this.makeLineChart(featureName, dataToChart, false);
           } else if (chartType == 'categorical') {
             chart = this.makeBarChart(featureName, dataToChart);
           } else {
@@ -7753,7 +7795,7 @@ limitations under the License.
           }
         },
 
-        makeLineChart: function(featureName, data) {
+        makeLineChart: function(featureName, data, isInferEvolution) {
           // numerical data:
           // {"0" (model id):
           //     {"1" (label): [{"step": 19.0, "scalar": 0.09157766401767},
@@ -7792,7 +7834,7 @@ limitations under the License.
               },
             },
             {
-              title: 'Feature value',
+              title: featureName,
               evaluate: (d) => formatValueOrNaN(d.datum.step),
             },
             {
@@ -7814,6 +7856,7 @@ limitations under the License.
             });
           }
           chart.tooltipColumns = toolTipColumns;
+          chart.tooltipPosition = 'auto';
 
           const allSeries = [];
           let colorIndex = 0;
@@ -7851,7 +7894,10 @@ limitations under the License.
                 colorScale.push(this.pdPlotColors[colorIndex].brighter());
               }
             }
-            if (this.isBinaryClassification_(this.modelType, this.multiClass)) {
+            if (
+              this.isBinaryClassification_(this.modelType, this.multiClass) &&
+              !isInferEvolution
+            ) {
               const label = this.formatChartKey(
                 'classification threshold',
                 modelInd,

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -7365,13 +7365,17 @@ limitations under the License.
             return;
           }
           const inferences = example.inferences;
+          const isBinary = this.isBinaryClassification_(
+            this.modelType,
+            this.multiClass
+          );
           const data = [];
           for (let i = 0; i < inferences.length; i++) {
             const inference = inferences[i];
             for (let modelInd = 0; modelInd < inference.length; modelInd++) {
               const modelInference = inference[modelInd];
               for (
-                let labelInd = 0;
+                let labelInd = isBinary ? 1 : 0;
                 labelInd < modelInference.length;
                 labelInd++
               ) {

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -7375,18 +7375,23 @@ limitations under the License.
             for (let modelInd = 0; modelInd < inference.length; modelInd++) {
               const modelInference = inference[modelInd];
               for (
-                let labelInd = isBinary ? 1 : 0;
+                let labelInd = 0;
                 labelInd < modelInference.length;
                 labelInd++
               ) {
+                const label = modelInference[labelInd].label;
+                // Only consider positive label for binary case
+                if (isBinary && label !== '1') {
+                  continue;
+                }
                 const value = modelInference[labelInd].score;
                 if (!data[modelInd]) {
                   data[modelInd] = {};
                 }
-                if (!data[modelInd][labelInd]) {
-                  data[modelInd][labelInd] = [{}];
+                if (!data[modelInd][label]) {
+                  data[modelInd][label] = [{}];
                 }
-                data[modelInd][labelInd].push({step: i, scalar: value});
+                data[modelInd][label].push({step: i, scalar: value});
               }
             }
           }


### PR DESCRIPTION
Add a plot showing the evolution of inference values over the runs below
the inferences table.

cc @jameswex, @tolga-b 

* Motivation for features / changes

We want to see how the inference values (for each category, for each model etc.) have evolved with the inferences.

* Technical description of changes

When the selected example changes or `newInferences_` is called, we run a function to plot the inference evolution.
If no example is selected, or we have only 1 inference (ie nothing to compare), nothing is plotted.
Otherwise, the function uses the inferences data from the example to create a chart with the same function that is used by the partial dependence plots (`makeLineChart`). The chart is added to a div below the inference table.

* Screenshots of UI changes

Age demo:
![age](https://user-images.githubusercontent.com/6004563/68130582-7c840880-ff13-11e9-8da8-06ba3af0ddc2.png)
Iris demo:
![iris](https://user-images.githubusercontent.com/6004563/68130583-7c840880-ff13-11e9-9a60-3a9373d255cc.png)
Multi demo:
![multi](https://user-images.githubusercontent.com/6004563/68130584-7d1c9f00-ff13-11e9-81a5-794e0f885cb8.png)


* Detailed steps to verify changes work correctly (as executed by you)

Open `multi`, `iris` and `age` examples, select a datapoint, edit it and run inference.
The inference evolution plot should appear below the inferences table.
Then, when clicking on another datapoint, the plot should update accordingly.

* Alternate designs / implementations considered

I initially wanted to add part of this code to `tf-inference-viewer.html`, but this requires some refactoring and long architectural discussions. I still think it is a good idea for the future.