### PR TITLE
test_util: don’t warn when raw byte strings passed

### DIFF
--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -120,10 +120,15 @@ class CustomScalarsPluginTest(tf.test.TestCase):
         with test_util.FileWriterCache.get(
             os.path.join(self.logdir, "foo")
         ) as writer:
-            writer.add_summary(summary.pb(self.foo_layout))
+            writer.add_summary(
+                test_util.ensure_tb_summary_proto(summary.pb(self.foo_layout))
+            )
             for step in range(4):
                 writer.add_summary(
-                    scalar_summary.pb("squares", step * step), step
+                    test_util.ensure_tb_summary_proto(
+                        scalar_summary.pb("squares", step * step)
+                    ),
+                    step,
                 )
 
         with test_util.FileWriterCache.get(
@@ -131,12 +136,19 @@ class CustomScalarsPluginTest(tf.test.TestCase):
         ) as writer:
             for step in range(3):
                 writer.add_summary(
-                    scalar_summary.pb("increments", step + 1), step
+                    test_util.ensure_tb_summary_proto(
+                        scalar_summary.pb("increments", step + 1)
+                    ),
+                    step,
                 )
 
         # The '.' run lacks scalar data but has a layout.
         with test_util.FileWriterCache.get(self.logdir) as writer:
-            writer.add_summary(summary.pb(self.logdir_layout))
+            writer.add_summary(
+                test_util.ensure_tb_summary_proto(
+                    summary.pb(self.logdir_layout)
+                )
+            )
 
         self.plugin = self.createPlugin(self.logdir)
 
@@ -273,7 +285,11 @@ class CustomScalarsPluginTest(tf.test.TestCase):
         # Generate a directory with a layout but no scalars data.
         directory = os.path.join(self.logdir, "no_scalars")
         with test_util.FileWriterCache.get(directory) as writer:
-            writer.add_summary(summary.pb(self.logdir_layout))
+            writer.add_summary(
+                test_util.ensure_tb_summary_proto(
+                    summary.pb(self.logdir_layout)
+                )
+            )
 
         local_plugin = self.createPlugin(directory)
         self.assertFalse(local_plugin.is_active())

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -64,10 +64,11 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
         if isinstance(event, event_pb2.Event):
             tf_event = tf.compat.v1.Event.FromString(event.SerializeToString())
         else:
-            logger.warn(
-                "Added TensorFlow event proto. "
-                "Please prefer TensorBoard copy of the proto"
-            )
+            if not isinstance(summary, bytes):
+                logging.error(
+                    "Added TensorFlow event proto. "
+                    "Please prefer TensorBoard copy of the proto"
+                )
             tf_event = event
         super(FileWriter, self).add_event(tf_event)
 
@@ -77,11 +78,12 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
                 summary.SerializeToString()
             )
         else:
-            logger.warn(
-                "Added TensorFlow summary proto. "
-                "Please prefer TensorBoard copy of the proto"
-            )
             tf_summary = summary
+            if not isinstance(summary, bytes):
+                logging.error(
+                    "Added TensorFlow summary proto. "
+                    "Please prefer TensorBoard copy of the proto"
+                )
         super(FileWriter, self).add_summary(tf_summary, global_step)
 
     def add_session_log(self, session_log, global_step=None):
@@ -90,11 +92,12 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
                 session_log.SerializeToString()
             )
         else:
-            logger.warn(
-                "Added TensorFlow session_log proto. "
-                "Please prefer TensorBoard copy of the proto"
-            )
             tf_session_log = session_log
+            if not isinstance(session_log, bytes):
+                logging.error(
+                    "Added TensorFlow session_log proto. "
+                    "Please prefer TensorBoard copy of the proto"
+                )
         super(FileWriter, self).add_session_log(tf_session_log, global_step)
 
     def add_graph(self, graph, global_step=None, graph_def=None):

--- a/tensorboard/util/test_util.py
+++ b/tensorboard/util/test_util.py
@@ -64,12 +64,12 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
         if isinstance(event, event_pb2.Event):
             tf_event = tf.compat.v1.Event.FromString(event.SerializeToString())
         else:
-            if not isinstance(summary, bytes):
-                logging.error(
+            tf_event = event
+            if not isinstance(event, bytes):
+                logger.error(
                     "Added TensorFlow event proto. "
                     "Please prefer TensorBoard copy of the proto"
                 )
-            tf_event = event
         super(FileWriter, self).add_event(tf_event)
 
     def add_summary(self, summary, global_step=None):
@@ -80,7 +80,7 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
         else:
             tf_summary = summary
             if not isinstance(summary, bytes):
-                logging.error(
+                logger.error(
                     "Added TensorFlow summary proto. "
                     "Please prefer TensorBoard copy of the proto"
                 )
@@ -94,7 +94,7 @@ class FileWriter(tf.compat.v1.summary.FileWriter):
         else:
             tf_session_log = session_log
             if not isinstance(session_log, bytes):
-                logging.error(
+                logger.error(
                     "Added TensorFlow session_log proto. "
                     "Please prefer TensorBoard copy of the proto"
                 )


### PR DESCRIPTION
Summary:
Some arguments may be passed as TensorFlow protos, TensorBoard protos,
or raw byte strings. We want to warn against the TensorFlow protos, but
were also warning against the raw byte strings. This change fixes all
existing warnings, so we bump the log level to `error` to discourage
regressions.

Test Plan:
After changing the warnings in `test_util.py` to `AssertionError`s, all
tests still pass where 18 of them used to fail.

wchargin-branch: testutil-permit-bytes-protos
