### PR TITLE
ci: update `nbfmt.py` to enforce exact output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: yamllint -c docs/.yamllint docs docs/.yamllint
       - name: 'Install nbfmt.py for checking notebook formatting'
         run: |
-          nbfmt_version="e9d8ddf8c0f1160d0eae654f30c028d2b0287538"
+          nbfmt_version="04458102aafe1ccc9d703b832db3ac4d038ecd6c"
           wget "https://raw.githubusercontent.com/tensorflow/docs/${nbfmt_version}/tools/nbfmt.py"
           pip install absl-py
           chmod +x ./nbfmt.py


### PR DESCRIPTION
Summary:
A new version of `nbfmt.py` enforces that notebooks be identical to the
formatted versions, whereas previously trailing whitespace was ignored:
<https://github.com/tensorflow/docs/commit/04458102aafe1ccc9d703b832db3ac4d038ecd6c>

Test Plan:
All existing docs are correctly formatted and so CI still passes.
Removing the final newline from one of the docs now causes CI to fail:
<https://github.com/tensorflow/tensorboard/runs/552833330>

wchargin-branch: nbfmt-enforce-exact
