### PR TITLE
ci: update `buildifier` to 3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ on:
   pull_request: {}
 
 env:
-  BUILDIFIER: '0.29.0'
-  BUILDIFIER_SHA256SUM: '4c985c883eafdde9c0e8cf3c8595b8bfdf32e77571c369bf8ddae83b042028d6'
+  BUILDIFIER: '3.0.0'
+  BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
 
 jobs:
   lint-python-flake8:


### PR DESCRIPTION
Summary:
This appears to be needed for the `load-on-top` to actually have any
effect: we currently suppress that lint, but even after enabling it lint
still passes with Buildifier 0.29.0 and properly fails only with a later
version.

wchargin-branch: ci-buildifier-3.0.0
