### PR TITLE
hparams: recognize empty plugin content

### DIFF
--- a/tensorboard/plugins/hparams/backend_context.py
+++ b/tensorboard/plugins/hparams/backend_context.py
@@ -192,10 +192,10 @@ class Context(object):
           The experiment or None if no such experiment is found.
         """
         # We expect only one run to have an `EXPERIMENT_TAG`; look
-        # through all of them an arbitrarily pick the first one.
+        # through all of them and arbitrarily pick the first one.
         for tags in hparams_run_to_tag_to_content.values():
             maybe_content = tags.get(metadata.EXPERIMENT_TAG)
-            if maybe_content:
+            if maybe_content is not None:
                 return metadata.parse_experiment_plugin_data(maybe_content)
         return None
 


### PR DESCRIPTION
Summary:
Addresses a deferred review comment from #3449. This shouldn’t matter in
practice, because `HParamsPluginData` values always supposed to have one
of the `oneof data` fields set, so even an experiment with no hparams,
no metrics, and no start time would have plugin content of `\x12\x00`.
But conceptually this code is trying to check for `None`, not “`None` or
empty”, so this saves future readers from having to convince themselves
that the two conditions are equivalent.

Test Plan:
Unit tests pass and a spot-check of the dashboard checks out.

wchargin-branch: hparams-empty-plugin-content
