### PR TITLE
Enable strict Typescript option

### DIFF
--- a/tensorboard/components/experimental/plugin_lib/message.ts
+++ b/tensorboard/components/experimental/plugin_lib/message.ts
@@ -124,7 +124,7 @@ export class IPC {
     this.port.postMessage(JSON.stringify(message));
   }
 
-  sendMessage(type: MessageType, payload: PayloadType): Promise<PayloadType> {
+  sendMessage(type: MessageType, payload?: PayloadType): Promise<PayloadType> {
     const id = this.id++;
     const message: Message = {type, id, payload, error: null, isReply: false};
     this.postMessage(message);

--- a/tensorboard/components/experimental/plugin_util/message.ts
+++ b/tensorboard/components/experimental/plugin_util/message.ts
@@ -125,7 +125,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
       this.port.postMessage(JSON.stringify(message));
     }
 
-    sendMessage(type: MessageType, payload: PayloadType): Promise<PayloadType> {
+    sendMessage(type: MessageType, payload?: PayloadType): Promise<PayloadType> {
       const id = this.id++;
       const message: Message = {type, id, payload, error: null, isReply: false};
       this.postMessage(message);

--- a/tensorboard/components/experimental/plugin_util/message.ts
+++ b/tensorboard/components/experimental/plugin_util/message.ts
@@ -125,7 +125,10 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
       this.port.postMessage(JSON.stringify(message));
     }
 
-    sendMessage(type: MessageType, payload?: PayloadType): Promise<PayloadType> {
+    sendMessage(
+      type: MessageType,
+      payload?: PayloadType
+    ): Promise<PayloadType> {
       const id = this.id++;
       const message: Message = {type, id, payload, error: null, isReply: false};
       this.postMessage(message);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,8 @@
     "inlineSourceMap": true,
     "lib": ["dom", "es2018"],
     "moduleResolution": "node",
-    "noImplicitAny": true,
     "skipLibCheck": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true,
+    "strict": true,
   },
   "exclude": [
     "bazel-*"


### PR DESCRIPTION
* Motivation for features / changes
Stricter TS options allow TensorBoard to capture more errors.

* Technical description of changes
Enables TS's 'strict' compiler option.

* Detailed steps to verify changes work correctly (as executed by you)
Ran Bazel build on tensorboard with+without the `-c dbg` option and observed no errors after fixing plugin_lib.