### PR TITLE
uploader: add cookie support to frontend handshake

### DIFF
--- a/tensorboard/uploader/server_info.py
+++ b/tensorboard/uploader/server_info.py
@@ -35,13 +35,15 @@ def _server_info_request():
   return request
 
 
-def fetch_server_info(origin):
+def fetch_server_info(origin, cookie=None):
   """Fetches server info from a remote server.
 
   Args:
     origin: The server with which to communicate. Should be a string
       like "https://tensorboard.dev", including protocol, host, and (if
       needed) port.
+    cookie: Optional; a string to send as the `Cookie` header. Can be
+      used to connect to frontend servers behind authentication walls.
 
   Returns:
     A `server_info_pb2.ServerInfoResponse` message.
@@ -57,7 +59,10 @@ def fetch_server_info(origin):
         endpoint,
         data=post_body,
         timeout=_REQUEST_TIMEOUT_SECONDS,
-        headers={"User-Agent": "tensorboard/%s" % version.VERSION},
+        headers={
+            "User-Agent": "tensorboard/%s" % version.VERSION,
+            "Cookie": cookie or "",
+        },
     )
   except requests.RequestException as e:
     raise CommunicationError("Failed to connect to backend: %s" % e)

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -105,6 +105,14 @@ def _define_flags(parser):
       'to connect. If not set, defaults to %r.' % _DEFAULT_ORIGIN)
 
   parser.add_argument(
+      '--cookie_file',
+      type=str,
+      default='',
+      help='Path to file containing value of HTTP Cookie header to '
+      'send to frontend given by `--origin` for initial handshake. If '
+      'empty or unset (the default), no cookie will be sent.')
+
+  parser.add_argument(
       '--api_endpoint',
       type=str,
       default='',
@@ -506,11 +514,16 @@ def _get_intent(flags):
 
 def _get_server_info(flags):
   origin = flags.origin or _DEFAULT_ORIGIN
+  if flags.cookie_file:
+    with open(flags.cookie_file, "r") as infile:
+      cookie = infile.read()
+  else:
+    cookie = None
   if not flags.origin:
     # Temporary fallback to hardcoded API endpoint when not specified.
     api_endpoint = flags.api_endpoint or _HARDCODED_API_ENDPOINT
     return server_info_lib.create_server_info(origin, api_endpoint)
-  server_info = server_info_lib.fetch_server_info(origin)
+  server_info = server_info_lib.fetch_server_info(origin, cookie=cookie)
   # Override with any API server explicitly specified on the command
   # line, but only if the server accepted our initial handshake.
   if flags.api_endpoint and server_info.api_server.endpoint:


### PR DESCRIPTION
Summary:
This enables communicating with frontends that require authentication.

Test Plan:
Unit tests included. As an integration test, visit the landing page for
an auth-walled frontend and capture your cookie via browser dev tools.
Securely store the cookie via `(umask 277 && xsel -ob >/tmp/cookie)`,
then pass it to the uploader:

```
bazel run //tensorboard -- \
    dev --origin http://localhost:9090 --cookie_file /tmp/cookie list
```

Also, make sure that the normal non-cookie flow still works when
connecting to a local server that does support the handshake but does
not require authentication:

```
bazel run //tensorboard -- dev --origin http://localhost:8080 list
```

wchargin-branch: uploader-cookie
