### PR TITLE
build: lock down default visibilities

### DIFF
--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -1,7 +1,7 @@
 # Description:
 # Event processing logic for TensorBoard
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -11,6 +11,7 @@ py_library(
     name = "io_wrapper",
     srcs = ["io_wrapper.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/compat:tensorflow",
         "//tensorboard/util:tb_logging",
@@ -23,6 +24,7 @@ py_test(
     size = "small",
     srcs = ["io_wrapper_test.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":io_wrapper",
         "//tensorboard:expect_tensorflow_installed",
@@ -34,6 +36,7 @@ py_library(
     name = "data_provider",
     srcs = ["data_provider.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":event_accumulator",
         "//tensorboard:errors",
@@ -48,6 +51,7 @@ py_test(
     name = "data_provider_test",
     srcs = ["data_provider_test.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":data_provider",
         ":event_multiplexer",
@@ -70,6 +74,7 @@ py_library(
     name = "directory_loader",
     srcs = ["directory_loader.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":directory_watcher",
         ":io_wrapper",
@@ -83,6 +88,7 @@ py_test(
     size = "small",
     srcs = ["directory_loader_test.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":directory_loader",
         ":directory_watcher",
@@ -97,6 +103,7 @@ py_library(
     name = "directory_watcher",
     srcs = ["directory_watcher.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":io_wrapper",
         "//tensorboard/compat:tensorflow",
@@ -109,6 +116,7 @@ py_test(
     size = "small",
     srcs = ["directory_watcher_test.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":directory_watcher",
         "//tensorboard:expect_tensorflow_installed",
@@ -119,6 +127,7 @@ py_library(
     name = "reservoir",
     srcs = ["reservoir.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
 )
 
 py_test(
@@ -126,6 +135,7 @@ py_test(
     size = "small",
     srcs = ["reservoir_test.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":reservoir",
         "//tensorboard:expect_tensorflow_installed",
@@ -136,6 +146,7 @@ py_library(
     name = "event_file_loader",
     srcs = ["event_file_loader.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard:data_compat",
         "//tensorboard:dataclass_compat",
@@ -151,6 +162,7 @@ py_test(
     size = "small",
     srcs = ["event_file_loader_test.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":event_file_loader",
         "//tensorboard:expect_tensorflow_installed",
@@ -166,6 +178,7 @@ py_test(
     srcs = ["event_file_loader_test.py"],
     main = "event_file_loader_test.py",
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":event_file_loader",
         "//tensorboard:expect_tensorflow_installed",
@@ -203,6 +216,7 @@ py_test(
     size = "small",
     srcs = ["event_accumulator_test.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":event_accumulator",
         "//tensorboard:data_compat",
@@ -226,6 +240,7 @@ py_test(
     size = "small",
     srcs = ["plugin_event_accumulator_test.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":event_accumulator",
         "//tensorboard:expect_tensorflow_installed",
@@ -264,6 +279,7 @@ py_test(
     size = "small",
     srcs = ["event_multiplexer_test.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":event_accumulator",
         ":event_multiplexer",
@@ -277,6 +293,7 @@ py_test(
     size = "small",
     srcs = ["plugin_event_multiplexer_test.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":event_accumulator",
         ":event_multiplexer",
@@ -289,6 +306,7 @@ py_library(
     name = "plugin_asset_util",
     srcs = ["plugin_asset_util.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/compat:tensorflow",
     ],
@@ -298,6 +316,7 @@ py_library(
     name = "event_file_inspector",
     srcs = ["event_file_inspector.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":event_accumulator",
         ":io_wrapper",
@@ -311,6 +330,7 @@ py_test(
     size = "small",
     srcs = ["event_file_inspector_test.py"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
     deps = [
         ":event_file_inspector",
         "//tensorboard:expect_tensorflow_installed",

--- a/tensorboard/components/vz_bar_chart/BUILD
+++ b/tensorboard/components/vz_bar_chart/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 

--- a/tensorboard/components/vz_chart_helpers/BUILD
+++ b/tensorboard/components/vz_chart_helpers/BUILD
@@ -16,6 +16,7 @@ tf_web_library(
         "vz-chart-tooltip.ts",
     ],
     path = "/vz-chart-helpers",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_imports:d3",
         "//tensorboard/components/tf_imports:lodash",
@@ -23,7 +24,6 @@ tf_web_library(
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/vz_sorting",
     ],
-    visibility = ["//visibility:public"],
 )
 
 tensorboard_webcomponent_library(

--- a/tensorboard/components/vz_chart_helpers/BUILD
+++ b/tensorboard/components/vz_chart_helpers/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
@@ -23,6 +23,7 @@ tf_web_library(
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/vz_sorting",
     ],
+    visibility = ["//visibility:public"],
 )
 
 tensorboard_webcomponent_library(

--- a/tensorboard/components/vz_example_viewer/BUILD
+++ b/tensorboard/components/vz_example_viewer/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
@@ -12,6 +12,7 @@ tf_web_library(
         "vz-example-viewer.ts",
     ],
     path = "/vz-example-viewer",
+    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_imports:d3",
         "//tensorboard/components/tf_imports:polymer",
@@ -34,6 +35,7 @@ tf_web_library(
     name = "demo",
     srcs = ["index.html"],
     path = "/vz-example-viewer",
+    visibility = ["//visibility:public"],
     deps = [
         ":vz_example_viewer",
         "//tensorboard/components/tf_imports:polymer",
@@ -47,5 +49,6 @@ tensorboard_html_binary(
     compile = True,  # Run Closure Compiler
     input_path = "/vz-example-viewer/index.html",
     output_path = "/vz-example-viewer/demo.html",
+    visibility = ["//visibility:public"],
     deps = [":demo"],
 )

--- a/tensorboard/plugins/hparams/external_users/BUILD
+++ b/tensorboard/plugins/hparams/external_users/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//tensorboard:internal"])
+
 licenses(["notice"])  # Apache 2.0
 
 # The group of packages that are allowed to use the 'tf_hparams_main:legacy'

--- a/tensorboard/plugins/hparams/tf_hparams_backend/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_backend/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")

--- a/tensorboard/plugins/hparams/tf_hparams_dashboard/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_dashboard/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 

--- a/tensorboard/plugins/hparams/tf_hparams_google_analytics_tracker/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_google_analytics_tracker/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
@@ -20,6 +20,7 @@ tf_web_library(
 tf_web_test(
     name = "test",
     src = "/tf-hparams-google-analytics-tracker/test/tf-hparams-google-analytics-tracker-test.html",
+    visibility = ["//visibility:public"],
     web_library = ":test_lib",
 )
 
@@ -30,6 +31,7 @@ tf_web_library(
         "test/tf-hparams-google-analytics-tracker-test.html",
     ],
     path = "/tf-hparams-google-analytics-tracker",
+    visibility = ["//visibility:public"],
     deps = [
         ":tf_hparams_google_analytics_tracker",
         "//tensorboard/components/tf_imports:polymer",
@@ -43,6 +45,7 @@ tf_web_library(
 tensorboard_webcomponent_library(
     name = "legacy",
     srcs = [":tf_hparams_google_analytics_tracker"],
+    visibility = ["//visibility:public"],
     destdir = "tf-hparams-google-analytics-tracker",
     deps = [
         "//tensorboard/components/tf_imports:polymer_lib",

--- a/tensorboard/plugins/hparams/tf_hparams_main/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_main/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//tensorboard:internal"])
 
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")

--- a/tensorboard/tools/BUILD
+++ b/tensorboard/tools/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//tensorboard:internal"])
+
 licenses(["notice"])  # Apache 2.0
 
 py_binary(

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//tensorboard:internal"])
+
 filegroup(
     name = "jspbfix",
     srcs = ["jspbfix.js"],

--- a/third_party/chromium/BUILD
+++ b/third_party/chromium/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//tensorboard:internal"])
+
 load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_archive")
 
 licenses(["notice"])

--- a/third_party/protobuf/BUILD
+++ b/third_party/protobuf/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//tensorboard:internal"])


### PR DESCRIPTION
Summary:
This patch ensures that all packages have a `default_visibility` setting
of `//tensorboard:internal` or stricter, while preserving each target’s
visibility by adjusting explicitly as needed. This patch is not intended
to actually change the visibility of any target. The purpose of this
patch is to ensure that removing an explicit `visibility` spec on a
target always leaves that target with TensorBoard-internal visibility.

The `third_party/*.BUILD` (e.g., `third_party/urllib3.BUILD`) shims are
excepted.

Test Plan:
Buildozer says that we got ’em all:

```
$ buildozer 'print default_visibility' //tensorboard/...:__pkg__ | sort -u
[:internal]
[//tensorboard:internal]
[//tensorboard/plugins/hparams:__subpackages__]
[//visibility:private]
```

wchargin-branch: vis-default-lockdown
