### PR TITLE
uploader: use fixed (UTC) timezone in formatter unit tests

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -61,7 +61,6 @@ py_test(
         ":util",
         "//tensorboard:test",
         "//tensorboard/uploader/proto:protos_all_py_pb2",
-        "@org_pythonhosted_mock",
     ],
 )
 

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -61,6 +61,7 @@ py_test(
         ":util",
         "//tensorboard:test",
         "//tensorboard/uploader/proto:protos_all_py_pb2",
+        "@org_pythonhosted_mock",
     ],
 )
 

--- a/tensorboard/uploader/formatters_test.py
+++ b/tensorboard/uploader/formatters_test.py
@@ -161,6 +161,43 @@ class TensorBoardExporterTest(tb_test.TestCase):
         ]
         self.assertEqual(output.split("\n"), expected_lines)
 
+    def testJsonFormatterWithNonUtcTimezone(self):
+        experiment = experiment_pb2.Experiment(
+            experiment_id="deadbeef",
+            # NOTE(cais): `name` and `description` are missing here.
+            num_runs=2,
+            num_tags=4,
+            num_scalars=60,
+            total_blob_bytes=1234,
+        )
+        util.set_timestamp(experiment.create_time, 981173106)
+        util.set_timestamp(experiment.update_time, 1015218367)
+        experiment_url = "http://tensorboard.dev/deadbeef"
+        formatter = formatters.JsonFormatter()
+        output = self._format(
+            formatter,
+            experiment,
+            experiment_url,
+            timezone="America/Los_Angeles",
+        )
+        expected_lines = [
+            "{",
+            '  "url": "http://tensorboard.dev/deadbeef",',
+            '  "name": "",',
+            '  "description": "",',
+            '  "id": "deadbeef",',
+            # NOTE(cais): Here we assert that the JsonFormat output is not
+            # affected by the timezone.
+            '  "created": "2001-02-03T04:05:06Z",',
+            '  "updated": "2002-03-04T05:06:07Z",',
+            '  "runs": 2,',
+            '  "tags": 4,',
+            '  "scalars": 60,',
+            '  "binary_object_bytes": 1234',
+            "}",
+        ]
+        self.assertEqual(output.split("\n"), expected_lines)
+
 
 if __name__ == "__main__":
     tb_test.main()

--- a/tensorboard/uploader/formatters_test.py
+++ b/tensorboard/uploader/formatters_test.py
@@ -36,7 +36,7 @@ from tensorboard.uploader import util
 
 
 class TensorBoardExporterTest(tb_test.TestCase):
-    def _run(self, formatter, experiment, experiment_url):
+    def _format(self, formatter, experiment, experiment_url):
         """Test helper that ensures formatting is done with fixed timezone."""
         try:
             with mock.patch.dict(os.environ, {"TZ": "UTC"}):
@@ -59,7 +59,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
         util.set_timestamp(experiment.update_time, 1015218367)
         experiment_url = "http://tensorboard.dev/deadbeef"
         formatter = formatters.ReadableFormatter()
-        output = self._run(formatter, experiment, experiment_url)
+        output = self._format(formatter, experiment, experiment_url)
         expected_lines = [
             "http://tensorboard.dev/deadbeef",
             "\tName                 A name for the experiment",
@@ -87,7 +87,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
         util.set_timestamp(experiment.update_time, 1015218367)
         experiment_url = "http://tensorboard.dev/deadbeef"
         formatter = formatters.ReadableFormatter()
-        output = self._run(formatter, experiment, experiment_url)
+        output = self._format(formatter, experiment, experiment_url)
         expected_lines = [
             "http://tensorboard.dev/deadbeef",
             "\tName                 [No Name]",
@@ -115,7 +115,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
         util.set_timestamp(experiment.update_time, 1015218367)
         experiment_url = "http://tensorboard.dev/deadbeef"
         formatter = formatters.JsonFormatter()
-        output = self._run(formatter, experiment, experiment_url)
+        output = self._format(formatter, experiment, experiment_url)
         expected_lines = [
             "{",
             '  "url": "http://tensorboard.dev/deadbeef",',


### PR DESCRIPTION
* Motivation for features / changes
  * @stephanwlee brought to my attention a test failure that happens under certain test configs in `//tensorboard/uploader:formatters_test`
  * This failure has to do with different timezone settings that are apparently used in different test environments
* Technical description of changes
  * Add a helper method that sets system timezone to "UTC" and use the helper method from the unit tests.