### PR TITLE
Implement commitChanges on vz-line-chart2

### DIFF
--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -219,11 +219,8 @@ limitations under the License.
           this.$.chart.setSeriesMetadata(name, metadata);
         },
 
-        /**
-         * Not yet implemented.
-         */
         commitChanges() {
-          // Temporarily rolled back due to PR curves breakage.
+          this.$.chart.commitChanges();
         },
 
         redraw() {

--- a/tensorboard/components/vz_line_chart2/microbenchmark/renders_spec.ts
+++ b/tensorboard/components/vz_line_chart2/microbenchmark/renders_spec.ts
@@ -61,6 +61,7 @@ benchmark({
     context.container.appendChild(context.chart);
 
     context.chart.setVisibleSeries([]);
+    context.chart.commitChanges();
 
     await polymerFlush();
   },
@@ -82,6 +83,7 @@ benchmark({
 
     context.chart.setSeriesData('sine', DATA_POINTS.sine1k);
     context.chart.setVisibleSeries(['sine']);
+    context.chart.commitChanges();
 
     await polymerFlush();
   },
@@ -103,6 +105,7 @@ benchmark({
 
     context.chart.setSeriesData('sine', DATA_POINTS.sine1k);
     context.chart.setVisibleSeries(['sine']);
+    context.chart.commitChanges();
 
     await polymerFlush();
   },
@@ -124,6 +127,7 @@ benchmark({
 
     context.chart.setSeriesData('cosine', DATA_POINTS.cosine100k);
     context.chart.setVisibleSeries(['cosine']);
+    context.chart.commitChanges();
 
     await polymerFlush();
   },
@@ -146,6 +150,7 @@ benchmark({
     context.chart.setSeriesData('sine', DATA_POINTS.sine1k);
     context.chart.setSeriesData('cosine', DATA_POINTS.cosine1k);
     context.chart.setVisibleSeries(['cosine']);
+    context.chart.commitChanges();
     context.even = true;
 
     await polymerFlush();
@@ -177,6 +182,7 @@ benchmark({
     context.chart.setVisibleSeries(
       FIVE_HUNDRED_1K_DATA_POINTS.map(({name}) => name)
     );
+    context.chart.commitChanges();
 
     await polymerFlush();
   },
@@ -201,6 +207,7 @@ benchmark({
       context.chart.setSeriesData(name, data);
     });
     context.chart.setVisibleSeries(datapoints.map(({name}) => name));
+    context.chart.commitChanges();
 
     await polymerFlush();
     context.index = 0;
@@ -234,6 +241,7 @@ benchmark({
         context.container.appendChild(chart);
         chart.setSeriesData(name, data);
         chart.setVisibleSeries([name]);
+        chart.commitChanges();
         return chart;
       }
     );
@@ -264,6 +272,7 @@ benchmark({
         chart.style.height = '50px';
         context.container.appendChild(chart);
         chart.setSeriesData(name, data);
+        chart.commitChanges();
         return chart;
       }
     );
@@ -277,12 +286,14 @@ benchmark({
     context.charts.forEach((chart: any) => {
       chart.setVisibleSeries([]);
     });
+    context.chart.commitChanges();
 
     await context.flushAsync();
 
     context.charts.forEach((chart: any, index: number) => {
       chart.setVisibleSeries([context.names[index]]);
     });
+    context.chart.commitChanges();
 
     await context.flushAsync();
   },
@@ -300,6 +311,7 @@ benchmark({
 
     context.chart.setSeriesData('cosine', DATA_POINTS.cosine1k);
     context.chart.setVisibleSeries(['cosine']);
+    context.chart.commitChanges();
     context.chart.smoothingEnabled = true;
     context.even = true;
 
@@ -328,6 +340,7 @@ benchmark({
 
     context.chart.setSeriesData('cosine', DATA_POINTS.cosine100k);
     context.chart.setVisibleSeries(['cosine']);
+    context.chart.commitChanges();
     context.chart.smoothingEnabled = true;
     context.even = true;
 
@@ -358,6 +371,7 @@ benchmark({
 
     context.chart.setSeriesData('cosine', DATA_POINTS.cosine100k);
     context.chart.setVisibleSeries(['cosine']);
+    context.chart.commitChanges();
     context.chart.smoothingEnabled = true;
     context.even = true;
 

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -338,11 +338,9 @@ namespace vz_line_chart2 {
       }
     },
 
-    /**
-     * Not yet implemented.
-     */
     commitChanges() {
-      // Temporarily rolled back due to PR curves breakage.
+      if (!this._chart) return;
+      this._chart.commitChanges();
     },
 
     /**
@@ -433,6 +431,7 @@ namespace vz_line_chart2 {
           this._chart.setSeriesMetadata(name, this._seriesMetadataCache[name]);
         });
       this._chart.setVisibleSeries(this._visibleSeriesCache);
+      this._chart.commitChanges();
     },
 
     _smoothingChanged: function() {

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -664,6 +664,7 @@ limitations under the License.
             dataSeries.getData()
           );
         });
+        this.$.loader.commitChanges();
       },
       _computeSeriesNames() {
         const runLookup = new Set(this.runs);

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
@@ -382,6 +382,7 @@ limitations under the License.
         Object.entries(_nameToDataSeries).forEach(([name, series]) => {
           this.$.loader.setSeriesData(name, series.getData());
         });
+        this.$.loader.commitChanges();
       },
       _computeSelectedRunsSet(runs) {
         const mapping = {};

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-line-chart.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-line-chart.html
@@ -110,6 +110,7 @@ limitations under the License.
           seriesData.push({step: xData[i], scalar: yData[i]});
         }
         chart.setSeriesData(this._defaultSeriesName, seriesData);
+        chart.commitChanges();
       },
     });
   </script>

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -407,11 +407,15 @@ limitations under the License.
         for (let i = 0; i < seriesData.length; i++) {
           seriesData[i] = _.mapValues(fieldsToData, (values) => values[i]);
         }
-        this.$$('tf-line-chart-data-loader').setSeriesData(run, seriesData);
+        const loader = this.$$('tf-line-chart-data-loader');
+        loader.setSeriesData(run, seriesData);
+        loader.commitChanges();
       },
       _clearSeriesData(run) {
         // Clears data for a run in the chart.
-        this.$$('tf-line-chart-data-loader').setSeriesData(run, []);
+        const loader = this.$$('tf-line-chart-data-loader');
+        loader.setSeriesData(run, []);
+        loader.commitChanges();
       },
       _updateRunToPrCurveEntry(runToDataOverTime, runToStepCap) {
         const runToEntry = {};

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -226,6 +226,7 @@ limitations under the License.
               const name = this._getSeriesNameFromDatum(datum);
               scalarChart.setSeriesMetadata(name, datum);
               scalarChart.setSeriesData(name, formattedData);
+              scalarChart.commitChanges();
             };
           },
           readOnly: true,


### PR DESCRIPTION
This is a roll forward of 46b6e615a (#3552). The commit partially rolls back
27d0023e7 (#3524) which introduces `commitChanges` which was supposed to be
invoked after setting data, visible series, or metadata.

This change addresses the regression caused by 27d0023e7 which forgot to
call the new API in all places where we use the vz-line-chart2.
