### PR TITLE
backend: always provide data provider on context

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -165,10 +165,9 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
             max_reload_threads=flags.max_reload_threads,
             event_file_active_filter=_get_event_file_active_filter(flags),
         )
-        if flags.generic_data != "false":
-            data_provider = event_data_provider.MultiplexerDataProvider(
-                multiplexer, flags.logdir or flags.logdir_spec
-            )
+        data_provider = event_data_provider.MultiplexerDataProvider(
+            multiplexer, flags.logdir or flags.logdir_spec
+        )
 
     if reload_interval >= 0:
         # We either reload the multiplexer once when TensorBoard starts up, or we

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -589,9 +589,12 @@ it receives new data at least once per 24 hour period)\
             default="auto",
             choices=["false", "auto", "true"],
             help="""\
-[experimental] Whether to use generic data provider infrastructure. The
-"auto" option enables this only for dashboards that are considered
-stable under the new codepaths. (default: %(default)s)\
+[experimental] Hints whether plugins should read from generic data
+provider infrastructure. For plugins that support only the legacy
+multiplexer APIs or only the generic data APIs, this option has no
+effect. The "auto" option enables this only for plugins that are
+considered to have stable support for generic data providers. (default:
+%(default)s)\
 """,
         )
 


### PR DESCRIPTION
Summary:
Until now, `context.data_provider` was provided unless `generic_data`
was explicitly set to `false`. Now, it’s provided in all cases (except
the legacy DB modes). This was always expected to be safe, and has been
live by default since TensorBoard 1.15.0.

This is needed to write plugins that unconditionally assume that a data
provider is available.

A consequence of this is that `is_active`’s use of the experimental
`list_plugins` method is now always on as well. This has been on by
default for two months, but was first released in TensorBoard 2.2.0
(just released), so it’s slightly riskier, but also expected to be safe.

Test Plan:
Run TensorBoard with `--generic_data false`. If pointing at an empty
logdir, no plugins are shown as active. If pointing at a full plugin,
all appropriate plugins are shown as active. The debugger plugin is
still marked as active if `--debugger_port` is specified and as inactive
if no relevant flags are given, so the fallback `is_active` calls are
still working.

wchargin-branch: backend-always-data-provider
