### PR TITLE
[DebuggerV2] Avoid loading source files that are loaded or loading

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -675,7 +675,7 @@ export class DebuggerEffects {
         return (
           runId !== null &&
           fileContent !== null &&
-          fileContent.loadState !== DataLoadState.LOADING
+          fileContent.loadState === DataLoadState.NOT_LOADED
         );
       }),
       tap(({lineSpec}) =>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -1150,7 +1150,7 @@ describe('Debugger effects', () => {
     });
 
     for (const loadState of [DataLoadState.LOADED, DataLoadState.LOADING]) {
-      it('skips loading a loaded or loeading source file', () => {
+      it(`skips loading when file is loaded or loading: ${loadState}`, () => {
         const runId = '__default_debugger_run__';
         const fileIndex = 2;
         const fileContentC: SourceFileResponse = {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -1149,6 +1149,50 @@ describe('Debugger effects', () => {
       ]);
     });
 
+    for (const loadState of [DataLoadState.LOADED, DataLoadState.LOADING]) {
+      it('skips loading a loaded or loeading source file', () => {
+        const runId = '__default_debugger_run__';
+        const fileIndex = 2;
+        const fileContentC: SourceFileResponse = {
+          ...fileSpecC,
+          lines: [''],
+        };
+        const fetchSourceFileSpy = createFetchSourceFileSpy(
+          runId,
+          fileIndex,
+          fileContentC.host_name,
+          fileContentC.file_path,
+          fileContentC.lines
+        );
+        store.overrideSelector(getActiveRunId, runId);
+        store.overrideSelector(getSourceFileList, [
+          fileSpecA,
+          fileSpecB,
+          fileSpecC,
+        ]);
+        store.overrideSelector(getFocusedSourceFileIndex, fileIndex);
+        store.overrideSelector(getFocusedSourceFileContent, {
+          loadState,
+          lines: null,
+        });
+        store.refreshState();
+
+        action.next(
+          sourceLineFocused({
+            sourceLineSpec: {
+              ...fileSpecC,
+              lineno: 42,
+            },
+          })
+        );
+
+        // Due to the LOADED or LOADING state of the file, no request should
+        // have been made for the content of the file.
+        expect(fetchSourceFileSpy).not.toHaveBeenCalled();
+        expect(dispatchedActions).toEqual([]);
+      });
+    }
+
     it('does not load a file being loaded', () => {
       const runId = '__default_debugger_run__';
       const fileIndex = 2;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -1149,8 +1149,17 @@ describe('Debugger effects', () => {
       ]);
     });
 
-    for (const loadState of [DataLoadState.LOADED, DataLoadState.LOADING]) {
-      it(`skips loading when file is loaded or loading: ${loadState}`, () => {
+    for (const {loadState, loadStateName} of [
+      {
+        loadState: DataLoadState.LOADED,
+        loadStateName: 'LOADED',
+      },
+      {
+        loadState: DataLoadState.LOADING,
+        loadStateName: 'LOADING',
+      },
+    ]) {
+      it(`skips loading when file state is ${loadStateName}`, () => {
         const runId = '__default_debugger_run__';
         const fileIndex = 2;
         const fileContentC: SourceFileResponse = {


### PR DESCRIPTION
* Technical description of changes
  * Previously, a source-file content was always loaded from the data source even if it's been loaded already.
  * In this PR, we change the behavior so that source files that are already loaded or currently loading are not requested again under the `sourceLineFocused` action.
* Detailed steps to verify changes work correctly (as executed by you)
  * Unit test added.
  * Verified in a child PR that no repeated request occurs in the browser.