### PR TITLE
diagnose: warn on broken What-If Tool version

### DIFF
--- a/tensorboard/tools/diagnose_tensorboard.py
+++ b/tensorboard/tools/diagnose_tensorboard.py
@@ -240,6 +240,23 @@ def installed_packages():
         )
         yield Suggestion("Fix conflicting installations", message)
 
+    wit_version = packages.get("tensorboard-plugin-wit")
+    if wit_version == "tensorboard-plugin-wit==1.6.0.post2":
+        # This is only incompatible with TensorBoard prior to 2.2.0, but
+        # we just issue a blanket warning so that we don't have to pull
+        # in a `pkg_resources` dep to parse the version.
+        preamble = reflow(
+            """
+            Versions of the What-If Tool (`tensorboard-plugin-wit`)
+            prior to 1.6.0.post3 are incompatible with some versions of
+            TensorBoard. Please upgrade this package to the latest
+            version to resolve any startup errors:
+            """
+        )
+        command = "pip install -U tensorboard-plugin-wit"
+        message = "%s\n\n\t%s" % (preamble, command)
+        yield Suggestion("Upgrade `tensorboard-plugin-wit`", message)
+
 
 @check
 def tensorboard_python_version():


### PR DESCRIPTION
Summary:
Issues like #3460, #3481, and #3592 are all caused by an incompatibility
between certain versions of TensorBoard and the standalone What-If Tool.
This patch adds a check to the diagnosis script to warn accordingly.

Test Plan:
Install `tensorflow==2.1.0 tensorboard-plugin-wit==1.6.0.post2` into a
new virtualenv, and note that TensorBoard fails to start. Then run the
diagnosis script and note that it prints a suggestion with a command
that, when executed, solves the problem.

wchargin-branch: diagnose-broken-wit
