### PR TITLE
Use `tensorboard.errors` in histograms and distributions

### DIFF
--- a/tensorboard/plugins/distribution/BUILD
+++ b/tensorboard/plugins/distribution/BUILD
@@ -31,6 +31,7 @@ py_test(
     deps = [
         ":compressor",
         ":distributions_plugin",
+        "//tensorboard:errors",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_accumulator",

--- a/tensorboard/plugins/distribution/distributions_plugin.py
+++ b/tensorboard/plugins/distribution/distributions_plugin.py
@@ -74,7 +74,11 @@ class DistributionsPlugin(base_plugin.TBPlugin):
     )
 
   def distributions_impl(self, tag, run):
-    """Result of the form `(body, mime_type)`, or `ValueError`."""
+    """Result of the form `(body, mime_type)`.
+
+    Raises:
+      tensorboard.errors.PublicError: On invalid request.
+    """
     (histograms, mime_type) = self._histograms_plugin.histograms_impl(
         tag, run, downsample_to=self.SAMPLE_SIZE)
     return ([self._compress(histogram) for histogram in histograms],
@@ -98,10 +102,5 @@ class DistributionsPlugin(base_plugin.TBPlugin):
     """Given a tag and single run, return an array of compressed histograms."""
     tag = request.args.get('tag')
     run = request.args.get('run')
-    try:
-      (body, mime_type) = self.distributions_impl(tag, run)
-      code = 200
-    except ValueError as e:
-      (body, mime_type) = (str(e), 'text/plain')
-      code = 400
-    return http_util.Respond(request, body, mime_type, code=code)
+    (body, mime_type) = self.distributions_impl(tag, run)
+    return http_util.Respond(request, body, mime_type)

--- a/tensorboard/plugins/distribution/distributions_plugin_test.py
+++ b/tensorboard/plugins/distribution/distributions_plugin_test.py
@@ -22,10 +22,10 @@ from __future__ import print_function
 import collections
 import os.path
 
-import six
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
+from tensorboard import errors
 from tensorboard.backend.event_processing import plugin_event_accumulator as event_accumulator  # pylint: disable=line-too-long
 from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
 from tensorboard.plugins import base_plugin
@@ -137,7 +137,7 @@ class DistributionsPluginTest(tf.test.TestCase):
         (bps, _unused_icdfs) = zip(*bps_and_icdfs)
         self.assertEqual(bps, compressor.NORMAL_HISTOGRAM_BPS)
     else:
-      with six.assertRaisesRegex(self, ValueError, 'No histogram tag'):
+      with self.assertRaises(errors.NotFoundError):
         self.plugin.distributions_impl(self._DISTRIBUTION_TAG, run_name)
 
   def test_distributions_with_scalars(self):

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -17,6 +17,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":metadata",
+        "//tensorboard:errors",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
@@ -36,6 +37,7 @@ py_test(
     deps = [
         ":histograms_plugin",
         ":summary",
+        "//tensorboard:errors",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
         "//tensorboard/backend/event_processing:event_accumulator",

--- a/tensorboard/plugins/histogram/histograms_plugin_test.py
+++ b/tensorboard/plugins/histogram/histograms_plugin_test.py
@@ -22,10 +22,10 @@ from __future__ import print_function
 import collections
 import os.path
 
-import six
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
+from tensorboard import errors
 from tensorboard.backend.event_processing import plugin_event_accumulator as event_accumulator  # pylint: disable=line-too-long
 from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer  # pylint: disable=line-too-long
 from tensorboard.plugins import base_plugin
@@ -130,7 +130,7 @@ class HistogramsPluginTest(tf.test.TestCase):
       self._check_histograms_result(tag_name, run_name, downsample=False)
       self._check_histograms_result(tag_name, run_name, downsample=True)
     else:
-      with six.assertRaisesRegex(self, ValueError, 'No histogram tag'):
+      with self.assertRaises(errors.NotFoundError):
         self.plugin.histograms_impl(self._HISTOGRAM_TAG, run_name)
 
   def _check_histograms_result(self, tag_name, run_name, downsample):


### PR DESCRIPTION
Summary:
We now raise `errors.NotFoundError` rather than manually propagating an
error message and status code.

The response code was previously 400 Bad Request, but 404 Not Found is
more appropriate, and is consistent with the scalars plugin.

Test Plan:
Requesting `/data/plugin/histograms/histograms?run=foo&tag=bar` yields
an error with the same message as before (but now with a “Not found:”
prefix), and the histograms and distributions dashboards both work.

wchargin-branch: histograms-notfound
