### PR TITLE
Add wall_time field to GetOrCreateBlobSequenceRequest

### DIFF
--- a/tensorboard/uploader/proto/write_service.proto
+++ b/tensorboard/uploader/proto/write_service.proto
@@ -277,12 +277,14 @@ message GetOrCreateBlobSequenceRequest {
   string tag = 3;
   // Step index within the run.
   int64 step = 4;
+  // Timestamp of the creation of this blob sequence.
+  google.protobuf.Timestamp wall_time = 5;
   // The total number of elements expected in the sequence.
   // This effectively delares a number of initially empty 'upload slots',
   // to be filled with subsequent WriteBlob RPCs.
-  int64 final_sequence_length = 5;
+  int64 final_sequence_length = 6;
   // Note that metadata.plugin_data.content does not carry the payload.
-  .tensorboard.SummaryMetadata metadata = 6;
+  .tensorboard.SummaryMetadata metadata = 7;
 }
 
 message GetOrCreateBlobSequenceResponse {

--- a/tensorboard/uploader/proto/write_service.proto
+++ b/tensorboard/uploader/proto/write_service.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package tensorboard.service;
 
+import "google/protobuf/timestamp.proto";
 // TODO(bileschi): write_service.proto imports export_service.proto for the
 // definition of Experiment and ExperimentMask.  It would be better to excise
 // those into one file that both services depend on.


### PR DESCRIPTION
Whenever we provide a `step`, we should also provide a `wall_time` (as seen in scalar.proto and tensor.proto).  This was inadvertently omitted here before.  Note it's safe to change the proto field IDs because this message is not actually used yet.