### PR TITLE
data: document that `TensorTimeSeries` extends `_TimeSeries`

### DIFF
--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -409,7 +409,8 @@ class Run(object):
 class _TimeSeries(object):
     """Metadata about time series data for a particular run and tag.
 
-    Superclass of `ScalarTimeSeries` and `BlobSequenceTimeSeries`.
+    Superclass of `ScalarTimeSeries`, `TensorTimeSeries`, and
+    `BlobSequenceTimeSeries`.
     """
 
     __slots__ = (


### PR DESCRIPTION
Summary:
Slight docs omission pointed out by @caisq in #3284.

wchargin-branch: data-timeseries-super-docs
