### PR TITLE
docs: import TensorFlow in `migrate.ipynb`

### DIFF
--- a/docs/migrate.ipynb
+++ b/docs/migrate.ipynb
@@ -72,31 +72,11 @@
       "metadata": {
         "colab": {},
         "colab_type": "code",
-        "id": "c_AuRHaXMO3q"
-      },
-      "outputs": [],
-      "source": [
-        "try:\n",
-        "  %tensorflow_version 2.x\n",
-        "except:\n",
-        "  pass"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "c50hsFk2MiWs"
       },
       "outputs": [],
       "source": [
-        "try:\n",
-        "  # %tensorflow_version only exists in Colab.\n",
-        "  %tensorflow_version 2.x\n",
-        "except Exception:\n",
-        "  pass\n"
+        "import tensorflow as tf"
       ]
     },
     {


### PR DESCRIPTION
This notebook was broken because it didn't have an `import tensorflow as tf`.

TF2 is the default in Colab now.  You can delete these `%tensdorflow_version` from all your notebooks.