### PR TITLE
python: fix invalid escape sequences

### DIFF
--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -591,7 +591,7 @@ class ParseEventFilesSpecTest(tb_test.TestCase):
     self.assertPlatformSpecificLogdirParsing(
         posixpath, '/lol/cat', {'/lol/cat': None})
     self.assertPlatformSpecificLogdirParsing(
-        ntpath, 'C:\\lol\cat', {'C:\\lol\cat': None})
+        ntpath, r'C:\lol\cat', {r'C:\lol\cat': None})
 
   def testRunName(self):
     self.assertPlatformSpecificLogdirParsing(
@@ -609,9 +609,9 @@ class ParseEventFilesSpecTest(tb_test.TestCase):
       os.environ['HOME'] = '/usr/eliza'
       self.assertPlatformSpecificLogdirParsing(
           posixpath, '~/lol/cat~dog', {'/usr/eliza/lol/cat~dog': None})
-      os.environ['HOME'] = 'C:\\Users\eliza'
+      os.environ['HOME'] = r'C:\Users\eliza'
       self.assertPlatformSpecificLogdirParsing(
-          ntpath, '~\lol\cat~dog', {'C:\\Users\eliza\lol\cat~dog': None})
+          ntpath, r'~\lol\cat~dog', {r'C:\Users\eliza\lol\cat~dog': None})
     finally:
       if oldhome is not None:
         os.environ['HOME'] = oldhome
@@ -623,10 +623,10 @@ class ParseEventFilesSpecTest(tb_test.TestCase):
       self.assertPlatformSpecificLogdirParsing(
           posixpath, 'a:~/lol,b:~/cat',
           {'/usr/eliza/lol': 'a', '/usr/eliza/cat': 'b'})
-      os.environ['HOME'] = 'C:\\Users\eliza'
+      os.environ['HOME'] = r'C:\Users\eliza'
       self.assertPlatformSpecificLogdirParsing(
-          ntpath, 'aa:~\lol,bb:~\cat',
-          {'C:\\Users\eliza\lol': 'aa', 'C:\\Users\eliza\cat': 'bb'})
+          ntpath, r'aa:~\lol,bb:~\cat',
+          {r'C:\Users\eliza\lol': 'aa', r'C:\Users\eliza\cat': 'bb'})
     finally:
       if oldhome is not None:
         os.environ['HOME'] = oldhome

--- a/tensorboard/manager_test.py
+++ b/tensorboard/manager_test.py
@@ -76,7 +76,7 @@ class TensorBoardInfoTest(tb_test.TestCase):
     with six.assertRaisesRegex(
         self,
         ValueError,
-        "expected 'start_time' of type.*int.*, but found: datetime\."):
+        r"expected 'start_time' of type.*int.*, but found: datetime\."):
       manager._info_to_string(info)
 
   def test_serialization_rejects_wrong_version(self):
@@ -346,7 +346,7 @@ class TensorBoardInfoIoTest(tb_test.TestCase):
     with six.assertRaisesRegex(
         self,
         ValueError,
-        "expected 'start_time' of type.*int.*, but found: datetime\."):
+        r"expected 'start_time' of type.*int.*, but found: datetime\."):
       manager.write_info_file(info)
     self.assertEqual(self._list_info_dir(), [])
 


### PR DESCRIPTION
Summary:
Python has historically been lax about invalid escapes: `"m\n\o"` is a
four-character string `m<Newline><Backslash>o`. As of Python 3.8, this
is a syntax warning. These can all be fixed by explicitly escaping the
backslashes or just using raw strings.

Test Plan:
All of our Python files now parse without warning on Python 3.8:

```
~/git/cpython/python - <<EOF
import ast
import glob
for f in glob.glob("tensorboard/**/*.py", recursive=True):
    ast.parse(open(f).read(), filename=f)
EOF
```

wchargin-branch: fix-py38-escapes
