### PR TITLE
plugins_listing: handle failures in plugin `is_active`

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -457,14 +457,22 @@ class TensorBoardWSGI(object):
             ):  # pylint: disable=unidiomatic-typecheck
                 # This plugin's existence is a backend implementation detail.
                 continue
-            start = time.time()
-            is_active = plugin.is_active()
-            elapsed = time.time() - start
-            logger.info(
-                "Plugin listing: is_active() for %s took %0.3f seconds",
-                plugin.plugin_name,
-                elapsed,
-            )
+            try:
+                start = time.time()
+                is_active = plugin.is_active()
+                elapsed = time.time() - start
+                logger.info(
+                    "Plugin listing: is_active() for %s took %0.3f seconds",
+                    plugin.plugin_name,
+                    elapsed,
+                )
+            except Exception:
+                is_active = False
+                logger.error(
+                    "Plugin listing: is_active() for %s failed (marking inactive)",
+                    plugin.plugin_name,
+                    exc_info=True,
+                )
 
             plugin_metadata = plugin.frontend_metadata()
             output_metadata = {


### PR DESCRIPTION
Summary:
Prior to this change, any error thrown by a plugin’s `is_active`
implementation would cause the entire response to 500, which renders
TensorBoard completely inoperable. Now, such failures mark the offending
plugin as inactive and continue with the rest of the response.

Test Plan:
Unit tests added. With this patch installed onto a Windows machine,
TensorBoard now works instead of crashing trying to load the debugger
plugin.

wchargin-branch: robust-is-active
