### PR TITLE
Add suppression to externs that conflict with Closure Compiler builtins.

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/externs.js
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/externs.js
@@ -25,7 +25,11 @@
 /** @type {!Object} */ var UMAP;
 /** @type {!Object} */ var graphlib;
 /** @type {!Object} */ var Plottable;
-/** @type {!Object} */ var GroupEffect;
+/**
+ * @suppress {duplicate} Already in the Closure Compiler builtin externs.
+ * @type {!Object}
+ */
+var GroupEffect;
 /** @type {!Object} */ var module;
 /** @type {!Object} */ var exports;
 /** @type {!Object} */ var define;
@@ -33,7 +37,11 @@
 /** @type {!Object} */ var tf;
 /** @type {!Object} */ var mobilenet;
 /** @type {!Function|undefined} */ var ga;
-/** @type {!Function|undefined} */ var KeyframeEffect;
+/**
+ * @suppress {duplicate} Already in the Closure Compiler builtin externs.
+ * @type {!Function|undefined}
+ */
+var KeyframeEffect;
 /** @type {!Object} */ var tensor_widget;
 /** @type {!Object} */ var tb_plugin_lib;
 


### PR DESCRIPTION
These symbols do not appear to be Tensorflow-specific, and are already part of the standard Closure Compiler externs, which may introduce errors when both definitions are used at the same time.