### PR TITLE
debugger: add missing `:expect_ngrx_store_testing` deps

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
@@ -44,6 +44,7 @@ tf_ts_library(
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "@npm//@angular/common",
         "@npm//@angular/compiler",
         "@npm//@angular/core",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/BUILD
@@ -43,6 +43,7 @@ tf_ts_library(
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "@npm//@angular/common",
         "@npm//@angular/compiler",
         "@npm//@angular/core",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/BUILD
@@ -45,6 +45,7 @@ tf_ts_library(
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:types",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/testing",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "@npm//@angular/common",
         "@npm//@angular/compiler",
         "@npm//@angular/core",


### PR DESCRIPTION
Summary:
Some tests imported `@ngrx/store/testing` without declaring a build
dependency, which broke the internal sync

Test Plan:
A test sync fails before this patch (<http://cl/314143306>) and passes
with it (<http://cl/314146699>).

wchargin-branch: debugger-fix-build-20200601
