### PR TITLE
Fix 'visibilitychange' event handling in auto reload logic

### DIFF
--- a/tensorboard/components/tf_tensorboard/autoReloadBehavior.ts
+++ b/tensorboard/components/tf_tensorboard/autoReloadBehavior.ts
@@ -53,7 +53,7 @@ namespace tf_tensorboard {
       },
     },
     attached: function() {
-      this._boundHandleVisibilityChange_ = this._handleVisibilityChange.bind(
+      this._boundHandleVisibilityChange = this._handleVisibilityChange.bind(
         this
       );
       document.addEventListener(

--- a/tensorboard/components/tf_tensorboard/test/autoReloadTests.ts
+++ b/tensorboard/components/tf_tensorboard/test/autoReloadTests.ts
@@ -59,7 +59,7 @@ namespace tf_tensorboard {
 
       function simulateVisibilityChange(visibility) {
         isDocumentVisible = visibility;
-        testElement._handleVisibilityChange();
+        document.dispatchEvent(new Event('visibilitychange'));
       }
 
       it('reads and writes autoReload state from localStorage', function() {


### PR DESCRIPTION
* Motivation for features / changes

In #3483 I attempted to pause and restart auto reload behavior based on page visibility. 

Unfortunately a change I made to event handling just before merging into master inadvertently disabled the logic. The change happened in a seam in the code that was not covered by tests.

This change fixes the event handling and improves the test coverage.
