### PR TITLE
Respect nodename in `server_info_test`

### DIFF
--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -49,7 +49,10 @@ class FetchServerInfoTest(tb_test.TestCase):
       future.result(timeout=3)  # wait for server termination
 
     self.addCleanup(cleanup)
-    return "http://localhost:%d" % server.server_port
+    if ":" in localhost and not localhost.startswith("["):
+      # IPv6 IP address, probably "::1".
+      localhost = "[%s]" % localhost
+    return "http://%s:%d" % (localhost, server.server_port)
 
   def test_fetches_response(self):
     expected_result = server_info_pb2.ServerInfoResponse()


### PR DESCRIPTION
Summary:
On some machines, including standard Ubuntu 16.04, binding to `::1` and
then trying to open an HTTP connection to `localhost` can in some cases
try to connect only over IPv4, which fails. This commit changes a test
to connect to the node name given by the socket rather than hard-coding
`localhost`.

Test Plan:
Tested in an upcoming GitHub Actions workflow. Googlers, see test sync:
<http://cl/281679857>

wchargin-branch: serverinfotest-nodename
