### PR TITLE
Add message types and rpc method to support exporting BLOBs

### DIFF
--- a/tensorboard/uploader/proto/blob.proto
+++ b/tensorboard/uploader/proto/blob.proto
@@ -12,3 +12,14 @@ enum BlobState {
   // Object is finalized.
   CURRENT = 2;
 }
+
+message Blob {
+  // For Blobs that haven't started uploading, this is an empty string.
+  string blob_id = 1;
+
+  BlobState state = 2;
+}
+
+message BlobSequence {
+  repeated Blob blob = 1;
+}

--- a/tensorboard/uploader/proto/blob.proto
+++ b/tensorboard/uploader/proto/blob.proto
@@ -14,12 +14,17 @@ enum BlobState {
 }
 
 message Blob {
-  // For Blobs that haven't started uploading, this is an empty string.
+  // A non-empty ID for the blob.
   string blob_id = 1;
-
   BlobState state = 2;
 }
 
+message BlobSequenceEntry {
+  // Optional. If absent, this represents a "hole" in the sequence:
+  // there is expected to be a blob here, but upload has not started.
+  Blob blob = 1;
+}
+
 message BlobSequence {
-  repeated Blob blob = 1;
+  repeated BlobSequenceEntry entries = 1;
 }

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -16,8 +16,8 @@ service TensorBoardExporterService {
   // Stream scalars for all the runs and tags in an experiment.
   rpc StreamExperimentData(StreamExperimentDataRequest)
       returns (stream StreamExperimentDataResponse) {}
-  // Stream BLOB as chunks for a given blob_id.
-  rpc StreamBlobData(StreamBlobRequest) returns (stream StreamBlobResponse) {}
+  // Stream blob as chunks for a given blob_id.
+  rpc StreamBlobData(StreamBlobDataRequest) returns (stream StreamBlobDataResponse) {}
 }
 
 // Request to stream the experiment_id of all the experiments owned by the
@@ -150,16 +150,16 @@ message StreamExperimentDataResponse {
     repeated int64 steps = 1;
     // Timestamp of the creation of this point.
     repeated google.protobuf.Timestamp wall_times = 2;
-    // Value of the BLOB sequence at this step / timestamp.
+    // Value of the blob sequence at this step / timestamp.
     repeated BlobSequence values = 3;
   }
 }
 
-message StreamBlobRequest {
+message StreamBlobDataRequest {
   string blob_id = 1;
 }
 
-message StreamBlobResponse {
+message StreamBlobDataResponse {
   // The bytes in this chunk.
   bytes data = 1;
   // The position in the blob where this chunk begins.
@@ -170,7 +170,7 @@ message StreamBlobResponse {
   reserved 3;
   // Indicates that this is the last chunk of the stream.
   bool final_chunk = 4;
-  // CRC32C of the entire blob.  Required, to protect against data corruption.
-  // This should be set only when finalize_object=True.
+  // CRC32C of the entire blob. This should be set when final_chunk=True, to
+  // protect against data corruption.
   fixed32 final_crc32c = 5;
 }

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -17,7 +17,7 @@ service TensorBoardExporterService {
   rpc StreamExperimentData(StreamExperimentDataRequest)
       returns (stream StreamExperimentDataResponse) {}
   // Stream BLOB as chunks for a given blob_id.
-  rpc StreamBlob(StreamBlobRequest) returns (stream StreamBlobResponse) {}
+  rpc StreamBlobData(StreamBlobRequest) returns (stream StreamBlobResponse) {}
 }
 
 // Request to stream the experiment_id of all the experiments owned by the

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package tensorboard.service;
 
 import "google/protobuf/timestamp.proto";
+import "tensorboard/uploader/proto/blob.proto";
 import "tensorboard/uploader/proto/experiment.proto";
 import "tensorboard/compat/proto/summary.proto";
 import "tensorboard/compat/proto/tensor.proto";
@@ -15,6 +16,8 @@ service TensorBoardExporterService {
   // Stream scalars for all the runs and tags in an experiment.
   rpc StreamExperimentData(StreamExperimentDataRequest)
       returns (stream StreamExperimentDataResponse) {}
+  // Stream BLOB as chunks for a given blob_id.
+  rpc StreamBlob(StreamBlobRequest) returns (stream StreamBlobResponse) {}
 }
 
 // Request to stream the experiment_id of all the experiments owned by the
@@ -103,10 +106,18 @@ message StreamExperimentDataResponse {
   string run_name = 2;
   // The metadata of the tag `tag_name`.
   .tensorboard.SummaryMetadata tag_metadata = 3;
+
   // Data to store for the tag `tag_name.
-  ScalarPoints points = 4;
-  // Tensor data to store.
-  TensorPoints tensors = 5;
+  oneof data {
+    // Scalar data to store.
+    ScalarPoints points = 4;
+
+    // Tensor data to store.
+    TensorPoints tensors = 5;
+
+    // Blob sequences to store.
+    BlobSequencePoints blob_sequences = 6;
+  }
 
   // Data for the scalars are stored in a columnar fashion to optimize it for
   // exporting the data into textual formats like JSON.
@@ -133,4 +144,33 @@ message StreamExperimentDataResponse {
     // Value of the point at this step / timestamp.
     repeated .tensorboard.TensorProto values = 3;
   }
+
+  message BlobSequencePoints {
+    // Step index within the run.
+    repeated int64 steps = 1;
+    // Timestamp of the creation of this point.
+    repeated google.protobuf.Timestamp wall_times = 2;
+    // Value of the BLOB sequence at this step / timestamp.
+    repeated BlobSequence values = 3;
+  }
+}
+
+message StreamBlobRequest {
+  string blob_id = 1;
+}
+
+message StreamBlobResponse {
+  // The bytes in this chunk.
+  bytes data = 1;
+  // The position in the blob where this chunk begins.
+  // This must equal the sum of the sizes of the chunks sent so far.  Ignored
+  // if no data is provided.
+  int64 offset = 2;
+  // TODO(b/150443776): Add `crc32a = 3;` once the server can populate it.
+  reserved 3;
+  // Indicates that this is the last chunk of the stream.
+  bool final_chunk = 4;
+  // CRC32C of the entire blob.  Required, to protect against data corruption.
+  // This should be set only when finalize_object=True.
+  fixed32 final_crc32c = 5;
 }

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -17,7 +17,8 @@ service TensorBoardExporterService {
   rpc StreamExperimentData(StreamExperimentDataRequest)
       returns (stream StreamExperimentDataResponse) {}
   // Stream blob as chunks for a given blob_id.
-  rpc StreamBlobData(StreamBlobDataRequest) returns (stream StreamBlobDataResponse) {}
+  rpc StreamBlobData(StreamBlobDataRequest)
+      returns (stream StreamBlobDataResponse) {}
 }
 
 // Request to stream the experiment_id of all the experiments owned by the


### PR DESCRIPTION
* Motivation for features / changes
  * Support tbdev uploader's exporting of BLOBs (e.g., GraphDefs)

* Technical description of changes
  * Add the following message types to tensorboard/uploader/proto/blob.proto:
    * `Blob`, with fields blob_id and state (using the existing `BlobState` message type in the same file)
    * `BlobSequence`, which is composed of `Blob`s
  * In tensorboard/uploader/exporter_service.proto:
    * Add the following message type:  `BlobSequencePoints`, this is in parallel to the existing `ScalarPoints` and `TensorPoints` message types in the same file.
    * Change the existing `points` (scalars), `tensors`, and to-be-added `blob_sequences` into a `oneof`.
    * Add the following rpc method to `TensorBoardExporterService`: `StreamBlobData`.

Co-author: wchargin@