### PR TITLE
custom_scalars: use `tensorboard.compat` protos in test

### DIFF
--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -120,10 +120,15 @@ class CustomScalarsPluginTest(tf.test.TestCase):
         with test_util.FileWriterCache.get(
             os.path.join(self.logdir, "foo")
         ) as writer:
-            writer.add_summary(summary.pb(self.foo_layout))
+            writer.add_summary(
+                test_util.ensure_tb_summary_proto(summary.pb(self.foo_layout))
+            )
             for step in range(4):
                 writer.add_summary(
-                    scalar_summary.pb("squares", step * step), step
+                    test_util.ensure_tb_summary_proto(
+                        scalar_summary.pb("squares", step * step)
+                    ),
+                    step,
                 )
 
         with test_util.FileWriterCache.get(
@@ -131,12 +136,19 @@ class CustomScalarsPluginTest(tf.test.TestCase):
         ) as writer:
             for step in range(3):
                 writer.add_summary(
-                    scalar_summary.pb("increments", step + 1), step
+                    test_util.ensure_tb_summary_proto(
+                        scalar_summary.pb("increments", step + 1)
+                    ),
+                    step,
                 )
 
         # The '.' run lacks scalar data but has a layout.
         with test_util.FileWriterCache.get(self.logdir) as writer:
-            writer.add_summary(summary.pb(self.logdir_layout))
+            writer.add_summary(
+                test_util.ensure_tb_summary_proto(
+                    summary.pb(self.logdir_layout)
+                )
+            )
 
         self.plugin = self.createPlugin(self.logdir)
 
@@ -273,7 +285,11 @@ class CustomScalarsPluginTest(tf.test.TestCase):
         # Generate a directory with a layout but no scalars data.
         directory = os.path.join(self.logdir, "no_scalars")
         with test_util.FileWriterCache.get(directory) as writer:
-            writer.add_summary(summary.pb(self.logdir_layout))
+            writer.add_summary(
+                test_util.ensure_tb_summary_proto(
+                    summary.pb(self.logdir_layout)
+                )
+            )
 
         local_plugin = self.createPlugin(directory)
         self.assertFalse(local_plugin.is_active())


### PR DESCRIPTION
Summary:
This gets rid of the “Please prefer TensorBoard copy of the proto”
message in the test logs.

Test Plan:
After changing the warnings in `test_util.py` to `AssertionError`s, this
test passes where it used to fail.

wchargin-branch: custom-scalars-tb-proto
