### PR TITLE
ng: fix infinite loop when on plugin selector

### DIFF
--- a/tensorboard/webapp/header/header_test.ts
+++ b/tensorboard/webapp/header/header_test.ts
@@ -154,7 +154,7 @@ describe('header test', () => {
     const fixture = TestBed.createComponent(HeaderComponent);
     fixture.detectChanges();
 
-    const [, barEl] = fixture.debugElement.queryAll(By.css('.mat-tab-label'));
+    const [, barEl] = fixture.debugElement.queryAll(By.css('.plugin-name'));
     barEl.nativeElement.click();
     fixture.detectChanges();
     await fixture.whenStable();

--- a/tensorboard/webapp/header/plugin_selector_component.ng.html
+++ b/tensorboard/webapp/header/plugin_selector_component.ng.html
@@ -17,14 +17,20 @@ limitations under the License.
 <mat-tab-group
   class="active-plugin-list"
   [selectedIndex]="getActivePluginIndex()"
-  (selectedTabChange)="onActivePluginSelectionChanged($event)"
   animationDuration="100ms"
 >
-  <mat-tab
-    *ngFor="let plugin of activePlugins"
-    [label]="plugin.tab_name"
-    [disabled]="!plugin.enabled"
-  >
+  <mat-tab *ngFor="let plugin of activePlugins" [disabled]="!plugin.enabled">
+    <ng-template mat-tab-label>
+      <!-- Manually subscribe to the click event on the tab content element.
+      Cannot trust the selectedTabChange event since it is async and can cause
+      infinte loop. -->
+      <span
+        class="plugin-name"
+        (click)="onActivePluginSelection($event, plugin.id)"
+      >
+        {{plugin.tab_name}}
+      </span>
+    </ng-template>
   </mat-tab>
 </mat-tab-group>
 <mat-form-field floatLabel="never" *ngIf="disabledPlugins.length > 0">

--- a/tensorboard/webapp/header/plugin_selector_component.scss
+++ b/tensorboard/webapp/header/plugin_selector_component.scss
@@ -42,6 +42,15 @@ mat-option {
   overflow: hidden;
 }
 
+.plugin-name {
+  align-items: center;
+  display: inline-flex;
+  height: 100%;
+  justify-content: center;
+  padding: 0 12px;
+  width: 100%;
+}
+
 :host ::ng-deep .active-plugin-list {
   // Override mat-tab styling. By default, mat-tab has the right styling but,
   // here, we are using it under dark header background. Must invert the color.
@@ -82,8 +91,12 @@ mat-option {
 
   .mat-tab-label {
     min-width: 48px; /* default is 160px which is too big for us */
-    padding: 0 12px; /* default is 24px */
+    padding: 0; /* default is 24px */
     text-transform: uppercase;
+  }
+
+  .mat-tab-label-content {
+    height: 100%;
   }
 
   mat-tab-header:not(.mat-tab-header-pagination-controls-enabled) {

--- a/tensorboard/webapp/header/plugin_selector_component.ts
+++ b/tensorboard/webapp/header/plugin_selector_component.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {MatTabChangeEvent} from '@angular/material/tabs';
 import {MatSelectChange} from '@angular/material/select';
 
 import {PluginId} from '../types/api';
@@ -41,8 +40,9 @@ export class PluginSelectorComponent {
     return this.activePlugins.findIndex(({id}) => id === this.selectedPlugin);
   }
 
-  onActivePluginSelectionChanged({index}: MatTabChangeEvent) {
-    this.onPluginSelectionChanged.emit(this.activePlugins[index].id);
+  onActivePluginSelection(event: Event, pluginId: PluginId) {
+    event.stopPropagation();
+    this.onPluginSelectionChanged.emit(pluginId);
   }
 
   onDisabledPluginSelectionChanged(selectChangeEvent: MatSelectChange) {


### PR DESCRIPTION
cause: mat-tab-group emits the changed event in the Angular's equivalent
to `componentDidUpdate`. The problem is that:
1. it emits the [change in a promise](https://github.com/angular/components/blob/58b8d30efb0e71f0f4bbc541405cda1adce26f16/src/material/tabs/tab-group.ts#L207-L213) (next tick)
2. it emits the change when the value is changed programmatically.

While lacking complete understanding of the flow, empirically, I found there to be some kind of event dispatch queue and the emission to not invoke our callback immediately.

Logging result
<details>

```
# Clicked on graphs, images, audio in quickly
11:50:44.922 tab-group: scheduling async
11:50:45.086 tab-group: triggering async
11:50:45.153 tab-group: scheduling async
11:50:45.202 tab-group: triggering async
11:50:45.249 tab-group: scheduling async
11:50:45.274 tab-group: triggering async
11:50:45.322 tab-group: scheduling async
11:50:45.430 tab-group: triggering async
# `onActivePluginSelectionChanged` is the callback that listens to
# mat-tab-group's changed event.
# Because flux cycle is synchronous, it makes sense to action to get dispatched
# then schedule a new update (update should change the value to `graphs` when
# the current value is audio).
11:50:46.085 onActivePluginSelectionChanged graphs
11:50:46.086 [Core] Plugin Changed
11:50:46.136 ngOnChanges graphs
11:50:46.139 tab-group: scheduling async
# Huh? which async is triggered? If this is the `graphs` from `11:50:46.139` or
# one from `11:50:45.202`?
11:50:46.440 tab-group: triggering async
# It looks like `triggering async` has almost nothing to do with the event we
# get.
11:50:46.510 onActivePluginSelectionChanged images
```

</details>

fix: no longer use the mat-tab-group's change event and listen directly
at the click event.

Fixes b/155104143.
