### PR TITLE
hparams: minimize calls to context.hparams_metadata()

### DIFF
--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -295,11 +295,13 @@ class Context(object):
 
         return result
 
-    def _compute_metric_infos(self, experiment_id, run_to_tag_to_content):
+    def _compute_metric_infos(
+        self, experiment_id, hparams_run_to_tag_to_content
+    ):
         return (
             api_pb2.MetricInfo(name=api_pb2.MetricName(group=group, tag=tag))
             for tag, group in self._compute_metric_names(
-                experiment_id, run_to_tag_to_content
+                experiment_id, hparams_run_to_tag_to_content
             )
         )
 


### PR DESCRIPTION
This refactors some parts of the hparams plugin to minimize the number of times it calls `context.hparams_metadata()` since each one translates to a `DataProvider.list_tensors()` call that may be expensive.  We do this by basically getting the result of the unfiltered `hparams_metadata()` call (ignoring the tag filters) once at the start of the request, and then refactoring all the subsequent places that would call `hparams_metadata()` so that they just look up the tags they need from that dict rather than making a new call.

The result should be that we now only call `hparams_metadata()` once for both the `/experiment` and `/list_session_groups` routes.  This should be a pretty much strict improvement (no matter how fast the backing RPC is) with the only possible exception being that `/experiment` in the case where an explicit experiment proto was logged, since previously would only have had to return the single run containing that tag, but now it has to return and postprocess all runs with hparams summary data, which might be substantially larger.  (For `/list_session_groups` we iterate over all sessions later in the handler anyway, so this is presumably negligible overhead in that case.)  We can examine later whether or not there might be any benefit from splitting that back into two DataProvider calls for cases where those calls are much faster.

Also, no optimization is done for the `/download_data` route since it's not in the critical path of interacting with the page.

TESTED=unit tests pass; tested locally with demo data; tested to confirm reduction in calls to DataProvider backend