### PR TITLE
Keep legacy scheme URL params for WIT

### DIFF
--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -221,8 +221,13 @@ namespace tf_storage {
   export function migrateLegacyURLScheme() {
     /**
      * TODO(psybuzz): move to some compatibility file.
-     * Convert URL hash params from the legacy scheme (list taken on 1/16/2020)
-     * to the new scheme. Luckily, WIT only stored strings, booleans.
+     * For each WIT URL param in the legacy scheme, create another URL param
+     * in the new scheme. Once WIT migrates to using the new plugin API
+     * `getURLPluginData()`, we can update this method to delete the legacy
+     * scheme params.
+     *
+     * This list of params was taken on 1/16/2020. Luckily, WIT only stored
+     * strings, booleans.
      */
     const witUrlCompatibilitySet = new Set<string>([
       'examplesPath',
@@ -252,7 +257,6 @@ namespace tf_storage {
       for (let oldName of witUrlCompatibilitySet) {
         if (oldName in items) {
           const oldValue = items[oldName];
-          delete items[oldName];
           items[`p.whatif.${oldName}`] = oldValue;
         }
       }


### PR DESCRIPTION
* Motivation for features / changes
Clients that link to the What if Tool in TensorBoard may still be using a legacy URL scheme.  This scheme is deprecated, and can be removed once WIT uses the new URL reading API `getURLPluginData()`.  Currently, TensorBoard auto-upgrades WIT params to the new scheme, breaking the WIT's auto-loading of config data.

Until then, we actually need to preserve both the old AND the new scheme to ensure nothing breaks during migration.
e.g.
`https://<tensorboard-url>/#whatif&examplesPath=...&p.whatif.examplesPath=...`