### PR TITLE
Provide upload limits in ServerInfo, and skip uploading blobs that are too large

### DIFF
--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -40,12 +40,16 @@ message ServerInfoResponse {
   // The client should only upload data for the plugins in the response even
   // if it is capable of uploading more data.
   PluginControl plugin_control = 4;
-  // The maximum allowed size for blob uploads.
-  // Note that the WriteBlob RPC endpoint also enforces a limit, which should be
-  // kept in sync with the one reported here.  Providing this limit in advance
-  // allows the uploader to print a better error message and to skip the upload
-  // if it is expected to fail anyway.
-  int64 max_blob_size = 5;
+  // Limits on the upload process that the client should honor.
+  // This may include limits on data size, chunk size, records per request,
+  // request rate, bandwidth, etc.  The server may enforce such limits, in which
+  // case the values reported here should be kept in sync.  Providing these
+  // limits in advance allows the client to avoid triggering server errors (both
+  // through more efficent operation and by earlier detection of real error
+  // conditions), and to print better error messages.
+  // If this field is not set, the client should choose reasonable default
+  // values to guide its behavior.
+  UploadLimits upload_limits = 5;
 }
 
 enum CompatibilityVerdict {
@@ -97,4 +101,10 @@ message PluginControl {
   // Plugins for which data should be uploaded. These are plugin names as
   // stored in the the `SummaryMetadata.plugin_data.plugin_name` proto field.
   repeated string allowed_plugins = 1;
+}
+
+message UploadLimits {
+  // The maximum allowed size for blob uploads.
+  // If this is 0, no blobs should be uploaded.
+  int64 max_blob_size = 1;
 }

--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -40,6 +40,12 @@ message ServerInfoResponse {
   // The client should only upload data for the plugins in the response even
   // if it is capable of uploading more data.
   PluginControl plugin_control = 4;
+  // The maximum allowed size for blob uploads.
+  // Note that the WriteBlob RPC endpoint also enforces a limit, which should be
+  // kept in sync with the one reported here.  Providing this limit in advance
+  // allows the uploader to print a better error message and to skip the upload
+  // if it is expected to fail anyway.
+  int64 max_blob_size = 5;
 }
 
 enum CompatibilityVerdict {

--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -105,6 +105,8 @@ message PluginControl {
 
 message UploadLimits {
   // The maximum allowed size for blob uploads.
-  // If this is 0, no blobs should be uploaded.
+  // If this is 0, it is allowed to upload blobs of size 0 (though note
+  // the server may enforce a *minimum* blob size, which is a separate issue).
+  // If this is negative, no blobs should be uploaded.
   int64 max_blob_size = 1;
 }

--- a/tensorboard/uploader/server_info.py
+++ b/tensorboard/uploader/server_info.py
@@ -31,7 +31,8 @@ from tensorboard.uploader.proto import server_info_pb2
 _REQUEST_TIMEOUT_SECONDS = 10
 
 # Maximum blob size, if not specified by server_info
-_DEFAULT_MAX_BLOB_SIZE = 10 * (2 ** 20)   # 10 MB
+_DEFAULT_MAX_BLOB_SIZE = 10 * (2 ** 20)  # 10 MiB
+
 
 def _server_info_request(upload_plugins):
     """Generates a ServerInfoRequest
@@ -171,14 +172,15 @@ def max_blob_size(server_info):
     Returns:
       A integer giving the maximum size allowed for blob uploads, in bytes.
     """
-    if server_info.HasField("max_blob_size"):
-        return server_info.plugin_control.max_blob_size
+
+    if server_info.HasField("upload_limits"):
+        return server_info.upload_limits.max_blob_size
     else:
-        # Old server: gracefully degrade to 10 MB.
-        # TODO(@davidsoergel): Promote this
-        # branch to an error once we're confident that we won't roll
-        # back to old server versions.
+        # Old server: gracefully degrade to 10 MiB.
+        # TODO(@davidsoergel): Promote this branch to an error once we're
+        # confident that we won't roll back to old server versions.
         return _DEFAULT_MAX_BLOB_SIZE
+
 
 class CommunicationError(RuntimeError):
     """Raised upon failure to communicate with the server."""

--- a/tensorboard/uploader/server_info.py
+++ b/tensorboard/uploader/server_info.py
@@ -30,6 +30,8 @@ from tensorboard.uploader.proto import server_info_pb2
 # Request timeout for communicating with remote server.
 _REQUEST_TIMEOUT_SECONDS = 10
 
+# Maximum blob size, if not specified by server_info
+_DEFAULT_MAX_BLOB_SIZE = 10 * (2 ** 20)   # 10 MB
 
 def _server_info_request(upload_plugins):
     """Generates a ServerInfoRequest
@@ -151,6 +153,32 @@ def allowed_plugins(server_info):
         # back to old server versions.
         return frozenset((scalars_metadata.PLUGIN_NAME,))
 
+
+def max_blob_size(server_info):
+    """Determines the maximum allowed size for blob uploads.
+
+    This pulls from the `max_blob_size` on the `server_info` when that
+    submessage is set, else falls back to a default.
+
+    Note that the RPC endpoint also enforces a limit, which should be kept in
+    sync with the one provided by server_info.  Here the purpose is to provide
+    a better error message and to avoid attempting the upload if it is expected
+    to fail anyway.
+
+    Args:
+      server_info: A `server_info_pb2.ServerInfoResponse` message.
+
+    Returns:
+      A integer giving the maximum size allowed for blob uploads, in bytes.
+    """
+    if server_info.HasField("max_blob_size"):
+        return server_info.plugin_control.max_blob_size
+    else:
+        # Old server: gracefully degrade to 10 MB.
+        # TODO(@davidsoergel): Promote this
+        # branch to an error once we're confident that we won't roll
+        # back to old server versions.
+        return _DEFAULT_MAX_BLOB_SIZE
 
 class CommunicationError(RuntimeError):
     """Raised upon failure to communicate with the server."""

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -225,6 +225,32 @@ class AllowedPluginsTest(tb_test.TestCase):
         self.assertEqual(actual, frozenset(["foo", "bar"]))
 
 
+_DEFAULT_MAX_BLOB_SIZE = 10 * (2 ** 20)  # 10 MiB
+
+
+class MaxBlobSizeTest(tb_test.TestCase):
+    """Tests for `max_blob_size`."""
+
+    def test_old_server_no_upload_limits(self):
+        info = server_info_pb2.ServerInfoResponse()
+        actual = server_info.max_blob_size(info)
+        self.assertEqual(actual, _DEFAULT_MAX_BLOB_SIZE)
+
+    def test_upload_limits_provided_with_max_blob_size(self):
+        info = server_info_pb2.ServerInfoResponse()
+        info.upload_limits.max_blob_size = 42
+        actual = server_info.max_blob_size(info)
+        self.assertEqual(actual, 42)
+
+    def test_upload_limits_provided_without_max_blob_size(self):
+        # This just shows that proto3 default value of 0 is reported as usual,
+        # not handled as a special case.
+        info = server_info_pb2.ServerInfoResponse()
+        info.upload_limits.SetInParent()
+        actual = server_info.max_blob_size(info)
+        self.assertEqual(actual, 0)
+
+
 def _localhost():
     """Gets family and nodename for a loopback address."""
     s = socket

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -225,16 +225,13 @@ class AllowedPluginsTest(tb_test.TestCase):
         self.assertEqual(actual, frozenset(["foo", "bar"]))
 
 
-_DEFAULT_MAX_BLOB_SIZE = 10 * (2 ** 20)  # 10 MiB
-
-
 class MaxBlobSizeTest(tb_test.TestCase):
     """Tests for `max_blob_size`."""
 
     def test_old_server_no_upload_limits(self):
         info = server_info_pb2.ServerInfoResponse()
         actual = server_info.max_blob_size(info)
-        self.assertEqual(actual, _DEFAULT_MAX_BLOB_SIZE)
+        self.assertEqual(actual, server_info._DEFAULT_MAX_BLOB_SIZE)
 
     def test_upload_limits_provided_with_max_blob_size(self):
         info = server_info_pb2.ServerInfoResponse()
@@ -243,8 +240,8 @@ class MaxBlobSizeTest(tb_test.TestCase):
         self.assertEqual(actual, 42)
 
     def test_upload_limits_provided_without_max_blob_size(self):
-        # This just shows that proto3 default value of 0 is reported as usual,
-        # not handled as a special case.
+        # This just shows that the proto3 default value of 0 is reported as
+        # usual, not handled as a special case.
         info = server_info_pb2.ServerInfoResponse()
         info.upload_limits.SetInParent()
         actual = server_info.max_blob_size(info)

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -87,6 +87,7 @@ class TensorBoardUploader(object):
         writer_client,
         logdir,
         allowed_plugins,
+        max_blob_size,
         logdir_poll_rate_limiter=None,
         rpc_rate_limiter=None,
         blob_rpc_rate_limiter=None,
@@ -101,6 +102,7 @@ class TensorBoardUploader(object):
           allowed_plugins: collection of string plugin names; events will only
             be uploaded if their time series's metadata specifies one of these
             plugin names
+          max_blob_size: the maximum allowed size for blob uploads.
           logdir_poll_rate_limiter: a `RateLimiter` to use to limit logdir
             polling frequency, to avoid thrashing disks, especially on networked
             file systems
@@ -117,6 +119,7 @@ class TensorBoardUploader(object):
         self._api = writer_client
         self._logdir = logdir
         self._allowed_plugins = frozenset(allowed_plugins)
+        self._max_blob_size = max_blob_size
         self._name = name
         self._description = description
         self._request_sender = None
@@ -166,6 +169,7 @@ class TensorBoardUploader(object):
             response.experiment_id,
             self._api,
             allowed_plugins=self._allowed_plugins,
+            max_blob_size=self._max_blob_size,
             rpc_rate_limiter=self._rpc_rate_limiter,
             blob_rpc_rate_limiter=self._blob_rpc_rate_limiter,
         )
@@ -312,6 +316,7 @@ class _BatchedRequestSender(object):
         experiment_id,
         api,
         allowed_plugins,
+        max_blob_size,
         rpc_rate_limiter,
         blob_rpc_rate_limiter,
     ):
@@ -323,11 +328,10 @@ class _BatchedRequestSender(object):
             experiment_id, api, rpc_rate_limiter,
         )
         self._blob_request_sender = _BlobRequestSender(
-            experiment_id, api, blob_rpc_rate_limiter
+            experiment_id, api, blob_rpc_rate_limiter, max_blob_size
         )
 
         # TODO(nielsene): add tensor case here
-        # TODO(soergel): add blob case here
 
     def send_requests(self, run_to_events):
         """Accepts a stream of TF events and sends batched write RPCs.
@@ -612,12 +616,13 @@ class _BlobRequestSender(object):
     methods concurrently.
     """
 
-    def __init__(self, experiment_id, api, rpc_rate_limiter):
+    def __init__(self, experiment_id, api, rpc_rate_limiter, max_blob_size):
         if experiment_id is None:
             raise ValueError("experiment_id cannot be None")
         self._experiment_id = experiment_id
         self._api = api
         self._rpc_rate_limiter = rpc_rate_limiter
+        self._max_blob_size = max_blob_size
 
         # Start in the empty state, just like self._new_request().
         self._run_name = None
@@ -677,14 +682,16 @@ class _BlobRequestSender(object):
                 blob_sequence_id,
             )
 
+            sent_blobs = 0
             for seq_index, blob in enumerate(self._blobs):
                 # Note the _send_blob() stream is internally flow-controlled.
                 # This rate limit applies to *starting* the stream.
                 self._rpc_rate_limiter.tick()
-                self._send_blob(blob_sequence_id, seq_index, blob)
+                sent_blobs += self._send_blob(blob_sequence_id, seq_index, blob)
 
             logger.info(
-                "Sent %d blobs for sequence id: %s",
+                "Sent %d of %d blobs for sequence id: %s",
+                sent_blobs,
                 len(self._blobs),
                 blob_sequence_id,
             )
@@ -720,6 +727,14 @@ class _BlobRequestSender(object):
     def _send_blob(self, blob_sequence_id, seq_index, blob):
         # TODO(soergel): retry and resume logic
 
+        if len(blob) > self._max_blob_size:
+            logger.warn(
+                "Blob too large; skipping.  Size %d exceeds limit of %d bytes.",
+                len(blob),
+                self._max_blob_size,
+            )
+            return 0
+
         request_iterator = self._write_blob_request_iterator(
             blob_sequence_id, seq_index, blob
         )
@@ -740,9 +755,11 @@ class _BlobRequestSender(object):
                 upload_duration_secs,
                 len(blob) / upload_duration_secs / (1024 * 1024),
             )
+            return 1
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.ALREADY_EXISTS:
                 logger.error("Attempted to re-upload existing blob.  Skipping.")
+                return 0
             else:
                 logger.info("WriteBlob RPC call got error %s", e)
                 raise

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -725,10 +725,17 @@ class _BlobRequestSender(object):
         return blob_sequence_id
 
     def _send_blob(self, blob_sequence_id, seq_index, blob):
+        """Tries to send a single blob for a given index within a blob sequence.
+
+        The blob will not be sent if it was sent already, or if it is too large.
+
+        Returns:
+          The number of blobs successfully sent (i.e., 1 or 0).
+        """
         # TODO(soergel): retry and resume logic
 
         if len(blob) > self._max_blob_size:
-            logger.warn(
+            logger.warning(
                 "Blob too large; skipping.  Size %d exceeds limit of %d bytes.",
                 len(blob),
                 self._max_blob_size,

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -600,7 +600,6 @@ class _UploadIntent(_Intent):
             max_blob_size=server_info_lib.max_blob_size(server_info),
             name=self.name,
             description=self.description,
-            max_blob_size=server_info_lib.max_blob_size(server_info),
         )
         experiment_id = uploader.create_experiment()
         url = server_info_lib.experiment_url(server_info, experiment_id)

--- a/tensorboard/uploader/uploader_main.py
+++ b/tensorboard/uploader/uploader_main.py
@@ -597,8 +597,10 @@ class _UploadIntent(_Intent):
             api_client,
             self.logdir,
             allowed_plugins=server_info_lib.allowed_plugins(server_info),
+            max_blob_size=server_info_lib.max_blob_size(server_info),
             name=self.name,
             description=self.description,
+            max_blob_size=server_info_lib.max_blob_size(server_info),
         )
         experiment_id = uploader.create_experiment()
         url = server_info_lib.experiment_url(server_info, experiment_id)

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -72,6 +72,7 @@ def _create_mock_client():
 
 _SCALARS_ONLY = frozenset((scalars_metadata.PLUGIN_NAME,))
 
+_TEN_MEGABYTES = 10 * (2 ** 20)
 
 # Sentinel for `_create_*` helpers, for arguments for which we want to
 # supply a default other than the `None` used by the code under test.
@@ -82,6 +83,7 @@ def _create_uploader(
     writer_client=_USE_DEFAULT,
     logdir=None,
     allowed_plugins=_USE_DEFAULT,
+    max_blob_size=_USE_DEFAULT,
     logdir_poll_rate_limiter=_USE_DEFAULT,
     rpc_rate_limiter=_USE_DEFAULT,
     blob_rpc_rate_limiter=_USE_DEFAULT,
@@ -92,6 +94,8 @@ def _create_uploader(
         writer_client = _create_mock_client()
     if allowed_plugins is _USE_DEFAULT:
         allowed_plugins = _SCALARS_ONLY
+    if max_blob_size is _USE_DEFAULT:
+        max_blob_size = _TEN_MEGABYTES
     if logdir_poll_rate_limiter is _USE_DEFAULT:
         logdir_poll_rate_limiter = util.RateLimiter(0)
     if rpc_rate_limiter is _USE_DEFAULT:
@@ -102,6 +106,7 @@ def _create_uploader(
         writer_client,
         logdir,
         allowed_plugins=allowed_plugins,
+        max_blob_size=max_blob_size,
         logdir_poll_rate_limiter=logdir_poll_rate_limiter,
         rpc_rate_limiter=rpc_rate_limiter,
         blob_rpc_rate_limiter=blob_rpc_rate_limiter,
@@ -114,6 +119,7 @@ def _create_request_sender(
     experiment_id=None,
     api=None,
     allowed_plugins=_USE_DEFAULT,
+    max_blob_size=_USE_DEFAULT,
     rpc_rate_limiter=_USE_DEFAULT,
     blob_rpc_rate_limiter=_USE_DEFAULT,
 ):
@@ -121,6 +127,8 @@ def _create_request_sender(
         api = _create_mock_client()
     if allowed_plugins is _USE_DEFAULT:
         allowed_plugins = _SCALARS_ONLY
+    if max_blob_size is _USE_DEFAULT:
+        max_blob_size = _TEN_MEGABYTES
     if rpc_rate_limiter is _USE_DEFAULT:
         rpc_rate_limiter = util.RateLimiter(0)
     if blob_rpc_rate_limiter is _USE_DEFAULT:
@@ -129,6 +137,7 @@ def _create_request_sender(
         experiment_id=experiment_id,
         api=api,
         allowed_plugins=allowed_plugins,
+        max_blob_size=max_blob_size,
         rpc_rate_limiter=rpc_rate_limiter,
         blob_rpc_rate_limiter=blob_rpc_rate_limiter,
     )
@@ -281,6 +290,41 @@ class TensorboardUploaderTest(tf.test.TestCase):
         self.assertEqual(10, mock_client.WriteBlob.call_count)
         self.assertEqual(0, mock_rate_limiter.tick.call_count)
         self.assertEqual(10, mock_blob_rate_limiter.tick.call_count)
+
+    @mock.patch.object(uploader_lib, "BLOB_CHUNK_SIZE", 100)
+    def test_upload_skip_large_blob(self):
+        mock_client = _create_mock_client()
+        mock_rate_limiter = mock.create_autospec(util.RateLimiter)
+        mock_blob_rate_limiter = mock.create_autospec(util.RateLimiter)
+        uploader = _create_uploader(
+            mock_client,
+            "/logs/foo",
+            rpc_rate_limiter=mock_rate_limiter,
+            blob_rpc_rate_limiter=mock_blob_rate_limiter,
+            allowed_plugins=[
+                scalars_metadata.PLUGIN_NAME,
+                graphs_metadata.PLUGIN_NAME,
+            ],
+            max_blob_size=100,
+        )
+        uploader.create_experiment()
+
+        graph_event = event_pb2.Event(graph_def=bytes(950))
+
+        mock_logdir_loader = mock.create_autospec(logdir_loader.LogdirLoader)
+        mock_logdir_loader.get_run_events.side_effect = [
+            {"run 1": [graph_event],},
+            AbortUploadError,
+        ]
+
+        with mock.patch.object(
+            uploader, "_logdir_loader", mock_logdir_loader
+        ), self.assertRaises(AbortUploadError):
+            uploader.start_uploading()
+        self.assertEqual(1, mock_client.CreateExperiment.call_count)
+        self.assertEqual(0, mock_client.WriteBlob.call_count)
+        self.assertEqual(0, mock_rate_limiter.tick.call_count)
+        self.assertEqual(1, mock_blob_rate_limiter.tick.call_count)
 
     def test_upload_server_error(self):
         mock_client = _create_mock_client()

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -72,8 +72,6 @@ def _create_mock_client():
 
 _SCALARS_ONLY = frozenset((scalars_metadata.PLUGIN_NAME,))
 
-_TEN_MEGABYTES = 10 * (2 ** 20)
-
 # Sentinel for `_create_*` helpers, for arguments for which we want to
 # supply a default other than the `None` used by the code under test.
 _USE_DEFAULT = object()
@@ -95,7 +93,7 @@ def _create_uploader(
     if allowed_plugins is _USE_DEFAULT:
         allowed_plugins = _SCALARS_ONLY
     if max_blob_size is _USE_DEFAULT:
-        max_blob_size = _TEN_MEGABYTES
+        max_blob_size = 12345
     if logdir_poll_rate_limiter is _USE_DEFAULT:
         logdir_poll_rate_limiter = util.RateLimiter(0)
     if rpc_rate_limiter is _USE_DEFAULT:
@@ -128,7 +126,7 @@ def _create_request_sender(
     if allowed_plugins is _USE_DEFAULT:
         allowed_plugins = _SCALARS_ONLY
     if max_blob_size is _USE_DEFAULT:
-        max_blob_size = _TEN_MEGABYTES
+        max_blob_size = 12345
     if rpc_rate_limiter is _USE_DEFAULT:
         rpc_rate_limiter = util.RateLimiter(0)
     if blob_rpc_rate_limiter is _USE_DEFAULT:


### PR DESCRIPTION
Introduces a new `UploadLimits` submessage within `ServerInfoResponse`, to allow the server to advise the uploader client about limits that it should honor (e.g. things like data sizes, upload rates, and so on).

The only limit actually supported is `max_blob_size`.  The uploader uses this value to skip sending large blobs that the server would end up rejecting anyway. 

Context: b/152312275, b/152770109, and internal email threads.