### PR TITLE
Import `Callable` from `collections.abc`

### DIFF
--- a/tensorboard/plugins/audio/audio_plugin_test.py
+++ b/tensorboard/plugins/audio/audio_plugin_test.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
+import collections.abc
 import json
 import os
 import shutil
@@ -143,9 +143,11 @@ class AudioPluginTest(tf.test.TestCase):
     def testRoutesProvided(self):
         """Tests that the plugin offers the correct routes."""
         routes = self.plugin.get_plugin_apps()
-        self.assertIsInstance(routes["/audio"], collections.Callable)
-        self.assertIsInstance(routes["/individualAudio"], collections.Callable)
-        self.assertIsInstance(routes["/tags"], collections.Callable)
+        self.assertIsInstance(routes["/audio"], collections.abc.Callable)
+        self.assertIsInstance(
+            routes["/individualAudio"], collections.abc.Callable
+        )
+        self.assertIsInstance(routes["/tags"], collections.abc.Callable)
 
     def testOldStyleAudioRoute(self):
         """Tests that the /audio routes returns correct old-style data."""

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
+import collections.abc
 import contextlib
 import json
 import os
@@ -160,8 +160,8 @@ class CorePluginNoDataTest(tf.test.TestCase):
     def testRoutesProvided(self):
         """Tests that the plugin offers the correct routes."""
         routes = self.plugin.get_plugin_apps()
-        self.assertIsInstance(routes["/data/logdir"], collections.Callable)
-        self.assertIsInstance(routes["/data/runs"], collections.Callable)
+        self.assertIsInstance(routes["/data/logdir"], collections.abc.Callable)
+        self.assertIsInstance(routes["/data/runs"], collections.abc.Callable)
 
     def testIndex_returnsActualHtml(self):
         """Test the format of the root / endpoint."""

--- a/tensorboard/plugins/debugger/debugger_plugin_test.py
+++ b/tensorboard/plugins/debugger/debugger_plugin_test.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
+import collections.abc
 import json
 
 import tensorflow as tf
@@ -37,7 +37,7 @@ class DebuggerPluginTest(debugger_plugin_testlib.DebuggerPluginTestBase):
         pills."""
         apps = self.plugin.get_plugin_apps()
         self.assertIn("/health_pills", apps)
-        self.assertIsInstance(apps["/health_pills"], collections.Callable)
+        self.assertIsInstance(apps["/health_pills"], collections.abc.Callable)
 
     def testHealthPillsPluginIsActive(self):
         # The multiplexer has sampled health pills.

--- a/tensorboard/plugins/debugger/events_writer_manager_test.py
+++ b/tensorboard/plugins/debugger/events_writer_manager_test.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
+import collections.abc
 import json
 
 import tensorflow as tf
@@ -37,7 +37,7 @@ class DebuggerPluginTest(debugger_plugin_testlib.DebuggerPluginTestBase):
         pills."""
         apps = self.plugin.get_plugin_apps()
         self.assertIn("/health_pills", apps)
-        self.assertIsInstance(apps["/health_pills"], collections.Callable)
+        self.assertIsInstance(apps["/health_pills"], collections.abc.Callable)
 
     def testHealthPillsPluginIsActive(self):
         # The multiplexer has sampled health pills.

--- a/tensorboard/plugins/distribution/distributions_plugin_test.py
+++ b/tensorboard/plugins/distribution/distributions_plugin_test.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
+import collections.abc
 import os.path
 
 from six.moves import xrange  # pylint: disable=redefined-builtin
@@ -115,8 +115,10 @@ class DistributionsPluginTest(tf.test.TestCase):
         """Tests that the plugin offers the correct routes."""
         self.set_up_with_runs([self._RUN_WITH_SCALARS])
         routes = self.plugin.get_plugin_apps()
-        self.assertIsInstance(routes["/distributions"], collections.Callable)
-        self.assertIsInstance(routes["/tags"], collections.Callable)
+        self.assertIsInstance(
+            routes["/distributions"], collections.abc.Callable
+        )
+        self.assertIsInstance(routes["/tags"], collections.abc.Callable)
 
     def test_index(self):
         self.set_up_with_runs(

--- a/tensorboard/plugins/graph/graphs_plugin_test.py
+++ b/tensorboard/plugins/graph/graphs_plugin_test.py
@@ -20,7 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import argparse
-import collections
+import collections.abc
 import math
 import functools
 import os.path
@@ -135,9 +135,9 @@ class GraphsPluginBaseTest(object):
     def testRoutesProvided(self, plugin):
         """Tests that the plugin offers the correct routes."""
         routes = plugin.get_plugin_apps()
-        self.assertIsInstance(routes["/graph"], collections.Callable)
-        self.assertIsInstance(routes["/run_metadata"], collections.Callable)
-        self.assertIsInstance(routes["/info"], collections.Callable)
+        self.assertIsInstance(routes["/graph"], collections.abc.Callable)
+        self.assertIsInstance(routes["/run_metadata"], collections.abc.Callable)
+        self.assertIsInstance(routes["/info"], collections.abc.Callable)
 
 
 class GraphsPluginV1Test(GraphsPluginBaseTest, tf.test.TestCase):

--- a/tensorboard/plugins/histogram/histograms_plugin_test.py
+++ b/tensorboard/plugins/histogram/histograms_plugin_test.py
@@ -20,7 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import argparse
-import collections
+import collections.abc
 import functools
 import os.path
 
@@ -156,8 +156,8 @@ class HistogramsPluginTest(tf.test.TestCase):
     def test_routes_provided(self, plugin):
         """Tests that the plugin offers the correct routes."""
         routes = plugin.get_plugin_apps()
-        self.assertIsInstance(routes["/histograms"], collections.Callable)
-        self.assertIsInstance(routes["/tags"], collections.Callable)
+        self.assertIsInstance(routes["/histograms"], collections.abc.Callable)
+        self.assertIsInstance(routes["/tags"], collections.abc.Callable)
 
     @with_runs(
         [_RUN_WITH_SCALARS, _RUN_WITH_LEGACY_HISTOGRAM, _RUN_WITH_HISTOGRAM,]

--- a/tensorboard/plugins/image/images_plugin_test.py
+++ b/tensorboard/plugins/image/images_plugin_test.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import argparse
-import collections
+import collections.abc
 import functools
 import json
 import os
@@ -167,11 +167,11 @@ class ImagesPluginTest(tf.test.TestCase):
     @with_images_plugin
     def testRoutesProvided(self, plugin):
         """Tests that the plugin offers the correct routes."""
-        self.assertIsInstance(self.routes["/images"], collections.Callable)
+        self.assertIsInstance(self.routes["/images"], collections.abc.Callable)
         self.assertIsInstance(
-            self.routes["/individualImage"], collections.Callable
+            self.routes["/individualImage"], collections.abc.Callable
         )
-        self.assertIsInstance(self.routes["/tags"], collections.Callable)
+        self.assertIsInstance(self.routes["/tags"], collections.abc.Callable)
 
     @with_images_plugin
     def testOldStyleImagesRoute(self, plugin):

--- a/tensorboard/plugins/mesh/mesh_plugin_test.py
+++ b/tensorboard/plugins/mesh/mesh_plugin_test.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
+import collections.abc
 import os
 import shutil
 import numpy as np
@@ -170,9 +170,9 @@ class MeshPluginTest(tf.test.TestCase):
 
     def testRoutes(self):
         """Tests that the /tags route offers the correct run to tag mapping."""
-        self.assertIsInstance(self.routes["/tags"], collections.Callable)
-        self.assertIsInstance(self.routes["/meshes"], collections.Callable)
-        self.assertIsInstance(self.routes["/data"], collections.Callable)
+        self.assertIsInstance(self.routes["/tags"], collections.abc.Callable)
+        self.assertIsInstance(self.routes["/meshes"], collections.abc.Callable)
+        self.assertIsInstance(self.routes["/data"], collections.abc.Callable)
 
     def testTagsRoute(self):
         """Tests that the /tags route offers the correct run to tag mapping."""

--- a/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
+++ b/tensorboard/plugins/pr_curve/pr_curves_plugin_test.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
+import collections.abc
 import functools
 import os.path
 
@@ -121,10 +121,10 @@ class PrCurvesPluginTest(tf.test.TestCase):
     def testRoutesProvided(self):
         """Tests that the plugin offers the correct routes."""
         routes = self.plugin.get_plugin_apps()
-        self.assertIsInstance(routes["/tags"], collections.Callable)
-        self.assertIsInstance(routes["/pr_curves"], collections.Callable)
+        self.assertIsInstance(routes["/tags"], collections.abc.Callable)
+        self.assertIsInstance(routes["/pr_curves"], collections.abc.Callable)
         self.assertIsInstance(
-            routes["/available_time_entries"], collections.Callable
+            routes["/available_time_entries"], collections.abc.Callable
         )
 
     def testTagsProvided(self):

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -20,7 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import argparse
-import collections
+import collections.abc
 import csv
 import functools
 import os.path
@@ -185,8 +185,8 @@ class ScalarsPluginTest(tf.test.TestCase):
     def testRoutesProvided(self, plugin):
         """Tests that the plugin offers the correct routes."""
         routes = plugin.get_plugin_apps()
-        self.assertIsInstance(routes["/scalars"], collections.Callable)
-        self.assertIsInstance(routes["/tags"], collections.Callable)
+        self.assertIsInstance(routes["/scalars"], collections.abc.Callable)
+        self.assertIsInstance(routes["/tags"], collections.abc.Callable)
 
     @with_runs(
         [_RUN_WITH_LEGACY_SCALARS, _RUN_WITH_SCALARS, _RUN_WITH_HISTOGRAM]

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
+import collections.abc
 import os
 import textwrap
 import numpy as np
@@ -52,8 +52,8 @@ class TextPluginTest(tf.test.TestCase):
 
     def testRoutesProvided(self):
         routes = self.plugin.get_plugin_apps()
-        self.assertIsInstance(routes["/tags"], collections.Callable)
-        self.assertIsInstance(routes["/text"], collections.Callable)
+        self.assertIsInstance(routes["/tags"], collections.abc.Callable)
+        self.assertIsInstance(routes["/text"], collections.abc.Callable)
 
     def generate_testdata(self, include_text=True, logdir=None):
         tf.compat.v1.reset_default_graph()

--- a/tensorboard/summary/summary_test.py
+++ b/tensorboard/summary/summary_test.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
+import collections.abc
 import sys
 import unittest
 
@@ -40,13 +40,13 @@ class SummaryExportsBaseTest(object):
     def test_each_plugin_has_an_export(self):
         for plugin in self.plugins:
             self.assertIsInstance(
-                getattr(self.module, plugin), collections.Callable
+                getattr(self.module, plugin), collections.abc.Callable
             )
 
     def test_plugins_export_pb_functions(self):
         for plugin in self.plugins:
             self.assertIsInstance(
-                getattr(self.module, "%s_pb" % plugin), collections.Callable
+                getattr(self.module, "%s_pb" % plugin), collections.abc.Callable
             )
 
     def test_all_exports_correspond_to_plugins(self):


### PR DESCRIPTION
Summary:
In Python 3.9, `collections.Callable` is slated to be removed in favor
of `collections.abc.Callable` (and likewise with the other ABCs, but
this is the only one that we use).

Fixes #3202.

Test Plan:
Running `git grep -P 'collections\.(?!OrderedDict|Counter)[A-Z]'` no
longer finds any matches.

wchargin-branch: collections-abc-callable
