### PR TITLE
build: lock down `data_compat` and `dataclass_compat`

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -458,7 +458,6 @@ py_library(
     name = "data_compat",
     srcs = ["data_compat.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/compat:tensorflow",
         "//tensorboard/compat/proto:protos_all_py_pb2",
@@ -496,7 +495,6 @@ py_library(
     name = "dataclass_compat",
     srcs = ["dataclass_compat.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins/graph:metadata",


### PR DESCRIPTION
Summary:
These should both have been internal from the beginning, but team policy
when `data_compat` was created was to be public by default, and we
followed precedent with `dataclass_compat`. There are no remaining
Google-internal non-TensorBoard dependents.

Test Plan:
Googlers, see <http://cl/305916851> for test sync.

wchargin-branch: vis-lock-down-compats
