### PR TITLE
[DebuggerV2] Backend: Implement basic features of /alerts route

### DIFF
--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -58,7 +58,8 @@ def run_in_background(target):
 def _alert_to_json(alert):
     # TODO(cais): Replace this with Alert.to_json() when supported by the
     # backend.
-    global debug_events_monitors
+    from tensorflow.python.debug.lib import debug_events_monitors
+
     if isinstance(alert, debug_events_monitors.InfNanAlert):
         return {
             "alert_type": "InfNanAlert",
@@ -148,8 +149,6 @@ class DebuggerV2EventMultiplexer(object):
             try:
                 from tensorflow.python.debug.lib import debug_events_reader
                 from tensorflow.python.debug.lib import debug_events_monitors
-
-                global debug_events_monitors
 
                 self._reader = debug_events_reader.DebugDataReader(self._logdir)
                 self._monitors = [

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -207,7 +207,7 @@ class DebuggerV2EventMultiplexer(object):
         """Get alerts from the debugged TensorFlow program.
 
         Args:
-          run: The tfdbg2 run to get `ExecutionDigest`s from.
+          run: The tfdbg2 run to get Alerts from.
           begin: Beginning alert index.
           end: Ending alert index.
         """

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -38,7 +38,9 @@ _HOST_NAME = socket.gethostname()
 _CURRENT_FILE_FULL_PATH = os.path.abspath(__file__)
 
 
-def _generate_tfdbg_v2_data(logdir, tensor_debug_mode="NO_TENSOR"):
+def _generate_tfdbg_v2_data(
+    logdir, tensor_debug_mode="NO_TENSOR", logarithm_times=None
+):
     """Generate a simple dump of tfdbg v2 data by running a TF2 program.
 
     The run is instrumented by the enable_dump_debug_info() API.
@@ -54,6 +56,8 @@ def _generate_tfdbg_v2_data(logdir, tensor_debug_mode="NO_TENSOR"):
       tensor_debug_mode: Mode for dumping debug tensor values, as an optional
         string. See the documentation of
         `tf.debugging.experimental.enable_dump_debug_info()` for details.
+      logarithm_times: Optionally take logarithm of the final `x` file _ times
+        iteratively, in order to produce nans.
     """
     writer = tf.debugging.experimental.enable_dump_debug_info(
         logdir, circular_buffer_size=-1, tensor_debug_mode=tensor_debug_mode
@@ -82,6 +86,18 @@ def _generate_tfdbg_v2_data(logdir, tensor_debug_mode="NO_TENSOR"):
         x = tf.constant([1, 3, 3, 7], dtype=tf.float32)
         for i in range(3):
             assert my_function(x).numpy() == 42.0
+
+        logarithm_times = 0 if logarithm_times is None else logarithm_times
+        for i in range(logarithm_times):
+            x = tf.math.log(x)
+        # Expected iteration results:
+        #   [0.        1.0986123 1.0986123 1.9459102]
+        #   [-inf 0.09404784 0.09404784 0.6657298 ]
+        #   [nan -2.3639517  -2.3639517  -0.40687138]
+        #   [nan nan nan nan]
+        #   [nan nan nan nan]
+        #   [nan nan nan nan]
+
         writer.FlushNonExecutionFiles()
         writer.FlushExecutionFiles()
     finally:
@@ -152,6 +168,162 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         run = data["__default_debugger_run__"]
         self.assertIsInstance(run["start_time"], float)
         self.assertGreater(run["start_time"], 0)
+
+    def testAlertsWhenNoAlertExists(self):
+        _generate_tfdbg_v2_data(self.logdir)
+        run = self._getExactlyOneRun()
+        response = self.server.get(
+            _ROUTE_PREFIX + "/alerts?run=%s&begin=0&end=0" % run
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        data = json.loads(response.get_data())
+        self.assertEqual(
+            data,
+            {
+                "begin": 0,
+                "end": 0,
+                "num_alerts": 0,
+                "per_type_alert_limit": 1000,
+                "alerts": [],
+            },
+        )
+
+    def testGetAlertNumberOnlyWhenAlertExistsCurtHealthMode(self):
+        _generate_tfdbg_v2_data(
+            self.logdir, tensor_debug_mode="CURT_HEALTH", logarithm_times=4
+        )
+        run = self._getExactlyOneRun()
+        response = self.server.get(
+            _ROUTE_PREFIX + "/alerts?run=%s&begin=0&end=0" % run
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        data = json.loads(response.get_data())
+        self.assertEqual(
+            data,
+            {
+                "begin": 0,
+                "end": 0,
+                "num_alerts": 3,
+                "per_type_alert_limit": 1000,
+                "alerts": [],
+            },
+        )
+
+    def testGetAlertsContentWhenAlertExistsConciseHealthMode(self):
+        _generate_tfdbg_v2_data(
+            self.logdir, tensor_debug_mode="CONCISE_HEALTH", logarithm_times=4
+        )
+        run = self._getExactlyOneRun()
+        response = self.server.get(
+            _ROUTE_PREFIX + "/alerts?run=%s&begin=0&end=3" % run
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        data = json.loads(response.get_data())
+        self.assertEqual(data["begin"], 0)
+        self.assertEqual(data["end"], 3)
+        self.assertEqual(data["num_alerts"], 3)
+        self.assertEqual(data["per_type_alert_limit"], 1000)
+        alerts = data["alerts"]
+        self.assertLen(alerts, 3)
+        self.assertEqual(
+            alerts[0],
+            {
+                "alert_type": "InfNanAlert",
+                "op_type": "Log",
+                "output_slot": 0,
+                "size": 4.0,
+                "num_neg_inf": 1.0,
+                "num_pos_inf": 0.0,
+                "num_nan": 0.0,
+                "execution_index": 4,
+                "graph_execution_trace_index": None,
+            },
+        )
+        self.assertEqual(
+            alerts[1],
+            {
+                "alert_type": "InfNanAlert",
+                "op_type": "Log",
+                "output_slot": 0,
+                "size": 4.0,
+                "num_neg_inf": 0.0,
+                "num_pos_inf": 0.0,
+                "num_nan": 1.0,
+                "execution_index": 5,
+                "graph_execution_trace_index": None,
+            },
+        )
+        self.assertEqual(
+            alerts[2],
+            {
+                "alert_type": "InfNanAlert",
+                "op_type": "Log",
+                "output_slot": 0,
+                "size": 4.0,
+                "num_neg_inf": 0.0,
+                "num_pos_inf": 0.0,
+                "num_nan": 4.0,
+                "execution_index": 6,
+                "graph_execution_trace_index": None,
+            },
+        )
+
+    def testGetAlertsWithInvalidBeginOrEndWhenAlertExistsCurtHealthMode(self):
+        _generate_tfdbg_v2_data(
+            self.logdir, tensor_debug_mode="CURT_HEALTH", logarithm_times=4
+        )
+        run = self._getExactlyOneRun()
+
+        # begin = 0; end = 5
+        response = self.server.get(
+            _ROUTE_PREFIX + "/alerts?run=%s&begin=0&end=5" % run
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        self.assertEqual(
+            json.loads(response.get_data()),
+            {"error": "Invalid argument: end index (5) out of bounds (3)"},
+        )
+
+        # begin = -1; end = 2
+        response = self.server.get(
+            _ROUTE_PREFIX + "/alerts?run=%s&begin=-1&end=2" % run
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        self.assertEqual(
+            json.loads(response.get_data()),
+            {"error": "Invalid argument: Invalid begin index (-1)"},
+        )
+
+        # begin = 2; end = 1
+        response = self.server.get(
+            _ROUTE_PREFIX + "/alerts?run=%s&begin=2&end=1" % run
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            "application/json", response.headers.get("content-type")
+        )
+        self.assertEqual(
+            json.loads(response.get_data()),
+            {
+                "error": "Invalid argument: "
+                "end index (1) is unexpectedly less than begin index (2)"
+            },
+        )
 
     def testServeExecutionDigestsWithEqualBeginAndEnd(self):
         _generate_tfdbg_v2_data(self.logdir)

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -97,6 +97,7 @@ def _generate_tfdbg_v2_data(
         #   [nan nan nan nan]
         #   [nan nan nan nan]
         #   [nan nan nan nan]
+        #   ...
 
         writer.FlushNonExecutionFiles()
         writer.FlushExecutionFiles()


### PR DESCRIPTION
### Technical description of changes
- The /alerts route is based on the recently-added InfNanMonitor
  in tfdbg2's tensorflow part.
- The route serves information about:
  - How many inf/nan events (InfNanAlert) exist
  - Number limit for each type of alerts (currently there is only
    one type: InfNanAlert)
  - The details of each alert, in the specified begin/end range.
- Modify the dummy TF2 program (`_generate_tfdbg_v2_data()`) in
  debugger_v2_plugin_test.py to intentionally generate `inf`s and `nan`s.

### Detailed steps to verify changes work correctly (as executed by you)
- Python unit tests added.

