### PR TITLE
DataFrame API: Add ExperimentFromDev to namespace tb.data.experimental.*

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -64,6 +64,7 @@ py_library(
         ":errors",
         ":lazy",
         ":version",
+        "//tensorboard/data:lib_init_only",
     ],
 )
 

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -45,6 +45,7 @@ py_library(
         ":lib_init_only",
         ":notebook",
         ":program",
+        "//tensorboard/data:lib_init_only",
         "//tensorboard/summary",
         "//tensorboard/summary/writer",
     ],
@@ -64,7 +65,6 @@ py_library(
         ":errors",
         ":lazy",
         ":version",
-        "//tensorboard/data:lib_init_only",
     ],
 )
 

--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorboard import data
 from tensorboard import errors  # public export
 from tensorboard import lazy as _lazy
 from tensorboard import version as _version
@@ -74,6 +73,13 @@ __all__ = [
 #
 # See <https://github.com/tensorflow/tensorboard/issues/1989> for
 # additional discussion.
+
+
+@_lazy.lazy_load("tensorboard.data")
+def data():
+    import importlib
+
+    return importlib.import_module("tensorboard.data")
 
 
 @_lazy.lazy_load("tensorboard.notebook")

--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from tensorboard import data
 from tensorboard import errors  # public export
 from tensorboard import lazy as _lazy
 from tensorboard import version as _version

--- a/tensorboard/data/BUILD
+++ b/tensorboard/data/BUILD
@@ -8,6 +8,16 @@ licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])
 
 py_library(
+    name = "lib_init_only",
+    srcs = ["__init__.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//tensorboard:internal"],
+    deps = [
+        "//tensorboard/data/experimental:lib_init_only",
+    ],
+)
+
+py_library(
     name = "provider",
     srcs = ["provider.py"],
     srcs_version = "PY3",

--- a/tensorboard/data/experimental/BUILD
+++ b/tensorboard/data/experimental/BUILD
@@ -22,7 +22,6 @@ py_library(
         "//tensorboard:expect_grpc_installed",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_pandas_installed",
-        "//tensorboard:lazy",
         "//tensorboard/uploader:auth",
         "//tensorboard/uploader:server_info",
         "//tensorboard/uploader:util",

--- a/tensorboard/data/experimental/BUILD
+++ b/tensorboard/data/experimental/BUILD
@@ -22,6 +22,7 @@ py_library(
         "//tensorboard:expect_grpc_installed",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:expect_pandas_installed",
+        "//tensorboard:lazy",
         "//tensorboard/uploader:auth",
         "//tensorboard/uploader:server_info",
         "//tensorboard/uploader:util",
@@ -47,6 +48,16 @@ py_test(
         "//tensorboard/uploader/proto:protos_all_py_pb2",
         "//tensorboard/util:grpc_util",
         "@org_pythonhosted_mock",
+    ],
+)
+
+py_library(
+    name = "lib_init_only",
+    srcs = ["__init__.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//tensorboard:internal"],
+    deps = [
+        ":experiment_from_dev",
     ],
 )
 

--- a/tensorboard/data/experimental/BUILD
+++ b/tensorboard/data/experimental/BUILD
@@ -10,13 +10,13 @@ exports_files(["LICENSE"])
 py_library(
     name = "base_experiment",
     srcs = ["base_experiment.py"],
-    srcs_version = "PY3",
+    srcs_version = "PY2AND3",
 )
 
 py_library(
     name = "experiment_from_dev",
     srcs = ["experiment_from_dev.py"],
-    srcs_version = "PY3",
+    srcs_version = "PY2AND3",
     deps = [
         ":base_experiment",
         "//tensorboard:expect_grpc_installed",
@@ -63,7 +63,7 @@ py_library(
 py_binary(
     name = "test_binary",
     srcs = ["test_binary.py"],
-    srcs_version = "PY3",
+    srcs_version = "PY2AND3",
     deps = [
         "//tensorboard/data/experimental:experiment_from_dev",
         "@org_pythonhosted_six",

--- a/tensorboard/data/experimental/BUILD
+++ b/tensorboard/data/experimental/BUILD
@@ -10,13 +10,13 @@ exports_files(["LICENSE"])
 py_library(
     name = "base_experiment",
     srcs = ["base_experiment.py"],
-    srcs_version = "PY2AND3",
+    srcs_version = "PY3",
 )
 
 py_library(
     name = "experiment_from_dev",
     srcs = ["experiment_from_dev.py"],
-    srcs_version = "PY2AND3",
+    srcs_version = "PY3",
     deps = [
         ":base_experiment",
         "//tensorboard:expect_grpc_installed",
@@ -53,7 +53,7 @@ py_test(
 py_library(
     name = "lib_init_only",
     srcs = ["__init__.py"],
-    srcs_version = "PY2AND3",
+    srcs_version = "PY3",
     visibility = ["//tensorboard:internal"],
     deps = [
         ":experiment_from_dev",
@@ -63,7 +63,7 @@ py_library(
 py_binary(
     name = "test_binary",
     srcs = ["test_binary.py"],
-    srcs_version = "PY2AND3",
+    srcs_version = "PY3",
     deps = [
         "//tensorboard/data/experimental:experiment_from_dev",
         "@org_pythonhosted_six",

--- a/tensorboard/data/experimental/__init__.py
+++ b/tensorboard/data/experimental/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,4 +17,4 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorboard.data import experimental
+from tensorboard.data.experimental.experiment_from_dev import ExperimentFromDev

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -110,6 +110,7 @@ build() (
   # env markers are handled (https://github.com/pypa/setuptools/pull/1081)
   export PYTHONWARNINGS=ignore:DEPRECATION  # suppress Python 2.7 deprecation spam
   pip install -qU wheel 'setuptools>=36.2.0'
+  pip install -r requirements.txt
 
   # Overrides file timestamps in the zip archive to make the build
   # reproducible. (Date is mostly arbitrary, but must be past 1980 to be

--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -110,7 +110,6 @@ build() (
   # env markers are handled (https://github.com/pypa/setuptools/pull/1081)
   export PYTHONWARNINGS=ignore:DEPRECATION  # suppress Python 2.7 deprecation spam
   pip install -qU wheel 'setuptools>=36.2.0'
-  pip install -r requirements.txt
 
   # Overrides file timestamps in the zip archive to make the build
   # reproducible. (Date is mostly arbitrary, but must be past 1980 to be

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -1,4 +1,3 @@
-
 # Copyright 2017 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -1,3 +1,4 @@
+
 # Copyright 2017 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
* Motivation for features / changes
  * Put the experimental `ExperimentFromDev` API (accessing tensorboard.dev
    scalars as `pandas.DataFrame`s) under a public import path:
    `tensorboard.data.experimental.ExperimentFromDev`.
* Technical description of changes
  * Add the necessary `__init__.py` and the associated BUILD targets.
  * In build_pip_package.sh, add the line `pip install -r requirements.txt`,
     because we know have lines in the files imported from the
     `__init__.py` files that import third-party dependencies such as grpc and
     numpy.