### PR TITLE
ng: use replaceState for null pluginId to non-null

### DIFF
--- a/tensorboard/webapp/core/views/hash_storage_component.ts
+++ b/tensorboard/webapp/core/views/hash_storage_component.ts
@@ -74,10 +74,11 @@ export class HashStorageComponent implements OnInit, OnChanges, OnDestroy {
   ngOnChanges(changes: SimpleChanges) {
     if (changes['activePluginId']) {
       const activePluginIdChange = changes['activePluginId'];
-      const option: SetStringOption = {defaultValue: ''};
-      if (activePluginIdChange.firstChange) {
-        option.useLocationReplace = true;
-      }
+
+      const option: SetStringOption = {
+        defaultValue: '',
+        useLocationReplace: activePluginIdChange.previousValue === null,
+      };
 
       const value =
         activePluginIdChange.currentValue === null

--- a/tensorboard/webapp/core/views/hash_storage_component.ts
+++ b/tensorboard/webapp/core/views/hash_storage_component.ts
@@ -77,13 +77,16 @@ export class HashStorageComponent implements OnInit, OnChanges, OnDestroy {
 
       const option: SetStringOption = {
         defaultValue: '',
-        useLocationReplace: activePluginIdChange.previousValue === null,
+        useLocationReplace:
+          activePluginIdChange.previousValue === null ||
+          activePluginIdChange.firstChange,
       };
 
       const value =
         activePluginIdChange.currentValue === null
           ? ''
           : activePluginIdChange.currentValue;
+      console.log(value);
       this.deepLinker.setPluginId(value, option);
     }
   }

--- a/tensorboard/webapp/core/views/hash_storage_test.ts
+++ b/tensorboard/webapp/core/views/hash_storage_test.ts
@@ -98,7 +98,7 @@ describe('hash storage test', () => {
       {
         id: '',
         option: {
-          useLocationReplace: false,
+          useLocationReplace: true,
           defaultValue: '',
         },
       },
@@ -125,7 +125,7 @@ describe('hash storage test', () => {
     fixture.detectChanges();
 
     expect(setPluginIdSpy).toHaveBeenCalledWith('', {
-      useLocationReplace: false,
+      useLocationReplace: true,
       defaultValue: '',
     });
   });
@@ -136,7 +136,7 @@ describe('hash storage test', () => {
     fixture.detectChanges();
 
     expect(setPluginIdSpy).toHaveBeenCalledWith('', {
-      useLocationReplace: false,
+      useLocationReplace: true,
       defaultValue: '',
     });
   });

--- a/tensorboard/webapp/core/views/hash_storage_test.ts
+++ b/tensorboard/webapp/core/views/hash_storage_test.ts
@@ -21,6 +21,7 @@ import {CommonModule} from '@angular/common';
 import {getActivePlugin} from '../store';
 import {State} from '../store/core_types';
 import {pluginUrlHashChanged} from '../actions';
+import {SetStringOption} from '../../deeplink/types';
 
 import {HashStorageContainer} from './hash_storage_container';
 import {HashStorageComponent} from './hash_storage_component';
@@ -64,14 +65,58 @@ describe('hash storage test', () => {
     getPluginIdSpy = spyOn(deepLinker, 'getPluginId');
   });
 
-  it('sets the hash to plugin id by replacing on first load', () => {
-    store.overrideSelector(getActivePlugin, 'foo');
+  it('sets hash to plugin id when plugin id changes from null to value', () => {
+    const setPluginIdCalls: Array<{
+      id: string | null;
+      option: SetStringOption;
+    }> = [];
+    setPluginIdSpy.and.callFake(
+      (id: string | null, option: SetStringOption) => {
+        setPluginIdCalls.push({
+          id,
+          option,
+        });
+      }
+    );
+    store.overrideSelector(getActivePlugin, null);
     const fixture = TestBed.createComponent(HashStorageContainer);
     fixture.detectChanges();
-    expect(setPluginIdSpy).toHaveBeenCalledWith('foo', {
-      useLocationReplace: true,
-      defaultValue: '',
-    });
+
+    store.overrideSelector(getActivePlugin, null);
+    store.refreshState();
+    fixture.detectChanges();
+
+    store.overrideSelector(getActivePlugin, 'foo');
+    store.refreshState();
+    fixture.detectChanges();
+
+    store.overrideSelector(getActivePlugin, null);
+    store.refreshState();
+    fixture.detectChanges();
+
+    expect(setPluginIdCalls).toEqual([
+      {
+        id: '',
+        option: {
+          useLocationReplace: false,
+          defaultValue: '',
+        },
+      },
+      {
+        id: 'foo',
+        option: {
+          useLocationReplace: true,
+          defaultValue: '',
+        },
+      },
+      {
+        id: '',
+        option: {
+          useLocationReplace: false,
+          defaultValue: '',
+        },
+      },
+    ]);
   });
 
   it('sets the hash to empty string when activePlugin is not set', () => {
@@ -80,7 +125,7 @@ describe('hash storage test', () => {
     fixture.detectChanges();
 
     expect(setPluginIdSpy).toHaveBeenCalledWith('', {
-      useLocationReplace: true,
+      useLocationReplace: false,
       defaultValue: '',
     });
   });
@@ -91,7 +136,7 @@ describe('hash storage test', () => {
     fixture.detectChanges();
 
     expect(setPluginIdSpy).toHaveBeenCalledWith('', {
-      useLocationReplace: true,
+      useLocationReplace: false,
       defaultValue: '',
     });
   });


### PR DESCRIPTION
We are, when modifying the history to set the plugin id in the URL,
using replaceState as opposed to pushState on the initial plugin id set.
When done incorrectly, we can pushState and leave awkward intermediate
null plugin id in the URL.

Currently, our logic to use the `firstChange` of Angular's seem flaky
and often result in incorrect state. To remedy, we will replaceState
only when moving from `null` to non-null.

Test:
- tested by launching with `#images` and checked the history stack
- tested by launching with no hash and checked the history stack (after it changing to `#scalars`)