### PR TITLE
Expose line chart "scaled to fit" state

### DIFF
--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -296,23 +296,32 @@ namespace vz_line_chart2 {
     },
 
     /**
-     * Returns whether or not the current scales are fit to the visible data.
-     * When scales do not fit due to transformations (pan, zoom), calling
-     * resetDomain() will make them fit.
+     * Returns whether or not the current scales contain all visible data, after
+     * applying smoothing and outlier detection.
+     *
+     * This is true when there is no data, and false when data exists beyond the
+     * selected view due to transformations (pan, zoom).
      */
-    isDomainFitToData() {
+    isDataWithinVisibleDomain() {
       if (!this._chart) {
         return true;
       }
       return (
-        isScaleFitToData(this._chart.xAxis.getScale()) &&
-        isScaleFitToData(this._chart.yAxis.getScale())
+        isDataWithinVisibleDomain(this._chart.xAxis.getScale()) &&
+        isDataWithinVisibleDomain(this._chart.yAxis.getScale())
       );
 
-      function isScaleFitToData(scale) {
+      function isDataWithinVisibleDomain(scale) {
+        /**
+         * Domain represents the currently displayed region, possibly a zoomed
+         * in or zoomed out view of the data.
+         *
+         * Extent represents the extent of the data, the range of all provided
+         * datum values.
+         */
         const domain = scale.getTransformationDomain();
         const extent = scale.getTransformationExtent();
-        return domain[0] === extent[0] && domain[1] === extent[1];
+        return extent[0] >= domain[0] && extent[1] <= domain[1];
       }
     },
 

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -296,22 +296,22 @@ namespace vz_line_chart2 {
     },
 
     /**
-     * Returns whether or not the current scales contain all visible data, after
-     * applying smoothing and outlier detection.
+     * Returns whether the extent of rendered data values fits the current
+     * chart viewport domain (includes smoothing and outlier detection).
      *
-     * This is true when there is no data, and false when data exists beyond the
-     * selected view due to transformations (pan, zoom).
+     * This is true when there is no data, and false when the domain has been
+     * transformed from the extent via transformations (pan, zoom).
      */
-    isDataWithinVisibleDomain() {
+    isDataFitToDomain() {
       if (!this._chart) {
         return true;
       }
       return (
-        isDataWithinVisibleDomain(this._chart.xAxis.getScale()) &&
-        isDataWithinVisibleDomain(this._chart.yAxis.getScale())
+        isDataFitToDomain(this._chart.xAxis.getScale()) &&
+        isDataFitToDomain(this._chart.yAxis.getScale())
       );
 
-      function isDataWithinVisibleDomain(scale) {
+      function isDataFitToDomain(scale) {
         /**
          * Domain represents the currently displayed region, possibly a zoomed
          * in or zoomed out view of the data.
@@ -321,7 +321,7 @@ namespace vz_line_chart2 {
          */
         const domain = scale.getTransformationDomain();
         const extent = scale.getTransformationExtent();
-        return extent[0] >= domain[0] && extent[1] <= domain[1];
+        return extent[0] == domain[0] && extent[1] == domain[1];
       }
     },
 

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -321,7 +321,7 @@ namespace vz_line_chart2 {
          */
         const domain = scale.getTransformationDomain();
         const extent = scale.getTransformationExtent();
-        return extent[0] == domain[0] && extent[1] == domain[1];
+        return extent[0] === domain[0] && extent[1] === domain[1];
       }
     },
 

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -296,6 +296,25 @@ namespace vz_line_chart2 {
     },
 
     /**
+     * Returns whether or not the current scales are fit to the visible data.
+     * When scales do not fit due to transformations (pan, zoom), calling
+     * resetDomain() will make them fit.
+     */
+    isDomainFitToData() {
+      if (!this._chart) {
+        return true;
+      }
+      return isScaleFitToData(this._chart.xAxis.getScale()) &&
+          isScaleFitToData(this._chart.yAxis.getScale());
+
+      function isScaleFitToData(scale) {
+        const domain = scale.getTransformationDomain();
+        const extent = scale.getTransformationExtent();
+        return domain[0] === extent[0] && domain[1] === extent[1];
+      }
+    },
+
+    /**
      * Sets the series that the chart displays. Series with other names will
      * not be displayed.
      *

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -304,8 +304,10 @@ namespace vz_line_chart2 {
       if (!this._chart) {
         return true;
       }
-      return isScaleFitToData(this._chart.xAxis.getScale()) &&
-          isScaleFitToData(this._chart.yAxis.getScale());
+      return (
+        isScaleFitToData(this._chart.xAxis.getScale()) &&
+        isScaleFitToData(this._chart.yAxis.getScale())
+      );
 
       function isScaleFitToData(scale) {
         const domain = scale.getTransformationDomain();


### PR DESCRIPTION
VzLineChart2 clients can already set the series data and manually
trigger `resetDomain`. However, it is hard to know when to redraw.

TensorBoard may update data every 30s, so redrawing upon every
data change may disrupt users who are interested in examining a
specific region they panned/zoomed into.

To allow better UX offerings, this exposes internal chart state, so
that VzLineChart2 clients may redraw only when the chart scales
have no transformation applied (e.g. not panned/zoomed).

See also cl/316522213