### PR TITLE
uploader: status report, dry-run and one-shot modes

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -388,6 +388,11 @@ py_library(name = "expect_pkg_resources_installed")
 py_library(name = "expect_requests_installed")
 
 # This is a dummy rule used as a pandas dependency in open-source.
+# We expect tqdm to already be installed on the system, e.g. via
+# `pip install tqdm`.
+py_library(name = "expect_tqdm_installed")
+
+# This is a dummy rule used as a pandas dependency in open-source.
 # We expect pandas to already be installed on the system, e.g. via
 # `pip install pandas`.
 # NOTE: Unlike other parallel dependencies in this file, pandas is an

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -114,7 +114,8 @@ py_library(
     name = "upload_tracker",
     srcs = ["upload_tracker.py"],
     deps = [
-        "@org_pythonhosted_six",
+        ":util",
+        "//tensorboard:expect_tqdm_installed",
     ],
 )
 

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -91,6 +91,7 @@ py_library(
     srcs = ["uploader.py"],
     deps = [
         ":logdir_loader",
+        ":upload_tracker",
         ":util",
         "//tensorboard:expect_grpc_installed",
         "//tensorboard/backend:process_graph",
@@ -105,6 +106,14 @@ py_library(
         "//tensorboard/util:tb_logging",
         "//tensorboard/util:tensor_util",
         "@com_google_protobuf//:protobuf_python",
+        "@org_pythonhosted_six",
+    ],
+)
+
+py_library(
+    name = "upload_tracker",
+    srcs = ["upload_tracker.py"],
+    deps = [
         "@org_pythonhosted_six",
     ],
 )

--- a/tensorboard/uploader/flags_parser.py
+++ b/tensorboard/uploader/flags_parser.py
@@ -106,6 +106,13 @@ def define_flags(parser):
         "logdir.",
     )
     upload.add_argument(
+        "--dry_run",
+        action="store_true",
+        help="Run the uploader without actually sending data to the server. "
+        "Useful for estimating the kinds and amount of data that will be "
+        "uploaded in a default, non-dry-run usage of the uploader.",
+    )
+    upload.add_argument(
         "--plugins",
         type=lambda option: option.split(","),
         default=[],

--- a/tensorboard/uploader/flags_parser.py
+++ b/tensorboard/uploader/flags_parser.py
@@ -99,6 +99,13 @@ def define_flags(parser):
         help="Experiment description. Markdown format.  Max 600 characters.",
     )
     upload.add_argument(
+        "--one_shot",
+        action="store_true",
+        help="Upload only the currently-existing data in the logdir and exit, "
+        "instead of continuously listening for and uploading new data in the "
+        "logdir.",
+    )
+    upload.add_argument(
         "--plugins",
         type=lambda option: option.split(","),
         default=[],

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import sys
+
 import tqdm
 
 
@@ -29,48 +31,71 @@ class UploadTracker(object):
         self._num_tensors_uploaded = 0
         self._num_blob_sequences = 0
         self._num_blob_sequences_uploaded = 0
-        self._progress_bar = tqdm.tqdm(self._dummy_generator())
+        self._description_length = 30
+
+    def _set_description(self, text):
+        if len(text) < self._description_length:
+            text += " " * self._description_length
+        elif len(text) > self._description_length:
+            text = text[: self._description_length]
+        self._progress_bar.set_description(text)
 
     def _dummy_generator(self):
         while True:
             # Yield an arbitrary value 0: The progress bar is indefinite.
-            yield 0
+            yield 1
+
+    def send_start(self):
+        self._progress_bar = tqdm.tqdm(
+            self._dummy_generator(), unit=" requests"
+        )
+        self._progress_bar.set_description("Upload starting...")
+        self._progress_bar.update()
+
+    def send_done(self):
+        self._set_description("Upload done.")
+        self._progress_bar.close()
+        sys.stdout.write(
+            "Uploaded %d scalars, %d tensors, %d blob sequences\n"
+            % (
+                self._num_scalars_uploaded,
+                self._num_tensors_uploaded,
+                self._num_blob_sequences_uploaded,
+            )
+        )
 
     def scalar_start(self):
         self._num_scalars += 1
-        self._progress_bar.set_description("Uploading scalars")
+        self._set_description("Uploading scalars")
         self._progress_bar.update()
         # print("scalar_start(): num_scalars = %s" % self._num_scalars)  # DEBUG
 
     def tensor_start(self):
         self._num_tensors += 1
-        self._progress_bar.set_description("Uploading tensors")
+        self._set_description("Uploading tensors")
         self._progress_bar.update()
         # print("tensor_start(): num_tensors = %s" % self._num_tensors)  # DEBUG
 
     def blob_sequence_start(self):
         self._num_blob_sequences += 1
-        self._progress_bar.set_description("Uploading blobs")
+        self._set_description("Uploading blobs")
         self._progress_bar.update()
         # print("blob_sequence_start(): num_blob_sequences = %s" % self._num_blob_sequences)  # DEBUG
 
     def scalar_done(self, is_uploaded):
         if is_uploaded:
             self._num_scalars_uploaded += 1
-        self._progress_bar.set_description("Done uploading scalars")
+        self._set_description("Done uploading scalars")
         self._progress_bar.update()
-        # print(
-        #     "scalar_done(): num_scalars_uploaded = %s" % self._num_scalars_uploaded
-        # )  # DEBUG
 
     def tensor_done(self, is_uploaded):
         if is_uploaded:
             self._num_tensors_uploaded += 1
-        self._progress_bar.set_description("Done uploading tensors")
+        self._set_description("Done uploading tensors")
         self._progress_bar.update()
 
     def blob_sequence_done(self, is_uploaded):
         if is_uploaded:
             self._num_blob_sequences_uploaded += 1
-        self._progress_bar.set_description("Done uploading blobs")
+        self._set_description("Done uploading blobs")
         self._progress_bar.update()

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -39,20 +39,26 @@ class UploadTracker(object):
     def scalar_start(self):
         self._num_scalars += 1
         self._progress_bar.set_description("Uploading scalars")
+        self._progress_bar.update()
         # print("scalar_start(): num_scalars = %s" % self._num_scalars)  # DEBUG
 
     def tensor_start(self):
         self._num_tensors += 1
         self._progress_bar.set_description("Uploading tensors")
+        self._progress_bar.update()
         # print("tensor_start(): num_tensors = %s" % self._num_tensors)  # DEBUG
 
     def blob_sequence_start(self):
         self._num_blob_sequences += 1
+        self._progress_bar.set_description("Uploading blobs")
+        self._progress_bar.update()
         # print("blob_sequence_start(): num_blob_sequences = %s" % self._num_blob_sequences)  # DEBUG
 
     def scalar_done(self, is_uploaded):
         if is_uploaded:
             self._num_scalars_uploaded += 1
+        self._progress_bar.set_description("Done uploading scalars")
+        self._progress_bar.update()
         # print(
         #     "scalar_done(): num_scalars_uploaded = %s" % self._num_scalars_uploaded
         # )  # DEBUG
@@ -60,7 +66,11 @@ class UploadTracker(object):
     def tensor_done(self, is_uploaded):
         if is_uploaded:
             self._num_tensors_uploaded += 1
+        self._progress_bar.set_description("Done uploading tensors")
+        self._progress_bar.update()
 
     def blob_sequence_done(self, is_uploaded):
         if is_uploaded:
             self._num_blob_sequences_uploaded += 1
+        self._progress_bar.set_description("Done uploading blobs")
+        self._progress_bar.update()

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -33,8 +33,8 @@ class UploadTracker(object):
     def __init__(self):
         self._cumulative_num_scalars = 0
         self._cumulative_num_tensors = 0
-        self._cumulative_num_blob_sequences = 0
-        self._cumulative_num_blob_sequences_uploaded = 0
+        self._cumulative_num_blobs = 0
+        self._cumulative_num_blobs_uploaded = 0
 
     def _dummy_generator(self):
         while True:
@@ -44,8 +44,8 @@ class UploadTracker(object):
     def send_start(self):
         self._num_scalars = 0
         self._num_tensors = 0
-        self._num_blob_sequences = 0
-        self._num_blob_sequences_uploaded = 0
+        self._num_blobs = 0
+        self._num_blobs_uploaded = 0
         self._progress_bar = None
 
     def _update_status(self, message):
@@ -59,31 +59,25 @@ class UploadTracker(object):
     def send_done(self):
         self._cumulative_num_scalars += self._num_scalars
         self._cumulative_num_tensors += self._num_tensors
-        self._cumulative_num_blob_sequences += self._num_blob_sequences
-        self._cumulative_num_blob_sequences += self._num_blob_sequences
-        self._cumulative_num_blob_sequences_uploaded += (
-            self._num_blob_sequences_uploaded
-        )
-        if (
-            self._num_scalars
-            or self._num_tensors
-            or self._num_blob_sequences_uploaded
-        ):
+        self._cumulative_num_blobs += self._num_blobs
+        self._cumulative_num_blobs += self._num_blobs
+        self._cumulative_num_blobs_uploaded += self._num_blobs_uploaded
+        if self._num_scalars or self._num_tensors or self._num_blobs_uploaded:
             if self._progress_bar:
                 self._update_status("")
                 self._progress_bar.close()
             # TODO(cais): Only populate the existing data types.
             sys.stdout.write(
-                "[%s] Uploaded %d scalars, %d tensors, %d binary-object sequences "
-                "(Cumulative: %d scalars, %d tensors, %d binary-object sequences)\n"
+                "[%s] Uploaded %d scalars, %d tensors, %d binary objects "
+                "(Cumulative: %d scalars, %d tensors, %d binary objects)\n"
                 % (
                     readable_time_string(),
                     self._num_scalars,
                     self._num_tensors,
-                    self._num_blob_sequences_uploaded,
+                    self._num_blobs_uploaded,
                     self._cumulative_num_scalars,
                     self._cumulative_num_tensors,
-                    self._cumulative_num_blob_sequences_uploaded,
+                    self._cumulative_num_blobs_uploaded,
                 )
             )
             sys.stdout.flush()
@@ -106,10 +100,10 @@ class UploadTracker(object):
     def tensors_done(self):
         pass
 
-    def blob_sequence_start(self):
-        self._num_blob_sequences += 1
-        self._update_status("Uploading binary-object sequence...")
+    def blob_start(self):
+        self._num_blobs += 1
+        self._update_status("Uploading binary object...")
 
-    def blob_sequence_done(self, is_uploaded):
+    def blob_done(self, is_uploaded):
         if is_uploaded:
-            self._num_blob_sequences_uploaded += 1
+            self._num_blobs_uploaded += 1

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -1,0 +1,66 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Progress tracker for uploader."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tqdm
+
+
+class UploadTracker(object):
+    def __init__(self):
+        self._num_scalars = 0
+        self._num_scalars_uploaded = 0
+        self._num_tensors = 0
+        self._num_tensors_uploaded = 0
+        self._num_blob_sequences = 0
+        self._num_blob_sequences_uploaded = 0
+        self._progress_bar = tqdm.tqdm(self._dummy_generator())
+
+    def _dummy_generator(self):
+        while True:
+            # Yield an arbitrary value 0: The progress bar is indefinite.
+            yield 0
+
+    def scalar_start(self):
+        self._num_scalars += 1
+        self._progress_bar.set_description("Uploading scalars")
+        # print("scalar_start(): num_scalars = %s" % self._num_scalars)  # DEBUG
+
+    def tensor_start(self):
+        self._num_tensors += 1
+        self._progress_bar.set_description("Uploading tensors")
+        # print("tensor_start(): num_tensors = %s" % self._num_tensors)  # DEBUG
+
+    def blob_sequence_start(self):
+        self._num_blob_sequences += 1
+        # print("blob_sequence_start(): num_blob_sequences = %s" % self._num_blob_sequences)  # DEBUG
+
+    def scalar_done(self, is_uploaded):
+        if is_uploaded:
+            self._num_scalars_uploaded += 1
+        # print(
+        #     "scalar_done(): num_scalars_uploaded = %s" % self._num_scalars_uploaded
+        # )  # DEBUG
+
+    def tensor_done(self, is_uploaded):
+        if is_uploaded:
+            self._num_tensors_uploaded += 1
+
+    def blob_sequence_done(self, is_uploaded):
+        if is_uploaded:
+            self._num_blob_sequences_uploaded += 1

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -84,12 +84,12 @@ class UploadTracker(object):
     def scalars_done(self):
         pass
 
-    def tensor_start(self):
-        self._num_tensors += 1
-        self._set_description("Uploading tensors")
+    def tensors_start(self, num_tensors):
+        self._num_tensors += num_tensors
+        self._set_description("Uploading %d tensors" % num_tensors)
         self._progress_bar.update()
 
-    def tensor_done(self, is_uploaded):
+    def tensors_done(self):
         pass
 
     def blob_sequence_start(self):

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -26,7 +26,17 @@ import tqdm
 
 def readable_time_string():
     """Get a human-readable time string for the present."""
-    return f"{datetime.now():%Y-%m-%d %H:%M:%S%z}"
+    return f"{datetime.now():%Y-%m-%dT%H:%M:%S%z}"
+
+
+def readable_bytes_string(bytes):
+    """Get a human-readable string for number of bytes."""
+    if bytes >= 2 ** 20:
+        return "%.2f MB" % (float(bytes) / 2 ** 20)
+    elif bytes >= 2 ** 10:
+        return "%.2f kB" % (float(bytes) / 2 ** 10)
+    else:
+        return "%d B" % bytes
 
 
 class UploadTracker(object):
@@ -35,6 +45,8 @@ class UploadTracker(object):
         self._cumulative_num_tensors = 0
         self._cumulative_num_blobs = 0
         self._cumulative_num_blobs_uploaded = 0
+        self._cumulative_blob_bytes_uploaded = 0
+        self._cumulative_plugin_names = set()
 
     def _dummy_generator(self):
         while True:
@@ -46,6 +58,8 @@ class UploadTracker(object):
         self._num_tensors = 0
         self._num_blobs = 0
         self._num_blobs_uploaded = 0
+        self._blob_bytes_uploaded = 0
+        self._plugin_names = set()
         self._progress_bar = None
 
     def _update_status(self, message):
@@ -62,25 +76,33 @@ class UploadTracker(object):
         self._cumulative_num_blobs += self._num_blobs
         self._cumulative_num_blobs += self._num_blobs
         self._cumulative_num_blobs_uploaded += self._num_blobs_uploaded
+        self._cumulative_blob_bytes_uploaded += self._blob_bytes_uploaded
+        self._cumulative_plugin_names.update(self._plugin_names)
         if self._num_scalars or self._num_tensors or self._num_blobs_uploaded:
             if self._progress_bar:
                 self._update_status("")
                 self._progress_bar.close()
             # TODO(cais): Only populate the existing data types.
             sys.stdout.write(
-                "[%s] Uploaded %d scalars, %d tensors, %d binary objects "
-                "(Cumulative: %d scalars, %d tensors, %d binary objects)\n"
+                "[%s] Uploaded %d scalars, %d tensors, %d binary objects (%s) (Plugins: %s)\n"
+                "    (Cumulative: %d scalars, %d tensors, %d binary objects (%s))\n"
                 % (
                     readable_time_string(),
                     self._num_scalars,
                     self._num_tensors,
                     self._num_blobs_uploaded,
+                    readable_bytes_string(self._blob_bytes_uploaded),
+                    ", ".join(self._plugin_names),
                     self._cumulative_num_scalars,
                     self._cumulative_num_tensors,
                     self._cumulative_num_blobs_uploaded,
+                    readable_bytes_string(self._cumulative_blob_bytes_uploaded),
                 )
             )
             sys.stdout.flush()
+
+    def add_plugin_name(self, plugin_name):
+        self._plugin_names.add(plugin_name)
 
     def scalars_start(self, num_scalars):
         if not num_scalars:
@@ -100,10 +122,14 @@ class UploadTracker(object):
     def tensors_done(self):
         pass
 
-    def blob_start(self):
+    def blob_start(self, blob_bytes):
         self._num_blobs += 1
-        self._update_status("Uploading binary object...")
+        self._update_status(
+            "Uploading binary object (%s)..."
+            % readable_bytes_string(blob_bytes)
+        )
 
-    def blob_done(self, is_uploaded):
+    def blob_done(self, is_uploaded, blob_bytes_uploaded):
         if is_uploaded:
             self._num_blobs_uploaded += 1
+            self._blob_bytes_uploaded += blob_bytes_uploaded

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -41,6 +41,7 @@ def readable_bytes_string(bytes):
 
 class UploadTracker(object):
     """Tracker for uploader progress and status."""
+
     def __init__(self):
         self._cumulative_num_scalars = 0
         self._cumulative_num_tensors = 0

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -26,7 +26,6 @@ import tqdm
 class UploadTracker(object):
     def __init__(self):
         self._num_scalars = 0
-        self._num_scalars_uploaded = 0
         self._num_tensors = 0
         self._num_tensors_uploaded = 0
         self._num_blob_sequences = 0
@@ -34,6 +33,7 @@ class UploadTracker(object):
         self._description_length = 30
 
     def _set_description(self, text):
+        text = "[ %s ]"  % text
         if len(text) < self._description_length:
             text += " " * self._description_length
         elif len(text) > self._description_length:
@@ -58,33 +58,28 @@ class UploadTracker(object):
         sys.stdout.write(
             "Uploaded %d scalars, %d tensors, %d blob sequences\n"
             % (
-                self._num_scalars_uploaded,
+                self._num_scalars,
                 self._num_tensors_uploaded,
                 self._num_blob_sequences_uploaded,
             )
         )
 
-    def scalar_start(self):
-        self._num_scalars += 1
-        self._set_description("Uploading scalars")
+    def scalars_start(self, num_scalars):
+        self._num_scalars += num_scalars
+        self._set_description("Uploading %d scalars" % num_scalars)
         self._progress_bar.update()
-        # print("scalar_start(): num_scalars = %s" % self._num_scalars)  # DEBUG
 
     def tensor_start(self):
         self._num_tensors += 1
         self._set_description("Uploading tensors")
         self._progress_bar.update()
-        # print("tensor_start(): num_tensors = %s" % self._num_tensors)  # DEBUG
 
     def blob_sequence_start(self):
         self._num_blob_sequences += 1
         self._set_description("Uploading blobs")
         self._progress_bar.update()
-        # print("blob_sequence_start(): num_blob_sequences = %s" % self._num_blob_sequences)  # DEBUG
 
-    def scalar_done(self, is_uploaded):
-        if is_uploaded:
-            self._num_scalars_uploaded += 1
+    def scalars_done(self):
         self._set_description("Done uploading scalars")
         self._progress_bar.update()
 

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -390,10 +390,11 @@ class _UploadIntent(_Intent):
         """
     )
 
-    def __init__(self, logdir, name=None, description=None):
+    def __init__(self, logdir, name=None, description=None, one_shot=None):
         self.logdir = logdir
         self.name = name
         self.description = description
+        self.one_shot = one_shot
 
     def get_ack_message_body(self):
         return self._MESSAGE_TEMPLATE.format(logdir=self.logdir)
@@ -411,6 +412,7 @@ class _UploadIntent(_Intent):
             upload_limits=server_info_lib.upload_limits(server_info),
             name=self.name,
             description=self.description,
+            one_shot=self.one_shot,
         )
         experiment_id = uploader.create_experiment()
         url = server_info_lib.experiment_url(server_info, experiment_id)
@@ -503,6 +505,7 @@ def _get_intent(flags):
                 os.path.expanduser(flags.logdir),
                 name=flags.name,
                 description=flags.description,
+                one_shot=flags.one_shot,
             )
         else:
             raise base_plugin.FlagsError(

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -424,7 +424,11 @@ class _UploadIntent(_Intent):
             "Upload started and will continue reading any new data as it's added"
         )
         print("to the logdir. To stop uploading, press Ctrl-C.")
-        if not self.dry_run:
+        if self.dry_run:
+            print(
+                "This is a dry-run. Data are not uploaded to tensorboard.dev."
+            )
+        else:
             print("View your TensorBoard live at: %s" % url)
         try:
             uploader.start_uploading()
@@ -437,7 +441,9 @@ class _UploadIntent(_Intent):
             return
         # TODO(@nfelt): make it possible for the upload cycle to end once we
         #   detect that no more runs are active, so this code can be reached.
-        if not self.dry_run:
+        if self.dry_run:
+            print("Dry run concluded.")
+        else:
             print("Done! View your TensorBoard at %s" % url)
 
 


### PR DESCRIPTION
* Motivation for features / changes
  * This is a PoC of the three features in the uploader
    * Real-time updates to the console about what data is being uploaded
    * Dry-run mode, in which no data is sent to server via RPC
    * One-shot mode, in which the uploader uploads only the currently-existing data in the logdir and exists immediately.