### PR TITLE
Disable auto reload if page is not visible

### DIFF
--- a/tensorboard/components/tf_tensorboard/autoReloadBehavior.ts
+++ b/tensorboard/components/tf_tensorboard/autoReloadBehavior.ts
@@ -44,22 +44,28 @@ namespace tf_tensorboard {
         type: Boolean,
         value: false,
       },
+      _boundHandleVisibilityChange: {
+        type: Object,
+      },
       autoReloadIntervalSecs: {
         type: Number,
         value: 30,
       },
     },
     attached: function() {
+      this._boundHandleVisibilityChange_ = this._handleVisibilityChange.bind(
+        this
+      );
       document.addEventListener(
         'visibilitychange',
-        this._handleVisibilityChange.bind(this)
+        this._boundHandleVisibilityChange
       );
     },
     detached: function() {
       window.clearTimeout(this._autoReloadId);
       document.removeEventListener(
         'visibilitychange',
-        this._handleVisibilityChange.bind(this)
+        this._boundHandleVisibilityChange
       );
     },
     _autoReloadObserver: function(autoReload) {
@@ -90,7 +96,7 @@ namespace tf_tensorboard {
       }
       this.reload();
     },
-    _handleVisibilityChange() {
+    _handleVisibilityChange: function() {
       if (this._isDocumentVisible() && this._missedAutoReload) {
         this._missedAutoReload = false;
         this._doReload();
@@ -100,7 +106,7 @@ namespace tf_tensorboard {
      * Wraps Page Visibility API call to determine if document is visible.
      * Can be overriden for testing purposes.
      */
-    _isDocumentVisible() {
+    _isDocumentVisible: function() {
       return document.visibilityState === 'visible';
     },
   };


### PR DESCRIPTION
* Motivation for features / changes
Reduce the load on TensorBoard servers by disabling auto reload if the page is not considered visible.

* Technical description of changes
Do not auto reload if document is not visible according to the Page
Visibility API. When page again becomes visible perform an auto reload
if one has been missed.

* Detailed steps to verify changes work correctly (as executed by you)
Run a local TensorBoard.
Open localhost:6006.
Ensure option "Reload data every 30s." is selected.
Open detached network tab in chrome developer tools.
Watch for several minutes and observe that many network calls are made every 30s.
Open different tab in same window but with chrome developer tools still visible.
Watch for several minutes and observe that no network calls are made.
Switch back to TensorBoard tab and watch as network calls are immediately made and UI reloads graphs.
Continue to watch network tab as it again follows a 30s period for reload network calls.
