### PR TITLE
Defer image/audio/histogram v2 summary preprocessing using LazyTensorCreator

### DIFF
--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -92,6 +92,7 @@ py_library(
     deps = [
         ":metadata",
         "//tensorboard/compat",
+        "//tensorboard/util:lazy_tensor_creator",
     ],
 )
 

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -109,6 +109,7 @@ py_library(
         "//tensorboard:expect_numpy_installed",
         "//tensorboard/compat",
         "//tensorboard/compat/proto:protos_all_py_pb2",
+        "//tensorboard/util:lazy_tensor_creator",
         "//tensorboard/util:tensor_util",
     ],
 )

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -29,8 +29,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import functools
-
 import numpy as np
 
 from tensorboard.compat import tf2 as tf

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -107,7 +107,7 @@ py_library(
         ":metadata",
         "//tensorboard/compat",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "//tensorboard/util:tensor_util",
+        "//tensorboard/util:lazy_tensor_creator",
     ],
 )
 

--- a/tensorboard/plugins/image/summary_v2.py
+++ b/tensorboard/plugins/image/summary_v2.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 
 from tensorboard.compat import tf2 as tf
 from tensorboard.plugins.image import metadata
+from tensorboard.util import lazy_tensor_creator
 
 
 def image(name,
@@ -68,21 +69,29 @@ def image(name,
       tf.summary.summary_scope)
   with summary_scope(
       name, 'image_summary', values=[data, max_outputs, step]) as (tag, _):
-    tf.debugging.assert_rank(data, 4)
-    tf.debugging.assert_non_negative(max_outputs)
-    images = tf.image.convert_image_dtype(data, tf.uint8, saturate=True)
-    limited_images = images[:max_outputs]
-    encoded_images = tf.map_fn(tf.image.encode_png, limited_images,
-                               dtype=tf.string,
-                               name='encode_each_image')
-    # Workaround for map_fn returning float dtype for an empty elems input.
-    encoded_images = tf.cond(
-        tf.shape(input=encoded_images)[0] > 0,
-        lambda: encoded_images, lambda: tf.constant([], tf.string))
-    image_shape = tf.shape(input=images)
-    dimensions = tf.stack([tf.as_string(image_shape[2], name='width'),
-                           tf.as_string(image_shape[1], name='height')],
-                          name='dimensions')
-    tensor = tf.concat([dimensions, encoded_images], axis=0)
+    # Defer image encoding preprocessing by passing it as a callable to write(),
+    # wrapped in a LazyTensorCreator for backwards compatibility, so that we
+    # only do this work when summaries are actually written.
+    @lazy_tensor_creator.LazyTensorCreator
+    def lazy_tensor():
+      tf.debugging.assert_rank(data, 4)
+      tf.debugging.assert_non_negative(max_outputs)
+      images = tf.image.convert_image_dtype(data, tf.uint8, saturate=True)
+      limited_images = images[:max_outputs]
+      encoded_images = tf.map_fn(tf.image.encode_png, limited_images,
+                                 dtype=tf.string,
+                                 name='encode_each_image')
+      # Workaround for map_fn returning float dtype for an empty elems input.
+      encoded_images = tf.cond(
+          tf.shape(input=encoded_images)[0] > 0,
+          lambda: encoded_images, lambda: tf.constant([], tf.string))
+      image_shape = tf.shape(input=images)
+      dimensions = tf.stack([tf.as_string(image_shape[2], name='width'),
+                             tf.as_string(image_shape[1], name='height')],
+                            name='dimensions')
+      return tf.concat([dimensions, encoded_images], axis=0)
+
+    # To ensure that image encoding logic is only executed when summaries
+    # are written, we pass callable to `tensor` parameter.
     return tf.summary.write(
-        tag=tag, tensor=tensor, step=step, metadata=summary_metadata)
+        tag=tag, tensor=lazy_tensor, step=step, metadata=summary_metadata)

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -79,9 +79,29 @@ py_test(
 
 tb_proto_library(
     name = "grpc_util_test_proto",
-    has_services = True,
-    srcs = ["grpc_util_test.proto"],
     testonly = True,
+    srcs = ["grpc_util_test.proto"],
+    has_services = True,
+)
+
+py_library(
+    name = "lazy_tensor_creator",
+    srcs = ["lazy_tensor_creator.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        "//tensorboard/compat",
+    ],
+)
+
+py_test(
+    name = "lazy_tensor_creator_test",
+    size = "small",
+    srcs = ["lazy_tensor_creator_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":lazy_tensor_creator",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
 )
 
 py_library(

--- a/tensorboard/util/lazy_tensor_creator.py
+++ b/tensorboard/util/lazy_tensor_creator.py
@@ -1,0 +1,73 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Provides a lazy wrapper for deferring Tensor creation."""
+
+import threading
+
+from tensorboard.compat import tf2 as tf
+
+
+class LazyTensorCreator(object):
+  """Lazy auto-converting wrapper for a callable that returns a `tf.Tensor`.
+
+  This class wraps an arbitrary callable that returns a `Tensor` so that it
+  will be automatically converted to a `Tensor` by any logic that calls
+  `tf.convert_to_tensor()`. This also memoizes the callable so that it is
+  called at most once.
+
+  The intended use of this class is to defer the construction of a `Tensor`
+  (e.g. to avoid unnecessary wasted computation, or ensure any new ops are
+  created in a context only available later on in execution), while remaining
+  compatible with APIs that expect to be given an already materialized value
+  that can be converted to a `Tensor`.
+
+  This class is thread-safe.
+  """
+
+  def __init__(self, tensor_callable):
+    """Initializes a LazyTensorCreator object.
+
+    Args:
+      tensor_callable: A callable that returns a `tf.Tensor`.
+    """
+    if not callable(tensor_callable):
+      raise ValueError("Not a callable: %r" % tensor_callable)
+    self._tensor_callable = tensor_callable
+    self._tensor = None
+    self._tensor_lock = threading.Lock()
+
+  def __call__(self, dtype=None, name=None, as_ref=False):
+    del name  # ignored
+    if as_ref:
+      raise RuntimeError("Cannot use LazyTensorCreator to create ref tensor")
+    if self._tensor is None:
+      with self._tensor_lock:
+        if self._tensor is None:
+          self._tensor = self._tensor_callable()
+    if dtype not in (None, self._tensor.dtype):
+      raise RuntimeError("Cannot use LazyTensorCreator with explicit dtype")
+    return self._tensor
+
+
+def _lazy_tensor_creator_converter(value, dtype=None, name=None, as_ref=False):
+  if not isinstance(value, LazyTensorCreator):
+    raise RuntimeError("Expected LazyTensorCreator, got %r" % value)
+  return value(dtype, name, as_ref)
+
+
+tf.register_tensor_conversion_function(
+    base_type=LazyTensorCreator,
+    conversion_func=_lazy_tensor_creator_converter,
+    priority=0)

--- a/tensorboard/util/lazy_tensor_creator_test.py
+++ b/tensorboard/util/lazy_tensor_creator_test.py
@@ -80,6 +80,13 @@ class LazyTensorCreatorTest(tf.test.TestCase):
       # exposed as an argument to tf.convert_to_tensor.
       lazy_tensor(as_ref=True)
 
+  def test_reentrant_callable_does_not_deadlock(self):
+    @lazy_tensor_creator.LazyTensorCreator
+    def lazy_tensor(nested_call=False):
+      return lazy_tensor()
+    with self.assertRaisesRegex(RuntimeError, "reentrant callable"):
+      lazy_tensor()
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorboard/util/lazy_tensor_creator_test.py
+++ b/tensorboard/util/lazy_tensor_creator_test.py
@@ -1,0 +1,85 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from tensorboard.util import lazy_tensor_creator
+
+
+class LazyTensorCreatorTest(tf.test.TestCase):
+
+  def test_lazy_creation_with_memoization(self):
+    boxed_count = [0]
+    @lazy_tensor_creator.LazyTensorCreator
+    def lazy_tensor():
+      boxed_count[0] = boxed_count[0] + 1
+      return tf.constant(1)
+    self.assertEqual(0, boxed_count[0])
+    real_tensor = lazy_tensor()
+    self.assertEqual(1, boxed_count[0])
+    lazy_tensor()
+    self.assertEqual(1, boxed_count[0])
+
+  def test_conversion_explicit(self):
+    @lazy_tensor_creator.LazyTensorCreator
+    def lazy_tensor():
+      return tf.constant(1)
+    real_tensor = tf.convert_to_tensor(lazy_tensor)
+    self.assertEqual(tf.constant(1), real_tensor)
+
+  def test_conversion_identity(self):
+    @lazy_tensor_creator.LazyTensorCreator
+    def lazy_tensor():
+      return tf.constant(1)
+    real_tensor = tf.identity(lazy_tensor)
+    self.assertEqual(tf.constant(1), real_tensor)
+
+  def test_conversion_implicit(self):
+    @lazy_tensor_creator.LazyTensorCreator
+    def lazy_tensor():
+      return tf.constant(1)
+    real_tensor = lazy_tensor + tf.constant(1)
+    self.assertEqual(tf.constant(2), real_tensor)
+
+  def test_explicit_dtype_okay_if_matches(self):
+    @lazy_tensor_creator.LazyTensorCreator
+    def lazy_tensor():
+      return tf.constant(1, dtype=tf.int32)
+    real_tensor = tf.convert_to_tensor(lazy_tensor, dtype=tf.int32)
+    self.assertEqual(tf.int32, real_tensor.dtype)
+    self.assertEqual(tf.constant(1, dtype=tf.int32), real_tensor)
+
+  def test_explicit_dtype_rejected_if_different(self):
+    @lazy_tensor_creator.LazyTensorCreator
+    def lazy_tensor():
+      return tf.constant(1, dtype=tf.int32)
+    with self.assertRaisesRegex(RuntimeError, "dtype"):
+      tf.convert_to_tensor(lazy_tensor, dtype=tf.int64)
+
+  def test_as_ref_rejected(self):
+    @lazy_tensor_creator.LazyTensorCreator
+    def lazy_tensor():
+      return tf.constant(1, dtype=tf.int32)
+    with self.assertRaisesRegex(RuntimeError, "ref tensor"):
+      # Call conversion routine manually since this isn't actually
+      # exposed as an argument to tf.convert_to_tensor.
+      lazy_tensor(as_ref=True)
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorboard/util/lazy_tensor_creator_test.py
+++ b/tensorboard/util/lazy_tensor_creator_test.py
@@ -78,7 +78,8 @@ class LazyTensorCreatorTest(tf.test.TestCase):
     with self.assertRaisesRegex(RuntimeError, "ref tensor"):
       # Call conversion routine manually since this isn't actually
       # exposed as an argument to tf.convert_to_tensor.
-      lazy_tensor(as_ref=True)
+      lazy_tensor_creator._lazy_tensor_creator_converter(
+          lazy_tensor, as_ref=True)
 
   def test_reentrant_callable_does_not_deadlock(self):
     @lazy_tensor_creator.LazyTensorCreator

--- a/tensorboard/util/lazy_tensor_creator_test.py
+++ b/tensorboard/util/lazy_tensor_creator_test.py
@@ -90,7 +90,7 @@ class LazyTensorCreatorTest(tf.test.TestCase):
 
   def test_reentrant_callable_does_not_deadlock(self):
     @lazy_tensor_creator.LazyTensorCreator
-    def lazy_tensor(nested_call=False):
+    def lazy_tensor():
       return lazy_tensor()
     with self.assertRaisesRegex(RuntimeError, "reentrant callable"):
       lazy_tensor()

--- a/tensorboard/util/lazy_tensor_creator_test.py
+++ b/tensorboard/util/lazy_tensor_creator_test.py
@@ -21,7 +21,14 @@ import tensorflow as tf
 from tensorboard.util import lazy_tensor_creator
 
 
+tf.compat.v1.enable_eager_execution()
+
+
 class LazyTensorCreatorTest(tf.test.TestCase):
+
+  def assertEqualAsNumpy(self, a, b):
+    # TODO(#2507): Remove after we no longer test against TF 1.x.
+    self.assertEqual(a.numpy(), b.numpy())
 
   def test_lazy_creation_with_memoization(self):
     boxed_count = [0]
@@ -40,21 +47,21 @@ class LazyTensorCreatorTest(tf.test.TestCase):
     def lazy_tensor():
       return tf.constant(1)
     real_tensor = tf.convert_to_tensor(lazy_tensor)
-    self.assertEqual(tf.constant(1), real_tensor)
+    self.assertEqualAsNumpy(tf.constant(1), real_tensor)
 
   def test_conversion_identity(self):
     @lazy_tensor_creator.LazyTensorCreator
     def lazy_tensor():
       return tf.constant(1)
     real_tensor = tf.identity(lazy_tensor)
-    self.assertEqual(tf.constant(1), real_tensor)
+    self.assertEqualAsNumpy(tf.constant(1), real_tensor)
 
   def test_conversion_implicit(self):
     @lazy_tensor_creator.LazyTensorCreator
     def lazy_tensor():
       return tf.constant(1)
     real_tensor = lazy_tensor + tf.constant(1)
-    self.assertEqual(tf.constant(2), real_tensor)
+    self.assertEqualAsNumpy(tf.constant(2), real_tensor)
 
   def test_explicit_dtype_okay_if_matches(self):
     @lazy_tensor_creator.LazyTensorCreator
@@ -62,7 +69,7 @@ class LazyTensorCreatorTest(tf.test.TestCase):
       return tf.constant(1, dtype=tf.int32)
     real_tensor = tf.convert_to_tensor(lazy_tensor, dtype=tf.int32)
     self.assertEqual(tf.int32, real_tensor.dtype)
-    self.assertEqual(tf.constant(1, dtype=tf.int32), real_tensor)
+    self.assertEqualAsNumpy(tf.constant(1, dtype=tf.int32), real_tensor)
 
   def test_explicit_dtype_rejected_if_different(self):
     @lazy_tensor_creator.LazyTensorCreator


### PR DESCRIPTION
Continuation of PRs #2893, #2894, #2895 by @hongjunChoi .

This takes advantage of a recent change in `tf.summary.write()` as of https://github.com/tensorflow/tensorflow/commit/661f0ac0015184e970f9a3f04e845a9166ebfa7a that allows passing a callable as the `tensor` argument instead of an actual `tf.Tensor`.  With this functionality, `write()` will call the callable to get the tensor only if the tensor is going to be used (i.e. the summary writer exists and the summary recording condition is met).  This avoids overhead in executing preprocessing steps when they are not needed.  Among V2 summaries, only image, audio, and histogram do any real preprocessing, so those are the only ones changed in this PR.

In order to maintain backwards compatibility with the previous `write()` API, this introduces a shim layer called `LazyTensorCreator` that uses `tf.register_tensor_conversion_function()` to ensure that the callable we pass in can be automatically converted to a `tf.Tensor` in many contexts (and in particular, in the context of the call to `tf.identity()` which is used inside `write()`).  That way a version skew (e.g. TensorBoard 2.1 but TensorFlow 2.0) won't break the summary API integration; while technically we don't guarantee that a skew in this direction will work, this is a likely enough situation and a confusing enough error that it's worth a bit of work to avoid.

cc @alextp FYI