### PR TITLE
build: refactor ng_polymer_lib to be reused.

### DIFF
--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -6,11 +6,39 @@ load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 licenses(["notice"])  # Apache 2.0
 
 tf_web_library(
+    name = "polymer_lib",
+    srcs = [
+        "polymer_lib.html",
+    ],
+    path = "/",
+    deps = [
+        ":analytics",
+        ":security",
+        "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_storage",
+        "//tensorboard/components/tf_tensorboard",
+        "//tensorboard/components/tf_tensorboard:default_plugins",
+        "//tensorboard/components/tf_tensorboard:registry",
+    ],
+)
+
+# This Polymer only binary without entry point.
+tensorboard_html_binary(
+    name = "polymer_lib_binary",
+    compile = True,
+    input_path = "/polymer_lib.html",
+    output_path = "/polymer_lib_binary.html",
+    deps = [":polymer_lib"],
+)
+
+tf_web_library(
     name = "tensorboard",
     srcs = ["tensorboard.html"],
     path = "/",
     deps = [
         ":analytics",
+        ":polymer_lib_binary",
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_tensorboard",
         "//tensorboard/components/tf_tensorboard:default_plugins",
@@ -19,7 +47,7 @@ tf_web_library(
 
 tensorboard_html_binary(
     name = "index",
-    compile = True,
+    compile = False,
     input_path = "/tensorboard.html",
     js_path = "/index.js",
     output_path = "/index.html",
@@ -49,33 +77,4 @@ tf_web_library(
     ],
     path = "/",
     visibility = ["//visibility:public"],
-)
-
-tf_web_library(
-    name = "ng_polymer_lib",
-    srcs = [
-        "ng_polymer_lib.html",
-    ],
-    path = "/",
-    deps = [
-        ":analytics",
-        ":security",
-        "//tensorboard/components/tf_backend",
-        "//tensorboard/components/tf_imports:polymer",
-        "//tensorboard/components/tf_storage",
-        "//tensorboard/components/tf_tensorboard",
-        "//tensorboard/components/tf_tensorboard:default_plugins",
-        "//tensorboard/components/tf_tensorboard:registry",
-    ],
-)
-
-# This Polymer only binary (as opposed to ng_index) allows ng_index to be built without
-# JSCompiler step. In other words, Angular-only changes can be built faster
-# incrementally.
-tensorboard_html_binary(
-    name = "ng_polymer_lib_binary",
-    compile = False,
-    input_path = "/ng_polymer_lib.html",
-    output_path = "/ng_polymer_lib_binary.html",
-    deps = [":ng_polymer_lib"],
 )

--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -13,13 +13,9 @@ tf_web_library(
     path = "/",
     deps = [
         ":analytics",
-        ":security",
-        "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_imports:polymer",
-        "//tensorboard/components/tf_storage",
         "//tensorboard/components/tf_tensorboard",
         "//tensorboard/components/tf_tensorboard:default_plugins",
-        "//tensorboard/components/tf_tensorboard:registry",
     ],
 )
 
@@ -37,11 +33,7 @@ tf_web_library(
     srcs = ["tensorboard.html"],
     path = "/",
     deps = [
-        ":analytics",
         ":polymer_lib_binary",
-        "//tensorboard/components/tf_imports:polymer",
-        "//tensorboard/components/tf_tensorboard",
-        "//tensorboard/components/tf_tensorboard:default_plugins",
     ],
 )
 

--- a/tensorboard/components/polymer_lib.html
+++ b/tensorboard/components/polymer_lib.html
@@ -15,12 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <!-- Configures polymer and requires to be loaded at the top. -->
-<link rel="import" href="security.html" />
+<!-- TODO(stephanwlee): Hparams (vaadin-grid) cannot support strictTemplatePolciy. Figure out
+how to enable it back. -->
+<!-- <link rel="import" href="security.html" /> -->
 
 <link rel="import" href="analytics.html" />
 <link rel="import" href="tf-imports/polymer.html" />
-<link rel="import" href="tf-tensorboard/registry.html" />
 <link rel="import" href="tf-tensorboard/style.html" />
-<link rel="import" href="tf-backend/tf-backend.html" />
-<link rel="import" href="tf-storage/tf-storage.html" />
 <link rel="import" href="tf-tensorboard/default-plugins.html" />
+<link rel="import" href="tf-tensorboard/tf-tensorboard.html" />

--- a/tensorboard/components/tensorboard.uninlined.html
+++ b/tensorboard/components/tensorboard.uninlined.html
@@ -22,16 +22,7 @@ limitations under the License.
   <link rel="shortcut icon" href="%TENSORBOARD_FAVICON_URI%" />
   <link rel="apple-touch-icon" href="%TENSORBOARD_FAVICON_URI%" />
 
-  <!-- Configures polymer and requires to be loaded at the top. -->
-  <!-- TODO(stephanwlee): Hparams (vaadin-grid) cannot support strictTemplatePolciy. Figure out
-how to enable it back. -->
-  <!-- <link rel="import" href="security.html" /> -->
-
-  <link rel="import" href="analytics.html" />
-  <link rel="import" href="tf-imports/polymer.html" />
-  <link rel="import" href="tf-tensorboard/style.html" />
-  <link rel="import" href="tf-tensorboard/default-plugins.html" />
-  <link rel="import" href="tf-tensorboard/tf-tensorboard.html" />
+  <link rel="import" href="polymer_lib_binary.html" />
   <body>
     <tf-tensorboard use-hash brand="TensorBoard"></tf-tensorboard>
   </body>

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -122,7 +122,7 @@ tf_web_library(
     path = "/",
     deps = [
         ":tb_webapp",
-        "//tensorboard/components:ng_polymer_lib_binary",
+        "//tensorboard/components:polymer_lib_binary",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/monaco:requirejs",
     ],
 )

--- a/tensorboard/webapp/index.uninlined.html
+++ b/tensorboard/webapp/index.uninlined.html
@@ -20,7 +20,7 @@ limitations under the License.
 <link rel="shortcut icon" href="%TENSORBOARD_FAVICON_URI%" />
 <link rel="apple-touch-icon" href="%TENSORBOARD_FAVICON_URI%" />
 
-<link rel="import" href="ng_polymer_lib_binary.html" />
+<link rel="import" href="polymer_lib_binary.html" />
 <link rel="stylesheet" href="styles.css" />
 
 <body>


### PR DESCRIPTION
ng_polymer_lib and tensorboard.html should differ in only two things:
- only former has Angular related code bundled separately.
- only latter has entry point for tf-tensorboard
(`<body><tf-tensorboard>`).

This change refactors so that all the Polymer binary without the entry
point is shared between Polymer TensorBoard and Angular TensorBoard.