### PR TITLE
[backend] Split IsTensorFlowEventsFile into two separate functions

### DIFF
--- a/tensorboard/backend/event_processing/event_accumulator.py
+++ b/tensorboard/backend/event_processing/event_accumulator.py
@@ -820,13 +820,13 @@ def _GeneratorFromPath(path):
     """Create an event generator for file or directory at given path string."""
     if not path:
         raise ValueError("path must be a valid string")
-    if io_wrapper.IsTensorFlowEventsFile(path):
+    if io_wrapper.IsSummaryEventsFile(path):
         return event_file_loader.EventFileLoader(path)
     else:
         return directory_watcher.DirectoryWatcher(
             path,
             event_file_loader.EventFileLoader,
-            io_wrapper.IsTensorFlowEventsFile,
+            io_wrapper.IsSummaryEventsFile,
         )
 
 

--- a/tensorboard/backend/event_processing/io_wrapper.py
+++ b/tensorboard/backend/event_processing/io_wrapper.py
@@ -54,7 +54,10 @@ def IsTensorFlowEventsFile(path):
       ValueError: If the path is an empty string.
 
     Returns:
-      If path is formatted like a TensorFlowEventsFile.
+      If path is formatted like a TensorFlowEventsFile. Dummy files such as
+        those created with the '.profile-empty' suffixes and meant to hold
+        on `Summary` protos are treated as true TensorFlowEventsFiles. For
+        background, see: https://github.com/tensorflow/tensorboard/issues/2084.
     """
     if not path:
         raise ValueError("Path must be a nonempty string")
@@ -62,7 +65,18 @@ def IsTensorFlowEventsFile(path):
 
 
 def IsSummaryEventsFile(path):
-    """TODO(cais): Doc string."""
+    """Check whether the path is probably a TF Events file containing Summary.
+
+    Args:
+      path: A file path to check if it is an event file containing `Summary`
+        protos.
+
+    Returns:
+      If path is formatted like a TensorFlowEventsFile. Dummy files such as
+        those created with the '.profile-empty' suffixes and meant to hold
+        no `Summary` protos  are treated as `False`. For background, see:
+        https://github.com/tensorflow/tensorboard/issues/2084.
+    """
     return IsTensorFlowEventsFile(path) and not path.endswith(".profile-empty")
 
 

--- a/tensorboard/backend/event_processing/io_wrapper.py
+++ b/tensorboard/backend/event_processing/io_wrapper.py
@@ -61,6 +61,11 @@ def IsTensorFlowEventsFile(path):
     return "tfevents" in tf.compat.as_str_any(os.path.basename(path))
 
 
+def IsSummaryEventsFile(path):
+    """TODO(cais): Doc string."""
+    return IsTensorFlowEventsFile(path) and not path.endswith(".profile-empty")
+
+
 def ListDirectoryAbsolute(directory):
     """Yields all files in the given directory.
 

--- a/tensorboard/backend/event_processing/io_wrapper.py
+++ b/tensorboard/backend/event_processing/io_wrapper.py
@@ -56,7 +56,7 @@ def IsTensorFlowEventsFile(path):
     Returns:
       If path is formatted like a TensorFlowEventsFile. Dummy files such as
         those created with the '.profile-empty' suffixes and meant to hold
-        on `Summary` protos are treated as true TensorFlowEventsFiles. For
+        no `Summary` protos are treated as true TensorFlowEventsFiles. For
         background, see: https://github.com/tensorflow/tensorboard/issues/2084.
     """
     if not path:

--- a/tensorboard/backend/event_processing/io_wrapper_test.py
+++ b/tensorboard/backend/event_processing/io_wrapper_test.py
@@ -58,16 +58,28 @@ class IoWrapperTest(tf.test.TestCase):
         self.assertEqual(io_wrapper.PathSeparator("/cns/tmp/foo"), "/")
         self.assertEqual(io_wrapper.PathSeparator("gs://foo"), "/")
 
-    def testIsIsTensorFlowEventsFileTrue(self):
+    def testIsTensorFlowEventsFileTrue(self):
         self.assertTrue(
             io_wrapper.IsTensorFlowEventsFile(
                 "/logdir/events.out.tfevents.1473720042.com"
             )
         )
 
-    def testIsIsTensorFlowEventsFileFalse(self):
+    def testIsSummaryEventsFileTrue(self):
+        self.assertTrue(
+            io_wrapper.IsSummaryEventsFile(
+                "/logdir/events.out.tfevents.1473720042.com"
+            )
+        )
+
+    def testIsTensorFlowEventsFileFalse(self):
         self.assertFalse(
             io_wrapper.IsTensorFlowEventsFile("/logdir/model.ckpt")
+        )
+
+    def testIsSummaryEventsFileFalse(self):
+        self.assertFalse(
+            io_wrapper.IsSummaryEventsFile("/logdir/model.ckpt")
         )
 
     def testIsIsTensorFlowEventsFileWithEmptyInput(self):
@@ -75,6 +87,19 @@ class IoWrapperTest(tf.test.TestCase):
             self, ValueError, r"Path must be a nonempty string"
         ):
             io_wrapper.IsTensorFlowEventsFile("")
+
+    def testIsTensorFlowEventsFilesReturnsTrueForProfileEmptyEventsFiles(self):
+        self.assertTrue(
+            io_wrapper.IsTensorFlowEventsFile(
+                "/logdir/events.out.tfevents.1473720042.alice.profile-empty")
+        )
+
+
+    def testIsSummaryEventsFilesReturnsFalseForProfileEmptyEventsFiles(self):
+        self.assertFalse(
+            io_wrapper.IsSummaryEventsFile(
+                "/logdir/events.out.tfevents.1473720042.alice.profile-empty")
+        )
 
     def testListDirectoryAbsolute(self):
         temp_dir = tempfile.mkdtemp(prefix=self.get_temp_dir())

--- a/tensorboard/backend/event_processing/io_wrapper_test.py
+++ b/tensorboard/backend/event_processing/io_wrapper_test.py
@@ -78,9 +78,7 @@ class IoWrapperTest(tf.test.TestCase):
         )
 
     def testIsSummaryEventsFileFalse(self):
-        self.assertFalse(
-            io_wrapper.IsSummaryEventsFile("/logdir/model.ckpt")
-        )
+        self.assertFalse(io_wrapper.IsSummaryEventsFile("/logdir/model.ckpt"))
 
     def testIsIsTensorFlowEventsFileWithEmptyInput(self):
         with six.assertRaisesRegex(
@@ -91,14 +89,15 @@ class IoWrapperTest(tf.test.TestCase):
     def testIsTensorFlowEventsFilesReturnsTrueForProfileEmptyEventsFiles(self):
         self.assertTrue(
             io_wrapper.IsTensorFlowEventsFile(
-                "/logdir/events.out.tfevents.1473720042.alice.profile-empty")
+                "/logdir/events.out.tfevents.1473720042.alice.profile-empty"
+            )
         )
-
 
     def testIsSummaryEventsFilesReturnsFalseForProfileEmptyEventsFiles(self):
         self.assertFalse(
             io_wrapper.IsSummaryEventsFile(
-                "/logdir/events.out.tfevents.1473720042.alice.profile-empty")
+                "/logdir/events.out.tfevents.1473720042.alice.profile-empty"
+            )
         )
 
     def testListDirectoryAbsolute(self):

--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -624,13 +624,13 @@ def _GeneratorFromPath(path, event_file_active_filter=None):
     """Create an event generator for file or directory at given path string."""
     if not path:
         raise ValueError("path must be a valid string")
-    if io_wrapper.IsTensorFlowEventsFile(path):
+    if io_wrapper.IsSummaryEventsFile(path):
         return event_file_loader.EventFileLoader(path)
     elif event_file_active_filter:
         return directory_loader.DirectoryLoader(
             path,
             event_file_loader.TimestampedEventFileLoader,
-            path_filter=io_wrapper.IsTensorFlowEventsFile,
+            path_filter=io_wrapper.IsSummaryEventsFile,
             active_filter=event_file_active_filter,
         )
     else:

--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -637,7 +637,7 @@ def _GeneratorFromPath(path, event_file_active_filter=None):
         return directory_watcher.DirectoryWatcher(
             path,
             event_file_loader.EventFileLoader,
-            io_wrapper.IsTensorFlowEventsFile,
+            io_wrapper.IsSummaryEventsFile,
         )
 
 


### PR DESCRIPTION
* Motivation for features / changes
  * Fix https://github.com/tensorflow/tensorboard/issues/2084
  * The approach is suggested by @wchargin and @nfelt in https://github.com/tensorflow/tensorboard/issues/2084#issuecomment-570685175

* Technical description of changes
  * Split the logic of `IsTensorFlowEventsFile()` into two separate functions
    1. An unchanged `IsTensorFlowEventsFile()` function, which only checks the existence of the 'tfevents' substring in the path string.
    2. A new `IsSummaryEventsFile()` function, which returns `True` if and only if  `IsTensorFlowEventsFile()` returns `True` for the input path name *and* the path name does not end in the special suffix `.profile-empty`.
  * This prevents the `EventAccumulator` implementation from picking up the empty events.tfevents.*.profile-empty files, which under the single-event file mode, causes TensorBoard backend to stop reading the latest summaries in the other (i.e., main, non-profiler-generated) events.* file. The *.profile-empty file was designed to make the TensorBoard backend recognize the subfolder created by the Profile plugin as a valid sub logdir, event when it contains no other events files.

* Detailed steps to verify changes work correctly (as executed by you)
  * Added new unit tests
  * Manually verified that #2084 is resolved by running `bazel run -c opt tensorboard -- --logdir /path/to/logdir` using the reproduction code in #2084. 
    * Screenshot: 
![image](https://user-images.githubusercontent.com/16824702/71785529-9e127680-2fce-11ea-98e0-b2efecd99880.png)
