### PR TITLE
Support experiment name and description in uploader

### DIFF
--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -174,10 +174,10 @@ def update_experiment_metadata(
     """
     logger.info("Modifying experiment %r", experiment_id)
     if name is not None:
-        logger.info("Setting exp %r name to ", experiment_id, name)
+        logger.info("Setting exp %r name to %r", experiment_id, name)
     if description is not None:
         logger.info(
-            "Setting exp %r description to ", experiment_id, description
+            "Setting exp %r description to %r", experiment_id, description
         )
     experiment = experiment_pb2.Experiment(
         experiment_id=experiment_id, name=name, description=description

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -194,8 +194,8 @@ def update_experiment_metadata(
         if e.code() == grpc.StatusCode.PERMISSION_DENIED:
             raise PermissionDeniedError()
         if e.code() == grpc.StatusCode.INVALID_ARGUMENT:
-            details=''
-            if hasattr(e, 'details'):
+            details = ""
+            if hasattr(e, "details"):
                 details = e.details
             raise InvalidArgumentError(details)
         raise

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -64,7 +64,14 @@ logger = tb_logging.get_logger()
 class TensorBoardUploader(object):
     """Uploads a TensorBoard logdir to TensorBoard.dev."""
 
-    def __init__(self, writer_client, logdir, rpc_rate_limiter=None):
+    def __init__(
+        self,
+        writer_client,
+        logdir,
+        rpc_rate_limiter=None,
+        name=None,
+        description=None,
+    ):
         """Constructs a TensorBoardUploader.
 
         Args:
@@ -77,9 +84,13 @@ class TensorBoardUploader(object):
             of chunks.  Note the chunk stream is internally rate-limited by
             backpressure from the server, so it is not a concern that we do not
             explicitly rate-limit within the stream here.
+          name: String name to assign to the experiment.
+          description: String description to assign to the experiment.
         """
         self._api = writer_client
         self._logdir = logdir
+        self._name = name
+        self._description = description
         self._request_sender = None
         if rpc_rate_limiter is None:
             self._rpc_rate_limiter = util.RateLimiter(
@@ -103,7 +114,9 @@ class TensorBoardUploader(object):
     def create_experiment(self):
         """Creates an Experiment for this upload session and returns the ID."""
         logger.info("Creating experiment")
-        request = write_service_pb2.CreateExperimentRequest()
+        request = write_service_pb2.CreateExperimentRequest(
+            name=self._name, description=self._description
+        )
         response = grpc_util.call_with_retries(
             self._api.CreateExperiment, request
         )

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -194,10 +194,7 @@ def update_experiment_metadata(
         if e.code() == grpc.StatusCode.PERMISSION_DENIED:
             raise PermissionDeniedError()
         if e.code() == grpc.StatusCode.INVALID_ARGUMENT:
-            details = ""
-            if hasattr(e, "details"):
-                details = e.details
-            raise InvalidArgumentError(details)
+            raise InvalidArgumentError(e.details())
         raise
 
 

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -551,8 +551,8 @@ def _raise_if_bad_experiment_description(description):
     if description and len(description) > _EXPERIMENT_DESCRIPTION_MAX_CHARS:
         raise ValueError(
             "Experiment description is too long.  Limit is %s characters.\n"
-            "%r was provided." % (_EXPERIMENT_DESCRIPTION_MAX_CHARS,
-            description)
+            "%r was provided."
+            % (_EXPERIMENT_DESCRIPTION_MAX_CHARS, description)
         )
 
 

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -473,11 +473,11 @@ class _UpdateMetadataIntent(_Intent):
             )
         except grpc.RpcError as e:
             _die("Internal error modifying experiment: %s" % e)
-        print("Modified experiment %s." % experiment_id)
+        logging.info("Modified experiment %s.", experiment_id)
         if self.name is not None:
-            print(f"Set name to {repr(self.name)}")
+            logging.info("Set name to %r", self.name)
         if self.description is not None:
-            print(f"Set description to {repr(self.description)}")
+            logging.info(f"Set description to %r", repr(self.description))
 
 
 class _ListIntent(_Intent):
@@ -527,7 +527,7 @@ class _ListIntent(_Intent):
                 ("Tags", str(experiment.num_tags)),
             ]
             for (name, value) in data:
-                print("\t%s %s" % (name.ljust(11), value))
+                print("\t%s %s" % (name.ljust(12), value))
         sys.stdout.flush()
         if not count:
             sys.stderr.write(
@@ -542,17 +542,17 @@ def _raise_if_bad_experiment_name(name):
     if name and len(name) > _EXPERIMENT_NAME_MAX_CHARS:
         raise ValueError(
             "Experiment name is too long.  Limit is "
-            f"{_EXPERIMENT_NAME_MAX_CHARS} characters.\n"
-            f"{repr(name)} was provided."
+            "%s characters.\n"`
+            "%r was provided." % (_EXPERIMENT_DESCRIPTION_MAX_CHARS, name)
         )
 
 
 def _raise_if_bad_experiment_description(description):
     if description and len(description) > _EXPERIMENT_DESCRIPTION_MAX_CHARS:
         raise ValueError(
-            "Experiment description is too long.  Limit is "
-            f"{_EXPERIMENT_DESCRIPTION_MAX_CHARS} characters.\n"
-            f"{repr(description)} was provided."
+            "Experiment description is too long.  Limit is %s characters.\n"
+            "%r was provided." % (_EXPERIMENT_DESCRIPTION_MAX_CHARS,
+            description)
         )
 
 

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -589,7 +589,7 @@ class _UploadIntent(_Intent):
             channel
         )
         _die_if_bad_experiment_name(self.name)
-        _raise_if_bad_experiment_description(self.description)
+        _die_if_bad_experiment_description(self.description)
         uploader = uploader_lib.TensorBoardUploader(
             api_client,
             self.logdir,
@@ -597,7 +597,7 @@ class _UploadIntent(_Intent):
             description=self.description,
         )
         experiment_id = uploader.create_experiment()
-        udieserver_info_lib.experiment_url(server_info, experiment_id)
+        url = server_info_lib.experiment_url(server_info, experiment_id)
         print(
             "Upload started and will continue reading any new data as it's added"
         )

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -409,6 +409,8 @@ class _ListIntent(_Intent):
             url = server_info_lib.experiment_url(server_info, experiment_id)
             print(url)
             data = [
+                ("Name", experiment.name or "[No Name]"),
+                ("Description", experiment.description or "[No Description]"),
                 ("Id", experiment.experiment_id),
                 ("Created", util.format_time(experiment.create_time)),
                 ("Updated", util.format_time(experiment.update_time)),
@@ -417,7 +419,7 @@ class _ListIntent(_Intent):
                 ("Tags", str(experiment.num_tags)),
             ]
             for (name, value) in data:
-                print("\t%s %s" % (name.ljust(10), value))
+                print("\t%s %s" % (name.ljust(11), value))
         sys.stdout.flush()
         if not count:
             sys.stderr.write(

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -542,7 +542,7 @@ def _raise_if_bad_experiment_name(name):
     if name and len(name) > _EXPERIMENT_NAME_MAX_CHARS:
         raise ValueError(
             "Experiment name is too long.  Limit is "
-            "%s characters.\n"`
+            "%s characters.\n"
             "%r was provided." % (_EXPERIMENT_DESCRIPTION_MAX_CHARS, name)
         )
 

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -65,6 +65,7 @@ _SUBCOMMAND_KEY_UPLOAD = "UPLOAD"
 _SUBCOMMAND_KEY_DELETE = "DELETE"
 _SUBCOMMAND_KEY_LIST = "LIST"
 _SUBCOMMAND_KEY_EXPORT = "EXPORT"
+_SUBCOMMAND_KEY_UPDATE_METADATA = "UPDATEMETADATA"
 _SUBCOMMAND_KEY_AUTH = "AUTH"
 _AUTH_SUBCOMMAND_FLAG = "_uploader__subcommand_auth"
 _AUTH_SUBCOMMAND_KEY_REVOKE = "REVOKE"
@@ -152,6 +153,34 @@ def _define_flags(parser):
         help="Title of the experiment.  Max 100 characters.",
     )
     upload.add_argument(
+        "--description",
+        type=str,
+        default=None,
+        help="Experiment description. Markdown format.  Max 600 characters.",
+    )
+
+    update_metadata = subparsers.add_parser(
+        "update-metadata",
+        help="change the name, description, or other user "
+        "metadata associated with an experiment.",
+    )
+    update_metadata.set_defaults(
+        **{_SUBCOMMAND_FLAG: _SUBCOMMAND_KEY_UPDATE_METADATA}
+    )
+    update_metadata.add_argument(
+        "--experiment_id",
+        metavar="EXPERIMENT_ID",
+        type=str,
+        default=None,
+        help="ID of the experiment on which to modify the metadata.",
+    )
+    update_metadata.add_argument(
+        "--name",
+        type=str,
+        default=None,
+        help="Title of the experiment.  Max 100 characters.",
+    )
+    update_metadata.add_argument(
         "--description",
         type=str,
         default=None,
@@ -390,6 +419,68 @@ class _DeleteExperimentIntent(_Intent):
         print("Deleted experiment %s." % experiment_id)
 
 
+class _UpdateMetadataIntent(_Intent):
+    """The user intends to update the metadata for an experiment."""
+
+    _MESSAGE_TEMPLATE = textwrap.dedent(
+        u"""\
+        This will modify the metadata associated with the experiment on
+        https://tensorboard.dev with the following experiment ID:
+
+        {experiment_id}
+
+        You have chosen to modify an experiment. All experiments uploaded
+        to TensorBoard.dev are publicly visible. Do not upload sensitive
+        data.
+        """
+    )
+
+    def __init__(self, experiment_id, name=None, description=None):
+        self.experiment_id = experiment_id
+        self.name = name
+        self.description = description
+
+    def get_ack_message_body(self):
+        return self._MESSAGE_TEMPLATE.format(experiment_id=self.experiment_id)
+
+    def execute(self, server_info, channel):
+        api_client = write_service_pb2_grpc.TensorBoardWriterServiceStub(
+            channel
+        )
+        experiment_id = self.experiment_id
+        _raise_if_bad_experiment_name(self.name)
+        _raise_if_bad_experiment_description(self.description)
+        if not experiment_id:
+            raise base_plugin.FlagsError(
+                "Must specify a non-empty experiment ID to modify."
+            )
+        try:
+            uploader_lib.update_experiment_metadata(
+                api_client,
+                experiment_id,
+                name=self.name,
+                description=self.description,
+            )
+        except uploader_lib.ExperimentNotFoundError:
+            _die(
+                "No such experiment %s. Either it never existed or it has "
+                "already been deleted." % experiment_id
+            )
+        except uploader_lib.PermissionDeniedError:
+            _die(
+                "Cannot modify experiment %s because it is owned by a "
+                "different user." % experiment_id
+            )
+        except grpc.RpcError as e:
+            _die("Internal error modifying experiment: %s" % e)
+        print("Modified experiment %s." % experiment_id)
+        if self.name is not None:
+            print(f"Set name to {repr(self.name)}")
+        if self.description is not None:
+            print(f"Set description to {repr(self.description)}")
+
+
+
 class _ListIntent(_Intent):
     """The user intends to list all their experiments."""
 
@@ -448,6 +539,27 @@ class _ListIntent(_Intent):
         sys.stderr.flush()
 
 
+def _raise_if_bad_experiment_name(name):
+    if name and len(name) > _EXPERIMENT_NAME_MAX_CHARS:
+        raise ValueError(
+            "Experiment name is too long.  Limit is "
+            f"{_EXPERIMENT_NAME_MAX_CHARS} characters.\n"
+            f"{repr(name)} was provided."
+        )
+
+
+def _raise_if_bad_experiment_description(description):
+    if (
+        description
+        and len(description) > _EXPERIMENT_DESCRIPTION_MAX_CHARS
+    ):
+        raise ValueError(
+            "Experiment description is too long.  Limit is "
+            f"{_EXPERIMENT_DESCRIPTION_MAX_CHARS} characters.\n"
+            f"{repr(description)} was provided."
+        )
+
+
 class _UploadIntent(_Intent):
     """The user intends to upload an experiment from the given logdir."""
 
@@ -475,21 +587,8 @@ class _UploadIntent(_Intent):
         api_client = write_service_pb2_grpc.TensorBoardWriterServiceStub(
             channel
         )
-        if self.name and len(self.name) > _EXPERIMENT_NAME_MAX_CHARS:
-            raise ValueError(
-                "Experiment name is too long.  Limit is "
-                f"{_EXPERIMENT_NAME_MAX_CHARS} characters.\n"
-                f"{repr(self.name)} was provided."
-            )
-        if (
-            self.description
-            and len(self.description) > _EXPERIMENT_DESCRIPTION_MAX_CHARS
-        ):
-            raise ValueError(
-                "Experiment description is too long.  Limit is "
-                f"{_EXPERIMENT_DESCRIPTION_MAX_CHARS} characters.\n"
-                f"{repr(self.description)} was provided."
-            )
+        _raise_if_bad_experiment_name(self.name)
+        _raise_if_bad_experiment_description(self.description)
         uploader = uploader_lib.TensorBoardUploader(
             api_client,
             self.logdir,
@@ -591,6 +690,22 @@ def _get_intent(flags):
         else:
             raise base_plugin.FlagsError(
                 "Must specify directory to upload via `--logdir`."
+            )
+    if cmd == _SUBCOMMAND_KEY_UPDATE_METADATA:
+        if flags.experiment_id:
+            if flags.name is not None or flags.description is not None:
+                return _UpdateMetadataIntent(
+                    flags.experiment_id,
+                    name=flags.name,
+                    description=flags.description,
+                )
+            else:
+                raise base_plugin.FlagsError(
+                    "Must specify either `--name` or `--description`."
+                )
+        else:
+            raise base_plugin.FlagsError(
+                "Must specify experiment to modify via `--experiment_id`."
             )
     elif cmd == _SUBCOMMAND_KEY_DELETE:
         if flags.experiment_id:

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -480,7 +480,6 @@ class _UpdateMetadataIntent(_Intent):
             print(f"Set description to {repr(self.description)}")
 
 
-
 class _ListIntent(_Intent):
     """The user intends to list all their experiments."""
 
@@ -549,10 +548,7 @@ def _raise_if_bad_experiment_name(name):
 
 
 def _raise_if_bad_experiment_description(description):
-    if (
-        description
-        and len(description) > _EXPERIMENT_DESCRIPTION_MAX_CHARS
-    ):
+    if description and len(description) > _EXPERIMENT_DESCRIPTION_MAX_CHARS:
         raise ValueError(
             "Experiment description is too long.  Limit is "
             f"{_EXPERIMENT_DESCRIPTION_MAX_CHARS} characters.\n"

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -98,7 +98,7 @@ class TensorboardUploaderTest(tf.test.TestCase):
         mock_client = _create_mock_client()
         new_description = """
         **description**"
-        may have "strange" unicode chars 🌴 \/<>
+        may have "strange" unicode chars 🌴 \\/<>
         """
         uploader = uploader_lib.TensorBoardUploader(
             mock_client, logdir, description=new_description
@@ -868,6 +868,18 @@ class UpdateExperimentMetadataTest(tf.test.TestCase):
 
         with self.assertRaises(uploader_lib.PermissionDeniedError):
             uploader_lib.update_experiment_metadata(mock_client, "123", name="")
+
+    def test_invalid_argument(self):
+        mock_client = _create_mock_client()
+        error = test_util.grpc_error(
+            grpc.StatusCode.INVALID_ARGUMENT,
+            "too many")
+        mock_client.UpdateExperiment.side_effect = error
+
+        with self.assertRaises(uploader_lib.InvalidArgumentError) as cm:
+            uploader_lib.update_experiment_metadata(mock_client, "123", name="")
+        msg = str(cm.exception)
+        self.assertIn("too many", msg)
 
     def test_internal_error(self):
         mock_client = _create_mock_client()

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -872,8 +872,8 @@ class UpdateExperimentMetadataTest(tf.test.TestCase):
     def test_invalid_argument(self):
         mock_client = _create_mock_client()
         error = test_util.grpc_error(
-            grpc.StatusCode.INVALID_ARGUMENT,
-            "too many")
+            grpc.StatusCode.INVALID_ARGUMENT, "too many"
+        )
         mock_client.UpdateExperiment.side_effect = error
 
         with self.assertRaises(uploader_lib.InvalidArgumentError) as cm:

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -79,18 +79,20 @@ class TensorboardUploaderTest(tf.test.TestCase):
         logdir = "/logs/foo"
         mock_client = _create_mock_client()
         uploader_name = uploader_lib.TensorBoardUploader(
-            mock_client, logdir, name="name")
+            mock_client, logdir, name="name"
+        )
         uploader_description = uploader_lib.TensorBoardUploader(
-            mock_client, logdir, description="description")
+            mock_client, logdir, description="description"
+        )
         uploader_both = uploader_lib.TensorBoardUploader(
-            mock_client, logdir, name="name", description="description")
+            mock_client, logdir, name="name", description="description"
+        )
         eid_name = uploader_name.create_experiment()
         self.assertEqual(eid_name, "123")
         eid_description = uploader_description.create_experiment()
         self.assertEqual(eid_description, "123")
         eid_both = uploader_both.create_experiment()
         self.assertEqual(eid_both, "123")
-
 
     def test_start_uploading_without_create_experiment_fails(self):
         mock_client = _create_mock_client()

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -130,11 +130,9 @@ class TensorboardUploaderTest(tf.test.TestCase):
         (args, _) = mock_client.CreateExperiment.call_args
 
         expected_request = write_service_pb2.CreateExperimentRequest(
-            name=new_name,
-            description=new_description,
+            name=new_name, description=new_description,
         )
         self.assertEqual(args[0], expected_request)
-
 
     def test_start_uploading_without_create_experiment_fails(self):
         mock_client = _create_mock_client()
@@ -842,13 +840,14 @@ class UpdateExperimentMetadataTest(tf.test.TestCase):
         mock_client.UpdateExperiment.return_value = response
 
         uploader_lib.update_experiment_metadata(
-            mock_client, "123", name=new_name)
+            mock_client, "123", name=new_name
+        )
 
         expected_request = write_service_pb2.UpdateExperimentRequest(
             experiment=experiment_pb2.Experiment(
-                experiment_id="123",
-                name=new_name),
-            experiment_mask=experiment_pb2.ExperimentMask(name=True)
+                experiment_id="123", name=new_name
+            ),
+            experiment_mask=experiment_pb2.ExperimentMask(name=True),
         )
         mock_client.UpdateExperiment.assert_called_once()
         (args, _) = mock_client.UpdateExperiment.call_args

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -75,6 +75,23 @@ class TensorboardUploaderTest(tf.test.TestCase):
         eid = uploader.create_experiment()
         self.assertEqual(eid, "123")
 
+    def test_create_experiment_with_name_and_description(self):
+        logdir = "/logs/foo"
+        mock_client = _create_mock_client()
+        uploader_name = uploader_lib.TensorBoardUploader(
+            mock_client, logdir, name="name")
+        uploader_description = uploader_lib.TensorBoardUploader(
+            mock_client, logdir, description="description")
+        uploader_both = uploader_lib.TensorBoardUploader(
+            mock_client, logdir, name="name", description="description")
+        eid_name = uploader_name.create_experiment()
+        self.assertEqual(eid_name, "123")
+        eid_description = uploader_description.create_experiment()
+        self.assertEqual(eid_description, "123")
+        eid_both = uploader_both.create_experiment()
+        self.assertEqual(eid_both, "123")
+
+
     def test_start_uploading_without_create_experiment_fails(self):
         mock_client = _create_mock_client()
         uploader = uploader_lib.TensorBoardUploader(mock_client, "/logs/foo")


### PR DESCRIPTION
* Motivation for features / changes
Adds the ability to list, upload, and modify experiments with names & descriptions.

* Technical description of changes
Adds user intent & checking for 

* Screenshots of UI changes
```
bazel run //tensorboard -- dev list
```
```
Total: 17 experiment(s)
https://tensorboard.dev/experiment/F0EqjQjYTOCk4AdY5oskbQ/
        Name        this is demoable now.
        Description a *description* 💁👌🎍😍
        Created     2020-02-21 12:06:42 (23 minutes ago)
        Updated     2020-02-21 12:30:07 (6 seconds ago)
        Scalars     18807
        Runs        21
        Tags        7
https://tensorboard.dev/experiment/xDROKjLAS0eKh9Lfpdwamg
        Name        [No Name]
        Description [No Description]
...

* Detailed steps to verify changes work correctly (as executed by you)
```
bazel run //tensorboard -- dev upload --logdir /tmp/scalars_demo
bazel run //tensorboard -- dev upload --logdir /tmp/scalars_demo --name="my first name"
bazel run //tensorboard -- dev upload --logdir /tmp/scalars_demo --name="my first name" --description="**********************************************************************************************************************************************************************************************************************************************"
bazel run //tensorboard -- dev update-metadata --experiment_id=F0EqjQjYTOCk4AdY5oskbQ --description 'a *description* 💁👌🎍😍'
```

* Alternate designs / implementations considered
@googlers see API design doc