### PR TITLE
docs: remove outdated `bazel-bin` instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,9 +14,6 @@ TensorBoard builds are done with [Bazel](https://bazel.build), so you may need t
 You can build and run TensorBoard via Bazel (from within the TensorFlow nightly virtualenv) as follows:
 
 ```sh
-(tf)$ bazel build tensorboard
-(tf)$ ./bazel-bin/tensorboard/tensorboard --logdir path/to/logs
-# Or combine the above steps as:
 (tf)$ bazel run //tensorboard -- --logdir /path/to/logs
 ```
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,6 +20,10 @@ You can build and run TensorBoard via Bazel (from within the TensorFlow nightly 
 (tf)$ bazel run //tensorboard -- --logdir /path/to/logs
 ```
 
+You may see warnings about “Limited tf.compat.v2.summary API due to missing TensorBoard installation” appear when you run TensorBoard. These are spurious: you can ignore them. (See [an explanation of why these warnings occur][why-warnings] if you’re curious.)
+
+[why-warnings]: https://github.com/tensorflow/tensorboard/issues/2968#issuecomment-558405994
+
 For any changes to the frontend, you’ll need to install [Yarn][yarn] to lint your code (`yarn lint`, `yarn fix-lint`). You’ll also need Yarn to add or remove any NPM dependencies.
 
 To generate fake log data for a plugin, run its demo script. For instance, this command generates fake scalar data in `/tmp/scalars_demo`:


### PR DESCRIPTION
Summary:
Running Python binaries directly through `bazel-bin/` skips the Bazel
wrapper that sets up the environment correctly. This is not guaranteed
to work; users should run `bazel run //tensorboard --` instead.

We included the `bazel-bin/` form before `bazel run` was changed to
release the Bazel server lock, but this was fixed in 2017:
<https://github.com/bazelbuild/bazel/issues/2337>
…so there’s no longer really any reason to promote this form at all.

wchargin-branch: docs-no-bazel-bin
