### PR TITLE
csp: allow style to be served from 'self'

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -214,6 +214,7 @@ def Respond(request,
         ),
         "object-src 'none'",
         'style-src %s' % _create_csp_string(
+            "'self'",
             # used by google-chart
             'https://www.gstatic.com',
             'data:',

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -194,7 +194,7 @@ class RespondTest(tb_test.TestCase):
     expected_csp = (
         "default-src 'self';font-src 'self';frame-ancestors *;"
         "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
-        "style-src https://www.gstatic.com data: 'unsafe-inline';"
+        "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
         "script-src 'self' 'unsafe-eval' 'sha256-abcdefghi'"
     )
     self.assertEqual(r.headers.get('Content-Security-Policy'), expected_csp)
@@ -206,7 +206,7 @@ class RespondTest(tb_test.TestCase):
     expected_csp = (
         "default-src 'self';font-src 'self';frame-ancestors *;"
         "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
-        "style-src https://www.gstatic.com data: 'unsafe-inline';"
+        "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
         "script-src 'none'"
     )
     self.assertEqual(r.headers.get('Content-Security-Policy'), expected_csp)
@@ -218,7 +218,7 @@ class RespondTest(tb_test.TestCase):
     expected_csp = (
         "default-src 'self';font-src 'self';frame-ancestors *;"
         "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
-        "style-src https://www.gstatic.com data: 'unsafe-inline';"
+        "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
         "script-src 'self'"
     )
     self.assertEqual(r.headers.get('Content-Security-Policy'), expected_csp)
@@ -231,7 +231,7 @@ class RespondTest(tb_test.TestCase):
     expected_csp = (
         "default-src 'self';font-src 'self';frame-ancestors *;"
         "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
-        "style-src https://www.gstatic.com data: 'unsafe-inline';"
+        "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
         "script-src 'self' 'sha256-abcdefghi'"
     )
     self.assertEqual(r.headers.get('Content-Security-Policy'), expected_csp)
@@ -246,7 +246,7 @@ class RespondTest(tb_test.TestCase):
     expected_csp = (
         "default-src 'self';font-src 'self';frame-ancestors *;"
         "frame-src 'self';img-src 'self' data: blob: https://example.com;"
-        "object-src 'none';style-src https://www.gstatic.com data: "
+        "object-src 'none';style-src 'self' https://www.gstatic.com data: "
         "'unsafe-inline' https://googol.com;script-src "
         "https://tensorflow.org/tensorboard 'self' 'unsafe-eval' 'sha256-abcd'"
     )


### PR DESCRIPTION
As per our revised design on CSP, we decided to trust everything that
comes from our server. This change lax the style-src requirement a
little to trust styles from the server.
