### PR TITLE
docs: update docs for dynamic plugin authors

### DIFF
--- a/tensorboard/examples/plugins/example_basic/README.md
+++ b/tensorboard/examples/plugins/example_basic/README.md
@@ -14,13 +14,13 @@ A plugin is comprised of three components:
 
 The backend and frontend operate within a plugin lifecycle:
 
-  - **1) Plugin setup**: When a user starts `tensorboard --logdir ...`, TensorBoard discovers available plugins, allows them to parse command line flags if needed, and configures URL routes to be served.
+  - **1) Plugin initializes**: When a user starts `tensorboard --logdir ...`, TensorBoard discovers available plugins, allows them to parse command line flags if needed, and configures URL routes to be served.
 
-  - **2) Web session creation**: When a user opens the frontend in a web browser, TensorBoard reads plugin frontend metadata and collects all active plugins.
+  - **2) User loads TensorBoard**: When a user opens the frontend in a web browser, TensorBoard reads plugin frontend metadata and collects all active plugins.
 
-  - **3) Dashboard open**: When a user selects the plugin's dashboard in the UI, TensorBoard loads an IFrame with the plugin's ES module and tells it to render.
+  - **3) User opens the dashboard**: When a user selects the plugin's dashboard in the UI, TensorBoard loads an IFrame with the plugin's ES module and tells it to render.
 
-  - **4) Route handling**: When a plugin's frontend makes URL requests to its backend, route handlers can respond with collected data.
+  - **4) Plugin handles routes**: When a plugin's frontend makes URL requests to its backend, route handlers can respond with collected data.
 
 
 ### Backend: How the plugin processes data, and sends it to the browser
@@ -44,7 +44,6 @@ You can start building the backend by subclassing `TBPlugin` in [`base_plugin.py
 
 ```python
 class MyPlugin(base_plugin.TBPlugin):
-  ### Plugin setup
   plugin_name = "My Awesome Plugin"
 
   def __init__(self, context): # ...
@@ -52,7 +51,7 @@ class MyPlugin(base_plugin.TBPlugin):
   def get_plugin_apps(self):
     return { "/tags": self._serve_tags }
 
-  ### Web session creation
+  ### Upon loading TensorBoard in browser
   def is_active(self): # ...
 
   def frontend_metadata(self):
@@ -78,8 +77,6 @@ For example:
 
 ```python
 class MyLoader(base_plugin.TBLoader):
-  ### Plugin Setup
-
   def define_flags(self, parser):
     parser.add_argument_group('custom').add_argument('--enable_my_extras')
 
@@ -114,7 +111,7 @@ class MyPlugin(base_plugin.TBPlugin):
   def __init__(self, context):
     self.multiplexer = context.multiplexer
 
-  def collect_data(self):
+  def preprocess_data(self):
     """
     {runName: { images: [tag1, tag2, tag3],
                 scalarValues: [tagA, tagB, tagC],
@@ -137,7 +134,7 @@ class MyPlugin(base_plugin.TBPlugin):
     content = PluginRunToTagToContent(plugin_name)
 ```
 
-For the complete EventMultiplexer API, see [`event_multiplexer.py`](https://github.com/tensorflow/tensorboard/blob/master/tensorboard/backend/event_processing/event_multiplexer.py).
+For the complete EventMultiplexer API, see [`PluginEventMultiplexer`][`PluginEventMultiplexer`].
 
 ### Frontend: How the plugin visualizes your new data
 

--- a/tensorboard/examples/plugins/example_basic/README.md
+++ b/tensorboard/examples/plugins/example_basic/README.md
@@ -99,7 +99,7 @@ It's recommended that plugins using flags call the `parser.add_argument_group(pl
 
 ## Reading data from event files
 
-On instantiation, a plugin is provided a [`PluginEventMultiplexer`] object from which to read data. The `PluginRunToTagToContent` method on the multiplexer returns a dictionary containing all run–tag pairs and associated summary metadata for your plugin.
+On instantiation, a plugin is provided a [`PluginEventMultiplexer`] object as a field on the TBContext, from which to read data. The `PluginRunToTagToContent` method on the multiplexer returns a dictionary containing all run–tag pairs and associated summary metadata for your plugin.
 
 Plugins are not technically restricted from arbitrary file system and network access, but we strongly recommend using the multiplexer exclusively. This abstracts over the filesystem (local or remote), provides a consistent user experience for runs and tags across plugins, and is optimized for TensorBoard read patterns.
 

--- a/tensorboard/examples/plugins/example_basic/README.md
+++ b/tensorboard/examples/plugins/example_basic/README.md
@@ -2,51 +2,160 @@
 
 ## Overview
 
-You know (and, we hope, love!) TensorBoard’s core features like the scalar dashboard, the graph explorer, and the embedding projector. However, in every TensorBoard user’s life, there comes a time when they want some cool new visualization that just…doesn’t exist yet. That’s what the TensorBoard plugin system is for.
+You know (and, we hope, love!) TensorBoard’s core features! However, in every TensorBoard user’s life, there comes a time when you want some cool new visualization that just…doesn’t exist yet. That’s what the TensorBoard plugin system is for.
 
-This document will explain high level concepts using the example plugin and provide guidelines on plugin authorship. To get started right away, jump to the [Local Development](#local-development) section.
+This document will explain high level concepts using the example plugin and provide guidelines on plugin authorship. To get started with an example, jump to the [Getting Started](#getting-started) section.
 
 A plugin is comprised of three components:
 
   - The **Backend** is where you write Python code that does post-processing of your data and serves the data to your plugin frontend in the browser.
   - The **Frontend** is where your custom visualization lives.
-  - The optional **Summary** component is how users of your plugins will write data that your plugin can read from their TensorFlow programs.
+  - The optional **Summary** component is how users of your plugins will write data that your plugin can read from their TensorFlow programs. See [docs](https://www.tensorflow.org/api_docs/python/tf/summary) for details.
+
+The backend and frontend operate within a plugin lifecycle:
+
+  - **1) Plugin setup**: When a user starts `tensorboard --logdir ...`, TensorBoard discovers available plugins, allows them to parse command line flags if needed, and configures URL routes to be served.
+
+  - **2) Web Session Creation**: When a user opens the frontend in a web browser, TensorBoard reads plugin frontend metadata and collects all active plugins.
+
+  - **3) Dashboard Open**: When a user selects the plugin's dashboard in the UI, TensorBoard loads an IFrame with the plugin's ES module and tells it to render.
+
+  - **4) Route Handling**: When a plugin's frontend makes URL requests to its backend, route handlers can respond with collected data.
+
 
 ### Backend: How the plugin processes data, and sends it to the browser
 
-TensorBoard detects plugins using the [Python `entry_points` mechanism][entrypoints-spec]; see [the example plugin’s `setup.py`][entrypoints-declaration] for an example of how to declare a plugin to TensorBoard. The plugin backend is responsible for providing information about its frontend counterpart, serving frontend resources, and surfacing necessary data to the frontend by implementing routes (endpoints). You can start building the backend by subclassing `TBPlugin` in [`base_plugin.py`] (if your plugin does non-trivial work at the load time, consider using `TBLoader`). It must have a `plugin_name` (please refer to [naming](#guideline_on_naming_and_branding) section for naming your plugin) class attribute and implement the following methods:
+#### Terminology
 
-  - `is_active`: This should return whether the plugin is active (whether there exists relevant data for the plugin to process). TensorBoard will hide inactive plugins from the main navigation bar. We strongly recommend this to be a cheap operation.
-  - `get_plugin_apps`: This should return a `dict` mapping route paths to WSGI applications: e.g., `"/tags"` might map to `self._serve_tags`.
-  - `define_flags`: Optional method needed to expose command-line flags. Please prefix flags with the name of the plugin to avoid collision.
-  - `fix_flags`: Optional method needed to fix or sanitize command-line flags.
+First, let's define some terminology used in TensorBoard. Definitions can be found in [base_plugin.py](https://github.com/tensorflow/tensorboard/blob/master/tensorboard/plugins/base_plugin.py).
+
+  - `TBPlugin`: The base class for all plugins. Can be used as an entry point. Defining a TBPlugin is required.
+  - `TBLoader`: The base class for plugins requiring flag parsing or custom loading. Defining a TBLoader is optional.
+  - `TBContext`: The container of information passed from TensorBoard core to plugins when they are constructed. Includes 'logdir', 'flags', 'multiplexer', etc.
+  - `EventMultiplexer`: The provided utility for managing event data across runs, tags. Other multiplexers exist for database providers, etc.
+
+A plugin backend is responsible for providing information about its frontend counterpart, serving frontend resources, and surfacing necessary data to the frontend by implementing routes (endpoints). TensorBoard begins by detecting plugins using the [Python `entry_points` mechanism][entrypoints-spec]; see the example plugin's [`setup.py`][entrypoints-declaration] for a full example of how to declare a plugin. The entry point must define either a `TBPlugin` or `TBLoader` class.
 
 [entrypoints-spec]: https://packaging.python.org/specifications/entry-points/
 [entrypoints-declaration]: https://github.com/tensorflow/tensorboard/blob/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81/tensorboard/plugins/example/setup.py#L31-L35
 [`base_plugin.py`]: https://github.com/tensorflow/tensorboard/blob/master/tensorboard/plugins/base_plugin.py
 
-On instantiation, a plugin is provided a [`PluginEventMultiplexer`] object from which to read data. The `PluginRunToTagToContent` method on the multiplexer returns a dictionary containing all run–tag pairs and associated summary metadata for your plugin. For more information about summaries, please refer to the relevant section below.
+You can start building the backend by subclassing `TBPlugin` in [`base_plugin.py`] with this structure:
+
+```python
+class MyPlugin(base_plugin.TBPlugin):
+  ### On Plugin Setup
+  plugin_name = "My Awesome Plugin"
+
+  def __init__(self, context): # ...
+
+  def get_plugin_apps(self):
+    return { "/tags": self._serve_tags }
+
+  ### On Web Session Creation
+  def is_active(self): # ...
+
+  def frontend_metadata(self):
+    return base_plugin.FrontendMetadata(es_module_path = "/index.js", tab_name = "Awesome ML")
+
+  ### On Route Handling
+  def _serve_tags(self): # Returns a WSGI application that responds to the request.
+```
+
+#### TBPlugin
+  - `plugin_name`: Required field used as a unique ID for the plugin.
+  - `get_plugin_apps()`: This should return a `dict` mapping route paths to WSGI applications: e.g., `"/tags"` might map to `self._serve_tags`.
+  - `is_active()`: This should return whether the plugin is active (whether there exists relevant data for the plugin to process). TensorBoard will hide inactive plugins from the main navigation bar. We strongly recommend this to be a cheap operation.
+  - `frontend_metadata()`: Defines how the plugin will be displayed on the frontend. See base_plugin.FrontendMetadata()
+    - `disable_reload`: Whether to disable the reload button and auto-reload timer. A `bool`; defaults to `False`.
+    - `es_module_path`: ES module to use as an entry point to this plugin. A `str` that is a key in the result of `get_plugin_apps()`.
+    - `remove_dom`: Whether to remove the plugin DOM when switching to a different plugin. A `bool`; defaults to `False`.
+    - `tab_name`: Name to show in the menu item for this dashboard within
+        the navigation bar. May differ from the plugin name. Should be a `str` or `None` to indicate to use the plugin name.
+
+If your plugin requires parsing flags or custom loading, consider defining a `TBLoader` as the entry point. Doing so is optional.
+
+For example:
+
+```python
+class MyLoader(base_plugin.TBLoader):
+  ### On Plugin Setup
+
+  def define_flags(self, parser):
+    parser.add_argument_group('custom').add_argument('--enable_my_extras')
+
+  def fix_flags(self, flags):
+    if flags.enable_my_extras:
+      raise ValueError('Extras not ready')
+
+  def load(self, context):
+    return MyPlugin(context)
+```
+
+#### TBLoader
+  - `define_flags(parser)`: Optional method that takes an argparse.Namespace and exposes command-line flags. Please prefix flags with the name of the plugin to avoid collision.
+  - `fix_flags(flags)`: Optional method needed to fix or sanitize command-line flags.
+  - `load(context)`: Required method that takes a TBContext and returns a TBPlugin instance.
+
+It's recommended that plugins using flags call the `parser.add_argument_group(plugin_name)`. To learn more about the flag definition, see [docs](https://docs.python.org/library/argparse.html#adding-arguments)
+
+
+
+## Reading data from event files
+
+On instantiation, a plugin is provided a [`PluginEventMultiplexer`] object from which to read data. The `PluginRunToTagToContent` method on the multiplexer returns a dictionary containing all run–tag pairs and associated summary metadata for your plugin.
 
 Plugins are not technically restricted from arbitrary file system and network access, but we strongly recommend using the multiplexer exclusively. This abstracts over the filesystem (local or remote), provides a consistent user experience for runs and tags across plugins, and is optimized for TensorBoard read patterns.
 
 [`PluginEventMultiplexer`]: https://github.com/tensorflow/tensorboard/blob/master/tensorboard/backend/event_processing/plugin_event_multiplexer.py
 
+Example use of the multiplexer:
+```python
+class MyPlugin(base_plugin.TBPlugin):
+  def __init__(self, context):
+    self.multiplexer = context.multiplexer
+
+  def collect_data(self):
+    """
+    {runName: { images: [tag1, tag2, tag3],
+                scalarValues: [tagA, tagB, tagC],
+                histograms: [tagX, tagY, tagZ],
+                compressedHistograms: [tagX, tagY, tagZ],
+                graph: true, meta_graph: true}}
+    """
+    runs = self.multiplexer.Runs()
+
+    """
+    [
+      {wall_time: 100..., step: 1, tensor_proto: ...},
+      {wall_time: 100..., step: 2, tensor_proto: ...},
+      ...
+    ]
+    """
+    events = self.multiplexer.Tensors(run, tag)
+
+    """{run: {tag: content}, ...}"""
+    content = PluginRunToTagToContent(plugin_name)
+```
+
+For the complete EventMultiplexer API, see [`event_multiplexer.py`](https://github.com/tensorflow/tensorboard/blob/master/tensorboard/backend/event_processing/event_multiplexer.py).
+
 ### Frontend: How the plugin visualizes your new data
 
-Now that we have an API, it’s time for the cool part: adding a visualization.
+Now that we have an API, it’s time for the cool part: adding a visualization!
 
-TensorBoard does not impose any framework/tool requirements for building a frontend—you can use React, Vue.js, jQuery, DOM API, or any new famous frameworks and use, for example, Webpack to create a JavaScript bundle. TensorBoard only requires an [ES Module] that is an entry point to your frontend ([example ES module][example-es-module]). Do note that all frontend resources have to be served by the plugin backend ([example backend][example-backend])
+TensorBoard does not impose any framework/tool requirements for building a frontend—you can use React, Vue.js, jQuery, DOM API, or any new famous frameworks and use, for example, Webpack to create a JavaScript bundle. TensorBoard only requires an [ES Module] that is an entry point to your frontend ([example ES module][example-es-module]). Do note that all frontend resources have to be served by the plugin backend ([example backend][example-backend]).
+
+In the Dashboard Open phase, TensorBoard will create an IFrame and load the ES module defined by the backend's metadata. It will call the `render()` method in the module.
 
 [ES Module]: https://hacks.mozilla.org/2018/03/es-modules-a-cartoon-deep-dive/
 [example-es-module]: https://github.com/tensorflow/tensorboard/blob/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81/tensorboard/plugins/example/tensorboard_plugin_example/static/index.js#L16
 [example-backend]: https://github.com/tensorflow/tensorboard/blob/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81/tensorboard/plugins/example/tensorboard_plugin_example/plugin.py#L45
 
-Consistency in user interface and experience, we believe, is important for happy users; for example, a run selection should be consistent for all plugins in TensorBoard. TensorBoard will provide a library that helps you build a dashboard like Scalars dashboard by providing UI components. Below are components we _will_ provide as a library that can be bundled into your frontend binary (please follow [issue #2357][dynamic-plugin-tracking-bug] for progress):
+Consistency in user interface and experience, we believe, is important for happy users; for example, a run selection should be consistent for all plugins in TensorBoard. TensorBoard will provide a library that helps you build a dashboard like Scalars dashboard by providing UI components. We _will_ provide a library that can be bundled into your frontend binary (please follow [issue #2357][dynamic-plugin-tracking-bug] for progress):
 
 [dynamic-plugin-tracking-bug]: https://github.com/tensorflow/tensorboard/issues/2357
 
-- `tf-dashboard-layout`: A custom element that makes it easy to set up a sidebar section and main section within TensorBoard. The sidebar should hold configuration options, and the run selector.
-- `tf-runs-selector`: A custom element to enable or disable various runs in the TensorBoard frontend.
 
 ### Summaries: How the plugin gets data
 
@@ -60,17 +169,7 @@ Your plugin will need to provide a way for users to log **summaries**, which are
 [greeting-op]: https://github.com/tensorflow/tensorboard/blob/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81/tensorboard/plugins/example/tensorboard_plugin_example/summary_v2.py#L28-L48
 [owner-identifier]: https://github.com/tensorflow/tensorboard/blob/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81/tensorboard/plugins/example/tensorboard_plugin_example/summary_v2.py#L64
 
-## Guideline on naming and branding
-
-We recommend that your plugin have an intuitive name that reflects the functionality—users, seeing the name, should be able to identify that it is a TensorBoard plugin and its function. Also, we recommend that you include the name of the plugin as part of the Pip package. For instance, a plugin `foo` should be distributed in a Pip package named `tensorboard_plugin_foo`.
-
-A predictable package naming scheme not only helps users find your plugin, but also helps you find a unique plugin name by surveying PyPI. TensorBoard requires that all loaded plugins kave unique names. However, the plugin name can differ from the [user-facing display name][display-name]; display names are not strictly required to be unique.
-
-[display-name]: https://github.com/tensorflow/tensorboard/blob/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81/tensorboard/plugins/base_plugin.py#L35-L39
-
-Lastly, when distributing a custom plugin of TensorBoard, we recommend that it be branded as “Foo for TensorBoard” (rather than “TensorBoard Foo”). TensorBoard is distributed under the Apache 2.0 license, but the name itself is a trademark of Google LLC.
-
-## Local Development
+## Getting Started
 
 To get started right away, copy the directory `tensorboard/examples/plugins/example_basic` into a desired folder and, in a virtualenv with TensorBoard installed, run:
 
@@ -78,9 +177,7 @@ To get started right away, copy the directory `tensorboard/examples/plugins/exam
 python setup.py develop
 ```
 
-This will link the plugin into your virtualenv. You can edit the plugin’s source code and data files and see changes reflected without having to reinstall the plugin.
-
-Then, just run
+This will link the plugin into your virtualenv. Then, just run
 
 ```
 tensorboard --logdir /tmp/whatever
@@ -88,7 +185,7 @@ tensorboard --logdir /tmp/whatever
 
 and open TensorBoard to see the plugin’s “hello world” screen.
 
-After making changes to the Python code, you must restart TensorBoard for your changes to take effect. If your plugin reads data files at runtime, you can edit those and see changes reflected immediately.
+After making changes to the Python code, you must restart TensorBoard for your changes to take effect. The example plugin serves web assets at runtime, so changes reflected upon reloading the page.
 
 To uninstall, you can run
 
@@ -103,3 +200,13 @@ to unlink the plugin from your virtualenv, after which you can also delete the `
 A plugin should be distributed as a Pip package, and may be uploaded to PyPI. Please follow the [PyPI distribution archive upload guide][pypi-upload] for more information.
 
 [pypi-upload]: https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives
+
+## Guideline on naming and branding
+
+We recommend that your plugin have an intuitive name that reflects the functionality—users, seeing the name, should be able to identify that it is a TensorBoard plugin and its function. Also, we recommend that you include the name of the plugin as part of the Pip package. For instance, a plugin `foo` should be distributed in a Pip package named `tensorboard_plugin_foo`.
+
+A predictable package naming scheme not only helps users find your plugin, but also helps you find a unique plugin name by surveying PyPI. TensorBoard requires that all loaded plugins kave unique names. However, the plugin name can differ from the [user-facing display name][display-name]; display names are not strictly required to be unique.
+
+[display-name]: https://github.com/tensorflow/tensorboard/blob/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81/tensorboard/plugins/base_plugin.py#L35-L39
+
+Lastly, when distributing a custom plugin of TensorBoard, we recommend that it be branded as “Foo for TensorBoard” (rather than “TensorBoard Foo”). TensorBoard is distributed under the Apache 2.0 license, but the name itself is a trademark of Google LLC.


### PR DESCRIPTION
Motivation for features / changes

In an attempt to improve the onboarding experience for plugin authors, this updates the documentation describing the process.  Changes include:

  - Added section on Plugin Lifecycle
  - Added code sample showing bare-structure of TBPlugin, TBLoader
  - Added documentation on TBContext, EventMultiplexer, frontend_metadata

Sub goals of this change are to:

  - More comprehensive coverage of public API in a single place
  - Reduce the need to read internal TensorBoard source code
  - Focus more on backend API.  In the future, cover frontend with more examples

If the diff is hard to read, a preview can be [found here](https://github.com/psybuzz/tensorboard/tree/docs1/tensorboard/examples/plugins/example_basic)