### PR TITLE
cleanup: fix import statement

### DIFF
--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -41,5 +41,6 @@ ng_module(
     deps = [
         ":http_client",
         "//tensorboard/webapp/angular:expect_angular_common_http_testing",
+        "@npm//@angular/core",
     ],
 )

--- a/tensorboard/webapp/webapp_data_source/tb_server_data_source_module.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_server_data_source_module.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {NgModule} from '@angular/core';
-import {HttpClientModule} from '@angular/common/http';
 
 import {TBHttpClientModule} from './tb_http_client_module';
 import {TBServerDataSource} from './tb_server_data_source';


### PR DESCRIPTION
This unblocks the sync which failed because of the strict_deps violation.

- tensorboard/webapp/webapp_data_source/tb_server_data_source_module.ts had extraneous import statement.
- tb_http_client_testing.ts had missing import on BUILD.