### PR TITLE
scalars: remove unused tooltip column DOM

### DIFF
--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -704,6 +704,7 @@ namespace vz_line_chart2 {
         if (col.static) return;
         self.drawTooltipColumn.call(self, this, col, point);
       });
+      columns.exit().remove();
       columns
         .enter()
         .append('td')


### PR DESCRIPTION
When tooltipColumns become shorter after a change, we currently do not
remove the DOM. This can lead to an awkward UX where a column in the
tooltip never updates and go stale.

This change removes the tooltip row column DOM when they are no longer
shown.
