### PR TITLE
web.bzl: avoid depset union operators

### DIFF
--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -203,11 +203,13 @@ def _tf_web_library(ctx):
     # If a rule exists purely to export other build rules, then it's
     # appropriate for the exported sources to be included in the
     # development web server.
-    devserver_manifests = depset(order="postorder")
     export_deps = unfurl(ctx.attr.exports)
-    for dep in export_deps:
-      devserver_manifests += dep.webfiles.manifests
-    devserver_manifests = manifests + devserver_manifests
+    devserver_manifests = depset(
+        order = "postorder",
+        transitive = (
+            [manifests] + [dep.webfiles.manifests for dep in export_deps]
+        ),
+    )
   params = struct(
       label=str(ctx.label),
       bind="localhost:6006",


### PR DESCRIPTION
Summary:
The `+`, `+=`, and `|` operators on depsets, as well as `depset.union`,
are deprecated due to performance problems:
<https://github.com/bazelbuild/bazel/issues/5817>

As of a recent Bazel commit, `.union` is removed is removed entirely, so
the operators may be soon on the chopping block:
<https://github.com/bazelbuild/bazel/commit/693963f44ad2d62d858a24ed5dad4698d3835223>

This commit removes remaining uses from TensorBoard.

Google-internal source: <http://cl/283060975> (thanks, @laurentlb!).

Test Plan:
Running `bazel run //tensorboard` still works.

Co-authored-by: Laurent Le Brun <laurentlb@google.com>
wchargin-branch: remove-depset-union
