### PR TITLE
data: expose downsampling preferences to plugins

### DIFF
--- a/tensorboard/plugins/base_plugin.py
+++ b/tensorboard/plugins/base_plugin.py
@@ -254,6 +254,7 @@ class TBContext(object):
         logdir=None,
         multiplexer=None,
         plugin_name_to_instance=None,
+        sampling_hints=None,
         window_title=None,
     ):
         """Instantiates magic container.
@@ -291,6 +292,10 @@ class TBContext(object):
               plugin may be absent from this mapping until it is registered. Plugin
               logic should handle cases in which a plugin is absent from this
               mapping, lest a KeyError is raised.
+          sampling_hints: Map from plugin name to `int` or `NoneType`, where
+              the value represents the user-specified downsampling limit as
+              given to the `--samples_per_plugin` flag, or `None` if none was
+              explicitly given for this plugin.
           window_title: A string specifying the window title.
         """
         self.assets_zip_provider = assets_zip_provider
@@ -301,6 +306,7 @@ class TBContext(object):
         self.logdir = logdir
         self.multiplexer = multiplexer
         self.plugin_name_to_instance = plugin_name_to_instance
+        self.sampling_hints = sampling_hints
         self.window_title = window_title
 
 

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -48,6 +48,8 @@ WARNING_TEMPLATE = textwrap.dedent(
   2d tables are supported. Showing a 2d slice of the data instead."""
 )
 
+_DEFAULT_DOWNSAMPLING = 100  # text tensors per time series
+
 
 def make_table_row(contents, tag="td"):
     """Given an iterable of string contents, make a table row.
@@ -212,6 +214,9 @@ class TextPlugin(base_plugin.TBPlugin):
           context: A base_plugin.TBContext instance.
         """
         self._multiplexer = context.multiplexer
+        self._downsample_to = (context.sampling_hints or {}).get(
+            self.plugin_name, _DEFAULT_DOWNSAMPLING
+        )
         if context.flags and context.flags.generic_data == "true":
             self._data_provider = context.data_provider
         else:
@@ -261,7 +266,7 @@ class TextPlugin(base_plugin.TBPlugin):
             all_text = self._data_provider.read_tensors(
                 experiment_id=experiment,
                 plugin_name=metadata.PLUGIN_NAME,
-                downsample=100,
+                downsample=self._downsample_to,
                 run_tag_filter=provider.RunTagFilter(runs=[run], tags=[tag]),
             )
             text = all_text.get(run, {}).get(tag, None)


### PR DESCRIPTION
Summary:
We add a `sampling_hints` attribute to the `TBContext` magic container,
which is populated with the parsed form of the `--samples_per_plugin`
flag. Existing plugins’ generic data modes are updated to read from this
map instead of using hard-coded thresholds.

Test Plan:
This change is not actually observable as is, because the multiplexer
data provider ignores its downsampling argument. But after patching in a
change to make the data provider respect the downsampling argument, this
change has the effect that increasing the `--samples_per_plugin` over
the default (e.g., `images=20`) now properly increases the number of
samples shown in generic data mode, whereas previously it had no effect.

wchargin-branch: data-downsampling-flag
