### PR TITLE
demos: use Windows-compatible path names

### DIFF
--- a/tensorboard/plugins/audio/audio_demo.py
+++ b/tensorboard/plugins/audio/audio_demo.py
@@ -271,7 +271,7 @@ def run_all(logdir, verbose=False):
     ]
     for (i, wave_constructor) in enumerate(waves):
         wave_name = wave_constructor.__name__
-        run_name = "wave:%02d,%s" % (i + 1, wave_name)
+        run_name = "%02d_%s" % (i + 1, wave_name)
         if verbose:
             print("--- Running: %s" % run_name)
         run(logdir, run_name, wave_name, wave_constructor)

--- a/tensorboard/plugins/scalar/scalars_demo.py
+++ b/tensorboard/plugins/scalar/scalars_demo.py
@@ -137,7 +137,7 @@ def run_all(logdir, verbose=False):
     for initial_temperature in [270.0, 310.0, 350.0]:
         for final_temperature in [270.0, 310.0, 350.0]:
             for heat_coefficient in [0.001, 0.005]:
-                run_name = "temperature:t0=%g,tA=%g,kH=%g" % (
+                run_name = "t0=%g,tA=%g,kH=%g" % (
                     initial_temperature,
                     final_temperature,
                     heat_coefficient,


### PR DESCRIPTION
Summary:
The audio and scalars demos wrote runs with embedded colons, like
`wave:01,sine_wave`. But Windows prohibits colons in file and directory
names. This patch changes the demos to emit paths that Windows likes.

Fixes #3445.

Test Plan:
Run the audio and scalars demos:

```
rm -rf /tmp/audio_demo /tmp/scalars_demo
bazel run //tensorboard/plugins/audio:audio_demo
bazel run //tensorboard/plugins/scalar:scalars_demo
```

Then, check the output to ensure that all filenames use only characters
that are valid on Windows:

```
find /tmp/audio_demo /tmp/scalars_demo -printf '%f\n' |
    grep '[<>:"/\\|?*]'
```

Running the same query over a logdir of all existing demo output shows
that audio and scalars were the only offenders.

wchargin-branch: demo-windows-paths
