### PR TITLE
Revert "Rename BlobState enum values (#3355)"

### DIFF
--- a/tensorboard/uploader/proto/blob.proto
+++ b/tensorboard/uploader/proto/blob.proto
@@ -6,9 +6,9 @@ enum BlobState {
   // Object state is unknown. This value should never be used; it is present
   // only as a proto3 best practice.
   // See https://developers.google.com/protocol-buffers/docs/proto3#enum
-  BLOB_STATE_UNKNOWN = 0;
+  UNKNOWN = 0;
   // Object is being written and not yet finalized.
-  BLOB_STATE_UNFINALIZED = 1;
+  UNFINALIZED = 1;
   // Object is finalized.
-  BLOB_STATE_CURRENT = 2;
+  CURRENT = 2;
 }


### PR DESCRIPTION
This reverts commit 89f5a6a72c599b3b44578d14f4c032c2a8f279ba.

That commit was submitted prematurely, in that the corresponding internal change was not yet approved, so it broke the sync.