### PR TITLE
Add link to TensorBoard.dev in the TensorBoard docs home page

### DIFF
--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -20,7 +20,8 @@ landing_page:
           <li>Profiling TensorFlow programs</li>
           <li>And much more</li>
         </ul>
-        <a href="https://tensorboard.dev">TensorBoard.dev</a> lets you easily host, track, and share your experiment results.
+        <a href="https://tensorboard.dev">TensorBoard.dev</a> lets you easily 
+        host, track, and share your experiment results.
       image_path: /tensorboard/images/tensorboard.gif
       buttons:
       - label: Get started

--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -20,7 +20,7 @@ landing_page:
           <li>Profiling TensorFlow programs</li>
           <li>And much more</li>
         </ul>
-        <a href="https://tensorboard.dev">TensorBoard.dev</a> lets you easily 
+        <a href="https://tensorboard.dev">TensorBoard.dev</a> lets you easily
         host, track, and share your experiment results.
       image_path: /tensorboard/images/tensorboard.gif
       buttons:

--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -20,6 +20,7 @@ landing_page:
           <li>Profiling TensorFlow programs</li>
           <li>And much more</li>
         </ul>
+        <a href="https://tensorboard.dev">TensorBoard.dev</a> lets you easily host, track, and share your experiment results.
       image_path: /tensorboard/images/tensorboard.gif
       buttons:
       - label: Get started


### PR DESCRIPTION
Add a link to TensorBoard.dev in the TensorBoard docs home page.

Comments on exact wording are welcome. 