### PR TITLE
Use bare raise for reraising _OutOfSpaceError

### DIFF
--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -572,9 +572,9 @@ class _ScalarBatchedRequestSender(object):
         util.set_timestamp(point.wall_time, event.wall_time)
         try:
             self._byte_budget_manager.add_point(point)
-        except _OutOfSpaceError as e:
+        except _OutOfSpaceError:
             tag_proto.points.pop()
-            raise e
+            raise
         return point
 
 
@@ -723,9 +723,9 @@ class _TensorBatchedRequestSender(object):
         util.set_timestamp(point.wall_time, event.wall_time)
         try:
             self._byte_budget_manager.add_point(point)
-        except _OutOfSpaceError as e:
+        except _OutOfSpaceError:
             tag_proto.points.pop()
-            raise e
+            raise
         return point
 
 


### PR DESCRIPTION
* Motivation for features / changes

I recently read a draft python totw that claims a best practice is to use a "bare raise" when reraising a caught exception/error. I am applying that best practice to some code I recently modified, although it doesn't have any real practical impact.