### PR TITLE
Add experient_metadata to DataProvider

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -102,6 +102,22 @@ class DataProvider(object):
         """
         return ""
 
+    def experiment_metadata(self, experiment_id):
+        """Retrive metadata of a given experiment.
+
+        The metadata may include fields such as name and description
+        of the experiment, as well as a timestamp for the experiment.
+
+        Args:
+          experiment_id:  ID of the experiment in question.
+
+        Returns:
+          If the metadata does not exist, `None`.
+          Otherwise, an `ExperimentMetadata` object containing metadata about
+            the experiment.
+        """
+        return None
+
     def list_plugins(self, experiment_id):
         """List all plugins that own data in a given experiment.
 
@@ -305,6 +321,35 @@ class DataProvider(object):
           tensorboard.errors.PublicError: See `DataProvider` class docstring.
         """
         pass
+
+
+class ExperimentMetadata(object):
+    """Metadata about an experiment.
+
+    Attributes:
+      experiment_name: A user-facing name for the experiment (as a `str`).
+      experiment_description: A user-facing description for the experiment
+        (as a `str`).
+      creation_time: A timestamp for the creation of the experiment, as `float`
+        seconds since the epoch.
+    """
+
+    def __init__(self, experiment_name, experiment_description, creation_time):
+        self._experiment_name = experiment_name
+        self._experiment_description = experiment_description
+        self._creation_time = creation_time
+
+    @property
+    def experiment_name(self):
+        return self._experiment_name
+
+    @property
+    def experiment_description(self):
+        return self._experiment_description
+
+    @property
+    def creation_time(self):
+        return self._creation_time
 
 
 class Run(object):

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -103,7 +103,7 @@ class DataProvider(object):
         return ""
 
     def experiment_metadata(self, experiment_id):
-        """Retrive metadata of a given experiment.
+        """Retrieve metadata of a given experiment.
 
         The metadata may include fields such as name and description
         of the experiment, as well as a timestamp for the experiment.

--- a/tensorboard/data/provider_test.py
+++ b/tensorboard/data/provider_test.py
@@ -31,6 +31,18 @@ class DataProviderTest(tb_test.TestCase):
             provider.DataProvider()
 
 
+class ExperimentMetadataTest(tb_test.TestCase):
+    def test_attributes(self):
+        e1 = provider.ExperimentMetadata(
+            experiment_name="FooExperiment",
+            experiment_description="Experiment on Foo",
+            creation_time=1.25,
+        )
+        self.assertEqual(e1.experiment_name, "FooExperiment")
+        self.assertEqual(e1.experiment_description, "Experiment on Foo")
+        self.assertEqual(e1.creation_time, 1.25)
+
+
 class RunTest(tb_test.TestCase):
     def test_eq(self):
         a1 = provider.Run(run_id="a", run_name="aa", start_time=1.25)


### PR DESCRIPTION
* Motivation for features / changes
  * Lay foundation for displaying experiment metadata (incl. timestamp for creation, name and description) in tensorboard.dev

* Technical description of changes
  * Add method `experiment_metadata()` to `DataProvider` base class, with a default return value of `None`.
  * Add data class for experiment metadata: `ExperimentMetadata`. 
