### PR TITLE
docs: drop profile plugin offline policy exemption

### DIFF
--- a/ADDING_A_PLUGIN.md
+++ b/ADDING_A_PLUGIN.md
@@ -162,7 +162,7 @@ Consistency in user interface and experience, we believe, is important for happy
 
 [dynamic-plugin-tracking-bug]: https://github.com/tensorflow/tensorboard/issues/2357
 
-We recommend that you vendor all resources required to use your plugin, including scripts, stylesheets, fonts, and images. All built-in TensorBoard plugins follow this policy (except for the profile plugin, which for legacy reasons depends on a CDN).
+We recommend that you vendor all resources required to use your plugin, including scripts, stylesheets, fonts, and images. All built-in TensorBoard plugins follow this policy.
 
 
 ### Summaries: How the plugin gets data

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ working example featuring the scalar dashboard.
 
 TensorBoard is designed to run entirely offline, without requiring any access
 to the Internet. For instance, this may be on your local machine, behind a
-corporate firewall, or in a datacenter. Currently, there is one exception where
-TensorBoard does require Internet access: the optional profile plugin, when
-active, connects to a Google-hosted CDN to load the Google Charts library.
+corporate firewall, or in a datacenter.
 
 [TensorBoard: Getting Started]: https://www.tensorflow.org/tensorboard/get_started
 [TensorBoard.dev]: https://tensorboard.dev


### PR DESCRIPTION
Summary:
The profile plugin is no longer bundled with TensorBoard, so everything
built in to TensorBoard should now be fully functional while offline.

wchargin-branch: docs-fully-offline
