### PR TITLE
Update --reload_multifile_inactive_secs default to 24 hours

### DIFF
--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -559,7 +559,7 @@ of running out of memory if the logdir contains many active event files.
             "--reload_multifile_inactive_secs",
             metavar="SECONDS",
             type=int,
-            default=4000,
+            default=86400,
             help="""\
 [experimental] Configures the age threshold in seconds at which an event file
 that has no event wall time more recent than that will be considered an
@@ -568,7 +568,7 @@ no maximum age will be enforced, but beware of running out of memory and
 heavier filesystem read traffic. If set to 0, this reverts to the older
 last-file-only polling strategy (akin to --reload_multifile=false).
 (default: %(default)s - intended to ensure an event file remains active if
-it receives new data at least once per hour)\
+it receives new data at least once per 24 hour period)\
 """,
         )
 


### PR DESCRIPTION
We've gotten feedback that 1 hour is too short for the default (b/145081930 internally), since for various reasons people might write to an event file only every several hours, and currently there is no indication (unless turning on verbose logs) for why the new data is not loading.

Of course, there's no guarantee that 24 hours will always be enough either, but that seems like a better balance for now until we have a more robust approach, some of which are described in the original PR: https://github.com/tensorflow/tensorboard/pull/1867

