### PR TITLE
Upgrade min Bazel required and upgrade CI to use 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ env:
   # Grab the BAZEL_SHA256SUM from the Bazel releases page; e.g.:
   # bazel-0.20.0-linux-x86_64.sha256
   global:
-    - BAZEL=0.26.1
-    - BAZEL_SHA256SUM=6c50e142a0a405d3d8598050d6c1b3920c8cdb82a7ffca6fc067cb474275148f
+    - BAZEL=2.1.0
+    - BAZEL_SHA256SUM=e13581d44faad6ac807dd917e682fef20359d26728166ac35dadd8ee653a580d
   matrix:
     - TF_VERSION_ID=tensorflow==1.15.0
     - TF_VERSION_ID=tf-nightly

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,7 +16,7 @@ http_archive(
 load("@bazel_skylib//lib:versions.bzl", "versions")
 # Keep this version in sync with the BAZEL environment variable defined
 # in our .travis.yml config.
-versions.check(minimum_bazel_version = "0.26.1")
+versions.check(minimum_bazel_version = "1.0.0")
 
 http_archive(
     name = "io_bazel_rules_webtesting",


### PR DESCRIPTION
Bazel is now out of the beta mode (version 0.x). We want to depend on
1+ for better long term support in the future.