### PR TITLE
ng: prevent double dashboard reload on mount 

### DIFF
--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -88,6 +88,9 @@ export class PluginsComponent implements OnChanges {
   @Input()
   lastUpdated?: number;
 
+  @Input()
+  reloadId!: number;
+
   readonly LoadingMechanismType = LoadingMechanismType;
 
   private readonly pluginInstances = new Map<string, HTMLElement>();
@@ -96,7 +99,8 @@ export class PluginsComponent implements OnChanges {
     if (change['activePlugin'] && this.activePlugin) {
       this.renderPlugin(this.activePlugin!);
     }
-    if (change['lastUpdated']) {
+
+    if (change['reloadId'] && !change['reloadId'].firstChange) {
       this.reload();
     }
   }
@@ -141,6 +145,7 @@ export class PluginsComponent implements OnChanges {
         pluginElement = document.createElement(
           customElementPlugin.element_name
         );
+        (pluginElement as any).reloadOnReady = false;
         this.pluginsContainer.nativeElement.appendChild(pluginElement);
         break;
       }

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -51,6 +51,7 @@ const lastLoadedTimeInMs = createSelector(
       [activePlugin]="activePlugin$ | async"
       [noEnabledPlugin]="noEnabledPlugin$ | async"
       [lastUpdated]="lastLoadedTimeInMs$ | async"
+      [reloadId]="reloadId$ | async"
     ></plugins-component>
   `,
   styles: ['plugins-component { height: 100%; }'],
@@ -71,6 +72,9 @@ export class PluginsContainer {
     })
   );
   readonly lastLoadedTimeInMs$ = this.store.pipe(select(lastLoadedTimeInMs));
+
+  // An id that changes when data has to be refreshed.
+  readonly reloadId$ = this.store.select(lastLoadedTimeInMs);
 
   constructor(private readonly store: Store<State>) {}
 }

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -91,7 +91,17 @@ describe('plugins_component', () => {
         // data file in the karma server.
         module_path: 'random_esmodule.js',
       } as IframeLoadingMechanism,
-      tab_name: 'Bar',
+      tab_name: 'Foo',
+      remove_dom: false,
+    },
+    baz: {
+      disable_reload: false,
+      enabled: true,
+      loading_mechanism: {
+        type: LoadingMechanismType.CUSTOM_ELEMENT,
+        element_name: 'tb-baz',
+      } as CustomElementLoadingMechanism,
+      tab_name: 'Baz',
       remove_dom: false,
     },
   };
@@ -253,6 +263,9 @@ describe('plugins_component', () => {
   });
 
   describe('updates', () => {
+    let barReloadSpy: jasmine.Spy;
+    let bazReloadSpy: jasmine.Spy;
+
     function setLastLoadedTime(
       timeInMs: number | null,
       state = DataLoadState.LOADED
@@ -265,48 +278,67 @@ describe('plugins_component', () => {
       store.refreshState();
     }
 
+    beforeEach(() => {
+      barReloadSpy = jasmine.createSpy();
+      bazReloadSpy = jasmine.createSpy();
+      const bar = document.createElement('div');
+      (bar as any).reload = barReloadSpy;
+      const baz = document.createElement('div');
+      (baz as any).reload = bazReloadSpy;
+      spyOn(document, 'createElement')
+        .and.callThrough()
+        .withArgs('tb-baz')
+        .and.returnValue(baz)
+        .withArgs('tb-bar')
+        .and.returnValue(bar);
+    });
+
+    it('does not reload on render', () => {
+      setActivePlugin('bar');
+      setLastLoadedTime(0, DataLoadState.NOT_LOADED);
+      const fixture = TestBed.createComponent(PluginsContainer);
+      fixture.detectChanges();
+
+      expect(barReloadSpy).not.toHaveBeenCalled();
+      expect(bazReloadSpy).not.toHaveBeenCalled();
+    });
+
     it('invokes reload method on the dashboard DOM', () => {
       const fixture = TestBed.createComponent(PluginsContainer);
 
       setLastLoadedTime(null, DataLoadState.NOT_LOADED);
       setActivePlugin('bar');
       fixture.detectChanges();
-      setActivePlugin('foo');
+      setActivePlugin('baz');
       fixture.detectChanges();
       setActivePlugin('bar');
       fixture.detectChanges();
 
-      const {nativeElement} = fixture.debugElement.query(By.css('.plugins'));
-      // Stamped 'bar' and 'foo'
-      expect(nativeElement.children.length).toBe(2);
-      const [barElement, fooElement] = nativeElement.children;
-      const barReloadSpy = jasmine.createSpy();
-      barElement.reload = barReloadSpy;
-      const fooReloadSpy = jasmine.createSpy();
-      fooElement.reload = fooReloadSpy;
+      expect(barReloadSpy).toHaveBeenCalledTimes(0);
+      expect(bazReloadSpy).not.toHaveBeenCalled();
 
       setLastLoadedTime(1);
       fixture.detectChanges();
       expect(barReloadSpy).toHaveBeenCalledTimes(1);
-      expect(fooReloadSpy).not.toHaveBeenCalled();
+      expect(bazReloadSpy).not.toHaveBeenCalled();
 
       setLastLoadedTime(1);
       fixture.detectChanges();
       expect(barReloadSpy).toHaveBeenCalledTimes(1);
-      expect(fooReloadSpy).not.toHaveBeenCalled();
+      expect(bazReloadSpy).not.toHaveBeenCalled();
 
       setLastLoadedTime(2);
       fixture.detectChanges();
       expect(barReloadSpy).toHaveBeenCalledTimes(2);
-      expect(fooReloadSpy).not.toHaveBeenCalled();
+      expect(bazReloadSpy).not.toHaveBeenCalled();
 
-      setActivePlugin('foo');
+      setActivePlugin('baz');
       fixture.detectChanges();
 
       setLastLoadedTime(3);
       fixture.detectChanges();
       expect(barReloadSpy).toHaveBeenCalledTimes(2);
-      expect(fooReloadSpy).toHaveBeenCalledTimes(1);
+      expect(bazReloadSpy).toHaveBeenCalledTimes(1);
     });
 
     it('does not invoke reload method on dom if disable_reload', () => {
@@ -328,10 +360,8 @@ describe('plugins_component', () => {
       setActivePlugin('bar');
       fixture.detectChanges();
 
-      const {nativeElement} = fixture.debugElement.query(By.css('.plugins'));
-      const [barElement] = nativeElement.children;
-      const barReloadSpy = jasmine.createSpy();
-      barElement.reload = barReloadSpy;
+      setLastLoadedTime(0);
+      fixture.detectChanges();
 
       setLastLoadedTime(1);
       fixture.detectChanges();


### PR DESCRIPTION
Cause: dashboards, on Polymer's `ready` invoke `reload`. That means,
when the Angular's plugin_component mount the Polymer dashboard onto the
DOM, it will fetch the `data` right away. In addition to that, on
plugin_container mount, we fetch the `plugins_listing` and upon its
completion, invoke `reload` again.

To be clear, the fact that `reload` was getting triggered based on last
fetch time of `plugins_listing` was not ideal; it does imitate the way
Polymer based tf-tensorboard does (Promise.then) and it does tie with
the reloader but using the last loaded time as a proxy to user's action
(e.g., reload button click) is not correct. Ideally, we should only make
the data requests from `effects` but our Polymer code is ill-suited for
that.

Addressed the issue by ignoring first two triggers (initial values and the
first `pluginsListing` load) of the `pluginsListingLoaded`