### PR TITLE
ci: don’t store Pip HTTP cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ env:
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:
-  # Reuse the pip cache directory across build machines.
-  pip: true
   # Cache directories for Bazel. See ci/bazelrc for details.
   directories:
     - $HOME/.cache/tb-bazel-repo

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ env:
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:
+  # Don't cache the Pip directory. We pull in a new `tf-nightly` wheel
+  # every day, and Pip caches are never evicted, so this quickly bloats
+  # to many gigabytes and adds minutes to the CI time.
+  pip: false
   # Cache directories for Bazel. See ci/bazelrc for details.
   directories:
     - $HOME/.cache/tb-bazel-repo


### PR DESCRIPTION
Summary:
The Pip HTTP cache stores all downloaded wheels and is never evicted.
With new `tf-nightly` wheels every day, this adds up quickly. We last
cleared our Travis caches about a month ago, and they’re up to 14.3 GB.

Investigation shows that the Pip HTTP cache accounts for the majority of
the cache (about 70% after about a month of cache accrual), and also
that jobs with larger caches have significantly longer startup times,
with delta on the order of 8 minutes (again, after about a month). Also,
uploading large caches at the end of a job can take minutes, and Travis
doesn’t report success until this finishes. Fetching `tf-nightly` should
be comparatively cheap.

This reverts part of #2278.

Test Plan:
This PR reduces the “before install” time (i.e., time spent by Travis
internals before it gets to our script, including restoring cache) from
9m40s to 4m59s, a 48% improvement. The “install” time is increased from
3m36s to 3m56s, which seems acceptable.

wchargin-branch: ci-drop-pip-http-cache
