### PR TITLE
Size of text in heading changed to default style in Image plugin dashboard

### DIFF
--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
@@ -178,15 +178,6 @@ TensorFlow run.
         background-color: var(--tb-ui-light-accent);
         color: var(--tb-ui-dark-accent);
       }
-      h3 {
-        color: var(--paper-grey-800);
-        margin: 0;
-        font-weight: normal;
-        font-size: 14px;
-        margin-bottom: 5px;
-        display: block;
-        pointer-events: none;
-      }
       .no-data-warning {
         max-width: 540px;
         margin: 80px auto 0 auto;


### PR DESCRIPTION
The image plugin dashboard seems like below : 

![Screenshot from 2020-03-05 00-42-23](https://user-images.githubusercontent.com/35633037/76087907-1ac8cd80-5fdd-11ea-8e22-0110fefea881.png)

Therefore I solved the text of heading to default size which seems : 

![Screenshot from 2020-03-03 21-37-49](https://user-images.githubusercontent.com/35633037/76087964-37fd9c00-5fdd-11ea-9786-3e1bb8115049.png)

