### PR TITLE
build: fix all `load-on-top` lint warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ on:
   pull_request: {}
 
 env:
-  BUILDIFIER: '0.29.0'
-  BUILDIFIER_SHA256SUM: '4c985c883eafdde9c0e8cf3c8595b8bfdf32e77571c369bf8ddae83b042028d6'
+  BUILDIFIER: '3.0.0'
+  BUILDIFIER_SHA256SUM: 'e92a6793c7134c5431c58fbc34700664f101e5c9b1c1fcd93b97978e8b7f88db'
 
 jobs:
   lint-python-flake8:

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -1,10 +1,10 @@
 # Description:
 # TensorBoard, a dashboard for investigating TensorFlow
 
-package(default_visibility = [":internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:zipper.bzl", "tensorboard_zip_file")
+
+package(default_visibility = [":internal"])
 
 licenses(["notice"])
 

--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -1,9 +1,9 @@
 # Description:
 # TensorBoard, a dashboard for investigating TensorFlow
 
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/experimental/plugin_util/BUILD
+++ b/tensorboard/components/experimental/plugin_util/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/experimental/plugin_util/test/BUILD
+++ b/tensorboard/components/experimental/plugin_util/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -1,8 +1,8 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_config", "tf_ts_devserver", "tf_ts_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_backend/BUILD
+++ b/tensorboard/components/tf_backend/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_backend/test/BUILD
+++ b/tensorboard/components/tf_backend/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_card_heading/BUILD
+++ b/tensorboard/components/tf_card_heading/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_categorization_utils/BUILD
+++ b/tensorboard/components/tf_categorization_utils/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_categorization_utils/test/BUILD
+++ b/tensorboard/components/tf_categorization_utils/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_color_scale/BUILD
+++ b/tensorboard/components/tf_color_scale/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_color_scale/test/BUILD
+++ b/tensorboard/components/tf_color_scale/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_dashboard_common/BUILD
+++ b/tensorboard/components/tf_dashboard_common/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_imports/BUILD
+++ b/tensorboard/components/tf_imports/BUILD
@@ -1,8 +1,8 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:hacks.bzl", "tensorboard_typescript_bundle")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_line_chart_data_loader/BUILD
+++ b/tensorboard/components/tf_line_chart_data_loader/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_markdown_view/BUILD
+++ b/tensorboard/components/tf_markdown_view/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_option_selector/BUILD
+++ b/tensorboard/components/tf_option_selector/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_paginated_view/BUILD
+++ b/tensorboard/components/tf_paginated_view/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_paginated_view/test/BUILD
+++ b/tensorboard/components/tf_paginated_view/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_runs_selector/BUILD
+++ b/tensorboard/components/tf_runs_selector/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_storage/BUILD
+++ b/tensorboard/components/tf_storage/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_storage/test/BUILD
+++ b/tensorboard/components/tf_storage/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_tensorboard/test/BUILD
+++ b/tensorboard/components/tf_tensorboard/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_utils/BUILD
+++ b/tensorboard/components/tf_utils/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/vz_bar_chart/BUILD
+++ b/tensorboard/components/vz_bar_chart/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/vz_chart_helpers/BUILD
+++ b/tensorboard/components/vz_chart_helpers/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/vz_example_viewer/BUILD
+++ b/tensorboard/components/vz_example_viewer/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/vz_line_chart2/BUILD
+++ b/tensorboard/components/vz_line_chart2/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/vz_line_chart2/test/BUILD
+++ b/tensorboard/components/vz_line_chart2/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/vz_sorting/BUILD
+++ b/tensorboard/components/vz_sorting/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/vz_sorting/test/BUILD
+++ b/tensorboard/components/vz_sorting/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/defs/BUILD
+++ b/tensorboard/defs/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/functionaltests/BUILD
+++ b/tensorboard/functionaltests/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@io_bazel_rules_webtesting//web:py.bzl", "py_web_test_suite")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 

--- a/tensorboard/functionaltests/browsers/BUILD
+++ b/tensorboard/functionaltests/browsers/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@io_bazel_rules_webtesting//web:web.bzl", "browser")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -1,11 +1,11 @@
 # Description:
 # TensorBoard plugin for audio
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
-
-load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/audio/tf_audio_dashboard/BUILD
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/BUILD
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/custom_scalar/BUILD
+++ b/tensorboard/plugins/custom_scalar/BUILD
@@ -1,11 +1,11 @@
 # Description:
 # TensorBoard plugin for custom scalars plots
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
-
-load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 ng_module(
     name = "data_source",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 ng_module(
     name = "store",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 tf_ts_library(
     name = "testing",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/monaco/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/monaco/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/distribution/tf_distribution_dashboard/BUILD
+++ b/tensorboard/plugins/distribution/tf_distribution_dashboard/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/distribution/vz_distribution_chart/BUILD
+++ b/tensorboard/plugins/distribution/vz_distribution_chart/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph/BUILD
+++ b/tensorboard/plugins/graph/tf_graph/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph/demo/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_app/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_app/BUILD
@@ -1,8 +1,8 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_app/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_app/demo/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_board/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_board/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_board/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_board/demo/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_common/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_common/test/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_common/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_controls/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_controls/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_controls/demo/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_dashboard/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_debugger_data_card/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_debugger_data_card/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_debugger_data_card/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_debugger_data_card/demo/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_info/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_info/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_info/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_info/demo/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_loader/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_loader/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_loader/demo/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_loader/demo/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_node_search/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_node_search/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -1,11 +1,11 @@
 # Description:
 # TensorBoard plugin for histograms
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
-
-load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/histogram/tf_histogram_dashboard/test/BUILD
+++ b/tensorboard/plugins/histogram/tf_histogram_dashboard/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/histogram/vz_histogram_timeseries/BUILD
+++ b/tensorboard/plugins/histogram/vz_histogram_timeseries/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -1,12 +1,12 @@
 # Description:
 # TensorBoard plugin for hparams
 
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
-
-load("//tensorboard/defs:web.bzl", "tf_web_library")
-load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/hparams/tf_hparams_backend/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_backend/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/hparams/tf_hparams_dashboard/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_dashboard/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/hparams/tf_hparams_google_analytics_tracker/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_google_analytics_tracker/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/hparams/tf_hparams_main/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_main/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -1,11 +1,11 @@
 # Description:
 # TensorBoard plugin for images
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
-
-load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/image/tf_image_dashboard/BUILD
+++ b/tensorboard/plugins/image/tf_image_dashboard/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/mesh/BUILD
+++ b/tensorboard/plugins/mesh/BUILD
@@ -1,10 +1,10 @@
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
-
-load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 # Public-facing API, included in Pip package.
 py_library(

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/BUILD
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -1,11 +1,11 @@
 # Description:
 # TensorBoard plugin for precision-recall curves.
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
-
-load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 py_library(
     name = "metadata",

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/BUILD
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/BUILD
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/profile_redirect/tf_profile_redirect_dashboard/BUILD
+++ b/tensorboard/plugins/profile_redirect/tf_profile_redirect_dashboard/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -1,12 +1,12 @@
 # Embedding Projector plugin.
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
-
-load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 py_library(
     name = "projector_plugin",

--- a/tensorboard/plugins/projector/tf_projector_plugin/BUILD
+++ b/tensorboard/plugins/projector/tf_projector_plugin/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/projector/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/projector/vz_projector/test/BUILD
+++ b/tensorboard/plugins/projector/vz_projector/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -1,11 +1,11 @@
 # Description:
 # TensorBoard plugin for scalars
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
-
-load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -1,11 +1,11 @@
 # Description:
 # TensorBoard plugin for the Text
 
+load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
-
-load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/text/tf_text_dashboard/BUILD
+++ b/tensorboard/plugins/text/tf_text_dashboard/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/uploader/proto/BUILD
+++ b/tensorboard/uploader/proto/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:protos.bzl", "tb_proto_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/webapp/core/BUILD
+++ b/tensorboard/webapp/core/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 ng_module(
     name = "core",

--- a/tensorboard/webapp/core/actions/BUILD
+++ b/tensorboard/webapp/core/actions/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 tf_ts_library(
     name = "actions",

--- a/tensorboard/webapp/core/store/BUILD
+++ b/tensorboard/webapp/core/store/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 ng_module(
     name = "store",

--- a/tensorboard/webapp/core/testing/BUILD
+++ b/tensorboard/webapp/core/testing/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 tf_ts_library(
     name = "testing",

--- a/tensorboard/webapp/testing/BUILD
+++ b/tensorboard/webapp/testing/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 

--- a/tensorboard/webapp/types/BUILD
+++ b/tensorboard/webapp/types/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 # TODO(stephanwlee): move this into shareable place and use it in Polymer-based
 # modules when Angular is ready to be built as part of TensorBoard.

--- a/third_party/chromium/BUILD
+++ b/third_party/chromium/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_archive")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 


### PR DESCRIPTION
Summary:
We currently suppress the `load-on-top` warning, but the Google-internal
linter still nags us about it. This patch fixes all existing occurrences
so that we can start enforcing the lint in CI in a subsequent patch.

Generated with:

```
git ls-files -z '*BUILD' third_party/js.bzl |
    xargs -0 ~/Downloads/buildifier --warnings=load-on-top --lint=fix
```

where `~/Downloads/buildifier` is at version 3.0.0.

Test Plan:
Running the CI Buildifier command without the `load-on-top` exemption
now passes:

```
git ls-files -z '*BUILD' third_party/js.bzl |
    xargs -0 ~/Downloads/buildifier --mode=check --lint=warn \
        --warnings=-native-py,-native-java,-constant-glob
```

Before this change, with Buildifier 3.0.0, that check failed.

wchargin-branch: build-fix-load-on-top
