### PR TITLE
Refactor distributions plugin name into metadata file

### DIFF
--- a/tensorboard/plugins/distribution/BUILD
+++ b/tensorboard/plugins/distribution/BUILD
@@ -14,6 +14,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         ":compressor",
+        ":metadata",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",
         "//tensorboard/plugins:base_plugin",
@@ -84,4 +85,10 @@ py_test(
         ":compressor",
         "//tensorboard:expect_tensorflow_installed",
     ],
+)
+
+py_library(
+    name = "metadata",
+    srcs = ["metadata.py"],
+    srcs_version = "PY2AND3",
 )

--- a/tensorboard/plugins/distribution/distributions_plugin.py
+++ b/tensorboard/plugins/distribution/distributions_plugin.py
@@ -28,6 +28,7 @@ from tensorboard import plugin_util
 from tensorboard.backend import http_util
 from tensorboard.plugins import base_plugin
 from tensorboard.plugins.distribution import compressor
+from tensorboard.plugins.distribution import metadata
 from tensorboard.plugins.histogram import histograms_plugin
 
 
@@ -40,7 +41,7 @@ class DistributionsPlugin(base_plugin.TBPlugin):
     `tensorboard.plugins.histogram.summary` module).
     """
 
-    plugin_name = "distributions"
+    plugin_name = metadata.PLUGIN_NAME
 
     # Use a round number + 1 since sampling includes both start and end steps,
     # so N+1 samples corresponds to dividing the step sequence into N intervals.

--- a/tensorboard/plugins/distribution/metadata.py
+++ b/tensorboard/plugins/distribution/metadata.py
@@ -1,0 +1,23 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Information on the distributions plugin."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# This name is used as the plugin prefix route and to identify this plugin
+# generally.
+PLUGIN_NAME = "distributions"


### PR DESCRIPTION
* Motivation for features / changes
We need to reliably access the distributions plugin name from Google-internal code.

* Technical description of changes
Like other plugins, move distributions plugin name into its own `metadata.py` file.

* Detailed steps to verify changes work correctly (as executed by you)
Loaded TensorBoard on logdir with histograms and ensured distributions plugin still works.
