### PR TITLE
uploader: fix invalid argument error handling

### DIFF
--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -472,11 +472,8 @@ class _UpdateMetadataIntent(_Intent):
                 "Cannot modify experiment %s because it is owned by a "
                 "different user." % experiment_id
             )
-        except uploader_lib.InvalidArgumentError as cm:
-            _die(
-                "Server cannot modify experiment as requested.\n"
-                "Server responded: %s" % cm.description()
-            )
+        except uploader_lib.InvalidArgumentError as e:
+            _die("Server cannot modify experiment as requested: %s" % e)
         except grpc.RpcError as e:
             _die("Internal error modifying experiment: %s" % e)
         logging.info("Modified experiment %s.", experiment_id)


### PR DESCRIPTION
Test Plan:
Run `tensorboard dev update-metadata --experiment_id x --name z` (which
raises an `InvalidArgumentError` because `x` is not a valid ID). Before
this patch, this crashes with a stack trace:

```
  File ".../tensorboard/uploader/uploader_main.py", line 478, in execute
    "Server responded: %s" % cm.description()
AttributeError: 'InvalidArgumentError' object has no attribute 'description'
```

Now, it prints a proper error message:

```
Server cannot modify experiment as requested: Invalid experiment ID: 'x'
```

wchargin-branch: uploader-fix-einval
