### PR TITLE
Expand UploadLimits proto and use it in TensorBoardUploader.

### DIFF
--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -114,11 +114,11 @@ message UploadLimits {
   // non-positive then no blobs should be uploaded.
   int64 max_blob_request_size = 5;
 
-  // The minimum interval between WriteScalar requests, in seconds.
+  // The minimum interval between WriteScalar requests, in milliseconds.
   int64 min_scalar_request_interval = 6;
-  // The minimum interval between WriteTensor requests, in seconds.
+  // The minimum interval between WriteTensor requests, in milliseconds.
   int64 min_tensor_request_interval = 7;
-  // The minimum interval between WriteBlob requests, in seconds.
+  // The minimum interval between WriteBlob requests, in milliseconds.
   int64 min_blob_request_interval = 8;
 
   // The maximum allowed size for blob uploads.

--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -113,4 +113,14 @@ message UploadLimits {
   // If this is 0, it is allowed to upload tensor points of size 0.
   // If this is negative, no blobs should be uploaded.
   int64 max_tensor_point_size = 2;
+
+  int64 max_scalar_request_size = 3;
+  int64 max_tensor_request_size = 4;
+  // BDTODO: We'll see.
+  int64 max_blob_request_size = 5;
+
+  int64 scalar_request_interval_sec = 6;
+  int64 tensor_request_interval_sec = 7;
+  // BDTODO: We'll see.
+  int64 blob_request_interval_sec = 8;
 }

--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -104,6 +104,23 @@ message PluginControl {
 }
 
 message UploadLimits {
+  // The maximum allowed WriteScalar request size, in bytes. If this is
+  // non-positive then no blobs should be uploaded.
+  int64 max_scalar_request_size = 3;
+  // The maximum allowed WriteTensor request size, in bytes. If this is
+  // non-positive then no blobs should be uploaded.
+  int64 max_tensor_request_size = 4;
+  // The maximum allowed WriteBlob request size, in bytes. If this is
+  // non-positive then no blobs should be uploaded.
+  int64 max_blob_request_size = 5;
+
+  // The minimum interval between WriteScalar requests, in seconds.
+  int64 min_scalar_request_interval = 6;
+  // The minimum interval between WriteTensor requests, in seconds.
+  int64 min_tensor_request_interval = 7;
+  // The minimum interval between WriteBlob requests, in seconds.
+  int64 min_blob_request_interval = 8;
+
   // The maximum allowed size for blob uploads.
   // If this is 0, it is allowed to upload blobs of size 0 (though note
   // the server may enforce a *minimum* blob size, which is a separate issue).
@@ -114,13 +131,4 @@ message UploadLimits {
   // If this is negative, no blobs should be uploaded.
   int64 max_tensor_point_size = 2;
 
-  int64 max_scalar_request_size = 3;
-  int64 max_tensor_request_size = 4;
-  // BDTODO: We'll see.
-  int64 max_blob_request_size = 5;
-
-  int64 scalar_request_interval_sec = 6;
-  int64 tensor_request_interval_sec = 7;
-  // BDTODO: We'll see.
-  int64 blob_request_interval_sec = 8;
 }

--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -130,5 +130,4 @@ message UploadLimits {
   // If this is 0, it is allowed to upload tensor points of size 0.
   // If this is negative, no blobs should be uploaded.
   int64 max_tensor_point_size = 2;
-
 }

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -29,8 +29,9 @@ from google.protobuf import message
 from tensorboard.compat.proto import graph_pb2
 from tensorboard.compat.proto import summary_pb2
 from tensorboard.compat.proto import types_pb2
-from tensorboard.uploader.proto import write_service_pb2
+from tensorboard.uploader.proto import server_info_pb2
 from tensorboard.uploader.proto import experiment_pb2
+from tensorboard.uploader.proto import write_service_pb2
 from tensorboard.uploader import logdir_loader
 from tensorboard.uploader import util
 from tensorboard.backend import process_graph
@@ -50,17 +51,14 @@ _MIN_LOGDIR_POLL_INTERVAL_SECS = 5
 
 # Minimum interval between initiating write RPCs.  When writes would otherwise
 # happen more frequently, the process will sleep to use up the rest of the time.
-_MIN_SCALAR_WRITE_RPC_INTERVAL_SECS = 5
-
-# BDTODO
-_MIN_TENSOR_WRITE_RPC_INTERVAL_SECS = 0.5
+_DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_SECS = 5
 
 # Minimum interval between initiating blob write RPC streams.  When writes would
 # otherwise happen more frequently, the process will sleep to use up the rest of
 # the time.  This may differ from the above RPC rate limit, because blob streams
 # are not batched, so sending a sequence of N blobs requires N streams, which
 # could reasonably be sent more frequently.
-_MIN_BLOB_WRITE_RPC_INTERVAL_SECS = 1
+_DEPRECATED_MIN_BLOB_REQUEST_INTERVAL_SECS = 1
 
 # Age in seconds of last write after which an event file is considered inactive.
 # TODO(@nfelt): consolidate with TensorBoard --reload_multifile default logic.
@@ -77,16 +75,12 @@ _MAX_VARINT64_LENGTH_BYTES = 10
 # Deadline Exceeded errors in the RPC server.
 #
 # [1]: https://github.com/grpc/grpc/blob/e70d8582b4b0eedc45e3d25a57b58a08b94a9f4a/include/grpc/impl/codegen/grpc_types.h#L447  # pylint: disable=line-too-long
-_MAX_WRITE_SCALARS_LENGTH_BYTES = 1024 * 128
-
-# BDTODO: Notice that for rate limiter we use TENSOR_WRITE/SCALAR_WRITE
-# BDTODO
-_MAX_WRITE_TENSORS_LENGTH_BYTES = 1024 * 64
+_DEPRECATED_MAX_SCALAR_TENSOR_REQUEST_SIZE_BYTES = 1024 * 128
 
 logger = tb_logging.get_logger()
 
 # Leave breathing room within 2^22 (4 MiB) gRPC limit, using 256 KiB chunks
-BLOB_CHUNK_SIZE = (2 ** 22) - (2 ** 18)
+_DEPRECATED_MAX_BLOB_REQUEST_SIZE_BYTES = (2 ** 22) - (2 ** 18)
 
 
 class TensorBoardUploader(object):
@@ -97,14 +91,17 @@ class TensorBoardUploader(object):
         writer_client,
         logdir,
         allowed_plugins,
-        max_blob_size,
-        max_tensor_point_size=None,
+        upload_limits=None,
         logdir_poll_rate_limiter=None,
         rpc_rate_limiter=None,
         tensor_rpc_rate_limiter=None,
         blob_rpc_rate_limiter=None,
         name=None,
         description=None,
+        # The following arguments are deprecated in favor of upload_limits and
+        # will be removed shortly.
+        max_blob_size=None,
+        max_tensor_point_size=None,
     ):
         """Constructs a TensorBoardUploader.
 
@@ -114,9 +111,7 @@ class TensorBoardUploader(object):
           allowed_plugins: collection of string plugin names; events will only
             be uploaded if their time series's metadata specifies one of these
             plugin names
-          max_blob_size: the maximum allowed size for blob uploads.
-          max_tensor_point_size: the maximum allowed size for a single tensor
-            point
+          upload_limits: instance of tensorboard.service.UploadLimits proto.
           logdir_poll_rate_limiter: a `RateLimiter` to use to limit logdir
             polling frequency, to avoid thrashing disks, especially on networked
             file systems
@@ -129,19 +124,35 @@ class TensorBoardUploader(object):
             explicitly rate-limit within the stream here.
           name: String name to assign to the experiment.
           description: String description to assign to the experiment.
+          max_blob_size: the maximum allowed size for blob uploads. Deprecated.
+            Use upload_limits instead.
+          max_tensor_point_size: the maximum allowed size for a single tensor
+            point. Deprecated. Use upload_limits instead.
         """
         self._api = writer_client
         self._logdir = logdir
         self._allowed_plugins = frozenset(allowed_plugins)
-        self._max_blob_size = max_blob_size
-        # Note: All callers should set this value. When they do, remove the
-        # default.
-        if max_tensor_point_size is None:
-            # If max_tensor_point_size is not specified then effectively disable
-            # tensor uploads by setting max size to a negative value.
-            self._max_tensor_point_size = -1
+        if upload_limits is None:
+          # This branch of code is highly deprecated. We hope to delete it after
+          # cleaning up some Google-internal code.
+          self._upload_limits = server_info_pb2.UploadLimits()
+          self._upload_limits.max_scalar_request_size = _DEPRECATED_MAX_SCALAR_TENSOR_REQUEST_SIZE_BYTES
+          self._upload_limits.max_tensor_request_size = _DEPRECATED_MAX_SCALAR_TENSOR_REQUEST_SIZE_BYTES
+          self._upload_limits.max_blob_request_size = _DEPRECATED_MAX_BLOB_REQUEST_SIZE_BYTES
+          self._upload_limits.min_scalar_request_interval = _DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_SECS
+          self._upload_limits.min_tensor_request_interval = _DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_SECS
+          self._upload_limits.max_blob_size = max_blob_size
+          # Note: All callers should set this value. When they do, remove the
+          # default.
+          if max_tensor_point_size is None:
+              # If max_tensor_point_size is not specified then effectively disable
+              # tensor uploads by setting max size to a negative value.
+              self._upload_limits.max_tensor_point_size = -1
+          else:
+              self._upload_limits.max_tensor_point_size = max_tensor_point_size
         else:
-            self._max_tensor_point_size = max_tensor_point_size
+          self._upload_limits = upload_limits
+
         self._name = name
         self._description = description
         self._request_sender = None
@@ -154,21 +165,21 @@ class TensorBoardUploader(object):
 
         if rpc_rate_limiter is None:
             self._rpc_rate_limiter = util.RateLimiter(
-                _MIN_SCALAR_WRITE_RPC_INTERVAL_SECS
+                self._upload_limits.min_scalar_request_interval
             )
         else:
             self._rpc_rate_limiter = rpc_rate_limiter
 
         if tensor_rpc_rate_limiter is None:
             self._tensor_rpc_rate_limiter = util.RateLimiter(
-                _MIN_TENSOR_WRITE_RPC_INTERVAL_SECS
+                self._upload_limits.min_tensor_request_interval
             )
         else:
             self._tensor_rpc_rate_limiter = tensor_rpc_rate_limiter
 
         if blob_rpc_rate_limiter is None:
             self._blob_rpc_rate_limiter = util.RateLimiter(
-                _MIN_BLOB_WRITE_RPC_INTERVAL_SECS
+                self._upload_limits.min_blob_request_interval
             )
         else:
             self._blob_rpc_rate_limiter = blob_rpc_rate_limiter
@@ -199,8 +210,7 @@ class TensorBoardUploader(object):
             response.experiment_id,
             self._api,
             allowed_plugins=self._allowed_plugins,
-            max_blob_size=self._max_blob_size,
-            max_tensor_point_size=self._max_tensor_point_size,
+            upload_limits=self._upload_limits,
             rpc_rate_limiter=self._rpc_rate_limiter,
             tensor_rpc_rate_limiter=self._tensor_rpc_rate_limiter,
             blob_rpc_rate_limiter=self._blob_rpc_rate_limiter,
@@ -348,8 +358,7 @@ class _BatchedRequestSender(object):
         experiment_id,
         api,
         allowed_plugins,
-        max_blob_size,
-        max_tensor_point_size,
+        upload_limits,
         rpc_rate_limiter,
         tensor_rpc_rate_limiter,
         blob_rpc_rate_limiter,
@@ -359,13 +368,13 @@ class _BatchedRequestSender(object):
         self._tag_metadata = {}
         self._allowed_plugins = frozenset(allowed_plugins)
         self._scalar_request_sender = _ScalarBatchedRequestSender(
-            experiment_id, api, rpc_rate_limiter,
+            experiment_id, api, rpc_rate_limiter, upload_limits.max_scalar_request_size
         )
         self._tensor_request_sender = _TensorBatchedRequestSender(
-            experiment_id, api, tensor_rpc_rate_limiter, max_tensor_point_size
+            experiment_id, api, tensor_rpc_rate_limiter, upload_limits.max_tensor_request_size, upload_limits.max_tensor_point_size
         )
         self._blob_request_sender = _BlobRequestSender(
-            experiment_id, api, blob_rpc_rate_limiter, max_blob_size
+            experiment_id, api, blob_rpc_rate_limiter, upload_limits.max_blob_request_size, upload_limits.max_blob_size
         )
 
     def send_requests(self, run_to_events):
@@ -469,13 +478,13 @@ class _ScalarBatchedRequestSender(object):
     methods concurrently.
     """
 
-    def __init__(self, experiment_id, api, rpc_rate_limiter):
+    def __init__(self, experiment_id, api, rpc_rate_limiter, max_request_size):
         if experiment_id is None:
             raise ValueError("experiment_id cannot be None")
         self._experiment_id = experiment_id
         self._api = api
         self._rpc_rate_limiter = rpc_rate_limiter
-        self._byte_budget_manager = _ByteBudgetManager(_MAX_WRITE_SCALARS_LENGTH_BYTES)
+        self._byte_budget_manager = _ByteBudgetManager(max_request_size)
 
         self._runs = {}  # cache: map from run name to `Run` proto in request
         self._tags = (
@@ -617,15 +626,15 @@ class _TensorBatchedRequestSender(object):
     """
 
     def __init__(
-        self, experiment_id, api, rpc_rate_limiter, max_tensor_point_size
+        self, experiment_id, api, rpc_rate_limiter, max_request_size, max_tensor_point_size
     ):
         if experiment_id is None:
             raise ValueError("experiment_id cannot be None")
         self._experiment_id = experiment_id
         self._api = api
         self._rpc_rate_limiter = rpc_rate_limiter
+        self._byte_budget_manager = _ByteBudgetManager(max_request_size)
         self._max_tensor_point_size = max_tensor_point_size
-        self._byte_budget_manager = _ByteBudgetManager(_MAX_WRITE_TENSORS_LENGTH_BYTES)
 
         self._runs = {}  # cache: map from run name to `Run` proto in request
         self._tags = (
@@ -889,12 +898,13 @@ class _BlobRequestSender(object):
     methods concurrently.
     """
 
-    def __init__(self, experiment_id, api, rpc_rate_limiter, max_blob_size):
+    def __init__(self, experiment_id, api, rpc_rate_limiter, max_blob_request_size, max_blob_size):
         if experiment_id is None:
             raise ValueError("experiment_id cannot be None")
         self._experiment_id = experiment_id
         self._api = api
         self._rpc_rate_limiter = rpc_rate_limiter
+        self._max_blob_request_size = max_blob_request_size
         self._max_blob_size = max_blob_size
 
         # Start in the empty state, just like self._new_request().
@@ -1049,9 +1059,9 @@ class _BlobRequestSender(object):
         # In the future we may want to stream from disk; that will require
         # refactoring here.
         # TODO(soergel): compute crc32c's to allow server-side data validation.
-        for offset in range(0, len(blob), BLOB_CHUNK_SIZE):
-            chunk = blob[offset : offset + BLOB_CHUNK_SIZE]
-            finalize_object = offset + BLOB_CHUNK_SIZE >= len(blob)
+        for offset in range(0, len(blob), self._max_blob_request_size):
+            chunk = blob[offset : offset + self._max_blob_request_size]
+            finalize_object = offset + self._max_blob_request_size >= len(blob)
             request = write_service_pb2.WriteBlobRequest(
                 blob_sequence_id=blob_sequence_id,
                 index=seq_index,

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -51,7 +51,7 @@ _MIN_LOGDIR_POLL_INTERVAL_SECS = 5
 
 # Minimum interval between initiating write RPCs.  When writes would otherwise
 # happen more frequently, the process will sleep to use up the rest of the time.
-_DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_MILLISECS = 1000
+_DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_MILLISECS = 5000
 
 # Minimum interval between initiating blob write RPC streams.  When writes would
 # otherwise happen more frequently, the process will sleep to use up the rest of

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -51,14 +51,14 @@ _MIN_LOGDIR_POLL_INTERVAL_SECS = 5
 
 # Minimum interval between initiating write RPCs.  When writes would otherwise
 # happen more frequently, the process will sleep to use up the rest of the time.
-_DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_SECS = 5
+_DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_MILLISECS = 1000
 
 # Minimum interval between initiating blob write RPC streams.  When writes would
 # otherwise happen more frequently, the process will sleep to use up the rest of
 # the time.  This may differ from the above RPC rate limit, because blob streams
 # are not batched, so sending a sequence of N blobs requires N streams, which
 # could reasonably be sent more frequently.
-_DEPRECATED_MIN_BLOB_REQUEST_INTERVAL_SECS = 1
+_DEPRECATED_MIN_BLOB_REQUEST_INTERVAL_MILLISECS = 1000
 
 # Age in seconds of last write after which an event file is considered inactive.
 # TODO(@nfelt): consolidate with TensorBoard --reload_multifile default logic.
@@ -147,15 +147,16 @@ class TensorBoardUploader(object):
                 _DEPRECATED_MAX_BLOB_REQUEST_SIZE_BYTES
             )
             self._upload_limits.min_scalar_request_interval = (
-                _DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_SECS
+                _DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_MILLISECS
             )
             self._upload_limits.min_tensor_request_interval = (
-                _DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_SECS
+                _DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_MILLISECS
             )
             self._upload_limits.max_blob_size = max_blob_size
             if max_tensor_point_size is None:
-                # If max_tensor_point_size is not specified then effectively disable
-                # tensor uploads by setting max size to a negative value.
+                # If max_tensor_point_size is not specified then effectively
+                # disable tensor uploads by setting max size to a negative
+                # value.
                 self._upload_limits.max_tensor_point_size = -1
             else:
                 self._upload_limits.max_tensor_point_size = (
@@ -176,21 +177,21 @@ class TensorBoardUploader(object):
 
         if rpc_rate_limiter is None:
             self._rpc_rate_limiter = util.RateLimiter(
-                self._upload_limits.min_scalar_request_interval
+                self._upload_limits.min_scalar_request_interval / 1000
             )
         else:
             self._rpc_rate_limiter = rpc_rate_limiter
 
         if tensor_rpc_rate_limiter is None:
             self._tensor_rpc_rate_limiter = util.RateLimiter(
-                self._upload_limits.min_tensor_request_interval
+                self._upload_limits.min_tensor_request_interval / 1000
             )
         else:
             self._tensor_rpc_rate_limiter = tensor_rpc_rate_limiter
 
         if blob_rpc_rate_limiter is None:
             self._blob_rpc_rate_limiter = util.RateLimiter(
-                self._upload_limits.min_blob_request_interval
+                self._upload_limits.min_blob_request_interval / 1000
             )
         else:
             self._blob_rpc_rate_limiter = blob_rpc_rate_limiter

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -135,7 +135,7 @@ class TensorBoardUploader(object):
         if upload_limits is None:
             # This branch of code is highly deprecated. Callers to
             # TensorBoardUploader will soon be updated to always pass in
-            # upload_limits and this code and it will then be deleted.
+            # upload_limits and this code will then be deleted.
             self._upload_limits = server_info_pb2.UploadLimits()
             self._upload_limits.max_scalar_request_size = (
                 _DEPRECATED_MAX_SCALAR_TENSOR_REQUEST_SIZE_BYTES

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -133,25 +133,36 @@ class TensorBoardUploader(object):
         self._logdir = logdir
         self._allowed_plugins = frozenset(allowed_plugins)
         if upload_limits is None:
-          # This branch of code is highly deprecated. We hope to delete it after
-          # cleaning up some Google-internal code.
-          self._upload_limits = server_info_pb2.UploadLimits()
-          self._upload_limits.max_scalar_request_size = _DEPRECATED_MAX_SCALAR_TENSOR_REQUEST_SIZE_BYTES
-          self._upload_limits.max_tensor_request_size = _DEPRECATED_MAX_SCALAR_TENSOR_REQUEST_SIZE_BYTES
-          self._upload_limits.max_blob_request_size = _DEPRECATED_MAX_BLOB_REQUEST_SIZE_BYTES
-          self._upload_limits.min_scalar_request_interval = _DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_SECS
-          self._upload_limits.min_tensor_request_interval = _DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_SECS
-          self._upload_limits.max_blob_size = max_blob_size
-          # Note: All callers should set this value. When they do, remove the
-          # default.
-          if max_tensor_point_size is None:
-              # If max_tensor_point_size is not specified then effectively disable
-              # tensor uploads by setting max size to a negative value.
-              self._upload_limits.max_tensor_point_size = -1
-          else:
-              self._upload_limits.max_tensor_point_size = max_tensor_point_size
+            # This branch of code is highly deprecated. Callers to
+            # TensorBoardUploader will soon be updated to always pass in
+            # upload_limits and this code and it will then be deleted.
+            self._upload_limits = server_info_pb2.UploadLimits()
+            self._upload_limits.max_scalar_request_size = (
+                _DEPRECATED_MAX_SCALAR_TENSOR_REQUEST_SIZE_BYTES
+            )
+            self._upload_limits.max_tensor_request_size = (
+                _DEPRECATED_MAX_SCALAR_TENSOR_REQUEST_SIZE_BYTES
+            )
+            self._upload_limits.max_blob_request_size = (
+                _DEPRECATED_MAX_BLOB_REQUEST_SIZE_BYTES
+            )
+            self._upload_limits.min_scalar_request_interval = (
+                _DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_SECS
+            )
+            self._upload_limits.min_tensor_request_interval = (
+                _DEPRECATED_MIN_SCALAR_TENSOR_REQUEST_INTERVAL_SECS
+            )
+            self._upload_limits.max_blob_size = max_blob_size
+            if max_tensor_point_size is None:
+                # If max_tensor_point_size is not specified then effectively disable
+                # tensor uploads by setting max size to a negative value.
+                self._upload_limits.max_tensor_point_size = -1
+            else:
+                self._upload_limits.max_tensor_point_size = (
+                    max_tensor_point_size
+                )
         else:
-          self._upload_limits = upload_limits
+            self._upload_limits = upload_limits
 
         self._name = name
         self._description = description
@@ -368,13 +379,24 @@ class _BatchedRequestSender(object):
         self._tag_metadata = {}
         self._allowed_plugins = frozenset(allowed_plugins)
         self._scalar_request_sender = _ScalarBatchedRequestSender(
-            experiment_id, api, rpc_rate_limiter, upload_limits.max_scalar_request_size
+            experiment_id,
+            api,
+            rpc_rate_limiter,
+            upload_limits.max_scalar_request_size,
         )
         self._tensor_request_sender = _TensorBatchedRequestSender(
-            experiment_id, api, tensor_rpc_rate_limiter, upload_limits.max_tensor_request_size, upload_limits.max_tensor_point_size
+            experiment_id,
+            api,
+            tensor_rpc_rate_limiter,
+            upload_limits.max_tensor_request_size,
+            upload_limits.max_tensor_point_size,
         )
         self._blob_request_sender = _BlobRequestSender(
-            experiment_id, api, blob_rpc_rate_limiter, upload_limits.max_blob_request_size, upload_limits.max_blob_size
+            experiment_id,
+            api,
+            blob_rpc_rate_limiter,
+            upload_limits.max_blob_request_size,
+            upload_limits.max_blob_size,
         )
 
     def send_requests(self, run_to_events):
@@ -626,7 +648,12 @@ class _TensorBatchedRequestSender(object):
     """
 
     def __init__(
-        self, experiment_id, api, rpc_rate_limiter, max_request_size, max_tensor_point_size
+        self,
+        experiment_id,
+        api,
+        rpc_rate_limiter,
+        max_request_size,
+        max_tensor_point_size,
     ):
         if experiment_id is None:
             raise ValueError("experiment_id cannot be None")
@@ -898,7 +925,14 @@ class _BlobRequestSender(object):
     methods concurrently.
     """
 
-    def __init__(self, experiment_id, api, rpc_rate_limiter, max_blob_request_size, max_blob_size):
+    def __init__(
+        self,
+        experiment_id,
+        api,
+        rpc_rate_limiter,
+        max_blob_request_size,
+        max_blob_size,
+    ):
         if experiment_id is None:
             raise ValueError("experiment_id cannot be None")
         self._experiment_id = experiment_id

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -155,7 +155,7 @@ def _create_uploader(
         writer_client,
         logdir,
         allowed_plugins=_SCALARS_HISTOGRAMS_AND_GRAPHS,
-        upload_limits = upload_limits,
+        upload_limits=upload_limits,
         logdir_poll_rate_limiter=logdir_poll_rate_limiter,
         rpc_rate_limiter=rpc_rate_limiter,
         tensor_rpc_rate_limiter=tensor_rpc_rate_limiter,
@@ -166,9 +166,7 @@ def _create_uploader(
 
 
 def _create_request_sender(
-    experiment_id=None,
-    api=None,
-    allowed_plugins=_USE_DEFAULT,
+    experiment_id=None, api=None, allowed_plugins=_USE_DEFAULT,
 ):
     if api is _USE_DEFAULT:
         api = _create_mock_client()
@@ -212,7 +210,10 @@ def _create_scalar_request_sender(
 
 
 def _create_tensor_request_sender(
-    experiment_id=None, api=_USE_DEFAULT, max_request_size=_USE_DEFAULT , max_tensor_point_size=_USE_DEFAULT,
+    experiment_id=None,
+    api=_USE_DEFAULT,
+    max_request_size=_USE_DEFAULT,
+    max_tensor_point_size=_USE_DEFAULT,
 ):
     if api is _USE_DEFAULT:
         api = _create_mock_client()
@@ -1033,7 +1034,9 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
         long_experiment_id = "A" * 12
         with self.assertRaises(RuntimeError) as cm:
             _create_scalar_request_sender(
-                experiment_id=long_experiment_id, api=mock_client, max_request_size=12
+                experiment_id=long_experiment_id,
+                api=mock_client,
+                max_request_size=12,
             )
         self.assertEqual(
             str(cm.exception), "Byte budget too small for base request"
@@ -1044,7 +1047,9 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
         event = event_pb2.Event(step=1, wall_time=123.456)
         event.summary.value.add(tag="foo", simple_value=1.0)
         long_run_name = "A" * 12
-        sender = _create_scalar_request_sender("123", mock_client, max_request_size=12)
+        sender = _create_scalar_request_sender(
+            "123", mock_client, max_request_size=12
+        )
         with self.assertRaises(RuntimeError) as cm:
             self._add_events(sender, long_run_name, [event])
         self.assertEqual(str(cm.exception), "add_event failed despite flush")
@@ -1060,9 +1065,12 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
         event_2 = event_pb2.Event(step=2)
         event_2.summary.value.add(tag="bar", simple_value=-2.0)
 
-        sender = _create_scalar_request_sender("123", mock_client,
+        sender = _create_scalar_request_sender(
+            "123",
+            mock_client,
             # Set a limit to request size
-            max_request_size=1024)
+            max_request_size=1024,
+        )
         self._add_events(sender, long_run_1, _apply_compat([event_1]))
         self._add_events(sender, long_run_2, _apply_compat([event_2]))
         sender.flush()
@@ -1101,9 +1109,12 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
         event.summary.value.add(tag=long_tag_1, simple_value=1.0)
         event.summary.value.add(tag=long_tag_2, simple_value=2.0)
 
-        sender = _create_scalar_request_sender("123", mock_client,
+        sender = _create_scalar_request_sender(
+            "123",
+            mock_client,
             # Set a limit to request size
-            max_request_size=1024)
+            max_request_size=1024,
+        )
         self._add_events(sender, "train", _apply_compat([event]))
         sender.flush()
         requests = [c[0][0] for c in mock_client.WriteScalar.call_args_list]
@@ -1143,9 +1154,12 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
                 summary.value[0].ClearField("metadata")
             events.append(event_pb2.Event(summary=summary, step=step))
 
-        sender = _create_scalar_request_sender("123", mock_client,
+        sender = _create_scalar_request_sender(
+            "123",
+            mock_client,
             # Set a limit to request size
-            max_request_size=1024)
+            max_request_size=1024,
+        )
         self._add_events(sender, "train", _apply_compat(events))
         sender.flush()
         requests = [c[0][0] for c in mock_client.WriteScalar.call_args_list]
@@ -1335,7 +1349,9 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
         long_experiment_id = "A" * 12
         with self.assertRaises(RuntimeError) as cm:
             _create_tensor_request_sender(
-                experiment_id=long_experiment_id, api=mock_client, max_request_size=12
+                experiment_id=long_experiment_id,
+                api=mock_client,
+                max_request_size=12,
             )
         self.assertEqual(
             str(cm.exception), "Byte budget too small for base request"
@@ -1348,7 +1364,9 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
             tag="one", tensor=tensor_pb2.TensorProto(double_val=[1.0])
         )
         long_run_name = "A" * 12
-        sender = _create_tensor_request_sender("123", mock_client, max_request_size=12)
+        sender = _create_tensor_request_sender(
+            "123", mock_client, max_request_size=12
+        )
         with self.assertRaises(RuntimeError) as cm:
             self._add_events(sender, long_run_name, [event])
         self.assertEqual(str(cm.exception), "add_event failed despite flush")
@@ -1368,9 +1386,12 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
             tag="two", tensor=tensor_pb2.TensorProto(double_val=[2.0])
         )
 
-        sender = _create_tensor_request_sender("123", mock_client,
+        sender = _create_tensor_request_sender(
+            "123",
+            mock_client,
             # Set a limit to request size
-            max_request_size=1024)
+            max_request_size=1024,
+        )
         self._add_events(sender, long_run_1, _apply_compat([event_1]))
         self._add_events(sender, long_run_2, _apply_compat([event_2]))
         sender.flush()
@@ -1397,9 +1418,12 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
             tag=long_tag_2, tensor=tensor_pb2.TensorProto(double_val=[2.0])
         )
 
-        sender = _create_tensor_request_sender("123", mock_client,
+        sender = _create_tensor_request_sender(
+            "123",
+            mock_client,
             # Set a limit to request size
-            max_request_size=1024)
+            max_request_size=1024,
+        )
         self._add_events(sender, "train", _apply_compat([event]))
         sender.flush()
         requests = [c[0][0] for c in mock_client.WriteTensor.call_args_list]
@@ -1431,9 +1455,12 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
             )
             events.append(event)
 
-        sender = _create_tensor_request_sender("123", mock_client,
+        sender = _create_tensor_request_sender(
+            "123",
+            mock_client,
             # Set a limit to request size
-            max_request_size=1024)
+            max_request_size=1024,
+        )
         self._add_events(sender, "train", _apply_compat(events))
         sender.flush()
         requests = [c[0][0] for c in mock_client.WriteTensor.call_args_list]

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -38,6 +38,7 @@ from tensorboard import data_compat
 from tensorboard import dataclass_compat
 from tensorboard.uploader.proto import experiment_pb2
 from tensorboard.uploader.proto import scalar_pb2
+from tensorboard.uploader.proto import server_info_pb2
 from tensorboard.uploader.proto import write_service_pb2
 from tensorboard.uploader.proto import write_service_pb2_grpc
 from tensorboard.uploader import test_util
@@ -116,34 +117,48 @@ _USE_DEFAULT = object()
 def _create_uploader(
     writer_client=_USE_DEFAULT,
     logdir=None,
+    max_scalar_request_size=_USE_DEFAULT,
+    max_blob_request_size=_USE_DEFAULT,
     max_blob_size=_USE_DEFAULT,
-    max_tensor_point_size=_USE_DEFAULT,
     logdir_poll_rate_limiter=_USE_DEFAULT,
     rpc_rate_limiter=_USE_DEFAULT,
+    tensor_rpc_rate_limiter=_USE_DEFAULT,
     blob_rpc_rate_limiter=_USE_DEFAULT,
     name=None,
     description=None,
 ):
     if writer_client is _USE_DEFAULT:
         writer_client = _create_mock_client()
+    if max_scalar_request_size is _USE_DEFAULT:
+        max_scalar_request_size = 128000
+    if max_blob_request_size is _USE_DEFAULT:
+        max_blob_request_size = 128000
     if max_blob_size is _USE_DEFAULT:
         max_blob_size = 12345
-    if max_tensor_point_size is _USE_DEFAULT:
-        max_tensor_point_size = 11111
     if logdir_poll_rate_limiter is _USE_DEFAULT:
         logdir_poll_rate_limiter = util.RateLimiter(0)
     if rpc_rate_limiter is _USE_DEFAULT:
         rpc_rate_limiter = util.RateLimiter(0)
+    if tensor_rpc_rate_limiter is _USE_DEFAULT:
+        tensor_rpc_rate_limiter = util.RateLimiter(0)
     if blob_rpc_rate_limiter is _USE_DEFAULT:
         blob_rpc_rate_limiter = util.RateLimiter(0)
+
+    upload_limits = server_info_pb2.UploadLimits()
+    upload_limits.max_scalar_request_size = max_scalar_request_size
+    upload_limits.max_tensor_request_size = 128000
+    upload_limits.max_blob_request_size = max_blob_request_size
+    upload_limits.max_blob_size = max_blob_size
+    upload_limits.max_tensor_point_size = 11111
+
     return uploader_lib.TensorBoardUploader(
         writer_client,
         logdir,
         allowed_plugins=_SCALARS_HISTOGRAMS_AND_GRAPHS,
-        max_blob_size=max_blob_size,
-        max_tensor_point_size=max_tensor_point_size,
+        upload_limits = upload_limits,
         logdir_poll_rate_limiter=logdir_poll_rate_limiter,
         rpc_rate_limiter=rpc_rate_limiter,
+        tensor_rpc_rate_limiter=tensor_rpc_rate_limiter,
         blob_rpc_rate_limiter=blob_rpc_rate_limiter,
         name=name,
         description=description,
@@ -154,57 +169,62 @@ def _create_request_sender(
     experiment_id=None,
     api=None,
     allowed_plugins=_USE_DEFAULT,
-    max_blob_size=_USE_DEFAULT,
-    max_tensor_point_size=_USE_DEFAULT,
-    rpc_rate_limiter=_USE_DEFAULT,
-    blob_rpc_rate_limiter=_USE_DEFAULT,
 ):
     if api is _USE_DEFAULT:
         api = _create_mock_client()
     if allowed_plugins is _USE_DEFAULT:
         allowed_plugins = _SCALARS_HISTOGRAMS_AND_GRAPHS
-    if max_blob_size is _USE_DEFAULT:
-        max_blob_size = 12345
-    if max_tensor_point_size is _USE_DEFAULT:
-        max_tensor_point_size = 11111
-    if rpc_rate_limiter is _USE_DEFAULT:
-        rpc_rate_limiter = util.RateLimiter(0)
-    if blob_rpc_rate_limiter is _USE_DEFAULT:
-        blob_rpc_rate_limiter = util.RateLimiter(0)
+
+    upload_limits = server_info_pb2.UploadLimits()
+    upload_limits.max_blob_size = 12345
+    upload_limits.max_tensor_point_size = 11111
+    upload_limits.max_scalar_request_size = 128000
+    upload_limits.max_tensor_request_size = 128000
+
+    rpc_rate_limiter = util.RateLimiter(0)
+    tensor_rpc_rate_limiter = util.RateLimiter(0)
+    blob_rpc_rate_limiter = util.RateLimiter(0)
+
     return uploader_lib._BatchedRequestSender(
         experiment_id=experiment_id,
         api=api,
         allowed_plugins=allowed_plugins,
-        max_blob_size=max_blob_size,
-        max_tensor_point_size=max_tensor_point_size,
+        upload_limits=upload_limits,
         rpc_rate_limiter=rpc_rate_limiter,
+        tensor_rpc_rate_limiter=tensor_rpc_rate_limiter,
         blob_rpc_rate_limiter=blob_rpc_rate_limiter,
     )
 
 
 def _create_scalar_request_sender(
-    experiment_id=None, api=None,
+    experiment_id=None, api=_USE_DEFAULT, max_request_size=_USE_DEFAULT
 ):
     if api is _USE_DEFAULT:
         api = _create_mock_client()
+    if max_request_size is _USE_DEFAULT:
+        max_request_size = 128000
     return uploader_lib._ScalarBatchedRequestSender(
         experiment_id=experiment_id,
         api=api,
         rpc_rate_limiter=util.RateLimiter(0),
+        max_request_size=max_request_size,
     )
 
 
 def _create_tensor_request_sender(
-    experiment_id=None, api=None, max_tensor_point_size=_USE_DEFAULT,
+    experiment_id=None, api=_USE_DEFAULT, max_request_size=_USE_DEFAULT , max_tensor_point_size=_USE_DEFAULT,
 ):
     if api is _USE_DEFAULT:
         api = _create_mock_client()
+    if max_request_size is _USE_DEFAULT:
+        max_request_size = 128000
     if max_tensor_point_size is _USE_DEFAULT:
         max_tensor_point_size = 11111
     return uploader_lib._TensorBatchedRequestSender(
         experiment_id=experiment_id,
         api=api,
         rpc_rate_limiter=util.RateLimiter(0),
+        max_request_size=max_request_size,
         max_tensor_point_size=max_tensor_point_size,
     )
 
@@ -278,16 +298,18 @@ class TensorboardUploaderTest(tf.test.TestCase):
         with self.assertRaisesRegex(RuntimeError, "call create_experiment()"):
             uploader.start_uploading()
 
-    # Send each Event below in a separate WriteScalarRequest
-    @mock.patch.object(uploader_lib, "_MAX_REQUEST_LENGTH_BYTES", 100)
     def test_start_uploading_scalars(self):
         mock_client = _create_mock_client()
         mock_rate_limiter = mock.create_autospec(util.RateLimiter)
+        mock_tensor_rate_limiter = mock.create_autospec(util.RateLimiter)
         mock_blob_rate_limiter = mock.create_autospec(util.RateLimiter)
         uploader = _create_uploader(
             mock_client,
             "/logs/foo",
+            # Send each Event below in a separate WriteScalarRequest
+            max_scalar_request_size=100,
             rpc_rate_limiter=mock_rate_limiter,
+            tensor_rpc_rate_limiter=mock_tensor_rate_limiter,
             blob_rpc_rate_limiter=mock_blob_rate_limiter,
         )
         uploader.create_experiment()
@@ -325,16 +347,19 @@ class TensorboardUploaderTest(tf.test.TestCase):
             uploader.start_uploading()
         self.assertEqual(4 + 6, mock_client.WriteScalar.call_count)
         self.assertEqual(4 + 6, mock_rate_limiter.tick.call_count)
+        self.assertEqual(0, mock_tensor_rate_limiter.tick.call_count)
         self.assertEqual(0, mock_blob_rate_limiter.tick.call_count)
 
     def test_start_uploading_tensors(self):
         mock_client = _create_mock_client()
         mock_rate_limiter = mock.create_autospec(util.RateLimiter)
+        mock_tensor_rate_limiter = mock.create_autospec(util.RateLimiter)
         mock_blob_rate_limiter = mock.create_autospec(util.RateLimiter)
         uploader = _create_uploader(
             mock_client,
             "/logs/foo",
             rpc_rate_limiter=mock_rate_limiter,
+            tensor_rpc_rate_limiter=mock_tensor_rate_limiter,
             blob_rpc_rate_limiter=mock_blob_rate_limiter,
         )
         uploader.create_experiment()
@@ -359,19 +384,22 @@ class TensorboardUploaderTest(tf.test.TestCase):
         ), self.assertRaises(AbortUploadError):
             uploader.start_uploading()
         self.assertEqual(1, mock_client.WriteTensor.call_count)
-        self.assertEqual(1, mock_rate_limiter.tick.call_count)
+        self.assertEqual(0, mock_rate_limiter.tick.call_count)
+        self.assertEqual(1, mock_tensor_rate_limiter.tick.call_count)
         self.assertEqual(0, mock_blob_rate_limiter.tick.call_count)
 
-    # Verify behavior with lots of small chunks
-    @mock.patch.object(uploader_lib, "BLOB_CHUNK_SIZE", 100)
     def test_start_uploading_graphs(self):
         mock_client = _create_mock_client()
         mock_rate_limiter = mock.create_autospec(util.RateLimiter)
+        mock_tensor_rate_limiter = mock.create_autospec(util.RateLimiter)
         mock_blob_rate_limiter = mock.create_autospec(util.RateLimiter)
         uploader = _create_uploader(
             mock_client,
             "/logs/foo",
+            # Verify behavior with lots of small chunks
+            max_blob_request_size=100,
             rpc_rate_limiter=mock_rate_limiter,
+            tensor_rpc_rate_limiter=mock_tensor_rate_limiter,
             blob_rpc_rate_limiter=mock_blob_rate_limiter,
         )
         uploader.create_experiment()
@@ -413,9 +441,9 @@ class TensorboardUploaderTest(tf.test.TestCase):
                 set(r.blob_sequence_id for r in requests), {"blob%d" % i},
             )
         self.assertEqual(0, mock_rate_limiter.tick.call_count)
+        self.assertEqual(0, mock_tensor_rate_limiter.tick.call_count)
         self.assertEqual(10, mock_blob_rate_limiter.tick.call_count)
 
-    @mock.patch.object(uploader_lib, "BLOB_CHUNK_SIZE", 100)
     def test_upload_skip_large_blob(self):
         mock_client = _create_mock_client()
         mock_rate_limiter = mock.create_autospec(util.RateLimiter)
@@ -423,9 +451,11 @@ class TensorboardUploaderTest(tf.test.TestCase):
         uploader = _create_uploader(
             mock_client,
             "/logs/foo",
+            # Verify behavior with lots of small chunks
+            max_blob_request_size=100,
+            max_blob_size=100,
             rpc_rate_limiter=mock_rate_limiter,
             blob_rpc_rate_limiter=mock_blob_rate_limiter,
-            max_blob_size=100,
         )
         uploader.create_experiment()
 
@@ -1000,10 +1030,10 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
 
     def test_no_budget_for_base_request(self):
         mock_client = _create_mock_client()
-        long_experiment_id = "A" * uploader_lib._MAX_REQUEST_LENGTH_BYTES
+        long_experiment_id = "A" * 12
         with self.assertRaises(RuntimeError) as cm:
             _create_scalar_request_sender(
-                experiment_id=long_experiment_id, api=mock_client,
+                experiment_id=long_experiment_id, api=mock_client, max_request_size=12
             )
         self.assertEqual(
             str(cm.exception), "Byte budget too small for base request"
@@ -1013,16 +1043,16 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
         mock_client = _create_mock_client()
         event = event_pb2.Event(step=1, wall_time=123.456)
         event.summary.value.add(tag="foo", simple_value=1.0)
-        long_run_name = "A" * uploader_lib._MAX_REQUEST_LENGTH_BYTES
+        long_run_name = "A" * 12
+        sender = _create_scalar_request_sender("123", mock_client, max_request_size=12)
         with self.assertRaises(RuntimeError) as cm:
-            sender = _create_scalar_request_sender("123", mock_client)
             self._add_events(sender, long_run_name, [event])
         self.assertEqual(str(cm.exception), "add_event failed despite flush")
 
-    @mock.patch.object(uploader_lib, "_MAX_REQUEST_LENGTH_BYTES", 1024)
     def test_break_at_run_boundary(self):
         mock_client = _create_mock_client()
-        # Choose run name sizes such that one run fits, but not two.
+        # Choose run name sizes such that one run fits in a 1024 byte request,
+        # but not two.
         long_run_1 = "A" * 768
         long_run_2 = "B" * 768
         event_1 = event_pb2.Event(step=1)
@@ -1030,7 +1060,9 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
         event_2 = event_pb2.Event(step=2)
         event_2.summary.value.add(tag="bar", simple_value=-2.0)
 
-        sender = _create_scalar_request_sender("123", mock_client)
+        sender = _create_scalar_request_sender("123", mock_client,
+            # Set a limit to request size
+            max_request_size=1024)
         self._add_events(sender, long_run_1, _apply_compat([event_1]))
         self._add_events(sender, long_run_2, _apply_compat([event_2]))
         sender.flush()
@@ -1058,18 +1090,20 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
         )
         self.assertEqual(requests, expected)
 
-    @mock.patch.object(uploader_lib, "_MAX_REQUEST_LENGTH_BYTES", 1024)
     def test_break_at_tag_boundary(self):
         mock_client = _create_mock_client()
-        # Choose tag name sizes such that one tag fits, but not two. Note
-        # that tag names appear in both `Tag.name` and the summary metadata.
+        # Choose tag name sizes such that one tag fits in a 1024 byte requst,
+        # but not two. Note that tag names appear in both `Tag.name` and the
+        # summary metadata.
         long_tag_1 = "a" * 384
         long_tag_2 = "b" * 384
         event = event_pb2.Event(step=1)
         event.summary.value.add(tag=long_tag_1, simple_value=1.0)
         event.summary.value.add(tag=long_tag_2, simple_value=2.0)
 
-        sender = _create_scalar_request_sender("123", mock_client)
+        sender = _create_scalar_request_sender("123", mock_client,
+            # Set a limit to request size
+            max_request_size=1024)
         self._add_events(sender, "train", _apply_compat([event]))
         sender.flush()
         requests = [c[0][0] for c in mock_client.WriteScalar.call_args_list]
@@ -1099,7 +1133,6 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
         )
         self.assertEqual(requests, expected)
 
-    @mock.patch.object(uploader_lib, "_MAX_REQUEST_LENGTH_BYTES", 1024)
     def test_break_at_scalar_point_boundary(self):
         mock_client = _create_mock_client()
         point_count = 2000  # comfortably saturates a single 1024-byte request
@@ -1110,7 +1143,9 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
                 summary.value[0].ClearField("metadata")
             events.append(event_pb2.Event(summary=summary, step=step))
 
-        sender = _create_scalar_request_sender("123", mock_client)
+        sender = _create_scalar_request_sender("123", mock_client,
+            # Set a limit to request size
+            max_request_size=1024)
         self._add_events(sender, "train", _apply_compat(events))
         sender.flush()
         requests = [c[0][0] for c in mock_client.WriteScalar.call_args_list]
@@ -1137,9 +1172,7 @@ class ScalarBatchedRequestSenderTest(tf.test.TestCase):
                 self.assertEqual(point.step, total_points_in_result)
                 self.assertEqual(point.value, -2.0 * point.step)
                 total_points_in_result += 1
-            self.assertLessEqual(
-                request.ByteSize(), uploader_lib._MAX_REQUEST_LENGTH_BYTES
-            )
+            self.assertLessEqual(request.ByteSize(), 1024)
         self.assertEqual(total_points_in_result, point_count)
 
     def test_prunes_tags_and_runs(self):
@@ -1299,10 +1332,10 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
 
     def test_no_budget_for_base_request(self):
         mock_client = _create_mock_client()
-        long_experiment_id = "A" * uploader_lib._MAX_REQUEST_LENGTH_BYTES
+        long_experiment_id = "A" * 12
         with self.assertRaises(RuntimeError) as cm:
             _create_tensor_request_sender(
-                experiment_id=long_experiment_id, api=mock_client,
+                experiment_id=long_experiment_id, api=mock_client, max_request_size=12
             )
         self.assertEqual(
             str(cm.exception), "Byte budget too small for base request"
@@ -1314,16 +1347,16 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
         event.summary.value.add(
             tag="one", tensor=tensor_pb2.TensorProto(double_val=[1.0])
         )
-        long_run_name = "A" * uploader_lib._MAX_REQUEST_LENGTH_BYTES
+        long_run_name = "A" * 12
+        sender = _create_tensor_request_sender("123", mock_client, max_request_size=12)
         with self.assertRaises(RuntimeError) as cm:
-            sender = _create_tensor_request_sender("123", mock_client)
             self._add_events(sender, long_run_name, [event])
         self.assertEqual(str(cm.exception), "add_event failed despite flush")
 
-    @mock.patch.object(uploader_lib, "_MAX_REQUEST_LENGTH_BYTES", 1024)
     def test_break_at_run_boundary(self):
         mock_client = _create_mock_client()
-        # Choose run name sizes such that one run fits, but not two.
+        # Choose run name sizes such that one run fits in a 1024 byte request,
+        # but not two.
         long_run_1 = "A" * 768
         long_run_2 = "B" * 768
         event_1 = event_pb2.Event(step=1)
@@ -1335,7 +1368,9 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
             tag="two", tensor=tensor_pb2.TensorProto(double_val=[2.0])
         )
 
-        sender = _create_tensor_request_sender("123", mock_client)
+        sender = _create_tensor_request_sender("123", mock_client,
+            # Set a limit to request size
+            max_request_size=1024)
         self._add_events(sender, long_run_1, _apply_compat([event_1]))
         self._add_events(sender, long_run_2, _apply_compat([event_2]))
         sender.flush()
@@ -1348,10 +1383,10 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
         self.assertEqual(1, len(requests[1].runs))
         self.assertEqual(long_run_2, requests[1].runs[0].name)
 
-    @mock.patch.object(uploader_lib, "_MAX_REQUEST_LENGTH_BYTES", 1024)
     def test_break_at_tag_boundary(self):
         mock_client = _create_mock_client()
-        # Choose tag name sizes such that one tag fits, but not two.
+        # Choose tag name sizes such that one tag fits in a 1024 byte request,
+        # but not two.
         long_tag_1 = "a" * 600
         long_tag_2 = "b" * 600
         event = event_pb2.Event(step=1, wall_time=1)
@@ -1362,7 +1397,9 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
             tag=long_tag_2, tensor=tensor_pb2.TensorProto(double_val=[2.0])
         )
 
-        sender = _create_tensor_request_sender("123", mock_client)
+        sender = _create_tensor_request_sender("123", mock_client,
+            # Set a limit to request size
+            max_request_size=1024)
         self._add_events(sender, "train", _apply_compat([event]))
         sender.flush()
         requests = [c[0][0] for c in mock_client.WriteTensor.call_args_list]
@@ -1380,7 +1417,6 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
         self.assertEqual(1, len(requests[1].runs[0].tags))
         self.assertEqual(long_tag_2, requests[1].runs[0].tags[0].name)
 
-    @mock.patch.object(uploader_lib, "_MAX_REQUEST_LENGTH_BYTES", 1024)
     def test_break_at_tensor_point_boundary(self):
         mock_client = _create_mock_client()
         point_count = 2000  # comfortably saturates a single 1024-byte request
@@ -1395,7 +1431,9 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
             )
             events.append(event)
 
-        sender = _create_tensor_request_sender("123", mock_client)
+        sender = _create_tensor_request_sender("123", mock_client,
+            # Set a limit to request size
+            max_request_size=1024)
         self._add_events(sender, "train", _apply_compat(events))
         sender.flush()
         requests = [c[0][0] for c in mock_client.WriteTensor.call_args_list]
@@ -1419,9 +1457,7 @@ class TensorBatchedRequestSenderTest(tf.test.TestCase):
                     [1.0 * point.step, -1.0 * point.step],
                 )
                 total_points_in_result += 1
-            self.assertLessEqual(
-                request.ByteSize(), uploader_lib._MAX_REQUEST_LENGTH_BYTES
-            )
+            self.assertLessEqual(request.ByteSize(), 1024)
         self.assertEqual(total_points_in_result, point_count)
 
     def test_strip_large_tensors(self):


### PR DESCRIPTION
* Motivation for features / changes

There are a number of new parameters that impact the throughput of uploading data that we want the TensorBoard.dev frontend to return to the uploader in the handshake. Each of scalar, tensor, and blob now have a max\_[scalars|tensor|blob]\_request\_size and min\_[scalars|tensor|blob]\_request\_interval parameters.

* Technical description of changes

Update the UploadLimits proto to include the new fields. Allow an instance of UploadLimits to be passed to TensorBoardUploader and use this throughout the code instead of the constants that have been used.

None of the clients for TensorBoardUploader are yet updated to pass UploadLimits (there is one in this git repo and there is one internal to Google) so temporarily have TensorBoardUploader construct its own UploadLimits if None is passed, where values are all based on now-deprecated constants and arguments to the constructor.  We hope to update clients in the next day or two so this is intended to be very temporary.

Tests have been updated to use UploadLimits as arguments exclusively.