### PR TITLE
build: clamp down `//tensorboard:lib` visibility

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -39,7 +39,7 @@ py_library(
     name = "lib",
     srcs = ["__init__.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//visibility:public"],
+    visibility = ["//tensorboard:internal"],
     deps = [
         ":lib_init_only",
         ":notebook",


### PR DESCRIPTION
Summary:
This target is primarily intended to be used by our Pip package; clients
should not depend on this hourglass dependency.

Test Plan:
All Google-internal dependents have been migrated; a test sync passes.

wchargin-branch: build-lib-internal
