### PR TITLE
When available, use inspect.getfullargspec instead of inspect.getargspec.

### DIFF
--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -60,10 +60,14 @@ class RawEventFileLoader(object):
         """
         logger.debug("Loading events from %s", self._file_path)
 
+        # getargspec is deprecated in Python3, use getfullargspec if it exists.
+        try:
+            getmaybefullargspec = inspect.getfullargspec
+        except AttributeError:
+            getmaybefullargspec = inspect.getargspec  # pylint: disable=deprecated-method
+
         # GetNext() expects a status argument on TF <= 1.7.
-        get_next_args = inspect.getargspec(
-            self._reader.GetNext
-        ).args  # pylint: disable=deprecated-method
+        get_next_args = getmaybefullargspec(self._reader.GetNext).args
         # First argument is self
         legacy_get_next = len(get_next_args) > 1
 

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -62,12 +62,12 @@ class RawEventFileLoader(object):
 
         # getargspec is deprecated in Python3, use getfullargspec if it exists.
         try:
-            getmaybefullargspec = inspect.getfullargspec
+            getargspec = inspect.getfullargspec
         except AttributeError:
-            getmaybefullargspec = inspect.getargspec  # pylint: disable=deprecated-method
+            getargspec = inspect.getargspec  # pylint: disable=deprecated-method
 
         # GetNext() expects a status argument on TF <= 1.7.
-        get_next_args = getmaybefullargspec(self._reader.GetNext).args
+        get_next_args = getargspec(self._reader.GetNext).args
         # First argument is self
         legacy_get_next = len(get_next_args) > 1
 


### PR DESCRIPTION
The former is only available in Python3, in which getargspec was
deprecated. 

* Motivation for features / changes
This allows to get rid of a deprecation warning when using Python3.

* Technical description of changes
Uses a Python3 drop-in replacement, when available.
Both return a namedtuple with an equivalent "args" attribute, so the
functionality is unchanged.

* Screenshots of UI changes
N/A

* Detailed steps to verify changes work correctly (as executed by you)
Ran event_file_loader_test, in Python2 and Python3.

* Alternate designs / implementations considered
