### PR TITLE
uploader: require experiment metadata from server

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -20,6 +20,7 @@ py_library(
         "//tensorboard:expect_grpc_installed",
         "//tensorboard/uploader/proto:protos_all_py_pb2",
         "//tensorboard/util:grpc_util",
+        "//tensorboard/util:tb_logging",
         "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -32,6 +32,7 @@ from tensorboard.uploader.proto import experiment_pb2
 from tensorboard.uploader.proto import export_service_pb2
 from tensorboard.uploader import util
 from tensorboard.util import grpc_util
+from tensorboard.util import tb_logging
 
 # Characters that are assumed to be safe in filenames. Note that the
 # server's experiment IDs are base64 encodings of 16-byte blobs, so they
@@ -46,6 +47,8 @@ _MAX_INT64 = 2 ** 63 - 1
 
 # Output filename for scalar data within an experiment directory.
 _FILENAME_SCALARS = "scalars.json"
+
+logger = tb_logging.get_logger()
 
 
 class TensorBoardExporter(object):
@@ -206,7 +209,7 @@ def list_experiments(api_client, fieldmask=None, read_time=None):
             )
         else:
             # No data: not technically a problem, but not expected.
-            logging.warn(
+            logger.warn(
                 "StreamExperiments RPC returned response with no experiments: <%r>",
                 response,
             )

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -115,7 +115,8 @@ class TensorBoardExporter(object):
         """
         if read_time is None:
             read_time = time.time()
-        for experiment_id in self._request_experiment_ids(read_time):
+        for experiment in list_experiments(self._api, read_time=read_time):
+            experiment_id = experiment.experiment_id
             experiment_dir = _experiment_directory(self._outdir, experiment_id)
             os.mkdir(experiment_dir)
 
@@ -133,18 +134,6 @@ class TensorBoardExporter(object):
                     raise GrpcTimeoutException(experiment_id)
                 else:
                     raise
-
-    def _request_experiment_ids(self, read_time):
-        """Yields all of the calling user's experiment IDs, as strings."""
-        for experiment in list_experiments(self._api, read_time=read_time):
-            if isinstance(experiment, experiment_pb2.Experiment):
-                yield experiment.experiment_id
-            elif isinstance(experiment, six.string_types):
-                yield experiment
-            else:
-                raise AssertionError(
-                    "Unexpected experiment type: %r" % (experiment,)
-                )
 
     def _request_scalar_data(self, experiment_id, read_time):
         """Yields JSON-serializable blocks of scalar data."""
@@ -191,7 +180,11 @@ def list_experiments(api_client, fieldmask=None, read_time=None):
 
     Yields:
       For each experiment owned by the user, an `experiment_pb2.Experiment`
-      value, or a simple string experiment ID for older servers.
+      value.
+
+    Raises:
+      RuntimeError: If the server returns experiment IDs but no experiments,
+        as in an old, unsupported version of the protocol.
     """
     if read_time is None:
         read_time = time.time()
@@ -206,10 +199,17 @@ def list_experiments(api_client, fieldmask=None, read_time=None):
         if response.experiments:
             for experiment in response.experiments:
                 yield experiment
+        elif response.experiment_ids:
+            raise RuntimeError(
+                "Server sent experiment_ids without experiments: <%r>"
+                % (list(response.experiment_ids),)
+            )
         else:
-            # Old servers.
-            for experiment_id in response.experiment_ids:
-                yield experiment_id
+            # No data: not technically a problem, but not expected.
+            logging.warn(
+                "StreamExperiments RPC returned response with no experiments: <%r>",
+                response,
+            )
 
 
 class OutputDirectoryExistsError(ValueError):

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -515,10 +515,6 @@ class _ListIntent(_Intent):
         count = 0
         for experiment in gen:
             count += 1
-            if not isinstance(experiment, experiment_pb2.Experiment):
-                url = server_info_lib.experiment_url(server_info, experiment)
-                print(url)
-                continue
             experiment_id = experiment.experiment_id
             url = server_info_lib.experiment_url(server_info, experiment_id)
             print(url)


### PR DESCRIPTION
Summary:
The `StreamExperiments` RPC response used to send only `experiment_ids`,
but now sends `experiments` with additional metadata. This server-side
change has been live since late November 2019, so we’re confident that
we won’t need to roll it back. Thus, we can drop compatibility for the
old code path in new uploader clients.

Test Plan:
Unit tests updated; verified that the `list` and `export` subcommands
still work.

wchargin-branch: uploader-require-experiment-metadata
