### PR TITLE
images: add data provider support

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -470,6 +470,7 @@ py_library(
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins/graph:metadata",
         "//tensorboard/plugins/histogram:metadata",
+        "//tensorboard/plugins/image:metadata",
         "//tensorboard/plugins/scalar:metadata",
         "//tensorboard/util:tensor_util",
     ],

--- a/tensorboard/dataclass_compat.py
+++ b/tensorboard/dataclass_compat.py
@@ -29,6 +29,7 @@ from tensorboard.compat.proto import event_pb2
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.graph import metadata as graphs_metadata
 from tensorboard.plugins.histogram import metadata as histograms_metadata
+from tensorboard.plugins.image import metadata as images_metadata
 from tensorboard.plugins.scalar import metadata as scalars_metadata
 from tensorboard.util import tensor_util
 
@@ -87,6 +88,8 @@ def _migrate_value(value):
     plugin_name = value.metadata.plugin_data.plugin_name
     if plugin_name == histograms_metadata.PLUGIN_NAME:
         return _migrate_histogram_value(value)
+    if plugin_name == images_metadata.PLUGIN_NAME:
+        return _migrate_image_value(value)
     if plugin_name == scalars_metadata.PLUGIN_NAME:
         return _migrate_scalar_value(value)
     return (value,)
@@ -99,4 +102,9 @@ def _migrate_scalar_value(value):
 
 def _migrate_histogram_value(value):
     value.metadata.data_class = summary_pb2.DATA_CLASS_TENSOR
+    return (value,)
+
+
+def _migrate_image_value(value):
+    value.metadata.data_class = summary_pb2.DATA_CLASS_BLOB_SEQUENCE
     return (value,)

--- a/tensorboard/plugins/image/images_plugin.py
+++ b/tensorboard/plugins/image/images_plugin.py
@@ -25,8 +25,10 @@ import six
 from six.moves import urllib
 from werkzeug import wrappers
 
+from tensorboard import errors
 from tensorboard import plugin_util
 from tensorboard.backend import http_util
+from tensorboard.data import provider
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.image import metadata
 from tensorboard.compat import tf
@@ -67,6 +69,10 @@ class ImagesPlugin(base_plugin.TBPlugin):
         """
         self._multiplexer = context.multiplexer
         self._db_connection_provider = context.db_connection_provider
+        if context.flags and context.flags.generic_data == "true":
+            self._data_provider = context.data_provider
+        else:
+            self._data_provider = None
 
     def get_plugin_apps(self):
         return {
@@ -78,6 +84,9 @@ class ImagesPlugin(base_plugin.TBPlugin):
     def is_active(self):
         """The images plugin is active iff any run has at least one relevant
         tag."""
+        if self._data_provider:
+            return False  # `list_plugins` as called by TB core suffices
+
         if self._db_connection_provider:
             # The plugin is active if one relevant tag can be found in the database.
             db = self._db_connection_provider()
@@ -100,7 +109,24 @@ class ImagesPlugin(base_plugin.TBPlugin):
     def frontend_metadata(self):
         return base_plugin.FrontendMetadata(element_name="tf-image-dashboard")
 
-    def _index_impl(self):
+    def _index_impl(self, experiment):
+        if self._data_provider:
+            mapping = self._data_provider.list_blob_sequences(
+                experiment_id=experiment, plugin_name=metadata.PLUGIN_NAME,
+            )
+            result = {run: {} for run in mapping}
+            for (run, tag_to_content) in six.iteritems(mapping):
+                for (tag, metadatum) in six.iteritems(tag_to_content):
+                    description = plugin_util.markdown_to_safe_html(
+                        metadatum.description
+                    )
+                    result[run][tag] = {
+                        "displayName": metadatum.display_name,
+                        "description": description,
+                        "samples": metadatum.max_length - 2,
+                    }
+            return result
+
         if self._db_connection_provider:
             db = self._db_connection_provider()
             cursor = db.execute(
@@ -179,18 +205,21 @@ class ImagesPlugin(base_plugin.TBPlugin):
         Returns:
           A werkzeug.Response application.
         """
+        experiment = plugin_util.experiment_id(request.environ)
         tag = request.args.get("tag")
         run = request.args.get("run")
         sample = int(request.args.get("sample", 0))
         try:
-            response = self._image_response_for_run(run, tag, sample)
+            response = self._image_response_for_run(
+                experiment, run, tag, sample
+            )
         except KeyError:
             return http_util.Respond(
                 request, "Invalid run or tag", "text/plain", code=400
             )
         return http_util.Respond(request, response, "application/json")
 
-    def _image_response_for_run(self, run, tag, sample):
+    def _image_response_for_run(self, experiment, run, tag, sample):
         """Builds a JSON-serializable object with information about images.
 
         Args:
@@ -205,6 +234,33 @@ class ImagesPlugin(base_plugin.TBPlugin):
           A list of dictionaries containing the wall time, step, and URL
           for each image.
         """
+        if self._data_provider:
+            # Downsample reads to 10 images per time series, which is the
+            # default size guidance for images under the multiplexer loading
+            # logic.
+            SAMPLE_COUNT = 10
+            all_images = self._data_provider.read_blob_sequences(
+                experiment_id=experiment,
+                plugin_name=metadata.PLUGIN_NAME,
+                downsample=SAMPLE_COUNT,
+                run_tag_filter=provider.RunTagFilter(runs=[run], tags=[tag]),
+            )
+            images = all_images.get(run, {}).get(tag, None)
+            if images is None:
+                raise errors.NotFoundError(
+                    "No image data for run=%r, tag=%r" % (run, tag)
+                )
+            return [
+                {
+                    "wall_time": datum.wall_time,
+                    "step": datum.step,
+                    "query": self._data_provider_query(
+                        datum.values[sample + 2]
+                    ),
+                }
+                for datum in images
+                if len(datum.values) - 2 > sample
+            ]
         if self._db_connection_provider:
             db = self._db_connection_provider()
             cursor = db.execute(
@@ -292,6 +348,9 @@ class ImagesPlugin(base_plugin.TBPlugin):
         )
         return query_string
 
+    def _data_provider_query(self, blob_reference):
+        return urllib.parse.urlencode({"blob_key": blob_reference.blob_key})
+
     def _get_individual_image(self, run, tag, index, sample):
         """Returns the actual image bytes for a given image.
 
@@ -353,12 +412,16 @@ class ImagesPlugin(base_plugin.TBPlugin):
     @wrappers.Request.application
     def _serve_individual_image(self, request):
         """Serves an individual image."""
-        run = request.args.get("run")
-        tag = request.args.get("tag")
-        index = int(request.args.get("index", "0"))
-        sample = int(request.args.get("sample", "0"))
         try:
-            data = self._get_individual_image(run, tag, index, sample)
+            if self._data_provider:
+                blob_key = request.args["blob_key"]
+                data = self._data_provider.read_blob(blob_key)
+            else:
+                run = request.args.get("run")
+                tag = request.args.get("tag")
+                index = int(request.args.get("index", "0"))
+                sample = int(request.args.get("sample", "0"))
+                data = self._get_individual_image(run, tag, index, sample)
         except (KeyError, IndexError):
             return http_util.Respond(
                 request,
@@ -374,5 +437,6 @@ class ImagesPlugin(base_plugin.TBPlugin):
 
     @wrappers.Request.application
     def _serve_tags(self, request):
-        index = self._index_impl()
+        experiment = plugin_util.experiment_id(request.environ)
+        index = self._index_impl(experiment)
         return http_util.Respond(request, index, "application/json")

--- a/tensorboard/plugins/image/images_plugin_test.py
+++ b/tensorboard/plugins/image/images_plugin_test.py
@@ -18,7 +18,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import argparse
 import collections
+import functools
 import json
 import os
 import shutil
@@ -32,6 +34,7 @@ from werkzeug import test as werkzeug_test
 from werkzeug import wrappers
 
 from tensorboard.backend import application
+from tensorboard.backend.event_processing import data_provider
 from tensorboard.backend.event_processing import (
     plugin_event_multiplexer as event_multiplexer,
 )
@@ -44,7 +47,8 @@ tf.compat.v1.disable_v2_behavior()
 
 
 class ImagesPluginTest(tf.test.TestCase):
-    def setUp(self):
+    def _create_data(self):
+        """Write test data to disk, returning `(logdir, multiplexer)`."""
         self.log_dir = tempfile.mkdtemp()
 
         # We use numpy.random to generate images. We seed to avoid non-determinism
@@ -104,13 +108,47 @@ class ImagesPluginTest(tf.test.TestCase):
             {"foo": foo_directory, "bar": bar_directory,}
         )
         multiplexer.Reload()
-        context = base_plugin.TBContext(
-            logdir=self.log_dir, multiplexer=multiplexer
-        )
-        plugin = images_plugin.ImagesPlugin(context)
+        return (self.log_dir, multiplexer)
+
+    def _initialize_plugin_specific_attrs(self, plugin):
         wsgi_app = application.TensorBoardWSGI([plugin])
         self.server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
         self.routes = plugin.get_plugin_apps()
+
+    def with_images_plugin(fn):
+        """Run a test with a bare multiplexer and with a data provider.
+
+        The decorated function will receive an initialized
+        `ImagesPlugin` object as its first positional argument, and the
+        plugin-specific attributes on `self` will have been initialized.
+        """
+
+        @functools.wraps(fn)
+        def wrapper(self, *args, **kwargs):
+            (logdir, multiplexer) = self._create_data()
+            with self.subTest("bare multiplexer"):
+                ctx = base_plugin.TBContext(
+                    logdir=logdir, multiplexer=multiplexer
+                )
+                plugin = images_plugin.ImagesPlugin(ctx)
+                self._initialize_plugin_specific_attrs(plugin)
+                fn(self, plugin, *args, **kwargs)
+            with self.subTest("generic data provider"):
+                flags = argparse.Namespace(generic_data="true")
+                provider = data_provider.MultiplexerDataProvider(
+                    multiplexer, logdir
+                )
+                ctx = base_plugin.TBContext(
+                    flags=flags,
+                    logdir=logdir,
+                    multiplexer=multiplexer,
+                    data_provider=provider,
+                )
+                plugin = images_plugin.ImagesPlugin(ctx)
+                self._initialize_plugin_specific_attrs(plugin)
+                fn(self, plugin, *args, **kwargs)
+
+        return wrapper
 
     def tearDown(self):
         shutil.rmtree(self.log_dir, ignore_errors=True)
@@ -126,7 +164,8 @@ class ImagesPluginTest(tf.test.TestCase):
         """
         return json.loads(byte_content.decode("utf-8"))
 
-    def testRoutesProvided(self):
+    @with_images_plugin
+    def testRoutesProvided(self, plugin):
         """Tests that the plugin offers the correct routes."""
         self.assertIsInstance(self.routes["/images"], collections.Callable)
         self.assertIsInstance(
@@ -134,7 +173,8 @@ class ImagesPluginTest(tf.test.TestCase):
         )
         self.assertIsInstance(self.routes["/tags"], collections.Callable)
 
-    def testOldStyleImagesRoute(self):
+    @with_images_plugin
+    def testOldStyleImagesRoute(self, plugin):
         """Tests that the /images routes returns correct old-style data."""
         response = self.server.get(
             "/data/plugin/images/images?run=foo&tag=baz/image/0&sample=0"
@@ -148,22 +188,34 @@ class ImagesPluginTest(tf.test.TestCase):
         # Verify that the 1st entry is correct.
         entry = entries[0]
         self.assertEqual(0, entry["step"])
-        parsed_query = urllib.parse.parse_qs(entry["query"])
-        self.assertListEqual(["foo"], parsed_query["run"])
-        self.assertListEqual(["baz/image/0"], parsed_query["tag"])
-        self.assertListEqual(["0"], parsed_query["sample"])
-        self.assertListEqual(["0"], parsed_query["index"])
+        parsed_query_1 = urllib.parse.parse_qs(entry["query"])
+        if plugin._data_provider:
+            self.assertItemsEqual(["blob_key"], parsed_query_1)
+            self.assertTrue(parsed_query_1["blob_key"])
+        else:
+            self.assertListEqual(["foo"], parsed_query_1["run"])
+            self.assertListEqual(["baz/image/0"], parsed_query_1["tag"])
+            self.assertListEqual(["0"], parsed_query_1["sample"])
+            self.assertListEqual(["0"], parsed_query_1["index"])
 
         # Verify that the 2nd entry is correct.
         entry = entries[1]
         self.assertEqual(1, entry["step"])
-        parsed_query = urllib.parse.parse_qs(entry["query"])
-        self.assertListEqual(["foo"], parsed_query["run"])
-        self.assertListEqual(["baz/image/0"], parsed_query["tag"])
-        self.assertListEqual(["0"], parsed_query["sample"])
-        self.assertListEqual(["1"], parsed_query["index"])
+        parsed_query_2 = urllib.parse.parse_qs(entry["query"])
+        if plugin._data_provider:
+            self.assertItemsEqual(["blob_key"], parsed_query_2)
+            self.assertTrue(parsed_query_2["blob_key"])
+        else:
+            self.assertListEqual(["foo"], parsed_query_2["run"])
+            self.assertListEqual(["baz/image/0"], parsed_query_2["tag"])
+            self.assertListEqual(["0"], parsed_query_2["sample"])
+            self.assertListEqual(["1"], parsed_query_2["index"])
 
-    def testNewStyleImagesRoute(self):
+        if plugin._data_provider:
+            self.assertNotEqual(parsed_query_1, parsed_query_2)
+
+    @with_images_plugin
+    def testNewStyleImagesRoute(self, plugin):
         """Tests that the /images routes returns correct new-style data."""
         response = self.server.get(
             "/data/plugin/images/images?run=bar&tag=quux/image_summary&sample=0"
@@ -177,40 +229,64 @@ class ImagesPluginTest(tf.test.TestCase):
         # Verify that the 1st entry is correct.
         entry = entries[0]
         self.assertEqual(0, entry["step"])
-        parsed_query = urllib.parse.parse_qs(entry["query"])
-        self.assertListEqual(["bar"], parsed_query["run"])
-        self.assertListEqual(["quux/image_summary"], parsed_query["tag"])
-        self.assertListEqual(["0"], parsed_query["sample"])
-        self.assertListEqual(["0"], parsed_query["index"])
+        parsed_query_1 = urllib.parse.parse_qs(entry["query"])
+        if plugin._data_provider:
+            self.assertItemsEqual(["blob_key"], parsed_query_1)
+            self.assertTrue(parsed_query_1["blob_key"])
+        else:
+            self.assertListEqual(["bar"], parsed_query_1["run"])
+            self.assertListEqual(["quux/image_summary"], parsed_query_1["tag"])
+            self.assertListEqual(["0"], parsed_query_1["sample"])
+            self.assertListEqual(["0"], parsed_query_1["index"])
 
         # Verify that the 2nd entry is correct.
         entry = entries[1]
         self.assertEqual(1, entry["step"])
-        parsed_query = urllib.parse.parse_qs(entry["query"])
-        self.assertListEqual(["bar"], parsed_query["run"])
-        self.assertListEqual(["quux/image_summary"], parsed_query["tag"])
-        self.assertListEqual(["0"], parsed_query["sample"])
-        self.assertListEqual(["1"], parsed_query["index"])
+        parsed_query_2 = urllib.parse.parse_qs(entry["query"])
+        if plugin._data_provider:
+            self.assertItemsEqual(["blob_key"], parsed_query_2)
+            self.assertTrue(parsed_query_2["blob_key"])
+        else:
+            self.assertListEqual(["bar"], parsed_query_2["run"])
+            self.assertListEqual(["quux/image_summary"], parsed_query_2["tag"])
+            self.assertListEqual(["0"], parsed_query_2["sample"])
+            self.assertListEqual(["1"], parsed_query_2["index"])
 
-    def testOldStyleIndividualImageRoute(self):
+        if plugin._data_provider:
+            self.assertNotEqual(parsed_query_1, parsed_query_2)
+
+    @with_images_plugin
+    def testOldStyleIndividualImageRoute(self, plugin):
         """Tests fetching an individual image from an old-style summary."""
         response = self.server.get(
-            "/data/plugin/images/individualImage"
-            "?run=foo&tag=baz/image/0&sample=0&index=0"
+            "/data/plugin/images/images?run=foo&tag=baz/image/0&sample=0"
+        )
+        self.assertEqual(200, response.status_code)
+        entries = self._DeserializeResponse(response.get_data())
+        query_string = entries[0]["query"]
+        response = self.server.get(
+            "/data/plugin/images/individualImage?" + query_string
         )
         self.assertEqual(200, response.status_code)
         self.assertEqual("image/png", response.headers.get("content-type"))
 
-    def testNewStyleIndividualImageRoute(self):
+    @with_images_plugin
+    def testNewStyleIndividualImageRoute(self, plugin):
         """Tests fetching an individual image from a new-style summary."""
         response = self.server.get(
-            "/data/plugin/images/individualImage"
-            "?run=bar&tag=quux/image_summary&sample=0&index=0"
+            "/data/plugin/images/images?run=bar&tag=quux/image_summary&sample=0"
+        )
+        self.assertEqual(200, response.status_code)
+        entries = self._DeserializeResponse(response.get_data())
+        query_string = entries[0]["query"]
+        response = self.server.get(
+            "/data/plugin/images/individualImage?" + query_string
         )
         self.assertEqual(200, response.status_code)
         self.assertEqual("image/png", response.headers.get("content-type"))
 
-    def testRunsRoute(self):
+    @with_images_plugin
+    def testRunsRoute(self, plugin):
         """Tests that the /runs route offers the correct run to tag mapping."""
         response = self.server.get("/data/plugin/images/tags")
         self.assertEqual(200, response.status_code)


### PR DESCRIPTION
Summary:
This patch teaches the images plugin about the generic data APIs and
newfound blob sequence support, guarded behind the `--generic_data=true`
feature flag.

Test Plan:
Setting `--generic_data` to either `false` or `true` has no observable
effect, even if TensorBoard is patched to never pass a multiplexer to
plugins’ `TBContext` (to prevent accidentally reads along the old path).
Unit tests expanded to cover both the old and new paths.

wchargin-branch: generic-images
