### PR TITLE
Uploader uses entire UploadLimits from handshake

### DIFF
--- a/tensorboard/uploader/proto/server_info.proto
+++ b/tensorboard/uploader/proto/server_info.proto
@@ -104,30 +104,35 @@ message PluginControl {
 }
 
 message UploadLimits {
-  // The maximum allowed WriteScalar request size, in bytes. If this is
-  // non-positive then no blobs should be uploaded.
+  // The maximum allowed WriteScalar request size, in bytes.
+  // If this is 0 or unset, client should use a reasonable default value.
+  // If this is negative, no scalars should be uploaded.
   int64 max_scalar_request_size = 3;
-  // The maximum allowed WriteTensor request size, in bytes. If this is
-  // non-positive then no blobs should be uploaded.
+  // The maximum allowed WriteTensor request size, in bytes.
+  // If this is 0 or unset, client should use a reasonable default value.
+  // If this is negative, no tensors should be uploaded.
   int64 max_tensor_request_size = 4;
-  // The maximum allowed WriteBlob request size, in bytes. If this is
-  // non-positive then no blobs should be uploaded.
+  // The maximum allowed WriteBlob request size, in bytes.
+  // If this is 0 or unset, client should use a reasonable default value.
+  // If this is negative, no blobs should be uploaded.
   int64 max_blob_request_size = 5;
 
   // The minimum interval between WriteScalar requests, in milliseconds.
+  // If this is 0 or unset, client should use a reasonable default value.
   int64 min_scalar_request_interval = 6;
   // The minimum interval between WriteTensor requests, in milliseconds.
+  // If this is 0 or unset, client should use a reasonable default value.
   int64 min_tensor_request_interval = 7;
   // The minimum interval between WriteBlob requests, in milliseconds.
+  // If this is 0 or unset, client should use a reasonable default value.
   int64 min_blob_request_interval = 8;
 
   // The maximum allowed size for blob uploads.
-  // If this is 0, it is allowed to upload blobs of size 0 (though note
-  // the server may enforce a *minimum* blob size, which is a separate issue).
+  // If this is 0 or unset, client should use a reasonable default value.
   // If this is negative, no blobs should be uploaded.
   int64 max_blob_size = 1;
   // The maximum allowed size for tensor point uploads.
-  // If this is 0, it is allowed to upload tensor points of size 0.
+  // If this is 0 or unset, client should use a reasonable default value.
   // If this is negative, no blobs should be uploaded.
   int64 max_tensor_point_size = 2;
 }

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -408,10 +408,7 @@ class _UploadIntent(_Intent):
             api_client,
             self.logdir,
             allowed_plugins=server_info_lib.allowed_plugins(server_info),
-            max_blob_size=server_info_lib.max_blob_size(server_info),
-            max_tensor_point_size=server_info_lib.max_tensor_point_size(
-                server_info
-            ),
+            upload_limits=server_info_lib.upload_limits(server_info),
             name=self.name,
             description=self.description,
         )


### PR DESCRIPTION
* Motivation for features / changes

Continue work to get upload-related parameters from the frontend handshake.

* Technical description of changes

The logic in uploader_subcommand reads UploadLimits from the handshake
and passes it to the TensorBoardUploader.

If any individual field in UploadLimits is missing, use a reasonable
default.

With this and some Google-internal code cleanup we can now delete the
deprecated fields in TensorBoardUploader.

* Detailed steps to verify changes work correctly (as executed by you)

Wrote tests.

Brought up a local frontend and made sure values from it are honored by the uploader.

Ran uploader against prod frontend and ensured it falls back to defaults.