### PR TITLE
Make VSCode resolve imports in node_modules instead of bazel-*

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,9 @@
     "lib": ["dom", "es2018"],
     "moduleResolution": "node",
     "noImplicitAny": true,
-    "noResolve": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "types": []
   },
   "exclude": [
     "bazel-*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,8 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "types": []
-  }
+  },
+  "exclude": [
+    "bazel-*"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "downlevelIteration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "inlineSourceMap": true,


### PR DESCRIPTION
VSCode on Mac was getting hung up with 'Initializing JS/TS language features'.  Apparently it was trying (and failing) to walk the `bazel-*` directories that are left after any bazel build.  Excluding those directories from processing via `tsconfig.json` is completely harmless, and restores normal VSCode functioning.