### PR TITLE
[DebuggerV2] Add basic ng impl of actions, store, data_source & new Alerts view

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -1,6 +1,7 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ng_web_test_suite", "tf_ts_library")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -19,9 +20,49 @@ ng_module(
         "debugger_component.ng.html",
     ],
     deps = [
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive",
+        "@npm//@angular/common",
         "@npm//@angular/core",
+        "@npm//@ngrx/effects",
         "@npm//@ngrx/store",
         "@npm//rxjs",
+    ],
+)
+
+tf_ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = [
+        "debugger_container_test.ts",
+    ],
+    tsconfig = "//:tsconfig-test",
+    deps = [
+        ":debugger_v2",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "@npm//@angular/common",
+        "@npm//@angular/compiler",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+    ],
+)
+
+tf_ng_web_test_suite(
+    name = "karma_test",
+    deps = [
+        ":test_lib",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:debugger_store_test_lib",
     ],
 )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -63,6 +63,7 @@ tf_ng_web_test_suite(
     name = "karma_test",
     deps = [
         ":test_lib",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects:debugger_effects_test_lib",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:debugger_store_test_lib",
     ],
 )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/BUILD
@@ -1,0 +1,17 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+licenses(["notice"])  # Apache 2.
+
+tf_ts_library(
+    name = "actions",
+    srcs = [
+        "debugger_actions.ts",
+        "index.ts",
+    ],
+    deps = [
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
+        "@npm//@ngrx/store",
+    ],
+)

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
@@ -1,0 +1,49 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {createAction, props} from '@ngrx/store';
+
+import {DebuggerRunListing} from '../store/debugger_types';
+
+// HACK: Below import is for type inference.
+// https://github.com/bazelbuild/rules_nodejs/issues/1013
+/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
+
+/**
+ * Actions for Debugger V2.
+ */
+
+/**
+ * Actions for the Debugger Component.
+ */
+export const debuggerLoaded = createAction('[Debugger] Debugger Loaded');
+
+export const debuggerRunsRequested = createAction(
+  '[Debugger] Debugger Runs Requested'
+);
+
+export const debuggerRunsLoaded = createAction(
+  '[Debugger] Debugger Runs Loaded',
+  props<{runs: DebuggerRunListing}>()
+);
+
+export const debuggerRunsRequestFailed = createAction(
+  '[Debugger] Debugger Runs Request Failed'
+);
+
+/**
+ * Actions for the Alerts Component.
+ */
+export const alertsViewLoaded = createAction('[Alerts] Alerts View Loaded');

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
@@ -46,4 +46,4 @@ export const debuggerRunsRequestFailed = createAction(
 /**
  * Actions for the Alerts Component.
  */
-export const alertsViewLoaded = createAction('[Alerts] Alerts View Loaded');
+export const alertsViewLoaded = createAction('[Debugger] Alerts View Loaded');

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/index.ts
@@ -12,18 +12,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
-import {DebuggerRunListing} from './store/debugger_types';
 
-@Component({
-  selector: 'debugger-component',
-  templateUrl: './debugger_component.ng.html',
-  styleUrls: ['./debugger_component.css'],
-})
-export class DebuggerComponent {
-  @Input()
-  runs: DebuggerRunListing = {};
-
-  @Input()
-  runIds: string[] = [];
-}
+export * from './debugger_actions';

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/BUILD
@@ -1,0 +1,17 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+ng_module(
+    name = "data_source",
+    srcs = [
+        "tfdbg2_data_source.ts",
+        "tfdbg2_data_source_module.ts",
+    ],
+    deps = [
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
+        "//tensorboard/webapp/angular:expect_angular_common_http",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+    ],
+)

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source.ts
@@ -29,7 +29,7 @@ export abstract class Tfdbg2DataSource {
 
 @Injectable()
 export class Tfdbg2HttpServerDataSource implements Tfdbg2DataSource {
-  private readonly httpPathPrefix = '/data/plugin/debugger-v2';
+  private readonly httpPathPrefix = 'data/plugin/debugger-v2';
 
   constructor(private http: HttpClient) {}
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source.ts
@@ -13,15 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {HttpClient} from '@angular/common/http';
-import {Injectable, InjectionToken} from '@angular/core';
+import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs';
 import {DebuggerRunListing} from '../store/debugger_types';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
-
-export const TFDBG2_DATA_SOURCE = new InjectionToken<Tfdbg2DataSource>(
-  'tfdbg2 data source'
-);
 
 export abstract class Tfdbg2DataSource {
   abstract fetchRuns(): Observable<DebuggerRunListing>;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source.ts
@@ -1,0 +1,43 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {HttpClient} from '@angular/common/http';
+import {Injectable, InjectionToken} from '@angular/core';
+import {Observable} from 'rxjs';
+import {DebuggerRunListing} from '../store/debugger_types';
+
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+
+export const TFDBG2_DATA_SOURCE = new InjectionToken<Tfdbg2DataSource>(
+  'tfdbg2 data source'
+);
+
+export abstract class Tfdbg2DataSource {
+  abstract fetchRuns(): Observable<DebuggerRunListing>;
+}
+
+@Injectable()
+export class Tfdbg2HttpServerDataSource implements Tfdbg2DataSource {
+  private readonly httpPathPrefix = '/data/plugin/debugger-v2';
+
+  constructor(private http: HttpClient) {}
+
+  fetchRuns() {
+    // TODO(cais): Once the backend uses an DataProvider that unifies tfdbg and
+    // non-tfdbg plugins, switch to using `tf_backend.runStore.refresh()`.
+    return this.http.get<DebuggerRunListing>(this.httpPathPrefix + '/runs');
+  }
+
+  // TODO(cais): Implement fetchEnvironments().
+}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source_module.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source_module.ts
@@ -12,18 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
-import {DebuggerRunListing} from './store/debugger_types';
+import {NgModule} from '@angular/core';
+import {HttpClientModule} from '@angular/common/http';
+import {Tfdbg2HttpServerDataSource} from './tfdbg2_data_source';
 
-@Component({
-  selector: 'debugger-component',
-  templateUrl: './debugger_component.ng.html',
-  styleUrls: ['./debugger_component.css'],
+@NgModule({
+  imports: [HttpClientModule],
+  providers: [Tfdbg2HttpServerDataSource],
 })
-export class DebuggerComponent {
-  @Input()
-  runs: DebuggerRunListing = {};
-
-  @Input()
-  runIds: string[] = [];
-}
+export class Tfdbg2ServerDataSourceModule {}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.ng.html
@@ -16,6 +16,10 @@ limitations under the License.
 -->
 
 <div>
-  <!-- TODO(cais): Use ngSwitch on the active/inactive state. -->
-  <tf-debugger-v2-inactive></tf-debugger-v2-inactive>
+  <tf-debugger-v2-inactive
+    *ngIf="runIds.length === 0; else dataAvailable"
+  ></tf-debugger-v2-inactive>
+  <ng-template #dataAvailable>
+    <tf-debugger-v2-alerts></tf-debugger-v2-alerts>
+  </ng-template>
 </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.ng.html
@@ -21,6 +21,6 @@ limitations under the License.
   ></tf-debugger-v2-inactive>
   <ng-template #dataAvailable>
     <tf-debugger-v2-alerts></tf-debugger-v2-alerts>
-    <!-- TODO(cais): Add more elemens, such as timeline, graph, source code, etc.-->
+    <!-- TODO(cais): Add more elements, such as timeline, graph, source code, etc.-->
   </ng-template>
 </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.ng.html
@@ -21,5 +21,6 @@ limitations under the License.
   ></tf-debugger-v2-inactive>
   <ng-template #dataAvailable>
     <tf-debugger-v2-alerts></tf-debugger-v2-alerts>
+    <!-- TODO(cais): Add more elemens, such as timeline, graph, source code, etc.-->
   </ng-template>
 </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
@@ -52,7 +52,6 @@ export class DebuggerContainer implements OnInit {
   constructor(private readonly store: Store<State>) {}
 
   ngOnInit(): void {
-    console.log('Dispatching debuggerLoaded'); // DEBUG
     this.store.dispatch(debuggerLoaded());
   }
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
@@ -31,14 +31,7 @@ import {getDebuggerRuns} from './store';
   `,
 })
 export class DebuggerContainer implements OnInit {
-  readonly runs$ = this.store.pipe(
-    select(
-      createSelector(
-        getDebuggerRuns,
-        (runs): DebuggerRunListing => runs
-      )
-    )
-  );
+  readonly runs$ = this.store.pipe(select(getDebuggerRuns));
 
   readonly runsIds$ = this.store.pipe(
     select(

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
@@ -12,20 +12,47 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
-import {Store} from '@ngrx/store';
+import {Component, OnInit} from '@angular/core';
+import {createSelector, select, Store} from '@ngrx/store';
+import {DebuggerRunListing, State} from './store/debugger_types';
+
+import {debuggerLoaded} from './actions';
+import {getDebuggerRuns} from './store';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
-
-// TODO(cais): Move to a separate file.
-export interface State {}
 
 @Component({
   selector: 'tf-debugger-v2',
   template: `
-    <debugger-component></debugger-component>
+    <debugger-component
+      [runs]="runs$ | async"
+      [runIds]="runsIds$ | async"
+    ></debugger-component>
   `,
 })
-export class DebuggerContainer {
+export class DebuggerContainer implements OnInit {
+  readonly runs$ = this.store.pipe(
+    select(
+      createSelector(
+        getDebuggerRuns,
+        (runs): DebuggerRunListing => runs
+      )
+    )
+  );
+
+  readonly runsIds$ = this.store.pipe(
+    select(
+      createSelector(
+        getDebuggerRuns,
+        (runs): string[] => Object.keys(runs)
+      )
+    )
+  );
+
   constructor(private readonly store: Store<State>) {}
+
+  ngOnInit(): void {
+    console.log('Dispatching debuggerLoaded'); // DEBUG
+    this.store.dispatch(debuggerLoaded());
+  }
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
@@ -17,7 +17,7 @@ import {createSelector, select, Store} from '@ngrx/store';
 import {DebuggerRunListing, State} from './store/debugger_types';
 
 import {debuggerLoaded} from './actions';
-import {getDebuggerRuns} from './store';
+import {getDebuggerRunListing} from './store';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
@@ -31,12 +31,12 @@ import {getDebuggerRuns} from './store';
   `,
 })
 export class DebuggerContainer implements OnInit {
-  readonly runs$ = this.store.pipe(select(getDebuggerRuns));
+  readonly runs$ = this.store.pipe(select(getDebuggerRunListing));
 
   readonly runsIds$ = this.store.pipe(
     select(
       createSelector(
-        getDebuggerRuns,
+        getDebuggerRunListing,
         (runs): string[] => Object.keys(runs)
       )
     )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container_test.ts
@@ -1,0 +1,132 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * Unit tests for the Debugger Container.
+ */
+import {CommonModule} from '@angular/common';
+import {TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+import {Store} from '@ngrx/store';
+import {provideMockStore, MockStore} from '@ngrx/store/testing';
+
+import {debuggerLoaded} from './actions';
+import {DebuggerComponent} from './debugger_component';
+import {DebuggerContainer} from './debugger_container';
+import {DataLoadState, State} from './store/debugger_types';
+import {createDebuggerState, createState} from './testing';
+import {AlertsModule} from './views/alerts/alerts_module';
+import {InactiveModule} from './views/inactive/inactive_module';
+
+/** @typehack */ import * as _typeHackStore from '@ngrx/store';
+
+describe('Debugger Container test', () => {
+  let store: MockStore<State>;
+  let dispatchSpy: jasmine.Spy;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DebuggerComponent, DebuggerContainer],
+      imports: [AlertsModule, CommonModule, InactiveModule],
+      providers: [
+        provideMockStore({
+          initialState: createState(createDebuggerState()),
+        }),
+        DebuggerContainer,
+      ],
+    }).compileComponents();
+    store = TestBed.get(Store);
+    dispatchSpy = spyOn(store, 'dispatch');
+  });
+
+  it('renders debugger component initially with inactive component', () => {
+    const fixture = TestBed.createComponent(DebuggerContainer);
+    fixture.detectChanges();
+
+    const inactiveElement = fixture.debugElement.query(
+      By.css('tf-debugger-v2-inactive')
+    );
+    expect(inactiveElement).toBeTruthy();
+    const alertsElement = fixture.debugElement.query(
+      By.css('tf-debugger-v2-alerts')
+    );
+    expect(alertsElement).toBeNull();
+  });
+
+  it('rendering debugger component dispatches debuggeRunsRequested', () => {
+    const fixture = TestBed.createComponent(DebuggerContainer);
+    fixture.detectChanges();
+    expect(dispatchSpy).toHaveBeenCalledWith(debuggerLoaded());
+  });
+
+  it('updates the UI to hide inactive component when store has 1 run', () => {
+    const fixture = TestBed.createComponent(DebuggerContainer);
+    fixture.detectChanges();
+
+    store.setState(
+      createState(
+        createDebuggerState({
+          runs: {
+            foo_run: {
+              startTimeMs: 111,
+              tensorFlowVersion: '2.1.0',
+            },
+          },
+          runsLoaded: {
+            state: DataLoadState.LOADED,
+            lastLoadedTimeInMs: Date.now(),
+          },
+        })
+      )
+    );
+    fixture.detectChanges();
+
+    const inactiveElement = fixture.debugElement.query(
+      By.css('tf-debugger-v2-inactive')
+    );
+    expect(inactiveElement).toBeNull();
+    const alertsElement = fixture.debugElement.query(
+      By.css('tf-debugger-v2-alerts')
+    );
+    expect(alertsElement).toBeTruthy();
+  });
+
+  it('updates the UI to hide inactive component when store has no run', () => {
+    const fixture = TestBed.createComponent(DebuggerContainer);
+    fixture.detectChanges();
+
+    store.setState(
+      createState(
+        createDebuggerState({
+          runs: {},
+          runsLoaded: {
+            state: DataLoadState.LOADED,
+            lastLoadedTimeInMs: Date.now(),
+          },
+        })
+      )
+    );
+    fixture.detectChanges();
+
+    const inactiveElement = fixture.debugElement.query(
+      By.css('tf-debugger-v2-inactive')
+    );
+    expect(inactiveElement).toBeTruthy();
+    const alertsElement = fixture.debugElement.query(
+      By.css('tf-debugger-v2-alerts')
+    );
+    expect(alertsElement).toBeNull();
+  });
+});

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_module.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_module.ts
@@ -13,15 +13,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
+import {StoreModule} from '@ngrx/store';
+import {EffectsModule} from '@ngrx/effects';
 
+import {Tfdbg2ServerDataSourceModule} from './data_source/tfdbg2_data_source_module';
 import {DebuggerComponent} from './debugger_component';
 import {DebuggerContainer} from './debugger_container';
+import {DebuggerEffects} from './effects';
+import {reducers} from './store/debugger_reducers';
+import {DEBUGGER_FEATURE_KEY} from './store/debugger_types';
+import {AlertsModule} from './views/alerts/alerts_module';
 import {InactiveModule} from './views/inactive/inactive_module';
 
 @NgModule({
   declarations: [DebuggerComponent, DebuggerContainer],
-  imports: [InactiveModule],
+  imports: [
+    AlertsModule,
+    CommonModule,
+    InactiveModule,
+    Tfdbg2ServerDataSourceModule,
+    StoreModule.forFeature(DEBUGGER_FEATURE_KEY, reducers),
+    EffectsModule.forFeature([DebuggerEffects]),
+  ],
   exports: [DebuggerContainer],
 })
 export class DebuggerModule {}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/BUILD
@@ -1,0 +1,25 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+ng_module(
+    name = "effects",
+    srcs = [
+        "debugger_effects.ts",
+        "index.ts",
+    ],
+    deps = [
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)
+
+# TODO(cais): After TestBed.inject() is figured out in OSS, add
+# debugger_effects_test.ts.

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/BUILD
@@ -21,5 +21,26 @@ ng_module(
     ],
 )
 
-# TODO(cais): After TestBed.inject() is figured out in OSS, add
-# debugger_effects_test.ts.
+tf_ts_library(
+    name = "debugger_effects_test_lib",
+    testonly = True,
+    srcs = [
+        "debugger_effects_test.ts",
+    ],
+    deps = [
+        ":effects",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing",
+        "//tensorboard/webapp/angular:expect_angular_common_http_testing",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "@npm//@angular/common",
+        "@npm//@angular/compiler",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+        "@npm//rxjs",
+    ],
+)

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -1,0 +1,77 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Injectable} from '@angular/core';
+import {Action, Store} from '@ngrx/store';
+import {Actions, ofType, createEffect} from '@ngrx/effects';
+import {Observable, of, zip} from 'rxjs';
+import {
+  map,
+  mergeMap,
+  catchError,
+  withLatestFrom,
+  filter,
+  tap,
+} from 'rxjs/operators';
+import {
+  debuggerLoaded,
+  debuggerRunsRequested,
+  debuggerRunsRequestFailed,
+  debuggerRunsLoaded,
+} from '../actions';
+import {getDebuggerRunsLoaded} from '../store/debugger_selectors';
+import {
+  DataLoadState,
+  State,
+  DebuggerRunListing,
+} from '../store/debugger_types';
+import {Tfdbg2HttpServerDataSource} from '../data_source/tfdbg2_data_source';
+
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+/** @typehack */ import * as _typeHackNgrx from '@ngrx/store/src/models';
+
+@Injectable()
+export class DebuggerEffects {
+  /**
+   * Requires to be exported for JSCompiler. JSCompiler, otherwise,
+   * think it is unused property and deadcode eliminate away.
+   */
+  /** @export */
+  readonly loadPluginsListing$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(debuggerLoaded),
+      withLatestFrom(this.store.select(getDebuggerRunsLoaded)),
+      filter(([, {state}]) => state !== DataLoadState.LOADING),
+      tap(() => this.store.dispatch(debuggerRunsRequested())),
+      mergeMap(() => {
+        console.log('Calling fetchRuns()'); // DEBUG
+        return this.dataSource.fetchRuns().pipe(
+          map(
+            (runs) => {
+              console.log('debuggerRunsLoaded: runs =', runs); // DEBUG
+              return debuggerRunsLoaded({runs: runs as DebuggerRunListing});
+            }
+            // TODO(cais): Add catchError() to pipe.
+          )
+        ) as Observable<Action>;
+      })
+    )
+  );
+
+  constructor(
+    private actions$: Actions,
+    private store: Store<State>,
+    private dataSource: Tfdbg2HttpServerDataSource
+  ) {}
+}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -15,11 +15,10 @@ limitations under the License.
 import {Injectable} from '@angular/core';
 import {Action, Store} from '@ngrx/store';
 import {Actions, ofType, createEffect} from '@ngrx/effects';
-import {Observable, of, zip} from 'rxjs';
+import {Observable} from 'rxjs';
 import {
   map,
   mergeMap,
-  catchError,
   withLatestFrom,
   filter,
   tap,
@@ -27,7 +26,6 @@ import {
 import {
   debuggerLoaded,
   debuggerRunsRequested,
-  debuggerRunsRequestFailed,
   debuggerRunsLoaded,
 } from '../actions';
 import {getDebuggerRunsLoaded} from '../store/debugger_selectors';

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -16,13 +16,7 @@ import {Injectable} from '@angular/core';
 import {Action, Store} from '@ngrx/store';
 import {Actions, ofType, createEffect} from '@ngrx/effects';
 import {Observable} from 'rxjs';
-import {
-  map,
-  mergeMap,
-  withLatestFrom,
-  filter,
-  tap,
-} from 'rxjs/operators';
+import {map, mergeMap, withLatestFrom, filter, tap} from 'rxjs/operators';
 import {
   debuggerLoaded,
   debuggerRunsRequested,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -40,7 +40,7 @@ export class DebuggerEffects {
    * think it is unused property and deadcode eliminate away.
    */
   /** @export */
-  readonly loadPluginsListing$ = createEffect(() =>
+  readonly loadRunListing$ = createEffect(() =>
     this.actions$.pipe(
       ofType(debuggerLoaded),
       withLatestFrom(this.store.select(getDebuggerRunsLoaded)),

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -42,6 +42,8 @@ export class DebuggerEffects {
   /** @export */
   readonly loadRunListing$ = createEffect(() =>
     this.actions$.pipe(
+      // TODO(cais): Explore consolidating this effect with the greater
+      // webapp (in tensorboard/webapp), e.g., during PluginChanged actions.
       ofType(debuggerLoaded),
       withLatestFrom(this.store.select(getDebuggerRunsLoaded)),
       filter(([, {state}]) => state !== DataLoadState.LOADING),

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -31,7 +31,8 @@ import {
 import {Tfdbg2HttpServerDataSource} from '../data_source/tfdbg2_data_source';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
-/** @typehack */ import * as _typeHackNgrx from '@ngrx/store/src/models';
+/** @typehack */ import * as _typeHackNgrxStore from '@ngrx/store/src/models';
+/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects/effects';
 
 @Injectable()
 export class DebuggerEffects {
@@ -56,7 +57,7 @@ export class DebuggerEffects {
             }
             // TODO(cais): Add catchError() to pipe.
           )
-        ) as Observable<Action>;
+        );
       })
     )
   );

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -55,11 +55,9 @@ export class DebuggerEffects {
       filter(([, {state}]) => state !== DataLoadState.LOADING),
       tap(() => this.store.dispatch(debuggerRunsRequested())),
       mergeMap(() => {
-        console.log('Calling fetchRuns()'); // DEBUG
         return this.dataSource.fetchRuns().pipe(
           map(
             (runs) => {
-              console.log('debuggerRunsLoaded: runs =', runs); // DEBUG
               return debuggerRunsLoaded({runs: runs as DebuggerRunListing});
             }
             // TODO(cais): Add catchError() to pipe.

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -13,15 +13,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {TestBed} from '@angular/core/testing';
-import {
-  HttpClientTestingModule,
-} from '@angular/common/http/testing';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {provideMockActions} from '@ngrx/effects/testing';
 import {Action, Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {ReplaySubject, of} from 'rxjs';
 
-import {debuggerLoaded, debuggerRunsRequested, debuggerRunsLoaded} from '../actions';
+import {
+  debuggerLoaded,
+  debuggerRunsRequested,
+  debuggerRunsLoaded,
+} from '../actions';
 import {Tfdbg2HttpServerDataSource} from '../data_source/tfdbg2_data_source';
 import {State, DebuggerRunListing} from '../store/debugger_types';
 import {createDebuggerState, createState} from '../testing';
@@ -33,13 +35,6 @@ describe('Debugger effects', () => {
   let store: MockStore<State>;
   let fetchRuns: jasmine.Spy;
   let dispatchSpy: jasmine.Spy;
-
-  const dummyRunListing: DebuggerRunListing = {
-    'foo_run': {
-      tensorFlowVersion: "2.2.0",
-      startTimeMs: 1337
-    },
-  };
 
   beforeEach(async () => {
     action = new ReplaySubject<Action>(1);
@@ -57,11 +52,6 @@ describe('Debugger effects', () => {
     debuggerEffects = TestBed.get(DebuggerEffects);
     store = TestBed.get(Store);
     dispatchSpy = spyOn(store, 'dispatch');
-
-    const dataSource = TestBed.get(Tfdbg2HttpServerDataSource);
-    fetchRuns = spyOn(dataSource, 'fetchRuns')
-      .withArgs()
-      .and.returnValue(of(dummyRunListing));
   });
 
   describe('Runs loading', () => {
@@ -74,15 +64,30 @@ describe('Debugger effects', () => {
       });
     });
 
-    it('debugerLoaded action triggers successful run loading', () => {
+    it('debugerLoaded action triggers run loading that succeeeds', () => {
+      const runListingForTest: DebuggerRunListing = {
+        foo_run: {
+          tensorFlowVersion: '2.2.0',
+          startTimeMs: 1337,
+        },
+      };
+      const fetchRuns = spyOn(
+        TestBed.get(Tfdbg2HttpServerDataSource),
+        'fetchRuns'
+      )
+        .withArgs()
+        .and.returnValue(of(runListingForTest));
+
       action.next(debuggerLoaded());
 
       expect(fetchRuns).toHaveBeenCalled();
       expect(dispatchSpy).toHaveBeenCalledTimes(1);
       expect(dispatchSpy).toHaveBeenCalledWith(debuggerRunsRequested());
-      expect(recordedActions).toEqual([debuggerRunsLoaded({
-         runs: dummyRunListing
-      })]);
+      expect(recordedActions).toEqual([
+        debuggerRunsLoaded({
+          runs: runListingForTest,
+        }),
+      ]);
     });
   });
 });

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -1,0 +1,88 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TestBed} from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+} from '@angular/common/http/testing';
+import {provideMockActions} from '@ngrx/effects/testing';
+import {Action, Store} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {ReplaySubject, of} from 'rxjs';
+
+import {debuggerLoaded, debuggerRunsRequested, debuggerRunsLoaded} from '../actions';
+import {Tfdbg2HttpServerDataSource} from '../data_source/tfdbg2_data_source';
+import {State, DebuggerRunListing} from '../store/debugger_types';
+import {createDebuggerState, createState} from '../testing';
+import {DebuggerEffects} from './debugger_effects';
+
+describe('Debugger effects', () => {
+  let debuggerEffects: DebuggerEffects;
+  let action: ReplaySubject<Action>;
+  let store: MockStore<State>;
+  let fetchRuns: jasmine.Spy;
+  let dispatchSpy: jasmine.Spy;
+
+  const dummyRunListing: DebuggerRunListing = {
+    'foo_run': {
+      tensorFlowVersion: "2.2.0",
+      startTimeMs: 1337
+    },
+  };
+
+  beforeEach(async () => {
+    action = new ReplaySubject<Action>(1);
+
+    const initialState = createState(createDebuggerState());
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        provideMockActions(action),
+        DebuggerEffects,
+        Tfdbg2HttpServerDataSource,
+        provideMockStore({initialState}),
+      ],
+    }).compileComponents();
+    debuggerEffects = TestBed.get(DebuggerEffects);
+    store = TestBed.get(Store);
+    dispatchSpy = spyOn(store, 'dispatch');
+
+    const dataSource = TestBed.get(Tfdbg2HttpServerDataSource);
+    fetchRuns = spyOn(dataSource, 'fetchRuns')
+      .withArgs()
+      .and.returnValue(of(dummyRunListing));
+  });
+
+  describe('Runs loading', () => {
+    let recordedActions: Action[] = [];
+
+    beforeEach(() => {
+      recordedActions = [];
+      debuggerEffects.loadRunListing$.subscribe((action: Action) => {
+        recordedActions.push(action);
+      });
+    });
+
+    it('debugerLoaded action triggers successful run loading', () => {
+      action.next(debuggerLoaded());
+
+      expect(fetchRuns).toHaveBeenCalled();
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+      expect(dispatchSpy).toHaveBeenCalledWith(debuggerRunsRequested());
+      expect(recordedActions).toEqual([debuggerRunsLoaded({
+         runs: dummyRunListing
+      })]);
+    });
+  });
+});

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -33,7 +33,6 @@ describe('Debugger effects', () => {
   let debuggerEffects: DebuggerEffects;
   let action: ReplaySubject<Action>;
   let store: MockStore<State>;
-  let fetchRuns: jasmine.Spy;
   let dispatchSpy: jasmine.Spy;
 
   beforeEach(async () => {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/index.ts
@@ -12,18 +12,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
-import {DebuggerRunListing} from './store/debugger_types';
 
-@Component({
-  selector: 'debugger-component',
-  templateUrl: './debugger_component.ng.html',
-  styleUrls: ['./debugger_component.css'],
-})
-export class DebuggerComponent {
-  @Input()
-  runs: DebuggerRunListing = {};
-
-  @Input()
-  runIds: string[] = [];
-}
+export * from './debugger_effects';

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
@@ -1,0 +1,45 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+ng_module(
+    name = "store",
+    srcs = [
+        "debugger_reducers.ts",
+        "debugger_selectors.ts",
+        "index.ts",
+    ],
+    deps = [
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)
+
+ng_module(
+    name = "types",
+    srcs = [
+        "debugger_types.ts",
+    ],
+    deps = [
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)
+
+tf_ts_library(
+    name = "debugger_store_test_lib",
+    testonly = True,
+    srcs = [
+        "debugger_reducers_test.ts",
+    ],
+    tsconfig = "//:tsconfig-test",
+    deps = [
+        ":store",
+        ":types",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
@@ -12,7 +12,6 @@ ng_module(
     ],
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
-        "@npm//@ngrx/store",
     ],
 )
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
@@ -23,6 +23,7 @@ ng_module(
         "debugger_types.ts",
     ],
     deps = [
+        "//tensorboard/webapp/types",
         "@npm//@ngrx/store",
         "@npm//rxjs",
     ],

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
@@ -13,7 +13,6 @@ ng_module(
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
         "@npm//@ngrx/store",
-        "@npm//rxjs",
     ],
 )
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {Action, createReducer, on} from '@ngrx/store';
 
 import * as actions from '../actions';
-import {DebuggerState, DataLoadState} from './debugger_types';
+import {DataLoadState, DebuggerState} from './debugger_types';
 
 // HACK: These imports are for type inference.
 // https://github.com/bazelbuild/rules_nodejs/issues/1013

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -59,6 +59,7 @@ const reducer = createReducer(
     actions.debuggerRunsLoaded,
     (state: DebuggerState, {runs}): DebuggerState => {
       return {
+        ...state,
         runs,
         runsLoaded: {
           state: DataLoadState.LOADED,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -1,0 +1,76 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Action, createReducer, on} from '@ngrx/store';
+
+import * as actions from '../actions';
+import {DebuggerState, DataLoadState} from './debugger_types';
+
+// HACK: These imports are for type inference.
+// https://github.com/bazelbuild/rules_nodejs/issues/1013
+/** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
+
+const initialState: DebuggerState = {
+  runs: {},
+  runsLoaded: {
+    state: DataLoadState.NOT_LOADED,
+    lastLoadedTimeInMs: null,
+  },
+};
+
+const reducer = createReducer(
+  initialState,
+  on(
+    actions.debuggerRunsRequested,
+    (state: DebuggerState): DebuggerState => {
+      console.log('on debuggerRunsRequested'); // DEBUG
+      return {
+        ...state,
+        runsLoaded: {
+          ...state.runsLoaded,
+          state: DataLoadState.LOADING,
+        },
+      };
+    }
+  ),
+  on(
+    actions.debuggerRunsRequestFailed,
+    (state: DebuggerState): DebuggerState => {
+      console.log('on debuggerRunsRequestFailed'); // DEBUG
+      return {
+        ...state,
+        runsLoaded: {
+          ...state.runsLoaded,
+          state: DataLoadState.FAILED,
+        },
+      };
+    }
+  ),
+  on(
+    actions.debuggerRunsLoaded,
+    (state: DebuggerState, {runs}): DebuggerState => {
+      return {
+        runs,
+        runsLoaded: {
+          state: DataLoadState.LOADED,
+          lastLoadedTimeInMs: Date.now(),
+        },
+      };
+    }
+  )
+);
+
+export function reducers(state: DebuggerState, action: Action) {
+  return reducer(state, action);
+}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -34,7 +34,6 @@ const reducer = createReducer(
   on(
     actions.debuggerRunsRequested,
     (state: DebuggerState): DebuggerState => {
-      console.log('on debuggerRunsRequested'); // DEBUG
       return {
         ...state,
         runsLoaded: {
@@ -47,7 +46,6 @@ const reducer = createReducer(
   on(
     actions.debuggerRunsRequestFailed,
     (state: DebuggerState): DebuggerState => {
-      console.log('on debuggerRunsRequestFailed'); // DEBUG
       return {
         ...state,
         runsLoaded: {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
@@ -1,0 +1,64 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import * as actions from '../actions';
+import {reducers} from './debugger_reducers';
+import {DataLoadState} from './debugger_types';
+import {createDebuggerState} from '../testing';
+
+describe('Debugger reducers', () => {
+  describe('Runs loading', () => {
+    it('sets runsLoaded to loading on requesting runs', () => {
+      const state = createDebuggerState();
+      const nextState = reducers(state, actions.debuggerRunsRequested());
+      expect(nextState.runsLoaded.state).toEqual(DataLoadState.LOADING);
+      expect(nextState.runsLoaded.lastLoadedTimeInMs).toBeNull();
+    });
+
+    it('set runsLoad to failed on request failure', () => {
+      const state = createDebuggerState({
+        runsLoaded: {state: DataLoadState.LOADING, lastLoadedTimeInMs: null},
+      });
+      const nextState = reducers(state, actions.debuggerRunsRequestFailed());
+      expect(nextState.runsLoaded.state).toEqual(DataLoadState.FAILED);
+      expect(nextState.runsLoaded.lastLoadedTimeInMs).toBeNull();
+    });
+
+    it('sets runsLoaded and runs on successful runs loading', () => {
+      const state = createDebuggerState();
+      const t0 = Date.now();
+      const nextState = reducers(
+        state,
+        actions.debuggerRunsLoaded({
+          runs: {
+            foo_debugger_run: {
+              startTimeMs: 111,
+              tensorFlowVersion: '2.1.0',
+            },
+          },
+        })
+      );
+      expect(nextState.runsLoaded.state).toEqual(DataLoadState.LOADED);
+      expect(nextState.runsLoaded.lastLoadedTimeInMs).toBeGreaterThanOrEqual(
+        t0
+      );
+      expect(nextState.runs).toEqual({
+        foo_debugger_run: {
+          startTimeMs: 111,
+          tensorFlowVersion: '2.1.0',
+        },
+      });
+    });
+  });
+});

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
@@ -60,5 +60,42 @@ describe('Debugger reducers', () => {
         },
       });
     });
+
+    it('Overrides existing runs on successful runs loading', () => {
+      const state = createDebuggerState({
+        runs: {
+          foo_debugger_run: {
+            startTimeMs: 111,
+            tensorFlowVersion: '2.2.0',
+          },
+        },
+        runsLoaded: {
+          state: DataLoadState.LOADED,
+          lastLoadedTimeInMs: 0,
+        },
+      });
+      const t0 = Date.now();
+      const nextState = reducers(
+        state,
+        actions.debuggerRunsLoaded({
+          runs: {
+            bar_debugger_run: {
+              startTimeMs: 222,
+              tensorFlowVersion: '2.3.0',
+            },
+          },
+        })
+      );
+      expect(nextState.runsLoaded.state).toEqual(DataLoadState.LOADED);
+      expect(nextState.runsLoaded.lastLoadedTimeInMs).toBeGreaterThanOrEqual(
+        t0
+      );
+      expect(nextState.runs).toEqual({
+        bar_debugger_run: {
+          startTimeMs: 222,
+          tensorFlowVersion: '2.3.0',
+        },
+      });
+    });
   });
 });

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -1,0 +1,44 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {createSelector, createFeatureSelector} from '@ngrx/store';
+import {
+  DEBUGGER_FEATURE_KEY,
+  DebuggerRunListing,
+  DebuggerState,
+  State,
+  LoadState,
+} from './debugger_types';
+
+// HACK: These imports are for type inference.
+// https://github.com/bazelbuild/rules_nodejs/issues/1013
+/** @typehack */ import * as _typeHackSelector from '@ngrx/store/src/selector';
+/** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
+
+const selectDebuggerState = createFeatureSelector<State, DebuggerState>(
+  DEBUGGER_FEATURE_KEY
+);
+
+export const getDebuggerRuns = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): DebuggerRunListing => {
+    return state.runs;
+  }
+);
+
+export const getDebuggerRunsLoaded = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): LoadState => state.runsLoaded
+);

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -31,7 +31,7 @@ const selectDebuggerState = createFeatureSelector<State, DebuggerState>(
   DEBUGGER_FEATURE_KEY
 );
 
-export const getDebuggerRuns = createSelector(
+export const getDebuggerRunListing = createSelector(
   selectDebuggerState,
   (state: DebuggerState): DebuggerRunListing => {
     return state.runs;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -13,21 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {LoadState} from '../../../../webapp/types/api';
+
+export {DataLoadState, LoadState} from '../../../../webapp/types/api';
+
 export const DEBUGGER_FEATURE_KEY = 'debugger';
-
-// TODO(cais): Maybe deduplicate this with tensorboard/webapp.
-export enum DataLoadState {
-  NOT_LOADED,
-  LOADED,
-  LOADING,
-  FAILED,
-}
-
-export interface LoadState {
-  state: DataLoadState;
-  // Time since epoch.
-  lastLoadedTimeInMs: number | null;
-}
 
 export interface DebuggerRunMetadata {
   // Time at which the debugger run started. Milliseconds since the epoch.

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -1,0 +1,52 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export const DEBUGGER_FEATURE_KEY = 'debugger';
+
+// TODO(cais): Maybe deduplicate this with tensorboard/webapp.
+export enum DataLoadState {
+  NOT_LOADED,
+  LOADED,
+  LOADING,
+  FAILED,
+}
+
+export interface LoadState {
+  state: DataLoadState;
+  // Time since epoch.
+  lastLoadedTimeInMs: number | null;
+}
+
+export interface DebuggerRunMetadata {
+  // Time at which the debugger run started. Milliseconds since the epoch.
+  startTimeMs: number;
+
+  // TensorFlow Version string.
+  tensorFlowVersion: string;
+}
+
+export interface DebuggerRunListing {
+  [runId: string]: DebuggerRunMetadata;
+}
+
+export interface DebuggerState {
+  // Names of the runs that are available.
+  runs: DebuggerRunListing;
+  runsLoaded: LoadState;
+}
+
+export interface State {
+  [DEBUGGER_FEATURE_KEY]?: DebuggerState;
+}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -38,5 +38,5 @@ export interface DebuggerState {
 }
 
 export interface State {
-  [DEBUGGER_FEATURE_KEY]?: DebuggerState;
+  [DEBUGGER_FEATURE_KEY]: DebuggerState;
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/index.ts
@@ -15,9 +15,4 @@ limitations under the License.
 
 export * from './debugger_reducers';
 export * from './debugger_selectors';
-export {
-  DataLoadState,
-  DEBUGGER_FEATURE_KEY,
-  DebuggerState,
-  State,
-} from './debugger_types';
+export {DEBUGGER_FEATURE_KEY, DebuggerState, State} from './debugger_types';

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/index.ts
@@ -12,18 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
-import {DebuggerRunListing} from './store/debugger_types';
 
-@Component({
-  selector: 'debugger-component',
-  templateUrl: './debugger_component.ng.html',
-  styleUrls: ['./debugger_component.css'],
-})
-export class DebuggerComponent {
-  @Input()
-  runs: DebuggerRunListing = {};
-
-  @Input()
-  runIds: string[] = [];
-}
+export * from './debugger_reducers';
+export * from './debugger_selectors';
+export {
+  DataLoadState,
+  DEBUGGER_FEATURE_KEY,
+  DebuggerState,
+  State,
+} from './debugger_types';

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/BUILD
@@ -8,5 +8,7 @@ tf_ts_library(
     srcs = ["index.ts"],
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
     ],
 )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/BUILD
@@ -1,0 +1,12 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+tf_ts_library(
+    name = "testing",
+    testonly = True,
+    srcs = ["index.ts"],
+    deps = [
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
+    ],
+)

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
@@ -12,18 +12,26 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
-import {DebuggerRunListing} from './store/debugger_types';
+import {
+  DEBUGGER_FEATURE_KEY,
+  DataLoadState,
+  DebuggerState,
+  State,
+} from '../store/debugger_types';
 
-@Component({
-  selector: 'debugger-component',
-  templateUrl: './debugger_component.ng.html',
-  styleUrls: ['./debugger_component.css'],
-})
-export class DebuggerComponent {
-  @Input()
-  runs: DebuggerRunListing = {};
+export function createDebuggerState(
+  override?: Partial<DebuggerState>
+): DebuggerState {
+  return {
+    runs: {},
+    runsLoaded: {
+      state: DataLoadState.NOT_LOADED,
+      lastLoadedTimeInMs: null,
+    },
+    ...override,
+  };
+}
 
-  @Input()
-  runIds: string[] = [];
+export function createState(debuggerState: DebuggerState): State {
+  return {[DEBUGGER_FEATURE_KEY]: debuggerState};
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
@@ -12,6 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+
+import {Component, NgModule} from '@angular/core';
+import {Store} from '@ngrx/store';
+
 import {
   DEBUGGER_FEATURE_KEY,
   DataLoadState,
@@ -35,3 +39,21 @@ export function createDebuggerState(
 export function createState(debuggerState: DebuggerState): State {
   return {[DEBUGGER_FEATURE_KEY]: debuggerState};
 }
+
+// Below are minimalist Angular contains and modules only for testing. They
+// serve to decouple the details of Debugger from the testing of outside modules
+// that use it.
+
+@Component({
+  selector: 'tf-debugger-v2',
+  template: ``,
+})
+export class TestingDebuggerContainer {
+  constructor(private readonly store: Store<{}>) {}
+}
+
+@NgModule({
+  declarations: [TestingDebuggerContainer],
+  exports: [TestingDebuggerContainer],
+})
+export class TestingDebuggerModule {}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
@@ -17,8 +17,8 @@ import {Component, NgModule} from '@angular/core';
 import {Store} from '@ngrx/store';
 
 import {
-  DEBUGGER_FEATURE_KEY,
   DataLoadState,
+  DEBUGGER_FEATURE_KEY,
   DebuggerState,
   State,
 } from '../store/debugger_types';

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
@@ -1,0 +1,24 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+licenses(["notice"])  # Apache 2.0
+
+ng_module(
+    name = "alerts",
+    srcs = [
+        "alerts_component.ts",
+        "alerts_container.ts",
+        "alerts_module.ts",
+    ],
+    assets = [
+        "alerts_component.css",
+        "alerts_component.ng.html",
+    ],
+    deps = [
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.css
@@ -12,18 +12,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
-import {DebuggerRunListing} from './store/debugger_types';
 
-@Component({
-  selector: 'debugger-component',
-  templateUrl: './debugger_component.ng.html',
-  styleUrls: ['./debugger_component.css'],
-})
-export class DebuggerComponent {
-  @Input()
-  runs: DebuggerRunListing = {};
-
-  @Input()
-  runIds: string[] = [];
-}
+/* TODO(cais): Flesh out the styling. */

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ng.html
@@ -1,4 +1,6 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+<!--
+@license
+Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -11,19 +13,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-==============================================================================*/
-import {Component, Input} from '@angular/core';
-import {DebuggerRunListing} from './store/debugger_types';
+-->
 
-@Component({
-  selector: 'debugger-component',
-  templateUrl: './debugger_component.ng.html',
-  styleUrls: ['./debugger_component.css'],
-})
-export class DebuggerComponent {
-  @Input()
-  runs: DebuggerRunListing = {};
-
-  @Input()
-  runIds: string[] = [];
-}
+<div>
+  <div>Debugging</div>
+  <div>
+    <span>Alerts</span>
+  </div>
+  <!-- TODO(cais): Flesh out the details. -->
+</div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ts
@@ -12,18 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
-import {DebuggerRunListing} from './store/debugger_types';
+import {Component} from '@angular/core';
 
 @Component({
-  selector: 'debugger-component',
-  templateUrl: './debugger_component.ng.html',
-  styleUrls: ['./debugger_component.css'],
+  selector: 'alerts-component',
+  templateUrl: './alerts_component.ng.html',
+  styleUrls: ['./alerts_component.css'],
 })
-export class DebuggerComponent {
-  @Input()
-  runs: DebuggerRunListing = {};
-
-  @Input()
-  runIds: string[] = [];
-}
+export class AlertsComponent {}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
@@ -12,18 +12,26 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
-import {DebuggerRunListing} from './store/debugger_types';
+import {Component, OnInit} from '@angular/core';
+import {Store} from '@ngrx/store';
+
+import {alertsViewLoaded} from '../../actions';
+
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+
+// TODO(cais): Move to a separate file.
+export interface AlertsState {}
 
 @Component({
-  selector: 'debugger-component',
-  templateUrl: './debugger_component.ng.html',
-  styleUrls: ['./debugger_component.css'],
+  selector: 'tf-debugger-v2-alerts',
+  template: `
+    <alerts-component></alerts-component>
+  `,
 })
-export class DebuggerComponent {
-  @Input()
-  runs: DebuggerRunListing = {};
+export class AlertsContainer implements OnInit {
+  constructor(private readonly store: Store<AlertsState>) {}
 
-  @Input()
-  runIds: string[] = [];
+  ngOnInit(): void {
+    this.store.dispatch(alertsViewLoaded());
+  }
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_module.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_module.ts
@@ -12,18 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component, Input} from '@angular/core';
-import {DebuggerRunListing} from './store/debugger_types';
 
-@Component({
-  selector: 'debugger-component',
-  templateUrl: './debugger_component.ng.html',
-  styleUrls: ['./debugger_component.css'],
+import {NgModule} from '@angular/core';
+
+import {AlertsComponent} from './alerts_component';
+import {AlertsContainer} from './alerts_container';
+
+@NgModule({
+  declarations: [AlertsComponent, AlertsContainer],
+  exports: [AlertsContainer],
 })
-export class DebuggerComponent {
-  @Input()
-  runs: DebuggerRunListing = {};
-
-  @Input()
-  runIds: string[] = [];
-}
+export class AlertsModule {}

--- a/tensorboard/webapp/core/effects/core_effects.ts
+++ b/tensorboard/webapp/core/effects/core_effects.ts
@@ -32,7 +32,7 @@ import {
   pluginsListingFailed,
 } from '../actions';
 import {getPluginsListLoaded} from '../store';
-import {LoadState} from '../../types/api';
+import {DataLoadState} from '../../types/api';
 import {State} from '../store/core_types';
 import {TBServerDataSource} from '../../webapp_data_source/tb_server_data_source';
 
@@ -50,7 +50,7 @@ export class CoreEffects {
     this.actions$.pipe(
       ofType(coreLoaded, reload),
       withLatestFrom(this.store.select(getPluginsListLoaded)),
-      filter(([, {state}]) => state !== LoadState.LOADING),
+      filter(([, {state}]) => state !== DataLoadState.LOADING),
       tap(() => this.store.dispatch(pluginsListingRequested())),
       mergeMap(() => {
         return zip(

--- a/tensorboard/webapp/core/effects/core_effects.ts
+++ b/tensorboard/webapp/core/effects/core_effects.ts
@@ -32,7 +32,7 @@ import {
   pluginsListingFailed,
 } from '../actions';
 import {getPluginsListLoaded} from '../store';
-import {DataLoadState} from '../../types/api';
+import {DataLoadState} from '../../types/data';
 import {State} from '../store/core_types';
 import {TBServerDataSource} from '../../webapp_data_source/tb_server_data_source';
 

--- a/tensorboard/webapp/core/effects/core_effects_test.ts
+++ b/tensorboard/webapp/core/effects/core_effects_test.ts
@@ -28,7 +28,8 @@ import {State} from '../store';
 
 import {createPluginMetadata, createState, createCoreState} from '../testing';
 
-import {PluginsListing, DataLoadState} from '../../types/api';
+import {PluginsListing} from '../../types/api';
+import {DataLoadState} from '../../types/data';
 import {TBServerDataSource} from '../../webapp_data_source/tb_server_data_source';
 
 describe('core_effects', () => {

--- a/tensorboard/webapp/core/effects/core_effects_test.ts
+++ b/tensorboard/webapp/core/effects/core_effects_test.ts
@@ -28,7 +28,7 @@ import {State} from '../store';
 
 import {createPluginMetadata, createState, createCoreState} from '../testing';
 
-import {PluginsListing, LoadState as DataLoadState} from '../../types/api';
+import {PluginsListing, DataLoadState} from '../../types/api';
 import {TBServerDataSource} from '../../webapp_data_source/tb_server_data_source';
 
 describe('core_effects', () => {

--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Action, createReducer, on} from '@ngrx/store';
-import {DataLoadState} from '../../types/api';
+import {DataLoadState} from '../../types/data';
 import * as actions from '../actions';
 import {CoreState} from './core_types';
 

--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Action, createReducer, on} from '@ngrx/store';
-import {LoadState as DataLoadState} from '../../types/api';
+import {DataLoadState} from '../../types/api';
 import * as actions from '../actions';
 import {CoreState} from './core_types';
 

--- a/tensorboard/webapp/core/store/core_reducers_test.ts
+++ b/tensorboard/webapp/core/store/core_reducers_test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import * as actions from '../actions';
 import {reducers} from './core_reducers';
 import {createPluginMetadata, createCoreState} from '../testing';
-import {LoadState} from '../../types/api';
+import {DataLoadState} from '../../types/api';
 
 function createPluginsListing() {
   return {
@@ -50,12 +50,12 @@ describe('core reducer', () => {
     {
       specSetName: '#pluginsListingRequested',
       action: actions.pluginsListingRequested(),
-      expectedState: LoadState.LOADING,
+      expectedState: DataLoadState.LOADING,
     },
     {
       specSetName: '#pluginsListingFailed',
       action: actions.pluginsListingFailed(),
-      expectedState: LoadState.FAILED,
+      expectedState: DataLoadState.FAILED,
     },
   ].forEach(({specSetName, action, expectedState}) => {
     describe(specSetName, () => {
@@ -63,7 +63,7 @@ describe('core reducer', () => {
         const state = createCoreState({
           pluginsListLoaded: {
             lastLoadedTimeInMs: null,
-            state: LoadState.NOT_LOADED,
+            state: DataLoadState.NOT_LOADED,
           },
         });
         const nextState = reducers(state, action);
@@ -75,7 +75,7 @@ describe('core reducer', () => {
         const state = createCoreState({
           pluginsListLoaded: {
             lastLoadedTimeInMs: 1337,
-            state: LoadState.NOT_LOADED,
+            state: DataLoadState.NOT_LOADED,
           },
         });
         const nextState = reducers(state, action);
@@ -106,7 +106,7 @@ describe('core reducer', () => {
         activePlugin: 'foo',
         plugins: {},
         pluginsListLoaded: {
-          state: LoadState.NOT_LOADED,
+          state: DataLoadState.NOT_LOADED,
           lastLoadedTimeInMs: null,
         },
       });
@@ -116,7 +116,7 @@ describe('core reducer', () => {
       );
 
       expect(nextState.pluginsListLoaded).toEqual({
-        state: LoadState.LOADED,
+        state: DataLoadState.LOADED,
         lastLoadedTimeInMs: 1000,
       });
     });

--- a/tensorboard/webapp/core/store/core_reducers_test.ts
+++ b/tensorboard/webapp/core/store/core_reducers_test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import * as actions from '../actions';
 import {reducers} from './core_reducers';
 import {createPluginMetadata, createCoreState} from '../testing';
-import {DataLoadState} from '../../types/api';
+import {DataLoadState} from '../../types/data';
 
 function createPluginsListing() {
   return {

--- a/tensorboard/webapp/core/store/core_selectors.ts
+++ b/tensorboard/webapp/core/store/core_selectors.ts
@@ -14,8 +14,8 @@ limitations under the License.
 ==============================================================================*/
 
 import {createSelector, createFeatureSelector} from '@ngrx/store';
-import {PluginId, PluginsListing} from '../../types/api';
-import {CoreState, State, CORE_FEATURE_KEY, LoadState} from './core_types';
+import {LoadState, PluginId, PluginsListing} from '../../types/api';
+import {CoreState, State, CORE_FEATURE_KEY} from './core_types';
 
 // HACK: These imports are for type inference.
 // https://github.com/bazelbuild/rules_nodejs/issues/1013

--- a/tensorboard/webapp/core/store/core_selectors.ts
+++ b/tensorboard/webapp/core/store/core_selectors.ts
@@ -14,7 +14,8 @@ limitations under the License.
 ==============================================================================*/
 
 import {createSelector, createFeatureSelector} from '@ngrx/store';
-import {LoadState, PluginId, PluginsListing} from '../../types/api';
+import {PluginId, PluginsListing} from '../../types/api';
+import {LoadState} from '../../types/data';
 import {CoreState, State, CORE_FEATURE_KEY} from './core_types';
 
 // HACK: These imports are for type inference.

--- a/tensorboard/webapp/core/store/core_types.ts
+++ b/tensorboard/webapp/core/store/core_types.ts
@@ -18,7 +18,8 @@ limitations under the License.
 // redundant copies in sync.  If the state shape and the API types need to
 // diverge in the future, that's straightforward: we'll leave types/api in place,
 // remove this import, and write the divergent state types explicitly here.
-import {PluginId, PluginsListing, LoadState} from '../../types/api';
+import {PluginId, PluginsListing} from '../../types/api';
+import {LoadState} from '../../types/data';
 
 export const CORE_FEATURE_KEY = 'core';
 

--- a/tensorboard/webapp/core/store/core_types.ts
+++ b/tensorboard/webapp/core/store/core_types.ts
@@ -18,19 +18,9 @@ limitations under the License.
 // redundant copies in sync.  If the state shape and the API types need to
 // diverge in the future, that's straightforward: we'll leave types/api in place,
 // remove this import, and write the divergent state types explicitly here.
-import {
-  PluginId,
-  PluginsListing,
-  LoadState as DataLoadState,
-} from '../../types/api';
+import {PluginId, PluginsListing, LoadState} from '../../types/api';
 
 export const CORE_FEATURE_KEY = 'core';
-
-export interface LoadState {
-  state: DataLoadState;
-  // Time since epoch.
-  lastLoadedTimeInMs: number | null;
-}
 
 export interface CoreState {
   activePlugin: PluginId | null;

--- a/tensorboard/webapp/core/testing/index.ts
+++ b/tensorboard/webapp/core/testing/index.ts
@@ -12,11 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {
-  PluginMetadata,
-  LoadingMechanismType,
-  DataLoadState,
-} from '../../types/api';
+import {LoadingMechanismType, PluginMetadata} from '../../types/api';
+import {DataLoadState} from '../../types/data';
 import {CoreState, State, CORE_FEATURE_KEY} from '../store/core_types';
 
 export function createPluginMetadata(displayName: string): PluginMetadata {

--- a/tensorboard/webapp/core/testing/index.ts
+++ b/tensorboard/webapp/core/testing/index.ts
@@ -12,7 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {PluginMetadata, LoadingMechanismType, LoadState} from '../../types/api';
+import {
+  PluginMetadata,
+  LoadingMechanismType,
+  DataLoadState,
+} from '../../types/api';
 import {CoreState, State, CORE_FEATURE_KEY} from '../store/core_types';
 
 export function createPluginMetadata(displayName: string): PluginMetadata {
@@ -32,7 +36,7 @@ export function createCoreState(override?: Partial<CoreState>): CoreState {
     activePlugin: null,
     plugins: {},
     pluginsListLoaded: {
-      state: LoadState.NOT_LOADED,
+      state: DataLoadState.NOT_LOADED,
       lastLoadedTimeInMs: null,
     },
     reloadPeriodInMs: 30000,

--- a/tensorboard/webapp/plugins/BUILD
+++ b/tensorboard/webapp/plugins/BUILD
@@ -36,7 +36,7 @@ tf_ts_library(
     tsconfig = "//:tsconfig-test",
     deps = [
         ":plugins",
-        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin:debugger_v2",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/core",
         "//tensorboard/webapp/core/store",

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -16,7 +16,8 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store, select, createSelector} from '@ngrx/store';
 
 import {getPlugins, getActivePlugin, getPluginsListLoaded} from '../core/store';
-import {LoadState, PluginMetadata} from '../types/api';
+import {PluginMetadata} from '../types/api';
+import {LoadState} from '../types/data';
 import {State} from '../core/store/core_types';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -16,8 +16,8 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store, select, createSelector} from '@ngrx/store';
 
 import {getPlugins, getActivePlugin, getPluginsListLoaded} from '../core/store';
-import {PluginMetadata} from '../types/api';
-import {LoadState, State} from '../core/store/core_types';
+import {LoadState, PluginMetadata} from '../types/api';
+import {State} from '../core/store/core_types';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
 

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -20,7 +20,7 @@ import {provideMockStore, MockStore} from '@ngrx/store/testing';
 import {PluginsContainer} from './plugins_container';
 import {PluginsComponent} from './plugins_component';
 
-import {PluginId, LoadingMechanismType, LoadState} from '../types/api';
+import {DataLoadState, PluginId, LoadingMechanismType} from '../types/api';
 import {createState, createCoreState} from '../core/testing';
 import {State} from '../core/store';
 // store/index.ts doesn't export this, but it's OK to use for testing
@@ -182,7 +182,7 @@ describe('plugins_component', () => {
   describe('updates', () => {
     function setLastLoadedTime(
       timeInMs: number | null,
-      state = LoadState.LOADED
+      state = DataLoadState.LOADED
     ) {
       store.setState(
         createState(
@@ -201,7 +201,7 @@ describe('plugins_component', () => {
     it('invokes reload method on the dashboard DOM', () => {
       const fixture = TestBed.createComponent(PluginsContainer);
 
-      setLastLoadedTime(null, LoadState.NOT_LOADED);
+      setLastLoadedTime(null, DataLoadState.NOT_LOADED);
       fixture.detectChanges();
 
       const {nativeElement} = fixture.debugElement.query(By.css('.plugins'));

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -20,7 +20,8 @@ import {provideMockStore, MockStore} from '@ngrx/store/testing';
 import {PluginsContainer} from './plugins_container';
 import {PluginsComponent} from './plugins_component';
 
-import {DataLoadState, PluginId, LoadingMechanismType} from '../types/api';
+import {PluginId, LoadingMechanismType} from '../types/api';
+import {DataLoadState} from '../types/data';
 import {createState, createCoreState} from '../core/testing';
 import {State} from '../core/store';
 // store/index.ts doesn't export this, but it's OK to use for testing

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -26,7 +26,7 @@ import {State} from '../core/store';
 // store/index.ts doesn't export this, but it's OK to use for testing
 import {CoreState} from '../core/store/core_types';
 
-import {DebuggerModule} from '../../plugins/debugger_v2/tf_debugger_v2_plugin/debugger_module';
+import {TestingDebuggerModule} from '../../plugins/debugger_v2/tf_debugger_v2_plugin/testing';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
@@ -68,7 +68,7 @@ describe('plugins_component', () => {
     await TestBed.configureTestingModule({
       providers: [provideMockStore({initialState}), PluginsContainer],
       declarations: [PluginsContainer, PluginsComponent],
-      imports: [DebuggerModule],
+      imports: [TestingDebuggerModule],
     }).compileComponents();
     store = TestBed.get(Store);
   });

--- a/tensorboard/webapp/types/BUILD
+++ b/tensorboard/webapp/types/BUILD
@@ -8,5 +8,6 @@ tf_ts_library(
     name = "types",
     srcs = [
         "api.ts",
+        "data.ts",
     ],
 )

--- a/tensorboard/webapp/types/api.ts
+++ b/tensorboard/webapp/types/api.ts
@@ -13,19 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-export enum DataLoadState {
-  NOT_LOADED,
-  LOADED,
-  LOADING,
-  FAILED,
-}
-
-export interface LoadState {
-  state: DataLoadState;
-  // Time since epoch.
-  lastLoadedTimeInMs: number | null;
-}
-
 export type PluginId = string;
 
 export enum LoadingMechanismType {

--- a/tensorboard/webapp/types/api.ts
+++ b/tensorboard/webapp/types/api.ts
@@ -12,11 +12,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-export enum LoadState {
+
+export enum DataLoadState {
   NOT_LOADED,
   LOADED,
   LOADING,
   FAILED,
+}
+
+export interface LoadState {
+  state: DataLoadState;
+  // Time since epoch.
+  lastLoadedTimeInMs: number | null;
 }
 
 export type PluginId = string;

--- a/tensorboard/webapp/types/data.ts
+++ b/tensorboard/webapp/types/data.ts
@@ -13,30 +13,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {LoadState} from '../../../../webapp/types/data';
+/** Data-related types */
 
-export {DataLoadState, LoadState} from '../../../../webapp/types/data';
-
-export const DEBUGGER_FEATURE_KEY = 'debugger';
-
-export interface DebuggerRunMetadata {
-  // Time at which the debugger run started. Milliseconds since the epoch.
-  startTimeMs: number;
-
-  // TensorFlow Version string.
-  tensorFlowVersion: string;
+export enum DataLoadState {
+  NOT_LOADED,
+  LOADED,
+  LOADING,
+  FAILED,
 }
 
-export interface DebuggerRunListing {
-  [runId: string]: DebuggerRunMetadata;
-}
-
-export interface DebuggerState {
-  // Names of the runs that are available.
-  runs: DebuggerRunListing;
-  runsLoaded: LoadState;
-}
-
-export interface State {
-  [DEBUGGER_FEATURE_KEY]?: DebuggerState;
+export interface LoadState {
+  state: DataLoadState;
+  // Time since epoch.
+  lastLoadedTimeInMs: number | null;
 }


### PR DESCRIPTION
* Technical description of changes
  * Add HTTP data source implementation in data_soruce/tfdbg2_data_source.ts. Currently the data source doesn't exist in the backend, but will be added soon (#3051)
  * Add actions in actions/. Currently there is only a small number of actions, related to the loading of the debugger v2 plugin, loading of the debugger runs from the data source.
  * Add effects in effects/. Currently there is only one effect: dispatch actions on `debuggerLoaded`.
  * Add types, store and redudcer in store/.
  * Add a new view in view/alerts/. The new `tf-debugger-v2-alerts` element (`AlertsContainer`) is rendered conditionally in lieu of the existing `InactiveContainer` when there is at least 1 debugger run available via the data source.
  * Add unit tests:
    * For reducer: debugger_reducer_test.ts
    * For the overall DebuggerContainer: debugger_container_test.ts
    * To make //tensorboard/webapp:karma_test_chromium pass, we need to decouple the states of the PluginModule and those of the DebuggerModule. This is achieve by creating `TestingDebuggerModule` in testing/ and using it in /tensorboard/webapp.

The code pattern is largely based on the work of @stephanwlee 

