### PR TITLE
Fixed the typing on ts 3.7+

### DIFF
--- a/tensorboard/webapp/plugins/plugins.component.ts
+++ b/tensorboard/webapp/plugins/plugins.component.ts
@@ -73,7 +73,7 @@ export class PluginsComponent implements OnChanges {
 
     if (this.pluginInstances.has(plugin.id)) {
       const instance = this.pluginInstances.get(plugin.id) as HTMLElement;
-      instance.style.display = null;
+      instance.style.removeProperty('display');
       return;
     }
 


### PR DESCRIPTION
TypeScript on [1] removed the null type on CSSStyleDeclaration.display.
As a result, our code violates the type checking when we do
`element.style.display = null`. Fixed it.

[1]:
https://github.com/microsoft/TypeScript/commit/29becf05012bfa7ba20d50b0d16813971e46b8a6

Co-authored-by: Martin Probst <martin@probst.io>