### PR TITLE
graph: fix no data UI

### DIFF
--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.html
@@ -80,7 +80,7 @@ by default. The user can select a different run from a dropdown menu.
     </template>
     <template
       is="dom-if"
-      if="[[!_datasetsState(datasetsFetched, _datasets, 'PRESENT')]]"
+      if="[[_datasetsState(_datasetsFetched, _datasets, 'PRESENT')]]"
     >
       <tf-dashboard-layout>
         <tf-graph-controls


### PR DESCRIPTION
This change fixes the regression that erroneously showed graph canvas
when no data was fetched.

Two issues:
- wrong property binding
- inverted conditional (we only want to show tf-dashboard-layout when dataset is `PRESENT`)

Fixes #3004.