### PR TITLE
CI: Apply new Jupyter Notebook formatting checks (and fix the resulting failure)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: yamllint -c docs/.yamllint docs docs/.yamllint
       - name: 'Install nbfmt.py for checking notebook formatting'
         run: |
-          nbfmt_version="04458102aafe1ccc9d703b832db3ac4d038ecd6c"
+          nbfmt_version="78692e5013fe070a33c7501245157b395c2e7e84"
           wget "https://raw.githubusercontent.com/tensorflow/docs/${nbfmt_version}/tools/nbfmt.py"
           pip install absl-py
           chmod +x ./nbfmt.py

--- a/tensorboard/plugins/mesh/Mesh_Plugin_Tensorboard.ipynb
+++ b/tensorboard/plugins/mesh/Mesh_Plugin_Tensorboard.ipynb
@@ -4,6 +4,40 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
+        "id": "djUvWu41mtXa"
+      },
+      "source": [
+        "##### Copyright 2019 The TensorFlow Authors."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "cellView": "form",
+        "colab": {},
+        "colab_type": "code",
+        "id": "su2RaORHpReL"
+      },
+      "outputs": [],
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
         "id": "Jp9JqDRqxVWU"
       },
       "source": [


### PR DESCRIPTION
`nbfmt.py` previously tolerated several errors that should have been failures.  That is fixed in https://github.com/tensorflow/docs/commit/f10110518e0fa60bc855e77354ae3eea156532c7.

Here we use the new version of `nbfmt.py`, and fix the remaining missing license issue to allow CI to pass.