### PR TITLE
Show warning if trace viewer is used with WebComponents v0

### DIFF
--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
@@ -15,6 +15,75 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<!-- Before any Trace Viewer scripts run, show warning if needed. -->
+<style>
+  .no-webcomponents-container.hidden {
+    display: none;
+  }
+
+  .no-webcomponents-container {
+    display: flex;
+    justify-content: center;
+    margin-top: 80px;
+    font-family: Roboto, sans-serif;
+  }
+
+  .no-webcomponents-container .title {
+    font-size: 22px;
+    font-weight: bold;
+  }
+
+  .no-webcomponents-container .contents {
+    max-width: 600px;
+  }
+</style>
+
+<div class="no-webcomponents-container hidden">
+  <div class="contents">
+    <div class="title">The trace viewer is currently unavailable.</div>
+    <p>
+      For more details, see
+      <a
+        href="https://github.com/tensorflow/tensorboard/issues/3209"
+        rel="noopener"
+        target="_blank"
+        >this issue</a
+      >.
+    </p>
+    <br />
+    <br />
+  </div>
+</div>
+
+<script>
+  const canUseWebComponentsV0 =
+    typeof document.registerElement === 'function' &&
+    typeof Element.prototype.createShadowRoot === 'function';
+  if (!canUseWebComponentsV0) {
+    const containerEl = document.querySelector('.no-webcomponents-container');
+    const contentsEl = document.querySelector(
+      '.no-webcomponents-container .contents'
+    );
+    containerEl.classList.remove('hidden');
+
+    const currentURL = new URL(window.location.href);
+    const relativeTraceURL = currentURL.searchParams.get('trace_data_url');
+    const traceURL = new URL(relativeTraceURL, window.location.href).toString();
+
+    const workaroundEl = document.createElement('p');
+    workaroundEl.textContent =
+      `If you are running a Chromium-based browser, ` +
+      `one workaround is to download your data as JSON and load it in your ` +
+      `browser's viewer at "about://tracing". This run's data can be found ` +
+      `here:`;
+    const profileDataLink = document.createElement('i');
+    profileDataLink.textContent = `${traceURL}`;
+
+    contentsEl.appendChild(workaroundEl);
+    contentsEl.appendChild(profileDataLink);
+  }
+</script>
+
 <link rel="import" href="trace_viewer_full.html" />
 
 <!--

--- a/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
+++ b/tensorboard/components/tf_trace_viewer/tf-trace-viewer.html
@@ -15,7 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<!-- Before any Trace Viewer scripts run, show warning if needed. -->
+<!--
+If WebComponents V0 are not available, show a warning before any Polymer or
+Trace Viewer scripts can run.
+-->
 <style>
   .no-webcomponents-container.hidden {
     display: none;
@@ -52,6 +55,11 @@ limitations under the License.
     </p>
     <br />
     <br />
+    <p>
+      If you are running a Chromium-based browser, one workaround is to download
+      your data as JSON and load it in your browser's viewer at
+      "about://tracing". This run's data can be found here:
+    </p>
   </div>
 </div>
 
@@ -70,16 +78,8 @@ limitations under the License.
     const relativeTraceURL = currentURL.searchParams.get('trace_data_url');
     const traceURL = new URL(relativeTraceURL, window.location.href).toString();
 
-    const workaroundEl = document.createElement('p');
-    workaroundEl.textContent =
-      `If you are running a Chromium-based browser, ` +
-      `one workaround is to download your data as JSON and load it in your ` +
-      `browser's viewer at "about://tracing". This run's data can be found ` +
-      `here:`;
     const profileDataLink = document.createElement('i');
     profileDataLink.textContent = `${traceURL}`;
-
-    contentsEl.appendChild(workaroundEl);
     contentsEl.appendChild(profileDataLink);
   }
 </script>


### PR DESCRIPTION
* Motivation for features / changes

Warn users of tf-nightly who use the trace viewer in the existing Profiler plugin that it is broken.

* Technical description of changes

Within the Trace viewer iframe, detect whether WebComponentsV0 are available.  Show the warning if it is not.

* Screenshots of UI changes

![image](https://user-images.githubusercontent.com/2322480/74486003-e6943e00-4e70-11ea-95bf-b3730533665b.png)

Tested on both Chrome M80 and M79, checked that the warning only shows in the newer version.  Note that, when origin trial is available, the warning should not appear.