### PR TITLE
Add download links to HParams plugin

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -27,6 +27,7 @@ py_library(
     name = "hparams_plugin",
     srcs = [
         "backend_context.py",
+        "download_data.py",
         "get_experiment.py",
         "hparams_plugin.py",
         "list_metric_evals.py",
@@ -49,6 +50,21 @@ py_library(
         "@com_google_protobuf//:protobuf_python",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",
+    ],
+)
+
+py_test(
+    name = "download_data_test",
+    size = "small",
+    srcs = [
+        "download_data_test.py",
+    ],
+    deps = [
+        ":hparams_plugin",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/backend/event_processing:event_accumulator",
+        "//tensorboard/backend/event_processing:event_multiplexer",
+        "@org_pythonhosted_mock",
     ],
 )
 

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -64,6 +64,7 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend/event_processing:event_accumulator",
         "//tensorboard/backend/event_processing:event_multiplexer",
+        "@com_google_protobuf//:protobuf_python",
         "@org_pythonhosted_mock",
     ],
 )

--- a/tensorboard/plugins/hparams/download_data.py
+++ b/tensorboard/plugins/hparams/download_data.py
@@ -99,7 +99,7 @@ class Handler(object):
                 elif isinstance(value, float):
                     if math.isnan(value):
                         return r"$\mathrm{NaN}$"
-                    if not math.isfinite(value):
+                    if value in (float('inf'), float('-inf')):
                         return r"$%s\infty$" % ("-" if value < 0 else "+")
                     scientific = "%.3g" % value
                     if "e" in scientific:

--- a/tensorboard/plugins/hparams/download_data.py
+++ b/tensorboard/plugins/hparams/download_data.py
@@ -99,7 +99,7 @@ class Handler(object):
                 elif isinstance(value, float):
                     if math.isnan(value):
                         return r"$\mathrm{NaN}$"
-                    if value in (float('inf'), float('-inf')):
+                    if value in (float("inf"), float("-inf")):
                         return r"$%s\infty$" % ("-" if value < 0 else "+")
                     scientific = "%.3g" % value
                     if "e" in scientific:

--- a/tensorboard/plugins/hparams/download_data.py
+++ b/tensorboard/plugins/hparams/download_data.py
@@ -1,0 +1,137 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Classes and functions for handling the DownloadData API call."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+from tensorboard.plugins.hparams import error
+from six import StringIO
+import math
+import csv
+
+
+class OutputFormat(object):
+    """An enum used to list the valid output formats for API calls."""
+
+    JSON = "json"
+    CSV = "csv"
+    LATEX = "latex"
+
+
+class Handler(object):
+    """Handles a DownloadData request."""
+
+    def __init__(self, context, experiment, session_groups, response_format):
+        """Constructor.
+
+        Args:
+          context: A backend_context.Context instance.
+          experiment: Experiment proto.
+          session_groups: ListSessionGroupsResponse proto.
+          response_format: A string in the OutputFormat enum.
+        """
+        self._context = context
+        self._experiment = experiment
+        self._session_groups = session_groups
+        self._response_format = response_format
+
+    def run(self):
+        """Handles the request specified on construction.
+
+        Returns:
+          A response body.
+          A mime type (string) for the response.
+        """
+        experiment = self._experiment
+        session_groups = self._session_groups
+        response_format = self._response_format
+
+        header = []
+        for hparam_info in experiment.hparam_infos:
+            header.append(hparam_info.display_name or hparam_info.name)
+
+        for metric_info in experiment.metric_infos:
+            header.append(metric_info.display_name or metric_info.name.tag)
+
+        rows = []
+
+        def _get_value(value):
+            if value.HasField("number_value"):
+                return value.number_value
+            if value.HasField("string_value"):
+                return value.string_value
+            if value.HasField("bool_value"):
+                return value.bool_value
+            # hyperparameter values can be optional in a session group
+            return ""
+
+        for group in session_groups.session_groups:
+            row = []
+            for hparam_info in experiment.hparam_infos:
+                row.append(_get_value(group.hparams[hparam_info.name]))
+            for metric_value in group.metric_values:
+                row.append(metric_value.value)
+            rows.append(row)
+
+        if response_format == OutputFormat.JSON:
+            mime_type = "application/json"
+            body = dict(header=header, rows=rows)
+        elif response_format == OutputFormat.LATEX:
+
+            def latex_format(value):
+                if isinstance(value, int):
+                    return "$%d$" % value
+                elif isinstance(value, float):
+                    if math.isnan(value):
+                        return r"$\mathrm{NaN}$"
+                    if not math.isfinite(value):
+                        return r"$%s\infty$" % ("-" if value < 0 else "+")
+                    scientific = "%.3g" % value
+                    if "e" in scientific:
+                        coefficient, exponent = scientific.split("e")
+                        return "$%s\\cdot 10^{%d}$" % (
+                            coefficient,
+                            int(exponent),
+                        )
+                    return "$%s$" % scientific
+                return value.replace("_", "\\_").replace("%", "\\%")
+
+            mime_type = "application/x-latex"
+            top_part = "\\begin{table}[tbp]\n\\begin{tabular}{%s}\n" % (
+                "l" * len(header)
+            )
+            header_part = (
+                " & ".join(map(latex_format, header)) + " \\\\ \\hline\n"
+            )
+            middle_part = "".join(
+                " & ".join(map(latex_format, row)) + " \\\\\n" for row in rows
+            )
+            bottom_part = "\\hline\n\\end{tabular}\n\\end{table}\n"
+            body = top_part + header_part + middle_part + bottom_part
+        elif response_format == OutputFormat.CSV:
+            string_io = StringIO()
+            writer = csv.writer(string_io)
+            writer.writerow(header)
+            writer.writerows(rows)
+            body = string_io.getvalue()
+            mime_type = "text/csv"
+        else:
+            raise error.HParamsError(
+                "Invalid reponses format: %s" % response_format
+            )
+        return body, mime_type

--- a/tensorboard/plugins/hparams/download_data_test.py
+++ b/tensorboard/plugins/hparams/download_data_test.py
@@ -1,0 +1,295 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for download_data."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+    # python version >= 3.3
+    from unittest import mock
+except ImportError:
+    import mock  # pylint: disable=unused-import
+import tensorflow as tf
+
+from google.protobuf import text_format
+from tensorboard.backend.event_processing import plugin_event_multiplexer
+
+from tensorboard.plugins import base_plugin
+from tensorboard.plugins.hparams import api_pb2
+from tensorboard.plugins.hparams import backend_context
+from tensorboard.plugins.hparams import download_data
+
+EXPERIMENT = """
+description: 'Test experiment'
+user: 'Test user'
+hparam_infos: [
+  {
+    name: 'initial_temp'
+    type: DATA_TYPE_FLOAT64
+  },
+  {
+    name: 'final_temp'
+    type: DATA_TYPE_FLOAT64
+  },
+  { name: 'string_hparam' },
+  { name: 'bool_hparam' },
+  { name: 'optional_string_hparam' }
+]
+metric_infos: [
+  { name: { tag: 'current_temp' } },
+  { name: { tag: 'delta_temp' } },
+  { name: { tag: 'optional_metric' } }
+]
+"""
+
+SESSION_GROUPS = """
+session_groups {
+  name: "group_1"
+  hparams { key: "bool_hparam" value { bool_value: true } }
+  hparams { key: "final_temp" value { number_value: 150.0 } }
+  hparams { key: "initial_temp" value { number_value: 270.0 } }
+  hparams { key: "string_hparam" value { string_value: "a string" } }
+  metric_values {
+    name { tag: "current_temp" }
+    value: 10
+    training_step: 1
+    wall_time_secs: 1.0
+  }
+  metric_values { name { tag: "delta_temp" } value: 15
+    training_step: 2
+    wall_time_secs: 10.0
+  }
+  metric_values { name { tag: "optional_metric" } value: 33
+    training_step: 20
+    wall_time_secs: 2.0
+  }
+  sessions {
+    name: "session_1"
+    start_time_secs: 314159
+    end_time_secs: 314164
+    status: STATUS_SUCCESS
+    metric_values {
+      name { tag: "current_temp" }
+      value: 10
+      training_step: 1
+      wall_time_secs: 1.0
+    }
+    metric_values {
+      name { tag: "delta_temp" }
+      value: 15
+      training_step: 2
+      wall_time_secs: 10.0
+    }
+
+    metric_values {
+      name { tag: "optional_metric" }
+      value: 33
+      training_step: 20
+      wall_time_secs: 2.0
+    }
+  }
+}
+session_groups {
+  name: "group_2"
+  hparams { key: "bool_hparam" value { bool_value: false } }
+  hparams { key: "final_temp" value { number_value: 100.0 } }
+  hparams { key: "initial_temp" value { number_value: 280.0 } }
+  hparams { key: "string_hparam" value { string_value: "AAAAA"}}
+  metric_values {
+    name { tag: "current_temp" }
+    value: 51.0
+    training_step: 1
+    wall_time_secs: 1.0
+  }
+  metric_values {
+    name { tag: "delta_temp" }
+    value: 44.5
+    training_step: 2
+    wall_time_secs: 10.3333333
+  }
+  sessions {
+    name: "session_2"
+    start_time_secs: 314159
+    end_time_secs: 314164
+    status: STATUS_SUCCESS
+    metric_values {
+      name { tag: "current_temp" }
+      value: 100
+      training_step: 1
+      wall_time_secs: 1.0
+    }
+    metric_values { name { tag: "delta_temp" }
+      value: 150
+      training_step: 3
+      wall_time_secs: 11.0
+    }
+  }
+  sessions {
+    name: "session_3"
+    start_time_secs: 314159
+    end_time_secs: 314164
+    status: STATUS_FAILURE
+    metric_values {
+      name { tag: "current_temp" }
+      value: 1.0
+      training_step: 1
+      wall_time_secs: 1.0
+    }
+    metric_values { name { tag: "delta_temp" }
+      value: 1.5
+      training_step: 2
+      wall_time_secs: 10.0
+    }
+  }
+  sessions {
+    name: "session_5"
+    start_time_secs: 314159
+    end_time_secs: 314164
+    status: STATUS_SUCCESS
+    metric_values {
+      name { tag: "current_temp" }
+      value: 52.0
+      training_step: 1
+      wall_time_secs: 1.0
+    }
+    metric_values { name { tag: "delta_temp" }
+      value: -18
+      training_step: 2
+      wall_time_secs: 10.0
+    }
+  }
+}
+session_groups {
+  name: "group_3"
+  hparams { key: "bool_hparam" value { bool_value: true } }
+  hparams { key: "final_temp" value { number_value: 0.000012 } }
+  hparams { key: "initial_temp" value { number_value: 300.0 } }
+  hparams { key: "string_hparam" value { string_value: "a string_3"}}
+  hparams {
+    key: 'optional_string_hparam' value { string_value: 'BB' }
+  }
+  metric_values {
+    name { tag: "current_temp" }
+    value: 101.0
+    training_step: 1
+    wall_time_secs: 1.0
+  }
+  metric_values { name { tag: "delta_temp" } value: -15100000.0
+    training_step: 2
+    wall_time_secs: 10.0
+  }
+  sessions {
+    name: "session_4"
+    start_time_secs: 314159
+    end_time_secs: 314164
+    status: STATUS_UNKNOWN
+    metric_values {
+      name { tag: "current_temp" }
+      value: 101.0
+      training_step: 1
+      wall_time_secs: 1.0
+    }
+    metric_values { name { tag: "delta_temp" } value: -151000000.0
+      training_step: 2
+      wall_time_secs: 10.0
+    }
+  }
+}
+total_size: 3
+"""
+
+
+EXPECTED_LATEX = r"""\begin{table}[tbp]
+\begin{tabular}{llllllll}
+initial\_temp & final\_temp & string\_hparam & bool\_hparam & optional\_string\_hparam & current\_temp & delta\_temp & optional\_metric \\ \hline
+$270$ & $150$ & a string & $1$ &  & $10$ & $15$ & $33$ \\
+$280$ & $100$ & AAAAA & $0$ &  & $51$ & $44.5$ \\
+$300$ & $1.2\cdot 10^{-5}$ & a string\_3 & $1$ & BB & $101$ & $-1.51\cdot 10^{7}$ \\
+\hline
+\end{tabular}
+\end{table}
+"""
+
+EXPECTED_CSV = """initial_temp,final_temp,string_hparam,bool_hparam,optional_string_hparam,current_temp,delta_temp,optional_metric\r
+270.0,150.0,a string,True,,10.0,15.0,33.0\r
+280.0,100.0,AAAAA,False,,51.0,44.5\r
+300.0,1.2e-05,a string_3,True,BB,101.0,-15100000.0\r
+"""
+
+
+class DownloadDataTest(tf.test.TestCase):
+    def setUp(self):
+        self._mock_tb_context = mock.create_autospec(base_plugin.TBContext)
+        self._mock_multiplexer = mock.create_autospec(
+            plugin_event_multiplexer.EventMultiplexer
+        )
+        self._mock_tb_context.multiplexer = self._mock_multiplexer
+
+    def _run_handler(self, experiment, session_groups, response_format):
+        experiment_proto = text_format.Merge(experiment, api_pb2.Experiment())
+        session_groups_proto = text_format.Merge(
+            session_groups, api_pb2.ListSessionGroupsResponse()
+        )
+        handler = download_data.Handler(
+            backend_context.Context(self._mock_tb_context),
+            experiment_proto,
+            session_groups_proto,
+            response_format,
+        )
+        return handler.run()
+
+    def test_csv(self):
+        body, mime_type = self._run_handler(
+            EXPERIMENT, SESSION_GROUPS, download_data.OutputFormat.CSV
+        )
+        self.assertEqual("text/csv", mime_type)
+        self.assertEqual(EXPECTED_CSV, body)
+
+    def test_latex(self):
+        body, mime_type = self._run_handler(
+            EXPERIMENT, SESSION_GROUPS, download_data.OutputFormat.LATEX
+        )
+        self.assertEqual("application/x-latex", mime_type)
+        self.assertEqual(EXPECTED_LATEX, body)
+
+    def test_json(self):
+        body, mime_type = self._run_handler(
+            EXPERIMENT, SESSION_GROUPS, download_data.OutputFormat.JSON
+        )
+        self.assertEqual("application/json", mime_type)
+        expected_result = {
+            "header": [
+                "initial_temp",
+                "final_temp",
+                "string_hparam",
+                "bool_hparam",
+                "optional_string_hparam",
+                "current_temp",
+                "delta_temp",
+                "optional_metric",
+            ],
+            "rows": [
+                [270.0, 150.0, "a string", True, "", 10.0, 15.0, 33.0],
+                [280.0, 100.0, "AAAAA", False, "", 51.0, 44.5],
+                [300.0, 1.2e-05, "a string_3", True, "BB", 101.0, -15100000.0],
+            ],
+        }
+        self.assertEqual(expected_result, body)
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -23,6 +23,9 @@ from __future__ import division
 from __future__ import print_function
 
 import json
+import csv
+from six import StringIO
+
 
 import werkzeug
 from werkzeug import wrappers
@@ -42,6 +45,14 @@ from tensorboard.util import tb_logging
 
 
 logger = tb_logging.get_logger()
+
+
+class OutputFormat(object):
+    """An enum used to list the valid output formats for API calls."""
+
+    JSON = "json"
+    CSV = "csv"
+    LATEX = "latex"
 
 
 class HParamsPlugin(base_plugin.TBPlugin):
@@ -64,6 +75,7 @@ class HParamsPlugin(base_plugin.TBPlugin):
         """See base class."""
 
         return {
+            "/download_data": self.download_data_route,
             "/experiment": self.get_experiment_route,
             "/session_groups": self.list_session_groups_route,
             "/metric_evals": self.list_metric_evals_route,
@@ -89,6 +101,107 @@ class HParamsPlugin(base_plugin.TBPlugin):
 
     def frontend_metadata(self):
         return base_plugin.FrontendMetadata(element_name="tf-hparams-dashboard")
+
+    # ---- /download_data- -------------------------------------------------------
+    @wrappers.Request.application
+    def download_data_route(self, request):
+        response_format = request.args.get("format")
+        request_proto = _parse_request_argument(
+            request, api_pb2.ListSessionGroupsRequest
+        )
+        session_groups = list_session_groups.Handler(
+            self._context, request_proto
+        ).run()
+        experiment = get_experiment.Handler(self._context).run()
+        try:
+            body, mime_type = self.download_data_impl(
+                experiment, session_groups, response_format
+            )
+        except ValueError as e:
+            return http_util.Respond(
+                request=request,
+                content=str(e),
+                content_type="text/plain",
+                code=400,
+            )
+        return http_util.Respond(request, body, mime_type)
+
+    def download_data_impl(self, experiment, session_groups, response_format):
+        """Provides a response for downloading data for an HParams table.
+
+        Args:
+          experiment: Experiment proto.
+          session_groups: ListSessionGroupsResponse proto.
+          response_format: A string in the OutputFormat enum.
+
+        Raises:
+          ValueError: If the scalars plugin is not registered.
+
+        Returns:
+          2 entities:
+            - A JSON object response body.
+            - A mime type (string) for the response.
+        """
+        header = []
+        for hparam_info in experiment.hparam_infos:
+            header.append(hparam_info.display_name or hparam_info.name)
+
+        for metric_info in experiment.metric_infos:
+            header.append(metric_info.display_name or metric_info.name.tag)
+
+        rows = []
+
+        def _get_value(value):
+            if value.HasField("number_value"):
+                return value.number_value
+            if value.HasField("string_value"):
+                return value.string_value
+            if value.HasField("bool_value"):
+                return value.bool_value
+            return None
+
+        for group in session_groups.session_groups:
+            row = []
+            for hparam_info in experiment.hparam_infos:
+                row.append(_get_value(group.hparams[hparam_info.name]))
+            for metric_value in group.metric_values:
+                row.append(metric_value.value)
+            rows.append(row)
+
+        if response_format == OutputFormat.JSON:
+            mime_type = "application/json"
+            body = dict(header=header, rows=rows)
+        elif response_format == OutputFormat.LATEX:
+
+            def latex_format(value):
+                if isinstance(value, int):
+                    return str(value)
+                elif isinstance(value, float):
+                    return "%.3g" % value
+                return value.replace("_", "\\_").replace("%", "\\%")
+
+            mime_type = "application/x-latex"
+            top_part = "\\begin{table}[]\n\\begin{tabular}{%s}\n" % (
+                "l" * len(header)
+            )
+            header_part = (
+                " & ".join(map(latex_format, header)) + " \\\\ \\hline\n"
+            )
+            middle_part = "".join(
+                [" & ".join(map(latex_format, row)) + " \\\\\n" for row in rows]
+            )
+            bottom_part = "\\hline\n\\end{tabular}\n\\end{table}\n"
+            body = top_part + header_part + middle_part + bottom_part
+        elif response_format == OutputFormat.CSV:
+            string_io = StringIO()
+            writer = csv.writer(string_io)
+            writer.writerow(header)
+            writer.writerows(rows)
+            body = string_io.getvalue()
+            mime_type = "text/csv"
+        else:
+            raise ValueError("Invalid reponses format: %s" % response_format)
+        return body, mime_type
 
     # ---- /experiment -----------------------------------------------------------
     @wrappers.Request.application

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -23,8 +23,6 @@ from __future__ import division
 from __future__ import print_function
 
 import json
-import csv
-from six import StringIO
 
 
 import werkzeug
@@ -32,6 +30,7 @@ from werkzeug import wrappers
 
 from tensorboard.plugins.hparams import api_pb2
 from tensorboard.plugins.hparams import backend_context
+from tensorboard.plugins.hparams import download_data
 from tensorboard.plugins.hparams import error
 from tensorboard.plugins.hparams import get_experiment
 from tensorboard.plugins.hparams import list_metric_evals
@@ -45,14 +44,6 @@ from tensorboard.util import tb_logging
 
 
 logger = tb_logging.get_logger()
-
-
-class OutputFormat(object):
-    """An enum used to list the valid output formats for API calls."""
-
-    JSON = "json"
-    CSV = "csv"
-    LATEX = "latex"
 
 
 class HParamsPlugin(base_plugin.TBPlugin):
@@ -105,103 +96,22 @@ class HParamsPlugin(base_plugin.TBPlugin):
     # ---- /download_data- -------------------------------------------------------
     @wrappers.Request.application
     def download_data_route(self, request):
-        response_format = request.args.get("format")
-        request_proto = _parse_request_argument(
-            request, api_pb2.ListSessionGroupsRequest
-        )
-        session_groups = list_session_groups.Handler(
-            self._context, request_proto
-        ).run()
-        experiment = get_experiment.Handler(self._context).run()
         try:
-            body, mime_type = self.download_data_impl(
-                experiment, session_groups, response_format
+            response_format = request.args.get("format")
+            request_proto = _parse_request_argument(
+                request, api_pb2.ListSessionGroupsRequest
             )
-        except ValueError as e:
-            return http_util.Respond(
-                request=request,
-                content=str(e),
-                content_type="text/plain",
-                code=400,
-            )
-        return http_util.Respond(request, body, mime_type)
-
-    def download_data_impl(self, experiment, session_groups, response_format):
-        """Provides a response for downloading data for an HParams table.
-
-        Args:
-          experiment: Experiment proto.
-          session_groups: ListSessionGroupsResponse proto.
-          response_format: A string in the OutputFormat enum.
-
-        Raises:
-          ValueError: If the scalars plugin is not registered.
-
-        Returns:
-          2 entities:
-            - A JSON object response body.
-            - A mime type (string) for the response.
-        """
-        header = []
-        for hparam_info in experiment.hparam_infos:
-            header.append(hparam_info.display_name or hparam_info.name)
-
-        for metric_info in experiment.metric_infos:
-            header.append(metric_info.display_name or metric_info.name.tag)
-
-        rows = []
-
-        def _get_value(value):
-            if value.HasField("number_value"):
-                return value.number_value
-            if value.HasField("string_value"):
-                return value.string_value
-            if value.HasField("bool_value"):
-                return value.bool_value
-            return None
-
-        for group in session_groups.session_groups:
-            row = []
-            for hparam_info in experiment.hparam_infos:
-                row.append(_get_value(group.hparams[hparam_info.name]))
-            for metric_value in group.metric_values:
-                row.append(metric_value.value)
-            rows.append(row)
-
-        if response_format == OutputFormat.JSON:
-            mime_type = "application/json"
-            body = dict(header=header, rows=rows)
-        elif response_format == OutputFormat.LATEX:
-
-            def latex_format(value):
-                if isinstance(value, int):
-                    return str(value)
-                elif isinstance(value, float):
-                    return "%.3g" % value
-                return value.replace("_", "\\_").replace("%", "\\%")
-
-            mime_type = "application/x-latex"
-            top_part = "\\begin{table}[]\n\\begin{tabular}{%s}\n" % (
-                "l" * len(header)
-            )
-            header_part = (
-                " & ".join(map(latex_format, header)) + " \\\\ \\hline\n"
-            )
-            middle_part = "".join(
-                [" & ".join(map(latex_format, row)) + " \\\\\n" for row in rows]
-            )
-            bottom_part = "\\hline\n\\end{tabular}\n\\end{table}\n"
-            body = top_part + header_part + middle_part + bottom_part
-        elif response_format == OutputFormat.CSV:
-            string_io = StringIO()
-            writer = csv.writer(string_io)
-            writer.writerow(header)
-            writer.writerows(rows)
-            body = string_io.getvalue()
-            mime_type = "text/csv"
-        else:
-            raise ValueError("Invalid reponses format: %s" % response_format)
-        return body, mime_type
+            session_groups = list_session_groups.Handler(
+                self._context, request_proto
+            ).run()
+            experiment = get_experiment.Handler(self._context).run()
+            body, mime_type = download_data.Handler(
+                self._context, experiment, session_groups, response_format
+            ).run()
+            return http_util.Respond(request, body, mime_type)
+        except error.HParamsError as e:
+            logger.error("HParams error: %s" % e)
+            raise werkzeug.exceptions.BadRequest(description=str(e))
 
     # ---- /experiment -----------------------------------------------------------
     @wrappers.Request.application

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -98,6 +98,9 @@ class HParamsPlugin(base_plugin.TBPlugin):
     def download_data_route(self, request):
         try:
             response_format = request.args.get("format")
+            columns_visibility = json.loads(
+                request.args.get("columnsVisibility")
+            )
             request_proto = _parse_request_argument(
                 request, api_pb2.ListSessionGroupsRequest
             )
@@ -106,7 +109,11 @@ class HParamsPlugin(base_plugin.TBPlugin):
             ).run()
             experiment = get_experiment.Handler(self._context).run()
             body, mime_type = download_data.Handler(
-                self._context, experiment, session_groups, response_format
+                self._context,
+                experiment,
+                session_groups,
+                response_format,
+                columns_visibility,
             ).run()
             return http_util.Respond(request, body, mime_type)
         except error.HParamsError as e:

--- a/tensorboard/plugins/hparams/tf_hparams_backend/tf-hparams-backend.html
+++ b/tensorboard/plugins/hparams/tf_hparams_backend/tf-hparams-backend.html
@@ -48,14 +48,14 @@ limitations under the License.
           return this._sendRequest('experiment', experimentRequest);
         }
 
-        getDowloadURL(format, listSessionGroupsRequest) {
+        getDownloadUrl(format, listSessionGroupsRequest) {
           return (
             this._apiUrl +
-            '/download_data' +
-            '?format=' +
-            format +
-            '&request=' +
-            JSON.stringify(listSessionGroupsRequest)
+            '/download_data?' +
+            new URLSearchParams({
+              format: format,
+              request: JSON.stringify(listSessionGroupsRequest),
+            })
           );
         }
 

--- a/tensorboard/plugins/hparams/tf_hparams_backend/tf-hparams-backend.html
+++ b/tensorboard/plugins/hparams/tf_hparams_backend/tf-hparams-backend.html
@@ -48,6 +48,17 @@ limitations under the License.
           return this._sendRequest('experiment', experimentRequest);
         }
 
+        getDowloadURL(format, listSessionGroupsRequest) {
+          return (
+            this._apiUrl +
+            '/download_data' +
+            '?format=' +
+            format +
+            '&request=' +
+            JSON.stringify(listSessionGroupsRequest)
+          );
+        }
+
         listSessionGroups(listSessionGroupsRequest) {
           return this._sendRequest('session_groups', listSessionGroupsRequest);
         }

--- a/tensorboard/plugins/hparams/tf_hparams_backend/tf-hparams-backend.html
+++ b/tensorboard/plugins/hparams/tf_hparams_backend/tf-hparams-backend.html
@@ -48,12 +48,13 @@ limitations under the License.
           return this._sendRequest('experiment', experimentRequest);
         }
 
-        getDownloadUrl(format, listSessionGroupsRequest) {
+        getDownloadUrl(format, listSessionGroupsRequest, columnsVisibility) {
           return (
             this._apiUrl +
             '/download_data?' +
             new URLSearchParams({
               format: format,
+              columnsVisibility: JSON.stringify(columnsVisibility),
               request: JSON.stringify(listSessionGroupsRequest),
             })
           );

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.html
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.html
@@ -201,35 +201,65 @@ TODO(erez): Add aggregation controls for repeated sessions.
               </paper-listbox>
             </paper-dropdown-menu>
           </div>
-          <div class="section paging">
-            <div class="section-title">Paging</div>
-            <div>
-              Number of matching session groups: [[_totalSessionGroupsCountStr]]
+          <vaadin-split-layout vertical id="paging-download">
+            <div class="section paging">
+              <div class="section-title">Paging</div>
+              <div>
+                Number of matching session groups:
+                [[_totalSessionGroupsCountStr]]
+              </div>
+              <div class="inline-element page-number-input">
+                <paper-input
+                  label="Page #"
+                  value="{{_pageNumberInput.value}}"
+                  allowed-pattern="[0-9]"
+                  error-message="Invalid input"
+                  invalid="[[_pageNumberInput.invalid]]"
+                  on-value-changed="_queryServer"
+                >
+                  <div slot="suffix" class="page-suffix">
+                    / [[_pageCountStr]]
+                  </div>
+                </paper-input>
+              </div>
+              <div class="inline-element page-size-input">
+                <paper-input
+                  label="Max # of session groups per page:"
+                  value="{{_pageSizeInput.value}}"
+                  allowed-pattern="[0-9]"
+                  error-message="Invalid input"
+                  invalid="[[_pageSizeInput.invalid]]"
+                  on-value-changed="_queryServer"
+                >
+                </paper-input>
+              </div>
             </div>
-            <div class="inline-element page-number-input">
-              <paper-input
-                label="Page #"
-                value="{{_pageNumberInput.value}}"
-                allowed-pattern="[0-9]"
-                error-message="Invalid input"
-                invalid="[[_pageNumberInput.invalid]]"
-                on-value-changed="_queryServer"
-              >
-                <div slot="suffix" class="page-suffix">/ [[_pageCountStr]]</div>
-              </paper-input>
+            <div class="section download">
+              <template is="dom-if" if="[[_hparams]]">
+                Download data as
+                <span>
+                  <a
+                    id="csvLink"
+                    download="hparams_table.csv"
+                    href="[[_csvUrl()]]"
+                    >CSV</a
+                  >
+                  <a
+                    id="jsonLink"
+                    download="hparams_table.json"
+                    href="[[_jsonUrl()]]"
+                    >JSON</a
+                  >
+                  <a
+                    id="latexLink"
+                    download="hparams_table.tex"
+                    href="[[_latexUrl()]]"
+                    >LATEX</a
+                  >
+                </span>
+              </template>
             </div>
-            <div class="inline-element page-size-input">
-              <paper-input
-                label="Max # of session groups per page:"
-                value="{{_pageSizeInput.value}}"
-                allowed-pattern="[0-9]"
-                error-message="Invalid input"
-                invalid="[[_pageSizeInput.invalid]]"
-                on-value-changed="_queryServer"
-              >
-              </paper-input>
-            </div>
-          </div>
+          </vaadin-split-layout>
         </vaadin-split-layout>
       </vaadin-split-layout>
     </div>
@@ -279,12 +309,22 @@ TODO(erez): Add aggregation controls for repeated sessions.
         flex-shrink: 0;
         flex-grow: 0;
       }
+      #paging-download {
+        flex-basis: 90%;
+        flex-shrink: 1;
+        flex-grow: 1;
+      }
       .sorting {
         flex-basis: auto;
         flex-shrink: 0;
         flex-grow: 0;
       }
       .paging {
+        flex-basis: auto;
+        flex-shrink: 0;
+        flex-grow: 0;
+      }
+      .download {
         flex-basis: auto;
         flex-shrink: 0;
         flex-grow: 0;
@@ -543,6 +583,20 @@ TODO(erez): Add aggregation controls for repeated sessions.
 
       reload() {
         this._queryServer();
+      },
+
+      _csvUrl() {
+        return this._downloadDataUrl('csv');
+      },
+      _jsonUrl() {
+        return this._downloadDataUrl('json');
+      },
+      _latexUrl() {
+        return this._downloadDataUrl('latex');
+      },
+      _downloadDataUrl(format) {
+        const request = this._buildListSessionGroupsRequest();
+        return this.backend.getDowloadURL(format, request);
       },
 
       // Sends a request for experiment to the server, and updates

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.html
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.html
@@ -241,19 +241,19 @@ TODO(erez): Add aggregation controls for repeated sessions.
                   <a
                     id="csvLink"
                     download="hparams_table.csv"
-                    href="[[_csvUrl(_sessionGroupsRequest, _hparams, _metrics)]]"
+                    href="[[_csvUrl(_sessionGroupsRequest, configuration)]]"
                     >CSV</a
                   >
                   <a
                     id="jsonLink"
                     download="hparams_table.json"
-                    href="[[_jsonUrl(_sessionGroupsRequest, _hparams, _metrics)]]"
+                    href="[[_jsonUrl(_sessionGroupsRequest, configuration)]]"
                     >JSON</a
                   >
                   <a
                     id="latexLink"
                     download="hparams_table.tex"
-                    href="[[_latexUrl(_sessionGroupsRequest, _hparams, _metrics)]]"
+                    href="[[_latexUrl(_sessionGroupsRequest, configuration)]]"
                     >LaTeX</a
                   >
                 </span>
@@ -589,17 +589,17 @@ TODO(erez): Add aggregation controls for repeated sessions.
         this._queryServer();
       },
 
-      _csvUrl(request, _, __) {
-        return this._downloadDataUrl(request, 'csv');
+      _csvUrl(request, configuration) {
+        return this._downloadDataUrl(request, configuration, 'csv');
       },
-      _jsonUrl(request, _, __) {
-        return this._downloadDataUrl(request, 'json');
+      _jsonUrl(request, configuration) {
+        return this._downloadDataUrl(request, configuration, 'json');
       },
-      _latexUrl(request, _, __) {
-        return this._downloadDataUrl(request, 'latex');
+      _latexUrl(request, configuration) {
+        return this._downloadDataUrl(request, configuration, 'latex');
       },
-      _downloadDataUrl(request, format) {
-        const visibility = this._computeColumnsVisibility();
+      _downloadDataUrl(request, configuration, format) {
+        const visibility = configuration.columnsVisibility;
         return this.backend.getDownloadUrl(format, request, visibility);
       },
 

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.html
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.html
@@ -254,7 +254,7 @@ TODO(erez): Add aggregation controls for repeated sessions.
                     id="latexLink"
                     download="hparams_table.tex"
                     href="[[_latexUrl()]]"
-                    >LATEX</a
+                    >LaTeX</a
                   >
                 </span>
               </template>
@@ -596,7 +596,7 @@ TODO(erez): Add aggregation controls for repeated sessions.
       },
       _downloadDataUrl(format) {
         const request = this._buildListSessionGroupsRequest();
-        return this.backend.getDowloadURL(format, request);
+        return this.backend.getDownloadUrl(format, request);
       },
 
       // Sends a request for experiment to the server, and updates

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.html
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.html
@@ -235,25 +235,25 @@ TODO(erez): Add aggregation controls for repeated sessions.
               </div>
             </div>
             <div class="section download">
-              <template is="dom-if" if="[[_hparams]]">
+              <template is="dom-if" if="[[_sessionGroupsRequest]]">
                 Download data as
                 <span>
                   <a
                     id="csvLink"
                     download="hparams_table.csv"
-                    href="[[_csvUrl()]]"
+                    href="[[_csvUrl(_sessionGroupsRequest, _hparams, _metrics)]]"
                     >CSV</a
                   >
                   <a
                     id="jsonLink"
                     download="hparams_table.json"
-                    href="[[_jsonUrl()]]"
+                    href="[[_jsonUrl(_sessionGroupsRequest, _hparams, _metrics)]]"
                     >JSON</a
                   >
                   <a
                     id="latexLink"
                     download="hparams_table.tex"
-                    href="[[_latexUrl()]]"
+                    href="[[_latexUrl(_sessionGroupsRequest, _hparams, _metrics)]]"
                     >LaTeX</a
                   >
                 </span>
@@ -574,6 +574,10 @@ TODO(erez): Add aggregation controls for repeated sessions.
         // by the query, or 'unknown' if the server didn't send that
         // information.
         _totalSessionGroupsCountStr: String,
+
+        // Computed query that is send to the backend when panes are updated to
+        // create ListSessionGroupsRequest and retrieve the response
+        _sessionGroupsRequest: Object,
       } /* properties */,
 
       observers: [
@@ -585,18 +589,18 @@ TODO(erez): Add aggregation controls for repeated sessions.
         this._queryServer();
       },
 
-      _csvUrl() {
-        return this._downloadDataUrl('csv');
+      _csvUrl(request, _, __) {
+        return this._downloadDataUrl(request, 'csv');
       },
-      _jsonUrl() {
-        return this._downloadDataUrl('json');
+      _jsonUrl(request, _, __) {
+        return this._downloadDataUrl(request, 'json');
       },
-      _latexUrl() {
-        return this._downloadDataUrl('latex');
+      _latexUrl(request, _, __) {
+        return this._downloadDataUrl(request, 'latex');
       },
-      _downloadDataUrl(format) {
-        const request = this._buildListSessionGroupsRequest();
-        return this.backend.getDownloadUrl(format, request);
+      _downloadDataUrl(request, format) {
+        const visibility = this._computeColumnsVisibility()
+        return this.backend.getDownloadUrl(format, request, visibility);
       },
 
       // Sends a request for experiment to the server, and updates
@@ -795,6 +799,7 @@ TODO(erez): Add aggregation controls for repeated sessions.
           // If query configuration is not valid don't send a request.
           return;
         }
+        this.set('_sessionGroupsRequest', request);
         // Note that the responses to the RPCs sent
         // to the backend may return in a different order than the order in
         // which they were sent. If we just update sessionGroups in the

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.html
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.html
@@ -599,7 +599,7 @@ TODO(erez): Add aggregation controls for repeated sessions.
         return this._downloadDataUrl(request, 'latex');
       },
       _downloadDataUrl(request, format) {
-        const visibility = this._computeColumnsVisibility()
+        const visibility = this._computeColumnsVisibility();
         return this.backend.getDownloadUrl(format, request, visibility);
       },
 


### PR DESCRIPTION
Fixes #2210.

* Motivation for features / changes
As suggested in #2210, the tables computed in the HParams dashboard are very useful and are currently hard to extract, either by inspecting the DOM or calling the API. This provides a more clear UI to dump the tables and use directly in downstream tasks.

* Technical description of changes
Added another endpoint to the HParams backend to support downloading the table with session groups in different format

* Screenshots of UI changes
<img width="1159" alt="Screenshot 2019-12-19 at 22 48 43" src="https://user-images.githubusercontent.com/7776575/71212696-1defcf80-22b2-11ea-88ab-111860be37f6.png">

* Detailed steps to verify changes work correctly (as executed by you)

Create mock HParams data by using the script at

> bazel run //tensorboard/plugins/hparams:hparams_minimal_demo

And then verifying the download links at 
> bazel run //tensorboard -- --logdir /tmp/hparams_minimal_demo

New tests are run with
> bazel test //tensorboard/plugins/hparams:download_data_test

* Alternate designs / implementations considered
The buttons could have been inside the table but I found hard to find the right location without disrupting the layout. The current location on the sidebar is consistent with the way in which the data is fetched, no matter the rendering chosen