### PR TITLE
readme: update Travis badge to travis-ci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TensorBoard [![Travis build status](https://www.travis-ci.com/tensorflow/tensorboard.svg?branch=master)](https://travis-ci.com/tensorflow/tensorboard/) [![Compat check PyPI](https://python-compatibility-tools.appspot.com/one_badge_image?package=tensorboard)](https://python-compatibility-tools.appspot.com/one_badge_target?package=tensorboard)
+# TensorBoard [![Travis build status](https://travis-ci.org/tensorflow/tensorboard.svg?branch=master)](https://travis-ci.org/tensorflow/tensorboard/) [![Compat check PyPI](https://python-compatibility-tools.appspot.com/one_badge_image?package=tensorboard)](https://python-compatibility-tools.appspot.com/one_badge_target?package=tensorboard)
 
 TensorBoard is a suite of web applications for inspecting and understanding your
 TensorFlow runs and graphs.


### PR DESCRIPTION
Summary:
We’ve migrated from travis-ci.com back to travis-ci.org. This restores
the old badge URL, which is still the correct URL as autogenerated by
the Travis UI.

This reverts commit 9b6e29e7c5619e41da1fb29e466a83254333d0a6.

Test Plan:
The link resolves to a valid image, which marks the build as “passing”.

wchargin-branch: readme-ci-badge-org
