### PR TITLE
ng: fixed the TS conformance issue

### DIFF
--- a/tensorboard/webapp/plugins/plugins.component.ts
+++ b/tensorboard/webapp/plugins/plugins.component.ts
@@ -58,10 +58,10 @@ export class PluginsComponent implements OnChanges {
   private readonly pluginInstances = new Map<string, HTMLElement>();
 
   ngOnChanges(change: SimpleChanges): void {
-    if (change.activePlugin && this.activePlugin) {
+    if (change['activePlugin'] && this.activePlugin) {
       this.renderPlugin(this.activePlugin!);
     }
-    if (change.lastUpdated) {
+    if (change['lastUpdated']) {
       this.reload();
     }
   }
@@ -99,7 +99,10 @@ export class PluginsComponent implements OnChanges {
         pluginElement = document.createElement('iframe');
         pluginElement.id = plugin.id;
         // Ideally should use the DOMSanitizer but it is not usable in TypeScript.
-        pluginElement.src = `data/plugin_entry.html?name=${plugin.id}`;
+        pluginElement.setAttribute(
+          'src',
+          `data/plugin_entry.html?name=${plugin.id}`
+        );
         this.pluginsContainer.nativeElement.appendChild(pluginElement);
         break;
       }


### PR DESCRIPTION
1. Cannot set `src` without TrustedURL. Fixed it by tricking the
conformance checker for now.
2. `SimpleChanges` is an object whose keys are names of the input or prop.
Prevent variable mangling by accessing via square brackets.
