### PR TITLE
ci: remove Python 2.7 from `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 language: python
 python:
   - "3.6"
-  - "2.7"
 
 branches:
   only:


### PR DESCRIPTION
Summary:
A new year, a new dawn. The <https://pythonclock.org/> has expired, and
TensorFlow has dropped Python 2 support:
<https://groups.google.com/a/tensorflow.org/d/msg/developers/ifEAGK3aPls/jlEuWYObBgAJ>

As noted in the above announcement, TensorFlow 2.1.0 will be released
with Python 2.7 support, but we’ve already released the corresponding
TensorBoard 2.1.0, so we no longer need to test with Python 2 at head.

Test Plan:
That CI passes quickly suffices.

wchargin-branch: travis-nopy2
