### PR TITLE
Add link to TensorBoard.dev from tensorboard base page.

### DIFF
--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -27,18 +27,18 @@ landing_page:
         classname: button
   - classname: devsite-landing-row-cards
     items:
+    - heading: "TensorBoard.dev: a new way to share your ML experiment results"
+      image_path: /resources/images/tf-logo-card-16x9.png
+      path: https://blog.tensorflow.org/2019/12/introducing-tensorboarddev-new-way-to.html
+      buttons:
+      - label: "Read on TensorFlow blog"
+        path: https://blog.tensorflow.org/2019/12/introducing-tensorboarddev-new-way-to.html
     - heading: "The What-If Tool: Code-Free Probing of Machine Learning Models"
       image_path: /resources/images/tf-logo-card-16x9.png
       path: https://ai.googleblog.com/2018/09/the-what-if-tool-code-free-probing-of.html
       buttons:
       - label: "Read on Google AI blog"
         path: https://ai.googleblog.com/2018/09/the-what-if-tool-code-free-probing-of.html
-    - heading: "Interactive supervision with TensorBoard"
-      image_path: /resources/images/tf-logo-card-16x9.png
-      path: https://medium.com/tensorflow/interactive-supervision-with-tensorboard-9a101c91d3f7
-      buttons:
-      - label: "Read on TensorFlow blog"
-        path: https://medium.com/tensorflow/interactive-supervision-with-tensorboard-9a101c91d3f7
     - heading: "Hands-on TensorBoard"
       youtube_id: eBbEDRsCmv4
       buttons:

--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -33,20 +33,13 @@ landing_page:
       buttons:
       - label: "Read on TensorFlow blog"
         path: https://blog.tensorflow.org/2019/12/introducing-tensorboarddev-new-way-to.html
-    - heading: "The What-If Tool: Code-Free Probing of Machine Learning Models"
-      image_path: /resources/images/tf-logo-card-16x9.png
-      path: https://ai.googleblog.com/2018/09/the-what-if-tool-code-free-probing-of.html
+    - heading: "What's new in TensorBoard (TF Dev Summit '19)"
+      youtube_id: xM8sO33x_OU
       buttons:
-      - label: "Read on Google AI blog"
-        path: https://ai.googleblog.com/2018/09/the-what-if-tool-code-free-probing-of.html
+      - label: Watch the video
+        path: https://www.youtube.com/watch?v=xM8sO33x_OU
     - heading: "Hands-on TensorBoard"
       youtube_id: eBbEDRsCmv4
       buttons:
       - label: Watch the video
         path: https://www.youtube.com/watch?v=eBbEDRsCmv4
-    - heading: "TensorBoard on GitHub"
-      image_path: /resources/images/github-card-16x9.png
-      path: https://github.com/tensorflow/tensorboard
-      buttons:
-      - label: "View on GitHub"
-        path: https://github.com/tensorflow/tensorboard

--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -38,7 +38,7 @@ landing_page:
       buttons:
       - label: Watch the video
         path: https://www.youtube.com/watch?v=xM8sO33x_OU
-    - heading: "Hands-on TensorBoard"
+    - heading: "Hands-on TensorBoard  (TF Dev Summit '17)"
       youtube_id: eBbEDRsCmv4
       buttons:
       - label: Watch the video


### PR DESCRIPTION
* Motivation for features / changes
Replaces an older blog post with a link to the newer blog post about TensorBoard.dev

* Technical description of changes
Purely a documentation change.