### PR TITLE
Add name and description to Colab example

### DIFF
--- a/docs/tbdev_getting_started.ipynb
+++ b/docs/tbdev_getting_started.ipynb
@@ -194,7 +194,9 @@
       },
       "outputs": [],
       "source": [
-        "!tensorboard dev upload --logdir ./logs"
+        "!tensorboard dev upload --logdir ./logs \\\n",
+        "  --name \"Simple experiment with MNIST\" \\\n",
+        "  --description \"Training results from https://colab.sandbox.google.com/github/tensorflow/tensorboard/blob/master/docs/tbdev_getting_started.ipynb\""
       ]
     },
     {


### PR DESCRIPTION
Add the new name and description capability to the [Colab example](https://colab.sandbox.google.com/github/tensorflow/tensorboard/blob/master/docs/tbdev_getting_started.ipynb). This will help new users discover this feature.