### PR TITLE
[uploader] Move BlobSequence to a nested location to avoid name clash

### DIFF
--- a/tensorboard/uploader/proto/blob.proto
+++ b/tensorboard/uploader/proto/blob.proto
@@ -24,7 +24,3 @@ message BlobSequenceEntry {
   // there is expected to be a blob here, but upload has not started.
   Blob blob = 1;
 }
-
-message BlobSequence {
-  repeated BlobSequenceEntry entries = 1;
-}

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -146,6 +146,10 @@ message StreamExperimentDataResponse {
     repeated .tensorboard.TensorProto values = 3;
   }
 
+  message BlobSequence {
+    repeated BlobSequenceEntry entries = 1;
+  }
+
   message BlobSequencePoints {
     // Step index within the run.
     repeated int64 steps = 1;


### PR DESCRIPTION
* Motivation for features / changes
  * Fix a proto name clash discovered during sync

* Technical description of changes
  * `BlobSequence` is already defined in another .proto file, in the same namespace. To avoid the clash and the resultant test failure, move it to a nested location first. Later we can work on deduplication internally.

