### PR TITLE
lint: add --diff flag to show black diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - run: pip freeze --all
       - name: 'Lint Python code for style with Black'
         # You can run `black .` to fix all Black complaints.
-        run: black --check .
+        run: black --check --diff .
 
   lint-docs:
     runs-on: ubuntu-16.04


### PR DESCRIPTION
This should hopefully help make this even more self-service by indicating to the PR author exactly what the problem is in the file.