### PR TITLE
[DebuggerV2] Fix a few CSS issues in overall layout

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.css
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 .bottom-section {
+  box-sizing: border-box;
   border-top: 1px solid rgba(0, 0, 0, 0.12);
   height: 34%;
   padding-top: 6px;
@@ -21,13 +22,17 @@ limitations under the License.
 }
 
 .debugger-container {
+  box-sizing: border-box;
   background-color: #fff;
   height: 100%;
+  overflow: hidden;
 }
 
 .top-section {
+  box-sizing: border-box;
   height: 66%;
   padding: 6px 0;
+  white-space: nowrap;
   width: 100%;
 }
 
@@ -56,6 +61,7 @@ tf-debugger-v2-source-files {
 
 tf-debugger-v2-stack-trace {
   display: inline-block;
+  height: 100%;
   width: 30%;
 }
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.css
@@ -42,7 +42,6 @@ limitations under the License.
 }
 
 .stack-frame-array {
-  height: 300px;
   overflow-x: hidden;
   overflow-y: auto;
   /* Minus padding-left of the parent (stack-trace-container). */
@@ -90,8 +89,8 @@ limitations under the License.
 .stack-trace-container {
   border-left: 1px solid rgba(0, 0, 0, 0.12);
   box-sizing: border-box;
-  display: flexbox;
-  flex-direction: column;
+  display: flex;
+  flex-flow: column;
   font-size: 10px;
   font-family: 'Roboto Mono', monospace;
   height: 100%;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.css
@@ -45,6 +45,8 @@ limitations under the License.
   height: 300px;
   overflow-x: hidden;
   overflow-y: auto;
+  /* Minus padding-left of the parent (stack-trace-container). */
+  width: calc(100% - 8px);
 }
 
 .stack-frame-container {
@@ -87,6 +89,7 @@ limitations under the License.
 
 .stack-trace-container {
   border-left: 1px solid rgba(0, 0, 0, 0.12);
+  box-sizing: border-box;
   display: flexbox;
   flex-direction: column;
   font-size: 10px;


### PR DESCRIPTION
* Motivation for features / changes
  * Fix a few CSS issues in DebuggerV2's overall layout
* Technical description of changes
  * The issues fixed include:
    1. The top-section and bottom-section of the overall layout doesn't have
        `box-sizing: border-box;` and hence overflows by the amount of border
        and padding, causing scroll bars to appear. This is fixed by applying the 
        said CSS property.
    2. The top section has three children. They some times wrap undesirably 
        (e.g., when zoom ratio is <100%) This is fixed by applying
        `white-space: nowrap`.
    3. The stack trace component at the lower-right corner doesn't have `height`
        set and hence grows downward beyond the bound. This is fixed by
        `height: 100%`
        * Before: ![image](https://user-images.githubusercontent.com/16824702/84164271-5346d000-aa40-11ea-9cb2-5cb185581609.png)
        * After: ![image](https://user-images.githubusercontent.com/16824702/84164598-b5073a00-aa40-11ea-9577-0b7e8042fe98.png)
    4. The scroll list for stack frames in stack trace component has a width
        that doesn't take into account the padding on the left of the parent element, 
        which causes the scroll bar to go out of bound.
        * Before: ![image](https://user-images.githubusercontent.com/16824702/84164968-21823900-aa41-11ea-93f7-8fa8ee755445.png)
        * After: ![image](https://user-images.githubusercontent.com/16824702/84164875-0a434b80-aa41-11ea-958b-0677c52c2e73.png)
