### PR TITLE
build: add an `__init__`-only `tensorboard` library

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -58,7 +58,7 @@ py_library(
     name = "lib_init_only",
     srcs = ["__init__.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//visibility:public"],
+    visibility = ["//tensorboard:internal"],
     deps = [
         ":errors",
         ":lazy",

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -41,12 +41,28 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
-        ":errors",
-        ":lazy",
+        ":lib_init_only",
         ":notebook",
         ":program",
         "//tensorboard/summary",
         "//tensorboard/summary/writer",
+    ],
+)
+
+# The dependencies needed to initialize the `tensorboard` module itself,
+# which are not sufficient to resolve all of its lazy imports. Use only
+# if you're intending to link in a proper subset of TensorBoard's public
+# API, you're linking in that subset explicitly in your downstream
+# target, and you know what you're doing.
+py_library(
+    name = "lib_init_only",
+    srcs = ["__init__.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":errors",
+        ":lazy",
+        ":version",
     ],
 )
 


### PR DESCRIPTION
Summary:
This enables Bazel targets to depend on `tensorboard.notebook` without
pulling in all of the summary writing infrastructure, by explicitly
depending on both `:lib_init_only` and `:notebook`. This results in a
very thin dependency graph: try

```
bazel query 'deps(//tensorboard:lib_init_only + //tensorboard:notebook)'
```

to see.

Test Plan:
A binary that depends on `:lib_init_only` and `:notebook` can import
`tensorboard` and run `tensorboard.notebook.list()`, while trying to
evaluate `tensorboard.summary.scalar` raises an `ImportError`. Googlers,
see <http://cl/296370945>.

wchargin-branch: lib-init-only
