### PR TITLE
data: fix `is_active`s in generic data mode

### DIFF
--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -77,9 +77,7 @@ class GraphsPlugin(base_plugin.TBPlugin):
     def is_active(self):
         """The graphs plugin is active iff any run has a graph or metadata."""
         if self._data_provider:
-            # We don't have an experiment ID, and modifying the backend core
-            # to provide one would break backward compatibility. Hack for now.
-            return True
+            return False  # `list_plugins` as called by TB core suffices
 
         return bool(self.info_impl())
 

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -302,23 +302,28 @@ class GraphsPluginV1Test(GraphsPluginBaseTest, tf.test.TestCase):
 
     @with_runs([_RUN_WITH_GRAPH_WITHOUT_METADATA])
     def test_is_active_with_graph_without_run_metadata(self, plugin):
-        self.assertTrue(plugin.is_active())
+        if plugin._data_provider:
+            self.assertFalse(plugin.is_active())
+        else:
+            self.assertTrue(plugin.is_active())
 
     @with_runs([_RUN_WITHOUT_GRAPH_WITH_METADATA])
     def test_is_active_without_graph_with_run_metadata(self, plugin):
-        self.assertTrue(plugin.is_active())
+        if plugin._data_provider:
+            self.assertFalse(plugin.is_active())
+        else:
+            self.assertTrue(plugin.is_active())
 
     @with_runs([_RUN_WITH_GRAPH_WITH_METADATA])
     def test_is_active_with_both(self, plugin):
-        self.assertTrue(plugin.is_active())
+        if plugin._data_provider:
+            self.assertFalse(plugin.is_active())
+        else:
+            self.assertTrue(plugin.is_active())
 
     @with_runs([_RUN_WITHOUT_GRAPH_WITHOUT_METADATA])
     def test_is_inactive_without_both(self, plugin):
-        if plugin._data_provider:
-            # Hack, for now.
-            self.assertTrue(plugin.is_active())
-        else:
-            self.assertFalse(plugin.is_active())
+        self.assertFalse(plugin.is_active())
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -77,9 +77,7 @@ class HistogramsPlugin(base_plugin.TBPlugin):
         """This plugin is active iff any run has at least one histograms
         tag."""
         if self._data_provider:
-            # We don't have an experiment ID, and modifying the backend core
-            # to provide one would break backward compatibility. Hack for now.
-            return True
+            return False  # `list_plugins` as called by TB core suffices
 
         if self._db_connection_provider:
             # The plugin is active if one relevant tag can be found in the database.

--- a/tensorboard/plugins/histogram/histograms_plugin_test.py
+++ b/tensorboard/plugins/histogram/histograms_plugin_test.py
@@ -251,25 +251,30 @@ class HistogramsPluginTest(tf.test.TestCase):
 
     @with_runs([_RUN_WITH_LEGACY_HISTOGRAM])
     def test_active_with_legacy_histogram(self, plugin):
-        self.assertTrue(plugin.is_active())
+        if plugin._data_provider:
+            self.assertFalse(plugin.is_active())
+        else:
+            self.assertTrue(plugin.is_active())
 
     @with_runs([_RUN_WITH_HISTOGRAM])
     def test_active_with_histogram(self, plugin):
-        self.assertTrue(plugin.is_active())
+        if plugin._data_provider:
+            self.assertFalse(plugin.is_active())
+        else:
+            self.assertTrue(plugin.is_active())
 
     @with_runs([_RUN_WITH_SCALARS])
     def test_active_with_scalars(self, plugin):
-        if plugin._data_provider:
-            # Hack, for now.
-            self.assertTrue(plugin.is_active())
-        else:
-            self.assertFalse(plugin.is_active())
+        self.assertFalse(plugin.is_active())
 
     @with_runs(
         [_RUN_WITH_SCALARS, _RUN_WITH_LEGACY_HISTOGRAM, _RUN_WITH_HISTOGRAM,]
     )
     def test_active_with_all(self, plugin):
-        self.assertTrue(plugin.is_active())
+        if plugin._data_provider:
+            self.assertFalse(plugin.is_active())
+        else:
+            self.assertTrue(plugin.is_active())
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -75,9 +75,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
         """The scalars plugin is active iff any run has at least one scalar
         tag."""
         if self._data_provider:
-            # We don't have an experiment ID, and modifying the backend core
-            # to provide one would break backward compatibility. Hack for now.
-            return True
+            return False  # `list_plugins` as called by TB core suffices
 
         if self._db_connection_provider:
             # The plugin is active if one relevant tag can be found in the database.

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -281,25 +281,30 @@ class ScalarsPluginTest(tf.test.TestCase):
 
     @with_runs([_RUN_WITH_LEGACY_SCALARS])
     def test_active_with_legacy_scalars(self, plugin):
-        self.assertTrue(plugin.is_active())
+        if plugin._data_provider:
+            self.assertFalse(plugin.is_active())
+        else:
+            self.assertTrue(plugin.is_active())
 
     @with_runs([_RUN_WITH_SCALARS])
     def test_active_with_scalars(self, plugin):
-        self.assertTrue(plugin.is_active())
+        if plugin._data_provider:
+            self.assertFalse(plugin.is_active())
+        else:
+            self.assertTrue(plugin.is_active())
 
     @with_runs([_RUN_WITH_HISTOGRAM])
     def test_active_with_histogram(self, plugin):
-        if plugin._data_provider:
-            # Hack, for now.
-            self.assertTrue(plugin.is_active())
-        else:
-            self.assertFalse(plugin.is_active())
+        self.assertFalse(plugin.is_active())
 
     @with_runs(
         [_RUN_WITH_LEGACY_SCALARS, _RUN_WITH_SCALARS, _RUN_WITH_HISTOGRAM]
     )
     def test_active_with_all(self, plugin):
-        self.assertTrue(plugin.is_active())
+        if plugin._data_provider:
+            self.assertFalse(plugin.is_active())
+        else:
+            self.assertTrue(plugin.is_active())
 
     @test_util.run_v1_only("Requires contrib for db writer")
     def test_scalars_db_without_exp(self):


### PR DESCRIPTION
Summary:
Now that the TensorBoard backend core marks plugins as enabled if the
data provider has corresponding data (#3124), plugins can mark
themselves inactive when they don’t have data, rather than being enabled
unconditionally in generic data mode.

Test Plan:
Run TensorBoard against the scalars, images, and histograms demos
(individually), and note that it behaves the same way with generic data
mode enabled or disabled. (Note that the histogram demo has no graphs.)

wchargin-branch: data-isactive-false-by-default
