### PR TITLE
[DebuggerV2] Implement routes /execution/data and /stack_frames/stack_frames

### DIFF
--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -250,7 +250,7 @@ class DebuggerV2EventMultiplexer(object):
                 # TODO(cais): Use public method (`stack_frame_by_id()`` when
                 # available).
                 # pylint: disable=protected-access
-                self._reader._stack_frame_by_id(stack_frame_id)
+                self._reader._stack_frame_by_id[stack_frame_id]
                 # pylint: enable=protected-access
                 for stack_frame_id in stack_frame_ids
             ]

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -225,27 +225,33 @@ class DebuggerV2EventMultiplexer(object):
         runs = self.Runs()
         if run not in runs:
             return None
-        # TODO(cais): Use public method `self._reader.source_files()` when available.
-        # pylint: disable=protected-access
-        return list(self._reader._host_name_file_path_to_offset.keys())
-        # pylint: enable=protected-access
+        return self._reader.source_file_list()
 
     def SourceLines(self, run, index):
         runs = self.Runs()
         if run not in runs:
             return None
-        # TODO(cais): Use public method `self._reader.source_files()` when available.
-        # pylint: disable=protected-access
-        source_file_list = list(
-            self._reader._host_name_file_path_to_offset.keys()
-        )
-        # pylint: enable=protected-access
         try:
-            host_name, file_path = source_file_list[index]
+            host_name, file_path = self._reader.source_file_list()[index]
         except IndexError:
             raise IndexError("There is no source-code file at index %d" % index)
         return {
             "host_name": host_name,
             "file_path": file_path,
             "lines": self._reader.source_lines(host_name, file_path),
+        }
+
+    def StackFrames(self, run, stack_frame_ids):
+        runs = self.Runs()
+        if run not in runs:
+            return None
+        return {
+            "stack_frames": [
+                # TODO(cais): Use public method (`stack_frame_by_id()`` when
+                # available).
+                # pylint: disable=protected-access
+                self._reader._stack_frame_by_id(stack_frame_id)
+                # pylint: enable=protected-access
+                for stack_frame_id in stack_frame_ids
+            ]
         }

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -190,7 +190,7 @@ class DebuggerV2EventMultiplexer(object):
             ],
         }
 
-    def Execution(self, run, begin, end):
+    def ExecutionData(self, run, begin, end):
         """Get Execution data objects (Detailed, non-digest form).
 
         Args:

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -247,8 +247,8 @@ class DebuggerV2EventMultiplexer(object):
             return None
         return {
             "stack_frames": [
-                # TODO(cais): Use public method (`stack_frame_by_id()`` when
-                # available).
+                # TODO(cais): Use public method (`stack_frame_by_id()`) when
+                # available.
                 # pylint: disable=protected-access
                 self._reader._stack_frame_by_id[stack_frame_id]
                 # pylint: enable=protected-access

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -153,7 +153,7 @@ class DebuggerV2EventMultiplexer(object):
             )
         if end >= 0 and end < begin:
             raise ValueError(
-                "end index (%d) is unexpected less than begin index (%d)"
+                "end index (%d) is unexpectedly less than begin index (%d)"
                 % (end, begin)
             )
         if end < 0:  # This means all digests.

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -198,7 +198,7 @@ def stack_frames_run_tag_filter(run, stack_frame_ids):
     """
     return provider.RunTagFilter(
         runs=[run],
-        # The stack farme IDS are UUIDs, which do not container underscores.
+        # The stack-frame IDS are UUIDs, which do not contain underscores.
         # Hence it's safe to concatenate them with underscores.
         tags=[STACK_FRAMES_BLOB_TAG_PREFIX + "_" + "_".join(stack_frame_ids)],
     )

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -287,7 +287,7 @@ class LocalDebuggerV2DataProvider(provider.DataProvider):
             )
         elif blob_key.startswith(EXECUTION_DATA_BLOB_TAG_PREFIX):
             run, begin, end = _parse_execution_data_blob_key(blob_key)
-            return json.dumps(self._multiplexer.Execution(run, begin, end))
+            return json.dumps(self._multiplexer.ExecutionData(run, begin, end))
         elif blob_key.startswith(SOURCE_FILE_LIST_BLOB_TAG):
             run = _parse_source_file_list_blob_key(blob_key)
             return json.dumps(self._multiplexer.SourceFileList(run))

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -270,6 +270,7 @@ class LocalDebuggerV2DataProvider(provider.DataProvider):
             for tag in run_tag_filter.tags:
                 if (
                     tag.startswith(EXECUTION_DIGESTS_BLOB_TAG_PREFIX)
+                    or tag.startswith(EXECUTION_DATA_BLOB_TAG_PREFIX)
                     or tag.startswith(SOURCE_FILE_BLOB_TAG_PREFIX)
                     or tag in (SOURCE_FILE_LIST_BLOB_TAG,)
                 ):

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -133,6 +133,9 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
             experiment, self.plugin_name, run_tag_filter=run_tag_filter
         )
         tag = next(iter(run_tag_filter.tags))
+        print(
+            "begin=%d, end=%d, run=%s, tag=%s" % (begin, end, run, tag)
+        )  # DEBUG
         try:
             return http_util.Respond(
                 request,

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -133,9 +133,6 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
             experiment, self.plugin_name, run_tag_filter=run_tag_filter
         )
         tag = next(iter(run_tag_filter.tags))
-        print(
-            "begin=%d, end=%d, run=%s, tag=%s" % (begin, end, run, tag)
-        )  # DEBUG
         try:
             return http_util.Respond(
                 request,

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -265,7 +265,6 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
                 "application/json",
             )
         except KeyError as e:
-            # TOOD(cais): More informative error message text.
             return http_util.Respond(
                 request,
                 {"error": "Cannot find stack frame with ID: %s" % e},

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -233,8 +233,22 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
         run = request.args.get("run")
         if run is None:
             return _missing_run_error_response(request)
-        stack_frame_ids = request.args.get("stack_frame_ids").split(",")
-        # TODO(cais): Handle empty stack_frame_ids.
+        stack_frame_ids = request.args.get("stack_frame_ids")
+        if stack_frame_ids is None:
+            return http_util.Respond(
+                request,
+                {"error": "Missing stack_frame_ids parameter"},
+                "application/json",
+                code=400,
+            )
+        if not stack_frame_ids:
+            return http_util.Respond(
+                request,
+                {"error": "Empty stack_frame_ids parameter"},
+                "application/json",
+                code=400,
+            )
+        stack_frame_ids = stack_frame_ids.split(",")
         run_tag_filter = debug_data_provider.stack_frames_run_tag_filter(
             run, stack_frame_ids
         )
@@ -253,5 +267,8 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
         except KeyError as e:
             # TOOD(cais): More informative error message text.
             return http_util.Respond(
-                request, {"error": str(e)}, "application/json", code=400,
+                request,
+                {"error": "Cannot find stack frame with ID: %s" % e},
+                "application/json",
+                code=400,
             )

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -286,7 +286,9 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         )
         self.assertEqual(
             json.loads(response.get_data()),
-            {"error": "end index (1) is unexpected less than begin index (2)"},
+            {
+                "error": "end index (1) is unexpectedly less than begin index (2)"
+            },
         )
 
     def testServeExecutionDigests400ResponseIfRunParamIsNotSpecified(self):
@@ -411,7 +413,9 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         )
         self.assertEqual(
             json.loads(response.get_data()),
-            {"error": "end index (1) is unexpected less than begin index (2)"},
+            {
+                "error": "end index (1) is unexpectedly less than begin index (2)"
+            },
         )
 
     def testServeSourceFileListIncludesThisTestFile(self):

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -362,7 +362,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
             if i > 0:
                 self.assertEqual(
                     execution["input_tensor_ids"],
-                    data["executions"][i - 1]["input_tensor_ids"]
+                    data["executions"][i - 1]["input_tensor_ids"],
                 )
                 self.assertEqual(
                     execution["graph_id"], data["executions"][i - 1]["graph_id"]

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -315,7 +315,6 @@ class DebuggerV2PluginTest(tf.test.TestCase):
             "application/json", response.headers.get("content-type")
         )
         data = json.loads(response.get_data())
-        print(data)  # DEBUG
         self.assertEqual(data["begin"], 0)
         self.assertEqual(data["end"], 1)
         self.assertLen(data["executions"], 1)
@@ -465,6 +464,15 @@ class DebuggerV2PluginTest(tf.test.TestCase):
                 % invalid_index
             },
         )
+
+    def testServeStackFrames(self):
+        _generate_tfdbg_v2_data(self.logdir)
+        run = self._getExactlyOneRun()
+        response = self.server.get(
+            _ROUTE_PREFIX + "/execution/data?run=%s&begin=0&end=1" % run
+        )
+        data = json.loads(response.get_data())
+        stack_frame_ids = data["executions"][0]["stack_frame_ids"]
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -37,7 +37,7 @@ _HOST_NAME = socket.gethostname()
 _CURRENT_FILE_FULL_PATH = os.path.abspath(__file__)
 
 
-def _generate_tfdbg_v2_data(logdir):
+def _generate_tfdbg_v2_data(logdir, tensor_debug_mode="NO_TENSOR"):
     """Generate a simple dump of tfdbg v2 data by running a TF2 program.
 
     The run is instrumented by the enable_dump_debug_info() API.
@@ -50,9 +50,12 @@ def _generate_tfdbg_v2_data(logdir):
 
     Args:
       logdir: Logdir to write the debugger data to.
+      tensor_debug_mode: Mode for dumping debug tensor values, as an optional
+        string. See the documentation of
+        `tf.debugging.experimental.enable_dump_debug_info()` for details.
     """
     writer = tf.debugging.experimental.enable_dump_debug_info(
-        logdir, circular_buffer_size=-1
+        logdir, circular_buffer_size=-1, tensor_debug_mode=tensor_debug_mode
     )
     try:
 
@@ -300,6 +303,74 @@ class DebuggerV2PluginTest(tf.test.TestCase):
             json.loads(response.get_data()),
             {"error": "run parameter is not provided"},
         )
+
+    def testServeASingleExecutionDataObject(self):
+        _generate_tfdbg_v2_data(self.logdir, tensor_debug_mode="CONCISE_HEALTH")
+        run = self._getExactlyOneRun()
+        response = self.server.get(
+            _ROUTE_PREFIX + "/execution/data?run=%s&begin=0&end=1" % run
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        data = json.loads(response.get_data())
+        print(data)  # DEBUG
+        self.assertEqual(data["begin"], 0)
+        self.assertEqual(data["end"], 1)
+        self.assertLen(data["executions"], 1)
+        execution = data["executions"][0]
+        self.assertStartsWith(execution["op_type"], "__inference_my_function_")
+        self.assertLen(execution["output_tensor_device_ids"], 1)
+        self.assertEqual(execution["host_name"], _HOST_NAME)
+        self.assertTrue(execution["stack_frame_ids"])
+        self.assertLen(execution["input_tensor_ids"], 1)
+        self.assertLen(execution["output_tensor_ids"], 1)
+        self.assertTrue(execution["graph_id"])
+        # CONCISE_HEALTH mode:
+        #   [[Unused tensor ID, #(elements), #(-inf), #(+inf), #(nan)]].
+        self.assertEqual(execution["tensor_debug_mode"], 3)
+        self.assertAllClose(
+            execution["debug_tensor_values"], [[-1.0, 1.0, 0.0, 0.0, 0.0]]
+        )
+
+    def testServeMultipleExecutionDataObject(self):
+        _generate_tfdbg_v2_data(self.logdir, tensor_debug_mode="CURT_HEALTH")
+        run = self._getExactlyOneRun()
+        response = self.server.get(
+            _ROUTE_PREFIX + "/execution/data?run=%s&begin=0&end=-1" % run
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        data = json.loads(response.get_data())
+        self.assertEqual(data["begin"], 0)
+        self.assertEqual(data["end"], 3)
+        self.assertLen(data["executions"], 3)
+        for i in range(3):
+            execution = data["executions"][i]
+            self.assertStartsWith(
+                execution["op_type"], "__inference_my_function_"
+            )
+            self.assertLen(execution["output_tensor_device_ids"], 1)
+            self.assertEqual(execution["host_name"], _HOST_NAME)
+            self.assertTrue(execution["stack_frame_ids"])
+            self.assertLen(execution["input_tensor_ids"], 1)
+            self.assertLen(execution["output_tensor_ids"], 1)
+            self.assertTrue(execution["graph_id"])
+            if i > 0:
+                self.assertEqual(
+                    execution["input_tensor_ids"],
+                    data["executions"][i - 1]["input_tensor_ids"]
+                )
+                self.assertEqual(
+                    execution["graph_id"], data["executions"][i - 1]["graph_id"]
+                )
+            # CURT_HEALTH mode:
+            #   [[Unused tensor ID, #(inf_or_nan)]].
+            self.assertEqual(execution["tensor_debug_mode"], 2)
+            self.assertAllClose(execution["debug_tensor_values"], [[-1.0, 0.0]])
 
     def testServeSourceFileListIncludesThisTestFile(self):
         _generate_tfdbg_v2_data(self.logdir)


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing the backend of the DebuggerV2 plugin

* Technical description of changes
  * The route /execution/data is similar to the existing /execution/digests in that
    it concerns the top-level execution events. However, it serves the detailed, larger-size
    data objects, which additionally includes fields such as input/output tensor IDs, host name
    stack frame IDs, tensor debug mode and  debug tensor value (if any).
    * Note that the implementation differs from the original design in the TDD in that the impl
      permits multiple execution data objects to be served in a batch, using the begin and end
      params, in a way similar to the /execution/digests path. This is based on the consideration
      that in some cases, multiple detailed data objects are desired and it's more efficient to serve
      them in the same HTTP response, instead of requiring multiple requests/responses.
  * The /stack_frames/stack_frames route serves the stack frames (tuples of (host_name,
    file_path, lineno, function)) by ID. The implementation closely follows the design.

* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests added.

