### PR TITLE
uploader: improve ending console message

### DIFF
--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -292,7 +292,7 @@ class UploadTracker(object):
         """Write an update indicating the start of the uploading."""
         if not self._verbosity:
             return
-        start_message = "%s[%s]%s Uploader started.\n" % (
+        start_message = "%s[%s]%s Uploader started." % (
             _STYLE_BOLD,
             readable_time_string(),
             _STYLE_RESET,

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -256,6 +256,7 @@ _STYLE_BOLD = "\033[1m"
 _STYLE_GREEN = "\033[32m"
 _STYLE_YELLOW = "\033[33m"
 _STYLE_DARKGRAY = "\033[90m"
+_STYLE_UP_LINE = "\033[1A"
 _STYLE_ERASE_LINE = "\033[2K"
 
 
@@ -284,7 +285,12 @@ class UploadTracker(object):
             return
         message += "." * 3
         sys.stdout.write(
-            _STYLE_ERASE_LINE + color_code + message + _STYLE_RESET + "\r"
+            _STYLE_UP_LINE
+            + _STYLE_ERASE_LINE
+            + color_code
+            + message
+            + _STYLE_RESET
+            + "\n"
         )
         sys.stdout.flush()
 
@@ -297,7 +303,7 @@ class UploadTracker(object):
             readable_time_string(),
             _STYLE_RESET,
         )
-        sys.stdout.write(start_message)
+        sys.stdout.write(start_message + "\n")
         sys.stdout.flush()
 
     def has_data(self):
@@ -311,7 +317,8 @@ class UploadTracker(object):
         if not self._stats.has_new_data_since_last_summarize():
             return
         uploaded_str, skipped_str = self._stats.summarize()
-        uploaded_message = "%s[%s]%s Total uploaded: %s\n" % (
+        uploaded_message = "%s%s[%s]%s Total uploaded: %s\n" % (
+            _STYLE_UP_LINE,
             _STYLE_BOLD,
             readable_time_string(),
             _STYLE_RESET,
@@ -323,6 +330,7 @@ class UploadTracker(object):
                 "%sTotal skipped: %s\n%s"
                 % (_STYLE_DARKGRAY, skipped_str, _STYLE_RESET)
             )
+        sys.stdout.write("\n")
         sys.stdout.flush()
         # TODO(cais): Add summary of what plugins have been involved, once it's
         # clear how to get canonical plugin names.

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -256,7 +256,6 @@ _STYLE_BOLD = "\033[1m"
 _STYLE_GREEN = "\033[32m"
 _STYLE_YELLOW = "\033[33m"
 _STYLE_DARKGRAY = "\033[90m"
-_STYLE_UP_LINE = "\033[1A"
 _STYLE_ERASE_LINE = "\033[2K"
 
 
@@ -285,12 +284,7 @@ class UploadTracker(object):
             return
         message += "." * 3
         sys.stdout.write(
-            _STYLE_UP_LINE
-            + _STYLE_ERASE_LINE
-            + color_code
-            + message
-            + _STYLE_RESET
-            + "\n"
+            _STYLE_ERASE_LINE + color_code + message + _STYLE_RESET + "\r"
         )
         sys.stdout.flush()
 
@@ -317,8 +311,7 @@ class UploadTracker(object):
         if not self._stats.has_new_data_since_last_summarize():
             return
         uploaded_str, skipped_str = self._stats.summarize()
-        uploaded_message = "%s%s[%s]%s Total uploaded: %s\n" % (
-            _STYLE_UP_LINE,
+        uploaded_message = "%s[%s]%s Total uploaded: %s\n" % (
             _STYLE_BOLD,
             readable_time_string(),
             _STYLE_RESET,
@@ -330,7 +323,6 @@ class UploadTracker(object):
                 "%sTotal skipped: %s\n%s"
                 % (_STYLE_DARKGRAY, skipped_str, _STYLE_RESET)
             )
-        sys.stdout.write("\n")
         sys.stdout.flush()
         # TODO(cais): Add summary of what plugins have been involved, once it's
         # clear how to get canonical plugin names.

--- a/tensorboard/uploader/upload_tracker_test.py
+++ b/tensorboard/uploader/upload_tracker_test.py
@@ -364,7 +364,7 @@ class UploadTrackerTest(tb_test.TestCase):
                     self.mock_write.call_args[0][0],
                 )
                 blob_tracker.mark_uploaded(is_uploaded=False)
-        self.assertEqual(self.mock_write.call_count, 6)
+        self.assertEqual(self.mock_write.call_count, 7)
         self.assertEqual(self.mock_flush.call_count, 5)
         self.assertIn(
             "Total uploaded: 0 scalars, 0 tensors, 0 binary objects\n",

--- a/tensorboard/uploader/upload_tracker_test.py
+++ b/tensorboard/uploader/upload_tracker_test.py
@@ -364,7 +364,7 @@ class UploadTrackerTest(tb_test.TestCase):
                     self.mock_write.call_args[0][0],
                 )
                 blob_tracker.mark_uploaded(is_uploaded=False)
-        self.assertEqual(self.mock_write.call_count, 7)
+        self.assertEqual(self.mock_write.call_count, 6)
         self.assertEqual(self.mock_flush.call_count, 5)
         self.assertIn(
             "Total uploaded: 0 scalars, 0 tensors, 0 binary objects\n",

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -442,17 +442,24 @@ class UploadIntent(_Intent):
             )
         else:
             print("View your TensorBoard live at: %s" % url)
+        interrupted = False
         try:
             uploader.start_uploading()
         except uploader_lib.ExperimentNotFoundError:
             print("Experiment was deleted; uploading has been cancelled")
             return
         except KeyboardInterrupt:
+            interrupted = True
             pass
         finally:
+            print()
+            if interrupted:
+                end_message = "Interrupted."
+            else:
+                end_message = "Done."
             if not self.dry_run:
-                print()
-                print("Done! View your TensorBoard at %s" % url)
+                end_message += " View your TensorBoard at %s" % url
+            print(end_message)
 
 
 class _ExportIntent(_Intent):


### PR DESCRIPTION
* Motivation for features / changes
  * Fixes https://github.com/tensorflow/tensorboard/issues/3712
* Technical description of changes
  * In the `finally` block of `UploadIntent.execute()`, format the ending message
    according to whether this is interrupted by keyboard or not and whether this is a
    dry run.
* Screenshots of UI changes
  * Interrupted case: ![image](https://user-images.githubusercontent.com/16824702/84220500-f0d1ec00-aaa0-11ea-981c-e02fd055b33f.png)
  * Done (--one_shot ending) case, non-dry-run: ![image](https://user-images.githubusercontent.com/16824702/84220605-2e367980-aaa1-11ea-9824-112c52e6897c.png)