### PR TITLE
cleanup: set targeted dom-change listener

### DIFF
--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-list.html
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-list.html
@@ -58,7 +58,11 @@ Properties out:
           No matches
         </div>
       </template>
-      <template is="dom-repeat" items="[[_itemsMatchingRegex]]">
+      <template
+        is="dom-repeat"
+        items="[[_itemsMatchingRegex]]"
+        on-dom-change="_synchronizeColors"
+      >
         <div class="item">
           <paper-checkbox
             checked$="[[_isChecked(item, selectionState.*)]]"

--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-list.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-list.ts
@@ -82,10 +82,6 @@ namespace tf_dashboard_common {
       },
     },
 
-    listeners: {
-      'dom-change': '_synchronizeColors',
-    },
-
     observers: [
       '_synchronizeColors(useCheckboxColors)',
       '_synchronizeColors(coloring)',

--- a/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.html
+++ b/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.html
@@ -48,7 +48,11 @@ handle these situations gracefully.
       on-bind-value-changed="_debouncedRegexChange"
     ></paper-input>
     <div id="outer-container" class="scrollbar">
-      <template is="dom-repeat" items="[[namesMatchingRegex]]">
+      <template
+        is="dom-repeat"
+        items="[[namesMatchingRegex]]"
+        on-dom-change="synchronizeColors"
+      >
         <div class="name-row">
           <div
             class="icon-container checkbox-container vertical-align-container"

--- a/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.ts
@@ -85,9 +85,6 @@ namespace tf_dashboard_common {
         },
       },
     },
-    listeners: {
-      'dom-change': 'synchronizeColors',
-    },
     observers: ['_setIsolatorIcon(selectionState, names)'],
     _makeRegex: function(regexString) {
       try {

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -256,6 +256,7 @@ limitations under the License.
             id="dashboards-template"
             items="[[_dashboardData]]"
             as="dashboardDatum"
+            on-dom-change="_onTemplateChanged"
           >
             <div
               class="dashboard-container"
@@ -904,25 +905,6 @@ limitations under the License.
           }
         });
 
-        // We have to wait for our dashboard-containers to be stamped
-        // before we can do anything.
-        const dashboardsTemplate = this.$$('#dashboards-template');
-        const onDomChange = () => {
-          // This will trigger an observer that kicks off everything.
-          const dashboardContainersStamped = {};
-          for (const container of this.root.querySelectorAll(
-            '.dashboard-container'
-          )) {
-            dashboardContainersStamped[container.dataset.dashboard] = true;
-          }
-          this._dashboardContainersStamped = dashboardContainersStamped;
-        };
-        dashboardsTemplate.addEventListener(
-          'dom-change',
-          onDomChange,
-          /*useCapture=*/ false
-        );
-
         this._reloadData();
         this._lastReloadTime = new Date().toString();
       },
@@ -943,6 +925,17 @@ limitations under the License.
             if (typeof maybeMetadata === 'boolean') return maybeMetadata;
             return maybeMetadata && maybeMetadata.enabled;
           });
+      },
+
+      _onTemplateChanged() {
+        // This will trigger an observer that kicks off everything.
+        const dashboardContainersStamped = {};
+        for (const container of this.root.querySelectorAll(
+          '.dashboard-container'
+        )) {
+          dashboardContainersStamped[container.dataset.dashboard] = true;
+        }
+        this._dashboardContainersStamped = dashboardContainersStamped;
       },
 
       /**

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -194,7 +194,13 @@ limitations under the License.
       <template is="dom-if" if="[[_seriesNames.length]]">
         <iron-collapse opened="[[_matchesListOpened]]">
           <div id="matches-list">
-            <template is="dom-repeat" items="[[_seriesNames]]" as="seriesName">
+            <template
+              is="dom-repeat"
+              items="[[_seriesNames]]"
+              as="seriesName"
+              id="match-list-repeat"
+              on-dom-change="_matchListEntryColorUpdated"
+            >
               <div class="match-list-entry">
                 <span class="match-entry-symbol">
                   [[_determineSymbol(_nameToDataSeries, seriesName)]]
@@ -450,9 +456,6 @@ limitations under the License.
         // Clear the data series when the tag filter changes.
         '_refreshDataSeries(_tagFilter)',
       ],
-      listeners: {
-        'dom-change': '_matchListEntryColorUpdated',
-      },
       reload() {
         this.$.loader.reload();
       },
@@ -719,12 +722,14 @@ limitations under the License.
         );
       },
       _matchListEntryColorUpdated(event) {
-        const [maybeDomRepeat] = event.path;
-        if (maybeDomRepeat.nodeName !== 'DOM-REPEAT') return;
+        const domRepeat = this.$$('#match-list-repeat');
+        if (!domRepeat) {
+          return;
+        }
         this.root
           .querySelectorAll('.match-list-entry')
           .forEach((entryElement) => {
-            const seriesName = maybeDomRepeat.itemForElement(entryElement);
+            const seriesName = domRepeat.itemForElement(entryElement);
             entryElement.style.color = this._determineColor(
               this._colorScale,
               seriesName

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -721,7 +721,7 @@ limitations under the License.
           !this._missingTagsCollapsibleOpened
         );
       },
-      _matchListEntryColorUpdated(event) {
+      _matchListEntryColorUpdated() {
         const domRepeat = this.$$('#match-list-repeat');
         if (!domRepeat) {
           return;

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
@@ -130,7 +130,13 @@ limitations under the License.
       <template is="dom-if" if="[[_seriesNames.length]]">
         <iron-collapse opened="[[_matchesListOpened]]">
           <div id="matches-list">
-            <template is="dom-repeat" items="[[_seriesNames]]" as="seriesName">
+            <template
+              is="dom-repeat"
+              items="[[_seriesNames]]"
+              as="seriesName"
+              id="match-list-repeat"
+              on-dom-change="_matchListEntryColorUpdated"
+            >
               <div class="match-list-entry">
                 <span class="match-entry-symbol">
                   [[_determineSymbol(_nameToDataSeries, seriesName)]]
@@ -269,9 +275,6 @@ limitations under the License.
         // Clear the data series when the tag filter changes.
         '_refreshDataSeries(_tagFilter)',
       ],
-      listeners: {
-        'dom-change': '_matchListEntryColorUpdated',
-      },
       reload() {
         this.$.loader.reload();
       },
@@ -424,12 +427,14 @@ limitations under the License.
         return title || 'untitled';
       },
       _matchListEntryColorUpdated(event) {
-        const [maybeDomRepeat] = event.path;
-        if (maybeDomRepeat.nodeName !== 'DOM-REPEAT') return;
+        const domRepeat = this.$$('#match-list-repeat');
+        if (!domRepeat) {
+          return;
+        }
         this.root
           .querySelectorAll('.match-list-entry')
           .forEach((entryElement) => {
-            const seriesName = maybeDomRepeat.itemForElement(entryElement);
+            const seriesName = domRepeat.itemForElement(entryElement);
             entryElement.style.color = this._determineColor(
               this._colorScale,
               seriesName


### PR DESCRIPTION
Instead of component-level listener for dom-change, we now put the
listener on the specific template (dom-if or dom-repeat) that we care
about.
