### PR TITLE
Rewrite core_plugin_test.py to use DB import mode instead of tf.contrib DB writer

### DIFF
--- a/tensorboard/plugins/core/BUILD
+++ b/tensorboard/plugins/core/BUILD
@@ -32,14 +32,15 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":core_plugin",
-        "//tensorboard:expect_sqlite3_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/backend:application",
+        "//tensorboard/backend/event_processing:db_import_multiplexer",
         "//tensorboard/backend/event_processing:event_multiplexer",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins:base_plugin",
         "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
+        "@org_pythonhosted_mock",
         "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -350,7 +350,6 @@ class CorePluginLogdirModeTest(CorePluginTestBase, tf.test.TestCase):
 class CorePluginDbImportModeTest(CorePluginTestBase, tf.test.TestCase):
     def create_multiplexer(self):
         db_path = os.path.join(self.get_temp_dir(), "db.db")
-        print(self.id(), db_path)  # DO NOT SUBMIT
         db_uri = "sqlite:%s" % db_path
         db_connection_provider = application.create_sqlite_connection_provider(
             db_uri

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -69,23 +69,7 @@ class FakeFlags(object):
         self.path_prefix = path_prefix
 
 
-class CorePluginTest(tf.test.TestCase):
-
-    def setUp(self):
-        super(CorePluginTest, self).setUp()
-        self.temp_dir = self.get_temp_dir()
-        self.addCleanup(shutil.rmtree, self.temp_dir)
-        self.db_path = os.path.join(self.temp_dir, "db.db")
-        self.db = sqlite3.connect(self.db_path)
-        self.db_uri = "sqlite:" + self.db_path
-        self._start_logdir_based_server(self.temp_dir)
-        self._start_db_based_server()
-
-    def testRoutesProvided(self):
-        """Tests that the plugin offers the correct routes."""
-        routes = self.logdir_based_plugin.get_plugin_apps()
-        self.assertIsInstance(routes["/data/logdir"], collections.Callable)
-        self.assertIsInstance(routes["/data/runs"], collections.Callable)
+class CorePluginFlagsTest(tf.test.TestCase):
 
     def testFlag(self):
         loader = core_plugin.CorePluginLoader()
@@ -145,6 +129,25 @@ class CorePluginTest(tf.test.TestCase):
         msg = str(cm.exception)
         self.assertIn("must start with slash", msg)
         self.assertIn(repr("noslash"), msg)
+
+
+class CorePluginTest(tf.test.TestCase):
+
+    def setUp(self):
+        super(CorePluginTest, self).setUp()
+        self.temp_dir = self.get_temp_dir()
+        self.addCleanup(shutil.rmtree, self.temp_dir)
+        self.db_path = os.path.join(self.temp_dir, "db.db")
+        self.db = sqlite3.connect(self.db_path)
+        self.db_uri = "sqlite:" + self.db_path
+        self._start_logdir_based_server(self.temp_dir)
+        self._start_db_based_server()
+
+    def testRoutesProvided(self):
+        """Tests that the plugin offers the correct routes."""
+        routes = self.logdir_based_plugin.get_plugin_apps()
+        self.assertIsInstance(routes["/data/logdir"], collections.Callable)
+        self.assertIsInstance(routes["/data/runs"], collections.Callable)
 
     def testIndex_returnsActualHtml(self):
         """Test the format of the /data/runs endpoint."""

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -24,8 +24,13 @@ import json
 import os
 import shutil
 import six
-import sqlite3
 import zipfile
+
+try:
+    # python version >= 3.3
+    from unittest import mock
+except ImportError:
+    import mock  # pylint: disable=unused-import
 
 import tensorflow as tf
 
@@ -33,9 +38,8 @@ from werkzeug import test as werkzeug_test
 from werkzeug import wrappers
 
 from tensorboard.backend import application
-from tensorboard.backend.event_processing import (
-    plugin_event_multiplexer as event_multiplexer,
-)
+from tensorboard.backend.event_processing import db_import_multiplexer
+from tensorboard.backend.event_processing import plugin_event_multiplexer as event_multiplexer
 from tensorboard.compat.proto import graph_pb2
 from tensorboard.compat.proto import meta_graph_pb2
 from tensorboard.plugins import base_plugin
@@ -220,75 +224,56 @@ class CorePluginDbModeTest(tf.test.TestCase):
         self.assertEqual(parsed_object["data_location"], self.db_uri)
 
 
-class CorePluginTest(tf.test.TestCase):
+class CorePluginTestBase(object):
 
     def setUp(self):
-        super(CorePluginTest, self).setUp()
-        self.temp_dir = self.get_temp_dir()
-        self.addCleanup(shutil.rmtree, self.temp_dir)
-        self.db_path = os.path.join(self.temp_dir, "db.db")
-        self.db = sqlite3.connect(self.db_path)
-        self.db_uri = "sqlite:" + self.db_path
-        self._start_logdir_based_server(self.temp_dir)
-        self._start_db_based_server()
+        super(CorePluginTestBase, self).setUp()
+        self.logdir = self.get_temp_dir()
+        self.multiplexer = self.create_multiplexer()
+        db_uri = None
+        db_connection_provider = None
+        if isinstance(self.multiplexer, db_import_multiplexer.DbImportMultiplexer):
+            db_uri = self.multiplexer.db_uri
+            db_connection_provider = self.multiplexer.db_connection_provider
+        context = base_plugin.TBContext(
+            assets_zip_provider=get_test_assets_zip_provider(),
+            logdir=self.logdir,
+            multiplexer=self.multiplexer,
+            db_uri=db_uri,
+            db_connection_provider=db_connection_provider,
+        )
+        self.plugin = core_plugin.CorePlugin(context)
+        app = application.TensorBoardWSGI([self.plugin])
+        self.server = werkzeug_test.Client(app, wrappers.BaseResponse)
 
-    @test_util.run_v1_only("Uses tf.contrib when adding runs.")
+    def create_multiplexer(self):
+      raise NotImplementedError()
+
+    def _add_run(self, run_name):
+        run_path = os.path.join(self.logdir, run_name)
+        with test_util.FileWriter(run_path) as writer:
+          writer.add_test_summary("foo")
+        self.multiplexer.AddRunsFromDirectory(self.logdir)
+        self.multiplexer.Reload()
+
+    def _get_json(self, server, path):
+        response = server.get(path)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("application/json", response.headers.get("Content-Type"))
+        return json.loads(response.get_data().decode("utf-8"))
+
     def testRuns(self):
         """Test the format of the /data/runs endpoint."""
         self._add_run("run1")
-        run_json = self._get_json(self.db_based_server, "/data/runs")
-        self.assertEqual(run_json, ["run1"])
-        run_json = self._get_json(self.logdir_based_server, "/data/runs")
+        run_json = self._get_json(self.server, "/data/runs")
         self.assertEqual(run_json, ["run1"])
 
-    @test_util.run_v1_only("Uses tf.contrib when adding runs.")
-    def testExperiments(self):
-        """Test the format of the /data/experiments endpoint."""
-        self._add_run("run1", experiment_name="exp1")
-        self._add_run("run2", experiment_name="exp1")
-        self._add_run("run3", experiment_name="exp2")
+class CorePluginLogdirModeTest(CorePluginTestBase, tf.test.TestCase):
 
-        [exp1, exp2] = self._get_json(self.db_based_server, "/data/experiments")
-        self.assertEqual(exp1.get("name"), "exp1")
-        self.assertEqual(exp2.get("name"), "exp2")
+    def create_multiplexer(self):
+        return event_multiplexer.EventMultiplexer()
 
-        exp_json = self._get_json(self.logdir_based_server, "/data/experiments")
-        self.assertEqual(exp_json, [])
-
-    @test_util.run_v1_only("Uses tf.contrib when adding runs.")
-    def testExperimentRuns(self):
-        """Test the format of the /data/experiment_runs endpoint."""
-        self._add_run("run1", experiment_name="exp1")
-        self._add_run("run2", experiment_name="exp1")
-        self._add_run("run3", experiment_name="exp2")
-
-        [exp1, exp2] = self._get_json(self.db_based_server, "/data/experiments")
-
-        exp1_runs = self._get_json(
-            self.db_based_server,
-            "/experiment/%s/data/experiment_runs" % exp1.get("id"),
-        )
-        self.assertEqual(len(exp1_runs), 2)
-        self.assertEqual(exp1_runs[0].get("name"), "run1")
-        self.assertEqual(exp1_runs[1].get("name"), "run2")
-        self.assertEqual(len(exp1_runs[0].get("tags")), 1)
-        self.assertEqual(exp1_runs[0].get("tags")[0].get("name"), "mytag")
-        self.assertEqual(len(exp1_runs[1].get("tags")), 1)
-        self.assertEqual(exp1_runs[1].get("tags")[0].get("name"), "mytag")
-
-        exp2_runs = self._get_json(
-            self.db_based_server,
-            "/experiment/%s/data/experiment_runs" % exp2.get("id"),
-        )
-        self.assertEqual(len(exp2_runs), 1)
-        self.assertEqual(exp2_runs[0].get("name"), "run3")
-
-        # TODO(stephanwlee): Write test on runs that do not have any tag.
-
-        exp_json = self._get_json(self.logdir_based_server, "/data/experiments")
-        self.assertEqual(exp_json, [])
-
-    @test_util.run_v1_only("Uses tf.contrib when adding runs.")
+    # Not in base class because DB import mode does not set started_time.
     def testRunsAppendOnly(self):
         """Test that new runs appear after old ones in /data/runs."""
         fake_wall_times = {
@@ -300,10 +285,7 @@ class CorePluginTest(tf.test.TestCase):
             "enigmatic": None,
         }
 
-        stubs = tf.compat.v1.test.StubOutForTesting()
-
-        def FirstEventTimestamp_stub(multiplexer_self, run_name):
-            del multiplexer_self
+        def FirstEventTimestamp_stub(run_name):
             matches = [
                 candidate_name
                 for candidate_name in fake_wall_times
@@ -316,163 +298,105 @@ class CorePluginTest(tf.test.TestCase):
             else:
                 return wall_time
 
-        stubs.SmartSet(
-            self.multiplexer, "FirstEventTimestamp", FirstEventTimestamp_stub
-        )
+        with mock.patch.object(self.multiplexer, "FirstEventTimestamp") as mock_first_event_timestamp:
+            mock_first_event_timestamp.side_effect = FirstEventTimestamp_stub
+            # Start with a single run.
+            self._add_run("run1")
 
-        # Start with a single run.
-        self._add_run("run1")
-
-        # Add one run: it should come last.
-        self._add_run("avocado")
-        self.assertEqual(
-            self._get_json(self.db_based_server, "/data/runs"),
-            ["run1", "avocado"],
-        )
-        self.assertEqual(
-            self._get_json(self.logdir_based_server, "/data/runs"),
-            ["run1", "avocado"],
-        )
-
-        # Add another run: it should come last, too.
-        self._add_run("zebra")
-        self.assertEqual(
-            self._get_json(self.db_based_server, "/data/runs"),
-            ["run1", "avocado", "zebra"],
-        )
-        self.assertEqual(
-            self._get_json(self.logdir_based_server, "/data/runs"),
-            ["run1", "avocado", "zebra"],
-        )
-
-        # And maybe there's a run for which we somehow have no timestamp.
-        self._add_run("mysterious")
-        with self.db:
-            self.db.execute(
-                "UPDATE Runs SET started_time=NULL WHERE run_name=?",
-                ["mysterious"],
+            # Add one run: it should come last.
+            self._add_run("avocado")
+            self.assertEqual(
+                self._get_json(self.server, "/data/runs"),
+                ["run1", "avocado"],
             )
-        self.assertEqual(
-            self._get_json(self.db_based_server, "/data/runs"),
-            ["run1", "avocado", "zebra", "mysterious"],
-        )
-        self.assertEqual(
-            self._get_json(self.logdir_based_server, "/data/runs"),
-            ["run1", "avocado", "zebra", "mysterious"],
-        )
 
-        # Add another timestamped run: it should come before the timestamp-less one.
-        self._add_run("ox")
-        self.assertEqual(
-            self._get_json(self.db_based_server, "/data/runs"),
-            ["run1", "avocado", "zebra", "ox", "mysterious"],
-        )
-        self.assertEqual(
-            self._get_json(self.logdir_based_server, "/data/runs"),
-            ["run1", "avocado", "zebra", "ox", "mysterious"],
-        )
-
-        # Add another timestamp-less run, lexicographically before the other one:
-        # it should come after all timestamped runs but first among timestamp-less.
-        self._add_run("enigmatic")
-        with self.db:
-            self.db.execute(
-                "UPDATE Runs SET started_time=NULL WHERE run_name=?",
-                ["enigmatic"],
+            # Add another run: it should come last, too.
+            self._add_run("zebra")
+            self.assertEqual(
+                self._get_json(self.server, "/data/runs"),
+                ["run1", "avocado", "zebra"],
             )
-        self.assertEqual(
-            self._get_json(self.db_based_server, "/data/runs"),
-            ["run1", "avocado", "zebra", "ox", "enigmatic", "mysterious"],
-        )
-        self.assertEqual(
-            self._get_json(self.logdir_based_server, "/data/runs"),
-            ["run1", "avocado", "zebra", "ox", "enigmatic", "mysterious"],
-        )
 
-        stubs.CleanUp()
+            # And maybe there's a run for which we somehow have no timestamp.
+            self._add_run("mysterious")
+            self.assertEqual(
+                self._get_json(self.server, "/data/runs"),
+                ["run1", "avocado", "zebra", "mysterious"],
+            )
 
-    def _start_logdir_based_server(self, temp_dir):
-        self.logdir = temp_dir
-        self.multiplexer = event_multiplexer.EventMultiplexer(
-            size_guidance=application.DEFAULT_SIZE_GUIDANCE,
-            purge_orphaned_data=True,
-        )
-        context = base_plugin.TBContext(
-            assets_zip_provider=get_test_assets_zip_provider(),
-            logdir=self.logdir,
-            multiplexer=self.multiplexer,
-            window_title="title foo",
-        )
-        self.logdir_based_plugin = core_plugin.CorePlugin(context)
-        app = application.TensorBoardWSGI([self.logdir_based_plugin])
-        self.logdir_based_server = werkzeug_test.Client(
-            app, wrappers.BaseResponse
-        )
+            # Add another timestamped run: it should come before the timestamp-less one.
+            self._add_run("ox")
+            self.assertEqual(
+                self._get_json(self.server, "/data/runs"),
+                ["run1", "avocado", "zebra", "ox", "mysterious"],
+            )
 
-    def _start_db_based_server(self):
-        db_connection_provider = application.create_sqlite_connection_provider(
-            self.db_uri
-        )
-        context = base_plugin.TBContext(
-            assets_zip_provider=get_test_assets_zip_provider(),
+            # Add another timestamp-less run, lexicographically before the other one:
+            # it should come after all timestamped runs but first among timestamp-less.
+            self._add_run("enigmatic")
+            self.assertEqual(
+                self._get_json(self.server, "/data/runs"),
+                ["run1", "avocado", "zebra", "ox", "enigmatic", "mysterious"],
+            )
+
+
+class CorePluginDbImportModeTest(CorePluginTestBase, tf.test.TestCase):
+
+    def create_multiplexer(self):
+        db_path = os.path.join(self.get_temp_dir(), "db.db")
+        print(self.id(), db_path)  # DO NOT SUBMIT
+        db_uri = "sqlite:%s" % db_path
+        db_connection_provider = application.create_sqlite_connection_provider(db_uri)
+        return db_import_multiplexer.DbImportMultiplexer(
+            db_uri=db_uri,
             db_connection_provider=db_connection_provider,
-            db_uri=self.db_uri,
-            window_title="title foo",
+            purge_orphaned_data=True,
+            max_reload_threads=1,
         )
-        self.db_based_plugin = core_plugin.CorePlugin(context)
-        app = application.TensorBoardWSGI([self.db_based_plugin])
-        self.db_based_server = werkzeug_test.Client(app, wrappers.BaseResponse)
 
     def _add_run(self, run_name, experiment_name="experiment"):
-        self._generate_test_data(run_name, experiment_name)
+        run_path = os.path.join(self.logdir, experiment_name, run_name)
+        with test_util.FileWriter(run_path) as writer:
+          writer.add_test_summary("foo")
         self.multiplexer.AddRunsFromDirectory(self.logdir)
         self.multiplexer.Reload()
 
-    def _get_json(self, server, path):
-        response = server.get(path)
-        self.assertEqual(200, response.status_code)
-        self.assertEqual("application/json", response.headers.get("Content-Type"))
-        return json.loads(response.get_data().decode("utf-8"))
+    def testExperiments(self):
+        """Test the format of the /data/experiments endpoint."""
+        self._add_run("run1", experiment_name="exp1")
+        self._add_run("run2", experiment_name="exp1")
+        self._add_run("run3", experiment_name="exp2")
 
-    def _generate_test_data(self, run_name, experiment_name):
-        """Generates the test data directory.
+        [exp1, exp2] = self._get_json(self.server, "/data/experiments")
+        self.assertEqual(exp1.get("name"), "exp1")
+        self.assertEqual(exp2.get("name"), "exp2")
 
-        The test data has a single run of the given name, containing:
-          - a graph definition and metagraph definition
+    def testExperimentRuns(self):
+        """Test the format of the /data/experiment_runs endpoint."""
+        self._add_run("run1", experiment_name="exp1")
+        self._add_run("run2", experiment_name="exp1")
+        self._add_run("run3", experiment_name="exp2")
 
-        Arguments:
-          run_name: The directory under self.logdir into which to write
-              events.
-        """
-        run_path = os.path.join(self.logdir, run_name)
-        with test_util.FileWriterCache.get(run_path) as writer:
+        [exp1, exp2] = self._get_json(self.server, "/data/experiments")
 
-            # Add a simple graph event.
-            graph_def = graph_pb2.GraphDef()
-            node1 = graph_def.node.add()
-            node1.name = "a"
-            node2 = graph_def.node.add()
-            node2.name = "b"
-            node2.attr["very_large_attr"].s = b"a" * 2048  # 2 KB attribute
-
-            writer.add_graph(graph=None, graph_def=graph_def)
-
-        # Write data for the run to the database.
-        # TODO(nickfelt): Figure out why reseting the graph is necessary.
-        tf.compat.v1.reset_default_graph()
-        db_writer = tf.contrib.summary.create_db_writer(
-            db_uri=self.db_path,
-            experiment_name=experiment_name,
-            run_name=run_name,
-            user_name="user",
+        exp1_runs = self._get_json(
+            self.server,
+            "/experiment/%s/data/experiment_runs" % exp1.get("id"),
         )
-        with db_writer.as_default(), tf.contrib.summary.always_record_summaries():
-            tf.contrib.summary.scalar("mytag", 1)
+        self.assertEqual(len(exp1_runs), 2)
+        self.assertEqual(exp1_runs[0].get("name"), "run1")
+        self.assertEqual(exp1_runs[1].get("name"), "run2")
+        self.assertEqual(len(exp1_runs[0].get("tags")), 1)
+        self.assertEqual(exp1_runs[0].get("tags")[0].get("name"), "foo")
+        self.assertEqual(len(exp1_runs[1].get("tags")), 1)
+        self.assertEqual(exp1_runs[1].get("tags")[0].get("name"), "foo")
 
-        with tf.compat.v1.Session() as sess:
-            sess.run(tf.compat.v1.global_variables_initializer())
-            sess.run(tf.contrib.summary.summary_writer_initializer_op())
-            sess.run(tf.contrib.summary.all_summary_ops())
+        exp2_runs = self._get_json(
+            self.server,
+            "/experiment/%s/data/experiment_runs" % exp2.get("id"),
+        )
+        self.assertEqual(len(exp2_runs), 1)
+        self.assertEqual(exp2_runs[0].get("name"), "run3")
 
 
 def get_test_assets_zip_provider():

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -70,7 +70,6 @@ class FakeFlags(object):
 
 
 class CorePluginTest(tf.test.TestCase):
-    _only_use_meta_graph = False  # Server data contains only a GraphDef
 
     def setUp(self):
         super(CorePluginTest, self).setUp()
@@ -425,12 +424,7 @@ class CorePluginTest(tf.test.TestCase):
             node2.name = "b"
             node2.attr["very_large_attr"].s = b"a" * 2048  # 2 KB attribute
 
-            meta_graph_def = meta_graph_pb2.MetaGraphDef(graph_def=graph_def)
-
-            if self._only_use_meta_graph:
-                writer.add_meta_graph(meta_graph_def)
-            else:
-                writer.add_graph(graph=None, graph_def=graph_def)
+            writer.add_graph(graph=None, graph_def=graph_def)
 
         # Write data for the run to the database.
         # TODO(nickfelt): Figure out why reseting the graph is necessary.
@@ -448,11 +442,6 @@ class CorePluginTest(tf.test.TestCase):
             sess.run(tf.compat.v1.global_variables_initializer())
             sess.run(tf.contrib.summary.summary_writer_initializer_op())
             sess.run(tf.contrib.summary.all_summary_ops())
-
-
-class CorePluginUsingMetagraphOnlyTest(CorePluginTest):
-    # Tests new ability to use only the MetaGraphDef
-    _only_use_meta_graph = True  # Server data contains only a MetaGraphDef
 
 
 def get_test_assets_zip_provider():


### PR DESCRIPTION
This removes the `tf.contrib.summary.create_db_writer()` dependency from core_plugin_test.py, which partially addresses #1718 and #1705, and reverts the applicable part of #3143 (a temporary fix).

I've preserved most of the test coverage of the underlying DB-reading code by changing the test data population strategy to instead just use the DbImportMultiplexer logic that already exists within TensorBoard.  That logic doesn't set `started_time` so we lose some coverage in that the test that specifically tests that behavior is now logdir-only, because it didn't seem worth the trouble to get it to keep working.

I also refactored the rest of the tests a little bit to remove cruft and reorganize the test cases a little more logically.  Ultimately a lot of this should be cleaned up further as part of #2573.  (And ultimately we should either drop the DB reading logic entirely or encapsulate it inside a DataProvider, but that's a battle for another day.)



