### PR TITLE
Expose visibility for build rules needed for WIT dynamic plugin

### DIFF
--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -40,6 +40,7 @@ tf_web_library(
         "security.html",
     ],
     path = "/",
+    visibility = ["//visibility:public"],
 )
 
 tf_web_library(

--- a/tensorboard/components/vz_line_chart2/BUILD
+++ b/tensorboard/components/vz_line_chart2/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
@@ -27,6 +27,7 @@ tf_web_library(
         "//tensorboard/components/vz_chart_helpers",
         "//tensorboard/components/vz_line_chart:dragZoomInteraction",
     ],
+    visibility = ["//visibility:public"],
 )
 
 tensorboard_webcomponent_library(

--- a/tensorboard/components/vz_line_chart2/BUILD
+++ b/tensorboard/components/vz_line_chart2/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//tensorboard:internal"])
+package(default_visibility = ["//visibility:public"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")


### PR DESCRIPTION
* Motivation for features / changes

In order for WIT to move to a dynamic plugin, some build rules need to be made visibility public so WIT build can use them.

* Detailed steps to verify changes work correctly (as executed by you)

Building current draft of WIT dynamic plugin in its own repo and needed access to these rules.
