### PR TITLE
Partially revert "improve rerender of vz_line_chart (#3524)"

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -219,6 +219,13 @@ limitations under the License.
           this.$.chart.setSeriesMetadata(name, metadata);
         },
 
+        /**
+         * Not yet implemented.
+         */
+        commitChanges() {
+          // Temporarily rolled back due to PR curves breakage.
+        },
+
         redraw() {
           cancelAnimationFrame(this._redrawRaf);
           this._redrawRaf = window.requestAnimationFrame(() => {

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -219,10 +219,6 @@ limitations under the License.
           this.$.chart.setSeriesMetadata(name, metadata);
         },
 
-        commitChanges() {
-          this.$.chart.commitChanges();
-        },
-
         redraw() {
           cancelAnimationFrame(this._redrawRaf);
           this._redrawRaf = window.requestAnimationFrame(() => {

--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -855,6 +855,13 @@ namespace vz_line_chart2 {
     }
 
     /**
+     * Not yet implemented.
+     */
+    public commitChanges() {
+      // Temporarily rolled back due to PR curves breakage.
+    }
+
+    /**
      * Samples a dataset so that it contains no more than _MAX_MARKERS number of
      * data points. This function returns the original dataset if it does not
      * exceed that many points.

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -338,11 +338,6 @@ namespace vz_line_chart2 {
       }
     },
 
-    commitChanges() {
-      if (!this._chart) return;
-      this._chart.commitChanges();
-    },
-
     /**
      * Reset the chart domain. If the chart has not rendered yet, a call to this
      * method no-ops.
@@ -431,7 +426,6 @@ namespace vz_line_chart2 {
           this._chart.setSeriesMetadata(name, this._seriesMetadataCache[name]);
         });
       this._chart.setVisibleSeries(this._visibleSeriesCache);
-      this._chart.commitChanges();
     },
 
     _smoothingChanged: function() {

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -339,6 +339,13 @@ namespace vz_line_chart2 {
     },
 
     /**
+     * Not yet implemented.
+     */
+    commitChanges() {
+      // Temporarily rolled back due to PR curves breakage.
+    },
+
+    /**
      * Reset the chart domain. If the chart has not rendered yet, a call to this
      * method no-ops.
      */

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -226,7 +226,6 @@ limitations under the License.
               const name = this._getSeriesNameFromDatum(datum);
               scalarChart.setSeriesMetadata(name, datum);
               scalarChart.setSeriesData(name, formattedData);
-              scalarChart.commitChanges();
             };
           },
           readOnly: true,


### PR DESCRIPTION
Summary:
This reverts commit 27d0023e728aba79d0129f890e41c6c2c4c436b9, then
reinstates stubs for the new method definitions due to Google-internal
code that expects them to exist.

Stopgap for #3551 pending real fix.

Test Plan:
Opening the PR curves dashboard and sliding one of the step sliders now
correctly renders the PR curve instead of showing just the final datum.

wchargin-branch: revert-3524
