### PR TITLE
uploader: inline graph filtering from `dataclass_compat`

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -497,7 +497,6 @@ py_library(
     srcs = ["dataclass_compat.py"],
     srcs_version = "PY2AND3",
     deps = [
-        "//tensorboard/backend:process_graph",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins/graph:metadata",
         "//tensorboard/plugins/histogram:metadata",

--- a/tensorboard/dataclass_compat.py
+++ b/tensorboard/dataclass_compat.py
@@ -78,7 +78,11 @@ def _migrate_graph_event(old_event, experimental_filter_graph=False):
     if experimental_filter_graph:
         try:
             graph_def = graph_pb2.GraphDef().FromString(graph_bytes)
-        except message.DecodeError:
+        # The reason for the RuntimeWarning catch here is b/27494216, whereby
+        # some proto parsers incorrectly raise that instead of DecodeError
+        # on certain kinds of malformed input.  Triggering this seems to require
+        # a combination of mysterious circumstances.
+        except (message.DecodeError, RuntimeWarning):
             logger.warning(
                 "Could not parse GraphDef of size %d. Skipping.",
                 len(graph_bytes),

--- a/tensorboard/dataclass_compat.py
+++ b/tensorboard/dataclass_compat.py
@@ -25,11 +25,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
-from google.protobuf import message
-from tensorboard.backend import process_graph
 from tensorboard.compat.proto import event_pb2
-from tensorboard.compat.proto import graph_pb2
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.compat.proto import types_pb2
 from tensorboard.plugins.graph import metadata as graphs_metadata
@@ -39,60 +35,32 @@ from tensorboard.plugins.image import metadata as images_metadata
 from tensorboard.plugins.scalar import metadata as scalars_metadata
 from tensorboard.plugins.text import metadata as text_metadata
 from tensorboard.util import tensor_util
-from tensorboard.util import tb_logging
-
-logger = tb_logging.get_logger()
 
 
-def migrate_event(event, experimental_filter_graph=False):
+def migrate_event(event):
     """Migrate an event to a sequence of events.
 
     Args:
       event: An `event_pb2.Event`. The caller transfers ownership of the
         event to this method; the event may be mutated, and may or may
         not appear in the returned sequence.
-      experimental_filter_graph: When a graph event is encountered, process the
-        GraphDef to filter out attributes that are too large to be shown in the
-        graph UI.
 
     Returns:
       A sequence of `event_pb2.Event`s to use instead of `event`.
     """
     if event.HasField("graph_def"):
-        return _migrate_graph_event(
-            event, experimental_filter_graph=experimental_filter_graph
-        )
+        return _migrate_graph_event(event)
     if event.HasField("summary"):
         return _migrate_summary_event(event)
     return (event,)
 
 
-def _migrate_graph_event(old_event, experimental_filter_graph=False):
+def _migrate_graph_event(old_event):
     result = event_pb2.Event()
     result.wall_time = old_event.wall_time
     result.step = old_event.step
     value = result.summary.value.add(tag=graphs_metadata.RUN_GRAPH_NAME)
     graph_bytes = old_event.graph_def
-
-    # TODO(@davidsoergel): Move this stopgap to a more appropriate place.
-    if experimental_filter_graph:
-        try:
-            graph_def = graph_pb2.GraphDef().FromString(graph_bytes)
-        # The reason for the RuntimeWarning catch here is b/27494216, whereby
-        # some proto parsers incorrectly raise that instead of DecodeError
-        # on certain kinds of malformed input.  Triggering this seems to require
-        # a combination of mysterious circumstances.
-        except (message.DecodeError, RuntimeWarning):
-            logger.warning(
-                "Could not parse GraphDef of size %d. Skipping.",
-                len(graph_bytes),
-            )
-            return (old_event,)
-        # Use the default filter parameters:
-        # limit_attr_size=1024, large_attrs_key="_too_large_attrs"
-        process_graph.prepare_graph_for_ui(graph_def)
-        graph_bytes = graph_def.SerializeToString()
-
     value.tensor.CopyFrom(tensor_util.make_tensor_proto([graph_bytes]))
     value.metadata.plugin_data.plugin_name = graphs_metadata.PLUGIN_NAME
     # `value.metadata.plugin_data.content` left as the empty proto

--- a/tensorboard/dataclass_compat_test.py
+++ b/tensorboard/dataclass_compat_test.py
@@ -23,6 +23,8 @@ import os
 import numpy as np
 import tensorflow as tf
 
+from google.protobuf import message
+
 from tensorboard import dataclass_compat
 from tensorboard.backend.event_processing import event_file_loader
 from tensorboard.compat.proto import event_pb2
@@ -38,6 +40,12 @@ from tensorboard.plugins.scalar import metadata as scalar_metadata
 from tensorboard.plugins.scalar import summary as scalar_summary
 from tensorboard.util import tensor_util
 from tensorboard.util import test_util
+
+try:
+    # python version >= 3.3
+    from unittest import mock
+except ImportError:
+    import mock  # pylint: disable=unused-import
 
 
 class MigrateEventTest(tf.test.TestCase):
@@ -254,18 +262,64 @@ class MigrateEventTest(tf.test.TestCase):
         self.assertProtoEquals(expected_graph_def, new_graph_def)
 
     def test_graph_def_experimental_filter_graph_corrupt(self):
-        # Simulate legacy graph event with an unparseable graph
+        # Simulate legacy graph event with an unparseable graph.
+        # We can't be sure whether this will produce `DecodeError` or
+        # `RuntimeWarning`, so we also check both cases below.
         old_event = event_pb2.Event()
         old_event.step = 0
         old_event.wall_time = 456.75
         # Careful: some proto parsers choke on byte arrays filled with 0, but
         # others don't (silently producing an empty proto, I guess).
         # Thus `old_event.graph_def = bytes(1024)` is an unreliable example.
-        old_event.graph_def = b"bogus"
+        old_event.graph_def = b"<malformed>"
 
         new_events = self._migrate_event(
             old_event, experimental_filter_graph=True
         )
+        # _migrate_event emits both the original event and the migrated event,
+        # but here there is no migrated event becasue the graph was unparseable.
+        self.assertLen(new_events, 1)
+        self.assertProtoEquals(new_events[0], old_event)
+
+    def test_graph_def_experimental_filter_graph_DecodeError(self):
+        # Simulate raising DecodeError when parsing a graph event
+        old_event = event_pb2.Event()
+        old_event.step = 0
+        old_event.wall_time = 456.75
+        old_event.graph_def = b"<malformed>"
+
+        with mock.patch(
+            "tensorboard.compat.proto.graph_pb2.GraphDef"
+        ) as mockGraphDef:
+            instance = mockGraphDef.return_value
+            instance.FromString.side_effect = message.DecodeError
+
+            new_events = self._migrate_event(
+                old_event, experimental_filter_graph=True
+            )
+
+        # _migrate_event emits both the original event and the migrated event,
+        # but here there is no migrated event becasue the graph was unparseable.
+        self.assertLen(new_events, 1)
+        self.assertProtoEquals(new_events[0], old_event)
+
+    def test_graph_def_experimental_filter_graph_RuntimeWarning(self):
+        # Simulate raising RuntimeWarning when parsing a graph event
+        old_event = event_pb2.Event()
+        old_event.step = 0
+        old_event.wall_time = 456.75
+        old_event.graph_def = b"<malformed>"
+
+        with mock.patch(
+            "tensorboard.compat.proto.graph_pb2.GraphDef"
+        ) as mockGraphDef:
+            instance = mockGraphDef.return_value
+            instance.FromString.side_effect = RuntimeWarning
+
+            new_events = self._migrate_event(
+                old_event, experimental_filter_graph=True
+            )
+
         # _migrate_event emits both the original event and the migrated event,
         # but here there is no migrated event becasue the graph was unparseable.
         self.assertLen(new_events, 1)

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -110,8 +110,8 @@ py_library(
         "//tensorboard/util:grpc_util",
         "//tensorboard/util:tb_logging",
         "//tensorboard/util:tensor_util",
-        "@org_pythonhosted_six",
         "@com_google_protobuf//:protobuf_python",
+        "@org_pythonhosted_six",
     ],
 )
 
@@ -127,16 +127,16 @@ py_test(
         "//tensorboard:expect_grpc_testing_installed",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
-        "//tensorboard/plugins/histogram:summary_v2",
         "//tensorboard/plugins/graph:metadata",
+        "//tensorboard/plugins/histogram:summary_v2",
         "//tensorboard/plugins/scalar:metadata",
         "//tensorboard/plugins/scalar:summary_v2",
         "//tensorboard/summary:summary_v1",
         "//tensorboard/uploader/proto:protos_all_py_pb2",
         "//tensorboard/uploader/proto:protos_all_py_pb2_grpc",
         "//tensorboard/util:test_util",
-        "@org_pythonhosted_mock",
         "@com_google_protobuf//:protobuf_python",
+        "@org_pythonhosted_mock",
     ],
 )
 

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -99,6 +99,7 @@ py_library(
         "//tensorboard:data_compat",
         "//tensorboard:dataclass_compat",
         "//tensorboard:expect_grpc_installed",
+        "//tensorboard/backend:process_graph",
         "//tensorboard/backend/event_processing:directory_loader",
         "//tensorboard/backend/event_processing:event_file_loader",
         "//tensorboard/backend/event_processing:io_wrapper",
@@ -110,6 +111,7 @@ py_library(
         "//tensorboard/util:tb_logging",
         "//tensorboard/util:tensor_util",
         "@org_pythonhosted_six",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -126,6 +128,7 @@ py_test(
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/plugins/histogram:summary_v2",
+        "//tensorboard/plugins/graph:metadata",
         "//tensorboard/plugins/scalar:metadata",
         "//tensorboard/plugins/scalar:summary_v2",
         "//tensorboard/summary:summary_v1",
@@ -133,6 +136,7 @@ py_test(
         "//tensorboard/uploader/proto:protos_all_py_pb2_grpc",
         "//tensorboard/util:test_util",
         "@org_pythonhosted_mock",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )
 

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -25,6 +25,8 @@ import time
 import grpc
 import six
 
+from google.protobuf import message
+from tensorboard.compat.proto import graph_pb2
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.uploader.proto import write_service_pb2
 from tensorboard.uploader.proto import experiment_pb2
@@ -32,9 +34,11 @@ from tensorboard.uploader import logdir_loader
 from tensorboard.uploader import util
 from tensorboard import data_compat
 from tensorboard import dataclass_compat
+from tensorboard.backend import process_graph
 from tensorboard.backend.event_processing import directory_loader
 from tensorboard.backend.event_processing import event_file_loader
 from tensorboard.backend.event_processing import io_wrapper
+from tensorboard.plugins.graph import metadata as graphs_metadata
 from tensorboard.plugins.scalar import metadata as scalar_metadata
 from tensorboard.util import grpc_util
 from tensorboard.util import tb_logging
@@ -425,12 +429,11 @@ class _BatchedRequestSender(object):
         for (run_name, events) in six.iteritems(run_to_events):
             for event in events:
                 v2_event = data_compat.migrate_event(event)
-                dataclass_events = dataclass_compat.migrate_event(
-                    v2_event, experimental_filter_graph=True
-                )
-                for dataclass_event in dataclass_events:
-                    if dataclass_event.summary:
-                        for value in dataclass_event.summary.value:
+                events = dataclass_compat.migrate_event(v2_event)
+                events = _filter_graph_defs(events)
+                for event in events:
+                    if event.summary:
+                        for value in event.summary.value:
                             yield (run_name, event, value)
 
 
@@ -833,3 +836,35 @@ def _varint_cost(n):
         result += 1
         n >>= 7
     return result
+
+
+def _filter_graph_defs(events):
+    for e in events:
+        for v in e.summary.value:
+            if (
+                v.metadata.plugin_data.plugin_name
+                != graphs_metadata.PLUGIN_NAME
+            ):
+                continue
+            if v.tag == graphs_metadata.RUN_GRAPH_NAME:
+                data = v.tensor.string_val
+                data[:] = map(_filtered_graph_bytes, data)
+        yield e
+
+
+def _filtered_graph_bytes(graph_bytes):
+    try:
+        graph_def = graph_pb2.GraphDef().FromString(graph_bytes)
+    # The reason for the RuntimeWarning catch here is b/27494216, whereby
+    # some proto parsers incorrectly raise that instead of DecodeError
+    # on certain kinds of malformed input. Triggering this seems to require
+    # a combination of mysterious circumstances.
+    except (message.DecodeError, RuntimeWarning):
+        logger.warning(
+            "Could not parse GraphDef of size %d.", len(graph_bytes),
+        )
+        return graph_bytes
+    # Use the default filter parameters:
+    # limit_attr_size=1024, large_attrs_key="_too_large_attrs"
+    process_graph.prepare_graph_for_ui(graph_def)
+    return graph_def.SerializeToString()

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -868,7 +868,7 @@ def _filtered_graph_bytes(graph_bytes):
     # a combination of mysterious circumstances.
     except (message.DecodeError, RuntimeWarning):
         logger.warning(
-            "Could not parse GraphDef of size %d.", len(graph_bytes),
+            "Could not parse GraphDef of size %d. Skipping.", len(graph_bytes),
         )
         return None
     # Use the default filter parameters:

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -316,11 +316,7 @@ class TensorboardUploaderTest(tf.test.TestCase):
             requests = list(call[0][0])
             data = b"".join(r.data for r in requests)
             actual_graph_def = graph_pb2.GraphDef.FromString(data)
-<<<<<<< HEAD
-            self.assertEqual(actual_graph_def, expected_graph_def)
-=======
             self.assertProtoEquals(expected_graph_def, actual_graph_def)
->>>>>>> 0f36c3feb115827bfc8f1b8b73720ef487e6655b
             self.assertEqual(
                 set(r.blob_sequence_id for r in requests), {"blob%d" % i},
             )
@@ -368,7 +364,10 @@ class TensorboardUploaderTest(tf.test.TestCase):
         # Three graphs: one short, one long, one corrupt.
         bytes_0 = _create_example_graph_bytes(123)
         bytes_1 = _create_example_graph_bytes(9999)
-        bytes_2 = b"\x0a\x7fbogus"  # invalid (truncated) proto
+        # invalid (truncated) proto: length-delimited field 1 (0x0a) of
+        # length 0x7f specified, but only len("bogus") = 5 bytes given
+        # <https://developers.google.com/protocol-buffers/docs/encoding>
+        bytes_2 = b"\x0a\x7fbogus"
 
         logdir = self.get_temp_dir()
         for (i, b) in enumerate([bytes_0, bytes_1, bytes_2]):

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -398,11 +398,11 @@ class TensorboardUploaderTest(tf.test.TestCase):
             except message.DecodeError:
                 actual_graph_defs.append(None)
 
-        with self.subTest("small graphs should pass through unchanged"):
+        with self.subTest("graphs with small attr values should be unchanged"):
             expected_graph_def_0 = graph_pb2.GraphDef.FromString(bytes_0)
             self.assertEqual(actual_graph_defs[0], expected_graph_def_0)
 
-        with self.subTest("large graphs should be filtered"):
+        with self.subTest("large attr values should be filtered out"):
             expected_graph_def_1 = graph_pb2.GraphDef.FromString(bytes_1)
             del expected_graph_def_1.node[1].attr["large"]
             expected_graph_def_1.node[1].attr["_too_large_attrs"].list.s.append(
@@ -411,9 +411,8 @@ class TensorboardUploaderTest(tf.test.TestCase):
             requests = list(mock_client.WriteBlob.call_args[0][0])
             self.assertEqual(actual_graph_defs[1], expected_graph_def_1)
 
-        with self.subTest("corrupt graphs should be passed through unchanged"):
-            self.assertIsNone(actual_graph_defs[2])
-            self.assertEqual(actual_blobs[2], bytes_2)
+        with self.subTest("corrupt graphs should be skipped"):
+            self.assertLen(actual_blobs, 2)
 
     def test_upload_server_error(self):
         mock_client = _create_mock_client()


### PR DESCRIPTION
Summary:
We initially used `dataclass_compat` to perform filtering of large
graphs as a stopgap mechanism. This commit moves that filtering into the
uploader, which is the only surface in which it’s actually used. As a
result, `dataclass_compat` no longer takes extra arguments and so can be
moved into `EventFileLoader` in a future change.

Test Plan:
Unit tests added to the uploader for the small graph, large graph, and
corrupt graph cases.

wchargin-branch: uploader-graph-filtering
