### PR TITLE
notebook: fix `cgi.escape` for Python 3.8

### DIFF
--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -29,10 +29,14 @@ import sys
 import textwrap
 import time
 
-if sys.version_info >= (3, 8):
-  import html as cgi
-else:
+try:
+  import html
+  html_escape = html.escape
+  del html
+except ImportError:
   import cgi
+  html_escape = cgi.escape
+  del cgi
 
 from tensorboard import manager
 
@@ -384,7 +388,7 @@ def _display_ipython(port, height, display_handle):
       </script>
   """
   replacements = [
-      ("%HTML_ID%", cgi.escape(frame_id, quote=True)),
+      ("%HTML_ID%", html_escape(frame_id, quote=True)),
       ("%JSON_ID%", json.dumps(frame_id)),
       ("%PORT%", "%d" % port),
       ("%HEIGHT%", "%d" % height),

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import cgi
 import datetime
 import errno
 import json
@@ -29,6 +28,11 @@ import shlex
 import sys
 import textwrap
 import time
+
+if sys.version_info >= (3, 8):
+  import html as cgi
+else:
+  import cgi
 
 from tensorboard import manager
 


### PR DESCRIPTION
Fixes #3015

Simply imports `html` instead of `cgi` if our Python version is 3.8 or newer, keeps `cgi` otherwise in order to maintain backwards compat.

Importing `html` as `cgi` is kinda ugly IMO, but I'm not really sure on how to fix it without having another if condition when calling `escape()`.

Another option would be to do `from html import escape`, but it seems that it'd break the code style currently going on for external libraries.