### PR TITLE
Experimental plugins specified using ExperimentalPluginLoader

### DIFF
--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -64,6 +64,7 @@ py_library(
     deps = [
         ":empty_path_redirect",
         ":experiment_id",
+        ":experimental_plugin",
         ":http_util",
         ":path_prefix",
         ":security_validator",
@@ -138,6 +139,12 @@ py_test(
         "//tensorboard:test",
         "@org_pocoo_werkzeug",
     ],
+)
+
+py_library(
+    name = "experimental_plugin",
+    srcs = ["experimental_plugin.py"],
+    srcs_version = "PY2AND3",
 )
 
 py_library(

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -116,9 +116,7 @@ def _apply_tensor_size_guidance(sampling_hints):
     return tensor_size_guidance
 
 
-def standard_tensorboard_wsgi(
-    flags, plugin_loaders, assets_zip_provider
-):
+def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
     """Construct a TensorBoardWSGIApp with standard plugins and multiplexer.
 
     Args:
@@ -183,11 +181,7 @@ def standard_tensorboard_wsgi(
         )
 
     return TensorBoardWSGIApp(
-        flags,
-        plugin_loaders,
-        data_provider,
-        assets_zip_provider,
-        multiplexer,
+        flags, plugin_loaders, data_provider, assets_zip_provider, multiplexer,
     )
 
 

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -116,7 +116,9 @@ def _apply_tensor_size_guidance(sampling_hints):
     return tensor_size_guidance
 
 
-def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider, experimental_plugins=[]):
+def standard_tensorboard_wsgi(
+    flags, plugin_loaders, assets_zip_provider, experimental_plugins=[]
+):
     """Construct a TensorBoardWSGIApp with standard plugins and multiplexer.
 
     Args:
@@ -185,8 +187,14 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider, experi
         )
 
     return TensorBoardWSGIApp(
-        flags, plugin_loaders, data_provider, assets_zip_provider, multiplexer, experimental_plugins
+        flags,
+        plugin_loaders,
+        data_provider,
+        assets_zip_provider,
+        multiplexer,
+        experimental_plugins,
     )
+
 
 def _handling_errors(wsgi_app):
     def wrapper(*args):
@@ -264,13 +272,21 @@ def TensorBoardWSGIApp(
             continue
         tbplugins.append(plugin)
         plugin_name_to_instance[plugin.plugin_name] = plugin
-    return TensorBoardWSGI(tbplugins, flags.path_prefix, data_provider, experimental_plugins)
+    return TensorBoardWSGI(
+        tbplugins, flags.path_prefix, data_provider, experimental_plugins
+    )
 
 
 class TensorBoardWSGI(object):
     """The TensorBoard WSGI app that delegates to a set of TBPlugin."""
 
-    def __init__(self, plugins, path_prefix="", data_provider=None, experimental_plugins=[]):
+    def __init__(
+        self,
+        plugins,
+        path_prefix="",
+        data_provider=None,
+        experimental_plugins=[],
+    ):
         """Constructs TensorBoardWSGI instance.
 
         Args:
@@ -485,9 +501,15 @@ class TensorBoardWSGI(object):
         )
         plugins_to_consider = filter(
             # Filter out experimental plugins that were not activated using the query param.
-            lambda plugin: (plugin.plugin_name not in self._experimental_plugins) or
-            (plugin.plugin_name in request.args.getlist(EXPERIMENTAL_PLUGINS_QUERY_PARAM)),
-            self._plugins)
+            lambda plugin: (
+                plugin.plugin_name not in self._experimental_plugins
+            )
+            or (
+                plugin.plugin_name
+                in request.args.getlist(EXPERIMENTAL_PLUGINS_QUERY_PARAM)
+            ),
+            self._plugins,
+        )
         for plugin in plugins_to_consider:
             if (
                 type(plugin) is core_plugin.CorePlugin

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -284,8 +284,8 @@ class TensorBoardWSGI(object):
             `/plugins_listing`.
           experimental_plugins: A list of plugin names that are only provided
               experimentally. The corresponding plugins will only be activated for
-              a user if the user has specified the plugin with the expplugin query
-              parameter in the URL.
+              a user if the user has specified the plugin with the experimentalPlugin
+              query parameter in the URL.
 
         Returns:
           A WSGI application for the set of all TBPlugin instances.
@@ -879,7 +879,15 @@ def make_plugin_loader(plugin_spec):
 
 
 class ExperimentalPluginLoader(base_plugin.TBLoader):
-    """A wrapper around TBLoader that signifies that the TBLoader is for a plugin in experimental state. ExperimentalPluginLoader is also a TBLoader. All calls are proxied to the base TBLoader passed at init. It effectively acts as an annotation."""
+    """A wrapper around TBLoader to annotate a plugin as experimental.
+
+       Experimental plugins are hidden from users by default. The plugin will only
+       be enabled for a user if the user has specified the plugin with the
+       experimentalPlugin query parameter in the URL.
+
+       ExperimentalPluginLoader is also a TBLoader. All calls are proxied to the
+       base_loader TBLoader passed at init.
+    """
 
     def __init__(self, base_loader):
         """Creates the loader, which proxies all calls to the underlying base_loader.

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -305,9 +305,7 @@ class TensorBoardWSGI(object):
         self._plugins = plugins
         self._path_prefix = path_prefix
         self._data_provider = data_provider
-        self._experimental_plugins = frozenset(
-            experimental_plugins if experimental_plugins is not None else []
-        )
+        self._experimental_plugins = frozenset(experimental_plugins or ())
         if self._path_prefix.endswith("/"):
             # Should have been fixed by `fix_flags`.
             raise ValueError(

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -372,7 +372,56 @@ class ApplicationTest(tb_test.TestCase):
             parsed_object = self._get_json("/data/plugins_listing")
         self.assertEqual(parsed_object["foo"]["enabled"], False)
         self.assertEqual(parsed_object["baz"]["enabled"], True)
+    
+    def testPluginsListingWithExperimentalPlugin(self):
+        plugins = [
+            FakePlugin(plugin_name="bar"),
+            FakePlugin(plugin_name="foo"),
+            FakePlugin(plugin_name="bazz"),
+        ]
+        app = application.TensorBoardWSGI(plugins, experimental_plugins=["foo"])
+        self._install_server(app)
 
+        plugins_without_flag = self._get_json("/data/plugins_listing")
+        self.assertIsNotNone(plugins_without_flag.get("bar"))
+        self.assertIsNone(plugins_without_flag.get("foo"))
+        self.assertIsNotNone(plugins_without_flag.get("bazz"))
+
+        plugins_with_flag = self._get_json("/data/plugins_listing?expplugin=foo")
+        self.assertIsNotNone(plugins_with_flag.get("bar"))
+        self.assertIsNotNone(plugins_with_flag.get("foo"))
+        self.assertIsNotNone(plugins_with_flag.get("bazz"))
+
+        plugins_with_useless_flag = self._get_json("/data/plugins_listing?expplugin=bar")
+        self.assertIsNotNone(plugins_with_useless_flag.get("bar"))
+        self.assertIsNone(plugins_with_useless_flag.get("foo"))
+        self.assertIsNotNone(plugins_with_useless_flag.get("bazz"))
+    
+    def testPluginsListingWithMultipleExperimentalPlugins(self):
+        plugins = [
+            FakePlugin(plugin_name="bar"),
+            FakePlugin(plugin_name="foo"),
+            FakePlugin(plugin_name="bazz"),
+        ]
+        app = application.TensorBoardWSGI(plugins, experimental_plugins=["bar", "bazz"])
+        self._install_server(app)
+
+        plugins_without_flag = self._get_json("/data/plugins_listing")
+        self.assertIsNone(plugins_without_flag.get("bar"))
+        self.assertIsNotNone(plugins_without_flag.get("foo"))
+        self.assertIsNone(plugins_without_flag.get("bazz"))
+
+        plugins_with_one_flag = self._get_json("/data/plugins_listing?expplugin=bar")
+        self.assertIsNotNone(plugins_with_one_flag.get("bar"))
+        self.assertIsNotNone(plugins_with_one_flag.get("foo"))
+        self.assertIsNone(plugins_with_one_flag.get("bazz"))
+
+        plugins_with_multiple_flags = self._get_json("/data/plugins_listing?expplugin=bar&expplugin=bazz")
+        self.assertIsNotNone(plugins_with_multiple_flags.get("bar"))
+        self.assertIsNotNone(plugins_with_multiple_flags.get("foo"))
+        self.assertIsNotNone(plugins_with_multiple_flags.get("bazz"))
+        
+    
     def testPluginEntry(self):
         """Test the data/plugin_entry.html endpoint."""
         response = self.server.get("/data/plugin_entry.html?name=baz")

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -388,14 +388,14 @@ class ApplicationTest(tb_test.TestCase):
         self.assertIsNotNone(plugins_without_flag.get("bazz"))
 
         plugins_with_flag = self._get_json(
-            "/data/plugins_listing?expplugin=foo"
+            "/data/plugins_listing?experimentalPlugin=foo"
         )
         self.assertIsNotNone(plugins_with_flag.get("bar"))
         self.assertIsNotNone(plugins_with_flag.get("foo"))
         self.assertIsNotNone(plugins_with_flag.get("bazz"))
 
         plugins_with_useless_flag = self._get_json(
-            "/data/plugins_listing?expplugin=bar"
+            "/data/plugins_listing?experimentalPlugin=bar"
         )
         self.assertIsNotNone(plugins_with_useless_flag.get("bar"))
         self.assertIsNone(plugins_with_useless_flag.get("foo"))
@@ -418,14 +418,14 @@ class ApplicationTest(tb_test.TestCase):
         self.assertIsNone(plugins_without_flag.get("bazz"))
 
         plugins_with_one_flag = self._get_json(
-            "/data/plugins_listing?expplugin=bar"
+            "/data/plugins_listing?experimentalPlugin=bar"
         )
         self.assertIsNotNone(plugins_with_one_flag.get("bar"))
         self.assertIsNotNone(plugins_with_one_flag.get("foo"))
         self.assertIsNone(plugins_with_one_flag.get("bazz"))
 
         plugins_with_multiple_flags = self._get_json(
-            "/data/plugins_listing?expplugin=bar&expplugin=bazz"
+            "/data/plugins_listing?experimentalPlugin=bar&experimentalPlugin=bazz"
         )
         self.assertIsNotNone(plugins_with_multiple_flags.get("bar"))
         self.assertIsNotNone(plugins_with_multiple_flags.get("foo"))

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -372,7 +372,7 @@ class ApplicationTest(tb_test.TestCase):
             parsed_object = self._get_json("/data/plugins_listing")
         self.assertEqual(parsed_object["foo"]["enabled"], False)
         self.assertEqual(parsed_object["baz"]["enabled"], True)
-    
+
     def testPluginsListingWithExperimentalPlugin(self):
         plugins = [
             FakePlugin(plugin_name="bar"),
@@ -387,23 +387,29 @@ class ApplicationTest(tb_test.TestCase):
         self.assertIsNone(plugins_without_flag.get("foo"))
         self.assertIsNotNone(plugins_without_flag.get("bazz"))
 
-        plugins_with_flag = self._get_json("/data/plugins_listing?expplugin=foo")
+        plugins_with_flag = self._get_json(
+            "/data/plugins_listing?expplugin=foo"
+        )
         self.assertIsNotNone(plugins_with_flag.get("bar"))
         self.assertIsNotNone(plugins_with_flag.get("foo"))
         self.assertIsNotNone(plugins_with_flag.get("bazz"))
 
-        plugins_with_useless_flag = self._get_json("/data/plugins_listing?expplugin=bar")
+        plugins_with_useless_flag = self._get_json(
+            "/data/plugins_listing?expplugin=bar"
+        )
         self.assertIsNotNone(plugins_with_useless_flag.get("bar"))
         self.assertIsNone(plugins_with_useless_flag.get("foo"))
         self.assertIsNotNone(plugins_with_useless_flag.get("bazz"))
-    
+
     def testPluginsListingWithMultipleExperimentalPlugins(self):
         plugins = [
             FakePlugin(plugin_name="bar"),
             FakePlugin(plugin_name="foo"),
             FakePlugin(plugin_name="bazz"),
         ]
-        app = application.TensorBoardWSGI(plugins, experimental_plugins=["bar", "bazz"])
+        app = application.TensorBoardWSGI(
+            plugins, experimental_plugins=["bar", "bazz"]
+        )
         self._install_server(app)
 
         plugins_without_flag = self._get_json("/data/plugins_listing")
@@ -411,17 +417,20 @@ class ApplicationTest(tb_test.TestCase):
         self.assertIsNotNone(plugins_without_flag.get("foo"))
         self.assertIsNone(plugins_without_flag.get("bazz"))
 
-        plugins_with_one_flag = self._get_json("/data/plugins_listing?expplugin=bar")
+        plugins_with_one_flag = self._get_json(
+            "/data/plugins_listing?expplugin=bar"
+        )
         self.assertIsNotNone(plugins_with_one_flag.get("bar"))
         self.assertIsNotNone(plugins_with_one_flag.get("foo"))
         self.assertIsNone(plugins_with_one_flag.get("bazz"))
 
-        plugins_with_multiple_flags = self._get_json("/data/plugins_listing?expplugin=bar&expplugin=bazz")
+        plugins_with_multiple_flags = self._get_json(
+            "/data/plugins_listing?expplugin=bar&expplugin=bazz"
+        )
         self.assertIsNotNone(plugins_with_multiple_flags.get("bar"))
         self.assertIsNotNone(plugins_with_multiple_flags.get("foo"))
         self.assertIsNotNone(plugins_with_multiple_flags.get("bazz"))
-        
-    
+
     def testPluginEntry(self):
         """Test the data/plugin_entry.html endpoint."""
         response = self.server.get("/data/plugin_entry.html?name=baz")

--- a/tensorboard/backend/experimental_plugin.py
+++ b/tensorboard/backend/experimental_plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tensorboard/backend/experimental_plugin.py
+++ b/tensorboard/backend/experimental_plugin.py
@@ -1,0 +1,55 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Experimental plugin support for TensorBoard.
+
+Contains the mechanism for marking plugins as experimental.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+class ExperimentalPlugin(object):
+    """A marker class used to annotate a plugin as experimental.
+
+    Experimental plugins are hidden from users by default. The plugin will only
+    be enabled for a user if the user has specified the plugin with the
+    experimentalPlugin query parameter in the URL.
+
+    The marker class can annotate either TBPlugin or TBLoader instances, whichever
+    is most convenient.
+
+    Typical usage is to create a new class that inherits from both an existing
+    TBPlugin/TBLoader class and this marker class. For example:
+
+    class ExperimentalGraphsPlugin(
+        graphs_plugin.GraphsPlugin,
+        experimental_plugin.ExperimentalPlugin,
+    ):
+        pass
+
+
+    class ExperimentalDebuggerPluginLoader(
+        debugger_plugin_loader.DebuggerPluginLoader,
+        experimental_plugin.ExperimentalPlugin
+    ):
+        pass
+
+    Note: This class is itself an experimental mechanism and is subject to
+    modification or removal without warning.
+    """
+
+    pass

--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 namespace tf_backend {
-  const EXPERIMENTAL_PLUGINS_QUERY_PARAM = 'expplugin';
+  const EXPERIMENTAL_PLUGINS_QUERY_PARAM = 'experimentalPlugin';
 
   export interface Router {
     environment: () => string;
@@ -38,7 +38,7 @@ namespace tf_backend {
    */
   export function createRouter(
     dataDir = 'data',
-    windowLocationUrl = new URL(window.location.href)
+    urlSearchParams = new URLSearchParams(window.location.search)
   ): Router {
     if (dataDir[dataDir.length - 1] === '/') {
       dataDir = dataDir.slice(0, dataDir.length - 1);
@@ -62,7 +62,7 @@ namespace tf_backend {
           dataDir,
           '/plugins_listing',
           createSearchParam({
-            [EXPERIMENTAL_PLUGINS_QUERY_PARAM]: windowLocationUrl.searchParams.getAll(
+            [EXPERIMENTAL_PLUGINS_QUERY_PARAM]: urlSearchParams.getAll(
               EXPERIMENTAL_PLUGINS_QUERY_PARAM
             ),
           })

--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 namespace tf_backend {
+  const EXPERIMENTAL_PLUGINS_QUERY_PARAM = 'expplugin';
+
   export interface Router {
     environment: () => string;
     experiments: () => string;
@@ -34,7 +36,10 @@ namespace tf_backend {
    *
    * @param dataDir {string=} The base prefix for data endpoints.
    */
-  export function createRouter(dataDir = 'data'): Router {
+  export function createRouter(
+    dataDir = 'data',
+    windowLocationUrl = new URL(window.location.href)
+  ): Router {
     if (dataDir[dataDir.length - 1] === '/') {
       dataDir = dataDir.slice(0, dataDir.length - 1);
     }
@@ -52,7 +57,16 @@ namespace tf_backend {
           params
         );
       },
-      pluginsListing: () => createDataPath(dataDir, '/plugins_listing'),
+      pluginsListing: () =>
+        createDataPath(
+          dataDir,
+          '/plugins_listing',
+          createSearchParam({
+            [EXPERIMENTAL_PLUGINS_QUERY_PARAM]: windowLocationUrl.searchParams.getAll(
+              EXPERIMENTAL_PLUGINS_QUERY_PARAM
+            ),
+          })
+        ),
       runs: () => createDataPath(dataDir, '/runs'),
       runsForExperiment: (id) => {
         return createDataPath(

--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -186,21 +186,24 @@ namespace tf_backend {
 
       describe('#pluginsListing', () => {
         it('returns /plugins_listing with no query params', () => {
-          const router = createRouter('data', new URL('http://some.url'));
+          const router = createRouter('data', new URLSearchParams(''));
           assert.equal(router.pluginsListing(), 'data/plugins_listing');
         });
 
-        it('returns /plugins_listing with expplugin query params', () => {
+        it('returns /plugins_listing with experimentalPlugin query params', () => {
           const router = createRouter(
             'data',
-            new URL(
-              'http://some.url?' +
-                'expplugin=plugin1&to_ignore=ignoreme&expplugin=plugin2'
+            new URLSearchParams(
+                'experimentalPlugin=plugin1&' +
+                'to_ignore=ignoreme&' +
+                'experimentalPlugin=plugin2'
             )
           );
           assert.equal(
             router.pluginsListing(),
-            'data/plugins_listing?expplugin=plugin1&expplugin=plugin2'
+            'data/plugins_listing?' +
+              'experimentalPlugin=plugin1&' +
+              'experimentalPlugin=plugin2'
           );
         });
       });

--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -194,7 +194,7 @@ namespace tf_backend {
           const router = createRouter(
             'data',
             new URLSearchParams(
-                'experimentalPlugin=plugin1&' +
+              'experimentalPlugin=plugin1&' +
                 'to_ignore=ignoreme&' +
                 'experimentalPlugin=plugin2'
             )

--- a/tensorboard/components/tf_backend/test/backendTests.ts
+++ b/tensorboard/components/tf_backend/test/backendTests.ts
@@ -172,10 +172,6 @@ namespace tf_backend {
           });
         });
 
-        it('returns correct value for #pluginsListing', () => {
-          assert.equal(router.pluginsListing(), 'data/plugins_listing');
-        });
-
         it('returns correct value for #runs', () => {
           assert.equal(router.runs(), 'data/runs');
         });
@@ -184,6 +180,27 @@ namespace tf_backend {
           assert.equal(
             router.runsForExperiment(1),
             'data/experiment_runs?experiment=1'
+          );
+        });
+      });
+
+      describe('#pluginsListing', () => {
+        it('returns /plugins_listing with no query params', () => {
+          const router = createRouter('data', new URL('http://some.url'));
+          assert.equal(router.pluginsListing(), 'data/plugins_listing');
+        });
+
+        it('returns /plugins_listing with expplugin query params', () => {
+          const router = createRouter(
+            'data',
+            new URL(
+              'http://some.url?' +
+                'expplugin=plugin1&to_ignore=ignoreme&expplugin=plugin2'
+            )
+          );
+          assert.equal(
+            router.pluginsListing(),
+            'data/plugins_listing?expplugin=plugin1&expplugin=plugin2'
           );
         });
       });

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -413,7 +413,10 @@ class TensorBoard(object):
     def _make_server(self):
         """Constructs the TensorBoard WSGI app and instantiates the server."""
         app = application.standard_tensorboard_wsgi(
-            self.flags, self.plugin_loaders, self.assets_zip_provider, self.experimental_plugins,
+            self.flags,
+            self.plugin_loaders,
+            self.assets_zip_provider,
+            self.experimental_plugins,
         )
         return self.server_class(app, self.flags)
 

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -112,6 +112,7 @@ class TensorBoard(object):
       plugin_loaders: Set from plugins passed to constructor.
       assets_zip_provider: Set by constructor.
       server_class: Set by constructor.
+      experimental_plugins: Set by constructor.
       flags: An argparse.Namespace set by the configure() method.
       cache_key: As `manager.cache_key`; set by the configure() method.
     """
@@ -122,6 +123,7 @@ class TensorBoard(object):
         assets_zip_provider=None,
         server_class=None,
         subcommands=None,
+        experimental_plugins=[],
     ):
         """Creates new instance.
 
@@ -133,6 +135,10 @@ class TensorBoard(object):
           server_class: An optional factory for a `TensorBoardServer` to use
             for serving the TensorBoard WSGI app. If provided, its callable
             signature should match that of `TensorBoardServer.__init__`.
+          experimental_plugins: A list of plugin names that are only provided
+            experimentally. The corresponding plugins will only be activated for
+            a user if the user has specified the plugin with the expplugin query
+            parameter in the URL.
 
         :type plugins:
           list[
@@ -161,6 +167,7 @@ class TensorBoard(object):
             if name in self.subcommands or name == _SERVE_SUBCOMMAND_NAME:
                 raise ValueError("Duplicate subcommand name: %r" % name)
             self.subcommands[name] = subcommand
+        self.experimental_plugins = experimental_plugins
         self.flags = None
 
     def configure(self, argv=("",), **kwargs):
@@ -406,7 +413,7 @@ class TensorBoard(object):
     def _make_server(self):
         """Constructs the TensorBoard WSGI app and instantiates the server."""
         app = application.standard_tensorboard_wsgi(
-            self.flags, self.plugin_loaders, self.assets_zip_provider
+            self.flags, self.plugin_loaders, self.assets_zip_provider, self.experimental_plugins,
         )
         return self.server_class(app, self.flags)
 

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -112,7 +112,6 @@ class TensorBoard(object):
       plugin_loaders: Set from plugins passed to constructor.
       assets_zip_provider: Set by constructor.
       server_class: Set by constructor.
-      experimental_plugins: Set by constructor.
       flags: An argparse.Namespace set by the configure() method.
       cache_key: As `manager.cache_key`; set by the configure() method.
     """
@@ -123,7 +122,6 @@ class TensorBoard(object):
         assets_zip_provider=None,
         server_class=None,
         subcommands=None,
-        experimental_plugins=[],
     ):
         """Creates new instance.
 
@@ -135,10 +133,6 @@ class TensorBoard(object):
           server_class: An optional factory for a `TensorBoardServer` to use
             for serving the TensorBoard WSGI app. If provided, its callable
             signature should match that of `TensorBoardServer.__init__`.
-          experimental_plugins: A list of plugin names that are only provided
-            experimentally. The corresponding plugins will only be activated for
-            a user if the user has specified the plugin with the expplugin query
-            parameter in the URL.
 
         :type plugins:
           list[
@@ -167,7 +161,6 @@ class TensorBoard(object):
             if name in self.subcommands or name == _SERVE_SUBCOMMAND_NAME:
                 raise ValueError("Duplicate subcommand name: %r" % name)
             self.subcommands[name] = subcommand
-        self.experimental_plugins = experimental_plugins
         self.flags = None
 
     def configure(self, argv=("",), **kwargs):
@@ -413,10 +406,7 @@ class TensorBoard(object):
     def _make_server(self):
         """Constructs the TensorBoard WSGI app and instantiates the server."""
         app = application.standard_tensorboard_wsgi(
-            self.flags,
-            self.plugin_loaders,
-            self.assets_zip_provider,
-            self.experimental_plugins,
+            self.flags, self.plugin_loaders, self.assets_zip_provider
         )
         return self.server_class(app, self.flags)
 


### PR DESCRIPTION
* Motivation for features / changes

Allow an administrator of a Tensorboard to mark certain plugins as "experimental" and hidden to users by default. Users would then need to add query parameter "experimentalPlugin=" to the URL to see the experimental plugin.

* Technical description of changes

Introduce simpler marker class ExperimentalPlugin which acts as an annotation on either TBPlugin or TBLoader that indicates a plugin is experimental. TensorBoardWSGIApp() uses isinstance() to determine if a plugin is experimental and passes the information as a list of names, "experimental_plugins", in its call to TensorBoardWSGI()

TensorBoardWSGI._serve_plugins_listing() filters out plugins that are included in experimental_plugins but are not specified in an experimentalPlugin query parameter.

There is logic in createRouter() that forward "experimentalPlugin" query parameter values from the original TensorBoard request to the call to the plugins_listing endpoint.

* Screenshots of UI changes

Using an example where "images" and "graphs" are marked as experimental.

No query parameters:
![image](https://user-images.githubusercontent.com/17152369/75914650-21abe080-5e23-11ea-966c-43976c329668.png)

"experimentalPlugin=images" query parameter:
![image](https://user-images.githubusercontent.com/17152369/75944524-f39bc000-5e65-11ea-8a85-e9a1072a440a.png)

"experimentalPlugin=images&experimentalPlugin=graphs" query parameters:
![image](https://user-images.githubusercontent.com/17152369/75944594-1a59f680-5e66-11ea-83b9-62c85849a855.png)

* Detailed steps to verify changes work correctly (as executed by you)

Modify the list of plugins in default.py to use ExperimentalPlugin. Modify Images, Graphs,a nd Debugger plugins (a mix of TBPlugin and TBLoader):


class ExperimentalImagePlugin(
    images_plugin.ImagesPlugin,
    application.ExperimentalPlugin
):
    pass


class ExperimentalGraphsPlugin(
    graphs_plugin.GraphsPlugin,
    application.ExperimentalPlugin,
):
    pass


class ExperimentalDebuggerPluginLoader(
    debugger_plugin_loader.DebuggerPluginLoader,
    application.ExperimentalPlugin
):
    pass

Start server.

Open "http://localhost:6006/" without query parameters. Note that "Images" and "Graphs" do not appear as plugins.

Open "http://localhost:6006/?experimentalPlugin=images&experimentalPlugin=graphs&experimentalPlugin=debugger". Note that "Images", "Graphs", and "Debugger" appear as plugins.