### PR TITLE
[WIP] Ad-hoc run color changing

### DIFF
--- a/tensorboard/components/tf_color_scale/colorScale.ts
+++ b/tensorboard/components/tf_color_scale/colorScale.ts
@@ -55,6 +55,15 @@ namespace tf_color_scale {
       }
       return this.identifiers.get(s) as string;
     }
+
+    public reassignColors(): this {
+      const old_identifiers = this.identifiers;
+      this.identifiers = d3.map();
+      old_identifiers.each((s, i) => {
+        this.identifiers.set(i, this.palette[Math.floor(Math.random() * this.palette.length)]);
+      });
+      return this;
+    }
   }
 
   /**
@@ -64,22 +73,22 @@ namespace tf_color_scale {
   function createAutoUpdateColorScale(
     store: tf_backend.BaseStore,
     getDomain: () => string[]
-  ): (runName: string) => string {
+  ): [(runName: string) => string, () => ({})] {
     const colorScale = new ColorScale();
     function updateRunsColorScale(): void {
       colorScale.setDomain(getDomain());
     }
     store.addListener(updateRunsColorScale);
     updateRunsColorScale();
-    return (domain) => colorScale.getColor(domain);
+    return [(domain) => colorScale.getColor(domain), () => colorScale.reassignColors()];
   }
 
-  export const runsColorScale = createAutoUpdateColorScale(
+  export const [runsColorScale, runsColorReassign] = createAutoUpdateColorScale(
     tf_backend.runsStore,
     () => tf_backend.runsStore.getRuns()
   );
 
-  export const experimentsColorScale = createAutoUpdateColorScale(
+  export const [experimentsColorScale, experimentsColorReassign] = createAutoUpdateColorScale(
     tf_backend.experimentsStore,
     () => {
       return tf_backend.experimentsStore.getExperiments().map(({name}) => name);

--- a/tensorboard/components/tf_color_scale/colorScale.ts
+++ b/tensorboard/components/tf_color_scale/colorScale.ts
@@ -89,11 +89,9 @@ namespace tf_color_scale {
     ];
   }
 
-  export const [
-    runsColorScale,
-    runsColorReassign,
-  ] = createAutoUpdateColorScale(tf_backend.runsStore, () =>
-    tf_backend.runsStore.getRuns()
+  export const [runsColorScale, runsColorReassign] = createAutoUpdateColorScale(
+    tf_backend.runsStore,
+    () => tf_backend.runsStore.getRuns()
   );
 
   export const [

--- a/tensorboard/components/tf_color_scale/colorScale.ts
+++ b/tensorboard/components/tf_color_scale/colorScale.ts
@@ -60,7 +60,10 @@ namespace tf_color_scale {
       const old_identifiers = this.identifiers;
       this.identifiers = d3.map();
       old_identifiers.each((s, i) => {
-        this.identifiers.set(i, this.palette[Math.floor(Math.random() * this.palette.length)]);
+        this.identifiers.set(
+          i,
+          this.palette[Math.floor(Math.random() * this.palette.length)]
+        );
       });
       return this;
     }
@@ -73,25 +76,30 @@ namespace tf_color_scale {
   function createAutoUpdateColorScale(
     store: tf_backend.BaseStore,
     getDomain: () => string[]
-  ): [(runName: string) => string, () => ({})] {
+  ): [(runName: string) => string, () => {}] {
     const colorScale = new ColorScale();
     function updateRunsColorScale(): void {
       colorScale.setDomain(getDomain());
     }
     store.addListener(updateRunsColorScale);
     updateRunsColorScale();
-    return [(domain) => colorScale.getColor(domain), () => colorScale.reassignColors()];
+    return [
+      (domain) => colorScale.getColor(domain),
+      () => colorScale.reassignColors(),
+    ];
   }
 
-  export const [runsColorScale, runsColorReassign] = createAutoUpdateColorScale(
-    tf_backend.runsStore,
-    () => tf_backend.runsStore.getRuns()
+  export const [
+    runsColorScale,
+    runsColorReassign,
+  ] = createAutoUpdateColorScale(tf_backend.runsStore, () =>
+    tf_backend.runsStore.getRuns()
   );
 
-  export const [experimentsColorScale, experimentsColorReassign] = createAutoUpdateColorScale(
-    tf_backend.experimentsStore,
-    () => {
-      return tf_backend.experimentsStore.getExperiments().map(({name}) => name);
-    }
-  );
+  export const [
+    experimentsColorScale,
+    experimentsColorReassign,
+  ] = createAutoUpdateColorScale(tf_backend.experimentsStore, () => {
+    return tf_backend.experimentsStore.getExperiments().map(({name}) => name);
+  });
 } // tf_color_scale

--- a/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.ts
@@ -24,6 +24,7 @@ namespace tf_dashboard_common {
         type: Object,
         value: {
           getColor: () => '',
+          reassignColors: () => ({}),
         },
       },
       regex: {
@@ -176,6 +177,10 @@ namespace tf_dashboard_common {
         newSelectionState[n] = !anyToggledOn;
       });
       this.selectionState = newSelectionState;
+    },
+    reassignColors: function() {
+      this.coloring.reassignColors();
+      this.synchronizeColors();
     },
   });
 } // namespace tf_dashboard_common

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -53,6 +53,9 @@ Properties out:
     <paper-button class="x-button" id="toggle-all" on-tap="_toggleAll">
       Toggle All Runs
     </paper-button>
+    <paper-button class="x-button" id="reassign-colors" on-tap="_reassignColors">
+      Reassign Colors
+    </paper-button>
     <template is="dom-if" if="[[dataLocation]]">
       <div id="data-location">
         <tf-wbr-string value="[[_clippedDataLocation]]" /><!--
@@ -152,6 +155,7 @@ Properties out:
           type: Object,
           value: {
             getColor: tf_color_scale.runsColorScale,
+            reassignColors: tf_color_scale.runsColorReassign,
           },
         },
       },
@@ -175,6 +179,9 @@ Properties out:
       },
       _toggleAll: function() {
         this.$.multiCheckbox.toggleAll();
+      },
+      _reassignColors: function() {
+        this.$.multiCheckbox.reassignColors();
       },
       _getClippedDataLocation: function(dataLocation, dataLocationClipLength) {
         if (dataLocation === undefined) {

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -53,7 +53,11 @@ Properties out:
     <paper-button class="x-button" id="toggle-all" on-tap="_toggleAll">
       Toggle All Runs
     </paper-button>
-    <paper-button class="x-button" id="reassign-colors" on-tap="_reassignColors">
+    <paper-button
+      class="x-button"
+      id="reassign-colors"
+      on-tap="_reassignColors"
+    >
       Reassign Colors
     </paper-button>
     <template is="dom-if" if="[[dataLocation]]">


### PR DESCRIPTION
## Motivation for features / changes

This is a proof of concept/work in progress PR for the #893 feature request. Currently, this just adds a "Reassign Colors" button under the "Toggle All Runs" button, which selects the colours for the runs randomly from the current pallet (instead of sequentially, which is the current default).

## Images
<details>

Before clicking the "Reassign Colors" button:
![image](https://user-images.githubusercontent.com/3747318/71823845-45fc7280-30a9-11ea-83c8-fcc7bae477fe.png)

After:
![image](https://user-images.githubusercontent.com/3747318/71823971-81973c80-30a9-11ea-91a3-2c83e7bc1002.png)

</details>

## ToDo/Considerations

- This is a really bare-bones implementation, just to get things started and hopefully motivate other people to also contribute to this feature.
- The original feature request asked for a colour picker interface, which I might add later (I don't have a lot of free time, so any contributions/suggestions are welcome).
- There already exists a colour pallet system builtin into `colorScale`, so if a colour picker interface ever gets implemented, it would probably be pretty easy to also allow users to switch colour pallets.
- Currently, the color of the _plots_ gets updated on the next data reload and not immediately after pressing the "Reassign Colors" button. We should probably trigger an update in the `colorScale.reassignColors` function, but I didn't have time to figure out how to do that yet.
- It is completely untested apart from the "Scalars" tab, so there -may be- probably is some bugs.