### PR TITLE
ng: add plugin-id on tab for testability

### DIFF
--- a/tensorboard/webapp/header/plugin_selector_component.ng.html
+++ b/tensorboard/webapp/header/plugin_selector_component.ng.html
@@ -27,6 +27,7 @@ limitations under the License.
       <span
         class="plugin-name"
         (click)="onActivePluginSelection($event, plugin.id)"
+        [attr.data-plugin-id]="plugin.id"
       >
         {{plugin.tab_name}}
       </span>
@@ -39,7 +40,11 @@ limitations under the License.
     [value]="selectedPlugin"
     (selectionChange)="onDisabledPluginSelectionChanged($event)"
   >
-    <mat-option *ngFor="let plugin of disabledPlugins" [value]="plugin.id">
+    <mat-option
+      *ngFor="let plugin of disabledPlugins"
+      [value]="plugin.id"
+      [attr.data-plugin-id]="plugin.id"
+    >
       {{ plugin.tab_name }}
     </mat-option>
   </mat-select>


### PR DESCRIPTION
We would like our webdriver tests to be able to find these nodes without
inspecting the textNode (with plugin name as opposed to plugin id). This
change adds data attribute adds one.
