### PR TITLE
TB versions after 2.1 should work with TF 2.1

### DIFF
--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -115,6 +115,10 @@ class DebuggerV2EventMultiplexer(object):
                 self._reader.update()
                 # TODO(cais): Start off a reading thread here, instead of being
                 # called only once here.
+            except AttributeError as error:
+                # Gracefully fail for users with TensorFlow 2.1.0 and older,
+                # which may have debug_events_reader without DebugDataReader.
+                return {}
             except ValueError as error:
                 # When no DebugEvent file set is found in the logdir, a
                 # `ValueError` is thrown.

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -117,8 +117,9 @@ class DebuggerV2EventMultiplexer(object):
                 # called only once here.
             except AttributeError as error:
                 # Gracefully fail for users without the required API changes to
-                # debug_events_reader introduced in TF 2.1.0.dev20200103.
-                # This should be safe to remove when TF 2.2 is released.
+                # debug_events_reader.DebugDataReader introduced in
+                # TF 2.1.0.dev20200103. This should be safe to remove when
+                # TF 2.2 is released.
                 return {}
             except ValueError as error:
                 # When no DebugEvent file set is found in the logdir, a

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -116,8 +116,9 @@ class DebuggerV2EventMultiplexer(object):
                 # TODO(cais): Start off a reading thread here, instead of being
                 # called only once here.
             except AttributeError as error:
-                # Gracefully fail for users with TensorFlow 2.1.0 and older,
-                # which may have debug_events_reader without DebugDataReader.
+                # Gracefully fail for users without the required API changes to
+                # debug_events_reader introduced in TF 2.1.0.dev20200103.
+                # This should be safe to remove when TF 2.2 is released.
                 return {}
             except ValueError as error:
                 # When no DebugEvent file set is found in the logdir, a


### PR DESCRIPTION
TB 2.1.0 works great with TF 2.1.0.  However, tip-of-tree TB doesn't work with TF 2.1.0, since ToT TB depends on TF's DebugDataReader, which was introduced after TF 2.1.0.  Running this combination produces:

```
AttributeError: module 'tensorflow.python.debug.lib.debug_events_reader' has no attribute 'DebugDataReader'
```

@caisq, do we plan to support, say, TB 2.2 or ToT TB working with TF 2.1?
If not, we can close this.