### PR TITLE
[DebuggerV2] Temporarily disable debugger_v2_plugin_test

### DIFF
--- a/tensorboard/plugins/debugger_v2/BUILD
+++ b/tensorboard/plugins/debugger_v2/BUILD
@@ -57,6 +57,10 @@ py_test(
     size = "medium",
     srcs = ["debugger_v2_plugin_test.py"],
     srcs_version = "PY2AND3",
+    tags = [
+        "manual",
+        "notap",  # TODO(b/153722488): Re-enable the test.
+    ],
     deps = [
         ":debug_data_multiplexer",
         ":debugger_v2_plugin",


### PR DESCRIPTION
* Motivation for features / changes
  * The imminent submission of internal CL/290949452 will cause the test to break due to newly-instrumented Const ops, which are previously untracked. Considering the complexity of the sync'ing of tensorflow and tensorboard code, I'll disable the test first. The test will later be fixed to reflect the newly-added Const ops and then re-enabled. See b/153722488.
* Technical description of changes
  * Disable the test by applying proper tags.