### PR TITLE
polymer: (partial) remove data binding on style

### DIFF
--- a/tensorboard/components/tf_card_heading/tf-card-heading.html
+++ b/tensorboard/components/tf_card_heading/tf-card-heading.html
@@ -56,8 +56,8 @@ limitations under the License.
             <span>
               <span
                 itemprop="run"
+                id="heading-run"
                 class="heading-label heading-right run"
-                style="background: [[_runBackground]]; color: [[_runColor]]"
                 >[[run]]</span
               >
             </span>
@@ -114,6 +114,10 @@ limitations under the License.
       paper-dialog-scrollable {
         max-width: 640px;
       }
+      #heading-run {
+        background: var(--tf-card-heading-background-color);
+        color: var(--tf-card-heading-color);
+      }
     </style>
   </template>
   <script>
@@ -131,12 +135,14 @@ limitations under the License.
           type: String,
           computed: '_computeRunBackground(color)',
           readOnly: true,
+          observer: '_updateHeadingStyle',
         },
 
         _runColor: {
           type: String,
           computed: '_computeRunColor(color)',
           readOnly: true,
+          observer: '_updateHeadingStyle',
         },
 
         _nameLabel: {
@@ -148,6 +154,13 @@ limitations under the License.
           type: String,
           computed: '_computeTagLabel(displayName, tag)',
         },
+      },
+
+      _updateHeadingStyle() {
+        this.updateStyles({
+          '--tf-card-heading-background-color': this._runBackground,
+          '--tf-card-heading-color': this._runColor,
+        });
       },
 
       _computeRunBackground(color) {

--- a/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
+++ b/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
@@ -115,7 +115,6 @@ limitations under the License.
                   min="1"
                   max="[[_pageCount]]"
                   value="[[_pageInputValue]]"
-                  style="display: inline-block; width: [[_inputWidth]];"
                   on-input="_handlePageInputEvent"
                   on-change="_handlePageChangeEvent"
                   on-focus="_handlePageFocusEvent"
@@ -262,6 +261,11 @@ limitations under the License.
         flex-direction: row;
         flex-wrap: wrap;
       }
+
+      #page-input {
+        display: inline-block;
+        width: var(--tf-category-paginated-view-page-input-width, 100%);
+      }
     </style>
   </template>
   <script>
@@ -386,6 +390,7 @@ limitations under the License.
         _inputWidth: {
           type: String,
           computed: '_computeInputWidth(_pageCount)',
+          observer: '_updateInputWidth',
         },
 
         _pageInputValue: {
@@ -587,6 +592,11 @@ limitations under the License.
         if (pageInput) {
           pageInput.value = newValue;
         }
+      },
+      _updateInputWidth() {
+        this.updateStyles({
+          '--tf-category-paginated-view-page-input-width': this._inputWidth,
+        });
       },
     });
   </script>

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -195,10 +195,7 @@ limitations under the License.
         <iron-collapse opened="[[_matchesListOpened]]">
           <div id="matches-list">
             <template is="dom-repeat" items="[[_seriesNames]]" as="seriesName">
-              <div
-                class="match-list-entry"
-                style="color: [[_determineColor(_colorScale, seriesName)]];"
-              >
+              <div class="match-list-entry">
                 <span class="match-entry-symbol">
                   [[_determineSymbol(_nameToDataSeries, seriesName)]]
                 </span>
@@ -453,6 +450,9 @@ limitations under the License.
         // Clear the data series when the tag filter changes.
         '_refreshDataSeries(_tagFilter)',
       ],
+      listeners: {
+        'dom-change': '_matchListEntryColorUpdated',
+      },
       reload() {
         this.$.loader.reload();
       },
@@ -717,6 +717,19 @@ limitations under the License.
           '_missingTagsCollapsibleOpened',
           !this._missingTagsCollapsibleOpened
         );
+      },
+      _matchListEntryColorUpdated(event) {
+        const [maybeDomRepeat] = event.path;
+        if (maybeDomRepeat.nodeName !== 'DOM-REPEAT') return;
+        this.root
+          .querySelectorAll('.match-list-entry')
+          .forEach((entryElement) => {
+            const seriesName = maybeDomRepeat.itemForElement(entryElement);
+            entryElement.style.color = this._determineColor(
+              this._colorScale,
+              seriesName
+            );
+          });
       },
     });
   </script>

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
@@ -131,10 +131,7 @@ limitations under the License.
         <iron-collapse opened="[[_matchesListOpened]]">
           <div id="matches-list">
             <template is="dom-repeat" items="[[_seriesNames]]" as="seriesName">
-              <div
-                class="match-list-entry"
-                style="color: [[_determineColor(_colorScale, seriesName)]];"
-              >
+              <div class="match-list-entry">
                 <span class="match-entry-symbol">
                   [[_determineSymbol(_nameToDataSeries, seriesName)]]
                 </span>
@@ -272,6 +269,9 @@ limitations under the License.
         // Clear the data series when the tag filter changes.
         '_refreshDataSeries(_tagFilter)',
       ],
+      listeners: {
+        'dom-change': '_matchListEntryColorUpdated',
+      },
       reload() {
         this.$.loader.reload();
       },
@@ -422,6 +422,19 @@ limitations under the License.
       _computeTitleDisplayString(title) {
         // If no title is provided, use a placeholder string.
         return title || 'untitled';
+      },
+      _matchListEntryColorUpdated(event) {
+        const [maybeDomRepeat] = event.path;
+        if (maybeDomRepeat.nodeName !== 'DOM-REPEAT') return;
+        this.root
+          .querySelectorAll('.match-list-entry')
+          .forEach((entryElement) => {
+            const seriesName = maybeDomRepeat.itemForElement(entryElement);
+            entryElement.style.color = this._determineColor(
+              this._colorScale,
+              seriesName
+            );
+          });
       },
     });
   </script>


### PR DESCRIPTION
More details here: https://github.com/tensorflow/tensorboard/issues/2935

Enforcing resin causes several styles in TensorBoard to misbehave
because it fails to correctly sanitize content of the `style` attribute.
We use different techniques (such as CSS variable and imperative
JavaScript) to workaround the issue.

This change only addresses the issues on scalars and custom scalars
dashboard.
