### PR TITLE
uploader: implement tensor exporting

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -17,6 +17,7 @@ py_library(
         "//tensorboard/uploader/proto:protos_all_py_pb2",
         "//tensorboard/util:grpc_util",
         "//tensorboard/util:tb_logging",
+        "//tensorboard/util:tensor_util",
         "@org_pythonhosted_six",
     ],
 )
@@ -30,6 +31,7 @@ py_test(
         ":util",
         "//tensorboard:expect_grpc_installed",
         "//tensorboard:expect_grpc_testing_installed",
+        "//tensorboard:expect_numpy_installed",
         "//tensorboard:test",
         "//tensorboard/compat/proto:protos_all_py_pb2",
         "//tensorboard/uploader/proto:protos_all_py_pb2",

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -37,6 +37,7 @@ py_test(
         "//tensorboard/uploader/proto:protos_all_py_pb2",
         "//tensorboard/uploader/proto:protos_all_py_pb2_grpc",
         "//tensorboard/util:grpc_util",
+        "//tensorboard/util:tensor_util",
         "@org_pythonhosted_mock",
     ],
 )

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -314,7 +314,7 @@ class TensorBoardExporter(object):
         while True:
             tensor_file_path = os.path.join(
                 _DIRNAME_TENSORS,
-                "%.6f.npz" % wall_time + ("_%d" % index if index else ""),
+                "%.6f" % wall_time + ("_%d" % index if index else "") + ".npz",
             )
             if not os.path.exists(
                 os.path.join(experiment_dir, tensor_file_path)

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -54,6 +54,11 @@ _MAX_INT64 = 2 ** 63 - 1
 _FILENAME_METADATA = "metadata.json"
 # Output filename for scalar data within an experiment directory.
 _FILENAME_SCALARS = "scalars.json"
+# Output filename for tensors dat within an experiment directory.
+# This file does not contain the actual values of the tensors. Instead,
+# it holds `tensors_file_path`s, which point to numpy .npz files that
+# store the actual tensor values. The json file additional additionally
+# contains other metadata such as run and tag names and `wall_time`s.
 _FILENAME_TENSORS = "tensors.json"
 # Output filename for blob sequences data within an experiment directory.
 # This file does not contain the actual contents of the blobs. Instead,

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -28,6 +28,7 @@ import string
 import time
 
 import six
+import numpy as np
 
 from tensorboard.uploader.proto import blob_pb2
 from tensorboard.uploader.proto import experiment_pb2
@@ -35,6 +36,7 @@ from tensorboard.uploader.proto import export_service_pb2
 from tensorboard.uploader import util
 from tensorboard.util import grpc_util
 from tensorboard.util import tb_logging
+from tensorboard.util import tensor_util
 
 # Characters that are assumed to be safe in filenames. Note that the
 # server's experiment IDs are base64 encodings of 16-byte blobs, so they
@@ -52,12 +54,14 @@ _MAX_INT64 = 2 ** 63 - 1
 _FILENAME_METADATA = "metadata.json"
 # Output filename for scalar data within an experiment directory.
 _FILENAME_SCALARS = "scalars.json"
+_FILENAME_TENSORS = "tensors.json"
 # Output filename for blob sequences data within an experiment directory.
 # This file does not contain the actual contents of the blobs. Instead,
 # it holds `blob_file_path`s that point to the binary files that contain
 # the blobs' contents, in addition to other metadata such as run and tag names.
 _FILENAME_BLOB_SEQUENCES = "blob_sequences.json"
 
+_DIRNAME_TENSORS = "tensors"
 _DIRNAME_BLOBS = "blobs"
 _FILENAME_BLOBS_PREFIX = "blob_"
 _FILENAME_BLOBS_SUFFIX = ".bin"
@@ -167,9 +171,11 @@ class TensorBoardExporter(object):
                         )
                         for filename in (
                             _FILENAME_SCALARS,
+                            _FILENAME_TENSORS,
                             _FILENAME_BLOB_SEQUENCES,
                         )
                     }
+                    os.mkdir(os.path.join(experiment_dir, _DIRNAME_TENSORS))
                     os.mkdir(os.path.join(experiment_dir, _DIRNAME_BLOBS))
                     for block, filename in data:
                         outfile = file_handles[filename]
@@ -230,6 +236,11 @@ class TensorBoardExporter(object):
                     response.points
                 )
                 filename = _FILENAME_SCALARS
+            elif response.HasField("tensors"):
+                json_data[u"points"] = self._process_tensor_points(
+                    response.tensors, experiment_id
+                )
+                filename = _FILENAME_TENSORS
             elif response.HasField("blob_sequences"):
                 json_data[u"points"] = self._process_blob_sequence_points(
                     response.blob_sequences, experiment_id
@@ -237,14 +248,6 @@ class TensorBoardExporter(object):
                 filename = _FILENAME_BLOB_SEQUENCES
             if filename:
                 yield json_data, filename
-            else:
-                logger.warning(
-                    "Skipping a response from experiment-data stream "
-                    "due to the lack of any valid data type (such as "
-                    "scalars and blob sequences): run=%s, tag=%s. "
-                    "Updating tensorboard install may fix this warning."
-                    % (response.run_name, response.tag_name)
-                )
 
     def _process_scalar_points(self, points):
         """Process scalar data points.
@@ -263,6 +266,61 @@ class TensorBoardExporter(object):
             u"wall_times": wall_times,
             u"values": list(points.values),
         }
+
+    def _process_tensor_points(self, points, experiment_id):
+        """Process tensor data points.
+
+        Args:
+          points: `export_service_pb2.StreamExperimentDataResponse.TensorPoints`
+            proto.
+          experiment_id: ID of the experiment that the `TensorPoints` is a part
+            of.
+
+        Returns:
+          A JSON-serializable `dict` for the steps, wall_times and paths to the
+            .npy files that contain the saved tensor values.
+        """
+        experiment_dir = _experiment_directory(self._outdir, experiment_id)
+        tensor_file_paths = []
+        wall_times = [t.ToNanoseconds() / 1e9 for t in points.wall_times]
+        for step, wall_time, tensor_proto in zip(
+            points.steps, wall_times, points.values
+        ):
+            tensor_file_path = self._get_tensor_file_path(
+                experiment_dir, wall_time
+            )
+            np.save(
+                os.path.join(experiment_dir, tensor_file_path),
+                tensor_util.make_ndarray(tensor_proto),
+            )
+            tensor_file_paths.append(tensor_file_path)
+        return {
+            u"steps": list(points.steps),
+            u"wall_times": wall_times,
+            u"tensor_file_paths": tensor_file_paths,
+        }
+
+    def _get_tensor_file_path(self, experiment_dir, wall_time):
+        """Get a nonexistent path for a tensor value.
+
+        Args:
+          experiment_dir: Experiment directory.
+          wall_time: Timestamp of the tensor (seconds since the epoch in double).
+
+        Returns:
+          A nonexistent path for the tensor, relative to the experiemnt_dir.
+        """
+        index = 0
+        while True:
+            tensor_file_path = os.path.join(
+                _DIRNAME_TENSORS,
+                "%.6f.npy" % wall_time + ("_%d" % index if index else ""),
+            )
+            if not os.path.exists(
+                os.path.join(experiment_dir, tensor_file_path)
+            ):
+                return tensor_file_path
+            index += 1
 
     def _process_blob_sequence_points(self, blob_sequences, experiment_id):
         """Process blob sequence points.

--- a/tensorboard/uploader/exporter_test.py
+++ b/tensorboard/uploader/exporter_test.py
@@ -266,9 +266,6 @@ class TensorBoardExporterTest(tb_test.TestCase):
 
     def test_e2e_success_case_with_only_tensors_data(self):
         mock_api_client = self._create_mock_api_client()
-        mock_api_client.StreamExperiments.return_value = iter(
-            [_make_experiments_response(["789"])]
-        )
 
         def stream_experiments(request, **kwargs):
             del request  # unused

--- a/tensorboard/uploader/exporter_test.py
+++ b/tensorboard/uploader/exporter_test.py
@@ -25,6 +25,7 @@ import os
 
 import grpc
 import grpc_testing
+import numpy as np
 
 try:
     # python version >= 3.3
@@ -41,6 +42,7 @@ from tensorboard.uploader import exporter as exporter_lib
 from tensorboard.uploader import test_util
 from tensorboard.uploader import util
 from tensorboard.util import grpc_util
+from tensorboard.util import tensor_util
 from tensorboard import test as tb_test
 from tensorboard.compat.proto import summary_pb2
 
@@ -132,11 +134,23 @@ class TensorBoardExporterTest(tb_test.TestCase):
         self.assertEqual(next(generator), "123")
         expected_files.append(os.path.join("experiment_123", "metadata.json"))
         expected_files.append(os.path.join("experiment_123", "scalars.json"))
+        expected_files.append(os.path.join("experiment_123", "tensors.json"))
         # blob_sequences.json should exist and be empty.
         expected_files.append(
             os.path.join("experiment_123", "blob_sequences.json")
         )
         self.assertCountEqual(expected_files, _outdir_files(outdir))
+
+        # Check that the tensors and blob_sequences data files are empty, because
+        # there are no tensors or blob sequences.
+        with open(
+            os.path.join(outdir, "experiment_123", "tensors.json")
+        ) as infile:
+            self.assertEqual(infile.read(), "")
+        with open(
+            os.path.join(outdir, "experiment_123", "blob_sequences.json")
+        ) as infile:
+            self.assertEqual(infile.read(), "")
 
         expected_eids_request = export_service_pb2.StreamExperimentsRequest()
         expected_eids_request.read_timestamp.CopyFrom(start_time_pb)
@@ -163,6 +177,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
 
         expected_files.append(os.path.join("experiment_456", "metadata.json"))
         expected_files.append(os.path.join("experiment_456", "scalars.json"))
+        expected_files.append(os.path.join("experiment_456", "tensors.json"))
         # blob_sequences.json should exist and be empty.
         expected_files.append(
             os.path.join("experiment_456", "blob_sequences.json")
@@ -178,6 +193,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
         # was in the second response batch in the list of IDs.
         expected_files.append(os.path.join("experiment_789", "metadata.json"))
         expected_files.append(os.path.join("experiment_789", "scalars.json"))
+        expected_files.append(os.path.join("experiment_789", "tensors.json"))
         # blob_sequences.json should exist and be empty.
         expected_files.append(
             os.path.join("experiment_789", "blob_sequences.json")
@@ -247,6 +263,179 @@ class TensorBoardExporterTest(tb_test.TestCase):
                 "update_time": "2002-03-04T05:06:07Z",
             },
         )
+
+    def test_e2e_success_case_with_only_tensors_data(self):
+        mock_api_client = self._create_mock_api_client()
+        mock_api_client.StreamExperiments.return_value = iter(
+            [_make_experiments_response(["789"])]
+        )
+
+        def stream_experiments(request, **kwargs):
+            del request  # unused
+            self.assertEqual(kwargs["metadata"], grpc_util.version_metadata())
+
+            response = export_service_pb2.StreamExperimentsResponse()
+            response.experiments.add(experiment_id="123")
+            yield response
+
+        def stream_experiment_data(request, **kwargs):
+            self.assertEqual(kwargs["metadata"], grpc_util.version_metadata())
+            for run in ("train_1", "train_2"):
+                for tag in ("dense_1/kernel", "dense_1/bias"):
+                    response = export_service_pb2.StreamExperimentDataResponse()
+                    response.run_name = run
+                    response.tag_name = tag
+                    display_name = "%s:%s" % (request.experiment_id, tag)
+                    response.tag_metadata.CopyFrom(
+                        test_util.scalar_metadata(display_name)
+                    )
+                    for step in range(2):
+                        response.tensors.steps.append(step)
+                        response.tensors.wall_times.add(
+                            seconds=1571084520 + step,
+                            nanos=862939144 if run == "train_1" else 962939144,
+                        )
+                        response.tensors.values.append(
+                            tensor_util.make_tensor_proto(
+                                np.ones([3, 2]) * step
+                            )
+                        )
+                    yield response
+
+        mock_api_client.StreamExperiments = mock.Mock(wraps=stream_experiments)
+        mock_api_client.StreamExperimentData = mock.Mock(
+            wraps=stream_experiment_data
+        )
+
+        outdir = os.path.join(self.get_temp_dir(), "outdir")
+        exporter = exporter_lib.TensorBoardExporter(mock_api_client, outdir)
+        start_time = 1571084846.25
+        start_time_pb = test_util.timestamp_pb(1571084846250000000)
+
+        generator = exporter.export(read_time=start_time)
+        expected_files = []
+        self.assertTrue(os.path.isdir(outdir))
+        self.assertCountEqual(expected_files, _outdir_files(outdir))
+        mock_api_client.StreamExperiments.assert_not_called()
+        mock_api_client.StreamExperimentData.assert_not_called()
+
+        # The first iteration should request the list of experiments and
+        # data for one of them.
+        self.assertEqual(next(generator), "123")
+        expected_files.append(os.path.join("experiment_123", "metadata.json"))
+        # scalars.json should exist and be empty.
+        expected_files.append(os.path.join("experiment_123", "scalars.json"))
+        expected_files.append(os.path.join("experiment_123", "tensors.json"))
+        # blob_sequences.json should exist and be empty.
+        expected_files.append(
+            os.path.join("experiment_123", "blob_sequences.json")
+        )
+        expected_files.append(
+            os.path.join("experiment_123", "tensors", "1571084520.862939.npz")
+        )
+        expected_files.append(
+            os.path.join("experiment_123", "tensors", "1571084520.862939_1.npz")
+        )
+        expected_files.append(
+            os.path.join("experiment_123", "tensors", "1571084520.962939.npz")
+        )
+        expected_files.append(
+            os.path.join("experiment_123", "tensors", "1571084520.962939_1.npz")
+        )
+        self.assertCountEqual(expected_files, _outdir_files(outdir))
+
+        # Check that the scalars and blob_sequences data files are empty, because
+        # there are no scalars or blob sequences.
+        with open(
+            os.path.join(outdir, "experiment_123", "scalars.json")
+        ) as infile:
+            self.assertEqual(infile.read(), "")
+        with open(
+            os.path.join(outdir, "experiment_123", "blob_sequences.json")
+        ) as infile:
+            self.assertEqual(infile.read(), "")
+
+        expected_eids_request = export_service_pb2.StreamExperimentsRequest()
+        expected_eids_request.read_timestamp.CopyFrom(start_time_pb)
+        expected_eids_request.limit = 2 ** 63 - 1
+        expected_eids_request.experiments_mask.create_time = True
+        expected_eids_request.experiments_mask.update_time = True
+        expected_eids_request.experiments_mask.name = True
+        expected_eids_request.experiments_mask.description = True
+        mock_api_client.StreamExperiments.assert_called_once_with(
+            expected_eids_request, metadata=grpc_util.version_metadata()
+        )
+
+        expected_data_request = export_service_pb2.StreamExperimentDataRequest()
+        expected_data_request.experiment_id = "123"
+        expected_data_request.read_timestamp.CopyFrom(start_time_pb)
+        mock_api_client.StreamExperimentData.assert_called_once_with(
+            expected_data_request, metadata=grpc_util.version_metadata()
+        )
+
+        # The final StreamExperiments continuation shouldn't need to send any
+        # RPCs.
+        mock_api_client.StreamExperiments.reset_mock()
+        mock_api_client.StreamExperimentData.reset_mock()
+        self.assertEqual(list(generator), [])
+
+        # Check tensor data.
+        with open(
+            os.path.join(outdir, "experiment_123", "tensors.json")
+        ) as infile:
+            jsons = [json.loads(line) for line in infile]
+        self.assertLen(jsons, 4)
+
+        datum = jsons[0]
+        self.assertEqual(datum.pop("run"), "train_1")
+        self.assertEqual(datum.pop("tag"), "dense_1/kernel")
+        summary_metadata = summary_pb2.SummaryMetadata.FromString(
+            base64.b64decode(datum.pop("summary_metadata"))
+        )
+        expected_summary_metadata = test_util.scalar_metadata(
+            "123:dense_1/kernel"
+        )
+        self.assertEqual(summary_metadata, expected_summary_metadata)
+        points = datum.pop("points")
+        self.assertEqual(points.pop("steps"), [0, 1])
+        self.assertEqual(
+            points.pop("tensors_file_path"),
+            os.path.join("tensors", "1571084520.862939.npz"),
+        )
+        self.assertEqual(datum, {})
+
+        datum = jsons[3]
+        self.assertEqual(datum.pop("run"), "train_2")
+        self.assertEqual(datum.pop("tag"), "dense_1/bias")
+        summary_metadata = summary_pb2.SummaryMetadata.FromString(
+            base64.b64decode(datum.pop("summary_metadata"))
+        )
+        expected_summary_metadata = test_util.scalar_metadata(
+            "123:dense_1/bias"
+        )
+        self.assertEqual(summary_metadata, expected_summary_metadata)
+        points = datum.pop("points")
+        self.assertEqual(points.pop("steps"), [0, 1])
+        self.assertEqual(
+            points.pop("tensors_file_path"),
+            os.path.join("tensors", "1571084520.962939_1.npz"),
+        )
+        self.assertEqual(datum, {})
+
+        # Load and check the tensor data from the save .npz files.
+        for filename in (
+            "1571084520.862939.npz",
+            "1571084520.862939_1.npz",
+            "1571084520.962939.npz",
+            "1571084520.962939_1.npz",
+        ):
+            tensors = np.load(
+                os.path.join(outdir, "experiment_123", "tensors", filename)
+            )
+            tensors = [tensors[key] for key in tensors.keys()]
+            self.assertLen(tensors, 2)
+            np.testing.assert_array_equal(tensors[0], 0 * np.ones([3, 2]))
+            np.testing.assert_array_equal(tensors[1], 1 * np.ones([3, 2]))
 
     def test_e2e_success_case_with_blob_sequence_data(self):
         """Covers exporting of complete and incomplete blob sequences
@@ -346,8 +535,9 @@ class TensorBoardExporterTest(tb_test.TestCase):
         # data for one of them.
         self.assertEqual(next(generator), "123")
         expected_files.append(os.path.join("experiment_123", "metadata.json"))
-        # scalars.json should exist and be empty.
+        # scalars.json and tensors.json should exist and be empty.
         expected_files.append(os.path.join("experiment_123", "scalars.json"))
+        expected_files.append(os.path.join("experiment_123", "tensors.json"))
         expected_files.append(
             os.path.join("experiment_123", "blob_sequences.json")
         )
@@ -358,9 +548,14 @@ class TensorBoardExporterTest(tb_test.TestCase):
         # an unfinished blob.
         self.assertCountEqual(expected_files, _outdir_files(outdir))
 
-        # Check that the scalars data file is empty, because there no scalars.
+        # Check that the scalars and tensors data files are empty, because there
+        # no scalars or tensors.
         with open(
             os.path.join(outdir, "experiment_123", "scalars.json")
+        ) as infile:
+            self.assertEqual(infile.read(), "")
+        with open(
+            os.path.join(outdir, "experiment_123", "tensors.json")
         ) as infile:
             self.assertEqual(infile.read(), "")
 


### PR DESCRIPTION
* Motivation for features / changes
  * Implement the exporting of tensor values (used in Histograms and other tensorboard dashboards)
* Technical description of changes
  * Add a new json file in the exported experiment directory: tensors.json. It contains runs, tags, timestamps and pointers to .npy files in the tensors/ subdirectory.
  * Tensor values are saved as .npy (numpy uncompressed) files through the `numpy.save()` method to the tensors/ subdirectory. Their file names are deduplicated wall_times followed by the .npy extension.
* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests added.
  * Manual testing against a dev api_endpoint.

