### PR TITLE
ci: skip `yarn install` on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ install:
       -r tensorboard/pip_package/requirements.txt \
       -r tensorboard/pip_package/requirements_dev.txt \
       ;
-  - yarn install --ignore-engines
   - |
     # Install TensorFlow if requested
     if [ -n "${TF_VERSION_ID}" ]; then


### PR DESCRIPTION
Summary:
This was previously needed to run `yarn lint`, but we run that on GitHub
Actions now (in parallel with Travis!), so it’s entirely superfluous and
takes about a minute to run.

Test Plan:
Ensure that Travis is still happy.

wchargin-branch: ci-travis-no-yarn
