### PR TITLE
cleanup: mirror bazel_{nodejs,sass} rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,7 +53,10 @@ rules_closure_dependencies(
 http_archive(
     name = "build_bazel_rules_nodejs",
     sha256 = "7c4a690268be97c96f04d505224ec4cb1ae53c2c2b68be495c9bd2634296a5cd",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.34.0/rules_nodejs-0.34.0.tar.gz"],
+    urls = [
+        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_nodejs/releases/download/0.34.0/rules_nodejs-0.34.0.tar.gz",
+        "https://github.com/bazelbuild/rules_nodejs/releases/download/0.34.0/rules_nodejs-0.34.0.tar.gz",
+    ],
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
@@ -82,7 +85,10 @@ http_archive(
     name = "io_bazel_rules_sass",
     sha256 = "2ad5580e1ab6dabc6bea40699a7d78f8cae3f98b48d112812f43a0e2beec3eef",
     strip_prefix = "rules_sass-1.23.1",
-    urls = ["https://github.com/bazelbuild/rules_sass/archive/1.23.1.zip"],
+    urls = [
+        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_sass/archive/1.23.1.zip",
+        "https://github.com/bazelbuild/rules_sass/archive/1.23.1.zip",
+    ],
 )
 
 load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")


### PR DESCRIPTION
TensorBoard uses TensorFlow mirror so we do not hit github.com when building
TensorBoard. 

This change adds missing TensorFlow mirror before github.com so our build is
more reliable (it falls back to github.com if the mirror is down). 