### PR TITLE
ng: make error page last reload time hideable

### DIFF
--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -50,7 +50,9 @@ limitations under the License.
 
     <p>
       <!-- Class name used to hide this element in screenshot tests. -->
-      <span class="last-reload-time">Last reload: {{lastUpdated | date: 'medium'}}</span>
+      <span class="last-reload-time"
+        >Last reload: {{lastUpdated | date: 'medium'}}</span
+      >
     </p>
   </div>
 </div>

--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -49,7 +49,8 @@ limitations under the License.
     </p>
 
     <p>
-      <i>Last reload: {{lastUpdated | date: 'medium'}}</i>
+      <!-- Class name used to hide this element in screenshot tests. -->
+      <span class="last-reload-time">Last reload: {{lastUpdated | date: 'medium'}}</span>
     </p>
   </div>
 </div>

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -62,6 +62,9 @@ import {PluginRegistryModule} from './plugin_registry_module';
         margin: 80px auto 0;
         max-width: 540px;
       }
+      .last-reload-time {
+        font-style: italic;
+      }
     `,
     'iframe { border: 0; height: 100%; width: 100%; }',
   ],


### PR DESCRIPTION
This assigns a CSS class so we can hide it in screenshot tests, since it's not deterministic.

Confirmed to work in internal testing.