### PR TITLE
tf-runs-selector: fix data location clipping behavior

### DIFF
--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -61,7 +61,8 @@ Properties out:
         <tf-wbr-string
           value="[[_clippedDataLocation]]"
           delimiter-pattern="[[_dataLocationDelimiterPattern]]"
-          ></tf-wbr-string><!--
+        ></tf-wbr-string
+        ><!--
           We use HTML comments to remove spaces before the ellipsis.
         --><template
           is="dom-if"

--- a/tensorboard/components/tf_runs_selector/tf-runs-selector.html
+++ b/tensorboard/components/tf_runs_selector/tf-runs-selector.html
@@ -61,7 +61,7 @@ Properties out:
         <tf-wbr-string
           value="[[_clippedDataLocation]]"
           delimiter-pattern="[[_dataLocationDelimiterPattern]]"
-        /><!--
+          ></tf-wbr-string><!--
           We use HTML comments to remove spaces before the ellipsis.
         --><template
           is="dom-if"
@@ -196,7 +196,7 @@ Properties out:
         if (dataLocation.length > dataLocationClipLength) {
           // Clip the dataLocation to avoid blocking the runs selector. Let the
           // user view a more full version of the dataLocation.
-          dataLocation.substring(0, dataLocationClipLength);
+          return dataLocation.substring(0, dataLocationClipLength);
         } else {
           return dataLocation;
         }


### PR DESCRIPTION
Summary:
The data location (`--logdir` path shown beneath the runs selector) is
meant to be clipped when it’s very long, with an option to show the
whole thing in a modal, but this was broken in two ways. First, the data
location was simply missing due to a JS type error. Second, the link to
open the modal was accidentally nested inside a `tf-wbr-string` element
because that tag is not self-closing. This patch fixes both errors.

Test Plan:
Run with `--logdir /tmp/"$(for i in {1..100}; do printf abc/; done)"`
and navigate to the scalars dashboard. Note that: before this patch, the
data location is not shown at all; with just the JavaScript change, the
data location is shown, but the modal-opening ellipsis is not; with this
patch, the data location is shown, and the all-important link is, too.

A quick check shows that other uses of `tf-wbr-string` do treat it as
self-closing, but all are benign because they’re immediately followed by
a closing tag rather than a sibling element.

wchargin-branch: data-location-clipping
