### PR TITLE
ng: implement reload button and info icon

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -144,6 +144,8 @@ tf_svg_bundle(
         # When modifying below, please make sure to update
         # //tensorboard/webapp/testing/mat_icon.module.ts.
         "@com_google_material_design_icon//:settings_24px.svg",
+        "@com_google_material_design_icon//:help_outline_24px.svg",
+        "@com_google_material_design_icon//:refresh_24px.svg",
     ],
     out = "icon_bundle.svg",
 )

--- a/tensorboard/webapp/core/actions/core_actions.ts
+++ b/tensorboard/webapp/core/actions/core_actions.ts
@@ -38,7 +38,9 @@ export const pluginUrlHashChanged = createAction(
 
 export const coreLoaded = createAction('[Core] Loaded');
 
-export const reload = createAction('[Core] Reload');
+export const manualReload = createAction('[Core] User Triggered Reload');
+
+export const reload = createAction('[Core] Auto Reload');
 
 export const pluginsListingRequested = createAction(
   '[Core] PluginListing Fetch Requested'

--- a/tensorboard/webapp/core/effects/core_effects.ts
+++ b/tensorboard/webapp/core/effects/core_effects.ts
@@ -26,6 +26,7 @@ import {
 } from 'rxjs/operators';
 import {
   coreLoaded,
+  manualReload,
   reload,
   pluginsListingRequested,
   pluginsListingLoaded,
@@ -49,7 +50,7 @@ export class CoreEffects {
   /** @export */
   readonly loadPluginsListing$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(coreLoaded, reload),
+      ofType(coreLoaded, reload, manualReload),
       withLatestFrom(this.store.select(getPluginsListLoaded)),
       filter(([, {state}]) => state !== DataLoadState.LOADING),
       tap(() => this.store.dispatch(pluginsListingRequested())),

--- a/tensorboard/webapp/core/effects/core_effects_test.ts
+++ b/tensorboard/webapp/core/effects/core_effects_test.ts
@@ -83,6 +83,7 @@ describe('core_effects', () => {
   [
     {specSetName: '#coreLoaded', onAction: coreActions.coreLoaded()},
     {specSetName: '#reload', onAction: coreActions.reload()},
+    {specSetName: '#manualReload', onAction: coreActions.manualReload()},
   ].forEach(({specSetName, onAction}) => {
     describe(specSetName, () => {
       let recordedActions: Action[] = [];

--- a/tensorboard/webapp/header/BUILD
+++ b/tensorboard/webapp/header/BUILD
@@ -17,6 +17,7 @@ ng_module(
         "header_module.ts",
         "plugin_selector_component.ts",
         "plugin_selector_container.ts",
+        "reload_container.ts",
         "types.ts",
     ],
     assets = [
@@ -24,6 +25,8 @@ ng_module(
         "plugin_selector_component.ng.html",
     ],
     deps = [
+        "//tensorboard/webapp/angular:expect_angular_material_button",
+        "//tensorboard/webapp/angular:expect_angular_material_icon",
         "//tensorboard/webapp/angular:expect_angular_material_select",
         "//tensorboard/webapp/angular:expect_angular_material_tabs",
         "//tensorboard/webapp/angular:expect_angular_material_toolbar",
@@ -49,6 +52,7 @@ tf_ts_library(
     deps = [
         ":header",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_select",
         "//tensorboard/webapp/angular:expect_angular_material_tabs",
         "//tensorboard/webapp/angular:expect_angular_material_toolbar",
@@ -58,6 +62,7 @@ tf_ts_library(
         "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/core/testing",
         "//tensorboard/webapp/settings",
+        "//tensorboard/webapp/testing:mat_icon",
         "//tensorboard/webapp/types",
         "@npm//@angular/common",
         "@npm//@angular/compiler",

--- a/tensorboard/webapp/header/header_component.ts
+++ b/tensorboard/webapp/header/header_component.ts
@@ -20,9 +20,18 @@ import {Component} from '@angular/core';
     <mat-toolbar color="primary">
       <span class="brand">TensorBoard</span>
       <plugin-selector class="plugins"></plugin-selector>
-      <span class="settings">
-        <settings-button></settings-button>
-      </span>
+      <app-header-reload></app-header-reload>
+      <settings-button></settings-button>
+      <a
+        class="readme"
+        mat-icon-button
+        href="https://github.com/tensorflow/tensorboard/blob/master/README.md"
+        rel="noopener noreferrer"
+        target="_blank"
+        aria-label="Help"
+      >
+        <mat-icon svgIcon="help_outline_24px"></mat-icon>
+      </a>
     </mat-toolbar>
   `,
   styles: [
@@ -36,7 +45,9 @@ import {Component} from '@angular/core';
       }
 
       .brand,
-      .settings {
+      .readme,
+      app-header-reload,
+      settings-button {
         flex: 0 0 auto;
       }
 

--- a/tensorboard/webapp/header/header_module.ts
+++ b/tensorboard/webapp/header/header_module.ts
@@ -16,9 +16,11 @@ import {NgModule} from '@angular/core';
 // Uses `async` pipe.
 import {CommonModule} from '@angular/common';
 
+import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
+import {MatSelectModule} from '@angular/material/select';
 import {MatTabsModule} from '@angular/material/tabs';
 import {MatToolbarModule} from '@angular/material/toolbar';
-import {MatSelectModule} from '@angular/material/select';
 
 import {CoreModule} from '../core/core_module';
 import {SettingsModule} from '../settings/settings_module';
@@ -26,18 +28,22 @@ import {SettingsModule} from '../settings/settings_module';
 import {HeaderComponent} from './header_component';
 import {PluginSelectorComponent} from './plugin_selector_component';
 import {PluginSelectorContainer} from './plugin_selector_container';
+import {ReloadContainer} from './reload_container';
 
 @NgModule({
   declarations: [
     HeaderComponent,
     PluginSelectorComponent,
     PluginSelectorContainer,
+    ReloadContainer,
   ],
   exports: [HeaderComponent, PluginSelectorContainer],
   providers: [],
   imports: [
-    MatToolbarModule,
+    MatButtonModule,
+    MatIconModule,
     MatTabsModule,
+    MatToolbarModule,
     MatSelectModule,
     CommonModule,
     CoreModule,

--- a/tensorboard/webapp/header/reload_container.ts
+++ b/tensorboard/webapp/header/reload_container.ts
@@ -1,0 +1,95 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Component} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
+
+import {State} from '../core/store/core_types';
+import {getPluginsListLoaded} from '../core/store/core_selectors';
+import {manualReload} from '../core/actions';
+import {DataLoadState} from '../types/data';
+
+@Component({
+  selector: 'app-header-reload',
+  template: `
+    <button
+      class="reload-button"
+      [class.loading]="isReloading$ | async"
+      mat-icon-button
+      (click)="triggerReload()"
+      [title]="getReloadTitle(lastLoadedTimeInMs$ | async | date: 'medium')"
+    >
+      <mat-icon class="refresh-icon" svgIcon="refresh_24px"></mat-icon>
+    </button>
+  `,
+  styles: [
+    `
+      .reload-button,
+      .refresh-icon {
+        align-items: center;
+        display: flex;
+        justify-content: center;
+      }
+
+      .reload-button.loading {
+        animation: rotate 2s linear infinite;
+      }
+
+      @keyframes rotate {
+        0% {
+          transform: rotate(0deg);
+        }
+        50% {
+          transform: rotate(180deg);
+        }
+        100% {
+          transform: rotate(360deg);
+        }
+      }
+    `,
+  ],
+})
+export class ReloadContainer {
+  isReloading$: Observable<boolean> = this.store
+    .select(getPluginsListLoaded)
+    .pipe(
+      map((loaded) => {
+        return loaded.state === DataLoadState.LOADING;
+      })
+    );
+
+  lastLoadedTimeInMs$: Observable<number | null> = this.store
+    .select(getPluginsListLoaded)
+    .pipe(
+      map((loaded) => {
+        return loaded.lastLoadedTimeInMs;
+      })
+    );
+
+  constructor(private readonly store: Store<State>) {}
+
+  triggerReload() {
+    this.store.dispatch(manualReload());
+  }
+
+  getReloadTitle(dateString: string | null) {
+    if (!dateString) {
+      return 'Loading...';
+    }
+
+    return `Last Updated: ${dateString}`;
+  }
+}

--- a/tensorboard/webapp/testing/mat_icon.module.ts
+++ b/tensorboard/webapp/testing/mat_icon.module.ts
@@ -14,7 +14,11 @@ limitations under the License.
 ==============================================================================*/
 import {Component, Input, NgModule} from '@angular/core';
 
-const KNOWN_SVG_ICON = new Set(['settings_24px']);
+const KNOWN_SVG_ICON = new Set([
+  'settings_24px',
+  'help_outline_24px',
+  'refresh_24px',
+]);
 
 /**
  * Requires to be exported for AOT. Do not use it otherwise.

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -524,8 +524,18 @@ def tensorboard_js_workspace():
                 "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/3.0.1/action/svg/production/ic_settings_24px.svg",
                 "https://raw.githubusercontent.com/google/material-design-icons/3.0.1/action/svg/production/ic_settings_24px.svg",
             ],
+            "962aee2433f026ed7843790f6757dc3c25c34f349feb9b4fe816629b1b22442d": [
+                "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/3.0.1/action/svg/production/ic_help_outline_24px.svg",
+                "https://raw.githubusercontent.com/google/material-design-icons/3.0.1/action/svg/production/ic_help_outline_24px.svg",
+            ],
+            "b4d30acd39de79f490eff59d72fb1f06502c117c8815359d539e4f20515494de": [
+                "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/3.0.1/navigation/svg/production/ic_refresh_24px.svg",
+                "https://raw.githubusercontent.com/google/material-design-icons/3.0.1/navigation/svg/production/ic_refresh_24px.svg",
+            ],
         },
         rename = {
             "ic_settings_24px.svg": "settings_24px.svg",
+            "ic_help_outline_24px.svg": "help_outline_24px.svg",
+            "ic_refresh_24px.svg": "refresh_24px.svg",
         },
     )


### PR DESCRIPTION
Polymer based TensorBoard renders info icon that brings user to our
documentation on GitHub and reload button for manual reload. This change
enables both in ng tensorboard.

**Screenshot**
![image](https://user-images.githubusercontent.com/2547313/76030224-7f573000-5eea-11ea-9df4-8c6544ef999c.png)
