### PR TITLE
Improve WIT parsing of model results

### DIFF
--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -832,7 +832,7 @@ def run_inference(examples, serving_bundle):
         if len(returned_keys) == 1:
           key_to_use = returned_keys[0]
         # Use default keys if necessary.
-        elif serving_bundle.model_type == == 'classification':
+        elif serving_bundle.model_type == 'classification':
           key_to_use = 'probabilities'
         else:
           key_to_use = 'predictions'

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -820,22 +820,22 @@ def run_inference(examples, serving_bundle):
         tf.io.parse_example([ex.SerializeToString() for ex in examples],
         serving_bundle.feature_spec)).batch(batch_size))
 
-    if serving_bundle.use_predict:
-      preds_key = serving_bundle.predict_output_tensor
-    elif serving_bundle.model_type == 'regression':
-      preds_key = 'predictions'
-    else:
-      preds_key = 'probabilities'
+    # Use the specified key if one is provided.
+    key_to_use = (serving_bundle.predict_output_tensor
+        if serving_bundle.use_predict else None)
 
     values = []
     for pred in preds:
-      # If the prediction dictionary contains only one key, use that key.
-      returned_keys = list(pred.keys())
-      if len(returned_keys) == 1:
-        key_to_use = returned_keys[0]
-      else:
-        key_to_use = preds_key
-
+      if key_to_use is None:
+        # If the prediction dictionary only contains one key, use it.
+        returned_keys = list(pred.keys())
+        if len(returned_keys) == 1:
+          key_to_use = returned_keys[0]
+        # Use default keys if necessary.
+        elif self.config.get('model_type') == 'classification':
+          key_to_use = 'probabilities'
+        else:
+          key_to_use = 'predictions'
       if key_to_use not in pred:
         raise KeyError(
           '"%s" not found in model predictions dictionary' % key_to_use)

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -832,7 +832,7 @@ def run_inference(examples, serving_bundle):
         if len(returned_keys) == 1:
           key_to_use = returned_keys[0]
         # Use default keys if necessary.
-        elif self.config.get('model_type') == 'classification':
+        elif serving_bundle.model_type == == 'classification':
           key_to_use = 'probabilities'
         else:
           key_to_use = 'predictions'

--- a/tensorboard/plugins/interactive_inference/utils/inference_utils.py
+++ b/tensorboard/plugins/interactive_inference/utils/inference_utils.py
@@ -829,7 +829,18 @@ def run_inference(examples, serving_bundle):
 
     values = []
     for pred in preds:
-      values.append(pred[preds_key])
+      # If the prediction dictionary contains only one key, use that key.
+      returned_keys = list(pred.keys())
+      if len(returned_keys) == 1:
+        key_to_use = returned_keys[0]
+      else:
+        key_to_use = preds_key
+
+      if key_to_use not in pred:
+        raise KeyError(
+          '"%s" not found in model predictions dictionary' % key_to_use)
+
+      values.append(pred[key_to_use])
     return (common_utils.convert_prediction_values(values, serving_bundle),
             None)
   elif serving_bundle.custom_predict_fn:

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
@@ -535,7 +535,7 @@ class WitWidgetBase(object):
             returned_keys = list(pred.keys())
             if len(returned_keys) == 1:
               key_to_use = returned_keys[0]
-            # Use default keys if necessary.
+            # Use a default key if necessary.
             elif self.config.get('model_type') == 'classification':
               key_to_use = 'probabilities'
             else:

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
@@ -524,27 +524,28 @@ class WitWidgetBase(object):
       if 'baseline_scores' in response:
         all_baseline_scores.extend(response['baseline_scores'])
 
+      # Use the specified key if one is provided.
+      key_to_use = self.config.get('predict_output_tensor')
+
       for pred in response['predictions']:
         # If the prediction contains a key to fetch the prediction, use it.
         if isinstance(pred, dict):
-          # If the dictionary only contains one key, use it.
-          results_keys = list(pred.keys())
-          if len(results_keys) == 1:
-            results_key = results_keys[0]
-          else:
-            results_key = self.config.get('predict_output_tensor')
-            # Use default keys if no specific one is provided.
-            if results_key is None:
-              if self.config.get('model_type') == 'classification':
-                results_key = 'probabilities'
-              else:
-                results_key = 'outputs'
+          if key_to_use is None:
+            # If the dictionary only contains one key, use it.
+            returned_keys = list(pred.keys())
+            if len(returned_keys) == 1:
+              key_to_use = returned_keys[0]
+            # Use default keys if necessary.
+            elif self.config.get('model_type') == 'classification':
+              key_to_use = 'probabilities'
+            else:
+              key_to_use = 'outputs'
 
-          if results_key not in pred:
+          if key_to_use not in pred:
             raise KeyError(
-              '"%s" not found in model predictions dictionary' % results_key)
+              '"%s" not found in model predictions dictionary' % key_to_use)
 
-          pred = pred[results_key]
+          pred = pred[key_to_use]
 
         # If the model is regression and the response is a list, extract the
         # score by taking the first element.

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/base.py
@@ -530,7 +530,7 @@ class WitWidgetBase(object):
           # If the dictionary only contains one key, use it.
           results_keys = list(pred.keys())
           if len(results_keys) == 1:
-            result_key = results_keys[0]
+            results_key = results_keys[0]
           else:
             results_key = self.config.get('predict_output_tensor')
             # Use default keys if no specific one is provided.

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
@@ -274,8 +274,9 @@ class WitWidget(base.WitWidgetBase):
       output.eval_js("""inferenceCallback({inferences})""".format(
           inferences=json.dumps(inferences)))
     except Exception as e:
+      print(e)
       output.eval_js("""backendError({error})""".format(
-          error=json.dumps({'msg': str(e)})))
+          error=json.dumps({'msg': repr(e)})))
 
   def delete_example(self, index):
     self.examples.pop(index)
@@ -307,7 +308,8 @@ class WitWidget(base.WitWidgetBase):
           callback_dict=json.dumps(callback_dict)))
     except Exception as e:
       output.eval_js(
-          """backendError({error})""".format(error=json.dumps({'msg': str(e)})))
+          """backendError({error})""".format(
+            error=json.dumps({'msg': repr(e)})))
 
   def get_eligible_features(self):
     features_list = base.WitWidgetBase.get_eligible_features_impl(self)
@@ -321,7 +323,7 @@ class WitWidget(base.WitWidgetBase):
           json_mapping=json.dumps(json_mapping)))
     except Exception as e:
       output.eval_js("""backendError({error})""".format(
-          error=json.dumps({'msg': str(e)})))
+          error=json.dumps({'msg': repr(e)})))
 
   def sort_eligible_features(self, info):
     try:
@@ -330,7 +332,7 @@ class WitWidget(base.WitWidgetBase):
           features_list=json.dumps(features_list)))
     except Exception as e:
       output.eval_js("""backendError({error})""".format(
-          error=json.dumps({'msg': str(e)})))
+          error=json.dumps({'msg': repr(e)})))
 
   def _generate_sprite(self):
     sprite = base.WitWidgetBase.create_sprite(self)

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/colab/wit.py
@@ -274,7 +274,6 @@ class WitWidget(base.WitWidgetBase):
       output.eval_js("""inferenceCallback({inferences})""".format(
           inferences=json.dumps(inferences)))
     except Exception as e:
-      print(e)
       output.eval_js("""backendError({error})""".format(
           error=json.dumps({'msg': repr(e)})))
 

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/wit.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/jupyter/wit.py
@@ -72,7 +72,7 @@ class WitWidget(widgets.DOMWidget, base.WitWidgetBase):
 
   def _report_error(self, err):
     self.error = {
-      'msg': str(err),
+      'msg': repr(err),
       'counter': self.error_counter
     }
     self.error_counter += 1

--- a/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
+++ b/tensorboard/plugins/interactive_inference/witwidget/notebook/visualization.py
@@ -308,11 +308,15 @@ class WitConfigBuilder(object):
     return self
 
   def set_predict_output_tensor(self, tensor):
-    """Sets the name of the output tensor for models that use the Predict API.
+    """Sets the name of the output tensor for models that need output parsing.
 
     If using WIT with set_uses_predict_api(True), then call this to specify
     the name of the output tensor of the model or models that returns the
     inference results to be explored by WIT.
+
+    If using an AI Platform model which returns multiple prediction
+    results in a dictionary, this method specifies the key corresponding to
+    the inference results to be explored by WIT.
 
     Args:
       tensor: The name of the output tensor.


### PR DESCRIPTION
* Motivation for features / changes

If a model returns multiple predictions in a dictionary, make the parsing of this dictionary more fool-proof, improve error statements, and simplify parsing of binary classification results.

* Technical description of changes

For both AI platform models and estimators, if the model returns a dictionary of results and the dictionary only has one key, use that result automatically instead of requiring the user to specify the key name of that only result.

Add more-detailed error string in the case of not being able to parse prediction results correctly.

Use repr(error) instead of str(error) to get better displayed errors in WIT from the backend.

If a classification model only returns a single class score, auto-convert that to be the class score for class 1 and set the class score for class 0 correctly. This matches up with how many binary classification models return results and simplifies code necessary to use them. It was done in a 100% backwards compatible way with what users were already doing to get around this issue.

* Screenshots of UI changes

N/A

* Detailed steps to verify changes work correctly (as executed by you)

Tested not needing to call set_predict_output_tensor anymore for models that only return a single result in a dictionary.

Tested exception case in notebooks to see better errors displayed.

Tested binary classifiers with adjustment code still work as before, and also they now work without needing the adjust_prediction override as well.
