### PR TITLE
add lint check against PY2 BUILD targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           git ls-files -z '*BUILD' | xargs -0 buildifier --mode=check --lint=warn
           --warnings=-load-on-top,-native-py,-native-java,-constant-glob
       - run: ./tensorboard/tools/mirror_urls_test.sh
-      - name: "Lint for no py2 BUILD targets"
+      - name: 'Lint for no py2 BUILD targets'
         # Use | to start a literal so YAML doesn't complain about the '!' character.
         run: |
           ! git grep 'python_version = "PY2"' '*BUILD'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           --warnings=-load-on-top,-native-py,-native-java,-constant-glob
       - run: ./tensorboard/tools/mirror_urls_test.sh
       - name: "Lint for no py2 BUILD targets"
+        # Use | to start a literal so YAML doesn't complain about the '!' character.
         run: |
           ! git grep 'python_version = "PY2"' '*BUILD'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
           git ls-files -z '*BUILD' | xargs -0 buildifier --mode=check --lint=warn
           --warnings=-load-on-top,-native-py,-native-java,-constant-glob
       - run: ./tensorboard/tools/mirror_urls_test.sh
+      - name: "Lint for no py2 BUILD targets"
+        run: ! git grep 'python_version = "PY2"' '*BUILD'
 
   check-misc:
     runs-on: ubuntu-16.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,8 @@ jobs:
           --warnings=-load-on-top,-native-py,-native-java,-constant-glob
       - run: ./tensorboard/tools/mirror_urls_test.sh
       - name: "Lint for no py2 BUILD targets"
-        run: ! git grep 'python_version = "PY2"' '*BUILD'
+        run: |
+          ! git grep 'python_version = "PY2"' '*BUILD'
 
   check-misc:
     runs-on: ubuntu-16.04

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -45,7 +45,6 @@ py_binary(
     name = "uploader",
     srcs = ["uploader_main.py"],
     main = "uploader_main.py",
-    python_version = "PY2",
     deps = [":uploader_main_lib"],
 )
 


### PR DESCRIPTION
Adds a link check to avoid creating `python_version = "PY2"` BUILD targets (e.g. py_binary or py_test), since we should be running all our python binaries using python3 at this point, so that we can start introducing py3-only code.

This also removes the one violation of this check, which was `//tensorboard/uploader:uploader`.

Tested by ensuring link check failed prior to removing the violation, then passes afterwards.