### PR TITLE
build: explicitly export files used by other packages

### DIFF
--- a/tensorboard/defs/BUILD
+++ b/tensorboard/defs/BUILD
@@ -45,3 +45,8 @@ tb_proto_library(
 )
 
 exports_files(["web_test_python_stub.template.py"])
+
+exports_files(
+    ["clutz.d.ts"],
+    visibility = ["//tensorboard:internal"],
+)


### PR DESCRIPTION
Summary:
Currently, implicitly exported source files inherit the package default
visibility. The Bazel team intends to change this such that they are
instead package-private by default. For details, see:
<https://github.com/bazelbuild/proposals/blob/master/designs/2019-10-24-file-visibility.md>

This commit updates our build files to be compatible with that change.

cc @aehlig

Test Plan:
Googlers, see test sync: <http://cl/281077794>.

wchargin-branch: build-explicit-export
