### PR TITLE
compat: avoid tf.__version__ in tf2 API lazy loader

### DIFF
--- a/tensorboard/compat/__init__.py
+++ b/tensorboard/compat/__init__.py
@@ -67,10 +67,9 @@ def tf2():
     Raises:
       ImportError: if a TF-2.0 API is not available.
     """
-    # Import the `tf` compat API from this file and check if it's already TF 2.0.
-    if tf.__version__.startswith("2."):
-        return tf
-    elif hasattr(tf, "compat") and hasattr(tf.compat, "v2"):
-        # As a fallback, try `tensorflow.compat.v2` if it's defined.
+    # Resolve the lazy `tf` compat API from earlier in this file and try to find
+    # tf.compat.v2. Don't check tf.__version__ since this is not always reliable
+    # if TF was built with tf_api_version!=2.
+    if hasattr(tf, "compat") and hasattr(tf.compat, "v2"):
         return tf.compat.v2
     raise ImportError("cannot import tensorflow 2.0 API")


### PR DESCRIPTION
Similar to #3515, this is problematic because `tf.__version__.startswith("2.")` does not necessary imply that the TF 2.x API is available at the `tensorflow` root API package; in particular this will not be true if TensorFlow was built with `--define=tf_api_version=1`.

Rather than attempting to detect that situation correctly, as in #3515, we sidestep the problem by just always relying on `tf.compat.v2` regardless of what the root API package is providing. This should be safe because we only care about versions of TensorFlow that should consistently provide the `tf.compat.v2` sub-API, and unlike in #3515 where this is resolved as part of the TensorFlow API import process itself, here the `tf2` lazy loader is only invoked at runtime (i.e. after import time) at which point the API should be intact.

Test plan: unit tests should suffice for OSS; confirmed internally that this fixes the repro case using `--define=tf_api_version=1`.