### PR TITLE
pagination: fix pagination input interaction

### DIFF
--- a/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
+++ b/tensorboard/components/tf_paginated_view/tf-category-paginated-view.html
@@ -569,7 +569,7 @@ limitations under the License.
       },
       _handlePageInputEvent(e) {
         this.set('_pageInputRawValue', e.target.value);
-        const oneIndexedPage = e.target.valueAsNumber;
+        const oneIndexedPage = Number(e.target.value || NaN);
         if (isNaN(oneIndexedPage)) return;
         const page = Math.max(1, Math.min(oneIndexedPage, this._pageCount)) - 1;
         this._setActiveIndex(this._limit * page);


### PR DESCRIPTION
Bug: the view did not paginated when user modifies the input on the
tf_category_paginated_view manually.

As wchargin@ pointed out, the number `<input>` did not have a value for
`valueAsNumber` when modified the input field. We now use the
`input.value` to get its stringified value.

Tested by manually interacting with the UI element.

Fixes #3067.