### PR TITLE
lib: clarify extents of public API

### DIFF
--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -20,7 +20,17 @@ from __future__ import print_function
 
 from tensorboard import errors  # public export
 from tensorboard import lazy
-from tensorboard import version
+from tensorboard import version  # public export
+
+# TensorBoard public API.
+__all__ = [
+    "__version__",
+    "errors",
+    "notebook",
+    "program",
+    "summary",
+    "version",
+]
 
 
 # Please be careful when changing the structure of this file.
@@ -99,3 +109,5 @@ def load_ipython_extension(ipython):
 
 
 __version__ = version.VERSION
+
+del lazy

--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 
 from tensorboard import errors  # public export
 from tensorboard import lazy as _lazy
-from tensorboard import version  # public export
+from tensorboard import version as _version
 
 # TensorBoard public API.
 __all__ = [
@@ -29,7 +29,6 @@ __all__ = [
     "notebook",
     "program",
     "summary",
-    "version",
 ]
 
 
@@ -108,4 +107,4 @@ def load_ipython_extension(ipython):
     notebook._load_ipython_extension(ipython)
 
 
-__version__ = version.VERSION
+__version__ = _version.VERSION

--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorboard import errors  # public export
-from tensorboard import lazy
+from tensorboard import lazy as _lazy
 from tensorboard import version  # public export
 
 # TensorBoard public API.
@@ -76,21 +76,21 @@ __all__ = [
 # additional discussion.
 
 
-@lazy.lazy_load("tensorboard.notebook")
+@_lazy.lazy_load("tensorboard.notebook")
 def notebook():
     import importlib
 
     return importlib.import_module("tensorboard.notebook")
 
 
-@lazy.lazy_load("tensorboard.program")
+@_lazy.lazy_load("tensorboard.program")
 def program():
     import importlib
 
     return importlib.import_module("tensorboard.program")
 
 
-@lazy.lazy_load("tensorboard.summary")
+@_lazy.lazy_load("tensorboard.summary")
 def summary():
     import importlib
 
@@ -109,5 +109,3 @@ def load_ipython_extension(ipython):
 
 
 __version__ = version.VERSION
-
-del lazy


### PR DESCRIPTION
Summary:
In particular, `tensorboard.lazy` is private. This was always the intent
and is probably not likely to be super confusing, but we might as well
be as explicit as possible about the extent of our public API surface.

Test Plan:
The Pip package smoke test suffices. As an extra check, after installing
the Pip package into a new virtualenv, `from tensorboard import *` only
imports the desired symbols (cf. `list(locals())`).

wchargin-branch: lib-private
