### PR TITLE
ng: expose core initialState as public

### DIFF
--- a/tensorboard/webapp/core/store/BUILD
+++ b/tensorboard/webapp/core/store/BUILD
@@ -26,6 +26,7 @@ tf_ts_library(
     name = "core_store_test_lib",
     testonly = True,
     srcs = [
+        "core_initial_state_provider_test.ts",
         "core_reducers_test.ts",
     ],
     tsconfig = "//:tsconfig-test",
@@ -33,6 +34,7 @@ tf_ts_library(
         ":store",
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/core/testing",
+        "//tensorboard/webapp/deeplink",
         "//tensorboard/webapp/types",
         "@npm//@types/jasmine",
     ],

--- a/tensorboard/webapp/core/store/core_initial_state_provider.ts
+++ b/tensorboard/webapp/core/store/core_initial_state_provider.ts
@@ -18,6 +18,7 @@ import {StoreConfig} from '@ngrx/store';
 import {CoreState} from './core_types';
 import {HashDeepLinker} from '../../deeplink';
 import {DataLoadState} from '../../types/data';
+import {initialState} from './core_types';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
 
@@ -28,15 +29,8 @@ export const CORE_STORE_CONFIG_TOKEN = new InjectionToken<
 export function getConfig(deepLinker: HashDeepLinker): StoreConfig<CoreState> {
   return {
     initialState: {
+      ...initialState,
       activePlugin: deepLinker.getPluginId() || null,
-      plugins: {},
-      pluginsListLoaded: {
-        state: DataLoadState.NOT_LOADED,
-        lastLoadedTimeInMs: null,
-      },
-      reloadPeriodInMs: 30000,
-      reloadEnabled: false,
-      pageSize: 15,
     },
   };
 }

--- a/tensorboard/webapp/core/store/core_initial_state_provider.ts
+++ b/tensorboard/webapp/core/store/core_initial_state_provider.ts
@@ -17,7 +17,6 @@ import {StoreConfig} from '@ngrx/store';
 
 import {CoreState} from './core_types';
 import {HashDeepLinker} from '../../deeplink';
-import {DataLoadState} from '../../types/data';
 import {initialState} from './core_types';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
@@ -31,6 +30,6 @@ export function getConfig(deepLinker: HashDeepLinker): StoreConfig<CoreState> {
     initialState: {
       ...initialState,
       activePlugin: deepLinker.getPluginId() || null,
-    },
+    } as CoreState,
   };
 }

--- a/tensorboard/webapp/core/store/core_initial_state_provider_test.ts
+++ b/tensorboard/webapp/core/store/core_initial_state_provider_test.ts
@@ -1,0 +1,81 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {getConfig} from './core_initial_state_provider';
+import {DeepLinkerInterface, SetStringOption} from '../../deeplink/types';
+import {HashDeepLinker} from '../../deeplink/hash';
+import {CoreState} from './core_types';
+
+class TestableDeepLinker implements DeepLinkerInterface {
+  getString(key: string): string {
+    throw new Error('Method not implemented.');
+  }
+  setString(
+    key: string,
+    value: string,
+    options?: SetStringOption | undefined
+  ): void {
+    throw new Error('Method not implemented.');
+  }
+  getPluginId(): string {
+    throw new Error('Method not implemented.');
+  }
+  setPluginId(pluginId: string, options?: SetStringOption | undefined): void {
+    throw new Error('Method not implemented.');
+  }
+}
+
+describe('core_initial_state_provider', () => {
+  describe('#getConfig', () => {
+    let deeplinker: HashDeepLinker;
+    let getPluginIdSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      deeplinker = new TestableDeepLinker() as HashDeepLinker;
+      getPluginIdSpy = spyOn(deeplinker, 'getPluginId').and.returnValue('foo');
+    });
+
+    it('returns initialState', () => {
+      const config = getConfig(deeplinker);
+
+      expect(config.initialState).toBeDefined();
+    });
+
+    it('returns type of CoreState', () => {
+      const config = getConfig(deeplinker);
+      const state = config.initialState as CoreState;
+
+      expect(state.activePlugin).toBeDefined();
+      expect(state.pageSize).toBeDefined();
+      expect(state.plugins).toBeDefined();
+      expect(state.pluginsListLoaded).toBeDefined();
+      expect(state.reloadEnabled).toBeDefined();
+      expect(state.reloadPeriodInMs).toBeDefined();
+    });
+
+    it('sets activePlugin from the deeplinker', () => {
+      getPluginIdSpy.and.returnValue('bar');
+      const config = getConfig(deeplinker);
+
+      expect((config.initialState as CoreState).activePlugin).toBe('bar');
+    });
+
+    it('sets null if deeplinker does not have activePluginId', () => {
+      getPluginIdSpy.and.returnValue('');
+      const config = getConfig(deeplinker);
+
+      expect((config.initialState as CoreState).activePlugin).toBeNull();
+    });
+  });
+});

--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -15,26 +15,11 @@ limitations under the License.
 import {Action, createReducer, on} from '@ngrx/store';
 import {DataLoadState} from '../../types/data';
 import * as actions from '../actions';
-import {CoreState} from './core_types';
+import {CoreState, initialState} from './core_types';
 
 // HACK: These imports are for type inference.
 // https://github.com/bazelbuild/rules_nodejs/issues/1013
 /** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
-
-// TODO(stephanwlee): Since initialState is now injected, look for a way to
-// remove this.
-
-const initialState: CoreState = {
-  activePlugin: null,
-  plugins: {},
-  pluginsListLoaded: {
-    state: DataLoadState.NOT_LOADED,
-    lastLoadedTimeInMs: null,
-  },
-  reloadPeriodInMs: 30000,
-  reloadEnabled: false,
-  pageSize: 15,
-};
 
 const reducer = createReducer(
   initialState,

--- a/tensorboard/webapp/core/store/core_types.ts
+++ b/tensorboard/webapp/core/store/core_types.ts
@@ -19,7 +19,7 @@ limitations under the License.
 // diverge in the future, that's straightforward: we'll leave types/api in place,
 // remove this import, and write the divergent state types explicitly here.
 import {PluginId, PluginsListing} from '../../types/api';
-import {LoadState} from '../../types/data';
+import {DataLoadState, LoadState} from '../../types/data';
 
 export const CORE_FEATURE_KEY = 'core';
 
@@ -35,3 +35,15 @@ export interface CoreState {
 export interface State {
   [CORE_FEATURE_KEY]?: CoreState;
 }
+
+export const initialState: CoreState = {
+  activePlugin: null,
+  plugins: {},
+  pluginsListLoaded: {
+    state: DataLoadState.NOT_LOADED,
+    lastLoadedTimeInMs: null,
+  },
+  reloadPeriodInMs: 30000,
+  reloadEnabled: false,
+  pageSize: 15,
+};

--- a/tensorboard/webapp/core/store/core_types.ts
+++ b/tensorboard/webapp/core/store/core_types.ts
@@ -29,6 +29,8 @@ export interface CoreState {
   pluginsListLoaded: LoadState;
   reloadPeriodInMs: number;
   reloadEnabled: boolean;
+  // Size of a page in a general paginated view that is configurable by user via
+  // settings.
   pageSize: number;
 }
 


### PR DESCRIPTION
Internal application would like to use the intialState for other
purposes. Expose it as a public API.
