### PR TITLE
uploader: remove inoperative `f`-string

### DIFF
--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -483,7 +483,7 @@ class _UpdateMetadataIntent(_Intent):
         if self.name is not None:
             logging.info("Set name to %r", self.name)
         if self.description is not None:
-            logging.info(f"Set description to %r", repr(self.description))
+            logging.info("Set description to %r", repr(self.description))
 
 
 class _ListIntent(_Intent):


### PR DESCRIPTION
Summary:
This `f`-string has no interpolations, so it *can* be a normal string,
and the Bazel target is marked `srcs_version = "PY2AND3"`, so it *must*
be a normal string.

Test Plan:
This module now parses under Python 2:

```
python2 -c '__import__("ast").parse(__import__("sys").stdin.read())' \
    <tensorboard/uploader/uploader_main.py
```

wchargin-branch: uploader-remove-fstring
