### PR TITLE
build: tag all web tests with "webtest"

### DIFF
--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -53,6 +53,7 @@ def tf_ng_web_test_suite(runtime_deps = [], bootstrap = [], deps = [], **kwargs)
     It has Angular specific configurations that we want as defaults.
     """
 
+    kwargs.setdefault("tags", []).append("webtest")
     karma_web_test_suite(
         srcs = [],
         bootstrap = bootstrap + [

--- a/tensorboard/defs/web_testing.bzl
+++ b/tensorboard/defs/web_testing.bzl
@@ -67,6 +67,7 @@ def tf_web_test(name, web_library, src, **kwargs):
     )
     kwargs.setdefault("flaky", True)
     kwargs.setdefault("timeout", "short")
+    kwargs.setdefault("tags", []).append("webtest")
     py_web_test_suite(
         name = name,
         srcs = [python_stub_output],

--- a/tensorboard/functionaltests/BUILD
+++ b/tensorboard/functionaltests/BUILD
@@ -14,7 +14,7 @@ py_web_test_suite(
     # TODO(@jart): Make this fast and not flaky.
     flaky = True,
     srcs_version = "PY2AND3",
-    tags = ["manual"],
+    tags = ["manual", "webtest"],
     deps = [
         "//tensorboard/plugins/audio:audio_demo",
         "//tensorboard/plugins/scalar:scalars_demo",


### PR DESCRIPTION
Summary:
Web tests take a long time to Vulcanize and run, and some have very
wide-reaching dependencies. For example, `core_test_chromium` depends on
all of `//tensorboard`. They’re also especially flaky when many of them
are run concurrently, as they run out of resources even on capable
machines. All this makes `bazel test //tensorboard/...` prohibitively
expensive for quick incremental iteration. This commit adds build tags
such that one can write

    bazel test //tensorboard/... --test_tag_filters=-webtest --build_tests_only

to run all affected tests except web tests. (Using `--build_tests_only`
prevents Vulcanization of targets that match the `//tensorboard/...`
pattern but are only needed by tests tagged as `webtest`.)

Test Plan:
This query used to return all the web tests, and now returns no results:

```
bazel query '
    let alltests = tests(//tensorboard/...) in
    let chromium = @org_chromium_chromium//file:file in
    rdeps($alltests - attr(tags, webtest, $alltests), $chromium)
'
```

wchargin-branch: tag-webtests
