### PR TITLE
ng: change default page size

### DIFF
--- a/tensorboard/webapp/core/store/core_types.ts
+++ b/tensorboard/webapp/core/store/core_types.ts
@@ -47,5 +47,5 @@ export const initialState: CoreState = {
   },
   reloadPeriodInMs: 30000,
   reloadEnabled: false,
-  pageSize: 15,
+  pageSize: 12,
 };


### PR DESCRIPTION
To minimize the change between Polymer based TensorBoard and the Angular
one, we want to make the defaults congruent.

Currently, the Polymer's default is defined to be 12 and is defined in
paginatedViewStore.ts
