### PR TITLE
Place histogram bucketing logic on CPU explicitly when using TPUStrategy

### DIFF
--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -80,6 +80,8 @@ def histogram(name, data, step=None, buckets=None, description=None):
       return tf.summary.write(
           tag=tag, tensor=tensor, step=step, metadata=histogram_metadata)
 
+  # `_buckets()` has dynamic output shapes which is not supported on TPU's. As so, place
+  # the bucketing ops on outside compilation cluster so that the function in executed on CPU.
   if isinstance(tf.distribute.get_strategy(),
                 tf.distribute.experimental.TPUStrategy):
     return tf.compat.v1.tpu.outside_compilation(

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -72,11 +72,19 @@ def histogram(name, data, step=None, buckets=None, description=None):
   summary_scope = (
       getattr(tf.summary.experimental, 'summary_scope', None) or
       tf.summary.summary_scope)
-  with summary_scope(
-      name, 'histogram_summary', values=[data, buckets, step]) as (tag, _):
-    tensor = _buckets(data, bucket_count=buckets)
-    return tf.summary.write(
-        tag=tag, tensor=tensor, step=step, metadata=summary_metadata)
+
+  def histogram_summary(data, buckets, histogram_metadata, step):
+    with summary_scope(
+        name, 'histogram_summary', values=[data, buckets, step]) as (tag, _):
+      tensor = _buckets(data, bucket_count=buckets)
+      return tf.summary.write(
+          tag=tag, tensor=tensor, step=step, metadata=histogram_metadata)
+
+  if isinstance(tf.distribute.get_strategy(),
+                tf.distribute.experimental.TPUStrategy):
+    return tf.compat.v1.tpu.outside_compilation(
+      histogram_summary, data, buckets, summary_metadata, step)
+  return histogram_summary(data, buckets, summary_metadata, step)
 
 
 def _buckets(data, bucket_count=None):

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -82,6 +82,8 @@ def histogram(name, data, step=None, buckets=None, description=None):
 
   # `_buckets()` has dynamic output shapes which is not supported on TPU's. As so, place
   # the bucketing ops on outside compilation cluster so that the function in executed on CPU.
+  # TODO(https://github.com/tensorflow/tensorboard/issues/2885): Remove this special
+  # handling once dynamic shapes are supported on TPU's.
   if isinstance(tf.distribute.get_strategy(),
                 tf.distribute.experimental.TPUStrategy):
     return tf.compat.v1.tpu.outside_compilation(


### PR DESCRIPTION
* Motivation for features / changes
Manually place bucketing logic in writing histogram to CPU when TPUStrategy is used.

* Technical description of changes
`_buckets()` generates a graph with dynamic shapes which are not supported on TPU. As so, place the function in outside compilation cluster when TPUStrategy is in scope. 

