### PR TITLE
data: require experiment ID in multiplexer provider

### DIFF
--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -191,11 +191,16 @@ class GraphsPluginV1Test(GraphsPluginBaseTest, tf.test.TestCase):
         },
       }
 
-    self.assertItemsEqual(expected, plugin.info_impl())
+    self.assertItemsEqual(expected, plugin.info_impl('eid'))
 
   @with_runs([_RUN_WITH_GRAPH_WITH_METADATA])
   def test_graph_simple(self, plugin):
-    graph = self._get_graph(plugin, tag=None, is_conceptual=False)
+    graph = self._get_graph(
+        plugin,
+        tag=None,
+        is_conceptual=False,
+        experiment='eid',
+    )
     node_names = set(node.name for node in graph.node)
     self.assertEqual({
         'k1', 'k2', 'pow', 'sub', 'expected', 'sub_1', 'error',
@@ -210,6 +215,7 @@ class GraphsPluginV1Test(GraphsPluginBaseTest, tf.test.TestCase):
         plugin,
         tag=None,
         is_conceptual=False,
+        experiment='eid',
         limit_attr_size=self._MESSAGE_PREFIX_LENGTH_LOWER_BOUND,
         large_attrs_key=key)
     large_attrs = {

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -183,26 +183,26 @@ class ScalarsPluginTest(tf.test.TestCase):
             },
         },
         # _RUN_WITH_HISTOGRAM omitted: No scalar data.
-    }, plugin.index_impl())
+    }, plugin.index_impl('eid'))
 
   @with_runs([_RUN_WITH_LEGACY_SCALARS, _RUN_WITH_SCALARS, _RUN_WITH_HISTOGRAM])
   def _test_scalars_json(self, plugin, run_name, tag_name, should_work=True):
     if should_work:
       (data, mime_type) = plugin.scalars_impl(
-          tag_name, run_name, None, scalars_plugin.OutputFormat.JSON)
+          tag_name, run_name, 'eid', scalars_plugin.OutputFormat.JSON)
       self.assertEqual('application/json', mime_type)
       self.assertEqual(len(data), self._STEPS)
     else:
       with self.assertRaises(errors.NotFoundError):
         plugin.scalars_impl(
-            self._SCALAR_TAG, run_name, None, scalars_plugin.OutputFormat.JSON
+            self._SCALAR_TAG, run_name, 'eid', scalars_plugin.OutputFormat.JSON
         )
 
   @with_runs([_RUN_WITH_LEGACY_SCALARS, _RUN_WITH_SCALARS, _RUN_WITH_HISTOGRAM])
   def _test_scalars_csv(self, plugin, run_name, tag_name, should_work=True):
     if should_work:
       (data, mime_type) = plugin.scalars_impl(
-          tag_name, run_name, None, scalars_plugin.OutputFormat.CSV)
+          tag_name, run_name, 'eid', scalars_plugin.OutputFormat.CSV)
       self.assertEqual('text/csv', mime_type)
       s = StringIO(data)
       reader = csv.reader(s)
@@ -211,7 +211,7 @@ class ScalarsPluginTest(tf.test.TestCase):
     else:
       with self.assertRaises(errors.NotFoundError):
         plugin.scalars_impl(
-            self._SCALAR_TAG, run_name, None, scalars_plugin.OutputFormat.CSV
+            self._SCALAR_TAG, run_name, 'eid', scalars_plugin.OutputFormat.CSV
         )
 
   def test_scalars_json_with_legacy_scalars(self):
@@ -264,7 +264,7 @@ class ScalarsPluginTest(tf.test.TestCase):
     self.generate_run_to_db('exp1', self._RUN_WITH_SCALARS)
 
     (data, mime_type) = self.plugin.scalars_impl(
-        self._SCALAR_TAG, self._RUN_WITH_SCALARS, None,
+        self._SCALAR_TAG, self._RUN_WITH_SCALARS, 'eid',
         scalars_plugin.OutputFormat.JSON)
     self.assertEqual('application/json', mime_type)
     # When querying DB-based backend without an experiment id, it returns all


### PR DESCRIPTION
Summary:
Experiment IDs must be passed to the data provider, but the multiplexer
provider doesn’t actually need them, so code that forgets to pass the ID
will be silently broken on other providers. This commit updates the
multiplexer provider to explicitly fail when the ID is omitted.

This would have caught bugs in earlier drafts of both #2981 and #2991,
which were written by different people, so clearly the mistake is easy
to make. :-)

Test Plan:
Running with `--generic_data true`, the scalars, histograms, and
distributions dashboards all still work. The graphs dashboard has the
same error as prior to this change (see comments on #2991). Unit tests
have been updated to always pass experiment IDs.

wchargin-branch: muxprovider-safety-eid
