### PR TITLE
Use tf-wbr-string in tf-node-info

### DIFF
--- a/tensorboard/components/tf_runs_selector/BUILD
+++ b/tensorboard/components/tf_runs_selector/BUILD
@@ -8,7 +8,6 @@ tf_web_library(
     name = "tf_runs_selector",
     srcs = [
         "tf-runs-selector.html",
-        "tf-wbr-string.html",
     ],
     path = "/tf-runs-selector",
     deps = [
@@ -16,6 +15,7 @@ tf_web_library(
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_wbr_string",
         "@org_polymer_paper_button",
         "@org_polymer_paper_dialog",
         "@org_polymer_paper_styles",

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -39,7 +39,7 @@ Properties out:
       <h2>Data Location</h2>
       <tf-wbr-string
         value="[[dataLocation]]"
-        delimiter-pattern="[[_dataLocationDelimiterPattern]]"
+        delimiters="[[_dataLocationWbrDelimiters]]"
       />
     </paper-dialog>
     <div id="top-text">
@@ -60,7 +60,7 @@ Properties out:
       <div id="data-location">
         <tf-wbr-string
           value="[[_clippedDataLocation]]"
-          delimiter-pattern="[[_dataLocationDelimiterPattern]]"
+          delimiters="[[_dataLocationWbrDelimiters]]"
         /><!--
           We use HTML comments to remove spaces before the ellipsis.
         --><template
@@ -154,9 +154,9 @@ Properties out:
           value: 250,
           readOnly: true,
         },
-        _dataLocationDelimiterPattern: {
+        _dataLocationWbrDelimiters: {
           type: String,
-          value: '[/=_,-]',
+          value: '/=_,-',
           readOnly: true,
         },
         coloring: {

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -39,7 +39,8 @@ Properties out:
       <h2>Data Location</h2>
       <tf-wbr-string
         value="[[dataLocation]]"
-        delimiter-pattern="[[_dataLocationDelimiterPattern]]" />
+        delimiter-pattern="[[_dataLocationDelimiterPattern]]"
+      />
     </paper-dialog>
     <div id="top-text">
       <h3 id="tooltip-help" class="tooltip-container">Runs</h3>
@@ -59,7 +60,8 @@ Properties out:
       <div id="data-location">
         <tf-wbr-string
           value="[[_clippedDataLocation]]"
-          delimiter-pattern="[[_dataLocationDelimiterPattern]]" /><!--
+          delimiter-pattern="[[_dataLocationDelimiterPattern]]"
+        /><!--
           We use HTML comments to remove spaces before the ellipsis.
         --><template
           is="dom-if"

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -39,7 +39,7 @@ Properties out:
       <h2>Data Location</h2>
       <tf-wbr-string
         value="[[dataLocation]]"
-        delimiters="[[_dataLocationWbrDelimiters]]"
+        delimiter-pattern="[[_dataLocationWbrDelimiters]]"
       />
     </paper-dialog>
     <div id="top-text">
@@ -60,7 +60,7 @@ Properties out:
       <div id="data-location">
         <tf-wbr-string
           value="[[_clippedDataLocation]]"
-          delimiters="[[_dataLocationWbrDelimiters]]"
+          delimiter-pattern="[[_dataLocationWbrDelimiters]]"
         /><!--
           We use HTML comments to remove spaces before the ellipsis.
         --><template
@@ -156,7 +156,7 @@ Properties out:
         },
         _dataLocationWbrDelimiters: {
           type: String,
-          value: '/=_,-',
+          value: '[/=_,-]',
           readOnly: true,
         },
         coloring: {

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -22,7 +22,7 @@ limitations under the License.
 <link rel="import" href="../tf-color-scale/tf-color-scale.html" />
 <link rel="import" href="../tf-dashboard-common/scrollbar-style.html" />
 <link rel="import" href="../tf-dashboard-common/tf-multi-checkbox.html" />
-<link rel="import" href="tf-wbr-string.html" />
+<link rel="import" href="../tf-wbr-string/tf-wbr-string.html" />
 
 <!--
 tf-runs-selector creates a set of checkboxes to display which runs are
@@ -37,7 +37,9 @@ Properties out:
   <template>
     <paper-dialog with-backdrop id="data-location-dialog">
       <h2>Data Location</h2>
-      <tf-wbr-string value="[[dataLocation]]" />
+      <tf-wbr-string
+        value="[[dataLocation]]"
+        delimiter-pattern="[[_dataLocationDelimiterPattern]]" />
     </paper-dialog>
     <div id="top-text">
       <h3 id="tooltip-help" class="tooltip-container">Runs</h3>
@@ -55,7 +57,9 @@ Properties out:
     </paper-button>
     <template is="dom-if" if="[[dataLocation]]">
       <div id="data-location">
-        <tf-wbr-string value="[[_clippedDataLocation]]" /><!--
+        <tf-wbr-string
+          value="[[_clippedDataLocation]]"
+          delimiter-pattern="[[_dataLocationDelimiterPattern]]" /><!--
           We use HTML comments to remove spaces before the ellipsis.
         --><template
           is="dom-if"
@@ -146,6 +150,11 @@ Properties out:
         _dataLocationClipLength: {
           type: Number,
           value: 250,
+          readOnly: true,
+        },
+        _dataLocationDelimiterPattern: {
+          type: String,
+          value: '[/=_,-]',
           readOnly: true,
         },
         coloring: {

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -39,7 +39,7 @@ Properties out:
       <h2>Data Location</h2>
       <tf-wbr-string
         value="[[dataLocation]]"
-        delimiter-pattern="[[_dataLocationWbrDelimiters]]"
+        delimiter-pattern="[[_dataLocationDelimiterPattern]]"
       />
     </paper-dialog>
     <div id="top-text">
@@ -60,7 +60,7 @@ Properties out:
       <div id="data-location">
         <tf-wbr-string
           value="[[_clippedDataLocation]]"
-          delimiter-pattern="[[_dataLocationWbrDelimiters]]"
+          delimiter-pattern="[[_dataLocationDelimiterPattern]]"
         /><!--
           We use HTML comments to remove spaces before the ellipsis.
         --><template
@@ -154,7 +154,7 @@ Properties out:
           value: 250,
           readOnly: true,
         },
-        _dataLocationWbrDelimiters: {
+        _dataLocationDelimiterPattern: {
           type: String,
           value: '[/=_,-]',
           readOnly: true,

--- a/tensorboard/components/tf_wbr_string/BUILD
+++ b/tensorboard/components/tf_wbr_string/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_library(
+    name = "tf_wbr_string",
+    srcs = [
+        "tf-wbr-string.html",
+    ],
+    path = "/tf-wbr-string",
+    deps = [
+        "//tensorboard/components/tf_imports:polymer",
+    ],
+)

--- a/tensorboard/components/tf_wbr_string/test/BUILD
+++ b/tensorboard/components/tf_wbr_string/test/BUILD
@@ -1,0 +1,28 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//tensorboard:internal"],
+)
+
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_test(
+    name = "test",
+    src = "/tf-wbr-string/test/tests.html",
+    web_library = ":test_web_library",
+)
+
+tf_web_library(
+    name = "test_web_library",
+    srcs = [
+        "tfWbrStringTests.ts",
+        "tests.html",
+    ],
+    path = "/tf-wbr-string/test",
+    deps = [
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_imports:web_component_tester",
+        "//tensorboard/components/tf_wbr_string",
+    ],
+)

--- a/tensorboard/components/tf_wbr_string/test/BUILD
+++ b/tensorboard/components/tf_wbr_string/test/BUILD
@@ -16,8 +16,8 @@ tf_web_test(
 tf_web_library(
     name = "test_web_library",
     srcs = [
-        "tfWbrStringTests.ts",
         "tests.html",
+        "tfWbrStringTests.ts",
     ],
     path = "/tf-wbr-string/test",
     deps = [

--- a/tensorboard/components/tf_wbr_string/test/tests.html
+++ b/tensorboard/components/tf_wbr_string/test/tests.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<html>
+  <head>
+    <link rel="import" href="../../tf-imports/polymer.html" />
+    <script src="../../web-component-tester/browser.js"></script>
+    <link rel="import" href="../tf-wbr-string.html" />
+  </head>
+  <body>
+    <test-fixture id="tf-wbr-string">
+      <template>
+        <tf-wbr-string />
+      </template>
+    </test-fixture>
+
+    <script src="tfWbrStringTests.js"></script>
+  </body>
+</html>

--- a/tensorboard/components/tf_wbr_string/test/tfWbrStringTests.ts
+++ b/tensorboard/components/tf_wbr_string/test/tfWbrStringTests.ts
@@ -19,7 +19,7 @@ namespace tf_wbr_string {
 
   window.HTMLImports.whenReady(() => {
     describe('tf-wbr-string', () => {
-      it('adds wbrs for single character', (done) => {
+      it('adds wbrs for patterns with a single character', (done) => {
         let testElement: any = fixture('tf-wbr-string');
         testElement.value = 'I/have/a/delimiter';
         testElement.delimiterPattern = '/';
@@ -27,11 +27,14 @@ namespace tf_wbr_string {
           expect(testElement.shadowRoot.innerHTML).to.have.string(
             'I/<wbr>have/<wbr>a/<wbr>delimiter<wbr>'
           );
+          expect(testElement.shadowRoot.textContent.trim()).to.equal(
+            'I/have/a/delimiter'
+          );
           done();
         });
       });
 
-      it('adds wbrs for multiple single characters', (done) => {
+      it('adds wbrs for patterns with multiple single characters', (done) => {
         let testElement: any = fixture('tf-wbr-string');
         testElement.value = 'I_have-multiple_delimiter.s';
         testElement.delimiterPattern = '[_.\\-]';
@@ -43,13 +46,86 @@ namespace tf_wbr_string {
         });
       });
 
-      it('adds wbrs for arbitrary regex patterns', (done) => {
+      it('adds wbrs for more complex patterns', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'thea_heats_tea';
+        testElement.delimiterPattern = 'the|eat';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'the<wbr>a_heat<wbr>s_tea<wbr>'
+          );
+          done();
+        });
+      });
+
+      it('ignores overlapped matches', (done) => {
         let testElement: any = fixture('tf-wbr-string');
         testElement.value = 'the_theatre_heats_tea';
         testElement.delimiterPattern = 'the|eat';
         flush(() => {
+          // The "eat" in "theatre" is ignored.
           expect(testElement.shadowRoot.innerHTML).to.have.string(
             'the<wbr>_the<wbr>atre_heat<wbr>s_tea<wbr>'
+          );
+          done();
+        });
+      });
+
+      it('allows empty matches to consume remainder of the string', (done) => {
+        // The current handling of empty matches may not desirable but we warn
+        // against this in the documentation. We could consider improving this
+        // in the future.
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'the_theatre_heats_tea';
+        testElement.delimiterPattern = '(the|eat)?';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'the<wbr>_theatre_heats_tea<wbr>'
+          );
+          done();
+        });
+      });
+
+      it('adds single wbr for empty value', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = '';
+        testElement.delimiterPattern = '/';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string('<wbr>');
+          expect(testElement.shadowRoot.textContent.trim()).to.equal('');
+          done();
+        });
+      });
+
+      it('adds single wbr for undefined value', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = null;
+        testElement.delimiterPattern = '/';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string('<wbr>');
+          expect(testElement.shadowRoot.textContent.trim()).to.equal('');
+          done();
+        });
+      });
+
+      it('adds single wbr for empty pattern', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'Empty delimiter pattern';
+        testElement.delimiterPattern = '';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'Empty delimiter pattern<wbr>'
+          );
+          done();
+        });
+      });
+
+      it('adds single wbr for undefined pattern', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'undefined pattern';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'undefined pattern<wbr>'
           );
           done();
         });

--- a/tensorboard/components/tf_wbr_string/test/tfWbrStringTests.ts
+++ b/tensorboard/components/tf_wbr_string/test/tfWbrStringTests.ts
@@ -19,49 +19,37 @@ namespace tf_wbr_string {
 
   window.HTMLImports.whenReady(() => {
     describe('tf-wbr-string', () => {
-      it('adds wbrs for single delimiter', (done) => {
+      it('adds wbrs for single character', (done) => {
         let testElement: any = fixture('tf-wbr-string');
-        testElement.value = 'I_have_a_delimiter';
-        testElement.delimiters = '_';
+        testElement.value = 'I/have/a/delimiter';
+        testElement.delimiterPattern = '/';
         flush(() => {
           expect(testElement.shadowRoot.innerHTML).to.have.string(
-            'I_<wbr>have_<wbr>a_<wbr>delimiter<wbr>'
+            'I/<wbr>have/<wbr>a/<wbr>delimiter<wbr>'
           );
           done();
         });
       });
 
-      it('adds wbrs for multiple delimiters', (done) => {
+      it('adds wbrs for multiple single characters', (done) => {
         let testElement: any = fixture('tf-wbr-string');
-        testElement.value = 'I_have<multiple_delimiter.s';
-        testElement.delimiters = '_.<';
+        testElement.value = 'I_have-multiple_delimiter.s';
+        testElement.delimiterPattern = '[_.\\-]';
         flush(() => {
           expect(testElement.shadowRoot.innerHTML).to.have.string(
-            'I_<wbr>have&lt;<wbr>multiple_<wbr>delimiter.<wbr>s<wbr>'
+            'I_<wbr>have-<wbr>multiple_<wbr>delimiter.<wbr>s<wbr>'
           );
           done();
         });
       });
 
-      it('handles regex character class special characters', (done) => {
+      it('adds wbrs for arbitrary regex patterns', (done) => {
         let testElement: any = fixture('tf-wbr-string');
-        testElement.value = 'I^have-many]special[delimiters^here';
-        testElement.delimiters = '^-][';
+        testElement.value = 'the_theatre_heats_tea';
+        testElement.delimiterPattern = 'the|eat';
         flush(() => {
           expect(testElement.shadowRoot.innerHTML).to.have.string(
-            'I^<wbr>have-<wbr>many]<wbr>special[<wbr>delimiters^<wbr>here'
-          );
-          done();
-        });
-      });
-
-      it('handles regex metacharacters as delimiters', (done) => {
-        let testElement: any = fixture('tf-wbr-string');
-        testElement.value = 'I have\twhite space';
-        testElement.delimiters = '\\s';
-        flush(() => {
-          expect(testElement.shadowRoot.innerHTML).to.have.string(
-            'I <wbr>have\t<wbr>white <wbr>space<wbr>'
+            'the<wbr>_the<wbr>atre_heat<wbr>s_tea<wbr>'
           );
           done();
         });

--- a/tensorboard/components/tf_wbr_string/test/tfWbrStringTests.ts
+++ b/tensorboard/components/tf_wbr_string/test/tfWbrStringTests.ts
@@ -1,0 +1,71 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace tf_wbr_string {
+  const {expect} = chai;
+  declare function fixture(id: string): void;
+  declare function flush(callback: Function): void;
+
+  window.HTMLImports.whenReady(() => {
+    describe('tf-wbr-string', () => {
+      it('adds wbrs for single delimiter', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'I_have_a_delimiter';
+        testElement.delimiters = '_';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'I_<wbr>have_<wbr>a_<wbr>delimiter<wbr>'
+          );
+          done();
+        });
+      });
+
+      it('adds wbrs for multiple delimiters', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'I_have<multiple_delimiter.s';
+        testElement.delimiters = '_.<';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'I_<wbr>have&lt;<wbr>multiple_<wbr>delimiter.<wbr>s<wbr>'
+          );
+          done();
+        });
+      });
+
+      it('handles regex character class special characters', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'I^have-many]special[delimiters^here';
+        testElement.delimiters = '^-][';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'I^<wbr>have-<wbr>many]<wbr>special[<wbr>delimiters^<wbr>here'
+          );
+          done();
+        });
+      });
+
+      it('handles regex metacharacters as delimiters', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'I have\twhite space';
+        testElement.delimiters = '\\s';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'I <wbr>have\t<wbr>white <wbr>space<wbr>'
+          );
+          done();
+        });
+      });
+    });
+  });
+} // namespace tf_wbr_string

--- a/tensorboard/components/tf_wbr_string/tf-wbr-string.html
+++ b/tensorboard/components/tf_wbr_string/tf-wbr-string.html
@@ -46,10 +46,13 @@ limitations under the License.
       },
       _computeParts(value, delimiters) {
         const result = [];
-        const delimiterRegExp = new RegExp('[' + delimiters + ']');
-        if (value == null) {
-          value = '';
+        if (value == null || delimiters == null) {
+          return [];
         }
+        // Convert the list of characters into a
+        const delimiterRegExp = new RegExp(
+          '[' + delimiters.replace(/([\^\[\]\-])/g, '\\$1') + ']'
+        );
         while (true) {
           const idx = value.search(delimiterRegExp);
           if (idx === -1) {

--- a/tensorboard/components/tf_wbr_string/tf-wbr-string.html
+++ b/tensorboard/components/tf_wbr_string/tf-wbr-string.html
@@ -37,16 +37,16 @@ limitations under the License.
       properties: {
         /** The value to render with word breaks. */
         value: String,
-        /** The regular expression for specifying word break delimiters. */
-        delimiterPattern: String,
+        /** List of characters to use as word break delimiters. */
+        delimiters: String,
         _parts: {
           type: Array /* string[] */,
-          computed: '_computeParts(value, delimiterPattern)',
+          computed: '_computeParts(value, delimiters)',
         },
       },
-      _computeParts(value, delimiterPattern) {
+      _computeParts(value, delimiters) {
         const result = [];
-        const delimiterRegExp = new RegExp(delimiterPattern);
+        const delimiterRegExp = new RegExp('[' + delimiters + ']');
         if (value == null) {
           value = '';
         }

--- a/tensorboard/components/tf_wbr_string/tf-wbr-string.html
+++ b/tensorboard/components/tf_wbr_string/tf-wbr-string.html
@@ -18,8 +18,8 @@ limitations under the License.
 <link rel="import" href="../tf-imports/polymer.html" />
 
 <!--
-  tf-wbr-string safely renders a string, with <wbr> elements inserted
-  around specified delimiters.
+  tf-wbr-string safely renders a string, with <wbr> word break elements inserted
+  after substrings that match a regular expression pattern.
 -->
 <dom-module id="tf-wbr-string">
   <template>
@@ -38,8 +38,11 @@ limitations under the License.
         /** The value to render with word breaks. */
         value: String,
         /**
-         * Regular expression pattern for specifying delimiters. Word breaks are
-         * inserted after each match.
+         * Regular expression pattern for specifying delimiters. <wbr> elements
+         * are inserted after all non-overlapping matches. A match that is
+         * overlapped by another match further to the left is ignored. Empty
+         * matches will consume the remainder of the string so it is advised
+         * to not allow empty matches in your pattern.
          */
         delimiterPattern: String,
         _parts: {
@@ -49,9 +52,6 @@ limitations under the License.
       },
       _computeParts(value, delimiterPattern) {
         const result = [];
-        if (value == null) {
-          return [];
-        }
         while (true) {
           const delimiterRegExp = new RegExp(delimiterPattern, 'g');
           delimiterRegExp.test(value);

--- a/tensorboard/components/tf_wbr_string/tf-wbr-string.html
+++ b/tensorboard/components/tf_wbr_string/tf-wbr-string.html
@@ -37,30 +37,30 @@ limitations under the License.
       properties: {
         /** The value to render with word breaks. */
         value: String,
-        /** List of characters to use as word break delimiters. */
-        delimiters: String,
+        /**
+         * Regular expression pattern for specifying delimiters. Word breaks are
+         * inserted after each match.
+         */
+        delimiterPattern: String,
         _parts: {
           type: Array /* string[] */,
-          computed: '_computeParts(value, delimiters)',
+          computed: '_computeParts(value, delimiterPattern)',
         },
       },
-      _computeParts(value, delimiters) {
+      _computeParts(value, delimiterPattern) {
         const result = [];
-        if (value == null || delimiters == null) {
+        if (value == null) {
           return [];
         }
-        // Convert the list of characters into a
-        const delimiterRegExp = new RegExp(
-          '[' + delimiters.replace(/([\^\[\]\-])/g, '\\$1') + ']'
-        );
         while (true) {
-          const idx = value.search(delimiterRegExp);
-          if (idx === -1) {
+          const delimiterRegExp = new RegExp(delimiterPattern, 'g');
+          delimiterRegExp.test(value);
+          if (delimiterRegExp.lastIndex === 0) {
             result.push(value);
             break;
           } else {
-            result.push(value.slice(0, idx + 1));
-            value = value.slice(idx + 1);
+            result.push(value.slice(0, delimiterRegExp.lastIndex));
+            value = value.slice(delimiterRegExp.lastIndex);
           }
         }
         return result;

--- a/tensorboard/components/tf_wbr_string/tf-wbr-string.html
+++ b/tensorboard/components/tf_wbr_string/tf-wbr-string.html
@@ -19,7 +19,7 @@ limitations under the License.
 
 <!--
   tf-wbr-string safely renders a string, with <wbr> elements inserted
-  around select delimiters (see `const delimiterPattern` in this file).
+  around specified delimiters.
 -->
 <dom-module id="tf-wbr-string">
   <template>
@@ -37,19 +37,21 @@ limitations under the License.
       properties: {
         /** The value to render with word breaks. */
         value: String,
+        /** The regular expression for specifying word break delimiters. */
+        delimiterPattern: String,
         _parts: {
           type: Array /* string[] */,
-          computed: '_computeParts(value)',
+          computed: '_computeParts(value, delimiterPattern)',
         },
       },
-      _computeParts(value) {
+      _computeParts(value, delimiterPattern) {
         const result = [];
-        const delimiterPattern = /[/=_,-]/;
+        const delimiterRegExp = new RegExp(delimiterPattern);
         if (value == null) {
           value = '';
         }
         while (true) {
-          const idx = value.search(delimiterPattern);
+          const idx = value.search(delimiterRegExp);
           if (idx === -1) {
             result.push(value);
             break;

--- a/tensorboard/plugins/graph/tf_graph_info/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_info/BUILD
@@ -16,6 +16,7 @@ tf_web_library(
     deps = [
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_wbr_string",
         "//tensorboard/plugins/graph/tf_graph_common",
         "//tensorboard/plugins/graph/tf_graph_debugger_data_card",
         "//tensorboard/plugins/graph/tf_graph_op_compat_card",

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
@@ -164,7 +164,7 @@ limitations under the License.
           >
           </paper-icon-button>
           <div class="node-name">
-            <tf-wbr-string value="[[_node.name]]" delimiter-pattern="[/]" />
+            <tf-wbr-string value="[[_node.name]]" delimiters="/" />
           </div>
         </div>
         <div secondary>

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
@@ -24,6 +24,7 @@ limitations under the License.
 <link rel="import" href="../tf-imports/polymer.html" />
 <link rel="import" href="../tf-graph-common/tf-graph-common.html" />
 <link rel="import" href="../tf-graph-common/tf-node-icon.html" />
+<link rel="import" href="../tf-wbr-string/tf-wbr-string.html" />
 <link rel="import" href="tf-node-list-item.html" />
 
 <dom-module id="tf-node-info">
@@ -162,7 +163,9 @@ limitations under the License.
             class="toggle-button"
           >
           </paper-icon-button>
-          <div class="node-name" id="nodetitle"></div>
+          <div class="node-name">
+            <tf-wbr-string value="[[_node.name]]" delimiter-pattern="[/]" />
+          </div>
         </div>
         <div secondary>
           <tf-node-icon
@@ -578,11 +581,6 @@ limitations under the License.
             return '[' + shape.join(', ') + ']';
           });
         },
-        _getPrintableHTMLNodeName: function(graphNodeName) {
-          // Insert an optional line break before each slash so that
-          // long node names wrap cleanly at path boundaries.
-          return (graphNodeName || '').replace(/\//g, '<wbr>/');
-        },
         _getRenderInfo: function(graphNodeName, renderHierarchy) {
           return this.renderHierarchy.getOrCreateRenderNodeByName(
             graphNodeName
@@ -744,12 +742,6 @@ limitations under the License.
             '_groupButtonText',
             tf.graph.scene.node.getGroupSettingLabel(this._node)
           );
-
-          if (this._node) {
-            Polymer.dom(
-              this.$.nodetitle
-            ).innerHTML = this._getPrintableHTMLNodeName(this._node.name);
-          }
         },
         _resizeList: function(selector) {
           var list = document.querySelector(selector);

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
@@ -164,7 +164,7 @@ limitations under the License.
           >
           </paper-icon-button>
           <div class="node-name">
-            <tf-wbr-string value="[[_node.name]]" delimiters="/" />
+            <tf-wbr-string value="[[_node.name]]" delimiter-pattern="/" />
           </div>
         </div>
         <div secondary>

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.html
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.html
@@ -227,11 +227,6 @@ limitations under the License.
         _getNode: function(nodeName, graphHierarchy) {
           return graphHierarchy.node(nodeName);
         },
-        _getPrintableHTMLNodeName: function(nodeName) {
-          // Insert an optional line break before each slash so that
-          // long node names wrap cleanly at path boundaries.
-          return (nodeName || '').replace(/\//g, '<wbr>/');
-        },
         _getRenderInfo: function(nodeName, renderHierarchy) {
           return this.renderHierarchy.getOrCreateRenderNodeByName(nodeName);
         },


### PR DESCRIPTION
* Motivation for features / changes

tf-node-info assigns some user-generated value to an element using innerHTML.  It does this because it augments the user-generated value with some \<wbr\> tags.  Need to find a way to do this that is less prone to attack.

* Technical description of changes

There is a nice tf-wbr-string component that already does what we want. Refactor to a common location and allow callers to specify the delimiter for \<wbr\> insertion.

* Detailed steps to verify changes work correctly (as executed by you)

Run tensorboard and manually inspect DOM in the run selector and in the graph node info title to ensure \<wbr\>s are being properly inserted in text.

For the graph node, more specifically, have to drill down several layers in the debug model to generate a node title with sufficient length.
