### PR TITLE
Document offline policy and privacy guarantees

### DIFF
--- a/ADDING_A_PLUGIN.md
+++ b/ADDING_A_PLUGIN.md
@@ -162,6 +162,8 @@ Consistency in user interface and experience, we believe, is important for happy
 
 [dynamic-plugin-tracking-bug]: https://github.com/tensorflow/tensorboard/issues/2357
 
+We recommend that you vendor all resources required to use your plugin, including scripts, stylesheets, fonts, and images. All built-in TensorBoard plugins follow this policy (except for the profile plugin, which for legacy reasons depends on a CDN).
+
 
 ### Summaries: How the plugin gets data
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ You may also be interested in the hosted TensorBoard solution at
 share your ML experiments for free. For example, [this experiment][] shows a
 working example featuring the scalar dashboard.
 
-TensorBoard can run entirely offline on your local machine, in a corporate
-environment, or in a datacenter, without connecting to Google servers. There is
-one exception: the optional profile plugin, when active, connects to a
-Google-hosted CDN to load the Google Charts library. Your data is never shared
-with Google unless you explicitly upload it to [TensorBoard.dev][] for public
-viewing.
+TensorBoard is designed to run entirely offline, without requiring any access
+to the Internet. For instance, this may be on your local machine, behind a
+corporate firewall, or in a datacenter. Currently, there is one exception where
+TensorBoard does require Internet access: the optional profile plugin, when
+active, connects to a Google-hosted CDN to load the Google Charts library.
+
+Your data is only shared with Google if you explicitly upload it to
+TensorBoard.dev for public viewing.
 
 [TensorBoard: Getting Started]: https://www.tensorflow.org/tensorboard/get_started
 [TensorBoard.dev]: https://tensorboard.dev

--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ corporate firewall, or in a datacenter. Currently, there is one exception where
 TensorBoard does require Internet access: the optional profile plugin, when
 active, connects to a Google-hosted CDN to load the Google Charts library.
 
-Your data is only shared with Google if you explicitly upload it to
-TensorBoard.dev for public viewing.
-
 [TensorBoard: Getting Started]: https://www.tensorflow.org/tensorboard/get_started
 [TensorBoard.dev]: https://tensorboard.dev
 [This experiment]: https://tensorboard.dev/experiment/AdYd1TgeTlaLWXx6I8JUbA/#scalars

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ You may also be interested in the hosted TensorBoard solution at
 share your ML experiments for free. For example, [this experiment][] shows a
 working example featuring the scalar dashboard.
 
+TensorBoard can run entirely offline on your local machine, in a corporate
+environment, or in a datacenter, without connecting to Google servers. There is
+one exception: the optional profile plugin, when active, connects to a
+Google-hosted CDN to load the Google Charts library. Your data is never shared
+with Google unless you explicitly upload it to [TensorBoard.dev][] for public
+viewing.
+
 [TensorBoard: Getting Started]: https://www.tensorflow.org/tensorboard/get_started
 [TensorBoard.dev]: https://tensorboard.dev
 [This experiment]: https://tensorboard.dev/experiment/AdYd1TgeTlaLWXx6I8JUbA/#scalars


### PR DESCRIPTION
Summary:
TensorBoard goes to great efforts to work fully functionally offline,
vendoring fonts, scripts, and assets. We’ve promised this publicly in
some venues (e.g., [twice][1] in [this talk][2]), but it has never been
explicitly stated in our core documentation. This commit documents our
offline-first principles in our README and plugin development guide.

[1]: https://youtu.be/XcHWLsVmHvk?t=54
[2]: https://youtu.be/XcHWLsVmHvk?t=294

wchargin-branch: offline-privacy-guarantees
