### PR TITLE
ng: allow palette to be inlined via genrule.

### DIFF
--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -88,10 +88,9 @@ def tf_sass_binary(deps = [], include_paths = [], **kwargs):
     theme library paths for better node_modules library resolution.
     """
     sass_binary(
-        deps = deps + ["//tensorboard/webapp:theme"],
+        deps = deps + ["//tensorboard/webapp/theme"],
         include_paths = include_paths + [
             "external/npm/node_modules",
-            "tensorboard/webapp/theme",
         ],
         **kwargs
     )

--- a/tensorboard/webapp/styles.scss
+++ b/tensorboard/webapp/styles.scss
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-@import 'tb_theme';
+@import 'tensorboard/webapp/theme/tb_theme';

--- a/tensorboard/webapp/theme/BUILD
+++ b/tensorboard/webapp/theme/BUILD
@@ -2,6 +2,8 @@ load("//tensorboard/defs:defs.bzl", "tf_sass_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
+licenses(["notice"])  # Apache 2.0
+
 tf_sass_library(
     name = "theme",
     srcs = [
@@ -11,4 +13,14 @@ tf_sass_library(
     deps = [
         "//tensorboard/webapp:angular_material_theming",
     ],
+)
+
+genrule(
+    name = "inline_palette",
+    srcs = [
+        "_variable.scss",
+        "_tb_theme.template.scss",
+    ],
+    outs = ["_tb_theme.scss"],
+    cmd = "cat $(SRCS) > $@",
 )

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -13,20 +13,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-@import '../angular_material_theming';
-@import './tb_palette';
+@import 'tensorboard/webapp/angular_material_theming';
+
+/***********************************************************
+ * VARIABLE FILE IS INLINED WITH GENRULE. DO NOT IMPORT IT.
+ * Variable file declares values for $tb-primary, $tb-accent
+ * and $tb-warn
+ **********************************************************/
 
 // Angular Material theme definition.
 
 // Include non-theme styles for core.
 @include mat-core();
 
-// Defined in go/ls-visd-spec
-$_primary: mat-palette($tf-orange);
-$_accent: mat-palette($tf-orange);
-$_warn: mat-palette($mat-red);
-
-$tb-theme: mat-light-theme($_primary, $_accent, $_warn);
+$tb-theme: mat-light-theme($tb-primary, $tb-accent, $tb-warn);
 
 // Overriding mat-light-theme-foreground variables.
 $tb-foreground: map_merge(

--- a/tensorboard/webapp/theme/_variable.scss
+++ b/tensorboard/webapp/theme/_variable.scss
@@ -12,43 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-
 @import 'tensorboard/webapp/angular_material_theming';
+@import 'tensorboard/webapp/theme/tb_palette';
 
-$tf-slate: (
-  100: #f5f6f7,
-  200: #f5f6f7,
-  300: #c6cad1,
-  400: #8e98a3,
-  500: #8e98a3,
-  700: #425066,
-  900: #293241,
-  contrast: (
-    100: $dark-primary-text,
-    200: $dark-primary-text,
-    300: $dark-primary-text,
-    400: $dark-primary-text,
-    500: $light-primary-text,
-    700: $light-primary-text,
-    900: $light-primary-text,
-  ),
-);
-
-$tf-orange: (
-  100: #f57c00,
-  200: #f57c00,
-  300: #f57c00,
-  400: #f57c00,
-  500: #f57c00,
-  700: #f57c00,
-  900: #f57c00,
-  contrast: (
-    100: $dark-primary-text,
-    300: $dark-primary-text,
-    400: $dark-primary-text,
-    500: $light-primary-text,
-    600: $light-primary-text,
-    700: $light-primary-text,
-    900: $light-primary-text,
-  ),
-);
+$tb-primary: mat-palette($tf-orange);
+$tb-accent: mat-palette($tf-orange);
+$tb-warn: mat-palette($mat-red);


### PR DESCRIPTION
We have different instances of the TensorBoard that need to be themed
differently (colors and definitions of the colors). Because include_path
of sass_binary is getting deprecated, we decided to use genrules to
conditionally supply correct colors when building the SASS.

Sync: requires cl/300794214. 
End state: cl/300395379