### PR TITLE
diagnose: add check for `getaddrinfo`

### DIFF
--- a/tensorboard/tools/diagnose_tensorboard.py
+++ b/tensorboard/tools/diagnose_tensorboard.py
@@ -122,6 +122,18 @@ def which(name):
     return None
 
 
+def sgetattr(attr, default):
+  """Get an attribute off the `socket` module, or use a default."""
+  sentinel = object()
+  result = getattr(socket, attr, sentinel)
+  if result is sentinel:
+    print("socket.%s does not exist" % attr)
+    return default
+  else:
+    print("socket.%s = %r" % (attr, result))
+    return result
+
+
 @check
 def autoidentify():
   """Print the Git hash of this version of `diagnose_tensorboard.py`.
@@ -242,6 +254,26 @@ def tensorflow_python_version():
 @check
 def tensorboard_binary_path():
   logging.info("which tensorboard: %r", which("tensorboard"))
+
+
+@check
+def addrinfos():
+  sgetattr("has_ipv6", None)
+  family = sgetattr("AF_UNSPEC", 0)
+  socktype = sgetattr("SOCK_STREAM", 0)
+  protocol = 0
+  flags_loopback = sgetattr("AI_ADDRCONFIG", 0)
+  flags_wildcard = sgetattr("AI_PASSIVE", 0)
+
+  hints_loopback = (family, socktype, protocol, flags_loopback)
+  infos_loopback = socket.getaddrinfo(None, 0, *hints_loopback)
+  print("Loopback flags: %r" % (flags_loopback,))
+  print("Loopback infos: %r" % (infos_loopback,))
+
+  hints_wildcard = (family, socktype, protocol, flags_wildcard)
+  infos_wildcard = socket.getaddrinfo(None, 0, *hints_wildcard)
+  print("Wildcard flags: %r" % (flags_wildcard,))
+  print("Wildcard infos: %r" % (infos_wildcard,))
 
 
 @check


### PR DESCRIPTION
Summary:
Networking is hard. Everyone’s machine seems to do something different.
We have a lot of special cases in `program.py`, and we keep finding new
configurations. This commit adds a check to `diagnose_tensorboard.py`
that prints the available loopback and wildcard addresses on all address
families.

It could also be nice to check whether it is actually possible to
connect to sockets opened on the loopback address in various
configurations (e.g., with a direct socket-to-socket connection and with
a Python-provided WSGI server and URL fetcher). We defer such a change.

Test Plan:
On my machine, with Python 3, it prints:

```
socket.has_ipv6 = True
socket.AF_UNSPEC = <AddressFamily.AF_UNSPEC: 0>
socket.SOCK_STREAM = <SocketKind.SOCK_STREAM: 1>
socket.AI_ADDRCONFIG = <AddressInfo.AI_ADDRCONFIG: 32>
socket.AI_PASSIVE = <AddressInfo.AI_PASSIVE: 1>
Loopback flags: <AddressInfo.AI_ADDRCONFIG: 32>
Loopback infos: [(<AddressFamily.AF_INET6: 10>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('::1', 0, 0, 0)), (<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('127.0.0.1', 0))]
Wildcard flags: <AddressInfo.AI_PASSIVE: 1>
Wildcard infos: [(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('0.0.0.0', 0)), (<AddressFamily.AF_INET6: 10>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('::', 0, 0, 0))]
```

With Python 2, it prints the same thing except with only raw numbers for
the socket constants (`<AddressFamily.AI_ADDRCONFIG: 32>` becomes `32`).

wchargin-branch: diagnose-getaddrinfo
