### PR TITLE
[DebuggerV2] Remove a problematic assertion in debugger_v2_plugin_test

### DIFF
--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -841,7 +841,6 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEqual(digests[2]["op_type"], "Placeholder")
         self.assertEqual(digests[2]["output_slot"], 0)
         self.assertTrue(digests[2]["op_name"])
-        self.assertNotEqual(digests[2]["op_name"], digests[0]["op_name"])
         self.assertTrue(digests[2]["graph_id"])
 
         self.assertGreaterEqual(


### PR DESCRIPTION
The removed line of assertion is problematic, because the two ops belong to two tf.function graphs, which can legally have identical op names. Previously, they were different due to the old way in which we create debugger-generated names for Placeholder ops. But a new, improved way of doing it will cause the names of the ops to be the same. This change needs to be sync'ed in order to unblock the submission of CL/309292117.