### PR TITLE
[DebuggerV2] Remove transitive dependency on store-internal helper

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/BUILD
@@ -8,10 +8,11 @@ ng_module(
     srcs = [
         "debugger_reducers.ts",
         "debugger_selectors.ts",
+        "debugger_store_utils.ts",
         "index.ts",
     ],
     deps = [
-        ":debugger_store_utils",
+        ":debugger_store_helpers",
         ":types",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/data_source",
@@ -20,9 +21,9 @@ ng_module(
 )
 
 ng_module(
-    name = "debugger_store_utils",
+    name = "debugger_store_helpers",
     srcs = [
-        "debugger_store_utils.ts",
+        "debugger_store_helpers.ts",
     ],
     visibility = [
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store:__subpackages__",
@@ -68,7 +69,7 @@ tf_ts_library(
     tsconfig = "//:tsconfig-test",
     deps = [
         ":debug_tensor_value",
-        ":debugger_store_utils",
+        ":debugger_store_helpers",
         ":store",
         ":types",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers.ts
@@ -21,11 +21,11 @@ import {
   GraphExecutionDataResponse,
   SourceFileResponse,
 } from '../data_source/tfdbg2_data_source';
+import {getFocusedStackFramesHelper} from './debugger_store_helpers';
 import {
   computeBottommostLineSpec,
   findFileIndex,
   findBeginEndRangeIndex,
-  getFocusedStackFramesHelper,
   isFrameBottommostInStackTrace,
 } from './debugger_store_utils';
 import {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors.ts
@@ -14,10 +14,8 @@ limitations under the License.
 ==============================================================================*/
 
 import {createSelector, createFeatureSelector} from '@ngrx/store';
-import {
-  findFileIndex,
-  getFocusedStackFramesHelper,
-} from './debugger_store_utils';
+import {getFocusedStackFramesHelper} from './debugger_store_helpers';
+import {findFileIndex} from './debugger_store_utils';
 import {
   AlertsBreakdown,
   AlertsByIndex,

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_helpers.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_helpers.ts
@@ -1,0 +1,66 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * Internal helper functions for the NgRx store of Debugger V2.
+ */
+
+import {CodeLocationType, DebuggerState, StackFrame} from './debugger_types';
+
+/**
+ * Helper function that extracts the stack trace being focused on.
+ *
+ * This examines whether the current focused code location is for an
+ * eager (top-level) execution or a graph-op creation, and then queries
+ * the corresponding substates accordingly.
+ *
+ * @param state
+ */
+export function getFocusedStackFramesHelper(
+  state: DebuggerState
+): StackFrame[] | null {
+  if (state.codeLocationFocusType === null) {
+    return null;
+  }
+  let stackFrameIds: string[] = [];
+  if (state.codeLocationFocusType === CodeLocationType.EXECUTION) {
+    const {focusIndex, executionData} = state.executions;
+    if (focusIndex === null || executionData[focusIndex] === undefined) {
+      return null;
+    }
+    stackFrameIds = executionData[focusIndex].stack_frame_ids;
+  } else {
+    // This is CodeLocationType.GRAPH_OP_CREATION.
+    if (state.graphs.focusedOp === null) {
+      return null;
+    }
+    const {graphId, opName} = state.graphs.focusedOp;
+    if (
+      state.graphs.ops[graphId] === undefined ||
+      !state.graphs.ops[graphId].has(opName)
+    ) {
+      return null;
+    }
+    stackFrameIds = state.graphs.ops[graphId].get(opName)!.stack_frame_ids;
+  }
+  const stackFrames: StackFrame[] = [];
+  for (const stackFrameId of stackFrameIds) {
+    if (state.stackFrames[stackFrameId] != null) {
+      stackFrames.push(state.stackFrames[stackFrameId]);
+    } else {
+      return null;
+    }
+  }
+  return stackFrames;
+}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_store_utils.ts
@@ -16,8 +16,9 @@ limitations under the License.
  * Utility functions for the NgRx store of Debugger V2.
  */
 
+import {getFocusedStackFramesHelper} from './debugger_store_helpers';
+
 import {
-  CodeLocationType,
   DebuggerState,
   SourceFileSpec,
   SourceLineSpec,
@@ -157,53 +158,6 @@ export function beginEndRangesInclude(
   return (
     ranges.findIndex((range) => range.begin >= begin && range.end <= end) !== -1
   );
-}
-
-/**
- * Helper function that extracts the stack trace being focused on.
- *
- * This examines whether the current focused code location is for an
- * eager (top-level) execution or a graph-op creation, and then queries
- * the corresponding substates accordingly.
- *
- * @param state
- */
-export function getFocusedStackFramesHelper(
-  state: DebuggerState
-): StackFrame[] | null {
-  if (state.codeLocationFocusType === null) {
-    return null;
-  }
-  let stackFrameIds: string[] = [];
-  if (state.codeLocationFocusType === CodeLocationType.EXECUTION) {
-    const {focusIndex, executionData} = state.executions;
-    if (focusIndex === null || executionData[focusIndex] === undefined) {
-      return null;
-    }
-    stackFrameIds = executionData[focusIndex].stack_frame_ids;
-  } else {
-    // This is CodeLocationType.GRAPH_OP_CREATION.
-    if (state.graphs.focusedOp === null) {
-      return null;
-    }
-    const {graphId, opName} = state.graphs.focusedOp;
-    if (
-      state.graphs.ops[graphId] === undefined ||
-      !state.graphs.ops[graphId].has(opName)
-    ) {
-      return null;
-    }
-    stackFrameIds = state.graphs.ops[graphId].get(opName)!.stack_frame_ids;
-  }
-  const stackFrames: StackFrame[] = [];
-  for (const stackFrameId of stackFrameIds) {
-    if (state.stackFrames[stackFrameId] != null) {
-      stackFrames.push(state.stackFrames[stackFrameId]);
-    } else {
-      return null;
-    }
-  }
-  return stackFrames;
 }
 
 /**


### PR DESCRIPTION
* Motivation for features / changes
  * Remove transitive dependency on modules meant to be used only by the ngrx 
     store of debugger-v2.
* Technical description of changes
  * #3682 introduced a module meant to be used to be used only the ngrx store:
     debugger_store_utils, as marked by the BUILD visibility. Specifically, a 
     helper function (`getFocusedStackFramesHelper`) was added to the file
     debugger_store_utils.ts.  However, the file (debugger_store_utils.ts) contains
     some pre-existing functions that are not meant to be store-internal; they are 
     already used by non-store parts of debugger-2. 
  * This doesn't cause any build/test error in bazel because it seems to allow
     transitive dependencies on internal BUILD targets. But this causes errors in
     internal test infrastructure, which disallow such transitive dependencies.
  * To address this, we separated the helper function `getFocusedStackFramesHelper`
     into its own file and BUILD target (debugger_store_helpers.ts).
  * Imports and BUILD dependencies are adjusted accordingly
* Test:
  * Manual verification on internal test infrastructure.
