### PR TITLE
cleanup: migrate test over to karma based tooling

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -7,7 +7,6 @@ load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 licenses(["notice"])  # Apache 2.0
 
-
 # Angular module for the top-level app component together with all of its
 # injectable dependencies.  I.e., the entire Angular app.
 ng_module(
@@ -114,8 +113,8 @@ tf_web_library(
     ],
     path = "/",
     deps = [
-        "//tensorboard/components:ng_polymer_lib_binary",
         ":tb_webapp",
+        "//tensorboard/components:ng_polymer_lib_binary",
         "//tensorboard/webapp:material_theme",
     ],
 )
@@ -134,9 +133,7 @@ tf_ng_web_test_suite(
     name = "karma_test",
     deps = [
         "//tensorboard/webapp/core/effects:core_effects_test_lib",
-        # TODO(soergel): make this test work
-        # This test was not included here previously, and it fails.
-        # "//tensorboard/webapp/core/store:core_store_test_lib",
+        "//tensorboard/webapp/core/store:core_store_test_lib",
         "//tensorboard/webapp/header:test_lib",
         "//tensorboard/webapp/plugins:plugins_container_test_lib",
         "//tensorboard/webapp/reloader:test_lib",

--- a/tensorboard/webapp/core/effects/BUILD
+++ b/tensorboard/webapp/core/effects/BUILD
@@ -1,9 +1,9 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-# load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("@npm_angular_bazel//:index.bzl", "ng_module")
 
-tf_ts_library(
+ng_module(
     name = "effects",
     srcs = [
         "core.effects.ts",
@@ -12,8 +12,8 @@ tf_ts_library(
     deps = [
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/core/store",
-        "//tensorboard/webapp/webapp_data_source",
         "//tensorboard/webapp/types",
+        "//tensorboard/webapp/webapp_data_source",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@ngrx/effects",
@@ -22,14 +22,12 @@ tf_ts_library(
     ],
 )
 
-
 tf_ts_library(
     name = "core_effects_test_lib",
     testonly = True,
     srcs = [
         "core.effects.test.ts",
     ],
-    tsconfig = "//:tsconfig-test",
     deps = [
         ":effects",
         "//tensorboard/webapp/angular:expect_angular_common_http_testing",
@@ -37,8 +35,8 @@ tf_ts_library(
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/core/testing",
-        "//tensorboard/webapp/webapp_data_source",
         "//tensorboard/webapp/types",
+        "//tensorboard/webapp/webapp_data_source",
         "@npm//@angular/common",
         "@npm//@angular/compiler",
         "@npm//@angular/core",
@@ -48,16 +46,3 @@ tf_ts_library(
         "@npm//rxjs",
     ],
 )
-
-# TODO(soergel): Make this test work.
-# This did not exist previously, and it fails due to an Angular injection issue.
-# jasmine_node_test(
-#     name = "core_effects_jasmine_test",
-#     srcs = [
-#         ":core_effects_test_lib",
-#     ],
-#     deps = [
-#         "@npm//chai",
-#         "@npm//sinon",
-#     ],
-# )

--- a/tensorboard/webapp/core/store/BUILD
+++ b/tensorboard/webapp/core/store/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 ng_module(
@@ -29,33 +28,9 @@ tf_ts_library(
     tsconfig = "//:tsconfig-test",
     deps = [
         ":store",
-        "//tensorboard/webapp/angular:expect_angular_common_http_testing",
-        "//tensorboard/webapp/angular:expect_angular_core_testing",
-        "//tensorboard/webapp/webapp_data_source",
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/core/testing",
         "//tensorboard/webapp/types",
-        "@npm//@angular/common",
-        "@npm//@angular/compiler",
-        "@npm//@angular/core",
-        "@npm//@ngrx/effects",
-        "@npm//@ngrx/store",
-        "@npm//@types/chai",
         "@npm//@types/jasmine",
-        "@npm//@types/sinon",
-        "@npm//rxjs",
-        "@npm//chai",
-        "@npm//sinon",
-    ],
-)
-
-jasmine_node_test(
-    name = "core_store_jasmine_test",
-    srcs = [
-        ":core_store_test_lib",
-    ],
-    deps = [
-        "@npm//chai",
-        "@npm//sinon",
     ],
 )

--- a/tensorboard/webapp/core/store/core.reducers.test.ts
+++ b/tensorboard/webapp/core/store/core.reducers.test.ts
@@ -12,9 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {expect} from 'chai';
-import * as sinon from 'sinon';
-
 import * as actions from '../actions';
 import {reducers} from './core.reducers';
 import {createPluginMetadata, createCoreState} from '../testing';
@@ -34,7 +31,7 @@ describe('core reducer', () => {
 
       const nextState = reducers(state, actions.changePlugin({plugin: 'bar'}));
 
-      expect(nextState).to.have.property('activePlugin', 'bar');
+      expect(nextState.activePlugin).toBe('bar');
     });
 
     it('does not change plugins when activePlugin changes', () => {
@@ -45,10 +42,7 @@ describe('core reducer', () => {
 
       const nextState = reducers(state, actions.changePlugin({plugin: 'bar'}));
 
-      expect(nextState).to.have.deep.property(
-        'plugins',
-        createPluginsListing()
-      );
+      expect(nextState.plugins).toEqual(createPluginsListing());
     });
   });
 
@@ -74,9 +68,7 @@ describe('core reducer', () => {
         });
         const nextState = reducers(state, action);
 
-        expect(nextState)
-          .to.have.property('pluginsListLoaded')
-          .to.have.property('state', expectedState);
+        expect(nextState.pluginsListLoaded.state).toEqual(expectedState);
       });
 
       it('keeps the lastLoadedTimeInMs the same', () => {
@@ -88,25 +80,15 @@ describe('core reducer', () => {
         });
         const nextState = reducers(state, action);
 
-        expect(nextState)
-          .to.have.property('pluginsListLoaded')
-          .to.have.property('lastLoadedTimeInMs', 1337);
+        expect(nextState.pluginsListLoaded.lastLoadedTimeInMs).toBe(1337);
       });
     });
   });
 
   describe('#pluginsListingLoaded', () => {
-    // type definition of sinon differs in google3 and it cannot be strongly
-    // typed.
-    // TODO(stephanwlee): prefer to use jasmine from now on.
-    let clock: any;
-
     beforeEach(() => {
-      clock = sinon.useFakeTimers(1000);
-    });
-
-    afterEach(() => {
-      clock.restore();
+      // Angular's zonejs installs mock clock by default. No need for another.
+      jasmine.clock().mockDate(new Date(1000));
     });
 
     it('sets plugins with the payload', () => {
@@ -116,10 +98,7 @@ describe('core reducer', () => {
         actions.pluginsListingLoaded({plugins: createPluginsListing()})
       );
 
-      expect(nextState).to.have.deep.property(
-        'plugins',
-        createPluginsListing()
-      );
+      expect(nextState.plugins).toEqual(createPluginsListing());
     });
 
     it('sets the pluginsListLoaded', () => {
@@ -136,7 +115,7 @@ describe('core reducer', () => {
         actions.pluginsListingLoaded({plugins: createPluginsListing()})
       );
 
-      expect(nextState).to.have.deep.property('pluginsListLoaded', {
+      expect(nextState.pluginsListLoaded).toEqual({
         state: LoadState.LOADED,
         lastLoadedTimeInMs: 1000,
       });
@@ -150,7 +129,7 @@ describe('core reducer', () => {
         actions.pluginsListingLoaded({plugins: createPluginsListing()})
       );
 
-      expect(nextState).to.have.property('activePlugin', 'core');
+      expect(nextState.activePlugin).toBe('core');
     });
 
     it('does not change activePlugin when already defined', () => {
@@ -161,7 +140,7 @@ describe('core reducer', () => {
         actions.pluginsListingLoaded({plugins: createPluginsListing()})
       );
 
-      expect(nextState).to.have.property('activePlugin', 'foo');
+      expect(nextState.activePlugin).toBe('foo');
     });
   });
 
@@ -171,11 +150,11 @@ describe('core reducer', () => {
 
       const state2 = reducers(state1, actions.toggleReloadEnabled());
 
-      expect(state2).to.have.property('reloadEnabled', true);
+      expect(state2.reloadEnabled).toBe(true);
 
       const state3 = reducers(state2, actions.toggleReloadEnabled());
 
-      expect(state3).to.have.property('reloadEnabled', false);
+      expect(state3.reloadEnabled).toBe(false);
     });
   });
 
@@ -188,7 +167,7 @@ describe('core reducer', () => {
         actions.changeReloadPeriod({periodInMs: 1000})
       );
 
-      expect(nextState).to.have.property('reloadPeriodInMs', 1000);
+      expect(nextState.reloadPeriodInMs).toBe(1000);
     });
 
     it('ignores the action when periodInMs is non-positive', () => {
@@ -198,13 +177,13 @@ describe('core reducer', () => {
         baseState,
         actions.changeReloadPeriod({periodInMs: 0})
       );
-      expect(state1).to.have.property('reloadPeriodInMs', 1);
+      expect(state1.reloadPeriodInMs).toBe(1);
 
       const state2 = reducers(
         baseState,
         actions.changeReloadPeriod({periodInMs: -1000})
       );
-      expect(state2).to.have.property('reloadPeriodInMs', 1);
+      expect(state2.reloadPeriodInMs).toBe(1);
     });
   });
 });


### PR DESCRIPTION
Especially when we leverage Angular's module system, we need to use the
ng_module build rules to generate all necessary factory method. Although
it is yet unclear exactly why Angular's JIT compilation does not work
under node environment, the team decided to migrate all tests to the
karma based tooling.

This change addresses:
1. jasmine_node_test to karma_web_test (2 are remaining on tensor
widget)
2. fixed core effects that was using ts_library as oppposed to ng_module
(our app was broken because CoreEffectsModule did not get deps correctly
injected in)
3. migrated off of chai/sinon:
  This is tricky and requires some explanation. Normally, when running
  test with the karma executor, one would use webpack or its
  equivalent to build the binary. This should resolve all packages like
  React or chai correctly and bundle in all necessary sources, but
  karma_web_test, for speed, uses concatjs as a bundler which uses 
  requirejs by default. As such, we need some of our dependencies to be
  requirejs compatible some of which is not. For instance, `import
  'chai';` will fail and the test bundle will try to resolve 'chai'
  using ES module, which of cours will fail. Because karma_web_test by
  default uses jasmine framework, we do not have to have think about
  whether chai is requirejs compatible but adding other testing
  framework support quite tricky. To relieve ourselves from the
  headache, we have decided to move away from chai/sinon in favor of
  jasmine.
