### PR TITLE
sync: fix Werkzeug `BaseResponse` import

### DIFF
--- a/tensorboard/backend/security_validator_test.py
+++ b/tensorboard/backend/security_validator_test.py
@@ -27,7 +27,7 @@ except ImportError:
 import werkzeug
 from werkzeug import test as werkzeug_test
 from werkzeug.datastructures import Headers
-from werkzeug.wrappers.base_response import BaseResponse
+from werkzeug.wrappers import BaseResponse
 
 from tensorboard import test as tb_test
 from tensorboard.backend import security_validator


### PR DESCRIPTION
Summary:
This works as written in OSS, but must be imported directly from
`werkzeug.wrappers` internally.

Test Plan:
Googlers, see <http://b/144590350>.

wchargin-branch: security-validator-werkzeug-import
