### PR TITLE
ng: no active plugin warning page

### DIFF
--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -49,7 +49,7 @@ limitations under the License.
     </p>
 
     <p>
-      <i>Last reload: {{lastUpdated | date}}</i>
+      <i>Last reload: {{lastUpdated | date: 'medium'}}</i>
     </p>
   </div>
 </div>

--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -21,3 +21,35 @@ limitations under the License.
   <!-- render Angular built-in plugins with a dynamic component resolver. -->
   <ng-container #ngPluginContainer></ng-container>
 </div>
+<div *ngIf="noEnabledPlugin" class="no-plugin">
+  <div class="warning-message">
+    <h3>No dashboards are active for the current data set.</h3>
+    <p>Probable causes:</p>
+    <ul>
+      <li>You haven’t written any data to your event files.</li>
+      <li>TensorBoard can’t find your event files.</li>
+    </ul>
+
+    If you’re new to using TensorBoard, and want to find out how to add data and
+    set up your event files, check out the
+    <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md"
+      >README</a
+    >
+    and perhaps the
+    <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard"
+      >TensorBoard tutorial</a
+    >.
+    <p>
+      If you think TensorBoard is configured properly, please see
+      <a
+        href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong"
+        >the section of the README devoted to missing data problems</a
+      >
+      and consider filing an issue on GitHub.
+    </p>
+
+    <p>
+      <i>Last reload: {{lastUpdated | date}}</i>
+    </p>
+  </div>
+</div>

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -42,9 +42,25 @@ import {PluginRegistryModule} from './plugin_registry_module';
   templateUrl: './plugins_component.ng.html',
   styles: [
     `
+      :host {
+        display: block;
+        position: relative;
+      }
       .plugins {
         height: 100%;
         position: relative;
+      }
+      .no-plugin {
+        background-color: #fff;
+        bottom: 0;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+      .warning-message {
+        margin: 80px auto 0;
+        max-width: 540px;
       }
     `,
     'iframe { border: 0; height: 100%; width: 100%; }',
@@ -65,6 +81,9 @@ export class PluginsComponent implements OnChanges {
 
   @Input()
   activePlugin!: UiPluginMetadata | null;
+
+  @Input()
+  noEnabledPlugin!: boolean;
 
   @Input()
   lastUpdated?: number;

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -63,7 +63,11 @@ export class PluginsContainer {
     this.store.select(getPluginsListLoaded)
   ).pipe(
     map(([activePlugin, loadState]) => {
-      return activePlugin === null && loadState.state === DataLoadState.LOADED;
+      return (
+        activePlugin === null &&
+        (loadState.state === DataLoadState.LOADED ||
+          loadState.state === DataLoadState.FAILED)
+      );
     })
   );
   readonly lastLoadedTimeInMs$ = this.store.pipe(select(lastLoadedTimeInMs));

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -14,10 +14,12 @@ limitations under the License.
 ==============================================================================*/
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Store, select, createSelector} from '@ngrx/store';
+import {combineLatest} from 'rxjs';
+import {map} from 'rxjs/operators';
 
 import {getPlugins, getActivePlugin, getPluginsListLoaded} from '../core/store';
 import {PluginMetadata} from '../types/api';
-import {LoadState} from '../types/data';
+import {LoadState, DataLoadState} from '../types/data';
 import {State} from '../core/store/core_types';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
@@ -47,6 +49,7 @@ const lastLoadedTimeInMs = createSelector(
   template: `
     <plugins-component
       [activePlugin]="activePlugin$ | async"
+      [noEnabledPlugin]="noEnabledPlugin$ | async"
       [lastUpdated]="lastLoadedTimeInMs$ | async"
     ></plugins-component>
   `,
@@ -55,6 +58,14 @@ const lastLoadedTimeInMs = createSelector(
 })
 export class PluginsContainer {
   readonly activePlugin$ = this.store.pipe(select(activePlugin));
+  readonly noEnabledPlugin$ = combineLatest(
+    this.store.select(activePlugin),
+    this.store.select(getPluginsListLoaded)
+  ).pipe(
+    map(([activePlugin, loadState]) => {
+      return activePlugin === null && loadState.state === DataLoadState.LOADED;
+    })
+  );
   readonly lastLoadedTimeInMs$ = this.store.pipe(select(lastLoadedTimeInMs));
 
   constructor(private readonly store: Store<State>) {}

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -358,6 +358,18 @@ describe('plugins_component', () => {
       expect(fixture.debugElement.query(By.css('.no-plugin'))).not.toBeNull();
     });
 
+    it('shows warning when the plugins listing failed to load', () => {
+      store.overrideSelector(getActivePlugin, null);
+      store.overrideSelector(getPluginsListLoaded, {
+        state: DataLoadState.FAILED,
+        lastLoadedTimeInMs: null,
+      });
+      const fixture = TestBed.createComponent(PluginsContainer);
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.no-plugin'))).not.toBeNull();
+    });
+
     it('does not show warning when data is not yet loaded', () => {
       store.overrideSelector(getActivePlugin, null);
       store.overrideSelector(getPluginsListLoaded, {

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -339,4 +339,35 @@ describe('plugins_component', () => {
       expect(barReloadSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('warning pages', () => {
+    it('shows warning when no plugin is active after list is loaded', () => {
+      const fixture = TestBed.createComponent(PluginsContainer);
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.no-plugin'))).toBeNull();
+
+      store.overrideSelector(getActivePlugin, null);
+      store.overrideSelector(getPluginsListLoaded, {
+        state: DataLoadState.LOADED,
+        lastLoadedTimeInMs: 123,
+      });
+      store.refreshState();
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.no-plugin'))).not.toBeNull();
+    });
+
+    it('does not show warning when data is not yet loaded', () => {
+      store.overrideSelector(getActivePlugin, null);
+      store.overrideSelector(getPluginsListLoaded, {
+        state: DataLoadState.LOADING,
+        lastLoadedTimeInMs: 123,
+      });
+      const fixture = TestBed.createComponent(PluginsContainer);
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('.no-plugin'))).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
Angular version of the TensorBoard never implemented the page.
The copy and UX is almost exactly that of Polymer's (misses data
location; angular version currently does not fetch environments)

Requires #3584 to see the change.