### PR TITLE
ng: refactor theming for reusability

### DIFF
--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -91,6 +91,7 @@ def tf_sass_binary(deps = [], include_paths = [], **kwargs):
         deps = deps + ["//tensorboard/webapp:theme"],
         include_paths = include_paths + [
             "external/npm/node_modules",
+            "tensorboard/webapp/theme",
         ],
         **kwargs
     )

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -156,15 +156,11 @@ tf_sass_library(
     ],
 )
 
-tf_sass_library(
+# TODO(stephanwlee): remove the alias when all usages, internal, too,
+# //tensorboard/webapp:theme are removed.
+alias(
     name = "theme",
-    srcs = [
-        "_palette.scss",
-        "_theme.scss",
-    ],
-    deps = [
-        ":angular_material_theming",
-    ],
+    actual = "//tensorboard/webapp/theme",
 )
 
 tf_sass_binary(

--- a/tensorboard/webapp/styles.scss
+++ b/tensorboard/webapp/styles.scss
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-@import './theme';
+@import 'tb_theme';

--- a/tensorboard/webapp/theme/BUILD
+++ b/tensorboard/webapp/theme/BUILD
@@ -1,0 +1,14 @@
+load("//tensorboard/defs:defs.bzl", "tf_sass_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+tf_sass_library(
+    name = "theme",
+    srcs = [
+        "_tb_palette.scss",
+        "_tb_theme.scss",
+    ],
+    deps = [
+        "//tensorboard/webapp:angular_material_theming",
+    ],
+)

--- a/tensorboard/webapp/theme/_tb_palette.scss
+++ b/tensorboard/webapp/theme/_tb_palette.scss
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-@import './angular_material_theming';
+@import '../angular_material_theming';
 
 $tf-slate: (
   100: #f5f6f7,

--- a/tensorboard/webapp/theme/_tb_theme.scss
+++ b/tensorboard/webapp/theme/_tb_theme.scss
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-@import './angular_material_theming';
-@import './palette';
+@import '../angular_material_theming';
+@import './tb_palette';
 
 // Angular Material theme definition.
 
@@ -28,17 +28,16 @@ $_warn: mat-palette($mat-red);
 
 $tb-theme: mat-light-theme($_primary, $_accent, $_warn);
 
+// Overriding mat-light-theme-foreground variables.
 $tb-foreground: map_merge(
   $mat-light-theme-foreground,
   (
-    // Overriding mat-light-theme-foreground variables.
     text: mat-color($mat-gray, 900),
     secondary-text: mat-color($mat-gray, 700),
     disabled-text: mat-color($mat-gray, 600),
-
     // TB specific variable.
-    border: #ebebeb,
-    link: mat-color($mat-blue, 700)
+      border: #ebebeb,
+    link: mat-color($mat-blue, 700),
   )
 );
 


### PR DESCRIPTION
Absolute dependencies on "tb-theme" allows us to provide different theme
files for different applications.

Related change: cl/299960760