### PR TITLE
Give min-height to run selectors

### DIFF
--- a/tensorboard/components/tf_dashboard_common/dashboard-style.html
+++ b/tensorboard/components/tf_dashboard_common/dashboard-style.html
@@ -40,7 +40,6 @@ limitations under the License.
       }
 
       .settings {
-        contain: layout paint;
         min-height: 50px;
         overflow-x: hidden;
         overflow-y: auto;
@@ -78,10 +77,6 @@ limitations under the License.
 
       .sidebar-section:first-of-type {
         border: none;
-      }
-
-      .sidebar-section:last-of-type {
-        flex-grow: 1;
       }
 
       .sidebar-section paper-button {

--- a/tensorboard/components/tf_dashboard_common/dashboard-style.html
+++ b/tensorboard/components/tf_dashboard_common/dashboard-style.html
@@ -33,10 +33,24 @@ limitations under the License.
         display: flex;
         flex-direction: column;
         height: 100%;
-        margin-right: 20px;
+        margin-right: 10px;
         overflow-x: hidden;
         padding: 5px 0;
         text-overflow: ellipsis;
+      }
+
+      .settings {
+        contain: layout paint;
+        min-height: 50px;
+        overflow-x: hidden;
+        overflow-y: auto;
+        will-change: transform;
+      }
+
+      .runs-selector {
+        display: flex;
+        flex-grow: 1;
+        min-height: 200px;
       }
 
       tf-runs-selector {
@@ -55,9 +69,11 @@ limitations under the License.
 
       .sidebar-section {
         border-top: solid 1px rgba(0, 0, 0, 0.12);
+        margin-right: 10px;
         padding: var(--sidebar-vertical-padding) 0
           var(--sidebar-vertical-padding) var(--sidebar-left-padding);
         position: relative;
+        overflow: hidden;
       }
 
       .sidebar-section:first-of-type {
@@ -66,7 +82,6 @@ limitations under the License.
 
       .sidebar-section:last-of-type {
         flex-grow: 1;
-        display: flex;
       }
 
       .sidebar-section paper-button {

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-dashboard.html
@@ -39,7 +39,7 @@ tf-audio-dashboard displays a dashboard that loads audio from a TensorFlow run.
   <template>
     <tf-dashboard-layout>
       <div class="sidebar" slot="sidebar">
-        <div class="sidebar-section">
+        <div class="sidebar-section runs-selector">
           <tf-runs-selector
             id="runs-selector"
             selected-runs="{{_selectedRuns}}"

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
@@ -47,58 +47,60 @@ limitations under the License.
   <template>
     <tf-dashboard-layout>
       <div class="sidebar" slot="sidebar">
-        <div class="sidebar-section">
-          <div class="line-item">
-            <paper-checkbox checked="{{_showDownloadLinks}}"
-              >Show data download links</paper-checkbox
-            >
-          </div>
-          <div class="line-item">
-            <paper-checkbox checked="{{_ignoreYOutliers}}"
-              >Ignore outliers in chart scaling</paper-checkbox
-            >
-          </div>
-          <div id="tooltip-sorting">
-            <div id="tooltip-sorting-label">Tooltip sorting method:</div>
-            <paper-dropdown-menu
-              no-label-float
-              selected-item-label="{{_tooltipSortingMethod}}"
-            >
-              <paper-listbox
-                class="dropdown-content"
-                selected="0"
-                slot="dropdown-content"
+        <div class="settings">
+          <div class="sidebar-section">
+            <div class="line-item">
+              <paper-checkbox checked="{{_showDownloadLinks}}"
+                >Show data download links</paper-checkbox
               >
-                <paper-item>default</paper-item>
-                <paper-item>descending</paper-item>
-                <paper-item>ascending</paper-item>
-                <paper-item>nearest</paper-item>
-              </paper-listbox>
-            </paper-dropdown-menu>
+            </div>
+            <div class="line-item">
+              <paper-checkbox checked="{{_ignoreYOutliers}}"
+                >Ignore outliers in chart scaling</paper-checkbox
+              >
+            </div>
+            <div id="tooltip-sorting">
+              <div id="tooltip-sorting-label">Tooltip sorting method:</div>
+              <paper-dropdown-menu
+                no-label-float
+                selected-item-label="{{_tooltipSortingMethod}}"
+              >
+                <paper-listbox
+                  class="dropdown-content"
+                  selected="0"
+                  slot="dropdown-content"
+                >
+                  <paper-item>default</paper-item>
+                  <paper-item>descending</paper-item>
+                  <paper-item>ascending</paper-item>
+                  <paper-item>nearest</paper-item>
+                </paper-listbox>
+              </paper-dropdown-menu>
+            </div>
+          </div>
+          <div class="sidebar-section">
+            <tf-smoothing-input
+              weight="{{_smoothingWeight}}"
+              step="0.001"
+              min="0"
+              max="1"
+            ></tf-smoothing-input>
+          </div>
+          <div class="sidebar-section">
+            <tf-option-selector
+              id="x-type-selector"
+              name="Horizontal Axis"
+              selected-id="{{_xType}}"
+            >
+              <paper-button id="step">step</paper-button
+              ><!--
+            --><paper-button id="relative">relative</paper-button
+              ><!--
+            --><paper-button id="wall_time">wall</paper-button>
+            </tf-option-selector>
           </div>
         </div>
-        <div class="sidebar-section">
-          <tf-smoothing-input
-            weight="{{_smoothingWeight}}"
-            step="0.001"
-            min="0"
-            max="1"
-          ></tf-smoothing-input>
-        </div>
-        <div class="sidebar-section">
-          <tf-option-selector
-            id="x-type-selector"
-            name="Horizontal Axis"
-            selected-id="{{_xType}}"
-          >
-            <paper-button id="step">step</paper-button
-            ><!--
-            --><paper-button id="relative">relative</paper-button
-            ><!--
-            --><paper-button id="wall_time">wall</paper-button>
-          </tf-option-selector>
-        </div>
-        <div class="sidebar-section">
+        <div class="sidebar-section runs-selector">
           <tf-runs-selector selected-runs="{{_selectedRuns}}">
           </tf-runs-selector>
         </div>

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/tf-distribution-dashboard.html
@@ -47,18 +47,20 @@ limitations under the License.
   <template>
     <tf-dashboard-layout>
       <div class="sidebar" slot="sidebar">
-        <div class="sidebar-section">
-          <tf-option-selector
-            id="xTypeSelector"
-            name="Horizontal axis"
-            selected-id="{{_xType}}"
-          >
-            <paper-button id="step">step</paper-button>
-            <paper-button id="relative">relative</paper-button>
-            <paper-button id="wall_time">wall</paper-button>
-          </tf-option-selector>
+        <div class="settings">
+          <div class="sidebar-section">
+            <tf-option-selector
+              id="xTypeSelector"
+              name="Horizontal axis"
+              selected-id="{{_xType}}"
+            >
+              <paper-button id="step">step</paper-button>
+              <paper-button id="relative">relative</paper-button>
+              <paper-button id="wall_time">wall</paper-button>
+            </tf-option-selector>
+          </div>
         </div>
-        <div class="sidebar-section">
+        <div class="sidebar-section runs-selector">
           <tf-runs-selector selected-runs="{{_selectedRuns}}">
           </tf-runs-selector>
         </div>

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/tf-histogram-dashboard.html
@@ -46,28 +46,30 @@ limitations under the License.
   <template>
     <tf-dashboard-layout>
       <div slot="sidebar">
-        <div class="sidebar-section">
-          <tf-option-selector
-            id="histogramModeSelector"
-            name="Histogram mode"
-            selected-id="{{_histogramMode}}"
-          >
-            <paper-button id="overlay">overlay</paper-button>
-            <paper-button id="offset">offset</paper-button>
-          </tf-option-selector>
+        <div class="settings">
+          <div class="sidebar-section">
+            <tf-option-selector
+              id="histogramModeSelector"
+              name="Histogram mode"
+              selected-id="{{_histogramMode}}"
+            >
+              <paper-button id="overlay">overlay</paper-button>
+              <paper-button id="offset">offset</paper-button>
+            </tf-option-selector>
+          </div>
+          <div class="sidebar-section">
+            <tf-option-selector
+              id="timePropertySelector"
+              name="Offset time axis"
+              selected-id="{{_timeProperty}}"
+            >
+              <paper-button id="step">step</paper-button>
+              <paper-button id="relative">relative</paper-button>
+              <paper-button id="wall_time">wall</paper-button>
+            </tf-option-selector>
+          </div>
         </div>
-        <div class="sidebar-section">
-          <tf-option-selector
-            id="timePropertySelector"
-            name="Offset time axis"
-            selected-id="{{_timeProperty}}"
-          >
-            <paper-button id="step">step</paper-button>
-            <paper-button id="relative">relative</paper-button>
-            <paper-button id="wall_time">wall</paper-button>
-          </tf-option-selector>
-        </div>
-        <div class="sidebar-section">
+        <div class="sidebar-section runs-selector">
           <tf-runs-selector selected-runs="{{_selectedRuns}}">
           </tf-runs-selector>
         </div>

--- a/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
+++ b/tensorboard/plugins/image/tf_image_dashboard/tf-image-dashboard.html
@@ -45,54 +45,56 @@ TensorFlow run.
   <template>
     <tf-dashboard-layout>
       <div class="sidebar" slot="sidebar">
-        <div class="sidebar-section">
-          <div class="line-item">
-            <paper-checkbox checked="{{_actualSize}}"
-              >Show actual image size</paper-checkbox
-            >
+        <div class="settings">
+          <div class="sidebar-section">
+            <div class="line-item">
+              <paper-checkbox checked="{{_actualSize}}"
+                >Show actual image size</paper-checkbox
+              >
+            </div>
+          </div>
+          <div class="sidebar-section">
+            <h3 class="tooltip-container">Brightness adjustment</h3>
+            <div class="resettable-slider-container">
+              <paper-slider
+                min="0"
+                max="2"
+                snaps
+                pin
+                step="0.01"
+                value="{{_brightnessAdjustment}}"
+                immediate-value="{{_brightnessAdjustment}}"
+              ></paper-slider>
+              <paper-button
+                class="x-button"
+                on-tap="_resetBrightness"
+                disabled="[[_brightnessIsDefault]]"
+                >Reset</paper-button
+              >
+            </div>
+          </div>
+          <div class="sidebar-section">
+            <h3 class="tooltip-container">Contrast adjustment</h3>
+            <div class="resettable-slider-container">
+              <paper-slider
+                min="0"
+                max="500"
+                snaps
+                pin
+                step="1"
+                value="{{_contrastPercentage}}"
+                immediate-value="{{_contrastPercentage}}"
+              ></paper-slider>
+              <paper-button
+                class="x-button"
+                on-tap="_resetContrast"
+                disabled="[[_contrastIsDefault]]"
+                >Reset</paper-button
+              >
+            </div>
           </div>
         </div>
-        <div class="sidebar-section">
-          <h3 class="tooltip-container">Brightness adjustment</h3>
-          <div class="resettable-slider-container">
-            <paper-slider
-              min="0"
-              max="2"
-              snaps
-              pin
-              step="0.01"
-              value="{{_brightnessAdjustment}}"
-              immediate-value="{{_brightnessAdjustment}}"
-            ></paper-slider>
-            <paper-button
-              class="x-button"
-              on-tap="_resetBrightness"
-              disabled="[[_brightnessIsDefault]]"
-              >Reset</paper-button
-            >
-          </div>
-        </div>
-        <div class="sidebar-section">
-          <h3 class="tooltip-container">Contrast adjustment</h3>
-          <div class="resettable-slider-container">
-            <paper-slider
-              min="0"
-              max="500"
-              snaps
-              pin
-              step="1"
-              value="{{_contrastPercentage}}"
-              immediate-value="{{_contrastPercentage}}"
-            ></paper-slider>
-            <paper-button
-              class="x-button"
-              on-tap="_resetContrast"
-              disabled="[[_contrastIsDefault]]"
-              >Reset</paper-button
-            >
-          </div>
-        </div>
-        <div class="sidebar-section">
+        <div class="sidebar-section runs-selector">
           <tf-runs-selector
             id="runs-selector"
             selected-runs="{{_selectedRuns}}"

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-dashboard.html
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/tf-mesh-dashboard.html
@@ -40,48 +40,51 @@ limitations under the License.
   <template>
     <tf-dashboard-layout>
       <div slot="sidebar" class="all-controls">
-        <div class="sidebar-section view-control">
-          <h3 class="title">Point of view</h3>
-          <div>
-            <paper-radio-group
-              id="view-radio-group"
-              selected="{{_selectedView}}"
-            >
-              <paper-radio-button id="all-radio-button" name="all">
-                Display all points
-              </paper-radio-button>
-              <paper-tooltip
-                animation-delay="0"
-                for="all-radio-button"
-                position="right"
-                offset="0"
+        <div class="settings">
+          <div class="sidebar-section view-control">
+            <h3 class="title">Point of view</h3>
+            <div>
+              <paper-radio-group
+                id="view-radio-group"
+                selected="{{_selectedView}}"
               >
-                Zoom and center camera to display all points at once. Note, that
-                some points could be too far (i.e. too small) to be visible.
-              </paper-tooltip>
-              <paper-radio-button id="user-radio-button" name="user">
-                Current view
-              </paper-radio-button>
-              <paper-tooltip
-                animation-delay="0"
-                for="user-radio-button"
-                position="right"
-                offset="0"
-              >
-                Keep current camera position and zoom level.
-              </paper-tooltip>
-              <paper-radio-button id="share-radio-button" name="share">
-                Share viewpoint
-              </paper-radio-button>
-              <paper-tooltip
-                animation-delay="0"
-                for="share-radio-button"
-                position="right"
-                offset="0"
-              >
-                Share viewpoint among all cameras.
-              </paper-tooltip>
-            </paper-radio-group>
+                <paper-radio-button id="all-radio-button" name="all">
+                  Display all points
+                </paper-radio-button>
+                <paper-tooltip
+                  animation-delay="0"
+                  for="all-radio-button"
+                  position="right"
+                  offset="0"
+                >
+                  Zoom and center camera to display all points at once. Note,
+                  that some points could be too far (i.e. too small) to be
+                  visible.
+                </paper-tooltip>
+                <paper-radio-button id="user-radio-button" name="user">
+                  Current view
+                </paper-radio-button>
+                <paper-tooltip
+                  animation-delay="0"
+                  for="user-radio-button"
+                  position="right"
+                  offset="0"
+                >
+                  Keep current camera position and zoom level.
+                </paper-tooltip>
+                <paper-radio-button id="share-radio-button" name="share">
+                  Share viewpoint
+                </paper-radio-button>
+                <paper-tooltip
+                  animation-delay="0"
+                  for="share-radio-button"
+                  position="right"
+                  offset="0"
+                >
+                  Share viewpoint among all cameras.
+                </paper-tooltip>
+              </paper-radio-group>
+            </div>
           </div>
         </div>
         <div class="sidebar-section runs-selector">

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.html
@@ -44,30 +44,35 @@ limitations under the License.
   <template>
     <tf-dashboard-layout>
       <div class="sidebar" slot="sidebar">
-        <div class="sidebar-section">
-          <tf-option-selector
-            id="time-type-selector"
-            name="Time Display Type"
-            selected-id="{{_timeDisplayType}}"
-          >
-            <paper-button id="step">step</paper-button
-            ><!--
-            --><paper-button id="relative">relative</paper-button
-            ><!--
-            --><paper-button id="wall_time">wall</paper-button>
-          </tf-option-selector>
-        </div>
-        <template is="dom-if" if="[[_runToAvailableTimeEntries]]">
-          <div class="sidebar-section" id="steps-selector-container">
-            <tf-pr-curve-steps-selector
-              runs="[[_relevantSelectedRuns]]"
-              run-to-step="{{_runToStep}}"
-              run-to-available-time-entries="[[_runToAvailableTimeEntries]]"
-              time-display-type="[[_timeDisplayType]]"
-            ></tf-pr-curve-steps-selector>
+        <div class="settings">
+          <div class="sidebar-section">
+            <tf-option-selector
+              id="time-type-selector"
+              name="Time Display Type"
+              selected-id="{{_timeDisplayType}}"
+            >
+              <paper-button id="step">step</paper-button>
+              <!--
+            -->
+              <paper-button id="relative">relative</paper-button>
+              <!--
+            -->
+              <paper-button id="wall_time">wall</paper-button>
+            </tf-option-selector>
           </div>
-        </template>
-        <div class="sidebar-section">
+          <template is="dom-if" if="[[_runToAvailableTimeEntries]]">
+            <div class="sidebar-section" id="steps-selector-container">
+              <tf-pr-curve-steps-selector
+                runs="[[_relevantSelectedRuns]]"
+                run-to-step="{{_runToStep}}"
+                run-to-available-time-entries="[[_runToAvailableTimeEntries]]"
+                time-display-type="[[_timeDisplayType]]"
+              >
+              </tf-pr-curve-steps-selector>
+            </div>
+          </template>
+        </div>
+        <div class="sidebar-section runs-selector">
           <tf-runs-selector selected-runs="{{_selectedRuns}}">
           </tf-runs-selector>
         </div>
@@ -141,9 +146,10 @@ limitations under the License.
         max-width: 540px;
         margin: 80px auto 0 auto;
       }
+
       /** Do not let the steps selector occlude the run selector. */
       #steps-selector-container {
-        max-height: 40%;
+        max-height: 60%;
         overflow-y: auto;
       }
     </style>

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -55,60 +55,64 @@ limitations under the License.
   <template>
     <tf-dashboard-layout>
       <div class="sidebar" slot="sidebar">
-        <div class="sidebar-section">
-          <div class="line-item">
-            <paper-checkbox
-              id="show-download-links"
-              checked="{{_showDownloadLinks}}"
-              >Show data download links</paper-checkbox
-            >
-          </div>
-          <div class="line-item">
-            <paper-checkbox id="ignore-y-outlier" checked="{{_ignoreYOutliers}}"
-              >Ignore outliers in chart scaling</paper-checkbox
-            >
-          </div>
-          <div id="tooltip-sorting">
-            <div>Tooltip sorting method:</div>
-            <paper-dropdown-menu
-              no-label-float
-              selected-item-label="{{_tooltipSortingMethod}}"
-            >
-              <paper-listbox
-                class="dropdown-content"
-                selected="0"
-                slot="dropdown-content"
+        <div class="settings">
+          <div class="sidebar-section">
+            <div class="line-item">
+              <paper-checkbox
+                id="show-download-links"
+                checked="{{_showDownloadLinks}}"
+                >Show data download links</paper-checkbox
               >
-                <paper-item>default</paper-item>
-                <paper-item>descending</paper-item>
-                <paper-item>ascending</paper-item>
-                <paper-item>nearest</paper-item>
-              </paper-listbox>
-            </paper-dropdown-menu>
+            </div>
+            <div class="line-item">
+              <paper-checkbox
+                id="ignore-y-outlier"
+                checked="{{_ignoreYOutliers}}"
+                >Ignore outliers in chart scaling</paper-checkbox
+              >
+            </div>
+            <div id="tooltip-sorting">
+              <div>Tooltip sorting method:</div>
+              <paper-dropdown-menu
+                no-label-float
+                selected-item-label="{{_tooltipSortingMethod}}"
+              >
+                <paper-listbox
+                  class="dropdown-content"
+                  selected="0"
+                  slot="dropdown-content"
+                >
+                  <paper-item>default</paper-item>
+                  <paper-item>descending</paper-item>
+                  <paper-item>ascending</paper-item>
+                  <paper-item>nearest</paper-item>
+                </paper-listbox>
+              </paper-dropdown-menu>
+            </div>
+          </div>
+          <div class="sidebar-section">
+            <tf-smoothing-input
+              weight="{{_smoothingWeight}}"
+              step="0.001"
+              min="0"
+              max="0.999"
+            ></tf-smoothing-input>
+          </div>
+          <div class="sidebar-section">
+            <tf-option-selector
+              id="x-type-selector"
+              name="Horizontal Axis"
+              selected-id="{{_xType}}"
+            >
+              <paper-button id="step">step</paper-button
+              ><!--
+            --><paper-button id="relative">relative</paper-button
+              ><!--
+            --><paper-button id="wall_time">wall</paper-button>
+            </tf-option-selector>
           </div>
         </div>
-        <div class="sidebar-section">
-          <tf-smoothing-input
-            weight="{{_smoothingWeight}}"
-            step="0.001"
-            min="0"
-            max="0.999"
-          ></tf-smoothing-input>
-        </div>
-        <div class="sidebar-section">
-          <tf-option-selector
-            id="x-type-selector"
-            name="Horizontal Axis"
-            selected-id="{{_xType}}"
-          >
-            <paper-button id="step">step</paper-button
-            ><!--
-            --><paper-button id="relative">relative</paper-button
-            ><!--
-            --><paper-button id="wall_time">wall</paper-button>
-          </tf-option-selector>
-        </div>
-        <div class="sidebar-section">
+        <div class="sidebar-section runs-selector">
           <tf-runs-selector selected-runs="{{_selectedRuns}}">
           </tf-runs-selector>
         </div>

--- a/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
+++ b/tensorboard/plugins/text/tf_text_dashboard/tf-text-dashboard.html
@@ -41,7 +41,7 @@ tf-text-dashboard displays a dashboard that loads texts from a TensorFlow run.
   <template>
     <tf-dashboard-layout>
       <div class="sidebar" slot="sidebar">
-        <div class="sidebar-section">
+        <div class="sidebar-section runs-selector">
           <tf-runs-selector selected-runs="{{_selectedRuns}}">
           </tf-runs-selector>
         </div>


### PR DESCRIPTION
When window height is small (especially on smaller laptop), run
selectors completely collapse and do not show any item for the run.
This resulted in suboptimal experience and we would like to solve it by
giving a minimum height to the runs selector and allowing option to be
scrollable.

![image](https://user-images.githubusercontent.com/2547313/82107928-1527ec00-96e0-11ea-92dd-e56dffa60366.png)

For the review, I strongly recommend enabling hide whitespace:
![image](https://user-images.githubusercontent.com/2547313/82107948-3688d800-96e0-11ea-8c46-27988bafa5c9.png)
