### PR TITLE
[DebuggerV2] Improve the scrolling experience of the eager timeline

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/debugger_actions.ts
@@ -103,7 +103,8 @@ export const numExecutionsLoaded = createAction(
 );
 
 export const executionDigestsRequested = createAction(
-  '[Debugger] ExecutionDigests Requested'
+  '[Debugger] ExecutionDigests Requested',
+  props<{begin: number; end: number}>()
 );
 
 export const executionDigestsLoaded = createAction(

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -85,7 +85,7 @@ import {
   getSourceFileListLoaded,
   getFocusedSourceFileIndex,
 } from '../store/debugger_selectors';
-import {arrayOfBeginEndRangesIncludes} from '../store/debugger_store_utils';
+import {beginEndRangesInclude} from '../store/debugger_store_utils';
 import {
   DataLoadState,
   DebuggerRunListing,
@@ -436,7 +436,7 @@ export class DebuggerEffects {
       filter(([{begin, end}, loaded]) => {
         return (
           end > begin &&
-          !arrayOfBeginEndRangesIncludes(loaded.loadingRanges, begin, end)
+          !beginEndRangesInclude(loaded.loadingRanges, begin, end)
         );
       }),
       tap(([{begin, end}]) => {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -354,7 +354,7 @@ export class DebuggerEffects {
         const end = Math.min(numExecutions, pageSize);
         return (
           runId !== null && findRange(loaded.loadingRanges, begin, end) === -1
-        );
+        ); // TODO(cais): Add unit test for already loading.
       }),
       map(([, numExecutions, runId, pageSize]) => {
         const begin = 0;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -85,7 +85,7 @@ import {
   getSourceFileListLoaded,
   getFocusedSourceFileIndex,
 } from '../store/debugger_selectors';
-import {findRange} from '../store/debugger_store_utils';
+import {findBeginEndRangeIndex} from '../store/debugger_store_utils';
 import {
   DataLoadState,
   DebuggerRunListing,
@@ -346,8 +346,7 @@ export class DebuggerEffects {
       withLatestFrom(
         this.store.select(getNumExecutions),
         this.store.select(getActiveRunId),
-        this.store.select(getExecutionPageSize),
-        this.store.select(getExecutionDigestsLoaded)
+        this.store.select(getExecutionPageSize)
       ),
       filter(([, , runId]) => runId !== null),
       map(([, numExecutions, runId, pageSize]) => {
@@ -436,7 +435,8 @@ export class DebuggerEffects {
       withLatestFrom(this.store.select(getExecutionDigestsLoaded)),
       filter(([{begin, end}, loaded]) => {
         return (
-          end > begin && findRange(loaded.loadingRanges, begin, end) === -1
+          end > begin &&
+          findBeginEndRangeIndex(loaded.loadingRanges, begin, end) === -1
         );
       }),
       tap(([{begin, end}]) => {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -85,7 +85,7 @@ import {
   getSourceFileListLoaded,
   getFocusedSourceFileIndex,
 } from '../store/debugger_selectors';
-import {findBeginEndRangeIndex} from '../store/debugger_store_utils';
+import {arrayOfBeginEndRangesIncludes} from '../store/debugger_store_utils';
 import {
   DataLoadState,
   DebuggerRunListing,
@@ -436,7 +436,7 @@ export class DebuggerEffects {
       filter(([{begin, end}, loaded]) => {
         return (
           end > begin &&
-          findBeginEndRangeIndex(loaded.loadingRanges, begin, end) === -1
+          !arrayOfBeginEndRangesIncludes(loaded.loadingRanges, begin, end)
         );
       }),
       tap(([{begin, end}]) => {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -792,7 +792,6 @@ describe('Debugger effects', () => {
         `scrolling left triggers execution digest loading: ` +
           `dataAlreadyExists=${dataAlreadyExists}`,
         () => {
-          const dataAlreadyExists = false; // TODO(cais): Fix this.
           const originalScrollBeginIndex = 40;
           const scrollBeginIndex = originalScrollBeginIndex - 1;
           const numExecutions = 100;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -630,7 +630,7 @@ describe('Debugger effects', () => {
           }),
           numExecutionsRequested(),
           numExecutionsLoaded({numExecutions}),
-          executionDigestsRequested(),
+          executionDigestsRequested({begin: 0, end: 2}),
           executionDigestsLoaded(executionDigestsPageResponse),
           executionDataLoaded(executionDataResponse),
           stackFramesLoaded({stackFrames: {aa: stackFrame0, bb: stackFrame1}}),
@@ -744,8 +744,7 @@ describe('Debugger effects', () => {
           store.overrideSelector(getExecutionDigestsLoaded, {
             numExecutions,
             pageLoadedSizes,
-            state: DataLoadState.LOADED,
-            lastLoadedTimeInMs: 1234,
+            loadingRanges: [],
           });
 
           store.refreshState();
@@ -777,7 +776,10 @@ describe('Debugger effects', () => {
           } else {
             expect(fetchExecutionDigests).toHaveBeenCalledTimes(1);
             expect(dispatchedActions).toEqual([
-              executionDigestsRequested(),
+              executionDigestsRequested({
+                begin: 60,
+                end: 60 + pageSize,
+              }),
               executionDigestsLoaded(executionDigestsResponse),
             ]);
           }
@@ -816,8 +818,7 @@ describe('Debugger effects', () => {
           store.overrideSelector(getExecutionDigestsLoaded, {
             numExecutions,
             pageLoadedSizes,
-            state: DataLoadState.LOADED,
-            lastLoadedTimeInMs: 1234,
+            loadingRanges: [],
           });
 
           store.refreshState();
@@ -849,7 +850,10 @@ describe('Debugger effects', () => {
           } else {
             expect(fetchExecutionDigests).toHaveBeenCalledTimes(1);
             expect(dispatchedActions).toEqual([
-              executionDigestsRequested(),
+              executionDigestsRequested({
+                begin: 20,
+                end: 20 + pageSize,
+              }),
               executionDigestsLoaded(executionDigestsResponse),
             ]);
           }
@@ -893,8 +897,7 @@ describe('Debugger effects', () => {
           store.overrideSelector(getExecutionDigestsLoaded, {
             numExecutions,
             pageLoadedSizes,
-            state: DataLoadState.LOADED,
-            lastLoadedTimeInMs: 1234,
+            loadingRanges: [],
           });
 
           store.refreshState();
@@ -923,7 +926,10 @@ describe('Debugger effects', () => {
           } else {
             expect(fetchExecutionDigests).toHaveBeenCalledTimes(1);
             expect(dispatchedActions).toEqual([
-              executionDigestsRequested(),
+              executionDigestsRequested({
+                begin: 60,
+                end: 60 + pageSize,
+              }),
               executionDigestsLoaded(executionDigestsResponse),
             ]);
           }
@@ -1078,8 +1084,7 @@ describe('Debugger effects', () => {
       store.overrideSelector(getExecutionDigestsLoaded, {
         numExecutions,
         pageLoadedSizes: {},
-        state: DataLoadState.NOT_LOADED,
-        lastLoadedTimeInMs: null,
+        loadingRanges: [],
       });
 
       store.refreshState();
@@ -1103,7 +1108,10 @@ describe('Debugger effects', () => {
           alertType: AlertType.INF_NAN_ALERT,
           alerts: [alert0, alert1],
         }),
-        executionDigestsRequested(),
+        executionDigestsRequested({
+          begin: 8,
+          end: 12,
+        }),
         executionDigestsLoaded({
           num_digests: numExecutions,
           begin: 8,
@@ -1160,8 +1168,7 @@ describe('Debugger effects', () => {
         pageLoadedSizes: {
           2: 4, // The page of eecution digest has already been loaded.
         },
-        state: DataLoadState.LOADED,
-        lastLoadedTimeInMs: 1234,
+        loadingRanges: [],
       });
 
       store.refreshState();

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -402,7 +402,7 @@ const reducer = createReducer(
       ];
       const match = findRange(loadingRanges, range.begin, range.end);
       if (match === -1) {
-        loadingRanges.push(range);
+        loadingRanges.push({begin: range.begin, end: range.end});
       }
       const newState = {
         ...state,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -21,7 +21,7 @@ import {
   GraphExecutionDataResponse,
   SourceFileResponse,
 } from '../data_source/tfdbg2_data_source';
-import {findFileIndex, findRange} from './debugger_store_utils';
+import {findFileIndex, findBeginEndRangeIndex} from './debugger_store_utils';
 import {
   AlertsByIndex,
   AlertType,
@@ -400,7 +400,11 @@ const reducer = createReducer(
       const loadingRanges = [
         ...state.executions.executionDigestsLoaded.loadingRanges,
       ];
-      const match = findRange(loadingRanges, range.begin, range.end);
+      const match = findBeginEndRangeIndex(
+        loadingRanges,
+        range.begin,
+        range.end
+      );
       if (match === -1) {
         loadingRanges.push({begin: range.begin, end: range.end});
       }
@@ -430,7 +434,11 @@ const reducer = createReducer(
       const loadingRanges = [
         ...state.executions.executionDigestsLoaded.loadingRanges,
       ];
-      const matchIndex = findRange(loadingRanges, digests.begin, digests.end);
+      const matchIndex = findBeginEndRangeIndex(
+        loadingRanges,
+        digests.begin,
+        digests.end
+      );
       if (matchIndex !== -1) {
         loadingRanges.splice(matchIndex, 1);
       }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
@@ -507,8 +507,7 @@ describe('Debugger graphs reducers', () => {
           lastLoadedTimeInMs: null,
         },
         executionDigestsLoaded: {
-          state: DataLoadState.NOT_LOADED,
-          lastLoadedTimeInMs: null,
+          loadingRanges: [],
           pageLoadedSizes: {},
           numExecutions: 0,
         },
@@ -555,8 +554,7 @@ describe('Debugger graphs reducers', () => {
           lastLoadedTimeInMs: null,
         },
         executionDigestsLoaded: {
-          state: DataLoadState.NOT_LOADED,
-          lastLoadedTimeInMs: null,
+          loadingRanges: [],
           pageLoadedSizes: {},
           numExecutions: 0,
         },
@@ -583,6 +581,8 @@ describe('Debugger graphs reducers', () => {
     expect(nextState.executions.focusIndex).toBeNull();
   });
 
+  // TODO(cais): Add unit test for the case of already loading other pages or the
+  // page itself.
   it('Updates states on executionDigestsRequested', () => {
     const state = createDebuggerState({
       runs: {
@@ -603,18 +603,23 @@ describe('Debugger graphs reducers', () => {
         executionDigestsLoaded: {
           numExecutions: 1337,
           pageLoadedSizes: {},
-          state: DataLoadState.NOT_LOADED,
-          lastLoadedTimeInMs: null,
+          loadingRanges: [],
         },
       }),
     });
-    const nextState = reducers(state, actions.executionDigestsRequested());
-    expect(nextState.executions.executionDigestsLoaded.state).toBe(
-      DataLoadState.LOADING
+    const nextState = reducers(
+      state,
+      actions.executionDigestsRequested({
+        begin: 0,
+        end: 100,
+      })
     );
-    expect(
-      nextState.executions.executionDigestsLoaded.lastLoadedTimeInMs
-    ).toBeNull();
+    expect(nextState.executions.executionDigestsLoaded.loadingRanges).toEqual([
+      {
+        begin: 0,
+        end: 100,
+      },
+    ]);
     expect(nextState.executions.executionDigestsLoaded.numExecutions).toBe(
       1337
     );
@@ -628,7 +633,9 @@ describe('Debugger graphs reducers', () => {
     const numExecutions = 1337;
     const state = createDigestsStateWhileLoadingExecutionDigests(
       pageSize,
-      numExecutions
+      numExecutions,
+      0,
+      pageSize
     );
     const excutionDigestsResponse: ExecutionDigestsResponse = {
       begin: 0,
@@ -647,12 +654,9 @@ describe('Debugger graphs reducers', () => {
       state,
       actions.executionDigestsLoaded(excutionDigestsResponse)
     );
-    expect(nextState.executions.executionDigestsLoaded.state).toBe(
-      DataLoadState.LOADED
+    expect(nextState.executions.executionDigestsLoaded.loadingRanges).toEqual(
+      []
     );
-    expect(
-      nextState.executions.executionDigestsLoaded.lastLoadedTimeInMs
-    ).toBeGreaterThanOrEqual(t0);
     expect(nextState.executions.executionDigestsLoaded.numExecutions).toEqual(
       numExecutions
     );
@@ -676,6 +680,8 @@ describe('Debugger graphs reducers', () => {
     const state = createDigestsStateWhileLoadingExecutionDigests(
       pageSize,
       numExecutions,
+      0 /* Begin of loading range. */,
+      4 /* End of loading range. */,
       {
         0: {op_type: 'Relu', output_tensor_device_ids: ['a']},
         1: {op_type: 'Identity', output_tensor_device_ids: ['a']},
@@ -700,12 +706,9 @@ describe('Debugger graphs reducers', () => {
       state,
       actions.executionDigestsLoaded(excutionDigestsResponse)
     );
-    expect(nextState.executions.executionDigestsLoaded.state).toBe(
-      DataLoadState.LOADED
+    expect(nextState.executions.executionDigestsLoaded.loadingRanges).toEqual(
+      []
     );
-    expect(
-      nextState.executions.executionDigestsLoaded.lastLoadedTimeInMs
-    ).toBeGreaterThanOrEqual(t0);
     expect(nextState.executions.executionDigestsLoaded.numExecutions).toBe(
       numExecutions
     );
@@ -739,6 +742,8 @@ describe('Debugger graphs reducers', () => {
     const state = createDigestsStateWhileLoadingExecutionDigests(
       pageSize,
       numExecutions,
+      0 /* Begin of loading range. */,
+      2 /* End of loading range. */,
       {
         2: {op_type: 'Relu', output_tensor_device_ids: ['a']},
         3: {op_type: 'Identity', output_tensor_device_ids: ['a']},
@@ -763,12 +768,9 @@ describe('Debugger graphs reducers', () => {
       state,
       actions.executionDigestsLoaded(excutionDigestsResponse)
     );
-    expect(nextState.executions.executionDigestsLoaded.state).toBe(
-      DataLoadState.LOADED
+    expect(nextState.executions.executionDigestsLoaded.loadingRanges).toEqual(
+      []
     );
-    expect(
-      nextState.executions.executionDigestsLoaded.lastLoadedTimeInMs
-    ).toBeGreaterThanOrEqual(t0);
     expect(nextState.executions.executionDigestsLoaded.numExecutions).toBe(
       numExecutions
     );
@@ -804,6 +806,8 @@ describe('Debugger graphs reducers', () => {
     const state = createDigestsStateWhileLoadingExecutionDigests(
       pageSize,
       numExecutions,
+      2,
+      4,
       {
         0: {op_type: 'MatMul', output_tensor_device_ids: ['a']},
         1: {op_type: 'BiasAdd', output_tensor_device_ids: ['a']},
@@ -826,12 +830,9 @@ describe('Debugger graphs reducers', () => {
       state,
       actions.executionDigestsLoaded(excutionDigestsResponse)
     );
-    expect(nextState.executions.executionDigestsLoaded.state).toBe(
-      DataLoadState.LOADED
+    expect(nextState.executions.executionDigestsLoaded.loadingRanges).toEqual(
+      []
     );
-    expect(
-      nextState.executions.executionDigestsLoaded.lastLoadedTimeInMs
-    ).toBeGreaterThanOrEqual(t0);
     // Update in total execution count should be reflected.
     expect(nextState.executions.executionDigestsLoaded.numExecutions).toBe(
       numExecutions + 1
@@ -981,8 +982,7 @@ describe('Debugger graphs reducers', () => {
           lastLoadedTimeInMs: null,
         },
         executionDigestsLoaded: {
-          state: DataLoadState.NOT_LOADED,
-          lastLoadedTimeInMs: null,
+          loadingRanges: [],
           pageLoadedSizes: {},
           numExecutions: 0,
         },

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
@@ -633,12 +633,12 @@ describe('Debugger graphs reducers', () => {
   it('On executionDigestsLoaded: correct digests & page sizes updates', () => {
     const pageSize = 100;
     const numExecutions = 1337;
-    const state = createDigestsStateWhileLoadingExecutionDigests(
+    const state = createDigestsStateWhileLoadingExecutionDigests({
       pageSize,
       numExecutions,
-      0 /* Begin of loading range. */,
-      pageSize /* End of loading range. */
-    );
+      loadingBegin: 0,
+      loadingEnd: pageSize,
+    });
     // Add another range being loaded. Later will assert the range is preserved
     // by the reducer.
     state.executions.executionDigestsLoaded.loadingRanges.push({
@@ -687,19 +687,19 @@ describe('Debugger graphs reducers', () => {
   it('On executionDigestsLoaded: Incomplete 1st page --> larger 1st page', () => {
     const pageSize = 100;
     const numExecutions = 4;
-    const state = createDigestsStateWhileLoadingExecutionDigests(
+    const state = createDigestsStateWhileLoadingExecutionDigests({
       pageSize,
       numExecutions,
-      0 /* Begin of loading range. */,
-      4 /* End of loading range. */,
-      {
+      loadingBegin: 0,
+      loadingEnd: 4,
+      executionDigests: {
         0: {op_type: 'Relu', output_tensor_device_ids: ['a']},
         1: {op_type: 'Identity', output_tensor_device_ids: ['a']},
       },
-      {
+      pageLoadedSize: {
         0: 2 /* Previously loaded incomplete first page. */,
-      }
-    );
+      },
+    });
     const excutionDigestsResponse: ExecutionDigestsResponse = {
       begin: 0,
       end: 4,
@@ -749,19 +749,19 @@ describe('Debugger graphs reducers', () => {
   it('On executionDigestsLoaded: Adding a new page before existing', () => {
     const pageSize = 2;
     const numExecutions = 4;
-    const state = createDigestsStateWhileLoadingExecutionDigests(
+    const state = createDigestsStateWhileLoadingExecutionDigests({
       pageSize,
       numExecutions,
-      0 /* Begin of loading range. */,
-      2 /* End of loading range. */,
-      {
+      loadingBegin: 0,
+      loadingEnd: 2,
+      executionDigests: {
         2: {op_type: 'Relu', output_tensor_device_ids: ['a']},
         3: {op_type: 'Identity', output_tensor_device_ids: ['a']},
       },
-      {
+      pageLoadedSize: {
         1: 2 /* Previously loaded 2nd page. */,
-      }
-    );
+      },
+    });
     const excutionDigestsResponse: ExecutionDigestsResponse = {
       begin: 0,
       end: 2,
@@ -813,19 +813,19 @@ describe('Debugger graphs reducers', () => {
   it('On executionDigestsLoaded: Adding a new page after existing', () => {
     const pageSize = 2;
     const numExecutions = 4;
-    const state = createDigestsStateWhileLoadingExecutionDigests(
+    const state = createDigestsStateWhileLoadingExecutionDigests({
       pageSize,
       numExecutions,
-      2,
-      4,
-      {
+      loadingBegin: 2,
+      loadingEnd: 4,
+      executionDigests: {
         0: {op_type: 'MatMul', output_tensor_device_ids: ['a']},
         1: {op_type: 'BiasAdd', output_tensor_device_ids: ['a']},
       },
-      {
+      pageLoadedSize: {
         0: 2 /* Previously loaded 1st page. */,
-      }
-    );
+      },
+    });
     const excutionDigestsResponse: ExecutionDigestsResponse = {
       begin: 2,
       end: 4,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
@@ -243,8 +243,7 @@ describe('debugger selectors', () => {
               lastLoadedTimeInMs: null,
             },
             executionDigestsLoaded: {
-              state: DataLoadState.NOT_LOADED,
-              lastLoadedTimeInMs: null,
+              loadingRanges: [],
               pageLoadedSizes: {},
               numExecutions: 0,
             },
@@ -282,8 +281,7 @@ describe('debugger selectors', () => {
               lastLoadedTimeInMs: null,
             },
             executionDigestsLoaded: {
-              state: DataLoadState.NOT_LOADED,
-              lastLoadedTimeInMs: null,
+              loadingRanges: [],
               pageLoadedSizes: {},
               numExecutions: 0,
             },
@@ -323,8 +321,7 @@ describe('debugger selectors', () => {
                 lastLoadedTimeInMs: null,
               },
               executionDigestsLoaded: {
-                state: DataLoadState.NOT_LOADED,
-                lastLoadedTimeInMs: null,
+                loadingRanges: [],
                 pageLoadedSizes: {},
                 numExecutions: 0,
               },
@@ -353,8 +350,7 @@ describe('debugger selectors', () => {
               lastLoadedTimeInMs: null,
             },
             executionDigestsLoaded: {
-              state: DataLoadState.NOT_LOADED,
-              lastLoadedTimeInMs: null,
+              loadingRanges: [],
               pageLoadedSizes: {},
               numExecutions: 0,
             },
@@ -381,8 +377,7 @@ describe('debugger selectors', () => {
               lastLoadedTimeInMs: null,
             },
             executionDigestsLoaded: {
-              state: DataLoadState.NOT_LOADED,
-              lastLoadedTimeInMs: null,
+              loadingRanges: [],
               pageLoadedSizes: {},
               numExecutions: 10,
             },
@@ -411,8 +406,7 @@ describe('debugger selectors', () => {
               lastLoadedTimeInMs: null,
             },
             executionDigestsLoaded: {
-              state: DataLoadState.NOT_LOADED,
-              lastLoadedTimeInMs: null,
+              loadingRanges: [],
               pageLoadedSizes: {},
               numExecutions: 10,
             },
@@ -504,8 +498,7 @@ describe('debugger selectors', () => {
               lastLoadedTimeInMs: null,
             },
             executionDigestsLoaded: {
-              state: DataLoadState.NOT_LOADED,
-              lastLoadedTimeInMs: null,
+              loadingRanges: [],
               pageLoadedSizes: {},
               numExecutions: 0,
             },
@@ -535,8 +528,7 @@ describe('debugger selectors', () => {
               lastLoadedTimeInMs: null,
             },
             executionDigestsLoaded: {
-              state: DataLoadState.NOT_LOADED,
-              lastLoadedTimeInMs: null,
+              loadingRanges: [],
               pageLoadedSizes: {},
               numExecutions: 0,
             },
@@ -634,8 +626,7 @@ describe('debugger selectors', () => {
               lastLoadedTimeInMs: null,
             },
             executionDigestsLoaded: {
-              state: DataLoadState.NOT_LOADED,
-              lastLoadedTimeInMs: null,
+              loadingRanges: [],
               pageLoadedSizes: {},
               numExecutions: 0,
             },
@@ -885,8 +876,7 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphExecutions: createDebuggerGraphExecutionsState({
             executionDigestsLoaded: {
-              state: DataLoadState.LOADING,
-              lastLoadedTimeInMs: null,
+              loadingRanges: [],
               pageLoadedSizes: {},
               numExecutions: 10,
             },

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
@@ -36,7 +36,8 @@ export function findFileIndex(
 }
 
 /**
- * Find a range (with begin and end properties) in an array of such ranges.
+ * Find first range (with begin and end properties) in an array of range
+ * that strictly includes the `[begin, end)` range.
  *
  * @param range The ranges to search in.
  * @param begin The begin of the range to search for (inclusive).
@@ -50,11 +51,9 @@ export function findBeginEndRangeIndex(
 ): number {
   if (begin >= end) {
     throw new Error(
-      `Expected begin to be less than eng, ` +
+      `Expected begin to be less than end, ` +
         `but got begin=${begin}, end=${end}`
     );
   }
-  return ranges.findIndex(
-    (range) => range.begin === begin && range.end === end
-  );
+  return ranges.findIndex((range) => range.begin <= begin && range.end >= end);
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
@@ -36,8 +36,8 @@ export function findFileIndex(
 }
 
 /**
- * Find first range (with begin and end properties) in an array of range
- * that strictly includes the `[begin, end)` range.
+ * Find the first range (with begin and end properties) in an array of ranges
+ * that strictly includes `[begin, end)`.
  *
  * @param range The ranges to search in.
  * @param begin The begin of the range to search for (inclusive).

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
@@ -61,7 +61,7 @@ export function findBeginEndRangeIndex(
 }
 
 /**
- * Detemrine if an array of ranges contains a range that strictly includes
+ * Determines if an array of ranges contains a range that strictly includes
  * `[begin, end)`.
  *
  * @param ranges The ranges to search in.

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
@@ -70,7 +70,7 @@ export function findBeginEndRangeIndex(
  * @returns `True` if and only if one of the ranges of `ranges` strictly
  *   includes `[begin, end)`.
  */
-export function arrayOfBeginEndRangesIncludes(
+export function beginEndRangesInclude(
   ranges: Array<{begin: number; end: number}>,
   begin: number,
   end: number

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
@@ -36,17 +36,24 @@ export function findFileIndex(
 }
 
 /**
- * Find a range (with begin and end properties) in an array of ranges.
+ * Find a range (with begin and end properties) in an array of such ranges.
+ *
  * @param range The ranges to search in.
- * @param begin The begin of the range to search for.
- * @param end The end of the range to search for.
+ * @param begin The begin of the range to search for (inclusive).
+ * @param end The end of the range to search for (exclusive).
  * @returns Index (>=0) if found. -1 if not found.
  */
-export function findRange(
+export function findBeginEndRangeIndex(
   ranges: Array<{begin: number; end: number}>,
   begin: number,
   end: number
 ): number {
+  if (begin >= end) {
+    throw new Error(
+      `Expected begin to be less than eng, ` +
+        `but got begin=${begin}, end=${end}`
+    );
+  }
   return ranges.findIndex(
     (range) => range.begin === begin && range.end === end
   );

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
@@ -34,3 +34,20 @@ export function findFileIndex(
       item.file_path === fileSpec.file_path
   );
 }
+
+/**
+ * Find a range (with begin and end properties) in an array of ranges.
+ * @param range The ranges to search in.
+ * @param begin The begin of the range to search for.
+ * @param end The end of the range to search for.
+ * @returns Index (>=0) if found. -1 if not found.
+ */
+export function findRange(
+  ranges: Array<{begin: number; end: number}>,
+  begin: number,
+  end: number
+): number {
+  return ranges.findIndex(
+    (range) => range.begin === begin && range.end === end
+  );
+}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
@@ -37,9 +37,9 @@ export function findFileIndex(
 
 /**
  * Find the first range (with begin and end properties) in an array of ranges
- * that strictly includes `[begin, end)`.
+ * that equals `[begin, end)`.
  *
- * @param range The ranges to search in.
+ * @param ranges The ranges to search in.
  * @param begin The begin of the range to search for (inclusive).
  * @param end The end of the range to search for (exclusive).
  * @returns Index (>=0) if found. -1 if not found.
@@ -55,5 +55,33 @@ export function findBeginEndRangeIndex(
         `but got begin=${begin}, end=${end}`
     );
   }
-  return ranges.findIndex((range) => range.begin <= begin && range.end >= end);
+  return ranges.findIndex(
+    (range) => range.begin === begin && range.end === end
+  );
+}
+
+/**
+ * Detemrine if an array of ranges contains a range that strictly includes
+ * `[begin, end)`.
+ *
+ * @param ranges The ranges to search in.
+ * @param begin The begin of the range to search for (inclusive).
+ * @param end The end of the range to search for (exclusive).
+ * @returns `True` if and only if one of the ranges of `ranges` strictly
+ *   includes `[begin, end)`.
+ */
+export function arrayOfBeginEndRangesIncludes(
+  ranges: Array<{begin: number; end: number}>,
+  begin: number,
+  end: number
+): boolean {
+  if (begin >= end) {
+    throw new Error(
+      `Expected begin to be less than end, ` +
+        `but got begin=${begin}, end=${end}`
+    );
+  }
+  return (
+    ranges.findIndex((range) => range.begin >= begin && range.end <= end) !== -1
+  );
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -297,11 +297,14 @@ export interface DebugTensorValue {
   variance?: number;
 }
 
-export interface ExecutionDigestLoadState extends LoadState {
+export interface ExecutionDigestLoadState {
   // A map from page number to whether the page has been loaded
   //   - in full, in which case the value is pageSize.
   //   - partially, in which case the value is an integer < pageSize.
   pageLoadedSizes: {[page: number]: number};
+
+  // Execution-digest indices that are currently loading.
+  loadingRanges: Array<{begin: number; end: number}>;
 
   // Number of top-level executions available at the data source (not
   // necessarily loaded by frontend yet.)

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
@@ -233,6 +233,8 @@ export function createDebuggerSourceCodeState(
 export function createDigestsStateWhileLoadingExecutionDigests(
   pageSize: number,
   numExecutions: number,
+  loadingBegin: number,
+  loadingEnd: number,
   executionDigests?: {[index: number]: ExecutionDigest},
   pageLoadedSize?: {[page: number]: number}
 ): DebuggerState {
@@ -256,8 +258,12 @@ export function createDigestsStateWhileLoadingExecutionDigests(
       executionDigestsLoaded: {
         numExecutions,
         pageLoadedSizes: pageLoadedSize || {},
-        state: DataLoadState.LOADING,
-        lastLoadedTimeInMs: executionDigests == null ? Date.now() : null,
+        loadingRanges: [
+          {
+            begin: loadingBegin,
+            end: loadingEnd,
+          },
+        ],
       },
       executionDigests: executionDigests == null ? {} : executionDigests,
     }),
@@ -295,8 +301,7 @@ export function createDebuggerStateWithLoadedExecutionDigests(
       executionDigestsLoaded: {
         numExecutions: opTypes == null ? 1500 : opTypes.length,
         pageLoadedSizes: {},
-        state: DataLoadState.LOADED,
-        lastLoadedTimeInMs: Date.now(),
+        loadingRanges: [],
       },
       executionDigests: {},
       executionData: {},

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/index.ts
@@ -230,14 +230,22 @@ export function createDebuggerSourceCodeState(
  * Create a DebuggerState the emulates the state during the loading of
  * executionDigests, for testing.
  */
-export function createDigestsStateWhileLoadingExecutionDigests(
-  pageSize: number,
-  numExecutions: number,
-  loadingBegin: number,
-  loadingEnd: number,
-  executionDigests?: {[index: number]: ExecutionDigest},
-  pageLoadedSize?: {[page: number]: number}
-): DebuggerState {
+export function createDigestsStateWhileLoadingExecutionDigests(args: {
+  pageSize: number;
+  numExecutions: number;
+  loadingBegin: number;
+  loadingEnd: number;
+  executionDigests?: {[index: number]: ExecutionDigest};
+  pageLoadedSize?: {[page: number]: number};
+}): DebuggerState {
+  const {
+    pageSize,
+    numExecutions,
+    loadingBegin,
+    loadingEnd,
+    executionDigests,
+    pageLoadedSize,
+  } = args;
   return createDebuggerState({
     runs: {
       __default_debugger_run__: {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container_test.ts
@@ -71,8 +71,7 @@ describe('Execution Data Container', () => {
               lastLoadedTimeInMs: 111,
             },
             executionDigestsLoaded: {
-              state: DataLoadState.LOADED,
-              lastLoadedTimeInMs: 222,
+              loadingRanges: [],
               pageLoadedSizes: {0: 100},
               numExecutions: 1000,
             },
@@ -130,8 +129,7 @@ describe('Execution Data Container', () => {
               lastLoadedTimeInMs: 111,
             },
             executionDigestsLoaded: {
-              state: DataLoadState.LOADED,
-              lastLoadedTimeInMs: 222,
+              loadingRanges: [],
               pageLoadedSizes: {0: 100},
               numExecutions: 1000,
             },

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.css
@@ -61,10 +61,10 @@ limitations under the License.
 .timeline-slider {
   display: inline-block;
   height: 48px;
+  left: 340px; /* Total width of the two buttons and text div to the left. */
   padding: 0;
   position: absolute;
-  right: 40px;
-  width: calc(100% - 420px);
+  width: calc(100% - 420px); /* `left` plus some room on the right. */
 }
 
 /deep/ .timeline-slider .mat-slider-thumb {
@@ -77,6 +77,7 @@ limitations under the License.
 .navigation-position-info {
   display: inline-flex;
   font-size: 14px;
+  max-width: 200px;
   padding-left: 10px;
   padding-right: 10px;
   text-align: center;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.css
@@ -64,7 +64,7 @@ limitations under the License.
   left: 340px; /* Total width of the two buttons and text div to the left. */
   padding: 0;
   position: absolute;
-  width: calc(100% - 420px); /* `left` plus some room on the right. */
+  right: 40px;
 }
 
 /deep/ .timeline-slider .mat-slider-thumb {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.css
@@ -63,8 +63,8 @@ limitations under the License.
   height: 48px;
   padding: 0;
   position: absolute;
-  right: 0;
-  width: 440px;
+  right: 40px;
+  width: calc(100% - 420px);
 }
 
 /deep/ .timeline-slider .mat-slider-thumb {
@@ -75,18 +75,18 @@ limitations under the License.
 /* TODO(cais): Apply color #293241 to the thumb and the track. */
 
 .navigation-position-info {
-  display: inline-block;
+  display: inline-flex;
   font-size: 14px;
   padding-left: 10px;
   padding-right: 10px;
-  line-height: 48px;
   text-align: center;
   vertical-align: middle;
-  width: 200px;
 }
 
 .navigation-section {
   height: 48px;
+  line-height: 48px;
   position: relative;
   vertical-align: middle;
+  width: 100%;
 }

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.ng.html
@@ -52,7 +52,7 @@ limitations under the License.
         [min]="0"
         [max]="scrollBeginIndexUpperLimit"
         [value]="scrollBeginIndex"
-        (change)="onSliderChange.emit($event.value)"
+        (input)="onSliderChange.emit($event.value)"
       ></mat-slider>
     </div>
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container_test.ts
@@ -351,7 +351,7 @@ describe('Timeline Container', () => {
 
       const slider = fixture.debugElement.query(By.css('.timeline-slider'));
 
-      slider.triggerEventHandler('change', {value: scrollBeginIndex});
+      slider.triggerEventHandler('input', {value: scrollBeginIndex});
       fixture.detectChanges();
       expect(dispatchSpy).toHaveBeenCalledWith(
         executionScrollToIndex({index: scrollBeginIndex})


### PR DESCRIPTION
* Motivation for features / changes
  * Improve the usability of DebuggerV2, specifically it's timeline component.
* Technical description of changes
  * Previously, the mat-slider (see screenshot below) triggers actions on its
    `(change)` output, which means users won't see the eager-execution
    timeline update when dragging the slider thumb. They'll see it change
    only after they release the drag.
  * This PR changes the mat-slider output we listen to from `(change)` to
    `(input)`. This lets the eager-execution timeline update smoothly as
    the user drags the thumb of the mat-slider.
  * Previously, the loading state of all execution digests are lumped into a single
     boolean in the ngrx store, namely `state.executions.executionDigestsLoaded.state`.
     This is not adequate, especially given that the smoother scrolling experience
     makes simultaneous loading of multiple pages of execution digest much more
     likely. 
  * This PR replaces the `state` field with an array of begin-end ranges, .e.,
     `state.executions.executionDigestsLoaded.loadingRanges`. The selectors, reducers,
     effects, and their unit tests are adjusted accordingly.
    * The action `executionDigestsRequested`, which previously had no properties, now
       has a property that describes the requested range of execution digests.
    * This change makes the paged loading of execution digests more consistent with the
      paged loading of graph executions in DebuggerV2.
  * Also in this PR: improve the CSS of the timeline component to avoid line wrapping
     "Executions: <X> - <Y> of <ZZZ>" (see screenshot).
* Screenshots of UI changes
  * ![image](https://user-images.githubusercontent.com/16824702/83344575-984b6380-a2d6-11ea-91e1-6170103b8cfa.png)
* Detailed steps to verify changes work correctly (as executed by you)
  * Some existing unit tests affected by this change are updated.
  * Manual testing against a real tfdbg2 logdir (see screenshot above)
