### PR TITLE
Turn off JSCompiler for ng_tensorboard

### DIFF
--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -66,7 +66,7 @@ tf_web_library(
 # incrementally.
 tensorboard_html_binary(
     name = "ng_polymer_lib_binary",
-    compile = True,
+    compile = False,
     input_path = "/ng_polymer_lib.html",
     output_path = "/ng_polymer_lib_binary.html",
     deps = [":ng_polymer_lib"],


### PR DESCRIPTION
Context:
- JSCompiler adds overhead to our builds.
- ng_tensorboard makes another Vulcanization bundle than regular
  TensorBoard.
- in CI, we build both Vulcanized bundles because we do `bazel build
  tensorboard/...`.

This change turns off Vulcanization for currently develop only
ng_tensorboard. This change does not impact our Pip package but only CI
and local development.
