### PR TITLE
uploader: add rpc method GetExperiment to ExporterService

### DIFF
--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -16,8 +16,8 @@ service TensorBoardExporterService {
   // Get the metadata of an experiment, including the creation time, name,
   // description, counts of scalars, tensors and blob sequences, etc. See the
   // documentation string of `Experiment` for more details.
-  rpc GetExperimentMetadata(GetExperimentMetadataRequest)
-      returns (GetExperimentMetadataResponse) {}
+  rpc GetExperiment(GetExperimentRequest)
+      returns (GetExperimentResponse) {}
   // Stream scalars for all the runs and tags in an experiment.
   rpc StreamExperimentData(StreamExperimentDataRequest)
       returns (stream StreamExperimentDataResponse) {}
@@ -86,13 +86,20 @@ message StreamExperimentsResponse {
 }
 
 // Request to get the metadata of an experiment.
-message GetExperimentMetadataRequest {
+message GetExperimentRequest {
   // ID of the experiment to get.
   string experiment_id = 1;
+  // Field mask for what experiment data to return via the `experiments` field
+  // on the response. If not specified, this should be interpreted the same as
+  // an empty message: i.e., only the experiment ID should be returned. Other
+  // fields of `Experiment` will be populated if their corresponding bits in the
+  // `ExperimentMask` are set. The server may choose to populate fields that are
+  // not explicitly requested.
+  ExperimentMask experiments_mask = 2;
 }
 
-// Response to GetExperimentMetadataRequest.
-message GetExperimentMetadataResponse {
+// Response to GetExperimentRequest.
+message GetExperimentResponse {
   // Metadata about the experiment.
   // See the doc string of `Experiment` for more details.
   Experiment experiment = 1;

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -13,6 +13,11 @@ service TensorBoardExporterService {
   // Stream the experiment_id of all the experiments owned by the caller.
   rpc StreamExperiments(StreamExperimentsRequest)
       returns (stream StreamExperimentsResponse) {}
+  // Get the metadata of an experiment, including the creation time, name,
+  // description, counts of scalars, tensors and blob sequences, etc. See the
+  // documentation string of `Experiment` for more details.
+  rpc GetExperimentMetadata(GetExperimentMetadataRequest)
+      returns (GetExperimentMetadataResponse) {}
   // Stream scalars for all the runs and tags in an experiment.
   rpc StreamExperimentData(StreamExperimentDataRequest)
       returns (stream StreamExperimentDataResponse) {}
@@ -78,6 +83,19 @@ message StreamExperimentsResponse {
   // These messages may be partially populated, in accordance with the field
   // mask given in the request.
   repeated Experiment experiments = 2;
+}
+
+// Request to get the metadata of an experiment.
+message GetExperimentMetadataRequest {
+  // ID of the experiment to get.
+  string experiment_id = 1;
+}
+
+// Response to GetExperimentMetadataRequest.
+message GetExperimentMetadataResponse {
+  // Metadata about the experiment.
+  // See the doc string of `Experiment` for more details.
+  Experiment experiment = 1;
 }
 
 // Request to stream scalars from all the runs and tags in an experiment.

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -16,7 +16,7 @@ service TensorBoardExporterService {
   // Get the metadata of an experiment, including the creation time, name,
   // description, counts of scalars, tensors and blob sequences, etc. See the
   // documentation string of `Experiment` for more details.
-  rpc GetExperiment(GetExperimentRequest) returns (GetExperimentResponse) {}
+  rpc GetExperiment(GetExperimentRequest) returns (Experiment) {}
   // Stream scalars for all the runs and tags in an experiment.
   rpc StreamExperimentData(StreamExperimentDataRequest)
       returns (stream StreamExperimentDataResponse) {}
@@ -95,13 +95,6 @@ message GetExperimentRequest {
   // `ExperimentMask` are set. The server may choose to populate fields that are
   // not explicitly requested.
   ExperimentMask experiments_mask = 2;
-}
-
-// Response to GetExperimentRequest.
-message GetExperimentResponse {
-  // Metadata about the experiment.
-  // See the doc string of `Experiment` for more details.
-  Experiment experiment = 1;
 }
 
 // Request to stream scalars from all the runs and tags in an experiment.

--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -16,8 +16,7 @@ service TensorBoardExporterService {
   // Get the metadata of an experiment, including the creation time, name,
   // description, counts of scalars, tensors and blob sequences, etc. See the
   // documentation string of `Experiment` for more details.
-  rpc GetExperiment(GetExperimentRequest)
-      returns (GetExperimentResponse) {}
+  rpc GetExperiment(GetExperimentRequest) returns (GetExperimentResponse) {}
   // Stream scalars for all the runs and tags in an experiment.
   rpc StreamExperimentData(StreamExperimentDataRequest)
       returns (stream StreamExperimentDataResponse) {}


### PR DESCRIPTION
* Motivation for features / changes
  * In the experimental `ExperimentFromDev` class, support getting metadata including
    experiment name and description.
  * In the `ExperimentalFromDev.get_scalars()`, support progress indicaor.
* Technical description of changes
  * Add non-streaming rpc method `GetExperiment()` to `ExporterService`.
* Alternate designs / implementations considered
  * Add `Experiment` as a one-of response data type to `StreamExperimentDataResponse`
    * Con: In the current takeout paradigm, this leads to duplicate information.
    * Con: Wasteful when only the `Experiment` (metadata) is needed and all the scalars, tensor and blob sequences are not needed.