### PR TITLE
[DebuggerV2] Clicking tensor in graph execution component brings up graph view

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/debug_tensor_value_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/debug_tensor_value_component.ts
@@ -22,10 +22,10 @@ const basicDebugInfoStyle = `
     border: 1px solid #c0c0c0;
     border-radius: 4px;
     font-family: 'Roboto Mono', monospace;
-    height: 12px;
-    line-height: 12px;
+    height: 14px;
+    line-height: 14px;
     margin: 0 2px;
-    padding: 0 3px;
+    padding: 1px 3px;
     width: max-content;
   }
 `;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/debug_tensor_value_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/debug_tensor_value_component.ts
@@ -22,10 +22,10 @@ const basicDebugInfoStyle = `
     border: 1px solid #c0c0c0;
     border-radius: 4px;
     font-family: 'Roboto Mono', monospace;
-    height: 14px;
-    line-height: 14px;
+    height: 12px;
+    line-height: 12px;
     margin: 0 2px;
-    padding: 1px 3px;
+    padding: 0 3px;
     width: max-content;
   }
 `;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_component.ng.html
@@ -119,7 +119,7 @@ limitations under the License.
   <ng-template #noOpFocused>
     <div class="no-op-focused">
       No graph op selected. Click a tensor name in Graph Executions table to
-      view the neighborhood of an op in its graph.
+      view the neighborhood of the tensor's op in its graph.
     </div>
   </ng-template>
 </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_component.ng.html
@@ -118,8 +118,8 @@ limitations under the License.
 
   <ng-template #noOpFocused>
     <div class="no-op-focused">
-      No graph op selected. Click a row in Graph Executions table to view the
-      neighborhood of an op in its graph.
+      No graph op selected. Click a tensor name in Graph Executions table to
+      view the neighborhood of an op in its graph.
     </div>
   </ng-template>
 </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_op_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_op_component.css
@@ -25,6 +25,10 @@ limitations under the License.
   width: 200px;
 }
 
+.op-container:focus {
+  outline: 0;
+}
+
 .op-container:hover {
   border: 2px solid #ffd3b2;
 }
@@ -43,6 +47,10 @@ limitations under the License.
   text-align: right;
   text-decoration: underline;
   white-space: pre-wrap;
+}
+
+.op-name:focus {
+  outline: 0;
 }
 
 .op-type {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
@@ -83,17 +83,17 @@ limitations under the License.
   display: block;
   height: 16px;
   line-height: 16px;
+  margin: 2px 0 1px;
   overflow: hidden;
   padding: 0 2px;
   text-align: right;
   text-decoration: underline;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 100%;
 }
 
 .tensor-name:focus {
-  outline: 0;
+  outline: 1px solid #c6cad1;
 }
 
 .tensor-name-and-op-type {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
@@ -50,9 +50,9 @@ limitations under the License.
   border: 1px solid #c0c0c0;
   border-radius: 4px;
   direction: rtl;
+  display: block;
   font-family: 'Roboto Mono', monospace;
   font-size: 10px;
-  display: block;
   height: 14px;
   line-height: 14px;
   padding: 1px 3px;
@@ -73,6 +73,17 @@ limitations under the License.
   vertical-align: middle;
   white-space: nowrap;
   width: 100%;
+}
+
+.tensor-item-clickable {
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.tensor-item-clickable:focus {
+  outline: 2px solid #c6cad1;
 }
 
 .tensor-name {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
@@ -84,6 +84,7 @@ limitations under the License.
   height: 16px;
   line-height: 16px;
   margin: 2px 0 1px;
+  max-width: calc(100% - 3px);
   overflow: hidden;
   padding: 0 2px;
   text-align: right;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
@@ -67,35 +67,33 @@ limitations under the License.
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
   display: flex;
   flex-wrap: nowrap;
-  height: 36px;
-  line-height: 36px;
+  height: 38px;
+  line-height: 38px;
   text-align: left;
   vertical-align: middle;
   white-space: nowrap;
   width: 100%;
 }
 
-.tensor-item-clickable {
+.tensor-name {
   background-color: transparent;
   border: none;
   cursor: pointer;
-  padding: 0;
-}
-
-.tensor-item-clickable:focus {
-  outline: 2px solid #c6cad1;
-}
-
-.tensor-name {
   direction: rtl;
   display: block;
   height: 16px;
   line-height: 16px;
   overflow: hidden;
   padding: 0 2px;
+  text-align: right;
+  text-decoration: underline;
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;
+}
+
+.tensor-name:focus {
+  outline: 0;
 }
 
 .tensor-name-and-op-type {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
@@ -78,13 +78,14 @@ limitations under the License.
 .tensor-name {
   background-color: transparent;
   border: none;
+  box-sizing: border-box;
   cursor: pointer;
   direction: rtl;
   display: block;
   height: 16px;
   line-height: 16px;
   margin: 2px 0 1px;
-  max-width: calc(100% - 3px);
+  max-width: calc(100% - 2px);
   overflow: hidden;
   padding: 0 2px;
   text-align: right;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
@@ -37,19 +37,18 @@ limitations under the License.
           </div>
           {{ i }}
         </div>
-        <button
-          *ngIf="graphExecutionData[i]; else dataLoading"
-          class="tensor-item-clickable"
-          (click)="onClick.emit({
-            graph_id: graphExecutionData[i].graph_id,
-            op_name: graphExecutionData[i].op_name
-          })"
-        >
+        <div *ngIf="graphExecutionData[i]; else dataLoading">
           <div class="tensor-name-and-op-type">
-            <div class="tensor-name">
+            <button
+              class="tensor-name"
+              (click)="onTensorNameClick.emit({
+                graph_id: graphExecutionData[i].graph_id,
+                op_name: graphExecutionData[i].op_name
+              })"
+            >
               {{ graphExecutionData[i].op_name }}:{{
               graphExecutionData[i].output_slot }}
-            </div>
+            </button>
             <div class="op-type">
               {{ graphExecutionData[i].op_type }}
             </div>
@@ -63,7 +62,7 @@ limitations under the License.
             })"
           >
           </debug-tensor-value>
-        </button>
+        </div>
 
         <ng-template #dataLoading class="tensor-item">
           <div class="loading-spinner">

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
@@ -37,7 +37,14 @@ limitations under the License.
           </div>
           {{ i }}
         </div>
-        <div *ngIf="graphExecutionData[i]; else dataLoading">
+        <button
+          *ngIf="graphExecutionData[i]; else dataLoading"
+          class="tensor-item-clickable"
+          (click)="onClick.emit({
+            graph_id: graphExecutionData[i].graph_id,
+            op_name: graphExecutionData[i].op_name
+          })"
+        >
           <div class="tensor-name-and-op-type">
             <div class="tensor-name">
               {{ graphExecutionData[i].op_name }}:{{
@@ -56,7 +63,7 @@ limitations under the License.
             })"
           >
           </debug-tensor-value>
-        </div>
+        </button>
 
         <ng-template #dataLoading class="tensor-item">
           <div class="loading-spinner">

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
@@ -51,7 +51,7 @@ export class GraphExecutionsComponent implements OnChanges {
   onScrolledIndexChange = new EventEmitter<number>();
 
   @Output()
-  onClick = new EventEmitter<{
+  onTensorNameClick = new EventEmitter<{
     graph_id: string;
     op_name: string;
   }>();

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
@@ -50,6 +50,12 @@ export class GraphExecutionsComponent implements OnChanges {
   @Output()
   onScrolledIndexChange = new EventEmitter<number>();
 
+  @Output()
+  onClick = new EventEmitter<{
+    graph_id: string;
+    op_name: string;
+  }>();
+
   parseDebugTensorValue = parseDebugTensorValue;
 
   @ViewChild(CdkVirtualScrollViewport, {static: false})

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
@@ -64,12 +64,7 @@ export class GraphExecutionsContainer {
   }
 
   onTensorNameClick(event: {graph_id: string; op_name: string}) {
-    this.store.dispatch(
-      graphOpFocused({
-        graph_id: event.graph_id,
-        op_name: event.op_name,
-      })
-    );
+    this.store.dispatch(graphOpFocused(event));
   }
 
   constructor(private readonly store: Store<State>) {}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {Component} from '@angular/core';
 import {createSelector, select, Store} from '@ngrx/store';
 
-import {graphExecutionScrollToIndex} from '../../actions';
+import {graphExecutionScrollToIndex, graphOpFocused} from '../../actions';
 import {
   getGraphExecutionData,
   getGraphExecutionFocusIndex,
@@ -34,6 +34,7 @@ import {State} from '../../store/debugger_types';
       [graphExecutionIndices]="graphExecutionIndices$ | async"
       [focusIndex]="focusIndex$ | async"
       (onScrolledIndexChange)="onScrolledIndexChange($event)"
+      (onClick)="onClick($event)"
     ></graph-executions-component>
   `,
 })
@@ -60,6 +61,15 @@ export class GraphExecutionsContainer {
 
   onScrolledIndexChange(scrolledIndex: number) {
     this.store.dispatch(graphExecutionScrollToIndex({index: scrolledIndex}));
+  }
+
+  onClick(event: {graph_id: string; op_name: string}) {
+    this.store.dispatch(
+      graphOpFocused({
+        graph_id: event.graph_id,
+        op_name: event.op_name,
+      })
+    );
   }
 
   constructor(private readonly store: Store<State>) {}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
@@ -34,7 +34,7 @@ import {State} from '../../store/debugger_types';
       [graphExecutionIndices]="graphExecutionIndices$ | async"
       [focusIndex]="focusIndex$ | async"
       (onScrolledIndexChange)="onScrolledIndexChange($event)"
-      (onClick)="onClick($event)"
+      (onTensorNameClick)="onTensorNameClick($event)"
     ></graph-executions-component>
   `,
 })
@@ -63,7 +63,7 @@ export class GraphExecutionsContainer {
     this.store.dispatch(graphExecutionScrollToIndex({index: scrolledIndex}));
   }
 
-  onClick(event: {graph_id: string; op_name: string}) {
+  onTensorNameClick(event: {graph_id: string; op_name: string}) {
     this.store.dispatch(
       graphOpFocused({
         graph_id: event.graph_id,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -23,6 +23,7 @@ import {By} from '@angular/platform-browser';
 import {Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
 
+import {graphOpFocused} from '../../actions';
 import {DebuggerComponent} from '../../debugger_component';
 import {DebuggerContainer} from '../../debugger_container';
 import {
@@ -59,6 +60,8 @@ describe('Graph Executions Container', () => {
     graphExecutionData[i] = createTestGraphExecution({
       op_name: `TestOp_${i}`,
       op_type: `OpType_${i}`,
+      graph_id: 'g2',
+      graph_ids: ['g0', 'g1', 'g2'],
       tensor_debug_mode: TensorDebugMode.CONCISE_HEALTH,
       debug_tensor_value: [i, 100, 0, 0, 0],
     });
@@ -148,6 +151,29 @@ describe('Graph Executions Container', () => {
       By.css('debug-tensor-value')
     );
     expect(debugTensorValueElements.length).toBe(tensorContainers.length);
+
+    // Clicking the tensor item buttons should have dispatched proper actions.
+    const dispatchSpy = spyOn(store, 'dispatch');
+    const tensorItemClickables = fixture.debugElement.queryAll(
+      By.css('.tensor-item-clickable')
+    );
+    expect(tensorItemClickables.length).toBe(tensorContainers.length);
+    tensorItemClickables[0].nativeElement.click();
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      graphOpFocused({
+        graph_id: 'g2',
+        op_name: 'TestOp_0',
+      })
+    );
+    tensorItemClickables[tensorContainers.length - 1].nativeElement.click();
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      graphOpFocused({
+        graph_id: 'g2',
+        op_name: `TestOp_${tensorContainers.length - 1}`,
+      })
+    );
   }));
 
   it('renders # execs and execs viewport if # execs > 0; not loaded', fakeAsync(() => {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -152,10 +152,10 @@ describe('Graph Executions Container', () => {
     );
     expect(debugTensorValueElements.length).toBe(tensorContainers.length);
 
-    // Clicking the tensor item buttons should have dispatched proper actions.
+    // Clicking the tensor name buttons should dispatch the proper action.
     const dispatchSpy = spyOn(store, 'dispatch');
     const tensorItemClickables = fixture.debugElement.queryAll(
-      By.css('.tensor-item-clickable')
+      By.css('.tensor-name')
     );
     expect(tensorItemClickables.length).toBe(tensorContainers.length);
     tensorItemClickables[0].nativeElement.click();

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -151,14 +151,22 @@ describe('Graph Executions Container', () => {
       By.css('debug-tensor-value')
     );
     expect(debugTensorValueElements.length).toBe(tensorContainers.length);
+  }));
 
-    // Clicking the tensor name buttons should dispatch the proper action.
+  it('clicking the tensor name buttons dispatches graphOpFocused', fakeAsync(() => {
+    const fixture = TestBed.createComponent(GraphExecutionsContainer);
+    store.overrideSelector(getNumGraphExecutions, 2);
+    store.overrideSelector(getGraphExecutionData, {
+      0: graphExecutionData[0],
+      1: graphExecutionData[1],
+    });
+    fixture.autoDetectChanges();
+    tick();
+
     const dispatchSpy = spyOn(store, 'dispatch');
-    const tensorItemClickables = fixture.debugElement.queryAll(
-      By.css('.tensor-name')
-    );
-    expect(tensorItemClickables.length).toBe(tensorContainers.length);
-    tensorItemClickables[0].nativeElement.click();
+    const tensorNames = fixture.debugElement.queryAll(By.css('.tensor-name'));
+    expect(tensorNames.length).toBe(2);
+    tensorNames[0].nativeElement.click();
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
     expect(dispatchSpy).toHaveBeenCalledWith(
       graphOpFocused({
@@ -166,12 +174,12 @@ describe('Graph Executions Container', () => {
         op_name: 'TestOp_0',
       })
     );
-    tensorItemClickables[tensorContainers.length - 1].nativeElement.click();
+    tensorNames[1].nativeElement.click();
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
     expect(dispatchSpy).toHaveBeenCalledWith(
       graphOpFocused({
         graph_id: 'g2',
-        op_name: `TestOp_${tensorContainers.length - 1}`,
+        op_name: `TestOp_1`,
       })
     );
   }));


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing the graph-related frontend of DebuggerV2
* Technical description of changes
  * Add a click event listener to each tensor name in GraphExecutionComponent
  * Change the tensor name element from a `<div>` to a `<button>` to reflect the
     fact that it is clickable.
  * The listener dispatches the `graphOpFocused()` action with the corresponding
    `graph_id` and `op_name`, so the the `GraphComponent` can bring up the
    local graph structure view of the op.
  * Button outline CSS in GraphOpComponent to avoid extraneous outlines when
    focused.
* Screenshots of UI changes
  * ![image](https://user-images.githubusercontent.com/16824702/82565840-14141600-9b49-11ea-8f38-be93e7a2a580.png)
* Detailed steps to verify changes work correctly (as executed by you)
  * Unit test added
  * Manual testing against real logdirs with tfdbg2 data (see screenshot above)
