### PR TITLE
csp: allow font, style and script for Angular and Google Chart

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -200,6 +200,8 @@ def Respond(
             + [
                 "'self'" if _CSP_SCRIPT_SELF else "",
                 "'unsafe-eval'" if _CSP_SCRIPT_UNSAFE_EVAL else "",
+                # used by google-chart
+                "https://www.gstatic.com",
             ]
             + [
                 "'sha256-{}'".format(sha256)
@@ -212,7 +214,12 @@ def Respond(
             [
                 "default-src 'self'",
                 "font-src %s"
-                % _create_csp_string("'self'", *_CSP_FONT_DOMAINS_WHITELIST),
+                % _create_csp_string(
+                    "'self'",
+                    # used by Angular
+                    "https://fonts.gstatic.com",
+                    *_CSP_FONT_DOMAINS_WHITELIST
+                ),
                 "frame-ancestors *",
                 # Dynamic plugins are rendered inside an iframe.
                 "frame-src %s"
@@ -232,6 +239,8 @@ def Respond(
                     "'self'",
                     # used by google-chart
                     "https://www.gstatic.com",
+                    # used by Angular
+                    "https://fonts.googleapis.com",
                     "data:",
                     # inline styles: Polymer templates + d3 uses inline styles.
                     "'unsafe-inline'",

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -225,10 +225,11 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=["abcdefghi"]
         )
         expected_csp = (
-            "default-src 'self';font-src 'self';frame-ancestors *;"
-            "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
-            "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
-            "script-src 'self' 'unsafe-eval' 'sha256-abcdefghi'"
+            "default-src 'self';font-src 'self' https://fonts.gstatic.com;"
+            "frame-ancestors *;frame-src 'self';img-src 'self' data: blob:;"
+            "object-src 'none';style-src 'self' https://www.gstatic.com "
+            "https://fonts.googleapis.com data: 'unsafe-inline';"
+            "script-src 'self' 'unsafe-eval' https://www.gstatic.com 'sha256-abcdefghi'"
         )
         self.assertEqual(r.headers.get("Content-Security-Policy"), expected_csp)
 
@@ -239,10 +240,11 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=None
         )
         expected_csp = (
-            "default-src 'self';font-src 'self';frame-ancestors *;"
-            "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
-            "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
-            "script-src 'unsafe-eval'"
+            "default-src 'self';font-src 'self' https://fonts.gstatic.com;"
+            "frame-ancestors *;frame-src 'self';img-src 'self' data: blob:;"
+            "object-src 'none';style-src 'self' https://www.gstatic.com "
+            "https://fonts.googleapis.com data: 'unsafe-inline';"
+            "script-src 'unsafe-eval' https://www.gstatic.com"
         )
         self.assertEqual(r.headers.get("Content-Security-Policy"), expected_csp)
 
@@ -254,10 +256,11 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=None
         )
         expected_csp = (
-            "default-src 'self';font-src 'self';frame-ancestors *;"
-            "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
-            "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
-            "script-src 'none'"
+            "default-src 'self';font-src 'self' https://fonts.gstatic.com;"
+            "frame-ancestors *;frame-src 'self';img-src 'self' data: blob:;"
+            "object-src 'none';style-src 'self' https://www.gstatic.com "
+            "https://fonts.googleapis.com data: 'unsafe-inline';"
+            "script-src https://www.gstatic.com"
         )
         self.assertEqual(r.headers.get("Content-Security-Policy"), expected_csp)
 
@@ -269,10 +272,11 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=None
         )
         expected_csp = (
-            "default-src 'self';font-src 'self';frame-ancestors *;"
-            "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
-            "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
-            "script-src 'self'"
+            "default-src 'self';font-src 'self' https://fonts.gstatic.com;"
+            "frame-ancestors *;frame-src 'self';img-src 'self' data: blob:;"
+            "object-src 'none';style-src 'self' https://www.gstatic.com "
+            "https://fonts.googleapis.com data: 'unsafe-inline';"
+            "script-src 'self' https://www.gstatic.com"
         )
         self.assertEqual(r.headers.get("Content-Security-Policy"), expected_csp)
 
@@ -283,10 +287,11 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=["abcdefghi"]
         )
         expected_csp = (
-            "default-src 'self';font-src 'self';frame-ancestors *;"
-            "frame-src 'self';img-src 'self' data: blob:;object-src 'none';"
-            "style-src 'self' https://www.gstatic.com data: 'unsafe-inline';"
-            "script-src 'self' 'sha256-abcdefghi'"
+            "default-src 'self';font-src 'self' https://fonts.gstatic.com;"
+            "frame-ancestors *;frame-src 'self';img-src 'self' data: blob:;"
+            "object-src 'none';style-src 'self' https://www.gstatic.com "
+            "https://fonts.googleapis.com data: 'unsafe-inline';"
+            "script-src 'self' https://www.gstatic.com 'sha256-abcdefghi'"
         )
         self.assertEqual(r.headers.get("Content-Security-Policy"), expected_csp)
 
@@ -310,12 +315,13 @@ class RespondTest(tb_test.TestCase):
             q, "<b>hello</b>", "text/html", csp_scripts_sha256s=["abcd"]
         )
         expected_csp = (
-            "default-src 'self';font-src 'self';frame-ancestors *;"
-            "frame-src 'self' https://myframe.com;"
-            "img-src 'self' data: blob: https://example.com;"
-            "object-src 'none';style-src 'self' https://www.gstatic.com data: "
-            "'unsafe-inline' https://googol.com;script-src "
-            "https://tensorflow.org/tensorboard 'self' 'unsafe-eval' 'sha256-abcd'"
+            "default-src 'self';font-src 'self' https://fonts.gstatic.com;"
+            "frame-ancestors *;frame-src 'self' https://myframe.com;"
+            "img-src 'self' data: blob: https://example.com;object-src 'none';"
+            "style-src 'self' https://www.gstatic.com https://fonts.googleapis.com "
+            "data: 'unsafe-inline' https://googol.com;script-src "
+            "https://tensorflow.org/tensorboard 'self' 'unsafe-eval' "
+            "https://www.gstatic.com 'sha256-abcd'"
         )
         self.assertEqual(r.headers.get("Content-Security-Policy"), expected_csp)
 


### PR DESCRIPTION
* Motivation for features / changes
Profile plugin uses Angular and Google Chart. Angular and Google Chart need to load fonts, styles, and script form google servers. To use Angular and Google Chart, some URLs are added in CSP.

* Technical description of changes
Angular loads fonts from https://fonts.gstatic.com.
Angular loads styles from https://fonts.googleapis.com.
Google Chart loads script https://www.gstatic.com.
These URLs should be allowed in CSP.

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)
Run tensorboard with new Profile Plugin and check error message in Chrome developer console.

* Alternate designs / implementations considered
