### PR TITLE
hparams: accept Numpy scalars as hyperparameter values

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -218,6 +218,7 @@ py_library(
     deps = [
         ":metadata",
         ":protos_all_py_pb2",
+        "//tensorboard:expect_numpy_installed",
         "//tensorboard/compat",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "@org_pythonhosted_six",
@@ -233,6 +234,7 @@ py_test(
         ":metadata",
         ":protos_all_py_pb2",
         ":summary_v2",
+        "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard:test",
         "//tensorboard/compat/proto:protos_all_py_pb2",
@@ -253,6 +255,7 @@ py_test(
         ":metadata",
         ":protos_all_py_pb2",
         ":summary_v2",
+        "//tensorboard:expect_numpy_installed",
         "//tensorboard:test",
         "//tensorboard/compat:no_tensorflow",
         "//tensorboard/compat/proto:protos_all_py_pb2",

--- a/tensorboard/plugins/hparams/summary_v2_test.py
+++ b/tensorboard/plugins/hparams/summary_v2_test.py
@@ -26,6 +26,7 @@ import time
 import unittest
 
 from google.protobuf import text_format
+import numpy as np
 import six
 from six.moves import xrange  # pylint: disable=redefined-builtin
 
@@ -270,6 +271,28 @@ class HParamsTest(test.TestCase):
         self.assertNotEqual(
             get_group_name(hparams_1), get_group_name(hparams_2)
         )
+
+    def test_serialize_numpy_scalars(self):
+        hparams = {
+            "i32": np.array([1, 2], dtype=np.int32)[0],
+            "i64": np.array([1, 2], dtype=np.int64)[0],
+            "f_default": np.linspace(1.0, 2.0, 5)[0],
+            "f32": np.linspace(1.0, 2.0, 5, dtype=np.float32)[0],
+            "f64": np.linspace(1.0, 2.0, 5, dtype=np.float64)[0],
+            "bool": np.array([False, True])[0],
+        }
+        hp.hparams_pb(hparams)
+
+    @requires_tf
+    def test_serialize_tf_linspace_numpy(self):
+        # Should be subsumed by `test_serialize_numpy_scalars`; separate
+        # test because it's a common use case.
+        hparams = {
+            "f_default": tf.linspace(1.0, 2.0, 5).numpy()[0],
+            "f32": tf.cast(tf.linspace(1.0, 2.0, 5), tf.float32).numpy()[0],
+            "f64": tf.cast(tf.linspace(1.0, 2.0, 5), tf.float64).numpy()[0],
+        }
+        hp.hparams_pb(hparams)
 
 
 class HParamsConfigTest(test.TestCase):


### PR DESCRIPTION
Summary:
The `hp.hparams` and `hp.hparams_pb` functions now accept Numpy data
types, like `np.float32` or `np.int32`, as hyperparameter values.
Previously, some such data types happened to work: `np.float64`, for
instance, is a subclass of `float`, and so was being implicitly
converted, but `np.float32` is not. Permitting all Numpy types is a nice
convenience that avoids confusion.

Fixes #3057.

Test Plan:
The newly added tests fail before this change and pass after it.

wchargin-branch: hparams-numpy
