### PR TITLE
Add --plugins option to uploader

### DIFF
--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -8,11 +8,21 @@ package tensorboard.service;
 message ServerInfoRequest {
   // Client-side TensorBoard version, per `tensorboard.version.VERSION`.
   string version = 1;
+  // Plugins for which the client wishes to upload data, specified by the user.
+  // If specifed, the list of plugins will be confirmed by the server and
+  // echoed in the PluginControl message. If one of the plugins is not
+  // supported by the server then it will respond with compatibility verdict
+  // VERDICT_ERROR.
+  //
+  // These are plugin names as stored in the the
+  // `SummaryMetadata.plugin_data.plugin_name` proto field.
+  repeated string requested_plugins = 2;
 }
 
 message ServerInfoResponse {
-  // Primary bottom-line: is the server compatible with the client, and is
-  // there anything that the end user should be aware of?
+  // Primary bottom-line: is the server compatible with the client, can it
+  // serve its request, and is there anything that the end user should be
+  // aware of?
   Compatibility compatibility = 1;
   // Identifier for a gRPC server providing the `TensorBoardExporterService` and
   // `TensorBoardWriterService` services (under the `tensorboard.service` proto
@@ -20,19 +30,15 @@ message ServerInfoResponse {
   ApiServer api_server = 2;
   // How to generate URLs to experiment pages.
   ExperimentUrlFormat url_format = 3;
-  // For which plugins should we upload data? (Even if the uploader is
-  // structurally capable of uploading data from many plugins, we only actually
-  // upload data that can be currently displayed in TensorBoard.dev. Otherwise,
-  // users may be surprised to see that experiments that they uploaded a while
-  // ago and have since shared or published now have extra information that
-  // they didn't realize had been uploaded.)
+  // Information about the plugins for which data should be uploaded.
   //
-  // The client may always choose to upload less data than is permitted by this
-  // field: e.g., if the end user specifies not to upload data for a given
-  // plugin, or the client does not yet support uploading some kind of data.
+  // If ServerInfoRequest.requested_plugins is specified then
+  // that list of plugins will be confirmed by the server and echoed in the
+  // the response. Otherwise the server will return the default set of
+  // plugins it supports.
   //
-  // If this field is omitted, there are no upfront restrictions on what the
-  // client may send.
+  // The client should only upload data for the plugins in the response even
+  // if it is capable of uploading more data.
   PluginControl plugin_control = 4;
 }
 
@@ -75,7 +81,7 @@ message ExperimentUrlFormat {
 }
 
 message PluginControl {
-  // Only send data from plugins with these names. These are plugin names as
+  // Plugins for which data should be uploaded. These are plugin names as
   // stored in the the `SummaryMetadata.plugin_data.plugin_name` proto field.
   repeated string allowed_plugins = 1;
 }

--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -8,15 +8,15 @@ package tensorboard.service;
 message ServerInfoRequest {
   // Client-side TensorBoard version, per `tensorboard.version.VERSION`.
   string version = 1;
-  // Plugins for which the client wishes to upload data, specified by the user.
-  // If specifed, the list of plugins will be confirmed by the server and
-  // echoed in the PluginControl message. If one of the plugins is not
-  // supported by the server then it will respond with compatibility verdict
-  // VERDICT_ERROR.
+  // Information about the plugins for which the client wishes to upload data.
   //
-  // These are plugin names as stored in the the
-  // `SummaryMetadata.plugin_data.plugin_name` proto field.
-  repeated string requested_plugins = 2;
+  // If specified then the list of plugins will be confirmed by the server and
+  // echoed in the PluginControl.allowed_plugins field. Otherwise the server
+  // will return the default set of plugins it supports.
+  //
+  // If one of the plugins is not supported by the server then it will respond
+  // with compatibility verdict VERDICT_ERROR.
+  PluginSpecification plugin_specification = 2;
 }
 
 message ServerInfoResponse {
@@ -32,7 +32,7 @@ message ServerInfoResponse {
   ExperimentUrlFormat url_format = 3;
   // Information about the plugins for which data should be uploaded.
   //
-  // If ServerInfoRequest.requested_plugins is specified then
+  // If PluginSpecification.requested_plugins is specified then
   // that list of plugins will be confirmed by the server and echoed in the
   // the response. Otherwise the server will return the default set of
   // plugins it supports.
@@ -78,6 +78,13 @@ message ExperimentUrlFormat {
   // Placeholder string that should be replaced with an actual experiment ID.
   // (See docs for `template` field.)
   string id_placeholder = 2;
+}
+
+message PluginSpecification {
+  // Plugins for which the client wishes to upload data. These are plugin names
+  // as stored in the the `SummaryMetadata.plugin_data.plugin_name` proto
+  // field.
+  repeated string upload_plugins = 2;
 }
 
 message PluginControl {

--- a/tensorboard/uploader/server_info.py
+++ b/tensorboard/uploader/server_info.py
@@ -30,19 +30,32 @@ from tensorboard.uploader.proto import server_info_pb2
 _REQUEST_TIMEOUT_SECONDS = 10
 
 
-def _server_info_request():
+def _server_info_request(plugins):
+    """Generates a ServerInfoRequest
+
+    Args:
+      plugins: List of plugins, by name, requested by the user and to be
+        confirmed by the server.
+
+    Returns:
+      A `server_info_pb2.ServerInfoRequest` message.
+    """
     request = server_info_pb2.ServerInfoRequest()
     request.version = version.VERSION
+    if (plugins):
+      request.requested_plugins[:] = plugins
     return request
 
 
-def fetch_server_info(origin):
+def fetch_server_info(origin, plugins):
     """Fetches server info from a remote server.
 
     Args:
       origin: The server with which to communicate. Should be a string
         like "https://tensorboard.dev", including protocol, host, and (if
         needed) port.
+      plugins: List of plugins, by name, requested by the user and to be
+        confirmed by the server.
 
     Returns:
       A `server_info_pb2.ServerInfoResponse` message.
@@ -52,7 +65,7 @@ def fetch_server_info(origin):
         communicate with the remote server.
     """
     endpoint = "%s/api/uploader" % origin
-    post_body = _server_info_request().SerializeToString()
+    post_body = _server_info_request(plugins).SerializeToString()
     try:
         response = requests.post(
             endpoint,

--- a/tensorboard/uploader/server_info.py
+++ b/tensorboard/uploader/server_info.py
@@ -42,8 +42,8 @@ def _server_info_request(plugins):
     """
     request = server_info_pb2.ServerInfoRequest()
     request.version = version.VERSION
-    if (plugins):
-      request.requested_plugins[:] = plugins
+    if plugins:
+        request.requested_plugins[:] = plugins
     return request
 
 
@@ -88,13 +88,15 @@ def fetch_server_info(origin, plugins):
         )
 
 
-def create_server_info(frontend_origin, api_endpoint):
+def create_server_info(frontend_origin, api_endpoint, plugins):
     """Manually creates server info given a frontend and backend.
 
     Args:
       frontend_origin: The origin of the TensorBoard.dev frontend, like
         "https://tensorboard.dev" or "http://localhost:8000".
       api_endpoint: As to `server_info_pb2.ApiServer.endpoint`.
+      plugins: List of plugins, by name, requested by the user and to be
+        echoed back in the response.
 
     Returns:
       A `server_info_pb2.ServerInfoResponse` message.
@@ -108,6 +110,8 @@ def create_server_info(frontend_origin, api_endpoint):
         placeholder = "{%s}" % placeholder
     url_format.template = "%s/experiment/%s/" % (frontend_origin, placeholder)
     url_format.id_placeholder = placeholder
+    if (plugins is not None) and (len(plugins) > 0):
+        result.plugin_control.allowed_plugins[:] = plugins
     return result
 
 

--- a/tensorboard/uploader/server_info.py
+++ b/tensorboard/uploader/server_info.py
@@ -30,11 +30,11 @@ from tensorboard.uploader.proto import server_info_pb2
 _REQUEST_TIMEOUT_SECONDS = 10
 
 
-def _server_info_request(plugins):
+def _server_info_request(upload_plugins):
     """Generates a ServerInfoRequest
 
     Args:
-      plugins: List of plugins, by name, requested by the user and to be
+      upload_plugins: List of plugins, by name, requested by the user and to be
         confirmed by the server.
 
     Returns:
@@ -42,19 +42,19 @@ def _server_info_request(plugins):
     """
     request = server_info_pb2.ServerInfoRequest()
     request.version = version.VERSION
-    if plugins:
-        request.requested_plugins[:] = plugins
+    if upload_plugins:
+        request.plugin_specification.upload_plugins[:] = upload_plugins
     return request
 
 
-def fetch_server_info(origin, plugins):
+def fetch_server_info(origin, upload_plugins):
     """Fetches server info from a remote server.
 
     Args:
       origin: The server with which to communicate. Should be a string
         like "https://tensorboard.dev", including protocol, host, and (if
         needed) port.
-      plugins: List of plugins, by name, requested by the user and to be
+      upload_plugins: List of plugins, by name, requested by the user and to be
         confirmed by the server.
 
     Returns:
@@ -65,7 +65,7 @@ def fetch_server_info(origin, plugins):
         communicate with the remote server.
     """
     endpoint = "%s/api/uploader" % origin
-    post_body = _server_info_request(plugins).SerializeToString()
+    post_body = _server_info_request(upload_plugins).SerializeToString()
     try:
         response = requests.post(
             endpoint,

--- a/tensorboard/uploader/server_info.py
+++ b/tensorboard/uploader/server_info.py
@@ -90,15 +90,15 @@ def fetch_server_info(origin, upload_plugins):
         )
 
 
-def create_server_info(frontend_origin, api_endpoint, plugins):
+def create_server_info(frontend_origin, api_endpoint, upload_plugins):
     """Manually creates server info given a frontend and backend.
 
     Args:
       frontend_origin: The origin of the TensorBoard.dev frontend, like
         "https://tensorboard.dev" or "http://localhost:8000".
       api_endpoint: As to `server_info_pb2.ApiServer.endpoint`.
-      plugins: List of plugins, by name, requested by the user and to be
-        echoed back in the response.
+      upload_plugins: List of plugin names requested by the user and to be
+        verified by the server.
 
     Returns:
       A `server_info_pb2.ServerInfoResponse` message.
@@ -112,8 +112,7 @@ def create_server_info(frontend_origin, api_endpoint, plugins):
         placeholder = "{%s}" % placeholder
     url_format.template = "%s/experiment/%s/" % (frontend_origin, placeholder)
     url_format.id_placeholder = placeholder
-    if (plugins is not None) and (len(plugins) > 0):
-        result.plugin_control.allowed_plugins[:] = plugins
+    result.plugin_control.allowed_plugins[:] = upload_plugins
     return result
 
 

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -70,7 +70,7 @@ class FetchServerInfoTest(tb_test.TestCase):
             body = request.get_data()
             request_pb = server_info_pb2.ServerInfoRequest.FromString(body)
             self.assertEqual(request_pb.version, version.VERSION)
-            self.assertEqual(request_pb.requested_plugins, [])
+            self.assertEqual(request_pb.plugin_specification.upload_plugins, [])
             return wrappers.BaseResponse(expected_result.SerializeToString())
 
         origin = self._start_server(app)
@@ -84,7 +84,7 @@ class FetchServerInfoTest(tb_test.TestCase):
             request_pb = server_info_pb2.ServerInfoRequest.FromString(body)
             self.assertEqual(request_pb.version, version.VERSION)
             self.assertEqual(
-                request_pb.requested_plugins, ["plugin1", "plugin2"]
+                request_pb.plugin_specification.upload_plugins, ["plugin1", "plugin2"]
             )
             return wrappers.BaseResponse(
                 server_info_pb2.ServerInfoResponse().SerializeToString()

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -70,11 +70,29 @@ class FetchServerInfoTest(tb_test.TestCase):
             body = request.get_data()
             request_pb = server_info_pb2.ServerInfoRequest.FromString(body)
             self.assertEqual(request_pb.version, version.VERSION)
+            self.assertEqual(request_pb.requested_plugins, [])
             return wrappers.BaseResponse(expected_result.SerializeToString())
 
         origin = self._start_server(app)
-        result = server_info.fetch_server_info(origin)
+        result = server_info.fetch_server_info(origin, [])
         self.assertEqual(result, expected_result)
+
+    def test_fetches_with_plugins(self):
+        @wrappers.BaseRequest.application
+        def app(request):
+            body = request.get_data()
+            request_pb = server_info_pb2.ServerInfoRequest.FromString(body)
+            self.assertEqual(request_pb.version, version.VERSION)
+            self.assertEqual(
+                request_pb.requested_plugins, ["plugin1", "plugin2"]
+            )
+            return wrappers.BaseResponse(
+                server_info_pb2.ServerInfoResponse().SerializeToString()
+            )
+
+        origin = self._start_server(app)
+        result = server_info.fetch_server_info(origin, ["plugin1", "plugin2"])
+        self.assertIsNotNone(result)
 
     def test_econnrefused(self):
         (family, localhost) = _localhost()
@@ -83,7 +101,7 @@ class FetchServerInfoTest(tb_test.TestCase):
         self.addCleanup(s.close)
         port = s.getsockname()[1]
         with self.assertRaises(server_info.CommunicationError) as cm:
-            server_info.fetch_server_info("http://localhost:%d" % port)
+            server_info.fetch_server_info("http://localhost:%d" % port, [])
         msg = str(cm.exception)
         self.assertIn("Failed to connect to backend", msg)
         if os.name != "nt":
@@ -97,7 +115,7 @@ class FetchServerInfoTest(tb_test.TestCase):
 
         origin = self._start_server(app)
         with self.assertRaises(server_info.CommunicationError) as cm:
-            server_info.fetch_server_info(origin)
+            server_info.fetch_server_info(origin, [])
         msg = str(cm.exception)
         self.assertIn("Non-OK status from backend (502 Bad Gateway)", msg)
         self.assertIn("very sad", msg)
@@ -110,7 +128,7 @@ class FetchServerInfoTest(tb_test.TestCase):
 
         origin = self._start_server(app)
         with self.assertRaises(server_info.CommunicationError) as cm:
-            server_info.fetch_server_info(origin)
+            server_info.fetch_server_info(origin, [])
         msg = str(cm.exception)
         self.assertIn("Corrupt response from backend", msg)
         self.assertIn("an unlikely proto", msg)
@@ -123,7 +141,7 @@ class FetchServerInfoTest(tb_test.TestCase):
             return wrappers.BaseResponse(result.SerializeToString())
 
         origin = self._start_server(app)
-        result = server_info.fetch_server_info(origin)
+        result = server_info.fetch_server_info(origin, [])
         expected_user_agent = "tensorboard/%s" % version.VERSION
         self.assertEqual(result.compatibility.details, expected_user_agent)
 
@@ -131,10 +149,10 @@ class FetchServerInfoTest(tb_test.TestCase):
 class CreateServerInfoTest(tb_test.TestCase):
     """Tests for `create_server_info`."""
 
-    def test(self):
+    def test_response(self):
         frontend = "http://localhost:8080"
         backend = "localhost:10000"
-        result = server_info.create_server_info(frontend, backend)
+        result = server_info.create_server_info(frontend, backend, [])
 
         expected_compatibility = server_info_pb2.Compatibility()
         expected_compatibility.verdict = server_info_pb2.VERDICT_OK
@@ -151,6 +169,19 @@ class CreateServerInfoTest(tb_test.TestCase):
         )
         expected_url = "http://localhost:8080/experiment/123/"
         self.assertEqual(actual_url, expected_url)
+
+        self.assertEqual(result.plugin_control.allowed_plugins, [])
+
+    def test_response_with_plugins(self):
+        frontend = "http://localhost:8080"
+        backend = "localhost:10000"
+        result = server_info.create_server_info(
+            frontend, backend, ["plugin1", "plugin2"]
+        )
+
+        self.assertEqual(
+            result.plugin_control.allowed_plugins, ["plugin1", "plugin2"]
+        )
 
 
 class ExperimentUrlTest(tb_test.TestCase):

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -84,7 +84,8 @@ class FetchServerInfoTest(tb_test.TestCase):
             request_pb = server_info_pb2.ServerInfoRequest.FromString(body)
             self.assertEqual(request_pb.version, version.VERSION)
             self.assertEqual(
-                request_pb.plugin_specification.upload_plugins, ["plugin1", "plugin2"]
+                request_pb.plugin_specification.upload_plugins,
+                ["plugin1", "plugin2"],
             )
             return wrappers.BaseResponse(
                 server_info_pb2.ServerInfoResponse().SerializeToString()

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -746,7 +746,7 @@ def _get_server_info(flags):
     if flags.api_endpoint and not flags.origin:
         return server_info_lib.create_server_info(
             origin, flags.api_endpoint, flags.plugins
-        ) 
+        )
     server_info = server_info_lib.fetch_server_info(origin, flags.plugins)
     # Override with any API server explicitly specified on the command
     # line, but only if the server accepted our initial handshake.

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -745,8 +745,9 @@ def _get_server_info(flags):
     if flags.api_endpoint and not flags.origin:
         return server_info_lib.create_server_info(
             origin, flags.api_endpoint, flags.plugins
-        )
-    server_info = server_info_lib.fetch_server_info(origin, flags.plugins)
+        ) 
+    plugins = flags.plugins if hasattr(flags, 'plugins') else []
+    server_info = server_info_lib.fetch_server_info(origin, plugins)
     # Override with any API server explicitly specified on the command
     # line, but only if the server accepted our initial handshake.
     if flags.api_endpoint and server_info.api_server.endpoint:

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -743,7 +743,9 @@ def _get_intent(flags):
 def _get_server_info(flags):
     origin = flags.origin or _DEFAULT_ORIGIN
     if flags.api_endpoint and not flags.origin:
-        return server_info_lib.create_server_info(origin, flags.api_endpoint)
+        return server_info_lib.create_server_info(
+            origin, flags.api_endpoint, flags.plugins
+        )
     server_info = server_info_lib.fetch_server_info(origin, flags.plugins)
     # Override with any API server explicitly specified on the command
     # line, but only if the server accepted our initial handshake.

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -163,6 +163,7 @@ def _define_flags(parser):
         "--plugins",
         type=str,
         nargs="*",
+        default=[],
         help="List of plugins for which data should be uploaded. If "
         "unspecified then data will be uploaded for all plugins supported by "
         "the server.",
@@ -746,8 +747,7 @@ def _get_server_info(flags):
         return server_info_lib.create_server_info(
             origin, flags.api_endpoint, flags.plugins
         ) 
-    plugins = flags.plugins if hasattr(flags, 'plugins') else []
-    server_info = server_info_lib.fetch_server_info(origin, plugins)
+    server_info = server_info_lib.fetch_server_info(origin, flags.plugins)
     # Override with any API server explicitly specified on the command
     # line, but only if the server accepted our initial handshake.
     if flags.api_endpoint and server_info.api_server.endpoint:

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -159,6 +159,15 @@ def _define_flags(parser):
         help="Experiment description. Markdown format.  Max 600 characters.",
     )
 
+    upload.add_argument(
+        "--plugins",
+        type=str,
+        nargs="*",
+        help="List of plugins for which data should be uploaded. If "
+        "unspecified then data will be uploaded for all plugins supported by "
+        "the server.",
+    )
+
     update_metadata = subparsers.add_parser(
         "update-metadata",
         help="change the name, description, or other user "
@@ -735,7 +744,7 @@ def _get_server_info(flags):
     origin = flags.origin or _DEFAULT_ORIGIN
     if flags.api_endpoint and not flags.origin:
         return server_info_lib.create_server_info(origin, flags.api_endpoint)
-    server_info = server_info_lib.fetch_server_info(origin)
+    server_info = server_info_lib.fetch_server_info(origin, flags.plugins)
     # Override with any API server explicitly specified on the command
     # line, but only if the server accepted our initial handshake.
     if flags.api_endpoint and server_info.api_server.endpoint:


### PR DESCRIPTION
* Motivation for features / changes

Allow uploader users to specify the plugins for which data should be uploaded. It has two-fold purpose: 
(1) Allow users to specify "experimental" plugins that would otherwise not be uploaded.
(2) Allow users to list a subset of launched plugins, if they do not want to upload all launched plugin data.

* Technical description of changes

Add "--plugins" command line option for upload subcommand. The information is sent in the ServerInfoRequest (aka the handshake) and may impact the list of plugins returned in ServerInfoResponse.plugin_control.allowed_plugins.

Sample usage:
tensorboard dev upload --logdir <log dir> --plugins scalars graphs histograms

Outside of these specific changes:

It's expected that supported servers will evaluate the list of plugins and decide whether it is valid. If valid, the server will respond with the entire list of plugins or perhaps a sublist. If the list is invalid then it will respond with a CompatibilityVerdict of VERDICT_ERROR and a useful detail message to print to console.

If --plugins is not specified then the server is expected to respond with a default list of plugins to upload.
