### PR TITLE
plugin_util: cache Markdown converter for speed

### DIFF
--- a/tensorboard/plugin_util.py
+++ b/tensorboard/plugin_util.py
@@ -61,6 +61,10 @@ _ALLOWED_TAGS = [
     "th",
 ]
 
+# Cache Markdown converter to avoid expensive initialization at each
+# call to `markdown_to_safe_html`.
+_markdown = markdown.Markdown(extensions=["markdown.extensions.tables"])
+
 
 def markdown_to_safe_html(markdown_string):
     """Convert Markdown to HTML that's safe to splice into the DOM.
@@ -86,9 +90,7 @@ def markdown_to_safe_html(markdown_string):
                 "after UTF-8 decoding -->\n"
             ) % num_null_bytes
 
-    string_html = markdown.markdown(
-        markdown_string, extensions=["markdown.extensions.tables"]
-    )
+    string_html = _markdown.convert(markdown_string)
     string_sanitized = bleach.clean(
         string_html, tags=_ALLOWED_TAGS, attributes=_ALLOWED_ATTRIBUTES
     )


### PR DESCRIPTION
Summary:
Calling `markdown.markdown(s, ...)` is shorthand for creating a Markdown
converter `md = markdown.Markdown(...)` and calling `md.convert(s)` on
the converter. But the initialization is expensive when extensions are
in play: it requires iterating over package entry points, dynamically
importing modules, and mutating the newly initialized converter.

On my machine, rendering an empty Markdown string takes 123 µs (±322 ns)
with a fresh converter, or 96.7 ns (±1.05 ns) with a cached converter.
By default, the text plugin downsamples to 10 samples per time series,
but each sample can have an arbitrary number of Markdown calls when the
summary data is rank-1 or rank-2. Most non-text plugins also call this
to render summary descriptions. Loading the scalars plugin with my
standard test logdir calls this method 369 times. Loading the text
plugin with the text demo data calls this method 962 times, burning
about 118 ms on absolutely nothing.

Test Plan:
Run TensorBoard with `--verbosity 9` and pipe through `grep markdown`,
then load the scalars dashboard. Before this change, you’d see a bunch
of “imported extension module” and “loaded extension” spam, to the tune
of hundreds of lines per page load. After this change, you actually see
none (presumably because the logs happen at module import time, which is
before the `--verbosity` setting takes effect).

wchargin-branch: cache-markdown-converter
