### PR TITLE
Use cPython 3.5–compatible function definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
   BUILDIFIER_SHA256SUM: '4c985c883eafdde9c0e8cf3c8595b8bfdf32e77571c369bf8ddae83b042028d6'
 
 jobs:
-  lint-flake8:
+  lint-python-flake8:
     runs-on: ubuntu-16.04
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,22 @@ env:
   BUILDIFIER_SHA256SUM: '4c985c883eafdde9c0e8cf3c8595b8bfdf32e77571c369bf8ddae83b042028d6'
 
 jobs:
-  lint-python:
+  lint-flake8:
     runs-on: ubuntu-16.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # flake8 should run on each Python version that we target,
+        # because the errors and warnings can differ due to language
+        # changes, and we want to catch them all.
+        python_version: ['3.5', '3.7']
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: ${{ matrix.python_version }}
           architecture: 'x64'
-      - name: 'Install black and flake8'
+      - name: 'Install flake8'
         run: |
           python -m pip install -U pip
           pip install -r ./tensorboard/pip_package/requirements_dev.txt
@@ -41,6 +48,20 @@ jobs:
         # See: http://flake8.pycqa.org/en/3.7.8/user/error-codes.html
         # Use the comment '# noqa: <error code>' to suppress.
         run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+
+  lint-python:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+          architecture: 'x64'
+      - name: 'Install black'
+        run: |
+          python -m pip install -U pip
+          pip install -r ./tensorboard/pip_package/requirements_dev.txt
+      - run: pip freeze --all
       - name: 'Lint Python code for style with Black'
         # You can run `black .` to fix all Black complaints.
         run: black --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
 [tool.black]
 line-length = 80
-target-version = ["py27", "py36", "py37", "py38"]
+# TODO(@wchargin): Drop `py35` here once we drop support for Python 3.5
+# and aren't affected by <https://bugs.python.org/issue9232>.
+target-version = ["py27", "py35", "py36", "py37", "py38"]

--- a/tensorboard/data/provider.py
+++ b/tensorboard/data/provider.py
@@ -428,7 +428,7 @@ class _TimeSeries(object):
         max_wall_time,
         plugin_content,
         description,
-        display_name,
+        display_name
     ):
         self._max_step = max_step
         self._max_wall_time = max_wall_time
@@ -705,7 +705,7 @@ class BlobSequenceTimeSeries(_TimeSeries):
         max_length,
         plugin_content,
         description,
-        display_name,
+        display_name
     ):
         super(BlobSequenceTimeSeries, self).__init__(
             max_step=max_step,


### PR DESCRIPTION
Summary:
In Python as of PEP 3102, function definitions may include keyword-only
arguments after a splat (`def foo(x, *, y)`). But cPython 3.5 has a
parser bug (<https://bugs.python.org/issue9232>) when trailing commas
are used with this syntax, as in `def foo(x, *, y,)`. This is fixed in
Python 3.6 and up, but not backported to 3.5, so for now we should make
sure to omit these trailing commas.

The change to `pyproject.toml` prevents Black from re-introducing these
trailing commas. We leave `py27` in the `pyproject.toml` to avoid a mass
reformat removing `u`-prefixes from Unicode string literals (which is
fine, but should be a separate change for Bazel `srcs_version`).

We don’t run our full test suite on Python 3.5 yet, due to unrelated
issues (primarily, lack of `assert_not_called` and that `json.loads`
does not accept `bytes`). For now, it suffices to run `flake8` on both
Python 3.5 and Python 3.7, because that at least parses all the code.

Test Plan:
That CI passes suffices.

wchargin-branch: py35-fundefs
