### PR TITLE
[ng] Hash storage component to make changes to the hash

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -28,6 +28,7 @@ ng_module(
         "//tensorboard/webapp/core",
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/core/store",
+        "//tensorboard/webapp/core/views:hash_storage",
         "//tensorboard/webapp/header",
         "//tensorboard/webapp/plugins",
         "//tensorboard/webapp/reloader",
@@ -137,6 +138,7 @@ tf_ng_web_test_suite(
     deps = [
         "//tensorboard/webapp/core/effects:core_effects_test_lib",
         "//tensorboard/webapp/core/store:core_store_test_lib",
+        "//tensorboard/webapp/core/views:test_lib",
         "//tensorboard/webapp/header:test_lib",
         "//tensorboard/webapp/plugins:plugins_container_test_lib",
         "//tensorboard/webapp/reloader:test_lib",

--- a/tensorboard/webapp/app_container.ng.html
+++ b/tensorboard/webapp/app_container.ng.html
@@ -18,3 +18,4 @@ limitations under the License.
 <app-header></app-header>
 <plugins class="plugins"></plugins>
 <reloader></reloader>
+<hash-storage></hash-storage>

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -20,6 +20,7 @@ import {EffectsModule} from '@ngrx/effects';
 
 import {AppContainer} from './app_container';
 import {CoreModule} from './core/core_module';
+import {HashStorageModule} from './core/views/hash_storage_module';
 import {PluginsModule} from './plugins/plugins_module';
 
 import {ROOT_REDUCERS, metaReducers} from './reducer_config';
@@ -34,6 +35,7 @@ import {MatIconModule} from './mat_icon_module';
     BrowserModule,
     BrowserAnimationsModule,
     CoreModule,
+    HashStorageModule,
     HeaderModule,
     MatIconModule,
     PluginsModule,

--- a/tensorboard/webapp/core/actions/core_actions.ts
+++ b/tensorboard/webapp/core/actions/core_actions.ts
@@ -19,12 +19,19 @@ import {PluginId, PluginsListing} from '../../types/api';
 // https://github.com/bazelbuild/rules_nodejs/issues/1013
 /** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
 
+/**
+ * User has clicked on a button in the header to change the plugin.
+ */
 export const changePlugin = createAction(
   '[Core] Plugin Changed',
   props<{plugin: PluginId}>()
 );
 
-export const pluginHashChanged = createAction(
+/**
+ * Plugin information in the hash is changed by user action.
+ * e.g., user can use browser navigation button to change the hash.
+ */
+export const pluginUrlHashChanged = createAction(
   '[Core] Plugin Url Hash Changed',
   props<{plugin: PluginId}>()
 );

--- a/tensorboard/webapp/core/actions/core_actions.ts
+++ b/tensorboard/webapp/core/actions/core_actions.ts
@@ -24,6 +24,11 @@ export const changePlugin = createAction(
   props<{plugin: PluginId}>()
 );
 
+export const pluginHashChanged = createAction(
+  '[Core] Plugin Url Hash Changed',
+  props<{plugin: PluginId}>()
+);
+
 export const coreLoaded = createAction('[Core] Loaded');
 
 export const reload = createAction('[Core] Reload');

--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -36,6 +36,7 @@ const reducer = createReducer(
   initialState,
   on(
     actions.changePlugin,
+    actions.pluginHashChanged,
     (state: CoreState, {plugin}): CoreState => {
       return {...state, activePlugin: plugin};
     }

--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -36,7 +36,7 @@ const reducer = createReducer(
   initialState,
   on(
     actions.changePlugin,
-    actions.pluginHashChanged,
+    actions.pluginUrlHashChanged,
     (state: CoreState, {plugin}): CoreState => {
       return {...state, activePlugin: plugin};
     }

--- a/tensorboard/webapp/core/store/core_reducers_test.ts
+++ b/tensorboard/webapp/core/store/core_reducers_test.ts
@@ -30,7 +30,7 @@ describe('core reducer', () => {
       action: actions.changePlugin({plugin: 'bar'}),
     },
     {
-      action: actions.pluginHashChanged({plugin: 'bar'}),
+      action: actions.pluginUrlHashChanged({plugin: 'bar'}),
     },
   ].forEach(({action}) => {
     describe(action.type, () => {

--- a/tensorboard/webapp/core/store/core_reducers_test.ts
+++ b/tensorboard/webapp/core/store/core_reducers_test.ts
@@ -25,24 +25,33 @@ function createPluginsListing() {
 }
 
 describe('core reducer', () => {
-  describe('#changePlugin', () => {
-    it('sets activePlugin to the one in action payload', () => {
-      const state = createCoreState({activePlugin: 'foo', plugins: {}});
+  [
+    {
+      action: actions.changePlugin({plugin: 'bar'}),
+    },
+    {
+      action: actions.pluginHashChanged({plugin: 'bar'}),
+    },
+  ].forEach(({action}) => {
+    describe(action.type, () => {
+      it('sets activePlugin to the one in action payload', () => {
+        const state = createCoreState({activePlugin: 'foo', plugins: {}});
 
-      const nextState = reducers(state, actions.changePlugin({plugin: 'bar'}));
+        const nextState = reducers(state, action);
 
-      expect(nextState.activePlugin).toBe('bar');
-    });
-
-    it('does not change plugins when activePlugin changes', () => {
-      const state = createCoreState({
-        activePlugin: 'foo',
-        plugins: createPluginsListing(),
+        expect(nextState.activePlugin).toBe('bar');
       });
 
-      const nextState = reducers(state, actions.changePlugin({plugin: 'bar'}));
+      it('does not change plugins when activePlugin changes', () => {
+        const state = createCoreState({
+          activePlugin: 'foo',
+          plugins: createPluginsListing(),
+        });
 
-      expect(nextState.plugins).toEqual(createPluginsListing());
+        const nextState = reducers(state, action);
+
+        expect(nextState.plugins).toEqual(createPluginsListing());
+      });
     });
   });
 

--- a/tensorboard/webapp/core/views/BUILD
+++ b/tensorboard/webapp/core/views/BUILD
@@ -1,0 +1,43 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "hash_storage",
+    srcs = [
+        "hash_storage_component.ts",
+        "hash_storage_container.ts",
+        "hash_storage_module.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/core/actions",
+        "//tensorboard/webapp/core/store",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = [
+        "hash_storage_test.ts",
+    ],
+    tsconfig = "//:tsconfig-test",
+    deps = [
+        ":hash_storage",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
+        "//tensorboard/webapp/core/actions",
+        "//tensorboard/webapp/core/store",
+        "//tensorboard/webapp/core/testing",
+        "@npm//@angular/common",
+        "@npm//@angular/compiler",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/core/views/hash_storage_component.ts
+++ b/tensorboard/webapp/core/views/hash_storage_component.ts
@@ -1,0 +1,109 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnChanges,
+  SimpleChanges,
+  OnInit,
+  OnDestroy,
+  Output,
+  EventEmitter,
+} from '@angular/core';
+
+export enum ChangedProp {
+  ACTIVE_PLUGIN,
+}
+
+// TODO(tensorboard-team): remove below when storage.ts is pure TypeSccript module.
+const TAB = '__tab__';
+
+interface TfGlobalsElement extends HTMLElement {
+  tf_globals: {
+    setUseHash(use: boolean): void;
+  };
+}
+
+interface SetStringOption {
+  defaultValue?: string;
+  useLocationReplace?: boolean;
+}
+
+interface TfStorageElement extends HTMLElement {
+  tf_storage: {
+    setString(key: string, value: string, options: SetStringOption): void;
+    getString(key: string): string;
+  };
+}
+
+@Component({
+  selector: 'hash-storage-component',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HashStorageComponent implements OnInit, OnChanges, OnDestroy {
+  private readonly tfGlobals = (document.createElement(
+    'tf-globals'
+  ) as TfGlobalsElement).tf_globals;
+  private readonly tfStorage = (document.createElement(
+    'tf-storage'
+  ) as TfStorageElement).tf_storage;
+  private readonly onHashChange = this.onHashChangedImpl.bind(this);
+
+  @Input()
+  activePluginId!: string;
+
+  @Output()
+  onValueChange = new EventEmitter<{prop: ChangedProp; value: string}>();
+
+  private onHashChangedImpl() {
+    const activePluginId = this.tfStorage.getString(TAB);
+
+    if (activePluginId !== this.activePluginId) {
+      this.onValueChange.emit({
+        prop: ChangedProp.ACTIVE_PLUGIN,
+        value: activePluginId,
+      });
+    }
+  }
+
+  ngOnInit() {
+    // As opposed to fake hash that does not modify the URL.
+    this.tfGlobals.setUseHash(true);
+
+    // Cannot use the tf_storage hash listener because it does not have the zone.js
+    // treatment. According to [1], zone.js patches various asynchronosity and
+    // event listener for detecting "changes" in the application. Because the tf_storage
+    // version is outside of the zone.js patching, it causes bad renders in Angular.
+    // [1]: https://blog.angular-university.io/how-does-angular-2-change-detection-really-work/
+    window.addEventListener('hashchange', this.onHashChange);
+  }
+
+  ngOnDestroy() {
+    window.removeEventListener('hashchange', this.onHashChange);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['activePluginId']) {
+      const activePluginIdChange = changes['activePluginId'];
+      const option: SetStringOption = {};
+      if (activePluginIdChange.firstChange) {
+        option.useLocationReplace = true;
+      }
+      this.tfStorage.setString(TAB, activePluginIdChange.currentValue, option);
+    }
+  }
+}

--- a/tensorboard/webapp/core/views/hash_storage_component.ts
+++ b/tensorboard/webapp/core/views/hash_storage_component.ts
@@ -28,7 +28,8 @@ export enum ChangedProp {
   ACTIVE_PLUGIN,
 }
 
-// TODO(tensorboard-team): remove below when storage.ts is pure TypeSccript module.
+// TODO(tensorboard-team): remove below when storage.ts is pure TypeScript
+// module.
 const TAB = '__tab__';
 
 interface TfGlobalsElement extends HTMLElement {
@@ -84,10 +85,11 @@ export class HashStorageComponent implements OnInit, OnChanges, OnDestroy {
     // As opposed to fake hash that does not modify the URL.
     this.tfGlobals.setUseHash(true);
 
-    // Cannot use the tf_storage hash listener because it does not have the zone.js
-    // treatment. According to [1], zone.js patches various asynchronosity and
-    // event listener for detecting "changes" in the application. Because the tf_storage
-    // version is outside of the zone.js patching, it causes bad renders in Angular.
+    // Cannot use the tf_storage hash listener because it binds to event before the
+    // zone.js patch. According to [1], zone.js patches various asynchronos calls and
+    // event listeners to detect "changes" and mark components as dirty for re-render.
+    // When using tf_storage hash listener, it causes bad renders in Angular due to
+    // missing dirtiness detection.
     // [1]: https://blog.angular-university.io/how-does-angular-2-change-detection-really-work/
     window.addEventListener('hashchange', this.onHashChange);
   }

--- a/tensorboard/webapp/core/views/hash_storage_container.ts
+++ b/tensorboard/webapp/core/views/hash_storage_container.ts
@@ -17,7 +17,7 @@ import {Store, select} from '@ngrx/store';
 
 import {getActivePlugin} from '../store';
 import {State} from '../store/core_types';
-import {pluginHashChanged} from '../actions';
+import {pluginUrlHashChanged} from '../actions';
 
 import {ChangedProp} from './hash_storage_component';
 
@@ -49,7 +49,7 @@ export class HashStorageContainer {
   onValueChanged(change: {prop: ChangedProp; value: string}) {
     switch (change.prop) {
       case ChangedProp.ACTIVE_PLUGIN:
-        this.store.dispatch(pluginHashChanged({plugin: change.value}));
+        this.store.dispatch(pluginUrlHashChanged({plugin: change.value}));
         break;
     }
   }

--- a/tensorboard/webapp/core/views/hash_storage_container.ts
+++ b/tensorboard/webapp/core/views/hash_storage_container.ts
@@ -1,0 +1,56 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {Store, select} from '@ngrx/store';
+
+import {getActivePlugin} from '../store';
+import {State} from '../store/core_types';
+import {pluginHashChanged} from '../actions';
+
+import {ChangedProp} from './hash_storage_component';
+
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+
+@Component({
+  selector: 'hash-storage',
+  template: `
+    <hash-storage-component
+      [activePluginId]="activePluginId$ | async"
+      (onValueChange)="onValueChanged($event)"
+    >
+    </hash-storage-component>
+  `,
+  styles: [
+    `
+      :host {
+        display: none;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HashStorageContainer {
+  readonly activePluginId$ = this.store.pipe(select(getActivePlugin));
+
+  constructor(private readonly store: Store<State>) {}
+
+  onValueChanged(change: {prop: ChangedProp; value: string}) {
+    switch (change.prop) {
+      case ChangedProp.ACTIVE_PLUGIN:
+        this.store.dispatch(pluginHashChanged({plugin: change.value}));
+        break;
+    }
+  }
+}

--- a/tensorboard/webapp/core/views/hash_storage_module.ts
+++ b/tensorboard/webapp/core/views/hash_storage_module.ts
@@ -1,0 +1,26 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+
+import {HashStorageContainer} from './hash_storage_container';
+import {HashStorageComponent} from './hash_storage_component';
+
+@NgModule({
+  declarations: [HashStorageContainer, HashStorageComponent],
+  exports: [HashStorageContainer],
+  imports: [CommonModule],
+})
+export class HashStorageModule {}

--- a/tensorboard/webapp/core/views/hash_storage_test.ts
+++ b/tensorboard/webapp/core/views/hash_storage_test.ts
@@ -1,0 +1,103 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TestBed} from '@angular/core/testing';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Store} from '@ngrx/store';
+import {provideMockStore, MockStore} from '@ngrx/store/testing';
+import {CommonModule} from '@angular/common';
+
+import {getActivePlugin} from '../store';
+import {State} from '../store/core_types';
+import {pluginHashChanged} from '../actions';
+
+import {HashStorageContainer} from './hash_storage_container';
+import {HashStorageComponent} from './hash_storage_component';
+
+/** @typehack */ import * as _typeHackStore from '@ngrx/store';
+/** @typehack */ import * as _typeHackStoreTesting from '@ngrx/store/testing';
+
+describe('hash storage test', () => {
+  let store: MockStore<State>;
+  let dispatchSpy: jasmine.Spy;
+  let setStringSpy: jasmine.Spy;
+  let getStringSpy: jasmine.Spy;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, CommonModule],
+      providers: [provideMockStore(), HashStorageContainer],
+      declarations: [HashStorageContainer, HashStorageComponent],
+    }).compileComponents();
+    store = TestBed.get(Store);
+    dispatchSpy = spyOn(store, 'dispatch');
+
+    setStringSpy = jasmine.createSpy();
+    getStringSpy = jasmine.createSpy();
+
+    // Cannot safely stub out window.location.hash or rely on test framework
+    // to not make use of the hash (it does).
+
+    // Do not rely on Polymer bundle in the test.
+    const createElement = spyOn(document, 'createElement');
+    createElement.withArgs('tf-storage').and.returnValue({
+      tf_storage: {
+        setString: setStringSpy,
+        getString: getStringSpy,
+      },
+    } as any);
+    createElement.withArgs('tf-globals').and.returnValue({
+      tf_globals: {
+        setUseHash: jasmine.createSpy(),
+      },
+    } as any);
+    createElement.and.callThrough();
+  });
+
+  it('sets the hash to plugin id by replacing on first load', () => {
+    store.overrideSelector(getActivePlugin, 'foo');
+    const fixture = TestBed.createComponent(HashStorageContainer);
+    fixture.detectChanges();
+
+    expect(setStringSpy).toHaveBeenCalledWith(jasmine.any(String), 'foo', {
+      useLocationReplace: true,
+    });
+  });
+
+  it('changes hash with new pluginId on subsequent changes', () => {
+    store.overrideSelector(getActivePlugin, 'foo');
+    const fixture = TestBed.createComponent(HashStorageContainer);
+    fixture.detectChanges();
+    getStringSpy.and.returnValue('foo');
+
+    store.overrideSelector(getActivePlugin, 'bar');
+    store.refreshState();
+    fixture.detectChanges();
+
+    expect(setStringSpy).toHaveBeenCalledTimes(2);
+    expect(setStringSpy).toHaveBeenCalledWith(jasmine.any(String), 'bar', {});
+  });
+
+  it('dispatches plugin changed event when hash changes', () => {
+    store.overrideSelector(getActivePlugin, 'foo');
+    const fixture = TestBed.createComponent(HashStorageContainer);
+    fixture.detectChanges();
+    getStringSpy.and.returnValue('bar');
+
+    window.dispatchEvent(new Event('hashchange'));
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      pluginHashChanged({plugin: 'bar'})
+    );
+  });
+});

--- a/tensorboard/webapp/core/views/hash_storage_test.ts
+++ b/tensorboard/webapp/core/views/hash_storage_test.ts
@@ -20,7 +20,7 @@ import {CommonModule} from '@angular/common';
 
 import {getActivePlugin} from '../store';
 import {State} from '../store/core_types';
-import {pluginHashChanged} from '../actions';
+import {pluginUrlHashChanged} from '../actions';
 
 import {HashStorageContainer} from './hash_storage_container';
 import {HashStorageComponent} from './hash_storage_component';
@@ -97,7 +97,7 @@ describe('hash storage test', () => {
 
     window.dispatchEvent(new Event('hashchange'));
     expect(dispatchSpy).toHaveBeenCalledWith(
-      pluginHashChanged({plugin: 'bar'})
+      pluginUrlHashChanged({plugin: 'bar'})
     );
   });
 });

--- a/tensorboard/webapp/webapp_data_source/tb_server_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_server_data_source.ts
@@ -24,7 +24,6 @@ import {PluginsListing} from '../types/api';
 @Injectable()
 export class TBServerDataSource {
   // TODO(soergel): implements WebappDataSource
-  private tfStorage = document.createElement('tf-storage') as any;
   private tfBackend = (document.createElement('tf-backend') as any).tf_backend;
 
   constructor(private http: HttpClient) {}


### PR DESCRIPTION
This change emulates the behavior of tf_tensorboard where changing the plugin changes the hash in the URL. 

Ideally, tf_storage should break down into two pieces: utility for formatting data structure as string and one that actually writes data to a medium. In such world, the former can be used by hash_storage_component without depending on tf_storage. 