### PR TITLE
Debugger V1: Disable flaky tests with BUILD tags

### DIFF
--- a/tensorboard/plugins/debugger/BUILD
+++ b/tensorboard/plugins/debugger/BUILD
@@ -270,6 +270,10 @@ py_test(
     size = "medium",
     srcs = ["interactive_debugger_plugin_test.py"],
     srcs_version = "PY2AND3",
+    tags = [
+        "manual",  # b/152800638
+        "notap",
+    ],
     deps = [
         ":interactive_debugger_plugin",
         "//tensorboard:expect_numpy_installed",


### PR DESCRIPTION
* Motivation for features / changes
  * Disable the intereactive_debugger_plugin_test that is showing flaky timeout in internal builds, to avoid blocking releases
* Technical description of changes
  * Add the manual and notap tags.
