### PR TITLE
Add experiment name, description and time getters to environmentStore

### DIFF
--- a/tensorboard/components/tf_backend/environmentStore.ts
+++ b/tensorboard/components/tf_backend/environmentStore.ts
@@ -60,6 +60,18 @@ namespace tf_backend {
     public getWindowTitle(): string {
       return this.environment ? this.environment.windowTitle : '';
     }
+
+    public getExperimentName(): string {
+      return this.environment ? this.environment.experimentName : '';
+    }
+
+    public getExperimentDescription(): string {
+      return this.environment ? this.environment.experimentDescription : '';
+    }
+
+    public getCreationTime(): number | null {
+      return this.environment ? this.environment.creationTime : null;
+    }
   }
 
   export const environmentStore = new EnvironmentStore();


### PR DESCRIPTION
* Motivation for features / changes
  * Support experiment metadata (name, description, creation time) display in tensorboard.dev

* Technical description of changes
  * This is a follow-up to https://github.com/tensorflow/tensorboard/pull/3254
  * Add three getter methods to environmentStore.
  
* Detailed steps to verify changes work correctly (as executed by you)
  * Manual verify by running a frontend that talks to it (not included in this PR)
