### PR TITLE
scalars: promote generic data to stable

### DIFF
--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -60,7 +60,7 @@ class ScalarsPlugin(base_plugin.TBPlugin):
         """
         self._multiplexer = context.multiplexer
         self._db_connection_provider = context.db_connection_provider
-        if context.flags and context.flags.generic_data == "true":
+        if context.flags and context.flags.generic_data != "false":
             self._data_provider = context.data_provider
         else:
             self._data_provider = None

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -137,7 +137,9 @@ class ScalarsPluginTest(tf.test.TestCase):
                 (logdir, multiplexer) = self.load_runs(run_names)
                 with self.subTest("bare multiplexer"):
                     ctx = base_plugin.TBContext(
-                        logdir=logdir, multiplexer=multiplexer
+                        logdir=logdir,
+                        multiplexer=multiplexer,
+                        flags=argparse.Namespace(generic_data="false"),
                     )
                     fn(self, scalars_plugin.ScalarsPlugin(ctx), *args, **kwargs)
                 with self.subTest("generic data provider"):


### PR DESCRIPTION
Summary:
At this point, the generic data APIs are a fully featured replacement
for the multiplexer APIs, including `is_active` support. We now enable
them by default. They can still be disabled with `--generic_data false`.

Test Plan:
Patch the `MultiplexerDataProvider` to return hard-coded descriptions so
that the generic and non-generic flows are distinguishable, then note
that `tensorboard` uses the generic data APIs with `--generic_data`
either set to `true` or unspecified, and not when set to `false`.

wchargin-branch: data-stabilize-scalars
