### PR TITLE
[migration] computed decorator should not be used on complex properties

### DIFF
--- a/tensorboard/tools/migration/src/helper.ts
+++ b/tensorboard/tools/migration/src/helper.ts
@@ -9,7 +9,7 @@ import {resolve, dirname, basename, parse, format} from 'path';
 const chalk = require('chalk');
 const mkdirp = require('mkdirp');
 
-export const TS_LICENSE = `/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+export const TS_LICENSE = `/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/tools/migration/src/polymerelementify.ts
+++ b/tensorboard/tools/migration/src/polymerelementify.ts
@@ -322,8 +322,15 @@ function getPropsAstNodes(props: ts.PropertyAssignment) {
           ? valueInitializer.initializer
           : undefined;
       }
+      const allowedPropertiesForComputedDecorator = new Set([
+        'computed',
+        'type',
+      ]);
       const canExtractComputed =
         propProperties &&
+        propProperties.every((prop: ts.PropertyAssignment) => {
+          return allowedPropertiesForComputedDecorator.has(propName(prop));
+        }) &&
         (propProperties.find((prop: ts.PropertyAssignment) => {
           return (
             propName(prop) === 'computed' &&


### PR DESCRIPTION
According to [polymer docs](https://github.com/Polymer/polymer-decorators#computedtargets-string), complex properties that require wildcards or special props like 'reflectToAttribute' cannot use the @computed decorator.