### PR TITLE
backend: document behavior on empty experiment IDs

### DIFF
--- a/tensorboard/backend/experiment_id_test.py
+++ b/tensorboard/backend/experiment_id_test.py
@@ -76,6 +76,10 @@ class ExperimentIdMiddlewareTest(tb_test.TestCase):
     response = self.server.get("/experiment/123/x/y")
     self._assert_ok(response, eid="123", path="/x/y", script="/experiment/123")
 
+  def test_with_empty_experiment_empty_path(self):
+    response = self.server.get("/experiment/")
+    self._assert_ok(response, eid="", path="", script="/experiment/")
+
   def test_with_empty_experiment_root_path(self):
     response = self.server.get("/experiment//")
     self._assert_ok(response, eid="", path="/", script="/experiment/")

--- a/tensorboard/backend/experiment_id_test.py
+++ b/tensorboard/backend/experiment_id_test.py
@@ -76,6 +76,14 @@ class ExperimentIdMiddlewareTest(tb_test.TestCase):
     response = self.server.get("/experiment/123/x/y")
     self._assert_ok(response, eid="123", path="/x/y", script="/experiment/123")
 
+  def test_with_empty_experiment_root_path(self):
+    response = self.server.get("/experiment//")
+    self._assert_ok(response, eid="", path="/", script="/experiment/")
+
+  def test_with_empty_experiment_sub_path(self):
+    response = self.server.get("/experiment//x/y")
+    self._assert_ok(response, eid="", path="/x/y", script="/experiment/")
+
 
 if __name__ == "__main__":
   tb_test.main()


### PR DESCRIPTION
Summary:
Empty experiment IDs are handled just like non-empty ones. This is an
edge case that was being handled as intended, but should have a test to
clarify that this is in fact the desired behavior. This commit adds such
a test.

Test Plan:
Newly added test passes.

wchargin-branch: backend-empty-eid-test
