### PR TITLE
Unify instances of logger warn() to warning()

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -234,7 +234,7 @@ class TensorBoardWSGI(object):
                     type(plugin) is core_plugin.CorePlugin
                 ):  # pylint: disable=unidiomatic-typecheck
                     raise
-                logger.warn(
+                logger.warning(
                     "Plugin %s failed. Exception: %s",
                     plugin.plugin_name,
                     str(e),
@@ -518,7 +518,7 @@ class TensorBoardWSGI(object):
                         environ, start_response
                     )
 
-            logger.warn("path %s not found, sending 404", clean_path)
+            logger.warning("path %s not found, sending 404", clean_path)
             return http_util.Respond(
                 request, "Not found", "text/plain", code=404
             )(environ, start_response)

--- a/tensorboard/backend/event_processing/event_accumulator.py
+++ b/tensorboard/backend/event_processing/event_accumulator.py
@@ -347,7 +347,7 @@ class EventAccumulator(object):
             new_file_version = _ParseFileVersion(event.file_version)
             if self.file_version and self.file_version != new_file_version:
                 ## This should not happen.
-                logger.warn(
+                logger.warning(
                     (
                         "Found new file_version for event.proto. This will "
                         "affect purging logic for TensorFlow restarts. "
@@ -366,7 +366,7 @@ class EventAccumulator(object):
         # inside the meta_graph_def.
         if event.HasField("graph_def"):
             if self._graph is not None:
-                logger.warn(
+                logger.warning(
                     (
                         "Found more than one graph event per run, or there was "
                         "a metagraph containing a graph_def, as well as one or "
@@ -378,7 +378,7 @@ class EventAccumulator(object):
             self._graph_from_metagraph = False
         elif event.HasField("meta_graph_def"):
             if self._meta_graph is not None:
-                logger.warn(
+                logger.warning(
                     (
                         "Found more than one metagraph event per run. "
                         "Overwriting the metagraph with the newest event."
@@ -392,7 +392,7 @@ class EventAccumulator(object):
                 meta_graph.ParseFromString(self._meta_graph)
                 if meta_graph.graph_def:
                     if self._graph is not None:
-                        logger.warn(
+                        logger.warning(
                             (
                                 "Found multiple metagraphs containing graph_defs,"
                                 "but did not find any graph events.  Overwriting the "
@@ -404,7 +404,7 @@ class EventAccumulator(object):
         elif event.HasField("tagged_run_metadata"):
             tag = event.tagged_run_metadata.tag
             if tag in self._tagged_metadata:
-                logger.warn(
+                logger.warning(
                     'Found more than one "run metadata" event with tag '
                     + tag
                     + ". Overwriting it with the newest event."
@@ -428,7 +428,7 @@ class EventAccumulator(object):
                                 plugin_data.plugin_name
                             ][tag] = plugin_data.content
                         else:
-                            logger.warn(
+                            logger.warning(
                                 (
                                     "This summary with tag %r is oddly not associated with a "
                                     "plugin."
@@ -781,7 +781,7 @@ class EventAccumulator(object):
                 event.wall_time,
                 *expired_per_type
             )
-            logger.warn(purge_msg)
+            logger.warning(purge_msg)
 
 
 def _GetPurgeMessage(
@@ -845,7 +845,7 @@ def _ParseFileVersion(file_version):
     except ValueError:
         ## This should never happen according to the definition of file_version
         ## specified in event.proto.
-        logger.warn(
+        logger.warning(
             (
                 "Invalid event.proto file_version. Defaulting to use of "
                 "out-of-order event.step logic for purging expired events."

--- a/tensorboard/backend/event_processing/event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/event_accumulator_test.py
@@ -549,7 +549,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
         discard events based on the step value of SessionLog.START.
         """
         warnings = []
-        self.stubs.Set(logger, "warn", warnings.append)
+        self.stubs.Set(logger, "warning", warnings.append)
 
         gen = _EventGenerator(self)
         acc = ea.EventAccumulator(gen)
@@ -610,7 +610,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
         discard events based on the step value of SessionLog.START.
         """
         warnings = []
-        self.stubs.Set(logger, "warn", warnings.append)
+        self.stubs.Set(logger, "warning", warnings.append)
 
         gen = _EventGenerator(self)
         acc = ea.EventAccumulator(gen)

--- a/tensorboard/backend/event_processing/event_multiplexer.py
+++ b/tensorboard/backend/event_processing/event_multiplexer.py
@@ -129,7 +129,7 @@ class EventMultiplexer(object):
                 if name in self._paths and self._paths[name] != path:
                     # TODO(@decentralion) - Make it impossible to overwrite an old path
                     # with a new path (just give the new path a distinct name)
-                    logger.warn(
+                    logger.warning(
                         "Conflict for name %s: old path %s, new path %s",
                         name,
                         self._paths[name],
@@ -204,7 +204,7 @@ class EventMultiplexer(object):
 
         with self._accumulators_mutex:
             for name in names_to_delete:
-                logger.warn("Deleting accumulator '%s'", name)
+                logger.warning("Deleting accumulator '%s'", name)
                 del self._accumulators[name]
         logger.info("Finished with EventMultiplexer.Reload()")
         return self

--- a/tensorboard/backend/event_processing/plugin_event_accumulator.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator.py
@@ -299,7 +299,7 @@ class EventAccumulator(object):
             new_file_version = _ParseFileVersion(event.file_version)
             if self.file_version and self.file_version != new_file_version:
                 ## This should not happen.
-                logger.warn(
+                logger.warning(
                     (
                         "Found new file_version for event.proto. This will "
                         "affect purging logic for TensorFlow restarts. "
@@ -318,7 +318,7 @@ class EventAccumulator(object):
         # inside the meta_graph_def.
         if event.HasField("graph_def"):
             if self._graph is not None:
-                logger.warn(
+                logger.warning(
                     (
                         "Found more than one graph event per run, or there was "
                         "a metagraph containing a graph_def, as well as one or "
@@ -330,7 +330,7 @@ class EventAccumulator(object):
             self._graph_from_metagraph = False
         elif event.HasField("meta_graph_def"):
             if self._meta_graph is not None:
-                logger.warn(
+                logger.warning(
                     (
                         "Found more than one metagraph event per run. "
                         "Overwriting the metagraph with the newest event."
@@ -344,7 +344,7 @@ class EventAccumulator(object):
                 meta_graph.ParseFromString(self._meta_graph)
                 if meta_graph.graph_def:
                     if self._graph is not None:
-                        logger.warn(
+                        logger.warning(
                             (
                                 "Found multiple metagraphs containing graph_defs,"
                                 "but did not find any graph events.  Overwriting the "
@@ -356,7 +356,7 @@ class EventAccumulator(object):
         elif event.HasField("tagged_run_metadata"):
             tag = event.tagged_run_metadata.tag
             if tag in self._tagged_metadata:
-                logger.warn(
+                logger.warning(
                     'Found more than one "run metadata" event with tag '
                     + tag
                     + ". Overwriting it with the newest event."
@@ -381,7 +381,7 @@ class EventAccumulator(object):
                                     plugin_data.plugin_name
                                 ][tag] = plugin_data.content
                         else:
-                            logger.warn(
+                            logger.warning(
                                 (
                                     "This summary with tag %r is oddly not associated with a "
                                     "plugin."
@@ -611,7 +611,7 @@ class EventAccumulator(object):
                 event.wall_time,
                 num_expired,
             )
-            logger.warn(purge_msg)
+            logger.warning(purge_msg)
 
 
 def _GetPurgeMessage(
@@ -672,7 +672,7 @@ def _ParseFileVersion(file_version):
     except ValueError:
         ## This should never happen according to the definition of file_version
         ## specified in event.proto.
-        logger.warn(
+        logger.warning(
             (
                 "Invalid event.proto file_version. Defaulting to use of "
                 "out-of-order event.step logic for purging expired events."

--- a/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
+++ b/tensorboard/backend/event_processing/plugin_event_accumulator_test.py
@@ -206,7 +206,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
         discard events based on the step value of SessionLog.START.
         """
         warnings = []
-        self.stubs.Set(logger, "warn", warnings.append)
+        self.stubs.Set(logger, "warning", warnings.append)
 
         gen = _EventGenerator(self)
         acc = ea.EventAccumulator(gen)
@@ -267,7 +267,7 @@ class MockingEventAccumulatorTest(EventAccumulatorTest):
         discard events based on the step value of SessionLog.START.
         """
         warnings = []
-        self.stubs.Set(logger, "warn", warnings.append)
+        self.stubs.Set(logger, "warning", warnings.append)
 
         gen = _EventGenerator(self)
         acc = ea.EventAccumulator(gen)

--- a/tensorboard/backend/event_processing/plugin_event_multiplexer.py
+++ b/tensorboard/backend/event_processing/plugin_event_multiplexer.py
@@ -150,7 +150,7 @@ class EventMultiplexer(object):
                 if name in self._paths and self._paths[name] != path:
                     # TODO(@decentralion) - Make it impossible to overwrite an old path
                     # with a new path (just give the new path a distinct name)
-                    logger.warn(
+                    logger.warning(
                         "Conflict for name %s: old path %s, new path %s",
                         name,
                         self._paths[name],
@@ -260,7 +260,7 @@ class EventMultiplexer(object):
 
         with self._accumulators_mutex:
             for name in names_to_delete:
-                logger.warn("Deleting accumulator %r", name)
+                logger.warning("Deleting accumulator %r", name)
                 del self._accumulators[name]
         logger.info("Finished with EventMultiplexer.Reload()")
         return self

--- a/tensorboard/backend/security_validator.py
+++ b/tensorboard/backend/security_validator.py
@@ -48,7 +48,7 @@ _CSP_IGNORE = {
 
 
 def _maybe_raise_value_error(error_msg):
-    logger.warn("In 3.0, this warning will become an error:\n%s" % error_msg)
+    logger.warning("In 3.0, this warning will become an error:\n%s" % error_msg)
     # TODO(3.x): raise a value error.
 
 

--- a/tensorboard/backend/security_validator_test.py
+++ b/tensorboard/backend/security_validator_test.py
@@ -65,7 +65,7 @@ class SecurityValidatorMiddlewareTest(tb_test.TestCase):
         app = security_validator.SecurityValidatorMiddleware(_simple_app)
         server = werkzeug_test.Client(app, BaseResponse)
 
-        with mock.patch.object(logger, "warn") as mock_warn:
+        with mock.patch.object(logger, "warning") as mock_warn:
             server.get("")
 
         if expected_warn_substr is None:

--- a/tensorboard/encode_png_benchmark.py
+++ b/tensorboard/encode_png_benchmark.py
@@ -137,7 +137,7 @@ def main(unused_argv):
         )  # best-of-three timing
         unit_time = total_time / thread_count
         if total_time < 2.0:
-            logger.warn(
+            logger.warning(
                 "This benchmark is running too quickly! This "
                 "may cause misleading timing data. Consider "
                 "increasing the image size until it takes at "

--- a/tensorboard/plugins/audio/metadata.py
+++ b/tensorboard/plugins/audio/metadata.py
@@ -69,7 +69,7 @@ def parse_plugin_metadata(content):
     if result.version == 0:
         return result
     else:
-        logger.warn(
+        logger.warning(
             "Unknown metadata version: %s. The latest version known to "
             "this build of TensorBoard is %s; perhaps a newer build is "
             "available?",

--- a/tensorboard/plugins/beholder/beholder_plugin.py
+++ b/tensorboard/plugins/beholder/beholder_plugin.py
@@ -98,7 +98,7 @@ class BeholderPlugin(base_plugin.TBPlugin):
                 )
             return True
         except tf.errors.PermissionDeniedError as e:
-            logger.warn(
+            logger.warning(
                 "Unable to write Beholder config, controls will be disabled: %s",
                 e,
             )

--- a/tensorboard/plugins/beholder/video_writing.py
+++ b/tensorboard/plugins/beholder/video_writing.py
@@ -68,14 +68,14 @@ class VideoWriter(object):
                 if not self.output:
                     new_output = self.outputs[self.output_index]
                     if self.output_index > original_output_index:
-                        logger.warn(
+                        logger.warning(
                             "Falling back to video output %s", new_output.name()
                         )
                     self.output = new_output(self.directory, self.frame_shape)
                 self.output.emit_frame(np_array)
                 return
             except (IOError, OSError) as e:
-                logger.warn(
+                logger.warning(
                     "Video output type %s not available: %s",
                     self.current_output().name(),
                     str(e),

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -204,7 +204,7 @@ class CorePlugin(base_plugin.TBPlugin):
                 try:
                     return self._multiplexer.FirstEventTimestamp(run_name)
                 except ValueError as e:
-                    logger.warn(
+                    logger.warning(
                         "Unable to get first event timestamp for run %s: %s",
                         run_name,
                         e,

--- a/tensorboard/plugins/debugger/debugger_plugin.py
+++ b/tensorboard/plugins/debugger/debugger_plugin.py
@@ -434,7 +434,7 @@ class DebuggerPlugin(base_plugin.TBPlugin):
         events_loader = event_file_loader.EventFileLoader(file_path)
         for event in events_loader.Load():
             if not event.HasField("summary"):
-                logger.warn(
+                logger.warning(
                     "An event in a debugger events file lacks a summary."
                 )
                 continue
@@ -461,7 +461,7 @@ class DebuggerPlugin(base_plugin.TBPlugin):
                             )
                         )
                     except ValueError as err:
-                        logger.warn(
+                        logger.warning(
                             "Could not parse the JSON string containing data for "
                             "the debugger plugin: %r, %r",
                             content,
@@ -480,7 +480,7 @@ class DebuggerPlugin(base_plugin.TBPlugin):
                     continue
 
                 if not value.HasField("tensor"):
-                    logger.warn(
+                    logger.warning(
                         "An event in a debugger events file lacks a tensor value."
                     )
                     continue
@@ -489,7 +489,7 @@ class DebuggerPlugin(base_plugin.TBPlugin):
                     r"^(.*):(\d+):DebugNumericSummary$", value.node_name
                 )
                 if not match:
-                    logger.warn(
+                    logger.warning(
                         (
                             "A event with a health pill has an invalid watch, (i.e., an "
                             "unexpected debug op): %r"

--- a/tensorboard/plugins/debugger/debugger_server_lib.py
+++ b/tensorboard/plugins/debugger/debugger_server_lib.py
@@ -118,7 +118,7 @@ class DebuggerDataStreamHandler(
           event: The Event proto to be processed.
         """
         if not event.summary.value:
-            logger.warn("The summary of the event lacks a value.")
+            logger.warning("The summary of the event lacks a value.")
             return
 
         # The node name property is actually a watch key, which is a concatenation
@@ -141,7 +141,7 @@ class DebuggerDataStreamHandler(
             len(shape) != 1
             or shape[0] < constants.MIN_DEBUG_NUMERIC_SUMMARY_TENSOR_LENGTH
         ):
-            logger.warn(
+            logger.warning(
                 "Health-pill tensor either lacks a dimension or is "
                 "shaped incorrectly: %s" % shape
             )
@@ -149,7 +149,7 @@ class DebuggerDataStreamHandler(
 
         match = re.match(r"^(.*):(\d+)$", node_name_and_output_slot)
         if not match:
-            logger.warn(
+            logger.warning(
                 (
                     "A event with a health pill has an invalid node name and output "
                     "slot combination, (i.e., an unexpected debug op): %r"

--- a/tensorboard/plugins/debugger/tensor_store.py
+++ b/tensorboard/plugins/debugger/tensor_store.py
@@ -255,7 +255,7 @@ class TensorStore(object):
             if mapping == "image/png":
                 output = tensor_helper.array_to_base64_png(output)
             elif mapping and mapping != "none":
-                logger.warn(
+                logger.warning(
                     "Unsupported mapping mode after recomining time steps: %s",
                     mapping,
                 )

--- a/tensorboard/plugins/graph/graphs_plugin.py
+++ b/tensorboard/plugins/graph/graphs_plugin.py
@@ -138,7 +138,7 @@ class GraphsPlugin(base_plugin.TBPlugin):
                 # as a content of plugin data. It contains single string that denotes a version.
                 # https://github.com/tensorflow/tensorflow/blob/11f4ecb54708865ec757ca64e4805957b05d7570/tensorflow/python/ops/summary_ops_v2.py#L789-L790
                 if content != b"1":
-                    logger.warn(
+                    logger.warning(
                         "Ignoring unrecognizable version of RunMetadata."
                     )
                     continue
@@ -153,7 +153,7 @@ class GraphsPlugin(base_plugin.TBPlugin):
         for run_name, tag_to_content in six.iteritems(mapping):
             for (tag, content) in six.iteritems(tag_to_content):
                 if content != b"1":
-                    logger.warn(
+                    logger.warning(
                         "Ignoring unrecognizable version of RunMetadata."
                     )
                     continue
@@ -169,7 +169,7 @@ class GraphsPlugin(base_plugin.TBPlugin):
         for run_name, tag_to_content in six.iteritems(mapping):
             for (tag, content) in six.iteritems(tag_to_content):
                 if content != b"1":
-                    logger.warn(
+                    logger.warning(
                         "Ignoring unrecognizable version of RunMetadata."
                     )
                     continue

--- a/tensorboard/plugins/histogram/metadata.py
+++ b/tensorboard/plugins/histogram/metadata.py
@@ -67,7 +67,7 @@ def parse_plugin_metadata(content):
         if result.version == 0:
             return result
         else:
-            logger.warn(
+            logger.warning(
                 "Unknown metadata version: %s. The latest version known to "
                 "this build of TensorBoard is %s; perhaps a newer build is "
                 "available?",

--- a/tensorboard/plugins/image/metadata.py
+++ b/tensorboard/plugins/image/metadata.py
@@ -64,7 +64,7 @@ def parse_plugin_metadata(content):
     if result.version == 0:
         return result
     else:
-        logger.warn(
+        logger.warning(
             "Unknown metadata version: %s. The latest version known to "
             "this build of TensorBoard is %s; perhaps a newer build is "
             "available?",

--- a/tensorboard/plugins/pr_curve/metadata.py
+++ b/tensorboard/plugins/pr_curve/metadata.py
@@ -79,7 +79,7 @@ def parse_plugin_metadata(content):
     if result.version == 0:
         return result
     else:
-        logger.warn(
+        logger.warning(
             "Unknown metadata version: %s. The latest version known to "
             "this build of TensorBoard is %s; perhaps a newer build is "
             "available?",

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -484,7 +484,7 @@ class ProjectorPlugin(base_plugin.TBPlugin):
                 and _using_tf()
                 and not tf.io.gfile.glob(config.model_checkpoint_path + "*")
             ):
-                logger.warn(
+                logger.warning(
                     'Checkpoint file "%s" not found',
                     config.model_checkpoint_path,
                 )
@@ -503,7 +503,9 @@ class ProjectorPlugin(base_plugin.TBPlugin):
             try:
                 reader = tf.train.load_checkpoint(config.model_checkpoint_path)
             except Exception:  # pylint: disable=broad-except
-                logger.warn('Failed reading "%s"', config.model_checkpoint_path)
+                logger.warning(
+                    'Failed reading "%s"', config.model_checkpoint_path
+                )
         self.readers[run] = reader
         return reader
 

--- a/tensorboard/plugins/scalar/metadata.py
+++ b/tensorboard/plugins/scalar/metadata.py
@@ -64,7 +64,7 @@ def parse_plugin_metadata(content):
     if result.version == 0:
         return result
     else:
-        logger.warn(
+        logger.warning(
             "Unknown metadata version: %s. The latest version known to "
             "this build of TensorBoard is %s; perhaps a newer build is "
             "available?",

--- a/tensorboard/plugins/text/metadata.py
+++ b/tensorboard/plugins/text/metadata.py
@@ -63,7 +63,7 @@ def parse_plugin_metadata(content):
     if result.version == 0:
         return result
     else:
-        logger.warn(
+        logger.warning(
             "Unknown metadata version: %s. The latest version known to "
             "this build of TensorBoard is %s; perhaps a newer build is "
             "available?",

--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -666,7 +666,7 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
                     socket.AI_PASSIVE,
                 )
             except socket.gaierror as e:
-                logger.warn(
+                logger.warning(
                     "Failed to auto-detect wildcard address, assuming %s: %s",
                     fallback_address,
                     str(e),
@@ -681,7 +681,7 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
                 return addrs_by_family[socket.AF_INET6][0]
             if hasattr(socket, "AF_INET") and addrs_by_family[socket.AF_INET]:
                 return addrs_by_family[socket.AF_INET][0]
-        logger.warn(
+        logger.warning(
             "Failed to auto-detect wildcard address, assuming %s",
             fallback_address,
         )
@@ -714,7 +714,7 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
                     hasattr(errno, "EAFNOSUPPORT")
                     and e.errno != errno.EAFNOSUPPORT
                 ):
-                    logger.warn(
+                    logger.warning(
                         "Failed to dual-bind to IPv4 wildcard: %s", str(e)
                     )
         super(WerkzeugServer, self).server_bind()
@@ -728,7 +728,7 @@ class WerkzeugServer(serving.ThreadedWSGIServer, TensorBoardServer):
         exc_info = sys.exc_info()
         e = exc_info[1]
         if isinstance(e, IOError) and e.errno == errno.EPIPE:
-            logger.warn(
+            logger.warning(
                 "EPIPE caused by %s in HTTP serving" % str(client_address)
             )
         else:

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -442,7 +442,7 @@ def list_experiments(api_client, fieldmask=None, read_time=None):
             )
         else:
             # No data: not technically a problem, but not expected.
-            logger.warn(
+            logger.warning(
                 "StreamExperiments RPC returned response with no experiments: <%r>",
                 response,
             )


### PR DESCRIPTION
* Motivation for features / changes
  * `warn()` is deprecated. `warning()` should be used instead for code hygiene.
* Technical description of changes
  * This PR replaces usage of `logger.warn()` with `logger.warning()` through
    *.py files in the tensorboard/ directory.
  * Also updates mock patching accordingly.