### PR TITLE
[docs] fix link to image in plugin docs

### DIFF
--- a/ADDING_A_PLUGIN.md
+++ b/ADDING_A_PLUGIN.md
@@ -8,7 +8,7 @@ To get started right away, you can clone one of these examples:
   - [Basic summary 'Greeter'](./tensorboard/examples/plugins/example_basic)
   - [Raw scalars](./tensorboard/examples/plugins/example_raw_scalars)
 
-![Basic example plugin screenshot](tensorboard/docs/images/example_basic.png "Basic example plugin")
+![Example screenshot](./docs/images/example_basic.png "Basic example plugin")
 
 [example-basic]: https://github.com/tensorflow/tensorboard/blob/master/tensorboard/examples/plugins/example_basic
 


### PR DESCRIPTION
* Motivation for features / changes
A recent change I made added an image to the [docs](https://github.com/tensorflow/tensorboard/blob/master/ADDING_A_PLUGIN.md) has a broken relative link.

* Technical description of changes
Fixes the relative path to be 'docs/...' instead of 'tensorboard/docs/...'

* Screenshots of UI changes
Checked using Github's edit/preview feature:
![image](https://user-images.githubusercontent.com/2322480/71702330-a0cd5b80-2d83-11ea-966e-19795593d646.png)
