### PR TITLE
ng: fix iframe plugin rendering

### DIFF
--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -65,8 +65,12 @@ import {PluginRegistryModule} from './plugin_registry_module';
       .last-reload-time {
         font-style: italic;
       }
+      .plugins ::ng-deep iframe {
+        border: 0;
+        height: 100%;
+        width: 100%;
+      }
     `,
-    'iframe { border: 0; height: 100%; width: 100%; }',
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
Angular, by default, encapsulates styling using some component specific
hash attached to the DOM when stamping them. Unfortunately, the iframe
is not created by Angular, thus, need to be styled a bit differently.

This change allows iframe to be styled without the hash stamped out.

cc @caisq 