### PR TITLE
Surface HTML import interop for plugin_lib

### DIFF
--- a/tensorboard/components/experimental/plugin_lib/BUILD
+++ b/tensorboard/components/experimental/plugin_lib/BUILD
@@ -1,4 +1,5 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
+load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
@@ -15,4 +16,33 @@ tf_ts_library(
         "plugin-guest.ts",
         "runs.ts",
     ],
+)
+
+tf_ts_library(
+    name = "plugin_lib_polymer_interop_internal",
+    srcs = [
+        "polymer-interop.ts",
+    ],
+    deps = [
+        ":plugin_lib",
+    ],
+)
+
+tf_js_binary(
+    name = "plugin_lib_polymer_interop_binary",
+    compile = 1,
+    entry_point = ":polymer-interop.ts",
+    deps = [
+        ":plugin_lib_polymer_interop_internal",
+    ],
+)
+
+tf_web_library(
+    name = "plugin_lib_polymer_interop",
+    srcs = [
+        "plugin_lib_polymer_interop_binary.js",
+        "polymer-interop.html",
+    ],
+    path = "/tf-plugin-lib",
+    visibility = ["//visibility:public"],
 )

--- a/tensorboard/components/experimental/plugin_lib/polymer-interop.html
+++ b/tensorboard/components/experimental/plugin_lib/polymer-interop.html
@@ -1,6 +1,6 @@
 <!--
 @license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,10 +14,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<link rel="import" href="../plugin-host.html" />
-<script src="../../web-component-tester/browser.js"></script>
-
-<template id="iframe-template">
-  <iframe src="testable-iframe.html"></iframe>
-</template>
-<script src="plugin-test.js"></script>
+<script src="plugin_lib_polymer_interop_binary.js"></script>

--- a/tensorboard/components/experimental/plugin_lib/polymer-interop.ts
+++ b/tensorboard/components/experimental/plugin_lib/polymer-interop.ts
@@ -1,6 +1,4 @@
-<!--
-@license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,11 +11,19 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
-<link rel="import" href="../plugin-host.html" />
-<script src="../../web-component-tester/browser.js"></script>
+==============================================================================*/
+import * as publicApi from './index';
 
-<template id="iframe-template">
-  <iframe src="testable-iframe.html"></iframe>
-</template>
-<script src="plugin-test.js"></script>
+namespace tb_plugin_lib.experimental {
+  export const core = publicApi.core;
+  export const runs = publicApi.runs;
+}
+
+declare global {
+  interface Window {
+    // Typing is lost after rollup anyways.
+    tb_plugin_lib: any;
+  }
+}
+
+window.tb_plugin_lib = tb_plugin_lib;

--- a/tensorboard/components/experimental/plugin_lib/polymer-interop.ts
+++ b/tensorboard/components/experimental/plugin_lib/polymer-interop.ts
@@ -14,9 +14,8 @@ limitations under the License.
 ==============================================================================*/
 import * as publicApi from './index';
 
-namespace tb_plugin_lib.experimental {
-  export const core = publicApi.core;
-  export const runs = publicApi.runs;
+namespace tb_plugin_lib {
+  export const experimental = publicApi;
 }
 
 declare global {

--- a/tensorboard/components/experimental/plugin_lib/test/BUILD
+++ b/tensorboard/components/experimental/plugin_lib/test/BUILD
@@ -36,11 +36,10 @@ tf_web_library(
     testonly = True,
     srcs = [
         "testable-iframe.html",
-        "testable_plugin_bundle.js",
     ],
     path = "/tf-plugin-lib/test",
     deps = [
-        ":testable_plugin_bundle",
+        "//tensorboard/components/experimental/plugin_lib:plugin_lib_polymer_interop",
     ],
 )
 

--- a/tensorboard/components/experimental/plugin_lib/test/test.ts
+++ b/tensorboard/components/experimental/plugin_lib/test/test.ts
@@ -31,8 +31,7 @@ describe('plugin lib integration', () => {
     this.sandbox = sinon.sandbox.create({useFakeServer: true});
     this.sandbox.server.respondImmediately = true;
     this.iframe = await createIframe();
-    this.lib = (this.iframe.contentWindow as any).plugin_lib;
-    this.libInternal = (this.iframe.contentWindow as any).plugin_internal;
+    this.lib = (this.iframe.contentWindow as any).tb_plugin_lib.experimental;
   });
 
   afterEach(function() {
@@ -85,7 +84,7 @@ describe('plugin lib integration', () => {
 
         // Await another message to ensure the iframe processed the next message
         // (if any).
-        await this.libInternal.sendMessage('foo');
+        await this.lib.runs.getRuns();
 
         expect(runsChanged).to.not.have.been.called;
       });

--- a/tensorboard/components/experimental/plugin_lib/test/testable-iframe.html
+++ b/tensorboard/components/experimental/plugin_lib/test/testable-iframe.html
@@ -14,4 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<script src="testable_plugin_bundle.js"></script>
+
+<!--
+  WARNING: note that polymer-interop.html includes the plugin_lib's internals and
+  the public APIs. Do not import another plugin_lib which can cause wrong
+  registrations.
+-->
+<link rel="import" href="../polymer-interop.html" />

--- a/tensorboard/components/experimental/plugin_lib/test/testable-plugin-lib.ts
+++ b/tensorboard/components/experimental/plugin_lib/test/testable-plugin-lib.ts
@@ -12,8 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import * as public_api from '../index';
 import * as plugin_internal from '../plugin-guest.js';
 
-(window as any).plugin_lib = public_api;
 (window as any).plugin_internal = plugin_internal;

--- a/tensorboard/components/experimental/plugin_util/test/BUILD
+++ b/tensorboard/components/experimental/plugin_util/test/BUILD
@@ -17,11 +17,12 @@ tf_web_library(
     name = "test_web_library",
     srcs = [
         "plugin-test.ts",
+        "testable-iframe.html",
         "tests.html",
+        "//tensorboard/components/experimental/plugin_lib/test:testable_plugin_bundle.js",
     ],
     path = "/tf-plugin-util/test",
     deps = [
-        "//tensorboard/components/experimental/plugin_lib/test:testable_plugin_lib",
         "//tensorboard/components/experimental/plugin_util:plugin_host",
         "//tensorboard/components/tf_imports:web_component_tester",
     ],

--- a/tensorboard/components/experimental/plugin_util/test/testable-iframe.html
+++ b/tensorboard/components/experimental/plugin_util/test/testable-iframe.html
@@ -1,6 +1,6 @@
 <!--
 @license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,10 +14,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<link rel="import" href="../plugin-host.html" />
-<script src="../../web-component-tester/browser.js"></script>
-
-<template id="iframe-template">
-  <iframe src="testable-iframe.html"></iframe>
-</template>
-<script src="plugin-test.js"></script>
+<script src="testable_plugin_bundle.js"></script>

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/externs.js
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/externs.js
@@ -35,6 +35,7 @@
 /** @type {!Function|undefined} */ var ga;
 /** @type {!Function|undefined} */ var KeyframeEffect;
 /** @type {!Object} */ var tensor_widget;
+/** @type {!Object} */ var tb_plugin_lib;
 
 /**
  * Some weird webcomponents-lite.js thing.


### PR DESCRIPTION
plugin_lib was initially designed to be used with npm package and a
bundler. However, because we have a need to use it under traditional
Polymer code that uses HTML import, we need to devise a way for the
lib to work with tf_web_library.

Changed our test to use the new interop layer.

Also tested whether WIT builds with the library (https://github.com/stephanwlee/what-if-tool/commit/5bc972f544b0e23d1ac488b1c43a2c7c668eba7e). I was not able to check for correctness as wit does not build correct pip package.