### PR TITLE
Specify injectable as injectable.

### DIFF
--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {Injectable} from '@angular/core';
 
 import {TBFeatureFlagDataSource} from './tb_feature_flag_data_source_types';
 
@@ -21,6 +22,7 @@ const util = {
   },
 };
 
+@Injectable()
 export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
   getFeatures() {
     const params = util.getParams();


### PR DESCRIPTION
After Angular 9 upgrade, it has been throwing deprecation warning below.
```
DEPRECATED: DI is instantiating a token
"QueryParamsFeatureFlagDataSource" that inherits its @Injectable
decorator but does not provide one itself.  This will become an error in
v10. Please add @Injectable() to the "QueryParamsFeatureFlagDataSource"
class.
```

This change specifies `QueryParamsFeatureFlagDataSource` as an
Injectable.
