### PR TITLE
[DebuggerV2] Flesh out graph execution data display

### DIFF
--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -366,17 +366,15 @@ class DebuggerV2EventMultiplexer(object):
                 "trace_id support for GraphExecutionTraceData is "
                 "not implemented yet."
             )
-        digests = self._reader.graph_execution_traces(digest=True)
-        end = self._checkBeginEndIndices(begin, end, len(digests))
-        digests = digests[begin:end]
-        graph_executions = [
-            self._reader.read_graph_execution_trace(digest) for digest in digests
-        ]
+        graph_executions = self._reader.graph_execution_traces(digest=False)
+        end = self._checkBeginEndIndices(begin, end, len(graph_executions))
         return {
             "begin": begin,
             "end": end,
+            "num_digests": len(graph_executions),
             "graph_executions": [
-                graph_exec.to_json() for graph_exec in graph_executions
+                graph_exec.to_json()
+                for graph_exec in graph_executions[begin:end]
             ],
         }
 

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -366,15 +366,17 @@ class DebuggerV2EventMultiplexer(object):
                 "trace_id support for GraphExecutionTraceData is "
                 "not implemented yet."
             )
-        graph_executions = self._reader.graph_execution_traces(digest=False)
-        end = self._checkBeginEndIndices(begin, end, len(graph_executions))
+        digests = self._reader.graph_execution_traces(digest=True)
+        end = self._checkBeginEndIndices(begin, end, len(digests))
+        digests = digests[begin:end]
+        graph_executions = [
+            self._reader.read_graph_execution_trace(digest) for digest in digests
+        ]
         return {
             "begin": begin,
             "end": end,
-            "num_digests": len(graph_executions),
             "graph_executions": [
-                graph_exec.to_json()
-                for graph_exec in graph_executions[begin:end]
+                graph_exec.to_json() for graph_exec in graph_executions
             ],
         }
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
@@ -156,7 +156,7 @@ export const graphExecutionDataLoaded = createAction(
 );
 
 export const graphExecutionScrollToIndex = createAction(
-  '[Debugger] Scroll the Graph Execution List to Given Index',
+  '[Debugger] Scroll Intra-Graph Execution List to Given Index',
   props<{index: number}>()
 );
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
@@ -27,6 +27,7 @@ import {
 import {
   ExecutionDigestsResponse,
   ExecutionDataResponse,
+  GraphExecutionDataResponse,
   SourceFileResponse,
 } from '../data_source/tfdbg2_data_source';
 
@@ -144,6 +145,24 @@ export const numGraphExecutionsLoaded = createAction(
   props<{numGraphExecutions: number}>()
 );
 
+export const graphExecutionDataRequested = createAction(
+  '[Debugger] Intra-Graph Execution Data Requested',
+  props<{pageIndex: number}>()
+);
+
+export const graphExecutionDataLoaded = createAction(
+  '[Debugger] Intra-Graph Execution Data Loaded',
+  props<GraphExecutionDataResponse>()
+);
+
+export const graphExecutionScrollToIndex = createAction(
+  '[Debugger] Scroll the Graph Execution List to Given Index',
+  props<{index: number}>()
+);
+
+/**
+ * Actions related to source files and stack traces.
+ */
 export const sourceFileListRequested = createAction(
   '[Debugger] Source File List Requested.'
 );

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.css
@@ -15,13 +15,18 @@ limitations under the License.
 
 .bottom-section {
   border-top: 1px solid rgba(0, 0, 0, 0.12);
-  height: 353px;
+  height: 34%;
   padding-top: 6px;
   width: 100%;
 }
 
+.debugger-container {
+  background-color: #fff;
+  height: 100%;
+}
+
 .top-section {
-  height: 360px;
+  height: 66%;
   padding: 6px 0;
   width: 100%;
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.ng.html
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div>
+<div class="debugger-container">
   <tf-debugger-v2-inactive
     *ngIf="runIds.length === 0; else dataAvailable"
   ></tf-debugger-v2-inactive>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -593,7 +593,7 @@ export class DebuggerEffects {
           loadingPages,
           pageLoadedSizes,
         ]) => {
-          const missingPages = getMissingPages(
+          let missingPages: number[] = getMissingPages(
             scrollBeginIndex,
             Math.min(scrollBeginIndex + displayCount, numGraphExecutions),
             pageSize,
@@ -601,11 +601,9 @@ export class DebuggerEffects {
             pageLoadedSizes
           );
           // Omit pages that are already loading.
-          for (let i = missingPages.length - 1; i >= 0; --i) {
-            if (loadingPages.indexOf(missingPages[i]) !== -1) {
-              missingPages.splice(i, 1); // TODO(cais): Add unit test.
-            }
-          }
+          missingPages = missingPages.filter(
+            (page) => loadingPages.indexOf(page) === -1
+          );
           return {
             runId,
             missingPages,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -561,36 +561,27 @@ export class DebuggerEffects {
       withLatestFrom(
         this.store.select(getActiveRunId),
         this.store.select(getNumGraphExecutions),
-        this.store.select(getGraphExecutionScrollBeginIndex),
-        this.store.select(getGraphExecutionPageSize),
-        this.store.select(getGraphExecutionDisplayCount)
+        this.store.select(getGraphExecutionScrollBeginIndex)
       ),
       filter(([, runId, numGraphExecutions]) => {
         return runId !== null && numGraphExecutions > 0;
       }),
-      map(
-        ([
-          ,
-          runId,
-          numGraphExecutions,
-          scrollBeginIndex,
-          pageSize,
-          displayCount,
-        ]) => ({
-          runId,
-          numGraphExecutions,
-          scrollBeginIndex,
-          pageSize,
-          displayCount,
-        })
-      ),
+      map(([, runId, numGraphExecutions, scrollBeginIndex]) => ({
+        runId,
+        numGraphExecutions,
+        scrollBeginIndex,
+      })),
       withLatestFrom(
+        this.store.select(getGraphExecutionPageSize),
+        this.store.select(getGraphExecutionDisplayCount),
         this.store.select(getGraphExecutionDataLoadingPages),
         this.store.select(getGraphExecutionDataPageLoadedSizes)
       ),
       map(
         ([
-          {runId, numGraphExecutions, scrollBeginIndex, pageSize, displayCount},
+          {runId, numGraphExecutions, scrollBeginIndex},
+          pageSize,
+          displayCount,
           loadingPages,
           pageLoadedSizes,
         ]) => {
@@ -860,7 +851,7 @@ export class DebuggerEffects {
      *                                                                 |
      * on alert type focus --------> fetch alerts of a type -----------+
      *
-     * on source file requested ---> fetch source
+     * on source file requested ---> fetch source file
      *
      * on graph-execution scroll --> fetch graph-execution data
      *

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -64,9 +64,11 @@ import {
   getExecutionPageSize,
   getExecutionScrollBeginIndex,
   getFocusedSourceFileContent,
+  getGraphExecutionDataPageLoadedSizes,
   getGraphExecutionDisplayCount,
   getGraphExecutionPageSize,
   getGraphExecutionScrollBeginIndex,
+  getGraphExecutionDataLoadingPages,
   getNumExecutions,
   getNumExecutionsLoaded,
   getLoadedAlertsOfFocusedType,
@@ -77,8 +79,6 @@ import {
   getNumGraphExecutionsLoaded,
   getSourceFileListLoaded,
   getFocusedSourceFileIndex,
-  getGraphExecutionDataPageLoadedSizes,
-  getLoadingGraphExecutionPages,
 } from '../store/debugger_selectors';
 import {
   DataLoadState,
@@ -584,7 +584,7 @@ export class DebuggerEffects {
         })
       ),
       withLatestFrom(
-        this.store.select(getLoadingGraphExecutionPages),
+        this.store.select(getGraphExecutionDataLoadingPages),
         this.store.select(getGraphExecutionDataPageLoadedSizes)
       ),
       map(

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -860,7 +860,9 @@ export class DebuggerEffects {
      *                                                                 |
      * on alert type focus --------> fetch alerts of a type -----------+
      *
-     * on source file requested ---> fetch source file
+     * on source file requested ---> fetch source
+     *
+     * on graph-execution scroll --> fetch graph-execution data
      *
      **/
     this.loadData$ = createEffect(
@@ -921,10 +923,9 @@ export class DebuggerEffects {
           onLoad$
         );
 
-        // TODO(cais): Hook it up.
-        const onGraphExecutionScroll$ = this.onGraphExecutionScroll();
-
         const onSourceFileFocused$ = this.onSourceFileFocused();
+
+        const onGraphExecutionScroll$ = this.onGraphExecutionScroll();
 
         // ExecutionDigest and ExecutionData can be loaded in parallel.
         return merge(

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {provideMockActions} from '@ngrx/effects/testing';
 import {Action, Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
@@ -30,6 +30,9 @@ import {
   executionScrollLeft,
   executionScrollRight,
   executionScrollToIndex,
+  graphExecutionDataRequested,
+  graphExecutionDataLoaded,
+  graphExecutionScrollToIndex,
   numAlertsAndBreakdownRequested,
   numAlertsAndBreakdownLoaded,
   numExecutionsLoaded,
@@ -47,6 +50,7 @@ import {
   AlertsResponse,
   ExecutionDataResponse,
   ExecutionDigestsResponse,
+  GraphExecutionDataResponse,
   GraphExecutionDigestsResponse,
   SourceFileListResponse,
   SourceFileResponse,
@@ -62,10 +66,16 @@ import {
   getNumAlertsOfFocusedType,
   getNumExecutionsLoaded,
   getNumExecutions,
+  getNumGraphExecutions,
   getDisplayCount,
   getExecutionDigestsLoaded,
   getExecutionPageSize,
   getExecutionScrollBeginIndex,
+  getGraphExecutionDisplayCount,
+  getGraphExecutionDataLoadingPages,
+  getGraphExecutionDataPageLoadedSizes,
+  getGraphExecutionPageSize,
+  getGraphExecutionScrollBeginIndex,
   getLoadedAlertsOfFocusedType,
   getLoadedExecutionData,
   getLoadedStackFrames,
@@ -78,6 +88,7 @@ import {
   DebuggerRunListing,
   Execution,
   ExecutionDigest,
+  GraphExecution,
   State,
   SourceFileSpec,
   SourceFileContent,
@@ -86,9 +97,10 @@ import {
   createDebuggerState,
   createState,
   createTestExecutionData,
-  createTestStackFrame,
-  createTestInfNanAlert,
   createTestExecutionDigest,
+  createTestGraphExecution,
+  createTestInfNanAlert,
+  createTestStackFrame,
 } from '../testing';
 import {TBHttpClientTestingModule} from '../../../../webapp/webapp_data_source/tb_http_client_testing';
 
@@ -320,6 +332,20 @@ describe('Debugger effects', () => {
     )
       .withArgs(runId, begin, end)
       .and.returnValue(of(graphExcutionDigestsResponse));
+  }
+
+  function createFetchGraphExecutionDataSpy(
+    runId: string,
+    begin: number,
+    end: number,
+    graphExcutionDataResponse: GraphExecutionDataResponse
+  ) {
+    return spyOn(
+      TestBed.get(Tfdbg2HttpServerDataSource),
+      'fetchGraphExecutionData'
+    )
+      .withArgs(runId, begin, end)
+      .and.returnValue(of(graphExcutionDataResponse));
   }
 
   describe('loadData', () => {
@@ -878,6 +904,81 @@ describe('Debugger effects', () => {
           }
         }
       );
+    }
+  });
+
+  describe('graphExecutionScrollToIndex', () => {
+    beforeEach(() => {
+      debuggerEffects.loadData$.subscribe();
+    });
+
+    for (const {dataExists, page3Size, loadingPages} of [
+      {dataExists: false, page3Size: 0, loadingPages: [3]},
+      {dataExists: false, page3Size: 0, loadingPages: []},
+      {dataExists: true, page3Size: 2, loadingPages: []},
+    ]) {
+      it('triggers GraphExecution loading', fakeAsync(() => {
+        const runId = '__default_debugger_run__';
+        const originalScrollBeginIndex = 50;
+        const newScrollBeginIndex = originalScrollBeginIndex + 2;
+        const numGraphExecutions = 100;
+        const pageSize = 20;
+        const displayCount = 10;
+        store.overrideSelector(getActiveRunId, runId);
+        store.overrideSelector(getNumGraphExecutions, numGraphExecutions);
+        store.overrideSelector(
+          getGraphExecutionScrollBeginIndex,
+          newScrollBeginIndex
+        );
+        store.overrideSelector(getGraphExecutionPageSize, pageSize);
+        store.overrideSelector(getGraphExecutionDisplayCount, displayCount);
+        store.overrideSelector(getExecutionPageSize, pageSize);
+        store.overrideSelector(getGraphExecutionDataLoadingPages, loadingPages);
+        const pageLoadedSizes: {[pageIndex: number]: number} = {
+          0: 20,
+          1: 20,
+          2: 20,
+        };
+        pageLoadedSizes[3] = page3Size;
+        store.overrideSelector(
+          getGraphExecutionDataPageLoadedSizes,
+          pageLoadedSizes
+        );
+        store.refreshState();
+
+        const graphExecutions = new Array<GraphExecution>(pageSize).fill(
+          createTestGraphExecution()
+        );
+        const graphExecutionDataResponse: GraphExecutionDataResponse = {
+          begin: 60,
+          end: 60 + pageSize,
+          graph_executions: graphExecutions,
+        };
+        const fetchExecutionData = createFetchGraphExecutionDataSpy(
+          runId,
+          60,
+          60 + pageSize,
+          graphExecutionDataResponse
+        );
+
+        action.next(graphExecutionScrollToIndex({index: newScrollBeginIndex}));
+        tick(100);
+
+        if (dataExists || loadingPages.length > 0) {
+          expect(fetchExecutionData).not.toHaveBeenCalled();
+          expect(dispatchedActions).toEqual([]);
+        } else {
+          expect(fetchExecutionData).toHaveBeenCalledTimes(1);
+          expect(dispatchedActions).toEqual([
+            graphExecutionDataRequested({pageIndex: 3}),
+            graphExecutionDataLoaded({
+              begin: 60,
+              end: 60 + pageSize,
+              graph_executions: graphExecutions,
+            }),
+          ]);
+        }
+      }));
     }
   });
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -917,68 +917,77 @@ describe('Debugger effects', () => {
       {dataExists: false, page3Size: 0, loadingPages: []},
       {dataExists: true, page3Size: 2, loadingPages: []},
     ]) {
-      it('triggers GraphExecution loading', fakeAsync(() => {
-        const runId = '__default_debugger_run__';
-        const originalScrollBeginIndex = 50;
-        const newScrollBeginIndex = originalScrollBeginIndex + 2;
-        const numGraphExecutions = 100;
-        const pageSize = 20;
-        const displayCount = 10;
-        store.overrideSelector(getActiveRunId, runId);
-        store.overrideSelector(getNumGraphExecutions, numGraphExecutions);
-        store.overrideSelector(
-          getGraphExecutionScrollBeginIndex,
-          newScrollBeginIndex
-        );
-        store.overrideSelector(getGraphExecutionPageSize, pageSize);
-        store.overrideSelector(getGraphExecutionDisplayCount, displayCount);
-        store.overrideSelector(getExecutionPageSize, pageSize);
-        store.overrideSelector(getGraphExecutionDataLoadingPages, loadingPages);
-        const pageLoadedSizes: {[pageIndex: number]: number} = {
-          0: 20,
-          1: 20,
-          2: 20,
-        };
-        pageLoadedSizes[3] = page3Size;
-        store.overrideSelector(
-          getGraphExecutionDataPageLoadedSizes,
-          pageLoadedSizes
-        );
-        store.refreshState();
+      it(
+        `triggers GraphExecution loading: dataExists=${dataExists}, ` +
+          `loadingPages=${JSON.stringify(loadingPages)}`,
+        fakeAsync(() => {
+          const runId = '__default_debugger_run__';
+          const originalScrollBeginIndex = 50;
+          const newScrollBeginIndex = originalScrollBeginIndex + 2;
+          const numGraphExecutions = 100;
+          const pageSize = 20;
+          const displayCount = 10;
+          store.overrideSelector(getActiveRunId, runId);
+          store.overrideSelector(getNumGraphExecutions, numGraphExecutions);
+          store.overrideSelector(
+            getGraphExecutionScrollBeginIndex,
+            newScrollBeginIndex
+          );
+          store.overrideSelector(getGraphExecutionPageSize, pageSize);
+          store.overrideSelector(getGraphExecutionDisplayCount, displayCount);
+          store.overrideSelector(getExecutionPageSize, pageSize);
+          store.overrideSelector(
+            getGraphExecutionDataLoadingPages,
+            loadingPages
+          );
+          const pageLoadedSizes: {[pageIndex: number]: number} = {
+            0: 20,
+            1: 20,
+            2: 20,
+          };
+          pageLoadedSizes[3] = page3Size;
+          store.overrideSelector(
+            getGraphExecutionDataPageLoadedSizes,
+            pageLoadedSizes
+          );
+          store.refreshState();
 
-        const graphExecutions = new Array<GraphExecution>(pageSize).fill(
-          createTestGraphExecution()
-        );
-        const graphExecutionDataResponse: GraphExecutionDataResponse = {
-          begin: 60,
-          end: 60 + pageSize,
-          graph_executions: graphExecutions,
-        };
-        const fetchExecutionData = createFetchGraphExecutionDataSpy(
-          runId,
-          60,
-          60 + pageSize,
-          graphExecutionDataResponse
-        );
+          const graphExecutions = new Array<GraphExecution>(pageSize).fill(
+            createTestGraphExecution()
+          );
+          const graphExecutionDataResponse: GraphExecutionDataResponse = {
+            begin: 60,
+            end: 60 + pageSize,
+            graph_executions: graphExecutions,
+          };
+          const fetchExecutionData = createFetchGraphExecutionDataSpy(
+            runId,
+            60,
+            60 + pageSize,
+            graphExecutionDataResponse
+          );
 
-        action.next(graphExecutionScrollToIndex({index: newScrollBeginIndex}));
-        tick(100);
+          action.next(
+            graphExecutionScrollToIndex({index: newScrollBeginIndex})
+          );
+          tick(100);
 
-        if (dataExists || loadingPages.length > 0) {
-          expect(fetchExecutionData).not.toHaveBeenCalled();
-          expect(dispatchedActions).toEqual([]);
-        } else {
-          expect(fetchExecutionData).toHaveBeenCalledTimes(1);
-          expect(dispatchedActions).toEqual([
-            graphExecutionDataRequested({pageIndex: 3}),
-            graphExecutionDataLoaded({
-              begin: 60,
-              end: 60 + pageSize,
-              graph_executions: graphExecutions,
-            }),
-          ]);
-        }
-      }));
+          if (dataExists || loadingPages.length > 0) {
+            expect(fetchExecutionData).not.toHaveBeenCalled();
+            expect(dispatchedActions).toEqual([]);
+          } else {
+            expect(fetchExecutionData).toHaveBeenCalledTimes(1);
+            expect(dispatchedActions).toEqual([
+              graphExecutionDataRequested({pageIndex: 3}),
+              graphExecutionDataLoaded({
+                begin: 60,
+                end: 60 + pageSize,
+                graph_executions: graphExecutions,
+              }),
+            ]);
+          }
+        })
+      );
     }
   });
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -84,7 +84,7 @@ export function createInitialGraphExecutionsState(): GraphExecutions {
     scrollBeginIndex: 0,
     focusIndex: null,
     graphExecutionDigests: {},
-    loadingGraphExecutionDataPages: [],
+    graphExecutionDataLoadingPages: [],
     graphExecutionDataPageLoadedSizes: {},
     graphExecutionData: {},
   };
@@ -573,15 +573,15 @@ const reducer = createReducer(
       if (state.activeRunId === null) {
         return state;
       }
-      const loadingGraphExecutionDataPages = state.graphExecutions.loadingGraphExecutionDataPages.slice();
-      if (loadingGraphExecutionDataPages.indexOf(pageIndex) === -1) {
-        loadingGraphExecutionDataPages.push(pageIndex);
+      const graphExecutionDataLoadingPages = state.graphExecutions.graphExecutionDataLoadingPages.slice();
+      if (graphExecutionDataLoadingPages.indexOf(pageIndex) === -1) {
+        graphExecutionDataLoadingPages.push(pageIndex);
       }
       return {
         ...state,
         graphExecutions: {
           ...state.graphExecutions,
-          loadingGraphExecutionDataPages,
+          graphExecutionDataLoadingPages,
         },
       };
     }
@@ -593,18 +593,18 @@ const reducer = createReducer(
         return state;
       }
       const {pageSize} = state.graphExecutions;
-      const loadingGraphExecutionDataPages = state.graphExecutions.loadingGraphExecutionDataPages.slice();
+      const graphExecutionDataLoadingPages = state.graphExecutions.graphExecutionDataLoadingPages.slice();
       const graphExecutionDataPageLoadedSizes = {
         ...state.graphExecutions.graphExecutionDataPageLoadedSizes,
       };
       const graphExecutionData = {...state.graphExecutions.graphExecutionData};
-      // Update loadingGraphExecutionDataPages, graphExecutionDataPageLoadedSizes,
+      // Update graphExecutionDataLoadingPages, graphExecutionDataPageLoadedSizes,
       // and graphExecutionData.
       for (let i = data.begin; i < data.end; ++i) {
         const pageIndex = Math.floor(i / pageSize);
-        if (loadingGraphExecutionDataPages.indexOf(pageIndex) !== -1) {
-          loadingGraphExecutionDataPages.splice(
-            loadingGraphExecutionDataPages.indexOf(pageIndex),
+        if (graphExecutionDataLoadingPages.indexOf(pageIndex) !== -1) {
+          graphExecutionDataLoadingPages.splice(
+            graphExecutionDataLoadingPages.indexOf(pageIndex),
             1
           );
         }
@@ -620,7 +620,7 @@ const reducer = createReducer(
         ...state,
         graphExecutions: {
           ...state.graphExecutions,
-          loadingGraphExecutionDataPages,
+          graphExecutionDataLoadingPages,
           graphExecutionDataPageLoadedSizes,
           graphExecutionData,
         },

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -585,7 +585,7 @@ const reducer = createReducer(
         },
       };
     }
-  ), // TODO(cais): Add unit test.
+  ),
   on(
     actions.graphExecutionDataLoaded,
     (state: DebuggerState, data: GraphExecutionDataResponse): DebuggerState => {
@@ -598,8 +598,6 @@ const reducer = createReducer(
         ...state.graphExecutions.graphExecutionDataPageLoadedSizes,
       };
       const graphExecutionData = {...state.graphExecutions.graphExecutionData};
-      // Update graphExecutionDataLoadingPages, graphExecutionDataPageLoadedSizes,
-      // and graphExecutionData.
       for (let i = data.begin; i < data.end; ++i) {
         const pageIndex = Math.floor(i / pageSize);
         if (graphExecutionDataLoadingPages.indexOf(pageIndex) !== -1) {
@@ -608,13 +606,13 @@ const reducer = createReducer(
             1
           );
         }
+        if (graphExecutionDataPageLoadedSizes[pageIndex] === undefined) {
+          graphExecutionDataPageLoadedSizes[pageIndex] = 0;
+        }
         if (graphExecutionData[i] === undefined) {
-          graphExecutionData[i] = data.graph_executions[i - data.begin];
-          if (graphExecutionDataPageLoadedSizes[pageIndex] === undefined) {
-            graphExecutionDataPageLoadedSizes[pageIndex] = 0;
-          }
           graphExecutionDataPageLoadedSizes[pageIndex]++;
         }
+        graphExecutionData[i] = data.graph_executions[i - data.begin];
       }
       return {
         ...state,
@@ -626,7 +624,7 @@ const reducer = createReducer(
         },
       };
     }
-  ), // TODO(cais): Add unit test.
+  ),
   on(
     actions.graphExecutionScrollToIndex,
     (state: DebuggerState, action: {index: number}): DebuggerState => {
@@ -644,7 +642,7 @@ const reducer = createReducer(
         },
       };
     }
-  ), // TODO(cais): Add unit test.
+  ),
   ////////////////////////////////////////////////////////
   // Reducers related to source files and stack traces. //
   ////////////////////////////////////////////////////////

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
@@ -1448,8 +1448,8 @@ describe('Debugger reducers', () => {
           begin: 2,
           end: 4,
           graph_executions: [
-            createTestGraphExecution({op_name: 'TestOp_2'}),
-            createTestGraphExecution({op_name: 'TestOp_3'}),
+            createTestGraphExecution({op_name: 'TestOp_2_overwrite'}),
+            createTestGraphExecution({op_name: 'TestOp_3_overwrite'}),
           ],
         })
       );
@@ -1465,8 +1465,8 @@ describe('Debugger reducers', () => {
       expect(nextState.graphExecutions.graphExecutionData).toEqual({
         0: createTestGraphExecution({op_name: 'TestOp_0'}),
         1: createTestGraphExecution({op_name: 'TestOp_1'}),
-        2: createTestGraphExecution({op_name: 'TestOp_2'}),
-        3: createTestGraphExecution({op_name: 'TestOp_3'}),
+        2: createTestGraphExecution({op_name: 'TestOp_2_overwrite'}),
+        3: createTestGraphExecution({op_name: 'TestOp_3_overwrite'}),
       });
     });
   });

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -216,6 +216,13 @@ export const getGraphExecutionScrollBeginIndex = createSelector(
   }
 ); // TODO(cais): Add unit tests.
 
+export const getGraphExecutionDisplayCount = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): number => {
+    return state.graphExecutions.displayCount;
+  }
+); // TODO(cais): Add unit tests.
+
 export const getGraphExecutionPageSize = createSelector(
   selectDebuggerState,
   (state: DebuggerState): number => {
@@ -230,12 +237,12 @@ export const getLoadingGraphExecutionPages = createSelector(
   }
 ); // TODO(cais): Add unit tests.
 
-// export const getLoadedGraphExecutionPages = createSelector(
-//   selectDebuggerState,
-//   (state: DebuggerState): number[] => {
-//     return state.graphExecutions.loadedGraphExecutionDataPages;
-//   }
-// ); // TODO(cais): Add unit tests.
+export const getGraphExecutionDataPageLoadedSizes = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): {[page: number]: number} => {
+    return state.graphExecutions.graphExecutionDataPageLoadedSizes;
+  }
+); // TODO(cais): Add unit tests.
 
 export const getGraphExecutionData = createSelector(
   selectDebuggerState,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -214,42 +214,42 @@ export const getGraphExecutionScrollBeginIndex = createSelector(
   (state: DebuggerState): number => {
     return state.graphExecutions.scrollBeginIndex;
   }
-); // TODO(cais): Add unit tests.
+);
 
 export const getGraphExecutionDisplayCount = createSelector(
   selectDebuggerState,
   (state: DebuggerState): number => {
     return state.graphExecutions.displayCount;
   }
-); // TODO(cais): Add unit tests.
+);
 
 export const getGraphExecutionPageSize = createSelector(
   selectDebuggerState,
   (state: DebuggerState): number => {
     return state.graphExecutions.pageSize;
   }
-); // TODO(cais): Add unit tests.
+);
 
-export const getLoadingGraphExecutionPages = createSelector(
+export const getGraphExecutionDataLoadingPages = createSelector(
   selectDebuggerState,
   (state: DebuggerState): number[] => {
-    return state.graphExecutions.loadingGraphExecutionDataPages;
+    return state.graphExecutions.graphExecutionDataLoadingPages;
   }
-); // TODO(cais): Add unit tests.
+);
 
 export const getGraphExecutionDataPageLoadedSizes = createSelector(
   selectDebuggerState,
   (state: DebuggerState): {[page: number]: number} => {
     return state.graphExecutions.graphExecutionDataPageLoadedSizes;
   }
-); // TODO(cais): Add unit tests.
+);
 
 export const getGraphExecutionData = createSelector(
   selectDebuggerState,
   (state: DebuggerState): {[index: number]: GraphExecution} => {
     return state.graphExecutions.graphExecutionData;
   }
-); // TODO(cais): Add unit tests.
+);
 
 /**
  * Get the focused alert types (if any) of the execution digests current being

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -25,6 +25,7 @@ import {
   Execution,
   ExecutionDigest,
   ExecutionDigestLoadState,
+  GraphExecution,
   LoadState,
   SourceFileContent,
   SourceFileSpec,
@@ -207,6 +208,41 @@ export const getNumGraphExecutions = createSelector(
     return state.graphExecutions.executionDigestsLoaded.numExecutions;
   }
 );
+
+export const getGraphExecutionScrollBeginIndex = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): number => {
+    return state.graphExecutions.scrollBeginIndex;
+  }
+); // TODO(cais): Add unit tests.
+
+export const getGraphExecutionPageSize = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): number => {
+    return state.graphExecutions.pageSize;
+  }
+); // TODO(cais): Add unit tests.
+
+export const getLoadingGraphExecutionPages = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): number[] => {
+    return state.graphExecutions.loadingGraphExecutionDataPages;
+  }
+); // TODO(cais): Add unit tests.
+
+// export const getLoadedGraphExecutionPages = createSelector(
+//   selectDebuggerState,
+//   (state: DebuggerState): number[] => {
+//     return state.graphExecutions.loadedGraphExecutionDataPages;
+//   }
+// ); // TODO(cais): Add unit tests.
+
+export const getGraphExecutionData = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): {[index: number]: GraphExecution} => {
+    return state.graphExecutions.graphExecutionData;
+  }
+); // TODO(cais): Add unit tests.
 
 /**
  * Get the focused alert types (if any) of the execution digests current being

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
@@ -51,6 +51,7 @@ import {
   createState,
   createTestExecutionData,
   createTestExecutionDigest,
+  createTestGraphExecution,
   createTestInfNanAlert,
 } from '../testing';
 
@@ -837,11 +838,7 @@ describe('debugger selectors', () => {
           }),
         })
       );
-      expect(getGraphExecutionDataLoadingPages(state)).toEqual([
-        1,
-        2,
-        100,
-      ]);
+      expect(getGraphExecutionDataLoadingPages(state)).toEqual([1, 2, 100]);
     });
   });
 
@@ -883,31 +880,13 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphExecutions: createDebuggerGraphExecutionsState({
             graphExecutionData: {
-              10: {
-                op_name: 'Dense_1/MatMul',
-                op_type: 'MatMul',
-                output_slot: 0,
-                graph_id: 'g1',
-                graph_ids: ['g0', 'g1'],
-                tensor_debug_mode: 2,
-                debug_tensor_value: [0, 1],
-                device_name: '/GPU:0'
-              }
-            }
+              10: createTestGraphExecution(),
+            },
           }),
         })
       );
       expect(getGraphExecutionData(state)).toEqual({
-        10: {
-          op_name: 'Dense_1/MatMul',
-          op_type: 'MatMul',
-          output_slot: 0,
-          graph_id: 'g1',
-          graph_ids: ['g0', 'g1'],
-          tensor_debug_mode: 2,
-          debug_tensor_value: [0, 1],
-          device_name: '/GPU:0'
-        }
+        10: createTestGraphExecution(),
       });
     });
   });

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
@@ -22,6 +22,12 @@ import {
   getFocusedExecutionStackFrames,
   getFocusedSourceFileContent,
   getFocusedSourceFileIndex,
+  getGraphExecutionData,
+  getGraphExecutionDataLoadingPages,
+  getGraphExecutionDataPageLoadedSizes,
+  getGraphExecutionDisplayCount,
+  getGraphExecutionPageSize,
+  getGraphExecutionScrollBeginIndex,
   getLoadedAlertsOfFocusedType,
   getNumAlerts,
   getNumAlertsOfFocusedType,
@@ -764,6 +770,145 @@ describe('debugger selectors', () => {
         })
       );
       expect(getNumGraphExecutions(state)).toBe(10);
+    });
+  });
+
+  describe('getGraphExecutionScrollBeginIndex', () => {
+    it('returns correct initial zero state', () => {
+      const state = createState(createDebuggerState());
+      expect(getGraphExecutionScrollBeginIndex(state)).toBe(0);
+    });
+
+    it('returns correct non-zero state', () => {
+      const state = createState(
+        createDebuggerState({
+          graphExecutions: createDebuggerGraphExecutionsState({
+            scrollBeginIndex: 1234567,
+          }),
+        })
+      );
+      expect(getGraphExecutionScrollBeginIndex(state)).toBe(1234567);
+    });
+  });
+
+  describe('getGraphExecutionDisplayCount', () => {
+    it('returns correct value', () => {
+      const state = createState(
+        createDebuggerState({
+          graphExecutions: createDebuggerGraphExecutionsState({
+            displayCount: 240,
+          }),
+        })
+      );
+      expect(getGraphExecutionDisplayCount(state)).toBe(240);
+    });
+  });
+
+  describe('getGraphExecutionPageSize', () => {
+    it('returns correct value', () => {
+      const state = createState(
+        createDebuggerState({
+          graphExecutions: createDebuggerGraphExecutionsState({
+            pageSize: 126,
+          }),
+        })
+      );
+      expect(getGraphExecutionPageSize(state)).toBe(126);
+    });
+  });
+
+  describe('getGraphExecutionDataLoadingPages', () => {
+    it('returns correct empty value', () => {
+      const state = createState(
+        createDebuggerState({
+          graphExecutions: createDebuggerGraphExecutionsState({
+            graphExecutionDataLoadingPages: [],
+          }),
+        })
+      );
+      expect(getGraphExecutionDataLoadingPages(state)).toEqual([]);
+    });
+
+    it('returns correct non-empty value', () => {
+      const state = createState(
+        createDebuggerState({
+          graphExecutions: createDebuggerGraphExecutionsState({
+            graphExecutionDataLoadingPages: [1, 2, 100],
+          }),
+        })
+      );
+      expect(getGraphExecutionDataLoadingPages(state)).toEqual([
+        1,
+        2,
+        100,
+      ]);
+    });
+  });
+
+  describe('getGraphExecutionDataLoadingPages', () => {
+    it('returns correct empty value', () => {
+      const state = createState(
+        createDebuggerState({
+          graphExecutions: createDebuggerGraphExecutionsState({
+            graphExecutionDataPageLoadedSizes: {},
+          }),
+        })
+      );
+      expect(getGraphExecutionDataPageLoadedSizes(state)).toEqual({});
+    });
+
+    it('returns correct non-empty value', () => {
+      const state = createState(
+        createDebuggerState({
+          graphExecutions: createDebuggerGraphExecutionsState({
+            graphExecutionDataPageLoadedSizes: {0: 10, 2: 40},
+          }),
+        })
+      );
+      expect(getGraphExecutionDataPageLoadedSizes(state)).toEqual({
+        0: 10,
+        2: 40,
+      });
+    });
+  });
+
+  describe('getGraphExecutionData', () => {
+    it('returns correct initial empty state', () => {
+      const state = createState(createDebuggerState());
+      expect(getGraphExecutionData(state)).toEqual({});
+    });
+
+    it('returns correct non-empty value', () => {
+      const state = createState(
+        createDebuggerState({
+          graphExecutions: createDebuggerGraphExecutionsState({
+            graphExecutionData: {
+              10: {
+                op_name: 'Dense_1/MatMul',
+                op_type: 'MatMul',
+                output_slot: 0,
+                graph_id: 'g1',
+                graph_ids: ['g0', 'g1'],
+                tensor_debug_mode: 2,
+                debug_tensor_value: [0, 1],
+                device_name: '/GPU:0'
+              }
+            }
+          }),
+        })
+      );
+      expect(getGraphExecutionData(state)).toEqual({
+        10: {
+          op_name: 'Dense_1/MatMul',
+          op_type: 'MatMul',
+          output_slot: 0,
+          graph_id: 'g1',
+          graph_ids: ['g0', 'g1'],
+          tensor_debug_mode: 2,
+          debug_tensor_value: [0, 1],
+          device_name: '/GPU:0'
+        }
+      });
     });
   });
 });

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -259,8 +259,8 @@ export interface GraphExecutions extends PagedExecutions {
   // Indices to GraphExecution pages currently being loaded.
   loadingGraphExecutionDataPages: number[];
 
-  // // Indices to GraphExecution pages that have been loaded successfully.
-  // loadedGraphExecutionDataPages: number[];
+  // Number of items in each `GraphExecution` page that have been loaded.
+  graphExecutionDataPageLoadedSizes: {[page: number]: number};
 
   // Detailed data objects about intra-graph execution.
   graphExecutionData: {[index: number]: GraphExecution};

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -256,8 +256,14 @@ export interface GraphExecutions extends PagedExecutions {
   // Intra-graph execution digests the frontend has loaded so far.
   graphExecutionDigests: {[index: number]: GraphExecutionDigest};
 
+  // Indices to GraphExecution pages currently being loaded.
+  loadingGraphExecutionDataPages: number[];
+
+  // // Indices to GraphExecution pages that have been loaded successfully.
+  // loadedGraphExecutionDataPages: number[];
+
   // Detailed data objects about intra-graph execution.
-  graphExecutionData: {[index: number]: Execution};
+  graphExecutionData: {[index: number]: GraphExecution};
 }
 
 // The state of a loaded DebuggerV2 run.

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -257,7 +257,7 @@ export interface GraphExecutions extends PagedExecutions {
   graphExecutionDigests: {[index: number]: GraphExecutionDigest};
 
   // Indices to GraphExecution pages currently being loaded.
-  loadingGraphExecutionDataPages: number[];
+  graphExecutionDataLoadingPages: number[];
 
   // Number of items in each `GraphExecution` page that have been loaded.
   graphExecutionDataPageLoadedSizes: {[page: number]: number};

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
@@ -24,6 +24,7 @@ import {
   DebuggerState,
   Execution,
   Executions,
+  GraphExecution,
   ExecutionDigest,
   GraphExecutions,
   InfNanAlert,
@@ -85,6 +86,22 @@ export function createTestExecutionDigest(
   return {
     op_type: 'TestOp',
     output_tensor_device_ids: ['d0'],
+    ...override,
+  };
+}
+
+export function createTestGraphExecution(
+  override?: Partial<GraphExecution>
+): GraphExecution {
+  return {
+    op_name: 'test_namescope/TestOp',
+    op_type: 'TestOp',
+    output_slot: 0,
+    graph_id: 'g1',
+    graph_ids: ['g0', 'g1,'],
+    device_name: '/GPU:0',
+    tensor_debug_mode: 2,
+    debug_tensor_value: [0, 1],
     ...override,
   };
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
@@ -21,7 +21,7 @@ ng_module(
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
-        "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
+        "//tensorboard/webapp/angular:expect_angular_cdk_scrolling",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@ngrx/store",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
@@ -21,6 +21,7 @@ ng_module(
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
+        "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@ngrx/store",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
@@ -21,3 +21,55 @@ limitations under the License.
   margin-left: 8px;
   padding-left: 10px;
 }
+
+.graph-executions-viewport {
+  flex-grow: 1;
+  font-size: 12px;
+  width: 100%;
+  overflow-x: hidden;
+}
+
+.op-type {
+  display: inline-block;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  width: 80px;
+}
+
+.graph-execution-index {
+  display: inline-block;
+  text-align: right;
+  width: 40px;
+  padding-right: 4px;
+}
+
+.loading-spinner {
+  display: inline-block;
+}
+
+.tensor-container {
+  width: 100%;
+}
+
+.tensor-item {
+  display: flex;
+  flex-wrap: nowrap;
+  height: 24px;
+  line-height: 24px;
+  text-align: left;
+  vertical-align: top;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.tensor-name {
+  direction: rtl;
+  display: inline-block;
+  overflow: hidden;
+  padding-right: 8px;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 240px;
+}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
@@ -30,11 +30,17 @@ limitations under the License.
 }
 
 .op-type {
-  display: inline-block;
-  overflow: hidden;
-  text-align: left;
-  text-overflow: ellipsis;
-  width: 80px;
+  background-color: #e3e5e8;
+  border: 1px solid #c0c0c0;
+  border-radius: 4px;
+  direction: rtl;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 10px;
+  display: block;
+  height: 14px;
+  line-height: 14px;
+  padding: 1px 3px;
+  width: max-content;
 }
 
 .graph-execution-index {
@@ -53,10 +59,11 @@ limitations under the License.
 }
 
 .tensor-item {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
   display: flex;
   flex-wrap: nowrap;
-  height: 24px;
-  line-height: 24px;
+  height: 36px;
+  line-height: 36px;
   text-align: left;
   vertical-align: top;
   white-space: nowrap;
@@ -64,6 +71,15 @@ limitations under the License.
 }
 
 .tensor-name {
+  direction: rtl;
+  display: block;
+  height: 16px;
+  line-height: 16px;
+  padding: 0 2px;
+  width: 100%;
+}
+
+.tensor-name-and-op-type {
   direction: rtl;
   display: inline-block;
   overflow: hidden;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
@@ -22,11 +22,22 @@ limitations under the License.
   padding-left: 10px;
 }
 
+.graph-execution-index {
+  color: #757575;
+  display: inline-block;
+  width: 40px;
+  padding-right: 4px;
+}
+
 .graph-executions-viewport {
   flex-grow: 1;
   font-size: 12px;
   width: 100%;
   overflow-x: hidden;
+}
+
+.loading-spinner {
+  display: inline-block;
 }
 
 .op-type {
@@ -41,17 +52,6 @@ limitations under the License.
   line-height: 14px;
   padding: 1px 3px;
   width: max-content;
-}
-
-.graph-execution-index {
-  color: #757575;
-  display: inline-block;
-  width: 40px;
-  padding-right: 4px;
-}
-
-.loading-spinner {
-  display: inline-block;
 }
 
 .tensor-container {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
@@ -44,8 +44,8 @@ limitations under the License.
 }
 
 .graph-execution-index {
+  color: #757575;
   display: inline-block;
-  text-align: right;
   width: 40px;
   padding-right: 4px;
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
@@ -75,7 +75,10 @@ limitations under the License.
   display: block;
   height: 16px;
   line-height: 16px;
+  overflow: hidden;
   padding: 0 2px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   width: 100%;
 }
 
@@ -85,7 +88,5 @@ limitations under the License.
   overflow: hidden;
   padding-right: 8px;
   text-align: right;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   width: 240px;
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
@@ -31,29 +31,29 @@ limitations under the License.
       *cdkVirtualFor="let i of graphExecutionIndices"
       class="tensor-container"
     >
-      <div *ngIf="graphExecutionData[i]; else dataLoading" class="tensor-item">
+      <div class="tensor-item">
         <div class="graph-execution-index">
           {{ i }}
         </div>
-        <div class="tensor-name-and-op-type">
-          <div class="tensor-name">
-            {{ graphExecutionData[i].op_name }}:{{
-            graphExecutionData[i].output_slot }}
-          </div>
-          <div class="op-type">
-            {{ graphExecutionData[i].op_type }}
+        <div *ngIf="graphExecutionData[i]; else dataLoading">
+          <div class="tensor-name-and-op-type">
+            <div class="tensor-name">
+              {{ graphExecutionData[i].op_name }}:{{
+              graphExecutionData[i].output_slot }}
+            </div>
+            <div class="op-type">
+              {{ graphExecutionData[i].op_type }}
+            </div>
           </div>
         </div>
-      </div>
 
-      <ng-template #dataLoading class="tensor-item">
-        <div class="graph-execution-index">
-          {{ i }}
-        </div>
-        <div class="loading-spinner">
-          Loading...
-        </div>
-      </ng-template>
+        <ng-template #dataLoading class="tensor-item">
+          <div class="loading-spinner">
+            Loading...
+            <!-- TODO(cais): Use mat-spinner -->
+          </div>
+        </ng-template>
+      </div>
     </div>
   </cdk-virtual-scroll-viewport>
 </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
@@ -22,7 +22,8 @@ limitations under the License.
 
   <cdk-virtual-scroll-viewport
     #executionsScroll
-    itemSize="24"
+    *ngIf="numGraphExecutions !== null && numGraphExecutions > 0"
+    itemSize="37"
     class="graph-executions-viewport"
     (scrolledIndexChange)="onScrolledIndexChange.emit($event)"
   >
@@ -32,14 +33,16 @@ limitations under the License.
     >
       <div *ngIf="graphExecutionData[i]; else dataLoading" class="tensor-item">
         <div class="graph-execution-index">
-          {{ i }}
+          {{ i }}:
         </div>
-        <div class="tensor-name">
-          {{ graphExecutionData[i].op_name }}:{{
-          graphExecutionData[i].output_slot }}
-        </div>
-        <div class="op-type">
-          {{ graphExecutionData[i].op_type }}
+        <div class="tensor-name-and-op-type">
+          <div class="tensor-name">
+            {{ graphExecutionData[i].op_name }}:{{
+            graphExecutionData[i].output_slot }}
+          </div>
+          <div class="op-type">
+            {{ graphExecutionData[i].op_type }}
+          </div>
         </div>
       </div>
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
@@ -21,7 +21,6 @@ limitations under the License.
   </div>
 
   <cdk-virtual-scroll-viewport
-    #executionsScroll
     *ngIf="numGraphExecutions !== null && numGraphExecutions > 0"
     itemSize="37"
     class="graph-executions-viewport"

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
@@ -33,7 +33,7 @@ limitations under the License.
     >
       <div *ngIf="graphExecutionData[i]; else dataLoading" class="tensor-item">
         <div class="graph-execution-index">
-          {{ i }}:
+          {{ i }}
         </div>
         <div class="tensor-name-and-op-type">
           <div class="tensor-name">

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
@@ -20,5 +20,37 @@ limitations under the License.
     Graph Executions ({{ numGraphExecutions }})
   </div>
 
-  <!-- TODO(cais): Add cdk-virtual-scroll-viewport for graph executions -->
+  <cdk-virtual-scroll-viewport
+    #executionsScroll
+    itemSize="24"
+    class="graph-executions-viewport"
+    (scrolledIndexChange)="onScrolledIndexChange.emit($event)"
+  >
+    <div
+      *cdkVirtualFor="let i of graphExecutionIndices"
+      class="tensor-container"
+    >
+      <div *ngIf="graphExecutionData[i]; else dataLoading" class="tensor-item">
+        <div class="graph-execution-index">
+          {{ i }}
+        </div>
+        <div class="tensor-name">
+          {{ graphExecutionData[i].op_name }}:{{
+          graphExecutionData[i].output_slot }}
+        </div>
+        <div class="op-type">
+          {{ graphExecutionData[i].op_type }}
+        </div>
+      </div>
+
+      <ng-template #dataLoading class="tensor-item">
+        <div class="graph-execution-index">
+          {{ i }}
+        </div>
+        <div class="loading-spinner">
+          Loading...
+        </div>
+      </ng-template>
+    </div>
+  </cdk-virtual-scroll-viewport>
 </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
@@ -31,13 +31,13 @@ import {GraphExecution} from '../../store/debugger_types';
 })
 export class GraphExecutionsComponent {
   @Input()
-  numGraphExecutions: number | null = null;
+  numGraphExecutions!: number;
 
   @Input()
-  graphExecutionData: {[index: number]: GraphExecution} = {};
+  graphExecutionData!: {[index: number]: GraphExecution};
 
   @Input()
-  graphExecutionIndices: number[] | null = null;
+  graphExecutionIndices!: number[];
 
   @Output()
   onScrolledIndexChange = new EventEmitter<number>();

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
@@ -13,14 +13,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Component, Input} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+
+import {GraphExecution} from '../../store/debugger_types';
 
 @Component({
   selector: 'graph-executions-component',
   templateUrl: './graph_executions_component.ng.html',
   styleUrls: ['./graph_executions_component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GraphExecutionsComponent {
   @Input()
   numGraphExecutions: number | null = null;
+
+  @Input()
+  graphExecutionData: {[index: number]: GraphExecution} = {};
+
+  @Input()
+  graphExecutionIndices: number[] | null = null;
+
+  @Output()
+  onScrolledIndexChange = new EventEmitter<number>();
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
@@ -13,9 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Component} from '@angular/core';
-import {select, Store} from '@ngrx/store';
+import {createSelector, select, Store} from '@ngrx/store';
 
-import {getNumGraphExecutions} from '../../store';
+import {graphExecutionScrollToIndex} from '../../actions';
+import {getGraphExecutionData, getNumGraphExecutions} from '../../store';
 import {State} from '../../store/debugger_types';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
@@ -25,11 +26,34 @@ import {State} from '../../store/debugger_types';
   template: `
     <graph-executions-component
       [numGraphExecutions]="numGraphExecutions$ | async"
+      [graphExecutionData]="graphExecutionData$ | async"
+      [graphExecutionIndices]="graphExecutionIndices$ | async"
+      (onScrolledIndexChange)="onScrolledIndexChange($event)"
     ></graph-executions-component>
   `,
 })
 export class GraphExecutionsContainer {
   readonly numGraphExecutions$ = this.store.pipe(select(getNumGraphExecutions));
+
+  readonly graphExecutionData$ = this.store.pipe(select(getGraphExecutionData));
+
+  readonly graphExecutionIndices$ = this.store.pipe(
+    select(
+      createSelector(
+        getNumGraphExecutions,
+        (numGraphExecution: number): number[] | null => {
+          if (numGraphExecution === 0) {
+            return null;
+          }
+          return Array.from({length: numGraphExecution}).map((_, i) => i);
+        }
+      )
+    )
+  );
+
+  onScrolledIndexChange(scrolledIndex: number) {
+    this.store.dispatch(graphExecutionScrollToIndex({index: scrolledIndex}));
+  }
 
   constructor(private readonly store: Store<State>) {}
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -25,11 +25,7 @@ import {MockStore, provideMockStore} from '@ngrx/store/testing';
 import {DebuggerComponent} from '../../debugger_component';
 import {DebuggerContainer} from '../../debugger_container';
 import {State, GraphExecution} from '../../store/debugger_types';
-import {
-  getNumGraphExecutions,
-  getGraphExecutionData,
-  getGraphExecutionDisplayCount,
-} from '../../store';
+import {getNumGraphExecutions, getGraphExecutionData} from '../../store';
 import {
   createDebuggerState,
   createState,
@@ -46,7 +42,7 @@ import {GraphExecutionsModule} from './graph_executions_module';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
-fdescribe('Graph Executions Container', () => {
+describe('Graph Executions Container', () => {
   let store: MockStore<State>;
 
   beforeEach(async () => {
@@ -114,13 +110,51 @@ fdescribe('Graph Executions Container', () => {
       By.css('.tensor-container')
     );
     expect(tensorContainers.length).toBeGreaterThan(0);
+    const graphExecutionIndices = fixture.debugElement.queryAll(
+      By.css('.graph-execution-index')
+    );
     const tensorNames = fixture.debugElement.queryAll(By.css('.tensor-name'));
     const opTypes = fixture.debugElement.queryAll(By.css('.op-type'));
+    expect(graphExecutionIndices.length).toBe(tensorContainers.length);
     expect(tensorNames.length).toBe(tensorContainers.length);
     expect(opTypes.length).toBe(tensorContainers.length);
     for (let i = 0; i < tensorNames.length; ++i) {
+      expect(graphExecutionIndices[i].nativeElement.innerText).toBe(`${i}`);
       expect(tensorNames[i].nativeElement.innerText).toBe(`TestOp_${i}:0`);
       expect(opTypes[i].nativeElement.innerText).toBe(`OpType_${i}`);
     }
+  }));
+
+  it('renders # execs and execs viewport if # execs > 0; not loaded', fakeAsync(() => {
+    const fixture = TestBed.createComponent(GraphExecutionsContainer);
+    store.overrideSelector(getNumGraphExecutions, 120);
+    store.overrideSelector(getGraphExecutionData, {});
+    fixture.autoDetectChanges();
+    tick(500);
+
+    const titleElement = fixture.debugElement.query(
+      By.css('.graph-executions-title')
+    );
+    expect(titleElement.nativeElement.innerText).toBe('Graph Executions (120)');
+    const viewPort = fixture.debugElement.query(
+      By.css('.graph-executions-viewport')
+    );
+    expect(viewPort).not.toBeNull();
+    const tensorContainers = fixture.debugElement.queryAll(
+      By.css('.tensor-container')
+    );
+    expect(tensorContainers.length).toBeGreaterThan(0);
+    const graphExecutionIndices = fixture.debugElement.queryAll(
+      By.css('.graph-execution-index')
+    );
+    const loadingElements = fixture.debugElement.queryAll(
+      By.css('.loading-spinner')
+    );
+    const tensorNames = fixture.debugElement.queryAll(By.css('.tensor-name'));
+    const opTypes = fixture.debugElement.queryAll(By.css('.op-type'));
+    expect(graphExecutionIndices.length).toBe(tensorContainers.length);
+    expect(loadingElements.length).toBe(tensorContainers.length);
+    expect(tensorNames.length).toBe(0);
+    expect(opTypes.length).toBe(0);
   }));
 });

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -72,7 +72,7 @@ describe('Graph Executions Container', () => {
     const fixture = TestBed.createComponent(GraphExecutionsContainer);
     store.overrideSelector(getNumGraphExecutions, 0);
     fixture.autoDetectChanges();
-    tick(500);
+    tick();
 
     const titleElement = fixture.debugElement.query(
       By.css('.graph-executions-title')
@@ -96,7 +96,7 @@ describe('Graph Executions Container', () => {
     }
     store.overrideSelector(getGraphExecutionData, graphExecutionData);
     fixture.autoDetectChanges();
-    tick(500);
+    tick();
 
     const titleElement = fixture.debugElement.query(
       By.css('.graph-executions-title')
@@ -130,7 +130,7 @@ describe('Graph Executions Container', () => {
     store.overrideSelector(getNumGraphExecutions, 120);
     store.overrideSelector(getGraphExecutionData, {});
     fixture.autoDetectChanges();
-    tick(500);
+    tick();
 
     const titleElement = fixture.debugElement.query(
       By.css('.graph-executions-title')

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_module.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_module.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {ScrollingModule} from '@angular/cdk/scrolling';
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 
@@ -21,7 +22,7 @@ import {GraphExecutionsContainer} from './graph_executions_container';
 
 @NgModule({
   declarations: [GraphExecutionsComponent, GraphExecutionsContainer],
-  imports: [CommonModule],
+  imports: [CommonModule, ScrollingModule],
   exports: [GraphExecutionsContainer],
 })
 export class GraphExecutionsModule {}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.css
@@ -54,7 +54,7 @@ limitations under the License.
   border-left: 1px solid rgba(0, 0, 0, 0.12);
   font-size: 10px;
   font-family: 'Roboto Mono', monospace;
-  height: 360px;
+  height: 100%;
   margin-left: 8px;
   max-height: 360px;
   overflow-x: hidden;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.ng.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 
 <div>
-  <div>Execution Timeline</div>
+  <div>Eager Execution Timeline</div>
   <!-- TODO(cais): Add horizonal scroll bar for executions. -->
   <div class="top-level-executions">
     <div *ngIf="loadingNumExecutions" class="loading-num-executions">

--- a/tensorboard/webapp/angular/BUILD
+++ b/tensorboard/webapp/angular/BUILD
@@ -145,6 +145,15 @@ tf_ts_library(
     ],
 )
 
+# This is a dummy rule used as a @angular/cdk/scrolling dependency.
+tf_ts_library(
+    name = "expect_angular_cdk_scrolling",
+    srcs = [],
+    deps = [
+        "@npm//@angular/cdk",
+    ],
+)
+
 # This is a dummy rule used as a @ngrx/store/testing dependency.
 # This is not a replacement for @ngrx/store dependency.
 tf_ts_library(


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing DebuggerV2 plugin, specifically its GraphExecutionContainer that visualizes the details of the intra-graph execution events. 
* Technical description of changes
  * Add necessary actions, selectors, reducers and effects to support the lazy, paged loading of `GraphExecution`s
  * Add a `cdk-virtual-scroll-viewport` to `GraphExecutionComponent`
  * The lazy loading is triggered by scrolling events on the `cdk-virtual-scroll-viewport`
  * The displaying detailed debug-tensor summaries such as dtype, rank, shape, and numeric breakdown will be added in the follow PRs. This PR just adds displaying of the tensor name and op type in the `cdk-virtual-scroll-viewport`.
* Screenshots of UI changes
  * Loaded state: ![image](https://user-images.githubusercontent.com/16824702/79614243-24f6e500-80ce-11ea-8b9f-412cb831a449.png)
  * Loading state (mat-spinner to be added in follow-up CLs): ![image](https://user-images.githubusercontent.com/16824702/79614131-e19c7680-80cd-11ea-8dad-2dfd4b998ada.png)
* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests added
  * Manual testing against logdirs with real tfdbg2 data of different sizes

