### PR TITLE
docs: fix annotations related to TBLoader

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -190,8 +190,7 @@ def TensorBoardWSGIApp(
 
   Args:
     flags: An argparse.Namespace containing TensorBoard CLI flags.
-    plugins: A list of plugins, which can be provided as TBPlugin subclasses
-        or TBLoader instances or subclasses.
+    plugins: A list of plugin loader instances.
     assets_zip_provider: See TBContext documentation for more information.
     data_provider: Instance of `tensorboard.data.provider.DataProvider`. May
         be `None` if `flags.generic_data` is set to `"false"` in which case
@@ -202,6 +201,8 @@ def TensorBoardWSGIApp(
 
   Returns:
     A WSGI application that implements the TensorBoard backend.
+
+  :type plugins: list[base_plugin.TBLoader]
   """
   db_uri = None
   db_connection_provider = None
@@ -721,6 +722,11 @@ def make_plugin_loader(plugin_spec):
 
   Returns:
     A TBLoader for the given plugin.
+
+  :type plugin_spec:
+    Type[base_plugin.TBPlugin] | Type[base_plugin.TBLoader] |
+    base_plugin.TBLoader
+  :rtype: base_plugin.TBLoader
   """
   if isinstance(plugin_spec, base_plugin.TBLoader):
     return plugin_spec

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -86,7 +86,10 @@ def get_plugins():
 
   This list can be passed to the `tensorboard.program.TensorBoard` API.
 
-  :rtype: list[Union[base_plugin.TBLoader, Type[base_plugin.TBPlugin]]]
+  Returns:
+    The list of default plugins.
+
+  :rtype: list[Type[base_plugin.TBLoader] | Type[base_plugin.TBPlugin]]
   """
 
   return _PLUGINS[:]
@@ -101,7 +104,9 @@ def get_dynamic_plugins():
   This list can be passed to the `tensorboard.program.TensorBoard` API.
 
   Returns:
-    list of base_plugin.TBLoader or base_plugin.TBPlugin.
+    The list of dynamic plugins.
+
+  :rtype: list[Type[base_plugin.TBLoader] | Type[base_plugin.TBPlugin]]
 
   [1]: https://packaging.python.org/specifications/entry-points/
   """

--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -313,6 +313,21 @@ class TBLoader(object):
     """
     pass
 
+  def load(self, context):
+    """Loads a TBPlugin instance during the setup phase.
+
+    Args:
+      context: The TBContext instance.
+
+    Returns:
+      A plugin instance or None if it could not be loaded. Loaders that return
+      None are skipped.
+
+    :type context: TBContext
+    :rtype: TBPlugin | None
+    """
+    return None
+
 
 class BasicLoader(TBLoader):
   """Simple TBLoader that's sufficient for most plugins."""

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -122,13 +122,19 @@ class TensorBoard(object):
     """Creates new instance.
 
     Args:
-      plugin: A list of TensorBoard plugins to load, as TBPlugin classes or
+      plugins: A list of TensorBoard plugins to load, as TBPlugin classes or
         TBLoader instances or classes. If not specified, defaults to first-party
         plugins.
       assets_zip_provider: Delegates to TBContext or uses default if None.
       server_class: An optional factory for a `TensorBoardServer` to use
         for serving the TensorBoard WSGI app. If provided, its callable
         signature should match that of `TensorBoardServer.__init__`.
+
+    :type plugins:
+      list[
+        base_plugin.TBLoader | Type[base_plugin.TBLoader] |
+        Type[base_plugin.TBPlugin]
+      ]
     """
     if plugins is None:
       from tensorboard import default


### PR DESCRIPTION
* Motivation for features / changes
One step towards improving plugin authoring is to understand and document the public interfaces.  Authors can write a class that extends base_plugin's `TBLoader`, but its `load()` method was not documented.

* Technical description of changes
Adds a base class method `TBLoader.load()` and updates some related docstrings.