### PR TITLE
Let ExperimentIdMiddleware to be nested

### DIFF
--- a/tensorboard/backend/experiment_id.py
+++ b/tensorboard/backend/experiment_id.py
@@ -36,7 +36,8 @@ class ExperimentIdMiddleware(object):
     its first two path components stripped, and its experiment ID stored
     onto the WSGI environment with key taken from the `WSGI_ENVIRON_KEY`
     constant. All other requests will have paths unchanged and the
-    experiment ID set to the empty string.
+    experiment ID set to the empty string. It noops if the key taken from
+    the `WSGI_ENVIRON_KEY` is already present in the environment.
 
     Instances of this class are WSGI applications (see PEP 3333).
     """

--- a/tensorboard/backend/experiment_id.py
+++ b/tensorboard/backend/experiment_id.py
@@ -55,6 +55,10 @@ class ExperimentIdMiddleware(object):
         )
 
     def __call__(self, environ, start_response):
+        # Skip ExperimentIdMiddleware was already called.
+        if WSGI_ENVIRON_KEY in environ:
+            return self._application(environ, start_response)
+
         path = environ.get("PATH_INFO", "")
         m = self._pat.match(path)
         if m:


### PR DESCRIPTION
ExperimentIdMiddleware was not able to compose with itself because it
was always setting the WSGI environment variable with a value it
extracted from current path.

### True Motivation for change

I want to be able to do one of two things:
1. Remove experiment_id_middleware in OSS and introduce in application that actually makes use of it. If we were to remove it from application.py, it would break the sync so we have to make a concerted change. We cannot add the experiment_id_middleware in aforementioned app since there cannot be two instances of experiment_id_middleware wrapping one another.
2. (much less important) This change allows there to be alternative implementation of experiment_id_middleware as long as it populates the same WSGI environment key. It is less ideal but also allows us to hack around :\ 