### PR TITLE
Fix custom scalars full width mode

### DIFF
--- a/tensorboard/components/tf_paginated_view/tf-dom-repeat.html
+++ b/tensorboard/components/tf_paginated_view/tf-dom-repeat.html
@@ -165,6 +165,20 @@ limitations under the License.
         ) {
           return;
         }
+
+        const observer = new MutationObserver((mutationsList) => {
+          for (const mutation of mutationsList) {
+            if (mutation.type === 'childList') {
+              for (const node of mutation.addedNodes) {
+                if (node instanceof Element) {
+                  node.setAttribute('slot', 'items');
+                }
+              }
+            }
+          }
+        });
+        observer.observe(this, {childList: true});
+
         Array.from(this.children).forEach((child) => {
           Polymer.dom(this).removeChild(child);
         });

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard.html
@@ -192,36 +192,34 @@ writer.add_summary(layout_summary)
               initial-opened="[[category.metadata.opened]]"
             >
               <template>
-                <div>
-                  <template is="dom-if" if="[[chart.multiline]]">
-                    <tf-custom-scalar-multi-line-chart-card
-                      active="[[active]]"
-                      request-manager="[[_requestManager]]"
-                      runs="[[_selectedRuns]]"
-                      title="[[chart.title]]"
-                      x-type="[[_xType]]"
-                      smoothing-enabled="[[_smoothingEnabled]]"
-                      smoothing-weight="[[_smoothingWeight]]"
-                      tooltip-sorting-method="[[tooltipSortingMethod]]"
-                      ignore-y-outliers="[[_ignoreYOutliers]]"
-                      show-download-links="[[_showDownloadLinks]]"
-                      tag-regexes="[[chart.multiline.tag]]"
-                    ></tf-custom-scalar-multi-line-chart-card>
-                  </template>
-                  <template is="dom-if" if="[[chart.margin]]">
-                    <tf-custom-scalar-margin-chart-card
-                      active="[[active]]"
-                      request-manager="[[_requestManager]]"
-                      runs="[[_selectedRuns]]"
-                      title="[[chart.title]]"
-                      x-type="[[_xType]]"
-                      tooltip-sorting-method="[[tooltipSortingMethod]]"
-                      ignore-y-outliers="[[_ignoreYOutliers]]"
-                      show-download-links="[[_showDownloadLinks]]"
-                      margin-chart-series="[[chart.margin.series]]"
-                    ></tf-custom-scalar-margin-chart-card>
-                  </template>
-                </div>
+                <template is="dom-if" if="[[chart.multiline]]">
+                  <tf-custom-scalar-multi-line-chart-card
+                    active="[[active]]"
+                    request-manager="[[_requestManager]]"
+                    runs="[[_selectedRuns]]"
+                    title="[[chart.title]]"
+                    x-type="[[_xType]]"
+                    smoothing-enabled="[[_smoothingEnabled]]"
+                    smoothing-weight="[[_smoothingWeight]]"
+                    tooltip-sorting-method="[[tooltipSortingMethod]]"
+                    ignore-y-outliers="[[_ignoreYOutliers]]"
+                    show-download-links="[[_showDownloadLinks]]"
+                    tag-regexes="[[chart.multiline.tag]]"
+                  ></tf-custom-scalar-multi-line-chart-card>
+                </template>
+                <template is="dom-if" if="[[chart.margin]]">
+                  <tf-custom-scalar-margin-chart-card
+                    active="[[active]]"
+                    request-manager="[[_requestManager]]"
+                    runs="[[_selectedRuns]]"
+                    title="[[chart.title]]"
+                    x-type="[[_xType]]"
+                    tooltip-sorting-method="[[tooltipSortingMethod]]"
+                    ignore-y-outliers="[[_ignoreYOutliers]]"
+                    show-download-links="[[_showDownloadLinks]]"
+                    margin-chart-series="[[chart.margin.series]]"
+                  ></tf-custom-scalar-margin-chart-card>
+                </template>
               </template>
             </tf-category-paginated-view>
           </template>


### PR DESCRIPTION
Cause: due to the limitation of the tf-dom-repeat, we were rendering
custom scalars card inside a container which got in the way of `width:
100%` (since the said container is written to wrap the content, not the
container width).

Fix: tf-dom-repeat used to assign a slot attribute to the DOM we stamp.
However, if the stamped DOM is "dom-if" or "dom-repeat", then DOM will
be dynamically appended to the container _without_ the `slot="items"`.
Without it, the DOM stamped by dom-if does not show up in the items slot
in the container. We fixed it by using MutationObserver and dynamically
appending the slot property to any DOM that is created in the
tf-dom-repeat container.

Test plan:
- tested with the custom scalars demo. 
- made sure other plugins (i.e., scalars and images) did not regress.