### PR TITLE
docs: remove `pip install` from TensorBoard.dev guide

### DIFF
--- a/docs/tbdev_getting_started.ipynb
+++ b/docs/tbdev_getting_started.ipynb
@@ -72,19 +72,6 @@
       "metadata": {
         "colab": {},
         "colab_type": "code",
-        "id": "5C8BOea_rF49"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install -U tensorboard >piplog 2>&1"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "L3ns52Luracm"
       },
       "outputs": [],


### PR DESCRIPTION
Summary:
The Colab image has the latest version of TensorBoard (2.2.0) bundled,
so there’s no need to go through a separate install.

Test Plan:
Clicked “Run all” in Colab, and the whole notebook worked as designed.

wchargin-branch: docs-tbdev-no-pip-install
