### PR TITLE
ci: inspect cache size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,14 @@ cache:
 before_install:
   - elapsed() { TZ=UTC printf "Time %(%T)T %s\n" "$SECONDS" "$1"; }
   - elapsed "before_install"
+
+  - du -b ~/.cache
+  - du -b ~/.cache/pip
+  - du -b ~/.cache/pip/http
+  - du -b ~/.cache/tb-bazel-disk
+  - du -b ~/.cache/tb-bazel-repo
+  - exit 123
+
   - ci/download_bazel.sh "${BAZEL}" "${BAZEL_SHA256SUM}" ~/bazel
   - sudo mv ~/bazel /usr/local/bin/bazel
   - cp ci/bazelrc ~/.bazelrc


### PR DESCRIPTION
Summary:
Our Travis caches are steadily growing. I suspect that the Pip cache of
TensorFlow nightlies plays a role here, as there are new packages every
day and the old ones are never evicted. Let’s find out.

This is a test PR just to trigger CI. (It would be possible to actually
merge some logging like this, but we’d want to make sure that it doesn’t
slow down the actual success reporting. Therefore:
DO NOT SUBMIT

wchargin-branch: ci-inspect-cache
