### PR TITLE
Allow server to specify maximum tensor upload size

### DIFF
--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -109,4 +109,8 @@ message UploadLimits {
   // the server may enforce a *minimum* blob size, which is a separate issue).
   // If this is negative, no blobs should be uploaded.
   int64 max_blob_size = 1;
+  // The maximum allowed size for tensor point uploads.
+  // If this is 0, it is allowed to upload tensor points of size 0.
+  // If this is negative, no blobs should be uploaded.
+  int64 max_tensor_point_size = 2;
 }

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -270,6 +270,7 @@ class MaxTensorPointSizeTest(tb_test.TestCase):
         actual = server_info.max_tensor_point_size(info)
         self.assertEqual(actual, 0)
 
+
 def _localhost():
     """Gets family and nodename for a loopback address."""
     s = socket

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -262,10 +262,12 @@ class MaxTensorPointSizeTest(tb_test.TestCase):
         actual = server_info.max_tensor_point_size(info)
         self.assertEqual(actual, 42)
 
-    def test_upload_limits_provided_without_max_blob_size(self):
+    def test_upload_limits_provided_without_max_tensor_point_size(self):
         # This just shows that the proto3 default value of 0 is reported as
         # usual, not handled as a special case.
         info = server_info_pb2.ServerInfoResponse()
+        # Ensure upload_limits is set but do not explicitly set
+        # max_tensor_point_size.
         info.upload_limits.max_blob_size = 42
         actual = server_info.max_tensor_point_size(info)
         self.assertEqual(actual, 0)

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -248,6 +248,28 @@ class MaxBlobSizeTest(tb_test.TestCase):
         self.assertEqual(actual, 0)
 
 
+class MaxTensorPointSizeTest(tb_test.TestCase):
+    """Tests for `max_tensor_point_size`."""
+
+    def test_old_server_no_upload_limits(self):
+        info = server_info_pb2.ServerInfoResponse()
+        actual = server_info.max_tensor_point_size(info)
+        self.assertEqual(actual, server_info._DEFAULT_MAX_TENSOR_POINT_SIZE)
+
+    def test_upload_limits_provided_with_max_tensor_point_size(self):
+        info = server_info_pb2.ServerInfoResponse()
+        info.upload_limits.max_tensor_point_size = 42
+        actual = server_info.max_tensor_point_size(info)
+        self.assertEqual(actual, 42)
+
+    def test_upload_limits_provided_without_max_blob_size(self):
+        # This just shows that the proto3 default value of 0 is reported as
+        # usual, not handled as a special case.
+        info = server_info_pb2.ServerInfoResponse()
+        info.upload_limits.max_blob_size = 42
+        actual = server_info.max_tensor_point_size(info)
+        self.assertEqual(actual, 0)
+
 def _localhost():
     """Gets family and nodename for a loopback address."""
     s = socket

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -408,6 +408,9 @@ class _UploadIntent(_Intent):
             self.logdir,
             allowed_plugins=server_info_lib.allowed_plugins(server_info),
             max_blob_size=server_info_lib.max_blob_size(server_info),
+            max_tensor_point_size=server_info_lib.max_tensor_point_size(
+                server_info
+            ),
             name=self.name,
             description=self.description,
         )

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -117,6 +117,7 @@ def _create_uploader(
     writer_client=_USE_DEFAULT,
     logdir=None,
     max_blob_size=_USE_DEFAULT,
+    max_tensor_point_size=_USE_DEFAULT,
     logdir_poll_rate_limiter=_USE_DEFAULT,
     rpc_rate_limiter=_USE_DEFAULT,
     blob_rpc_rate_limiter=_USE_DEFAULT,
@@ -127,6 +128,8 @@ def _create_uploader(
         writer_client = _create_mock_client()
     if max_blob_size is _USE_DEFAULT:
         max_blob_size = 12345
+    if max_tensor_point_size is _USE_DEFAULT:
+        max_tensor_point_size = 11111
     if logdir_poll_rate_limiter is _USE_DEFAULT:
         logdir_poll_rate_limiter = util.RateLimiter(0)
     if rpc_rate_limiter is _USE_DEFAULT:
@@ -138,6 +141,7 @@ def _create_uploader(
         logdir,
         allowed_plugins=_SCALARS_HISTOGRAMS_AND_GRAPHS,
         max_blob_size=max_blob_size,
+        max_tensor_point_size=max_tensor_point_size,
         logdir_poll_rate_limiter=logdir_poll_rate_limiter,
         rpc_rate_limiter=rpc_rate_limiter,
         blob_rpc_rate_limiter=blob_rpc_rate_limiter,
@@ -151,6 +155,7 @@ def _create_request_sender(
     api=None,
     allowed_plugins=_USE_DEFAULT,
     max_blob_size=_USE_DEFAULT,
+    max_tensor_point_size=_USE_DEFAULT,
     rpc_rate_limiter=_USE_DEFAULT,
     blob_rpc_rate_limiter=_USE_DEFAULT,
 ):
@@ -160,6 +165,8 @@ def _create_request_sender(
         allowed_plugins = _SCALARS_HISTOGRAMS_AND_GRAPHS
     if max_blob_size is _USE_DEFAULT:
         max_blob_size = 12345
+    if max_tensor_point_size is _USE_DEFAULT:
+        max_tensor_point_size = 11111
     if rpc_rate_limiter is _USE_DEFAULT:
         rpc_rate_limiter = util.RateLimiter(0)
     if blob_rpc_rate_limiter is _USE_DEFAULT:
@@ -169,6 +176,7 @@ def _create_request_sender(
         api=api,
         allowed_plugins=allowed_plugins,
         max_blob_size=max_blob_size,
+        max_tensor_point_size=max_tensor_point_size,
         rpc_rate_limiter=rpc_rate_limiter,
         blob_rpc_rate_limiter=blob_rpc_rate_limiter,
     )
@@ -187,14 +195,17 @@ def _create_scalar_request_sender(
 
 
 def _create_tensor_request_sender(
-    experiment_id=None, api=None,
+    experiment_id=None, api=None, max_tensor_point_size=_USE_DEFAULT,
 ):
     if api is _USE_DEFAULT:
         api = _create_mock_client()
+    if max_tensor_point_size is _USE_DEFAULT:
+        max_tensor_point_size = 11111
     return uploader_lib._TensorBatchedRequestSender(
         experiment_id=experiment_id,
         api=api,
         rpc_rate_limiter=util.RateLimiter(0),
+        max_tensor_point_size=max_tensor_point_size,
     )
 
 
@@ -1202,10 +1213,12 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
             for value in event.summary.value:
                 sender.add_event(run_name, event, value, value.metadata)
 
-    def _add_events_and_flush(self, events):
+    def _add_events_and_flush(self, events, max_tensor_point_size=_USE_DEFAULT):
         mock_client = _create_mock_client()
         sender = _create_tensor_request_sender(
-            experiment_id="123", api=mock_client,
+            experiment_id="123",
+            api=mock_client,
+            max_tensor_point_size=max_tensor_point_size,
         )
         self._add_events(sender, "", events)
         sender.flush()
@@ -1410,6 +1423,58 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
                 request.ByteSize(), uploader_lib._MAX_REQUEST_LENGTH_BYTES
             )
         self.assertEqual(total_points_in_result, point_count)
+
+    def test_strip_large_tensors(self):
+        # Generate test data with varying tensor point sizes. Use raw bytes.
+        event_1 = event_pb2.Event(step=1)
+        event_1.summary.value.add(
+            tag="one", tensor=tensor_pb2.TensorProto(tensor_content=b"\x01\x02")
+        )
+        event_1.summary.value.add(
+            tag="two",
+            tensor=tensor_pb2.TensorProto(
+                tensor_content=b"\x01\x02\x03\x04\x05\x06"
+            ),
+        )
+        event_2 = event_pb2.Event(step=2)
+        event_2.summary.value.add(
+            tag="one", tensor=tensor_pb2.TensorProto(tensor_content=b"\x01\x02")
+        )
+        event_2.summary.value.add(
+            tag="two",
+            tensor=tensor_pb2.TensorProto(
+                tensor_content=b"\x01\x02\x03\x04\x05\x06\x07"
+            ),
+        )
+
+        run_proto = self._add_events_and_flush(
+            _apply_compat([event_1, event_2]), max_tensor_point_size=7 + 1
+        )
+        tag_data = {
+            tag.name: [(p.step, p.value.tensor_content) for p in tag.points]
+            for tag in run_proto.tags
+        }
+        # A single tensor point is filtered out.
+        self.assertEqual(
+            tag_data,
+            {
+                "one": [(1, b"\x01\x02"), (2, b"\x01\x02")],
+                "two": [(1, b"\x01\x02\x03\x04\x05\x06")],
+            },
+        )
+
+        run_proto_2 = self._add_events_and_flush(
+            _apply_compat([event_1, event_2]), max_tensor_point_size=6 + 1
+        )
+        tag_data_2 = {
+            tag.name: [(p.step, p.value.tensor_content) for p in tag.points]
+            for tag in run_proto_2.tags
+        }
+        # All tensor points from the same tag are filtered out, and the tag is pruned.
+        self.assertEqual(
+            tag_data_2, {
+              "one": [(1, b"\x01\x02"), (2, b"\x01\x02")],},
+        )
 
     def test_prunes_tags_and_runs(self):
         mock_client = _create_mock_client()

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -1472,8 +1472,7 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
         }
         # All tensor points from the same tag are filtered out, and the tag is pruned.
         self.assertEqual(
-            tag_data_2, {
-              "one": [(1, b"\x01\x02"), (2, b"\x01\x02")],},
+            tag_data_2, {"one": [(1, b"\x01\x02"), (2, b"\x01\x02")],},
         )
 
     def test_prunes_tags_and_runs(self):


### PR DESCRIPTION
* Motivation for features / changes

Backends should be able to impose size limits for uploading individual tensor points, similar to how they can impose size limits for individual blobs.

Fallback to a reasonable default value for the time being while we wait for backends to be updated to provide this information.

* Technical description of changes

Maximum size of tensor points is specified in the handshake response with the frontend. If the value is not present then fallback to some reasonable default. 

If a Tensor point larger than the maximum size is encountered, strip it from write requests and log a warning.

* Screenshots of UI changes

![image](https://user-images.githubusercontent.com/17152369/80813765-a6537a80-8b98-11ea-8252-daafe3712407.png)

* Detailed steps to verify changes work correctly (as executed by you)

Wrote tests.

Ran uploader with a frontend that does not specify max limit and observed that default value is used.

Ran uploader with a frontend that does specify max limit and observed that specified value is used.
