### PR TITLE
Add optional --experiment_id parameter to upload subcommand

### DIFF
--- a/tensorboard/uploader/flags_parser.py
+++ b/tensorboard/uploader/flags_parser.py
@@ -87,13 +87,6 @@ def define_flags(parser):
         help="Directory containing the logs to process",
     )
     upload.add_argument(
-        "--experiment_id",
-        metavar="ID",
-        type=str,
-        default=None,
-        help="Upload to a specific experiment ID",
-    )
-    upload.add_argument(
         "--name",
         type=str,
         default=None,
@@ -104,6 +97,13 @@ def define_flags(parser):
         type=str,
         default=None,
         help="Experiment description. Markdown format.  Max 600 characters.",
+    )
+    upload.add_argument(
+        "--experiment_id",
+        metavar="ID",
+        type=str,
+        default=None,
+        help="ID of an existing experiment to upload to",
     )
     upload.add_argument(
         "--plugins",

--- a/tensorboard/uploader/flags_parser.py
+++ b/tensorboard/uploader/flags_parser.py
@@ -87,6 +87,13 @@ def define_flags(parser):
         help="Directory containing the logs to process",
     )
     upload.add_argument(
+        "--experiment_id",
+        metavar="ID",
+        type=str,
+        default=None,
+        help="Upload to a specific experiment ID",
+    )
+    upload.add_argument(
         "--name",
         type=str,
         default=None,

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -159,24 +159,26 @@ class TensorBoardUploader(object):
             self._logdir, directory_loader_factory
         )
 
-    def create_experiment(self):
+    def create_experiment(self, experiment_id=None):
         """Creates an Experiment for this upload session and returns the ID."""
-        logger.info("Creating experiment")
-        request = write_service_pb2.CreateExperimentRequest(
-            name=self._name, description=self._description
-        )
-        response = grpc_util.call_with_retries(
-            self._api.CreateExperiment, request
-        )
+        if experiment_id is None:
+            logger.info("Creating experiment")
+	        request = write_service_pb2.CreateExperimentRequest(
+	            name=self._name, description=self._description
+	        )
+	        response = grpc_util.call_with_retries(
+	            self._api.CreateExperiment, request
+	        )
+			experiment_id = response.experiment_id
         self._request_sender = _BatchedRequestSender(
-            response.experiment_id,
+            experiment_id,
             self._api,
             allowed_plugins=self._allowed_plugins,
             max_blob_size=self._max_blob_size,
             rpc_rate_limiter=self._rpc_rate_limiter,
             blob_rpc_rate_limiter=self._blob_rpc_rate_limiter,
         )
-        return response.experiment_id
+        return experiment_id
 
     def start_uploading(self):
         """Blocks forever to continuously upload data from the logdir.

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -389,10 +389,11 @@ class _UploadIntent(_Intent):
         """
     )
 
-    def __init__(self, logdir, name=None, description=None):
+    def __init__(self, logdir, name=None, description=None, experiment_id=None):
         self.logdir = logdir
         self.name = name
         self.description = description
+        self.experiment_id = experiment_id
 
     def get_ack_message_body(self):
         return self._MESSAGE_TEMPLATE.format(logdir=self.logdir)
@@ -411,7 +412,7 @@ class _UploadIntent(_Intent):
             name=self.name,
             description=self.description,
         )
-        experiment_id = uploader.create_experiment()
+        experiment_id = uploader.create_experiment(experiment_id=self.experiment_id)
         url = server_info_lib.experiment_url(server_info, experiment_id)
         print(
             "Upload started and will continue reading any new data as it's added"
@@ -502,6 +503,7 @@ def _get_intent(flags):
                 os.path.expanduser(flags.logdir),
                 name=flags.name,
                 description=flags.description,
+                experiment_id=flags.experiment_id,
             )
         else:
             raise base_plugin.FlagsError(


### PR DESCRIPTION
* Motivation for features / changes

`tensorboard dev upload --logdir <MODEL_DIR> --experiment_id PgEl74YtR2KWjRSjsDtwiQ` would allow the user to upload additional data to the existing experiment `PgEl74YtR2KWjRSjsDtwiQ`.

I often leave a `tensorboard dev upload --logdir <MODEL_DIR>` command running during an active training session. However, sometimes the `tensorboard dev upload` command is interrupted before the training session ends. (For example, if the network dies, or if a training session is resumed at a later date.) The `--experiment_id` option allows the user to "resume uploading."

* Technical description of changes

I modified `uploader_lib.TensorBoardUploader.create_experiment` to accept an optional `experiment_id` parameter. If it's not `None` (the default) then the passed ID is used. Otherwise, it retrieves a new `experiment_id` using `CreateExperimentRequest`, as usual.

![image](https://user-images.githubusercontent.com/59632/80060389-48ad9700-84e3-11ea-8e28-77651343cfa5.png)

Beyond that, I added `--experiment_id` to the flags parser:

![image](https://user-images.githubusercontent.com/59632/80060563-b9ed4a00-84e3-11ea-9903-cf3443f8de19.png)

... and some boilerplate to use the flag:

![image](https://user-images.githubusercontent.com/59632/80060590-c96c9300-84e3-11ea-837e-3284bec069b9.png)

* Screenshots of UI changes

None

* Detailed steps to verify changes work correctly (as executed by you)

1. Create a new experiment as usual using `tensorboard dev upload --logdir <MODEL_DIR>`

2. Retrieve the experiment ID from the resulting URL

3. Interrupt the `tensorboard dev upload` command

4. Add additional training data to `<MODEL_DIR>`

5. Run `tensorboard dev upload --logdir <MODEL_DIR> --experiment_id <ID>`, where `<ID>` is the experiment ID retrieved in step 2

6. Visit the experiment URL and verify the new training data appears there

* Alternate designs / implementations considered

None