### PR TITLE
profile: suggest canonical Pip package name

### DIFF
--- a/tensorboard/plugins/profile_redirect/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard.html
+++ b/tensorboard/plugins/profile_redirect/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard.html
@@ -78,7 +78,7 @@ limitations under the License.
           _installCommand: {
             type: String,
             readOnly: true,
-            value: 'pip install -U tensorboard_plugin_profile',
+            value: 'pip install -U tensorboard-plugin-profile',
           },
         },
         async _copyInstallCommand() {


### PR DESCRIPTION
Summary:
If a Pip package name has hyphens, you can install it either with the
hyphenated name or with underscores (as it would be imported in Python),
so this code still worked, but we might as well suggest the canonical
name. Fixes #3615.

Test Plan:
Running `pip install -U tensorboard-plugin-profile` in a new virtualenv
still successfully installs the plugin.

wchargin-branch: profile-redirect-hyphenated-name
