### PR TITLE
graphs: use non-null tag name for run graphs

### DIFF
--- a/tensorboard/backend/event_processing/data_provider.py
+++ b/tensorboard/backend/event_processing/data_provider.py
@@ -200,7 +200,7 @@ class MultiplexerDataProvider(provider.DataProvider):
 
         result = collections.defaultdict(lambda: {})
         for (run, run_info) in six.iteritems(self._multiplexer.Runs()):
-            tag = None
+            tag = graphs_metadata.RUN_GRAPH_NAME
             if not self._test_run_tag(run_tag_filter, run, tag):
                 continue
             if not run_info[plugin_event_accumulator.GRAPH]:
@@ -230,7 +230,7 @@ class MultiplexerDataProvider(provider.DataProvider):
             lambda: collections.defaultdict(lambda: [])
         )
         for (run, run_info) in six.iteritems(self._multiplexer.Runs()):
-            tag = None
+            tag = graphs_metadata.RUN_GRAPH_NAME
             if not self._test_run_tag(run_tag_filter, run, tag):
                 continue
             if not run_info[plugin_event_accumulator.GRAPH]:

--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -125,9 +125,11 @@ class GraphsPlugin(base_plugin.TBPlugin):
             )
             for (run_name, tag_to_time_series) in six.iteritems(mapping):
                 for tag in tag_to_time_series:
-                    (run_item, tag_item) = add_row_item(run_name, tag)
-                    run_item["run_graph"] = True
-                    if tag_item:
+                    if tag == metadata.RUN_GRAPH_NAME:
+                        (run_item, _) = add_row_item(run_name, None)
+                        run_item["run_graph"] = True
+                    else:
+                        (_, tag_item) = add_row_item(run_name, tag)
                         tag_item["op_graph"] = True
             return result
 
@@ -203,6 +205,8 @@ class GraphsPlugin(base_plugin.TBPlugin):
         """Result of the form `(body, mime_type)`, or `None` if no graph
         exists."""
         if self._data_provider:
+            if tag is None:
+                tag = metadata.RUN_GRAPH_NAME
             graph_blob_sequences = self._data_provider.read_blob_sequences(
                 experiment_id=experiment,
                 plugin_name=metadata.PLUGIN_NAME,

--- a/tensorboard/plugins/graph/metadata.py
+++ b/tensorboard/plugins/graph/metadata.py
@@ -24,3 +24,10 @@ from __future__ import print_function
 # graph Summaries.
 # See `graphs_plugin.py` for details.
 PLUGIN_NAME = "graphs"
+
+# In the context of the data provider interface, tag name given to a
+# graph that logically applies at the run level. No other types of
+# graphs are currently supported; when added, they'll have type-specific
+# name scopes (like `"__op_graph__/foo"`, `"__conceptual_graph__/bar"`)
+# to preclude collisions with this hard-coded string.
+RUN_GRAPH_NAME = "__run_graph__"

--- a/tensorboard/plugins/graph/metadata.py
+++ b/tensorboard/plugins/graph/metadata.py
@@ -26,8 +26,13 @@ from __future__ import print_function
 PLUGIN_NAME = "graphs"
 
 # In the context of the data provider interface, tag name given to a
-# graph that logically applies at the run level. No other types of
-# graphs are currently supported; when added, they'll have type-specific
-# name scopes (like `"__op_graph__/foo"`, `"__conceptual_graph__/bar"`)
-# to preclude collisions with this hard-coded string.
+# graph read from the `graph_def` field of an `Event` proto, which is
+# not attached to a summary and thus does not have a proper tag name of
+# its own. Run level graphs always represent `GraphDef`s (graphs of
+# TensorFlow ops), never conceptual graphs, profile graphs, etc.
+#
+# No other types of graphs are currently supported in the data provider
+# interface; when added, they'll have type-specific name scopes (like
+# `"__op_graph__/foo"`, `"__conceptual_graph__/bar"`) to preclude
+# collisions with this hard-coded string.
 RUN_GRAPH_NAME = "__run_graph__"


### PR DESCRIPTION
Summary:
In the context of the data provider interface, names of experiments,
runs, and tags are never null (`None`). But the ad hoc implementation of
the data provider interface for graph data did use `None` to denote
run-level graphs, and the graphs plugin correspondingly invoked it with
tag `None`. This commit changes both the provider and the plugin to use
a new hard-coded tag name internally (`__run_graph__`; arbitrary). There
are no frontend or HTTP API changes.

Test Plan:
Graphs still work both with and without `--generic_data true`. With
generic data enabled, only run-level graphs are shown in the dropdown
menu, as before.

wchargin-branch: graphs-run-graph-tag
