### PR TITLE
hist: invoke redraw when colorScale changes

### DIFF
--- a/tensorboard/plugins/histogram/vz_histogram_timeseries/vz-histogram-timeseries.html
+++ b/tensorboard/plugins/histogram/vz_histogram_timeseries/vz-histogram-timeseries.html
@@ -289,7 +289,10 @@ visualization.
         _name: {type: String, value: null},
         _data: {type: Array, value: null},
       },
-      observers: ['redraw(timeProperty, _attached)', '_modeRedraw(mode)'],
+      observers: [
+        'redraw(timeProperty, colorScale, _attached)',
+        '_modeRedraw(mode)',
+      ],
       ready: function() {
         // Polymer's way of scoping styles on nodes that d3 created
         this.scopeSubtree(this.$.svg, true);


### PR DESCRIPTION
Bug: `colorScale` change did not take effect in histogram because it did not redraw
chart.

Fix: appending redraw observer to listen to `colorScale` changes.