### PR TITLE
pylint: remove unnecessary long-line suppressions

### DIFF
--- a/tensorboard/compat/tensorflow_stub/errors.py
+++ b/tensorboard/compat/tensorflow_stub/errors.py
@@ -179,7 +179,6 @@ DATA_LOSS = error_codes.DATA_LOSS
 # tf_export("errors.DATA_LOSS").export_constant(__name__, "DATA_LOSS")
 
 
-# pylint: disable=line-too-long
 # @tf_export("errors.CancelledError")
 class CancelledError(OpError):
     """Raised when an operation or step is cancelled.
@@ -200,7 +199,6 @@ class CancelledError(OpError):
         super(CancelledError, self).__init__(node_def, op, message, CANCELLED)
 
 
-# pylint: enable=line-too-long
 
 
 # @tf_export("errors.UnknownError")

--- a/tensorboard/plugins/debugger/debugger_plugin_loader.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_loader.py
@@ -136,9 +136,7 @@ the interactive Debugger Dashboard. This flag is mutually exclusive with
             '  pip install tensorflow')
 
     if flags.debugger_data_server_grpc_port > 0:
-      # pylint: disable=line-too-long
       from tensorboard.plugins.debugger import debugger_plugin as debugger_plugin_lib
-      # pylint: enable=line-too-long
 
       # debugger_data_server_grpc opens the non-interactive Debugger Plugin,
       # which appears as health pills in the Graph Plugin.
@@ -148,9 +146,7 @@ the interactive Debugger Dashboard. This flag is mutually exclusive with
       noninteractive_plugin.listen(flags.debugger_data_server_grpc_port)
       return noninteractive_plugin
     elif flags.debugger_port > 0:
-      # pylint: disable=line-too-long
       from tensorboard.plugins.debugger import interactive_debugger_plugin as interactive_debugger_plugin_lib
-      # pylint: enable=line-too-long
       interactive_plugin = (
           interactive_debugger_plugin_lib.InteractiveDebuggerPlugin(context))
       logger.info('Starting Interactive Debugger Plugin at gRPC port %d',

--- a/tensorboard/plugins/debugger/debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/debugger_server_lib.py
@@ -33,9 +33,7 @@ import tensorflow as tf
 from tensorflow.python.debug.lib import grpc_debug_server
 
 from tensorboard.plugins.debugger import constants
-# pylint: disable=line-too-long
 from tensorboard.plugins.debugger import events_writer_manager as events_writer_manager_lib
-# pylint: enable=line-too-long
 from tensorboard.plugins.debugger import numerics_alert
 from tensorboard.util import tb_logging
 from tensorboard.util import tensor_util

--- a/tensorboard/plugins/interactive_inference/interactive_inference_plugin_loader.py
+++ b/tensorboard/plugins/interactive_inference/interactive_inference_plugin_loader.py
@@ -41,6 +41,5 @@ class InteractiveInferencePluginLoader(base_plugin.TBLoader):
       import tensorflow
     except ImportError:
       return
-    # pylint: disable=line-too-long
     from tensorboard.plugins.interactive_inference.interactive_inference_plugin import InteractiveInferencePlugin
     return InteractiveInferencePlugin(context)


### PR DESCRIPTION
Summary:
In ec7e68d543a6, we removed `line-too-long` suppressions on import
lines. Most of the remaining `line-too-long` suppressions are also
unneeded, either because they’re around blocks of imports or because
none of the lines that they encapsulate is too long.

Test Plan:
The two remaining matches for `git grep line-too-long` are legitimate.

wchargin-branch: unsuppress-long-import-blocks
