### PR TITLE
cleanup: add third_party/js.bzl format to ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -84,3 +84,6 @@ ae32a4adcab8c3349c3bff21240078334fef1371  # black: reformat directory tensorboar
 
 # Small BUILD reformat (<https://github.com/tensorflow/tensorboard/pull/3054>)
 ea4e9bbc885784a283b8b79974132df7c6cdcc50  # Reformat all `*BUILD` files with `buildifier`
+
+# third_party/js.bzl reformat (<https://github.com/tensorflow/tensorboard/pull/3332>)
+3e17c44d5bc3c7af72f14059e39d4b872e95d573  # Buildifier format js.bzl for future edits (#3332)


### PR DESCRIPTION
Tested by configuring git to use the .git-blame-ignore-revs and `git blame third_party/js.bzl`.