### PR TITLE
uploader: fix `util_test` internally

### DIFF
--- a/tensorboard/uploader/util_test.py
+++ b/tensorboard/uploader/util_test.py
@@ -202,8 +202,8 @@ class FormatTimeTest(tb_test.TestCase):
   def _run(self, t=None, now=None):
     timestamp_pb = timestamp_pb2.Timestamp()
     util.set_timestamp(timestamp_pb, t)
-    now = datetime.datetime.fromtimestamp(now)
     with mock.patch.dict(os.environ, {"TZ": "UTC"}):
+      now = datetime.datetime.fromtimestamp(now)
       return util.format_time(timestamp_pb, now=now)
 
   def test_just_now(self):


### PR DESCRIPTION
Summary:
We mocked out the time zone to UTC for only one of two time-related
function calls. This was asymptomatic externally because [Bazel’s test
runner sets the `TZ` environment variable to `UTC`][1], but the internal
test runner has different semantics.

Test Plan:
Patching this into a sync CL fixes broken tests.

[1]: https://docs.bazel.build/versions/1.2.0/test-encyclopedia.html#initial-conditions

wchargin-branch: util-test-tz
