### PR TITLE
profile: remove Test PyPI index specification

### DIFF
--- a/tensorboard/plugins/profile_redirect/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard.html
+++ b/tensorboard/plugins/profile_redirect/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard.html
@@ -30,7 +30,12 @@ limitations under the License.
         Please install the new version of the profile plugin from PyPI by
         running the following command from the machine running TensorBoard:
       </p>
-      <textarea id="commandTextarea" readonly on-blur="_removeCopiedMessage">
+      <textarea
+        id="commandTextarea"
+        readonly
+        rows="1"
+        on-blur="_removeCopiedMessage"
+      >
 [[_installCommand]]</textarea
       >
       <div id="copyContainer">
@@ -48,7 +53,7 @@ limitations under the License.
       }
       #commandTextarea {
         margin-top: 1ex;
-        padding: 1ex 0;
+        padding: 1ex 1em;
         resize: vertical;
         width: 100%;
       }
@@ -73,10 +78,7 @@ limitations under the License.
           _installCommand: {
             type: String,
             readOnly: true,
-            value: [
-              'pip install --extra-index-url https://test.pypi.org/simple/ \\',
-              '    tensorboard_plugin_profile',
-            ].join('\n'),
+            value: 'pip install -U tensorboard_plugin_profile',
           },
         },
         async _copyInstallCommand() {


### PR DESCRIPTION
Summary:
The dynamic profile plugin is now available on stable PyPI:
<https://pypi.org/project/tensorboard-plugin-profile/2.2.0a1/>

Styling updated because the number of lines of text changed.

Test Plan:
The instructions still work in a new virtualenv, pulling in `2.2.0a1`.

wchargin-branch: profile-stable-pypi
