### PR TITLE
plugins: add experimental URL reading API for iframed plugins

### DIFF
--- a/tensorboard/components/experimental/plugin_lib/BUILD
+++ b/tensorboard/components/experimental/plugin_lib/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 

--- a/tensorboard/components/experimental/plugin_lib/BUILD
+++ b/tensorboard/components/experimental/plugin_lib/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library", "tf_js_binary")
+load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -9,10 +9,10 @@ licenses(["notice"])  # Apache 2.0
 tf_ts_library(
     name = "plugin_lib",
     srcs = [
+        "core.ts",
         "index.ts",
         "message.ts",
         "plugin-guest.ts",
-        "core.ts",
         "runs.ts",
     ],
 )

--- a/tensorboard/components/experimental/plugin_lib/BUILD
+++ b/tensorboard/components/experimental/plugin_lib/BUILD
@@ -16,12 +16,3 @@ tf_ts_library(
         "runs.ts",
     ],
 )
-
-tf_js_binary(
-    name = "plugin_lib_rollup",
-    compile = 1,
-    entry_point = "index.ts",
-    deps = [
-        ":plugin_lib",
-    ],
-)

--- a/tensorboard/components/experimental/plugin_lib/BUILD
+++ b/tensorboard/components/experimental/plugin_lib/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library", "tf_js_binary")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -12,6 +12,16 @@ tf_ts_library(
         "index.ts",
         "message.ts",
         "plugin-guest.ts",
+        "core.ts",
         "runs.ts",
+    ],
+)
+
+tf_js_binary(
+    name = "plugin_lib_rollup",
+    compile = 1,
+    entry_point = "index.ts",
+    deps = [
+        ":plugin_lib",
     ],
 )

--- a/tensorboard/components/experimental/plugin_lib/core.ts
+++ b/tensorboard/components/experimental/plugin_lib/core.ts
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,8 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import * as _runs from './runs';
-import * as _core from './core';
+import {sendMessage} from './plugin-guest';
 
-export const core = _core;
-export const runs = _runs;
+/**
+ * When called from a plugin with plugin_name `N`, it returns a promise which
+ * resolves to an object containing values from the URL hash that begin with
+ * `p.N.`
+ * @return {!Promise<{Object<string, string>}>}
+ */
+export async function getURLPluginData() {
+  return sendMessage('experimental.GetURLPluginData');
+}

--- a/tensorboard/components/experimental/plugin_lib/test/test.ts
+++ b/tensorboard/components/experimental/plugin_lib/test/test.ts
@@ -119,6 +119,7 @@ describe('plugin lib integration', () => {
           'sample_plugin',
           'tagFilter=loss',
           'p.sample_plugin.foo=bar',
+          'p.sample_plugin.foo=bar_from_duplicate',
           'smoothing=0.5',
           'p.sample_plugin.foo2=bar2',
           'p.sample_plugin2.foo=bar',
@@ -128,7 +129,7 @@ describe('plugin lib integration', () => {
 
         const data = await this.lib.core.getURLPluginData();
         expect(data).to.deep.equal({
-          foo: 'bar',
+          foo: 'bar_from_duplicate',
           foo2: 'bar2',
         });
       });

--- a/tensorboard/components/experimental/plugin_lib/test/test.ts
+++ b/tensorboard/components/experimental/plugin_lib/test/test.ts
@@ -99,11 +99,12 @@ describe('plugin lib integration', () => {
        * host's URL has been updated.
        */
       it('returns URL data', async function() {
-        tf_globals.setFakeHash(
-          'sample_plugin' +
-            '&p.sample_plugin.foo=bar' +
-            '&p.sample_plugin.foo2=bar2'
-        );
+        const hash = [
+          'sample_plugin',
+          'p.sample_plugin.foo=bar',
+          'p.sample_plugin.foo2=bar2',
+        ].join('&');
+        tf_globals.setFakeHash(hash);
         window.dispatchEvent(new Event('hashchange'));
 
         const data = await this.lib.core.getURLPluginData();
@@ -114,14 +115,15 @@ describe('plugin lib integration', () => {
       });
 
       it('ignores unrelated URL data', async function() {
-        tf_globals.setFakeHash(
-          'sample_plugin' +
-            '&tagFilter=loss' +
-            '&p.sample_plugin.foo=bar' +
-            '&smoothing=0.5' +
-            '&p.sample_plugin.foo2=bar2' +
-            '&p.sample_plugin2.foo=bar'
-        );
+        const hash = [
+          'sample_plugin',
+          'tagFilter=loss',
+          'p.sample_plugin.foo=bar',
+          'smoothing=0.5',
+          'p.sample_plugin.foo2=bar2',
+          'p.sample_plugin2.foo=bar',
+        ].join('&');
+        tf_globals.setFakeHash(hash);
         window.dispatchEvent(new Event('hashchange'));
 
         const data = await this.lib.core.getURLPluginData();
@@ -131,16 +133,31 @@ describe('plugin lib integration', () => {
         });
       });
 
+      it('handles incomplete URL data', async function() {
+        const hash = [
+          'sample_plugin',
+          'tagFilter=loss',
+          'p.sample_plugin',
+          'p.sample_plugin.',
+        ].join('&');
+        tf_globals.setFakeHash(hash);
+        window.dispatchEvent(new Event('hashchange'));
+
+        const data = await this.lib.core.getURLPluginData();
+        expect(data).to.deep.equal({});
+      });
+
       it('handles non alphanumeric data', async function() {
-        tf_globals.setFakeHash(
-          'sample_plugin' +
-            '&p.sample_plugin.foo=bar%20baz' +
-            '&p.sample_plugin.foo2=0.123' +
-            '&p.sample_plugin.foo3=false' +
-            '&p.sample_plugin.foo4=' +
-            '&p.sample_plugin.foo5' +
-            '&p.sample_plugin.foo.with.dots=bar.dotted'
-        );
+        const hash = [
+          'sample_plugin',
+          'p.sample_plugin.foo=bar%20baz',
+          'p.sample_plugin.foo2=0.123',
+          'p.sample_plugin.foo3=false',
+          'p.sample_plugin.foo4=',
+          'p.sample_plugin.foo5',
+          'p.sample_plugin.foo.with.dots=bar.dotted',
+        ].join('&');
+        tf_globals.setFakeHash(hash);
         window.dispatchEvent(new Event('hashchange'));
 
         const data = await this.lib.core.getURLPluginData();

--- a/tensorboard/components/experimental/plugin_lib/test/test.ts
+++ b/tensorboard/components/experimental/plugin_lib/test/test.ts
@@ -17,7 +17,7 @@ async function createIframe(): Promise<HTMLIFrameElement> {
   return new Promise<HTMLIFrameElement>((resolve) => {
     const iframe = document.createElement('iframe') as HTMLIFrameElement;
     document.body.appendChild(iframe);
-    iframe.src = './testable-iframe.html';
+    iframe.src = './testable-iframe.html?name=sample_plugin';
     iframe.onload = () => resolve(iframe);
   });
 }
@@ -86,6 +86,18 @@ describe('plugin lib integration', () => {
         await this.libInternal.sendMessage('foo');
 
         expect(runsChanged).to.not.have.been.called;
+      });
+    });
+  });
+
+  describe('lib.core', () => {
+    describe('#getURLPluginData', () => {
+      it('returns URL data', async function() {
+        tf_globals.setFakeHash('sample_plugin&p.sample_plugin.foo=bar');
+        window.dispatchEvent(new Event('hashchange'));
+
+        const data = await this.lib.core.getURLPluginData();
+        expect(data).to.deep.equal({foo: 'bar'});
       });
     });
   });

--- a/tensorboard/components/experimental/plugin_lib/test/test.ts
+++ b/tensorboard/components/experimental/plugin_lib/test/test.ts
@@ -108,8 +108,8 @@ describe('plugin lib integration', () => {
 
         const data = await this.lib.core.getURLPluginData();
         expect(data).to.deep.equal({
-          'foo': 'bar',
-          'foo2': 'bar2',
+          foo: 'bar',
+          foo2: 'bar2',
         });
       });
 
@@ -126,8 +126,8 @@ describe('plugin lib integration', () => {
 
         const data = await this.lib.core.getURLPluginData();
         expect(data).to.deep.equal({
-          'foo': 'bar',
-          'foo2': 'bar2',
+          foo: 'bar',
+          foo2: 'bar2',
         });
       });
 
@@ -145,10 +145,10 @@ describe('plugin lib integration', () => {
 
         const data = await this.lib.core.getURLPluginData();
         expect(data).to.deep.equal({
-          'foo': 'bar baz',
-          'foo2': '0.123',
-          'foo3': 'false',
-          'foo4': '',
+          foo: 'bar baz',
+          foo2: '0.123',
+          foo3: 'false',
+          foo4: '',
           'foo.with.dots': 'bar.dotted',
         });
       });

--- a/tensorboard/components/experimental/plugin_util/BUILD
+++ b/tensorboard/components/experimental/plugin_util/BUILD
@@ -30,10 +30,12 @@ tf_web_library(
     srcs = [
         "plugin-host.html",
         "runs-host-impl.ts",
+        "core-host-impl.ts",
     ],
     path = "/tf-plugin-util",
     deps = [
         ":host_internals",
         "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_storage",
     ],
 )

--- a/tensorboard/components/experimental/plugin_util/BUILD
+++ b/tensorboard/components/experimental/plugin_util/BUILD
@@ -28,9 +28,9 @@ tf_web_library(
 tf_web_library(
     name = "plugin_host",
     srcs = [
+        "core-host-impl.ts",
         "plugin-host.html",
         "runs-host-impl.ts",
-        "core-host-impl.ts",
     ],
     path = "/tf-plugin-util",
     deps = [

--- a/tensorboard/components/experimental/plugin_util/core-host-impl.ts
+++ b/tensorboard/components/experimental/plugin_util/core-host-impl.ts
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,8 +12,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import * as _runs from './runs';
-import * as _core from './core';
+/**
+ * Implements core plugin APIs.
+ */
+tb_plugin.host.listen('experimental.GetURLPluginData', (context) => {
+  const prefix = `p.${context.pluginName}.`;
+  const result: {[key: string]: string} = {};
 
-export const core = _core;
-export const runs = _runs;
+  for (let key in tf_storage.urlDict) {
+    if (key.startsWith(prefix)) {
+      const pluginKey = key.substring(prefix.length);
+      result[pluginKey] = tf_storage.urlDict[key];
+    }
+  }
+  return result;
+});

--- a/tensorboard/components/experimental/plugin_util/core-host-impl.ts
+++ b/tensorboard/components/experimental/plugin_util/core-host-impl.ts
@@ -16,6 +16,9 @@ limitations under the License.
  * Implements core plugin APIs.
  */
 tb_plugin.host.listen('experimental.GetURLPluginData', (context) => {
+  if (!context) {
+    return;
+  }
   const prefix = `p.${context.pluginName}.`;
   const result: {[key: string]: string} = {};
 

--- a/tensorboard/components/experimental/plugin_util/plugin-host-ipc.ts
+++ b/tensorboard/components/experimental/plugin_util/plugin-host-ipc.ts
@@ -19,7 +19,7 @@ namespace tb_plugin.host {
 
   export type PluginHostCallback = (
     context: PluginHostMessageContext,
-    data: any,
+    data: any
   ) => any;
 
   const portIPCs = new Set<lib.DO_NOT_USE_INTERNAL.IPC>();

--- a/tensorboard/components/experimental/plugin_util/plugin-host-ipc.ts
+++ b/tensorboard/components/experimental/plugin_util/plugin-host-ipc.ts
@@ -13,11 +13,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 namespace tb_plugin.host {
+  export type PluginHostMessageContext = {
+    pluginName: string | null;
+  };
+
+  export type PluginHostCallback = (
+    context: PluginHostMessageContext,
+    data: any,
+  ) => any;
+
   const portIPCs = new Set<lib.DO_NOT_USE_INTERNAL.IPC>();
   const VERSION = 'experimental';
   const listeners = new Map<
     lib.DO_NOT_USE_INTERNAL.MessageType,
-    lib.DO_NOT_USE_INTERNAL.MessageCallback
+    PluginHostCallback
   >();
 
   // TODO(@psybuzz): replace this and the port cleanup logic in broadcast() with
@@ -42,8 +51,31 @@ namespace tb_plugin.host {
     port.start();
 
     for (const [type, callback] of listeners) {
-      portIPC.listen(type, callback);
+      const callbackWithContext = wrapCallbackWithContext(callback, portIPC);
+      portIPC.listen(type, callbackWithContext);
     }
+  }
+
+  /**
+   * Provides context data from the IPC to the callback.
+   */
+  function wrapCallbackWithContext(
+    callback: PluginHostCallback,
+    ipc: lib.DO_NOT_USE_INTERNAL.IPC
+  ): lib.DO_NOT_USE_INTERNAL.MessageCallback {
+    return (payload) => {
+      const context: PluginHostMessageContext = {pluginName: null};
+
+      // 'name' is a keyword set in the iframe URL by tf-tensorboard's
+      // `_renderPluginIframe`.
+      const frame = ipcToFrame.get(ipc);
+      if (frame) {
+        const pluginName = new URL(frame.src).searchParams.get('name');
+        context.pluginName = pluginName;
+      }
+
+      return callback(context, payload);
+    };
   }
 
   /**
@@ -61,7 +93,7 @@ namespace tb_plugin.host {
     payload: lib.DO_NOT_USE_INTERNAL.PayloadType
   ): Promise<lib.DO_NOT_USE_INTERNAL.PayloadType[]> {
     for (const ipc of portIPCs) {
-      if (!ipcToFrame.get(ipc).isConnected) {
+      if (!ipcToFrame.get(ipc)!.isConnected) {
         portIPCs.delete(ipc);
         ipcToFrame.delete(ipc);
       }
@@ -76,11 +108,12 @@ namespace tb_plugin.host {
    */
   export function listen(
     type: lib.DO_NOT_USE_INTERNAL.MessageType,
-    callback: lib.DO_NOT_USE_INTERNAL.MessageCallback
+    callback: PluginHostCallback
   ) {
     listeners.set(type, callback);
     for (const ipc of portIPCs) {
-      ipc.listen(type, callback);
+      const callbackWithContext = wrapCallbackWithContext(callback, ipc);
+      ipc.listen(type, callbackWithContext);
     }
   }
 

--- a/tensorboard/components/experimental/plugin_util/plugin-host.html
+++ b/tensorboard/components/experimental/plugin_util/plugin-host.html
@@ -17,4 +17,6 @@ limitations under the License.
 <link rel="import" href="plugin-host-ipc.html" />
 
 <link rel="import" href="../tf-backend/tf-backend.html" />
+<link rel="import" href="../tf-storage/tf-storage.html" />
+<script src="core-host-impl.js"></script>
 <script src="runs-host-impl.js"></script>

--- a/tensorboard/components/experimental/plugin_util/test/plugin-test.ts
+++ b/tensorboard/components/experimental/plugin_util/test/plugin-test.ts
@@ -68,9 +68,19 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
         spec: 'guest (src) to host (dest)',
         beforeEachFunc: function() {
           this.destWindow = window;
-          this.destListen = tb_plugin.host.listen;
+          this.destListen = (
+            type: lib.DO_NOT_USE_INTERNAL.MessageType,
+            callback: Function
+          ) => {
+            tb_plugin.host.listen(type, (context, data) => {
+              return callback(data);
+            });
+          };
           this.destUnlisten = tb_plugin.host.unlisten;
-          this.destSendMessage = (type, payload) => {
+          this.destSendMessage = (
+            type: lib.DO_NOT_USE_INTERNAL.MessageType,
+            payload: lib.DO_NOT_USE_INTERNAL.PayloadType
+          ) => {
             return tb_plugin.host
               .broadcast(type, payload)
               .then(([result]) => result);

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -218,7 +218,7 @@ namespace tf_storage {
     return {get, set, getInitializer, getObserver, disposeBinding};
   }
 
-  export function initializeUrlDict() {
+  export function migrateLegacyURLScheme() {
     /**
      * TODO(psybuzz): move to some compatibility file.
      * Convert URL hash params from the legacy scheme (list taken on 1/16/2020)

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -48,12 +48,12 @@ namespace tf_storage {
    */
   export const DISAMBIGUATOR = 'disambiguator';
 
+  // Keep an up-to-date store of URL params, which iframed plugins can request.
   export let urlDict: StringDict = componentToDict(readComponent());
 
-  // Keep an up-to-date store of URL params, which iframed plugins can request.
   tf_storage.addHashListener(() => {
     tf_storage.urlDict = componentToDict(readComponent());
-  })
+  });
 
   export const {
     get: getString,

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -48,6 +48,13 @@ namespace tf_storage {
    */
   export const DISAMBIGUATOR = 'disambiguator';
 
+  export let urlDict: StringDict = componentToDict(readComponent());
+
+  // Keep an up-to-date store of URL params, which iframed plugins can request.
+  tf_storage.addHashListener(() => {
+    tf_storage.urlDict = componentToDict(readComponent());
+  })
+
   export const {
     get: getString,
     set: setString,
@@ -209,6 +216,50 @@ namespace tf_storage {
     }
 
     return {get, set, getInitializer, getObserver, disposeBinding};
+  }
+
+  export function initializeUrlDict() {
+    /**
+     * TODO(psybuzz): move to some compatibility file.
+     * Convert URL hash params from the legacy scheme (list taken on 1/16/2020)
+     * to the new scheme. Luckily, WIT only stored strings, booleans.
+     */
+    const witUrlCompatibilitySet = new Set<string>([
+      'examplesPath',
+      'hideModelPane2',
+      'modelName1',
+      'modelName2',
+      'inferenceAddress1',
+      'inferenceAddress2',
+      'modelType',
+      'modelVersion1',
+      'modelVersion2',
+      'modelSignature1',
+      'modelSignature2',
+      'maxExamples',
+      'labelVocabPath',
+      'multiClass',
+      'sequenceExamples',
+      'maxClassesToDisplay',
+      'samplingOdds',
+      'usePredictApi',
+      'predictInputTensor',
+      'predictOutputTensor',
+    ]);
+
+    const items = componentToDict(readComponent());
+    if (items[TAB] === 'whatif') {
+      for (let oldName of witUrlCompatibilitySet) {
+        if (oldName in items) {
+          const oldValue = items[oldName];
+          delete items[oldName];
+          items[`p.whatif.${oldName}`] = oldValue;
+        }
+      }
+    }
+    writeComponent(dictToComponent(items));
+
+    this.urlDict = items;
   }
 
   /**

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -907,6 +907,8 @@ limitations under the License.
           }
         });
 
+        tf_storage.initializeUrlDict();
+
         this._reloadData();
         this._lastReloadTime = new Date().toString();
       },

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -864,6 +864,8 @@ limitations under the License.
       _renderPluginIframe(container, selectedDashboard, loadingMechanism) {
         const iframe = document.createElement('iframe');
         iframe.id = 'dashboard'; // used in `_selectedDashboardComponent`
+        tb_plugin.host.registerPluginIframe(iframe, selectedDashboard);
+
         const srcUrl = new URL('data/plugin_entry.html', window.location.href);
         srcUrl.searchParams.set('name', selectedDashboard);
         iframe.setAttribute('src', srcUrl.toString());
@@ -907,7 +909,7 @@ limitations under the License.
           }
         });
 
-        tf_storage.initializeUrlDict();
+        tf_storage.migrateLegacyURLScheme();
 
         this._reloadData();
         this._lastReloadTime = new Date().toString();


### PR DESCRIPTION
* Motivation for features / changes
Clients may wish to construct a link to TensorBoard that automatically opens a specific dashboard with a specific view.  This could be achieved with `window.parent.location`, but is discouraged since it is fragile (assumes 1 layer of nested iframe and modifying the URL has wide consequences).

This provides iframed plugins a safer approach to reading the URL through the plugin library.

* Technical description of changes
Adds `getURLPluginData()` to the plugin library.