### PR TITLE
Include the size of the blob in the WriteBlobRequest

### DIFF
--- a/tensorboard/uploader/proto/write_service.proto
+++ b/tensorboard/uploader/proto/write_service.proto
@@ -332,6 +332,9 @@ message WriteBlobRequest {
   // CRC32C of the entire blob.  Required, to protect against data corruption.
   // This should be set only when finalize_object=True.
   fixed32 final_crc32c = 7;
+  // Final size of the entire blob.  Required in the first request to allow
+  // quota allocaion and management.
+  int64 final_size = 8;
 }
 
 message WriteBlobResponse {

--- a/tensorboard/uploader/proto/write_service.proto
+++ b/tensorboard/uploader/proto/write_service.proto
@@ -332,8 +332,8 @@ message WriteBlobRequest {
   // CRC32C of the entire blob.  Required, to protect against data corruption.
   // This should be set only when finalize_object=True.
   fixed32 final_crc32c = 7;
-  // Final size of the entire blob.  Required in the first request to allow
-  // quota allocaion and management.
+  // Final size in bytes of the entire blob.  Required in the first request
+  // to allow quota allocaion and management.
   int64 final_size = 8;
 }
 

--- a/tensorboard/uploader/proto/write_service.proto
+++ b/tensorboard/uploader/proto/write_service.proto
@@ -332,9 +332,9 @@ message WriteBlobRequest {
   // CRC32C of the entire blob.  Required, to protect against data corruption.
   // This should be set only when finalize_object=True.
   fixed32 final_crc32c = 7;
-  // Final size in bytes of the entire blob.  Required in the first request
-  // to allow quota allocaion and management.
-  int64 final_size = 8;
+  // Size in bytes of the entire blob.  Required in the first request
+  // to allow quota allocation and management.
+  int64 blob_bytes = 8;
 }
 
 message WriteBlobResponse {

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -763,6 +763,7 @@ class _BlobRequestSender(object):
                 crc32c=None,
                 finalize_object=finalize_object,
                 final_crc32c=None,
+                final_size=len(blob),
             )
             yield request
 

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -763,7 +763,7 @@ class _BlobRequestSender(object):
                 crc32c=None,
                 finalize_object=finalize_object,
                 final_crc32c=None,
-                final_size=len(blob),
+                blob_bytes=len(blob),
             )
             yield request
 


### PR DESCRIPTION
Quota management assumes that the blob's final size is available before we allow the upload to begin.  The existing quota tools correctly allocate or reject based on a known final size, but the backend at present is always passing zero, with a comment that it should be added to the request.