### PR TITLE
Revert "ng: prevent double dashboard reload on mount "

### DIFF
--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -88,9 +88,6 @@ export class PluginsComponent implements OnChanges {
   @Input()
   lastUpdated?: number;
 
-  @Input()
-  reloadId!: number;
-
   readonly LoadingMechanismType = LoadingMechanismType;
 
   private readonly pluginInstances = new Map<string, HTMLElement>();
@@ -99,8 +96,7 @@ export class PluginsComponent implements OnChanges {
     if (change['activePlugin'] && this.activePlugin) {
       this.renderPlugin(this.activePlugin!);
     }
-
-    if (change['reloadId'] && !change['reloadId'].firstChange) {
+    if (change['lastUpdated']) {
       this.reload();
     }
   }
@@ -145,7 +141,6 @@ export class PluginsComponent implements OnChanges {
         pluginElement = document.createElement(
           customElementPlugin.element_name
         );
-        (pluginElement as any).reloadOnReady = false;
         this.pluginsContainer.nativeElement.appendChild(pluginElement);
         break;
       }

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -51,7 +51,6 @@ const lastLoadedTimeInMs = createSelector(
       [activePlugin]="activePlugin$ | async"
       [noEnabledPlugin]="noEnabledPlugin$ | async"
       [lastUpdated]="lastLoadedTimeInMs$ | async"
-      [reloadId]="reloadId$ | async"
     ></plugins-component>
   `,
   styles: ['plugins-component { height: 100%; }'],
@@ -72,9 +71,6 @@ export class PluginsContainer {
     })
   );
   readonly lastLoadedTimeInMs$ = this.store.pipe(select(lastLoadedTimeInMs));
-
-  // An id that changes when data has to be refreshed.
-  readonly reloadId$ = this.store.select(lastLoadedTimeInMs);
 
   constructor(private readonly store: Store<State>) {}
 }


### PR DESCRIPTION
Reverts tensorflow/tensorboard#3589

This change causes regression that makes plugin, when newly mounted, do not
fetch any data. 