### PR TITLE
[DebuggerV2] Add HTTP route /graph_execution/data

### DIFF
--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -330,7 +330,7 @@ class DebuggerV2EventMultiplexer(object):
         # execution and intra-graph execution is supported by DebugDataReader.
         if trace_id is not None:
             raise NotImplementedError(
-                "trace_id support for GraphExecutoinTraceDigest is "
+                "trace_id support for GraphExecutionTraceDigest is "
                 "not implemented yet."
             )
         graph_exec_digests = self._reader.graph_execution_traces(digest=True)
@@ -363,7 +363,7 @@ class DebuggerV2EventMultiplexer(object):
         # execution and intra-graph execution is supported by DebugDataReader.
         if trace_id is not None:
             raise NotImplementedError(
-                "trace_id support for GraphExecutoinTraceData is "
+                "trace_id support for GraphExecutionTraceData is "
                 "not implemented yet."
             )
         graph_executions = self._reader.graph_execution_traces(digest=False)

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -315,7 +315,7 @@ class DebuggerV2EventMultiplexer(object):
         """Get `GraphExecutionTraceDigest`s.
 
         Args:
-          run: The tfdbg2 run to get `GraphExecutionDigest`s from.
+          run: The tfdbg2 run to get `GraphExecutionTraceDigest`s from.
           begin: Beginning graph-execution index.
           end: Ending graph-execution index.
 
@@ -344,7 +344,39 @@ class DebuggerV2EventMultiplexer(object):
             ],
         }
 
-    # TODO(cais): Add GraphExecutionTraceData().
+    def GraphExecutionData(self, run, begin, end, trace_id=None):
+        """Get `GraphExecutionTrace`s.
+
+        Args:
+          run: The tfdbg2 run to get `GraphExecutionTrace`s from.
+          begin: Beginning graph-execution index.
+          end: Ending graph-execution index.
+
+        Returns:
+          A JSON-serializable object containing the `ExecutionDigest`s and
+          related meta-information
+        """
+        runs = self.Runs()
+        if run not in runs:
+            return None
+        # TODO(cais): Implement support for trace_id once the joining of eager
+        # execution and intra-graph execution is supported by DebugDataReader.
+        if trace_id is not None:
+            raise NotImplementedError(
+                "trace_id support for GraphExecutoinTraceData is "
+                "not implemented yet."
+            )
+        graph_executions = self._reader.graph_execution_traces(digest=False)
+        end = self._checkBeginEndIndices(begin, end, len(graph_executions))
+        return {
+            "begin": begin,
+            "end": end,
+            "num_digests": len(graph_executions),
+            "graph_executions": [
+                graph_exec.to_json()
+                for graph_exec in graph_executions[begin:end]
+            ],
+        }
 
     def SourceFileList(self, run):
         runs = self.Runs()

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -236,6 +236,9 @@ def _parse_graph_execution_digest_blob_key(blob_key):
 def graph_execution_data_run_tag_filter(run, begin, end, trace_id=None):
     """Create a RunTagFilter for GraphExecutionTrace.
 
+    This method differs from `graph_execution_digest_run_tag_filter()` in that
+    it is for full-sized data objects for intra-graph execution events.
+
     Args:
       run: tfdbg2 run name.
       begin: Beginning index of GraphExecutionTrace.
@@ -260,9 +263,12 @@ def graph_execution_data_run_tag_filter(run, begin, end, trace_id=None):
 def _parse_graph_execution_data_blob_key(blob_key):
     """Parse the BLOB key for GraphExecutionTrace.
 
+    This method differs from `_parse_graph_execution_digest_blob_key()` in that
+    it is for full-sized data objects for intra-graph execution events.
+
     Args:
       blob_key: The BLOB key to parse. By contract, it should have the format:
-       `${GRAPH_EXECUTION_DIGESTS_BLOB_TAG_PREFIX}_${begin}_${end}.${run_id}`
+       `${GRAPH_EXECUTION_DATA_BLOB_TAG_PREFIX}_${begin}_${end}.${run_id}`
 
     Returns:
       - run ID

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -192,7 +192,7 @@ def graph_execution_digest_run_tag_filter(run, begin, end, trace_id=None):
       end: Ending index of GraphExecutionTraceDigests.
 
     Returns:
-      `RunTagFilter` for the run and range of ExecutionDigests.
+      `RunTagFilter` for the run and range of GraphExecutionTraceDigests.
     """
     # TODO(cais): Implement support for trace_id once joining of eager
     # execution and intra-graph execution is supported by DebugDataReader.
@@ -233,8 +233,48 @@ def _parse_graph_execution_digest_blob_key(blob_key):
     return run, begin, end
 
 
-# TODO(cais): Add graph_execution_data_run_tag_filter()
-# TODO(cais): Add _parse_graph_execution_data_blob_key()
+def graph_execution_data_run_tag_filter(run, begin, end, trace_id=None):
+    """Create a RunTagFilter for GraphExecutionTrace.
+
+    Args:
+      run: tfdbg2 run name.
+      begin: Beginning index of GraphExecutionTrace.
+      end: Ending index of GraphExecutionTrace.
+
+    Returns:
+      `RunTagFilter` for the run and range of GraphExecutionTrace.
+    """
+    # TODO(cais): Implement support for trace_id once joining of eager
+    # execution and intra-graph execution is supported by DebugDataReader.
+    if trace_id is not None:
+        raise NotImplementedError(
+            "trace_id support for graph_execution_data_run_tag_filter() is "
+            "not implemented yet."
+        )
+    return provider.RunTagFilter(
+        runs=[run],
+        tags=["%s_%d_%d" % (GRAPH_EXECUTION_DATA_BLOB_TAG_PREFIX, begin, end)],
+    )
+
+
+def _parse_graph_execution_data_blob_key(blob_key):
+    """Parse the BLOB key for GraphExecutionTrace.
+
+    Args:
+      blob_key: The BLOB key to parse. By contract, it should have the format:
+       `${GRAPH_EXECUTION_DIGESTS_BLOB_TAG_PREFIX}_${begin}_${end}.${run_id}`
+
+    Returns:
+      - run ID
+      - begin index
+      - end index
+    """
+    # TODO(cais): Support parsing trace_id when it is supported.
+    key_body, run = blob_key.split(".", 1)
+    key_body = key_body[len(GRAPH_EXECUTION_DATA_BLOB_TAG_PREFIX) :]
+    begin = int(key_body.split("_")[1])
+    end = int(key_body.split("_")[2])
+    return run, begin, end
 
 
 def source_file_list_run_tag_filter(run):
@@ -419,6 +459,7 @@ class LocalDebuggerV2DataProvider(provider.DataProvider):
                         EXECUTION_DIGESTS_BLOB_TAG_PREFIX,
                         EXECUTION_DATA_BLOB_TAG_PREFIX,
                         GRAPH_EXECUTION_DIGESTS_BLOB_TAG_PREFIX,
+                        GRAPH_EXECUTION_DATA_BLOB_TAG_PREFIX,
                         SOURCE_FILE_BLOB_TAG_PREFIX,
                         STACK_FRAMES_BLOB_TAG_PREFIX,
                     )
@@ -448,6 +489,11 @@ class LocalDebuggerV2DataProvider(provider.DataProvider):
             run, begin, end = _parse_graph_execution_digest_blob_key(blob_key)
             return json.dumps(
                 self._multiplexer.GraphExecutionDigests(run, begin, end)
+            )
+        elif blob_key.startswith(GRAPH_EXECUTION_DATA_BLOB_TAG_PREFIX):
+            run, begin, end = _parse_graph_execution_data_blob_key(blob_key)
+            return json.dumps(
+                self._multiplexer.GraphExecutionData(run, begin, end)
             )
         elif blob_key.startswith(SOURCE_FILE_LIST_BLOB_TAG):
             run = _parse_source_file_list_blob_key(blob_key)

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -214,6 +214,9 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
         As the names imply, this route differs from `serve_execution_data()`
         in that it is for intra-graph execution, while `serve_execution_data()`
         is for top-level (eager) execution.
+
+        Unlike `serve_graph_execution_digests()`, this method serves the
+        full-sized data objects for intra-graph execution events.
         """
         experiment = plugin_util.experiment_id(request.environ)
         run = request.args.get("run")

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -64,7 +64,7 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
             "/execution/digests": self.serve_execution_digests,
             "/execution/data": self.serve_execution_data,
             "/graph_execution/digests": self.serve_graph_execution_digests,
-            # TODO(cais): Implement /graph_execution/data.
+            "/graph_execution/data": self.serve_graph_execution_data,
             "/source_files/list": self.serve_source_files_list,
             "/source_files/file": self.serve_source_file,
             "/stack_frames/stack_frames": self.serve_stack_frames,
@@ -190,6 +190,38 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
         begin = int(request.args.get("begin", "0"))
         end = int(request.args.get("end", "-1"))
         run_tag_filter = debug_data_provider.graph_execution_digest_run_tag_filter(
+            run, begin, end
+        )
+        blob_sequences = self._data_provider.read_blob_sequences(
+            experiment, self.plugin_name, run_tag_filter=run_tag_filter
+        )
+        tag = next(iter(run_tag_filter.tags))
+        try:
+            return http_util.Respond(
+                request,
+                self._data_provider.read_blob(
+                    blob_sequences[run][tag][0].blob_key
+                ),
+                "application/json",
+            )
+        except errors.InvalidArgumentError as e:
+            return _error_response(request, str(e))
+
+    @wrappers.Request.application
+    def serve_graph_execution_data(self, request):
+        """Serve detailed data objects of intra-graph execution events.
+
+        As the names imply, this route differs from `serve_execution_data()`
+        in that it is for intra-graph execution, while `serve_execution_data()`
+        is for top-level (eager) execution.
+        """
+        experiment = plugin_util.experiment_id(request.environ)
+        run = request.args.get("run")
+        if run is None:
+            return _missing_run_error_response(request)
+        begin = int(request.args.get("begin", "0"))
+        end = int(request.args.get("end", "-1"))
+        run_tag_filter = debug_data_provider.graph_execution_data_run_tag_filter(
             run, begin, end
         )
         blob_sequences = self._data_provider.read_blob_sequences(


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing the HTTP backend of DebuggerV2: the `/graph_execution/data` serves full-size data objects for intra-graph execution events.
* Technical description of changes
  * This is a followed up #3472 that added the `/graph_execution/digests` route.
  * The added route `/graph_execution/digests` is a parallel to the existing route `/execution/data`
  * The underlying methods are also parallels to the existing execution route:
    * `DebugDataMultiplexer.GraphExecutionData()` --> `DebugDataMultiplexer.ExecutionData()`
    * `DebuggerV2Plugin.serve_graph_execution_data()` --> `DebuggerV2Plugin.serve_execution_data)`
* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests added.
* Alternate designs / implementations considered
  * Parameterize the existing `/execution/data` path to accommodate both top-level and intra-graph executions
    * Pro: slightly less code
    * Con: More complex control flow logic in the code, especially considering that the `/graph_execution/data` path will need to handle the `trace_id` parameter in the future, while the `/execution/data` doesn't have that parameter.
    * Con: More confusing HTTP route pattern to understand
