### PR TITLE
hparams: inline `Context.experiment`

### DIFF
--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -60,25 +60,6 @@ class Context(object):
         self._tb_context = tb_context
         self._max_domain_discrete_len = max_domain_discrete_len
 
-    def experiment(self, experiment_id):
-        """Returns the experiment protobuffer defining the experiment.
-
-        This method first attempts to find a metadata.EXPERIMENT_TAG tag and
-        retrieve the associated protobuffer. If no such tag is found, the method
-        will attempt to build a minimal experiment protobuffer by scanning for
-        all metadata.SESSION_START_INFO_TAG tags (to compute the hparam_infos
-        field of the experiment) and for all scalar tags (to compute the
-        metric_infos field of the experiment).
-
-        Returns:
-          The experiment protobuffer. If no tags are found from which an experiment
-          protobuffer can be built (possibly, because the event data has not been
-          completely loaded yet), returns None.
-        """
-        return self.experiment_from_metadata(
-            experiment_id, self.hparams_metadata(experiment_id)
-        )
-
     def experiment_from_metadata(
         self, experiment_id, hparams_run_to_tag_to_content
     ):

--- a/tensorboard/plugins/hparams/backend_context_test.py
+++ b/tensorboard/plugins/hparams/backend_context_test.py
@@ -154,7 +154,10 @@ class BackendContextTest(tf.test.TestCase):
         self._mock_multiplexer.AllSummaryMetadata.side_effect = None
         self._mock_multiplexer.AllSummaryMetadata.return_value = {run: {tag: m}}
         ctxt = backend_context.Context(self._mock_tb_context)
-        self.assertProtoEquals(experiment, ctxt.experiment(experiment_id="123"))
+        self.assertProtoEquals(
+            experiment,
+            ctxt.experiment_from_metadata("123", ctxt.hparams_metadata("123")),
+        )
 
     def test_experiment_without_experiment_tag(self):
         self.session_1_start_info_ = """
@@ -209,7 +212,9 @@ class BackendContextTest(tf.test.TestCase):
             }
         """
         ctxt = backend_context.Context(self._mock_tb_context)
-        actual_exp = ctxt.experiment(experiment_id="123")
+        actual_exp = ctxt.experiment_from_metadata(
+            "123", ctxt.hparams_metadata("123")
+        )
         _canonicalize_experiment(actual_exp)
         self.assertProtoEquals(expected_exp, actual_exp)
 
@@ -271,7 +276,9 @@ class BackendContextTest(tf.test.TestCase):
             }
         """
         ctxt = backend_context.Context(self._mock_tb_context)
-        actual_exp = ctxt.experiment(experiment_id="123")
+        actual_exp = ctxt.experiment_from_metadata(
+            "123", ctxt.hparams_metadata("123")
+        )
         _canonicalize_experiment(actual_exp)
         self.assertProtoEquals(expected_exp, actual_exp)
 
@@ -326,7 +333,9 @@ class BackendContextTest(tf.test.TestCase):
         ctxt = backend_context.Context(
             self._mock_tb_context, max_domain_discrete_len=1
         )
-        actual_exp = ctxt.experiment(experiment_id="123")
+        actual_exp = ctxt.experiment_from_metadata(
+            "123", ctxt.hparams_metadata("123")
+        )
         _canonicalize_experiment(actual_exp)
         self.assertProtoEquals(expected_exp, actual_exp)
 

--- a/tensorboard/plugins/hparams/get_experiment.py
+++ b/tensorboard/plugins/hparams/get_experiment.py
@@ -41,7 +41,10 @@ class Handler(object):
         Returns:
           An Experiment object.
         """
-        experiment = self._context.experiment(self._experiment_id)
+        experiment_id = self._experiment_id
+        experiment = self._context.experiment_from_metadata(
+            experiment_id, self._context.hparams_metadata(experiment_id)
+        )
         if experiment is None:
             raise error.HParamsError(
                 "Can't find an HParams-plugin experiment data in"


### PR DESCRIPTION
Summary:
This method makes it easy to accidentally make too many data provider
queries by hiding an `hparams_metadata` call. It only has one caller, so
we just inline it.

Addresses a deferred review comment from #3449.

Test Plan:
Unit tests pass, and the dashboard still behaves as expected for logdirs
with hparams and an experiment summary, with hparams but no experiment
summary, and with no hparams data at all.

wchargin-branch: hparams-inline-experiment
