### PR TITLE
ng: create feature_flag store for enabling exp features

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -29,6 +29,7 @@ ng_module(
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/core/views:hash_storage",
+        "//tensorboard/webapp/feature_flag",
         "//tensorboard/webapp/header",
         "//tensorboard/webapp/plugins",
         "//tensorboard/webapp/reloader",
@@ -131,10 +132,13 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/core/effects:core_effects_test_lib",
         "//tensorboard/webapp/core/store:core_store_test_lib",
         "//tensorboard/webapp/core/views:test_lib",
+        "//tensorboard/webapp/feature_flag/effects:effects_test_lib",
+        "//tensorboard/webapp/feature_flag/store:store_test_lib",
         "//tensorboard/webapp/header:test_lib",
         "//tensorboard/webapp/plugins:plugins_container_test_lib",
         "//tensorboard/webapp/reloader:test_lib",
         "//tensorboard/webapp/settings:test_lib",
+        "//tensorboard/webapp/webapp_data_source:feature_flag_test_lib",
     ],
 )
 

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -21,15 +21,13 @@ import {EffectsModule} from '@ngrx/effects';
 import {AppContainer} from './app_container';
 import {CoreModule} from './core/core_module';
 import {HashStorageModule} from './core/views/hash_storage_module';
-import {PluginsModule} from './plugins/plugins_module';
-import {SettingsModule} from './settings/settings_module';
-
-import {ROOT_REDUCERS, loggerMetaReducerFactory} from './reducer_config';
-
-import {HeaderModule} from './header/header_module';
-import {ReloaderModule} from './reloader/reloader_module';
-import {MatIconModule} from './mat_icon_module';
 import {FeatureFlagModule} from './feature_flag/feature_flag_module';
+import {HeaderModule} from './header/header_module';
+import {MatIconModule} from './mat_icon_module';
+import {PluginsModule} from './plugins/plugins_module';
+import {ROOT_REDUCERS, loggerMetaReducerFactory} from './reducer_config';
+import {ReloaderModule} from './reloader/reloader_module';
+import {SettingsModule} from './settings/settings_module';
 
 @NgModule({
   declarations: [AppContainer],

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -29,6 +29,7 @@ import {ROOT_REDUCERS, loggerMetaReducerFactory} from './reducer_config';
 import {HeaderModule} from './header/header_module';
 import {ReloaderModule} from './reloader/reloader_module';
 import {MatIconModule} from './mat_icon_module';
+import {FeatureFlagModule} from './feature_flag/feature_flag_module';
 
 @NgModule({
   declarations: [AppContainer],
@@ -36,6 +37,7 @@ import {MatIconModule} from './mat_icon_module';
     BrowserModule,
     BrowserAnimationsModule,
     CoreModule,
+    FeatureFlagModule,
     HashStorageModule,
     HeaderModule,
     MatIconModule,

--- a/tensorboard/webapp/feature_flag/BUILD
+++ b/tensorboard/webapp/feature_flag/BUILD
@@ -1,0 +1,26 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "feature_flag",
+    srcs = [
+        "feature_flag_module.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/feature_flag/effects",
+        "//tensorboard/webapp/feature_flag/store",
+        "//tensorboard/webapp/webapp_data_source:feature_flag",
+        "@npm//@angular/core",
+    ],
+)
+
+ng_module(
+    name = "types",
+    srcs = [
+        "types.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/webapp_data_source:feature_flag",
+    ],
+)

--- a/tensorboard/webapp/feature_flag/actions/BUILD
+++ b/tensorboard/webapp/feature_flag/actions/BUILD
@@ -1,0 +1,14 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "actions",
+    srcs = [
+        "feature_flag_actions.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/feature_flag:types",
+        "@npm//@ngrx/store",
+    ],
+)

--- a/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
+++ b/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
@@ -1,0 +1,28 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {createAction, props} from '@ngrx/store';
+
+import {FeatureValue} from '../types';
+
+/** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
+/** @typehack */ import * as _typeHackStoreModel from '@ngrx/store/src/models';
+
+export const featuresLoaded = createAction(
+  '[FEATURE FLAG] Features Loaded',
+  props<{
+    features: {[featureKey: string]: FeatureValue};
+  }>()
+);

--- a/tensorboard/webapp/feature_flag/effects/BUILD
+++ b/tensorboard/webapp/feature_flag/effects/BUILD
@@ -1,0 +1,37 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "effects",
+    srcs = [
+        "feature_flag_effects.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/feature_flag/actions",
+        "//tensorboard/webapp/webapp_data_source:feature_flag",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)
+
+ng_module(
+    name = "effects_test_lib",
+    testonly = True,
+    srcs = [
+        "feature_flag_effects_test.ts",
+    ],
+    deps = [
+        ":effects",
+        "//tensorboard/webapp/feature_flag/actions",
+        "//tensorboard/webapp/feature_flag/store",
+        "//tensorboard/webapp/webapp_data_source:feature_flag_testing",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+        "@npm//rxjs",
+    ],
+)

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects.ts
@@ -1,0 +1,52 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Injectable} from '@angular/core';
+import {createAction, Action} from '@ngrx/store';
+import {Actions, ofType, createEffect} from '@ngrx/effects';
+import {map} from 'rxjs/operators';
+
+import {TBFeatureFlagDataSource} from '../../webapp_data_source/tb_feature_flag_data_source_types';
+import {featuresLoaded} from '../actions/feature_flag_actions';
+
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+/** @typehack */ import * as _typeHackNgrx from '@ngrx/store/src/models';
+/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects';
+
+const effectsInitialized = createAction('[FEATURE FLAG] Effects Init');
+
+@Injectable()
+export class FeatureFlagEffects {
+  /** @export */
+  readonly getFeatureFlags$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(effectsInitialized),
+      map(() => {
+        const features = this.dataSource.getFeatures();
+        return featuresLoaded({features});
+      })
+    )
+  );
+
+  constructor(
+    private readonly actions$: Actions,
+    private readonly dataSource: TBFeatureFlagDataSource
+  ) {}
+
+  /** @export */
+  ngrxOnInitEffects(): Action {
+    return effectsInitialized();
+  }
+}

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
@@ -1,0 +1,78 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {TestBed} from '@angular/core/testing';
+
+import {provideMockActions} from '@ngrx/effects/testing';
+import {Action, Store} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {ReplaySubject} from 'rxjs';
+
+import {State} from '../store/feature_flag_types';
+import {
+  TBFeatureFlagTestingModule,
+  TestingTBFeatureFlagDataSource,
+} from '../../webapp_data_source/tb_feature_flag_testing';
+import {FeatureFlagEffects} from './feature_flag_effects';
+import {featuresLoaded} from '../actions/feature_flag_actions';
+
+describe('feature_flag_effects', () => {
+  let actions: ReplaySubject<Action>;
+  let store: MockStore<State>;
+  let dataSource: TestingTBFeatureFlagDataSource;
+  let effects: FeatureFlagEffects;
+
+  beforeEach(async () => {
+    actions = new ReplaySubject<Action>(1);
+    await TestBed.configureTestingModule({
+      imports: [TBFeatureFlagTestingModule],
+      providers: [
+        provideMockActions(actions),
+        FeatureFlagEffects,
+        provideMockStore(),
+      ],
+    }).compileComponents();
+    effects = TestBed.get(FeatureFlagEffects);
+    store = TestBed.get(Store);
+    dataSource = TestBed.get(TestingTBFeatureFlagDataSource);
+  });
+
+  describe('getFeatureFlags$', () => {
+    let recordedActions: Action[];
+
+    beforeEach(() => {
+      recordedActions = [];
+      effects.getFeatureFlags$.subscribe((action) => {
+        recordedActions.push(action);
+      });
+    });
+
+    it('loads features from the data source on init', () => {
+      spyOn(dataSource, 'getFeatures').and.returnValue({
+        enabledExperimentalPlugins: ['foo', 'bar'],
+      });
+
+      actions.next(effects.ngrxOnInitEffects());
+
+      expect(recordedActions).toEqual([
+        featuresLoaded({
+          features: {
+            enabledExperimentalPlugins: ['foo', 'bar'],
+          },
+        }),
+      ]);
+    });
+  });
+});

--- a/tensorboard/webapp/feature_flag/feature_flag_module.ts
+++ b/tensorboard/webapp/feature_flag/feature_flag_module.ts
@@ -1,0 +1,33 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {NgModule} from '@angular/core';
+import {StoreModule} from '@ngrx/store';
+import {EffectsModule} from '@ngrx/effects';
+
+import {TBFeatureFlagModule} from '../webapp_data_source/tb_feature_flag_module';
+
+import {FEAUTURE_FLAG_FEATURE_KEY} from './store/feature_flag_types';
+import {reducers} from './store/feature_flag_reducers';
+import {FeatureFlagEffects} from './effects/feature_flag_effects';
+
+@NgModule({
+  imports: [
+    TBFeatureFlagModule,
+    StoreModule.forFeature(FEAUTURE_FLAG_FEATURE_KEY, reducers),
+    EffectsModule.forFeature([FeatureFlagEffects]),
+  ],
+})
+export class FeatureFlagModule {}

--- a/tensorboard/webapp/feature_flag/store/BUILD
+++ b/tensorboard/webapp/feature_flag/store/BUILD
@@ -1,0 +1,36 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "store",
+    srcs = [
+        "feature_flag_reducers.ts",
+        "feature_flag_selectors.ts",
+        "feature_flag_types.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/feature_flag:types",
+        "//tensorboard/webapp/feature_flag/actions",
+        "//tensorboard/webapp/webapp_data_source:feature_flag",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)
+
+ng_module(
+    name = "store_test_lib",
+    testonly = True,
+    srcs = [
+        "feature_flag_reducers_test.ts",
+        "feature_flag_selectors_test.ts",
+        "testing.ts",
+    ],
+    deps = [
+        ":store",
+        "//tensorboard/webapp/feature_flag:types",
+        "//tensorboard/webapp/feature_flag/actions",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -1,0 +1,34 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Action, createReducer, on} from '@ngrx/store';
+import * as actions from '../actions/feature_flag_actions';
+import {FeatureFlagState} from './feature_flag_types';
+
+/** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
+
+const initialState: FeatureFlagState = {
+  enabledExperimentalPlugins: [],
+};
+
+const reducer = createReducer<FeatureFlagState>(
+  initialState,
+  on(actions.featuresLoaded, (state, {features}) => {
+    return {...state, ...features};
+  })
+);
+
+export function reducers(state: FeatureFlagState, action: Action) {
+  return reducer(state, action);
+}

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
@@ -1,0 +1,37 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import * as actions from '../actions/feature_flag_actions';
+import {reducers} from './feature_flag_reducers';
+import {buildFeatureFlagState} from './testing';
+
+describe('feature_flag_reducers', () => {
+  describe('featuresLoaded', () => {
+    it('sets the new feature flags onto the state', () => {
+      const prevState = buildFeatureFlagState({
+        enabledExperimentalPlugins: ['foo'],
+      });
+      const nextState = reducers(
+        prevState,
+        actions.featuresLoaded({
+          features: {
+            enabledExperimentalPlugins: ['foo', 'bar'],
+          },
+        })
+      );
+
+      expect(nextState.enabledExperimentalPlugins).toEqual(['foo', 'bar']);
+    });
+  });
+});

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
@@ -33,5 +33,22 @@ describe('feature_flag_reducers', () => {
 
       expect(nextState.enabledExperimentalPlugins).toEqual(['foo', 'bar']);
     });
+
+    it('sets the feature value of other features', () => {
+      const prevState = buildFeatureFlagState({
+        enabledExperimentalPlugins: [],
+      });
+      const nextState = reducers(
+        prevState,
+        actions.featuresLoaded({
+          features: {
+            enabledExperimentalPlugins: [],
+            enableMagicalFeature: true,
+          },
+        })
+      );
+
+      expect(nextState.enableMagicalFeature).toBe(true);
+    });
   });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -1,0 +1,43 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {createSelector, createFeatureSelector} from '@ngrx/store';
+
+import {
+  FeatureFlagState,
+  FEAUTURE_FLAG_FEATURE_KEY,
+  State,
+} from './feature_flag_types';
+import {FeatureValue} from '../types';
+
+/** @typehack */ import * as _typeHackNgrxStore from '@ngrx/store';
+
+const selectFeatureFlagState = createFeatureSelector<State, FeatureFlagState>(
+  FEAUTURE_FLAG_FEATURE_KEY
+);
+
+export const getFeature = createSelector(
+  selectFeatureFlagState,
+  (
+    state: FeatureFlagState,
+    featureId: keyof FeatureFlagState
+  ): FeatureValue | null => {
+    return state[featureId] || null;
+  }
+);
+
+export function getEnabledExperimentalPlugins(state: State): string[] {
+  return getFeature(state, 'enabledExperimentalPlugins') as string[];
+}

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -20,12 +20,12 @@ describe('feature_flag_selectors', () => {
     it('returns a current feature', () => {
       const state = buildState(
         buildFeatureFlagState({
-          enabledExperimentalPlugins: ['foo'],
+          enableMagicFeature: true,
         })
       );
-      const actual = selectors.getFeature(state, 'enabledExperimentalPlugins');
+      const actual = selectors.getFeature(state, 'enableMagicFeature');
 
-      expect(actual).toEqual(['foo']);
+      expect(actual).toBe(true);
     });
 
     it('returns null if the value is not present', () => {

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -1,0 +1,55 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import * as selectors from './feature_flag_selectors';
+import {buildFeatureFlagState, buildState} from './testing';
+
+describe('feature_flag_selectors', () => {
+  describe('getFeature', () => {
+    it('returns a current feature', () => {
+      const state = buildState(
+        buildFeatureFlagState({
+          enabledExperimentalPlugins: ['foo'],
+        })
+      );
+      const actual = selectors.getFeature(state, 'enabledExperimentalPlugins');
+
+      expect(actual).toEqual(['foo']);
+    });
+
+    it('returns null if the value is not present', () => {
+      const state = buildState(
+        buildFeatureFlagState({
+          enabledExperimentalPlugins: ['foo'],
+        })
+      );
+      const actual = selectors.getFeature(state, 'bar');
+
+      expect(actual).toBeNull();
+    });
+  });
+
+  describe('getEnabledExperimentalPlugins', () => {
+    it('returns value in array', () => {
+      const state = buildState(
+        buildFeatureFlagState({
+          enabledExperimentalPlugins: ['bar'],
+        })
+      );
+      const actual = selectors.getFeature(state, 'enabledExperimentalPlugins');
+
+      expect(actual).toEqual(['bar']);
+    });
+  });
+});

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -1,0 +1,27 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {FeatureValue} from '../types';
+
+export const FEAUTURE_FLAG_FEATURE_KEY = 'feature';
+
+export interface FeatureFlagState {
+  enabledExperimentalPlugins: string[];
+  [featureId: string]: FeatureValue;
+}
+
+export interface State {
+  [FEAUTURE_FLAG_FEATURE_KEY]?: FeatureFlagState;
+}

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -23,5 +23,5 @@ export interface FeatureFlagState {
 }
 
 export interface State {
-  [FEAUTURE_FLAG_FEATURE_KEY]?: FeatureFlagState;
+  [FEAUTURE_FLAG_FEATURE_KEY]: FeatureFlagState;
 }

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -1,0 +1,32 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {
+  FeatureFlagState,
+  FEAUTURE_FLAG_FEATURE_KEY,
+} from './feature_flag_types';
+
+export function buildFeatureFlagState(override: Partial<FeatureFlagState>) {
+  return {
+    enabledExperimentalPlugins: ['foo'],
+    ...override,
+  };
+}
+
+export function buildState(featureFlagState: FeatureFlagState) {
+  return {
+    [FEAUTURE_FLAG_FEATURE_KEY]: featureFlagState,
+  };
+}

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -1,0 +1,18 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export {
+  FeatureValue,
+} from '../webapp_data_source/tb_feature_flag_data_source_types';

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 ng_module(
     name = "webapp_data_source",
@@ -29,6 +29,46 @@ ng_module(
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//rxjs",
+    ],
+)
+
+ng_module(
+    name = "feature_flag",
+    srcs = [
+        "tb_feature_flag_data_source.ts",
+        "tb_feature_flag_data_source_types.ts",
+        "tb_feature_flag_module.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/types",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//rxjs",
+    ],
+)
+
+ng_module(
+    name = "feature_flag_testing",
+    testonly = True,
+    srcs = [
+        "tb_feature_flag_testing.ts",
+    ],
+    deps = [
+        ":feature_flag",
+        "@npm//@angular/core",
+    ],
+)
+
+ng_module(
+    name = "feature_flag_test_lib",
+    testonly = True,
+    srcs = [
+        "tb_feature_flag_data_source_test.ts",
+    ],
+    deps = [
+        ":feature_flag",
+        "@npm//@angular/core",
+        "@npm//@types/jasmine",
     ],
 )
 

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -30,4 +30,4 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
   }
 }
 
-export const TEST_ONLY = util;
+export const TEST_ONLY = {util};

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -1,0 +1,33 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {TBFeatureFlagDataSource} from './tb_feature_flag_data_source_types';
+
+const util = {
+  getParams() {
+    return new URLSearchParams(window.location.search);
+  },
+};
+
+export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
+  getFeatures() {
+    const params = util.getParams();
+    return {
+      enabledExperimentalPlugins: params.getAll('experimentalPlugin'),
+    };
+  }
+}
+
+export const TEST_ONLY = util;

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -1,0 +1,51 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TestBed} from '@angular/core/testing';
+
+import {
+  QueryParamsFeatureFlagDataSource,
+  TEST_ONLY,
+} from './tb_feature_flag_data_source';
+
+describe('tb_feature_flag_data_source', () => {
+  describe('QueryParamsFeatureFlagDataSource', () => {
+    let dataSource: QueryParamsFeatureFlagDataSource;
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        providers: [QueryParamsFeatureFlagDataSource],
+      }).compileComponents();
+
+      dataSource = TestBed.get(QueryParamsFeatureFlagDataSource);
+    });
+
+    describe('getFeatures', () => {
+      it('returns enabledExperimentalPlugins from the query params', () => {
+        spyOn(TEST_ONLY, 'getParams').and.returnValue(
+          new URLSearchParams('experimentalPlugin=a&experimentalPlugin=b')
+        );
+        expect(dataSource.getFeatures()).toEqual({
+          enabledExperimentalPlugins: ['a', 'b'],
+        });
+      });
+
+      it('returns empty enabledExperimentalPlugins when empty', () => {
+        spyOn(TEST_ONLY, 'getParams').and.returnValue(new URLSearchParams(''));
+        expect(dataSource.getFeatures()).toEqual({
+          enabledExperimentalPlugins: [],
+        });
+      });
+    });
+  });
+});

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -32,7 +32,7 @@ describe('tb_feature_flag_data_source', () => {
 
     describe('getFeatures', () => {
       it('returns enabledExperimentalPlugins from the query params', () => {
-        spyOn(TEST_ONLY, 'getParams').and.returnValue(
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
           new URLSearchParams('experimentalPlugin=a&experimentalPlugin=b')
         );
         expect(dataSource.getFeatures()).toEqual({
@@ -41,7 +41,9 @@ describe('tb_feature_flag_data_source', () => {
       });
 
       it('returns empty enabledExperimentalPlugins when empty', () => {
-        spyOn(TEST_ONLY, 'getParams').and.returnValue(new URLSearchParams(''));
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+          new URLSearchParams('')
+        );
         expect(dataSource.getFeatures()).toEqual({
           enabledExperimentalPlugins: [],
         });

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
@@ -1,0 +1,25 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Injectable} from '@angular/core';
+
+export type FeatureValue = string | boolean | number | string[];
+
+@Injectable()
+export abstract class TBFeatureFlagDataSource {
+  abstract getFeatures(): {
+    enabledExperimentalPlugins: string[];
+    [featureKey: string]: FeatureValue;
+  };
+}

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_types.ts
@@ -14,10 +14,24 @@ limitations under the License.
 ==============================================================================*/
 import {Injectable} from '@angular/core';
 
+/**
+ * Example of the feature value:
+ *
+ * reload interval: number
+ * is feature enabled: boolean
+ * enabled experimental plugins: string[]
+ */
 export type FeatureValue = string | boolean | number | string[];
 
 @Injectable()
 export abstract class TBFeatureFlagDataSource {
+  /**
+   * Gets feature flags defined.
+   *
+   * The "feature" is very loosely defined so other applications can define more
+   * flags. It is up to the application to better type the flags and create necessary
+   * facilities (e.g., strongly typed selector).
+   */
   abstract getFeatures(): {
     enabledExperimentalPlugins: string[];
     [featureKey: string]: FeatureValue;

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_module.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_module.ts
@@ -1,0 +1,29 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {NgModule} from '@angular/core';
+
+import {TBFeatureFlagDataSource} from './tb_feature_flag_data_source_types';
+import {QueryParamsFeatureFlagDataSource} from './tb_feature_flag_data_source';
+
+@NgModule({
+  providers: [
+    {
+      provide: TBFeatureFlagDataSource,
+      useClass: QueryParamsFeatureFlagDataSource,
+    },
+  ],
+})
+export class TBFeatureFlagModule {}

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_testing.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_testing.ts
@@ -1,0 +1,38 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {NgModule, Injectable} from '@angular/core';
+
+import {TBFeatureFlagDataSource} from './tb_feature_flag_data_source_types';
+
+@Injectable()
+export class TestingTBFeatureFlagDataSource extends TBFeatureFlagDataSource {
+  getFeatures() {
+    return {
+      enabledExperimentalPlugins: [] as string[],
+    };
+  }
+}
+
+@NgModule({
+  providers: [
+    TestingTBFeatureFlagDataSource,
+    {
+      provide: TBFeatureFlagDataSource,
+      useExisting: TestingTBFeatureFlagDataSource,
+    },
+  ],
+})
+export class TBFeatureFlagTestingModule {}


### PR DESCRIPTION
We do not currently have a solid design for our flagging (experimental)
system. Regardless of the details of the system, because the flagging
system can impact many things (e.g., UI, data source, etc...), we want
to persist the flagging state in the store.

This is laying that foundation with a QueryParams backed implementation.
