### PR TITLE
uploader: display per-experiment tensor bytes in `dev list` output

### DIFF
--- a/tensorboard/uploader/formatters.py
+++ b/tensorboard/uploader/formatters.py
@@ -66,6 +66,7 @@ class ReadableFormatter(BaseExperimentFormatter):
             ("Runs", str(experiment.num_runs)),
             ("Tags", str(experiment.num_tags)),
             ("Scalars", str(experiment.num_scalars)),
+            ("Tensor bytes", str(experiment.total_tensor_bytes)),
             ("Binary object bytes", str(experiment.total_blob_bytes)),
         ]
         for name, value in data:
@@ -94,6 +95,7 @@ class JsonFormatter(object):
             ("runs", experiment.num_runs),
             ("tags", experiment.num_tags),
             ("scalars", experiment.num_scalars),
+            ("tensor_bytes", experiment.total_tensor_bytes),
             ("binary_object_bytes", experiment.total_blob_bytes),
         ]
         return json.dumps(

--- a/tensorboard/uploader/formatters_test.py
+++ b/tensorboard/uploader/formatters_test.py
@@ -48,6 +48,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
             num_runs=2,
             num_tags=4,
             num_scalars=60,
+            total_tensor_bytes=789,
             total_blob_bytes=1234,
         )
         util.set_timestamp(experiment.create_time, 981173106)
@@ -65,6 +66,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
             "\tRuns                 2",
             "\tTags                 4",
             "\tScalars              60",
+            "\tTensor bytes         789",
             "\tBinary object bytes  1234",
         ]
         self.assertEqual(output.split("\n"), expected_lines)
@@ -77,6 +79,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
             num_runs=2,
             num_tags=4,
             num_scalars=60,
+            total_tensor_bytes=0,
             total_blob_bytes=1234,
         )
         util.set_timestamp(experiment.create_time, 981173106)
@@ -99,6 +102,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
             "\tRuns                 2",
             "\tTags                 4",
             "\tScalars              60",
+            "\tTensor bytes         0",
             "\tBinary object bytes  1234",
         ]
         self.assertEqual(output.split("\n"), expected_lines)
@@ -110,6 +114,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
             num_runs=2,
             num_tags=4,
             num_scalars=60,
+            total_tensor_bytes=789,
             total_blob_bytes=1234,
         )
         util.set_timestamp(experiment.create_time, 981173106)
@@ -127,6 +132,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
             "\tRuns                 2",
             "\tTags                 4",
             "\tScalars              60",
+            "\tTensor bytes         789",
             "\tBinary object bytes  1234",
         ]
         self.assertEqual(output.split("\n"), expected_lines)
@@ -138,6 +144,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
             num_runs=2,
             num_tags=4,
             num_scalars=60,
+            total_tensor_bytes=789,
             total_blob_bytes=1234,
         )
         util.set_timestamp(experiment.create_time, 981173106)
@@ -156,6 +163,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
             '  "runs": 2,',
             '  "tags": 4,',
             '  "scalars": 60,',
+            '  "tensor_bytes": 789,',
             '  "binary_object_bytes": 1234',
             "}",
         ]
@@ -168,6 +176,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
             num_runs=2,
             num_tags=4,
             num_scalars=60,
+            total_tensor_bytes=789,
             total_blob_bytes=1234,
         )
         util.set_timestamp(experiment.create_time, 981173106)
@@ -193,6 +202,7 @@ class TensorBoardExporterTest(tb_test.TestCase):
             '  "runs": 2,',
             '  "tags": 4,',
             '  "scalars": 60,',
+            '  "tensor_bytes": 789,',
             '  "binary_object_bytes": 1234',
             "}",
         ]

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -332,6 +332,7 @@ class _ListIntent(_Intent):
             num_runs=True,
             num_tags=True,
             num_scalars=True,
+            total_tensor_bytes=True,
             total_blob_bytes=True,
         )
         gen = exporter_lib.list_experiments(api_client, fieldmask=fieldmask)


### PR DESCRIPTION
* Motivation for features / changes
  * Enable uploader's `tensorboard dev list` command to display the amount of tensor data in each experiment. The data is already available in the current server implementation.
* Technical description of changes
  * Set the field mask for `total_tensor_bytes` to `True`
  * Add human-readable "Tensor bytes" field for the non-JSON mode. This is parallel to the existing "Binary object bytes" field.
  * Add the key "tensor_bytes" to the JSON mode. This is parallel to the existing "binary_object_bytes" key.
* Screenshots of UI changes
  * Non-JSON mode: ![image](https://user-images.githubusercontent.com/16824702/81098891-053a2c00-8ed8-11ea-88b3-9c6231e95c9c.png)
  * JSON mode: ![image](https://user-images.githubusercontent.com/16824702/81099627-37985900-8ed9-11ea-9674-2b5a5a8e3679.png)
* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests updated
  * Manual testing against our DEV endpoint.