### PR TITLE
[ng] add analytics on active dashboard changes

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -23,6 +23,7 @@ ng_module(
     ],
     deps = [
         ":config",
+        "//tensorboard/webapp/analytics",
         "//tensorboard/webapp/angular:expect_angular_material_icon",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "//tensorboard/webapp/core",
@@ -35,6 +36,16 @@ ng_module(
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/effects",
         "@npm//@ngrx/store",
+    ],
+)
+
+tf_ts_library(
+    name = "app_state",
+    srcs = [
+        "app_state.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/core/store",
     ],
 )
 
@@ -135,6 +146,7 @@ tensorboard_html_binary(
 tf_ng_web_test_suite(
     name = "karma_test",
     deps = [
+        "//tensorboard/webapp/analytics:test_lib",
         "//tensorboard/webapp/core/effects:core_effects_test_lib",
         "//tensorboard/webapp/core/store:core_store_test_lib",
         "//tensorboard/webapp/header:test_lib",

--- a/tensorboard/webapp/analytics/BUILD
+++ b/tensorboard/webapp/analytics/BUILD
@@ -1,0 +1,53 @@
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "analytics",
+    srcs = [
+        "analytics_module.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/analytics/effects",
+        "//tensorboard/webapp/core/actions",
+        "//tensorboard/webapp/core/store",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ts_library(
+    name = "logger",
+    srcs = [
+        "analytics_logger.ts",
+    ],
+    deps = [
+        "@npm//@angular/core",
+    ],
+)
+
+tf_ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = [
+        "analytics_test.ts",
+    ],
+    tsconfig = "//:tsconfig-test",
+    deps = [
+        ":analytics",
+        ":logger",
+        "//tensorboard/webapp/analytics/effects",
+        "//tensorboard/webapp/core",
+        "//tensorboard/webapp/core/actions",
+        "//tensorboard/webapp/core/store",
+        "//tensorboard/webapp/core/testing",
+        "//tensorboard/webapp/types",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+        "@npm//rxjs",
+    ],
+)

--- a/tensorboard/webapp/analytics/analytics_logger.ts
+++ b/tensorboard/webapp/analytics/analytics_logger.ts
@@ -1,0 +1,34 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Injectable} from '@angular/core';
+
+export abstract class AnalyticsLogger {
+  sendPageView(plugin: string) {}
+}
+
+// We fake the global 'ga' object, so the object is a noop. The
+// google.analytics typing gives the object a type of UniversalAnalytics.ga.
+// We do not track open source users.
+declare const ga: Function;
+
+@Injectable()
+export class GoogleAnalyticsLogger implements AnalyticsLogger {
+  sendPageView(plugin: string) {
+    let pathname = window.location.pathname;
+    pathname += pathname.endsWith('/') ? plugin : '/' + plugin;
+    ga('set', 'page', pathname);
+    ga('send', 'pageview');
+  }
+}

--- a/tensorboard/webapp/analytics/analytics_module.ts
+++ b/tensorboard/webapp/analytics/analytics_module.ts
@@ -1,0 +1,25 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {NgModule} from '@angular/core';
+import {EffectsModule} from '@ngrx/effects';
+
+import {AnalyticsEffects} from './effects';
+import {AnalyticsLogger, GoogleAnalyticsLogger} from './analytics_logger';
+
+@NgModule({
+  imports: [EffectsModule.forFeature([AnalyticsEffects])],
+  providers: [{provide: AnalyticsLogger, useClass: GoogleAnalyticsLogger}],
+})
+export class AnalyticsModule {}

--- a/tensorboard/webapp/analytics/analytics_test.ts
+++ b/tensorboard/webapp/analytics/analytics_test.ts
@@ -1,0 +1,97 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TestBed} from '@angular/core/testing';
+import {Store, Action, MemoizedSelector} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {provideMockActions} from '@ngrx/effects/testing';
+import {ReplaySubject} from 'rxjs';
+
+import {changePlugin} from '../core/actions';
+import {getActivePlugin} from '../core/store';
+import {State} from '../core/store';
+import {AnalyticsLogger} from './analytics_logger';
+import {AnalyticsEffects} from './effects';
+import {createState, createCoreState} from '../core/testing';
+
+describe('changing plugins', () => {
+  let logger: AnalyticsLogger;
+  let action: ReplaySubject<Action>;
+  let store: MockStore<State>;
+  let recordedActions: Action[];
+  let recordedAnalyticsEvents: string[];
+  let analyticsEffects: AnalyticsEffects;
+  let activePluginSelector: MemoizedSelector<State, string | null>;
+
+  class MockAnalyticsLogger extends AnalyticsLogger {
+    sendPageView(plugin: string) {
+      recordedAnalyticsEvents.push(`PageView: ${plugin}`);
+    }
+  }
+
+  function mockPluginChange(plugin: string) {
+    activePluginSelector.setResult(plugin);
+    store.refreshState();
+    action.next(changePlugin({plugin}));
+  }
+
+  beforeEach(async () => {
+    action = new ReplaySubject<Action>(1);
+
+    await TestBed.configureTestingModule({
+      providers: [
+        provideMockActions(action),
+        provideMockStore({initialState: createState(createCoreState())}),
+        AnalyticsEffects,
+        {provide: AnalyticsLogger, useClass: MockAnalyticsLogger},
+      ],
+    }).compileComponents();
+    store = TestBed.get(Store);
+    activePluginSelector = store.overrideSelector(getActivePlugin, null);
+
+    logger = TestBed.get(AnalyticsLogger);
+    analyticsEffects = TestBed.get(AnalyticsEffects);
+
+    recordedActions = [];
+    analyticsEffects.actions$.subscribe((action: Action) => {
+      recordedActions.push(action);
+    });
+
+    recordedAnalyticsEvents = [];
+    analyticsEffects.analytics$.subscribe();
+  });
+
+  it('fires upon changing active plugin', () => {
+    mockPluginChange('scalars');
+    mockPluginChange('debugger');
+    mockPluginChange('scalars');
+    mockPluginChange('images');
+
+    expect(recordedActions.length).toBe(4);
+    expect(recordedAnalyticsEvents).toEqual([
+      'PageView: scalars',
+      'PageView: debugger',
+      'PageView: scalars',
+      'PageView: images',
+    ]);
+  });
+
+  it('does not fire multiple times on the same plugin', () => {
+    mockPluginChange('scalars');
+    mockPluginChange('scalars');
+
+    expect(recordedActions.length).toBe(2);
+    expect(recordedAnalyticsEvents).toEqual(['PageView: scalars']);
+  });
+});

--- a/tensorboard/webapp/analytics/analytics_test.ts
+++ b/tensorboard/webapp/analytics/analytics_test.ts
@@ -25,7 +25,7 @@ import {AnalyticsLogger} from './analytics_logger';
 import {AnalyticsEffects} from './effects';
 import {createState, createCoreState} from '../core/testing';
 
-describe('changing plugins', () => {
+describe('analytics', () => {
   let logger: AnalyticsLogger;
   let action: ReplaySubject<Action>;
   let store: MockStore<State>;

--- a/tensorboard/webapp/analytics/effects/BUILD
+++ b/tensorboard/webapp/analytics/effects/BUILD
@@ -1,0 +1,21 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "effects",
+    srcs = [
+        "analytics_effects.ts",
+        "index.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp/analytics:logger",
+        "//tensorboard/webapp/core/actions",
+        "//tensorboard/webapp/core/store",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)

--- a/tensorboard/webapp/analytics/effects/analytics_effects.ts
+++ b/tensorboard/webapp/analytics/effects/analytics_effects.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Injectable} from '@angular/core';
-import {Store, createAction} from '@ngrx/store';
+import {Store} from '@ngrx/store';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
 import {
   tap,

--- a/tensorboard/webapp/analytics/effects/analytics_effects.ts
+++ b/tensorboard/webapp/analytics/effects/analytics_effects.ts
@@ -1,0 +1,63 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Injectable} from '@angular/core';
+import {Store, createAction} from '@ngrx/store';
+import {Actions, createEffect, ofType} from '@ngrx/effects';
+import {
+  tap,
+  withLatestFrom,
+  filter,
+  map,
+  distinctUntilChanged,
+} from 'rxjs/operators';
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+/** @typehack */ import * as _typeHackNgrxStore from '@ngrx/store/src/models';
+/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects/effects';
+
+import {State} from '../../app_state';
+import {changePlugin} from '../../core/actions';
+import {getActivePlugin} from '../../core/store';
+import {AnalyticsLogger} from '../analytics_logger';
+
+const analyticsFired = createAction('[Analytics] Event Fired');
+
+@Injectable()
+export class AnalyticsEffects {
+  // Export so that JSCompiler preserves this effect, and disable dispatch,
+  // since an output action is not needed.
+  /** @export */
+  readonly analytics$ = createEffect(() => {
+    return this.createPageViewObservable().pipe(map(() => analyticsFired()));
+  });
+
+  constructor(
+    public actions$: Actions,
+    private store: Store<State>,
+    private logger: AnalyticsLogger
+  ) {}
+
+  private createPageViewObservable() {
+    return this.actions$.pipe(
+      ofType(changePlugin),
+      withLatestFrom(this.store.select(getActivePlugin)),
+      filter(([action, pluginId]) => Boolean(pluginId)),
+      map(([action, pluginId]) => pluginId),
+      distinctUntilChanged(),
+      tap((pluginId) => {
+        this.logger.sendPageView(pluginId!);
+      })
+    );
+  }
+}

--- a/tensorboard/webapp/analytics/effects/analytics_effects.ts
+++ b/tensorboard/webapp/analytics/effects/analytics_effects.ts
@@ -22,30 +22,32 @@ import {
   map,
   distinctUntilChanged,
 } from 'rxjs/operators';
-/** @typehack */ import * as _typeHackRxjs from 'rxjs';
-/** @typehack */ import * as _typeHackNgrxStore from '@ngrx/store/src/models';
-/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects/effects';
 
 import {State} from '../../app_state';
 import {changePlugin} from '../../core/actions';
 import {getActivePlugin} from '../../core/store';
 import {AnalyticsLogger} from '../analytics_logger';
 
-const analyticsFired = createAction('[Analytics] Event Fired');
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+/** @typehack */ import * as _typeHackNgrxStore from '@ngrx/store/src/models';
+/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects/effects';
 
 @Injectable()
 export class AnalyticsEffects {
   // Export so that JSCompiler preserves this effect, and disable dispatch,
   // since an output action is not needed.
   /** @export */
-  readonly analytics$ = createEffect(() => {
-    return this.createPageViewObservable().pipe(map(() => analyticsFired()));
-  });
+  readonly analytics$ = createEffect(
+    () => {
+      return this.createPageViewObservable();
+    },
+    {dispatch: false}
+  );
 
   constructor(
-    public actions$: Actions,
-    private store: Store<State>,
-    private logger: AnalyticsLogger
+    public readonly actions$: Actions,
+    private readonly store: Store<State>,
+    private readonly logger: AnalyticsLogger
   ) {}
 
   private createPageViewObservable() {
@@ -53,10 +55,10 @@ export class AnalyticsEffects {
       ofType(changePlugin),
       withLatestFrom(this.store.select(getActivePlugin)),
       filter(([action, pluginId]) => Boolean(pluginId)),
-      map(([action, pluginId]) => pluginId),
+      map(([action, pluginId]) => pluginId!),
       distinctUntilChanged(),
       tap((pluginId) => {
-        this.logger.sendPageView(pluginId!);
+        this.logger.sendPageView(pluginId);
       })
     );
   }

--- a/tensorboard/webapp/analytics/effects/index.ts
+++ b/tensorboard/webapp/analytics/effects/index.ts
@@ -1,0 +1,15 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+export * from './analytics_effects';

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -18,6 +18,7 @@ import {NgModule} from '@angular/core';
 import {StoreModule} from '@ngrx/store';
 import {EffectsModule} from '@ngrx/effects';
 
+import {AnalyticsModule} from './analytics/analytics_module';
 import {AppContainer} from './app_container';
 import {CoreModule} from './core/core_module';
 import {PluginsModule} from './plugins/plugins_module';
@@ -31,6 +32,7 @@ import {MatIconModule} from './mat_icon_module';
 @NgModule({
   declarations: [AppContainer],
   imports: [
+    AnalyticsModule,
     BrowserModule,
     BrowserAnimationsModule,
     CoreModule,

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -18,7 +18,6 @@ import {NgModule} from '@angular/core';
 import {StoreModule} from '@ngrx/store';
 import {EffectsModule} from '@ngrx/effects';
 
-import {AnalyticsModule} from './analytics/analytics_module';
 import {AppContainer} from './app_container';
 import {CoreModule} from './core/core_module';
 import {PluginsModule} from './plugins/plugins_module';
@@ -32,7 +31,6 @@ import {MatIconModule} from './mat_icon_module';
 @NgModule({
   declarations: [AppContainer],
   imports: [
-    AnalyticsModule,
     BrowserModule,
     BrowserAnimationsModule,
     CoreModule,

--- a/tensorboard/webapp/app_state.ts
+++ b/tensorboard/webapp/app_state.ts
@@ -1,0 +1,17 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {State as CoreState} from './core/store';
+
+export type State = CoreState;


### PR DESCRIPTION
* Motivation for features / changes
Part of the effort to add existing functionality to the ng_index entry point.

* Technical description of changes
Upon selecting a different plugin's dashboard, a 'ga' function will fire a pageView event.  In OSS, this is a no-op.

* Detailed steps to verify changes work correctly (as executed by you)
Manually tested with a logpoint, and added a test.