### PR TITLE
uploader: Add field mask for total_blob_bytes

### DIFF
--- a/tensorboard/uploader/proto/experiment.proto
+++ b/tensorboard/uploader/proto/experiment.proto
@@ -48,4 +48,5 @@ message ExperimentMask {
   bool name = 7;
   bool description = 8;
   bool total_tensor_bytes = 9;
+  bool total_blob_bytes = 10;
 }


### PR DESCRIPTION
* Motivation for features / changes
  * Add the field mask for the `total_blob_bytes` field added in #3448
