### PR TITLE
cleanup: lint and protect against skipped tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - run: yarn lint
         # Make sure no tests are skipped with "focused" tests.
       - run: |
-          ! git grep -E 'f(it|describe)\(' 'tensorboard/webapp/*_test.ts' 'tensorboard/plugins/*_test.ts'
+          ! git grep -E 'f(it|describe)\(' 'tensorboard/*_test.ts'
 
   lint-build:
     runs-on: ubuntu-16.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - run: yarn install --ignore-engines
         # You can run `yarn fix-lint` to fix all Prettier complaints.
       - run: yarn lint
+        # Make sure no tests are skipped with "focused" tests.
+      - run: |
+          ! find tensorboard/webapp -type f -regex '.*_test.ts$' -exec grep -E 'f(it|describe)\(' {} +
 
   lint-build:
     runs-on: ubuntu-16.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - run: yarn lint
         # Make sure no tests are skipped with "focused" tests.
       - run: |
-          ! find tensorboard/webapp -type f -regex '.*_test.ts$' -exec grep -E 'f(it|describe)\(' {} +
+          ! git grep -E 'f(it|describe)\(' 'tensorboard/webapp/*_test.ts' 'tensorboard/plugins/*_test.ts'
 
   lint-build:
     runs-on: ubuntu-16.04


### PR DESCRIPTION
As a developer, it is super easy to erroneously commit fdescribe or
fit. This lint protects against that.
