### PR TITLE
deps: factor out `requirements.txt` files

### DIFF
--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -32,6 +32,7 @@ sh_binary(
         "LICENSE",
         "MANIFEST.in",
         "README.rst",
+        "requirements.txt",
         "setup.cfg",
         "setup.py",
         ":deterministic_tar_gz",

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -75,6 +75,7 @@ build() (
   mv -f "tensorboard/pip_package/LICENSE" .
   mv -f "tensorboard/pip_package/MANIFEST.in" .
   mv -f "tensorboard/pip_package/README.rst" .
+  mv -f "tensorboard/pip_package/requirements.txt" .
   mv -f "tensorboard/pip_package/setup.cfg" .
   mv -f "tensorboard/pip_package/setup.py" .
   rm -rf "tensorboard/pip_package"

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -1,0 +1,18 @@
+# Non-vendored runtime dependencies of TensorBoard.
+
+absl-py >= 0.4
+# futures is a backport of the python 3.2+ concurrent.futures module
+futures >= 3.1.1; python_version < "3"
+grpcio >= 1.24.3
+google-auth >= 1.6.3, < 2
+google-auth-oauthlib >= 0.4.1, < 0.5
+markdown >= 2.6.8
+numpy >= 1.12.0
+protobuf >= 3.6.0
+requests >= 2.21.0, < 3
+setuptools >= 41.0.0
+six >= 1.10.0
+werkzeug >= 0.11.15
+# python3 specifically requires wheel 0.26
+wheel; python_version < "3"
+wheel >= 0.26; python_version >= "3"

--- a/tensorboard/pip_package/requirements.txt
+++ b/tensorboard/pip_package/requirements.txt
@@ -1,3 +1,18 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 # Non-vendored runtime dependencies of TensorBoard.
 
 absl-py >= 0.4

--- a/tensorboard/pip_package/requirements_dev.txt
+++ b/tensorboard/pip_package/requirements_dev.txt
@@ -1,0 +1,15 @@
+# Dependencies of TensorBoard used only for testing or development.
+
+# For tests
+grpcio-testing==1.24.3
+# For gfile S3 test
+boto3==1.9.86
+moto==1.3.7
+
+# For linting
+black==19.0b0, python_version >= "3"
+flake8==3.7.8
+yamllint==1.17.0
+
+# For building Pip package
+virtualenv==16.7.7

--- a/tensorboard/pip_package/requirements_dev.txt
+++ b/tensorboard/pip_package/requirements_dev.txt
@@ -22,7 +22,7 @@ boto3==1.9.86
 moto==1.3.7
 
 # For linting
-black==19.0b0, python_version >= "3"
+black==19.10b0; python_version >= "3"
 flake8==3.7.8
 yamllint==1.17.0
 

--- a/tensorboard/pip_package/requirements_dev.txt
+++ b/tensorboard/pip_package/requirements_dev.txt
@@ -1,3 +1,18 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 # Dependencies of TensorBoard used only for testing or development.
 
 # For tests

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -22,34 +22,21 @@ from setuptools import find_packages, setup
 import tensorboard.version
 
 
-REQUIRED_PACKAGES = [
-    "absl-py >= 0.4",
-    # futures is a backport of the python 3.2+ concurrent.futures module
-    'futures >= 3.1.1; python_version < "3"',
-    "grpcio >= 1.24.3",
-    "google-auth >= 1.6.3, < 2",
-    "google-auth-oauthlib >= 0.4.1, < 0.5",
-    "markdown >= 2.6.8",
-    "numpy >= 1.12.0",
-    "protobuf >= 3.6.0",
-    "requests >= 2.21.0, < 3",
-    "setuptools >= 41.0.0",
-    "six >= 1.10.0",
-    "werkzeug >= 0.11.15",
-    # python3 specifically requires wheel 0.26
-    'wheel; python_version < "3"',
-    'wheel >= 0.26; python_version >= "3"',
-]
-
-CONSOLE_SCRIPTS = [
-    "tensorboard = tensorboard.main:run_main",
-]
+def get_required_packages():
+    with open("requirements.txt") as f:
+        return f.read().splitlines()
 
 
 def get_readme():
     with open("README.rst") as f:
         return f.read()
 
+
+REQUIRED_PACKAGES = get_required_packages()
+
+CONSOLE_SCRIPTS = [
+    "tensorboard = tensorboard.main:run_main",
+]
 
 setup(
     name="tensorboard",


### PR DESCRIPTION
Summary:
This commit starts deduplicating our various representations of Python
dependencies. We extract `requirements.txt` for runtime dependencies and
`requirements_dev.txt` for tools, linters, and test-only deps. The CI
configuration will soon be changed to depend on these. (We don’t make
that change atomically because we need this intermediate state to safely
migrate some internal processes.) See #3038 for context.

Test Plan:
The output of `bazel build //tensorboard/pip_package` is bit-for-bit
identical before and after this change. In a new virtualenv (either
Python 2 or Python 3), one can successfully run all tests with the
declared dependencies:

```
pip install \
    tensorflow \
    -r tensorboard/pip_package/requirements.txt \
    -r tensorboard/pip_package/requirements_dev.txt \
&& bazel test //tensorboard/...
```

(modulo flaky web test failures).

wchargin-branch: deps-requirements-txt
