### PR TITLE
backend: fix locking for `_plugin_to_tag_to_content`

### DIFF
--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -156,6 +156,13 @@ class EventAccumulator(object):
         # first event encountered per tag, so we must store that first instance of
         # content for each tag.
         self._plugin_to_tag_to_content = collections.defaultdict(dict)
+        # Locks the dict `_plugin_to_tag_to_content` (but not its individual
+        # values), as well as the `_plugin_tag_locks` dict.
+        self._plugin_tag_metalock = threading.Lock()
+        # `_plugin_tag_locks[p]` locks the dict `_plugin_to_tag_to_content[p]`.
+        #
+        # Liveness condition: while `_plugin_tag_locks[p]` is held,
+        # `_plugin_tag_metalock` must not be waited-for.
         self._plugin_tag_locks = collections.defaultdict(threading.Lock)
 
         self.path = path
@@ -250,11 +257,26 @@ class EventAccumulator(object):
           A dict mapping tag names to bytestrings of plugin-specific content-- by
           convention, in the form of binary serialized protos.
         """
-        if plugin_name not in self._plugin_to_tag_to_content:
-            raise KeyError("Plugin %r could not be found." % plugin_name)
-        with self._plugin_tag_locks[plugin_name]:
-            # Return a snapshot to avoid concurrent mutation and iteration issues.
-            return dict(self._plugin_to_tag_to_content[plugin_name])
+        released_metalock = False
+        try:
+            # Acquire without context manager so that we can release early.
+            self._plugin_tag_metalock.acquire()
+            if plugin_name not in self._plugin_to_tag_to_content:
+                raise KeyError("Plugin %r could not be found." % plugin_name)
+            with self._plugin_tag_locks[plugin_name]:
+                tag_to_content = self._plugin_to_tag_to_content[plugin_name]
+                self._plugin_tag_metalock.release()
+                released_metalock = True
+                # Return a snapshot to avoid concurrent mutation and iteration issues.
+                return dict(tag_to_content)
+        finally:
+            if not released_metalock:
+                try:
+                    self._plugin_tag_metalock.release()
+                except RuntimeError:
+                    # Already released; we may have been interrupted
+                    # before setting `released_metalock`.
+                    pass
 
     def SummaryMetadata(self, tag):
         """Given a summary tag name, return the associated metadata object.
@@ -358,12 +380,13 @@ class EventAccumulator(object):
                         self.summary_metadata[tag] = value.metadata
                         plugin_data = value.metadata.plugin_data
                         if plugin_data.plugin_name:
-                            with self._plugin_tag_locks[
-                                plugin_data.plugin_name
-                            ]:
-                                self._plugin_to_tag_to_content[
+                            with self._plugin_tag_metalock:
+                                with self._plugin_tag_locks[
                                     plugin_data.plugin_name
-                                ][tag] = plugin_data.content
+                                ]:
+                                    self._plugin_to_tag_to_content[
+                                        plugin_data.plugin_name
+                                    ][tag] = plugin_data.content
                         else:
                             logger.warn(
                                 (


### PR DESCRIPTION
Summary:
The `plugin_event_accumulator` tries to maintain fine-grained locks for
each plugin, but didn’t properly lock its table of locks, and didn’t
lock around accesses to the table of plugins. This commit replaces the
fine-grained locking with a simple coarse-grained lock.

Because all `dict`s involved are keyed only on Python strings, for which
`__hash__`, `__eq__`, and `__del__` are implemented in C, this should be
a no-op in CPython implementations. But correct concurrency is
[explicitly part of Google style][style], and without this patch some
subsequent changes would need to make this problem worse, so we might as
well just fix it Once and For All.

[style]: https://google.github.io/styleguide/pyguide.html#218-threading

Test Plan:
The primary safety concern due to this change is potential for liveness
failure, but this change basically contracts a number of locks into one,
so any lock waiting cycle that exists now would also have existed
previously.

wchargin-branch: mux-lock-locks
