### PR TITLE
Update keras_util_test with explicit model name

### DIFF
--- a/tensorboard/plugins/graph/keras_util_test.py
+++ b/tensorboard/plugins/graph/keras_util_test.py
@@ -775,9 +775,7 @@ class KerasUtilTest(tf.test.TestCase):
             tf.keras.layers.concatenate(sub_model([inputs2, inputs1]))
         )
         model = tf.keras.models.Model(
-            inputs=[inputs2, inputs1],
-            outputs=main_outputs,
-            name="model_1",
+            inputs=[inputs2, inputs1], outputs=main_outputs, name="model_1",
         )
 
         self.assertGraphDefToModel(expected_proto, model)

--- a/tensorboard/plugins/graph/keras_util_test.py
+++ b/tensorboard/plugins/graph/keras_util_test.py
@@ -199,7 +199,7 @@ class KerasUtilTest(tf.test.TestCase):
         d2 = tf.keras.layers.Dense(64, activation="relu")
 
         model = tf.keras.models.Model(
-          inputs=inputs, outputs=d2(d1(d0(inputs))), name='model')
+          inputs=inputs, outputs=d2(d1(d0(inputs))), name="model")
         self.assertGraphDefToModel(expected_proto, model)
 
     def test_keras_model_to_graph_def_functional_model_with_cycle(self):

--- a/tensorboard/plugins/graph/keras_util_test.py
+++ b/tensorboard/plugins/graph/keras_util_test.py
@@ -198,7 +198,8 @@ class KerasUtilTest(tf.test.TestCase):
         d1 = tf.keras.layers.Dense(64, activation="relu")
         d2 = tf.keras.layers.Dense(64, activation="relu")
 
-        model = tf.keras.models.Model(inputs=inputs, outputs=d2(d1(d0(inputs))))
+        model = tf.keras.models.Model(
+          inputs=inputs, outputs=d2(d1(d0(inputs))), name='model')
         self.assertGraphDefToModel(expected_proto, model)
 
     def test_keras_model_to_graph_def_functional_model_with_cycle(self):
@@ -274,7 +275,7 @@ class KerasUtilTest(tf.test.TestCase):
         d2 = tf.keras.layers.Dense(64, activation="relu")
 
         model = tf.keras.models.Model(
-            inputs=inputs, outputs=d1(d2(d1(d0(inputs))))
+            inputs=inputs, outputs=d1(d2(d1(d0(inputs)))), name="model"
         )
         self.assertGraphDefToModel(expected_proto, model)
 
@@ -315,7 +316,8 @@ class KerasUtilTest(tf.test.TestCase):
         inputs = tf.keras.layers.Input(shape=(None, 5), name="lstm_input")
         encoder = tf.keras.layers.SimpleRNN(256)
 
-        model = tf.keras.models.Model(inputs=inputs, outputs=encoder(inputs))
+        model = tf.keras.models.Model(
+          inputs=inputs, outputs=encoder(inputs), name="model")
         self.assertGraphDefToModel(expected_proto, model)
 
     def DISABLED_test_keras_model_to_graph_def_nested_sequential_model(self):
@@ -622,6 +624,7 @@ class KerasUtilTest(tf.test.TestCase):
         model = tf.keras.models.Model(
             inputs=[main_input, auxiliary_input],
             outputs=[main_output, auxiliary_output],
+            name="model"
         )
 
         self.assertGraphDefToModel(expected_proto, model)
@@ -761,14 +764,18 @@ class KerasUtilTest(tf.test.TestCase):
         d2 = tf.keras.layers.Dense(64, activation="relu")
 
         sub_model = tf.keras.models.Model(
-            inputs=[inputs2, inputs1], outputs=[d0(inputs1), d1(inputs2)]
+            inputs=[inputs2, inputs1], 
+            outputs=[d0(inputs1), d1(inputs2)],
+            name="model"
         )
 
         main_outputs = d2(
             tf.keras.layers.concatenate(sub_model([inputs2, inputs1]))
         )
         model = tf.keras.models.Model(
-            inputs=[inputs2, inputs1], outputs=main_outputs
+            inputs=[inputs2, inputs1], 
+            outputs=main_outputs,
+            name="model_1"
         )
 
         self.assertGraphDefToModel(expected_proto, model)

--- a/tensorboard/plugins/graph/keras_util_test.py
+++ b/tensorboard/plugins/graph/keras_util_test.py
@@ -199,7 +199,8 @@ class KerasUtilTest(tf.test.TestCase):
         d2 = tf.keras.layers.Dense(64, activation="relu")
 
         model = tf.keras.models.Model(
-          inputs=inputs, outputs=d2(d1(d0(inputs))), name="model")
+            inputs=inputs, outputs=d2(d1(d0(inputs))), name="model"
+        )
         self.assertGraphDefToModel(expected_proto, model)
 
     def test_keras_model_to_graph_def_functional_model_with_cycle(self):
@@ -317,7 +318,8 @@ class KerasUtilTest(tf.test.TestCase):
         encoder = tf.keras.layers.SimpleRNN(256)
 
         model = tf.keras.models.Model(
-          inputs=inputs, outputs=encoder(inputs), name="model")
+            inputs=inputs, outputs=encoder(inputs), name="model"
+        )
         self.assertGraphDefToModel(expected_proto, model)
 
     def DISABLED_test_keras_model_to_graph_def_nested_sequential_model(self):
@@ -624,7 +626,7 @@ class KerasUtilTest(tf.test.TestCase):
         model = tf.keras.models.Model(
             inputs=[main_input, auxiliary_input],
             outputs=[main_output, auxiliary_output],
-            name="model"
+            name="model",
         )
 
         self.assertGraphDefToModel(expected_proto, model)
@@ -764,18 +766,18 @@ class KerasUtilTest(tf.test.TestCase):
         d2 = tf.keras.layers.Dense(64, activation="relu")
 
         sub_model = tf.keras.models.Model(
-            inputs=[inputs2, inputs1], 
+            inputs=[inputs2, inputs1],
             outputs=[d0(inputs1), d1(inputs2)],
-            name="model"
+            name="model",
         )
 
         main_outputs = d2(
             tf.keras.layers.concatenate(sub_model([inputs2, inputs1]))
         )
         model = tf.keras.models.Model(
-            inputs=[inputs2, inputs1], 
+            inputs=[inputs2, inputs1],
             outputs=main_outputs,
-            name="model_1"
+            name="model_1",
         )
 
         self.assertGraphDefToModel(expected_proto, model)


### PR DESCRIPTION
* Motivation for features / changes
This is an update for test case. The name of the model will be soon changed when Keras team refactor the class structure between layer, network and model. The functional model will have new class name, which will cause this test to fail.

* Technical description of changes

* Screenshots of UI changes
N/A

* Detailed steps to verify changes work correctly (as executed by you)
This PR is test only.

* Alternate designs / implementations considered
N/A.
