### PR TITLE
core: make TensorBoardWSGIApp args a bit easier to use

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -20,10 +20,12 @@ Provides TensorBoardWSGIApp for building a TensorBoard WSGI app.
 import base64
 import collections
 import hashlib
+import io
 import json
 import re
 import textwrap
 import time
+import zipfile
 
 import six
 from six.moves.urllib import (
@@ -73,10 +75,13 @@ def TensorBoardWSGIApp(
       flags: An argparse.Namespace containing TensorBoard CLI flags.
       plugins: A list of plugins, which can be provided as TBPlugin subclasses
           or TBLoader instances or subclasses.
-      assets_zip_provider: See TBContext documentation for more information.
       data_provider: Instance of `tensorboard.data.provider.DataProvider`. May
           be `None` if `flags.generic_data` is set to `"false"` in which case
           `deprecated_multiplexer` must be passed instead.
+      assets_zip_provider: See TBContext documentation for more information. If
+          `None` a placeholder assets zipfile will be used containing only a
+          default `index.html` file, and the actual frontend assets must be
+          supplied by middleware wrapping this WSGI app.
       deprecated_multiplexer: Optional `plugin_event_multiplexer.EventMultiplexer`
           to use for any plugins not yet enabled for the DataProvider API.
           Required if the data_provider argument is not passed.
@@ -86,6 +91,8 @@ def TensorBoardWSGIApp(
 
     :type plugins: list[base_plugin.TBLoader]
     """
+    if assets_zip_provider is None:
+        assets_zip_provider = _placeholder_assets_zip_provider
     plugin_name_to_instance = {}
     context = base_plugin.TBContext(
         data_provider=data_provider,
@@ -547,3 +554,11 @@ def _clean_path(path):
     if path != "/" and path.endswith("/"):
         return path[:-1]
     return path
+
+
+def _placeholder_assets_zip_provider():
+    """Defines a default assets zip provider containing a dummy index.html."""
+    memfile = io.BytesIO()
+    with zipfile.ZipFile(memfile, mode="w") as zf:
+        zf.writestr("index.html", "TensorBoard placeholder index.html")
+    return memfile

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -71,7 +71,8 @@ def TensorBoardWSGIApp(
 
     Args:
       flags: An argparse.Namespace containing TensorBoard CLI flags.
-      plugins: A list of plugin loader instances.
+      plugins: A list of plugins, which can be provided as TBPlugin subclasses
+          or TBLoader instances or subclasses.
       assets_zip_provider: See TBContext documentation for more information.
       data_provider: Instance of `tensorboard.data.provider.DataProvider`. May
           be `None` if `flags.generic_data` is set to `"false"` in which case

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -685,7 +685,6 @@ class MakePluginLoaderTest(tb_test.TestCase):
 class TensorBoardPluginsTest(tb_test.TestCase):
     def setUp(self):
         self.context = None
-        dummy_assets_zip_provider = lambda: None
         # The application should have added routes for both plugins.
         self.app = application.TensorBoardWSGIApp(
             FakeFlags(logdir=self.get_temp_dir()),
@@ -713,7 +712,6 @@ class TensorBoardPluginsTest(tb_test.TestCase):
                 ),
             ],
             data_provider=FakeDataProvider(),
-            assets_zip_provider=dummy_assets_zip_provider,
         )
 
         self.server = werkzeug_test.Client(self.app, wrappers.BaseResponse)


### PR DESCRIPTION
Small changes to make it easier to use `TensorBoardWSGIApp` directly:

- Clarify that `plugins` can accept several types, not just plugin loader instances (pursuant to the follow-up comments of https://github.com/tensorflow/tensorboard/pull/2884/files#r342324613)

- Change `assets_zip_provider` so that it's actually optional to omit, in which case we use a placeholder dummy zipfile that contains only an index.html