### PR TITLE
ng: remove paper-styles global style rules

### DIFF
--- a/tensorboard/components/tf_tensorboard/style.html
+++ b/tensorboard/components/tf_tensorboard/style.html
@@ -24,5 +24,23 @@ limitations under the License.
     padding: 0;
     height: 100%;
     font-family: Roboto, sans-serif;
+    color: var(--primary-text-color);
+
+    /* Legacy mechanism to avoid issues with subpixel anti-aliasing on macOS.
+     *
+     * In the past [1], macOS subpixel AA caused excessive bolding for light-on-dark text; this rule
+     * avoids that by requesting non-subpixel AA always, rather than the default behavior, which is
+     * to use subpixel AA when available. The original issue was "fixed" by removing subpixel AA in
+     * macOS 14 (Mojave), but for legacy reasons they preserved the bolding effect as an option.
+     * Chrome then in turn updated its font rendering to apply that bolding effect [2], which means
+     * that even though the `-webkit-font-smoothing` docs [3] suggest that setting `antialiased`
+     * would have no effect for recent versions of macOS, it still is needed to avoid the bolding.
+     *
+     * [1]: http://www.lighterra.com/articles/macosxtextaabug/
+     * [2]: https://bugs.chromium.org/p/chromium/issues/detail?id=858861
+     * [3]: https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth
+     *
+     */
+    -webkit-font-smoothing: antialiased;
   }
 </style>

--- a/third_party/polymer.bzl
+++ b/third_party/polymer.bzl
@@ -1173,8 +1173,8 @@ def tensorboard_polymer_workspace():
       ],
       strip_prefix = "paper-styles-2.1.0",
       path = "/paper-styles",
+      # Deliberately omitting "classes/global.html" from srcs below.
       srcs = [
-          "classes/global.html",
           "classes/shadow.html",
           "classes/typography.html",
           "color.html",


### PR DESCRIPTION
This addresses b/156301620 by removing our dependency on the [global paper-styles CSS rules][1], which include a bunch of default behavior (like small-caps for all <a> tags) that we don't actually want, and as a result we either have to override the defaults or they bleed into pages in unwanted ways.

This primarily affects ng-tensorboard, since ng-tensorboard is not using Shadow DOM so its components are not immune to global CSS styles.  For Polymer tensorboard, the only rules that had any effect were those defined on <body>, which we've ported into tf_tensorboard/style.html (adapting them slightly; e.g. we omit the font-family rule since there is already a font-family rule in that CSS stylesheet that can take precedence).

The main impacts to the visual appearance are:

- subtle font changes to <a> tags in various places - the lettering spacing, font size, line height, etc. now pick up the actual, context-appropriate defaults, so e.g. for the compare info bar the link font is no longer different from the text font

- the no dashboard active error page styling is now the same as Polymer TensorBoard (and the error pages for individual dashboards having no data) with the more vanilla header styling, and regular blue links and regular paragraph spacing rather than the weird small-caps links and cramped spacing. We might want to restore some parts of the lost styling (e.g. making the links text-colored for consistency, or making the header font bigger) but that should be done as an intentional change.

[1]: https://github.com/PolymerElements/paper-styles/blob/a828cc4eecd99fde335ea60e02e398fb19bfa57c/classes/global.html