### PR TITLE
ci: build faster by opt out of building dev targets

### DIFF
--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -49,6 +49,7 @@ tf_web_library(
         "ng_polymer_lib.html",
     ],
     path = "/",
+    tags = ["manual"],
     deps = [
         ":analytics",
         ":security",
@@ -69,6 +70,7 @@ tensorboard_html_binary(
     compile = True,
     input_path = "/ng_polymer_lib.html",
     output_path = "/ng_polymer_lib_binary.html",
+    tags = ["manual"],
     deps = [":ng_polymer_lib"],
 )
 

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -73,6 +73,7 @@ tf_js_binary(
         "//tensorboard:dev_build": ":main.ts",
         "//conditions:default": "main_prod.ts",
     }),
+    tags = ["manual"],
     deps = [
         ":ng_main",
         "//tensorboard/webapp/angular:expect_angular_material_tabs",


### PR DESCRIPTION
Currently, in our CI, we do `bazel build tensorboard/...` which also
builds tensorboard_html_binary for Angular based TensorBoard which is
not used, yet. Opt out of doing already expensive operations twice.