### PR TITLE
benchmark: remove unused deps

### DIFF
--- a/tensorboard/components/vz_line_chart2/microbenchmark/BUILD
+++ b/tensorboard/components/vz_line_chart2/microbenchmark/BUILD
@@ -25,7 +25,6 @@ tf_web_library(
     deps = [
         "//tensorboard/components/tf_imports:plottable",
         "//tensorboard/components/tf_imports:polymer",
-        "//tensorboard/components/tf_imports:web_component_tester",
         "//tensorboard/components/vz_line_chart2",
     ],
 )


### PR DESCRIPTION
webcomponent_tester has transitive dependency on sinon which is
incompatible with our build rules. Remove to unbreak our CI.

Tested: cl/305912155