### PR TITLE
Updates images_demo for TF v2 compatiblity.

### DIFF
--- a/tensorboard/plugins/image/images_demo.py
+++ b/tensorboard/plugins/image/images_demo.py
@@ -53,6 +53,7 @@ IMAGE_CREDIT = textwrap.dedent(
 (IMAGE_WIDTH, IMAGE_HEIGHT) = (640, 480)
 _IMAGE_DATA = None
 
+tf.compat.v1.disable_eager_execution()
 
 def image_data(verbose=False):
     """Get the raw encoded image data, downloading it if necessary."""
@@ -85,13 +86,13 @@ def convolve(image, pixel_filter, channels=3, name=None):
     Returns:
       A 3D `float32` `Tensor` of the same shape as the input.
     """
-    with tf.name_scope(name, "convolve"):
+    with tf.name_scope(name or "convolve"):
         tf.compat.v1.assert_type(image, tf.float32)
         channel_filter = tf.eye(channels)
         filter_ = tf.expand_dims(
             tf.expand_dims(pixel_filter, -1), -1
         ) * tf.expand_dims(tf.expand_dims(channel_filter, 0), 0)
-        result_batch = tf.nn.conv2d(
+        result_batch = tf.compat.v1.nn.conv2d(
             tf.stack([image]),  # batch
             filter=filter_,
             strides=[1, 1, 1, 1],
@@ -192,7 +193,7 @@ def run_box_to_gaussian(logdir, verbose=False):
 
     with tf.compat.v1.Session() as sess:
         sess.run(image.initializer)
-        writer = tf.summary.FileWriter(os.path.join(logdir, "box_to_gaussian"))
+        writer = tf.compat.v1.summary.FileWriter(os.path.join(logdir, "box_to_gaussian"))
         writer.add_graph(sess.graph)
         for step in xrange(8):
             if verbose:
@@ -282,7 +283,7 @@ def run_sobel(logdir, verbose=False):
 
     with tf.compat.v1.Session() as sess:
         sess.run(image.initializer)
-        writer = tf.summary.FileWriter(os.path.join(logdir, "sobel"))
+        writer = tf.compat.v1.summary.FileWriter(os.path.join(logdir, "sobel"))
         writer.add_graph(sess.graph)
         for step in xrange(8):
             if verbose:

--- a/tensorboard/plugins/image/images_demo.py
+++ b/tensorboard/plugins/image/images_demo.py
@@ -55,6 +55,7 @@ _IMAGE_DATA = None
 
 tf.disable_v2_behavior()
 
+
 def image_data(verbose=False):
     """Get the raw encoded image data, downloading it if necessary."""
     # This is a principled use of the `global` statement; don't lint me.
@@ -199,9 +200,7 @@ def run_box_to_gaussian(logdir, verbose=False):
             if verbose:
                 logger.info("--- box_to_gaussian: step: %s" % step)
                 feed_dict = {blur_radius: step}
-            run_options = tf.RunOptions(
-                trace_level=tf.RunOptions.FULL_TRACE
-            )
+            run_options = tf.RunOptions(trace_level=tf.RunOptions.FULL_TRACE)
             run_metadata = config_pb2.RunMetadata()
             s = sess.run(
                 summ,
@@ -289,9 +288,7 @@ def run_sobel(logdir, verbose=False):
             if verbose:
                 logger.info("--- sobel: step: %s" % step)
                 feed_dict = {kernel_radius: step}
-            run_options = tf.RunOptions(
-                trace_level=tf.RunOptions.FULL_TRACE
-            )
+            run_options = tf.RunOptions(trace_level=tf.RunOptions.FULL_TRACE)
             run_metadata = config_pb2.RunMetadata()
             s = sess.run(
                 summ,

--- a/tensorboard/plugins/image/images_demo.py
+++ b/tensorboard/plugins/image/images_demo.py
@@ -27,7 +27,7 @@ import textwrap
 from six.moves import urllib
 from six.moves import xrange  # pylint: disable=redefined-builtin
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from tensorboard.compat.proto import config_pb2
 from tensorboard.plugins.image import summary as image_summary
@@ -53,7 +53,7 @@ IMAGE_CREDIT = textwrap.dedent(
 (IMAGE_WIDTH, IMAGE_HEIGHT) = (640, 480)
 _IMAGE_DATA = None
 
-tf.compat.v1.disable_eager_execution()
+tf.disable_v2_behavior()
 
 def image_data(verbose=False):
     """Get the raw encoded image data, downloading it if necessary."""
@@ -86,13 +86,13 @@ def convolve(image, pixel_filter, channels=3, name=None):
     Returns:
       A 3D `float32` `Tensor` of the same shape as the input.
     """
-    with tf.name_scope(name or "convolve"):
-        tf.compat.v1.assert_type(image, tf.float32)
+    with tf.name_scope(name, "convolve"):
+        tf.assert_type(image, tf.float32)
         channel_filter = tf.eye(channels)
         filter_ = tf.expand_dims(
             tf.expand_dims(pixel_filter, -1), -1
         ) * tf.expand_dims(tf.expand_dims(channel_filter, 0), 0)
-        result_batch = tf.compat.v1.nn.conv2d(
+        result_batch = tf.nn.conv2d(
             tf.stack([image]),  # batch
             filter=filter_,
             strides=[1, 1, 1, 1],
@@ -127,11 +127,11 @@ def run_box_to_gaussian(logdir, verbose=False):
     if verbose:
         logger.info("--- Starting run: box_to_gaussian")
 
-    tf.compat.v1.reset_default_graph()
-    tf.compat.v1.set_random_seed(0)
+    tf.reset_default_graph()
+    tf.set_random_seed(0)
 
     image = get_image(verbose=verbose)
-    blur_radius = tf.compat.v1.placeholder(shape=(), dtype=tf.int32)
+    blur_radius = tf.placeholder(shape=(), dtype=tf.int32)
     with tf.name_scope("filter"):
         blur_side_length = blur_radius * 2 + 1
         pixel_filter = tf.ones((blur_side_length, blur_side_length))
@@ -191,16 +191,16 @@ def run_box_to_gaussian(logdir, verbose=False):
         ),
     )
 
-    with tf.compat.v1.Session() as sess:
+    with tf.Session() as sess:
         sess.run(image.initializer)
-        writer = tf.compat.v1.summary.FileWriter(os.path.join(logdir, "box_to_gaussian"))
+        writer = tf.summary.FileWriter(os.path.join(logdir, "box_to_gaussian"))
         writer.add_graph(sess.graph)
         for step in xrange(8):
             if verbose:
                 logger.info("--- box_to_gaussian: step: %s" % step)
                 feed_dict = {blur_radius: step}
-            run_options = tf.compat.v1.RunOptions(
-                trace_level=tf.compat.v1.RunOptions.FULL_TRACE
+            run_options = tf.RunOptions(
+                trace_level=tf.RunOptions.FULL_TRACE
             )
             run_metadata = config_pb2.RunMetadata()
             s = sess.run(
@@ -226,11 +226,11 @@ def run_sobel(logdir, verbose=False):
     if verbose:
         logger.info("--- Starting run: sobel")
 
-    tf.compat.v1.reset_default_graph()
-    tf.compat.v1.set_random_seed(0)
+    tf.reset_default_graph()
+    tf.set_random_seed(0)
 
     image = get_image(verbose=verbose)
-    kernel_radius = tf.compat.v1.placeholder(shape=(), dtype=tf.int32)
+    kernel_radius = tf.placeholder(shape=(), dtype=tf.int32)
 
     with tf.name_scope("horizontal_kernel"):
         kernel_side_length = kernel_radius * 2 + 1
@@ -281,16 +281,16 @@ def run_sobel(logdir, verbose=False):
         ),
     )
 
-    with tf.compat.v1.Session() as sess:
+    with tf.Session() as sess:
         sess.run(image.initializer)
-        writer = tf.compat.v1.summary.FileWriter(os.path.join(logdir, "sobel"))
+        writer = tf.summary.FileWriter(os.path.join(logdir, "sobel"))
         writer.add_graph(sess.graph)
         for step in xrange(8):
             if verbose:
                 logger.info("--- sobel: step: %s" % step)
                 feed_dict = {kernel_radius: step}
-            run_options = tf.compat.v1.RunOptions(
-                trace_level=tf.compat.v1.RunOptions.FULL_TRACE
+            run_options = tf.RunOptions(
+                trace_level=tf.RunOptions.FULL_TRACE
             )
             run_metadata = config_pb2.RunMetadata()
             s = sess.run(


### PR DESCRIPTION
* Motivation for features / changes
`bazel run tensorboard/plugins/image:images_demo` failed in TF v2+

* Technical description of changes
modifies calls locations where API changed between v1 + v2

* Detailed steps to verify changes work correctly (as executed by you)
```
bazel run tensorboard/plugins/image:images_demo
tensorboard --logdir /tmp/images_demo
```

* Alternate designs / implementations considered
May be nice to produce a new version without compat calls (that wouldn't work with tf v1)