### PR TITLE
hparams: follow standard `is_active` pattern

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -165,10 +165,9 @@ def standard_tensorboard_wsgi(flags, plugin_loaders, assets_zip_provider):
             max_reload_threads=flags.max_reload_threads,
             event_file_active_filter=_get_event_file_active_filter(flags),
         )
-        if flags.generic_data != "false":
-            data_provider = event_data_provider.MultiplexerDataProvider(
-                multiplexer, flags.logdir or flags.logdir_spec
-            )
+        data_provider = event_data_provider.MultiplexerDataProvider(
+            multiplexer, flags.logdir or flags.logdir_spec
+        )
 
     if reload_interval >= 0:
         # We either reload the multiplexer once when TensorBoard starts up, or we

--- a/tensorboard/plugins/hparams/hparams_plugin.py
+++ b/tensorboard/plugins/hparams/hparams_plugin.py
@@ -74,22 +74,7 @@ class HParamsPlugin(base_plugin.TBPlugin):
         }
 
     def is_active(self):
-        """Returns True if the hparams plugin is active.
-
-        The hparams plugin is active iff there is a tag with the hparams
-        plugin name as its plugin name and the scalars plugin is
-        registered and active.
-        """
-        if not self._context.multiplexer:
-            return False
-        scalars_plugin = self._get_scalars_plugin()
-        if not scalars_plugin or not scalars_plugin.is_active():
-            return False
-        return bool(
-            self._context.multiplexer.PluginRunToTagToContent(
-                metadata.PLUGIN_NAME
-            )
-        )
+        return False  # `list_plugins` as called by TB core suffices
 
     def frontend_metadata(self):
         return base_plugin.FrontendMetadata(element_name="tf-hparams-dashboard")
@@ -172,11 +157,7 @@ class HParamsPlugin(base_plugin.TBPlugin):
             )
             scalars_plugin = self._get_scalars_plugin()
             if not scalars_plugin:
-                raise error.HParamsError(
-                    "Internal error: the scalars plugin is not"
-                    " registered; yet, the hparams plugin is"
-                    " active."
-                )
+                raise werkzeug.exceptions.NotFound("Scalars plugin not loaded")
             return http_util.Respond(
                 request,
                 json.dumps(


### PR DESCRIPTION
Summary:
Until now, the hparams plugin has been active only when hparams data is
present *and* the scalars plugin is loaded and active. This cross-plugin
dependency is unique and doesn’t fit well into the data provider world,
so we remove it. The hparams plugin is now active iff hparams data is
available, via the standard `data_plugin_names` API.

Correspondingly, we loosen the error handling in parts of the plugin
that rely on the scalars plugin being active. As long as the scalars
plugin is included in the TensorBoard instance, this should not be a
problem: TensorBoard core loads all plugins before accepting requests to
any of them. If the hparams plugin is used in an installation with no
scalars plugin, the errors will now be 404s instead of 500s. This seems
acceptable, as running without a scalars plugin is not a common pattern.

Test Plan:
The hparams plugin is still marked as active in logdirs that contain
hparams data and inactive in logdirs that don’t.

wchargin-branch: hparams-data-provider-is-active
