### PR TITLE
data: use `six.string_types` for `RunTagFilter` type checking

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -784,7 +784,7 @@ class RunTagFilter(object):
     def _parse_optional_string_set(self, name, value):
         if value is None:
             return None
-        if isinstance(value, str):
+        if isinstance(value, six.string_types):
             # Prevent confusion: strings _are_ iterable, but as
             # sequences of characters, so this likely signals an error.
             raise TypeError(
@@ -793,7 +793,7 @@ class RunTagFilter(object):
             )
         value = frozenset(value)
         for item in value:
-            if not isinstance(item, str):
+            if not isinstance(item, six.string_types):
                 raise TypeError(
                     "%s: expected `None` or collection of strings; "
                     "got item of type %r: %r" % (name, type(item), item)


### PR DESCRIPTION
Summary:
We don’t generally support Python 2 anymore, but this is required in the
short term for an internal fix. (This fixes an error “expected `None` or
collection of strings” when the list has a `unicode` value.)

wchargin-branch: rtf-six-strings
