### PR TITLE
as_numpy_dtype is a property, not a method

### DIFF
--- a/tensorboard/compat/tensorflow_stub/dtypes.py
+++ b/tensorboard/compat/tensorflow_stub/dtypes.py
@@ -199,10 +199,10 @@ class DType(object):
         # there is no simple way to get the min value of a dtype, we have to check
         # float and int types separately
         try:
-            return np.finfo(self.as_numpy_dtype()).min
+            return np.finfo(self.as_numpy_dtype).min
         except:  # bare except as possible raises by finfo not documented
             try:
-                return np.iinfo(self.as_numpy_dtype()).min
+                return np.iinfo(self.as_numpy_dtype).min
             except:
                 if self.base_dtype == bfloat16:
                     return _np_bfloat16(float.fromhex("-0x1.FEp127"))
@@ -226,10 +226,10 @@ class DType(object):
         # there is no simple way to get the max value of a dtype, we have to check
         # float and int types separately
         try:
-            return np.finfo(self.as_numpy_dtype()).max
+            return np.finfo(self.as_numpy_dtype).max
         except:  # bare except as possible raises by finfo not documented
             try:
-                return np.iinfo(self.as_numpy_dtype()).max
+                return np.iinfo(self.as_numpy_dtype).max
             except:
                 if self.base_dtype == bfloat16:
                     return _np_bfloat16(float.fromhex("0x1.FEp127"))


### PR DESCRIPTION
This makes explicit that as_numpy_dtype(0) returns a scalar value, not a dtype. (And accordingly, we use the dtype instead of the scalar.)
