### PR TITLE
Uploader: remove py2-compatible versions of file-system functions

### DIFF
--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -110,7 +110,7 @@ class TensorBoardExporter(object):
         self._outdir = output_directory
         parent_dir = os.path.dirname(self._outdir)
         if parent_dir:
-            _mkdir_p(parent_dir)
+            os.makedirs(parent_dir, exist_ok=True)
         try:
             os.mkdir(self._outdir)
         except OSError as e:
@@ -154,7 +154,7 @@ class TensorBoardExporter(object):
             os.mkdir(experiment_dir)
 
             metadata_filepath = os.path.join(experiment_dir, _FILENAME_METADATA)
-            with _open_excl(metadata_filepath) as outfile:
+            with open(metadata_filepath, "x") as outfile:
                 json.dump(experiment_metadata, outfile, sort_keys=True)
                 outfile.write("\n")
 
@@ -163,7 +163,7 @@ class TensorBoardExporter(object):
                 with contextlib.ExitStack() as stack:
                     file_handles = {
                         filename: stack.enter_context(
-                            _open_excl(os.path.join(experiment_dir, filename))
+                            open(os.path.join(experiment_dir, filename), "x")
                         )
                         for filename in (
                             _FILENAME_SCALARS,
@@ -324,7 +324,7 @@ class TensorBoardExporter(object):
             _DIRNAME_BLOBS,
             _FILENAME_BLOBS_PREFIX + blob_id + _FILENAME_BLOBS_SUFFIX,
         )
-        with _open_excl(blob_abspath, "wb") as f:
+        with open(blob_abspath, "xb") as f:
             try:
                 for response in self._api.StreamBlobData(
                     request, metadata=grpc_util.version_metadata()
@@ -411,26 +411,3 @@ def _experiment_directory(base_dir, experiment_id):
             )
         )
     return os.path.join(base_dir, "experiment_%s" % experiment_id)
-
-
-def _mkdir_p(path):
-    """Like `os.makedirs(path, exist_ok=True)`, but Python 2-compatible."""
-    try:
-        os.makedirs(path)
-    except OSError as e:
-        if e.errno != errno.EEXIST or not os.path.isdir(path):
-            raise
-
-
-def _open_excl(path, mode="w"):
-    """Like `open(path, mode.replace("w", "x"))`, but Python 2-compatible."""
-    try:
-        # `os.O_EXCL` works on Windows as well as POSIX-compliant systems.
-        # See: <https://bugs.python.org/issue12760>
-        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL)
-    except OSError as e:
-        if e.errno == errno.EEXIST:
-            raise OutputFileExistsError(path)
-        else:
-            raise
-    return os.fdopen(fd, mode)

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -389,11 +389,6 @@ class OutputDirectoryExistsError(ValueError):
     pass
 
 
-class OutputFileExistsError(ValueError):
-    # Like Python 3's `__builtins__.FileExistsError`.
-    pass
-
-
 class GrpcTimeoutException(Exception):
     def __init__(self, experiment_id):
         super(GrpcTimeoutException, self).__init__(experiment_id)

--- a/tensorboard/uploader/exporter_test.py
+++ b/tensorboard/uploader/exporter_test.py
@@ -653,65 +653,6 @@ class ListExperimentsTest(tb_test.TestCase):
         self.assertEqual(list(gen), expected)
 
 
-class MkdirPTest(tb_test.TestCase):
-    def test_makes_full_chain(self):
-        path = os.path.join(self.get_temp_dir(), "a", "b", "c")
-        exporter_lib._mkdir_p(path)
-        self.assertTrue(os.path.isdir(path))
-
-    def test_makes_leaf(self):
-        base = os.path.join(self.get_temp_dir(), "a", "b")
-        exporter_lib._mkdir_p(base)
-        leaf = os.path.join(self.get_temp_dir(), "a", "b", "c")
-        exporter_lib._mkdir_p(leaf)
-        self.assertTrue(os.path.isdir(leaf))
-
-    def test_fails_when_path_is_a_normal_file(self):
-        path = os.path.join(self.get_temp_dir(), "somefile")
-        with open(path, "w"):
-            pass
-        with self.assertRaises(OSError) as cm:
-            exporter_lib._mkdir_p(path)
-        self.assertEqual(cm.exception.errno, errno.EEXIST)
-
-    def test_propagates_other_errors(self):
-        base = os.path.join(self.get_temp_dir(), "somefile")
-        with open(base, "w"):
-            pass
-        leaf = os.path.join(self.get_temp_dir(), "somefile", "somedir")
-        with self.assertRaises(OSError) as cm:
-            exporter_lib._mkdir_p(leaf)
-        self.assertNotEqual(cm.exception.errno, errno.EEXIST)
-        if os.name == "nt":
-            expected_errno = errno.ENOENT
-        else:
-            expected_errno = errno.ENOTDIR
-        self.assertEqual(cm.exception.errno, expected_errno)
-
-
-class OpenExclTest(tb_test.TestCase):
-    def test_success(self):
-        path = os.path.join(self.get_temp_dir(), "test.txt")
-        with exporter_lib._open_excl(path) as outfile:
-            outfile.write("hello\n")
-        with open(path) as infile:
-            self.assertEqual(infile.read(), "hello\n")
-
-    def test_fails_when_file_exists(self):
-        path = os.path.join(self.get_temp_dir(), "test.txt")
-        with open(path, "w"):
-            pass
-        with self.assertRaises(exporter_lib.OutputFileExistsError) as cm:
-            exporter_lib._open_excl(path)
-        self.assertEqual(str(cm.exception), path)
-
-    def test_propagates_other_errors(self):
-        path = os.path.join(self.get_temp_dir(), "enoent", "test.txt")
-        with self.assertRaises(OSError) as cm:
-            exporter_lib._open_excl(path)
-        self.assertEqual(cm.exception.errno, errno.ENOENT)
-
-
 def _create_mock_api_client():
     # Create a stub instance (using a test channel) in order to derive a mock
     # from it with autospec enabled. Mocking TensorBoardExporterServiceStub


### PR DESCRIPTION
* Motivation for features / changes
  * As we discussed during the code review of #3410, the two py2-compatible file-system functions used by uploader can be removed, because pip releases and bazel tests of the uploader are py3 only now. This will cut some lines of code and reduce complexity and maintenance overhead. 
* Technical description of changes
  * Remove the `_open_excl()` and `_mkdir_p()` functions from exporter.py. 
  * Remove the no-longer-used custom error class `OutputFileExistsError`
  * Remove their unit tests in exporter_test.py
  * Replace their usages with the equivalent py3 versions.
