### PR TITLE
scalars: remove unused global constants

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -205,9 +205,6 @@ limitations under the License.
   </template>
 
   <script>
-    const PLUGIN_NAME = 'scalars';
-    const NUM_DEFAULT_OPENED_PANE = 3;
-
     Polymer({
       is: 'tf-scalar-dashboard',
       properties: {


### PR DESCRIPTION
Summary:
These constants are declared outside a scope, so attempting to define
them in any other file gives a compile-time error. They’re never used,
so we can just delete them.

Test Plan:
The scalars dashboard still seems to render fine.

wchargin-branch: scalars-no-consts
