### PR TITLE
Proto changes to support experiment name & description.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: google

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,19 @@ jobs:
         run: |
           ! git grep 'python_version = "PY2"' '*BUILD'
 
+  lint-proto:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: clang-format lint
+        uses: DoozyX/clang-format-lint-action@v0.5
+        with:
+          source: ./tensorboard
+          # Exclude tensorboard/compat because the source of truth is TensorFlow.
+          exclude: ./tensorboard/compat/proto
+          extensions: 'proto'
+          clangFormatVersion: 9
+
   check-misc:
     runs-on: ubuntu-16.04
     steps:

--- a/tensorboard/backend/empty_path_redirect_test.py
+++ b/tensorboard/backend/empty_path_redirect_test.py
@@ -38,7 +38,9 @@ class EmptyPathRedirectMiddlewareTest(tb_test.TestCase):
         app = empty_path_redirect.EmptyPathRedirectMiddleware(app)
         app = self._lax_strip_foo_middleware(app)
         self.app = app
-        self.server = werkzeug_test.Client(self.app, werkzeug.BaseResponse)
+        self.server = werkzeug_test.Client(
+            self.app, werkzeug.wrappers.BaseResponse
+        )
 
     def _lax_strip_foo_middleware(self, app):
         """Strips a `/foo` prefix if it exists; no-op otherwise."""

--- a/tensorboard/backend/experiment_id_test.py
+++ b/tensorboard/backend/experiment_id_test.py
@@ -33,7 +33,9 @@ class ExperimentIdMiddlewareTest(tb_test.TestCase):
     def setUp(self):
         super(ExperimentIdMiddlewareTest, self).setUp()
         self.app = experiment_id.ExperimentIdMiddleware(self._echo_app)
-        self.server = werkzeug_test.Client(self.app, werkzeug.BaseResponse)
+        self.server = werkzeug_test.Client(
+            self.app, werkzeug.wrappers.BaseResponse
+        )
 
     def _echo_app(self, environ, start_response):
         # https://www.python.org/dev/peps/pep-0333/#environ-variables

--- a/tensorboard/backend/path_prefix_test.py
+++ b/tensorboard/backend/path_prefix_test.py
@@ -63,7 +63,7 @@ class PathPrefixMiddlewareTest(tb_test.TestCase):
 
     def test_empty_path_prefix(self):
         app = path_prefix.PathPrefixMiddleware(self._echo_app, "")
-        server = werkzeug_test.Client(app, werkzeug.BaseResponse)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.BaseResponse)
 
         with self.subTest("at empty"):
             self._assert_ok(server.get(""), path="", script="")
@@ -77,7 +77,7 @@ class PathPrefixMiddlewareTest(tb_test.TestCase):
 
     def test_nonempty_path_prefix(self):
         app = path_prefix.PathPrefixMiddleware(self._echo_app, "/pfx")
-        server = werkzeug_test.Client(app, werkzeug.BaseResponse)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.BaseResponse)
 
         with self.subTest("at root"):
             response = server.get("/pfx")
@@ -103,7 +103,7 @@ class PathPrefixMiddlewareTest(tb_test.TestCase):
         app = self._echo_app
         app = path_prefix.PathPrefixMiddleware(app, "/bar")
         app = path_prefix.PathPrefixMiddleware(app, "/foo")
-        server = werkzeug_test.Client(app, werkzeug.BaseResponse)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.BaseResponse)
 
         response = server.get("/foo/bar/baz/quux")
         self._assert_ok(response, path="/baz/quux", script="/foo/bar")

--- a/tensorboard/plugins/custom_scalar/layout.proto
+++ b/tensorboard/plugins/custom_scalar/layout.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 
 package tensorboard;
 
-
 /**
  * Encapsulates information on a single chart. Many charts appear in a category.
  */

--- a/tensorboard/uploader/proto/BUILD
+++ b/tensorboard/uploader/proto/BUILD
@@ -10,6 +10,7 @@ exports_files(["LICENSE"])
 tb_proto_library(
     name = "protos_all",
     srcs = [
+        "experiment.proto",
         "export_service.proto",
         "scalar.proto",
         "server_info.proto",

--- a/tensorboard/uploader/proto/experiment.proto
+++ b/tensorboard/uploader/proto/experiment.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package tensorboard.service;
+
+import "google/protobuf/timestamp.proto";
+
+// Metadata about an experiment.
+message Experiment {
+  // Permanent ID of this experiment; e.g.: "AdYd1TgeTlaLWXx6I8JUbA".
+  string experiment_id = 1;
+  // The time that the experiment was created.
+  google.protobuf.Timestamp create_time = 2;
+  // The time that the experiment was last modified: i.e., the most recent time
+  // that scalars were added to the experiment.
+  google.protobuf.Timestamp update_time = 3;
+  // The number of scalars in this experiment, across all time series.
+  int64 num_scalars = 4;
+  // The number of distinct run names in this experiment.
+  int64 num_runs = 5;
+  // The number of distinct tag names in this experiment. A tag name that
+  // appears in multiple runs will be counted only once.
+  int64 num_tags = 6;
+  // User provided name of the experiment.
+  string name = 7;
+  // User provided description of the experiment, in markdown source format.
+  string description = 8;
+}
+
+// Field mask for `Experiment`. The `experiment_id` field is always implicitly
+// considered to be requested. Other fields of `Experiment` will be populated
+// if their corresponding bits in the `ExperimentMask` are set. The server may
+// choose to populate fields that are not explicitly requested.
+message ExperimentMask {
+  reserved 1;
+  reserved "experiment_id";
+  bool create_time = 2;
+  bool update_time = 3;
+  bool num_scalars = 4;
+  bool num_runs = 5;
+  bool num_tags = 6;
+  bool name = 7;
+  bool description = 8;
+}

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -4,6 +4,7 @@ package tensorboard.service;
 
 import "google/protobuf/timestamp.proto";
 import "tensorboard/compat/proto/summary.proto";
+import "third_party/tensorboard/uploader/proto/experiment.proto";
 
 // Service for exporting data from TensorBoard.dev.
 service TensorBoardExporterService {
@@ -69,44 +70,6 @@ message StreamExperimentsResponse {
   // These messages may be partially populated, in accordance with the field
   // mask given in the request.
   repeated Experiment experiments = 2;
-}
-
-// Metadata about an experiment.
-// TODO: The definition of an experiment should be pulled
-// out into a separate file, similar to scalar.proto.
-message Experiment {
-  // Permanent ID of this experiment; e.g.: "AdYd1TgeTlaLWXx6I8JUbA".
-  string experiment_id = 1;
-  // The time that the experiment was created.
-  google.protobuf.Timestamp create_time = 2;
-  // The time that the experiment was last modified: i.e., the most recent time
-  // that scalars were added to the experiment.
-  google.protobuf.Timestamp update_time = 3;
-  // The number of scalars in this experiment, across all time series.
-  int64 num_scalars = 4;
-  // The number of distinct run names in this experiment.
-  int64 num_runs = 5;
-  // The number of distinct tag names in this experiment. A tag name that
-  // appears in multiple runs will be counted only once.
-  int64 num_tags = 6;
-  // User provided name of the experiment.
-  string name = 7;
-  // User provided desription of the experiment, in markdown source format.
-  string description = 8;
-}
-
-// Field mask for `Experiment`. The `experiment_id` field is always implicitly
-// considered to be requested. Other fields of `Experiment` will be populated
-// if their corresponding bits in the `ExperimentMask` are set. The server may
-// choose to populate fields that are not explicitly requested.
-message ExperimentMask {
-  reserved 1;
-  reserved "experiment_id";
-  bool create_time = 2;
-  bool update_time = 3;
-  bool num_scalars = 4;
-  bool num_runs = 5;
-  bool num_tags = 6;
 }
 
 // Request to stream scalars from all the runs and tags in an experiment.

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -72,6 +72,8 @@ message StreamExperimentsResponse {
 }
 
 // Metadata about an experiment.
+// TODO: The definition of an experiment should be pulled
+// out into a separate file, similar to scalar.proto.
 message Experiment {
   // Permanent ID of this experiment; e.g.: "AdYd1TgeTlaLWXx6I8JUbA".
   string experiment_id = 1;
@@ -87,6 +89,10 @@ message Experiment {
   // The number of distinct tag names in this experiment. A tag name that
   // appears in multiple runs will be counted only once.
   int64 num_tags = 6;
+  // User provided name of the experiment.
+  string name = 7;
+  // User provided desription of the experiment, in markdown source format.
+  string description = 8;
 }
 
 // Field mask for `Experiment`. The `experiment_id` field is always implicitly

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -4,7 +4,6 @@ package tensorboard.service;
 
 import "google/protobuf/timestamp.proto";
 import "tensorboard/compat/proto/summary.proto";
-import "third_party/tensorboard/uploader/proto/experiment.proto";
 
 // Service for exporting data from TensorBoard.dev.
 service TensorBoardExporterService {

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -4,7 +4,6 @@ package tensorboard.service;
 
 import "google/protobuf/timestamp.proto";
 import "tensorboard/compat/proto/summary.proto";
-import "third_party/tensorboard/uploader/proto/experiment.proto";
 
 // Service for exporting data from TensorBoard.dev.
 service TensorBoardExporterService {
@@ -70,6 +69,39 @@ message StreamExperimentsResponse {
   // These messages may be partially populated, in accordance with the field
   // mask given in the request.
   repeated Experiment experiments = 2;
+}
+
+// Metadata about an experiment.
+// TODO(bileschi): Centralize on the Experiment in experiment.proto
+message Experiment {
+  // Permanent ID of this experiment; e.g.: "AdYd1TgeTlaLWXx6I8JUbA".
+  string experiment_id = 1;
+  // The time that the experiment was created.
+  google.protobuf.Timestamp create_time = 2;
+  // The time that the experiment was last modified: i.e., the most recent time
+  // that scalars were added to the experiment.
+  google.protobuf.Timestamp update_time = 3;
+  // The number of scalars in this experiment, across all time series.
+  int64 num_scalars = 4;
+  // The number of distinct run names in this experiment.
+  int64 num_runs = 5;
+  // The number of distinct tag names in this experiment. A tag name that
+  // appears in multiple runs will be counted only once.
+  int64 num_tags = 6;
+}
+
+// Field mask for `Experiment`. The `experiment_id` field is always implicitly
+// considered to be requested. Other fields of `Experiment` will be populated
+// if their corresponding bits in the `ExperimentMask` are set. The server may
+// choose to populate fields that are not explicitly requested.
+message ExperimentMask {
+  reserved 1;
+  reserved "experiment_id";
+  bool create_time = 2;
+  bool update_time = 3;
+  bool num_scalars = 4;
+  bool num_runs = 5;
+  bool num_tags = 6;
 }
 
 // Request to stream scalars from all the runs and tags in an experiment.

--- a/tensorboard/uploader/proto/write_service.proto
+++ b/tensorboard/uploader/proto/write_service.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package tensorboard.service;
 
+import "tensorboard/uploader/proto/experiment.proto";
 import "tensorboard/uploader/proto/scalar.proto";
-import "third_party/tensorboard/uploader/proto/experiment.proto";
 import "tensorboard/compat/proto/summary.proto";
 
 // Service for writing data to TensorBoard.dev.
@@ -24,9 +24,6 @@ service TensorBoardWriterService {
   // Request that the calling user and all their data be permanently deleted.
   // Used for testing purposes.
   rpc DeleteOwnUser(DeleteOwnUserRequest) returns (DeleteOwnUserResponse) {}
-  // Request to mutate metadata associated with an experiment.
-  rpc UpdateExperimentMetadata(UpdateExperimentMetadataRequest)
-      returns (UpdateExperimentMetadataResponse) {}
   // Request to mutate metadata associated with an experiment.
   rpc UpdateExperimentMetadata(UpdateExperimentMetadataRequest)
       returns (UpdateExperimentMetadataResponse) {}
@@ -137,21 +134,6 @@ message DeleteOwnUserRequest {
 // Everything the caller needs to know about how the deletion went.
 message DeleteOwnUserResponse {
   // This is empty on purpose.
-}
-
-
-// Request to change the name of one experiment.
-message UpdateExperimentMetadataRequest {
-  Experiment updates = 1;
-  ExperimentMetadataMask update_mask = 2;
-}
-
-message ExperimentMetadataMask {
-  reserved 1 to 6;
-  reserved "experiment_id", "create_time", "update_time", "num_scalars",
-      "num_runs", "num_tags";
-  bool name = 7;
-  bool description = 8;
 }
 
 // Request to change the metadata of one experiment.

--- a/tensorboard/uploader/proto/write_service.proto
+++ b/tensorboard/uploader/proto/write_service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package tensorboard.service;
 
 import "tensorboard/uploader/proto/scalar.proto";
+import "third_party/tensorboard/uploader/proto/experiment.proto";
 import "tensorboard/compat/proto/summary.proto";
 
 // Service for writing data to TensorBoard.dev.
@@ -23,12 +24,12 @@ service TensorBoardWriterService {
   // Request that the calling user and all their data be permanently deleted.
   // Used for testing purposes.
   rpc DeleteOwnUser(DeleteOwnUserRequest) returns (DeleteOwnUserResponse) {}
-  // Request to mutate the name of an experiment.
-  rpc SetExperimentName(SetExperimentNameRequest)
-      returns (SetExperimentNameResponse) {}
-  // Request to mutate the description of an experiment.
-  rpc SetExperimentDescription(SetExperimentDescriptionRequest)
-      returns (SetExperimentDescriptionResponse) {}
+  // Request to mutate metadata associated with an experiment.
+  rpc UpdateExperimentMetadata(UpdateExperimentMetadataRequest)
+      returns (UpdateExperimentMetadataResponse) {}
+  // Request to mutate metadata associated with an experiment.
+  rpc UpdateExperimentMetadata(UpdateExperimentMetadataRequest)
+      returns (UpdateExperimentMetadataResponse) {}
 }
 
 // This is currently empty on purpose.  No information is necessary
@@ -138,28 +139,36 @@ message DeleteOwnUserResponse {
   // This is empty on purpose.
 }
 
+
 // Request to change the name of one experiment.
-message SetExperimentNameRequest{
-  // Permanent ID of this experiment.  Should match the id in the request.
-  string experiment_id = 1;
-  // User provided name of the experiment.
-  string name = 2;
+message UpdateExperimentMetadataRequest {
+  Experiment updates = 1;
+  ExperimentMetadataMask update_mask = 2;
+}
+
+message ExperimentMetadataMask {
+  reserved 1 to 6;
+  reserved "experiment_id", "create_time", "update_time", "num_scalars",
+      "num_runs", "num_tags";
+  bool name = 7;
+  bool description = 8;
+}
+
+// Request to change the metadata of one experiment.
+message UpdateExperimentMetadataRequest{
+  // Description of the data to set.  The experiment_id field must match
+  // an experiment_id in the database.  The remaining fields should be set
+  // to the desired metadata to be written.  Only those fields marked True
+  // in the experiment_mask will be written. The service may deny
+  // modification of some metadata used for internal bookkeeping, such as
+  // num_scalars, etc.
+  Experiment experiment = 1;
+  // Field mask for what experiment data to set.  The service may deny requests
+  // to set some metatadata.
+  ExperimentMask experiment_mask = 2;
 }
 
 // Response for setting experiment name.
-message SetExperimentNameResponse{
-  // This is empty on purpose.
-}
-
-// Request to change the description of one experiment.
-message SetExperimentDescriptionRequest{
-  // Permanent ID of this experiment.  Should match the id in the request.
-  string experiment_id = 1;
-  // User provided description of the experiment, in markdown source format.
-  string description = 2;
-}
-
-// Response for setting experiment description.
-message SetExperimentDescriptionResponse{
+message UpdateExperimentMetadataResponse{
   // This is empty on purpose.
 }

--- a/tensorboard/uploader/proto/write_service.proto
+++ b/tensorboard/uploader/proto/write_service.proto
@@ -23,13 +23,22 @@ service TensorBoardWriterService {
   // Request that the calling user and all their data be permanently deleted.
   // Used for testing purposes.
   rpc DeleteOwnUser(DeleteOwnUserRequest) returns (DeleteOwnUserResponse) {}
+  // Request to mutate the name of an experiment.
+  rpc SetExperimentName(SetExperimentNameRequest)
+      returns (SetExperimentNameResponse) {}
+  // Request to mutate the description of an experiment.
+  rpc SetExperimentDescription(SetExperimentDescriptionRequest)
+      returns (SetExperimentDescriptionResponse) {}
 }
 
 // This is currently empty on purpose.  No information is necessary
 // to request a URL, except. authorization of course, which doesn't
 // come within the proto.
 message CreateExperimentRequest {
-  // This is empty on purpose.
+  // User provided name of the experiment.
+  string name = 1;
+  // User provided description of the experiment, in markdown source format.
+  string description = 2;
 }
 
 // Carries all information necessary to:
@@ -126,5 +135,31 @@ message DeleteOwnUserRequest {
 
 // Everything the caller needs to know about how the deletion went.
 message DeleteOwnUserResponse {
+  // This is empty on purpose.
+}
+
+// Request to change the name of one experiment.
+message SetExperimentNameRequest{
+  // Permanent ID of this experiment.  Should match the id in the request.
+  string experiment_id = 1;
+  // User provided name of the experiment.
+  string name = 2;
+}
+
+// Response for setting experiment name.
+message SetExperimentNameResponse{
+  // This is empty on purpose.
+}
+
+// Request to change the description of one experiment.
+message SetExperimentDescriptionRequest{
+  // Permanent ID of this experiment.  Should match the id in the request.
+  string experiment_id = 1;
+  // User provided description of the experiment, in markdown source format.
+  string description = 2;
+}
+
+// Response for setting experiment description.
+message SetExperimentDescriptionResponse{
   // This is empty on purpose.
 }

--- a/tensorboard/uploader/proto/write_service.proto
+++ b/tensorboard/uploader/proto/write_service.proto
@@ -136,9 +136,8 @@ message DeleteOwnUserResponse {
   // This is empty on purpose.
 }
 
-
 // Request to change the metadata of one experiment.
-message UpdateExperimentMetadataRequest{
+message UpdateExperimentMetadataRequest {
   // Description of the data to set.  The experiment_id field must match
   // an experiment_id in the database.  The remaining fields should be set
   // to the desired metadata to be written.  Only those fields marked True
@@ -152,6 +151,6 @@ message UpdateExperimentMetadataRequest{
 }
 
 // Response for setting experiment name.
-message UpdateExperimentMetadataResponse{
+message UpdateExperimentMetadataResponse {
   // This is empty on purpose.
 }

--- a/tensorboard/uploader/proto/write_service.proto
+++ b/tensorboard/uploader/proto/write_service.proto
@@ -4,7 +4,6 @@ package tensorboard.service;
 
 import "tensorboard/uploader/proto/experiment.proto";
 import "tensorboard/uploader/proto/scalar.proto";
-import "third_party/tensorboard/uploader/proto/experiment.proto";
 import "tensorboard/compat/proto/summary.proto";
 
 // Service for writing data to TensorBoard.dev.
@@ -28,12 +27,6 @@ service TensorBoardWriterService {
   // Request to mutate metadata associated with an experiment.
   rpc UpdateExperimentMetadata(UpdateExperimentMetadataRequest)
       returns (UpdateExperimentMetadataResponse) {}
-<<<<<<< HEAD
-=======
-  // Request to mutate metadata associated with an experiment.
-  rpc UpdateExperimentMetadata(UpdateExperimentMetadataRequest)
-      returns (UpdateExperimentMetadataResponse) {}
->>>>>>> 779c5f272b9ac22991b4d5c038c283cff3b483a0
 }
 
 // This is currently empty on purpose.  No information is necessary

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -409,6 +409,8 @@ class _ListIntent(_Intent):
             url = server_info_lib.experiment_url(server_info, experiment_id)
             print(url)
             data = [
+                ("Name", experiment.name),
+                ("Description", experiment.description),
                 ("Id", experiment.experiment_id),
                 ("Created", util.format_time(experiment.create_time)),
                 ("Updated", util.format_time(experiment.update_time)),

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -409,8 +409,6 @@ class _ListIntent(_Intent):
             url = server_info_lib.experiment_url(server_info, experiment_id)
             print(url)
             data = [
-                ("Name", experiment.name),
-                ("Description", experiment.description),
                 ("Id", experiment.experiment_id),
                 ("Created", util.format_time(experiment.create_time)),
                 ("Updated", util.format_time(experiment.update_time)),

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -41,5 +41,6 @@ ng_module(
     deps = [
         ":http_client",
         "//tensorboard/webapp/angular:expect_angular_common_http_testing",
+        "@npm//@angular/core",
     ],
 )

--- a/tensorboard/webapp/webapp_data_source/tb_server_data_source_module.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_server_data_source_module.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {NgModule} from '@angular/core';
-import {HttpClientModule} from '@angular/common/http';
 
 import {TBHttpClientModule} from './tb_http_client_module';
 import {TBServerDataSource} from './tb_server_data_source';

--- a/third_party/fonts.bzl
+++ b/third_party/fonts.bzl
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "filegroup_external")
-load("@io_bazel_rules_closure//closure:defs.bzl", "web_library_external")
 
 def tensorboard_fonts_workspace():
   """Downloads TensorBoard fonts."""


### PR DESCRIPTION
* Motivation for features / changes
Support for experiment name & description in TensorBoard.dev

* Technical description of changes
Extends proto service adding:
SetExperimentName and SetExperimentDescription
Extends uploader to read those fields during export

* Screenshots of UI changes
OSS product users should see no chnage.

* Detailed steps to verify changes work correctly (as executed by you)
bazel test tensorboard:all in a virtual env
