### PR TITLE
summary: avoid using 'tensorflow' package in import logic

### DIFF
--- a/tensorboard/summary/_tf/summary/__init__.py
+++ b/tensorboard/summary/_tf/summary/__init__.py
@@ -124,8 +124,9 @@ def reexport_tf_summary():
 
     # API packages to check for the original V2 summary API, in preference order
     # to avoid going "under the hood" to the _api packages unless necessary.
+    # Skip the top-level `tensorflow` package since it's hard to confirm that it
+    # is the actual v2 API (just checking tf.__version__ is not always enough).
     packages = [
-        "tensorflow",
         "tensorflow.compat.v2",
         "tensorflow_core._api.v2",
         "tensorflow_core._api.v2.compat.v2",
@@ -135,11 +136,6 @@ def reexport_tf_summary():
         "tensorflow._api.v2.compat.v2",
         "tensorflow._api.v1.compat.v2",
     ]
-    # If we aren't sure we're on V2, don't use tf.summary since it could be V1.
-    # Note there may be false positives since the __version__ attribute may not be
-    # defined at this point in the import process.
-    if not getattr(tf, "__version__", "").startswith("2."):  # noqa: F821
-        packages.remove("tensorflow")
 
     def dynamic_wildcard_import(module):
         """Implements the logic of "from module import *" for the given


### PR DESCRIPTION
The logic in `tensorboard/summary/_tf/summary/__init__.py` has a routine where it searches a bunch of possible TF package names in `sys.modules` in order to find the v2 summary API symbols that it needs to re-export.  This can have a false positive for the first package - `tensorflow` itself - since depending on the build configuration, i.e. when building with `--define=tf_api_version=1`, this package still contains the v1 rather than v2 API.  We had attempted to guard against this issue by only using `tensorflow` when `tf.__version__` was 2.x, but this check isn't sufficient because it's still possible to build 2.x TF versions with `--define=tf_api_version=1`.  In that case, this logic would mistakenly try to import the symbols from `tensorflow`, resulting in a bunch of deprecation warnings and not actually managing to re-export the critical symbols like `create_file_writer()`.

Rather than attempting to fix this check, we just avoid ever trying to use `tensorflow`.  The other package names we try all have "v2" in the package name so I don't think the same issue can affect them; they will always contain the v2 API.  This change might mean that we fall back to using `_api` packages more often, but while that's ugly, we're already doing it in some of the cases depending on where within the TF API hierarchy the re-exporting logic gets first triggered, so it's not really a change from the status quo.

Tested by patching this change internally and confirming it addresses the issues we were seeing; the existing pip package smoke tests should suffice for OSS.