### PR TITLE
documentaion: Update tensorflow tutorial links.  Add a link to hosted TensorBoard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Learning][].
 For in-depth information on the Graph Visualizer, see this tutorial:
 [TensorBoard: Graph Visualization][].
 
-[TensorBoard: Visualizing Learning]: https://www.tensorflow.org/get_started/summaries_and_tensorboard
-[TensorBoard: Graph Visualization]: https://www.tensorflow.org/get_started/graph_viz
+[TensorBoard: Visualizing Learning]: https://www.tensorflow.org/r1/summaries
+[TensorBoard: Graph Visualization]: https://www.tensorflow.org/tensorboard/graphs
 
 You may also want to watch
 [this video tutorial][] that walks
@@ -21,6 +21,13 @@ through setting up and using TensorBoard. There's an associated
 [this video tutorial]: https://www.youtube.com/watch?v=eBbEDRsCmv4
 
 [tutorial with an end-to-end example of training TensorFlow and using TensorBoard]: https://github.com/martinwicke/tf-dev-summit-tensorboard-tutorial
+
+You may also be interested in the hosted TensorBoard solution at
+[TensorBoard.dev][].  [This experiment][] shows a working example featuring the
+scalar dashboard.
+
+[TensorBoard.dev]: https://tensorboard.dev
+[This experiment]: https://tensorboard.dev/experiment/AdYd1TgeTlaLWXx6I8JUbA/#scalars
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -5,26 +5,15 @@ TensorFlow runs and graphs.
 
 This README gives an overview of key concepts in TensorBoard, as well as how to
 interpret the visualizations TensorBoard provides. For an in-depth example of
-using TensorBoard, see the tutorial: [TensorBoard: Visualizing
-Learning][].
-For in-depth information on the Graph Visualizer, see this tutorial:
-[TensorBoard: Graph Visualization][].
-
-[TensorBoard: Visualizing Learning]: https://www.tensorflow.org/r1/summaries
-[TensorBoard: Graph Visualization]: https://www.tensorflow.org/tensorboard/graphs
-
-You may also want to watch
-[this video tutorial][] that walks
-through setting up and using TensorBoard. There's an associated
-[tutorial with an end-to-end example of training TensorFlow and using TensorBoard][].
-
-[this video tutorial]: https://www.youtube.com/watch?v=eBbEDRsCmv4
-
-[tutorial with an end-to-end example of training TensorFlow and using TensorBoard]: https://github.com/martinwicke/tf-dev-summit-tensorboard-tutorial
+using TensorBoard, see the tutorial: [TensorBoard: Getting Started][].
+Documentation on how to use TensorBoard to work with images, graphs, hyper
+parameters, and more are linked from there, along with tutorial walk-throughs in
+Colab.
 
 You may also be interested in the hosted TensorBoard solution at
-[TensorBoard.dev][].  [This experiment][] shows a working example featuring the
-scalar dashboard.
+[TensorBoard.dev][].  You can use TensorBoard.dev to easily host, track, and
+share your ML experiments for free.  For example, [this experiment][] shows a
+working example featuring the scalar dashboard.
 
 [TensorBoard.dev]: https://tensorboard.dev
 [This experiment]: https://tensorboard.dev/experiment/AdYd1TgeTlaLWXx6I8JUbA/#scalars

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ parameters, and more are linked from there, along with tutorial walk-throughs in
 Colab.
 
 You may also be interested in the hosted TensorBoard solution at
-[TensorBoard.dev][].  You can use TensorBoard.dev to easily host, track, and
-share your ML experiments for free.  For example, [this experiment][] shows a
+[TensorBoard.dev][]. You can use TensorBoard.dev to easily host, track, and
+share your ML experiments for free. For example, [this experiment][] shows a
 working example featuring the scalar dashboard.
 
+[TensorBoard: Getting Started]: https://www.tensorflow.org/tensorboard/get_started
 [TensorBoard.dev]: https://tensorboard.dev
 [This experiment]: https://tensorboard.dev/experiment/AdYd1TgeTlaLWXx6I8JUbA/#scalars
 


### PR DESCRIPTION
* Motivation for features / changes
Fixes broken links
Adds a way to play with a tensorboard without installing anything.

* Technical description of changes
Just some readme fixes.

* Screenshots of UI changes
![capture](https://user-images.githubusercontent.com/547150/69361323-41474080-0c5a-11ea-90d7-aa98a633780c.png)
