### PR TITLE
Fix projector plugin links in docs

### DIFF
--- a/docs/tensorboard_projector_plugin.ipynb
+++ b/docs/tensorboard_projector_plugin.ipynb
@@ -45,13 +45,13 @@
         "\n",
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tensorboard/image_summaries\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
+        "    <a target=\"_blank\" href=\"https://www.tensorflow.org/tensorboard/tensorboard_projector_plugin\"><img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/docs/image_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tensorboard/blob/master/docs/tensorboard_projector_plugin.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/tensorboard/blob/master/docs/image_summaries.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/tensorflow/tensorboard/blob/master/docs/tensorboard_projector_plugin.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
         "</table>"
       ]


### PR DESCRIPTION
* Motivation for features / changes

Links in projector plugin notebook were copied from image summaries notebook without changing so they are incorrect.

* Technical description of changes

Fixes links to link to the project plugin notebook

* Screenshots of UI changes

<img width="780" alt="Screen Shot 2020-04-29 at 12 59 26 AM" src="https://user-images.githubusercontent.com/5288285/80573394-b7439680-89b4-11ea-9cec-d70e5de53c2c.png">

* Detailed steps to verify changes work correctly (as executed by you)

Click on the links to view the notebook and verify they link to the projector plugin notebook

* Alternate designs / implementations considered

N/A