### PR TITLE
[DebuggerV2] Clicking on Inf/NaN alerts scrolls to the 1st graph execution with Inf/NaN

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -106,6 +106,7 @@ const initialState: DebuggerState = {
     alertsBreakdown: {},
     alerts: {},
     executionIndices: {},
+    graphExecutionIndices: {},
     focusType: null,
   },
   executions: createInitialExecutionsState(),
@@ -225,13 +226,22 @@ const reducer = createReducer(
       ]
         ? state.alerts.executionIndices[alertType].slice()
         : [];
+      const graphExecutionIndices: number[] = state.alerts
+        .graphExecutionIndices[alertType]
+        ? state.alerts.graphExecutionIndices[alertType].slice()
+        : [];
       for (let i = 0; i < alerts.length; ++i) {
         const alertIndex = begin + i;
         const alert = alerts[i];
         updatedAlerts[alertIndex] = alert;
         if (alert.alert_type === AlertType.INF_NAN_ALERT) {
           // TOOD(cais): Deal with other alert types with execution index.
-          executionIndices[alertIndex] = (alert as InfNanAlert).execution_index;
+          const infNanAlert = alert as InfNanAlert;
+          executionIndices[alertIndex] = infNanAlert.execution_index;
+          if (infNanAlert.graph_execution_trace_index !== null) {
+            graphExecutionIndices[alertIndex] =
+              infNanAlert.graph_execution_trace_index;
+          }
         }
       }
       if (state.alerts.alerts[alertType] !== undefined) {
@@ -239,6 +249,7 @@ const reducer = createReducer(
       }
 
       let scrollBeginIndex = state.executions.scrollBeginIndex;
+      let graphExecutionFocusIndex = state.graphExecutions.focusIndex;
       if (alertType === AlertType.INF_NAN_ALERT && begin === 0) {
         // TOOD(cais): Deal with other alert types with execution index.
         const alert = alerts[0] as InfNanAlert;
@@ -248,6 +259,9 @@ const reducer = createReducer(
           0,
           executionIndex - Math.floor(state.executions.displayCount / 2)
         );
+        if (alert.graph_execution_trace_index !== null) {
+          graphExecutionFocusIndex = alert.graph_execution_trace_index;
+        }
       }
 
       return {
@@ -255,6 +269,10 @@ const reducer = createReducer(
         executions: {
           ...state.executions,
           scrollBeginIndex,
+        },
+        graphExecutions: {
+          ...state.graphExecutions,
+          focusIndex: graphExecutionFocusIndex,
         },
         alerts: {
           ...state.alerts,
@@ -272,6 +290,10 @@ const reducer = createReducer(
           executionIndices: {
             ...state.alerts.executionIndices,
             [alertType]: executionIndices,
+          },
+          graphExecutionIndices: {
+            ...state.alerts.graphExecutionIndices,
+            [alertType]: graphExecutionIndices,
           },
         },
       };

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
@@ -253,71 +253,86 @@ describe('Debugger reducers', () => {
         expectedScrollBegin: 0,
       },
     ]) {
-      it('Updates alerts data and scrollBeginIndex: empty initial state', () => {
-        const firstAlertExecutionIndex = 10;
-        const state = createDebuggerState({
-          activeRunId: '__default_debugger_run__',
-          alerts: createAlertsState({
-            alertsLoaded: {
-              state: DataLoadState.LOADING,
-              lastLoadedTimeInMs: null,
-            },
-          }),
-          executions: createDebuggerExecutionsState({
-            displayCount,
-            scrollBeginIndex: 0,
-          }),
-        }); // `alerts` state is in an empty initial state.
-        const alert0 = createTestInfNanAlert({
-          op_type: 'RealDiv',
-          execution_index: firstAlertExecutionIndex,
-        });
-        const alert1 = createTestInfNanAlert({
-          op_type: 'Log',
-          execution_index: firstAlertExecutionIndex + 1,
-        });
-        const nextState = reducers(
-          state,
-          actions.alertsOfTypeLoaded({
-            numAlerts: 2,
-            alertsBreakdown: {
-              InfNanAlert: 2,
-            },
-            begin: 0,
-            end: 2,
-            alertType: 'InfNanAlert',
-            alerts: [alert0, alert1],
-          })
-        );
-        expect(nextState.alerts.alertsLoaded.state).toBe(DataLoadState.LOADED);
-        expect(
-          nextState.alerts.alertsLoaded.lastLoadedTimeInMs
-        ).toBeGreaterThan(0);
-        expect(nextState.alerts.numAlerts).toBe(2);
-        expect(nextState.alerts.alertsBreakdown).toEqual({
-          [AlertType.INF_NAN_ALERT]: 2,
-        });
-        expect(Object.keys(nextState.alerts.alerts)).toEqual([
-          AlertType.INF_NAN_ALERT,
-        ]);
-        const alertsOfType = nextState.alerts.alerts[AlertType.INF_NAN_ALERT];
-        expect(Object.keys(alertsOfType).length).toBe(2);
-        expect(alertsOfType[0]).toEqual(alert0);
-        expect(alertsOfType[1]).toEqual(alert1);
-        expect(Object.keys(nextState.alerts.executionIndices)).toEqual([
-          AlertType.INF_NAN_ALERT,
-        ]);
-        const executionIndices =
-          nextState.alerts.executionIndices[AlertType.INF_NAN_ALERT];
-        expect(executionIndices).toEqual([
-          firstAlertExecutionIndex,
-          firstAlertExecutionIndex + 1,
-        ]);
-        // Verify that the first alert is scrolled into view.
-        expect(nextState.executions.scrollBeginIndex).toEqual(
-          expectedScrollBegin
-        );
-      });
+      it(
+        'Updates alerts data and scrollBeginIndex and graph-exec focusIndex: ' +
+          'empty initial state',
+        () => {
+          const firstAlertExecutionIndex = 10;
+          const firstAlertGraphExecutionIndex = 100;
+          const state = createDebuggerState({
+            activeRunId: '__default_debugger_run__',
+            alerts: createAlertsState({
+              alertsLoaded: {
+                state: DataLoadState.LOADING,
+                lastLoadedTimeInMs: null,
+              },
+            }),
+            executions: createDebuggerExecutionsState({
+              displayCount,
+              scrollBeginIndex: 0,
+            }),
+          }); // `alerts` state is in an empty initial state.
+          const alert0 = createTestInfNanAlert({
+            op_type: 'RealDiv',
+            execution_index: firstAlertExecutionIndex,
+            graph_execution_trace_index: 100,
+          });
+          const alert1 = createTestInfNanAlert({
+            op_type: 'Log',
+            execution_index: firstAlertExecutionIndex + 1,
+            graph_execution_trace_index: firstAlertGraphExecutionIndex * 2,
+          });
+          const nextState = reducers(
+            state,
+            actions.alertsOfTypeLoaded({
+              numAlerts: 2,
+              alertsBreakdown: {
+                InfNanAlert: 2,
+              },
+              begin: 0,
+              end: 2,
+              alertType: 'InfNanAlert',
+              alerts: [alert0, alert1],
+            })
+          );
+          expect(nextState.alerts.alertsLoaded.state).toBe(
+            DataLoadState.LOADED
+          );
+          expect(
+            nextState.alerts.alertsLoaded.lastLoadedTimeInMs
+          ).toBeGreaterThan(0);
+          expect(nextState.alerts.numAlerts).toBe(2);
+          expect(nextState.alerts.alertsBreakdown).toEqual({
+            [AlertType.INF_NAN_ALERT]: 2,
+          });
+          expect(Object.keys(nextState.alerts.alerts)).toEqual([
+            AlertType.INF_NAN_ALERT,
+          ]);
+          const alertsOfType = nextState.alerts.alerts[AlertType.INF_NAN_ALERT];
+          expect(Object.keys(alertsOfType).length).toBe(2);
+          expect(alertsOfType[0]).toEqual(alert0);
+          expect(alertsOfType[1]).toEqual(alert1);
+          expect(Object.keys(nextState.alerts.executionIndices)).toEqual([
+            AlertType.INF_NAN_ALERT,
+          ]);
+          const executionIndices =
+            nextState.alerts.executionIndices[AlertType.INF_NAN_ALERT];
+          expect(executionIndices).toEqual([
+            firstAlertExecutionIndex,
+            firstAlertExecutionIndex + 1,
+          ]);
+          // Verify that the top-level execution for the first alert is scrolled
+          // into view.
+          expect(nextState.executions.scrollBeginIndex).toBe(
+            expectedScrollBegin
+          );
+          // Verify that the intra-graph execution for the first alert
+          // with a graph_execution_trace_index is focused on.
+          expect(nextState.graphExecutions.focusIndex).toBe(
+            firstAlertGraphExecutionIndex
+          );
+        }
+      );
     }
 
     it('Updates alerts data: non-empty initial state', () => {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
@@ -321,13 +321,19 @@ describe('Debugger reducers', () => {
             firstAlertExecutionIndex,
             firstAlertExecutionIndex + 1,
           ]);
+          const graphExecutionIndices =
+            nextState.alerts.graphExecutionIndices[AlertType.INF_NAN_ALERT];
+          expect(graphExecutionIndices).toEqual([
+            firstAlertGraphExecutionIndex,
+            firstAlertGraphExecutionIndex * 2,
+          ]);
           // Verify that the top-level execution for the first alert is scrolled
           // into view.
           expect(nextState.executions.scrollBeginIndex).toBe(
             expectedScrollBegin
           );
-          // Verify that the intra-graph execution for the first alert
-          // with a graph_execution_trace_index is focused on.
+          // Verify that the intra-graph execution for the first alert with a
+          // graph_execution_trace_index is focused on.
           expect(nextState.graphExecutions.focusIndex).toBe(
             firstAlertGraphExecutionIndex
           );

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
@@ -309,24 +309,22 @@ describe('Debugger reducers', () => {
             AlertType.INF_NAN_ALERT,
           ]);
           const alertsOfType = nextState.alerts.alerts[AlertType.INF_NAN_ALERT];
-          expect(Object.keys(alertsOfType).length).toBe(2);
-          expect(alertsOfType[0]).toEqual(alert0);
-          expect(alertsOfType[1]).toEqual(alert1);
-          expect(Object.keys(nextState.alerts.executionIndices)).toEqual([
-            AlertType.INF_NAN_ALERT,
-          ]);
-          const executionIndices =
-            nextState.alerts.executionIndices[AlertType.INF_NAN_ALERT];
-          expect(executionIndices).toEqual([
-            firstAlertExecutionIndex,
-            firstAlertExecutionIndex + 1,
-          ]);
-          const graphExecutionIndices =
-            nextState.alerts.graphExecutionIndices[AlertType.INF_NAN_ALERT];
-          expect(graphExecutionIndices).toEqual([
-            firstAlertGraphExecutionIndex,
-            firstAlertGraphExecutionIndex * 2,
-          ]);
+          expect(alertsOfType).toEqual({
+            0: alert0,
+            1: alert1,
+          });
+          expect(nextState.alerts.executionIndices).toEqual({
+            [AlertType.INF_NAN_ALERT]: [
+              firstAlertExecutionIndex,
+              firstAlertExecutionIndex + 1,
+            ],
+          });
+          expect(nextState.alerts.graphExecutionIndices).toEqual({
+            [AlertType.INF_NAN_ALERT]: [
+              firstAlertGraphExecutionIndex,
+              firstAlertGraphExecutionIndex * 2,
+            ],
+          });
           // Verify that the top-level execution for the first alert is scrolled
           // into view.
           expect(nextState.executions.scrollBeginIndex).toBe(
@@ -345,10 +343,12 @@ describe('Debugger reducers', () => {
       const alert0 = createTestInfNanAlert({
         op_type: 'RealDiv',
         execution_index: 10,
+        graph_execution_trace_index: 5,
       });
       const alert1 = createTestInfNanAlert({
         op_type: 'Log',
         execution_index: 11,
+        graph_execution_trace_index: 6,
       });
       const state = createDebuggerState({
         activeRunId: '__default_debugger_run__',
@@ -361,6 +361,12 @@ describe('Debugger reducers', () => {
           alertsBreakdown: {[AlertType.INF_NAN_ALERT]: 1},
           alerts: {
             [AlertType.INF_NAN_ALERT]: {0: alert0},
+          },
+          executionIndices: {
+            [AlertType.INF_NAN_ALERT]: [10],
+          },
+          graphExecutionIndices: {
+            [AlertType.INF_NAN_ALERT]: [5],
           },
         }),
       }); // `alerts` state is in a non-empty initial state.
@@ -386,19 +392,18 @@ describe('Debugger reducers', () => {
       expect(nextState.alerts.alertsBreakdown).toEqual({
         [AlertType.INF_NAN_ALERT]: 2,
       });
-      expect(Object.keys(nextState.alerts.alerts)).toEqual([
-        AlertType.INF_NAN_ALERT,
-      ]);
-      const alertsOfType = nextState.alerts.alerts[AlertType.INF_NAN_ALERT];
-      expect(Object.keys(alertsOfType).length).toBe(2);
-      expect(alertsOfType[0]).toEqual(alert0);
-      expect(alertsOfType[1]).toEqual(alert1);
-      expect(Object.keys(nextState.alerts.executionIndices)).toEqual([
-        AlertType.INF_NAN_ALERT,
-      ]);
-      const executionIndices =
-        nextState.alerts.executionIndices[AlertType.INF_NAN_ALERT];
-      expect(executionIndices[1]).toBe(11);
+      expect(nextState.alerts.alerts).toEqual({
+        [AlertType.INF_NAN_ALERT]: {
+          0: alert0,
+          1: alert1,
+        },
+      });
+      expect(nextState.alerts.executionIndices).toEqual({
+        [AlertType.INF_NAN_ALERT]: [10, 11],
+      });
+      expect(nextState.alerts.graphExecutionIndices).toEqual({
+        [AlertType.INF_NAN_ALERT]: [5, 6],
+      });
     });
 
     it('Updates alerts data: existing alert types other than the loaded', () => {
@@ -451,15 +456,13 @@ describe('Debugger reducers', () => {
         [AlertType.INF_NAN_ALERT]: 2,
         [AlertType.TENSOR_SHAPE_ALERT]: 1,
       });
-      expect(Object.keys(nextState.alerts.alerts).length).toBe(2);
-      const infNanAlerts = nextState.alerts.alerts[AlertType.INF_NAN_ALERT];
-      expect(Object.keys(infNanAlerts).length).toBe(2);
-      expect(infNanAlerts[0]).toEqual(alert0);
-      expect(infNanAlerts[1]).toEqual(alert1);
-      const tensorShapeAlerts =
-        nextState.alerts.alerts[AlertType.TENSOR_SHAPE_ALERT];
-      expect(Object.keys(tensorShapeAlerts).length).toBe(1);
-      expect(tensorShapeAlerts[0]).toEqual(tensorShapeAlert);
+      expect(nextState.alerts.alerts).toEqual({
+        [AlertType.INF_NAN_ALERT]: {
+          0: alert0,
+          1: alert1,
+        },
+        [AlertType.TENSOR_SHAPE_ALERT]: {0: tensorShapeAlert},
+      });
     });
   });
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -251,6 +251,13 @@ export const getGraphExecutionData = createSelector(
   }
 );
 
+export const getGraphExecutionFocusIndex = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): number | null => {
+    return state.graphExecutions.focusIndex;
+  }
+);
+
 /**
  * Get the focused alert types (if any) of the execution digests current being
  * displayed. For each displayed execution digest, there are two possibilities:

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
@@ -26,6 +26,7 @@ import {
   getGraphExecutionDataLoadingPages,
   getGraphExecutionDataPageLoadedSizes,
   getGraphExecutionDisplayCount,
+  getGraphExecutionFocusIndex,
   getGraphExecutionPageSize,
   getGraphExecutionScrollBeginIndex,
   getLoadedAlertsOfFocusedType,
@@ -889,5 +890,20 @@ describe('debugger selectors', () => {
         10: createTestGraphExecution(),
       });
     });
+  });
+
+  describe('getGraphExecutionFocusIndex', () => {
+    for (const focusIndex of [null, 0, 100]) {
+      it(`returns correct value: ${JSON.stringify(focusIndex)}`, () => {
+        const state = createState(
+          createDebuggerState({
+            graphExecutions: createDebuggerGraphExecutionsState({
+              focusIndex,
+            }),
+          })
+        );
+        expect(getGraphExecutionFocusIndex(state)).toBe(focusIndex);
+      });
+    }
   });
 });

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -248,9 +248,13 @@ export interface Alerts {
   // specific `alertType`.
   alerts: {[alertType: string]: AlertsByIndex};
 
-  // A map from alert index to top-level execution index, arranged by alert
-  // types. Applicable only to alerts that involve top-level execution.
+  // A map from alert type to top-level execution indices.
+  // Applicable only to alerts that involve top-level execution.
   executionIndices: {[alertType: string]: number[]};
+
+  // A map from alert type to intra-graph execution indices.
+  // Applicable only to alerts that involve intra-graph execution.
+  graphExecutionIndices: {[alertType: string]: number[]};
 
   // Which type of existing alerts is focused on (if any).
   // `null` corresponds to no focus.

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
@@ -143,6 +143,7 @@ export function createAlertsState(override?: Partial<Alerts>): Alerts {
     alertsBreakdown: {},
     alerts: {},
     executionIndices: {},
+    graphExecutionIndices: {},
     focusType: null,
     ...override,
   };

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
@@ -51,6 +51,7 @@ tf_ts_library(
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline",
+        "//tensorboard/webapp/angular:expect_angular_cdk_scrolling",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "@npm//@angular/common",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
@@ -22,11 +22,16 @@ limitations under the License.
   padding-left: 10px;
 }
 
+.graph-execution-focus {
+  display: inline-block;
+}
+
 .graph-execution-index {
   color: #757575;
   display: inline-block;
-  width: 40px;
   padding-right: 4px;
+  text-align: right;
+  width: 40px;
 }
 
 .graph-executions-viewport {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
@@ -32,6 +32,9 @@ limitations under the License.
     >
       <div class="tensor-item">
         <div class="graph-execution-index">
+          <div *ngIf="i === focusIndex" class="graph-execution-focus">
+            ▶
+          </div>
           {{ i }}
         </div>
         <div *ngIf="graphExecutionData[i]; else dataLoading">

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
@@ -55,7 +55,11 @@ export class GraphExecutionsComponent {
   private readonly viewPort?: CdkVirtualScrollViewport;
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (this.viewPort && changes['focusIndex']) {
+    if (
+      this.viewPort &&
+      changes['focusIndex'] &&
+      changes['focusIndex'].currentValue !== null
+    ) {
       const range = this.viewPort.getRenderedRange();
       const scrollIndex = changes['focusIndex'].currentValue;
       // Make sure that the index is scrolled to one third the view port.

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
@@ -56,18 +56,17 @@ export class GraphExecutionsComponent {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (this.viewPort && changes['focusIndex']) {
-      console.log('focusIndex -->', changes['focusIndex'].currentValue); // DEBUG
       const range = this.viewPort.getRenderedRange();
       const scrollIndex = changes['focusIndex'].currentValue;
-      // Handle programmatic scroll.
-      if (scrollIndex < range.start || scrollIndex > range.end) {
-        // Make sure that the index is scrolled to one third the view port.
-        // This is nicer than scrolling it merely to the top.
-        const halfRange = Math.floor((range.end - range.start) * 0.33);
-        const targetIndex = Math.max(scrollIndex - halfRange, 0);
-        this.viewPort.scrollToIndex(targetIndex);
-        // TODO(cais): Add unit test. DO NOT SUBMIT.
-      }
+      // Make sure that the index is scrolled to one third the view port.
+      // This is nicer than scrolling it merely to the top.
+      const thirdRange = Math.round((range.end - range.start) / 3);
+      const targetIndex = Math.max(scrollIndex - thirdRange, 0);
+      this.viewPort.scrollToIndex(targetIndex);
     }
   }
+
+  TEST_ONLY = {
+    getViewPort: () => this.viewPort,
+  };
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
@@ -34,7 +34,6 @@ import {State} from '../../store/debugger_types';
       [graphExecutionIndices]="graphExecutionIndices$ | async"
       [focusIndex]="focusIndex$ | async"
       (onScrolledIndexChange)="onScrolledIndexChange($event)"
-      P
     ></graph-executions-component>
   `,
 })

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
@@ -16,7 +16,11 @@ import {Component} from '@angular/core';
 import {createSelector, select, Store} from '@ngrx/store';
 
 import {graphExecutionScrollToIndex} from '../../actions';
-import {getGraphExecutionData, getNumGraphExecutions} from '../../store';
+import {
+  getGraphExecutionData,
+  getGraphExecutionFocusIndex,
+  getNumGraphExecutions,
+} from '../../store';
 import {State} from '../../store/debugger_types';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
@@ -28,7 +32,9 @@ import {State} from '../../store/debugger_types';
       [numGraphExecutions]="numGraphExecutions$ | async"
       [graphExecutionData]="graphExecutionData$ | async"
       [graphExecutionIndices]="graphExecutionIndices$ | async"
+      [focusIndex]="focusIndex$ | async"
       (onScrolledIndexChange)="onScrolledIndexChange($event)"
+      P
     ></graph-executions-component>
   `,
 })
@@ -50,6 +56,8 @@ export class GraphExecutionsContainer {
       )
     )
   );
+
+  readonly focusIndex$ = this.store.pipe(select(getGraphExecutionFocusIndex));
 
   onScrolledIndexChange(scrolledIndex: number) {
     this.store.dispatch(graphExecutionScrollToIndex({index: scrolledIndex}));

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -29,7 +29,11 @@ import {
   GraphExecution,
   TensorDebugMode,
 } from '../../store/debugger_types';
-import {getNumGraphExecutions, getGraphExecutionData} from '../../store';
+import {
+  getGraphExecutionData,
+  getGraphExecutionFocusIndex,
+  getNumGraphExecutions,
+} from '../../store';
 import {
   createDebuggerState,
   createState,
@@ -101,6 +105,7 @@ describe('Graph Executions Container', () => {
       });
     }
     store.overrideSelector(getGraphExecutionData, graphExecutionData);
+    store.overrideSelector(getGraphExecutionFocusIndex, 99);
     fixture.autoDetectChanges();
     tick();
 
@@ -126,6 +131,14 @@ describe('Graph Executions Container', () => {
     expect(opTypes.length).toBe(tensorContainers.length);
     for (let i = 0; i < tensorNames.length; ++i) {
       expect(graphExecutionIndices[i].nativeElement.innerText).toBe(`${i}`);
+      const focusElement = graphExecutionIndices[i].query(
+        By.css('.graph-execution-focus')
+      );
+      if (i === 99) {
+        expect(focusElement.nativeElement.innerText).toBe('▶');
+      } else {
+        expect(focusElement).toBeNull();
+      }
       expect(tensorNames[i].nativeElement.innerText).toBe(`TestOp_${i}:0`);
       expect(opTypes[i].nativeElement.innerText).toBe(`OpType_${i}`);
     }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -35,7 +35,6 @@ import {
   getGraphExecutionData,
   getGraphExecutionFocusIndex,
   getNumGraphExecutions,
-  getGraphExecutionDisplayCount,
 } from '../../store';
 import {
   createDebuggerState,
@@ -188,7 +187,7 @@ describe('Graph Executions Container', () => {
   for (const oldFocusIndex of [null, 0, 119]) {
     for (const newFocusIndex of [1, 60, 100, 118]) {
       it(
-        `Calls scrollToIndex on focusIndex change: ` +
+        `calls scrollToIndex on focusIndex change: ` +
           `${oldFocusIndex} --> ${newFocusIndex}`,
         fakeAsync(() => {
           const fixture = TestBed.createComponent(GraphExecutionsComponent);


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing DebuggerV2
  * Address the issue in which clicking on the "Inf/NaN" category in the alerts section of the app can focus only onto eager-execution events and not intra-graph execution events previously.
* Technical description of changes
  * Add selector for `DebuggerState.graphExecutions.focusIndex`
  * Set `DebuggerState.graphExecutions.focusIndex` in the reducer for action `alertsOfTypeLoaded`
  * Let the `focusIndex` be an input to `GraphExecutionComponent`. The `Component` listens to changes in the input value with `ngOnChange()` and calls the `scrollToIndex()` method of its constituent cdk-virtual-scroll-viewport element during changes.
  * Add an indicator div (right-pointing filled triangle) for the currently-focused graph-execution row in the cdk-virtual-scroll-viewport.
* Screenshots of UI changes
  * ![image](https://user-images.githubusercontent.com/16824702/80927169-d9009d00-8d69-11ea-81f2-4cae50a893e5.png)
* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests added for the new selector, reducer and component logic.
  * Manual testing against a real tfdbg2 logdir (see screenshot above.)

