### PR TITLE
projector: always check root logdir for embeddings

### DIFF
--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -335,9 +335,11 @@ class ProjectorPlugin(base_plugin.TBPlugin):
         """Returns a map of run paths to `ProjectorConfig` protos."""
         run_path_pairs = list(self.run_paths.items())
         self._append_plugin_asset_directories(run_path_pairs)
-        # If there are no summary event files, the projector should still work,
-        # treating the `logdir` as the model checkpoint directory.
-        if not run_path_pairs:
+        # Also accept the root logdir as a model checkpoint directory,
+        # so that the projector still works when there are no runs.
+        # (Case on `run` rather than `path` to avoid issues with
+        # absolute/relative paths on any filesystems.)
+        if not any(run == "." for (run, path) in run_path_pairs):
             run_path_pairs.append((".", self.logdir))
         if self._run_paths_changed() or _latest_checkpoints_changed(
             self._configs, run_path_pairs


### PR DESCRIPTION
Summary:
Previously, the projector plugin would look for checkpoints in the root
logdir only if there were no other logs. This led to a confusing
discontinuity: if you add logs to a subdirectory of a logdir with only
projector data, suddenly your projector data would disappear in the UI.
This patch changes the projector plugin to _always_ look in the root log
directory for checkpoints. Fixes #3686.

Test Plan:
Three cases to test:

  - checkpoints in root logdir, no other data
  - checkpoints and summary data in root logdir
  - checkpoints in root logdir, summary data in non-root run

Verify that each of these cases lets the projector plugin render and
that the data shows up only once (i.e., it’s not duplicated).

wchargin-branch: projector-always-check-root
