### PR TITLE
core: security validator middleware

### DIFF
--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -66,6 +66,7 @@ py_library(
         ":experiment_id",
         ":http_util",
         ":path_prefix",
+        ":security_validator",
         "//tensorboard:errors",
         "//tensorboard:expect_sqlite3_installed",
         "//tensorboard/backend/event_processing:data_provider",
@@ -167,5 +168,30 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/compat:tensorflow",
+    ],
+)
+
+py_library(
+    name = "security_validator",
+    srcs = ["security_validator.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        "//tensorboard/util:tb_logging",
+        "@org_pocoo_werkzeug",
+    ],
+)
+
+py_test(
+    name = "security_validator_test",
+    size = "small",
+    srcs = ["security_validator_test.py"],
+    srcs_version = "PY2AND3",
+    tags = ["support_notf"],
+    deps = [
+        ":security_validator",
+        "//tensorboard:test",
+        "//tensorboard/util:tb_logging",
+        "@org_pocoo_werkzeug",
+        "@org_pythonhosted_mock",
     ],
 )

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -46,6 +46,7 @@ from tensorboard.backend import empty_path_redirect
 from tensorboard.backend import experiment_id
 from tensorboard.backend import http_util
 from tensorboard.backend import path_prefix
+from tensorboard.backend import security_validator
 from tensorboard.backend.event_processing import db_import_multiplexer
 from tensorboard.backend.event_processing import data_provider as event_data_provider  # pylint: disable=line-too-long
 from tensorboard.backend.event_processing import plugin_event_accumulator as event_accumulator  # pylint: disable=line-too-long
@@ -340,6 +341,7 @@ class TensorBoardWSGI(object):
     app = empty_path_redirect.EmptyPathRedirectMiddleware(app)
     app = experiment_id.ExperimentIdMiddleware(app)
     app = path_prefix.PathPrefixMiddleware(app, self._path_prefix)
+    app = security_validator.SecurityValidatorMiddleware(app)
     app = _handling_errors(app)
     return app
 

--- a/tensorboard/backend/security_validator.py
+++ b/tensorboard/backend/security_validator.py
@@ -36,11 +36,16 @@ _HTML_MIME_TYPE = "text/html"
 # Matches CSP rule like "strict-src foobar baz".
 _CSP_PATTERN = re.compile(r"^([a-zA-Z0-9-]+) (.*)")
 _CSP_DEFAULT_SRC = "default-src"
-# Whitelist of allowed CSP rules.
+# Whitelist of allowed CSP violations.
 _CSP_IGNORE = {
+    # Allow TensorBoard to be iframed.
     "frame-ancestors": ["*"],
+    # Polymer-based code uses unsafe-inline.
     "style-src": ["'unsafe-inline'", "data:"],
+    # Used in canvas
     "img-src": ["blob:", "data:"],
+    # Used by numericjs.
+    # TODO(stephanwlee): remove it eventually.
     "script-src": ["'unsafe-eval'"],
 }
 

--- a/tensorboard/backend/security_validator.py
+++ b/tensorboard/backend/security_validator.py
@@ -1,0 +1,156 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Validates responses and their security features"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+import re
+
+from werkzeug import wrappers
+from werkzeug.datastructures import Headers
+from werkzeug import http
+
+from tensorboard.util import tb_logging
+
+Policy = collections.namedtuple("Poicy", ["name", "rules"])
+
+logger = tb_logging.get_logger()
+
+_HTML_MIME_TYPE = "text/html"
+_CSP_PATTERN = re.compile(r"^([a-z]+-[a-z]+)(.*)")
+_CSP_DEFAULT_SRC = "default-src"
+# Whitelist of allowed CSP rules.
+_CSP_IGNORE = {
+    "frame-ancestors": "*",
+    "style-src": ["'unsafe-inline'", "data:"],
+    "img-src": ["blob:", "data:"],
+    "script-src": ["'unsafe-eval'"],
+}
+
+
+class SecurityValidatorMiddleware(object):
+  """WSGI middleware validating security on response.
+
+  It validates:
+  - responses have Content-Type
+  - responses have X-Content-Type-Options: nosniff
+  - text/html responses have CSP header.
+
+  Instances of this class are WSGI applications (see PEP 3333).
+  """
+
+  def __init__(self, application):
+    """Initializes an `SecurityValidatorMiddleware`.
+
+    Args:
+      application: The WSGI application to wrap (see PEP 3333).
+    """
+    self._application = application
+
+  def __call__(self, environ, start_response):
+
+    def start_resposne_proxy(status, headers, exc_info=None):
+      self._validate_headers(headers)
+      return start_response(status, headers, exc_info)
+
+    return self._application(environ, start_resposne_proxy)
+
+  def _validate_headers(self, headers_list):
+    headers = Headers(headers_list)
+    self._validate_content_type(headers)
+    self._validate_x_content_type_options(headers)
+    self._validate_csps(headers)
+
+  def _validate_content_type(self, headers):
+    if headers.get("Content-Type"):
+      return
+
+    self._maybe_raise_value_error("Content-Type is required on a Response")
+
+  def _validate_x_content_type_options(self, headers):
+    # Both none and empty string are
+    option = headers.get("X-Content-Type-Options")
+    if option == "nosniff":
+      return
+
+    self._maybe_raise_value_error(
+        'X-Content-Type-Options is required to be "nosniff"'
+    )
+
+  def _validate_csps(self, headers):
+    mime_type, _ = http.parse_options_header(headers.get("Content-Type"))
+    if mime_type != _HTML_MIME_TYPE:
+      return
+
+    csp_texts = headers.get_all("Content-Security-Policy")
+    policies = []
+
+    for csp_text in csp_texts:
+      policies += self._parse_csp_text(csp_text)
+
+    self._validate_csp_policies(policies)
+
+  def _validate_csp_policies(self, policies):
+    has_default_src = False
+    violations = []
+
+    for name, rules in policies:
+      has_default_src = has_default_src or name == _CSP_DEFAULT_SRC
+
+      for rule in rules:
+        if rule in _CSP_IGNORE.get(name, []):
+          # There are cases where certain values are legitimate.
+          continue
+
+        if (
+            rule == "'self'" or rule == "'none'" or rule.startswith("https:")
+            or rule.startswith("'sha256-")
+        ):
+          continue
+
+        msg = "Illegal Content-Security-Policy for {name}: {rule}".format(
+            name=name, rule=rule
+        )
+        violations.append(msg)
+
+    if not has_default_src:
+      violations.append("Requires default-src for Content-Security-Policy")
+
+    if violations:
+      self._maybe_raise_value_error("\n".join(violations))
+
+  def _parse_csp_text(self, csp_text):
+    csp_srcs = csp_text.split(";")
+    policies = []
+    for csp_src in csp_srcs:
+      match = _CSP_PATTERN.match(csp_src)
+      if not match or len(match.groups()) < 2:
+        continue
+      name, rules = _CSP_PATTERN.match(csp_src).groups()
+      policies.append(
+          Policy(
+              name=name,
+              rules=[rule.strip() for rule in rules.split(" ") if rule]
+          )
+      )
+
+    return policies
+
+  def _maybe_raise_value_error(self, error_msg):
+    logger.warn("In 3.0, this warning will become an error:\n%s" % error_msg)
+    # TODO(3.x): raise a value error.

--- a/tensorboard/backend/security_validator.py
+++ b/tensorboard/backend/security_validator.py
@@ -122,10 +122,10 @@ class SecurityValidatorMiddleware(object):
 
     for directive in policies:
       name = directive.name
-      for directive in directive.value:
+      for value in directive.value:
         has_default_src = has_default_src or name == _CSP_DEFAULT_SRC
 
-        if directive in _CSP_IGNORE.get(name, []):
+        if value in _CSP_IGNORE.get(name, []):
           # There are cases where certain directives are legitimate.
           continue
 
@@ -138,14 +138,14 @@ class SecurityValidatorMiddleware(object):
         # stricter enforcement.
         # TODO(stephanwlee): deprecate the sha-based whitelisting.
         if (
-            directive == "'self'" or directive == "'none'"
-            or directive.startswith("https:")
-            or directive.startswith("'sha256-")
+            value == "'self'" or value == "'none'"
+            or value.startswith("https:")
+            or value.startswith("'sha256-")
         ):
           continue
 
-        msg = "Illegal Content-Security-Policy for {name}: {directive}".format(
-            name=name, directive=directive
+        msg = "Illegal Content-Security-Policy for {name}: {value}".format(
+            name=name, value=value
         )
         violations.append(msg)
 

--- a/tensorboard/backend/security_validator_test.py
+++ b/tensorboard/backend/security_validator_test.py
@@ -1,0 +1,193 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for `tensorboard.backend.security_validator`."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+  # python version >= 3.3
+  from unittest import mock    # pylint: disable=g-import-not-at-top
+except ImportError:
+  import mock    # pylint: disable=g-import-not-at-top,unused-import
+
+import werkzeug
+from werkzeug import test as werkzeug_test
+from werkzeug.datastructures import Headers
+
+from tensorboard import test as tb_test
+from tensorboard.backend import security_validator
+from tensorboard.util import tb_logging
+
+logger = tb_logging.get_logger()
+
+_WARN_PREFIX = "In 3.0, this warning will become an error:\n"
+
+
+def create_headers(
+    content_type="application/json",
+    x_content_type_options="nosniff",
+    content_secrurity_policy=""
+):
+  return Headers(
+      {
+          "Content-Type": content_type,
+          "X-Content-Type-Options": x_content_type_options,
+          "Content-Security-Policy": content_secrurity_policy,
+      }
+  )
+
+
+class SecurityValidatorMiddlewareTest(tb_test.TestCase):
+  """Tests for `SecurityValidatorMiddleware`."""
+
+  def setUp(self):
+    super(SecurityValidatorMiddlewareTest, self).setUp()
+    self.get_header = lambda req: {}
+    app = werkzeug.Request.application(
+        lambda req: werkzeug.Response("OK", headers=self.get_header(req))
+    )
+    app = security_validator.SecurityValidatorMiddleware(app)
+    self.server = werkzeug_test.Client(app, werkzeug.BaseResponse)
+    self.mock_warn = mock.patch.object(logger, "warn").start()
+
+  def tearDown(self):
+    super(SecurityValidatorMiddlewareTest, self).tearDown()
+    mock.patch.stopall()
+
+  def make_request_and_maybe_assert_warn(
+      self, headers, expected_warn_substr=None
+  ):
+    self.get_header = lambda req: headers
+    self.server.get("")
+
+    if expected_warn_substr is None:
+      self.mock_warn.assert_not_called()
+    else:
+      self.mock_warn.assert_called_with(_WARN_PREFIX + expected_warn_substr)
+
+  def test_validate_content_type(self):
+    self.make_request_and_maybe_assert_warn(
+        create_headers(content_type="application/json")
+    )
+
+    self.make_request_and_maybe_assert_warn(
+        create_headers(content_type=""),
+        "Content-Type is required on a Response"
+    )
+
+  def test_validate_x_content_type_options(self):
+    self.make_request_and_maybe_assert_warn(
+        create_headers(x_content_type_options="nosniff")
+    )
+
+    self.make_request_and_maybe_assert_warn(
+        create_headers(x_content_type_options=""),
+        'X-Content-Type-Options is required to be "nosniff"'
+    )
+
+  def test_validate_csp_text_html(self):
+    self.make_request_and_maybe_assert_warn(
+        create_headers(
+            content_type="text/html; charset=UTF-8",
+            content_secrurity_policy=(
+                "default-src 'self';script-src https://google.com;"
+            )
+        ),
+    )
+
+    self.make_request_and_maybe_assert_warn(
+        create_headers(
+            content_type="text/html; charset=UTF-8",
+            content_secrurity_policy="",
+        ),
+        "Requires default-src for Content-Security-Policy",
+    )
+
+    self.make_request_and_maybe_assert_warn(
+        create_headers(
+            content_type="text/html; charset=UTF-8",
+            content_secrurity_policy="default-src *"
+        ),
+        "Illegal Content-Security-Policy for default-src: *",
+    )
+
+    self.make_request_and_maybe_assert_warn(
+        create_headers(
+            content_type="text/html; charset=UTF-8",
+            content_secrurity_policy="default-src 'self';script-src *"
+        ),
+        "Illegal Content-Security-Policy for script-src: *",
+    )
+
+    self.make_request_and_maybe_assert_warn(
+        create_headers(
+            content_type="text/html; charset=UTF-8",
+            content_secrurity_policy=(
+                "script-src * 'sha256-foo' 'nonce-bar';"
+                "style-src http://google.com;object-src *;"
+                "img-src 'unsafe-inline';default-src 'self';"
+                "script-src *       'strict-dynamic'"
+            )
+        ), "\n".join(
+            [
+                "Illegal Content-Security-Policy for script-src: *",
+                "Illegal Content-Security-Policy for script-src: 'nonce-bar'",
+                "Illegal Content-Security-Policy for style-src: http://google.com",
+                "Illegal Content-Security-Policy for object-src: *",
+                "Illegal Content-Security-Policy for img-src: 'unsafe-inline'",
+                "Illegal Content-Security-Policy for script-src: *",
+                "Illegal Content-Security-Policy for script-src: 'strict-dynamic'",
+            ]
+        )
+    )
+
+    headers = create_headers(
+        content_type="text/html; charset=UTF-8",
+        content_secrurity_policy=(
+            "script-src * 'sha256-foo';"
+            "style-src http://google.com"
+        )
+    )
+    headers.add(
+        'Content-Security-Policy',
+        "default-src 'self';script-src 'nonce-bar';object-src *"
+    )
+    self.make_request_and_maybe_assert_warn(
+        headers, "\n".join(
+            [
+                "Illegal Content-Security-Policy for script-src: *",
+                "Illegal Content-Security-Policy for style-src: http://google.com",
+                "Illegal Content-Security-Policy for script-src: 'nonce-bar'",
+                "Illegal Content-Security-Policy for object-src: *",
+            ]
+        )
+    )
+
+  def test_validate_csp_non_text_html(self):
+    self.make_request_and_maybe_assert_warn(
+        create_headers(
+            content_type="application/xhtml",
+            content_secrurity_policy=(
+                "script-src * 'sha256-foo' 'nonce-bar';"
+                "style-src http://google.com;object-src *;"
+            )
+        ),
+    )
+
+
+if __name__ == "__main__":
+  tb_test.main()

--- a/tensorboard/backend/security_validator_test.py
+++ b/tensorboard/backend/security_validator_test.py
@@ -1,5 +1,5 @@
 # Copyright 2019 The TensorFlow Authors. All Rights Reserved.
-#
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -55,12 +55,10 @@ def create_headers(
 class SecurityValidatorMiddlewareTest(tb_test.TestCase):
   """Tests for `SecurityValidatorMiddleware`."""
 
-  @mock.patch.object(logger, "warn")
   def make_request_and_maybe_assert_warn(
       self,
       headers,
       expected_warn_substr,
-      mock_warn,
   ):
 
     @werkzeug.Request.application
@@ -70,7 +68,8 @@ class SecurityValidatorMiddlewareTest(tb_test.TestCase):
     app = security_validator.SecurityValidatorMiddleware(_simple_app)
     server = werkzeug_test.Client(app, BaseResponse)
 
-    server.get("")
+    with mock.patch.object(logger, "warn") as mock_warn:
+      server.get("")
 
     if expected_warn_substr is None:
       mock_warn.assert_not_called()


### PR DESCRIPTION
http_util enforces good practice in term of security to prevent content
sniffing and the content security policy. However, this is not
enforceable for other plugins.

With this middleware, we would like to tell developer to enhance the
security to protect users. When we go 3.0, we may convert the warns into
hard failures.
