### PR TITLE
[DebuggerV2] Add support for alert-type filtering to /alerts route

### DIFF
--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -242,13 +242,9 @@ class DebuggerV2EventMultiplexer(object):
                     "Filtering of alerts failed: alert type %s does not exist"
                     % alert_type_filter
                 )
-            end = self._checkBeginEndIndices(
-                begin, end, alerts_breakdown[alert_type_filter]
-            )
-            alert_list = alerts_by_type[alert_type_filter][begin:end]
-        else:
-            end = self._checkBeginEndIndices(begin, end, len(alerts))
-            alert_list = alerts[begin:end]
+            alerts = alerts_by_type[alert_type_filter]
+        end = self._checkBeginEndIndices(begin, end, alerts)
+        alerts = alerts[begin:end]
         return {
             "begin": begin,
             "end": end,
@@ -256,7 +252,7 @@ class DebuggerV2EventMultiplexer(object):
             "num_alerts": len(alerts),
             "alerts_breakdown": alerts_breakdown,
             "per_type_alert_limit": DEFAULT_PER_TYPE_ALERT_LIMIT,
-            "alerts": [_alert_to_json(alert) for alert in alert_list],
+            "alerts": [_alert_to_json(alert) for alert in alerts],
         }
 
     def ExecutionDigests(self, run, begin, end):

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -235,7 +235,7 @@ class DebuggerV2EventMultiplexer(object):
                 alert_type = "__MiscellaneousAlert__"
             alerts_breakdown[alert_type] = len(monitor_alerts)
             alerts_by_type[alert_type] = monitor_alerts
-
+        num_alerts = len(alerts)
         if alert_type_filter is not None:
             if alert_type_filter not in alerts_breakdown:
                 raise errors.InvalidArgumentError(
@@ -243,16 +243,15 @@ class DebuggerV2EventMultiplexer(object):
                     % alert_type_filter
                 )
             alerts = alerts_by_type[alert_type_filter]
-        end = self._checkBeginEndIndices(begin, end, alerts)
-        alerts = alerts[begin:end]
+        end = self._checkBeginEndIndices(begin, end, len(alerts))
         return {
             "begin": begin,
             "end": end,
             "alert_type": alert_type_filter,
-            "num_alerts": len(alerts),
+            "num_alerts": num_alerts,
             "alerts_breakdown": alerts_breakdown,
             "per_type_alert_limit": DEFAULT_PER_TYPE_ALERT_LIMIT,
-            "alerts": [_alert_to_json(alert) for alert in alerts],
+            "alerts": [_alert_to_json(alert) for alert in alerts[begin:end]],
         }
 
     def ExecutionDigests(self, run, begin, end):

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -202,13 +202,17 @@ class DebuggerV2EventMultiplexer(object):
             end = total_count
         return end
 
-    def Alerts(self, run, begin, end):
+    def Alerts(self, run, begin, end, alert_type_filter=None):
         """Get alerts from the debugged TensorFlow program.
 
         Args:
           run: The tfdbg2 run to get Alerts from.
           begin: Beginning alert index.
           end: Ending alert index.
+          alert_type_filter: Optional filter string for alert type, used to
+            restrict retrieved alerts data to a single type. If used,
+            `begin` and `end` refer to the beginning and ending indices within
+            the filtered alert type.
         """
         from tensorflow.python.debug.lib import debug_events_monitors
 
@@ -217,6 +221,7 @@ class DebuggerV2EventMultiplexer(object):
             return None
         alerts = []
         alerts_breakdown = dict()
+        alerts_by_type = dict()
         for monitor in self._monitors:
             monitor_alerts = monitor.alerts()
             if not monitor_alerts:
@@ -229,15 +234,29 @@ class DebuggerV2EventMultiplexer(object):
             else:
                 alert_type = "__MiscellaneousAlert__"
             alerts_breakdown[alert_type] = len(monitor_alerts)
-        end = self._checkBeginEndIndices(begin, end, len(alerts))
-        # TODO(cais): Add support for filtering by alert type.
+            alerts_by_type[alert_type] = monitor_alerts
+
+        if alert_type_filter is not None:
+            if alert_type_filter not in alerts_breakdown:
+                raise errors.InvalidArgumentError(
+                    "Filtering of alerts failed: alert type %s does not exist"
+                    % alert_type_filter
+                )
+            end = self._checkBeginEndIndices(
+                begin, end, alerts_breakdown[alert_type_filter]
+            )
+            alert_list = alerts_by_type[alert_type_filter][begin:end]
+        else:
+            end = self._checkBeginEndIndices(begin, end, len(alerts))
+            alert_list = alerts[begin:end]
         return {
             "begin": begin,
             "end": end,
+            "alert_type": alert_type_filter,
             "num_alerts": len(alerts),
             "alerts_breakdown": alerts_breakdown,
             "per_type_alert_limit": DEFAULT_PER_TYPE_ALERT_LIMIT,
-            "alerts": [_alert_to_json(alert) for alert in alerts[begin:end]],
+            "alerts": [_alert_to_json(alert) for alert in alert_list],
         }
 
     def ExecutionDigests(self, run, begin, end):

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -79,7 +79,6 @@ def _parse_alerts_blob_key(blob_key):
       - alert_type: alert type string used to filter retrieved alert data.
           `None` if no filtering is used.
     """
-    # TODO(cais): Add filter for alert type.
     key_body, run = blob_key.split(".", 1)
     key_body = key_body[len(ALERTS_BLOB_TAG_PREFIX) :]
     key_items = key_body.split("_")

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -69,8 +69,8 @@ def _parse_alerts_blob_key(blob_key):
       blob_key: The BLOB key to parse. By contract, it should have the format:
        - `${ALERTS_BLOB_TAG_PREFIX}_${begin}_${end}.${run_id}` when there is no
          alert type filter.
-      - `${ALERTS_BLOB_TAG_PREFIX}_${begin}_${end}_${alert_filter}.${run_id}`
-        when there is an alert type filter.
+       - `${ALERTS_BLOB_TAG_PREFIX}_${begin}_${end}_${alert_filter}.${run_id}`
+         when there is an alert type filter.
 
     Returns:
       - run ID

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -81,12 +81,12 @@ def _parse_alerts_blob_key(blob_key):
     """
     key_body, run = blob_key.split(".", 1)
     key_body = key_body[len(ALERTS_BLOB_TAG_PREFIX) :]
-    key_items = key_body.split("_")
+    key_items = key_body.split("_", 3)
     begin = int(key_items[1])
     end = int(key_items[2])
     alert_type = None
     if len(key_items) > 3:
-        alert_type = key_body.split("_", 3)[-1]
+        alert_type = key_items[3]
     return run, begin, end, alert_type
 
 

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -102,8 +102,9 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
             return _missing_run_error_response(request)
         begin = int(request.args.get("begin", "0"))
         end = int(request.args.get("end", "-1"))
+        alert_type = request.args.get("alert_type", None)
         run_tag_filter = debug_data_provider.alerts_run_tag_filter(
-            run, begin, end
+            run, begin, end, alert_type=alert_type
         )
         blob_sequences = self._data_provider.read_blob_sequences(
             experiment, self.plugin_name, run_tag_filter=run_tag_filter


### PR DESCRIPTION
* Motivation for features / changes
  * Forms a basis for the already open https://github.com/tensorflow/tensorboard/pull/3269
  * Allow the DebuggerV2 frontend to query alerts that belong to a specific alert type.

* Technical description of changes
  * Modify the multiplexer, data provider and serving method to support the "alert_type" parameter in requests.
  * Not that there is a slight change to requests to the same route without filters: previously there "alert_type" field was not populated; now it's populated with a `None` (`null`) value.

* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests added.
