### PR TITLE
csp: allow frame-src to be configured

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -40,6 +40,7 @@ _DISALLOWED_CHAR_IN_DOMAIN = re.compile(r'\s')
 # instead use a configurable via some kind of assets provider which would
 # hold configurations for the CSP.
 _CSP_FONT_DOMAINS_WHITELIST = []
+_CSP_FRAME_DOMAINS_WHITELIST = []
 _CSP_IMG_DOMAINS_WHITELIST = []
 _CSP_SCRIPT_DOMAINS_WHITELIST = []
 _CSP_SCRIPT_SELF = True
@@ -181,6 +182,7 @@ def Respond(request,
     _validate_global_whitelist(_CSP_IMG_DOMAINS_WHITELIST)
     _validate_global_whitelist(_CSP_STYLE_DOMAINS_WHITELIST)
     _validate_global_whitelist(_CSP_FONT_DOMAINS_WHITELIST)
+    _validate_global_whitelist(_CSP_FRAME_DOMAINS_WHITELIST)
     _validate_global_whitelist(_CSP_SCRIPT_DOMAINS_WHITELIST)
 
     frags = _CSP_SCRIPT_DOMAINS_WHITELIST + [
@@ -199,7 +201,10 @@ def Respond(request,
         ),
         'frame-ancestors *',
         # Dynamic plugins are rendered inside an iframe.
-        "frame-src 'self'",
+        'frame-src %s' % _create_csp_string(
+            "'self'",
+            *_CSP_FRAME_DOMAINS_WHITELIST
+        ),
         'img-src %s' % _create_csp_string(
             "'self'",
             # used by favicon

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -254,12 +254,14 @@ class RespondTest(tb_test.TestCase):
   @mock.patch.object(http_util, '_CSP_SCRIPT_DOMAINS_WHITELIST',
     ['https://tensorflow.org/tensorboard'])
   @mock.patch.object(http_util, '_CSP_STYLE_DOMAINS_WHITELIST', ['https://googol.com'])
+  @mock.patch.object(http_util, '_CSP_FRAME_DOMAINS_WHITELIST', ['https://myframe.com'])
   def testCsp_globalDomainWhiteList(self):
     q = wrappers.Request(wtest.EnvironBuilder().get_environ())
     r = http_util.Respond(q, '<b>hello</b>', 'text/html', csp_scripts_sha256s=['abcd'])
     expected_csp = (
         "default-src 'self';font-src 'self';frame-ancestors *;"
-        "frame-src 'self';img-src 'self' data: blob: https://example.com;"
+        "frame-src 'self' https://myframe.com;"
+        "img-src 'self' data: blob: https://example.com;"
         "object-src 'none';style-src 'self' https://www.gstatic.com data: "
         "'unsafe-inline' https://googol.com;script-src "
         "https://tensorflow.org/tensorboard 'self' 'unsafe-eval' 'sha256-abcd'"
@@ -273,6 +275,7 @@ class RespondTest(tb_test.TestCase):
         '_CSP_IMG_DOMAINS_WHITELIST',
         '_CSP_STYLE_DOMAINS_WHITELIST',
         '_CSP_FONT_DOMAINS_WHITELIST',
+        '_CSP_FRAME_DOMAINS_WHITELIST',
     ]
 
     for config in configs:


### PR DESCRIPTION
* Motivation for features / changes
Apps that embed TensorBoard backend can now configure `frame-src`, to allow the frontend to render iframes from contexts other than self.

* Technical description of changes
Adds _CSP_FRAME_DOMAINS_WHITELIST.