### PR TITLE
vulc: fix pretty print messing up whitespace

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -187,6 +187,9 @@ public final class Vulcanize {
     createFile(
         jsOutput, shouldExtractJs ? extractAndTransformJavaScript(document, jsPath) : "");
     Document normalizedDocument = getFlattenedHTML5Document(document);
+    // Prevent from correcting the DOM structure and messing up the whitespace
+    // in the template.
+    normalizedDocument.outputSettings().prettyPrint(false);
     createFile(output, normalizedDocument.toString());
   }
 


### PR DESCRIPTION
Our data location in the runs selector use tf-wbr-string which is
roughly written as `<template>[[prop]]<wbr></template>`. With the pretty
print, this was rewritten as
```
<template>
  [[prop]]
  <wbr>
</template>
```
which has whitespace and make the browser render the whitespace.

This change fixes the issue by turning off the pretty print.

Test plan: Checked the output of `bazel build tensorboard/components:polymer_lib_binary.html && cat bazel-bin/tensorboard/components/polymer_lib_binary.html | grep -A 5 id=\"tf-wbr-string\"`. Also checked the application and looked at the UI elements more carefully.