### PR TITLE
[DebuggerV2] Start fleshing out alerts component

### DIFF
--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -187,6 +187,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
                 "begin": 0,
                 "end": 0,
                 "num_alerts": 0,
+                "alerts_breakdown": {},
                 "per_type_alert_limit": 1000,
                 "alerts": [],
             },
@@ -211,6 +212,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
                 "begin": 0,
                 "end": 0,
                 "num_alerts": 3,
+                "alerts_breakdown": {"InfNanAlert": 3,},
                 "per_type_alert_limit": 1000,
                 "alerts": [],
             },
@@ -232,6 +234,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEqual(data["begin"], 0)
         self.assertEqual(data["end"], 3)
         self.assertEqual(data["num_alerts"], 3)
+        self.assertEqual(data["alerts_breakdown"], {"InfNanAlert": 3})
         self.assertEqual(data["per_type_alert_limit"], 1000)
         alerts = data["alerts"]
         self.assertLen(alerts, 3)

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -73,6 +73,7 @@ tf_ng_web_test_suite(
         ":test_lib",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects:debugger_effects_test_lib",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:debugger_store_test_lib",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts:alerts_container_test_lib",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline:timeline_test",
     ],
 )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
@@ -53,16 +53,16 @@ export const debuggerRunsRequestFailed = createAction(
 );
 
 /**
- * Actions for the Timeline Component.
+ * Number of alerts and their type breakdown are requested.
  */
-export const numAlertsRequested = createAction(
+export const numAlertsAndBreakdownRequested = createAction(
   '[Debugger] Number and Breakdown of Alerts Requested'
 );
 
 /**
- * Number of alerts and their type breakdown is loaded.
+ * Number of alerts and their type breakdown are loaded.
  */
-export const numAlertsLoaded = createAction(
+export const numAlertsAndBreakdownLoaded = createAction(
   '[Debugger] Number and Breakdown of Alerts Loaded',
   props<{numAlerts: number; alertsBreakdown: AlertsBreakdown}>()
 );

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
@@ -16,6 +16,7 @@ limitations under the License.
 import {createAction, props} from '@ngrx/store';
 
 import {
+  AlertsBreakdown,
   DebuggerRunListing,
   Execution,
   StackFramesById,
@@ -54,8 +55,21 @@ export const debuggerRunsRequestFailed = createAction(
 /**
  * Actions for the Timeline Component.
  */
-export const alertsViewLoaded = createAction('[Debugger] Alerts View Loaded');
+export const numAlertsRequested = createAction(
+  '[Debugger] Number and Breakdown of Alerts Requested'
+);
 
+/**
+ * Number of alerts and their type breakdown is loaded.
+ */
+export const numAlertsLoaded = createAction(
+  '[Debugger] Number and Breakdown of Alerts Loaded',
+  props<{numAlerts: number; alertsBreakdown: AlertsBreakdown}>()
+);
+
+/**
+ * Actions for the Timeline Component.
+ */
 export const numExecutionsRequested = createAction(
   '[Debugger] Number of Executions Requested'
 );

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/tfdbg2_data_source.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs';
 import {
+  Alert,
   DebuggerRunListing,
   Execution,
   ExecutionDigest,
@@ -46,6 +47,20 @@ export interface ExecutionDataResponse {
   executions: Execution[];
 }
 
+export interface AlertsResponse {
+  begin: number;
+
+  end: number;
+
+  num_alerts: number;
+
+  alerts_breakdown: {[alert_type: string]: number};
+
+  per_type_alert_limit: number;
+
+  alerts: Alert[];
+}
+
 export abstract class Tfdbg2DataSource {
   abstract fetchRuns(): Observable<DebuggerRunListing>;
 
@@ -65,6 +80,13 @@ export abstract class Tfdbg2DataSource {
     run: string,
     stackFrameIds: string[]
   ): Observable<StackFramesResponse>;
+
+  abstract fetchAlerts(
+    run: string,
+    begin: number,
+    end: number,
+    alert_type?: string
+  ): Observable<AlertsResponse>;
 }
 
 @Injectable()
@@ -115,6 +137,22 @@ export class Tfdbg2HttpServerDataSource implements Tfdbg2DataSource {
         },
       }
     );
+  }
+
+  fetchAlerts(run: string, begin: number, end: number, alert_type?: string) {
+    if (alert_type !== undefined) {
+      throw new Error(
+        `Support for alert_type fileter is not implemented yet ` +
+          `(received alert_type="${alert_type}")`
+      );
+    }
+    return this.http.get<AlertsResponse>(this.httpPathPrefix + '/alerts', {
+      params: {
+        run,
+        begin: String(begin),
+        end: String(end),
+      },
+    });
   }
 
   // TODO(cais): Implement fetchEnvironments().

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -498,7 +498,7 @@ export class DebuggerEffects {
      *  +> fetch run +> fetch num exec
      *               +> fetch num alerts
      *                   +
-     *                   +> if init load and non-empty execs
+     *                   +> if init load and non-zero number of execs
      *                       +
      *                       +>+-------------------+
      *                       | | fetch exec digest |

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -34,12 +34,15 @@ import {
   executionDigestsLoaded,
   executionScrollLeft,
   executionScrollRight,
+  numAlertsLoaded,
+  numAlertsRequested,
   numExecutionsLoaded,
   numExecutionsRequested,
   stackFramesLoaded,
 } from '../actions';
 import {
   getActiveRunId,
+  getAlertsLoaded,
   getDebuggerRunListing,
   getDebuggerRunsLoaded,
   getDisplayCount,
@@ -198,7 +201,44 @@ export class DebuggerEffects {
   }
 
   /**
-   * Emits when initial execution is data is required.
+   * When a debugger run exits, load number of alerts.
+   */
+  private createNumAlertsLoader(prevStream$: Observable<void>) {
+    return prevStream$.pipe(
+      withLatestFrom(
+        this.store.select(getDebuggerRunListing),
+        this.store.select(getAlertsLoaded)
+      ),
+      filter(([, runs, loaded]) => {
+        return (
+          Object.keys(runs).length > 0 && loaded.state !== DataLoadState.LOADING
+        );
+      }),
+      tap(() => this.store.dispatch(numAlertsRequested())),
+      mergeMap(([, runs]) => {
+        const runId = Object.keys(runs)[0];
+        const begin = 0;
+        const end = 0;
+        return this.dataSource.fetchAlerts(runId, begin, end).pipe(
+          tap((alerts) => {
+            this.store.dispatch(
+              numAlertsLoaded({
+                numAlerts: alerts.num_alerts,
+                alertsBreakdown: alerts.alerts_breakdown,
+              })
+            );
+          }),
+          map(() => void null)
+        );
+      })
+    );
+  }
+
+  /**
+   * Emits when initial execution digests and data are required.
+   *
+   * These initial data loading actions are required when the number of
+   * executions is greater than zero.
    */
   private createInitialExecutionDetector(
     prevStream$: Observable<void>
@@ -456,6 +496,7 @@ export class DebuggerEffects {
      * view load
      *  +
      *  +> fetch run +> fetch num exec
+     *               +> fetch num alerts
      *                   +
      *                   +> if init load
      *                       +
@@ -469,10 +510,18 @@ export class DebuggerEffects {
      **/
     this.loadData$ = createEffect(
       () => {
-        const onLoad$ = this.onDebuggerLoaded();
+        // This event can trigger the loading of
+        //   - number of executions
+        //   - number and breakdown of alerts.
+        // Therefore it needs to be a shared observable.
+        const onLoad$ = this.onDebuggerLoaded().pipe(share());
         const onNumExecutionLoaded$ = this.createNumExecutionLoader(onLoad$);
-        // This event can trigger both digest and data loads. Needs to be a
-        // shared observable.
+        const onNumAlertsLoaded$ = this.createNumAlertsLoader(onLoad$);
+
+        // This event can trigger the loading of
+        //   - execution-digest
+        //   - first execution data.
+        // Therefore it needs to be a shared observable.
         const onInitialExecution$ = this.createInitialExecutionDetector(
           onNumExecutionLoaded$
         ).pipe(share());
@@ -502,7 +551,11 @@ export class DebuggerEffects {
         );
 
         // ExecutionDigest and ExecutionData can be loaded in parallel.
-        return merge(onExcutionDigestLoaded$, onExecutionDataLoaded$).pipe(
+        return merge(
+          onNumAlertsLoaded$,
+          onExcutionDigestLoaded$,
+          onExecutionDataLoaded$
+        ).pipe(
           // createEffect expects an Observable that emits {}.
           map(() => ({}))
         );

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -27,8 +27,8 @@ import {
   executionDigestsRequested,
   executionScrollLeft,
   executionScrollRight,
-  numAlertsRequested,
-  numAlertsLoaded,
+  numAlertsAndBreakdownRequested,
+  numAlertsAndBreakdownLoaded,
   numExecutionsLoaded,
   numExecutionsRequested,
   stackFramesLoaded,
@@ -434,8 +434,8 @@ describe('Debugger effects', () => {
       expect(dispatchedActions).toEqual([
         debuggerRunsRequested(),
         debuggerRunsLoaded({runs: runListingForTest}),
-        numAlertsRequested(),
-        numAlertsLoaded({
+        numAlertsAndBreakdownRequested(),
+        numAlertsAndBreakdownLoaded({
           numAlerts: numAlertsResponseForTest.num_alerts,
           alertsBreakdown: numAlertsResponseForTest.alerts_breakdown,
         }),
@@ -472,8 +472,8 @@ describe('Debugger effects', () => {
       expect(dispatchedActions).toEqual([
         debuggerRunsRequested(),
         debuggerRunsLoaded({runs: runListingForTest}),
-        numAlertsRequested(),
-        numAlertsLoaded({
+        numAlertsAndBreakdownRequested(),
+        numAlertsAndBreakdownLoaded({
           numAlerts: numAlertsResponseForTest.num_alerts,
           alertsBreakdown: numAlertsResponseForTest.alerts_breakdown,
         }),

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -119,7 +119,6 @@ const reducer = createReducer(
         return state;
       }
       return {
-        // TODO(cais): Unit test.
         ...state,
         alerts: {
           ...state.alerts,
@@ -146,7 +145,7 @@ const reducer = createReducer(
             ...state.alerts.alertsLoaded,
             state: DataLoadState.LOADED,
             lastLoadedTimeInMs: Date.now(),
-          }, // TODO(cais): Unit test.
+          },
           numAlerts,
           alertsBreakdown,
         },

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -112,7 +112,7 @@ const reducer = createReducer(
     }
   ),
   on(
-    actions.numAlertsRequested,
+    actions.numAlertsAndBreakdownRequested,
     (state: DebuggerState): DebuggerState => {
       const runId = state.activeRunId;
       if (runId === null) {
@@ -132,7 +132,7 @@ const reducer = createReducer(
     }
   ),
   on(
-    actions.numAlertsLoaded,
+    actions.numAlertsAndBreakdownLoaded,
     (state: DebuggerState, {numAlerts, alertsBreakdown}): DebuggerState => {
       const runId = state.activeRunId;
       if (runId === null) {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -34,6 +34,15 @@ const initialState: DebuggerState = {
     lastLoadedTimeInMs: null,
   },
   activeRunId: null,
+  alerts: {
+    alertsLoaded: {
+      state: DataLoadState.NOT_LOADED,
+      lastLoadedTimeInMs: null,
+    },
+    numAlerts: 0,
+    alerts: {},
+    alertsBreakdown: {},
+  },
   executions: {
     numExecutionsLoaded: {
       state: DataLoadState.NOT_LOADED,
@@ -99,6 +108,48 @@ const reducer = createReducer(
         // TODO(cais): Handle multiple runs. We currently assumes there is only
         // one run, which is okay because the backend supports only one run
         // per experiment.
+      };
+    }
+  ),
+  on(
+    actions.numAlertsRequested,
+    (state: DebuggerState): DebuggerState => {
+      const runId = state.activeRunId;
+      if (runId === null) {
+        return state;
+      }
+      return {
+        // TODO(cais): Unit test.
+        ...state,
+        alerts: {
+          ...state.alerts,
+          alertsLoaded: {
+            ...state.alerts.alertsLoaded,
+            state: DataLoadState.LOADING,
+          },
+        },
+      };
+    }
+  ),
+  on(
+    actions.numAlertsLoaded,
+    (state: DebuggerState, {numAlerts, alertsBreakdown}): DebuggerState => {
+      const runId = state.activeRunId;
+      if (runId === null) {
+        return state;
+      }
+      return {
+        ...state,
+        alerts: {
+          ...state.alerts,
+          alertsLoaded: {
+            ...state.alerts.alertsLoaded,
+            state: DataLoadState.LOADED,
+            lastLoadedTimeInMs: Date.now(),
+          }, // TODO(cais): Unit test.
+          numAlerts,
+          alertsBreakdown,
+        },
       };
     }
   ),

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
@@ -118,16 +118,16 @@ describe('Debugger reducers', () => {
     expect(nextState.activeRunId).toEqual('__default_debugger_run__');
   });
 
-  it('Updates alert load state on numAlertsRequested', () => {
+  it('Updates alert load state on numAlertsAndBreakdownRequested', () => {
     const state = createDebuggerState({
       activeRunId: '__default_debugger_run__',
     });
-    const nextState = reducers(state, actions.numAlertsRequested());
+    const nextState = reducers(state, actions.numAlertsAndBreakdownRequested());
     expect(nextState.alerts.alertsLoaded.state).toEqual(DataLoadState.LOADING);
     expect(nextState.alerts.alertsLoaded.lastLoadedTimeInMs).toBeNull();
   });
 
-  it('Updates on numAlertsLoaded', () => {
+  it('Updates on numAlertsAndBreakdownLoaded', () => {
     const state = createDebuggerState({
       activeRunId: '__default_debugger_run__',
       alerts: createAlertsState({
@@ -139,7 +139,7 @@ describe('Debugger reducers', () => {
     });
     const nextState = reducers(
       state,
-      actions.numAlertsLoaded({
+      actions.numAlertsAndBreakdownLoaded({
         numAlerts: 30,
         alertsBreakdown: {
           InfNanAlerts: 29,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -15,6 +15,7 @@ limitations under the License.
 
 import {createSelector, createFeatureSelector, select} from '@ngrx/store';
 import {
+  AlertsBreakdown,
   DEBUGGER_FEATURE_KEY,
   DebuggerRunListing,
   DebuggerState,
@@ -51,6 +52,27 @@ export const getDebuggerRunsLoaded = createSelector(
 export const getActiveRunId = createSelector(
   selectDebuggerState,
   (state: DebuggerState): string | null => state.activeRunId
+);
+
+export const getAlertsLoaded = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): LoadState => {
+    return state.alerts.alertsLoaded;
+  }
+);
+
+export const getNumAlerts = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): number => {
+    return state.alerts.numAlerts;
+  }
+);
+
+export const getAlertsBreakdown = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): AlertsBreakdown => {
+    return state.alerts.alertsBreakdown;
+  }
 );
 
 export const getNumExecutionsLoaded = createSelector(

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
@@ -14,9 +14,12 @@ limitations under the License.
 ==============================================================================*/
 
 import {
+  getAlertsBreakdown,
+  getAlertsLoaded,
   getFocusedExecutionData,
   getFocusedExecutionIndex,
   getFocusedExecutionStackFrames,
+  getNumAlerts,
 } from './debugger_selectors';
 import {
   DataLoadState,
@@ -24,12 +27,83 @@ import {
   StackFrame,
 } from './debugger_types';
 import {
-  createState,
+  createAlertsState,
   createDebuggerState,
+  createState,
   createTestExecutionData,
 } from '../testing';
 
 describe('debugger selectors', () => {
+  describe('getAlertsLoaded', () => {
+    it('Returns correct NOT_LOADED state', () => {
+      const state = createState(createDebuggerState());
+      const alertsLoaded = getAlertsLoaded(state);
+      expect(alertsLoaded.state).toBe(DataLoadState.NOT_LOADED);
+      expect(alertsLoaded.lastLoadedTimeInMs).toBe(null);
+    });
+
+    it('Returns correct LOADING state', () => {
+      const state = createState(
+        createDebuggerState({
+          alerts: createAlertsState({
+            alertsLoaded: {
+              state: DataLoadState.LOADING,
+              lastLoadedTimeInMs: null,
+            },
+          }),
+        })
+      );
+      const alertsLoaded = getAlertsLoaded(state);
+      expect(alertsLoaded.state).toBe(DataLoadState.LOADING);
+      expect(alertsLoaded.lastLoadedTimeInMs).toBe(null);
+    });
+  });
+
+  describe('getNumAlerts', () => {
+    it('Returns correct zero numAlerts', () => {
+      const state = createState(createDebuggerState());
+      expect(getNumAlerts(state)).toBe(0);
+    });
+
+    it('Returns correct non-zero numAlerts', () => {
+      const state = createState(
+        createDebuggerState({
+          alerts: createAlertsState({
+            numAlerts: 95,
+          }),
+        })
+      );
+      expect(getNumAlerts(state)).toBe(95);
+    });
+  });
+
+  describe('getAlertsBreakdown', () => {
+    it('Returns correct empty object for initial state', () => {
+      const state = createState(createDebuggerState());
+      expect(getAlertsBreakdown(state)).toEqual({});
+    });
+
+    it('Returns correct non-empty map', () => {
+      const state = createState(
+        createDebuggerState({
+          alerts: createAlertsState({
+            numAlerts: 95,
+            alertsBreakdown: {
+              InfNanAlert: 50,
+              FooAlert: 30,
+              BarAlert: 15,
+            },
+          }),
+        })
+      );
+      expect(getAlertsBreakdown(state)).toEqual({
+        InfNanAlert: 50,
+        FooAlert: 30,
+        BarAlert: 15,
+      });
+    });
+  });
+
   describe('getFocusedExecutionIndex', () => {
     for (const focusIndex of [null, 0, 1]) {
       it(`returns null correctly: focusIndex=${focusIndex}`, () => {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -84,7 +84,11 @@ export interface Execution extends ExecutionDigest {
   debug_tensor_values: Array<number[] | null> | null;
 }
 
-export type AlertType = 'InfNanAlert';
+export enum AlertType {
+  FunctionRecompileAlert = 'FunctionRecompilesAlert',
+  InfNanAlert = 'InfNanAlert',
+  TensorShapeAlert = 'TensorShapeAlert',
+}
 
 export interface Alert {
   // TODO(cais): Add more possibilities to it.
@@ -92,7 +96,7 @@ export interface Alert {
 }
 
 export interface InfNanAlert extends Alert {
-  alert_type: 'InfNanAlert';
+  alert_type: AlertType.InfNanAlert;
 
   op_type: string;
 
@@ -127,6 +131,8 @@ export interface ExecutionDigestLoadState extends LoadState {
 
 // A map from the type of alert (e.g., 'InfNanAlert') to count of alerts
 // of that type.
+// TODO(cais): Explore tighter typing for `alertType`, ideally by using
+// the enum values from `AlertType`.
 export type AlertsBreakdown = {[alertType: string]: number};
 
 export interface Alerts {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -85,9 +85,9 @@ export interface Execution extends ExecutionDigest {
 }
 
 export enum AlertType {
-  FunctionRecompileAlert = 'FunctionRecompilesAlert',
-  InfNanAlert = 'InfNanAlert',
-  TensorShapeAlert = 'TensorShapeAlert',
+  FUNCTION_RECOMPILE_ALERT = 'FunctionRecompilesAlert',
+  INF_NAN_ALERT = 'InfNanAlert',
+  TENSOR_SHAPE_ALERT = 'TensorShapeAlert',
 }
 
 export interface Alert {
@@ -96,7 +96,7 @@ export interface Alert {
 }
 
 export interface InfNanAlert extends Alert {
-  alert_type: AlertType.InfNanAlert;
+  alert_type: AlertType.INF_NAN_ALERT;
 
   op_type: string;
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -84,6 +84,36 @@ export interface Execution extends ExecutionDigest {
   debug_tensor_values: Array<number[] | null> | null;
 }
 
+export type AlertType = 'InfNanAlert';
+
+export interface Alert {
+  // TODO(cais): Add more possibilities to it.
+  alert_type: AlertType;
+}
+
+export interface InfNanAlert extends Alert {
+  alert_type: 'InfNanAlert';
+
+  op_type: string;
+
+  output_slot: number;
+
+  size: number;
+
+  num_neg_inf: number;
+
+  num_pos_inf: number;
+
+  num_nan: number;
+
+  execution_index: number;
+
+  // This value is a `number` (non-negative integer) for InfNanAlerts due to
+  // intra-graph execution. It is `null` for InfNanAlerts due to eager
+  // execution.
+  graph_execution_trace_index: number | null;
+}
+
 export interface ExecutionDigestLoadState extends LoadState {
   // A map from page number to whether the page has been loaded
   //   - in full, in which case the value is pageSize.
@@ -93,6 +123,25 @@ export interface ExecutionDigestLoadState extends LoadState {
   // Number of top-level executions available at the data source (not
   // necessarilty loaded by frontend yet.)
   numExecutions: number;
+}
+
+// A map from the type of alert (e.g., 'InfNanAlert') to count of alerts
+// of that type.
+export type AlertsBreakdown = {[alertType: string]: number};
+
+export interface Alerts {
+  // Load state for alerts.
+  // This state can go from LOADED to LOADING, as the alerts can be loaded
+  // incrementally from the backend.
+  alertsLoaded: LoadState;
+
+  // Total number of alerts.
+  numAlerts: number;
+
+  alertsBreakdown: AlertsBreakdown;
+
+  // The alerts that have been loaded so far, by alertType.
+  alerts: {[alertType: string]: Alert[]};
 }
 
 export interface Executions {
@@ -143,6 +192,8 @@ export interface DebuggerState {
 
   // ID of the run being currently displayed.
   activeRunId: string | null;
+
+  alerts: Alerts;
 
   // Per-run detailed data.
   executions: Executions;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
@@ -17,6 +17,7 @@ import {Component, NgModule} from '@angular/core';
 import {Store} from '@ngrx/store';
 
 import {
+  Alerts,
   DataLoadState,
   DEBUGGER_FEATURE_KEY,
   DebuggerState,
@@ -63,8 +64,22 @@ export function createDebuggerState(
       lastLoadedTimeInMs: null,
     },
     activeRunId: null,
+    alerts: createAlertsState(),
     executions: createDebuggerExecutionsState(),
     stackFrames: {},
+    ...override,
+  };
+}
+
+export function createAlertsState(override?: Partial<Alerts>): Alerts {
+  return {
+    alertsLoaded: {
+      state: DataLoadState.NOT_LOADED,
+      lastLoadedTimeInMs: null,
+    },
+    numAlerts: 0,
+    alertsBreakdown: {},
+    alerts: {},
     ...override,
   };
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
@@ -35,7 +35,6 @@ tf_ts_library(
     tsconfig = "//:tsconfig-test",
     deps = [
         ":alerts",
-        # ":debugger_v2",  # TODO(cais): Clean up.
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin:debugger_v2",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
@@ -1,6 +1,7 @@
 package(default_visibility = ["//tensorboard:internal"])
 
 load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -22,5 +23,35 @@ ng_module(
         "@npm//@angular/core",
         "@npm//@ngrx/store",
         "@npm//rxjs",
+    ],
+)
+
+tf_ts_library(
+    name = "alerts_container_test_lib",
+    testonly = True,
+    srcs = [
+        "alerts_container_test.ts",
+    ],
+    tsconfig = "//:tsconfig-test",
+    deps = [
+        ":alerts",
+        # ":debugger_v2",  # TODO(cais): Clean up.
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin:debugger_v2",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
+        "@npm//@angular/common",
+        "@npm//@angular/compiler",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
     ],
 )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
@@ -17,6 +17,8 @@ ng_module(
     ],
     deps = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
         "@npm//@angular/core",
         "@npm//@ngrx/store",
         "@npm//rxjs",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.css
@@ -13,4 +13,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-/* TODO(cais): Flesh out the styling. */
+.alerts-breakdown-container {
+  font-size: 13px;
+  padding: 10px 0px 10px 50px;
+}
+
+.alerts-container {
+  font-family: sans-serif;
+}
+
+.alert-type-count {
+  display: inline-block;
+  margin-left: 40px;
+}
+
+.alert-type-name {
+  display: inline-block;
+}
+
+.debugging-title {
+  font-size: 18px;
+}
+
+.num-alerts-container {
+  padding: 10px 0px 10px 30px;
+}
+
+.num-alerts-label {
+  display: inline-block;
+  font-size: 13px;
+}
+
+.num-alerts-value {
+  display: inline-block;
+  font-size: 13px;
+  margin-left: 90px;
+}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.css
@@ -15,16 +15,25 @@ limitations under the License.
 
 .alerts-breakdown-container {
   font-size: 13px;
-  padding: 10px 0px 10px 50px;
+  padding: 10px 10px 10px 50px;
+  position: relative;
 }
 
 .alerts-container {
-  font-family: sans-serif;
+  font-family: 'Roboto', Arial, Helvetica, sans-serif;
+  vertical-align: middle;
 }
 
 .alert-type-count {
+  /* TODO(cais): Use colors specific to alert type. */
+  background-color: #e52592;
+  border-radius: 3px;
+  color: #fff;
   display: inline-block;
-  margin-left: 40px;
+  font-weight: normal;
+  padding: 3px;
+  position: absolute;
+  right: 20px;
 }
 
 .alert-type-name {
@@ -36,7 +45,9 @@ limitations under the License.
 }
 
 .num-alerts-container {
-  padding: 10px 0px 10px 30px;
+  font-weight: bold;
+  padding: 10px 10px 10px 30px;
+  position: relative;
 }
 
 .num-alerts-label {
@@ -45,7 +56,19 @@ limitations under the License.
 }
 
 .num-alerts-value {
+  border-radius: 12px;
   display: inline-block;
   font-size: 13px;
-  margin-left: 90px;
+  height: 24px;
+  position: absolute;
+  right: 20px;
+  text-align: center;
+  width: 24px;
+  -moz-border-radius: 12px;
+  -webkit-border-radius: 12px;
+}
+
+.num-alerts-value.non-zero {
+  background-color: #ffb780;
+  font-weight: bold;
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.css
@@ -30,7 +30,6 @@ limitations under the License.
   border-radius: 3px;
   color: #fff;
   display: inline-block;
-  font-weight: normal;
   padding: 3px;
   position: absolute;
   right: 20px;
@@ -59,10 +58,12 @@ limitations under the License.
   border-radius: 12px;
   display: inline-block;
   font-size: 13px;
-  height: 24px;
+  font-weight: normal;
+  line-height: 24px;
   position: absolute;
   right: 20px;
   text-align: center;
+  vertical-align: middle;
   width: 24px;
   -moz-border-radius: 12px;
   -webkit-border-radius: 12px;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.css
@@ -65,8 +65,8 @@ limitations under the License.
   text-align: center;
   vertical-align: middle;
   width: 24px;
-  -moz-border-radius: 12px;
-  -webkit-border-radius: 12px;
+  /* -moz-border-radius: 12px;
+  -webkit-border-radius: 12px; */
 }
 
 .num-alerts-value.non-zero {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ng.html
@@ -19,15 +19,17 @@ limitations under the License.
   <div class="debugging-title">Debugging</div>
   <div class="num-alerts-container">
     <div class="num-alerts-label">Alerts</div>
-    <div class="num-alerts-value">{{ numAlerts }}</div>
+    <div class="num-alerts-value" [ngClass]="[numAlerts > 0 ? 'non-zero' : '']">
+      {{ numAlerts }}
+    </div>
   </div>
   <div class="alerts-breakdown-container">
     <div *ngFor="let breakdown of alertsBreakdown;">
       <div class="alert-type-name">
-        {{ breakdown.alertType }}
+        {{ breakdown.displayName }}
       </div>
       <div class="alert-type-count">
-        {{ breakdown.count }}
+        {{ breakdown.displaySymbol }}: {{ breakdown.count }}
       </div>
       <div></div>
     </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ng.html
@@ -15,10 +15,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div>
-  <div>Debugging</div>
-  <div>
-    <span>Alerts</span>
+<div class="alerts-container">
+  <div class="debugging-title">Debugging</div>
+  <div class="num-alerts-container">
+    <div class="num-alerts-label">Alerts</div>
+    <div class="num-alerts-value">{{ numAlerts }}</div>
   </div>
-  <!-- TODO(cais): Flesh out the details. -->
+  <div class="alerts-breakdown-container">
+    <div *ngFor="let breakdown of alertsBreakdown;">
+      <div class="alert-type-name">
+        {{ breakdown.alertType }}
+      </div>
+      <div class="alert-type-count">
+        {{ breakdown.count }}
+      </div>
+      <div></div>
+    </div>
+  </div>
 </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ts
@@ -14,6 +14,12 @@ limitations under the License.
 ==============================================================================*/
 import {Component, Input} from '@angular/core';
 
+export interface AlertTypeDisplay {
+  displayName: string;
+  displaySymbol: string;
+  count: number;
+}
+
 @Component({
   selector: 'alerts-component',
   templateUrl: './alerts_component.ng.html',
@@ -25,5 +31,5 @@ export class AlertsComponent {
   numAlerts: number = 0;
 
   @Input()
-  alertsBreakdown: Array<{alertType: string; count: number}> = [];
+  alertsBreakdown: AlertTypeDisplay[] = [];
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ts
@@ -12,11 +12,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {Component, Input} from '@angular/core';
 
 @Component({
   selector: 'alerts-component',
   templateUrl: './alerts_component.ng.html',
   styleUrls: ['./alerts_component.css'],
 })
-export class AlertsComponent {}
+export class AlertsComponent {
+  // Total number of alerts.
+  @Input()
+  numAlerts: number = 0;
+
+  @Input()
+  alertsBreakdown: Array<{alertType: string; count: number}> = [];
+}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
@@ -16,8 +16,18 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {createSelector, select, Store} from '@ngrx/store';
 
 import {getAlertsBreakdown, getNumAlerts, State} from '../../store';
+import {AlertTypeDisplay} from './alerts_component';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
+
+const ALERT_TYPE_TO_DISPLAY_NAME_AND_SYMBOL: {
+  [alertType: string]: {displayName: string; displaySymbol: string};
+} = {
+  InfNanAlert: {
+    displayName: 'NaN/∞',
+    displaySymbol: '∞',
+  },
+};
 
 @Component({
   selector: 'tf-debugger-v2-alerts',
@@ -39,10 +49,12 @@ export class AlertsContainer {
         getAlertsBreakdown,
         (alertsBreakdown) => {
           const alertTypes = Object.keys(alertsBreakdown);
-          return alertTypes.map((alertType) => ({
-            alertType,
-            count: alertsBreakdown[alertType],
-          }));
+          return alertTypes.map((alertType) => {
+            return {
+              ...ALERT_TYPE_TO_DISPLAY_NAME_AND_SYMBOL[alertType],
+              count: alertsBreakdown[alertType],
+            };
+          });
         }
       )
     )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
@@ -23,15 +23,15 @@ import {AlertType} from '../../store/debugger_types';
 const ALERT_TYPE_TO_DISPLAY_NAME_AND_SYMBOL: {
   [alertType: string]: {displayName: string; displaySymbol: string};
 } = {
-  [AlertType.FunctionRecompileAlert]: {
+  [AlertType.FUNCTION_RECOMPILE_ALERT]: {
     displayName: 'Function recompiles',
     displaySymbol: 'C',
   },
-  [AlertType.InfNanAlert]: {
+  [AlertType.INF_NAN_ALERT]: {
     displayName: 'NaN/∞',
     displaySymbol: '∞',
   },
-  [AlertType.TensorShapeAlert]: {
+  [AlertType.TENSOR_SHAPE_ALERT]: {
     displayName: 'Tensor shape',
     displaySymbol: '■',
   },

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
@@ -16,21 +16,22 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {createSelector, select, Store} from '@ngrx/store';
 
 import {getAlertsBreakdown, getNumAlerts, State} from '../../store';
+import {AlertType} from '../../store/debugger_types';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 const ALERT_TYPE_TO_DISPLAY_NAME_AND_SYMBOL: {
   [alertType: string]: {displayName: string; displaySymbol: string};
 } = {
-  FunctionRecompilesAlert: {
+  [AlertType.FunctionRecompileAlert]: {
     displayName: 'Function recompiles',
     displaySymbol: 'C',
   },
-  InfNanAlert: {
+  [AlertType.InfNanAlert]: {
     displayName: 'NaN/∞',
     displaySymbol: '∞',
   },
-  TensorShapeAlert: {
+  [AlertType.TensorShapeAlert]: {
     displayName: 'Tensor shape',
     displaySymbol: '■',
   },

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
@@ -16,16 +16,23 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {createSelector, select, Store} from '@ngrx/store';
 
 import {getAlertsBreakdown, getNumAlerts, State} from '../../store';
-import {AlertTypeDisplay} from './alerts_component';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
 const ALERT_TYPE_TO_DISPLAY_NAME_AND_SYMBOL: {
   [alertType: string]: {displayName: string; displaySymbol: string};
 } = {
+  FunctionRecompilesAlert: {
+    displayName: 'Function recompiles',
+    displaySymbol: 'C',
+  },
   InfNanAlert: {
     displayName: 'NaN/∞',
     displaySymbol: '∞',
+  },
+  TensorShapeAlert: {
+    displayName: 'Tensor shape',
+    displaySymbol: '■',
   },
 };
 
@@ -49,6 +56,7 @@ export class AlertsContainer {
         getAlertsBreakdown,
         (alertsBreakdown) => {
           const alertTypes = Object.keys(alertsBreakdown);
+          alertTypes.sort();
           return alertTypes.map((alertType) => {
             return {
               ...ALERT_TYPE_TO_DISPLAY_NAME_AND_SYMBOL[alertType],

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,9 +26,9 @@ import {DebuggerComponent} from '../../debugger_component';
 import {DebuggerContainer} from '../../debugger_container';
 import {State} from '../../store/debugger_types';
 import {
+  createAlertsState,
   createDebuggerState,
   createState,
-  createAlertsState,
 } from '../../testing';
 import {AlertsContainer} from './alerts_container';
 import {AlertsModule} from './alerts_module';

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
@@ -1,0 +1,163 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * Unit tests for the Debugger Container.
+ */
+import {CommonModule} from '@angular/common';
+import {TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+import {Store} from '@ngrx/store';
+import {provideMockStore, MockStore} from '@ngrx/store/testing';
+
+import {DebuggerComponent} from '../../debugger_component';
+import {DebuggerContainer} from '../../debugger_container';
+import {State} from '../../store/debugger_types';
+import {
+  createDebuggerState,
+  createState,
+  createAlertsState,
+} from '../../testing';
+import {AlertsContainer} from './alerts_container';
+import {AlertsModule} from './alerts_module';
+import {ExecutionDataModule} from '../execution_data/execution_data_module';
+import {InactiveModule} from '../inactive/inactive_module';
+import {StackTraceModule} from '../stack_trace/stack_trace_module';
+import {TimelineModule} from '../timeline/timeline_module';
+
+/** @typehack */ import * as _typeHackStore from '@ngrx/store';
+
+describe('Alerts Container', () => {
+  let store: MockStore<State>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DebuggerComponent, DebuggerContainer],
+      imports: [
+        AlertsModule,
+        CommonModule,
+        ExecutionDataModule,
+        InactiveModule,
+        StackTraceModule,
+        TimelineModule,
+      ],
+      providers: [
+        provideMockStore({
+          initialState: createState(createDebuggerState()),
+        }),
+        DebuggerContainer,
+      ],
+    }).compileComponents();
+    store = TestBed.get(Store);
+  });
+
+  it('renders number of alerts and breakdown: no alerts', () => {
+    const fixture = TestBed.createComponent(AlertsContainer);
+    store.setState(
+      createState(
+        createDebuggerState({
+          activeRunId: '__default_debugger_runs__',
+          alerts: createAlertsState(),
+        })
+      )
+    );
+    fixture.detectChanges();
+
+    const numAlertsValueElement = fixture.debugElement.query(
+      By.css('.num-alerts-value')
+    );
+    expect(numAlertsValueElement.nativeElement.innerText).toBe('0');
+    const alertTypeNameElements = fixture.debugElement.queryAll(
+      By.css('.alert-type-name')
+    );
+    expect(alertTypeNameElements.length).toBe(0);
+  });
+
+  it('renders number of alerts and breakdown: one alert type', () => {
+    const fixture = TestBed.createComponent(AlertsContainer);
+    store.setState(
+      createState(
+        createDebuggerState({
+          activeRunId: '__default_debugger_runs__',
+          alerts: createAlertsState({
+            numAlerts: 10,
+            alertsBreakdown: {
+              InfNanAlert: 10,
+            },
+          }),
+        })
+      )
+    );
+    fixture.detectChanges();
+
+    const numAlertsValueElement = fixture.debugElement.query(
+      By.css('.num-alerts-value')
+    );
+    expect(numAlertsValueElement.nativeElement.innerText).toBe('10');
+    const alertTypeNameElements = fixture.debugElement.queryAll(
+      By.css('.alert-type-name')
+    );
+    const alertTypeCountElements = fixture.debugElement.queryAll(
+      By.css('.alert-type-count')
+    );
+    expect(alertTypeNameElements.length).toBe(1);
+    expect(alertTypeNameElements[0].nativeElement.innerText).toBe('NaN/∞');
+    expect(alertTypeCountElements.length).toBe(1);
+    expect(alertTypeCountElements[0].nativeElement.innerText).toBe('∞: 10');
+  });
+
+  it('renders number of alerts and breakdown: three alert types', () => {
+    const fixture = TestBed.createComponent(AlertsContainer);
+    store.setState(
+      createState(
+        createDebuggerState({
+          activeRunId: '__default_debugger_runs__',
+          alerts: createAlertsState({
+            numAlerts: 11,
+            alertsBreakdown: {
+              FunctionRecompilesAlert: 5,
+              InfNanAlert: 4,
+              TensorShapeAlert: 2,
+            },
+          }),
+        })
+      )
+    );
+    fixture.detectChanges();
+
+    const numAlertsValueElement = fixture.debugElement.query(
+      By.css('.num-alerts-value')
+    );
+    expect(numAlertsValueElement.nativeElement.innerText).toBe('11');
+    const alertTypeNameElements = fixture.debugElement.queryAll(
+      By.css('.alert-type-name')
+    );
+    const alertTypeCountElements = fixture.debugElement.queryAll(
+      By.css('.alert-type-count')
+    );
+    expect(alertTypeNameElements.length).toBe(3);
+    expect(alertTypeNameElements[0].nativeElement.innerText).toBe(
+      'Function recompiles'
+    );
+    expect(alertTypeNameElements[1].nativeElement.innerText).toBe('NaN/∞');
+    expect(alertTypeNameElements[2].nativeElement.innerText).toBe(
+      'Tensor shape'
+    );
+    expect(alertTypeCountElements.length).toBe(3);
+    expect(alertTypeCountElements[0].nativeElement.innerText).toBe('C: 5');
+    expect(alertTypeCountElements[1].nativeElement.innerText).toBe('∞: 4');
+    expect(alertTypeCountElements[2].nativeElement.innerText).toBe('■: 2');
+  });
+});

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 /**
- * Unit tests for the Debugger Container.
+ * Unit tests for the the Alerts component and container.
  */
 import {CommonModule} from '@angular/common';
 import {TestBed} from '@angular/core/testing';

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_module.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_module.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 
 import {AlertsComponent} from './alerts_component';
@@ -20,6 +21,7 @@ import {AlertsContainer} from './alerts_container';
 
 @NgModule({
   declarations: [AlertsComponent, AlertsContainer],
+  imports: [CommonModule],
   exports: [AlertsContainer],
 })
 export class AlertsModule {}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container.ts
@@ -12,12 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {select, Store, createSelector} from '@ngrx/store';
 
 import {State} from '../../store/debugger_types';
 import {
-  alertsViewLoaded,
   executionDigestFocused,
   executionScrollLeft,
   executionScrollRight,
@@ -103,7 +102,7 @@ function getExecutionDigestForDisplay(
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TimelineContainer implements OnInit {
+export class TimelineContainer {
   readonly activeRunId$ = this.store.pipe(select(getActiveRunId));
 
   readonly loadingNumExecutions$ = this.store.pipe(
@@ -149,10 +148,6 @@ export class TimelineContainer implements OnInit {
   readonly numExecutions$ = this.store.pipe(select(getNumExecutions));
 
   constructor(private readonly store: Store<State>) {}
-
-  ngOnInit(): void {
-    this.store.dispatch(alertsViewLoaded());
-  }
 
   onNavigateLeft() {
     this.store.dispatch(executionScrollLeft());


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing DebuggerV2 plugin

* Technical description of changes
  * In the Python backend code, add alerts_breakdown, which is a breakdown of all alerts by their types.
  * Add an effect in debugger_effects.ts: On non-empty debugger runs, fetch number of alerts and their breakdown
  * Add display logic to AlertsComponent to visualize the alerts. 
  * Follow-up PRs will add actions and effects for when the alert categories are clicked.

* Screenshots of UI changes
  * When alerts are present:
    * 
![image](https://user-images.githubusercontent.com/16824702/74278222-e10aec80-4ce6-11ea-8ad7-92437250eeb1.png)
  * When there are no alerts:
    * 
![image](https://user-images.githubusercontent.com/16824702/74278487-48c13780-4ce7-11ea-965c-92f4503e4174.png)

* Detailed steps to verify changes work correctly (as executed by you)
  * Manual testing on a tfdbg2 dataset with nan and inf
  * Unit tests added.