### PR TITLE
uploader: add `PluginControl` handshake protos

### DIFF
--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -20,6 +20,16 @@ message ServerInfoResponse {
   ApiServer api_server = 2;
   // How to generate URLs to experiment pages.
   ExperimentUrlFormat url_format = 3;
+  // For which plugins should we upload data? (Even if the uploader is
+  // structurally capable of uploading data from many plugins, we only actually
+  // upload data that can be currently displayed in TensorBoard.dev. Otherwise,
+  // users may be surprised to see that experiments that they uploaded a while
+  // ago and have since shared or published now have extra information that
+  // they didn't realize had been uploaded.)
+  //
+  // If this field is omitted, the behavior of which data to send is at
+  // the discretion of the client.
+  PluginControl plugin_control = 4;
 }
 
 enum CompatibilityVerdict {
@@ -58,4 +68,10 @@ message ExperimentUrlFormat {
   // Placeholder string that should be replaced with an actual experiment ID.
   // (See docs for `template` field.)
   string id_placeholder = 2;
+}
+
+message PluginControl {
+  // Only send data from plugins with these names. These are plugin names as
+  // stored in the the `SummaryMetadata.plugin_data.plugin_name` proto field.
+  repeated string allowed_plugins = 1;
 }

--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -27,8 +27,8 @@ message ServerInfoResponse {
   // ago and have since shared or published now have extra information that
   // they didn't realize had been uploaded.)
   //
-  // If this field is omitted, the behavior of which data to send is at
-  // the discretion of the client.
+  // If this field is omitted, the behavior of which data to send is at the
+  // discretion of the client.
   PluginControl plugin_control = 4;
 }
 

--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -27,8 +27,12 @@ message ServerInfoResponse {
   // ago and have since shared or published now have extra information that
   // they didn't realize had been uploaded.)
   //
-  // If this field is omitted, the behavior of which data to send is at the
-  // discretion of the client.
+  // The client may always choose to upload less data than is permitted by this
+  // field: e.g., if the end user specifies not to upload data for a given
+  // plugin, or the client does not yet support uploading some kind of data.
+  //
+  // If this field is omitted, there are no upfront restrictions on what the
+  // client may send.
   PluginControl plugin_control = 4;
 }
 


### PR DESCRIPTION
Summary:
This enables us to flag features on the server side, so that we can
stage releases, and so that we can roll back in a pinch without
requiring an expedited PyPI push and end user version upgrade.

Test Plan:
No new behavior in this change. The protos still build.

wchargin-branch: uploader-plugincontrol-protos
