### PR TITLE
hparams: add missing build dep to `:metadata`

### DIFF
--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -314,6 +314,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":error",
+        ":protos_all_py_pb2",
         "//tensorboard/compat/proto:protos_all_py_pb2",
     ],
 )


### PR DESCRIPTION
Test Plan:
Importing `tensorboard.plugins.hparams.metadata` from `dataclass_compat`
no longer causes all the tests to break.

wchargin-branch: hparams-metadata-proto-dep
