### PR TITLE
pip_package: only build Python 3 wheel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ script:
   - elapsed && bazel fetch //tensorboard/...
   - elapsed && bazel build //tensorboard/...
   - elapsed && bazel test //tensorboard/... --test_tag_filters="${test_tag_filters}"
-  - elapsed && bazel run //tensorboard/pip_package:test_pip_package -- --default-python-only --tf-version "${TF_VERSION_ID}"
+  - elapsed && bazel run //tensorboard/pip_package:test_pip_package -- --tf-version "${TF_VERSION_ID}"
   # Run manual S3 test
   - elapsed && bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test
   - elapsed && bazel test //tensorboard/summary/writer:event_file_writer_s3_test

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -120,7 +120,6 @@ build() (
   # representable in a zip archive.)
   export SOURCE_DATE_EPOCH=1577836800  # 2020-01-01T00:00:00Z
 
-  python setup.py bdist_wheel --python-tag py2 >/dev/null
   python setup.py bdist_wheel --python-tag py3 >/dev/null
 
   cd "${original_wd}"  # Bazel gives "${output}" as a relative path >_>

--- a/tensorboard/pip_package/test_pip_package.sh
+++ b/tensorboard/pip_package/test_pip_package.sh
@@ -17,15 +17,11 @@ set -eu
 
 usage() {
   cat <<EOF
-usage: test_pip_package
-            [--only-default-python | --all-pythons]
-            [--tf-version VERSION]
+usage: test_pip_package [--tf-version VERSION]
 
 Test pre-built TensorBoard Pip packages.
 
 Options:
-  --all-pythons: Test on both Python 2 and Python 3. This is the default.
-  --default-python-only: Test only using the stock "python" binary.
   --tf-version VERSION: Test against the provided version of TensorFlow,
       given as a Pip package specifier like "tensorflow==2.0.0a0" or
       "tf-nightly". If empty, will test without installing TensorFlow.
@@ -43,19 +39,7 @@ main() {
   command -v virtualenv >/dev/null
   initialize_workdir
   extract_wheels
-  case "${pythons}" in
-    all)
-      smoke python2
-      smoke python3
-      ;;
-    default-only)
-      smoke python
-      ;;
-    *)
-      printf >&2 'invariant violation: unknown "pythons" value: %s\n' "${pythons}"
-      exit 1
-      ;;
-  esac
+  smoke python3
 }
 
 cleanup() {
@@ -72,14 +56,6 @@ parse_args() {
       --help)
         usage
         exit 2
-        ;;
-      --all-pythons)
-        pythons=all
-        shift
-        ;;
-      --default-python-only)
-        pythons=default-only
-        shift
         ;;
       --tf-version)
         if [ $# -lt 2 ]; then


### PR DESCRIPTION
Summary:
We no longer support Python 2, and so should not build packages for it,
because they’re not guaranteed to work at all. We likewise should run
the smoke test in Python 3 by default.

Test Plan:
Running `bazel run //tensorboard/pip_package:extract_pip_package` still
succeeds, now extracting only `tensorboard-2.2.0a0-py3-none-any.whl`.

wchargin-branch: pip-py3-only
