### PR TITLE
ng: set active plugin to first enabled plugin

### DIFF
--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -57,11 +57,11 @@ const reducer = createReducer(
   on(
     actions.pluginsListingLoaded,
     (state: CoreState, {plugins}): CoreState => {
-      const firstActivePlugin =
+      const firstEnabledPluginId =
         Object.keys(plugins).find((pluginId) => {
           return plugins[pluginId].enabled;
         }) || null;
-      const activePlugin = state.activePlugin || firstActivePlugin;
+      const activePlugin = state.activePlugin || firstEnabledPluginId;
       return {
         ...state,
         activePlugin,

--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -57,9 +57,11 @@ const reducer = createReducer(
   on(
     actions.pluginsListingLoaded,
     (state: CoreState, {plugins}): CoreState => {
-      const [firstPlugin] = Object.keys(plugins);
-      let activePlugin =
-        state.activePlugin !== null ? state.activePlugin : firstPlugin;
+      const firstActivePlugin =
+        Object.keys(plugins).find((pluginId) => {
+          return plugins[pluginId].enabled;
+        }) || null;
+      const activePlugin = state.activePlugin || firstActivePlugin;
       return {
         ...state,
         activePlugin,

--- a/tensorboard/webapp/core/store/core_reducers_test.ts
+++ b/tensorboard/webapp/core/store/core_reducers_test.ts
@@ -14,7 +14,11 @@ limitations under the License.
 ==============================================================================*/
 import * as actions from '../actions';
 import {reducers} from './core_reducers';
-import {createPluginMetadata, createCoreState} from '../testing';
+import {
+  buildPluginMetadata,
+  createPluginMetadata,
+  createCoreState,
+} from '../testing';
 import {DataLoadState} from '../../types/data';
 
 function createPluginsListing() {
@@ -130,15 +134,36 @@ describe('core reducer', () => {
       });
     });
 
-    it('sets activePlugin to the first plugin (by key order) when not defined', () => {
+    it('sets activePlugin to the first enabled plugin when not defined', () => {
       const state = createCoreState({activePlugin: null, plugins: {}});
 
       const nextState = reducers(
         state,
-        actions.pluginsListingLoaded({plugins: createPluginsListing()})
+        actions.pluginsListingLoaded({
+          plugins: {
+            foo: buildPluginMetadata({tab_name: 'foo', enabled: false}),
+            bar: buildPluginMetadata({tab_name: 'bar', enabled: true}),
+          },
+        })
       );
 
-      expect(nextState.activePlugin).toBe('core');
+      expect(nextState.activePlugin).toBe('bar');
+    });
+
+    it('sets the plugin to null when nothing is active', () => {
+      const state = createCoreState({activePlugin: null, plugins: {}});
+
+      const nextState = reducers(
+        state,
+        actions.pluginsListingLoaded({
+          plugins: {
+            foo: buildPluginMetadata({tab_name: 'foo', enabled: false}),
+            bar: buildPluginMetadata({tab_name: 'bar', enabled: false}),
+          },
+        })
+      );
+
+      expect(nextState.activePlugin).toBeNull();
     });
 
     it('does not change activePlugin when already defined', () => {


### PR DESCRIPTION
Previously, we were wrongly setting it to the first plugin in the
object.

Now, we set it to the first active plugin. If nothing is active, set
it to `null`.