### PR TITLE
Upgrade Travis to Xenial and floating tf-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: python
 python:
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - BUILDIFIER_SHA256SUM=4c985c883eafdde9c0e8cf3c8595b8bfdf32e77571c369bf8ddae83b042028d6
   matrix:
     - TF_VERSION_ID=tensorflow==1.15.0rc3
-    - TF_VERSION_ID=tf-nightly==2.1.0.dev20191222
+    - TF_VERSION_ID=tf-nightly
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - BUILDIFIER_SHA256SUM=4c985c883eafdde9c0e8cf3c8595b8bfdf32e77571c369bf8ddae83b042028d6
   matrix:
     - TF_VERSION_ID=tensorflow==1.15.0rc3
-    - TF_VERSION_ID=tf-nightly==2.1.0.dev20191118
+    - TF_VERSION_ID=tf-nightly==2.1.0.dev2019122
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - BUILDIFIER_SHA256SUM=4c985c883eafdde9c0e8cf3c8595b8bfdf32e77571c369bf8ddae83b042028d6
   matrix:
     - TF_VERSION_ID=tensorflow==1.15.0rc3
-    - TF_VERSION_ID=tf-nightly==2.1.0.dev2019122
+    - TF_VERSION_ID=tf-nightly==2.1.0.dev20191222
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:


### PR DESCRIPTION
* Motivation for features / changes
  * Unblock TensorBoard Travis CI from using the latest (floating) tf-nightly

* Technical description of changes
  * Update to .travis.yml to use Ubuntu 16.04 (xenial)
  * Update to .travis.yml to float the tf-nightly version
