### PR TITLE
Introduce reload-on-ready prop to dashboard

### DIFF
--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
@@ -115,6 +115,10 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
     Polymer({
       is: 'tf-audio-dashboard',
       properties: {
+        reloadOnReady: {
+          type: Boolean,
+          value: true,
+        },
         _selectedRuns: Array,
         _runToTagInfo: Object,
         _dataNotFound: Boolean,
@@ -134,7 +138,7 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
       },
 
       ready() {
-        this.reload();
+        if (this.reloadOnReady) this.reload();
       },
       reload() {
         this._fetchTags().then(() => {

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -371,6 +371,10 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
         is: 'tf-beholder-dashboard',
 
         properties: {
+          reloadOnReady: {
+            type: Boolean,
+            value: true,
+          },
           _requestManager: {
             type: Object,
             value: () => new tf_backend.RequestManager(10, 0),
@@ -528,7 +532,7 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
         },
 
         ready() {
-          this.reload();
+          if (this.reloadOnReady) this.reload();
         },
 
         reload() {

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
@@ -327,9 +327,13 @@ writer.add_summary(layout_summary)
           value: true,
           readOnly: true,
         },
+        reloadOnReady: {
+          type: Boolean,
+          value: true,
+        },
       },
       ready() {
-        this.reload();
+        if (this.reloadOnReady) this.reload();
       },
       reload() {
         const url = tf_backend.getRouter().pluginsListing();

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/tf-debugger-dashboard.html
@@ -670,6 +670,10 @@ limitations under the License.
          * }
          */
         _latestSessionRun: Object,
+        reloadOnReady: {
+          type: Boolean,
+          value: true,
+        },
       },
 
       observers: [
@@ -688,7 +692,7 @@ limitations under the License.
           false
         );
 
-        this.reload();
+        if (this.reloadOnReady) this.reload();
       },
 
       long_poll() {

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
@@ -141,6 +141,10 @@ limitations under the License.
     Polymer({
       is: 'tf-distribution-dashboard',
       properties: {
+        reloadOnReady: {
+          type: Boolean,
+          value: true,
+        },
         _xType: {
           type: String,
           value: 'step',
@@ -168,7 +172,7 @@ limitations under the License.
         },
       },
       ready() {
-        this.reload();
+        if (this.reloadOnReady) this.reload();
       },
       reload() {
         this._fetchTags().then(() => {

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -147,6 +147,10 @@ limitations under the License.
     Polymer({
       is: 'tf-histogram-dashboard',
       properties: {
+        reloadOnReady: {
+          type: Boolean,
+          value: true,
+        },
         _histogramMode: {
           type: String,
           value: 'offset',
@@ -194,7 +198,7 @@ limitations under the License.
       },
 
       ready() {
-        this.reload();
+        if (this.reloadOnReady) this.reload();
       },
       reload() {
         this._fetchTags().then(() => {

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
@@ -199,6 +199,10 @@ TensorFlow run.
     Polymer({
       is: 'tf-image-dashboard',
       properties: {
+        reloadOnReady: {
+          type: Boolean,
+          value: true,
+        },
         _selectedRuns: Array,
         _runToTagInfo: Object,
         _dataNotFound: Boolean,
@@ -248,7 +252,7 @@ TensorFlow run.
       },
 
       ready() {
-        this.reload();
+        if (this.reloadOnReady) this.reload();
       },
       reload() {
         this._fetchTags().then(() => {

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-dashboard.html
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-dashboard.html
@@ -214,6 +214,10 @@ limitations under the License.
       Polymer({
         is: 'mesh-dashboard',
         properties: {
+          reloadOnReady: {
+            type: Boolean,
+            value: true,
+          },
           /**
            * @type {Array<string>} list of runs names to display.
            */
@@ -248,7 +252,7 @@ limitations under the License.
             },
             false
           );
-          this.reload();
+          if (this.reloadOnReady) this.reload();
         },
         _getAllChildren() {
           return this.root.querySelectorAll('tf-mesh-loader');

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
@@ -153,6 +153,10 @@ limitations under the License.
     Polymer({
       is: 'tf-pr-curve-dashboard',
       properties: {
+        reloadOnReady: {
+          type: Boolean,
+          value: true,
+        },
         // Determines how the time entry is shown. One of step, relative, or
         // wall_time.
         _timeDisplayType: {
@@ -217,7 +221,7 @@ limitations under the License.
         },
       },
       ready() {
-        this.reload();
+        if (this.reloadOnReady) this.reload();
       },
       reload() {
         Promise.all([this._fetchTags()]).then(() => {

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -208,6 +208,10 @@ limitations under the License.
     Polymer({
       is: 'tf-scalar-dashboard',
       properties: {
+        reloadOnReady: {
+          type: Boolean,
+          value: true,
+        },
         _showDownloadLinks: {
           type: Boolean,
           notify: true,
@@ -306,7 +310,7 @@ limitations under the License.
         return index <= 2;
       },
       ready() {
-        this.reload();
+        if (this.reloadOnReady) this.reload();
       },
       reload() {
         this._fetchTags().then(() => {

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
@@ -112,6 +112,10 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
     Polymer({
       is: 'tf-text-dashboard',
       properties: {
+        reloadOnReady: {
+          type: Boolean,
+          value: true,
+        },
         _selectedRuns: Array,
         _runToTag: Object, // map<run: string, tags: string[]>
         _dataNotFound: Boolean,
@@ -132,7 +136,7 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
         },
       },
       ready() {
-        this.reload();
+        if (this.reloadOnReady) this.reload();
       },
       reload() {
         this._fetchTags().then(() => {


### PR DESCRIPTION
We now have different shell around dashboards. Especially the Angular
can now reason better on when the data should be fetched. Currently, all
dashboards `reload` as soon as mounted and we would like to be able to
control that.

Note that this change does not fix/address hparams since the logic is
deeply embedded into query-pane and makes request using observers which
fire on `ready` (props get set on ready and gets fired then).
