### PR TITLE
Convert BaseResponse to wrappers.BaseResponse

### DIFF
--- a/tensorboard/backend/empty_path_redirect_test.py
+++ b/tensorboard/backend/empty_path_redirect_test.py
@@ -38,7 +38,9 @@ class EmptyPathRedirectMiddlewareTest(tb_test.TestCase):
         app = empty_path_redirect.EmptyPathRedirectMiddleware(app)
         app = self._lax_strip_foo_middleware(app)
         self.app = app
-        self.server = werkzeug_test.Client(self.app, werkzeug.BaseResponse)
+        self.server = werkzeug_test.Client(
+            self.app, werkzeug.wrappers.BaseResponse
+        )
 
     def _lax_strip_foo_middleware(self, app):
         """Strips a `/foo` prefix if it exists; no-op otherwise."""

--- a/tensorboard/backend/experiment_id_test.py
+++ b/tensorboard/backend/experiment_id_test.py
@@ -33,7 +33,9 @@ class ExperimentIdMiddlewareTest(tb_test.TestCase):
     def setUp(self):
         super(ExperimentIdMiddlewareTest, self).setUp()
         self.app = experiment_id.ExperimentIdMiddleware(self._echo_app)
-        self.server = werkzeug_test.Client(self.app, werkzeug.BaseResponse)
+        self.server = werkzeug_test.Client(
+            self.app, werkzeug.wrappers.BaseResponse
+        )
 
     def _echo_app(self, environ, start_response):
         # https://www.python.org/dev/peps/pep-0333/#environ-variables

--- a/tensorboard/backend/path_prefix_test.py
+++ b/tensorboard/backend/path_prefix_test.py
@@ -63,7 +63,7 @@ class PathPrefixMiddlewareTest(tb_test.TestCase):
 
     def test_empty_path_prefix(self):
         app = path_prefix.PathPrefixMiddleware(self._echo_app, "")
-        server = werkzeug_test.Client(app, werkzeug.BaseResponse)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.BaseResponse)
 
         with self.subTest("at empty"):
             self._assert_ok(server.get(""), path="", script="")
@@ -77,7 +77,7 @@ class PathPrefixMiddlewareTest(tb_test.TestCase):
 
     def test_nonempty_path_prefix(self):
         app = path_prefix.PathPrefixMiddleware(self._echo_app, "/pfx")
-        server = werkzeug_test.Client(app, werkzeug.BaseResponse)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.BaseResponse)
 
         with self.subTest("at root"):
             response = server.get("/pfx")
@@ -103,7 +103,7 @@ class PathPrefixMiddlewareTest(tb_test.TestCase):
         app = self._echo_app
         app = path_prefix.PathPrefixMiddleware(app, "/bar")
         app = path_prefix.PathPrefixMiddleware(app, "/foo")
-        server = werkzeug_test.Client(app, werkzeug.BaseResponse)
+        server = werkzeug_test.Client(app, werkzeug.wrappers.BaseResponse)
 
         response = server.get("/foo/bar/baz/quux")
         self._assert_ok(response, path="/baz/quux", script="/foo/bar")


### PR DESCRIPTION
Although the werkzeug changelog did not say so, it seem to have removed
certain symbols from `werkzeug`. We now use
`werkzeug.wrappers.BaseResponse` instead.

Context:
https://werkzeug.palletsprojects.com/en/master/changes/#version-1-0-0

Fixes #3229.