### PR TITLE
[DebuggerV2] Add HTTP route /graph_execution/digests

### DIFF
--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -312,13 +312,12 @@ class DebuggerV2EventMultiplexer(object):
         }
 
     def GraphExecutionDigests(self, run, begin, end, trace_id=None):
-        """Get GraphExecutionTraceDigests.
+        """Get `GraphExecutionTraceDigest`s.
 
         Args:
-          run: The tfdbg2 run to get `ExecutionDigest`s from.
+          run: The tfdbg2 run to get `GraphExecutionDigest`s from.
           begin: Beginning graph-execution index.
           end: Ending graph-execution index.
-
 
         Returns:
           A JSON-serializable object containing the `ExecutionDigest`s and
@@ -327,15 +326,13 @@ class DebuggerV2EventMultiplexer(object):
         runs = self.Runs()
         if run not in runs:
             return None
-        # TODO(cais): Implement support for trace_id once joining of eager
+        # TODO(cais): Implement support for trace_id once the joining of eager
         # execution and intra-graph execution is supported by DebugDataReader.
         if trace_id is not None:
             raise NotImplementedError(
                 "trace_id support for GraphExecutoinTraceDigest is "
                 "not implemented yet."
             )
-        # TODO(cais): For scalability, use begin and end kwargs when available in
-        # `DebugDataReader.execution()`.`
         graph_exec_digests = self._reader.graph_execution_traces(digest=True)
         end = self._checkBeginEndIndices(begin, end, len(graph_exec_digests))
         return {

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -311,6 +311,44 @@ class DebuggerV2EventMultiplexer(object):
             "executions": [execution.to_json() for execution in executions],
         }
 
+    def GraphExecutionDigests(self, run, begin, end, trace_id=None):
+        """Get GraphExecutionTraceDigests.
+
+        Args:
+          run: The tfdbg2 run to get `ExecutionDigest`s from.
+          begin: Beginning graph-execution index.
+          end: Ending graph-execution index.
+
+
+        Returns:
+          A JSON-serializable object containing the `ExecutionDigest`s and
+          related meta-information
+        """
+        runs = self.Runs()
+        if run not in runs:
+            return None
+        # TODO(cais): Implement support for trace_id once joining of eager
+        # execution and intra-graph execution is supported by DebugDataReader.
+        if trace_id is not None:
+            raise NotImplementedError(
+                "trace_id support for GraphExecutoinTraceDigest is "
+                "not implemented yet."
+            )
+        # TODO(cais): For scalability, use begin and end kwargs when available in
+        # `DebugDataReader.execution()`.`
+        graph_exec_digests = self._reader.graph_execution_traces(digest=True)
+        end = self._checkBeginEndIndices(begin, end, len(graph_exec_digests))
+        return {
+            "begin": begin,
+            "end": end,
+            "num_digests": len(graph_exec_digests),
+            "graph_execution_digests": [
+                digest.to_json() for digest in graph_exec_digests[begin:end]
+            ],
+        }
+
+    # TODO(cais): Add GraphExecutionTraceData().
+
     def SourceFileList(self, run):
         runs = self.Runs()
         if run not in runs:

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -198,7 +198,7 @@ def graph_execution_digest_run_tag_filter(run, begin, end, trace_id=None):
     # execution and intra-graph execution is supported by DebugDataReader.
     if trace_id is not None:
         raise NotImplementedError(
-            "trace_id support for graph_execution_digest_run_tag_filter is "
+            "trace_id support for graph_execution_digest_run_tag_filter() is "
             "not implemented yet."
         )
     return provider.RunTagFilter(
@@ -231,6 +231,10 @@ def _parse_graph_execution_digest_blob_key(blob_key):
     begin = int(key_body.split("_")[1])
     end = int(key_body.split("_")[2])
     return run, begin, end
+
+
+# TODO(cais): Add graph_execution_data_run_tag_filter()
+# TODO(cais): Add _parse_graph_execution_data_blob_key()
 
 
 def source_file_list_run_tag_filter(run):

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -38,6 +38,8 @@ PLUGIN_NAME = "debugger-v2"
 ALERTS_BLOB_TAG_PREFIX = "alerts"
 EXECUTION_DIGESTS_BLOB_TAG_PREFIX = "execution_digests"
 EXECUTION_DATA_BLOB_TAG_PREFIX = "execution_data"
+GRAPH_EXECUTION_DIGESTS_BLOB_TAG_PREFIX = "graphexec_digests"
+GRAPH_EXECUTION_DATA_BLOB_TAG_PREFIX = "graphexec_data"
 SOURCE_FILE_LIST_BLOB_TAG = "source_file_list"
 SOURCE_FILE_BLOB_TAG_PREFIX = "source_file"
 STACK_FRAMES_BLOB_TAG_PREFIX = "stack_frames"
@@ -172,6 +174,60 @@ def _parse_execution_data_blob_key(blob_key):
     """
     key_body, run = blob_key.split(".", 1)
     key_body = key_body[len(EXECUTION_DATA_BLOB_TAG_PREFIX) :]
+    begin = int(key_body.split("_")[1])
+    end = int(key_body.split("_")[2])
+    return run, begin, end
+
+
+def graph_execution_digest_run_tag_filter(run, begin, end, trace_id=None):
+    """Create a RunTagFilter for GraphExecutionTraceDigests.
+
+    This differs from `graph_execution_data_run_tag_filter()` in that it is for
+    the small-size digest objects for intra-graph execution debug events, instead
+    of the full-size data objects.
+
+    Args:
+      run: tfdbg2 run name.
+      begin: Beginning index of GraphExecutionTraceDigests.
+      end: Ending index of GraphExecutionTraceDigests.
+
+    Returns:
+      `RunTagFilter` for the run and range of ExecutionDigests.
+    """
+    # TODO(cais): Implement support for trace_id once joining of eager
+    # execution and intra-graph execution is supported by DebugDataReader.
+    if trace_id is not None:
+        raise NotImplementedError(
+            "trace_id support for graph_execution_digest_run_tag_filter is "
+            "not implemented yet."
+        )
+    return provider.RunTagFilter(
+        runs=[run],
+        tags=[
+            "%s_%d_%d" % (GRAPH_EXECUTION_DIGESTS_BLOB_TAG_PREFIX, begin, end)
+        ],
+    )
+
+
+def _parse_graph_execution_digest_blob_key(blob_key):
+    """Parse the BLOB key for GraphExecutionTraceDigests.
+
+    This differs from `_parse_graph_execution_data_blob_key()` in that it is for
+    the small-size digest objects for intra-graph execution debug events,
+    instead of the full-size data objects.
+
+    Args:
+      blob_key: The BLOB key to parse. By contract, it should have the format:
+       `${GRAPH_EXECUTION_DIGESTS_BLOB_TAG_PREFIX}_${begin}_${end}.${run_id}`
+
+    Returns:
+      - run ID
+      - begin index
+      - end index
+    """
+    # TODO(cais): Support parsing trace_id when it is supported.
+    key_body, run = blob_key.split(".", 1)
+    key_body = key_body[len(GRAPH_EXECUTION_DIGESTS_BLOB_TAG_PREFIX) :]
     begin = int(key_body.split("_")[1])
     end = int(key_body.split("_")[2])
     return run, begin, end
@@ -358,6 +414,7 @@ class LocalDebuggerV2DataProvider(provider.DataProvider):
                         ALERTS_BLOB_TAG_PREFIX,
                         EXECUTION_DIGESTS_BLOB_TAG_PREFIX,
                         EXECUTION_DATA_BLOB_TAG_PREFIX,
+                        GRAPH_EXECUTION_DIGESTS_BLOB_TAG_PREFIX,
                         SOURCE_FILE_BLOB_TAG_PREFIX,
                         STACK_FRAMES_BLOB_TAG_PREFIX,
                     )
@@ -383,6 +440,11 @@ class LocalDebuggerV2DataProvider(provider.DataProvider):
         elif blob_key.startswith(EXECUTION_DATA_BLOB_TAG_PREFIX):
             run, begin, end = _parse_execution_data_blob_key(blob_key)
             return json.dumps(self._multiplexer.ExecutionData(run, begin, end))
+        elif blob_key.startswith(GRAPH_EXECUTION_DIGESTS_BLOB_TAG_PREFIX):
+            run, begin, end = _parse_graph_execution_digest_blob_key(blob_key)
+            return json.dumps(
+                self._multiplexer.GraphExecutionDigests(run, begin, end)
+            )
         elif blob_key.startswith(SOURCE_FILE_LIST_BLOB_TAG):
             run = _parse_source_file_list_blob_key(blob_key)
             return json.dumps(self._multiplexer.SourceFileList(run))

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -63,6 +63,8 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
             "/alerts": self.serve_alerts,
             "/execution/digests": self.serve_execution_digests,
             "/execution/data": self.serve_execution_data,
+            "/graph_execution/digests": self.serve_graph_execution_digests,
+            # TODO(cais): Implement /graph_execution/data.
             "/source_files/list": self.serve_source_files_list,
             "/source_files/file": self.serve_source_file,
             "/stack_frames/stack_frames": self.serve_stack_frames,
@@ -156,6 +158,38 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
         begin = int(request.args.get("begin", "0"))
         end = int(request.args.get("end", "-1"))
         run_tag_filter = debug_data_provider.execution_data_run_tag_filter(
+            run, begin, end
+        )
+        blob_sequences = self._data_provider.read_blob_sequences(
+            experiment, self.plugin_name, run_tag_filter=run_tag_filter
+        )
+        tag = next(iter(run_tag_filter.tags))
+        try:
+            return http_util.Respond(
+                request,
+                self._data_provider.read_blob(
+                    blob_sequences[run][tag][0].blob_key
+                ),
+                "application/json",
+            )
+        except errors.InvalidArgumentError as e:
+            return _error_response(request, str(e))
+
+    @wrappers.Request.application
+    def serve_graph_execution_digests(self, request):
+        """Serve digests of intra-graph execution events.
+
+        As the names imply, this route differs from `serve_execution_digests()`
+        in that it is for intra-graph execution, while `serve_execution_digests()`
+        is for top-level (eager) execution.
+        """
+        experiment = plugin_util.experiment_id(request.environ)
+        run = request.args.get("run")
+        if run is None:
+            return _missing_run_error_response(request)
+        begin = int(request.args.get("begin", "0"))
+        end = int(request.args.get("end", "-1"))
+        run_tag_filter = debug_data_provider.graph_execution_digest_run_tag_filter(
             run, begin, end
         )
         blob_sequences = self._data_provider.read_blob_sequences(

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -763,7 +763,6 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEqual(digests[2]["op_type"], "Unpack")
         self.assertEqual(digests[2]["output_slot"], 0)
         self.assertTrue(digests[2]["op_name"])
-        # The Unpack (unstack) op is from the same graph as the placeholders.
         self.assertTrue(digests[0]["graph_id"])
 
     def testServeGraphExecutionDigestsImplicitFullRange(self):


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing the HTTP backend of DebuggerV2: the `/graph_execution/digests` serves small-size digest data objects for intra-graph execution events.
* Technical description of changes
  * The added route `/graph_execution/digests` is a parallel to the existing route `/execution/digests`
  * The underlying methods are also parallels to the existing execution route:
    * `DebugDataMultiplexer.GraphExecutionDigests()` --> `DebugDataMultiplexer.ExecutionDigests()`
    * `DebuggerV2Plugin.serve_graph_execution_digests()` --> `DebuggerV2Plugin.serve_execution_digests()`
  * A follow-up PR will add the corresponding route for serving detailed data objects (i.e, `/graph_execution/data`)
* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests added.
* Alternate designs / implementations considered
  * Parameterize the existing `/execution/digests` path to accommodate both top-level and intra-graph executions
    * Pro: slightly less code
    * Con: More complex control flow logic in the code, especially considering that the `/graph_execution/digests` path will need to handle the `trace_id` parameter in the future, while the `/execution/digest` doesn't have that parameter.
    * Con: More confusing HTTP route pattern to understand
