### PR TITLE
Support jupyter-server-proxy (and other proxies)

### DIFF
--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -395,17 +395,17 @@ def _display_ipython(port, height, display_handle):
         replacements = [
             ("%HTML_ID%", html_escape(frame_id, quote=True)),
             ("%JSON_ID%", json.dumps(frame_id)),
-            ("%URL%", json.dumps(proxy_url)),
-            ("%PORT%", "0"),
             ("%HEIGHT%", "%d" % height),
+            ("%PORT%", "0"),
+            ("%URL%", json.dumps(proxy_url)),
         ]
     else:
         replacements = [
             ("%HTML_ID%", html_escape(frame_id, quote=True)),
             ("%JSON_ID%", json.dumps(frame_id)),
-            ("%URL%", json.dumps("/")),
-            ("%PORT%", "%d" % port),
             ("%HEIGHT%", "%d" % height),
+            ("%PORT%", "%d" % port),
+            ("%URL%", json.dumps("/")),
         ]
 
     for (k, v) in replacements:

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -394,15 +394,13 @@ def _display_ipython(port, height, display_handle):
         abs_path = os.environ["TENSORBOARD_PROXY_URL"]
         # Allow %PORT% in $TENSORBOARD_PROXY_URL
         abs_path = abs_path.replace("%PORT%", "%d" % port)
-        replacements.extend([
-            ("%ABS_PATH%", abs_path),
-            ("%PORT_CHANGE%", ""),
-        ])
+        replacements.extend(
+            [("%ABS_PATH%", abs_path), ("%PORT_CHANGE%", ""),]
+        )
     else:
-        replacements.extend([
-            ("%ABS_PATH%", "/"),
-            ("%PORT_CHANGE%", "url.port = %d;" % port),
-        ])
+        replacements.extend(
+            [("%ABS_PATH%", "/"), ("%PORT_CHANGE%", "url.port = %d;" % port),]
+        )
 
     for (k, v) in replacements:
         shell = shell.replace(k, v)


### PR DESCRIPTION
## Motivation for features / changes

Users will frequently want to run TensorBoard in environments where they are not allowed to open up or expose additional ports. For those cases [jupyter-server-proxy](https://github.com/jupyterhub/jupyter-server-proxy) allows forwarding web traffic to other services running on the system without opening new ports. (The Google Colab integration also works around this same issue of not being able to directly expose the port that TensorBoard runs on.)

This PR allows users to *optionally* pass the TensorBoard traffic through jupyter-server-proxy by setting the `TENSORBOARD_PROXY_URL` environment variable. When this variable is not set TensorBoard will behave as normal.

## Technical description of changes

This adds support for a new optional environment variable `TENSORBOARD_PROXY_URL` which if set will be used as the URL's path for the IFRAME displayed in the notebook when running `%tensorboard`.

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/8083866/82961668-01a43d00-9f8c-11ea-9b48-25398cad5e5b.png)

## Detailed steps to verify changes work correctly (as executed by you)

I've successfully run the Travis CI build on my fork of the project: https://travis-ci.com/github/zac-hopkinson/tensorboard

I've also built test environments of both JupyterLab and JupyterHub with the documentation that I used to both configure and test this feature. You can find this documentation here: https://github.com/zac-hopkinson/tensorboard-pr-test

You can skip reading the documentation and just `export TENSORBOARD_PROXY_URL="/proxy/%PORT%/"` to use this feature with JupyterLab or Jupyter Notebook

## Alternate designs / implementations considered

My first attempt at this added a new context to go along with _CONTEXT_COLAB, _CONTEXT_IPYTHON, and _CONTEXT_NONE in [notebook.py](https://github.com/tensorflow/tensorboard/blob/348ee57a437dd6bb63c4ee1917c52ecd0c3ae033/tensorboard/notebook.py#L53). After testing with different environments I decided that it wasn't a clean solution like I had hoped. I found that adding in the environment variable logic to _CONTEXT_IPYTHON and making sure it preserved backwards compatibility was a much cleaner solution. I'm open to ideas and feedback around this decision of course!

I also researched #3142. Initially I hadn't planned on supporting JupyterHub but after testing I found that this PR can handle both Jupyter Notebook/Lab and JupyterHub by just documenting how to configure each.

I also considered alternatives to the environment variable, such as a possible `~/.tensorboardrc` file for example, but that seemed like overkill.