### PR TITLE
Add download dialog to allow downloading projected points and metadata

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.html
@@ -264,6 +264,14 @@ limitations under the License.
         display: none;
         margin-top: 10px;
       }
+
+      .download-options-container {
+        display: flex;
+        flex-direction: column;
+        height: 100px;
+        justify-content: space-around;
+        padding: 20px;
+      }
     </style>
     <div class="title">DATA</div>
     <div class="container">
@@ -458,12 +466,12 @@ limitations under the License.
             animation-delay="0"
             fit-to-visible-bounds
           >
-            Download the metadata with applied modifications
+            Download projections or metadata with applied modifications
           </paper-tooltip>
-          <paper-button class="ink-button" on-click="downloadMetadataClicked"
+          <paper-button class="ink-button" on-tap="_openDownloadDialog"
             >Download</paper-button
           >
-          <a href="#" id="downloadMetadataLink" hidden></a>
+          <a href="#" id="downloadDataLink" hidden></a>
         </span>
         <span id="label-button" class="button-container">
           <paper-tooltip
@@ -641,6 +649,20 @@ limitations under the License.
                   >Test your shareable URL</paper-button
                 >
               </a>
+            </div>
+          </paper-dialog-scrollable>
+          <div class="dismiss-dialog-note">Click outside to dismiss.</div>
+        </paper-dialog>
+        <paper-dialog id="projectorDownloadDialog" with-backdrop>
+          <h2>Download projections or metadata with applied modifications</h2>
+          <paper-dialog-scrollable class="scrollable-container">
+            <div class="download-options-container">
+              <paper-button on-tap="downloadProjectionClicked">
+                Download currently visible projection (.json)
+              </paper-button>
+              <paper-button on-tap="downloadMetadataDataClicked">
+                Download metadata (.tsv)
+              </paper-button>
             </div>
           </paper-dialog-scrollable>
           <div class="dismiss-dialog-note">Click outside to dismiss.</div>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-data-panel.ts
@@ -389,7 +389,7 @@ namespace vz_projector {
       }
     }
 
-    private downloadMetadataClicked() {
+    private downloadMetadataDataClicked() {
       if (
         this.projector &&
         this.projector.dataSet &&
@@ -409,9 +409,26 @@ namespace vz_projector {
         });
 
         const textBlob = new Blob([tsvFile], {type: 'text/plain'});
-        this.$.downloadMetadataLink.download = 'metadata-edited.tsv';
-        this.$.downloadMetadataLink.href = window.URL.createObjectURL(textBlob);
-        this.$.downloadMetadataLink.click();
+        this.$.downloadDataLink.download = 'metadata-edited.tsv';
+        this.$.downloadDataLink.href = window.URL.createObjectURL(textBlob);
+        this.$.downloadDataLink.click();
+      }
+    }
+
+    private downloadProjectionClicked() {
+      if (this.projector && this.projector.dataSet) {
+        const state = this.projector.getCurrentState();
+        const {projections, selectedProjection} = state;
+        const projectionData = projections.map((projection) => {
+          return [0, 1, 2].map((i) => projection[`${selectedProjection}-${i}`]);
+        });
+
+        const textBlob = new Blob([JSON.stringify(projectionData)], {
+          type: 'application/json',
+        });
+        this.$.downloadDataLink.download = `projection (${selectedProjection}).json`;
+        this.$.downloadDataLink.href = window.URL.createObjectURL(textBlob);
+        this.$.downloadDataLink.click();
       }
     }
 
@@ -814,6 +831,10 @@ namespace vz_projector {
 
     _openConfigDialog(): void {
       this.$.projectorConfigDialog.open();
+    }
+
+    _openDownloadDialog(): void {
+      this.$.projectorDownloadDialog.open();
     }
   }
 


### PR DESCRIPTION
Lynn Cherny requested a feature to allow the user to download coordinates of the projected data. This PR adds new functionality to the already existing "Download" button, by making it open a dialog that allows the user whether to download the projected data or the metadata.

<img width="858" alt="Screen Shot 2019-11-08 at 3 01 59 PM" src="https://user-images.githubusercontent.com/7818584/68516479-01836080-0239-11ea-97ee-9ae1a1ddae69.png">
