### PR TITLE
ci: unpin 2019-10-23 nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - BAZEL_SHA256SUM=6c50e142a0a405d3d8598050d6c1b3920c8cdb82a7ffca6fc067cb474275148f
   matrix:
     - TF_VERSION_ID=tensorflow==1.15.0rc3
-    - TF_VERSION_ID=tf-nightly==2.1.0.dev20191023
+    - TF_VERSION_ID=tf-nightly
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:


### PR DESCRIPTION
Summary:
I never got around to investigating why these were broken (I couldn’t
reproduce the failure locally and didn’t have time to investigate on
Travis). The failures appear to be fixed now.

This reverts commit 9b188c1bd4b9747f7c6f130f45dd18901a9831d7.

Test Plan:
CI suffices.

wchargin-branch: unpin-20191023-nightly
