### PR TITLE
Detect and skip corrupt GraphDefs

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -460,7 +460,6 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_google_protobuf//:protobuf_python",
         "//tensorboard/compat:tensorflow",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins/audio:metadata",
@@ -468,6 +467,7 @@ py_library(
         "//tensorboard/plugins/image:metadata",
         "//tensorboard/plugins/scalar:metadata",
         "//tensorboard/util:tensor_util",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )
 

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -460,6 +460,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_google_protobuf//:protobuf_python",
         "//tensorboard/compat:tensorflow",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins/audio:metadata",

--- a/tensorboard/dataclass_compat.py
+++ b/tensorboard/dataclass_compat.py
@@ -26,7 +26,6 @@ from __future__ import division
 from __future__ import print_function
 
 
-
 from google.protobuf import message
 from tensorboard.backend import process_graph
 from tensorboard.compat.proto import event_pb2

--- a/tensorboard/dataclass_compat.py
+++ b/tensorboard/dataclass_compat.py
@@ -26,6 +26,8 @@ from __future__ import division
 from __future__ import print_function
 
 
+
+from google.protobuf import message
 from tensorboard.backend import process_graph
 from tensorboard.compat.proto import event_pb2
 from tensorboard.compat.proto import graph_pb2
@@ -38,6 +40,9 @@ from tensorboard.plugins.image import metadata as images_metadata
 from tensorboard.plugins.scalar import metadata as scalars_metadata
 from tensorboard.plugins.text import metadata as text_metadata
 from tensorboard.util import tensor_util
+from tensorboard.util import tb_logging
+
+logger = tb_logging.get_logger()
 
 
 def migrate_event(event, experimental_filter_graph=False):
@@ -72,11 +77,15 @@ def _migrate_graph_event(old_event, experimental_filter_graph=False):
 
     # TODO(@davidsoergel): Move this stopgap to a more appropriate place.
     if experimental_filter_graph:
-        graph_def = graph_pb2.GraphDef().FromString(graph_bytes)
-        # Use the default filter parameters:
-        # limit_attr_size=1024, large_attrs_key="_too_large_attrs"
-        process_graph.prepare_graph_for_ui(graph_def)
-        graph_bytes = graph_def.SerializeToString()
+        try:
+            graph_def = graph_pb2.GraphDef().FromString(graph_bytes)
+            # Use the default filter parameters:
+            # limit_attr_size=1024, large_attrs_key="_too_large_attrs"
+            process_graph.prepare_graph_for_ui(graph_def)
+            graph_bytes = graph_def.SerializeToString()
+        except message.DecodeError:
+            logger.warning("Could not parse GraphDef.  Skipping.")
+            return (old_event,)
 
     value.tensor.CopyFrom(tensor_util.make_tensor_proto([graph_bytes]))
     value.metadata.plugin_data.plugin_name = graphs_metadata.PLUGIN_NAME

--- a/tensorboard/dataclass_compat.py
+++ b/tensorboard/dataclass_compat.py
@@ -78,13 +78,16 @@ def _migrate_graph_event(old_event, experimental_filter_graph=False):
     if experimental_filter_graph:
         try:
             graph_def = graph_pb2.GraphDef().FromString(graph_bytes)
-            # Use the default filter parameters:
-            # limit_attr_size=1024, large_attrs_key="_too_large_attrs"
-            process_graph.prepare_graph_for_ui(graph_def)
-            graph_bytes = graph_def.SerializeToString()
         except message.DecodeError:
-            logger.warning("Could not parse GraphDef.  Skipping.")
+            logger.warning(
+                "Could not parse GraphDef of size %d. Skipping.",
+                len(graph_bytes),
+            )
             return (old_event,)
+        # Use the default filter parameters:
+        # limit_attr_size=1024, large_attrs_key="_too_large_attrs"
+        process_graph.prepare_graph_for_ui(graph_def)
+        graph_bytes = graph_def.SerializeToString()
 
     value.tensor.CopyFrom(tensor_util.make_tensor_proto([graph_bytes]))
     value.metadata.plugin_data.plugin_name = graphs_metadata.PLUGIN_NAME

--- a/tensorboard/dataclass_compat_test.py
+++ b/tensorboard/dataclass_compat_test.py
@@ -269,6 +269,7 @@ class MigrateEventTest(tf.test.TestCase):
         # _migrate_event emits both the original event and the migrated event,
         # but here there is no migrated event becasue the graph was unparseable.
         self.assertLen(new_events, 1)
+        self.assertProtoEquals(new_events[0], old_event)
 
 
 if __name__ == "__main__":

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -51,13 +51,13 @@ from tensorboard.summary import v1 as summary_v1
 from tensorboard.util import test_util as tb_test_util
 
 
-def _create_example_graph_bytes(test_attr_size):
+def _create_example_graph_bytes(large_attr_size):
     graph_def = graph_pb2.GraphDef()
     graph_def.node.add(name="alice", op="Person")
     graph_def.node.add(name="bob", op="Person")
 
     graph_def.node[1].attr["small"].s = b"small_attr_value"
-    graph_def.node[1].attr["large"].s = b"l" * test_attr_size
+    graph_def.node[1].attr["large"].s = b"l" * large_attr_size
     graph_def.node.add(
         name="friendship", op="Friendship", input=["alice", "bob"]
     )

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -41,6 +41,7 @@ from tensorboard.uploader import uploader as uploader_lib
 from tensorboard.uploader import logdir_loader
 from tensorboard.uploader import util
 from tensorboard.compat.proto import event_pb2
+from tensorboard.compat.proto import graph_pb2
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.plugins.histogram import summary_v2 as histogram_v2
 from tensorboard.plugins.graph import metadata as graphs_metadata
@@ -48,6 +49,19 @@ from tensorboard.plugins.scalar import metadata as scalars_metadata
 from tensorboard.plugins.scalar import summary_v2 as scalar_v2
 from tensorboard.summary import v1 as summary_v1
 from tensorboard.util import test_util as tb_test_util
+
+
+def _create_example_graph(test_attr_size):
+    graph_def = graph_pb2.GraphDef()
+    graph_def.node.add(name="alice", op="Person")
+    graph_def.node.add(name="bob", op="Person")
+
+    graph_def.node[1].attr["small"].s = b"small_attr_value"
+    graph_def.node[1].attr["large"].s = b"l" * test_attr_size
+    graph_def.node.add(
+        name="friendship", op="Friendship", input=["alice", "bob"]
+    )
+    return graph_def.SerializeToString()
 
 
 class AbortUploadError(Exception):
@@ -264,7 +278,7 @@ class TensorboardUploaderTest(tf.test.TestCase):
 
         # Of course a real Event stream will never produce the same Event twice,
         # but is this test context it's fine to reuse this one.
-        graph_event = event_pb2.Event(graph_def=bytes(950))
+        graph_event = event_pb2.Event(graph_def=_create_example_graph(950))
 
         mock_logdir_loader = mock.create_autospec(logdir_loader.LogdirLoader)
         mock_logdir_loader.get_run_events.side_effect = [
@@ -307,7 +321,7 @@ class TensorboardUploaderTest(tf.test.TestCase):
         )
         uploader.create_experiment()
 
-        graph_event = event_pb2.Event(graph_def=bytes(950))
+        graph_event = event_pb2.Event(graph_def=_create_example_graph(950))
 
         mock_logdir_loader = mock.create_autospec(logdir_loader.LogdirLoader)
         mock_logdir_loader.get_run_events.side_effect = [
@@ -342,7 +356,7 @@ class TensorboardUploaderTest(tf.test.TestCase):
 
         # Of course a real Event stream will never produce the same Event twice,
         # but is this test context it's fine to reuse this one.
-        graph_event = event_pb2.Event(graph_def=bytes(950))
+        graph_event = event_pb2.Event(graph_def=_create_example_graph(950))
 
         mock_logdir_loader = mock.create_autospec(logdir_loader.LogdirLoader)
         mock_logdir_loader.get_run_events.side_effect = [
@@ -383,7 +397,7 @@ class TensorboardUploaderTest(tf.test.TestCase):
         )
         uploader.create_experiment()
 
-        graph_event = event_pb2.Event(graph_def=bytes(950))
+        graph_event = event_pb2.Event(graph_def=_create_example_graph(950))
 
         mock_logdir_loader = mock.create_autospec(logdir_loader.LogdirLoader)
         mock_logdir_loader.get_run_events.side_effect = [

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -51,7 +51,7 @@ from tensorboard.summary import v1 as summary_v1
 from tensorboard.util import test_util as tb_test_util
 
 
-def _create_example_graph(test_attr_size):
+def _create_example_graph_bytes(test_attr_size):
     graph_def = graph_pb2.GraphDef()
     graph_def.node.add(name="alice", op="Person")
     graph_def.node.add(name="bob", op="Person")
@@ -278,7 +278,9 @@ class TensorboardUploaderTest(tf.test.TestCase):
 
         # Of course a real Event stream will never produce the same Event twice,
         # but is this test context it's fine to reuse this one.
-        graph_event = event_pb2.Event(graph_def=_create_example_graph(950))
+        graph_event = event_pb2.Event(
+            graph_def=_create_example_graph_bytes(950)
+        )
 
         mock_logdir_loader = mock.create_autospec(logdir_loader.LogdirLoader)
         mock_logdir_loader.get_run_events.side_effect = [
@@ -321,7 +323,9 @@ class TensorboardUploaderTest(tf.test.TestCase):
         )
         uploader.create_experiment()
 
-        graph_event = event_pb2.Event(graph_def=_create_example_graph(950))
+        graph_event = event_pb2.Event(
+            graph_def=_create_example_graph_bytes(950)
+        )
 
         mock_logdir_loader = mock.create_autospec(logdir_loader.LogdirLoader)
         mock_logdir_loader.get_run_events.side_effect = [
@@ -356,7 +360,9 @@ class TensorboardUploaderTest(tf.test.TestCase):
 
         # Of course a real Event stream will never produce the same Event twice,
         # but is this test context it's fine to reuse this one.
-        graph_event = event_pb2.Event(graph_def=_create_example_graph(950))
+        graph_event = event_pb2.Event(
+            graph_def=_create_example_graph_bytes(950)
+        )
 
         mock_logdir_loader = mock.create_autospec(logdir_loader.LogdirLoader)
         mock_logdir_loader.get_run_events.side_effect = [
@@ -397,7 +403,9 @@ class TensorboardUploaderTest(tf.test.TestCase):
         )
         uploader.create_experiment()
 
-        graph_event = event_pb2.Event(graph_def=_create_example_graph(950))
+        graph_event = event_pb2.Event(
+            graph_def=_create_example_graph_bytes(950)
+        )
 
         mock_logdir_loader = mock.create_autospec(logdir_loader.LogdirLoader)
         mock_logdir_loader.get_run_events.side_effect = [


### PR DESCRIPTION
Since #3497, we parse `GraphDef`s in `dataclass_compat.py` during upload.  If a graph is corrupt, that parsing fails.  Here we catch the resulting exception, issue a warning, and continue (omitting the graph).

This also updates tests to use valid GraphDefs where appropriate, as opposed to `bytes(1024)`, which apparently produces inconsistent results with different proto parsers (e.g., OSS vs. Google internal).