### PR TITLE
ng: make Polymer pagination configurable from Ng

### DIFF
--- a/tensorboard/components/tf_paginated_view/tf-paginated-view-store.html
+++ b/tensorboard/components/tf_paginated_view/tf-paginated-view-store.html
@@ -18,3 +18,13 @@ limitations under the License.
 <link rel="import" href="../tf-storage/tf-storage.html" />
 
 <script src="paginatedViewStore.js"></script>
+
+<script>
+  // HACK: this Polymer component allows stores to be accessible from
+  // tf-ng-tensorboard by exposing otherwise mangled smybols.
+  Polymer({
+    is: 'tf-paginated-view-store',
+    _template: null, // strictTemplatePolicy requires a template (even a null one).
+    tf_paginated_view: tf_paginated_view,
+  });
+</script>

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -32,6 +32,7 @@ ng_module(
         "//tensorboard/webapp/header",
         "//tensorboard/webapp/plugins",
         "//tensorboard/webapp/reloader",
+        "//tensorboard/webapp/settings",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/effects",

--- a/tensorboard/webapp/app_container.ng.html
+++ b/tensorboard/webapp/app_container.ng.html
@@ -19,3 +19,4 @@ limitations under the License.
 <plugins class="plugins"></plugins>
 <reloader></reloader>
 <hash-storage></hash-storage>
+<settings-polymer-interop></settings-polymer-interop>

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -22,6 +22,7 @@ import {AppContainer} from './app_container';
 import {CoreModule} from './core/core_module';
 import {HashStorageModule} from './core/views/hash_storage_module';
 import {PluginsModule} from './plugins/plugins_module';
+import {SettingsModule} from './settings/settings_module';
 
 import {ROOT_REDUCERS, metaReducers} from './reducer_config';
 
@@ -40,6 +41,7 @@ import {MatIconModule} from './mat_icon_module';
     MatIconModule,
     PluginsModule,
     ReloaderModule,
+    SettingsModule,
     StoreModule.forRoot(ROOT_REDUCERS, {
       metaReducers,
       runtimeChecks: {

--- a/tensorboard/webapp/core/actions/core_actions.ts
+++ b/tensorboard/webapp/core/actions/core_actions.ts
@@ -63,3 +63,11 @@ export const changeReloadPeriod = createAction(
   '[Core] Reload Period Change',
   props<{periodInMs: number}>()
 );
+
+/**
+ * Action for when user wants to an item count in a page of a paginated view.
+ */
+export const changePageSize = createAction(
+  '[Core] Page Size Change',
+  props<{size: number}>()
+);

--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -30,6 +30,7 @@ const initialState: CoreState = {
   },
   reloadPeriodInMs: 30000,
   reloadEnabled: true,
+  pageSize: 15,
 };
 
 const reducer = createReducer(
@@ -101,7 +102,14 @@ const reducer = createReducer(
         reloadPeriodInMs: nextReloadPeriod,
       };
     }
-  )
+  ),
+  on(actions.changePageSize, (state: CoreState, {size}) => {
+    const nextPageSize = size > 0 ? size : state.pageSize;
+    return {
+      ...state,
+      pageSize: nextPageSize,
+    };
+  })
 );
 
 export function reducers(state: CoreState, action: Action) {

--- a/tensorboard/webapp/core/store/core_selectors.ts
+++ b/tensorboard/webapp/core/store/core_selectors.ts
@@ -59,3 +59,10 @@ export const getReloadPeriodInMs = createSelector(
     return state.reloadPeriodInMs;
   }
 );
+
+export const getPageSize = createSelector(
+  selectCoreState,
+  (state: CoreState): number => {
+    return state.pageSize;
+  }
+);

--- a/tensorboard/webapp/core/store/core_types.ts
+++ b/tensorboard/webapp/core/store/core_types.ts
@@ -29,6 +29,7 @@ export interface CoreState {
   pluginsListLoaded: LoadState;
   reloadPeriodInMs: number;
   reloadEnabled: boolean;
+  pageSize: number;
 }
 
 export interface State {

--- a/tensorboard/webapp/core/testing/index.ts
+++ b/tensorboard/webapp/core/testing/index.ts
@@ -38,6 +38,7 @@ export function createCoreState(override?: Partial<CoreState>): CoreState {
     },
     reloadPeriodInMs: 30000,
     reloadEnabled: true,
+    pageSize: 10,
     ...override,
   };
 }

--- a/tensorboard/webapp/reducer_config.ts
+++ b/tensorboard/webapp/reducer_config.ts
@@ -36,8 +36,7 @@ export function logger(reducer: ActionReducer<any>): ActionReducer<any> {
   };
 }
 
-export const metaReducers: MetaReducer<any>[] =
-  config.env === 'dev' ? [logger] : [];
+export const metaReducers: MetaReducer<any>[] = [logger];
 
 export const ROOT_REDUCERS = new InjectionToken<
   ActionReducerMap<State, Action>

--- a/tensorboard/webapp/reducer_config.ts
+++ b/tensorboard/webapp/reducer_config.ts
@@ -36,7 +36,8 @@ export function logger(reducer: ActionReducer<any>): ActionReducer<any> {
   };
 }
 
-export const metaReducers: MetaReducer<any>[] = [logger];
+export const metaReducers: MetaReducer<any>[] =
+  config.env === 'dev' ? [logger] : [];
 
 export const ROOT_REDUCERS = new InjectionToken<
   ActionReducerMap<State, Action>

--- a/tensorboard/webapp/settings/BUILD
+++ b/tensorboard/webapp/settings/BUILD
@@ -7,6 +7,7 @@ ng_module(
     name = "settings",
     srcs = [
         "dialog_component.ts",
+        "polymer_interop_container.ts",
         "settings_button_component.ts",
         "settings_module.ts",
     ],
@@ -34,6 +35,7 @@ tf_ts_library(
     name = "test_lib",
     testonly = True,
     srcs = [
+        "polymer_interop_test.ts",
         "settings_test.ts",
     ],
     tsconfig = "//:tsconfig-test",

--- a/tensorboard/webapp/settings/dialog_component.ts
+++ b/tensorboard/webapp/settings/dialog_component.ts
@@ -13,14 +13,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Component, OnInit, OnDestroy} from '@angular/core';
-import {FormControl, Validators} from '@angular/forms';
+import {
+  FormControl,
+  Validators,
+  AbstractControl,
+  ValidatorFn,
+} from '@angular/forms';
 import {Store, select, createSelector} from '@ngrx/store';
 
 import {Subject} from 'rxjs';
 import {takeUntil, debounceTime, filter} from 'rxjs/operators';
 
-import {getReloadEnabled, getReloadPeriodInMs, State} from '../core/store';
-import {toggleReloadEnabled, changeReloadPeriod} from '../core/actions';
+import {
+  getReloadEnabled,
+  getReloadPeriodInMs,
+  State,
+  getPageSize,
+} from '../core/store';
+import {
+  toggleReloadEnabled,
+  changeReloadPeriod,
+  changePageSize,
+} from '../core/actions';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
@@ -28,6 +42,14 @@ const getReloadPeriodInSec = createSelector(
   getReloadPeriodInMs,
   (periodInMs) => Math.round(periodInMs / 1000)
 );
+
+export function createIntegerValidator(): ValidatorFn {
+  return (control: AbstractControl): {[key: string]: any} | null => {
+    const numValue = Number(control.value);
+    const valid = Math.round(numValue) === control.value;
+    return valid ? null : {integer: {value: control.value}};
+  };
+}
 
 @Component({
   selector: 'settings-dialog',
@@ -59,11 +81,32 @@ const getReloadPeriodInSec = createSelector(
         Reload period has to be minimum of 15 seconds.
       </mat-error>
     </div>
+    <div>
+      <mat-form-field>
+        <input
+          class="page-size"
+          matInput
+          type="number"
+          placeholder="Pagination Limit"
+          [formControl]="paginationControl"
+        />
+      </mat-form-field>
+      <mat-error
+        *ngIf="
+          paginationControl.hasError('min') ||
+          paginationControl.hasError('required') ||
+          paginationControl.hasError('integer')
+        "
+      >
+        Page size has to be a positive integer.
+      </mat-error>
+    </div>
   `,
   styleUrls: ['./dialog_component.css'],
 })
 export class SettingsDialogComponent implements OnInit, OnDestroy {
   readonly reloadEnabled$ = this.store.pipe(select(getReloadEnabled));
+  readonly pageSize$ = this.store.pipe(select(getPageSize));
   private readonly reloadPeriodInSec$ = this.store.pipe(
     select(getReloadPeriodInSec)
   );
@@ -71,6 +114,12 @@ export class SettingsDialogComponent implements OnInit, OnDestroy {
     Validators.required,
     Validators.min(15),
   ]);
+  readonly paginationControl = new FormControl(1, [
+    Validators.required,
+    Validators.min(1),
+    createIntegerValidator(),
+  ]);
+
   private ngUnsubscribe = new Subject();
 
   constructor(private store: Store<State>) {}
@@ -95,7 +144,8 @@ export class SettingsDialogComponent implements OnInit, OnDestroy {
     this.reloadPeriodControl.valueChanges
       .pipe(
         takeUntil(this.ngUnsubscribe),
-        debounceTime(500)
+        debounceTime(500),
+        filter(() => this.reloadPeriodControl.valid)
       )
       .subscribe(() => {
         if (!this.reloadPeriodControl.valid) {
@@ -103,6 +153,27 @@ export class SettingsDialogComponent implements OnInit, OnDestroy {
         }
         const periodInMs = this.reloadPeriodControl.value * 1000;
         this.store.dispatch(changeReloadPeriod({periodInMs}));
+      });
+
+    this.pageSize$
+      .pipe(
+        takeUntil(this.ngUnsubscribe),
+        filter((value) => value !== this.paginationControl.value)
+      )
+      .subscribe((value) => {
+        this.paginationControl.setValue(value);
+      });
+
+    this.paginationControl.valueChanges
+      .pipe(
+        takeUntil(this.ngUnsubscribe),
+        debounceTime(500),
+        filter(() => this.paginationControl.valid)
+      )
+      .subscribe(() => {
+        this.store.dispatch(
+          changePageSize({size: this.paginationControl.value})
+        );
       });
   }
 

--- a/tensorboard/webapp/settings/dialog_component.ts
+++ b/tensorboard/webapp/settings/dialog_component.ts
@@ -91,13 +91,7 @@ export function createIntegerValidator(): ValidatorFn {
           [formControl]="paginationControl"
         />
       </mat-form-field>
-      <mat-error
-        *ngIf="
-          paginationControl.hasError('min') ||
-          paginationControl.hasError('required') ||
-          paginationControl.hasError('integer')
-        "
-      >
+      <mat-error *ngIf="paginationControl.invalid">
         Page size has to be a positive integer.
       </mat-error>
     </div>

--- a/tensorboard/webapp/settings/dialog_component_test.ts
+++ b/tensorboard/webapp/settings/dialog_component_test.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {OverlayContainer} from '@angular/cdk/overlay';
-import {TestBed, tick, fakeAsync} from '@angular/core/testing';
+import {TestBed, tick, flush, fakeAsync} from '@angular/core/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCheckboxModule} from '@angular/material/checkbox';
@@ -29,7 +29,11 @@ import {SettingsDialogComponent} from './dialog_component';
 import {SettingsButtonComponent} from './settings_button_component';
 
 import {MatIconTestingModule} from '../testing/mat_icon.module';
-import {toggleReloadEnabled, changeReloadPeriod} from '../core/actions';
+import {
+  toggleReloadEnabled,
+  changeReloadPeriod,
+  changePageSize,
+} from '../core/actions';
 import {createCoreState, createState} from '../core/testing';
 import {State} from '../core/store';
 
@@ -191,6 +195,37 @@ describe('settings test', () => {
       reloadPeriod.nativeElement.dispatchEvent(new Event('input'));
 
       tick(1e10);
+
+      expect(dispatchSpy).not.toHaveBeenCalled();
+    }));
+  });
+
+  describe('changePageSize', () => {
+    it('dispatches changing the value', fakeAsync(async () => {
+      const fixture = TestBed.createComponent(SettingsDialogComponent);
+      fixture.detectChanges();
+
+      const reloadPeriod = fixture.debugElement.query(By.css('.page-size'));
+      reloadPeriod.nativeElement.value = 20;
+      reloadPeriod.nativeElement.dispatchEvent(new Event('input'));
+
+      expect(dispatchSpy).not.toHaveBeenCalled();
+
+      // We debounce it so it does not spam other components on very keystroke.
+      flush();
+
+      expect(dispatchSpy).toHaveBeenCalledWith(changePageSize({size: 20}));
+    }));
+
+    it('does not dispatch when input is invalid', fakeAsync(async () => {
+      const fixture = TestBed.createComponent(SettingsDialogComponent);
+      fixture.detectChanges();
+
+      const reloadPeriod = fixture.debugElement.query(By.css('.reload-period'));
+      reloadPeriod.nativeElement.value = 0;
+      reloadPeriod.nativeElement.dispatchEvent(new Event('input'));
+
+      flush();
 
       expect(dispatchSpy).not.toHaveBeenCalled();
     }));

--- a/tensorboard/webapp/settings/polymer_interop_container.ts
+++ b/tensorboard/webapp/settings/polymer_interop_container.ts
@@ -1,0 +1,69 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Component, ChangeDetectionStrategy} from '@angular/core';
+import {Store, select} from '@ngrx/store';
+import {Subject} from 'rxjs';
+import {takeUntil, distinctUntilChanged} from 'rxjs/operators';
+
+import {State, getPageSize} from '../core/store';
+
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+
+interface TfPaginatedViewStore extends HTMLElement {
+  tf_paginated_view: {
+    setLimit(limit: number): void;
+  };
+}
+
+/**
+ * SettingsPolymerInterop is a temporary interop module that writes settings in
+ * Ngrx store to Polymer-based TensorBoard components. As long as TensorBoard
+ * renders Polymer components, this module should be used.
+ *
+ * NOTE: there are two classes of settings in the Polymer land: (1) ones
+ * persisted in URL and (2) ones stored in JavaScript. This module interops with
+ * only (2) kinds. For (1), please refer to the hash_storage.
+ */
+@Component({
+  selector: 'settings-polymer-interop',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SettingsPolymerInteropContainer {
+  private readonly ngUnsubscribe = new Subject();
+  private readonly getPageSize$ = this.store.pipe(select(getPageSize));
+  private readonly paginatedViewStore = (document.createElement(
+    'tf-paginated-view-store'
+  ) as TfPaginatedViewStore).tf_paginated_view;
+
+  constructor(private store: Store<State>) {}
+
+  ngOnInit() {
+    this.getPageSize$
+      .pipe(
+        takeUntil(this.ngUnsubscribe),
+        distinctUntilChanged()
+      )
+      .subscribe((pageSize) => {
+        this.paginatedViewStore.setLimit(pageSize);
+      });
+  }
+
+  ngOnDestroy() {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
+  }
+}

--- a/tensorboard/webapp/settings/polymer_interop_test.ts
+++ b/tensorboard/webapp/settings/polymer_interop_test.ts
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorboard/webapp/settings/polymer_interop_test.ts
+++ b/tensorboard/webapp/settings/polymer_interop_test.ts
@@ -1,0 +1,84 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {DebugElement} from '@angular/core';
+import {TestBed, fakeAsync, tick} from '@angular/core/testing';
+import {Store} from '@ngrx/store';
+import {provideMockStore, MockStore} from '@ngrx/store/testing';
+
+import {SettingsPolymerInteropContainer} from './polymer_interop_container';
+
+import {getPageSize, State} from '../core/store';
+
+/** @typehack */ import * as _typeHackStore from '@ngrx/store';
+
+describe('settings polymer_interop', () => {
+  let store: MockStore<State>;
+  let setLimitCalls: number[];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [provideMockStore()],
+      declarations: [SettingsPolymerInteropContainer],
+    }).compileComponents();
+
+    store = TestBed.get(Store);
+    store.overrideSelector(getPageSize, 5);
+
+    setLimitCalls = [];
+    const createElementSpy = spyOn(document, 'createElement').and.callThrough();
+    createElementSpy.withArgs('tf-paginated-view-store').and.returnValue(({
+      tf_paginated_view: {
+        setLimit: (limit: number) => {
+          setLimitCalls.push(limit);
+        },
+      },
+    } as unknown) as HTMLElement);
+  });
+
+  it('sets pagination limit when pageSize changes', () => {
+    store.overrideSelector(getPageSize, 5);
+    const fixture = TestBed.createComponent(SettingsPolymerInteropContainer);
+    fixture.detectChanges();
+
+    expect(setLimitCalls).toEqual([5]);
+
+    store.overrideSelector(getPageSize, 10);
+    store.refreshState();
+    fixture.detectChanges();
+
+    expect(setLimitCalls).toEqual([5, 10]);
+  });
+
+  it('does not set limit when the value does not change', () => {
+    store.overrideSelector(getPageSize, 5);
+    const fixture = TestBed.createComponent(SettingsPolymerInteropContainer);
+    fixture.detectChanges();
+
+    expect(setLimitCalls).toEqual([5]);
+
+    store.overrideSelector(getPageSize, 5);
+    store.refreshState();
+    fixture.detectChanges();
+
+    expect(setLimitCalls).toEqual([5]);
+
+    store.overrideSelector(getPageSize, 10);
+    store.refreshState();
+    fixture.detectChanges();
+
+    expect(setLimitCalls).toEqual([5, 10]);
+  });
+});

--- a/tensorboard/webapp/settings/settings_module.ts
+++ b/tensorboard/webapp/settings/settings_module.ts
@@ -22,12 +22,16 @@ import {MatIconModule} from '@angular/material/icon';
 import {MatInputModule} from '@angular/material/input';
 
 import {SettingsButtonComponent} from './settings_button_component';
-
 import {SettingsDialogComponent} from './dialog_component';
+import {SettingsPolymerInteropContainer} from './polymer_interop_container';
 
 @NgModule({
-  declarations: [SettingsButtonComponent, SettingsDialogComponent],
-  exports: [SettingsButtonComponent],
+  declarations: [
+    SettingsButtonComponent,
+    SettingsDialogComponent,
+    SettingsPolymerInteropContainer,
+  ],
+  exports: [SettingsButtonComponent, SettingsPolymerInteropContainer],
   entryComponents: [SettingsDialogComponent],
   imports: [
     CommonModule,


### PR DESCRIPTION
This implements the pagination setting for Polymer based TensorBoard.
When changing the pagination setting, you can now change how many pages
of categories will be rendered on the Polymer side. Do note that
Angular based components will simply use selector to read the state from
the store instead.

TODO after the PR:
- stylize the settings dialog.