### PR TITLE
EngProd: Improve error message for fixing mismatched tf protos.

### DIFF
--- a/tensorboard/compat/proto/proto_test.py
+++ b/tensorboard/compat/proto/proto_test.py
@@ -202,7 +202,7 @@ class ProtoMatchTest(tf.test.TestCase):
                 tb_string.splitlines(1),
                 tf_string.splitlines(1),
                 fromfile=tb_path,
-                tofile=tf_path
+                tofile=tf_path,
             )
             diff = "".join(diff)
 

--- a/tensorboard/compat/proto/proto_test.py
+++ b/tensorboard/compat/proto/proto_test.py
@@ -161,7 +161,7 @@ PROTO_REPLACEMENTS = [
 
 
 MATCH_FAIL_MESSAGE_TEMPLATE = """
-{} and {} did not match: {}
+{}
 
 NOTE!
 ====
@@ -172,7 +172,7 @@ time.
 The proper fix is:
 
 1. In your TensorFlow clone, check out the version of TensorFlow whose
-   protos you want to update (e.g., `git cehckout v2.2.0-rc0`)
+   protos you want to update (e.g., `git checkout v2.2.0-rc0`)
 2. In your tensorboard repo, run:
 
     ./tensorboard/compat/proto/update.sh PATH_TO_TENSORFLOW_REPO
@@ -186,28 +186,28 @@ class ProtoMatchTest(tf.test.TestCase):
         for tf_path, tb_path in PROTO_IMPORTS:
             tf_pb2 = importlib.import_module(tf_path)
             tb_pb2 = importlib.import_module(tb_path)
-            expected = descriptor_pb2.FileDescriptorProto()
-            actual = descriptor_pb2.FileDescriptorProto()
-            tf_pb2.DESCRIPTOR.CopyToProto(expected)
-            tb_pb2.DESCRIPTOR.CopyToProto(actual)
+            tf_descriptor = descriptor_pb2.FileDescriptorProto()
+            tb_descriptor = descriptor_pb2.FileDescriptorProto()
+            tf_pb2.DESCRIPTOR.CopyToProto(tf_descriptor)
+            tb_pb2.DESCRIPTOR.CopyToProto(tb_descriptor)
 
             # Convert expected to be actual since this matches the
             # replacements done in proto/update.sh
-            actual = str(actual)
-            expected = str(expected)
+            tb_string = str(tb_descriptor)
+            tf_string = str(tf_descriptor)
             for orig, repl in PROTO_REPLACEMENTS:
-                expected = expected.replace(orig, repl)
+                tf_string = tf_string.replace(orig, repl)
 
             diff = difflib.unified_diff(
-                actual.splitlines(1), expected.splitlines(1)
+                tb_string.splitlines(1),
+                tf_string.splitlines(1),
+                fromfile=tb_path,
+                tofile=tf_path
             )
             diff = "".join(diff)
 
-            self.assertEquals(
-                diff,
-                "",
-                MATCH_FAIL_MESSAGE_TEMPLATE.format(tf_path, tb_path, diff),
-            )
+            if diff:
+                self.fail(MATCH_FAIL_MESSAGE_TEMPLATE.format(diff))
 
 
 if __name__ == "__main__":

--- a/tensorboard/compat/proto/proto_test.py
+++ b/tensorboard/compat/proto/proto_test.py
@@ -182,7 +182,6 @@ The proper fix is:
 
 
 class ProtoMatchTest(tf.test.TestCase):
-
     def test_each_proto_matches_tensorflow(self):
         for tf_path, tb_path in PROTO_IMPORTS:
             tf_pb2 = importlib.import_module(tf_path)

--- a/tensorboard/compat/proto/proto_test.py
+++ b/tensorboard/compat/proto/proto_test.py
@@ -160,7 +160,29 @@ PROTO_REPLACEMENTS = [
 ]
 
 
+MATCH_FAIL_MESSAGE_TEMPLATE = """
+{} and {} did not match: {}
+
+NOTE!
+====
+This is expected to happen when TensorFlow updates their proto definitions.
+We pin copies of the protos, but TensorFlow can freely update them at any
+time.
+
+The proper fix is:
+
+1. In your TensorFlow clone, check out the version of TensorFlow whose
+   protos you want to update (e.g., `git cehckout v2.2.0-rc0`)
+2. In your tensorboard repo, run:
+
+    ./tensorboard/compat/proto/update.sh PATH_TO_TENSORFLOW_REPO
+
+3. Review and commit any changes.
+"""
+
+
 class ProtoMatchTest(tf.test.TestCase):
+
     def test_each_proto_matches_tensorflow(self):
         for tf_path, tb_path in PROTO_IMPORTS:
             tf_pb2 = importlib.import_module(tf_path)
@@ -185,7 +207,7 @@ class ProtoMatchTest(tf.test.TestCase):
             self.assertEquals(
                 diff,
                 "",
-                "{} and {} did not match:\n{}".format(tf_path, tb_path, diff),
+                MATCH_FAIL_MESSAGE_TEMPLATE.format(tf_path, tb_path, diff),
             )
 
 


### PR DESCRIPTION
Improves an error message, giving better advice for how to fix the common issue wherein tf and tb proto common definitions have diverged.

Tested:
*  Deliberately caused a proto mismatch and witnessed the new error message.
*  Fixed the proto mismatched and saw the test passes.