### PR TITLE
projector: factor metadata out from frontend plugin

### DIFF
--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -17,6 +17,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        ":metadata",
         ":protos_all_py_pb2",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard/backend:http_util",
@@ -33,7 +34,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
-        ":projector_plugin",
+        ":metadata",
         ":protos_all_py_pb2",
         "//tensorboard/compat:tensorflow",
     ],
@@ -90,6 +91,12 @@ py_test(
         "//tensorboard/util:test_util",
         "@org_pocoo_werkzeug",
     ],
+)
+
+py_library(
+    name = "metadata",
+    srcs = ["metadata.py"],
+    srcs_version = "PY2AND3",
 )
 
 tb_proto_library(

--- a/tensorboard/plugins/projector/__init__.py
+++ b/tensorboard/plugins/projector/__init__.py
@@ -29,7 +29,7 @@ import os
 
 from google.protobuf import text_format as _text_format
 from tensorboard.compat import tf
-from tensorboard.plugins.projector import projector_plugin as _projector_plugin
+from tensorboard.plugins.projector import metadata as _metadata
 from tensorboard.plugins.projector.projector_config_pb2 import EmbeddingInfo
 from tensorboard.plugins.projector.projector_config_pb2 import SpriteMetadata
 from tensorboard.plugins.projector.projector_config_pb2 import ProjectorConfig
@@ -60,6 +60,6 @@ def visualize_embeddings(logdir, config):
 
     # Saving the config file in the logdir.
     config_pbtxt = _text_format.MessageToString(config)
-    path = os.path.join(logdir, _projector_plugin.PROJECTOR_FILENAME)
+    path = os.path.join(logdir, _metadata.PROJECTOR_FILENAME)
     with tf.io.gfile.GFile(path, "w") as f:
         f.write(config_pbtxt)

--- a/tensorboard/plugins/projector/metadata.py
+++ b/tensorboard/plugins/projector/metadata.py
@@ -1,0 +1,30 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Internal information about the projector plugin."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+PLUGIN_NAME = "projector"
+
+PLUGINS_DIR = "plugins"  # must match plugin_asset_util.PLUGINS_DIR
+PLUGIN_ASSETS_NAME = "org_tensorflow_tensorboard_projector"
+
+# FYI - the PROJECTOR_FILENAME is hardcoded in the visualize_embeddings
+# method in tf.contrib.tensorboard.plugins.projector module.
+# TODO(@decentralion): Fix duplication when we find a permanent home for the
+# projector module.
+PROJECTOR_FILENAME = "projector_config.pbtxt"

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -35,21 +35,11 @@ from google.protobuf import text_format
 from tensorboard.backend.http_util import Respond
 from tensorboard.compat import tf
 from tensorboard.plugins import base_plugin
+from tensorboard.plugins.projector import metadata
 from tensorboard.plugins.projector.projector_config_pb2 import ProjectorConfig
 from tensorboard.util import tb_logging
 
 logger = tb_logging.get_logger()
-
-# The prefix of routes provided by this plugin.
-_PLUGIN_PREFIX_ROUTE = "projector"
-
-# FYI - the PROJECTOR_FILENAME is hardcoded in the visualize_embeddings
-# method in tf.contrib.tensorboard.plugins.projector module.
-# TODO(@decentralion): Fix duplication when we find a permanent home for the
-# projector module.
-PROJECTOR_FILENAME = "projector_config.pbtxt"
-_PLUGIN_NAME = "org_tensorflow_tensorboard_projector"
-_PLUGINS_DIR = "plugins"
 
 # Number of tensors in the LRU cache.
 _TENSOR_CACHE_CAPACITY = 1
@@ -171,7 +161,7 @@ def _read_tensor_tsv_file(fpath):
 
 
 def _assets_dir_to_logdir(assets_dir):
-    sub_path = os.path.sep + _PLUGINS_DIR + os.path.sep
+    sub_path = os.path.sep + metadata.PLUGINS_DIR + os.path.sep
     if sub_path in assets_dir:
         two_parents_up = os.pardir + os.path.sep + os.pardir
         return os.path.abspath(os.path.join(assets_dir, two_parents_up))
@@ -183,7 +173,7 @@ def _latest_checkpoints_changed(configs, run_path_pairs):
     for run_name, assets_dir in run_path_pairs:
         if run_name not in configs:
             config = ProjectorConfig()
-            config_fpath = os.path.join(assets_dir, PROJECTOR_FILENAME)
+            config_fpath = os.path.join(assets_dir, metadata.PROJECTOR_FILENAME)
             if tf.io.gfile.exists(config_fpath):
                 with tf.io.gfile.GFile(config_fpath, "r") as f:
                     file_content = f.read()
@@ -238,7 +228,7 @@ def _using_tf():
 class ProjectorPlugin(base_plugin.TBPlugin):
     """Embedding projector."""
 
-    plugin_name = _PLUGIN_PREFIX_ROUTE
+    plugin_name = metadata.PLUGIN_NAME
 
     def __init__(self, context):
         """Instantiates ProjectorPlugin via TensorBoard core.
@@ -427,7 +417,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
         config_fpaths = {}
         for run_name, assets_dir in run_path_pairs:
             config = ProjectorConfig()
-            config_fpath = os.path.join(assets_dir, PROJECTOR_FILENAME)
+            config_fpath = os.path.join(assets_dir, metadata.PROJECTOR_FILENAME)
             if tf.io.gfile.exists(config_fpath):
                 with tf.io.gfile.GFile(config_fpath, "r") as f:
                     file_content = f.read()
@@ -509,11 +499,15 @@ class ProjectorPlugin(base_plugin.TBPlugin):
         return None
 
     def _append_plugin_asset_directories(self, run_path_pairs):
-        for run, assets in self.multiplexer.PluginAssets(_PLUGIN_NAME).items():
-            if PROJECTOR_FILENAME not in assets:
+        for run, assets in self.multiplexer.PluginAssets(
+            metadata.PLUGIN_ASSETS_NAME
+        ).items():
+            if metadata.PROJECTOR_FILENAME not in assets:
                 continue
             assets_dir = os.path.join(
-                self.run_paths[run], _PLUGINS_DIR, _PLUGIN_NAME
+                self.run_paths[run],
+                metadata.PLUGINS_DIR,
+                metadata.PLUGIN_ASSETS_NAME,
             )
             assets_path_pair = (run, os.path.abspath(assets_dir))
             run_path_pairs.append(assets_path_pair)


### PR DESCRIPTION
Summary:
This refactoring enables the public API `:projector` to not depend on
the frontend code. While factoring out these constant, we rename a
couple of them to match conventions in TensorBoard: e.g., `PLUGIN_NAME`
is typically used to represent the plugin name.

This is a helpful step in migrating `base_plugin.py` to use PY3-only
syntax (namely, hard-requiring kwargs to `TBContext`’s initializer).

Test Plan:
After syncing into Google, there are no longer any valid PY2 binaries
that transitively depend on `//tensorboard/plugins:base_plugin`.

wchargin-branch: projector-metadata
