### PR TITLE
infra: require Python3.6 to install Black

### DIFF
--- a/tensorboard/pip_package/requirements_dev.txt
+++ b/tensorboard/pip_package/requirements_dev.txt
@@ -22,7 +22,7 @@ boto3==1.9.86
 moto==1.3.7
 
 # For linting
-black==19.10b0; python_version >= "3"
+black==19.10b0; python_version >= "3.6"
 flake8==3.7.8
 yamllint==1.17.0
 


### PR DESCRIPTION
* Motivation for features / changes
Systems with older Python versions, say 3.5, will fail to install dev dependencies.  

* Technical description of changes
Require Python 3.6 or higher for Black, in the requirements_dev.txt.
