### PR TITLE
uploader: enable handshake by default

### DIFF
--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -68,9 +68,6 @@ _AUTH_SUBCOMMAND_FLAG = '_uploader__subcommand_auth'
 _AUTH_SUBCOMMAND_KEY_REVOKE = 'REVOKE'
 
 _DEFAULT_ORIGIN = "https://tensorboard.dev"
-# Compatibility measure until server-side /api/uploader support is
-# rolled out and stable.
-_HARDCODED_API_ENDPOINT = "api.tensorboard.dev:443"
 
 
 def _prompt_for_user_ack(intent):
@@ -506,10 +503,8 @@ def _get_intent(flags):
 
 def _get_server_info(flags):
   origin = flags.origin or _DEFAULT_ORIGIN
-  if not flags.origin:
-    # Temporary fallback to hardcoded API endpoint when not specified.
-    api_endpoint = flags.api_endpoint or _HARDCODED_API_ENDPOINT
-    return server_info_lib.create_server_info(origin, api_endpoint)
+  if flags.api_endpoint and not flags.origin:
+    return server_info_lib.create_server_info(origin, flags.api_endpoint)
   server_info = server_info_lib.fetch_server_info(origin)
   # Override with any API server explicitly specified on the command
   # line, but only if the server accepted our initial handshake.


### PR DESCRIPTION
Summary:
We’ve deployed production servers that support the handshake protocol
specified in #2878 and implemented on the client in #2879. This commit
enables that protocol by default.

Test Plan:
Running `bazel run //tensorboard -- dev list` still properly connects
and prints valid URLs. Re-running with the TensorBoard version patched
to `2.0.0a0` (in `version/version.py`) properly causes a handshake
failure. Setting `--origin` to point to a non-prod frontend properly
connects to the appropriate backend. Setting `--api_endpoint` to point
to a non-prod backend connects directly, skipping the handshake, and
printing `https://tensorboard.dev` URLs. Specifying both `--origin` and
`--api_endpoint` performs the handshake and overrides the backend
server only, printing URLs corresponding to the listed frontend.

Running `git grep api.tensorboard.dev` no longer finds any code results.

As a double check, building the Pip package and running it in a new
virtualenv still has a working `tensorboard dev upload` flow.

wchargin-branch: uploader-handshake
