### PR TITLE
ci: move linting to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,22 +24,15 @@ env:
   BUILDIFIER_SHA256SUM: '4c985c883eafdde9c0e8cf3c8595b8bfdf32e77571c369bf8ddae83b042028d6'
 
 jobs:
-  lint-flake8:
+  lint-python:
     runs-on: ubuntu-16.04
-    strategy:
-      fail-fast: false
-      matrix:
-        # flake8 should run on each Python version that we target,
-        # because the errors and warnings can differ due to language
-        # changes, and we want to catch them all.
-        python_version: ['3.6']
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: '3.6'
           architecture: 'x64'
-      - name: 'Install flake8'
+      - name: 'Install black and flake8'
         run: |
           python -m pip install -U pip
           pip install -r ./tensorboard/pip_package/requirements_dev.txt
@@ -48,8 +41,11 @@ jobs:
         # See: http://flake8.pycqa.org/en/3.7.8/user/error-codes.html
         # Use the comment '# noqa: <error code>' to suppress.
         run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - name: 'Lint Python code for style with Black'
+        # You can run `black .` to fix all Black complaints.
+        run: black --check .
 
-  lint-black-and-yaml:
+  lint-docs:
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v1
@@ -57,17 +53,15 @@ jobs:
         with:
           python-version: '3.6'
           architecture: 'x64'
-      - name: 'Install black and yamllint'
+      - name: 'Install yamllint'
         run: |
           python -m pip install -U pip
           pip install -r ./tensorboard/pip_package/requirements_dev.txt
       - run: pip freeze --all
-      - name: 'Lint Python code for style with Black'
-        # You can run `black .` to fix all Black complaints.
-        run: black --check .
       - name: 'Lint YAML for gotchas with yamllint'
         # Use '# yamllint disable-line rule:foo' to suppress.
         run: yamllint -c docs/.yamllint docs docs/.yamllint
+      - run: ./tensorboard/tools/docs_list_format_test.sh
 
   lint-frontend:
     runs-on: ubuntu-16.04
@@ -88,13 +82,12 @@ jobs:
           sudo mv ~/buildifier /usr/local/bin/buildifier
       - name: 'Lint BUILD files'
         run: git ls-files -z '*BUILD' | xargs -0 buildifier --mode=check
+      - run: ./tensorboard/tools/mirror_urls_test.sh
 
   check-misc:
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v1
       - run: ./tensorboard/tools/do_not_submit_test.sh
-      - run: ./tensorboard/tools/docs_list_format_test.sh
       - run: ./tensorboard/tools/license_test.sh
-      - run: ./tensorboard/tools/mirror_urls_test.sh
       - run: ./tensorboard/tools/whitespace_hygiene_test.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+# GitHub Actions CI definition for TensorBoard.
+#
+# YAML schema for GitHub Actions:
+# https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
+#
+# Helpful YAML parser to clarify YAML syntax:
+# https://yaml-online-parser.appspot.com/
+
+# For now, we only use GitHub Actions for lint checks, pending better
+# support for hermetic-style caching. See:
+# https://github.com/actions/cache/issues/109
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - '[0-9]+.*'
+      - 'ci-*'
+  pull_request: {}
+
+env:
+  BUILDIFIER: '0.29.0'
+  BUILDIFIER_SHA256SUM: '4c985c883eafdde9c0e8cf3c8595b8bfdf32e77571c369bf8ddae83b042028d6'
+
+jobs:
+  lint-flake8:
+    runs-on: ubuntu-16.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # flake8 should run on each Python version that we target,
+        # because the errors and warnings can differ due to language
+        # changes, and we want to catch them all.
+        python_version: ['3.6']
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python_version }}
+          architecture: 'x64'
+      - name: 'Install flake8'
+        run: |
+          python -m pip install -U pip
+          pip install -r ./tensorboard/pip_package/requirements_dev.txt
+      - run: pip freeze --all
+      - name: 'Lint Python code for errors with flake8'
+        # See: http://flake8.pycqa.org/en/3.7.8/user/error-codes.html
+        # Use the comment '# noqa: <error code>' to suppress.
+        run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+
+  lint-black-and-yaml:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+          architecture: 'x64'
+      - name: 'Install black and yamllint'
+        run: |
+          python -m pip install -U pip
+          pip install -r ./tensorboard/pip_package/requirements_dev.txt
+      - run: pip freeze --all
+      - name: 'Lint Python code for style with Black'
+        # You can run `black .` to fix all Black complaints.
+        run: black --check .
+      - name: 'Lint YAML for gotchas with yamllint'
+        # Use '# yamllint disable-line rule:foo' to suppress.
+        run: yamllint -c docs/.yamllint docs docs/.yamllint
+
+  lint-frontend:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+      - run: yarn install --ignore-engines
+        # You can run `yarn fix-lint` to fix all Prettier complaints.
+      - run: yarn lint
+
+  lint-build:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: 'Set up Buildifier'
+        run: |
+          ci/download_buildifier.sh "${BUILDIFIER}" "${BUILDIFIER_SHA256SUM}" ~/buildifier
+          sudo mv ~/buildifier /usr/local/bin/buildifier
+      - name: 'Lint BUILD files'
+        run: git ls-files -z '*BUILD' | xargs -0 buildifier --mode=check
+
+  check-misc:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v1
+      - run: ./tensorboard/tools/do_not_submit_test.sh
+      - run: ./tensorboard/tools/docs_list_format_test.sh
+      - run: ./tensorboard/tools/license_test.sh
+      - run: ./tensorboard/tools/mirror_urls_test.sh
+      - run: ./tensorboard/tools/whitespace_hygiene_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ env:
   global:
     - BAZEL=0.26.1
     - BAZEL_SHA256SUM=6c50e142a0a405d3d8598050d6c1b3920c8cdb82a7ffca6fc067cb474275148f
-    - BUILDIFIER=0.29.0
-    - BUILDIFIER_SHA256SUM=4c985c883eafdde9c0e8cf3c8595b8bfdf32e77571c369bf8ddae83b042028d6
   matrix:
     - TF_VERSION_ID=tensorflow==1.15.0rc3
     - TF_VERSION_ID=tf-nightly
@@ -42,8 +40,6 @@ before_install:
   - elapsed "before_install"
   - ci/download_bazel.sh "${BAZEL}" "${BAZEL_SHA256SUM}" ~/bazel
   - sudo mv ~/bazel /usr/local/bin/bazel
-  - ci/download_buildifier.sh "${BUILDIFIER}" "${BUILDIFIER_SHA256SUM}" ~/buildifier
-  - sudo mv ~/buildifier /usr/local/bin/buildifier
   - cp ci/bazelrc ~/.bazelrc
   - elapsed "before_install (done)"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,29 +72,8 @@ install:
   - elapsed "install (done)"
 
 before_script:
+  # Note: Lint checks happen on GitHub Actions; see .github/workflows/ci.yml.
   - elapsed "before_script"
-  # Do a fail-fast check for Python syntax errors or undefined names.
-  # See: http://flake8.pycqa.org/en/3.7.8/user/error-codes.html
-  # Use the comment '# noqa: <error code>' to suppress.
-  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-  # Lint frontend code
-  - yarn lint
-  # Lint backend code
-  - if [ -n "${PY3}" ]; then black --check .; fi
-  # Lint .yaml docs files. Use '# yamllint disable-line rule:foo' to suppress.
-  - yamllint -c docs/.yamllint docs docs/.yamllint
-  # Lint BUILD files
-  - git ls-files -z '*BUILD' | xargs -0 buildifier --mode=check
-  # Make sure that IPython notebooks have valid Markdown.
-  - tensorboard/tools/docs_list_format_test.sh
-  # Make sure we aren't accidentally including work-in-progress code.
-  - tensorboard/tools/do_not_submit_test.sh
-  # Make sure all necessary files have the license information.
-  - tensorboard/tools/license_test.sh
-  # Make sure that build URLs are valid.
-  - tensorboard/tools/mirror_urls_test.sh
-  # Make sure that files have no trailing whitespace.
-  - tensorboard/tools/whitespace_hygiene_test.py
   - |
     # Specify subset of tests to run depending on TF installation config.
     # We condition the value of --test_tag_filters so that we can run the

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "postinstall": "ngc -p angular-metadata.tsconfig.json",
     "build": "bazel build //...",
     "test": "ibazel test //...",
-    "lint": "prettier --check 'tensorboard/**/*.'{css,html,js,ts}",
-    "fix-lint": "prettier --write 'tensorboard/**/*.'{css,html,js,ts}"
+    "lint": "prettier --check 'tensorboard/**/*.'{css,html,js,ts} .github/**/*.yml",
+    "fix-lint": "prettier --write 'tensorboard/**/*.'{css,html,js,ts} .github/**/*.yml"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Summary:
GitHub Actions is a new first-party CI service offered by GitHub. It
requires no extra permissions. Its concurrency limits are appealing,
at 20 workflows per repo (1 workflow ≈ 1 commit) and concurrent jobs
ranging from 20 (free tier) to 180 (enterprise tier), with the option to
run on your own servers if this isn’t enough.

This commit adds a workflow definition to replace only the lint phase of
our Travis workflow, to take advantage of the improved latency: order of
seconds from pushing a commit to seeing actionable failure messages.
A full workflow for building and running tests is also possible, but is
too slow for comfort because it runs entirely without cache, pending
some proposed improvements to the caching support for GitHub Actions.

Test Plan:
Note that this commit triggers a GitHub Actions workflow that succeeds,
and that all Travis builds are a bit faster due to not running lint.

wchargin-branch: gh-actions-lint-only
