### PR TITLE
Revert "Add message types and rpc method to support exporting BLOBs (#3373)

### DIFF
--- a/tensorboard/uploader/proto/blob.proto
+++ b/tensorboard/uploader/proto/blob.proto
@@ -12,19 +12,3 @@ enum BlobState {
   // Object is finalized.
   BLOB_STATE_CURRENT = 2;
 }
-
-message Blob {
-  // A non-empty ID for the blob.
-  string blob_id = 1;
-  BlobState state = 2;
-}
-
-message BlobSequenceEntry {
-  // Optional. If absent, this represents a "hole" in the sequence:
-  // there is expected to be a blob here, but upload has not started.
-  Blob blob = 1;
-}
-
-message BlobSequence {
-  repeated BlobSequenceEntry entries = 1;
-}

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package tensorboard.service;
 
 import "google/protobuf/timestamp.proto";
-import "tensorboard/uploader/proto/blob.proto";
 import "tensorboard/uploader/proto/experiment.proto";
 import "tensorboard/compat/proto/summary.proto";
 import "tensorboard/compat/proto/tensor.proto";
@@ -16,9 +15,6 @@ service TensorBoardExporterService {
   // Stream scalars for all the runs and tags in an experiment.
   rpc StreamExperimentData(StreamExperimentDataRequest)
       returns (stream StreamExperimentDataResponse) {}
-  // Stream blob as chunks for a given blob_id.
-  rpc StreamBlobData(StreamBlobDataRequest)
-      returns (stream StreamBlobDataResponse) {}
 }
 
 // Request to stream the experiment_id of all the experiments owned by the
@@ -107,18 +103,10 @@ message StreamExperimentDataResponse {
   string run_name = 2;
   // The metadata of the tag `tag_name`.
   .tensorboard.SummaryMetadata tag_metadata = 3;
-
   // Data to store for the tag `tag_name.
-  oneof data {
-    // Scalar data to store.
-    ScalarPoints points = 4;
-
-    // Tensor data to store.
-    TensorPoints tensors = 5;
-
-    // Blob sequences to store.
-    BlobSequencePoints blob_sequences = 6;
-  }
+  ScalarPoints points = 4;
+  // Tensor data to store.
+  TensorPoints tensors = 5;
 
   // Data for the scalars are stored in a columnar fashion to optimize it for
   // exporting the data into textual formats like JSON.
@@ -145,33 +133,4 @@ message StreamExperimentDataResponse {
     // Value of the point at this step / timestamp.
     repeated .tensorboard.TensorProto values = 3;
   }
-
-  message BlobSequencePoints {
-    // Step index within the run.
-    repeated int64 steps = 1;
-    // Timestamp of the creation of this point.
-    repeated google.protobuf.Timestamp wall_times = 2;
-    // Value of the blob sequence at this step / timestamp.
-    repeated BlobSequence values = 3;
-  }
-}
-
-message StreamBlobDataRequest {
-  string blob_id = 1;
-}
-
-message StreamBlobDataResponse {
-  // The bytes in this chunk.
-  bytes data = 1;
-  // The position in the blob where this chunk begins.
-  // This must equal the sum of the sizes of the chunks sent so far.  Ignored
-  // if no data is provided.
-  int64 offset = 2;
-  // TODO(b/150443776): Add `crc32a = 3;` once the server can populate it.
-  reserved 3;
-  // Indicates that this is the last chunk of the stream.
-  bool final_chunk = 4;
-  // CRC32C of the entire blob. This should be set when final_chunk=True, to
-  // protect against data corruption.
-  fixed32 final_crc32c = 5;
 }


### PR DESCRIPTION
This reverts commit 2f83ec5ebf40bac5870a20faba10dbeb9ffae167.

* Motivation for features / changes
  * Sync failed due to a name clash. Reverting the PR that introduce the clashing `BlobSequence` message type first. Will fix the internal duplication first.