### PR TITLE
Always pass experiment IDs to scalars_impl

### DIFF
--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -178,7 +178,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
 
     def testDownloadData(self):
         body, mime_type = self.plugin.download_data_impl(
-            "foo", "squares/scalar_summary", "json"
+            "foo", "squares/scalar_summary", "exp_id", "json"
         )
         self.assertEqual("application/json", mime_type)
         self.assertEqual(4, len(body))
@@ -189,7 +189,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
             np.testing.assert_allclose(step * step, entry[2])
 
     def testScalars(self):
-        body = self.plugin.scalars_impl("bar", "increments")
+        body = self.plugin.scalars_impl("bar", "increments", "exp_id")
         self.assertTrue(body["regex_valid"])
         self.assertItemsEqual(
             ["increments/scalar_summary"], list(body["tag_to_events"].keys())

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -28,6 +28,7 @@ import json
 import werkzeug
 from werkzeug import wrappers
 
+from tensorboard import plugin_util
 from tensorboard.plugins.hparams import api_pb2
 from tensorboard.plugins.hparams import backend_context
 from tensorboard.plugins.hparams import download_data
@@ -164,6 +165,7 @@ class HParamsPlugin(base_plugin.TBPlugin):
     # ---- /metric_evals ---------------------------------------------------------
     @wrappers.Request.application
     def list_metric_evals_route(self, request):
+        experiment = plugin_util.experiment_id(request.environ)
         try:
             request_proto = _parse_request_argument(
                 request, api_pb2.ListMetricEvalsRequest
@@ -180,7 +182,7 @@ class HParamsPlugin(base_plugin.TBPlugin):
                 json.dumps(
                     list_metric_evals.Handler(
                         request_proto, scalars_plugin
-                    ).run()
+                    ).run(experiment)
                 ),
                 "application/json",
             )

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -181,8 +181,8 @@ class HParamsPlugin(base_plugin.TBPlugin):
                 request,
                 json.dumps(
                     list_metric_evals.Handler(
-                        request_proto, scalars_plugin
-                    ).run(experiment)
+                        request_proto, scalars_plugin, experiment
+                    ).run()
                 ),
                 "application/json",
             )

--- a/tensorboard/plugins/hparams/list_metric_evals.py
+++ b/tensorboard/plugins/hparams/list_metric_evals.py
@@ -35,17 +35,20 @@ class Handler(object):
         self._request = request
         self._scalars_plugin_instance = scalars_plugin_instance
 
-    def run(self):
+    def run(self, experiment):
         """Executes the request.
 
+        Args:
+            A experiment ID, as a possibly-empty `str`.
+
         Returns:
-           An array of tuples representing the metric evaluations--each of the form
-           (<wall time in secs>, <training step>, <metric value>).
+            An array of tuples representing the metric evaluations--each of the
+            form (<wall time in secs>, <training step>, <metric value>).
         """
         run, tag = metrics.run_tag_from_session_and_metric(
             self._request.session_name, self._request.metric_name
         )
         body, _ = self._scalars_plugin_instance.scalars_impl(
-            tag, run, None, scalars_plugin.OutputFormat.JSON
+            tag, run, experiment, scalars_plugin.OutputFormat.JSON
         )
         return body

--- a/tensorboard/plugins/hparams/list_metric_evals.py
+++ b/tensorboard/plugins/hparams/list_metric_evals.py
@@ -25,21 +25,20 @@ from tensorboard.plugins.scalar import scalars_plugin
 class Handler(object):
     """Handles a ListMetricEvals request."""
 
-    def __init__(self, request, scalars_plugin_instance):
+    def __init__(self, request, scalars_plugin_instance, experiment):
         """Constructor.
 
         Args:
-          request: A ListSessionGroupsRequest protobuf.
-          scalars_plugin_instance: A scalars_plugin.ScalarsPlugin.
+            request: A ListSessionGroupsRequest protobuf.
+            scalars_plugin_instance: A scalars_plugin.ScalarsPlugin.
+            experiment: A experiment ID, as a possibly-empty `str`.
         """
         self._request = request
         self._scalars_plugin_instance = scalars_plugin_instance
+        self._experiment = experiment
 
-    def run(self, experiment):
+    def run(self):
         """Executes the request.
-
-        Args:
-            A experiment ID, as a possibly-empty `str`.
 
         Returns:
             An array of tuples representing the metric evaluations--each of the
@@ -49,6 +48,6 @@ class Handler(object):
             self._request.session_name, self._request.metric_name
         )
         body, _ = self._scalars_plugin_instance.scalars_impl(
-            tag, run, experiment, scalars_plugin.OutputFormat.JSON
+            tag, run, self._experiment, scalars_plugin.OutputFormat.JSON
         )
         return body

--- a/tensorboard/plugins/hparams/list_metric_evals_test.py
+++ b/tensorboard/plugins/hparams/list_metric_evals_test.py
@@ -51,9 +51,9 @@ class ListMetricEvalsTest(tf.test.TestCase):
         request_proto = api_pb2.ListMetricEvalsRequest()
         text_format.Merge(request, request_proto)
         handler = list_metric_evals.Handler(
-            request_proto, self._mock_scalars_plugin
+            request_proto, self._mock_scalars_plugin, "exp_id"
         )
-        return handler.run("exp_id")
+        return handler.run()
 
     def test_run(self):
         result = self._run_handler(

--- a/tensorboard/plugins/hparams/list_metric_evals_test.py
+++ b/tensorboard/plugins/hparams/list_metric_evals_test.py
@@ -53,7 +53,7 @@ class ListMetricEvalsTest(tf.test.TestCase):
         handler = list_metric_evals.Handler(
             request_proto, self._mock_scalars_plugin
         )
-        return handler.run()
+        return handler.run("exp_id")
 
     def test_run(self):
         result = self._run_handler(


### PR DESCRIPTION
Hparams and Custom Scalars use the Scalars plugin's implementation to
generate data on the frontend.  When --generic_data was enabled by
default, the DataProvider started validating experiment IDs, so
callers of scalars_impl who passed experiment `None` would break.

This fixes https://github.com/tensorflow/tensorboard/issues/3279
by making Hparams, Custom Scalars pass the correct experiment ID.