### PR TITLE
ci: run TF 1.x builds against 1.15.0, not its RC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - BAZEL=0.26.1
     - BAZEL_SHA256SUM=6c50e142a0a405d3d8598050d6c1b3920c8cdb82a7ffca6fc067cb474275148f
   matrix:
-    - TF_VERSION_ID=tensorflow==1.15.0rc3
+    - TF_VERSION_ID=tensorflow==1.15.0
     - TF_VERSION_ID=tf-nightly
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 


### PR DESCRIPTION
Summary:
@davidsoergel made this sensible change in the 2.1 branch; we backport
it to master so that the branches run on consistent versions.

Test Plan:
CI suffices.

wchargin-branch: ci-tf1x-norc
