### PR TITLE
graph: getGradient should always return a string

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -731,7 +731,7 @@ module tf.graph.scene.node {
     id: string,
     colors: Array<{color: string; proportion: number}>,
     svgRoot?: SVGElement
-  ) {
+  ): string {
     let escapedId = tf.graph.util.escapeQuerySelector(id);
     if (!svgRoot) return `url(#${escapedId})`;
     let $svgRoot = d3.select(svgRoot);
@@ -760,6 +760,7 @@ module tf.graph.scene.node {
         cumulativeProportion += d.proportion;
       });
     }
+    return `url(#${escapedId})`;
   }
 
   export function removeGradientDefinitions(svgRoot: SVGElement) {


### PR DESCRIPTION
Fixes #2900

* Motivation for features / changes
#2900
Several places in `tensorboard/plugins/graph/tf_graph_common/node.ts` use `getGradient()`, expecting it to return a string.  The function doesn't always return a string, which causes errors in the Graph dashboard.

* Technical description of changes
This PR ensures that `getGradient()` always returns a string.

* Detailed steps to verify changes work correctly (as executed by you)
Retried the repro steps for #2900 and saw that it now works correctly (graph is not visually broken, console errors from before are gone).
I haven't written a test, but given the complexity of GraphV1 and contextual knowledge required, I'd like to know whether it makes sense to write one now, or just wait for GraphV2.