### PR TITLE
Uploader: Add `total_blob_bytes` field to `Experiment` proto

### DIFF
--- a/tensorboard/uploader/proto/experiment.proto
+++ b/tensorboard/uploader/proto/experiment.proto
@@ -29,7 +29,7 @@ message Experiment {
   // The number of bytes used for storage of tensors in this experiment,
   // across all time series, including estimated overhead. Output-only.
   int64 total_tensor_bytes = 9;
-  // The number of bytes used for storage of the content of blobs in this
+  // The number of bytes used for storage of the contents of blobs in this
   // experiment, across all time series, including estimated overhead.
   // Output-only.
   int64 total_blob_bytes = 9;

--- a/tensorboard/uploader/proto/experiment.proto
+++ b/tensorboard/uploader/proto/experiment.proto
@@ -32,7 +32,7 @@ message Experiment {
   // The number of bytes used for storage of the contents of blobs in this
   // experiment, across all time series, including estimated overhead.
   // Output-only.
-  int64 total_blob_bytes = 9;
+  int64 total_blob_bytes = 10;
 }
 
 // Field mask for `Experiment` used in get and update RPCs. The `experiment_id`

--- a/tensorboard/uploader/proto/experiment.proto
+++ b/tensorboard/uploader/proto/experiment.proto
@@ -29,6 +29,10 @@ message Experiment {
   // The number of bytes used for storage of tensors in this experiment,
   // across all time series, including estimated overhead. Output-only.
   int64 total_tensor_bytes = 9;
+  // The number of bytes used for storage of the content of blobs in this
+  // experiment, across all time series, including estimated overhead.
+  // Output-only.
+  int64 total_blob_bytes = 9;
 }
 
 // Field mask for `Experiment` used in get and update RPCs. The `experiment_id`


### PR DESCRIPTION
* Motivation for features / changes
  * Towards fixing b/152749189: displaying the number of blob bytes that an experiment contains int the `tensorboard dev list` command output
* Technical description of changes
  * Add a `total_blob_bytes` field to the `Experiment` proto, which is the respnose message type of `StreamExperiemnts`