### PR TITLE
[DebuggerV2] Remove flakiness in a Python unit test

### DIFF
--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer.py
@@ -55,9 +55,10 @@ def run_repeatedly_in_background(target, interval_sec):
       interval_sec: Time interval between repeats, in seconds.
 
     Returns:
-      A `threading.Event` object that can be used to interrupt an ongoing
-      waiting interval between successive runs of `target`. To interrupt the
-      interval, call the `set()` method of the object.
+      - A `threading.Event` object that can be used to interrupt an ongoing
+          waiting interval between successive runs of `target`. To interrupt the
+          interval, call the `set()` method of the object.
+      - The `threading.Thread` object on which `target` is run repeatedly.
     """
     event = threading.Event()
 
@@ -70,7 +71,7 @@ def run_repeatedly_in_background(target, interval_sec):
     # Use `daemon=True` to make sure the thread doesn't block program exit.
     thread = threading.Thread(target=_run_repeatedly, daemon=True)
     thread.start()
-    return event
+    return event, thread
 
 
 def _alert_to_json(alert):
@@ -180,7 +181,7 @@ class DebuggerV2EventMultiplexer(object):
                         self._reader, limit=DEFAULT_PER_TYPE_ALERT_LIMIT
                     )
                 ]
-                self._reload_needed_event = run_repeatedly_in_background(
+                self._reload_needed_event, _ = run_repeatedly_in_background(
                     self._reader.update, DEFAULT_RELOAD_INTERVAL_SEC
                 )
 

--- a/tensorboard/plugins/debugger_v2/debug_data_multiplexer_test.py
+++ b/tensorboard/plugins/debugger_v2/debug_data_multiplexer_test.py
@@ -45,7 +45,10 @@ class RunInBackgroundRepeatedlyTest(tf.test.TestCase):
             # `StopIteration` raised by `run_three_times()`.
             lambda target, daemon: OriginalThread(target=target, daemon=False),
         ):
-            interrupt_event = debug_data_multiplexer.run_repeatedly_in_background(
+            (
+                interrupt_event,
+                thread,
+            ) = debug_data_multiplexer.run_repeatedly_in_background(
                 run_three_times,
                 None,  # `interval_sec is None` means indefinite wait()
             )
@@ -54,6 +57,7 @@ class RunInBackgroundRepeatedlyTest(tf.test.TestCase):
             interrupt_event.set()
             time.sleep(0.05)
             interrupt_event.set()
+        thread.join()
         self.assertEqual(state["counter"], 3)
 
 

--- a/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
+++ b/tensorboard/plugins/debugger_v2/debugger_v2_plugin_test.py
@@ -130,6 +130,7 @@ class DebuggerV2PluginTest(tf.test.TestCase):
         def run_repeatedly_in_background_mock(target, interval_sec):
             del interval_sec  # Unused in this mock.
             target()
+            return None, None
 
         self.run_in_background_patch = tf.compat.v1.test.mock.patch.object(
             debug_data_multiplexer,


### PR DESCRIPTION
* Motivation for features / changes
  * Remove flakiness in `testRunInBackgroundRepeatedlyThreeTimes` for the method
    `debug_data_multiplexer.run_repeatedly_in_background()`
* Technical description of changes
  * The flakiness stems from the following fact: after the the `interrupt_event.set()` call
     the test checks the value of `state["counter"]` immediately. It doesn't wait for the
     background thread to stop (due to the deliberately-raised `StopIteration`), hence the
     counter may not have had a chance to increment to 3 before the assertion happens. 
     Hence the failure (2 != 3)
  * This change lets `run_repeatedly_in_background()` return the background thread,
    so that the test can use its `join()` method to ensure that the assertion is made after
     the termination of the thread.
* Detailed steps to verify changes work correctly (as executed by you)
  * 500 runs with bazel all passed.
  * 2000 runs using internal test infra structure on equivalent change all passed.
