### PR TITLE
[DebuggerV2] Implement the backend execution/digests route

### DIFF
--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -26,8 +26,6 @@ from __future__ import print_function
 # the same logdir, replace this magic string with actual run names.
 DEFAULT_DEBUGGER_RUN_NAME = "__default_debugger_run__"
 
-_DEFAULT_PAGE_SIZE = 1000
-
 
 def _execution_digest_to_json(execution_digest):
     # TODO(cais): Use the .to_json() method when avaiable.
@@ -142,6 +140,8 @@ class DebuggerV2EventMultiplexer(object):
         runs = self.Runs()
         if run not in runs:
             return None
+        # TODO(cais): For scalability, use begin and end kwargs when available in
+        # `DebugDataReader.execution()`.`
         execution_digests = self._reader.executions(digest=True)
         if begin < 0:
             raise IndexError("Invalid begin index (%d)" % begin)

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -59,7 +59,7 @@ class DebuggerV2EventMultiplexer(object):
         self._logdir = logdir
         self._reader = None
 
-    def FirstEventTimestampAndTensorFlowVersion(self, run):
+    def FirstEventTimestamp(self, run):
         """Return the timestamp of the first DebugEvent of the given run.
 
         This may perform I/O if no events have been loaded yet for the run.
@@ -71,25 +71,17 @@ class DebuggerV2EventMultiplexer(object):
             run of a tfdbg2-instrumented TensorFlow program.)
 
         Returns:
-          A tuple with two items:
-            - The wall_time of the first event of the run, which will be in seconds
-              since the epoch as a `float`.
-            - TensorFlow version used by the debugged program.
+            The wall_time of the first event of the run, which will be in seconds
+            since the epoch as a `float`.
         """
+        if self._reader is None:
+            raise ValueError("No tfdbg2 runs exists.")
         if run != DEFAULT_DEBUGGER_RUN_NAME:
             raise ValueError(
                 "Expected run name to be %s, but got %s"
                 % (DEFAULT_DEBUGGER_RUN_NAME, run)
             )
-        from tensorflow.python.debug.lib import debug_events_reader
-
-        with debug_events_reader.DebugEventsReader(self._logdir) as reader:
-            metadata_iterator = reader.metadata_iterator()
-            debug_event, _ = next(metadata_iterator)
-            return (
-                debug_event.wall_time,
-                debug_event.debug_metadata.tensorflow_version,
-            )
+        return self._reader.starting_wall_time()
 
     def PluginRunToTagToContent(self, plugin_name):
         raise NotImplementedError(

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -155,40 +155,17 @@ class LocalDebuggerV2DataProvider(provider.DataProvider):
             raise ValueError(
                 "run_tag_filter.runs is expected to be specified, but is not."
             )
-        if len(run_tag_filter.runs) != 1:
-            raise ValueError(
-                "run_tag_filter.runs is expected to have length 1, "
-                "but instead has length %d" % len(run_tag_filter.tags)
-            )
-        if not run_tag_filter:
-            raise ValueError(
-                "run_tag_filter is expected to be specified, but is not."
-            )
-        if not run_tag_filter.tags:
-            raise ValueError(
-                "run_tag_filter.tags is expected to be specified, but is not."
-            )
-        if len(run_tag_filter.tags) != 1:
-            raise ValueError(
-                "run_tag_filter.tags is expected to have length 1, "
-                "but instead has length %d" % len(run_tag_filter.tags)
-            )
 
-        run = next(iter(run_tag_filter.runs))
-        tag = next(iter(run_tag_filter.tags))
-        # TODO(cais): Can we do a loop here instead and relax the len == 1
-        # requirement?
-
-        if run in self._multiplexer.Runs():
-            if tag.startswith(EXECUTION_DIGESTS_BLOB_TAG_PREFIX):
-                blob_ref = provider.BlobReference(blob_key="%s.%s" % (tag, run))
-                output = {run: {tag: [blob_ref]}}
-                return output
-
-            else:
-                raise ValueError("Unrecognized tag: %s" % tag)
-        else:
-            return {}
+        output = dict()
+        for run in run_tag_filter.runs:
+            if run in self._multiplexer.Runs():
+                output[run] = dict()
+            for tag in run_tag_filter.tags:
+                if tag.startswith(EXECUTION_DIGESTS_BLOB_TAG_PREFIX):
+                    output[run][tag] = [
+                        provider.BlobReference(blob_key="%s.%s" % (tag, run))
+                    ]
+        return output
 
     def read_blob(self, blob_key):
         if blob_key.startswith(EXECUTION_DIGESTS_BLOB_TAG_PREFIX):

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -174,4 +174,4 @@ class LocalDebuggerV2DataProvider(provider.DataProvider):
                 self._multiplexer.ExecutionDigests(run, begin, end)
             )
         else:
-            raise ValueError("Unrecognized blob_key: %s" % key)
+            raise ValueError("Unrecognized blob_key: %s" % blob_key)

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -64,7 +64,7 @@ def _parse_execution_digest_blob_key(blob_key):
 
     Returns:
       - run ID
-      - begin index 
+      - begin index
       - end index
     """
 

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -29,7 +29,7 @@ from tensorboard.backend import http_util
 class DebuggerV2Plugin(base_plugin.TBPlugin):
     """Debugger V2 Plugin for TensorBoard."""
 
-    plugin_name = "debugger-v2"
+    plugin_name = debug_data_provider.PLUGIN_NAME
 
     def __init__(self, context):
         """Instantiates Debugger V2 Plugin via TensorBoard core.
@@ -49,6 +49,7 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
         # TODO(cais): Add routes as they are implemented.
         return {
             "/runs": self.serve_runs,
+            "/execution/digests": self.serve_execution_digests,
         }
 
     def is_active(self):
@@ -61,8 +62,8 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
         Returns:
           `True` if and only if data in tfdbg v2's DebugEvent format is available.
         """
-        # TODO(cais): Implement logic.
-        return False
+        # TODO(cais): Add unit test. DO NOT SUBMIT.
+        return bool(self._data_provider.list_runs(""))
 
     def frontend_metadata(self):
         return base_plugin.FrontendMetadata(
@@ -73,6 +74,36 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
     def serve_runs(self, request):
         experiment = plugin_util.experiment_id(request.environ)
         runs = self._data_provider.list_runs(experiment)
-        return http_util.Respond(
-            request, [run.run_id for run in runs], "application/json"
+        run_listing = dict()
+        for run in runs:
+            run_listing[run.run_id] = {
+                "startTimeMs": run.start_time * 1e3,
+                "tensorFlowVersion": run.tensorflow_version,
+            }
+        return http_util.Respond(request, run_listing, "application/json")
+
+    @wrappers.Request.application
+    def serve_execution_digests(self, request):
+        experiment = plugin_util.experiment_id(request.environ)
+        run = request.args.get("run")
+        begin = int(request.args.get("begin", "0"))
+        end = int(request.args.get("end", "-1"))
+        run_tag_filter = debug_data_provider.execution_digest_run_tag_filter(
+            run, begin, end
         )
+        blob_sequences = self._data_provider.read_blob_sequences(
+            experiment, self.plugin_name, run_tag_filter=run_tag_filter
+        )
+        tag = next(iter(run_tag_filter.tags))
+        try:
+            return http_util.Respond(
+                request,
+                self._data_provider.read_blob(
+                    blob_sequences[run][tag][0].blob_key
+                ),
+                "application/json",
+            )
+        except (IndexError, ValueError) as e:
+            return http_util.Respond(
+                request, {"error": str(e)}, "application/json", code=400,
+            )

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -62,7 +62,6 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
         Returns:
           `True` if and only if data in tfdbg v2's DebugEvent format is available.
         """
-        # TODO(cais): Add unit test. DO NOT SUBMIT.
         return bool(self._data_provider.list_runs(""))
 
     def frontend_metadata(self):

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -75,16 +75,20 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
         runs = self._data_provider.list_runs(experiment)
         run_listing = dict()
         for run in runs:
-            run_listing[run.run_id] = {
-                "startTimeMs": run.start_time * 1e3,
-                "tensorFlowVersion": run.tensorflow_version,
-            }
+            run_listing[run.run_id] = {"start_time": run.start_time}
         return http_util.Respond(request, run_listing, "application/json")
 
     @wrappers.Request.application
     def serve_execution_digests(self, request):
         experiment = plugin_util.experiment_id(request.environ)
         run = request.args.get("run")
+        if run is None:
+            return http_util.Respond(
+                request,
+                {"error": "run parameter is not provided"},
+                "application/json",
+                code=400,
+            )
         begin = int(request.args.get("begin", "0"))
         end = int(request.args.get("end", "-1"))
         run_tag_filter = debug_data_provider.execution_digest_run_tag_filter(

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -248,7 +248,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         )
         self.assertEqual(
             json.loads(response.get_data()),
-            {"error": "Invalid begin index (-1)"}
+            {"error": "Invalid begin index (-1)"},
         )
 
         # begin = 2; end = 1

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -247,7 +247,8 @@ class DebuggerV2PluginTest(tf.test.TestCase):
             "application/json", response.headers.get("content-type")
         )
         self.assertEqual(
-            response.get_data(), {"error": "Invalid begin index (-1)"}
+            json.loads(response.get_data()),
+            {"error": "Invalid begin index (-1)"}
         )
 
         # begin = 2; end = 1

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -90,8 +90,20 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         wsgi_app = application.TensorBoardWSGI([self.plugin])
         self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
 
+    def _getExactlyOneRun(self):
+        """Assert there is exactly one DebuggerV2 run and get its ID."""
+        run_listing = json.loads(
+            self.server.get(_ROUTE_PREFIX + "/runs").get_data()
+        )
+        self.assertLen(run_listing, 1)
+        return list(run_listing.keys())[0]
+
     def testPluginIsNotActiveByDefault(self):
         self.assertFalse(self.plugin.is_active())
+
+    def testPluginIsActiveWithDataExists(self):
+        _generate_tfdbg_v2_data(self.logdir)
+        self.assertTrue(self.plugin.is_active())
 
     def testServeRunsWithoutExistingRuns(self):
         response = self.server.get(_ROUTE_PREFIX + "/runs")
@@ -99,7 +111,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEqual(
             "application/json", response.headers.get("content-type")
         )
-        self.assertEqual(json.loads(response.get_data()), [])
+        self.assertEqual(json.loads(response.get_data()), dict())
 
     def testServeRunsWithExistingRuns(self):
         _generate_tfdbg_v2_data(self.logdir)
@@ -108,8 +120,147 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEqual(
             "application/json", response.headers.get("content-type")
         )
+        data = json.loads(response.get_data())
+        self.assertEqual(list(data.keys()), ["__default_debugger_run__"])
+        run = data["__default_debugger_run__"]
+        self.assertIsInstance(run["startTimeMs"], float)
+        self.assertGreater(run["startTimeMs"], 0)
+        self.assertEqual(run["tensorFlowVersion"], tf.__version__)
+
+    def testServeExecutionDigestsWithEqualBeginAndEnd(self):
+        _generate_tfdbg_v2_data(self.logdir)
+        run = self._getExactlyOneRun()
+        response = self.server.get(
+            _ROUTE_PREFIX + "/execution/digests?run=%s&begin=0&end=0" % run
+        )
+        self.assertEqual(200, response.status_code)
         self.assertEqual(
-            json.loads(response.get_data()), ["__default_debugger_run__"]
+            "application/json", response.headers.get("content-type")
+        )
+        data = json.loads(response.get_data())
+        self.assertEqual(
+            data,
+            {"begin": 0, "end": 0, "num_digests": 3, "execution_digests": [],},
+        )
+
+    def testServeExecutionDigestsWithEndGreaterThanBeginFullRange(self):
+        _generate_tfdbg_v2_data(self.logdir)
+        run = self._getExactlyOneRun()
+        response = self.server.get(
+            _ROUTE_PREFIX + "/execution/digests?run=%s&begin=0&end=3" % run
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        data = json.loads(response.get_data())
+        self.assertEqual(data["begin"], 0)
+        self.assertEqual(data["end"], 3)
+        self.assertEqual(data["num_digests"], 3)
+        execution_digests = data["execution_digests"]
+        self.assertLen(execution_digests, 3)
+        prev_wall_time = 0
+        for execution_digest in execution_digests:
+            self.assertGreaterEqual(
+                execution_digest["wall_time"], prev_wall_time
+            )
+            prev_wall_time = execution_digest["wall_time"]
+            self.assertStartsWith(
+                execution_digest["op_type"], "__inference_my_function"
+            )
+
+    def testServeExecutionDigestsWithImplicitFullRange(self):
+        _generate_tfdbg_v2_data(self.logdir)
+        run = self._getExactlyOneRun()
+        response = self.server.get(
+            _ROUTE_PREFIX + "/execution/digests?run=%s&begin=0" % run
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        data = json.loads(response.get_data())
+        self.assertEqual(data["begin"], 0)
+        self.assertEqual(data["end"], 3)
+        self.assertEqual(data["num_digests"], 3)
+        execution_digests = data["execution_digests"]
+        self.assertLen(execution_digests, 3)
+        prev_wall_time = 0
+        for execution_digest in execution_digests:
+            self.assertGreaterEqual(
+                execution_digest["wall_time"], prev_wall_time
+            )
+            prev_wall_time = execution_digest["wall_time"]
+            self.assertStartsWith(
+                execution_digest["op_type"], "__inference_my_function"
+            )
+
+    def testServeExecutionDigestsWithEndGreaterThanBeginPartialRange(self):
+        _generate_tfdbg_v2_data(self.logdir)
+        run = self._getExactlyOneRun()
+        response = self.server.get(
+            _ROUTE_PREFIX + "/execution/digests?run=%s&begin=0&end=2" % run
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        data = json.loads(response.get_data())
+        self.assertEqual(data["begin"], 0)
+        self.assertEqual(data["end"], 2)
+        self.assertEqual(data["num_digests"], 3)
+        execution_digests = data["execution_digests"]
+        self.assertLen(execution_digests, 2)
+        prev_wall_time = 0
+        for execution_digest in execution_digests:
+            self.assertGreaterEqual(
+                execution_digest["wall_time"], prev_wall_time
+            )
+            prev_wall_time = execution_digest["wall_time"]
+            self.assertStartsWith(
+                execution_digest["op_type"], "__inference_my_function"
+            )
+
+    def testServeExecutionDigestOutOfBoundsError(self):
+        _generate_tfdbg_v2_data(self.logdir)
+        run = self._getExactlyOneRun()
+
+        # begin = 0; end = 4
+        response = self.server.get(
+            _ROUTE_PREFIX + "/execution/digests?run=%s&begin=0&end=4" % run
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        self.assertEqual(
+            json.loads(response.get_data())["error"],
+            "end index (4) out of bounds (3)",
+        )
+
+        # begin = -1; end = 2
+        response = self.server.get(
+            _ROUTE_PREFIX + "/execution/digests?run=%s&begin=-1&end=2" % run
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        self.assertEqual(
+            json.loads(response.get_data())["error"], "Invalid begin index (-1)"
+        )
+
+        # begin = 2; end = 1
+        response = self.server.get(
+            _ROUTE_PREFIX + "/execution/digests?run=%s&begin=2&end=1" % run
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        self.assertEqual(
+            json.loads(response.get_data())["error"],
+            "end index (1) is unexpected less than begin index (2)",
         )
 
 

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -234,8 +234,8 @@ class DebuggerV2PluginTest(tf.test.TestCase):
             "application/json", response.headers.get("content-type")
         )
         self.assertEqual(
-            json.loads(response.get_data())["error"],
-            "end index (4) out of bounds (3)",
+            json.loads(response.get_data()),
+            {"error": "end index (4) out of bounds (3)"},
         )
 
         # begin = -1; end = 2
@@ -247,7 +247,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
             "application/json", response.headers.get("content-type")
         )
         self.assertEqual(
-            json.loads(response.get_data())["error"], "Invalid begin index (-1)"
+            response.get_data(), {"error": "Invalid begin index (-1)"}
         )
 
         # begin = 2; end = 1
@@ -259,8 +259,8 @@ class DebuggerV2PluginTest(tf.test.TestCase):
             "application/json", response.headers.get("content-type")
         )
         self.assertEqual(
-            json.loads(response.get_data())["error"],
-            "end index (1) is unexpected less than begin index (2)",
+            json.loads(response.get_data()),
+            {"error": "end index (1) is unexpected less than begin index (2)"},
         )
 
 

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -123,9 +123,8 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         data = json.loads(response.get_data())
         self.assertEqual(list(data.keys()), ["__default_debugger_run__"])
         run = data["__default_debugger_run__"]
-        self.assertIsInstance(run["startTimeMs"], float)
-        self.assertGreater(run["startTimeMs"], 0)
-        self.assertEqual(run["tensorFlowVersion"], tf.__version__)
+        self.assertIsInstance(run["start_time"], float)
+        self.assertGreater(run["start_time"], 0)
 
     def testServeExecutionDigestsWithEqualBeginAndEnd(self):
         _generate_tfdbg_v2_data(self.logdir)
@@ -262,6 +261,21 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEqual(
             json.loads(response.get_data()),
             {"error": "end index (1) is unexpected less than begin index (2)"},
+        )
+
+    def testServeExecutionDigests400ResponseIfRunParamIsNotSpecified(self):
+        response = self.server.get(
+            # `run` parameter is not specified here.
+            _ROUTE_PREFIX
+            + "/execution/digests?begin=0&end=0"
+        )
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        self.assertEqual(
+            json.loads(response.get_data()),
+            {"error": "run parameter is not provided"},
         )
 
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container_test.ts
@@ -80,8 +80,7 @@ describe('Debugger Container test', () => {
         createDebuggerState({
           runs: {
             foo_run: {
-              startTimeMs: 111,
-              tensorFlowVersion: '2.1.0',
+              start_time: 111,
             },
           },
           runsLoaded: {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -66,8 +66,7 @@ describe('Debugger effects', () => {
     it('debugerLoaded action triggers run loading that succeeeds', () => {
       const runListingForTest: DebuggerRunListing = {
         foo_run: {
-          tensorFlowVersion: '2.2.0',
-          startTimeMs: 1337,
+          start_time: 1337,
         },
       };
       const fetchRuns = spyOn(

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
@@ -43,8 +43,7 @@ describe('Debugger reducers', () => {
         actions.debuggerRunsLoaded({
           runs: {
             foo_debugger_run: {
-              startTimeMs: 111,
-              tensorFlowVersion: '2.1.0',
+              start_time: 111,
             },
           },
         })
@@ -55,8 +54,7 @@ describe('Debugger reducers', () => {
       );
       expect(nextState.runs).toEqual({
         foo_debugger_run: {
-          startTimeMs: 111,
-          tensorFlowVersion: '2.1.0',
+          start_time: 111,
         },
       });
     });
@@ -65,8 +63,7 @@ describe('Debugger reducers', () => {
       const state = createDebuggerState({
         runs: {
           foo_debugger_run: {
-            startTimeMs: 111,
-            tensorFlowVersion: '2.2.0',
+            start_time: 111,
           },
         },
         runsLoaded: {
@@ -80,8 +77,7 @@ describe('Debugger reducers', () => {
         actions.debuggerRunsLoaded({
           runs: {
             bar_debugger_run: {
-              startTimeMs: 222,
-              tensorFlowVersion: '2.3.0',
+              start_time: 222,
             },
           },
         })
@@ -92,8 +88,7 @@ describe('Debugger reducers', () => {
       );
       expect(nextState.runs).toEqual({
         bar_debugger_run: {
-          startTimeMs: 222,
-          tensorFlowVersion: '2.3.0',
+          start_time: 222,
         },
       });
     });

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -20,11 +20,8 @@ export {DataLoadState, LoadState} from '../../../../webapp/types/data';
 export const DEBUGGER_FEATURE_KEY = 'debugger';
 
 export interface DebuggerRunMetadata {
-  // Time at which the debugger run started. Milliseconds since the epoch.
-  startTimeMs: number;
-
-  // TensorFlow Version string.
-  tensorFlowVersion: string;
+  // Time at which the debugger run started. Seconds since the epoch.
+  start_time: number;
 }
 
 export interface DebuggerRunListing {


### PR DESCRIPTION
* Technical description of changes
  * Add `serve_execution_digests()` application route to DebuggerV2Plugin. It serves the HTTP requests to `/execution/digests`.
  * The logic of this new method is implemented using the `read_blob_sequences()` and `read_blob()`  methods of the `LocalDebuggerV2DataProvider`. As designed, the tags carry semantics specific to this route, as will be the case for other routes.
  * Note that there is some slight revision of the original design: we no longer surface the idea of "books" and "pages" in the DataProvider API. These are internal implementation details of data backend that should be hidden at this API level for simplicity.
  * `DebuggerV2EventMultiplexer` now has a new method `ExecutionDigests` to fulfill the data requests.

Also in this PR:
* The `/runs` route now response with a JSON object instead of an JSON array, with `startTimeMs` and `tensorFlowVersion` information. This matches the FE type specs.
* Flesh out the `DebuggerV2Plugin.is_active()` method.
  