### PR TITLE
Disable auto reload if page is not visible in ng_tensorboard

### DIFF
--- a/tensorboard/webapp/reloader/reloader_component.ts
+++ b/tensorboard/webapp/reloader/reloader_component.ts
@@ -39,7 +39,7 @@ export class ReloaderComponent {
 
   constructor(
     private store: Store<State>,
-    @Inject(DOCUMENT) private document: Document
+    @Inject(DOCUMENT) private readonly document: Document
   ) {}
 
   ngOnInit() {

--- a/tensorboard/webapp/reloader/reloader_component_test.ts
+++ b/tensorboard/webapp/reloader/reloader_component_test.ts
@@ -28,7 +28,7 @@ import {createState, createCoreState} from '../core/testing';
 describe('reloader_component', () => {
   let store: MockStore<State>;
   let dispatchSpy: jasmine.Spy;
-  let fakeDocument: any;
+  let fakeDocument: Document;
 
   function createFakeDocument() {
     return {
@@ -43,7 +43,9 @@ describe('reloader_component', () => {
   }
 
   function simulateVisibilityChange(visible: boolean) {
-    fakeDocument.visibilityState = visible ? 'visible' : 'hidden';
+    Object.defineProperty(fakeDocument, 'visibilityState', {
+      get: () => (visible ? 'visible' : 'hidden'),
+    });
     document.dispatchEvent(new Event('visibilitychange'));
   }
 


### PR DESCRIPTION
Note that this is the ng_tensorboard version of #3483.

* Motivation for features / changes
Reduce the load on TensorBoard servers by disabling auto reload if the page is not considered visible.

* Technical description of changes
Do not auto reload if document is not visible according to the Page
Visibility API. When page again becomes visible perform an auto reload
if one has been missed.

* Detailed steps to verify changes work correctly (as executed by you)
Run a local TensorBoard.
Open localhost:6006.
Ensure option "Reload data" is selected and choose a 15s "Reload Period".
Open detached network tab in chrome developer tools.
Watch for several minutes and observe that many network calls are made every 15s.
Open different tab in same window but with chrome developer tools still visible.
Watch for several minutes and observe that no network calls are made.
Switch back to TensorBoard tab and watch as network calls are immediately made and UI reloads graphs.
Continue to watch network tab as it again follows a 15s period for reload network calls.
