### PR TITLE
proto: sync to TensorFlow v2.2.0-rc0

### DIFF
--- a/tensorboard/compat/proto/allocation_description.proto
+++ b/tensorboard/compat/proto/allocation_description.proto
@@ -1,11 +1,12 @@
 syntax = "proto3";
 
 package tensorboard;
+
 option cc_enable_arenas = true;
 option java_outer_classname = "AllocationDescriptionProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/allocation_description_go_proto";
 
 message AllocationDescription {
   // Total number of bytes requested
@@ -25,4 +26,4 @@ message AllocationDescription {
 
   // Address of the allocation.
   uint64 ptr = 6;
-};
+}

--- a/tensorboard/compat/proto/api_def.proto
+++ b/tensorboard/compat/proto/api_def.proto
@@ -8,7 +8,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "ApiDefProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/api_def_go_proto";
 import "tensorboard/compat/proto/attr_value.proto";
 
 // Used to specify and override the default API & behavior in the

--- a/tensorboard/compat/proto/attr_value.proto
+++ b/tensorboard/compat/proto/attr_value.proto
@@ -1,14 +1,16 @@
 syntax = "proto3";
 
 package tensorboard;
+
+import "tensorboard/compat/proto/tensor.proto";
+import "tensorboard/compat/proto/tensor_shape.proto";
+import "tensorboard/compat/proto/types.proto";
+
 option cc_enable_arenas = true;
 option java_outer_classname = "AttrValueProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
-import "tensorboard/compat/proto/tensor.proto";
-import "tensorboard/compat/proto/tensor_shape.proto";
-import "tensorboard/compat/proto/types.proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/attr_value_go_proto";
 
 // Protocol buffer representing the value for an attr used to configure an Op.
 // Comment indicates the corresponding attr type.  Only the field matching the

--- a/tensorboard/compat/proto/cluster.proto
+++ b/tensorboard/compat/proto/cluster.proto
@@ -16,11 +16,12 @@ limitations under the License.
 syntax = "proto3";
 
 package tensorboard;
+
 option cc_enable_arenas = true;
 option java_outer_classname = "ClusterProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.distruntime";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
 
 // This file contains protos to be used when defining a TensorFlow
 // cluster.

--- a/tensorboard/compat/proto/config.proto
+++ b/tensorboard/compat/proto/config.proto
@@ -2,18 +2,18 @@ syntax = "proto3";
 
 package tensorboard;
 
-option cc_enable_arenas = true;
-option java_outer_classname = "ConfigProtos";
-option java_multiple_files = true;
-option java_package = "org.tensorflow.framework";
-
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf";
 import "tensorboard/compat/proto/cost_graph.proto";
 import "tensorboard/compat/proto/graph.proto";
 import "tensorboard/compat/proto/step_stats.proto";
 import "tensorboard/compat/proto/cluster.proto";
 import "tensorboard/compat/proto/debug.proto";
 import "tensorboard/compat/proto/rewriter_config.proto";
+
+option cc_enable_arenas = true;
+option java_outer_classname = "ConfigProtos";
+option java_multiple_files = true;
+option java_package = "org.tensorflow.framework";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
 
 message GPUOptions {
   // Fraction of the available GPU memory to allocate for each process.
@@ -367,6 +367,17 @@ message ConfigProto {
   // The execution of an individual op (for some op types) can be
   // parallelized on a pool of intra_op_parallelism_threads.
   // 0 means the system picks an appropriate number.
+  //
+  // If you create an ordinary session, e.g., from Python or C++,
+  // then there is exactly one intra op thread pool per process.
+  // The first session created determines the number of threads in this pool.
+  // All subsequent sessions reuse/share this one global pool.
+  //
+  // There are notable exceptions to the default behavior describe above:
+  // 1. There is an environment variable  for overriding this thread pool,
+  //    named TF_OVERRIDE_GLOBAL_THREADPOOL.
+  // 2. When connecting to a server, such as a remote `tf.train.Server`
+  //    instance, then this option will be ignored altogether.
   int32 intra_op_parallelism_threads = 2;
 
   // Nodes that perform blocking operations are enqueued on a pool of
@@ -456,6 +467,12 @@ message ConfigProto {
   // enabled, this field is ignored and sessions are always isolated.
   bool isolate_session_state = 15;
 
+  // When true, WorkerSessions are created with device attributes from the
+  // full cluster.
+  // This is helpful when a worker wants to partition a graph
+  // (for example during a PartitionedCallOp).
+  bool share_cluster_devices_in_session = 17;
+
   // Everything inside Experimental is subject to change and is not subject
   // to API stability guarantees in
   // https://www.tensorflow.org/guide/version_compat.
@@ -519,10 +536,8 @@ message ConfigProto {
     // CPU usage.
     bool disable_thread_spinning = 9;
 
-    // When true, WorkerSessions are created with device attributes from the
-    // full cluster.
-    // This is helpful when a worker wants to partition a graph
-    // (for example during a PartitionedCallOp).
+    // This was promoted to a non-experimental API. Please use
+    // ConfigProto.share_cluster_devices_in_session instead.
     bool share_cluster_devices_in_session = 10;
 
     // Metadata about the session.
@@ -567,11 +582,11 @@ message ConfigProto {
     // The XLA fusion autotuner can improve performance by executing a heuristic
     // search on the compiler parameters.
     int64 xla_fusion_autotuner_thresh = 15;
-  };
+  }
 
   Experimental experimental = 16;
 
-  // Next: 17
+  // Next: 18
 }
 
 // Options for a single Run() call.
@@ -625,7 +640,7 @@ message RunOptions {
     // and tail) latency.
     // Consider using this option for CPU-bound workloads like inference.
     bool use_run_handler_pool = 2;
-  };
+  }
 
   Experimental experimental = 8;
 

--- a/tensorboard/compat/proto/cost_graph.proto
+++ b/tensorboard/compat/proto/cost_graph.proto
@@ -1,13 +1,15 @@
 syntax = "proto3";
 
 package tensorboard;
+
+import "tensorboard/compat/proto/tensor_shape.proto";
+import "tensorboard/compat/proto/types.proto";
+
 option cc_enable_arenas = true;
 option java_outer_classname = "CostGraphProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
-import "tensorboard/compat/proto/tensor_shape.proto";
-import "tensorboard/compat/proto/types.proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/cost_graph_go_proto";
 
 message CostGraphDef {
   message Node {

--- a/tensorboard/compat/proto/debug.proto
+++ b/tensorboard/compat/proto/debug.proto
@@ -1,11 +1,12 @@
 syntax = "proto3";
 
 package tensorboard;
+
 option cc_enable_arenas = true;
 option java_outer_classname = "DebugProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
 
 // Option for watching a node in TensorFlow Debugger (tfdbg).
 message DebugTensorWatch {

--- a/tensorboard/compat/proto/function.proto
+++ b/tensorboard/compat/proto/function.proto
@@ -1,14 +1,16 @@
 syntax = "proto3";
 
 package tensorboard;
+
+import "tensorboard/compat/proto/attr_value.proto";
+import "tensorboard/compat/proto/node_def.proto";
+import "tensorboard/compat/proto/op_def.proto";
+
 option cc_enable_arenas = true;
 option java_outer_classname = "FunctionProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
-import "tensorboard/compat/proto/attr_value.proto";
-import "tensorboard/compat/proto/node_def.proto";
-import "tensorboard/compat/proto/op_def.proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/function_go_proto";
 
 // A library is a set of named functions.
 message FunctionDefLibrary {
@@ -36,6 +38,17 @@ message FunctionDef {
     map<string, AttrValue> attr = 1;
   }
   map<uint32, ArgAttrs> arg_attr = 7;
+
+  // Unique IDs for each resource argument, used to track aliasing resources. If
+  // Argument A and Argument B alias each other, then
+  // resource_arg_unique_ids[A.index] == resource_arg_unique_ids[B.index].
+  //
+  // If this field is empty, none of the arguments could alias; otherwise, every
+  // resource argument should have an entry in this field.
+  //
+  // When instantiated, the unique IDs will be attached to the _Arg nodes'
+  // "_resource_arg_unique_id" attribute.
+  map<uint32, uint32> resource_arg_unique_id = 8;
 
   // NOTE: field id 2 deleted on Jan 11, 2017, GraphDef version 21.
   reserved 2;

--- a/tensorboard/compat/proto/graph.proto
+++ b/tensorboard/compat/proto/graph.proto
@@ -1,14 +1,16 @@
 syntax = "proto3";
 
 package tensorboard;
+
+import "tensorboard/compat/proto/function.proto";
+import "tensorboard/compat/proto/node_def.proto";
+import "tensorboard/compat/proto/versions.proto";
+
 option cc_enable_arenas = true;
 option java_outer_classname = "GraphProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
-import "tensorboard/compat/proto/node_def.proto";
-import "tensorboard/compat/proto/function.proto";
-import "tensorboard/compat/proto/versions.proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/graph_go_proto";
 
 // Represents the graph of operations
 message GraphDef {
@@ -53,4 +55,4 @@ message GraphDef {
   //     consumer does not start until all return values of the callee
   //     function are ready.
   FunctionDefLibrary library = 2;
-};
+}

--- a/tensorboard/compat/proto/meta_graph.proto
+++ b/tensorboard/compat/proto/meta_graph.proto
@@ -1,13 +1,8 @@
 syntax = "proto3";
 
 package tensorboard;
-option cc_enable_arenas = true;
-option java_outer_classname = "MetaGraphProtos";
-option java_multiple_files = true;
-option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf";
-import "google/protobuf/any.proto";
 
+import "google/protobuf/any.proto";
 import "tensorboard/compat/proto/graph.proto";
 import "tensorboard/compat/proto/op_def.proto";
 import "tensorboard/compat/proto/tensor_shape.proto";
@@ -15,6 +10,12 @@ import "tensorboard/compat/proto/types.proto";
 import "tensorboard/compat/proto/saved_object_graph.proto";
 import "tensorboard/compat/proto/saver.proto";
 import "tensorboard/compat/proto/struct.proto";
+
+option cc_enable_arenas = true;
+option java_outer_classname = "MetaGraphProtos";
+option java_multiple_files = true;
+option java_package = "org.tensorflow.framework";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
 
 // NOTE: This protocol buffer is evolving, and will go through revisions in the
 // coming months.
@@ -67,6 +68,9 @@ message MetaGraphDef {
     // A flag to denote whether default-valued attrs have been stripped from
     // the nodes in this graph_def.
     bool stripped_default_attrs = 7;
+
+    // FunctionDef name to aliases mapping.
+    map<string, string> function_aliases = 8;
   }
   MetaInfoDef meta_info_def = 1;
 

--- a/tensorboard/compat/proto/node_def.proto
+++ b/tensorboard/compat/proto/node_def.proto
@@ -1,12 +1,14 @@
 syntax = "proto3";
 
 package tensorboard;
+
+import "tensorboard/compat/proto/attr_value.proto";
+
 option cc_enable_arenas = true;
 option java_outer_classname = "NodeProto";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
-import "tensorboard/compat/proto/attr_value.proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/node_def_go_proto";
 
 message NodeDef {
   // The name given to this operator. Used for naming inputs,
@@ -79,8 +81,8 @@ message NodeDef {
     // `original_node_names` can be used to map errors originating at the
     // current ndoe to some top level source code.
     repeated string original_func_names = 2;
-  };
+  }
 
   // This stores debug information associated with the node.
   ExperimentalDebugInfo experimental_debug_info = 6;
-};
+}

--- a/tensorboard/compat/proto/op_def.proto
+++ b/tensorboard/compat/proto/op_def.proto
@@ -5,7 +5,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "OpDefProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/op_def_go_proto";
 import "tensorboard/compat/proto/attr_value.proto";
 import "tensorboard/compat/proto/types.proto";
 

--- a/tensorboard/compat/proto/resource_handle.proto
+++ b/tensorboard/compat/proto/resource_handle.proto
@@ -1,14 +1,15 @@
 syntax = "proto3";
 
 package tensorboard;
+
+import "tensorboard/compat/proto/tensor_shape.proto";
+import "tensorboard/compat/proto/types.proto";
+
 option cc_enable_arenas = true;
 option java_outer_classname = "ResourceHandle";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
-
-import "tensorboard/compat/proto/tensor_shape.proto";
-import "tensorboard/compat/proto/types.proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/resource_handle_go_proto";
 
 // Protocol buffer representing a handle to a tensorflow resource. Handles are
 // not valid across executions, but can be serialized back and forth from within
@@ -39,4 +40,8 @@ message ResourceHandleProto {
 
   // Data types and shapes for the underlying resource.
   repeated DtypeAndShape dtypes_and_shapes = 6;
-};
+
+  // A set of devices containing the resource. If empty, the resource only
+  // exists on `device`.
+  repeated string allowed_devices = 7;
+}

--- a/tensorboard/compat/proto/rewriter_config.proto
+++ b/tensorboard/compat/proto/rewriter_config.proto
@@ -2,15 +2,14 @@ syntax = "proto3";
 
 package tensorboard;
 
+import "tensorboard/compat/proto/attr_value.proto";
+import "tensorboard/compat/proto/verifier_config.proto";
+
 option cc_enable_arenas = true;
 option java_outer_classname = "RewriterConfigProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf";
-
-import "tensorboard/compat/proto/attr_value.proto";
-import "tensorboard/compat/proto/verifier_config.proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
 
 message AutoParallelOptions {
   bool enable = 1;
@@ -130,7 +129,7 @@ message RewriterConfig {
   // effect on manually requested memory optimization passes in the optimizers
   // field.
   MemOptType memory_optimization = 4;
-  // A node name scope for node names which are valid outputs of recompuations.
+  // A node name scope for node names which are valid outputs of recomputations.
   // Inputs to nodes that match this scope may be recomputed (subject either to
   // manual annotation of those input nodes or to manual annotation and
   // heuristics depending on memory_optimization), but the nodes themselves will

--- a/tensorboard/compat/proto/saved_object_graph.proto
+++ b/tensorboard/compat/proto/saved_object_graph.proto
@@ -1,15 +1,16 @@
 syntax = "proto3";
 
-import "tensorboard/compat/proto/trackable_object_graph.proto";
-import "tensorboard/compat/proto/struct.proto";
+package tensorboard;
+
 import "tensorboard/compat/proto/tensor_shape.proto";
 import "tensorboard/compat/proto/types.proto";
-import "tensorboard/compat/proto/versions.proto";
 import "tensorboard/compat/proto/variable.proto";
+import "tensorboard/compat/proto/versions.proto";
+import "tensorboard/compat/proto/struct.proto";
+import "tensorboard/compat/proto/trackable_object_graph.proto";
 
 option cc_enable_arenas = true;
-
-package tensorboard;
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
 
 // A SavedObjectGraph is part of object-based SavedModels in TF 2.0. It
 // describes the directed graph of Python objects (or equivalent in other
@@ -37,8 +38,7 @@ message SavedObject {
   // graph.
   //
   // Note: currently only valid if kind == "user_object".
-  repeated TrackableObjectGraph.TrackableObject.ObjectReference
-      children = 1;
+  repeated TrackableObjectGraph.TrackableObject.ObjectReference children = 1;
 
   // Removed when forking SavedObject from TrackableObjectGraph.
   reserved "attributes";

--- a/tensorboard/compat/proto/saver.proto
+++ b/tensorboard/compat/proto/saver.proto
@@ -1,11 +1,12 @@
 syntax = "proto3";
 
 package tensorboard;
+
 option cc_enable_arenas = true;
 option java_outer_classname = "SaverProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.util";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
 
 // Protocol buffer representing the configuration of a Saver.
 message SaverDef {

--- a/tensorboard/compat/proto/step_stats.proto
+++ b/tensorboard/compat/proto/step_stats.proto
@@ -1,13 +1,15 @@
 syntax = "proto3";
 
 package tensorboard;
+
+import "tensorboard/compat/proto/allocation_description.proto";
+import "tensorboard/compat/proto/tensor_description.proto";
+
 option cc_enable_arenas = true;
 option java_outer_classname = "StepStatsProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
-import "tensorboard/compat/proto/allocation_description.proto";
-import "tensorboard/compat/proto/tensor_description.proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/step_stats_go_proto";
 
 // An allocation/de-allocation operation performed by the allocator.
 message AllocationRecord {
@@ -36,7 +38,7 @@ message AllocatorMemoryUsed {
 message NodeOutput {
   int32 slot = 1;
   TensorDescription tensor_description = 3;
-};
+}
 
 // For memory tracking.
 message MemoryStats {
@@ -72,7 +74,7 @@ message NodeExecStats {
   int64 op_end_rel_nanos = 15;
   int64 all_end_rel_nanos = 16;
   int64 scheduled_nanos = 17;
-};
+}
 
 message DeviceStepStats {
   string device = 1;
@@ -83,4 +85,4 @@ message DeviceStepStats {
 
 message StepStats {
   repeated DeviceStepStats dev_stats = 1;
-};
+}

--- a/tensorboard/compat/proto/struct.proto
+++ b/tensorboard/compat/proto/struct.proto
@@ -5,6 +5,8 @@ package tensorboard;
 import "tensorboard/compat/proto/tensor_shape.proto";
 import "tensorboard/compat/proto/types.proto";
 
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
+
 // `StructuredValue` represents a dynamically typed value representing various
 // data structures that are inspired by Python data structures typically used in
 // TensorFlow functions as inputs and outputs.

--- a/tensorboard/compat/proto/summary.proto
+++ b/tensorboard/compat/proto/summary.proto
@@ -1,12 +1,14 @@
 syntax = "proto3";
 
 package tensorboard;
+
+import "tensorboard/compat/proto/tensor.proto";
+
 option cc_enable_arenas = true;
 option java_outer_classname = "SummaryProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
-import "tensorboard/compat/proto/tensor.proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/summary_go_proto";
 
 // Metadata associated with a series of Summary data
 message SummaryDescription {
@@ -31,7 +33,7 @@ message HistogramProto {
   //   i != 0:  bucket_limit(i-1) .. bucket_limit(i)
   repeated double bucket_limit = 6 [packed = true];
   repeated double bucket = 7 [packed = true];
-};
+}
 
 // A SummaryMetadata encapsulates information on which plugins are able to make
 // use of a certain summary value.
@@ -59,7 +61,7 @@ message SummaryMetadata {
   // imposes constraints on the dtype and shape of the corresponding tensor
   // values. See `DataClass` docs for details.
   DataClass data_class = 4;
-};
+}
 
 enum DataClass {
   // Unknown data class, used (implicitly) for legacy data. Will not be

--- a/tensorboard/compat/proto/tensor.proto
+++ b/tensorboard/compat/proto/tensor.proto
@@ -1,14 +1,16 @@
 syntax = "proto3";
 
 package tensorboard;
+
+import "tensorboard/compat/proto/resource_handle.proto";
+import "tensorboard/compat/proto/tensor_shape.proto";
+import "tensorboard/compat/proto/types.proto";
+
 option cc_enable_arenas = true;
 option java_outer_classname = "TensorProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
-import "tensorboard/compat/proto/resource_handle.proto";
-import "tensorboard/compat/proto/tensor_shape.proto";
-import "tensorboard/compat/proto/types.proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/tensor_go_proto";
 
 // Protocol buffer representing a tensor.
 message TensorProto {
@@ -81,7 +83,7 @@ message TensorProto {
 
   // DT_UINT64
   repeated uint64 uint64_val = 17 [packed = true];
-};
+}
 
 // Protocol buffer representing the serialization format of DT_VARIANT tensors.
 message VariantTensorDataProto {

--- a/tensorboard/compat/proto/tensor_description.proto
+++ b/tensorboard/compat/proto/tensor_description.proto
@@ -1,14 +1,16 @@
 syntax = "proto3";
 
 package tensorboard;
+
+import "tensorboard/compat/proto/allocation_description.proto";
+import "tensorboard/compat/proto/tensor_shape.proto";
+import "tensorboard/compat/proto/types.proto";
+
 option cc_enable_arenas = true;
 option java_outer_classname = "TensorDescriptionProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
-import "tensorboard/compat/proto/types.proto";
-import "tensorboard/compat/proto/tensor_shape.proto";
-import "tensorboard/compat/proto/allocation_description.proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/tensor_description_go_proto";
 
 message TensorDescription {
   // Data type of tensor elements
@@ -19,4 +21,4 @@ message TensorDescription {
 
   // Information about the size and allocator used for the data
   AllocationDescription allocation_description = 4;
-};
+}

--- a/tensorboard/compat/proto/tensor_shape.proto
+++ b/tensorboard/compat/proto/tensor_shape.proto
@@ -5,7 +5,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "TensorShapeProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/tensor_shape_go_proto";
 
 package tensorboard;
 

--- a/tensorboard/compat/proto/trackable_object_graph.proto
+++ b/tensorboard/compat/proto/trackable_object_graph.proto
@@ -1,8 +1,9 @@
 syntax = "proto3";
 
-option cc_enable_arenas = true;
-
 package tensorboard;
+
+option cc_enable_arenas = true;
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
 
 // A TensorBundle addition which saves extra information about the objects which
 // own variables, allowing for more robust checkpoint loading into modified

--- a/tensorboard/compat/proto/types.proto
+++ b/tensorboard/compat/proto/types.proto
@@ -5,7 +5,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "TypesProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/types_go_proto";
 
 // (== suppress_warning documentation-presence ==)
 // LINT.IfChange

--- a/tensorboard/compat/proto/variable.proto
+++ b/tensorboard/compat/proto/variable.proto
@@ -6,8 +6,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "VariableProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/variable_go_proto";
 
 // Indicates when a distributed variable will be synced.
 enum VariableSynchronization {

--- a/tensorboard/compat/proto/verifier_config.proto
+++ b/tensorboard/compat/proto/verifier_config.proto
@@ -1,11 +1,12 @@
 syntax = "proto3";
 
 package tensorboard;
+
 option cc_enable_arenas = true;
 option java_outer_classname = "VerifierConfigProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
 
 // The config for graph verifiers.
 message VerifierConfig {

--- a/tensorboard/compat/proto/versions.proto
+++ b/tensorboard/compat/proto/versions.proto
@@ -1,11 +1,12 @@
 syntax = "proto3";
 
 package tensorboard;
+
 option cc_enable_arenas = true;
 option java_outer_classname = "VersionsProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/versions_go_proto";
 
 // Version information for a piece of serialized data
 //
@@ -29,4 +30,4 @@ message VersionDef {
 
   // Specific consumer versions which are disallowed (e.g. due to bugs).
   repeated int32 bad_consumers = 3;
-};
+}


### PR DESCRIPTION
Summary:
These are synced to TensorFlow tag v2.2.0-rc0 which resolves to
3c1e8c03419266bb6ba379d303d3e03a380617a8

Test Plan:
Running `bazel test //tensorboard/compat/proto:proto_test` now passes in
a virtualenv with `tensorflow==2.2.0rc0` installed.

Fixes #3391