### PR TITLE
Remove project metadata file from docs

### DIFF
--- a/docs/_project.yaml
+++ b/docs/_project.yaml
@@ -1,8 +1,0 @@
-name: TensorBoard
-home_url: /tensorboard/
-parent_project_metadata_path: /_project.yaml
-description: "TensorBoard: TensorFlow's visualization toolkit"
-hide_from_products_list: true
-content_license: cc-apache
-buganizer_id: 141521
-include: /_project_included.yaml


### PR DESCRIPTION
Because it's not need here.
See b/144359208 and cl/280710307 for context.