### PR TITLE
Post-release 2.1.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,38 @@
+# Release 2.1.0
+
+The 2.1 minor series tracks TensorFlow 2.1.
+
+## Features
+
+- Debugger: added ability to display Tensors as images, with selectable color map and zooming (#2729, #2764)
+- What-If Tool improvements:
+  - Added ability to set custom distance function for counterfactuals (#2607)
+  - Added ability to explore counterfactual examples for regression models (#2647)
+  - Added ability to consume arbitrary prediction-time information (#2660)
+  - Added ability to slice performance statistics by numeric features (in addition to categorical features) (#2678, #2704).
+  - Added PR/ROC curves by class for multi-class classification models (#2755)
+- Improvements for plugin developers:
+  - Added support for communication between TensorBoard and plugins in iframes (#2309, #2703)
+  - (Experimental) Added library for improved plugin integration (#2708)
+  - Enabled dynamic plugins in TensorBoard within Colab (#2798)
+- Security improvements, e.g. Content Security Policy configurations
+- Reduced overhead of image, audio, and histogram summary writing API methods (#2899)  - thanks @hongjunChoi
+
+## Bug fixes
+
+- What-If Tool:
+  - Fixed sometimes-stuck threshold sliders (#2682)
+  - Fixed PD plots in notebook mode with py3 kernels (#2669)
+  - Fixed info dialogs re. Fairness optimization (#2694)
+- Scalars dashboard: fixed unreliable data loading over slow network connections (#2825)
+- Fixed potential corruption when reading files from disk, when TensorFlow is not installed (#2791)
+- Fixed writing of histogram summaries when using TPUs (#2883) - thanks @hongjunChoi
+
+## TensorBoard.dev updates
+
+- The `tensorboard dev list` subcommand now provides detailed metadata about
+  each experiment.
+
 # Release 2.0.2
 
 ## Features

--- a/tensorboard/compat/proto/config.proto
+++ b/tensorboard/compat/proto/config.proto
@@ -540,6 +540,33 @@ message ConfigProto {
     // GraphDef must be passed in a single call to Session::Create(), and
     // Session::Extend() may not be supported.
     bool optimize_for_static_graph = 12;
+
+    // Whether to enable the MLIR-based TF->XLA bridge.
+    //
+    // This is a replacement to the existing bridge, and not ready for
+    // production usage yet.
+    // If this option is set to true when a session is created, MLIR is used to
+    // perform the set of graph transformations to put the graph in a form that
+    // can be executed with delegation of some computations to an accelerator.
+    // This builds on the model of XLA where a subset of the graph is
+    // encapsulated and attached to a "compile" operation, whose result is fed
+    // to an "execute" operation. The kernel for these operations is responsible
+    // to lower the encapsulated graph to a particular device.
+    bool enable_mlir_bridge = 13;
+
+    // If true, the session will not store an additional copy of the graph for
+    // each subgraph.
+    //
+    // If this option is set to true when a session is created, the
+    // `RunOptions.output_partition_graphs` options must not be set.
+    bool disable_output_partition_graphs = 14;
+
+    // Minimum number of batches run through the XLA graph before XLA fusion
+    // autotuner is enabled. Default value of zero disables the autotuner.
+    //
+    // The XLA fusion autotuner can improve performance by executing a heuristic
+    // search on the compiler parameters.
+    int64 xla_fusion_autotuner_thresh = 15;
   };
 
   Experimental experimental = 16;

--- a/tensorboard/compat/proto/event.proto
+++ b/tensorboard/compat/proto/event.proto
@@ -106,9 +106,14 @@ message WatchdogConfig {
   int64 timeout_ms = 1;
 }
 
+message RequestedExitCode {
+  int32 exit_code = 1;
+}
+
 message WorkerHeartbeatRequest {
   WorkerShutdownMode shutdown_mode = 1;
   WatchdogConfig watchdog_config = 2;
+  RequestedExitCode exit_code = 3;
 }
 
 message WorkerHeartbeatResponse {

--- a/tensorboard/compat/proto/struct.proto
+++ b/tensorboard/compat/proto/struct.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
+package tensorboard;
+
 import "tensorboard/compat/proto/tensor_shape.proto";
 import "tensorboard/compat/proto/types.proto";
-
-package tensorboard;
 
 // `StructuredValue` represents a dynamically typed value representing various
 // data structures that are inspired by Python data structures typically used in
@@ -120,6 +120,7 @@ message TypeSpecProto {
     DATA_ITERATOR_SPEC = 6;   // IteratorSpec from data/ops/iterator_ops.py
     OPTIONAL_SPEC = 7;        // tf.OptionalSpec
     PER_REPLICA_SPEC = 8;     // PerReplicaSpec from distribute/values.py
+    VARIABLE_SPEC = 9;        // tf.VariableSpec
   }
   TypeSpecClass type_spec_class = 1;
 

--- a/tensorboard/util/grpc_util_test.py
+++ b/tensorboard/util/grpc_util_test.py
@@ -129,8 +129,8 @@ class CallWithRetriesTest(tb_test.TestCase):
 
   def test_call_with_retries_includes_version_metadata(self):
     def digest(s):
-      """Hashes a string into a 32-bit integer."""
-      return int(hashlib.sha256(s.encode("utf-8")).hexdigest(), 16) & 0xffffffff
+      """Hashes a string into a positive 32-bit signed integer."""
+      return int(hashlib.sha256(s.encode("utf-8")).hexdigest(), 16) & 0x7fffffff
     def handler(request, context):
       metadata = context.invocation_metadata()
       client_version = grpc_util.extract_version(metadata)

--- a/tensorboard/version.py
+++ b/tensorboard/version.py
@@ -15,4 +15,4 @@
 
 """Contains the version string."""
 
-VERSION = '2.1.0a0'
+VERSION = '2.2.0a0'


### PR DESCRIPTION
Four commits to round out the 2.1.0 release process:

  - Bump tb-nightly version to 2.2.0a0
  - Cherrypick of 2.1.0 relnotes added to RELEASE.md
  - Cherrypick the TF proto sync
  - Fix a GRPC test that amusingly choked on the version change from 2.1.0a0 to 2.2.0a0.
