### PR TITLE
[DebuggerV2] Use Map for graph ops

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects.ts
@@ -684,10 +684,10 @@ export class DebuggerEffects {
         return (
           runId !== null &&
           (loadingOps[graph_id] === undefined ||
-            loadingOps[graph_id][op_name] === undefined ||
+            !loadingOps[graph_id].has(op_name) ||
             !(
-              loadingOps[graph_id][op_name] === DataLoadState.LOADING ||
-              loadingOps[graph_id][op_name] === DataLoadState.LOADED
+              loadingOps[graph_id].get(op_name) === DataLoadState.LOADING ||
+              loadingOps[graph_id].get(op_name) === DataLoadState.LOADED
             ))
         );
       }),

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/effects/debugger_effects_test.ts
@@ -1493,9 +1493,7 @@ describe('Debugger effects', () => {
       );
       store.overrideSelector(getActiveRunId, runId);
       store.overrideSelector(getLoadingGraphOps, {
-        g2: {
-          other_op: DataLoadState.LOADED,
-        },
+        g2: new Map([['other_op', DataLoadState.LOADED]]),
       });
       store.overrideSelector(getLoadedStackFrames, {});
       store.refreshState();
@@ -1522,9 +1520,7 @@ describe('Debugger effects', () => {
       it(`skips a loading or loaded op: state=${opLoadState}`, () => {
         store.overrideSelector(getActiveRunId, runId);
         store.overrideSelector(getLoadingGraphOps, {
-          g2: {
-            'namespace_1/op_1': opLoadState,
-          },
+          g2: new Map([['namespace_1/op_1', opLoadState]]),
         });
         store.refreshState();
 
@@ -1551,9 +1547,7 @@ describe('Debugger effects', () => {
       });
       store.overrideSelector(getActiveRunId, runId);
       store.overrideSelector(getLoadingGraphOps, {
-        g2: {
-          other_op: DataLoadState.LOADED,
-        },
+        g2: new Map([['other_op', DataLoadState.LOADED]]),
       });
       // The second stack frame is already loaded.
       store.overrideSelector(getLoadedStackFrames, {bbb2: stackFrame1});

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_graphs_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_graphs_reducers_test.ts
@@ -69,7 +69,7 @@ describe('Debugger reducers', () => {
         actions.graphOpInfoRequested({graph_id: 'g8', op_name: 'x'})
       );
       expect(nextState.graphs.loadingOps).toEqual({
-        g8: {x: DataLoadState.LOADING},
+        g8: new Map([['x', DataLoadState.LOADING]]),
       });
     });
 
@@ -77,8 +77,8 @@ describe('Debugger reducers', () => {
       const state = createDebuggerState({
         graphs: createDebuggerGraphsState({
           loadingOps: {
-            g1: {Op1: DataLoadState.LOADING},
-            g2: {Op2: DataLoadState.LOADING},
+            g1: new Map([['Op1', DataLoadState.LOADING]]),
+            g2: new Map([['Op2', DataLoadState.LOADING]]),
           },
         }),
       });
@@ -87,11 +87,11 @@ describe('Debugger reducers', () => {
         actions.graphOpInfoRequested({graph_id: 'g2', op_name: 'Op3'})
       );
       expect(nextState.graphs.loadingOps).toEqual({
-        g1: {Op1: DataLoadState.LOADING},
-        g2: {
-          Op2: DataLoadState.LOADING,
-          Op3: DataLoadState.LOADING,
-        },
+        g1: new Map([['Op1', DataLoadState.LOADING]]),
+        g2: new Map([
+          ['Op2', DataLoadState.LOADING],
+          ['Op3', DataLoadState.LOADING],
+        ]),
       });
     });
 
@@ -99,8 +99,8 @@ describe('Debugger reducers', () => {
       const state = createDebuggerState({
         graphs: createDebuggerGraphsState({
           loadingOps: {
-            g1: {Op1: DataLoadState.LOADING},
-            g2: {Op2: DataLoadState.LOADING},
+            g1: new Map([['Op1', DataLoadState.LOADING]]),
+            g2: new Map([['Op2', DataLoadState.LOADING]]),
           },
         }),
       });
@@ -109,8 +109,8 @@ describe('Debugger reducers', () => {
         actions.graphOpInfoRequested({graph_id: 'g2', op_name: 'Op2'})
       );
       expect(nextState.graphs.loadingOps).toEqual({
-        g1: {Op1: DataLoadState.LOADING},
-        g2: {Op2: DataLoadState.LOADING},
+        g1: new Map([['Op1', DataLoadState.LOADING]]),
+        g2: new Map([['Op2', DataLoadState.LOADING]]),
       });
     });
   });
@@ -124,7 +124,7 @@ describe('Debugger reducers', () => {
             g0: new Map([[opInfo0.op_name, opInfo0]]),
           },
           loadingOps: {
-            g2: {TestOp_1: DataLoadState.LOADING},
+            g2: new Map([['TestOp_1', DataLoadState.LOADING]]),
           },
         }),
       });
@@ -208,7 +208,7 @@ describe('Debugger reducers', () => {
         nextState.graphs.ops['g2'].get(opInfo2.op_name)!.consumers[0][0].data
       ).toBeUndefined();
       expect(nextState.graphs.loadingOps).toEqual({
-        g2: {TestOp_1: DataLoadState.LOADED},
+        g2: new Map([['TestOp_1', DataLoadState.LOADED]]),
       });
     });
 
@@ -221,11 +221,11 @@ describe('Debugger reducers', () => {
             g0: new Map([[opInfo0.op_name, opInfo0]]),
           },
           loadingOps: {
-            g1: {TestOp_11: DataLoadState.LOADING},
-            g2: {
-              TestOp_2: DataLoadState.LOADING,
-              TestOp_22: DataLoadState.LOADING,
-            },
+            g1: new Map([['TestOp_11', DataLoadState.LOADING]]),
+            g2: new Map([
+              ['TestOp_2', DataLoadState.LOADING],
+              ['TestOp_22', DataLoadState.LOADING],
+            ]),
           },
         }),
       });
@@ -340,11 +340,11 @@ describe('Debugger reducers', () => {
         ]),
       });
       expect(nextState.graphs.loadingOps).toEqual({
-        g1: {TestOp_11: DataLoadState.LOADING},
-        g2: {
-          TestOp_2: DataLoadState.LOADED,
-          TestOp_22: DataLoadState.LOADING,
-        },
+        g1: new Map([['TestOp_11', DataLoadState.LOADING]]),
+        g2: new Map([
+          ['TestOp_2', DataLoadState.LOADED],
+          ['TestOp_22', DataLoadState.LOADING],
+        ]),
       });
     });
 
@@ -357,7 +357,7 @@ describe('Debugger reducers', () => {
             g0: new Map([[opInfo0.op_name, opInfo0]]),
           },
           loadingOps: {
-            g2: {TestOp_3: DataLoadState.LOADING},
+            g2: new Map([['TestOp_3', DataLoadState.LOADING]]),
           },
         }),
       });
@@ -401,13 +401,10 @@ describe('Debugger reducers', () => {
 
       expect(nextState.graphs.ops).toEqual({
         g0: new Map([[opInfo0.op_name, opInfo0]]),
-        g2: new Map([
-          [opInfo1.op_name, opInfo1],
-          [opInfo2.op_name, opInfo2],
-        ]),
+        g2: new Map([[opInfo1.op_name, opInfo1], [opInfo2.op_name, opInfo2]]),
       });
       expect(nextState.graphs.loadingOps).toEqual({
-        g2: {TestOp_3: DataLoadState.LOADED},
+        g2: new Map([['TestOp_3', DataLoadState.LOADED]]),
       });
     });
 
@@ -420,7 +417,7 @@ describe('Debugger reducers', () => {
             g0: new Map([[opInfo0.op_name, opInfo0]]),
           },
           loadingOps: {
-            g2: {TestOp_4: DataLoadState.LOADING},
+            g2: new Map([['TestOp_4', DataLoadState.LOADING]]),
           },
         }),
       });
@@ -466,13 +463,10 @@ describe('Debugger reducers', () => {
 
       expect(nextState.graphs.ops).toEqual({
         g0: new Map([[opInfo0.op_name, opInfo0]]),
-        g2: new Map([
-          [opInfo1.op_name, opInfo1],
-          [opInfo2.op_name, opInfo2],
-        ]),
+        g2: new Map([[opInfo1.op_name, opInfo1], [opInfo2.op_name, opInfo2]]),
       });
       expect(nextState.graphs.loadingOps).toEqual({
-        g2: {TestOp_4: DataLoadState.LOADED},
+        g2: new Map([['TestOp_4', DataLoadState.LOADED]]),
       });
     });
   });

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_graphs_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_graphs_reducers_test.ts
@@ -121,7 +121,7 @@ describe('Debugger reducers', () => {
       const state = createDebuggerState({
         graphs: createDebuggerGraphsState({
           ops: {
-            g0: {[opInfo0.op_name]: opInfo0},
+            g0: new Map([[opInfo0.op_name, opInfo0]]),
           },
           loadingOps: {
             g2: {TestOp_1: DataLoadState.LOADING},
@@ -192,20 +192,20 @@ describe('Debugger reducers', () => {
 
       expect(nextState.graphs.ops).toEqual({
         // Verify the old graph op data hasn't changed.
-        g0: {[opInfo0.op_name]: opInfo0},
+        g0: new Map([[opInfo0.op_name, opInfo0]]),
         // 'g2' is the immediately-enclosing graph of the three ops.
-        g2: {
-          [opInfo1.op_name]: opInfo1,
-          [opInfo2.op_name]: opInfo2,
-          [opInfo3.op_name]: opInfo3,
-        },
+        g2: new Map([
+          [opInfo1.op_name, opInfo1],
+          [opInfo2.op_name, opInfo2],
+          [opInfo3.op_name, opInfo3],
+        ]),
       });
       // Verify that the input and consumer ops do not have the detailed data attached.
       expect(
-        nextState.graphs.ops['g2'][opInfo2.op_name].inputs[0].data
+        nextState.graphs.ops['g2'].get(opInfo2.op_name)!.inputs[0].data
       ).toBeUndefined();
       expect(
-        nextState.graphs.ops['g2'][opInfo2.op_name].consumers[0][0].data
+        nextState.graphs.ops['g2'].get(opInfo2.op_name)!.consumers[0][0].data
       ).toBeUndefined();
       expect(nextState.graphs.loadingOps).toEqual({
         g2: {TestOp_1: DataLoadState.LOADED},
@@ -217,7 +217,8 @@ describe('Debugger reducers', () => {
       const state = createDebuggerState({
         graphs: createDebuggerGraphsState({
           ops: {
-            g0: {[opInfo0.op_name]: opInfo0},
+            // TODO(cais): Is typing necessary?
+            g0: new Map([[opInfo0.op_name, opInfo0]]),
           },
           loadingOps: {
             g1: {TestOp_11: DataLoadState.LOADING},
@@ -328,15 +329,15 @@ describe('Debugger reducers', () => {
 
       expect(nextState.graphs.ops).toEqual({
         // Verify the old graph op data hasn't changed.
-        g0: {[opInfo0.op_name]: opInfo0},
+        g0: new Map([[opInfo0.op_name, opInfo0]]),
         // 'g2' is the immediately-enclosing graph of the three ops.
-        g2: {
-          [opInfo1a.op_name]: opInfo1a,
-          [opInfo1b.op_name]: opInfo1b,
-          [opInfo2.op_name]: opInfo2,
-          [opInfo3a.op_name]: opInfo3a,
-          [opInfo3b.op_name]: opInfo3b,
-        },
+        g2: new Map([
+          [opInfo1a.op_name, opInfo1a],
+          [opInfo1b.op_name, opInfo1b],
+          [opInfo2.op_name, opInfo2],
+          [opInfo3a.op_name, opInfo3a],
+          [opInfo3b.op_name, opInfo3b],
+        ]),
       });
       expect(nextState.graphs.loadingOps).toEqual({
         g1: {TestOp_11: DataLoadState.LOADING},
@@ -352,7 +353,8 @@ describe('Debugger reducers', () => {
       const state = createDebuggerState({
         graphs: createDebuggerGraphsState({
           ops: {
-            g0: {[opInfo0.op_name]: opInfo0}, // Pre-existing op in store.
+            // Pre-existing op in store.
+            g0: new Map([[opInfo0.op_name, opInfo0]]),
           },
           loadingOps: {
             g2: {TestOp_3: DataLoadState.LOADING},
@@ -398,11 +400,11 @@ describe('Debugger reducers', () => {
       );
 
       expect(nextState.graphs.ops).toEqual({
-        g0: {[opInfo0.op_name]: opInfo0},
-        g2: {
-          [opInfo1.op_name]: opInfo1,
-          [opInfo2.op_name]: opInfo2,
-        },
+        g0: new Map([[opInfo0.op_name, opInfo0]]),
+        g2: new Map([
+          [opInfo1.op_name, opInfo1],
+          [opInfo2.op_name, opInfo2],
+        ]),
       });
       expect(nextState.graphs.loadingOps).toEqual({
         g2: {TestOp_3: DataLoadState.LOADED},
@@ -414,7 +416,8 @@ describe('Debugger reducers', () => {
       const state = createDebuggerState({
         graphs: createDebuggerGraphsState({
           ops: {
-            g0: {[opInfo0.op_name]: opInfo0}, // Pre-existing op in store.
+            // Pre-existing op in store.
+            g0: new Map([[opInfo0.op_name, opInfo0]]),
           },
           loadingOps: {
             g2: {TestOp_4: DataLoadState.LOADING},
@@ -462,11 +465,11 @@ describe('Debugger reducers', () => {
       );
 
       expect(nextState.graphs.ops).toEqual({
-        g0: {[opInfo0.op_name]: opInfo0},
-        g2: {
-          [opInfo1.op_name]: opInfo1,
-          [opInfo2.op_name]: opInfo2,
-        },
+        g0: new Map([[opInfo0.op_name, opInfo0]]),
+        g2: new Map([
+          [opInfo1.op_name, opInfo1],
+          [opInfo2.op_name, opInfo2],
+        ]),
       });
       expect(nextState.graphs.loadingOps).toEqual({
         g2: {TestOp_4: DataLoadState.LOADED},

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -763,9 +763,7 @@ const reducer = createReducer(
           ...state.graphs,
           ops: {
             ...state.graphs.ops,
-            [graphId]: {
-              ...state.graphs.ops[graphId],
-            },
+            [graphId]: new Map(state.graphs.ops[graphId]),
           },
           loadingOps: {
             ...state.graphs.loadingOps,
@@ -783,21 +781,21 @@ const reducer = createReducer(
           // Same for `consumer.data` below.
           continue;
         }
-        newState.graphs.ops[graphId][input.op_name] = input.data;
+        newState.graphs.ops[graphId].set(input.op_name, input.data);
       }
       for (let i = 0; i < graphOpInfoResponse.consumers.length; ++i) {
         for (const consumer of graphOpInfoResponse.consumers[i]) {
           if (!consumer.data) {
             continue;
           }
-          newState.graphs.ops[graphId][consumer.op_name] = consumer.data;
+          newState.graphs.ops[graphId].set(consumer.op_name, consumer.data);
         }
       }
-      newState.graphs.ops[graphId][graphOpInfoResponse.op_name] = {
+      newState.graphs.ops[graphId].set(graphOpInfoResponse.op_name, {
         ...graphOpInfoResponse,
         // Remove `input.data` to avoid duplicated data in `opInfo`,
         // which is put into `newState.graphs.ops[graphId][opInfo.op_name]`
-        // later.
+        // later.d
         // Same for `consumer.data` below.
         inputs: graphOpInfoResponse.inputs.map((input) => ({
           op_name: input.op_name,
@@ -809,7 +807,7 @@ const reducer = createReducer(
             input_slot: consumer.input_slot,
           }));
         }),
-      };
+      });
       // Remove the loading marker for the op.
       newState.graphs.loadingOps[graphId][graphOpInfoResponse.op_name] =
         DataLoadState.LOADED;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -743,10 +743,13 @@ const reducer = createReducer(
         },
       };
       if (newState.graphs.loadingOps[graph_id] === undefined) {
-        newState.graphs.loadingOps[graph_id] = {};
+        newState.graphs.loadingOps[graph_id] = new Map<string, DataLoadState>();
       }
-      if (newState.graphs.loadingOps[graph_id][op_name] === undefined) {
-        newState.graphs.loadingOps[graph_id][op_name] = DataLoadState.LOADING;
+      if (!newState.graphs.loadingOps[graph_id].has(op_name)) {
+        newState.graphs.loadingOps[graph_id].set(
+          op_name,
+          DataLoadState.LOADING
+        );
       }
       return newState;
     }
@@ -767,9 +770,7 @@ const reducer = createReducer(
           },
           loadingOps: {
             ...state.graphs.loadingOps,
-            [graphId]: {
-              ...state.graphs.loadingOps[graphId],
-            },
+            [graphId]: new Map(state.graphs.loadingOps[graphId]),
           },
         },
       };
@@ -809,8 +810,10 @@ const reducer = createReducer(
         }),
       });
       // Remove the loading marker for the op.
-      newState.graphs.loadingOps[graphId][graphOpInfoResponse.op_name] =
-        DataLoadState.LOADED;
+      newState.graphs.loadingOps[graphId].set(
+        graphOpInfoResponse.op_name,
+        DataLoadState.LOADED
+      );
       return newState;
     }
   ),

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -308,7 +308,7 @@ export const getFocusedGraphOpInfo = createSelector(
     if (focusedOp === null || ops[focusedOp.graphId] === undefined) {
       return null;
     } else {
-      return ops[focusedOp.graphId][focusedOp.opName] || null;
+      return ops[focusedOp.graphId].get(focusedOp.opName) || null;
     }
   }
 );
@@ -320,18 +320,18 @@ export const getFocusedGraphOpInputs = createSelector(
     if (
       focusedOp === null ||
       ops[focusedOp.graphId] === undefined ||
-      ops[focusedOp.graphId][focusedOp.opName] === undefined
+      !ops[focusedOp.graphId].has(focusedOp.opName)
     ) {
       return null;
     } else {
       const graph = ops[focusedOp.graphId];
-      const {inputs} = graph[focusedOp.opName];
+      const {inputs} = graph.get(focusedOp.opName)!;
       return inputs.map((inputSpec) => {
         const spec: GraphOpInputSpec = {
           ...inputSpec,
         };
-        if (graph[inputSpec.op_name]) {
-          spec.data = graph[inputSpec.op_name];
+        if (graph.has(inputSpec.op_name)) {
+          spec.data = graph.get(inputSpec.op_name);
         }
         return spec;
       });
@@ -346,17 +346,17 @@ export const getFocusedGraphOpConsumers = createSelector(
     if (
       focusedOp === null ||
       ops[focusedOp.graphId] === undefined ||
-      ops[focusedOp.graphId][focusedOp.opName] === undefined
+      !ops[focusedOp.graphId].has(focusedOp.opName)
     ) {
       return null;
     } else {
       const graph = ops[focusedOp.graphId];
-      const {consumers} = graph[focusedOp.opName];
+      const {consumers} = graph.get(focusedOp.opName)!;
       return consumers.map((slotConsumers) => {
         return slotConsumers.map((consumerSpec) => {
           const spec: GraphOpConsumerSpec = {...consumerSpec};
-          if (graph[consumerSpec.op_name]) {
-            spec.data = graph[consumerSpec.op_name];
+          if (graph.has(consumerSpec.op_name)) {
+            spec.data = graph.get(consumerSpec.op_name);
           }
           return spec;
         });
@@ -536,11 +536,11 @@ export const getFocusedStackFrames = createSelector(
       const {graphId, opName} = state.graphs.focusedOp;
       if (
         state.graphs.ops[graphId] === undefined ||
-        state.graphs.ops[graphId][opName] === undefined
+        !state.graphs.ops[graphId].has(opName)
       ) {
         return null;
       }
-      stackFrameIds = state.graphs.ops[graphId][opName].stack_frame_ids;
+      stackFrameIds = state.graphs.ops[graphId].get(opName)!.stack_frame_ids;
     }
     const stackFrames: StackFrame[] = [];
     for (const stackFrameId of stackFrameIds) {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -442,9 +442,7 @@ export const getLoadedExecutionData = createSelector(
 
 export const getLoadingGraphOps = createSelector(
   selectDebuggerState,
-  (
-    state: DebuggerState
-  ): {[graph_id: string]: {[op_name: string]: DataLoadState}} =>
+  (state: DebuggerState): {[graph_id: string]: Map<string, DataLoadState>} =>
     state.graphs.loadingOps
 );
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
@@ -467,14 +467,20 @@ describe('debugger selectors', () => {
             },
             ops: {
               f1: new Map([
-                ['op1', createTestGraphOpInfo({
-                  op_type: 'Type1Op',
-                  op_name: 'foo',
-                })],
-                ['op2', createTestGraphOpInfo({
-                  op_type: 'Type2Op',
-                  op_name: 'bar',
-                })],
+                [
+                  'op1',
+                  createTestGraphOpInfo({
+                    op_type: 'Type1Op',
+                    op_name: 'foo',
+                  }),
+                ],
+                [
+                  'op2',
+                  createTestGraphOpInfo({
+                    op_type: 'Type2Op',
+                    op_name: 'bar',
+                  }),
+                ],
               ]),
             },
           }),
@@ -565,12 +571,18 @@ describe('debugger selectors', () => {
           graphs: {
             ops: {
               f1: new Map([
-                ['op7', createTestGraphOpInfo({
-                  stack_frame_ids: ['a1', 'a2'],
-                })],
-                ['op8', createTestGraphOpInfo({
-                  stack_frame_ids: ['a1', 'a3'],
-                })],
+                [
+                  'op7',
+                  createTestGraphOpInfo({
+                    stack_frame_ids: ['a1', 'a2'],
+                  }),
+                ],
+                [
+                  'op8',
+                  createTestGraphOpInfo({
+                    stack_frame_ids: ['a1', 'a3'],
+                  }),
+                ],
               ]),
             },
             loadingOps: {},
@@ -599,9 +611,12 @@ describe('debugger selectors', () => {
           graphs: {
             ops: {
               f1: new Map([
-                ['op1', createTestGraphOpInfo({
-                  stack_frame_ids: ['a1', 'a2'],
-                })],
+                [
+                  'op1',
+                  createTestGraphOpInfo({
+                    stack_frame_ids: ['a1', 'a2'],
+                  }),
+                ],
               ]),
             },
             loadingOps: {},
@@ -1040,10 +1055,7 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: new Map([
-                ['op1', op1Info],
-                ['op2', op2Info],
-              ]),
+              g1: new Map([['op1', op1Info], ['op2', op2Info]]),
             },
             focusedOp: null,
           }),
@@ -1057,10 +1069,7 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: new Map([
-                ['op1', op1Info],
-                ['op2', op2Info],
-              ]),
+              g1: new Map([['op1', op1Info], ['op2', op2Info]]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1077,10 +1086,7 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: new Map([
-                ['op1', op1Info],
-                ['op2', op2Info],
-              ]),
+              g1: new Map([['op1', op1Info], ['op2', op2Info]]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1181,10 +1187,7 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: new Map([
-                ['op1', op1Info],
-                ['op2', op2Info],
-              ]),
+              g1: new Map([['op1', op1Info], ['op2', op2Info]]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1293,10 +1296,7 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: new Map([
-                ['op1', op1Info],
-                ['op2', op2Info],
-              ]),
+              g1: new Map([['op1', op1Info], ['op2', op2Info]]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1328,17 +1328,23 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             loadingOps: {
-              g0: {},
-              g1: {Op1: DataLoadState.LOADING},
-              g2: {Op2a: DataLoadState.LOADED, Op2b: DataLoadState.FAILED},
+              g0: new Map(),
+              g1: new Map([['Op1', DataLoadState.LOADING]]),
+              g2: new Map([
+                ['Op2a', DataLoadState.LOADED],
+                ['Op2b', DataLoadState.FAILED],
+              ]),
             },
           }),
         })
       );
       expect(getLoadingGraphOps(state)).toEqual({
-        g0: {},
-        g1: {Op1: DataLoadState.LOADING},
-        g2: {Op2a: DataLoadState.LOADED, Op2b: DataLoadState.FAILED},
+        g0: new Map(),
+        g1: new Map([['Op1', DataLoadState.LOADING]]),
+        g2: new Map([
+          ['Op2a', DataLoadState.LOADED],
+          ['Op2b', DataLoadState.FAILED],
+        ]),
       });
     });
   });

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
@@ -48,6 +48,7 @@ import {
   CodeLocationType,
   DataLoadState,
   DEBUGGER_FEATURE_KEY,
+  GraphOpInfo,
   StackFrame,
 } from './debugger_types';
 import {
@@ -465,16 +466,16 @@ describe('debugger selectors', () => {
               opName: 'op2',
             },
             ops: {
-              f1: {
-                op1: createTestGraphOpInfo({
+              f1: new Map([
+                ['op1', createTestGraphOpInfo({
                   op_type: 'Type1Op',
                   op_name: 'foo',
-                }),
-                op2: createTestGraphOpInfo({
+                })],
+                ['op2', createTestGraphOpInfo({
                   op_type: 'Type2Op',
                   op_name: 'bar',
-                }),
-              },
+                })],
+              ]),
             },
           }),
         })
@@ -563,14 +564,14 @@ describe('debugger selectors', () => {
           activeRunId: '__default_debugger_run__',
           graphs: {
             ops: {
-              f1: {
-                op7: createTestGraphOpInfo({
+              f1: new Map([
+                ['op7', createTestGraphOpInfo({
                   stack_frame_ids: ['a1', 'a2'],
-                }),
-                op8: createTestGraphOpInfo({
+                })],
+                ['op8', createTestGraphOpInfo({
                   stack_frame_ids: ['a1', 'a3'],
-                }),
-              },
+                })],
+              ]),
             },
             loadingOps: {},
             focusedOp: {
@@ -597,11 +598,11 @@ describe('debugger selectors', () => {
           activeRunId: '__default_debugger_run__',
           graphs: {
             ops: {
-              f1: {
-                op1: createTestGraphOpInfo({
+              f1: new Map([
+                ['op1', createTestGraphOpInfo({
                   stack_frame_ids: ['a1', 'a2'],
-                }),
-              },
+                })],
+              ]),
             },
             loadingOps: {},
             focusedOp: null,
@@ -1039,10 +1040,10 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: {
-                op1: op1Info,
-                op2: op2Info,
-              },
+              g1: new Map([
+                ['op1', op1Info],
+                ['op2', op2Info],
+              ]),
             },
             focusedOp: null,
           }),
@@ -1056,10 +1057,10 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: {
-                op1: op1Info,
-                op2: op2Info,
-              },
+              g1: new Map([
+                ['op1', op1Info],
+                ['op2', op2Info],
+              ]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1076,10 +1077,10 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: {
-                op1: op1Info,
-                op2: op2Info,
-              },
+              g1: new Map([
+                ['op1', op1Info],
+                ['op2', op2Info],
+              ]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1141,9 +1142,7 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: {
-                op1: op1Info,
-              },
+              g1: new Map([['op1', op1Info]]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1160,9 +1159,7 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: {
-                op2: op2Info,
-              },
+              g1: new Map([['op2', op2Info]]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1184,10 +1181,10 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: {
-                op1: op1Info,
-                op2: op2Info,
-              },
+              g1: new Map([
+                ['op1', op1Info],
+                ['op2', op2Info],
+              ]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1255,9 +1252,7 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: {
-                op2: op2Info,
-              },
+              g1: new Map([['op2', op2Info]]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1274,9 +1269,7 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: {
-                op1: op1Info,
-              },
+              g1: new Map([['op1', op1Info]]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1300,10 +1293,10 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: {
-                op1: op1Info,
-                op2: op2Info,
-              },
+              g1: new Map([
+                ['op1', op1Info],
+                ['op2', op2Info],
+              ]),
             },
             focusedOp: {
               graphId: 'g1',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -422,11 +422,7 @@ export interface Graphs {
   // Information about ops in graphs, indexed by: graph_id / op_name.
   // `graph_id` refers to the immediately-enclosing graph of the ops.
   ops: {
-    [graph_id: string]: {
-      // TODO(#3661): Decide on a way to avoid potential conflict with
-      // JavaScript builtin names.
-      [op_name: string]: GraphOpInfo;
-    };
+    [graph_id: string]: Map<string, GraphOpInfo>;
   };
 
   // What ops are currently being loaded from the data source.

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_types.ts
@@ -428,11 +428,7 @@ export interface Graphs {
   // What ops are currently being loaded from the data source.
   // `graph_id` refers to the immediately-enclosing graph of the ops.
   loadingOps: {
-    [graph_id: string]: {
-      // TODO(#3661): Decide on a way to avoid potential conflict with
-      // JavaScript builtin names.
-      [op_name: string]: DataLoadState;
-    };
+    [graph_id: string]: Map<string, DataLoadState>;
   };
 
   // Op being focused on in the UI (if any).


### PR DESCRIPTION
* Motivation for features / changes
  * Fix #3661: graph ops are indexed by TensorFlow op names, which are theoretically
    possible to collide with JavaScript Object's built-in properties such as `toString`
    and `hasOwnProperty`. This PR uses `Map`s to resolve this danger.
* Technical description of changes
  * In debugger_types.ts, change the following two states in the ngrx state from
     `Object` to `Map`:
    * `graphs.ops`
    * `graphs.loadingOps`
  * All related reducer, selector, and effect code is updated.
  * All related unit tests are updated.
* Detailed steps to verify changes work correctly (as executed by you)
  * Made sure tests pass.
  * Manual verification against a real tfdbg2 logdir.
