### PR TITLE
Rollforward "Use tf-wbr-string in tf-node-info"

### DIFF
--- a/tensorboard/components/tf_runs_selector/BUILD
+++ b/tensorboard/components/tf_runs_selector/BUILD
@@ -8,7 +8,6 @@ tf_web_library(
     name = "tf_runs_selector",
     srcs = [
         "tf-runs-selector.html",
-        "tf-wbr-string.html",
     ],
     path = "/tf-runs-selector",
     deps = [
@@ -16,6 +15,7 @@ tf_web_library(
         "//tensorboard/components/tf_color_scale",
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_wbr_string",
         "@org_polymer_paper_button",
         "@org_polymer_paper_dialog",
         "@org_polymer_paper_styles",

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -22,7 +22,7 @@ limitations under the License.
 <link rel="import" href="../tf-color-scale/tf-color-scale.html" />
 <link rel="import" href="../tf-dashboard-common/scrollbar-style.html" />
 <link rel="import" href="../tf-dashboard-common/tf-multi-checkbox.html" />
-<link rel="import" href="tf-wbr-string.html" />
+<link rel="import" href="../tf-wbr-string/tf-wbr-string.html" />
 
 <!--
 tf-runs-selector creates a set of checkboxes to display which runs are
@@ -37,7 +37,10 @@ Properties out:
   <template>
     <paper-dialog with-backdrop id="data-location-dialog">
       <h2>Data Location</h2>
-      <tf-wbr-string value="[[dataLocation]]" />
+      <tf-wbr-string
+        value="[[dataLocation]]"
+        delimiter-pattern="[[_dataLocationDelimiterPattern]]"
+      />
     </paper-dialog>
     <div id="top-text">
       <h3 id="tooltip-help" class="tooltip-container">Runs</h3>
@@ -55,7 +58,10 @@ Properties out:
     </paper-button>
     <template is="dom-if" if="[[dataLocation]]">
       <div id="data-location">
-        <tf-wbr-string value="[[_clippedDataLocation]]" /><!--
+        <tf-wbr-string
+          value="[[_clippedDataLocation]]"
+          delimiter-pattern="[[_dataLocationDelimiterPattern]]"
+        /><!--
           We use HTML comments to remove spaces before the ellipsis.
         --><template
           is="dom-if"
@@ -146,6 +152,11 @@ Properties out:
         _dataLocationClipLength: {
           type: Number,
           value: 250,
+          readOnly: true,
+        },
+        _dataLocationDelimiterPattern: {
+          type: String,
+          value: '[/=_,-]',
           readOnly: true,
         },
         coloring: {

--- a/tensorboard/components/tf_wbr_string/BUILD
+++ b/tensorboard/components/tf_wbr_string/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//tensorboard:internal"])
+
+load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_library(
+    name = "tf_wbr_string",
+    srcs = [
+        "tf-wbr-string.html",
+    ],
+    path = "/tf-wbr-string",
+    deps = [
+        "//tensorboard/components/tf_imports:polymer",
+    ],
+)

--- a/tensorboard/components/tf_wbr_string/BUILD
+++ b/tensorboard/components/tf_wbr_string/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//tensorboard:internal"])
-
 load("//tensorboard/defs:web.bzl", "tf_web_library")
+
+package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_wbr_string/test/BUILD
+++ b/tensorboard/components/tf_wbr_string/test/BUILD
@@ -1,0 +1,28 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//tensorboard:internal"],
+)
+
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
+licenses(["notice"])  # Apache 2.0
+
+tf_web_test(
+    name = "test",
+    src = "/tf-wbr-string/test/tests.html",
+    web_library = ":test_web_library",
+)
+
+tf_web_library(
+    name = "test_web_library",
+    srcs = [
+        "tests.html",
+        "tfWbrStringTests.ts",
+    ],
+    path = "/tf-wbr-string/test",
+    deps = [
+        "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_imports:web_component_tester",
+        "//tensorboard/components/tf_wbr_string",
+    ],
+)

--- a/tensorboard/components/tf_wbr_string/test/BUILD
+++ b/tensorboard/components/tf_wbr_string/test/BUILD
@@ -1,9 +1,9 @@
+load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//tensorboard:internal"],
 )
-
-load("//tensorboard/defs:web.bzl", "tf_web_library", "tf_web_test")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/tensorboard/components/tf_wbr_string/test/tests.html
+++ b/tensorboard/components/tf_wbr_string/test/tests.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<html>
+  <head>
+    <link rel="import" href="../../tf-imports/polymer.html" />
+    <script src="../../web-component-tester/browser.js"></script>
+    <link rel="import" href="../tf-wbr-string.html" />
+  </head>
+  <body>
+    <test-fixture id="tf-wbr-string">
+      <template>
+        <tf-wbr-string />
+      </template>
+    </test-fixture>
+
+    <script src="tfWbrStringTests.js"></script>
+  </body>
+</html>

--- a/tensorboard/components/tf_wbr_string/test/tfWbrStringTests.ts
+++ b/tensorboard/components/tf_wbr_string/test/tfWbrStringTests.ts
@@ -1,0 +1,135 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+namespace tf_wbr_string {
+  const {expect} = chai;
+  declare function fixture(id: string): void;
+  declare function flush(callback: Function): void;
+
+  window.HTMLImports.whenReady(() => {
+    describe('tf-wbr-string', () => {
+      it('adds wbrs for patterns with a single character', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'I/have/a/delimiter';
+        testElement.delimiterPattern = '/';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'I/<wbr>have/<wbr>a/<wbr>delimiter<wbr>'
+          );
+          expect(testElement.shadowRoot.textContent.trim()).to.equal(
+            'I/have/a/delimiter'
+          );
+          done();
+        });
+      });
+
+      it('adds wbrs for patterns with multiple single characters', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'I_have-multiple_delimiter.s';
+        testElement.delimiterPattern = '[_.\\-]';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'I_<wbr>have-<wbr>multiple_<wbr>delimiter.<wbr>s<wbr>'
+          );
+          done();
+        });
+      });
+
+      it('adds wbrs for more complex patterns', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'thea_heats_tea';
+        testElement.delimiterPattern = 'the|eat';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'the<wbr>a_heat<wbr>s_tea<wbr>'
+          );
+          done();
+        });
+      });
+
+      it('ignores overlapped matches', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'the_theatre_heats_tea';
+        testElement.delimiterPattern = 'the|eat';
+        flush(() => {
+          // The "eat" in "theatre" is ignored.
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'the<wbr>_the<wbr>atre_heat<wbr>s_tea<wbr>'
+          );
+          done();
+        });
+      });
+
+      it('allows empty matches to consume remainder of the string', (done) => {
+        // The current handling of empty matches may not desirable but we warn
+        // against this in the documentation. We could consider improving this
+        // in the future.
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'the_theatre_heats_tea';
+        testElement.delimiterPattern = '(the|eat)?';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'the<wbr>_theatre_heats_tea<wbr>'
+          );
+          done();
+        });
+      });
+
+      it('adds single wbr for empty value', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = '';
+        testElement.delimiterPattern = '/';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string('<wbr>');
+          expect(testElement.shadowRoot.textContent.trim()).to.equal('');
+          done();
+        });
+      });
+
+      it('adds single wbr for undefined value', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = null;
+        testElement.delimiterPattern = '/';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string('<wbr>');
+          expect(testElement.shadowRoot.textContent.trim()).to.equal('');
+          done();
+        });
+      });
+
+      it('adds single wbr for empty pattern', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'Empty delimiter pattern';
+        testElement.delimiterPattern = '';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'Empty delimiter pattern<wbr>'
+          );
+          done();
+        });
+      });
+
+      it('adds single wbr for undefined pattern', (done) => {
+        let testElement: any = fixture('tf-wbr-string');
+        testElement.value = 'undefined pattern';
+        flush(() => {
+          expect(testElement.shadowRoot.innerHTML).to.have.string(
+            'undefined pattern<wbr>'
+          );
+          done();
+        });
+      });
+    });
+  });
+} // namespace tf_wbr_string

--- a/tensorboard/components/tf_wbr_string/tf-wbr-string.html
+++ b/tensorboard/components/tf_wbr_string/tf-wbr-string.html
@@ -18,8 +18,8 @@ limitations under the License.
 <link rel="import" href="../tf-imports/polymer.html" />
 
 <!--
-  tf-wbr-string safely renders a string, with <wbr> elements inserted
-  around select delimiters (see `const delimiterPattern` in this file).
+  tf-wbr-string safely renders a string, with <wbr> word break elements inserted
+  after substrings that match a regular expression pattern.
 -->
 <dom-module id="tf-wbr-string">
   <template>
@@ -37,25 +37,30 @@ limitations under the License.
       properties: {
         /** The value to render with word breaks. */
         value: String,
+        /**
+         * Regular expression pattern for specifying delimiters. <wbr> elements
+         * are inserted after all non-overlapping matches. A match that is
+         * overlapped by another match further to the left is ignored. Empty
+         * matches will consume the remainder of the string so it is advised
+         * to not allow empty matches in your pattern.
+         */
+        delimiterPattern: String,
         _parts: {
           type: Array /* string[] */,
-          computed: '_computeParts(value)',
+          computed: '_computeParts(value, delimiterPattern)',
         },
       },
-      _computeParts(value) {
+      _computeParts(value, delimiterPattern) {
         const result = [];
-        const delimiterPattern = /[/=_,-]/;
-        if (value == null) {
-          value = '';
-        }
         while (true) {
-          const idx = value.search(delimiterPattern);
-          if (idx === -1) {
+          const delimiterRegExp = new RegExp(delimiterPattern, 'g');
+          delimiterRegExp.test(value);
+          if (delimiterRegExp.lastIndex === 0) {
             result.push(value);
             break;
           } else {
-            result.push(value.slice(0, idx + 1));
-            value = value.slice(idx + 1);
+            result.push(value.slice(0, delimiterRegExp.lastIndex));
+            value = value.slice(delimiterRegExp.lastIndex);
           }
         }
         return result;

--- a/tensorboard/plugins/graph/tf_graph_info/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_info/BUILD
@@ -16,6 +16,7 @@ tf_web_library(
     deps = [
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:polymer",
+        "//tensorboard/components/tf_wbr_string",
         "//tensorboard/plugins/graph/tf_graph_common",
         "//tensorboard/plugins/graph/tf_graph_debugger_data_card",
         "//tensorboard/plugins/graph/tf_graph_op_compat_card",

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.html
@@ -24,6 +24,7 @@ limitations under the License.
 <link rel="import" href="../tf-imports/polymer.html" />
 <link rel="import" href="../tf-graph-common/tf-graph-common.html" />
 <link rel="import" href="../tf-graph-common/tf-node-icon.html" />
+<link rel="import" href="../tf-wbr-string/tf-wbr-string.html" />
 <link rel="import" href="tf-node-list-item.html" />
 
 <dom-module id="tf-node-info">
@@ -162,7 +163,9 @@ limitations under the License.
             class="toggle-button"
           >
           </paper-icon-button>
-          <div class="node-name" id="nodetitle"></div>
+          <div class="node-name">
+            <tf-wbr-string value="[[_node.name]]" delimiter-pattern="/" />
+          </div>
         </div>
         <div secondary>
           <tf-node-icon
@@ -578,11 +581,6 @@ limitations under the License.
             return '[' + shape.join(', ') + ']';
           });
         },
-        _getPrintableHTMLNodeName: function(graphNodeName) {
-          // Insert an optional line break before each slash so that
-          // long node names wrap cleanly at path boundaries.
-          return (graphNodeName || '').replace(/\//g, '<wbr>/');
-        },
         _getRenderInfo: function(graphNodeName, renderHierarchy) {
           return this.renderHierarchy.getOrCreateRenderNodeByName(
             graphNodeName
@@ -744,12 +742,6 @@ limitations under the License.
             '_groupButtonText',
             tf.graph.scene.node.getGroupSettingLabel(this._node)
           );
-
-          if (this._node) {
-            Polymer.dom(
-              this.$.nodetitle
-            ).innerHTML = this._getPrintableHTMLNodeName(this._node.name);
-          }
         },
         _resizeList: function(selector) {
           var list = document.querySelector(selector);

--- a/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.html
+++ b/tensorboard/plugins/graph/tf_graph_op_compat_card/tf-graph-op-compat-card.html
@@ -227,11 +227,6 @@ limitations under the License.
         _getNode: function(nodeName, graphHierarchy) {
           return graphHierarchy.node(nodeName);
         },
-        _getPrintableHTMLNodeName: function(nodeName) {
-          // Insert an optional line break before each slash so that
-          // long node names wrap cleanly at path boundaries.
-          return (nodeName || '').replace(/\//g, '<wbr>/');
-        },
         _getRenderInfo: function(nodeName, renderHierarchy) {
           return this.renderHierarchy.getOrCreateRenderNodeByName(nodeName);
         },


### PR DESCRIPTION
This is a rollforward of #3633 with fixes after a rollback in #3699.

Original PR description:

* Motivation for features / changes

tf-node-info assigns some user-generated value to an element using innerHTML.  It does this because it augments the user-generated value with some \<wbr\> tags.  Need to find a way to do this that is less prone to attack.

* Technical description of changes

There is a nice tf-wbr-string component that already does what we want. Refactor to a common location and allow callers to specify the delimiter for \<wbr\> insertion.

* Detailed steps to verify changes work correctly (as executed by you)

Run tensorboard and manually inspect DOM in the run selector and in the graph node info title to ensure \<wbr\>s are being properly inserted in text.

For the graph node, more specifically, have to drill down several layers in the debug model to generate a node title with sufficient length.
