### PR TITLE
Make --reload_multifile default value falsy None instead of False

### DIFF
--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -529,7 +529,7 @@ reload finishes, and requires --load_interval=0. (default: %(default)s)\
         # Custom str-to-bool converter since regular bool() doesn't work.
         type=lambda v: {'true': True, 'false': False}.get(v.lower(), v),
         choices=[True, False],
-        default=False,
+        default=None,
         help='''\
 [experimental] If true, this enables experimental support for continuously
 polling multiple event files in each run directory for newly appended data
@@ -537,7 +537,7 @@ polling multiple event files in each run directory for newly appended data
 polled as long as their most recently read data is newer than the threshold
 defined by --reload_multifile_inactive_secs, to limit resource usage. Beware
 of running out of memory if the logdir contains many active event files.
-(default: %(default)s)\
+(default: false)\
 ''')
 
     parser.add_argument(


### PR DESCRIPTION
This changes the default value from `False` to `None`, which doesn't change the semantics or interpretation (since we check it with `if flags.reload_multifile` so both False and falsy-None will fail that check), but does mean that other code can distinguish whether we're truly using the default or whether `--reload_multifile=false` was explicitly passed on the command line.  This means we can effectively change the flag from opt-in to opt-out in some contexts by setting the flag value to `True` if it's still `None` after parsing.