### PR TITLE
uploader: add rpc method ExporterService.GetExperiment

### DIFF
--- a/tensorboard/uploader/proto/export_service.proto
+++ b/tensorboard/uploader/proto/export_service.proto
@@ -13,6 +13,10 @@ service TensorBoardExporterService {
   // Stream the experiment_id of all the experiments owned by the caller.
   rpc StreamExperiments(StreamExperimentsRequest)
       returns (stream StreamExperimentsResponse) {}
+  // Get the metadata of an experiment, including the creation time, name,
+  // description, counts of scalars, tensors and blob sequences, etc. See the
+  // documentation string of `Experiment` for more details.
+  rpc GetExperiment(ExporterGetExperimentRequest) returns (Experiment) {}
   // Stream scalars for all the runs and tags in an experiment.
   rpc StreamExperimentData(StreamExperimentDataRequest)
       returns (stream StreamExperimentDataResponse) {}
@@ -78,6 +82,19 @@ message StreamExperimentsResponse {
   // These messages may be partially populated, in accordance with the field
   // mask given in the request.
   repeated Experiment experiments = 2;
+}
+
+// Request to get the metadata of an experiment.
+message ExporterGetExperimentRequest {
+  // ID of the experiment to get.
+  string experiment_id = 1;
+  // Field mask for what experiment data to return via the `experiments` field
+  // on the response. If not specified, this should be interpreted the same as
+  // an empty message: i.e., only the experiment ID should be returned. Other
+  // fields of `Experiment` will be populated if their corresponding bits in the
+  // `ExperimentMask` are set. The server may choose to populate fields that are
+  // not explicitly requested.
+  ExperimentMask experiments_mask = 2;
 }
 
 // Request to stream scalars from all the runs and tags in an experiment.


### PR DESCRIPTION
* Motivation for features / changes
  * This is the roll forward of go/tbpr/3614, with a change in the name of the request payload
    to avoid name collision.

The original intent of the PR hasn't changed:
> * Motivation for features / changes
>   * In the experimental `ExperimentFromDev` class, support getting metadata including
>     experiment name and description.
>   * In the `ExperimentalFromDev.get_scalars()`, support progress indicaor.
> * Technical description of changes
>   * Add non-streaming rpc method `GetExperiment()` to `ExporterService`.
> * Alternate designs / implementations considered
>   * Add `Experiment` as a one-of response data type to `StreamExperimentDataResponse`
>     * Con: In the current takeout paradigm, this leads to duplicate information.
>     * Con: Wasteful when only the `Experiment` (metadata) is needed and all the scalars, tensor and blob sequences are not needed.