### PR TITLE
Fix graph plugin with data provider, and its test

### DIFF
--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -116,7 +116,7 @@ class GraphsPlugin(base_plugin.TBPlugin):
       for (run_name, tag_to_time_series) in six.iteritems(mapping):
         for tag in tag_to_time_series:
           (run_item, tag_item) = add_row_item(run_name, tag)
-          run_item['op_graph'] = True
+          run_item['run_graph'] = True
           if tag_item:
             tag_item['op_graph'] = True
       return result

--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -249,7 +249,7 @@ class GraphsPlugin(base_plugin.TBPlugin):
     """Given a single run, return the graph definition in protobuf format."""
     experiment = plugin_util.experiment_id(request.environ)
     run = request.args.get('run')
-    tag = request.args.get('tag', '')
+    tag = request.args.get('tag')
     conceptual_arg = request.args.get('conceptual', False)
     is_conceptual = True if conceptual_arg == 'true' else False
 

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -173,12 +173,8 @@ class GraphsPluginV1Test(GraphsPluginBaseTest, tf.test.TestCase):
         'run': '_RUN_WITH_GRAPH_WITHOUT_METADATA',
         'run_graph': True,
         'tags': {},
-      }
-    }
-
-    if not plugin._data_provider:
-      # Hack, for now.
-      expected['_RUN_WITHOUT_GRAPH_WITH_METADATA'] = {
+      },
+      '_RUN_WITHOUT_GRAPH_WITH_METADATA': {
         'run': '_RUN_WITHOUT_GRAPH_WITH_METADATA',
         'run_graph': False,
         'tags': {
@@ -189,9 +185,18 @@ class GraphsPluginV1Test(GraphsPluginBaseTest, tf.test.TestCase):
             'op_graph': False,
           },
         },
-      }
+      },
+    }
 
-    self.assertItemsEqual(expected, plugin.info_impl('eid'))
+    if plugin._data_provider:
+      # Hack, for now.
+      # Data providers don't yet pass RunMetadata, so this entry excludes it.
+      expected['_RUN_WITH_GRAPH_WITH_METADATA']['tags'] = {}
+      # Data providers don't yet pass RunMetadata, so this entry is completely omitted.
+      del expected['_RUN_WITHOUT_GRAPH_WITH_METADATA']
+
+    actual = plugin.info_impl('eid')
+    self.assertEqual(expected, actual)
 
   @with_runs([_RUN_WITH_GRAPH_WITH_METADATA])
   def test_graph_simple(self, plugin):


### PR DESCRIPTION
This fixes the bug in #2991 found by @wchargin.

More importantly, it fixes the test that should have caught that bug in the first place (which has been broken since #1853): expected and actual data were being compared with `assertItemsEqual` instead of `assertEqual`, and so differences were not detected.