### PR TITLE
test: fix concurrent web test execution

### DIFF
--- a/tensorboard/defs/web.bzl
+++ b/tensorboard/defs/web.bzl
@@ -212,7 +212,7 @@ def _tf_web_library(ctx):
     )
   params = struct(
       label=str(ctx.label),
-      bind="localhost:6006",
+      bind="localhost:0",
       manifest=[long_path(ctx, man) for man in devserver_manifests.to_list()],
       external_asset=[struct(webpath=k, path=v)
                       for k, v in ctx.attr.external_assets.items()])

--- a/tensorboard/defs/web_testing.bzl
+++ b/tensorboard/defs/web_testing.bzl
@@ -66,7 +66,7 @@ def tf_web_test(name, web_library, src, **kwargs):
         testonly = 1,
     )
     kwargs.setdefault("flaky", True)
-    kwargs.setdefault("timeout", "short")
+    kwargs.setdefault("timeout", "moderate")
     kwargs.setdefault("tags", []).append("webtest")
     py_web_test_suite(
         name = name,


### PR DESCRIPTION
Summary:
Fixes #2643. The proximate cause was that the `rules_closure` web server
tries 10 ports before giving up, so when more than 10 tests are run
concurrently some of them will fail. We fix this by binding to port 0
rather than scanning. With this fix, running all 18 of our web tests
concurrently incurred timeouts, even on a machine with 64 GB of RAM and
a 12-core Xeon W-2135 processor. Increasing the timeouts to moderate
mitigates that problem.

Test Plan:
Running all web tests concurrently now passes:

```
bazel test //tensorboard/... \
    --test_tag_filters=webtest --cache_test_results=no
```

It takes 172 seconds on my machine, running with 12-fold parallelism.

wchargin-branch: web-test-flaky
