### PR TITLE
Stabilize generic data for plugins at parity

### DIFF
--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -63,7 +63,7 @@ class CorePlugin(base_plugin.TBPlugin):
         self._window_title = context.window_title
         self._multiplexer = context.multiplexer
         self._assets_zip_provider = context.assets_zip_provider
-        if context.flags and context.flags.generic_data == "true":
+        if context.flags and context.flags.generic_data != "false":
             self._data_provider = context.data_provider
         else:
             self._data_provider = None

--- a/tensorboard/plugins/core/core_plugin_test.py
+++ b/tensorboard/plugins/core/core_plugin_test.py
@@ -63,7 +63,7 @@ class FakeFlags(object):
         event_file="",
         db="",
         path_prefix="",
-        generic_data="false",
+        generic_data="true",
     ):
         self.bind_all = bind_all
         self.host = host

--- a/tensorboard/plugins/histogram/histograms_plugin.py
+++ b/tensorboard/plugins/histogram/histograms_plugin.py
@@ -67,7 +67,7 @@ class HistogramsPlugin(base_plugin.TBPlugin):
         self._downsample_to = (context.sampling_hints or {}).get(
             self.plugin_name, _DEFAULT_DOWNSAMPLING
         )
-        if context.flags and context.flags.generic_data == "true":
+        if context.flags and context.flags.generic_data != "false":
             self._data_provider = context.data_provider
         else:
             self._data_provider = None

--- a/tensorboard/plugins/histogram/histograms_plugin_test.py
+++ b/tensorboard/plugins/histogram/histograms_plugin_test.py
@@ -89,8 +89,9 @@ class HistogramsPluginTest(tf.test.TestCase):
             def wrapper(self, *args, **kwargs):
                 (logdir, multiplexer) = self.load_runs(run_names)
                 with self.subTest("bare multiplexer"):
+                    flags = argparse.Namespace(generic_data="false")
                     ctx = base_plugin.TBContext(
-                        logdir=logdir, multiplexer=multiplexer
+                        logdir=logdir, multiplexer=multiplexer, flags=flags,
                     )
                     fn(
                         self,
@@ -99,12 +100,10 @@ class HistogramsPluginTest(tf.test.TestCase):
                         **kwargs
                     )
                 with self.subTest("generic data provider"):
-                    flags = argparse.Namespace(generic_data="true")
                     provider = data_provider.MultiplexerDataProvider(
                         multiplexer, logdir
                     )
                     ctx = base_plugin.TBContext(
-                        flags=flags,
                         logdir=logdir,
                         multiplexer=multiplexer,
                         data_provider=provider,

--- a/tensorboard/plugins/image/images_plugin.py
+++ b/tensorboard/plugins/image/images_plugin.py
@@ -72,7 +72,7 @@ class ImagesPlugin(base_plugin.TBPlugin):
         self._downsample_to = (context.sampling_hints or {}).get(
             self.plugin_name, _DEFAULT_DOWNSAMPLING
         )
-        if context.flags and context.flags.generic_data == "true":
+        if context.flags and context.flags.generic_data != "false":
             self._data_provider = context.data_provider
         else:
             self._data_provider = None

--- a/tensorboard/plugins/image/images_plugin_test.py
+++ b/tensorboard/plugins/image/images_plugin_test.py
@@ -127,19 +127,18 @@ class ImagesPluginTest(tf.test.TestCase):
         def wrapper(self, *args, **kwargs):
             (logdir, multiplexer) = self._create_data()
             with self.subTest("bare multiplexer"):
+                flags = argparse.Namespace(generic_data="false")
                 ctx = base_plugin.TBContext(
-                    logdir=logdir, multiplexer=multiplexer
+                    logdir=logdir, multiplexer=multiplexer, flags=flags,
                 )
                 plugin = images_plugin.ImagesPlugin(ctx)
                 self._initialize_plugin_specific_attrs(plugin)
                 fn(self, plugin, *args, **kwargs)
             with self.subTest("generic data provider"):
-                flags = argparse.Namespace(generic_data="true")
                 provider = data_provider.MultiplexerDataProvider(
                     multiplexer, logdir
                 )
                 ctx = base_plugin.TBContext(
-                    flags=flags,
                     logdir=logdir,
                     multiplexer=multiplexer,
                     data_provider=provider,

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -215,7 +215,7 @@ class TextPlugin(base_plugin.TBPlugin):
         self._downsample_to = (context.sampling_hints or {}).get(
             self.plugin_name, _DEFAULT_DOWNSAMPLING
         )
-        if context.flags and context.flags.generic_data == "true":
+        if context.flags and context.flags.generic_data != "false":
             self._data_provider = context.data_provider
         else:
             self._data_provider = None

--- a/tensorboard/plugins/text/text_plugin_test.py
+++ b/tensorboard/plugins/text/text_plugin_test.py
@@ -61,17 +61,18 @@ class TextPluginTest(tf.test.TestCase):
                 multiplexer.AddRunsFromDirectory(self.logdir)
                 multiplexer.Reload()
                 with self.subTest("bare multiplexer"):
+                    flags = argparse.Namespace(generic_data="false")
                     ctx = base_plugin.TBContext(
-                        logdir=self.logdir, multiplexer=multiplexer
+                        logdir=self.logdir,
+                        multiplexer=multiplexer,
+                        flags=flags,
                     )
                     fn(self, text_plugin.TextPlugin(ctx), *args, **kwargs)
                 with self.subTest("generic data provider"):
-                    flags = argparse.Namespace(generic_data="true")
                     provider = data_provider.MultiplexerDataProvider(
                         multiplexer, self.logdir
                     )
                     ctx = base_plugin.TBContext(
-                        flags=flags,
                         logdir=self.logdir,
                         multiplexer=multiplexer,
                         data_provider=provider,


### PR DESCRIPTION
Summary:
We now use the data provider APIs by default for the core, histograms,
images, and text plugins (plus scalars, audio, PR curves, and hparams,
which are not new in this patch). This accounts for all summary-based
primary plugins except for the graphs plugin, which only supports
run-level graphs. In case of emergency, users can still opt out by
passing `--generic_data false`. The plan is to release TensorBoard 2.3
in this state and then remove the legacy paths in TensorBoard 2.4.

Note that the patch to the histograms plugin affects both the histograms
and distributions dashboards.

This is not (intended to be) a user-facing change.

Test Plan:
Note that all modified dashboards still behave properly unless the code
is patched to unconditionally remove the multiplexer from the context
*and* `--generic_data false` is also passed.

wchargin-branch: data-stabilize-core-histograms-images-text
