### PR TITLE
Bump Bazel minimum version to 2.1.0 to match CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,1 @@
-# For compatibility with Bazel 0.27 through 0.29. See:
-# <https://github.com/tensorflow/tensorboard/issues/2355>
-aquery --incompatible_use_python_toolchains=false
-build --incompatible_use_python_toolchains=false
-test --incompatible_use_python_toolchains=false
+# No options currently needed. Leaving empty file to preserve history.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,7 +16,7 @@ http_archive(
 load("@bazel_skylib//lib:versions.bzl", "versions")
 # Keep this version in sync with the BAZEL environment variable defined
 # in our .travis.yml config.
-versions.check(minimum_bazel_version = "1.0.0")
+versions.check(minimum_bazel_version = "2.1.0")
 
 http_archive(
     name = "io_bazel_rules_webtesting",


### PR DESCRIPTION
This updates the minimum version of Bazel we require to build to 2.1.0 so it matches our CI.  As the comment describes, these should stay in sync, since if we aren't actually building with the minimum version or running CI against it, it's easy for it to stop working without anyone noticing, at which point it can fail in a way that's harder to understand than the minimum version check.

If anyone really wants to try building with a lower Bazel version, they can always locally revert this change.

Also removes some .bazelrc options to not use Python toolchains; I'm not sure exactly at what point these become obsolete but they don't seem to have any impact on the build.  Tested that building and running TensorBoard without these options still worked as expected.