### PR TITLE
 vulc: fix mangled DOM due to a bug in the printer

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -187,7 +187,6 @@ public final class Vulcanize {
     createFile(
         jsOutput, shouldExtractJs ? extractAndTransformJavaScript(document, jsPath) : "");
     Document normalizedDocument = getFlattenedHTML5Document(document);
-    normalizedDocument.outputSettings().syntax(Document.OutputSettings.Syntax.html);
     createFile(output, normalizedDocument.toString());
   }
 


### PR DESCRIPTION
The issue is better described in #3557. Please refer to it.

Our HTML module traversal relies on the `document` so we cannot create
the document without nested document in one go. Instead, we do a post
processing of the document to prune away all the `document` so the
default jsoup's printer can print them without awkward `<#root>`
elements.

index.html size difference:
```
555323 before
554749 after
```

Fixes #3557.