### PR TITLE
uploader: make `util_test` py3-compatible internally

### DIFF
--- a/tensorboard/uploader/util_test.py
+++ b/tensorboard/uploader/util_test.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import datetime
 import os
+import time
 import unittest
 import mock
 
@@ -208,9 +209,13 @@ class FormatTimeTest(tb_test.TestCase):
     def _run(self, t=None, now=None):
         timestamp_pb = timestamp_pb2.Timestamp()
         util.set_timestamp(timestamp_pb, t)
-        with mock.patch.dict(os.environ, {"TZ": "UTC"}):
-            now = datetime.datetime.fromtimestamp(now)
-            return util.format_time(timestamp_pb, now=now)
+        try:
+            with mock.patch.dict(os.environ, {"TZ": "UTC"}):
+                time.tzset()
+                now = datetime.datetime.fromtimestamp(now)
+                return util.format_time(timestamp_pb, now=now)
+        finally:
+            time.tzset()
 
     def test_just_now(self):
         base = 1546398245


### PR DESCRIPTION
Summary:
Follow-up to #2978, which added explicit configuration of `TZ=UTC`. In
cPython 3, the time zone used by `datetime.datetime.fromtimestamp` is
[cached when `time` is imported][1] unless explicitly reset, so mocking
the environment variable is no longer sufficient. We now call `tzset`
ourselves; we could also just set `TZ=UTC` before importing `datetime`,
but this seems cleaner.

[1]: https://github.com/python/cpython/blob/2528a6c3d0660c03ae43d796628462ccf8e58190/Modules/timemodule.c#L1752-L1763

Test Plan:
A test sync shows that this test passes in both Python 2 and Python 3,
whereas it previously only passed in Python 2.

wchargin-branch: util-test-tzset
