### PR TITLE
debugger: fix genrule for sync

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -81,7 +81,8 @@ tf_ng_web_test_suite(
 py_binary(
     name = "extract_dtypes_from_python",
     srcs = ["extract_dtypes_from_python.py"],
-    srcs_version = "PY3",
+    python_version = "PY3",
+    srcs_version = "PY2AND3",
     deps = [
         "//tensorboard/compat/tensorflow_stub",
     ],

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/extract_dtypes_from_python.py
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/extract_dtypes_from_python.py
@@ -18,9 +18,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import sys
-import os
 import json
+import os
+import sys
 
 from tensorboard.compat.tensorflow_stub import dtypes
 


### PR DESCRIPTION
- genrule should use `exec_tools` for Python 3 (defaults to Python 2
otherwise).
- chmod -x on the Python file
- import order for lint
