### PR TITLE
DataFrame API: Let pivot default to False

### DIFF
--- a/tensorboard/data/experimental/BUILD
+++ b/tensorboard/data/experimental/BUILD
@@ -22,7 +22,6 @@ py_library(
         "//tensorboard:expect_grpc_installed",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_pandas_installed",
-        "//tensorboard:lazy",
         "//tensorboard/uploader:auth",
         "//tensorboard/uploader:server_info",
         "//tensorboard/uploader:util",

--- a/tensorboard/data/experimental/BUILD
+++ b/tensorboard/data/experimental/BUILD
@@ -22,6 +22,7 @@ py_library(
         "//tensorboard:expect_grpc_installed",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_pandas_installed",
+        "//tensorboard:lazy",
         "//tensorboard/uploader:auth",
         "//tensorboard/uploader:server_info",
         "//tensorboard/uploader:util",

--- a/tensorboard/data/experimental/base_experiment.py
+++ b/tensorboard/data/experimental/base_experiment.py
@@ -32,7 +32,7 @@ class BaseExperiment(metaclass=abc.ABCMeta):
         self,
         runs_filter=None,
         tags_filter=None,
-        pivot=True,
+        pivot=False,
         include_wall_time=False,
     ):
         """Export scalar data as a pandas.DataFrame.
@@ -45,7 +45,12 @@ class BaseExperiment(metaclass=abc.ABCMeta):
           pivot: Whether to returned DataFrame will be pivoted (via pandas’
             `pivot_data()` method to a “wide” format wherein the tags of a
             given run and a given step are all collected in a single row.
-            If not provided, defaults to `True`.
+            Setting `pivot` to `True` stipulates that the sets of step values
+            are identical among all tags of the experiment (after any run and
+            tag filtering), so that the pivoting operation will not introduce
+            missing values in the resultant DataFrame. Failing to meet this
+            condition will cause `pivot=True` to raise a `ValueError`.
+            If not provided, defaults to `False`.
           include_wall_time: Include wall_time (timestamps in nanoseconds since
             the epoch in float64) as a column in the returned DataFrame.
             If not provided, defaults to `False`.

--- a/tensorboard/data/experimental/base_experiment.py
+++ b/tensorboard/data/experimental/base_experiment.py
@@ -46,10 +46,10 @@ class BaseExperiment(metaclass=abc.ABCMeta):
             `pivot_data()` method to a “wide” format wherein the tags of a
             given run and a given step are all collected in a single row.
             Setting `pivot` to `True` stipulates that the sets of step values
-            are identical among all tags of the experiment (after any run and
-            tag filtering), so that the pivoting operation will not introduce
-            missing values in the resultant DataFrame. Failing to meet this
-            condition will cause `pivot=True` to raise a `ValueError`.
+            are identical among all tags in every run of the experiment (after
+            any run and tag filtering), so that the pivoting operation will not
+            introduce missing values in the resultant DataFrame. Failing to meet
+            this condition will cause `pivot=True` to raise a `ValueError`.
             If not provided, defaults to `False`.
           include_wall_time: Include wall_time (timestamps in nanoseconds since
             the epoch in float64) as a column in the returned DataFrame.

--- a/tensorboard/data/experimental/experiment_from_dev.py
+++ b/tensorboard/data/experimental/experiment_from_dev.py
@@ -25,6 +25,7 @@ import time
 import grpc
 import numpy as np
 
+from tensorboard import lazy
 from tensorboard.data.experimental import base_experiment
 from tensorboard.uploader import auth
 from tensorboard.uploader import util
@@ -38,7 +39,8 @@ from tensorboard.util import grpc_util
 DEFAULT_ORIGIN = "https://tensorboard.dev"
 
 
-def import_pandas():
+@lazy.lazy_load("pandas")
+def pandas():
     """Import pandas, guarded by a user-friendly error message on failure."""
     try:
         import pandas
@@ -75,10 +77,6 @@ class ExperimentFromDev(base_experiment.BaseExperiment):
         pivot=False,
         include_wall_time=False,
     ):
-        # NOTE(b/155980442): Import pandas early in this method, so if the
-        # Python environment does not have pandas installed, an error can be
-        # raised early, before any rpc call is made.
-        pandas = import_pandas()
         if runs_filter is not None:
             raise NotImplementedError(
                 "runs_filter support for get_scalars() is not implemented yet."

--- a/tensorboard/data/experimental/experiment_from_dev.py
+++ b/tensorboard/data/experimental/experiment_from_dev.py
@@ -25,7 +25,6 @@ import time
 import grpc
 import numpy as np
 
-from tensorboard import lazy
 from tensorboard.data.experimental import base_experiment
 from tensorboard.uploader import auth
 from tensorboard.uploader import util
@@ -39,8 +38,7 @@ from tensorboard.util import grpc_util
 DEFAULT_ORIGIN = "https://tensorboard.dev"
 
 
-@lazy.lazy_load("pandas")
-def pandas():
+def import_pandas():
     """Import pandas, guarded by a user-friendly error message on failure."""
     try:
         import pandas
@@ -74,9 +72,13 @@ class ExperimentFromDev(base_experiment.BaseExperiment):
         self,
         runs_filter=None,
         tags_filter=None,
-        pivot=True,
+        pivot=False,
         include_wall_time=False,
     ):
+        # NOTE(b/155980442): Import pandas early in this method, so if the
+        # Python environment does not have pandas installed, an error can be
+        # raised early, before any rpc call is made.
+        pandas = import_pandas()
         if runs_filter is not None:
             raise NotImplementedError(
                 "runs_filter support for get_scalars() is not implemented yet."

--- a/tensorboard/data/experimental/experiment_from_dev_test.py
+++ b/tensorboard/data/experimental/experiment_from_dev_test.py
@@ -79,7 +79,7 @@ class ExperimentFromDevTest(tb_test.TestCase):
             lambda api_endpoint: mock_api_client,
         ):
             experiment = experiment_from_dev.ExperimentFromDev("789")
-            for pivot in (True, False):
+            for pivot in (False, True):
                 for include_wall_time in (False, True):
                     with self.subTest(
                         "pivot=%s; include_wall_time=%s"
@@ -208,7 +208,7 @@ class ExperimentFromDevTest(tb_test.TestCase):
                 r"contains missing value\(s\).*different sets of "
                 r"steps.*pivot=False",
             ):
-                experiment.get_scalars()
+                experiment.get_scalars(pivot=True)
 
     def test_get_scalars_with_actual_inf_and_nan(self):
         """Test for get_scalars() call that involve inf and nan in user data."""
@@ -238,7 +238,7 @@ class ExperimentFromDevTest(tb_test.TestCase):
             lambda api_endpoint: mock_api_client,
         ):
             experiment = experiment_from_dev.ExperimentFromDev("789")
-            dataframe = experiment.get_scalars()
+            dataframe = experiment.get_scalars(pivot=True)
 
         expected = pandas.DataFrame(
             {

--- a/tensorboard/data/experimental/test_binary.py
+++ b/tensorboard/data/experimental/test_binary.py
@@ -38,6 +38,12 @@ def parse_args():
         help="Optional API endpoint used to override the default",
     )
     parser.add_argument(
+        "--pivot",
+        action="store_true",
+        help="Pivot the DataFrame, so that the tags become columns "
+        "of the DataFrame.",
+    )
+    parser.add_argument(
         "--include_wall_time",
         action="store_true",
         help="Include wall_time column(s) in the DataFrame",
@@ -49,7 +55,9 @@ def main(args):
     experiment = experiment_from_dev.ExperimentFromDev(
         args.experiment_id, api_endpoint=args.api_endpoint
     )
-    dataframe = experiment.get_scalars(include_wall_time=args.include_wall_time)
+    dataframe = experiment.get_scalars(
+        pivot=args.pivot, include_wall_time=args.include_wall_time
+    )
     print(dataframe)
 
 


### PR DESCRIPTION
* Motivation for features / changes
  * Improve the usability of the (experimental) DataFrame API
* Technical description of changes
  * Change the default value of the kwarg `pivot` to `False`.  Rationale: 
    * Many experiments don't have identical sets of steps across all tags. Raising an error at the end is not nice.
    * Raising a warning for missing values is potentially okay, but introduces users not seeing them and/or spamming stderr too much and hence users ignoring them. We don't want users to be misled.
    * As discussed else where, we will provide good examples and documentation to explain how to get the pivoted DataFrame that many users want (i.e., it's just setting `pivot=True` for experiments that meet the requirement.)
* Detailed steps to verify changes work correctly (as executed by you)
  * Manual verification using the test_binary.
