### PR TITLE
Change EventFileLoader to use tf_record_iterator when possible

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -150,6 +150,9 @@ py_test(
     deps = [
         ":event_file_loader",
         "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
+        "//tensorboard/summary/writer",
+        "@org_pythonhosted_six",
     ],
 )
 

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 import inspect
 
 from tensorboard.compat import tf
-from tensorboard.compat import _pywrap_tensorflow
 from tensorboard.compat.proto import event_pb2
 from tensorboard.util import platform_util
 from tensorboard.util import tb_logging
@@ -30,24 +29,80 @@ from tensorboard.util import tb_logging
 logger = tb_logging.get_logger()
 
 
+def _make_tf_record_iterator(file_path):
+    """Returns an iterator over TF records for the given tfrecord file."""
+    try:
+        from tensorboard.compat import _pywrap_tensorflow
+
+        py_record_reader_new = _pywrap_tensorflow.PyRecordReader_New
+    except (ImportError, AttributeError):
+        py_record_reader_new = None
+    # If PyRecordReader exists, use it, otherwise use tf_record_iterator().
+    # Check old first, then new, since tf_record_iterator existed previously but
+    # only gained the semantics we need at the time PyRecordReader was removed.
+    #
+    # TODO(#1711): Eventually remove PyRecordReader fallback once we can drop
+    # support for TF 2.1 and prior, and find a non-deprecated replacement for
+    # tf.compat.v1.io.tf_record_iterator.
+    if py_record_reader_new:
+        logger.debug("Opening a record reader pointing at %s", file_path)
+        return _PyRecordReaderIterator(py_record_reader_new, file_path)
+    else:
+        logger.debug("Opening a tf_record_iterator pointing at %s", file_path)
+        return tf.compat.v1.io.tf_record_iterator(file_path)
+
+
+class _PyRecordReaderIterator(object):
+    """Python iterator for TF Records based on PyRecordReader."""
+
+    def __init__(self, py_record_reader_new, file_path):
+        """Constructs a _PyRecordReaderIterator for the given file path.
+
+        Args:
+          py_record_reader_new: pywrap_tensorflow.PyRecordReader_New
+          file_path: file path of the tfrecord file to read
+        """
+        with tf.compat.v1.errors.raise_exception_on_not_ok_status() as status:
+            self._reader = py_record_reader_new(
+                tf.compat.as_bytes(file_path), 0, tf.compat.as_bytes(""), status
+            )
+        if not self._reader:
+            raise IOError(
+                "Failed to open a record reader pointing to %s" % file_path
+            )
+        # getargspec is deprecated in Python3, use getfullargspec if it exists.
+        try:
+            getargspec = inspect.getfullargspec
+        except AttributeError:
+            getargspec = inspect.getargspec  # pylint: disable=deprecated-method
+        # GetNext() expects a status argument (after `self`) on TF <= 1.7.
+        self._legacy_get_next = len(getargspec(self._reader.GetNext).args) > 1
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            if self._legacy_get_next:
+                with tf.compat.v1.errors.raise_exception_on_not_ok_status() as status:
+                    self._reader.GetNext(status)
+            else:
+                self._reader.GetNext()
+        except tf.errors.OutOfRangeError as e:
+            raise StopIteration
+        return self._reader.record()
+
+    next = __next__  # for python2 compatibility
+
+
 class RawEventFileLoader(object):
     """An iterator that yields Event protos as serialized bytestrings."""
 
     def __init__(self, file_path):
         if file_path is None:
             raise ValueError("A file path is required")
-        file_path = platform_util.readahead_file_path(file_path)
-        logger.debug("Opening a record reader pointing at %s", file_path)
-        with tf.compat.v1.errors.raise_exception_on_not_ok_status() as status:
-            self._reader = _pywrap_tensorflow.PyRecordReader_New(
-                tf.compat.as_bytes(file_path), 0, tf.compat.as_bytes(""), status
-            )
-        # Store it for logging purposes.
-        self._file_path = file_path
-        if not self._reader:
-            raise IOError(
-                "Failed to open a record reader pointing to %s" % file_path
-            )
+        self._file_path = platform_util.readahead_file_path(file_path)
+        self._iterator = _make_tf_record_iterator(self._file_path)
 
     def Load(self):
         """Loads all new events from disk as raw serialized proto bytestrings.
@@ -59,32 +114,18 @@ class RawEventFileLoader(object):
           All event proto bytestrings in the file that have not been yielded yet.
         """
         logger.debug("Loading events from %s", self._file_path)
-
-        # getargspec is deprecated in Python3, use getfullargspec if it exists.
-        try:
-            getargspec = inspect.getfullargspec
-        except AttributeError:
-            getargspec = inspect.getargspec  # pylint: disable=deprecated-method
-
-        # GetNext() expects a status argument on TF <= 1.7.
-        get_next_args = getargspec(self._reader.GetNext).args
-        # First argument is self
-        legacy_get_next = len(get_next_args) > 1
-
         while True:
             try:
-                if legacy_get_next:
-                    with tf.compat.v1.errors.raise_exception_on_not_ok_status() as status:
-                        self._reader.GetNext(status)
-                else:
-                    self._reader.GetNext()
-            except (tf.errors.DataLossError, tf.errors.OutOfRangeError) as e:
-                logger.debug("Cannot read more events: %s", e)
-                # We ignore partial read exceptions, because a record may be truncated.
-                # PyRecordReader holds the offset prior to the failed read, so retrying
-                # will succeed.
+                yield next(self._iterator)
+            except StopIteration:
+                logger.debug("End of file in %s", self._file_path)
                 break
-            yield self._reader.record()
+            except tf.errors.DataLossError as e:
+                # We swallow partial read exceptions; if the record was truncated
+                # and a later update completes it, retrying can then resume from
+                # the same point in the file since the iterator holds the offset.
+                logger.debug("Truncated record in %s (%s)", self._file_path, e)
+                break
         logger.debug("No more events in %s", self._file_path)
 
 

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -18,8 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import inspect
-
 from tensorboard.compat import tf
 from tensorboard.compat.proto import event_pb2
 from tensorboard.util import platform_util
@@ -70,24 +68,13 @@ class _PyRecordReaderIterator(object):
             raise IOError(
                 "Failed to open a record reader pointing to %s" % file_path
             )
-        # getargspec is deprecated in Python3, use getfullargspec if it exists.
-        try:
-            getargspec = inspect.getfullargspec
-        except AttributeError:
-            getargspec = inspect.getargspec  # pylint: disable=deprecated-method
-        # GetNext() expects a status argument (after `self`) on TF <= 1.7.
-        self._legacy_get_next = len(getargspec(self._reader.GetNext).args) > 1
 
     def __iter__(self):
         return self
 
     def __next__(self):
         try:
-            if self._legacy_get_next:
-                with tf.compat.v1.errors.raise_exception_on_not_ok_status() as status:
-                    self._reader.GetNext(status)
-            else:
-                self._reader.GetNext()
+            self._reader.GetNext()
         except tf.errors.OutOfRangeError as e:
             raise StopIteration
         return self._reader.record()

--- a/tensorboard/backend/event_processing/event_file_loader_test.py
+++ b/tensorboard/backend/event_processing/event_file_loader_test.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 import abc
 import io
 import os
-import tempfile
 
 import six
 import tensorflow as tf

--- a/tensorboard/backend/event_processing/event_file_loader_test.py
+++ b/tensorboard/backend/event_processing/event_file_loader_test.py
@@ -19,94 +19,136 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import abc
+import io
 import os
 import tempfile
 
+import six
 import tensorflow as tf
 
 
 from tensorboard.backend.event_processing import event_file_loader
+from tensorboard.compat.proto import event_pb2
+from tensorboard.summary.writer import record_writer
 
 
-class EventFileLoaderTest(tf.test.TestCase):
-    # A record containing a simple event.
-    RECORD = (
-        b'\x18\x00\x00\x00\x00\x00\x00\x00\xa3\x7fK"\t\x00\x00\xc0%\xddu'
-        b"\xd5A\x1a\rbrain.Event:1\xec\xf32\x8d"
-    )
+FILENAME = "test.events"
 
-    def _WriteToFile(self, filename, data):
-        with open(filename, "ab") as f:
-            f.write(data)
 
-    def _LoaderForTestFile(self, filename):
-        return event_file_loader.EventFileLoader(
-            os.path.join(self.get_temp_dir(), filename)
-        )
+@six.add_metaclass(abc.ABCMeta)
+class EventFileLoaderTestBase(object):
+    def _append_record(self, data):
+        with open(os.path.join(self.get_temp_dir(), FILENAME), "ab") as f:
+            record_writer.RecordWriter(f).write(data)
 
-    def testEmptyEventFile(self):
-        filename = tempfile.NamedTemporaryFile(dir=self.get_temp_dir()).name
-        self._WriteToFile(filename, b"")
-        loader = self._LoaderForTestFile(filename)
-        self.assertEqual(len(list(loader.Load())), 0)
+    def _make_loader(self):
+        return self._loader_class(os.path.join(self.get_temp_dir(), FILENAME))
 
-    def testSingleWrite(self):
-        filename = tempfile.NamedTemporaryFile(dir=self.get_temp_dir()).name
-        self._WriteToFile(filename, EventFileLoaderTest.RECORD)
-        loader = self._LoaderForTestFile(filename)
-        events = list(loader.Load())
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0].wall_time, 1440183447.0)
-        self.assertEqual(len(list(loader.Load())), 0)
+    @abc.abstractproperty
+    def _loader_class(self):
+        """Returns the Loader class under test."""
+        raise NotImplementedError()
 
-    def testMultipleWrites(self):
-        filename = tempfile.NamedTemporaryFile(dir=self.get_temp_dir()).name
-        self._WriteToFile(filename, EventFileLoaderTest.RECORD)
-        loader = self._LoaderForTestFile(filename)
-        self.assertEqual(len(list(loader.Load())), 1)
-        self._WriteToFile(filename, EventFileLoaderTest.RECORD)
-        self.assertEqual(len(list(loader.Load())), 1)
+    @abc.abstractmethod
+    def assertEventWallTimes(self, load_result, event_wall_times_in_order):
+        """Asserts that loader.Load() result has specified event wall times."""
+        raise NotImplementedError()
 
-    def testMultipleLoads(self):
-        filename = tempfile.NamedTemporaryFile(dir=self.get_temp_dir()).name
-        self._WriteToFile(filename, EventFileLoaderTest.RECORD)
-        loader = self._LoaderForTestFile(filename)
+    def testLoad_emptyEventFile(self):
+        with open(os.path.join(self.get_temp_dir(), FILENAME), "ab") as f:
+            f.write(b"")
+        loader = self._make_loader()
+        self.assertEmpty(list(loader.Load()))
+
+    def testLoad_staticEventFile(self):
+        self._append_record(_make_event(wall_time=1.0))
+        self._append_record(_make_event(wall_time=2.0))
+        self._append_record(_make_event(wall_time=3.0))
+        loader = self._make_loader()
+        self.assertEventWallTimes(loader.Load(), [1.0, 2.0, 3.0])
+
+    def testLoad_dynamicEventFile(self):
+        self._append_record(_make_event(wall_time=1.0))
+        loader = self._make_loader()
+        self.assertEventWallTimes(loader.Load(), [1.0])
+        self._append_record(_make_event(wall_time=2.0))
+        self.assertEventWallTimes(loader.Load(), [2.0])
+        self.assertEmpty(list(loader.Load()))
+
+    def testLoad_dynamicEventFileWithTruncation(self):
+        self._append_record(_make_event(wall_time=1.0))
+        self._append_record(_make_event(wall_time=2.0))
+        loader = self._make_loader()
+        # Use memory file to get at the raw record to emit.
+        with io.BytesIO() as mem_f:
+            record_writer.RecordWriter(mem_f).write(_make_event(wall_time=3.0))
+            record = mem_f.getvalue()
+        filepath = os.path.join(self.get_temp_dir(), FILENAME)
+        with open(filepath, "ab", buffering=0) as f:
+            # Record missing the last byte should result in data loss error
+            # that we log and swallow.
+            f.write(record[:-1])
+            self.assertEventWallTimes(loader.Load(), [1.0, 2.0])
+            # Retrying against the incomplete record has no effect.
+            self.assertEmpty(list(loader.Load()))
+            # Retrying after completing the record should return the new event.
+            f.write(record[-1:])
+            self.assertEventWallTimes(loader.Load(), [3.0])
+
+    def testLoad_noIterationDoesNotConsumeEvents(self):
+        self._append_record(_make_event(wall_time=1.0))
+        loader = self._make_loader()
         loader.Load()
         loader.Load()
-        self.assertEqual(len(list(loader.Load())), 1)
-
-    def testMultipleWritesAtOnce(self):
-        filename = tempfile.NamedTemporaryFile(dir=self.get_temp_dir()).name
-        self._WriteToFile(filename, EventFileLoaderTest.RECORD)
-        self._WriteToFile(filename, EventFileLoaderTest.RECORD)
-        loader = self._LoaderForTestFile(filename)
-        self.assertEqual(len(list(loader.Load())), 2)
-
-    def testMultipleWritesWithBadWrite(self):
-        filename = tempfile.NamedTemporaryFile(dir=self.get_temp_dir()).name
-        self._WriteToFile(filename, EventFileLoaderTest.RECORD)
-        self._WriteToFile(filename, EventFileLoaderTest.RECORD)
-        # Test that we ignore partial record writes at the end of the file.
-        self._WriteToFile(filename, b"123")
-        loader = self._LoaderForTestFile(filename)
-        self.assertEqual(len(list(loader.Load())), 2)
+        self.assertEventWallTimes(loader.Load(), [1.0])
 
 
-class RawEventFileLoaderTest(EventFileLoaderTest):
-    def _LoaderForTestFile(self, filename):
-        return event_file_loader.RawEventFileLoader(
-            os.path.join(self.get_temp_dir(), filename)
+class RawEventFileLoaderTest(EventFileLoaderTestBase, tf.test.TestCase):
+    @property
+    def _loader_class(self):
+        return event_file_loader.RawEventFileLoader
+
+    def assertEventWallTimes(self, load_result, event_wall_times_in_order):
+        self.assertEqual(
+            [
+                event_pb2.Event.FromString(record).wall_time
+                for record in load_result
+            ],
+            event_wall_times_in_order,
         )
 
-    def testSingleWrite(self):
-        filename = tempfile.NamedTemporaryFile(dir=self.get_temp_dir()).name
-        self._WriteToFile(filename, EventFileLoaderTest.RECORD)
-        loader = self._LoaderForTestFile(filename)
-        event_protos = list(loader.Load())
-        self.assertEqual(len(event_protos), 1)
-        # Record format has a 12 byte header and a 4 byte trailer.
-        expected_event_proto = EventFileLoaderTest.RECORD[12:-4]
-        self.assertEqual(event_protos[0], expected_event_proto)
+
+class EventFileLoaderTest(EventFileLoaderTestBase, tf.test.TestCase):
+    @property
+    def _loader_class(self):
+        return event_file_loader.EventFileLoader
+
+    def assertEventWallTimes(self, load_result, event_wall_times_in_order):
+        self.assertEqual(
+            [event.wall_time for event in load_result],
+            event_wall_times_in_order,
+        )
+
+
+class TimestampedEventFileLoaderTest(EventFileLoaderTestBase, tf.test.TestCase):
+    @property
+    def _loader_class(self):
+        return event_file_loader.TimestampedEventFileLoader
+
+    def assertEventWallTimes(self, load_result, event_wall_times_in_order):
+        transposed = list(zip(*load_result))
+        wall_times, events = transposed if transposed else ([], [])
+        self.assertEqual(
+            list(wall_times), event_wall_times_in_order,
+        )
+        self.assertEqual(
+            [event.wall_time for event in events], event_wall_times_in_order,
+        )
+
+
+def _make_event(**kwargs):
+    return event_pb2.Event(**kwargs).SerializeToString()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change addresses the most critical part of https://github.com/tensorflow/tensorboard/issues/1711 by relaxing our dependency on PyRecordReader, which was never part of the public TF API and is slated to be removed imminently (cc @av8ramit).  Now when it's missing, we instead use `tf.compat.v1.io.tf_record_iterator` which was recently updated in https://github.com/tensorflow/tensorflow/commit/54f1de4fcf81ed7e25247d84f9dadc761b5a1bb7 to no longer abandon the read offset after reaching EOF (which resolves the issue described in #1711 that prevented us from using it, since we couldn't use it to poll the end of a file for newly appended data).

The implementation here adopts the iterator style throughout, and wraps our legacy PyRecordReader usage inside an iterator API so it can be interchanged.

As part of this, I rewrote event_file_loader_test.py to modernize the structure and improve coverage, including making it actually exercise the truncated record path (the previous approach did not actually trigger that branch in the code), and adding coverage for TimestampedEventFileLoader.

Test plan: confirmed that the new test passes:
1. with no code-under-test changes on TF 2.0, py2 and py3
2. with code-under-test changes on TF 2.0, py2 and py3
3. with no code-under-test changes on TF nightly py3
4. with code-under-test changes on TF nightly py3
5. with code-under-test changes on TF nightly py3, PyRecordReader fallback disabled

The new test does not pass in case 5 against TF 2.0 rather than nightly, but instead fails because the tests for the dynamic event file correctly report that the tf_record_iterator implementation does not implement the expected preservation of the read offset.