### PR TITLE
[ng] expose tb_server_data_source as interface

### DIFF
--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -7,6 +7,7 @@ ng_module(
     srcs = [
         "tb_server_data_source.ts",
         "tb_server_data_source_module.ts",
+        "tb_server_data_source_types.ts",
     ],
     deps = [
         "//tensorboard/webapp/angular:expect_angular_common_http",

--- a/tensorboard/webapp/webapp_data_source/tb_server_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_server_data_source.ts
@@ -19,12 +19,19 @@ import {from} from 'rxjs';
 
 import {PluginsListing} from '../types/api';
 
+import {
+  TBServerDataSourceInterface,
+  TfBackendComponent,
+} from './tb_server_data_source_types';
+
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 @Injectable()
-export class TBServerDataSource {
+export class TBServerDataSource implements TBServerDataSourceInterface {
   // TODO(soergel): implements WebappDataSource
-  private tfBackend = (document.createElement('tf-backend') as any).tf_backend;
+  private tfBackend = (document.createElement(
+    'tf-backend'
+  ) as TfBackendComponent).tf_backend;
 
   constructor(private http: HttpClient) {}
 

--- a/tensorboard/webapp/webapp_data_source/tb_server_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_server_data_source_types.ts
@@ -1,0 +1,35 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Observable} from 'rxjs';
+
+import {PluginsListing} from '../types/api';
+
+export interface TfBackendComponent extends HTMLElement {
+  tf_backend: {
+    runsStore: {
+      refresh: () => Promise<void>;
+    };
+    environmentStore: {
+      refresh: () => Promise<void>;
+    };
+  };
+}
+
+export interface TBServerDataSourceInterface {
+  fetchPluginsListing(): Observable<PluginsListing>;
+  fetchRuns(): Observable<void>;
+  fetchEnvironments(): Observable<void>;
+}


### PR DESCRIPTION
We can provide an alternative implementation of the DataSource by using
Angular DI but the provided implementations require some common APIs so
they do not get out of sync. By implementing an interface, we can
guarantee some correctness at the compilation time.