### PR TITLE
Extract Experiment/ExperimentMask messages into experiment.proto

### DIFF
--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -28,6 +28,7 @@ import time
 
 import six
 
+from tensorboard.uploader.proto import experiment_pb2
 from tensorboard.uploader.proto import export_service_pb2
 from tensorboard.uploader import util
 from tensorboard.util import grpc_util
@@ -130,7 +131,7 @@ class TensorBoardExporter(object):
     def _request_experiment_ids(self, read_time):
         """Yields all of the calling user's experiment IDs, as strings."""
         for experiment in list_experiments(self._api, read_time=read_time):
-            if isinstance(experiment, export_service_pb2.Experiment):
+            if isinstance(experiment, experiment_pb2.Experiment):
                 yield experiment.experiment_id
             elif isinstance(experiment, six.string_types):
                 yield experiment
@@ -177,13 +178,13 @@ def list_experiments(api_client, fieldmask=None, read_time=None):
 
     Args:
       api_client: A TensorBoardExporterService stub instance.
-      fieldmask: An optional `export_service_pb2.ExperimentMask` value.
+      fieldmask: An optional `experiment_pb2.ExperimentMask` value.
       read_time: A fixed timestamp from which to export data, as float seconds
         since epoch (like `time.time()`). Optional; defaults to the current
         time.
 
     Yields:
-      For each experiment owned by the user, an `export_service_pb2.Experiment`
+      For each experiment owned by the user, an `experiment_pb2.Experiment`
       value, or a simple string experiment ID for older servers.
     """
     if read_time is None:

--- a/tensorboard/uploader/exporter_test.py
+++ b/tensorboard/uploader/exporter_test.py
@@ -33,6 +33,7 @@ except ImportError:
     import mock  # pylint: disable=unused-import
 
 
+from tensorboard.uploader.proto import experiment_pb2
 from tensorboard.uploader.proto import export_service_pb2
 from tensorboard.uploader.proto import export_service_pb2_grpc
 from tensorboard.uploader import exporter as exporter_lib
@@ -393,10 +394,10 @@ class ListExperimentsTest(tb_test.TestCase):
         expected = [
             "123",
             "456",
-            export_service_pb2.Experiment(experiment_id="789"),
-            export_service_pb2.Experiment(experiment_id="012"),
-            export_service_pb2.Experiment(experiment_id="345"),
-            export_service_pb2.Experiment(experiment_id="678"),
+            experiment_pb2.Experiment(experiment_id="789"),
+            experiment_pb2.Experiment(experiment_id="012"),
+            experiment_pb2.Experiment(experiment_id="345"),
+            experiment_pb2.Experiment(experiment_id="678"),
         ]
         self.assertEqual(list(gen), expected)
 

--- a/tensorboard/uploader/proto/BUILD
+++ b/tensorboard/uploader/proto/BUILD
@@ -11,6 +11,7 @@ tb_proto_library(
     name = "protos_all",
     srcs = [
         "blob.proto",
+        "experiment.proto",
         "export_service.proto",
         "scalar.proto",
         "server_info.proto",
@@ -18,7 +19,5 @@ tb_proto_library(
         "write_service.proto",
     ],
     has_services = True,
-    deps = [
-        "//tensorboard/compat/proto:protos_all",
-    ],
+    deps = ["//tensorboard/compat/proto:protos_all"],
 )

--- a/tensorboard/uploader/proto/experiment.proto
+++ b/tensorboard/uploader/proto/experiment.proto
@@ -3,107 +3,36 @@ syntax = "proto3";
 package tensorboard.service;
 
 import "google/protobuf/timestamp.proto";
-import "tensorboard/compat/proto/summary.proto";
-import "tensorboard/compat/proto/tensor.proto";
 
-// Service for exporting data from TensorBoard.dev.
-service TensorBoardExporterService {
-  // Stream the experiment_id of all the experiments owned by the caller.
-  rpc StreamExperiments(StreamExperimentsRequest)
-      returns (stream StreamExperimentsResponse) {}
-  // Stream scalars for all the runs and tags in an experiment.
-  rpc StreamExperimentData(StreamExperimentDataRequest)
-      returns (stream StreamExperimentDataResponse) {}
-}
-
-// Request to stream the experiment_id of all the experiments owned by the
-// caller from TensorBoard.dev.
-message StreamExperimentsRequest {
-  // Timestamp to get a consistent snapshot of the data in the database.
-  // This is useful when making multiple read RPCs and needing the data to be
-  // consistent across the read calls.
-  google.protobuf.Timestamp read_timestamp = 1;
-  // User ID defaults to the caller, but may be set to a different user for
-  // internal Takeout processes operating on behalf of a user.
-  string user_id = 2;
-  // Limits the number of experiment IDs returned. This is useful to check if
-  // user might have any data by setting limit=1. Also useful to preview the
-  // list of experiments. TODO(@karthikv2k): Support pagination.
-  int64 limit = 3;
-  // Field mask for what experiment data to return via the `experiments` field
-  // on the response. If not specified, this should be interpreted the same as
-  // an empty message: i.e., only the experiment ID should be returned. Other
-  // fields of `Experiment` will be populated if their corresponding bits in the
-  // `ExperimentMask` are set. The server may choose to populate fields that are
-  // not explicitly requested.
-  ExperimentMask experiments_mask = 4;
-}
-
-// Streams experiment metadata (ID, creation time, etc.) from TensorBoard.dev.
-message StreamExperimentsResponse {
-  // Deprecated in favor of `experiments`. If a response has `experiments` set,
-  // clients should ignore `experiment_ids` entirely. Otherwise, clients should
-  // treat `experiment_ids` as a list of `experiments` for which only the
-  // `experiment_id` field is set, with the understanding that the other fields
-  // were not populated regardless of the requested field mask.
-  //
-  // For example, the following responses should be treated the same:
-  //
-  //     # Response 1
-  //     experiment_ids: "123"
-  //     experiment_ids: "456"
-  //
-  //     # Response 2
-  //     experiments { experiment_id: "123" }
-  //     experiments { experiment_id: "456" }
-  //
-  //     # Response 3
-  //     experiment_ids: "789"
-  //     experiments { experiment_id: "123" }
-  //     experiments { experiment_id: "456" }
-  //
-  // See documentation on `experiments` for batching semantics.
-  repeated string experiment_ids = 1;
-  // List of experiments owned by the user. The entire list of experiments
-  // owned by the user is streamed in batches and each batch contains a list of
-  // experiments. A consumer of this stream needs to concatenate all these
-  // lists to get the full response. The order of experiments in the stream is
-  // not defined. Every response will contain at least one experiment.
-  //
-  // These messages may be partially populated, in accordance with the field
-  // mask given in the request.
-  repeated Experiment experiments = 2;
-}
-
-// Metadata about an experiment.  This contains both user provided metadata
-// along with internal book-keeping about the experiment.
-// TODO(bileschi): Move this and ExperimentMask into their own file.
+// Resource message representing an Experiment.
 message Experiment {
   // Permanent ID of this experiment; e.g.: "AdYd1TgeTlaLWXx6I8JUbA".
+  // Output-only.
   string experiment_id = 1;
-  // The time that the experiment was created.
+  // The time that the experiment was created. Output-only.
   google.protobuf.Timestamp create_time = 2;
   // The time that the experiment was last modified: i.e., the most recent time
-  // that scalars were added to the experiment.
+  // that scalars were added to the experiment. Output-only.
   google.protobuf.Timestamp update_time = 3;
   // The number of scalars in this experiment, across all time series.
+  // Output-only.
   int64 num_scalars = 4;
-  // The number of distinct run names in this experiment.
+  // The number of distinct run names in this experiment. Output-only.
   int64 num_runs = 5;
   // The number of distinct tag names in this experiment. A tag name that
-  // appears in multiple runs will be counted only once.
+  // appears in multiple runs will be counted only once. Output-only.
   int64 num_tags = 6;
   // User provided name of the experiment.
   string name = 7;
   // User provided description of the experiment, in markdown source format.
   string description = 8;
   // The number of bytes used for storage of tensors in this experiment,
-  // across all time series, including estimated overhead.
+  // across all time series, including estimated overhead. Output-only.
   int64 total_tensor_bytes = 9;
 }
 
-// Field mask for `Experiment`. The `experiment_id` field is always implicitly
-// considered to be set.
+// Field mask for `Experiment` used in get and update RPCs. The `experiment_id`
+// field is always implicitly considered to be set.
 message ExperimentMask {
   reserved 1;
   reserved "experiment_id";
@@ -115,63 +44,4 @@ message ExperimentMask {
   bool name = 7;
   bool description = 8;
   bool total_tensor_bytes = 9;
-}
-
-// Request to stream scalars from all the runs and tags in an experiment.
-message StreamExperimentDataRequest {
-  // The permanent ID of the experiment whose data need to be streamed.
-  string experiment_id = 1;
-  // Timestamp to get a consistent snapshot of the data in the database.
-  // This is useful when making multiple read RPCs and needing the data to be
-  // consistent across the read calls. Should be the same as the read timestamp
-  // used for the corresponding `StreamExperimentsRequest` for consistency.
-  google.protobuf.Timestamp read_timestamp = 2;
-}
-
-// Streams data from all the runs and tags in an experiment. Each stream
-// result only contains data for a single tag from a single run. For example if
-// there are five runs and each run had two tags, the RPC will return a stream
-// of at least ten `StreamExperimentDataResponse`s, each one having the
-// either scalars or tensors for one tag. The values from a single tag may be
-// split among multiple responses.  Users need to aggregate information from
-// entire stream to get data for the entire experiment. Empty experiments will
-// have zero stream results. Empty runs that doesn't have any tags need not
-// be supported by a hosted service.
-message StreamExperimentDataResponse {
-  // Name of the tag whose data is contained in this response.
-  string tag_name = 1;
-  // Name of the run that contains the tag `tag_name`.
-  string run_name = 2;
-  // The metadata of the tag `tag_name`.
-  .tensorboard.SummaryMetadata tag_metadata = 3;
-  // Data to store for the tag `tag_name.
-  ScalarPoints points = 4;
-  // Tensor data to store.
-  TensorPoints tensors = 5;
-
-  // Data for the scalars are stored in a columnar fashion to optimize it for
-  // exporting the data into textual formats like JSON.
-  // The data for the ith scalar is { steps[i], wall_times[i], values[i] }.
-  // The data here is sorted by step values in ascending order.
-  message ScalarPoints {
-    // Step index within the run.
-    repeated int64 steps = 1;
-    // Timestamp of the creation of this point.
-    repeated google.protobuf.Timestamp wall_times = 2;
-    // Value of the point at this step / timestamp.
-    repeated double values = 3;
-  }
-
-  // Data for the Tensors are stored in a columnar fashion to optimize it for
-  // exporting the data into textual formats like JSON.
-  // The data for the ith tensor is { steps[i], wall_times[i], values[i] }.
-  // The data here is sorted by step values in ascending order.
-  message TensorPoints {
-    // Step index within the run.
-    repeated int64 steps = 1;
-    // Timestamp of the creation of this point.
-    repeated google.protobuf.Timestamp wall_times = 2;
-    // Value of the point at this step / timestamp.
-    repeated .tensorboard.TensorProto values = 3;
-  }
 }

--- a/tensorboard/uploader/proto/experiment.proto
+++ b/tensorboard/uploader/proto/experiment.proto
@@ -1,0 +1,177 @@
+syntax = "proto3";
+
+package tensorboard.service;
+
+import "google/protobuf/timestamp.proto";
+import "tensorboard/compat/proto/summary.proto";
+import "tensorboard/compat/proto/tensor.proto";
+
+// Service for exporting data from TensorBoard.dev.
+service TensorBoardExporterService {
+  // Stream the experiment_id of all the experiments owned by the caller.
+  rpc StreamExperiments(StreamExperimentsRequest)
+      returns (stream StreamExperimentsResponse) {}
+  // Stream scalars for all the runs and tags in an experiment.
+  rpc StreamExperimentData(StreamExperimentDataRequest)
+      returns (stream StreamExperimentDataResponse) {}
+}
+
+// Request to stream the experiment_id of all the experiments owned by the
+// caller from TensorBoard.dev.
+message StreamExperimentsRequest {
+  // Timestamp to get a consistent snapshot of the data in the database.
+  // This is useful when making multiple read RPCs and needing the data to be
+  // consistent across the read calls.
+  google.protobuf.Timestamp read_timestamp = 1;
+  // User ID defaults to the caller, but may be set to a different user for
+  // internal Takeout processes operating on behalf of a user.
+  string user_id = 2;
+  // Limits the number of experiment IDs returned. This is useful to check if
+  // user might have any data by setting limit=1. Also useful to preview the
+  // list of experiments. TODO(@karthikv2k): Support pagination.
+  int64 limit = 3;
+  // Field mask for what experiment data to return via the `experiments` field
+  // on the response. If not specified, this should be interpreted the same as
+  // an empty message: i.e., only the experiment ID should be returned. Other
+  // fields of `Experiment` will be populated if their corresponding bits in the
+  // `ExperimentMask` are set. The server may choose to populate fields that are
+  // not explicitly requested.
+  ExperimentMask experiments_mask = 4;
+}
+
+// Streams experiment metadata (ID, creation time, etc.) from TensorBoard.dev.
+message StreamExperimentsResponse {
+  // Deprecated in favor of `experiments`. If a response has `experiments` set,
+  // clients should ignore `experiment_ids` entirely. Otherwise, clients should
+  // treat `experiment_ids` as a list of `experiments` for which only the
+  // `experiment_id` field is set, with the understanding that the other fields
+  // were not populated regardless of the requested field mask.
+  //
+  // For example, the following responses should be treated the same:
+  //
+  //     # Response 1
+  //     experiment_ids: "123"
+  //     experiment_ids: "456"
+  //
+  //     # Response 2
+  //     experiments { experiment_id: "123" }
+  //     experiments { experiment_id: "456" }
+  //
+  //     # Response 3
+  //     experiment_ids: "789"
+  //     experiments { experiment_id: "123" }
+  //     experiments { experiment_id: "456" }
+  //
+  // See documentation on `experiments` for batching semantics.
+  repeated string experiment_ids = 1;
+  // List of experiments owned by the user. The entire list of experiments
+  // owned by the user is streamed in batches and each batch contains a list of
+  // experiments. A consumer of this stream needs to concatenate all these
+  // lists to get the full response. The order of experiments in the stream is
+  // not defined. Every response will contain at least one experiment.
+  //
+  // These messages may be partially populated, in accordance with the field
+  // mask given in the request.
+  repeated Experiment experiments = 2;
+}
+
+// Metadata about an experiment.  This contains both user provided metadata
+// along with internal book-keeping about the experiment.
+// TODO(bileschi): Move this and ExperimentMask into their own file.
+message Experiment {
+  // Permanent ID of this experiment; e.g.: "AdYd1TgeTlaLWXx6I8JUbA".
+  string experiment_id = 1;
+  // The time that the experiment was created.
+  google.protobuf.Timestamp create_time = 2;
+  // The time that the experiment was last modified: i.e., the most recent time
+  // that scalars were added to the experiment.
+  google.protobuf.Timestamp update_time = 3;
+  // The number of scalars in this experiment, across all time series.
+  int64 num_scalars = 4;
+  // The number of distinct run names in this experiment.
+  int64 num_runs = 5;
+  // The number of distinct tag names in this experiment. A tag name that
+  // appears in multiple runs will be counted only once.
+  int64 num_tags = 6;
+  // User provided name of the experiment.
+  string name = 7;
+  // User provided description of the experiment, in markdown source format.
+  string description = 8;
+  // The number of bytes used for storage of tensors in this experiment,
+  // across all time series, including estimated overhead.
+  int64 total_tensor_bytes = 9;
+}
+
+// Field mask for `Experiment`. The `experiment_id` field is always implicitly
+// considered to be set.
+message ExperimentMask {
+  reserved 1;
+  reserved "experiment_id";
+  bool create_time = 2;
+  bool update_time = 3;
+  bool num_scalars = 4;
+  bool num_runs = 5;
+  bool num_tags = 6;
+  bool name = 7;
+  bool description = 8;
+  bool total_tensor_bytes = 9;
+}
+
+// Request to stream scalars from all the runs and tags in an experiment.
+message StreamExperimentDataRequest {
+  // The permanent ID of the experiment whose data need to be streamed.
+  string experiment_id = 1;
+  // Timestamp to get a consistent snapshot of the data in the database.
+  // This is useful when making multiple read RPCs and needing the data to be
+  // consistent across the read calls. Should be the same as the read timestamp
+  // used for the corresponding `StreamExperimentsRequest` for consistency.
+  google.protobuf.Timestamp read_timestamp = 2;
+}
+
+// Streams data from all the runs and tags in an experiment. Each stream
+// result only contains data for a single tag from a single run. For example if
+// there are five runs and each run had two tags, the RPC will return a stream
+// of at least ten `StreamExperimentDataResponse`s, each one having the
+// either scalars or tensors for one tag. The values from a single tag may be
+// split among multiple responses.  Users need to aggregate information from
+// entire stream to get data for the entire experiment. Empty experiments will
+// have zero stream results. Empty runs that doesn't have any tags need not
+// be supported by a hosted service.
+message StreamExperimentDataResponse {
+  // Name of the tag whose data is contained in this response.
+  string tag_name = 1;
+  // Name of the run that contains the tag `tag_name`.
+  string run_name = 2;
+  // The metadata of the tag `tag_name`.
+  .tensorboard.SummaryMetadata tag_metadata = 3;
+  // Data to store for the tag `tag_name.
+  ScalarPoints points = 4;
+  // Tensor data to store.
+  TensorPoints tensors = 5;
+
+  // Data for the scalars are stored in a columnar fashion to optimize it for
+  // exporting the data into textual formats like JSON.
+  // The data for the ith scalar is { steps[i], wall_times[i], values[i] }.
+  // The data here is sorted by step values in ascending order.
+  message ScalarPoints {
+    // Step index within the run.
+    repeated int64 steps = 1;
+    // Timestamp of the creation of this point.
+    repeated google.protobuf.Timestamp wall_times = 2;
+    // Value of the point at this step / timestamp.
+    repeated double values = 3;
+  }
+
+  // Data for the Tensors are stored in a columnar fashion to optimize it for
+  // exporting the data into textual formats like JSON.
+  // The data for the ith tensor is { steps[i], wall_times[i], values[i] }.
+  // The data here is sorted by step values in ascending order.
+  message TensorPoints {
+    // Step index within the run.
+    repeated int64 steps = 1;
+    // Timestamp of the creation of this point.
+    repeated google.protobuf.Timestamp wall_times = 2;
+    // Value of the point at this step / timestamp.
+    repeated .tensorboard.TensorProto values = 3;
+  }
+}

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package tensorboard.service;
 
 import "google/protobuf/timestamp.proto";
+import "tensorboard/uploader/proto/experiment.proto";
 import "tensorboard/compat/proto/summary.proto";
 import "tensorboard/compat/proto/tensor.proto";
 
@@ -73,48 +74,6 @@ message StreamExperimentsResponse {
   // These messages may be partially populated, in accordance with the field
   // mask given in the request.
   repeated Experiment experiments = 2;
-}
-
-// Metadata about an experiment.  This contains both user provided metadata
-// along with internal book-keeping about the experiment.
-// TODO(bileschi): Move this and ExperimentMask into their own file.
-message Experiment {
-  // Permanent ID of this experiment; e.g.: "AdYd1TgeTlaLWXx6I8JUbA".
-  string experiment_id = 1;
-  // The time that the experiment was created.
-  google.protobuf.Timestamp create_time = 2;
-  // The time that the experiment was last modified: i.e., the most recent time
-  // that scalars were added to the experiment.
-  google.protobuf.Timestamp update_time = 3;
-  // The number of scalars in this experiment, across all time series.
-  int64 num_scalars = 4;
-  // The number of distinct run names in this experiment.
-  int64 num_runs = 5;
-  // The number of distinct tag names in this experiment. A tag name that
-  // appears in multiple runs will be counted only once.
-  int64 num_tags = 6;
-  // User provided name of the experiment.
-  string name = 7;
-  // User provided description of the experiment, in markdown source format.
-  string description = 8;
-  // The number of bytes used for storage of tensors in this experiment,
-  // across all time series, including estimated overhead.
-  int64 total_tensor_bytes = 9;
-}
-
-// Field mask for `Experiment`. The `experiment_id` field is always implicitly
-// considered to be set.
-message ExperimentMask {
-  reserved 1;
-  reserved "experiment_id";
-  bool create_time = 2;
-  bool update_time = 3;
-  bool num_scalars = 4;
-  bool num_runs = 5;
-  bool num_tags = 6;
-  bool name = 7;
-  bool description = 8;
-  bool total_tensor_bytes = 9;
 }
 
 // Request to stream scalars from all the runs and tags in an experiment.

--- a/tensorboard/uploader/proto/write_service.proto
+++ b/tensorboard/uploader/proto/write_service.proto
@@ -3,10 +3,7 @@ syntax = "proto3";
 package tensorboard.service;
 
 import "google/protobuf/timestamp.proto";
-// TODO(bileschi): write_service.proto imports export_service.proto for the
-// definition of Experiment and ExperimentMask.  It would be better to excise
-// those into one file that both services depend on.
-import "tensorboard/uploader/proto/export_service.proto";
+import "tensorboard/uploader/proto/experiment.proto";
 import "tensorboard/uploader/proto/scalar.proto";
 import "tensorboard/uploader/proto/tensor.proto";
 import "tensorboard/uploader/proto/blob.proto";

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -31,7 +31,7 @@ import grpc
 import six
 
 from tensorboard.uploader import dev_creds
-from tensorboard.uploader.proto import export_service_pb2
+from tensorboard.uploader.proto import experiment_pb2
 from tensorboard.uploader.proto import export_service_pb2_grpc
 from tensorboard.uploader.proto import write_service_pb2_grpc
 from tensorboard.uploader import auth
@@ -390,7 +390,7 @@ class _ListIntent(_Intent):
         api_client = export_service_pb2_grpc.TensorBoardExporterServiceStub(
             channel
         )
-        fieldmask = export_service_pb2.ExperimentMask(
+        fieldmask = experiment_pb2.ExperimentMask(
             create_time=True,
             update_time=True,
             num_scalars=True,
@@ -401,7 +401,7 @@ class _ListIntent(_Intent):
         count = 0
         for experiment in gen:
             count += 1
-            if not isinstance(experiment, export_service_pb2.Experiment):
+            if not isinstance(experiment, experiment_pb2.Experiment):
                 url = server_info_lib.experiment_url(server_info, experiment)
                 print(url)
                 continue


### PR DESCRIPTION
This resolves a TODO to refactor the `Experiment` and `ExperimentMask` messages from `export_service.proto` into a standalone `experiment.proto` so they can be more properly shared across RPC service interfaces.

I also updated the comments on fields of the proto to indicate which fields are output-only and cannot be updated directly by RPC clients.  (To see the diff, look at only the second commit; I split the file copy out into the first commit since git's move detection can't handle this.)

Will be synchronized with internal changes; see cl/294800076.