### PR TITLE
(colab) Add 'list' and 'delete' to tbdev

### DIFF
--- a/docs/tbdev_getting_started.ipynb
+++ b/docs/tbdev_getting_started.ipynb
@@ -1,23 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "Getting Started with TensorBoard.dev",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "h3Nuf-G4xJ0u",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "h3Nuf-G4xJ0u"
       },
       "source": [
         "##### Copyright 2019 The TensorFlow Authors."
@@ -25,12 +12,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "zZ81_4tLxSvd",
-        "colab_type": "code",
+        "cellView": "form",
         "colab": {},
-        "cellView": "form"
+        "colab_type": "code",
+        "id": "zZ81_4tLxSvd"
       },
+      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -43,15 +32,13 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "wNBP_f0QUTfO",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "wNBP_f0QUTfO"
       },
       "source": [
         "# Getting started with [TensorBoard.dev](https://tensorboard.dev)"
@@ -60,8 +47,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "DLXZ3t1PWdOp",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "DLXZ3t1PWdOp"
       },
       "source": [
         "[TensorBoard.dev](https://tensorboard.dev) provides a managed [TensorBoard](https://tensorflow.org/tensorboard) experience that lets you upload and share your ML experiment results with everyone.\n",
@@ -72,8 +59,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "yjBn-ptXTppA",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "yjBn-ptXTppA"
       },
       "source": [
         "### Setup and imports"
@@ -81,11 +68,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "5C8BOea_rF49",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "5C8BOea_rF49"
       },
+      "outputs": [],
       "source": [
         "try:\n",
         "  # %tensorflow_version only exists in Colab.\n",
@@ -93,30 +82,28 @@
         "except Exception:\n",
         "  pass\n",
         "\n",
-        "!pip install -U tensorboard >piplog 2>&1"
-      ],
-      "execution_count": 0,
-      "outputs": []
+        "!pip install -U tensorboard \u003epiplog 2\u003e\u00261"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "L3ns52Luracm",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "L3ns52Luracm"
       },
+      "outputs": [],
       "source": [
         "import tensorflow as tf\n",
         "import datetime"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "GqUABmUTT1Cl",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "GqUABmUTT1Cl"
       },
       "source": [
         "### Train a simple model and create TensorBoard logs"
@@ -124,11 +111,13 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "LZExSr2Qrc5S",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "LZExSr2Qrc5S"
       },
+      "outputs": [],
       "source": [
         "mnist = tf.keras.datasets.mnist\n",
         "\n",
@@ -142,17 +131,17 @@
         "    tf.keras.layers.Dropout(0.2),\n",
         "    tf.keras.layers.Dense(10, activation='softmax')\n",
         "  ])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "dsVjm5CrUtXm",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "dsVjm5CrUtXm"
       },
+      "outputs": [],
       "source": [
         "model = create_model()\n",
         "model.compile(optimizer='adam',\n",
@@ -167,15 +156,13 @@
         "          epochs=5, \n",
         "          validation_data=(x_test, y_test), \n",
         "          callbacks=[tensorboard_callback])"
-      ],
-      "execution_count": 0,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "TgF35qdzIC3T",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "TgF35qdzIC3T"
       },
       "source": [
         "### Upload to TensorBoard.dev\n",
@@ -187,16 +174,84 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "n2PvxhOkW7vn",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "n2PvxhOkW7vn"
       },
+      "outputs": [],
       "source": [
         "!tensorboard dev upload --logdir ./logs"
-      ],
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "5QH5k4AUNE27"
+      },
+      "source": [
+        "Note that each experiment you upload has a unique experiment ID.  Even if you start a new upload with the same directory, you will get a new experiment ID. It is possible to look at the list of experiments you have uploaded using the `list` command."
+      ]
+    },
+    {
+      "cell_type": "code",
       "execution_count": 0,
-      "outputs": []
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "C2Pj3RQCNQvP"
+      },
+      "outputs": [],
+      "source": [
+        "!tensorboard dev list"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "JcZOGmjQNWk_"
+      },
+      "source": [
+        "To remove an experiment you have uploaded, you may use the `delete` command and specifiy the appropriate expriment_id."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "VSkJTT9rNWJq"
+      },
+      "outputs": [],
+      "source": [
+        "# You must replace YOUR_EXPERIMENT_ID with the value output from the previous\n",
+        "# tensorboard `list` command or `upload` command.  For example\n",
+        "# tensorboard dev delete --experiment_id pQpJNh00RG2Lf1zOe9BrQA\n",
+        "\n",
+        "!tensorboard dev delete --experiment_id YOUR_EXPERIMENT_ID_HERE"
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "Getting Started with TensorBoard.dev",
+      "provenance": [
+        {
+          "file_id": "/piper/depot/google3/third_party/tensorboard/g3doc/tbdev_getting_started.ipynb",
+          "timestamp": 1575401302584
+        }
+      ]
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/docs/tbdev_getting_started.ipynb
+++ b/docs/tbdev_getting_started.ipynb
@@ -1,10 +1,23 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Getting Started with TensorBoard.dev",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "h3Nuf-G4xJ0u"
+        "id": "h3Nuf-G4xJ0u",
+        "colab_type": "text"
       },
       "source": [
         "##### Copyright 2019 The TensorFlow Authors."
@@ -12,14 +25,12 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "cellView": "form",
-        "colab": {},
+        "id": "zZ81_4tLxSvd",
         "colab_type": "code",
-        "id": "zZ81_4tLxSvd"
+        "colab": {},
+        "cellView": "form"
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -32,13 +43,15 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "wNBP_f0QUTfO"
+        "id": "wNBP_f0QUTfO",
+        "colab_type": "text"
       },
       "source": [
         "# Getting started with [TensorBoard.dev](https://tensorboard.dev)"
@@ -47,8 +60,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "DLXZ3t1PWdOp"
+        "id": "DLXZ3t1PWdOp",
+        "colab_type": "text"
       },
       "source": [
         "[TensorBoard.dev](https://tensorboard.dev) provides a managed [TensorBoard](https://tensorflow.org/tensorboard) experience that lets you upload and share your ML experiment results with everyone.\n",
@@ -59,8 +72,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "yjBn-ptXTppA"
+        "id": "yjBn-ptXTppA",
+        "colab_type": "text"
       },
       "source": [
         "### Setup and imports"
@@ -68,13 +81,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
+        "id": "5C8BOea_rF49",
         "colab_type": "code",
-        "id": "5C8BOea_rF49"
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "try:\n",
         "  # %tensorflow_version only exists in Colab.\n",
@@ -82,28 +93,30 @@
         "except Exception:\n",
         "  pass\n",
         "\n",
-        "!pip install -U tensorboard \u003epiplog 2\u003e\u00261"
-      ]
+        "!pip install -U tensorboard >piplog 2>&1"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
+        "id": "L3ns52Luracm",
         "colab_type": "code",
-        "id": "L3ns52Luracm"
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "import tensorflow as tf\n",
         "import datetime"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "GqUABmUTT1Cl"
+        "id": "GqUABmUTT1Cl",
+        "colab_type": "text"
       },
       "source": [
         "### Train a simple model and create TensorBoard logs"
@@ -111,13 +124,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
+        "id": "LZExSr2Qrc5S",
         "colab_type": "code",
-        "id": "LZExSr2Qrc5S"
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "mnist = tf.keras.datasets.mnist\n",
         "\n",
@@ -131,17 +142,17 @@
         "    tf.keras.layers.Dropout(0.2),\n",
         "    tf.keras.layers.Dense(10, activation='softmax')\n",
         "  ])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
+        "id": "dsVjm5CrUtXm",
         "colab_type": "code",
-        "id": "dsVjm5CrUtXm"
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "model = create_model()\n",
         "model.compile(optimizer='adam',\n",
@@ -156,13 +167,15 @@
         "          epochs=5, \n",
         "          validation_data=(x_test, y_test), \n",
         "          callbacks=[tensorboard_callback])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "TgF35qdzIC3T"
+        "id": "TgF35qdzIC3T",
+        "colab_type": "text"
       },
       "source": [
         "### Upload to TensorBoard.dev\n",
@@ -174,11 +187,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
+        "id": "n2PvxhOkW7vn",
         "colab_type": "code",
-        "id": "n2PvxhOkW7vn"
+        "colab": {}
       },
       "outputs": [],
       "source": [
@@ -230,9 +242,9 @@
       "source": [
         "# You must replace YOUR_EXPERIMENT_ID with the value output from the previous\n",
         "# tensorboard `list` command or `upload` command.  For example\n",
-        "# tensorboard dev delete --experiment_id pQpJNh00RG2Lf1zOe9BrQA\n",
+        "# `tensorboard dev delete --experiment_id pQpJNh00RG2Lf1zOe9BrQA`\n",
         "\n",
-        "!tensorboard dev delete --experiment_id YOUR_EXPERIMENT_ID_HERE"
+        "## !tensorboard dev delete --experiment_id YOUR_EXPERIMENT_ID_HERE"
       ]
     }
   ],


### PR DESCRIPTION
Extends getting started example to include 'list' and 'delete' subcommands.

* Motivation for features / changes
Users didn't know they could list / delete.

* Technical description of changes
Adds a few new cells.

* Screenshots of UI changes
![image](https://user-images.githubusercontent.com/547150/70083657-d7745280-15da-11ea-868c-2ba415e79b56.png)
