### PR TITLE
uploader: set user agent for frontend handshake

### DIFF
--- a/tensorboard/uploader/server_info.py
+++ b/tensorboard/uploader/server_info.py
@@ -54,7 +54,10 @@ def fetch_server_info(origin):
   post_body = _server_info_request().SerializeToString()
   try:
     response = requests.post(
-        endpoint, data=post_body, timeout=_REQUEST_TIMEOUT_SECONDS
+        endpoint,
+        data=post_body,
+        timeout=_REQUEST_TIMEOUT_SECONDS,
+        headers={"User-Agent": "tensorboard/%s" % version.VERSION},
     )
   except requests.RequestException as e:
     raise CommunicationError("Failed to connect to backend: %s" % e)

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -111,6 +111,18 @@ class FetchServerInfoTest(tb_test.TestCase):
     self.assertIn("Corrupt response from backend", msg)
     self.assertIn("an unlikely proto", msg)
 
+  def test_user_agent(self):
+    @wrappers.BaseRequest.application
+    def app(request):
+      result = server_info_pb2.ServerInfoResponse()
+      result.compatibility.details = request.headers["User-Agent"]
+      return wrappers.BaseResponse(result.SerializeToString())
+
+    origin = self._start_server(app)
+    result = server_info.fetch_server_info(origin)
+    expected_user_agent = "tensorboard/%s" % version.VERSION
+    self.assertEqual(result.compatibility.details, expected_user_agent)
+
 
 class CreateServerInfoTest(tb_test.TestCase):
   """Tests for `create_server_info`."""


### PR DESCRIPTION
Test Plan:
Running against a local frontend server, `tensorboard/2.1.0a0` shows up
in the server logs where previously there was `python-requests/2.22.0`.
Unit tests also included.

wchargin-branch: uploader-user-agent
