### PR TITLE
Ensure EventFileLoader only uses no-TF stub when required

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -156,6 +156,22 @@ py_test(
     ],
 )
 
+py_test(
+    name = "event_file_loader_notf_test",
+    size = "small",
+    srcs = ["event_file_loader_test.py"],
+    main = "event_file_loader_test.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":event_file_loader",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/compat:no_tensorflow",
+        "//tensorboard/compat/proto:protos_all_py_pb2",
+        "//tensorboard/summary/writer",
+        "@org_pythonhosted_six",
+    ],
+)
+
 py_library(
     name = "event_accumulator",
     srcs = [

--- a/tensorboard/compat/__init__.py
+++ b/tensorboard/compat/__init__.py
@@ -74,36 +74,3 @@ def tf2():
         # As a fallback, try `tensorflow.compat.v2` if it's defined.
         return tf.compat.v2
     raise ImportError("cannot import tensorflow 2.0 API")
-
-
-# TODO(https://github.com/tensorflow/tensorboard/issues/1711): remove this
-@_lazy.lazy_load("tensorboard.compat._pywrap_tensorflow")
-def _pywrap_tensorflow():
-    """Provide pywrap_tensorflow access in TensorBoard.
-
-    pywrap_tensorflow cannot be accessed from tf.python.pywrap_tensorflow
-    and needs to be imported using
-    `from tensorflow.python import pywrap_tensorflow`. Therefore, we provide
-    a separate accessor function for it here.
-
-    NOTE: pywrap_tensorflow is not part of TensorFlow API and this
-    dependency will go away soon.
-
-    Returns:
-      pywrap_tensorflow import, if available.
-
-    Raises:
-      ImportError: if we couldn't import pywrap_tensorflow.
-    """
-    try:
-        from tensorboard.compat import notf
-    except ImportError:
-        try:
-            from tensorflow.python import pywrap_tensorflow
-
-            return pywrap_tensorflow
-        except ImportError:
-            pass
-    from tensorboard.compat.tensorflow_stub import pywrap_tensorflow
-
-    return pywrap_tensorflow

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -34,7 +34,6 @@ from google.protobuf import text_format
 
 from tensorboard.backend.http_util import Respond
 from tensorboard.compat import tf
-from tensorboard.compat import _pywrap_tensorflow
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.projector.projector_config_pb2 import ProjectorConfig
 from tensorboard.util import tb_logging


### PR DESCRIPTION
This addresses concern 2 from https://github.com/tensorflow/tensorboard/issues/1711#issuecomment-579512944, namely that the changes in #3185 were sufficient to fall back correctly if `pywrap_tensorflow` no longer contained a `PyRecordReader_New` symbol, but not actually sufficient in the eventual case that `pywrap_tensorflow` disappears entirely and can no longer be imported.  The previous code was using the `tensorboard.compat._pywrap_tensorflow` lazy-loader which would in that case have automatically started using the no-TF stub implementation of pywrap_tensorflow instead, which is undesirable relative to using `tf_record_iterator`.

We fix that by getting rid of `tensorboard.compat._pywrap_tensorflow` entirely, since it was unused elsewhere (the projector plugin imported it but did not use it; it was leftover cruft from #2096), and just explicitly handling the no-TF case up front.

I added a no-TF build target for the test to confirm that the fallback to the stub implementation works when forcing no-TF mode.  The stub implementation didn't previously support truncated records at all (it would fail in struct unpacking when truncated partway through a fixed-length field), let alone read offset preservation, so I also added that functionality to the implementation so that the set of strengthened tests from #3185 passes.