### PR TITLE
windows: explicitly register correct MIME types

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -382,7 +382,7 @@ class TensorBoard(object):
 
         old_signal_handler = signal.signal(signal_number, handler)
 
-    def _fix_mime_types(self, target=mimetypes):
+    def _fix_mime_types(self):
         """Fix incorrect entries in the `mimetypes` registry.
 
         On Windows, the Python standard library's `mimetypes` reads in
@@ -395,11 +395,6 @@ class TensorBoard(object):
         This method hard-codes the correct mappings for certain MIME
         types that are known to be either used by TensorBoard or
         problematic in general.
-
-        Args:
-          target: The registry to which to add types, either the
-            `mimetypes` module (default) or a `mimetypes.MimeTypes`
-            value.
         """
         # Known to be problematic when Visual Studio is installed:
         # <https://github.com/tensorflow/tensorboard/issues/3120>

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -37,6 +37,7 @@ from collections import defaultdict
 import errno
 import inspect
 import logging
+import mimetypes
 import os
 import signal
 import socket
@@ -279,6 +280,7 @@ class TensorBoard(object):
         :rtype: int
         """
         self._install_signal_handler(signal.SIGTERM, "SIGTERM")
+        self._fix_mime_types()
         subcommand_name = getattr(self.flags, _SUBCOMMAND_FLAG)
         if subcommand_name == _SERVE_SUBCOMMAND_NAME:
             runner = self._run_serve_subcommand
@@ -379,6 +381,32 @@ class TensorBoard(object):
             sys.exit(0)
 
         old_signal_handler = signal.signal(signal_number, handler)
+
+    def _fix_mime_types(self, target=mimetypes):
+        """Fix incorrect entries in the `mimetypes` registry.
+
+        On Windows, the Python standard library's `mimetypes` reads in
+        mappings from file extension to MIME type from the Windows
+        registry. Other applications can and do write incorrect values
+        to this registry, which causes `mimetypes.guess_type` to return
+        incorrect values, which causes TensorBoard to fail to render on
+        the frontend.
+
+        This method hard-codes the correct mappings for certain MIME
+        types that are known to be either used by TensorBoard or
+        problematic in general.
+
+        Args:
+          target: The registry to which to add types, either the
+            `mimetypes` module (default) or a `mimetypes.MimeTypes`
+            value.
+        """
+        # Known to be problematic when Visual Studio is installed:
+        # <https://github.com/tensorflow/tensorboard/issues/3120>
+        mimetypes.add_type("application/javascript", ".js")
+        # Not known to be problematic, but used by TensorBoard:
+        mimetypes.add_type("font/woff2", ".woff2")
+        mimetypes.add_type("text/html", ".html")
 
     def _make_server(self):
         """Constructs the TensorBoard WSGI app and instantiates the server."""


### PR DESCRIPTION
Summary:
The standard library’s `mimetypes.guess_type` can give incorrect results
on Windows, because arbitrary programs can influence its behavior by
writing to the registry. This can be worked around by reinstating the
correct MIME types with `mimetypes.add_type`, as in this patch. Fixes
#3120.

Test Plan:
To check that this patch works at all on Windows, edited the registry to
add a bad content type:

```
reg add HKCR\.js /v "Content Type" /d application/x-testing-123
```

…then verified that before this change, `mimetypes.guess_type("foo.js")`
gives the wrong value and TensorBoard does not render properly (strict
MIME type checking error in Chrome, as expected), whereas after this
change `mimetypes.guess_type("foo.js")` gives the correct value and
TensorBoard returns the correct content type in its JavaScript
responses. TensorBoard still does not render on Windows due to unrelated
errors in the debugger plugin.

To check that this set of patches is sufficient, `git grep guess_type`
shows call sites only in `core_plugin` and `projector_plugin`. The
former takes file names from `webfiles.zip`, which has only `html`,
`js`, and `woff2` files (plus a `LICENSE`). The latter has a fixed set
of inputs with extensions `html` and `js`.

wchargin-branch: windows-explicit-mime
