### PR TITLE
data: remove `latest_max_index`

### DIFF
--- a/tensorboard/backend/event_processing/data_provider.py
+++ b/tensorboard/backend/event_processing/data_provider.py
@@ -235,17 +235,19 @@ class MultiplexerDataProvider(provider.DataProvider):
                 result[run] = result_for_run
                 max_step = None
                 max_wall_time = None
-                latest_max_index = -1
+                max_length = None
                 for event in self._multiplexer.Tensors(run, tag):
                     if max_step is None or max_step < event.step:
                         max_step = event.step
-                        latest_max_index = _tensor_size(event.tensor_proto)
                     if max_wall_time is None or max_wall_time < event.wall_time:
                         max_wall_time = event.wall_time
+                    length = _tensor_size(event.tensor_proto)
+                    if max_length is None or length > max_length:
+                        max_length = length
                 result_for_run[tag] = provider.BlobSequenceTimeSeries(
                     max_step=max_step,
                     max_wall_time=max_wall_time,
-                    latest_max_index=latest_max_index,
+                    max_length=max_length,
                     plugin_content=summary_metadata.plugin_data.content,
                     description=summary_metadata.summary_description,
                     display_name=summary_metadata.display_name,

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -632,8 +632,8 @@ class BlobSequenceTimeSeries(_TimeSeries):
         nonnegative integer.
       max_wall_time: The largest wall time of any datum in this time series, as
         `float` seconds since epoch.
-      latest_max_index: The largest index in the sequence at max_step (0-based,
-        inclusive).
+      max_length: The largest length (number of blobs) of any datum in
+        this scalar time series, or `None` if this time series is empty.
       plugin_content: A bytestring of arbitrary plugin-specific metadata for this
         time series, as provided to `tf.summary.write` in the
         `plugin_data.content` field of the `metadata` argument.
@@ -641,27 +641,36 @@ class BlobSequenceTimeSeries(_TimeSeries):
         empty if no description was specified.
       display_name: An optional long-form Markdown description, as a `str` that is
         empty if no description was specified. Deprecated; may be removed soon.
+      latest_max_index: Deprecated; use `max_length` instead.
     """
 
-    __slots__ = ("_latest_max_index",)
+    __slots__ = ("_max_length",)
 
     def __init__(
         self,
-        max_step,
-        max_wall_time,
-        latest_max_index,
-        plugin_content,
-        description,
-        display_name,
+        max_step=None,
+        max_wall_time=None,
+        max_length=None,
+        plugin_content=None,
+        description=None,
+        display_name=None,
+        latest_max_index=None,
     ):
         super(BlobSequenceTimeSeries, self).__init__(
             max_step, max_wall_time, plugin_content, description, display_name
         )
-        self._latest_max_index = latest_max_index
+        if max_length is None:
+            max_length = latest_max_index
+        self._max_length = max_length
 
     @property
     def latest_max_index(self):
-        return self._latest_max_index
+        # Deprecated. Use `max_length` instead.
+        return self._max_length
+
+    @property
+    def max_length(self):
+        return self._max_length
 
     def __eq__(self, other):
         if not isinstance(other, BlobSequenceTimeSeries):
@@ -670,7 +679,7 @@ class BlobSequenceTimeSeries(_TimeSeries):
             return False
         if self._max_wall_time != other._max_wall_time:
             return False
-        if self._latest_max_index != other._latest_max_index:
+        if self._max_length != other._max_length:
             return False
         if self._plugin_content != other._plugin_content:
             return False
@@ -685,7 +694,7 @@ class BlobSequenceTimeSeries(_TimeSeries):
             (
                 self._max_step,
                 self._max_wall_time,
-                self._latest_max_index,
+                self._max_length,
                 self._plugin_content,
                 self._description,
                 self._display_name,
@@ -697,7 +706,7 @@ class BlobSequenceTimeSeries(_TimeSeries):
             (
                 "max_step=%r" % (self._max_step,),
                 "max_wall_time=%r" % (self._max_wall_time,),
-                "latest_max_index=%r" % (self._latest_max_index,),
+                "max_length=%r" % (self._max_length,),
                 "plugin_content=%r" % (self._plugin_content,),
                 "description=%r" % (self._description,),
                 "display_name=%r" % (self._display_name,),

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -641,49 +641,25 @@ class BlobSequenceTimeSeries(_TimeSeries):
         empty if no description was specified.
       display_name: An optional long-form Markdown description, as a `str` that is
         empty if no description was specified. Deprecated; may be removed soon.
-      latest_max_index: Deprecated; use `max_length` instead.
     """
 
     __slots__ = ("_max_length",)
 
     def __init__(
         self,
-<<<<<<< HEAD
         max_step,
         max_wall_time,
         max_length,
         plugin_content,
         description,
         display_name,
-=======
-        max_step=None,
-        max_wall_time=None,
-        max_length=None,
-        plugin_content=None,
-        description=None,
-        display_name=None,
-        latest_max_index=None,
->>>>>>> d9e31f3c517ef136c337601ff5f81593cd8d3ce2
     ):
         super(BlobSequenceTimeSeries, self).__init__(
             max_step, max_wall_time, plugin_content, description, display_name
         )
-<<<<<<< HEAD
         self._max_length = max_length
 
     @property
-=======
-        if max_length is None:
-            max_length = latest_max_index
-        self._max_length = max_length
-
-    @property
-    def latest_max_index(self):
-        # Deprecated. Use `max_length` instead.
-        return self._max_length
-
-    @property
->>>>>>> d9e31f3c517ef136c337601ff5f81593cd8d3ce2
     def max_length(self):
         return self._max_length
 

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -641,32 +641,23 @@ class BlobSequenceTimeSeries(_TimeSeries):
         empty if no description was specified.
       display_name: An optional long-form Markdown description, as a `str` that is
         empty if no description was specified. Deprecated; may be removed soon.
-      latest_max_index: Deprecated; use `max_length` instead.
     """
 
     __slots__ = ("_max_length",)
 
     def __init__(
         self,
-        max_step=None,
-        max_wall_time=None,
-        max_length=None,
-        plugin_content=None,
-        description=None,
-        display_name=None,
-        latest_max_index=None,
+        max_step,
+        max_wall_time,
+        max_length,
+        plugin_content,
+        description,
+        display_name,
     ):
         super(BlobSequenceTimeSeries, self).__init__(
             max_step, max_wall_time, plugin_content, description, display_name
         )
-        if max_length is None:
-            max_length = latest_max_index
         self._max_length = max_length
-
-    @property
-    def latest_max_index(self):
-        # Deprecated. Use `max_length` instead.
-        return self._max_length
 
     @property
     def max_length(self):

--- a/tensorboard/data/provider_test.py
+++ b/tensorboard/data/provider_test.py
@@ -236,29 +236,6 @@ class BlobSequenceTimeSeriesTest(tb_test.TestCase):
         # least warrant some scrutiny.
         self.assertNotEqual(hash(x1), hash(x3))
 
-    def test_legacy_forms(self):
-        new_kwargs = [
-            ("max_step", 66),
-            ("max_wall_time", 1234.5),
-            ("max_length", 6),
-            ("plugin_content", b"\x12"),
-            ("description", "one"),
-            ("display_name", "two"),
-        ]
-        old_kwargs = [
-            (k if k != "max_length" else "latest_max_index", v)
-            for (k, v) in new_kwargs
-        ]
-        args = [v for (k, v) in new_kwargs]
-        variants = [
-            provider.BlobSequenceTimeSeries(*args),
-            provider.BlobSequenceTimeSeries(**dict(new_kwargs)),
-            provider.BlobSequenceTimeSeries(**dict(old_kwargs)),
-        ]
-        canonical = variants[0]
-        for variant in variants:
-            self.assertEqual(canonical, variant)
-
 
 class BlobReferenceTest(tb_test.TestCase):
     def test_repr(self):

--- a/tensorboard/data/provider_test.py
+++ b/tensorboard/data/provider_test.py
@@ -193,7 +193,7 @@ class BlobSequenceTimeSeriesTest(tb_test.TestCase):
         x = provider.BlobSequenceTimeSeries(
             max_step=77,
             max_wall_time=1234.5,
-            latest_max_index=6,
+            max_length=6,
             plugin_content=b"AB\xCD\xEF!\x00",
             description="test test",
             display_name="one two",
@@ -201,7 +201,7 @@ class BlobSequenceTimeSeriesTest(tb_test.TestCase):
         repr_ = repr(x)
         self.assertIn(repr(x.max_step), repr_)
         self.assertIn(repr(x.max_wall_time), repr_)
-        self.assertIn(repr(x.latest_max_index), repr_)
+        self.assertIn(repr(x.max_length), repr_)
         self.assertIn(repr(x.plugin_content), repr_)
         self.assertIn(repr(x.description), repr_)
         self.assertIn(repr(x.display_name), repr_)
@@ -235,6 +235,29 @@ class BlobSequenceTimeSeriesTest(tb_test.TestCase):
         # contract, but _should_ pass; failure on this assertion would at
         # least warrant some scrutiny.
         self.assertNotEqual(hash(x1), hash(x3))
+
+    def test_legacy_forms(self):
+        new_kwargs = [
+            ("max_step", 66),
+            ("max_wall_time", 1234.5),
+            ("max_length", 6),
+            ("plugin_content", b"\x12"),
+            ("description", "one"),
+            ("display_name", "two"),
+        ]
+        old_kwargs = [
+            (k if k != "max_length" else "latest_max_index", v)
+            for (k, v) in new_kwargs
+        ]
+        args = [v for (k, v) in new_kwargs]
+        variants = [
+            provider.BlobSequenceTimeSeries(*args),
+            provider.BlobSequenceTimeSeries(**dict(new_kwargs)),
+            provider.BlobSequenceTimeSeries(**dict(old_kwargs)),
+        ]
+        canonical = variants[0]
+        for variant in variants:
+            self.assertEqual(canonical, variant)
 
 
 class BlobReferenceTest(tb_test.TestCase):


### PR DESCRIPTION
Summary:
This was replaced with `max_length`, which has the semantics that we
actually want.

Test Plan:
Running `git grep latest_max_index` gives no results.

wchargin-branch: data-remove-latest-max-index
