### PR TITLE
Update golden values and disabled corresponding tests in keras_util_test

### DIFF
--- a/tensorboard/plugins/graph/keras_util_test.py
+++ b/tensorboard/plugins/graph/keras_util_test.py
@@ -35,10 +35,26 @@ class KerasUtilTest(tf.test.TestCase):
             expected_proto, keras_util.keras_model_to_graph_def(model_config)
         )
 
-    def test_keras_model_to_graph_def_sequential_model(self):
+    def DISABLED_test_keras_model_to_graph_def_sequential_model(self):
         expected_proto = """
             node {
+              name: "sequential/dense_input"
+              attr {
+                key: "dtype"
+                value {
+                  type: DT_FLOAT
+                }
+              }
+              attr {
+                key: "keras_class"
+                value {
+                  s: "InputLayer"
+                }
+              }
+            }
+            node {
               name: "sequential/dense"
+              input: "sequential/dense_input"
               attr {
                 key: "dtype"
                 value {
@@ -302,10 +318,58 @@ class KerasUtilTest(tf.test.TestCase):
         model = tf.keras.models.Model(inputs=inputs, outputs=encoder(inputs))
         self.assertGraphDefToModel(expected_proto, model)
 
-    def test_keras_model_to_graph_def_nested_sequential_model(self):
+    def DISABLED_test_keras_model_to_graph_def_nested_sequential_model(self):
         expected_proto = """
             node {
+              name: "sequential_2/sequential_1_input"
+              attr {
+                key: "dtype"
+                value {
+                  type: DT_FLOAT
+                }
+              }
+              attr {
+                key: "keras_class"
+                value {
+                  s: "InputLayer"
+                }
+              }
+            }
+            node {
+              name: "sequential_2/sequential_1/sequential_input"
+              input: "sequential_2/sequential_1_input"
+              attr {
+                key: "dtype"
+                value {
+                  type: DT_FLOAT
+                }
+              }
+              attr {
+                key: "keras_class"
+                value {
+                  s: "InputLayer"
+                }
+              }
+            }
+            node {
+              name: "sequential_2/sequential_1/sequential/dense_input"
+              input: "sequential_2/sequential_1/sequential_input"
+              attr {
+                key: "dtype"
+                value {
+                  type: DT_FLOAT
+                }
+              }
+              attr {
+                key: "keras_class"
+                value {
+                  s: "InputLayer"
+                }
+              }
+            }
+            node {
               name: "sequential_2/sequential_1/sequential/dense"
+              input: "sequential_2/sequential_1/sequential/dense_input"
               attr {
                 key: "dtype"
                 value {
@@ -709,7 +773,7 @@ class KerasUtilTest(tf.test.TestCase):
 
         self.assertGraphDefToModel(expected_proto, model)
 
-    def test_keras_model_to_graph_def_functional_sequential_model(self):
+    def DISABLED_test_keras_model_to_graph_def_functional_sequential_model(self):
         expected_proto = """
             node {
               name: "model/func_seq_input"
@@ -727,8 +791,24 @@ class KerasUtilTest(tf.test.TestCase):
               }
             }
             node {
-              name: "model/sequential/dense"
+              name: "model/sequential/dense_input"
               input: "model/func_seq_input"
+              attr {
+                key: "dtype"
+                value {
+                  type: DT_FLOAT
+                }
+              }
+              attr {
+                key: "keras_class"
+                value {
+                  s: "InputLayer"
+                }
+              }
+            }
+            node {
+              name: "model/sequential/dense"
+              input: "model/sequential/dense_input"
               attr {
                 key: "dtype"
                 value {
@@ -790,8 +870,23 @@ class KerasUtilTest(tf.test.TestCase):
 
         self.assertGraphDefToModel(expected_proto, model)
 
-    def test_keras_model_to_graph_def_sequential_functional_model(self):
+    def DISABLED_test_keras_model_to_graph_def_sequential_functional_model(self):
         expected_proto = """
+            node {
+              name: "sequential/model_input"
+              attr {
+                key: "dtype"
+                value {
+                  type: DT_FLOAT
+                }
+              }
+              attr {
+                key: "keras_class"
+                value {
+                  s: "InputLayer"
+                }
+              }
+            }
             node {
               name: "sequential/model/func_seq_input"
               attr {

--- a/tensorboard/plugins/graph/keras_util_test.py
+++ b/tensorboard/plugins/graph/keras_util_test.py
@@ -773,7 +773,9 @@ class KerasUtilTest(tf.test.TestCase):
 
         self.assertGraphDefToModel(expected_proto, model)
 
-    def DISABLED_test_keras_model_to_graph_def_functional_sequential_model(self):
+    def DISABLED_test_keras_model_to_graph_def_functional_sequential_model(
+        self,
+    ):
         expected_proto = """
             node {
               name: "model/func_seq_input"
@@ -870,7 +872,9 @@ class KerasUtilTest(tf.test.TestCase):
 
         self.assertGraphDefToModel(expected_proto, model)
 
-    def DISABLED_test_keras_model_to_graph_def_sequential_functional_model(self):
+    def DISABLED_test_keras_model_to_graph_def_sequential_functional_model(
+        self,
+    ):
         expected_proto = """
             node {
               name: "sequential/model_input"


### PR DESCRIPTION
- `Sequential.get_config()` is changing
- This PR updates the golden values used in TB tests for Sequential configs
- And also disables the tests to prevent them from failing on the old format
- Please reenable the tests atfer the `Sequential.get_config()` change is merged
