### PR TITLE
[projector] support tensor stored in binary format

### DIFF
--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -160,6 +160,13 @@ def _read_tensor_tsv_file(fpath):
     return np.array(tensor, dtype="float32")
 
 
+def _read_tensor_binary_file(fpath, shape):
+    if len(shape) != 2:
+        raise ValueError("Tensor must be 2D, got shape {}".format(shape))
+    tensor = np.fromfile(fpath, dtype="float32")
+    return tensor.reshape(shape)
+
+
 def _assets_dir_to_logdir(assets_dir):
     sub_path = os.path.sep + metadata.PLUGINS_DIR + os.path.sep
     if sub_path in assets_dir:
@@ -363,17 +370,25 @@ class ProjectorPlugin(base_plugin.TBPlugin):
                 if embedding.tensor_name.endswith(":0"):
                     embedding.tensor_name = embedding.tensor_name[:-2]
                 # Find the size of embeddings associated with a tensors file.
-                if embedding.tensor_path and not embedding.tensor_shape:
+                if embedding.tensor_path:
                     fpath = _rel_to_abs_asset_path(
                         embedding.tensor_path, self.config_fpaths[run]
                     )
                     tensor = self.tensor_cache.get((run, embedding.tensor_name))
                     if tensor is None:
-                        tensor = _read_tensor_tsv_file(fpath)
+                        try:
+                            tensor = _read_tensor_tsv_file(fpath)
+                        except UnicodeDecodeError:
+                            tensor = _read_tensor_binary_file(
+                                fpath, embedding.tensor_shape
+                            )
                         self.tensor_cache.set(
                             (run, embedding.tensor_name), tensor
                         )
-                    embedding.tensor_shape.extend([len(tensor), len(tensor[0])])
+                    if not embedding.tensor_shape:
+                        embedding.tensor_shape.extend(
+                            [len(tensor), len(tensor[0])]
+                        )
 
             reader = self._get_reader_for_run(run)
             if not reader:
@@ -648,7 +663,12 @@ class ProjectorPlugin(base_plugin.TBPlugin):
                         "text/plain",
                         400,
                     )
-                tensor = _read_tensor_tsv_file(fpath)
+                try:
+                    tensor = _read_tensor_tsv_file(fpath)
+                except UnicodeDecodeError:
+                    tensor = _read_tensor_binary_file(
+                        fpath, embedding.tensor_shape
+                    )
             else:
                 reader = self._get_reader_for_run(run)
                 if not reader or not reader.has_tensor(name):


### PR DESCRIPTION
* Motivation for features / changes

Support loading tensor stored in binary format to reduce tensor saving/loading time and file size. This is already supported in the [standalone embedding projector](https://github.com/tensorflow/embedding-projector-standalone), but not in the opensource tensorboard projector.

* Technical description of changes

Added a function `_read_tensor_binary_file` to load tensor in binary format. The speedup is about 2-3  orders of magnitude for tensors of moderate size.

```python
In [1]: import numpy as np
In [2]: data = np.random.random((10000, 128)).astype(np.float32)
In [3]: data.tofile("vec.bin")
In [4]: np.savetxt("vec.txt", data, delimiter="\t")
In [5]: def read_tensor_tsv_file(fpath):
   ...:     with open(fpath) as f:
   ...:         tensor = []
   ...:         for line in f:
   ...:             line = line.rstrip("\n")
   ...:             if line:
   ...:                 tensor.append(list(map(float, line.split("\t"))))
   ...:     return np.array(tensor, dtype="float32")
   ...:
In [6]: %timeit np.fromfile("vec.bin", dtype="float32").reshape((10000, 128))
1.11 ms ± 14.1 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
In [7]: %timeit read_tensor_tsv_file("vec.txt")
537 ms ± 1.77 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you)

```bash
> ls binary_embedding
projector_config.pbtxt  vec.bin
> cat binary_embedding/projector_config.pbtxt
embeddings {
  tensor_name: "embedding"
  tensor_path: "vec.bin"
  tensor_shape: 10000
  tensor_shape: 128
}
> tensorboard --logdir binary_embedding
```
* Alternate designs / implementations considered
N/A