### PR TITLE
Silence deprecation warning spam about tf_record_iterator

### DIFF
--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import contextlib
+
 from tensorboard.compat import tf
 from tensorboard.compat.proto import event_pb2
 from tensorboard.util import platform_util
@@ -25,6 +27,26 @@ from tensorboard.util import tb_logging
 
 
 logger = tb_logging.get_logger()
+
+
+@contextlib.contextmanager
+def _null_context():
+  """Pre-Python-3.7-compatible standin for contextlib.null_context."""
+  yield
+
+
+# Might as well make this a singleton.
+_NULL_CONTEXT = _null_context()
+
+
+def _silence_deprecation_warnings():
+  """Context manager that best-effort silences TF deprecation warnings."""
+  try:
+    # Learn this one weird trick to make TF deprecation warnings go away.
+    from tensorflow.python.util import deprecation
+    return deprecation.silence()
+  except (ImportError, AttributeError):
+    return _NULL_CONTEXT
 
 
 def _make_tf_record_iterator(file_path):
@@ -55,7 +77,9 @@ def _make_tf_record_iterator(file_path):
         return _PyRecordReaderIterator(py_record_reader_new, file_path)
     else:
         logger.debug("Opening a tf_record_iterator pointing at %s", file_path)
-        return tf.compat.v1.io.tf_record_iterator(file_path)
+        # TODO(#1711): Find non-deprecated replacement for tf_record_iterator.
+        with _silence_deprecation_warnings():
+          return tf.compat.v1.io.tf_record_iterator(file_path)
 
 
 class _PyRecordReaderIterator(object):

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -31,8 +31,8 @@ logger = tb_logging.get_logger()
 
 @contextlib.contextmanager
 def _nullcontext():
-  """Pre-Python-3.7-compatible standin for contextlib.nullcontext."""
-  yield
+    """Pre-Python-3.7-compatible standin for contextlib.nullcontext."""
+    yield
 
 
 # Might as well make this a singleton.
@@ -40,13 +40,14 @@ _NULLCONTEXT = _nullcontext()
 
 
 def _silence_deprecation_warnings():
-  """Context manager that best-effort silences TF deprecation warnings."""
-  try:
-    # Learn this one weird trick to make TF deprecation warnings go away.
-    from tensorflow.python.util import deprecation
-    return deprecation.silence()
-  except (ImportError, AttributeError):
-    return _NULLCONTEXT
+    """Context manager that best-effort silences TF deprecation warnings."""
+    try:
+        # Learn this one weird trick to make TF deprecation warnings go away.
+        from tensorflow.python.util import deprecation
+
+        return deprecation.silence()
+    except (ImportError, AttributeError):
+        return _NULLCONTEXT
 
 
 def _make_tf_record_iterator(file_path):
@@ -79,7 +80,7 @@ def _make_tf_record_iterator(file_path):
         logger.debug("Opening a tf_record_iterator pointing at %s", file_path)
         # TODO(#1711): Find non-deprecated replacement for tf_record_iterator.
         with _silence_deprecation_warnings():
-          return tf.compat.v1.io.tf_record_iterator(file_path)
+            return tf.compat.v1.io.tf_record_iterator(file_path)
 
 
 class _PyRecordReaderIterator(object):

--- a/tensorboard/backend/event_processing/event_file_loader.py
+++ b/tensorboard/backend/event_processing/event_file_loader.py
@@ -30,13 +30,13 @@ logger = tb_logging.get_logger()
 
 
 @contextlib.contextmanager
-def _null_context():
-  """Pre-Python-3.7-compatible standin for contextlib.null_context."""
+def _nullcontext():
+  """Pre-Python-3.7-compatible standin for contextlib.nullcontext."""
   yield
 
 
 # Might as well make this a singleton.
-_NULL_CONTEXT = _null_context()
+_NULLCONTEXT = _nullcontext()
 
 
 def _silence_deprecation_warnings():
@@ -46,7 +46,7 @@ def _silence_deprecation_warnings():
     from tensorflow.python.util import deprecation
     return deprecation.silence()
   except (ImportError, AttributeError):
-    return _NULL_CONTEXT
+    return _NULLCONTEXT
 
 
 def _make_tf_record_iterator(file_path):


### PR DESCRIPTION
This puts a nice 🩹 over the deprecation warning spam emitted to the console by our usage of `tf.compat.v1.io.tf_record_iterator` (which we now do for new TF versions, as of https://github.com/tensorflow/tensorboard/pull/3185).

Actually migrating to something not deprecated is still tracked in #1711.

