### PR TITLE
build: include `__init__.py` in `//tensorboard`

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -25,6 +25,7 @@ py_binary(
     deps = [
         ":default",
         ":dynamic_plugins",
+        ":lib",
         ":program",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins:base_plugin",


### PR DESCRIPTION
Summary:
Needed for `tensorboard.__version__` to resolve, as used by (e.g.) the
What-If Tool. Fixes #3484.

Test Plan:
Running `bazel run //tensorboard -- --logdir /tmp/logs` in a virtualenv
with `tensorboard-plugin-wit==1.6.0.post3` installed now works, instead
of failing with:

```
  File "/VIRTUAL_ENV/lib/python3.7/site-packages/tensorboard_plugin_wit/wit_plugin_loader.py", line 51, in load
    version = pkg_resources.parse_version(tensorboard.__version__)
AttributeError: module 'tensorboard' has no attribute '__version__'
terminate called without an active exception
Fatal Python error: Aborted
```

wchargin-branch: build-include-init
