### PR TITLE
program: include dynamic plugins by default

### DIFF
--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -88,6 +88,20 @@ _PLUGINS = [
 
 
 def get_plugins():
+    """Returns a list specifying all known TensorBoard plugins.
+
+    This includes both first-party, statically bundled plugins and
+    dynamic plugins.
+
+    This list can be passed to the `tensorboard.program.TensorBoard` API.
+
+    Returns:
+      The list of default first-party plugins.
+    """
+    return get_static_plugins() + get_dynamic_plugins()
+
+
+def get_static_plugins():
     """Returns a list specifying TensorBoard's default first-party plugins.
 
     Plugins are specified in this list either via a TBLoader instance to load the
@@ -96,7 +110,7 @@ def get_plugins():
     This list can be passed to the `tensorboard.program.TensorBoard` API.
 
     Returns:
-      The list of default plugins.
+      The list of default first-party plugins.
 
     :rtype: list[Type[base_plugin.TBLoader] | Type[base_plugin.TBPlugin]]
     """

--- a/tensorboard/main.py
+++ b/tensorboard/main.py
@@ -62,7 +62,7 @@ def run_main():
         )
 
     tensorboard = program.TensorBoard(
-        default.get_plugins() + default.get_dynamic_plugins(),
+        default.get_plugins(),
         program.get_default_assets_zip_provider(),
         subcommands=[uploader_subcommand.UploaderSubcommand()],
     )


### PR DESCRIPTION
Summary:
The `tensorboard.program.TensorBoard` API now includes dynamic plugins
by default; previously, it only included static plugins. Fixes #3683.

We effect this change by modifying the internal `default.get_plugins`
method to return all the plugins to prevent this kind of confusion in
the future.

Test Plan:
Launch TensorBoard from a small Python script:

```python
import tensorboard as tb

program = tb.program.TensorBoard()
program.configure(logdir="/tmp/logs", bind_all=True)
program.main()
```

…and note that the projector plugin now shows up in the list of plugins,
whereas previously it was not loaded (neither active nor inactive). Note
that normal `tensorboard(1)` also still shows the correct plugins.

wchargin-branch: program-include-dynamic-plugins
