### PR TITLE
ci: pin to non-broken nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - BAZEL_SHA256SUM=6c50e142a0a405d3d8598050d6c1b3920c8cdb82a7ffca6fc067cb474275148f
   matrix:
     - TF_VERSION_ID=tensorflow==1.15.0rc3
-    - TF_VERSION_ID=tf-nightly
+    - TF_VERSION_ID=tf-nightly==2.1.0.dev20191118
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - BAZEL_SHA256SUM=6c50e142a0a405d3d8598050d6c1b3920c8cdb82a7ffca6fc067cb474275148f
   matrix:
     - TF_VERSION_ID=tensorflow==1.15.0rc3
-    - TF_VERSION_ID=tf-nightly==2.1.0.dev20191024
+    - TF_VERSION_ID=tf-nightly==2.1.0.dev20191118
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - BAZEL_SHA256SUM=6c50e142a0a405d3d8598050d6c1b3920c8cdb82a7ffca6fc067cb474275148f
   matrix:
     - TF_VERSION_ID=tensorflow==1.15.0rc3
-    - TF_VERSION_ID=tf-nightly==2.1.0.dev20191118
+    - TF_VERSION_ID=tf-nightly==2.1.0.dev20191024
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:


### PR DESCRIPTION
Summary:
Due to <https://github.com/tensorflow/tensorflow/issues/34427>.

This unblocks our CI until the upstream problem is identified and fixed.

Test Plan:
Fingers crossed.

wchargin-branch: pin-20191118-nightly
