### PR TITLE
[migrate] preserve preamble in all transforms

### DIFF
--- a/tensorboard/tools/migration/src/helper.ts
+++ b/tensorboard/tools/migration/src/helper.ts
@@ -1,3 +1,4 @@
+import * as ts from 'typescript';
 import {
   readFileSync,
   writeFileSync,
@@ -24,6 +25,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 `;
+
+export function getPreamble(content: string) {
+  const range = ts.getLeadingCommentRanges(content, 0);
+  const preamble = range
+    ? range.map(({pos, end}) => content.slice(pos, end)).join('\n')
+    : TS_LICENSE;
+  return preamble + '\n';
+}
 
 function centerText(text: string, character = '=', fillAll = false): string {
   const prettyText = text.length ? ' ' + text + ' ' : '';

--- a/tensorboard/tools/migration/src/polymer-html.ts
+++ b/tensorboard/tools/migration/src/polymer-html.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 import * as path from 'path';
-import {Exporter, fs} from './helper';
+import {Exporter, fs, getPreamble} from './helper';
 import {Node} from './html-helper';
 import {updateSource} from './ts-helper';
 const parse5 = require('parse5');
@@ -117,5 +117,6 @@ export function transform(
     sourceFile.statements
   );
   sourceFile = updateSource(sourceFile, update);
-  exporter.writeFile(mainTsPath, sourceFile.getText());
+  const result = getPreamble(sourceContent) + sourceFile.getText();
+  exporter.writeFile(mainTsPath, result);
 }

--- a/tensorboard/tools/migration/src/polymerelementify.ts
+++ b/tensorboard/tools/migration/src/polymerelementify.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import {Exporter, TS_LICENSE} from './helper';
+import {Exporter, getPreamble} from './helper';
 import {updateSource} from './ts-helper';
 
 const Kind = ts.SyntaxKind;
@@ -683,10 +683,6 @@ export function transform(
   sourceContent: string,
   exporter: Exporter
 ) {
-  const range = ts.getLeadingCommentRanges(sourceContent, 0);
-  const preamble = range
-    ? range.map(({pos, end}) => sourceContent.slice(pos, end)).join('\n')
-    : TS_LICENSE;
   let sourceFile = ts.createSourceFile(
     fileName,
     sourceContent,
@@ -695,7 +691,6 @@ export function transform(
   );
   sourceFile = removeModuleWrappers(sourceFile);
   sourceFile = transformPolymer(sourceFile);
-  const result = `${preamble}
-${sourceFile.getText()}`;
+  const result = getPreamble(sourceContent) + sourceFile.getText();
   exporter.writeFile(fileName, result);
 }

--- a/tensorboard/tools/migration/src/script-extract.ts
+++ b/tensorboard/tools/migration/src/script-extract.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 import * as path from 'path';
-import {Exporter, TS_LICENSE} from './helper';
+import {Exporter, getPreamble} from './helper';
 import {Node, findScripts} from './html-helper';
 const parse5 = require('parse5');
 
@@ -60,6 +60,6 @@ export function transform(
   const newFilePath = path.join(path.dirname(fileName), newFileName);
   exporter.writeFile(
     newFilePath,
-    [TS_LICENSE, '\n', sourceFile.getText()].join('\n')
+    [getPreamble(content), '\n', sourceFile.getText()].join('\n')
   );
 }

--- a/tensorboard/tools/migration/src/transfer-import.ts
+++ b/tensorboard/tools/migration/src/transfer-import.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 import * as path from 'path';
-import {Exporter, fs, renameExt} from './helper';
+import {Exporter, fs, renameExt, getPreamble} from './helper';
 import {Node, findScripts} from './html-helper';
 import {updateSource} from './ts-helper';
 const parse5 = require('parse5');
@@ -49,7 +49,8 @@ export function transform(
           );
         }),
       ]);
-      exporter.writeFile(tsScriptPath, sourceFile.getText());
+      const result = getPreamble(sourceContent) + sourceFile.getText();
+      exporter.writeFile(tsScriptPath, result);
     });
 }
 


### PR DESCRIPTION
Tested manually on the plugins/audio/tf_audio_dashboard.

jsToTs only renames the file, so it isn't affected.