### PR TITLE
[CorePlugin] Add experiment metadata to /data/environment route response

### DIFF
--- a/tensorboard/components/tf_backend/environmentStore.ts
+++ b/tensorboard/components/tf_backend/environmentStore.ts
@@ -16,8 +16,14 @@ namespace tf_backend {
   interface Environment {
     dataLocation: string;
     windowTitle: string;
+
+    /** Name of the experiment (if available). */
     experimentName?: string;
+
+    /** A description of the experiment (if available). */
     experimentDescription?: string;
+
+    /** Creation timestamp for the experiment (if available). */
     creationTime?: number;
   }
 

--- a/tensorboard/components/tf_backend/environmentStore.ts
+++ b/tensorboard/components/tf_backend/environmentStore.ts
@@ -16,6 +16,9 @@ namespace tf_backend {
   interface Environment {
     dataLocation: string;
     windowTitle: string;
+    experimentName?: string;
+    experimentDescription?: string;
+    creationTime?: number;
   }
 
   export class EnvironmentStore extends BaseStore {
@@ -24,14 +27,19 @@ namespace tf_backend {
     load() {
       const url = tf_backend.getRouter().environment();
       return this.requestManager.request(url).then((result) => {
-        const environment = {
+        const environment: Environment = {
           dataLocation: result.data_location,
           windowTitle: result.window_title,
-          experimentName: result.experiment_name,
-          experimentDescription: result.experiment_description,
-          creation_time: result.creation_time,
         };
-        console.log(`environment = `, environment);  // DEBUG
+        if (result.experiment_name !== undefined) {
+          environment.experimentName = result.experiment_name;
+        }
+        if (result.experiment_description !== undefined) {
+          environment.experimentDescription = result.experiment_description;
+        }
+        if (result.creation_time !== undefined) {
+          environment.creationTime = result.creation_time;
+        }
         if (_.isEqual(this.environment, environment)) return;
 
         this.environment = environment;

--- a/tensorboard/components/tf_backend/environmentStore.ts
+++ b/tensorboard/components/tf_backend/environmentStore.ts
@@ -27,7 +27,11 @@ namespace tf_backend {
         const environment = {
           dataLocation: result.data_location,
           windowTitle: result.window_title,
+          experimentName: result.experiment_name,
+          experimentDescription: result.experiment_description,
+          creation_time: result.creation_time,
         };
+        console.log(`environment = `, environment);  // DEBUG
         if (_.isEqual(this.environment, environment)) return;
 
         this.environment = environment;

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -144,19 +144,19 @@ class CorePlugin(base_plugin.TBPlugin):
             data_location = self._logdir or self._db_uri
             experiment_metadata = None
 
-        environment_data = {
+        environment = {
             "data_location": data_location,
             "window_title": self._window_title,
         }
         if experiment_metadata is not None:
-            environment_data.update(
+            environment.update(
                 {
                     "experiment_name": experiment_metadata.experiment_name,
                     "experiment_description": experiment_metadata.experiment_description,
                     "creation_time": experiment_metadata.creation_time,
                 }
             )
-        return http_util.Respond(request, environment_data, "application/json",)
+        return http_util.Respond(request, environment, "application/json",)
 
     @wrappers.Request.application
     def _serve_logdir(self, request):

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -65,9 +65,6 @@ class CorePlugin(base_plugin.TBPlugin):
         self._multiplexer = context.multiplexer
         self._db_connection_provider = context.db_connection_provider
         self._assets_zip_provider = context.assets_zip_provider
-        print(
-            "context.flags = %s" % context.flags
-        )  # DEBUG
         if context.flags and context.flags.generic_data == "true":
             self._data_provider = context.data_provider
         else:
@@ -139,7 +136,10 @@ class CorePlugin(base_plugin.TBPlugin):
         if self._data_provider:
             experiment = plugin_util.experiment_id(request.environ)
             data_location = self._data_provider.data_location(experiment)
-            experiment_metadata = self._data_provider.experiment_metadata()
+            experiment_id = plugin_util.experiment_id(request.environ)
+            experiment_metadata = self._data_provider.experiment_metadata(
+                experiment_id
+            )
         else:
             data_location = self._logdir or self._db_uri
             experiment_metadata = None

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -225,9 +225,6 @@ class CorePluginExperimentMetadataTest(tf.test.TestCase):
 
         self.context = base_plugin.TBContext(
             flags=FakeFlags(generic_data="true"),
-            assets_zip_provider=get_test_assets_zip_provider(),
-            logdir=self.get_temp_dir(),
-            multiplexer=event_multiplexer.EventMultiplexer(),
             data_provider=FakeDataProvider(),
         )
 
@@ -260,9 +257,6 @@ class CorePluginExperimentMetadataTest(tf.test.TestCase):
 
         self.context = base_plugin.TBContext(
             flags=FakeFlags(generic_data="true"),
-            assets_zip_provider=get_test_assets_zip_provider(),
-            logdir=self.get_temp_dir(),
-            multiplexer=event_multiplexer.EventMultiplexer(),
             data_provider=FakeDataProvider(),
         )
 

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import argparse
 import collections.abc
 import contextlib
 import json


### PR DESCRIPTION
* Motivation for features / changes
  * To support experiment metadata (e.g., name, description, time created) in tensorboard.dev, we need to make such metadata servable from the backend. 

* Technical description of changes
  * This PR implements part of this data pathway in CorePlugin. `CorePlugin._serve_environment()` now calls `DataProvider.experiment_metadata()` and populates its response with data fields in the object when they are present.
  * The TypeScript code in `environmentStore.ts` is revised accordingly.

* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests added in core_plugin_test.py

