### PR TITLE
data: require kwargs for time series initializers

### DIFF
--- a/tensorboard/data/BUILD
+++ b/tensorboard/data/BUILD
@@ -10,7 +10,7 @@ exports_files(["LICENSE"])
 py_library(
     name = "provider",
     srcs = ["provider.py"],
-    srcs_version = "PY2AND3",
+    srcs_version = "PY3",
     deps = [
         "//tensorboard:expect_numpy_installed",
         "@org_pythonhosted_six",

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -421,7 +421,13 @@ class _TimeSeries(object):
     )
 
     def __init__(
-        self, max_step, max_wall_time, plugin_content, description, display_name
+        self,
+        *,
+        max_step,
+        max_wall_time,
+        plugin_content,
+        description,
+        display_name,
     ):
         self._max_step = max_step
         self._max_wall_time = max_wall_time
@@ -692,6 +698,7 @@ class BlobSequenceTimeSeries(_TimeSeries):
 
     def __init__(
         self,
+        *,
         max_step,
         max_wall_time,
         max_length,
@@ -700,7 +707,11 @@ class BlobSequenceTimeSeries(_TimeSeries):
         display_name,
     ):
         super(BlobSequenceTimeSeries, self).__init__(
-            max_step, max_wall_time, plugin_content, description, display_name
+            max_step=max_step,
+            max_wall_time=max_wall_time,
+            plugin_content=plugin_content,
+            description=description,
+            display_name=display_name,
         )
         self._max_length = max_length
 

--- a/tensorboard/data/provider_test.py
+++ b/tensorboard/data/provider_test.py
@@ -61,6 +61,18 @@ class RunTest(tb_test.TestCase):
 
 
 class ScalarTimeSeriesTest(tb_test.TestCase):
+    def _scalar_time_series(
+        self, max_step, max_wall_time, plugin_content, description, display_name
+    ):
+        # Helper to use explicit kwargs.
+        return provider.ScalarTimeSeries(
+            max_step=max_step,
+            max_wall_time=max_wall_time,
+            plugin_content=plugin_content,
+            description=description,
+            display_name=display_name,
+        )
+
     def test_repr(self):
         x = provider.ScalarTimeSeries(
             max_step=77,
@@ -77,17 +89,17 @@ class ScalarTimeSeriesTest(tb_test.TestCase):
         self.assertIn(repr(x.display_name), repr_)
 
     def test_eq(self):
-        x1 = provider.ScalarTimeSeries(77, 1234.5, b"\x12", "one", "two")
-        x2 = provider.ScalarTimeSeries(77, 1234.5, b"\x12", "one", "two")
-        x3 = provider.ScalarTimeSeries(66, 4321.0, b"\x7F", "hmm", "hum")
+        x1 = self._scalar_time_series(77, 1234.5, b"\x12", "one", "two")
+        x2 = self._scalar_time_series(77, 1234.5, b"\x12", "one", "two")
+        x3 = self._scalar_time_series(66, 4321.0, b"\x7F", "hmm", "hum")
         self.assertEqual(x1, x2)
         self.assertNotEqual(x1, x3)
         self.assertNotEqual(x1, object())
 
     def test_hash(self):
-        x1 = provider.ScalarTimeSeries(77, 1234.5, b"\x12", "one", "two")
-        x2 = provider.ScalarTimeSeries(77, 1234.5, b"\x12", "one", "two")
-        x3 = provider.ScalarTimeSeries(66, 4321.0, b"\x7F", "hmm", "hum")
+        x1 = self._scalar_time_series(77, 1234.5, b"\x12", "one", "two")
+        x2 = self._scalar_time_series(77, 1234.5, b"\x12", "one", "two")
+        x3 = self._scalar_time_series(66, 4321.0, b"\x7F", "hmm", "hum")
         self.assertEqual(hash(x1), hash(x2))
         # The next check is technically not required by the `__hash__`
         # contract, but _should_ pass; failure on this assertion would at
@@ -123,6 +135,18 @@ class ScalarDatumTest(tb_test.TestCase):
 
 
 class TensorTimeSeriesTest(tb_test.TestCase):
+    def _tensor_time_series(
+        self, max_step, max_wall_time, plugin_content, description, display_name
+    ):
+        # Helper to use explicit kwargs.
+        return provider.TensorTimeSeries(
+            max_step=max_step,
+            max_wall_time=max_wall_time,
+            plugin_content=plugin_content,
+            description=description,
+            display_name=display_name,
+        )
+
     def test_repr(self):
         x = provider.TensorTimeSeries(
             max_step=77,
@@ -139,17 +163,17 @@ class TensorTimeSeriesTest(tb_test.TestCase):
         self.assertIn(repr(x.display_name), repr_)
 
     def test_eq(self):
-        x1 = provider.TensorTimeSeries(77, 1234.5, b"\x12", "one", "two")
-        x2 = provider.TensorTimeSeries(77, 1234.5, b"\x12", "one", "two")
-        x3 = provider.TensorTimeSeries(66, 4321.0, b"\x7F", "hmm", "hum")
+        x1 = self._tensor_time_series(77, 1234.5, b"\x12", "one", "two")
+        x2 = self._tensor_time_series(77, 1234.5, b"\x12", "one", "two")
+        x3 = self._tensor_time_series(66, 4321.0, b"\x7F", "hmm", "hum")
         self.assertEqual(x1, x2)
         self.assertNotEqual(x1, x3)
         self.assertNotEqual(x1, object())
 
     def test_hash(self):
-        x1 = provider.TensorTimeSeries(77, 1234.5, b"\x12", "one", "two")
-        x2 = provider.TensorTimeSeries(77, 1234.5, b"\x12", "one", "two")
-        x3 = provider.TensorTimeSeries(66, 4321.0, b"\x7F", "hmm", "hum")
+        x1 = self._tensor_time_series(77, 1234.5, b"\x12", "one", "two")
+        x2 = self._tensor_time_series(77, 1234.5, b"\x12", "one", "two")
+        x3 = self._tensor_time_series(66, 4321.0, b"\x7F", "hmm", "hum")
         self.assertEqual(hash(x1), hash(x2))
         # The next check is technically not required by the `__hash__`
         # contract, but _should_ pass; failure on this assertion would at
@@ -201,6 +225,25 @@ class TensorDatumTest(tb_test.TestCase):
 
 
 class BlobSequenceTimeSeriesTest(tb_test.TestCase):
+    def _blob_sequence_time_series(
+        self,
+        max_step,
+        max_wall_time,
+        max_length,
+        plugin_content,
+        description,
+        display_name,
+    ):
+        # Helper to use explicit kwargs.
+        return provider.BlobSequenceTimeSeries(
+            max_step=max_step,
+            max_wall_time=max_wall_time,
+            max_length=max_length,
+            plugin_content=plugin_content,
+            description=description,
+            display_name=display_name,
+        )
+
     def test_repr(self):
         x = provider.BlobSequenceTimeSeries(
             max_step=77,
@@ -219,13 +262,13 @@ class BlobSequenceTimeSeriesTest(tb_test.TestCase):
         self.assertIn(repr(x.display_name), repr_)
 
     def test_eq(self):
-        x1 = provider.BlobSequenceTimeSeries(
+        x1 = self._blob_sequence_time_series(
             77, 1234.5, 6, b"\x12", "one", "two"
         )
-        x2 = provider.BlobSequenceTimeSeries(
+        x2 = self._blob_sequence_time_series(
             77, 1234.5, 6, b"\x12", "one", "two"
         )
-        x3 = provider.BlobSequenceTimeSeries(
+        x3 = self._blob_sequence_time_series(
             66, 4321.0, 7, b"\x7F", "hmm", "hum"
         )
         self.assertEqual(x1, x2)
@@ -233,13 +276,13 @@ class BlobSequenceTimeSeriesTest(tb_test.TestCase):
         self.assertNotEqual(x1, object())
 
     def test_hash(self):
-        x1 = provider.BlobSequenceTimeSeries(
+        x1 = self._blob_sequence_time_series(
             77, 1234.5, 6, b"\x12", "one", "two"
         )
-        x2 = provider.BlobSequenceTimeSeries(
+        x2 = self._blob_sequence_time_series(
             77, 1234.5, 6, b"\x12", "one", "two"
         )
-        x3 = provider.BlobSequenceTimeSeries(
+        x3 = self._blob_sequence_time_series(
             66, 4321.0, 7, b"\x7F", "hmm", "hum"
         )
         self.assertEqual(hash(x1), hash(x2))


### PR DESCRIPTION
Summary:
This enables us to more easily add and change fields on these objects
without worrying about positional parameters. (Such changes are still
breaking, but these APIs have no stability guarantee.)

Test Plan:
All open-source consumers are already compliant except for tests, which
are updated in this commit. Google-internal clients have already been
updated; a test sync shows that all tests pass.

wchargin-branch: time-series-kwargs
