### PR TITLE
Temporarily disable dynamic plugin smoke test to unbreak build

### DIFF
--- a/tensorboard/examples/plugins/example_basic/BUILD
+++ b/tensorboard/examples/plugins/example_basic/BUILD
@@ -14,6 +14,9 @@ sh_test(
     size = "large",
     timeout = "moderate",
     srcs = ["smoke_test.sh"],
+    tags = [
+        "manual",  # https://github.com/tensorflow/tensorboard/issues/2987
+    ],
     # Don't just `glob(["**"])` because `setup.py` creates artifacts
     # like wheels and a `tensorboard_plugin_example.egg-info` directory,
     # and we want to make sure that those don't interfere with the test.


### PR DESCRIPTION
Summary:
See <https://github.com/tensorflow/tensorboard/issues/2987> for context.

Test Plan:
That CI passes suffices.

wchargin-branch: disable-dynplugin-smoke
