### PR TITLE
Improve usability and design of counterfactual controls (What-If Tool)

### DIFF
--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -1173,10 +1173,20 @@ limitations under the License.
         margin-right: 6px;
       }
       .counterfactual-delta label {
-        padding-top: 10px;
+        padding-top: 12px;
+        margin-left: 8px;
+        margin-right: 4px;
+        font-size: 14px;
+        color: rgb(60, 64, 67);
       }
       .counterfactual-delta paper-slider {
         height: 40px;
+        --paper-slider-active-color: #81c995;
+        --paper-slider-knob-color: #81c995;
+        --paper-slider-input-container-input: { 
+          font-size: 14px;
+          color: rgb(60, 64, 67);
+        }
       }
       .datapoint-button {
         color: #202124;
@@ -1437,6 +1447,28 @@ limitations under the License.
                             Show nearest counterfactual datapoint
                           </paper-toggle-button>
                         </div>
+                        <paper-icon-button
+                          icon="info-outline"
+                          class="info-icon no-padding"
+                          on-tap="openDialog"
+                        >
+                        </paper-icon-button>
+                        <paper-dialog
+                          class="dialog-text"
+                          horizontal-align="auto"
+                          vertical-align="auto"
+                        >
+                          <div class="dialog-title">
+                            Nearest counterfactual (neighbor of different
+                            classification)
+                          </div>
+                          <div>
+                            Compares the selected datapoint with its nearest
+                            neighbor from a different classification using L1 or
+                            L2 distance. If a custom distance function is set,
+                            it uses that function instead.
+                          </div>
+                        </paper-dialog>
                         <paper-radio-group
                           selected="{{nearestCounterfactualDist}}"
                         >
@@ -1461,12 +1493,36 @@ limitations under the License.
                             title="Minimum distance in inferred value to consider counterfactual"
                             class="counterfactual-delta"
                           >
+                            <label>Threshold</label>
+                            <paper-icon-button
+                              icon="info-outline"
+                              class="info-icon no-padding"
+                              on-tap="openDialog"
+                            >
+                            </paper-icon-button>
+                            <paper-dialog
+                              class="dialog-text"
+                              horizontal-align="auto"
+                              vertical-align="auto"
+                            >
+                              <div class="dialog-title">
+                                Counterfactual threshold
+                              </div>
+                              <div>
+                                  For regression, a neighbor point is considered as
+                                  a different classification if the difference in
+                                  inferred value is equal or greater than the
+                                  selected threshold.<br />
+                                  The threshold is initialized to the standard deviation of
+                                  the inferred values.
+                              </div>
+                            </paper-dialog>
                             <paper-slider
-                              pin
+                              editable
                               value="{{minCounterfactualValueDist}}"
                               max="[[maxCounterfactualValueDist]]"
+                              disabled$="[[!showNearestCounterfactual]]"
                             ></paper-slider>
-                            <label>Delta</label>
                           </div>
                         </template>
                         <paper-dropdown-menu
@@ -1490,42 +1546,6 @@ limitations under the License.
                             </template>
                           </paper-listbox>
                         </paper-dropdown-menu>
-                        <paper-icon-button
-                          icon="info-outline"
-                          class="info-icon no-padding"
-                          on-tap="openDialog"
-                        >
-                        </paper-icon-button>
-                        <paper-dialog
-                          class="dialog-text"
-                          horizontal-align="auto"
-                          vertical-align="auto"
-                        >
-                          <div class="dialog-title">
-                            Nearest counterfactual (neighbor of different
-                            classification)
-                          </div>
-                          <div>
-                            Compares the selected datapoint with its nearest
-                            neighbor from a different classification using L1 or
-                            L2 distance. If a custom distance function is set,
-                            it uses that function instead.
-                          </div>
-                          <div>
-                            <template
-                              is="dom-if"
-                              if="[[isRegression_(modelType)]]"
-                              restamp
-                            >
-                              For regression, a neighbor point is considered as
-                              a different classification if the difference in
-                              inferred value is equal or greater than the
-                              selected delta.<br />
-                              Delta is initialized to the standard deviation of
-                              the inferred values.
-                            </template>
-                          </div>
-                        </paper-dialog>
                       </div>
                       <div title="Select a datapoint to use this feature">
                         <div class="flex">
@@ -4261,9 +4281,8 @@ limitations under the License.
             inferenceValueStr,
             this.nearestCounterfactualModelIndex
           );
-          this.minCounterfactualValueDist = this.distanceStats_[
-            valueName
-          ].stdDev;
+          const stat = this.distanceStats_[valueName];
+          this.minCounterfactualValueDist = stat ? stat.stdDev : 0;
         },
 
         finalizeClosestCounterfactual: function(exInd, distances) {

--- a/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
+++ b/tensorboard/plugins/interactive_inference/tf_interactive_inference_dashboard/tf-interactive-inference-dashboard.html
@@ -1183,7 +1183,7 @@ limitations under the License.
         height: 40px;
         --paper-slider-active-color: #81c995;
         --paper-slider-knob-color: #81c995;
-        --paper-slider-input-container-input: { 
+        --paper-slider-input-container-input: {
           font-size: 14px;
           color: rgb(60, 64, 67);
         }
@@ -1509,12 +1509,12 @@ limitations under the License.
                                 Counterfactual threshold
                               </div>
                               <div>
-                                  For regression, a neighbor point is considered as
-                                  a different classification if the difference in
-                                  inferred value is equal or greater than the
-                                  selected threshold.<br />
-                                  The threshold is initialized to the standard deviation of
-                                  the inferred values.
+                                For regression, a neighbor point is considered
+                                as a different classification if the difference
+                                in inferred value is equal or greater than the
+                                selected threshold.<br />
+                                The threshold is initialized to the standard
+                                deviation of the inferred values.
                               </div>
                             </paper-dialog>
                             <paper-slider


### PR DESCRIPTION
Adjust position, color and behaviour of the counterfactual controls in the WIT dashboard.

cc @jameswex and @mpushkarna 

* Motivation for features / changes

Most changes come from discussions with Mahima.

* Technical description of changes

Add an input box to the slider (and remove its pin), make a separate info box for the threshold, rename *Delta* to *Threshold*, disable the slider when the feature is switched off, and adjust the CSS (color, position, font size).

* Screenshots of UI changes

![threshold](https://user-images.githubusercontent.com/6004563/68481291-b5cbb980-022e-11ea-8587-a8f206528cf2.png)

* Detailed steps to verify changes work correctly (as executed by you)

Most changes are merely visual: just open the tool for a regression model, so that the slider also appears.
Besides that, switch the counterfactual toggle on and off and check that the slider behaves accordingly.

* Alternate designs / implementations considered

Some discussions about what to do when values inserted are out of range, but the slider component handles this case by itself.
