### PR TITLE
pip_package: strip file timestamps from wheel

### DIFF
--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -114,6 +114,10 @@ build() (
   export PYTHONWARNINGS=ignore:DEPRECATION  # suppress Python 2.7 deprecation spam
   pip install -qU wheel 'setuptools>=36.2.0'
 
+  # Arbitrary date; overrides the file timestamps in the zip archive to
+  # make the build reproducible.
+  export SOURCE_DATE_EPOCH=1446856078
+
   python setup.py bdist_wheel --python-tag py2 >/dev/null
   python setup.py bdist_wheel --python-tag py3 >/dev/null
 

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -116,7 +116,7 @@ build() (
 
   # Arbitrary date; overrides the file timestamps in the zip archive to
   # make the build reproducible.
-  export SOURCE_DATE_EPOCH=1446856078
+  export SOURCE_DATE_EPOCH=1577836800
 
   python setup.py bdist_wheel --python-tag py2 >/dev/null
   python setup.py bdist_wheel --python-tag py3 >/dev/null

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -114,9 +114,10 @@ build() (
   export PYTHONWARNINGS=ignore:DEPRECATION  # suppress Python 2.7 deprecation spam
   pip install -qU wheel 'setuptools>=36.2.0'
 
-  # Arbitrary date; overrides the file timestamps in the zip archive to
-  # make the build reproducible.
-  export SOURCE_DATE_EPOCH=1577836800
+  # Overrides file timestamps in the zip archive to make the build
+  # reproducible. (Date is mostly arbitrary, but must be past 1980 to be
+  # representable in a zip archive.)
+  export SOURCE_DATE_EPOCH=1577836800  # 2020-01-01T00:00:00Z
 
   python setup.py bdist_wheel --python-tag py2 >/dev/null
   python setup.py bdist_wheel --python-tag py3 >/dev/null


### PR DESCRIPTION
Summary:
Our `//tensorboard/pip_package` target is *almost* built hermetically.
It turns out that the only source of skew is file timestamps in the zip
archive. Setting `SOURCE_DATE_EPOCH` fixes that:
<https://github.com/pypa/setuptools/issues/1468>

Test Plan:
The wheels and their container archive are now bit-for-bit hermetic, at
least on my machine:

```
$ bazel build //tensorboard/pip_package
Target //tensorboard/pip_package:pip_package up-to-date:
  bazel-bin/tensorboard/pip_package/pip_packages.tar.gz
INFO: Build completed successfully, 3 total actions
$ shasum -a 256 <bazel-bin/tensorboard/pip_package/pip_packages.tar.gz
6a37a171c7e274cd04fb7cb6772e5c93bde604669285b53c0c639127f7bf01f4  -
$ rm -f bazel-bin/tensorboard/pip_package/pip_packages.tar.gz
$ bazel build //tensorboard/pip_package
Target //tensorboard/pip_package:pip_package up-to-date:
  bazel-bin/tensorboard/pip_package/pip_packages.tar.gz
INFO: Build completed successfully, 2 total actions
$ shasum -a 256 <bazel-bin/tensorboard/pip_package/pip_packages.tar.gz
6a37a171c7e274cd04fb7cb6772e5c93bde604669285b53c0c639127f7bf01f4  -
```

(Bazel prints “Executing genrule //tensorboard/pip_package:pip_package”
in the middle there, so you know that it really is re-building.)

wchargin-branch: hermetic-wheel-modtimes
