### PR TITLE
ng: reconfigure MetaReducer to use Injectable

### DIFF
--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {NgModule} from '@angular/core';
-import {StoreModule} from '@ngrx/store';
+import {StoreModule, META_REDUCERS} from '@ngrx/store';
 import {EffectsModule} from '@ngrx/effects';
 
 import {AppContainer} from './app_container';
@@ -24,7 +24,7 @@ import {HashStorageModule} from './core/views/hash_storage_module';
 import {PluginsModule} from './plugins/plugins_module';
 import {SettingsModule} from './settings/settings_module';
 
-import {ROOT_REDUCERS, metaReducers} from './reducer_config';
+import {ROOT_REDUCERS, loggerMetaReducerFactory} from './reducer_config';
 
 import {HeaderModule} from './header/header_module';
 import {ReloaderModule} from './reloader/reloader_module';
@@ -43,7 +43,6 @@ import {MatIconModule} from './mat_icon_module';
     ReloaderModule,
     SettingsModule,
     StoreModule.forRoot(ROOT_REDUCERS, {
-      metaReducers,
       runtimeChecks: {
         strictStateSerializability: true,
         strictActionSerializability: true,
@@ -51,7 +50,13 @@ import {MatIconModule} from './mat_icon_module';
     }),
     EffectsModule.forRoot([]),
   ],
-  providers: [],
+  providers: [
+    {
+      provide: META_REDUCERS,
+      useFactory: loggerMetaReducerFactory,
+      multi: true,
+    },
+  ],
   bootstrap: [AppContainer],
 })
 export class AppModule {}

--- a/tensorboard/webapp/reducer_config.ts
+++ b/tensorboard/webapp/reducer_config.ts
@@ -23,7 +23,7 @@ import {
 export interface State {}
 
 // console.log all actions
-export function logger(reducer: ActionReducer<any>): ActionReducer<any> {
+function logger(reducer: ActionReducer<any>): ActionReducer<any> {
   return (state, action) => {
     const result = reducer(state, action);
     console.groupCollapsed(action.type);
@@ -36,8 +36,13 @@ export function logger(reducer: ActionReducer<any>): ActionReducer<any> {
   };
 }
 
-export const metaReducers: MetaReducer<any>[] =
-  config.env === 'dev' ? [logger] : [];
+export function loggerMetaReducerFactory(): MetaReducer {
+  return config.env !== 'dev'
+    ? (reducer) => (state, action) => {
+        return reducer(state, action);
+      }
+    : logger;
+}
 
 export const ROOT_REDUCERS = new InjectionToken<
   ActionReducerMap<State, Action>


### PR DESCRIPTION
Previously, even in the debug mode, the logger metaReducer had no
effect. When debugging the issue, it was found that the ngfactory which
is part of Angular's DI system prebuilds injectable for the META_REDUCER
and inlines an empty object [1]. Do note that this problem only manifests
when we try to configure metaReducer in a conditional. Also do note that
calling `isDevMode()` method is disallowed in AOT compiler, which is the
default compiler in Angular 9.

Tested the correct behavior under `bazel run -c dbg` vs. `bazel run`.

[1]: To reproduce, please build without this commit and inspect
bazel-bin/tensorboard/webapp/app_module.ngfactory.js. Look for, in very
dense code, USER_PROVIDED_META_REDUCERS and notice that it provides
an empty array.