### PR TITLE
Remove standalone uploader binary target

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -29,7 +29,7 @@ py_binary(
         ":program",
         "//tensorboard:expect_tensorflow_installed",
         "//tensorboard/plugins:base_plugin",
-        "//tensorboard/uploader:uploader_main_lib",
+        "//tensorboard/uploader:uploader_subcommand",
         "//tensorboard/util:tb_logging",
         "//tensorboard/util:timing",  # non-strict dep, for patching convenience
     ],

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -44,7 +44,7 @@ from tensorboard import default
 from tensorboard import program
 from tensorboard.compat import tf
 from tensorboard.plugins import base_plugin
-from tensorboard.uploader import uploader_main
+from tensorboard.uploader import uploader_subcommand
 from tensorboard.util import tb_logging
 
 
@@ -64,7 +64,7 @@ def run_main():
     tensorboard = program.TensorBoard(
         default.get_plugins() + default.get_dynamic_plugins(),
         program.get_default_assets_zip_provider(),
-        subcommands=[uploader_main.UploaderSubcommand()],
+        subcommands=[uploader_subcommand.UploaderSubcommand()],
     )
     try:
         from absl import app

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -8,7 +8,7 @@ licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])
 
 py_library(
-    name = "exporter_lib",
+    name = "exporter",
     srcs = ["exporter.py"],
     srcs_version = "PY3",
     deps = [
@@ -25,7 +25,7 @@ py_test(
     name = "exporter_test",
     srcs = ["exporter_test.py"],
     deps = [
-        ":exporter_lib",
+        ":exporter",
         ":test_util",
         ":util",
         "//tensorboard:expect_grpc_installed",
@@ -59,24 +59,17 @@ py_test(
     ],
 )
 
-py_binary(
-    name = "uploader",
-    srcs = ["uploader_main.py"],
-    main = "uploader_main.py",
-    deps = [":uploader_main_lib"],
-)
-
 py_library(
-    name = "uploader_main_lib",
-    srcs = ["uploader_main.py"],
+    name = "uploader_subcommand",
+    srcs = ["uploader_subcommand.py"],
     visibility = ["//tensorboard:internal"],
     deps = [
         ":auth",
-        ":exporter_lib",
+        ":exporter",
         ":flags_parser",
         ":formatters",
         ":server_info",
-        ":uploader_lib",
+        ":uploader",
         ":util",
         "//tensorboard:expect_absl_app_installed",
         "//tensorboard:expect_absl_flags_argparse_flags_installed",
@@ -91,7 +84,7 @@ py_library(
 )
 
 py_library(
-    name = "uploader_lib",
+    name = "uploader",
     srcs = ["uploader.py"],
     deps = [
         ":logdir_loader",
@@ -119,7 +112,7 @@ py_test(
     srcs_version = "PY3",
     deps = [
         ":test_util",
-        ":uploader_lib",
+        ":uploader",
         ":util",
         "//tensorboard:data_compat",
         "//tensorboard:dataclass_compat",

--- a/tensorboard/uploader/flags_parser.py
+++ b/tensorboard/uploader/flags_parser.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from absl.flags import argparse_flags
 
 SUBCOMMAND_FLAG = "_uploader__subcommand"
 SUBCOMMAND_KEY_UPLOAD = "UPLOAD"
@@ -31,23 +30,6 @@ AUTH_SUBCOMMAND_FLAG = "_uploader__subcommand_auth"
 AUTH_SUBCOMMAND_KEY_REVOKE = "REVOKE"
 
 DEFAULT_ORIGIN = "https://tensorboard.dev"
-
-
-def parse_flags(argv):
-    """Parse flags for TensorBoard.dev uploader.
-
-    Exits if flag values are invalid.
-
-    Args:
-      argv: CLI arguments, as with `sys.argv`, where the first argument is taken
-        to be the name of the program being executed.
-    """
-    parser = argparse_flags.ArgumentParser(
-        prog="uploader",
-        description=("Upload your TensorBoard experiments to TensorBoard.dev"),
-    )
-    define_flags(parser)
-    return parser.parse_args(argv[1:])
 
 
 def define_flags(parser):

--- a/tensorboard/uploader/flags_parser_test.py
+++ b/tensorboard/uploader/flags_parser_test.py
@@ -20,24 +20,44 @@ from __future__ import print_function
 
 import argparse
 
+from absl.flags import argparse_flags
+
 from tensorboard.uploader import flags_parser
 from tensorboard import test as tb_test
+
+
+def _define_and_parse_flags(argv):
+    """Defines and parses flags.
+
+    Creates an `ArgumentParser`, defines flags on the parser (the logic really
+    being tested), and parses given arguments.
+
+    Args:
+      argv: CLI arguments, as with `sys.argv`, where the first argument is taken
+        to be the name of the program being executed.
+    """
+    parser = argparse_flags.ArgumentParser(
+        prog="uploader",
+        description=("Upload your TensorBoard experiments to TensorBoard.dev"),
+    )
+    flags_parser.define_flags(parser)
+    return parser.parse_args(argv[1:])
 
 
 class FlagsParserTest(tb_test.TestCase):
     def test_unknown_command(self):
         with self.assertRaises(SystemExit):
-            flags_parser.parse_flags(["uploader", "unknown"])
+            _define_and_parse_flags(["uploader", "unknown"])
 
     def test_list(self):
-        flags = flags_parser.parse_flags(["uploader", "list"])
+        flags = _define_and_parse_flags(["uploader", "list"])
         self.assertEqual(
             flags_parser.SUBCOMMAND_KEY_LIST,
             getattr(flags, flags_parser.SUBCOMMAND_FLAG),
         )
 
     def test_upload_logdir(self):
-        flags = flags_parser.parse_flags(
+        flags = _define_and_parse_flags(
             ["uploader", "upload", "--logdir", "some/log/dir"]
         )
         self.assertEqual(
@@ -47,7 +67,7 @@ class FlagsParserTest(tb_test.TestCase):
         self.assertEqual("some/log/dir", flags.logdir)
 
     def test_upload_with_plugins(self):
-        flags = flags_parser.parse_flags(
+        flags = _define_and_parse_flags(
             ["uploader", "upload", "--plugins", "plugin1,plugin2"]
         )
         self.assertEqual(

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Main program for the TensorBoard.dev uploader."""
+"""Integration point between TensorBoard CLI and TensorBoard.dev uploader."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -44,11 +44,6 @@ from tensorboard import program
 from tensorboard.plugins import base_plugin
 
 
-# Temporary integration point for absl compatibility; will go away once
-# migrated to TensorBoard subcommand.
-_FLAGS = None
-
-
 _MESSAGE_TOS = u"""\
 Your use of this service is subject to Google's Terms of Service
 <https://policies.google.com/terms> and Privacy Policy
@@ -77,25 +72,6 @@ def _prompt_for_user_ack(intent):
     if response.lower() not in ("y", "yes"):
         sys.exit(0)
     sys.stderr.write("\n")
-
-
-def _parse_flags(argv=("",)):
-    """Integration point for `absl.app`.
-
-    Exits if flag values are invalid.
-
-    Args:
-      argv: CLI arguments, as with `sys.argv`, where the first argument is taken
-        to be the name of the program being executed.
-
-    Returns:
-      Either argv[:1] if argv was non-empty, or [''] otherwise, as a mechanism
-      for absl.app.run() compatibility.
-    """
-    arg0 = argv[0] if argv else ""
-    global _FLAGS
-    _FLAGS = flags_parser.parse_flags(argv)
-    return [arg0]
 
 
 def _run(flags):
@@ -611,14 +587,6 @@ def _die(message):
     sys.exit(1)
 
 
-def main(unused_argv):
-    global _FLAGS
-    flags = _FLAGS
-    # Prevent accidental use of `_FLAGS` until migration to TensorBoard
-    # subcommand is complete, at which point `_FLAGS` goes away.
-    del _FLAGS
-    return _run(flags)
-
 
 class UploaderSubcommand(program.TensorBoardSubcommand):
     """Integration point with `tensorboard` CLI."""
@@ -635,6 +603,3 @@ class UploaderSubcommand(program.TensorBoardSubcommand):
     def help(self):
         return "upload data to TensorBoard.dev"
 
-
-if __name__ == "__main__":
-    app.run(main, flags_parser=_parse_flags)

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Integration point between TensorBoard CLI and TensorBoard.dev uploader."""
+"""Entry point and high-level logic for TensorBoard.dev uploader."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -587,7 +587,6 @@ def _die(message):
     sys.exit(1)
 
 
-
 class UploaderSubcommand(program.TensorBoardSubcommand):
     """Integration point with `tensorboard` CLI."""
 
@@ -602,4 +601,3 @@ class UploaderSubcommand(program.TensorBoardSubcommand):
 
     def help(self):
         return "upload data to TensorBoard.dev"
-


### PR DESCRIPTION
* Motivation for features / changes

Remove standalone uploader binary target that shouldn't be used any longer.

* Technical description of changes

No longer make //tensorboard/uploader a binary target.

Rename uploader_main to uploader_subcommand.

Clean up some BUILD target names by removing "_lib" suffix.


* Testing

Run unit tests.

Run `bazel run tensorboard/uploader -- list` and bazel complains that target no longer exists.

Run `bazel run tensorboard -- dev list` and bazel succeeds at listing experiments.
