### PR TITLE
docs: quell fears about spurious warnings

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,6 +20,10 @@ You can build and run TensorBoard via Bazel (from within the TensorFlow nightly 
 (tf)$ bazel run //tensorboard -- --logdir /path/to/logs
 ```
 
+You may see warnings about “Limited tf.compat.v2.summary API due to missing TensorBoard installation” appear when you run TensorBoard. These are spurious: you can ignore them. (See [an explanation of why these warnings occur][why-warnings] if you’re curious.)
+
+[why-warnings]: https://github.com/tensorflow/tensorboard/issues/2968#issuecomment-558405994
+
 For any changes to the frontend, you’ll need to install [Yarn][yarn] to lint your code (`yarn lint`, `yarn fix-lint`). You’ll also need Yarn to add or remove any NPM dependencies.
 
 To generate fake log data for a plugin, run its demo script. For instance, this command generates fake scalar data in `/tmp/scalars_demo`:


### PR DESCRIPTION
Summary:
Running `bazel run //tensorboard` per the development instructions spits
out warnings in the TensorFlow layer. These warnings are accurate, but
not relevant, so we advise users to ignore them.

Test Plan:
Note that the link resolves correctly.

wchargin-branch: dev-spurious-warnings
