### PR TITLE
ng: unblock sync by resolving missing deps

### DIFF
--- a/tensorboard/webapp/feature_flag/BUILD
+++ b/tensorboard/webapp/feature_flag/BUILD
@@ -10,8 +10,11 @@ ng_module(
     deps = [
         "//tensorboard/webapp/feature_flag/effects",
         "//tensorboard/webapp/feature_flag/store",
+        "//tensorboard/webapp/feature_flag/store:types",
         "//tensorboard/webapp/webapp_data_source:feature_flag",
         "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
     ],
 )
 

--- a/tensorboard/webapp/feature_flag/effects/BUILD
+++ b/tensorboard/webapp/feature_flag/effects/BUILD
@@ -25,10 +25,11 @@ ng_module(
     ],
     deps = [
         ":effects",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/feature_flag/actions",
-        "//tensorboard/webapp/feature_flag/store",
+        "//tensorboard/webapp/feature_flag/store:types",
         "//tensorboard/webapp/webapp_data_source:feature_flag_testing",
-        "@npm//@angular/core",
         "@npm//@ngrx/effects",
         "@npm//@ngrx/store",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
@@ -48,7 +48,7 @@ describe('feature_flag_reducers', () => {
         })
       );
 
-      expect(nextState.enableMagicalFeature).toBe(true);
+      expect(nextState['enableMagicalFeature']).toBe(true);
     });
   });
 });

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -26,7 +26,7 @@ ng_module(
     deps = [
         ":http_client_testing",
         ":webapp_data_source",
-        "@npm//@angular/core",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
         "@npm//@types/jasmine",
     ],
 )
@@ -81,6 +81,7 @@ ng_module(
     ],
     deps = [
         ":feature_flag",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
         "@npm//@angular/core",
         "@npm//@types/jasmine",
     ],


### PR DESCRIPTION
Our test BUILD targets missed strict dependencies on "@angular/core/testing" and "@ngrx/store/testing". 

Resolved all missing deps and fixed the TypeScript conformance error.

Test: cl/303168891

Merge strat: rebase (two logically separate commits)