### PR TITLE
ng: fix tiny charts

### DIFF
--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -41,7 +41,12 @@ import {PluginRegistryModule} from './plugin_registry_module';
   selector: 'plugins-component',
   templateUrl: './plugins_component.ng.html',
   styles: [
-    '.plugins { height: 100%; }',
+    `
+      .plugins {
+        height: 100%;
+        position: relative;
+      }
+    `,
     'iframe { border: 0; height: 100%; width: 100%; }',
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -79,12 +84,27 @@ export class PluginsComponent implements OnChanges {
 
   private renderPlugin(plugin: UiPluginMetadata) {
     for (const element of this.pluginInstances.values()) {
-      element.style.display = 'none';
+      Object.assign(element.style, {
+        maxHeight: 0,
+        overflow: 'hidden',
+        /**
+         * We further make containers invisible. Some elements may anchor to
+         * the viewport instead of the container, in which case setting the max
+         * height here to 0 will not hide them.
+         **/
+        visibility: 'hidden',
+        position: 'absolute',
+      });
     }
 
     if (this.pluginInstances.has(plugin.id)) {
       const instance = this.pluginInstances.get(plugin.id) as HTMLElement;
-      instance.style.removeProperty('display');
+      Object.assign(instance.style, {
+        maxHeight: null,
+        overflow: null,
+        visibility: null,
+        position: null,
+      });
       return;
     }
 


### PR DESCRIPTION
There are many instances when vz_line_chart can be waiting to be
redrawn: it can wait for debouncing, requestAnimationFrame, and/or data.

One of the way Polymer based TensorBoard solved this asynchronousity is
by "visibility: hidden"ing the plugin container instead of "display:
none". This has an effect of giving the container non-zero width and
allows the vz_line_chart to properly render even in the background.

This change replicates
https://github.com/tensorflow/tensorboard/blob/34530f4789647a81687cc2983866820096b831b1/tensorboard/components/tf_tensorboard/tf-tensorboard.html#L412-L418.
