### PR TITLE
Revert "Add --plugins option to uploader (#3377)"

### DIFF
--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -8,21 +8,11 @@ package tensorboard.service;
 message ServerInfoRequest {
   // Client-side TensorBoard version, per `tensorboard.version.VERSION`.
   string version = 1;
-  // Information about the plugins for which the client wishes to upload data.
-  //
-  // If specified then the list of plugins will be confirmed by the server and
-  // echoed in the PluginControl.allowed_plugins field. Otherwise the server
-  // will return the default set of plugins it supports.
-  //
-  // If one of the plugins is not supported by the server then it will respond
-  // with compatibility verdict VERDICT_ERROR.
-  PluginSpecification plugin_specification = 2;
 }
 
 message ServerInfoResponse {
-  // Primary bottom-line: is the server compatible with the client, can it
-  // serve its request, and is there anything that the end user should be
-  // aware of?
+  // Primary bottom-line: is the server compatible with the client, and is
+  // there anything that the end user should be aware of?
   Compatibility compatibility = 1;
   // Identifier for a gRPC server providing the `TensorBoardExporterService` and
   // `TensorBoardWriterService` services (under the `tensorboard.service` proto
@@ -30,15 +20,19 @@ message ServerInfoResponse {
   ApiServer api_server = 2;
   // How to generate URLs to experiment pages.
   ExperimentUrlFormat url_format = 3;
-  // Information about the plugins for which data should be uploaded.
+  // For which plugins should we upload data? (Even if the uploader is
+  // structurally capable of uploading data from many plugins, we only actually
+  // upload data that can be currently displayed in TensorBoard.dev. Otherwise,
+  // users may be surprised to see that experiments that they uploaded a while
+  // ago and have since shared or published now have extra information that
+  // they didn't realize had been uploaded.)
   //
-  // If PluginSpecification.requested_plugins is specified then
-  // that list of plugins will be confirmed by the server and echoed in the
-  // the response. Otherwise the server will return the default set of
-  // plugins it supports.
+  // The client may always choose to upload less data than is permitted by this
+  // field: e.g., if the end user specifies not to upload data for a given
+  // plugin, or the client does not yet support uploading some kind of data.
   //
-  // The client should only upload data for the plugins in the response even
-  // if it is capable of uploading more data.
+  // If this field is omitted, there are no upfront restrictions on what the
+  // client may send.
   PluginControl plugin_control = 4;
 }
 
@@ -80,15 +74,8 @@ message ExperimentUrlFormat {
   string id_placeholder = 2;
 }
 
-message PluginSpecification {
-  // Plugins for which the client wishes to upload data. These are plugin names
-  // as stored in the the `SummaryMetadata.plugin_data.plugin_name` proto
-  // field.
-  repeated string upload_plugins = 2;
-}
-
 message PluginControl {
-  // Plugins for which data should be uploaded. These are plugin names as
+  // Only send data from plugins with these names. These are plugin names as
   // stored in the the `SummaryMetadata.plugin_data.plugin_name` proto field.
   repeated string allowed_plugins = 1;
 }

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -159,16 +159,6 @@ def _define_flags(parser):
         help="Experiment description. Markdown format.  Max 600 characters.",
     )
 
-    upload.add_argument(
-        "--plugins",
-        type=str,
-        nargs="*",
-        default=[],
-        help="List of plugins for which data should be uploaded. If "
-        "unspecified then data will be uploaded for all plugins supported by "
-        "the server.",
-    )
-
     update_metadata = subparsers.add_parser(
         "update-metadata",
         help="change the name, description, or other user "
@@ -744,10 +734,8 @@ def _get_intent(flags):
 def _get_server_info(flags):
     origin = flags.origin or _DEFAULT_ORIGIN
     if flags.api_endpoint and not flags.origin:
-        return server_info_lib.create_server_info(
-            origin, flags.api_endpoint, flags.plugins
-        )
-    server_info = server_info_lib.fetch_server_info(origin, flags.plugins)
+        return server_info_lib.create_server_info(origin, flags.api_endpoint)
+    server_info = server_info_lib.fetch_server_info(origin)
     # Override with any API server explicitly specified on the command
     # line, but only if the server accepted our initial handshake.
     if flags.api_endpoint and server_info.api_server.endpoint:


### PR DESCRIPTION
This reverts commit 343456b5768f290b9d8bc8483fec954c0074f4b7.

Test Plan:
Running `bazel run //tensorboard -- dev list` now works. Previously, it
failed with:

```
  File ".../tensorboard/uploader/uploader_main.py", line 750, in _get_server_info
    server_info = server_info_lib.fetch_server_info(origin, flags.plugins)
AttributeError: 'Namespace' object has no attribute 'plugins'
```

wchargin-branch: revert-uploader-plugins-flag
