### PR TITLE
Fix TensorFlow `Event` proto pollution in test

### DIFF
--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -76,6 +76,7 @@ class _EventGenerator(object):
         self.AddEvent(event)
 
     def AddEvent(self, event):
+        event = event_pb2.Event.FromString(event.SerializeToString())
         if self.zero_out_timestamps:
             event.wall_time = 0.0
         self.items.append(event)


### PR DESCRIPTION
Summary:
Tests for `plugin_event_accumulator` heavily mock out the internals of
that class to swap in a custom event source, but this source does not
follow the expected contract: it sometimes yields `tf.Event` protos
rather than the expected protos from `tensorboard.compat.proto`. This is
sometimes harmless, but can cause tests to falsely fail if the system
under test references properties that exist on the TensorBoard compat
protos but not the TensorFlow protos.

Test Plan:
After adding a safety check to `plugin_event_accumulator`—

```diff
diff --git a/tensorboard/backend/event_processing/plugin_event_accumulator.py b/tensorboard/backend/event_processing/plugin_event_accumulator.py
index 8a976fd8..2918de27 100644
--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -273,4 +273,7 @@ class EventAccumulator(object):
     def _ProcessEvent(self, event):
         """Called whenever an event is loaded."""
+        if not isinstance(event, event_pb2.Event):
+            raise TypeError(type(event))
+
         if self._first_event_timestamp is None:
             self._first_event_timestamp = event.wall_time
```

—all tests pass, whereas previously this test failed.

wchargin-branch: pea-test-tbevent
