### PR TITLE
ng: remove deprecated `get` and use `inject`

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container_test.ts
@@ -88,7 +88,7 @@ describe('Debugger Container', () => {
         TimelineContainer,
       ],
     }).compileComponents();
-    store = TestBed.get(Store);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     dispatchSpy = spyOn(store, 'dispatch');
   });
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -271,9 +271,9 @@ describe('Debugger effects', () => {
         provideMockStore({initialState}),
       ],
     }).compileComponents();
-    debuggerEffects = TestBed.get(DebuggerEffects);
+    debuggerEffects = TestBed.inject(DebuggerEffects);
 
-    store = TestBed.get(Store);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     dispatchSpy = spyOn(store, 'dispatch').and.callFake((action: Action) => {
       dispatchedActions.push(action);
     });
@@ -283,7 +283,10 @@ describe('Debugger effects', () => {
     runId: string,
     sourceFilesListResponse: SourceFileListResponse
   ) {
-    return spyOn(TestBed.get(Tfdbg2HttpServerDataSource), 'fetchSourceFileList')
+    return spyOn(
+      TestBed.inject(Tfdbg2HttpServerDataSource),
+      'fetchSourceFileList'
+    )
       .withArgs(runId)
       .and.returnValue(of(sourceFilesListResponse));
   }
@@ -296,11 +299,11 @@ describe('Debugger effects', () => {
     alert_type?: string
   ) {
     if (alert_type === undefined) {
-      return spyOn(TestBed.get(Tfdbg2HttpServerDataSource), 'fetchAlerts')
+      return spyOn(TestBed.inject(Tfdbg2HttpServerDataSource), 'fetchAlerts')
         .withArgs(runId, begin, end)
         .and.returnValue(of(alertsResponse));
     } else {
-      return spyOn(TestBed.get(Tfdbg2HttpServerDataSource), 'fetchAlerts')
+      return spyOn(TestBed.inject(Tfdbg2HttpServerDataSource), 'fetchAlerts')
         .withArgs(runId, begin, end, alert_type)
         .and.returnValue(of(alertsResponse));
     }
@@ -313,7 +316,7 @@ describe('Debugger effects', () => {
     excutionDigestsResponse: ExecutionDigestsResponse
   ) {
     return spyOn(
-      TestBed.get(Tfdbg2HttpServerDataSource),
+      TestBed.inject(Tfdbg2HttpServerDataSource),
       'fetchExecutionDigests'
     )
       .withArgs(runId, begin, end)
@@ -327,7 +330,7 @@ describe('Debugger effects', () => {
     graphExcutionDigestsResponse: GraphExecutionDigestsResponse
   ) {
     return spyOn(
-      TestBed.get(Tfdbg2HttpServerDataSource),
+      TestBed.inject(Tfdbg2HttpServerDataSource),
       'fetchGraphExecutionDigests'
     )
       .withArgs(runId, begin, end)
@@ -341,7 +344,7 @@ describe('Debugger effects', () => {
     graphExcutionDataResponse: GraphExecutionDataResponse
   ) {
     return spyOn(
-      TestBed.get(Tfdbg2HttpServerDataSource),
+      TestBed.inject(Tfdbg2HttpServerDataSource),
       'fetchGraphExecutionData'
     )
       .withArgs(runId, begin, end)
@@ -356,7 +359,7 @@ describe('Debugger effects', () => {
     };
 
     function createFetchRunsSpy(runsListing: DebuggerRunListing) {
-      return spyOn(TestBed.get(Tfdbg2HttpServerDataSource), 'fetchRuns')
+      return spyOn(TestBed.inject(Tfdbg2HttpServerDataSource), 'fetchRuns')
         .withArgs()
         .and.returnValue(of(runsListing));
     }
@@ -377,7 +380,7 @@ describe('Debugger effects', () => {
       response: ExecutionDataResponse
     ) {
       return spyOn(
-        TestBed.get(Tfdbg2HttpServerDataSource),
+        TestBed.inject(Tfdbg2HttpServerDataSource),
         'fetchExecutionData'
       )
         .withArgs(runId, begin, end)
@@ -386,7 +389,7 @@ describe('Debugger effects', () => {
 
     function createFetchStackFramesSpy(stackFrames: StackFramesResponse) {
       return spyOn(
-        TestBed.get(Tfdbg2HttpServerDataSource),
+        TestBed.inject(Tfdbg2HttpServerDataSource),
         'fetchStackFrames'
       ).and.returnValue(of(stackFrames));
     }
@@ -1173,7 +1176,7 @@ describe('Debugger effects', () => {
 
     it('does not fetch alerts when alerts are already loaded', () => {
       const fetchAlerts = spyOn(
-        TestBed.get(Tfdbg2HttpServerDataSource),
+        TestBed.inject(Tfdbg2HttpServerDataSource),
         'fetchAlerts'
       );
       store.overrideSelector(getActiveRunId, runId);
@@ -1200,7 +1203,7 @@ describe('Debugger effects', () => {
 
     it('does not fetch alerts when alert type focus is set to null', () => {
       const fetchAlerts = spyOn(
-        TestBed.get(Tfdbg2HttpServerDataSource),
+        TestBed.inject(Tfdbg2HttpServerDataSource),
         'fetchAlerts'
       );
       store.overrideSelector(getActiveRunId, runId);
@@ -1254,7 +1257,10 @@ describe('Debugger effects', () => {
       filePath: string,
       lines: string[]
     ) {
-      return spyOn(TestBed.get(Tfdbg2HttpServerDataSource), 'fetchSourceFile')
+      return spyOn(
+        TestBed.inject(Tfdbg2HttpServerDataSource),
+        'fetchSourceFile'
+      )
         .withArgs(runId, fileIndex)
         .and.returnValue(
           of({

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container_test.ts
@@ -66,7 +66,7 @@ describe('Alerts Container', () => {
         DebuggerContainer,
       ],
     }).compileComponents();
-    store = TestBed.get(Store);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     dispatchSpy = spyOn(store, 'dispatch');
   });
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -84,7 +84,7 @@ describe('Graph Executions Container', () => {
         DebuggerContainer,
       ],
     }).compileComponents();
-    store = TestBed.get(Store);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
   });
 
   it('does not render execs viewport if # execs = 0', fakeAsync(() => {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
@@ -62,7 +62,7 @@ describe('Source Files Container', () => {
       ],
       providers: [provideMockStore(), DebuggerContainer],
     }).compileComponents();
-    store = TestBed.get(Store);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     dispatchSpy = spyOn(store, 'dispatch');
   });
 

--- a/tensorboard/webapp/core/effects/core_effects_test.ts
+++ b/tensorboard/webapp/core/effects/core_effects_test.ts
@@ -63,12 +63,12 @@ describe('core_effects', () => {
         provideMockStore({initialState}),
       ],
     }).compileComponents();
-    coreEffects = TestBed.get(CoreEffects);
-    httpMock = TestBed.get(HttpTestingController);
-    store = TestBed.get(Store);
+    coreEffects = TestBed.inject(CoreEffects);
+    httpMock = TestBed.inject(HttpTestingController);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     dispatchSpy = spyOn(store, 'dispatch');
 
-    const dataSource = TestBed.get(TBServerDataSource);
+    const dataSource = TestBed.inject(TBServerDataSource);
     fetchRuns = spyOn(dataSource, 'fetchRuns')
       .withArgs()
       .and.returnValue(of(null));

--- a/tensorboard/webapp/core/views/hash_storage_test.ts
+++ b/tensorboard/webapp/core/views/hash_storage_test.ts
@@ -56,10 +56,10 @@ describe('hash storage test', () => {
       ],
       declarations: [HashStorageContainer, HashStorageComponent],
     }).compileComponents();
-    store = TestBed.get(Store);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     dispatchSpy = spyOn(store, 'dispatch');
 
-    const deepLinker = TestBed.get(HashDeepLinker);
+    const deepLinker = TestBed.inject(HashDeepLinker);
     setPluginIdSpy = spyOn(deepLinker, 'setPluginId');
     getPluginIdSpy = spyOn(deepLinker, 'getPluginId');
   });

--- a/tensorboard/webapp/deeplink/deeplink_test.ts
+++ b/tensorboard/webapp/deeplink/deeplink_test.ts
@@ -49,7 +49,7 @@ describe('deeplink', () => {
     } as any);
     createElementSpy.and.callThrough();
 
-    deepLinker = TestBed.get(HashDeepLinker);
+    deepLinker = TestBed.inject(HashDeepLinker);
   });
 
   it('uses real hash', () => {

--- a/tensorboard/webapp/deeplink/hash_test.ts
+++ b/tensorboard/webapp/deeplink/hash_test.ts
@@ -31,7 +31,7 @@ describe('hash storage test', () => {
       providers: [provideMockStore(), HashStorageContainer],
       declarations: [HashStorageContainer, HashStorageComponent],
     }).compileComponents();
-    store = TestBed.get(Store);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     dispatchSpy = spyOn(store, 'dispatch');
 
     setStringSpy = jasmine.createSpy();

--- a/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
+++ b/tensorboard/webapp/feature_flag/effects/feature_flag_effects_test.ts
@@ -44,9 +44,9 @@ describe('feature_flag_effects', () => {
         provideMockStore(),
       ],
     }).compileComponents();
-    effects = TestBed.get(FeatureFlagEffects);
-    store = TestBed.get(Store);
-    dataSource = TestBed.get(TestingTBFeatureFlagDataSource);
+    effects = TestBed.inject(FeatureFlagEffects);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    dataSource = TestBed.inject(TestingTBFeatureFlagDataSource);
   });
 
   describe('getFeatureFlags$', () => {

--- a/tensorboard/webapp/header/header_test.ts
+++ b/tensorboard/webapp/header/header_test.ts
@@ -81,7 +81,7 @@ describe('header test', () => {
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
-    store = TestBed.get(Store);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(getPlugins, {
       foo: createPluginMetadata('Foo Fighter'),
       bar: createPluginMetadata('Barber'),

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -107,7 +107,7 @@ describe('plugins_component', () => {
       declarations: [PluginsContainer, PluginsComponent],
       imports: [TestingDebuggerModule, ExtraDashboardModule],
     }).compileComponents();
-    store = TestBed.get(Store);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(getPlugins, PLUGINS);
     store.overrideSelector(getActivePlugin, null);
     store.overrideSelector(getPluginsListLoaded, {

--- a/tensorboard/webapp/reloader/reloader_component_test.ts
+++ b/tensorboard/webapp/reloader/reloader_component_test.ts
@@ -68,8 +68,8 @@ describe('reloader_component', () => {
       ],
       declarations: [ReloaderComponent],
     }).compileComponents();
-    store = TestBed.get(Store);
-    fakeDocument = TestBed.get(DOCUMENT);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    fakeDocument = TestBed.inject(DOCUMENT);
     dispatchSpy = spyOn(store, 'dispatch');
   });
 

--- a/tensorboard/webapp/settings/dialog_component_test.ts
+++ b/tensorboard/webapp/settings/dialog_component_test.ts
@@ -74,9 +74,9 @@ describe('settings test', () => {
         },
       })
       .compileComponents();
-    store = TestBed.get(Store);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     dispatchSpy = spyOn(store, 'dispatch');
-    overlayContainer = TestBed.get(OverlayContainer);
+    overlayContainer = TestBed.inject(OverlayContainer);
   });
 
   it('opens a dialog when clicking on the button', async () => {

--- a/tensorboard/webapp/settings/polymer_interop_test.ts
+++ b/tensorboard/webapp/settings/polymer_interop_test.ts
@@ -34,7 +34,7 @@ describe('settings polymer_interop', () => {
       declarations: [SettingsPolymerInteropContainer],
     }).compileComponents();
 
-    store = TestBed.get(Store);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(getPageSize, 5);
 
     setLimitCalls = [];

--- a/tensorboard/webapp/settings/settings_test.ts
+++ b/tensorboard/webapp/settings/settings_test.ts
@@ -70,9 +70,9 @@ describe('settings test', () => {
         },
       })
       .compileComponents();
-    store = TestBed.get(Store);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     dispatchSpy = spyOn(store, 'dispatch');
-    overlayContainer = TestBed.get(OverlayContainer);
+    overlayContainer = TestBed.inject(OverlayContainer);
   });
 
   it('opens a dialog when clicking on the button', async () => {

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -27,7 +27,7 @@ describe('tb_feature_flag_data_source', () => {
         providers: [QueryParamsFeatureFlagDataSource],
       }).compileComponents();
 
-      dataSource = TestBed.get(QueryParamsFeatureFlagDataSource);
+      dataSource = TestBed.inject(QueryParamsFeatureFlagDataSource);
     });
 
     describe('getFeatures', () => {

--- a/tensorboard/webapp/webapp_data_source/tb_server_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_server_data_source_test.ts
@@ -31,8 +31,8 @@ describe('tb_server_data_source', () => {
         providers: [TBServerDataSource],
       }).compileComponents();
 
-      httpMock = TestBed.get(HttpTestingController);
-      dataSource = TestBed.get(TBServerDataSource);
+      httpMock = TestBed.inject(HttpTestingController);
+      dataSource = TestBed.inject(TBServerDataSource);
     });
 
     describe('fetchPluginsListing', () => {


### PR DESCRIPTION
In Angular 9, `TestBed.get` is deprecated [1] in favor of inject.
This change simply changes to use `inject`.

[1]: https://angular.io/api/core/testing/TestBed

Fixes #3233.