### PR TITLE
Execute histogram bucketing logic only when summary is written for tf.summary.histogram()

### DIFF
--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -78,7 +78,6 @@ def histogram(name, data, step=None, buckets=None, description=None):
   def histogram_summary(data, buckets, histogram_metadata, step):
     with summary_scope(
         name, 'histogram_summary', values=[data, buckets, step]) as (tag, _):
-      
       # To ensure that histogram bucketing logic is only executed when summaries
       # are written, we pass callable to `tensor` parameter.
       get_tensor_fn = functools.partial(_buckets, data, buckets)


### PR DESCRIPTION
Currently for histogram summary, bucketing logic is executed every step regardless whether tf.summary.record_if() is satisfied or not.. As so, pass in callable that returns tensor to tf.summary.write() instead of directly passing tensor. 

