### PR TITLE
Disallow period from plugin names

### DIFF
--- a/ADDING_A_PLUGIN.md
+++ b/ADDING_A_PLUGIN.md
@@ -54,7 +54,7 @@ You can start building the backend by subclassing `TBPlugin` in [`base_plugin.py
 
 ```python
 class MyPlugin(base_plugin.TBPlugin):
-  plugin_name = "My_Awesome_Plugin"
+  plugin_name = "my_awesome_plugin"
 
   def __init__(self, context): # ...
 

--- a/ADDING_A_PLUGIN.md
+++ b/ADDING_A_PLUGIN.md
@@ -54,7 +54,7 @@ You can start building the backend by subclassing `TBPlugin` in [`base_plugin.py
 
 ```python
 class MyPlugin(base_plugin.TBPlugin):
-  plugin_name = "My Awesome Plugin"
+  plugin_name = "My_Awesome_Plugin"
 
   def __init__(self, context): # ...
 
@@ -72,7 +72,7 @@ class MyPlugin(base_plugin.TBPlugin):
 ```
 
 #### TBPlugin
-  - `plugin_name`: Required field used as a unique ID for the plugin.
+  - `plugin_name`: Required field used as a unique ID for the plugin. This must only contain alphanumeric characters, hyphens, and underscores.
   - `get_plugin_apps()`: This should return a `dict` mapping route paths to WSGI applications: e.g., `"/tags"` might map to `self._serve_tags`.
   - `is_active()`: This should return whether the plugin is active (whether there exists relevant data for the plugin to process). TensorBoard will hide inactive plugins from the main navigation bar. We strongly recommend this to be a cheap operation.
   - `frontend_metadata()`: Defines how the plugin will be displayed on the frontend. See [`base_plugin.FrontendMetadata()`](https://github.com/tensorflow/tensorboard/blob/18dec9279e18a8222c9d83f90219ecddad591c46/tensorboard/plugins/base_plugin.py#L101).

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -92,7 +92,7 @@ PLUGIN_ENTRY_ROUTE = "/plugin_entry.html"
 # Slashes in a plugin name could throw the router for a loop. An empty
 # name would be confusing, too. To be safe, let's restrict the valid
 # names as follows.
-_VALID_PLUGIN_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_VALID_PLUGIN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 logger = tb_logging.get_logger()
 

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -536,7 +536,7 @@ class ApplicationPluginNameTest(tb_test.TestCase):
 
     def testComprehensiveName(self):
         application.TensorBoardWSGI(
-            plugins=[FakePlugin(plugin_name="Scalar-Dashboard_3000.1")]
+            plugins=[FakePlugin(plugin_name="Scalar-Dashboard_3000")]
         )
 
     def testNameIsNone(self):
@@ -551,6 +551,12 @@ class ApplicationPluginNameTest(tb_test.TestCase):
         with six.assertRaisesRegex(self, ValueError, r"invalid name"):
             application.TensorBoardWSGI(
                 plugins=[FakePlugin(plugin_name="scalars/data")]
+            )
+
+    def testNameWithPeriods(self):
+        with six.assertRaisesRegex(self, ValueError, r"invalid name"):
+            application.TensorBoardWSGI(
+                plugins=[FakePlugin(plugin_name="scalars.data")]
             )
 
     def testNameWithSpaces(self):


### PR DESCRIPTION
* Motivation for features / changes

A proposed change to the URL scheme for plugins would involve describing a plugin-specific URL value like so:
`https://<tensorboard>/#my_plugin&p.my_plugin.key=value`

In this scheme, the prefix `p.` is special, and a period is used to separate a plugin name from a key name.  For the scheme to work, periods need to be disallowed from plugin names to prevent ambiguity.  E.g. is `&p.my_plugin.foo.key` referring to a plugin `my_plugin` with a key `foo.key`, OR a plugin `my_plugin.foo` with a key `key`?

* Alternate designs / implementations considered

Plugin names are already restricted, so alternatively, we could use some other character like `~` or `*` to distinguish a plugin name from key name in the URL.  e.g.
`https://<tensorboard>/#my_plugin&p.my_plugin~key=value`
`https://<tensorboard>/#my_plugin&p.my_plugin*key=value`