### PR TITLE
build: fix Pip package creation to use Python 3

### DIFF
--- a/tensorboard/pip_package/build_pip_package.sh
+++ b/tensorboard/pip_package/build_pip_package.sh
@@ -101,7 +101,7 @@ build() (
       s/^from webencodings/from tensorboard._vendor.webencodings/
     ' {} +
 
-  virtualenv -q venv
+  virtualenv -q -p python3 venv
   export VIRTUAL_ENV=venv
   export PATH="${PWD}/venv/bin:${PATH}"
   unset PYTHON_HOME


### PR DESCRIPTION
Summary:
The `//tensorboard/pip_package` target currently doesn’t build on
machines where `virtualenv(1)` defaults to using Python 2, because the
`bdist_wheel` invocation can’t parse the syntax:

```
  File "/tmp/tensorboard-pip.QY3U1MVs3Y/tensorboard/data/experimental/base_experiment.py", line 24
    class BaseExperiment(metaclass=abc.ABCMeta):
                                  ^
SyntaxError: invalid syntax
```

Test Plan:
Running `bazel build //tensorboard/pip_package` previously failed on my
machine, even when in a Python 3 virtualenv, and now works.

wchargin-branch: build-pip-package-with-py3
