### PR TITLE
[DebuggerV2] Implement backend routes: source_files

### DIFF
--- a/tensorboard/plugins/debugger_v2/BUILD
+++ b/tensorboard/plugins/debugger_v2/BUILD
@@ -40,6 +40,18 @@ py_library(
 )
 
 py_test(
+    name = "debug_data_multiplexer_test",
+    size = "small",
+    srcs = ["debug_data_multiplexer_test.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":debug_data_multiplexer",
+        "//tensorboard:expect_tensorflow_installed",
+    ],
+)
+
+
+py_test(
     name = "debugger_v2_plugin_test",
     size = "medium",
     srcs = ["debugger_v2_plugin_test.py"],

--- a/tensorboard/plugins/debugger_v2/BUILD
+++ b/tensorboard/plugins/debugger_v2/BUILD
@@ -45,6 +45,7 @@ py_test(
     srcs = ["debugger_v2_plugin_test.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":debug_data_multiplexer",
         ":debugger_v2_plugin",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",

--- a/tensorboard/plugins/debugger_v2/BUILD
+++ b/tensorboard/plugins/debugger_v2/BUILD
@@ -50,7 +50,6 @@ py_test(
     ],
 )
 
-
 py_test(
     name = "debugger_v2_plugin_test",
     size = "medium",

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -18,6 +18,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import threading
+
+
 # Dummy run name for the debugger.
 # Currently, the `DebuggerV2ExperimentMultiplexer` class is tied to a single
 # logdir, which holds at most one DebugEvent file set in the tfdbg v2 (tfdbg2
@@ -36,6 +39,23 @@ def _execution_digest_to_json(execution_digest):
             execution_digest.output_tensor_device_ids
         ),
     }
+
+
+def run_in_background(target):
+    """Run a target task in the background.
+
+    In the context of this module, `target` is the `update()` method of the
+    underlying reader for tfdbg2-format data.
+    This method is mocked by unit tests for deterministic behaviors during
+    testing.
+
+    TODO(cais): Implement repetition with sleeping periods in between.
+
+    Args:
+      target: The target task to run in the background, a callable with no args.
+    """
+    thread = threading.Thread(target=target)
+    thread.start()
 
 
 class DebuggerV2EventMultiplexer(object):
@@ -112,7 +132,7 @@ class DebuggerV2EventMultiplexer(object):
                 self._reader = debug_events_reader.DebugDataReader(self._logdir)
                 # NOTE(cais): Currently each logdir is enforced to have only one
                 # DebugEvent file set. So we add hard-coded default run name.
-                self._reader.update()
+                run_in_background(self._reader.update)
                 # TODO(cais): Start off a reading thread here, instead of being
                 # called only once here.
             except ValueError as error:
@@ -175,6 +195,23 @@ class DebuggerV2EventMultiplexer(object):
         if run not in runs:
             return None
         # TODO(cais): Use public method `self._reader.source_files()` when available.
-        return list(
+        # pylint: disable=protected-access
+        return list(self._reader._host_name_file_path_to_offset.keys())
+        # pylint: enable=protected-access
+
+    def SourceLines(self, run, index):
+        runs = self.Runs()
+        if run not in runs:
+            return None
+        # TODO(cais): Use public method `self._reader.source_files()` when available.
+        # pylint: disable=protected-access
+        source_file_list = list(
             self._reader._host_name_file_path_to_offset.keys()
-        )  # pylint: disable=protected-access
+        )
+        # pylint: enable=protected-access
+        host_name, file_path = source_file_list[index]
+        return {
+            "host_name": host_name,
+            "file_path": file_path,
+            "lines": self._reader.source_lines(host_name, file_path),
+        }

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -129,6 +129,17 @@ class DebuggerV2EventMultiplexer(object):
         }
 
     def ExecutionDigests(self, run, begin, end):
+        """Get ExecutionDigests.
+
+        Args:
+          run: The tfdbg2 run to get `ExecutionDigest`s from.
+          begin: Beginning execution index.
+          end: Ending execution index.
+
+        Returns:
+          A JSON-serializable object containing the `ExecutionDigest`s and
+          related meta-information
+        """
         runs = self.Runs()
         if run not in runs:
             return None
@@ -158,3 +169,12 @@ class DebuggerV2EventMultiplexer(object):
                 for digest in execution_digests[begin:end]
             ],
         }
+
+    def SourceFileList(self, run):
+        runs = self.Runs()
+        if run not in runs:
+            return None
+        # TODO(cais): Use public method `self._reader.source_files()` when available.
+        return list(
+            self._reader._host_name_file_path_to_offset.keys()
+        )  # pylint: disable=protected-access

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -49,11 +49,12 @@ def run_in_background(target):
     This method is mocked by unit tests for deterministic behaviors during
     testing.
 
-    TODO(cais): Implement repetition with sleeping periods in between.
-
     Args:
       target: The target task to run in the background, a callable with no args.
     """
+    # TODO(cais): Implement repetition with sleeping periods in between.
+    # TODO(cais): Add more unit tests in debug_data_multiplexer_test.py when the
+    # the behavior gets more complex.
     thread = threading.Thread(target=target)
     thread.start()
 
@@ -209,7 +210,10 @@ class DebuggerV2EventMultiplexer(object):
             self._reader._host_name_file_path_to_offset.keys()
         )
         # pylint: enable=protected-access
-        host_name, file_path = source_file_list[index]
+        try:
+            host_name, file_path = source_file_list[index]
+        except IndexError:
+            raise IndexError("There is no source-code file at index %d" % index)
         return {
             "host_name": host_name,
             "file_path": file_path,

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer_test.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer_test.py
@@ -1,0 +1,45 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import threading
+
+import tensorflow as tf
+
+from tensorboard.plugins.debugger_v2 import debug_data_multiplexer
+
+
+class MockThread(object):
+    """A mock for threading.Thread for testing."""
+
+    def __init__(self, target):
+        self._target = target
+
+    def start(self):
+        self._target()
+
+
+class DebuggerV2PluginTest(tf.test.TestCase):
+    def testRunInBackground(self):
+        mock_target = tf.compat.v1.test.mock.Mock()
+        with tf.compat.v1.test.mock.patch("threading.Thread", MockThread):
+            debug_data_multiplexer.run_in_background(mock_target)
+            mock_target.assert_called_once()
+
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -86,8 +86,7 @@ def _parse_source_file_list_blob_key(blob_key):
     Returns:
       - run ID
     """
-    return blob_key[blob_key.index(".") + 1:]
-
+    return blob_key[blob_key.index(".") + 1 :]
 
 
 def source_file_list_run_tag_filter(run):

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -123,7 +123,7 @@ def _parse_source_file_blob_key(blob_key):
 
     Args:
       blob_key: The BLOB key to parse. By contract, it should have the format:
-       `${SOURCE_FILE_LIST_BLOB_TAG}_${index}.${run_id}`
+       `${SOURCE_FILE_BLOB_TAG_PREFIX}_${index}.${run_id}`
 
     Returns:
       - run ID, as a str.

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -153,27 +153,22 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
         """
         experiment = plugin_util.experiment_id(request.environ)
         run = request.args.get("run")
-
-        begin = request.args.get("index")
-        if begin is None:
+        if run is None:
+            return _missing_run_error_response(request)
+        index = request.args.get("index")
+        # TOOD(cais): When the need arises, support serving a subset of a
+        # source file's lines.
+        if index is None:
             return http_util.Respond(
                 request,
                 {"error": "index is not provided for source file content"},
                 "application/json",
                 code=400,
             )
-        begin = int(begin)
-        if begin < 0:
-            return http_util.Respond(
-                request,
-                {
-                    "error": "negative index for source file content (%d)"
-                    % begin
-                },
-                "application/json",
-                code=400,
-            )
-        run_tag_filter = debug_data_provider.source_file_run_tag_filter(run)
+        index = int(index)
+        run_tag_filter = debug_data_provider.source_file_run_tag_filter(
+            run, index
+        )
         blob_sequences = self._data_provider.read_blob_sequences(
             experiment, self.plugin_name, run_tag_filter=run_tag_filter
         )

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -141,9 +141,9 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
     def serve_source_file(self, request):
         """Serves the content of a given source file.
 
-        The source file is referred to by the index in the list of all source files
-        invovled in the execution of the debugged program, which is available via the
-        `serve_source_files_list()`  serving route.
+        The source file is referred to by the index in the list of all source
+        files involved in the execution of the debugged program, which is
+        available via the `serve_source_files_list()`  serving route.
 
         Args:
           request: HTTP request.

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -311,6 +311,5 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         )
 
 
-
 if __name__ == "__main__":
     tf.test.main()

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -334,7 +334,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         response = self.server.get(
             _ROUTE_PREFIX + "/source_files/file?run=%s&index=%d" % (run, index)
         )
-        self.assertEqual(200, response.status_code)  # TODO(cais): Restore.
+        self.assertEqual(200, response.status_code)
         self.assertEqual(
             "application/json", response.headers.get("content-type")
         )
@@ -375,7 +375,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
             _ROUTE_PREFIX
             + "/source_files/file?run=%s&index=%d" % (run, invalid_index)
         )
-        self.assertEqual(400, response.status_code)  # TODO(cais): Restore.
+        self.assertEqual(400, response.status_code)
         self.assertEqual(
             "application/json", response.headers.get("content-type")
         )


### PR DESCRIPTION
* Technical description of changes
  * Route source_files/list lists all files
  * Route source_files/source_file provides access to the content
    of a given source file.
  * In `debug_data_multiplexer`, now call `self._reader.update()` on a separate thread instead of on the main thread. This prevents blocking the TensorBoad backend for a long time when the size of the debugger data is large. This asynchronous reading behavior is overridden by a mock to a synchronous behavior during unit tests.

* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests added