### PR TITLE
[DebuggerV2] Generalize StackTrace component to accommodate graph ops

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container_test.ts
@@ -39,9 +39,7 @@ import {
   TensorDebugMode,
 } from './store/debugger_types';
 import {
-  getCodeLocationFocusType,
-  getFocusedExecutionData,
-  getFocusedGraphOpInfo,
+  getCodeLocationOrigin,
   getFocusedSourceLineSpec,
   getFocusedStackFrames,
 } from './store';
@@ -570,147 +568,181 @@ describe('Debugger Container', () => {
   });
 
   describe('Stack Trace container', () => {
-    for (const {codeLocationType, expectedTypeString} of [
-      {
+    it('shows non-empty eager stack frames; highlights focused frame', () => {
+      const fixture = TestBed.createComponent(StackTraceContainer);
+      store.overrideSelector(getCodeLocationOrigin, {
         codeLocationType: CodeLocationType.EXECUTION,
-        expectedTypeString: 'Eager execution of',
-      },
-      {
-        codeLocationType: CodeLocationType.GRAPH_OP_CREATION,
-        expectedTypeString: 'Creation of graph op',
-      },
-    ]) {
-      it(
-        `shows non-empty stack frames; highlights focused frame; ` +
-          `code location type = ${codeLocationType}`,
-        () => {
-          const fixture = TestBed.createComponent(StackTraceContainer);
-          store.overrideSelector(getCodeLocationFocusType, codeLocationType);
-          if (codeLocationType === CodeLocationType.EXECUTION) {
-            store.overrideSelector(
-              getFocusedExecutionData,
-              createTestExecutionData({
-                op_type: 'FooOp',
-              })
-            );
-          } else if (codeLocationType === CodeLocationType.GRAPH_OP_CREATION) {
-            store.overrideSelector(
-              getFocusedGraphOpInfo,
-              createTestGraphOpInfo({
-                op_type: 'FooOp',
-                op_name: 'scope_1/foo_2',
-              })
-            );
-          }
-          const stackFrame0 = createTestStackFrame();
-          const stackFrame1 = createTestStackFrame();
-          const stackFrame2 = createTestStackFrame();
-          store.overrideSelector(getFocusedStackFrames, [
-            stackFrame0,
-            stackFrame1,
-            stackFrame2,
-          ]);
-          store.overrideSelector(getFocusedSourceLineSpec, {
-            host_name: stackFrame1[0],
-            file_path: stackFrame1[1],
-            lineno: stackFrame1[2],
-          });
-          fixture.detectChanges();
+        opType: 'FooOp',
+        executionIndex: 12,
+      });
+      const stackFrame0 = createTestStackFrame();
+      const stackFrame1 = createTestStackFrame();
+      const stackFrame2 = createTestStackFrame();
+      store.overrideSelector(getFocusedStackFrames, [
+        stackFrame0,
+        stackFrame1,
+        stackFrame2,
+      ]);
+      store.overrideSelector(getFocusedSourceLineSpec, {
+        host_name: stackFrame1[0],
+        file_path: stackFrame1[1],
+        lineno: stackFrame1[2],
+      });
+      fixture.detectChanges();
 
-          const stackTraceTypeElement = fixture.debugElement.query(
-            By.css('.stack-trace-type')
-          );
-          expect(stackTraceTypeElement.nativeElement.innerText.trim()).toBe(
-            expectedTypeString
-          );
-          const opTypeElement = fixture.debugElement.query(By.css('.op-type'));
-          expect(opTypeElement.nativeElement.innerText.trim()).toBe('FooOp');
-          const opNameElement = fixture.debugElement.query(By.css('.op-name'));
-          if (codeLocationType === CodeLocationType.EXECUTION) {
-            // Eager ops don't have names.
-            expect(opNameElement).toBeNull();
-          } else {
-            expect(opNameElement.nativeElement.innerText.trim()).toBe(
-              '"scope_1/foo_2"'
-            );
-          }
-          const hostNameElement = fixture.debugElement.query(
-            By.css('.stack-trace-host-name')
-          );
-          expect(hostNameElement.nativeElement.innerText).toBe(
-            '(Host name: localhost)'
-          );
-          const stackFrameContainers = fixture.debugElement.queryAll(
-            By.css('.stack-frame-container')
-          );
-          expect(stackFrameContainers.length).toBe(3);
-
-          const filePathElements = fixture.debugElement.queryAll(
-            By.css('.stack-frame-file-path')
-          );
-          expect(filePathElements.length).toBe(3);
-          expect(filePathElements[0].nativeElement.innerText).toBe(
-            stackFrame0[1].slice(stackFrame0[1].lastIndexOf('/') + 1)
-          );
-          expect(filePathElements[0].nativeElement.title).toBe(stackFrame0[1]);
-          expect(filePathElements[1].nativeElement.innerText).toBe(
-            stackFrame1[1].slice(stackFrame1[1].lastIndexOf('/') + 1)
-          );
-          expect(filePathElements[1].nativeElement.title).toBe(stackFrame1[1]);
-          expect(filePathElements[2].nativeElement.innerText).toBe(
-            stackFrame2[1].slice(stackFrame2[1].lastIndexOf('/') + 1)
-          );
-          expect(filePathElements[2].nativeElement.title).toBe(stackFrame2[1]);
-
-          const linenoElements = fixture.debugElement.queryAll(
-            By.css('.stack-frame-lineno')
-          );
-          expect(linenoElements.length).toBe(3);
-          expect(linenoElements[0].nativeElement.innerText).toBe(
-            `Line ${stackFrame0[2]}`
-          );
-          expect(linenoElements[1].nativeElement.innerText).toBe(
-            `Line ${stackFrame1[2]}`
-          );
-          expect(linenoElements[2].nativeElement.innerText).toBe(
-            `Line ${stackFrame2[2]}`
-          );
-
-          const functionElements = fixture.debugElement.queryAll(
-            By.css('.stack-frame-function')
-          );
-          expect(functionElements.length).toBe(3);
-          expect(functionElements[0].nativeElement.innerText).toBe(
-            stackFrame0[3]
-          );
-          expect(functionElements[1].nativeElement.innerText).toBe(
-            stackFrame1[3]
-          );
-          expect(functionElements[2].nativeElement.innerText).toBe(
-            stackFrame2[3]
-          );
-
-          // Check the focused stack frame has been highlighted by CSS class.
-          const focusedElements = fixture.debugElement.queryAll(
-            By.css('.focused-stack-frame')
-          );
-          expect(focusedElements.length).toBe(1);
-          const focusedFilePathElement = focusedElements[0].query(
-            By.css('.stack-frame-file-path')
-          );
-          expect(focusedFilePathElement.nativeElement.innerText).toBe(
-            stackFrame1[1].slice(stackFrame1[1].lastIndexOf('/') + 1)
-          );
-        }
+      const stackTraceTypeElement = fixture.debugElement.query(
+        By.css('.code-location-origin')
       );
-    }
+      expect(stackTraceTypeElement.nativeElement.innerText.trim()).toBe(
+        'Eager execution #12: FooOp'
+      );
+      const hostNameElement = fixture.debugElement.query(
+        By.css('.stack-trace-host-name')
+      );
+      expect(hostNameElement.nativeElement.innerText).toBe(
+        '(Host name: localhost)'
+      );
+      const stackFrameContainers = fixture.debugElement.queryAll(
+        By.css('.stack-frame-container')
+      );
+      expect(stackFrameContainers.length).toBe(3);
+
+      const filePathElements = fixture.debugElement.queryAll(
+        By.css('.stack-frame-file-path')
+      );
+      expect(filePathElements.length).toBe(3);
+      expect(filePathElements[0].nativeElement.innerText).toBe(
+        stackFrame0[1].slice(stackFrame0[1].lastIndexOf('/') + 1)
+      );
+      expect(filePathElements[0].nativeElement.title).toBe(stackFrame0[1]);
+      expect(filePathElements[1].nativeElement.innerText).toBe(
+        stackFrame1[1].slice(stackFrame1[1].lastIndexOf('/') + 1)
+      );
+      expect(filePathElements[1].nativeElement.title).toBe(stackFrame1[1]);
+      expect(filePathElements[2].nativeElement.innerText).toBe(
+        stackFrame2[1].slice(stackFrame2[1].lastIndexOf('/') + 1)
+      );
+      expect(filePathElements[2].nativeElement.title).toBe(stackFrame2[1]);
+
+      const linenoElements = fixture.debugElement.queryAll(
+        By.css('.stack-frame-lineno')
+      );
+      expect(linenoElements.length).toBe(3);
+      expect(linenoElements[0].nativeElement.innerText).toBe(
+        `Line ${stackFrame0[2]}`
+      );
+      expect(linenoElements[1].nativeElement.innerText).toBe(
+        `Line ${stackFrame1[2]}`
+      );
+      expect(linenoElements[2].nativeElement.innerText).toBe(
+        `Line ${stackFrame2[2]}`
+      );
+
+      const functionElements = fixture.debugElement.queryAll(
+        By.css('.stack-frame-function')
+      );
+      expect(functionElements.length).toBe(3);
+      expect(functionElements[0].nativeElement.innerText).toBe(stackFrame0[3]);
+      expect(functionElements[1].nativeElement.innerText).toBe(stackFrame1[3]);
+      expect(functionElements[2].nativeElement.innerText).toBe(stackFrame2[3]);
+
+      // Check the focused stack frame has been highlighted by CSS class.
+      const focusedElements = fixture.debugElement.queryAll(
+        By.css('.focused-stack-frame')
+      );
+      expect(focusedElements.length).toBe(1);
+      const focusedFilePathElement = focusedElements[0].query(
+        By.css('.stack-frame-file-path')
+      );
+      expect(focusedFilePathElement.nativeElement.innerText).toBe(
+        stackFrame1[1].slice(stackFrame1[1].lastIndexOf('/') + 1)
+      );
+    });
+
+    it('shows non-empty graph-op-creation stack frames; highlights focused frame', () => {
+      const fixture = TestBed.createComponent(StackTraceContainer);
+      store.overrideSelector(getCodeLocationOrigin, {
+        codeLocationType: CodeLocationType.GRAPH_OP_CREATION,
+        opType: 'FooOp',
+        opName: 'scope_1/foo_2',
+      });
+      const stackFrame0 = createTestStackFrame();
+      const stackFrame1 = createTestStackFrame();
+      store.overrideSelector(getFocusedStackFrames, [stackFrame0, stackFrame1]);
+      store.overrideSelector(getFocusedSourceLineSpec, {
+        host_name: stackFrame0[0],
+        file_path: stackFrame0[1],
+        lineno: stackFrame0[2],
+      });
+      fixture.detectChanges();
+
+      const stackTraceTypeElement = fixture.debugElement.query(
+        By.css('.code-location-origin')
+      );
+      expect(stackTraceTypeElement.nativeElement.innerText.trim()).toBe(
+        'Creation of graph op "scope_1/foo_2" FooOp'
+      );
+      const hostNameElement = fixture.debugElement.query(
+        By.css('.stack-trace-host-name')
+      );
+      expect(hostNameElement.nativeElement.innerText).toBe(
+        '(Host name: localhost)'
+      );
+      const stackFrameContainers = fixture.debugElement.queryAll(
+        By.css('.stack-frame-container')
+      );
+      expect(stackFrameContainers.length).toBe(2);
+
+      const filePathElements = fixture.debugElement.queryAll(
+        By.css('.stack-frame-file-path')
+      );
+      expect(filePathElements.length).toBe(2);
+      expect(filePathElements[0].nativeElement.innerText).toBe(
+        stackFrame0[1].slice(stackFrame0[1].lastIndexOf('/') + 1)
+      );
+      expect(filePathElements[0].nativeElement.title).toBe(stackFrame0[1]);
+      expect(filePathElements[1].nativeElement.innerText).toBe(
+        stackFrame1[1].slice(stackFrame1[1].lastIndexOf('/') + 1)
+      );
+      expect(filePathElements[1].nativeElement.title).toBe(stackFrame1[1]);
+
+      const linenoElements = fixture.debugElement.queryAll(
+        By.css('.stack-frame-lineno')
+      );
+      expect(linenoElements.length).toBe(2);
+      expect(linenoElements[0].nativeElement.innerText).toBe(
+        `Line ${stackFrame0[2]}`
+      );
+      expect(linenoElements[1].nativeElement.innerText).toBe(
+        `Line ${stackFrame1[2]}`
+      );
+
+      const functionElements = fixture.debugElement.queryAll(
+        By.css('.stack-frame-function')
+      );
+      expect(functionElements.length).toBe(2);
+      expect(functionElements[0].nativeElement.innerText).toBe(stackFrame0[3]);
+      expect(functionElements[1].nativeElement.innerText).toBe(stackFrame1[3]);
+
+      // Check the focused stack frame has been highlighted by CSS class.
+      const focusedElements = fixture.debugElement.queryAll(
+        By.css('.focused-stack-frame')
+      );
+      expect(focusedElements.length).toBe(1);
+      const focusedFilePathElement = focusedElements[0].query(
+        By.css('.stack-frame-file-path')
+      );
+      expect(focusedFilePathElement.nativeElement.innerText).toBe(
+        stackFrame0[1].slice(stackFrame1[1].lastIndexOf('/') + 1)
+      );
+    });
 
     it('shows no-stack-trace message when no op is focused', () => {
       const fixture = TestBed.createComponent(StackTraceContainer);
-      store.overrideSelector(getCodeLocationFocusType, null);
+      store.overrideSelector(getCodeLocationOrigin, null);
       fixture.detectChanges();
       expect(
-        fixture.debugElement.query(By.css('.stack-trace-type'))
+        fixture.debugElement.query(By.css('.code-location-origin'))
       ).toBeNull();
       expect(fixture.debugElement.query(By.css('.op-type'))).toBeNull();
       expect(fixture.debugElement.query(By.css('.op-name'))).toBeNull();

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_graphs_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_graphs_reducers_test.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 import * as actions from '../actions';
 import {reducers} from './debugger_reducers';
-import {DataLoadState} from './debugger_types';
+import {CodeLocationType, DataLoadState} from './debugger_types';
 import {
   createDebuggerGraphsState,
   createDebuggerState,
@@ -33,6 +33,9 @@ describe('Debugger reducers', () => {
         graphId: 'g2',
         opName: 'TestOp_12',
       });
+      expect(nextState.codeLocationFocusType).toBe(
+        CodeLocationType.GRAPH_OP_CREATION
+      );
     });
 
     it('sets focusedOp in graphs state from non-empty state', () => {
@@ -52,6 +55,9 @@ describe('Debugger reducers', () => {
         graphId: 'g2',
         opName: 'TestOp_12',
       });
+      expect(nextState.codeLocationFocusType).toBe(
+        CodeLocationType.GRAPH_OP_CREATION
+      );
     });
   });
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -529,6 +529,8 @@ const reducer = createReducer(
           ...state.executions,
           focusIndex: state.executions.scrollBeginIndex + action.displayIndex,
         },
+        // An eager-execution event was last focused on, update the
+        // code-location focus type to `EXECUTION`.
         codeLocationFocusType: CodeLocationType.EXECUTION,
       };
     }
@@ -695,6 +697,8 @@ const reducer = createReducer(
             opName: data.op_name,
           },
         },
+        // An graph event was last focused on, update the
+        // code-location focus type to `GRAPH_OP_CREATION`.
         codeLocationFocusType: CodeLocationType.GRAPH_OP_CREATION,
       };
     }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -25,12 +25,12 @@ import {findFileIndex} from './debugger_store_utils';
 import {
   AlertsByIndex,
   AlertType,
+  CodeLocationType,
   DataLoadState,
   DebuggerState,
   Executions,
   Graphs,
   GraphExecutions,
-  GraphOpInfo,
   InfNanAlert,
   StackFramesById,
   SourceFileSpec,
@@ -122,6 +122,7 @@ const initialState: DebuggerState = {
   graphExecutions: createInitialGraphExecutionsState(),
   graphs: createInitialGraphsState(),
   stackFrames: {},
+  codeLocationFocusType: null,
   sourceCode: {
     sourceFileListLoaded: {
       state: DataLoadState.NOT_LOADED,
@@ -528,6 +529,7 @@ const reducer = createReducer(
           ...state.executions,
           focusIndex: state.executions.scrollBeginIndex + action.displayIndex,
         },
+        codeLocationFocusType: CodeLocationType.EXECUTION,
       };
     }
   ),
@@ -693,6 +695,7 @@ const reducer = createReducer(
             opName: data.op_name,
           },
         },
+        codeLocationFocusType: CodeLocationType.GRAPH_OP_CREATION,
       };
     }
   ),

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
@@ -18,6 +18,7 @@ import {reducers} from './debugger_reducers';
 import {
   Alert,
   AlertType,
+  CodeLocationType,
   DataLoadState,
   Execution,
   StackFramesById,
@@ -969,6 +970,7 @@ describe('Debugger graphs reducers', () => {
       })
     );
     expect(nextState.executions.focusIndex).toBe(12);
+    expect(nextState.codeLocationFocusType).toBe(CodeLocationType.EXECUTION);
   });
 
   it(`Updates states on executionDigestFocused: scrollBeginIndex > 0`, () => {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -506,7 +506,7 @@ export const getCodeLocationOrigin = createSelector(
       } as CodeLocationGraphOpCreationOrigin;
     }
   }
-); // TODO(cais): Add unit test.
+);
 
 /**
  * Get the stack trace (frames) of the execution event currently focused on

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -22,7 +22,6 @@ import {
   AlertType,
   CodeLocationExecutionOrigin,
   CodeLocationGraphOpCreationOrigin,
-  CodeLocationOrigin,
   CodeLocationType,
   DataLoadState,
   DEBUGGER_FEATURE_KEY,
@@ -480,7 +479,7 @@ export const getCodeLocationOrigin = createSelector(
     executionIndex: number | null,
     executionData: Execution | null,
     graphOpInfo: GraphOpInfo | null
-  ): CodeLocationOrigin | null => {
+  ): CodeLocationExecutionOrigin | CodeLocationGraphOpCreationOrigin | null => {
     const {codeLocationFocusType} = state;
     if (codeLocationFocusType === null) {
       return null;
@@ -493,7 +492,7 @@ export const getCodeLocationOrigin = createSelector(
         codeLocationType: CodeLocationType.EXECUTION,
         opType: executionData.op_type,
         executionIndex,
-      } as CodeLocationExecutionOrigin;
+      };
     } else {
       // This is CodeLocationType.GRAPH_OP_CREATION.
       if (graphOpInfo === null) {
@@ -503,7 +502,7 @@ export const getCodeLocationOrigin = createSelector(
         codeLocationType: CodeLocationType.GRAPH_OP_CREATION,
         opType: graphOpInfo.op_type,
         opName: graphOpInfo.op_name,
-      } as CodeLocationGraphOpCreationOrigin;
+      };
     }
   }
 );

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -20,6 +20,7 @@ import {
   AlertsByIndex,
   Alerts,
   AlertType,
+  CodeLocationType,
   DataLoadState,
   DEBUGGER_FEATURE_KEY,
   DebuggerRunListing,
@@ -461,6 +462,13 @@ export const getFocusedExecutionData = createSelector(
   }
 );
 
+export const getCodeLocationFocusType = createSelector(
+  selectDebuggerState,
+  (state: DebuggerState): CodeLocationType | null => {
+    return state.codeLocationFocusType;
+  }
+);
+
 /**
  * Get the stack trace (frames) of the execution event currently focused on
  * (if any).
@@ -469,14 +477,33 @@ export const getFocusedExecutionData = createSelector(
  * If any of the stack frames is missing (i.e., hasn't been loaded from
  * the data source yet), returns null.
  */
-export const getFocusedExecutionStackFrames = createSelector(
+export const getFocusedStackFrames = createSelector(
   selectDebuggerState,
   (state: DebuggerState): StackFrame[] | null => {
-    const {focusIndex, executionData} = state.executions;
-    if (focusIndex === null || executionData[focusIndex] === undefined) {
+    if (state.codeLocationFocusType === null) {
       return null;
     }
-    const stackFrameIds = executionData[focusIndex].stack_frame_ids;
+    let stackFrameIds: string[] = [];
+    if (state.codeLocationFocusType === CodeLocationType.EXECUTION) {
+      const {focusIndex, executionData} = state.executions;
+      if (focusIndex === null || executionData[focusIndex] === undefined) {
+        return null;
+      }
+      stackFrameIds = executionData[focusIndex].stack_frame_ids;
+    } else {
+      // This is CodeLocationType.GRAPH_OP_CREATION.
+      if (state.graphs.focusedOp === null) {
+        return null;
+      }
+      const {graphId, opName} = state.graphs.focusedOp;
+      if (
+        state.graphs.ops[graphId] === undefined ||
+        state.graphs.ops[graphId][opName] === undefined
+      ) {
+        return null;
+      }
+      stackFrameIds = state.graphs.ops[graphId][opName].stack_frame_ids;
+    }
     const stackFrames: StackFrame[] = [];
     for (const stackFrameId of stackFrameIds) {
       if (state.stackFrames[stackFrameId] != null) {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
@@ -46,8 +46,6 @@ import {
 import {
   AlertType,
   CodeLocationType,
-  CodeLocationExecutionOrigin,
-  CodeLocationGraphOpCreationOrigin,
   DataLoadState,
   DEBUGGER_FEATURE_KEY,
   StackFrame,
@@ -460,7 +458,7 @@ describe('debugger selectors', () => {
         codeLocationType: CodeLocationType.EXECUTION,
         opType: 'Type2Op',
         executionIndex: 1,
-      } as CodeLocationExecutionOrigin);
+      });
     });
 
     it('returns correct origin for graph-op creation', () => {
@@ -491,7 +489,7 @@ describe('debugger selectors', () => {
         codeLocationType: CodeLocationType.GRAPH_OP_CREATION,
         opType: 'Type2Op',
         opName: 'bar',
-      } as CodeLocationGraphOpCreationOrigin);
+      });
     });
   });
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
@@ -19,7 +19,7 @@ import {
   getAlertsLoaded,
   getFocusedExecutionData,
   getFocusedExecutionIndex,
-  getFocusedExecutionStackFrames,
+  getFocusedStackFrames,
   getFocusedGraphOpConsumers,
   getFocusedGraphOpInfo,
   getFocusedGraphOpInputs,
@@ -44,6 +44,7 @@ import {
 } from './debugger_selectors';
 import {
   AlertType,
+  CodeLocationType,
   DataLoadState,
   DEBUGGER_FEATURE_KEY,
   StackFrame,
@@ -60,6 +61,7 @@ import {
   createTestGraphExecution,
   createTestInfNanAlert,
   createTestGraphOpInfo,
+  createTestStackFrame,
 } from '../testing';
 
 describe('debugger selectors', () => {
@@ -427,7 +429,7 @@ describe('debugger selectors', () => {
     });
   });
 
-  describe('getFocusedExecutionStackFrames', () => {
+  describe('getFocusedStackFrames', () => {
     it('returns correct stack frames when there is no focus', () => {
       const state = createState(
         createDebuggerState({
@@ -450,26 +452,16 @@ describe('debugger selectors', () => {
             executionDigests: {},
             executionData: {},
           },
+          codeLocationFocusType: null,
         })
       );
-      expect(getFocusedExecutionStackFrames(state)).toBe(null);
+      expect(getFocusedStackFrames(state)).toBe(null);
     });
 
-    it('returns correct stack frames when there is no focus', () => {
-      const stackFrame1: StackFrame = ['localhost', '/tmp/main.py', 10, 'main'];
-      const stackFrame2: StackFrame = [
-        'localhost',
-        '/tmp/model.py',
-        20,
-        'initialize',
-      ];
-      const stackFrame3: StackFrame = [
-        'localhost',
-        '/tmp/model.py',
-        30,
-        'create_weight',
-      ];
-
+    it('returns correct eager stack frames', () => {
+      const stackFrame1: StackFrame = createTestStackFrame();
+      const stackFrame2: StackFrame = createTestStackFrame();
+      const stackFrame3: StackFrame = createTestStackFrame();
       const state = createState(
         createDebuggerState({
           activeRunId: '__default_debugger_run__',
@@ -500,12 +492,45 @@ describe('debugger selectors', () => {
             a2: stackFrame2,
             a3: stackFrame3,
           },
+          codeLocationFocusType: CodeLocationType.EXECUTION,
         })
       );
-      expect(getFocusedExecutionStackFrames(state)).toEqual([
-        stackFrame1,
-        stackFrame3,
-      ]);
+      expect(getFocusedStackFrames(state)).toEqual([stackFrame1, stackFrame3]);
+    });
+
+    it('returns correct graph-op-creation stack frames', () => {
+      const stackFrame1: StackFrame = createTestStackFrame();
+      const stackFrame2: StackFrame = createTestStackFrame();
+      const stackFrame3: StackFrame = createTestStackFrame();
+      const state = createState(
+        createDebuggerState({
+          activeRunId: '__default_debugger_run__',
+          graphs: {
+            ops: {
+              f1: {
+                op7: createTestGraphOpInfo({
+                  stack_frame_ids: ['a1', 'a2'],
+                }),
+                op8: createTestGraphOpInfo({
+                  stack_frame_ids: ['a1', 'a3'],
+                }),
+              },
+            },
+            loadingOps: {},
+            focusedOp: {
+              graphId: 'f1',
+              opName: 'op8',
+            },
+          },
+          stackFrames: {
+            a1: stackFrame1,
+            a2: stackFrame2,
+            a3: stackFrame3,
+          },
+          codeLocationFocusType: CodeLocationType.GRAPH_OP_CREATION,
+        })
+      );
+      expect(getFocusedStackFrames(state)).toEqual([stackFrame1, stackFrame3]);
     });
 
     it('returns null when subset of frames is missing', () => {
@@ -540,7 +565,7 @@ describe('debugger selectors', () => {
           },
         })
       );
-      expect(getFocusedExecutionStackFrames(state)).toBeNull();
+      expect(getFocusedStackFrames(state)).toBeNull();
     });
   });
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -518,20 +518,52 @@ export interface DebuggerState {
   //     (top-level) execution.
   //   - `CodeLocationType.GRAPH_OP_CREATION` is for the code location of
   //     the creation of a graph op.
+  // This state is currently set based on what relevant part of the UI
+  // was clicked by the user most recently: whether it is an event in the
+  // eager-execution timeline or an item in the graph-execution scroll.
   codeLocationFocusType: CodeLocationType | null;
 
   sourceCode: SourceCodeState;
 }
 
 /**
- * The type of origin of a code location (incl. stack trace.)
+ * The type of origin of a code location (incl. stack trace).
  */
 export enum CodeLocationType {
   // The code location for an eager (top-level) execution.
-  EXECUTION = 'execution',
+  EXECUTION,
 
   // The code location for the creation of of an op (node) in a graph.
-  GRAPH_OP_CREATION = 'graph_op_creation',
+  GRAPH_OP_CREATION,
+}
+
+/**
+ * Information regarding the origin of a code location (incl. stack trace).
+ * This base interface is inherited by child interfaces for eager execution
+ * and graph-op creation, respectively.
+ */
+export interface CodeLocationOrigin {
+  codeLocationType: CodeLocationType;
+
+  opType: string;
+}
+
+/**
+ * A code location originated from an eager (top-level) execution event.
+ */
+export interface CodeLocationExecutionOrigin extends CodeLocationOrigin {
+  codeLocationType: CodeLocationType.EXECUTION;
+
+  executionIndex: number;
+}
+
+/**
+ * A code location originated from a graph-op creation event.
+ */
+export interface CodeLocationGraphOpCreationOrigin extends CodeLocationOrigin {
+  codeLocationType: CodeLocationType.GRAPH_OP_CREATION;
+
+  opName: string;
 }
 
 export interface State {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -512,7 +512,26 @@ export interface DebuggerState {
   // stack-frame IDs.
   stackFrames: StackFramesById;
 
+  // What the currently focused code location (stack trace) describes.
+  //   - `null` is for the case where no code location is focused on.
+  //   - `CodeLocationType.EXECUTION` is for the code location of an eager
+  //     (top-level) execution.
+  //   - `CodeLocationType.GRAPH_OP_CREATION` is for the code location of
+  //     the creation of a graph op.
+  codeLocationFocusType: CodeLocationType | null;
+
   sourceCode: SourceCodeState;
+}
+
+/**
+ * The type of origin of a code location (incl. stack trace.)
+ */
+export enum CodeLocationType {
+  // The code location for an eager (top-level) execution.
+  EXECUTION = 'execution',
+
+  // The code location for the creation of of an op (node) in a graph.
+  GRAPH_OP_CREATION = 'graph_op_creation',
 }
 
 export interface State {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
@@ -156,6 +156,7 @@ export function createDebuggerState(
     graphExecutions: createDebuggerGraphExecutionsState(),
     graphs: createDebuggerGraphsState(),
     stackFrames: {},
+    codeLocationFocusType: null,
     sourceCode: {
       sourceFileListLoaded: {
         state: DataLoadState.NOT_LOADED,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.css
@@ -34,6 +34,11 @@ limitations under the License.
   width: 40px;
 }
 
+.graph-executions-title {
+  box-shadow: 0 5px 3px -3px #ccc;
+  padding-bottom: 5px;
+}
+
 .graph-executions-viewport {
   flex-grow: 1;
   font-size: 12px;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.css
@@ -26,6 +26,7 @@ limitations under the License.
   display: inline-block;
   font-weight: normal;
   white-space: normal;
+  overflow-wrap: anywhere;
   padding: 0 20px;
 }
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.css
@@ -18,6 +18,26 @@ limitations under the License.
   font-weight: bold;
 }
 
+.no-stack-trace {
+  color: #808080;
+}
+
+.op-name {
+  word-wrap: anywhere;
+}
+
+.op-type {
+  background-color: #e3e5e8;
+  border: 1px solid #c0c0c0;
+  border-radius: 4px;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 10px;
+  height: 14px;
+  line-height: 14px;
+  padding: 1px 3px;
+  width: max-content;
+}
+
 .stack-frame-array {
   height: 360px;
   overflow-x: auto;
@@ -55,6 +75,11 @@ limitations under the License.
   width: 80px;
 }
 
+.stack-trace-aux-info {
+  margin-top: 3px;
+  padding-left: 24px;
+}
+
 .stack-trace-container {
   border-left: 1px solid rgba(0, 0, 0, 0.12);
   font-size: 10px;
@@ -63,10 +88,15 @@ limitations under the License.
   margin-left: 8px;
   max-height: 360px;
   overflow-x: hidden;
+  overflow-y: hidden;
   padding-left: 8px;
   width: 100%;
 }
 
+.stack-trace-header {
+  box-shadow: 0 5px 3px -3px #ccc;
+  padding-bottom: 3px;
+}
 .stack-trace-host-name {
   color: #808080;
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.ng.html
@@ -16,20 +16,53 @@ limitations under the License.
 -->
 
 <div class="stack-trace-container">
-  <div>
+  <div class="stack-trace-header">
     <span class="stack-trace-title">
       Stack Trace
     </span>
-    <span
-      *ngIf="stackFramesForDisplay !== null && stackFramesForDisplay.length > 0"
-      class="stack-trace-host-name"
+
+    <div
+      *ngIf="stackTraceType !== null; else noStackTrace"
+      class="stack-trace-aux-info"
     >
-      (on {{ stackFramesForDisplay[0].host_name }})
-    </span>
+      <span>
+        <span [ngSwitch]="stackTraceType" class="stack-trace-type">
+          <span *ngSwitchCase="CodeLocationType.EXECUTION">
+            Eager execution of
+          </span>
+          <span *ngSwitchCase="CodeLocationType.GRAPH_OP_CREATION">
+            Creation of graph op
+          </span>
+        </span>
+        <span
+          *ngIf="originOpInfo !== null && originOpInfo.opName !== null"
+          class="op-name"
+        >
+          "{{ originOpInfo.opName }}"
+        </span>
+        <span *ngIf="originOpInfo !== null" class="op-type">
+          {{ originOpInfo.opType }}
+        </span>
+      </span>
+      <div>
+        <span
+          *ngIf="stackFramesForDisplay !== null && stackFramesForDisplay.length > 0"
+          class="stack-trace-host-name"
+        >
+          (Host name: {{ stackFramesForDisplay[0].host_name }})
+        </span>
+      </div>
+    </div>
+
+    <ng-template #noStackTrace>
+      <div class="stack-trace-aux-info no-stack-trace">
+        Click an eager execution or graph op to show its original stack trace.
+      </div>
+    </ng-template>
   </div>
 
   <div
-    *ngIf="stackFramesForDisplay !== null; else loading_section"
+    *ngIf="stackFramesForDisplay !== null; else loadingSection"
     class="stack-frame-array"
   >
     <div
@@ -64,7 +97,7 @@ limitations under the License.
     </div>
   </div>
 
-  <ng-template #loading_section>
+  <ng-template #loadingSection>
     <!-- TODO(cais): Display loading spinner. -->
   </ng-template>
 </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.ng.html
@@ -22,26 +22,30 @@ limitations under the License.
     </span>
 
     <div
-      *ngIf="stackTraceType !== null; else noStackTrace"
+      *ngIf="codeLocationType !== null; else noStackTrace"
       class="stack-trace-aux-info"
     >
       <span>
-        <span [ngSwitch]="stackTraceType" class="stack-trace-type">
-          <span *ngSwitchCase="CodeLocationType.EXECUTION">
-            Eager execution of
-          </span>
-          <span *ngSwitchCase="CodeLocationType.GRAPH_OP_CREATION">
+        <span [ngSwitch]="codeLocationType" class="code-location-origin">
+          <div *ngSwitchCase="CodeLocationType.EXECUTION">
+            Eager execution
+            <span *ngIf="opType !== null" class="eager-execution-index">
+              #{{ executionIndex }}:
+            </span>
+            <span *ngIf="opType !== null" class="op-type">
+              {{ opType }}
+            </span>
+          </div>
+
+          <div *ngSwitchCase="CodeLocationType.GRAPH_OP_CREATION">
             Creation of graph op
-          </span>
-        </span>
-        <span
-          *ngIf="originOpInfo !== null && originOpInfo.opName !== null"
-          class="op-name"
-        >
-          "{{ originOpInfo.opName }}"
-        </span>
-        <span *ngIf="originOpInfo !== null" class="op-type">
-          {{ originOpInfo.opType }}
+            <span *ngIf="opName !== null" class="op-name">
+              "{{ opName }}"
+            </span>
+            <span *ngIf="opType !== null" class="op-type">
+              {{ opType }}
+            </span>
+          </div>
         </span>
       </span>
       <div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.ts
@@ -14,6 +14,8 @@ limitations under the License.
 ==============================================================================*/
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 
+import {CodeLocationType} from '../../store/debugger_types';
+
 export interface StackFrameForDisplay {
   host_name: string;
   file_path: string;
@@ -32,6 +34,20 @@ export interface StackFrameForDisplay {
 })
 export class StackTraceComponent {
   @Input()
+  stackTraceType!: CodeLocationType | null;
+
+  @Input()
+  originOpInfo!: {
+    // The name of the op that the stack trace is about.
+    // E.g., 'Dense_2/MatMul'.
+    // For eager execution, this is null.
+    opName: string | null;
+    // The type of the op that the stack trace is about.
+    // E.g., 'MatMul'.
+    opType: string;
+  } | null;
+
+  @Input()
   stackFramesForDisplay: StackFrameForDisplay[] | null = null;
 
   @Output()
@@ -40,4 +56,6 @@ export class StackTraceComponent {
     file_path: string;
     lineno: number;
   }>();
+
+  CodeLocationType = CodeLocationType;
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.ts
@@ -34,18 +34,20 @@ export interface StackFrameForDisplay {
 })
 export class StackTraceComponent {
   @Input()
-  stackTraceType!: CodeLocationType | null;
+  codeLocationType!: CodeLocationType | null;
 
   @Input()
-  originOpInfo!: {
-    // The name of the op that the stack trace is about.
-    // E.g., 'Dense_2/MatMul'.
-    // For eager execution, this is null.
-    opName: string | null;
-    // The type of the op that the stack trace is about.
-    // E.g., 'MatMul'.
-    opType: string;
-  } | null;
+  opType!: string | null;
+
+  // Index of eager (top-level) execution, not `null` only for
+  // `CodeLocationType.GRAPH_OP_CREATION`.
+  @Input()
+  opName!: string | null;
+
+  // Index of eager (top-level) execution, not `null` only for
+  // `CodeLocationType.EXECUTION`.
+  @Input()
+  executionIndex!: number | null;
 
   @Input()
   stackFramesForDisplay: StackFrameForDisplay[] | null = null;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container.ts
@@ -15,13 +15,16 @@ limitations under the License.
 import {Component} from '@angular/core';
 import {createSelector, select, Store} from '@ngrx/store';
 
-import {CodeLocationType, State} from '../../store/debugger_types';
+import {
+  CodeLocationType,
+  State,
+  CodeLocationGraphOpCreationOrigin,
+  CodeLocationExecutionOrigin,
+} from '../../store/debugger_types';
 
 import {sourceLineFocused} from '../../actions';
 import {
-  getCodeLocationFocusType,
-  getFocusedExecutionData,
-  getFocusedGraphOpInfo,
+  getCodeLocationOrigin,
   getFocusedSourceLineSpec,
   getFocusedStackFrames,
 } from '../../store';
@@ -33,44 +36,67 @@ import {StackFrameForDisplay} from './stack_trace_component';
   selector: 'tf-debugger-v2-stack-trace',
   template: `
     <stack-trace-component
-      [stackTraceType]="stackTraceType$ | async"
-      [originOpInfo]="originOpInfo$ | async"
+      [codeLocationType]="codeLocationType$ | async"
+      [opType]="opType$ | async"
+      [opName]="opName$ | async"
+      [executionIndex]="executionIndex$ | async"
       [stackFramesForDisplay]="stackFramesForDisplay$ | async"
       (onSourceLineClicked)="onSourceLineClicked($event)"
     ></stack-trace-component>
   `,
 })
 export class StackTraceContainer {
-  readonly stackTraceType$ = this.store.pipe(select(getCodeLocationFocusType));
-
-  readonly originOpInfo$ = this.store.pipe(
+  readonly codeLocationType$ = this.store.pipe(
     select(
       createSelector(
-        getCodeLocationFocusType,
-        getFocusedExecutionData,
-        getFocusedGraphOpInfo,
-        (codeLocationFocusType, executionData, graphOpInfo) => {
-          if (codeLocationFocusType === null) {
+        getCodeLocationOrigin,
+        (originInfo): CodeLocationType | null => {
+          return originInfo === null ? null : originInfo.codeLocationType;
+        }
+      )
+    )
+  );
+
+  readonly opType$ = this.store.pipe(
+    select(
+      createSelector(
+        getCodeLocationOrigin,
+        (originInfo): string | null => {
+          return originInfo === null ? null : originInfo.opType;
+        }
+      )
+    )
+  );
+
+  readonly opName$ = this.store.pipe(
+    select(
+      createSelector(
+        getCodeLocationOrigin,
+        (originInfo): string | null => {
+          if (
+            originInfo === null ||
+            originInfo.codeLocationType !== CodeLocationType.GRAPH_OP_CREATION
+          ) {
             return null;
           }
-          if (codeLocationFocusType === CodeLocationType.EXECUTION) {
-            if (executionData === null) {
-              return null;
-            }
-            return {
-              opType: executionData.op_type,
-              opName: null,
-            };
-          } else {
-            // This is CodeLocationType.GRAPH_OP_CREATION.
-            if (graphOpInfo === null) {
-              return null;
-            }
-            return {
-              opType: graphOpInfo.op_type,
-              opName: graphOpInfo.op_name,
-            };
+          return (originInfo as CodeLocationGraphOpCreationOrigin).opName;
+        }
+      )
+    )
+  );
+
+  readonly executionIndex$ = this.store.pipe(
+    select(
+      createSelector(
+        getCodeLocationOrigin,
+        (originInfo): number | null => {
+          if (
+            originInfo === null ||
+            originInfo.codeLocationType !== CodeLocationType.EXECUTION
+          ) {
+            return null;
           }
+          return (originInfo as CodeLocationExecutionOrigin).executionIndex;
         }
       )
     )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container.ts
@@ -15,12 +15,7 @@ limitations under the License.
 import {Component} from '@angular/core';
 import {createSelector, select, Store} from '@ngrx/store';
 
-import {
-  CodeLocationType,
-  State,
-  CodeLocationGraphOpCreationOrigin,
-  CodeLocationExecutionOrigin,
-} from '../../store/debugger_types';
+import {CodeLocationType, State} from '../../store/debugger_types';
 
 import {sourceLineFocused} from '../../actions';
 import {
@@ -79,7 +74,7 @@ export class StackTraceContainer {
           ) {
             return null;
           }
-          return (originInfo as CodeLocationGraphOpCreationOrigin).opName;
+          return originInfo.opName;
         }
       )
     )
@@ -96,7 +91,7 @@ export class StackTraceContainer {
           ) {
             return null;
           }
-          return (originInfo as CodeLocationExecutionOrigin).executionIndex;
+          return originInfo.executionIndex;
         }
       )
     )


### PR DESCRIPTION
* Motivation for features / changes
  * Continue developing DebuggerV2 plugin.
  * Specifically, connect the graph ops with the StackTraceComponent and
     StackTraceContainer in order to display the original stack traces of graph ops.
* Technical description of changes
  * Add `codeLocationFocusType` enum to the ngrx state
  * This state is updated by actions `executionDigestFocused` and `graphOpFocused`
  * In `StackTraceComponent`, add additional inputs and html for displaying
     * Whether the stack trace of an eager execution or a graph op's original creation
        is being displayed
     * The type of the op
     * In the case of graph op, the name of the op
  * CSS adjustments in `StackTraceComponent` to accommodate the newly added
     elements
* Screenshots of UI changes
  * For eager execution: ![image](https://user-images.githubusercontent.com/16824702/82739828-1e810c00-9d11-11ea-85b5-b89d710f3a92.png)
  * For graph op creation: ![image](https://user-images.githubusercontent.com/16824702/82739823-0ad5a580-9d11-11ea-9847-fb1f5e8e3f09.png)
* Detailed steps to verify changes work correctly (as executed by you)
  * Unit tests added for the new selector and reducer logic
  * Unit tests added for the new ng html template with `ngIf` and `ngSwitch` logic.
