### PR TITLE
Add the missing `route-prefix` property to `<vz-projector-app>`

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-app.html
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-app.html
@@ -134,6 +134,7 @@ limitations under the License.
         pageViewLogging: {type: Boolean, value: false},
         eventLogging: {type: Boolean, value: false},
         projectorConfigJsonPath: {type: String, value: ''},
+        routePrefix: {type: String, value: ''},
         servingMode: {type: String, value: ''},
         documentationLink: {type: String, value: ''},
         bugReportLink: {type: String, value: ''},


### PR DESCRIPTION
`<vz-projector-app>` is piping through the `route-prefix` property however the property was not explicitly defined.