### PR TITLE
uploader: add options --dry_run and --one_shot

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -68,6 +68,7 @@ py_library(
     visibility = ["//tensorboard:internal"],
     deps = [
         ":auth",
+        ":dry_run_stubs",
         ":exporter",
         ":flags_parser",
         ":formatters",
@@ -121,9 +122,12 @@ py_test(
     srcs = ["uploader_test.py"],
     srcs_version = "PY3",
     deps = [
+        ":dry_run_stubs",
+        ":server_info",
         ":test_util",
         ":upload_tracker",
         ":uploader",
+        ":uploader_subcommand",
         ":util",
         "//tensorboard:data_compat",
         "//tensorboard:dataclass_compat",
@@ -152,6 +156,27 @@ py_test(
     deps = [
         ":upload_tracker",
         "//tensorboard:test",
+        "@org_pythonhosted_mock",
+    ],
+)
+
+py_library(
+    name = "dry_run_stubs",
+    srcs = ["dry_run_stubs.py"],
+    deps = [
+        "//tensorboard/uploader/proto:protos_all_py_pb2",
+        "//tensorboard/uploader/proto:protos_all_py_pb2_grpc",
+    ],
+)
+
+py_test(
+    name = "dry_run_stubs_test",
+    srcs = ["dry_run_stubs_test.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":dry_run_stubs",
+        "//tensorboard:test",
+        "//tensorboard/uploader/proto:protos_all_py_pb2",
         "@org_pythonhosted_mock",
     ],
 )

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -177,7 +177,6 @@ py_test(
         ":dry_run_stubs",
         "//tensorboard:test",
         "//tensorboard/uploader/proto:protos_all_py_pb2",
-        "@org_pythonhosted_mock",
     ],
 )
 

--- a/tensorboard/uploader/dry_run_stubs.py
+++ b/tensorboard/uploader/dry_run_stubs.py
@@ -1,0 +1,57 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Dry-run stubs for various rpc services."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorboard.uploader.proto import write_service_pb2
+from tensorboard.uploader.proto import write_service_pb2_grpc
+
+
+class DryRunTensorBoardWriterStub(object):
+    """A dry-run TensorBoardWriter gRPC Server.
+
+    Only the methods used by the `tensorboard dev upload` are
+    mocked out in this class.
+
+    When additional methods start to be used by the command,
+    their mocks should be added to this class.
+    """
+
+    def CreateExperiment(self, request, **kwargs):
+        """Create a new experiment and remember it has been created."""
+        del request, kwargs  # Unused.
+        return write_service_pb2.CreateExperimentResponse()
+
+    def WriteScalar(self, request, **kwargs):
+        del request, kwargs  # Unused.
+        return write_service_pb2.WriteScalarResponse()
+
+    def WriteTensor(self, request, **kwargs):
+        del request, kwargs  # Unused.
+        return write_service_pb2.WriteTensorResponse()
+
+    def GetOrCreateBlobSequence(self, request, **kwargs):
+        del request, kwargs  # Unused.
+        return write_service_pb2.GetOrCreateBlobSequenceResponse(
+            blob_sequence_id="dummy_blob_sequence_id"
+        )
+
+    def WriteBlob(self, request, **kwargs):
+        del kwargs  # Unused.
+        for item in request:
+            yield write_service_pb2.WriteBlobResponse()

--- a/tensorboard/uploader/dry_run_stubs_test.py
+++ b/tensorboard/uploader/dry_run_stubs_test.py
@@ -18,8 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from unittest import mock
-
 from tensorboard import test as tb_test
 from tensorboard.uploader import dry_run_stubs
 from tensorboard.uploader.proto import write_service_pb2

--- a/tensorboard/uploader/dry_run_stubs_test.py
+++ b/tensorboard/uploader/dry_run_stubs_test.py
@@ -1,0 +1,57 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for dry-run rpc servicers."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from unittest import mock
+
+from tensorboard import test as tb_test
+from tensorboard.uploader import dry_run_stubs
+from tensorboard.uploader.proto import write_service_pb2
+
+
+class DryRunTensorBoardWriterServicerTest(tb_test.TestCase):
+    def setUp(self):
+        super(DryRunTensorBoardWriterServicerTest, self).setUp()
+        self._stub = dry_run_stubs.DryRunTensorBoardWriterStub()
+
+    def testCreateExperiment(self):
+        self._stub.CreateExperiment(write_service_pb2.CreateExperimentRequest())
+
+    def testWriteScalar(self):
+        self._stub.WriteScalar(write_service_pb2.WriteScalarRequest())
+
+    def testWriteTensor(self):
+        self._stub.WriteTensor(write_service_pb2.WriteTensorRequest())
+
+    def testGetOrCreateBlobSequence(self):
+        self._stub.GetOrCreateBlobSequence(
+            write_service_pb2.GetOrCreateBlobSequenceRequest()
+        )
+
+    def testWriteBlob(self):
+        def dummy_iterator():
+            yield write_service_pb2.WriteBlobRequest()
+            yield write_service_pb2.WriteBlobRequest()
+
+        for response in self._stub.WriteBlob(dummy_iterator()):
+            self.assertTrue(response)
+
+
+if __name__ == "__main__":
+    tb_test.main()

--- a/tensorboard/uploader/flags_parser.py
+++ b/tensorboard/uploader/flags_parser.py
@@ -110,7 +110,7 @@ def define_flags(parser):
         "--dry_run",
         action="store_true",
         help="Perform a dry run of uploading. In a dry run, the data is read "
-        "the logdir as pointed to by the --logdir flag and statistics are "
+        "from the logdir as pointed to by the --logdir flag and statistics are "
         "displayed (if --verbose is not 0), but no data is actually uploaded "
         "to the server.",
     )

--- a/tensorboard/uploader/flags_parser.py
+++ b/tensorboard/uploader/flags_parser.py
@@ -107,6 +107,20 @@ def define_flags(parser):
         "statistics as data is uploaded.",
     )
     upload.add_argument(
+        "--dry_run",
+        action="store_true",
+        help="Perform a dry run of uploading. In a dry run, the data is read "
+        "the logdir as pointed to by the --logdir flag and statistics are "
+        "displayed (if --verbose is not 0), but no data is actually uploaded "
+        "to the server.",
+    )
+    upload.add_argument(
+        "--one_shot",
+        action="store_true",
+        help="Upload only the existing data in the logdir and then exit "
+        "immediately, instead of keep listening for new data in the logdir.",
+    )
+    upload.add_argument(
         "--plugins",
         type=lambda option: option.split(","),
         default=[],

--- a/tensorboard/uploader/flags_parser.py
+++ b/tensorboard/uploader/flags_parser.py
@@ -118,7 +118,8 @@ def define_flags(parser):
         "--one_shot",
         action="store_true",
         help="Upload only the existing data in the logdir and then exit "
-        "immediately, instead of keep listening for new data in the logdir.",
+        "immediately, instead of continuing to listen for new data in the "
+        "logdir.",
     )
     upload.add_argument(
         "--plugins",

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -304,18 +304,17 @@ class UploadTracker(object):
         """Determine if any data has been uploaded under the tracker's watch."""
         return self._stats.has_data()
 
-    def _update_cumulative_status(self, is_end=False):
+    def _update_cumulative_status(self):
         """Write an update summarizing the data uploaded since the start."""
         if not self._verbosity:
             return
         if not self._stats.has_new_data_since_last_summarize():
             return
         uploaded_str, skipped_str = self._stats.summarize()
-        uploaded_message = "%s[%s]%s%s Total uploaded: %s\n" % (
+        uploaded_message = "%s[%s]%s Total uploaded: %s\n" % (
             _STYLE_BOLD,
             readable_time_string(),
             _STYLE_RESET,
-            "Uploader ended." if is_end else "",
             uploaded_str,
         )
         sys.stdout.write(uploaded_message)

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -253,7 +253,6 @@ class UploadStats(object):
 
 _STYLE_RESET = "\033[0m"
 _STYLE_BOLD = "\033[1m"
-_STYLE_RED = "\033[31m"
 _STYLE_GREEN = "\033[32m"
 _STYLE_YELLOW = "\033[33m"
 _STYLE_DARKGRAY = "\033[90m"

--- a/tensorboard/uploader/upload_tracker_test.py
+++ b/tensorboard/uploader/upload_tracker_test.py
@@ -185,7 +185,7 @@ class UploadStatsTest(tb_test.TestCase):
         stats.add_blob(blob_bytes=2000, is_skipped=True)
         self.assertEqual(stats.has_new_data_since_last_summarize(), True)
 
-    def testHasDataInitiallyReturnsFlase(self):
+    def testHasDataInitiallyReturnsFalse(self):
         stats = upload_tracker.UploadStats()
         self.assertEqual(stats.has_data(), False)
 
@@ -204,7 +204,7 @@ class UploadStatsTest(tb_test.TestCase):
         )
         self.assertEqual(stats.has_data(), True)
 
-    def testHasDataReturnsTrueWithskippedTensors(self):
+    def testHasDataReturnsTrueWithSkippedTensors(self):
         stats = upload_tracker.UploadStats()
         stats.add_tensors(
             num_tensors=10,

--- a/tensorboard/uploader/upload_tracker_test.py
+++ b/tensorboard/uploader/upload_tracker_test.py
@@ -85,16 +85,6 @@ class UploadStatsTest(tb_test.TestCase):
                 tensor_bytes_skipped=0,
             )
 
-    def testAddTensorsNumTensorsSkippedGreaterThanNumTenosrsErrors(self):
-        stats = upload_tracker.UploadStats()
-        with self.assertRaises(AssertionError):
-            stats.add_tensors(
-                num_tensors=10,
-                num_tensors_skipped=12,
-                tensor_bytes=1000,
-                tensor_bytes_skipped=0,
-            )
-
     def testAddBlob(self):
         stats = upload_tracker.UploadStats()
         stats.add_blob(blob_bytes=1000, is_skipped=False)

--- a/tensorboard/uploader/upload_tracker_test.py
+++ b/tensorboard/uploader/upload_tracker_test.py
@@ -185,6 +185,45 @@ class UploadStatsTest(tb_test.TestCase):
         stats.add_blob(blob_bytes=2000, is_skipped=True)
         self.assertEqual(stats.has_new_data_since_last_summarize(), True)
 
+    def testHasDataInitiallyReturnsFlase(self):
+        stats = upload_tracker.UploadStats()
+        self.assertEqual(stats.has_data(), False)
+
+    def testHasDataReturnsTrueWithScalars(self):
+        stats = upload_tracker.UploadStats()
+        stats.add_scalars(1)
+        self.assertEqual(stats.has_data(), True)
+
+    def testHasDataReturnsTrueWithUnskippedTensors(self):
+        stats = upload_tracker.UploadStats()
+        stats.add_tensors(
+            num_tensors=10,
+            num_tensors_skipped=0,
+            tensor_bytes=1000,
+            tensor_bytes_skipped=0,
+        )
+        self.assertEqual(stats.has_data(), True)
+
+    def testHasDataReturnsTrueWithskippedTensors(self):
+        stats = upload_tracker.UploadStats()
+        stats.add_tensors(
+            num_tensors=10,
+            num_tensors_skipped=10,
+            tensor_bytes=1000,
+            tensor_bytes_skipped=1000,
+        )
+        self.assertEqual(stats.has_data(), True)
+
+    def testHasDataReturnsTrueWithUnskippedBlob(self):
+        stats = upload_tracker.UploadStats()
+        stats.add_blob(blob_bytes=1000, is_skipped=False)
+        self.assertEqual(stats.has_data(), True)
+
+    def testHasDataReturnsTrueWithSkippedBlob(self):
+        stats = upload_tracker.UploadStats()
+        stats.add_blob(blob_bytes=1000, is_skipped=True)
+        self.assertEqual(stats.has_data(), True)
+
 
 class UploadTrackerTest(tb_test.TestCase):
     """Test for the UploadTracker class."""
@@ -213,17 +252,18 @@ class UploadTrackerTest(tb_test.TestCase):
     def testSendTracker(self):
         tracker = upload_tracker.UploadTracker(verbosity=1)
         with tracker.send_tracker():
-            self.assertEqual(self.mock_write.call_count, 1)
-            self.assertEqual(self.mock_flush.call_count, 1)
+            self.assertEqual(self.mock_write.call_count, 2)
+            self.assertEqual(self.mock_flush.call_count, 2)
             self.assertIn(
                 "Data upload starting...", self.mock_write.call_args[0][0],
             )
-        self.assertEqual(self.mock_write.call_count, 2)
-        self.assertEqual(self.mock_flush.call_count, 2)
+        self.assertEqual(self.mock_write.call_count, 3)
+        self.assertEqual(self.mock_flush.call_count, 3)
         self.assertIn(
             "Listening for new data in logdir...",
             self.mock_write.call_args[0][0],
         )
+        self.assertEqual(tracker.has_data(), False)
 
     def testSendTrackerWithVerbosity0(self):
         tracker = upload_tracker.UploadTracker(verbosity=0)
@@ -243,6 +283,7 @@ class UploadTrackerTest(tb_test.TestCase):
             )
         self.assertEqual(self.mock_write.call_count, 1)
         self.assertEqual(self.mock_flush.call_count, 1)
+        self.assertEqual(tracker.has_data(), True)
 
     def testScalarsTrackerWithVerbosity0(self):
         tracker = upload_tracker.UploadTracker(verbosity=0)
@@ -266,6 +307,7 @@ class UploadTrackerTest(tb_test.TestCase):
                 "Uploading 150 tensors (2.0 kB) (Skipping 50 tensors, 3.9 kB)",
                 self.mock_write.call_args[0][0],
             )
+        self.assertEqual(tracker.has_data(), True)
 
     def testTensorsTrackerWithVerbosity0(self):
         tracker = upload_tracker.UploadTracker(verbosity=0)
@@ -294,6 +336,7 @@ class UploadTrackerTest(tb_test.TestCase):
                 "Uploading 200 tensors (5.9 kB)",
                 self.mock_write.call_args[0][0],
             )
+        self.assertEqual(tracker.has_data(), True)
 
     def testBlobTrackerUploaded(self):
         tracker = upload_tracker.UploadTracker(verbosity=1)
@@ -316,28 +359,32 @@ class UploadTrackerTest(tb_test.TestCase):
     def testBlobTrackerNotUploaded(self):
         tracker = upload_tracker.UploadTracker(verbosity=1)
         with tracker.send_tracker():
-            self.assertEqual(self.mock_write.call_count, 1)
-            self.assertEqual(self.mock_flush.call_count, 1)
+            self.assertEqual(self.mock_write.call_count, 2)
+            self.assertEqual(self.mock_flush.call_count, 2)
+            self.assertIn(
+                "Uploader started.", self.mock_write.call_args_list[0][0][0],
+            )
             with tracker.blob_tracker(
                 blob_bytes=2048 * 1024 * 1024
             ) as blob_tracker:
-                self.assertEqual(self.mock_write.call_count, 2)
-                self.assertEqual(self.mock_flush.call_count, 2)
+                self.assertEqual(self.mock_write.call_count, 3)
+                self.assertEqual(self.mock_flush.call_count, 3)
                 self.assertIn(
                     "Uploading binary object (2048.0 MB)",
                     self.mock_write.call_args[0][0],
                 )
                 blob_tracker.mark_uploaded(is_uploaded=False)
-        self.assertEqual(self.mock_write.call_count, 5)
-        self.assertEqual(self.mock_flush.call_count, 4)
+        self.assertEqual(self.mock_write.call_count, 6)
+        self.assertEqual(self.mock_flush.call_count, 5)
         self.assertIn(
             "Total uploaded: 0 scalars, 0 tensors, 0 binary objects\n",
-            self.mock_write.call_args_list[2][0][0],
+            self.mock_write.call_args_list[3][0][0],
         )
         self.assertIn(
             "Total skipped: 1 binary objects (2048.0 MB)\n",
-            self.mock_write.call_args_list[3][0][0],
+            self.mock_write.call_args_list[4][0][0],
         )
+        self.assertEqual(tracker.has_data(), True)
 
     def testInvalidVerbosityRaisesError(self):
         with self.assertRaises(ValueError):

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -78,6 +78,7 @@ class TensorBoardUploader(object):
         name=None,
         description=None,
         verbosity=None,
+        one_shot=None,
     ):
         """Constructs a TensorBoardUploader.
 
@@ -103,6 +104,10 @@ class TensorBoardUploader(object):
           verbosity: Level of verbosity, an integer. Supported value:
               0 - No upload statistics is printed.
               1 - Print upload statistics while uploading data (default).
+         one_shot: Once uploading starts, upload only the existing data in and
+          then return immediately, instead of the default behavior in which
+          the uploader keeps listening for new data in the logdir and upload
+          them when it appears.
         """
         self._api = writer_client
         self._logdir = logdir
@@ -112,6 +117,7 @@ class TensorBoardUploader(object):
         self._name = name
         self._description = description
         self._verbosity = 1 if verbosity is None else verbosity
+        self._one_shot = False if one_shot is None else one_shot
         self._request_sender = None
         if logdir_poll_rate_limiter is None:
             self._logdir_poll_rate_limiter = util.RateLimiter(
@@ -191,6 +197,8 @@ class TensorBoardUploader(object):
         while True:
             self._logdir_poll_rate_limiter.tick()
             self._upload_once()
+            if self._one_shot:
+                break
 
     def _upload_once(self):
         """Runs one upload cycle, sending zero or more RPCs."""

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -105,9 +105,9 @@ class TensorBoardUploader(object):
               0 - No upload statistics is printed.
               1 - Print upload statistics while uploading data (default).
          one_shot: Once uploading starts, upload only the existing data in and
-          then return immediately, instead of the default behavior in which
-          the uploader keeps listening for new data in the logdir and upload
-          them when it appears.
+          the logdir and then return immediately, instead of the default
+          behavior in which the uploader keeps listening for new data in the
+          logdir and upload them when it appears.
         """
         self._api = writer_client
         self._logdir = logdir

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -199,6 +199,11 @@ class TensorBoardUploader(object):
             self._upload_once()
             if self._one_shot:
                 break
+        if self._one_shot and not self._tracker.has_data():
+            logger.warning(
+                "One-shot mode was used on a logdir (%s) "
+                "without any uploadable data" % self._logdir
+            )
 
     def _upload_once(self):
         """Runs one upload cycle, sending zero or more RPCs."""

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -104,10 +104,10 @@ class TensorBoardUploader(object):
           verbosity: Level of verbosity, an integer. Supported value:
               0 - No upload statistics is printed.
               1 - Print upload statistics while uploading data (default).
-         one_shot: Once uploading starts, upload only the existing data in and
-          the logdir and then return immediately, instead of the default
-          behavior in which the uploader keeps listening for new data in the
-          logdir and upload them when it appears.
+         one_shot: Once uploading starts, upload only the existing data in
+            the logdir and then return immediately, instead of the default
+            behavior of continuing to listen for new data in the logdir and
+            upload them when it appears.
         """
         self._api = writer_client
         self._logdir = logdir

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -448,14 +448,11 @@ class UploadIntent(_Intent):
             print("Experiment was deleted; uploading has been cancelled")
             return
         except KeyboardInterrupt:
-            print()
-            print("Upload stopped. View your TensorBoard at %s" % url)
-            return
-        # TODO(@nfelt): make it possible for the upload cycle to end once we
-        #   detect that no more runs are active, so this code can be reached.
-
-        if not self.dry_run:
-            print("Done! View your TensorBoard at %s" % url)
+            pass
+        finally:
+            if not self.dry_run:
+                print()
+                print("Done! View your TensorBoard at %s" % url)
 
 
 class _ExportIntent(_Intent):

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -33,6 +33,7 @@ from tensorboard.uploader.proto import experiment_pb2
 from tensorboard.uploader.proto import export_service_pb2_grpc
 from tensorboard.uploader.proto import write_service_pb2_grpc
 from tensorboard.uploader import auth
+from tensorboard.uploader import dry_run_stubs
 from tensorboard.uploader import exporter as exporter_lib
 from tensorboard.uploader import flags_parser
 from tensorboard.uploader import formatters
@@ -375,7 +376,7 @@ def _die_if_bad_experiment_description(description):
         )
 
 
-class _UploadIntent(_Intent):
+class UploadIntent(_Intent):
     """The user intends to upload an experiment from the given logdir."""
 
     _MESSAGE_TEMPLATE = textwrap.dedent(
@@ -391,20 +392,31 @@ class _UploadIntent(_Intent):
     )
 
     def __init__(
-        self, logdir, name=None, description=None, verbosity=None,
+        self,
+        logdir,
+        name=None,
+        description=None,
+        verbosity=None,
+        dry_run=None,
+        one_shot=None,
     ):
         self.logdir = logdir
         self.name = name
         self.description = description
         self.verbosity = verbosity
+        self.dry_run = False if dry_run is None else dry_run
+        self.one_shot = False if one_shot is None else one_shot
 
     def get_ack_message_body(self):
         return self._MESSAGE_TEMPLATE.format(logdir=self.logdir)
 
     def execute(self, server_info, channel):
-        api_client = write_service_pb2_grpc.TensorBoardWriterServiceStub(
-            channel
-        )
+        if self.dry_run:
+            api_client = dry_run_stubs.DryRunTensorBoardWriterStub()
+        else:
+            api_client = write_service_pb2_grpc.TensorBoardWriterServiceStub(
+                channel
+            )
         _die_if_bad_experiment_name(self.name)
         _die_if_bad_experiment_description(self.description)
         uploader = uploader_lib.TensorBoardUploader(
@@ -415,6 +427,7 @@ class _UploadIntent(_Intent):
             name=self.name,
             description=self.description,
             verbosity=self.verbosity,
+            one_shot=self.one_shot,
         )
         experiment_id = uploader.create_experiment()
         url = server_info_lib.experiment_url(server_info, experiment_id)
@@ -422,7 +435,13 @@ class _UploadIntent(_Intent):
             "Upload started and will continue reading any new data as it's added"
         )
         print("to the logdir. To stop uploading, press Ctrl-C.")
-        print("View your TensorBoard live at: %s" % url)
+        if self.dry_run:
+            print(
+                "\n** This is a dry run. "
+                "No data will be sent to tensorboard.dev. **\n"
+            )
+        else:
+            print("View your TensorBoard live at: %s" % url)
         try:
             uploader.start_uploading()
         except uploader_lib.ExperimentNotFoundError:
@@ -434,7 +453,9 @@ class _UploadIntent(_Intent):
             return
         # TODO(@nfelt): make it possible for the upload cycle to end once we
         #   detect that no more runs are active, so this code can be reached.
-        print("Done! View your TensorBoard at %s" % url)
+
+        if not self.dry_run:
+            print("Done! View your TensorBoard at %s" % url)
 
 
 class _ExportIntent(_Intent):
@@ -503,11 +524,13 @@ def _get_intent(flags):
         raise base_plugin.FlagsError("Must specify subcommand (try --help).")
     if cmd == flags_parser.SUBCOMMAND_KEY_UPLOAD:
         if flags.logdir:
-            return _UploadIntent(
+            return UploadIntent(
                 os.path.expanduser(flags.logdir),
                 name=flags.name,
                 description=flags.description,
                 verbosity=flags.verbose,
+                dry_run=flags.dry_run,
+                one_shot=flags.one_shot,
             )
         else:
             raise base_plugin.FlagsError(

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -2000,21 +2000,20 @@ class UploadIntentTest(tf.test.TestCase):
             max_blob_size=128000,
         )
         with mock.patch.object(
+            server_info_lib,
+            "allowed_plugins",
+            return_value=_SCALARS_HISTOGRAMS_AND_GRAPHS,
+        ), mock.patch.object(
+            server_info_lib, "upload_limits", return_value=upload_limits
+        ), mock.patch.object(
             dry_run_stubs,
             "DryRunTensorBoardWriterStub",
             side_effect=dry_run_stubs.DryRunTensorBoardWriterStub,
         ) as mock_dry_run_stub:
-            with mock.patch.object(
-                server_info_lib,
-                "allowed_plugins",
-                return_value=_SCALARS_HISTOGRAMS_AND_GRAPHS,
-            ), mock.patch.object(
-                server_info_lib, "upload_limits", return_value=upload_limits
-            ):
-                intent = uploader_subcommand.UploadIntent(
-                    self.get_temp_dir(), dry_run=True, one_shot=True
-                )
-                intent.execute(mock_server_info, mock_channel)
+            intent = uploader_subcommand.UploadIntent(
+                self.get_temp_dir(), dry_run=True, one_shot=True
+            )
+            intent.execute(mock_server_info, mock_channel)
         self.assertEqual(mock_dry_run_stub.call_count, 1)
 
 

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -43,10 +43,13 @@ from tensorboard.uploader.proto import scalar_pb2
 from tensorboard.uploader.proto import server_info_pb2
 from tensorboard.uploader.proto import write_service_pb2
 from tensorboard.uploader.proto import write_service_pb2_grpc
+from tensorboard.uploader import dry_run_stubs
 from tensorboard.uploader import test_util
 from tensorboard.uploader import upload_tracker
 from tensorboard.uploader import uploader as uploader_lib
+from tensorboard.uploader import uploader_subcommand
 from tensorboard.uploader import logdir_loader
+from tensorboard.uploader import server_info as server_info_lib
 from tensorboard.uploader import util
 from tensorboard.compat.proto import event_pb2
 from tensorboard.compat.proto import graph_pb2
@@ -117,6 +120,18 @@ _SCALARS_HISTOGRAMS_AND_GRAPHS = frozenset(
 _USE_DEFAULT = object()
 
 
+def _create_upload_limits(
+    max_scalar_request_size, max_blob_request_size, max_blob_size,
+):
+    upload_limits = server_info_pb2.UploadLimits()
+    upload_limits.max_scalar_request_size = max_scalar_request_size
+    upload_limits.max_tensor_request_size = 128000
+    upload_limits.max_blob_request_size = max_blob_request_size
+    upload_limits.max_blob_size = max_blob_size
+    upload_limits.max_tensor_point_size = 11111
+    return upload_limits
+
+
 def _create_uploader(
     writer_client=_USE_DEFAULT,
     logdir=None,
@@ -130,6 +145,7 @@ def _create_uploader(
     name=None,
     description=None,
     verbosity=0,  # Use 0 to minimize littering the test output.
+    one_shot=None,
 ):
     if writer_client is _USE_DEFAULT:
         writer_client = _create_mock_client()
@@ -148,12 +164,9 @@ def _create_uploader(
     if blob_rpc_rate_limiter is _USE_DEFAULT:
         blob_rpc_rate_limiter = util.RateLimiter(0)
 
-    upload_limits = server_info_pb2.UploadLimits()
-    upload_limits.max_scalar_request_size = max_scalar_request_size
-    upload_limits.max_tensor_request_size = 128000
-    upload_limits.max_blob_request_size = max_blob_request_size
-    upload_limits.max_blob_size = max_blob_size
-    upload_limits.max_tensor_point_size = 11111
+    upload_limits = _create_upload_limits(
+        max_scalar_request_size, max_blob_request_size, max_blob_size
+    )
 
     return uploader_lib.TensorBoardUploader(
         writer_client,
@@ -167,6 +180,7 @@ def _create_uploader(
         name=name,
         description=description,
         verbosity=verbosity,
+        one_shot=one_shot,
     )
 
 
@@ -367,6 +381,60 @@ class TensorboardUploaderTest(tf.test.TestCase):
         # Check upload tracker calls.
         self.assertEqual(mock_tracker.send_tracker.call_count, 2)
         self.assertEqual(mock_tracker.scalars_tracker.call_count, 10)
+        self.assertLen(mock_tracker.scalars_tracker.call_args[0], 1)
+        self.assertEqual(mock_tracker.tensors_tracker.call_count, 0)
+        self.assertEqual(mock_tracker.blob_tracker.call_count, 0)
+
+    def test_start_uploading_scalars_one_shot(self):
+        """Check that one-shot uploading stops without AbortUploadError."""
+        mock_client = _create_mock_client()
+        mock_rate_limiter = mock.create_autospec(util.RateLimiter)
+        mock_tensor_rate_limiter = mock.create_autospec(util.RateLimiter)
+        mock_blob_rate_limiter = mock.create_autospec(util.RateLimiter)
+        mock_tracker = mock.MagicMock()
+        with mock.patch.object(
+            upload_tracker, "UploadTracker", return_value=mock_tracker
+        ):
+            uploader = _create_uploader(
+                mock_client,
+                "/logs/foo",
+                # Send each Event below in a separate WriteScalarRequest
+                max_scalar_request_size=100,
+                rpc_rate_limiter=mock_rate_limiter,
+                tensor_rpc_rate_limiter=mock_tensor_rate_limiter,
+                blob_rpc_rate_limiter=mock_blob_rate_limiter,
+                verbosity=1,  # In order to test the upload tracker.
+                one_shot=True,
+            )
+            uploader.create_experiment()
+
+        def scalar_event(tag, value):
+            return event_pb2.Event(summary=scalar_v2.scalar_pb(tag, value))
+
+        mock_logdir_loader = mock.create_autospec(logdir_loader.LogdirLoader)
+        mock_logdir_loader.get_run_events.side_effect = [
+            {
+                "run 1": _apply_compat(
+                    [scalar_event("1.1", 5.0), scalar_event("1.2", 5.0)]
+                ),
+                "run 2": _apply_compat(
+                    [scalar_event("2.1", 5.0), scalar_event("2.2", 5.0)]
+                ),
+            },
+            # Note the lack of AbortUploadError here.
+        ]
+
+        with mock.patch.object(uploader, "_logdir_loader", mock_logdir_loader):
+            uploader.start_uploading()
+
+        self.assertEqual(4, mock_client.WriteScalar.call_count)
+        self.assertEqual(4, mock_rate_limiter.tick.call_count)
+        self.assertEqual(0, mock_tensor_rate_limiter.tick.call_count)
+        self.assertEqual(0, mock_blob_rate_limiter.tick.call_count)
+
+        # Check upload tracker calls.
+        self.assertEqual(mock_tracker.send_tracker.call_count, 1)
+        self.assertEqual(mock_tracker.scalars_tracker.call_count, 4)
         self.assertLen(mock_tracker.scalars_tracker.call_args[0], 1)
         self.assertEqual(mock_tracker.tensors_tracker.call_count, 0)
         self.assertEqual(mock_tracker.blob_tracker.call_count, 0)
@@ -1924,6 +1992,31 @@ class VarintCostTest(tf.test.TestCase):
         self.assertEqual(uploader_lib._varint_cost(128), 2)
         self.assertEqual(uploader_lib._varint_cost(128 * 128 - 1), 2)
         self.assertEqual(uploader_lib._varint_cost(128 * 128), 3)
+
+
+class UploadIntentTest(tf.test.TestCase):
+    def testUploadIntentUnderDryRunOneShot(self):
+        """Test the upload intent under dry-run + one-shot modes."""
+        mock_server_info = mock.MagicMock()
+        mock_channel = mock.MagicMock()
+        upload_limits = _create_upload_limits(128000, 128000, 12345)
+        with mock.patch.object(
+            dry_run_stubs,
+            "DryRunTensorBoardWriterStub",
+            side_effect=dry_run_stubs.DryRunTensorBoardWriterStub,
+        ) as mock_dry_run_stub:
+            with mock.patch.object(
+                server_info_lib,
+                "allowed_plugins",
+                return_value=_SCALARS_HISTOGRAMS_AND_GRAPHS,
+            ), mock.patch.object(
+                server_info_lib, "upload_limits", return_value=upload_limits
+            ):
+                intent = uploader_subcommand.UploadIntent(
+                    self.get_temp_dir(), dry_run=True, one_shot=True
+                )
+                intent.execute(mock_server_info, mock_channel)
+        self.assertEqual(mock_dry_run_stub.call_count, 1)
 
 
 def _clear_wall_times(request):


### PR DESCRIPTION
* Motivation for features / changes
  * Improve the usability of the tensorboard.dev uploader
* Technical description of changes
  * Add `--dry_run` flag, which when enabled, causes the uploader to only read data
    from the logdir and display the statistics (if `--verbose` is the default `1`) and upload
    *no* data to the server.
    * This is implemented through a dry-run stub: `DryRunTensorBoardWriterStub`.
  * Add `--one_shot` flag, which when enabled, causes the uploader to exit immediately
     after all existing data in the logdir are uploaded.
    * This mode prints a warning message if the logdir doesn't contain any uploadable
       data.
* Screenshots
  * Dry run, one shot, non-empty logdir: ![image](https://user-images.githubusercontent.com/16824702/83833211-6dd41e80-a6b9-11ea-835e-7dce20abb66b.png)
  * Dry run, one shot, empty logdir: ![image](https://user-images.githubusercontent.com/16824702/83833264-893f2980-a6b9-11ea-994d-b19efd11cdd3.png)
