### PR TITLE
Remove unused deps blocking sync

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -25,6 +25,8 @@ ng_module(
         ":config",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "//tensorboard/webapp/core",
+        "//tensorboard/webapp/core/actions",
+        "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/header",
         "//tensorboard/webapp/plugins",
         "//tensorboard/webapp/reloader",

--- a/tensorboard/webapp/core/effects/BUILD
+++ b/tensorboard/webapp/core/effects/BUILD
@@ -15,11 +15,9 @@ tf_ts_library(
         "//tensorboard/webapp/webapp_data_source",
         "//tensorboard/webapp/types",
         "@npm//@angular/common",
-        "@npm//@angular/compiler",
         "@npm//@angular/core",
         "@npm//@ngrx/effects",
         "@npm//@ngrx/store",
-        "@npm//@types/jasmine",
         "@npm//rxjs",
     ],
 )

--- a/tensorboard/webapp/header/BUILD
+++ b/tensorboard/webapp/header/BUILD
@@ -22,6 +22,8 @@ ng_module(
         "//tensorboard/webapp/angular:expect_angular_material_tabs",
         "//tensorboard/webapp/angular:expect_angular_material_toolbar",
         "//tensorboard/webapp/core",
+        "//tensorboard/webapp/core/actions",
+        "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/settings",
         "//tensorboard/webapp/types",
         "@npm//@angular/common",

--- a/tensorboard/webapp/reloader/BUILD
+++ b/tensorboard/webapp/reloader/BUILD
@@ -11,6 +11,8 @@ ng_module(
     ],
     deps = [
         "//tensorboard/webapp/core",
+        "//tensorboard/webapp/core/store",
+        "//tensorboard/webapp/core/actions",
         "@npm//@angular/core",
         "@npm//@ngrx/store",
         "@npm//rxjs",

--- a/tensorboard/webapp/settings/BUILD
+++ b/tensorboard/webapp/settings/BUILD
@@ -20,6 +20,8 @@ ng_module(
         "//tensorboard/webapp/angular:expect_angular_material_icon",
         "//tensorboard/webapp/angular:expect_angular_material_input",
         "//tensorboard/webapp/core",
+        "//tensorboard/webapp/core/store",
+        "//tensorboard/webapp/core/actions",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@angular/forms",


### PR DESCRIPTION
Two copypasta dependencies broke our internal sync.

Also, internally we enforce strict deps, so I added a bunch that were transitive before. 

There are probably more unused deps that we can clean up later, but that are not blocking as far as I know.