### PR TITLE
[ng] Expose tf_globals as Polymer component for interop

### DIFF
--- a/tensorboard/components/tf_globals/BUILD
+++ b/tensorboard/components/tf_globals/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -9,13 +9,20 @@ tf_web_library(
     name = "tf_globals",
     srcs = [
         "globals.ts",
+        "globals-polymer.ts",
         "tf-globals.html",
     ],
     path = "/tf-globals",
+    deps = [
+        "//tensorboard/components/tf_imports:polymer",
+    ],
 )
 
 tensorboard_webcomponent_library(
     name = "legacy",
     srcs = [":tf_globals"],
     destdir = "tf-globals",
+    deps = [
+        "//tensorboard/components/tf_imports:polymer_lib",
+    ],
 )

--- a/tensorboard/components/tf_globals/globals-polymer.ts
+++ b/tensorboard/components/tf_globals/globals-polymer.ts
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/components/tf_globals/globals-polymer.ts
+++ b/tensorboard/components/tf_globals/globals-polymer.ts
@@ -1,6 +1,4 @@
-<!--
-@license
-Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +11,13 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
-<link rel="import" href="../tf-imports/polymer.html" />
-
-<script src="globals.js"></script>
-<script src="globals-polymer.js"></script>
+==============================================================================*/
+namespace tf_globals {
+  // HACK: this Polymer component allows stores to be accessible from
+  // tf-ng-tensorboard by exposing otherwise mangled smybols.
+  Polymer({
+    is: 'tf-globals',
+    _template: null, // strictTemplatePolicy requires a template (even a null one).
+    tf_globals: tf_globals,
+  });
+} // namespace tf_globals


### PR DESCRIPTION
We need to be able to turn off the fake hashing in the storage module when using angular based TensorBoard.