### PR TITLE
Fix vz_projector tests

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/test/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/test/BUILD
@@ -10,8 +10,6 @@ licenses(["notice"])  # Apache 2.0
 tf_web_test(
     name = "test",
     src = "/vz-projector/test/tests.html",
-    # TODO(@wchargin): This test does not work in headless mode.
-    tags = ["manual"],
     web_library = ":test_web_library",
 )
 

--- a/tensorboard/plugins/projector/vz_projector/test/tests.html
+++ b/tensorboard/plugins/projector/vz_projector/test/tests.html
@@ -19,6 +19,7 @@ limitations under the License.
 <meta charset="utf-8" />
 <script src="../../web-component-tester/browser.js"></script>
 <link rel="import" href="../../tf-imports/polymer.html" />
+<link rel="import" href="../bundle.html" />
 <body>
   <script src="assert.js"></script>
   <script src="sptree_test.js"></script>


### PR DESCRIPTION
Cause: it did not import the library under test. As a result, it was
using symbols that were not defined.
