### PR TITLE
[DebuggerV2] Add backend route /graphs/graph_info

### DIFF
--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -453,6 +453,33 @@ class DebuggerV2EventMultiplexer(object):
             ],
         }
 
+    def GraphInfo(self, run, graph_id):
+        """Get the information regarding a TensorFlow graph.
+
+        Args:
+          run: Name of the run.
+          graph_id: Debugger-generated ID of the graph in question.
+            This information is available in the return values
+            of `GraphOpInfo`, `GraphExecution`, etc.
+
+        Returns:
+          A JSON-serializable object containing the information regarding
+            the TensorFlow graph.
+
+        Raises:
+          NotFoundError if the graph_id is not known to the debugger.
+        """
+        runs = self.Runs()
+        if run not in runs:
+            return None
+        try:
+            graph = self._reader.graph_by_id(graph_id)
+        except KeyError:
+            raise errors.NotFoundError(
+                'There is no graph with ID "%s"' % graph_id
+            )
+        return graph.to_json()
+
     def GraphOpInfo(self, run, graph_id, op_name):
         """Get the information regarding a graph op's creation.
 

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -40,6 +40,7 @@ EXECUTION_DIGESTS_BLOB_TAG_PREFIX = "execution_digests"
 EXECUTION_DATA_BLOB_TAG_PREFIX = "execution_data"
 GRAPH_EXECUTION_DIGESTS_BLOB_TAG_PREFIX = "graphexec_digests"
 GRAPH_EXECUTION_DATA_BLOB_TAG_PREFIX = "graphexec_data"
+GRAPH_INFO_BLOB_TAG_PREFIX = "graph_info"
 GRAPH_OP_INFO_BLOB_TAG_PREFIX = "graph_op_info"
 SOURCE_FILE_LIST_BLOB_TAG = "source_file_list"
 SOURCE_FILE_BLOB_TAG_PREFIX = "source_file"
@@ -331,6 +332,44 @@ def _parse_graph_op_info_blob_key(blob_key):
     return run, graph_id, op_name
 
 
+def graph_info_run_tag_filter(run, graph_id):
+    """Create a RunTagFilter for graph info.
+
+    Args:
+      run: tfdbg2 run name.
+      graph_id: Debugger-generated ID of the graph in question.
+
+    Returns:
+      `RunTagFilter` for the run and range of graph info.
+    """
+    if not graph_id:
+        raise ValueError("graph_id must not be None or empty.")
+    return provider.RunTagFilter(
+        runs=[run], tags=["%s_%s" % (GRAPH_INFO_BLOB_TAG_PREFIX, graph_id)],
+    )
+
+
+def _parse_graph_info_blob_key(blob_key):
+    """Parse the BLOB key for graph info.
+
+    Args:
+      blob_key: The BLOB key to parse. By contract, it should have the format:
+       `${GRAPH_INFO_BLOB_TAG_PREFIX}_${graph_id}.${run_name}`,
+      wherein
+        - `graph_id` is a UUID
+        - op_name conforms to the TensorFlow spec:
+          `^[A-Za-z0-9.][A-Za-z0-9_.\\/>-]*$`
+        - `run_name` is assumed to contain no dots (`'.'`s).
+
+    Returns:
+      - run name
+      - graph_id
+    """
+    key_body, run = blob_key.split(".")
+    graph_id = key_body[len(GRAPH_INFO_BLOB_TAG_PREFIX) + 1 :]
+    return run, graph_id
+
+
 def source_file_list_run_tag_filter(run):
     """Create a RunTagFilter for listing source files.
 
@@ -514,6 +553,7 @@ class LocalDebuggerV2DataProvider(provider.DataProvider):
                         EXECUTION_DATA_BLOB_TAG_PREFIX,
                         GRAPH_EXECUTION_DIGESTS_BLOB_TAG_PREFIX,
                         GRAPH_EXECUTION_DATA_BLOB_TAG_PREFIX,
+                        GRAPH_INFO_BLOB_TAG_PREFIX,
                         GRAPH_OP_INFO_BLOB_TAG_PREFIX,
                         SOURCE_FILE_BLOB_TAG_PREFIX,
                         STACK_FRAMES_BLOB_TAG_PREFIX,
@@ -550,6 +590,9 @@ class LocalDebuggerV2DataProvider(provider.DataProvider):
             return json.dumps(
                 self._multiplexer.GraphExecutionData(run, begin, end)
             )
+        elif blob_key.startswith(GRAPH_INFO_BLOB_TAG_PREFIX):
+            run, graph_id = _parse_graph_info_blob_key(blob_key)
+            return json.dumps(self._multiplexer.GraphInfo(run, graph_id))
         elif blob_key.startswith(GRAPH_OP_INFO_BLOB_TAG_PREFIX):
             run, graph_id, op_name = _parse_graph_op_info_blob_key(blob_key)
             return json.dumps(

--- a/tensorboard/plugins/debugger_v2/debug_data_provider.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_provider.py
@@ -355,11 +355,6 @@ def _parse_graph_info_blob_key(blob_key):
     Args:
       blob_key: The BLOB key to parse. By contract, it should have the format:
        `${GRAPH_INFO_BLOB_TAG_PREFIX}_${graph_id}.${run_name}`,
-      wherein
-        - `graph_id` is a UUID
-        - op_name conforms to the TensorFlow spec:
-          `^[A-Za-z0-9.][A-Za-z0-9_.\\/>-]*$`
-        - `run_name` is assumed to contain no dots (`'.'`s).
 
     Returns:
       - run name

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -252,7 +252,7 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
         queried.
 
         The response contains a JSON object with the following fields:
-          - graph_id: The debugger-geneated ID (echoing the request).
+          - graph_id: The debugger-generated ID (echoing the request).
           - name: The name of the graph (if any). For TensorFlow 2.x
             Function Graphs (FuncGraphs), this is typically the name of
             the underlying Python function, optionally prefixed with

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin.py
@@ -65,6 +65,7 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
             "/execution/data": self.serve_execution_data,
             "/graph_execution/digests": self.serve_graph_execution_digests,
             "/graph_execution/data": self.serve_graph_execution_data,
+            "/graphs/graph_info": self.serve_graph_info,
             "/graphs/op_info": self.serve_graph_op_info,
             "/source_files/list": self.serve_source_files_list,
             "/source_files/file": self.serve_source_file,
@@ -241,6 +242,50 @@ class DebuggerV2Plugin(base_plugin.TBPlugin):
                 "application/json",
             )
         except errors.InvalidArgumentError as e:
+            return _error_response(request, str(e))
+
+    @wrappers.Request.application
+    def serve_graph_info(self, request):
+        """Serve basic information about a TensorFlow graph.
+
+        The request specifies the debugger-generated ID of the graph being
+        queried.
+
+        The response contains a JSON object with the following fields:
+          - graph_id: The debugger-geneated ID (echoing the request).
+          - name: The name of the graph (if any). For TensorFlow 2.x
+            Function Graphs (FuncGraphs), this is typically the name of
+            the underlying Python function, optionally prefixed with
+            TensorFlow-generated prefixed such as "__inference_".
+            Some graphs (e.g., certain outermost graphs) may have no names,
+            in which case this field is `null`.
+          - outer_graph_id: Outer graph ID (if any). For an outermost graph
+            without an outer graph context, this field is `null`.
+          - inner_graph_ids: Debugger-generated IDs of all the graphs
+            nested inside this graph. For a graph without any graphs nested
+            inside, this field is an empty array.
+        """
+        experiment = plugin_util.experiment_id(request.environ)
+        run = request.args.get("run")
+        if run is None:
+            return _missing_run_error_response(request)
+        graph_id = request.args.get("graph_id")
+        run_tag_filter = debug_data_provider.graph_info_run_tag_filter(
+            run, graph_id
+        )
+        blob_sequences = self._data_provider.read_blob_sequences(
+            experiment, self.plugin_name, run_tag_filter=run_tag_filter
+        )
+        tag = next(iter(run_tag_filter.tags))
+        try:
+            return http_util.Respond(
+                request,
+                self._data_provider.read_blob(
+                    blob_sequences[run][tag][0].blob_key
+                ),
+                "application/json",
+            )
+        except errors.NotFoundError as e:
             return _error_response(request, str(e))
 
     @wrappers.Request.application

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -1118,9 +1118,6 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         """Get the op info of an op with both inputs and consumers."""
         _generate_tfdbg_v2_data(self.logdir)
         run = self._getExactlyOneRun()
-
-        # Query the /graphs/graph route for the inner graph
-        # (the one that contains the AddV2 op).
         response = self.server.get(
             _ROUTE_PREFIX
             + "/graphs/graph_info?run=%s&graph_id=%s"

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -1097,6 +1097,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertEqual(data["name"], "my_function")
         self.assertTrue(outermost_graph_id)
         self.assertIsInstance(outermost_graph_id, str)
+        # This outer graph contains another inner graph (repeat_add).
         self.assertLen(data["inner_graph_ids"], 2)
         self.assertIn(graph_id, data["inner_graph_ids"])
 

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -1053,6 +1053,87 @@ class DebuggerV2PluginTest(tf.test.TestCase):
             },
         )
 
+    def testServeGraphInfo(self):
+        """Get the op info of an op with both inputs and consumers."""
+        _generate_tfdbg_v2_data(self.logdir)
+        run = self._getExactlyOneRun()
+        # First, look up the graph_id of the 1st AddV2 op.
+        response = self.server.get(
+            _ROUTE_PREFIX + "/graph_execution/digests?run=%s" % run
+        )
+        data = json.loads(response.get_data())
+        digests = data["graph_execution_digests"]
+        op_types = [digest["op_type"] for digest in digests]
+        op_index = op_types.index("AddV2")
+        graph_id = digests[op_index]["graph_id"]
+
+        # Query the /graphs/graph route for the inner graph
+        # This is the graph that contains the AddV2 op. It corresponds
+        # to the function "unstack_and_sum".
+        response = self.server.get(
+            _ROUTE_PREFIX
+            + "/graphs/graph_info?run=%s&graph_id=%s" % (run, graph_id)
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.get_data())
+        outer_graph_id = data["outer_graph_id"]
+        self.assertEqual(data["graph_id"], graph_id)
+        self.assertEqual(data["name"], "unstack_and_sum")
+        self.assertTrue(outer_graph_id)
+        self.assertIsInstance(outer_graph_id, str)
+        # The graph of unstack_and_sum has no inner graphs.
+        self.assertEqual(data["inner_graph_ids"], [])
+
+        # Query the /graphs/graph route for the outer graph.
+        # This corresponds to the function "my_function"
+        response = self.server.get(
+            _ROUTE_PREFIX
+            + "/graphs/graph_info?run=%s&graph_id=%s" % (run, outer_graph_id)
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.get_data())
+        outermost_graph_id = data["outer_graph_id"]
+        self.assertEqual(data["graph_id"], outer_graph_id)
+        self.assertEqual(data["name"], "my_function")
+        self.assertTrue(outermost_graph_id)
+        self.assertIsInstance(outermost_graph_id, str)
+        self.assertLen(data["inner_graph_ids"], 2)
+        self.assertIn(graph_id, data["inner_graph_ids"])
+
+        # Query the /graphs/graph route for the outermost graph.
+        # This is an unnamed outermost graph.
+        response = self.server.get(
+            _ROUTE_PREFIX
+            + "/graphs/graph_info?run=%s&graph_id=%s"
+            % (run, outermost_graph_id)
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.get_data())
+        self.assertEqual(data["graph_id"], outermost_graph_id)
+        self.assertIsNone(data["name"])
+        self.assertIsNone(data["outer_graph_id"])
+        self.assertEqual(data["inner_graph_ids"], [outer_graph_id])
+
+    def testServeGraphInfoRaisesErrorForInvalidGraphId(self):
+        """Get the op info of an op with both inputs and consumers."""
+        _generate_tfdbg_v2_data(self.logdir)
+        run = self._getExactlyOneRun()
+
+        # Query the /graphs/graph route for the inner graph
+        # (the one that contains the AddV2 op).
+        response = self.server.get(
+            _ROUTE_PREFIX
+            + "/graphs/graph_info?run=%s&graph_id=%s"
+            % (run, "nonsensical-graph-id")
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.get_data()),
+            {
+                "error": 'Not found: There is no graph with ID "nonsensical-graph-id"'
+            },
+        )
+
     def testServeGraphOpInfoForOpWithInputsAndConsumers(self):
         """Get the op info of an op with both inputs and consumers."""
         _generate_tfdbg_v2_data(self.logdir)

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -1067,7 +1067,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         op_index = op_types.index("AddV2")
         graph_id = digests[op_index]["graph_id"]
 
-        # Query the /graphs/graph route for the inner graph
+        # Query the /graphs/graph_info route for the inner graph.
         # This is the graph that contains the AddV2 op. It corresponds
         # to the function "unstack_and_sum".
         response = self.server.get(
@@ -1084,7 +1084,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         # The graph of unstack_and_sum has no inner graphs.
         self.assertEqual(data["inner_graph_ids"], [])
 
-        # Query the /graphs/graph route for the outer graph.
+        # Query the /graphs/graph_info route for the outer graph.
         # This corresponds to the function "my_function"
         response = self.server.get(
             _ROUTE_PREFIX
@@ -1100,7 +1100,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         self.assertLen(data["inner_graph_ids"], 2)
         self.assertIn(graph_id, data["inner_graph_ids"])
 
-        # Query the /graphs/graph route for the outermost graph.
+        # Query the /graphs/graph_info route for the outermost graph.
         # This is an unnamed outermost graph.
         response = self.server.get(
             _ROUTE_PREFIX


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing the backend of DebuggerV2.
* Technical description of changes
  * Add HTTP route `/graphs/graph`. This is at the same level as `/graphs/op`. But instead of serving information about individual ops, the new route serves information about the graph (its ID, name, relation to other graphs, etc.)
  * Use `DebuggedGraph.to_json()` to implement the serving of graph info.
* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests added.
