### PR TITLE
 [DebuggerV2] Improve CSS layout of rightmost sections

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.css
@@ -17,10 +17,9 @@ limitations under the License.
   box-sizing: border-box;
   border-top: 1px solid rgba(0, 0, 0, 0.12);
   display: flex;
+  flex-grow: 1;
   height: 34%;
-  justify-content: space-between;
   padding-top: 6px;
-  width: 100%;
 }
 
 .debugger-container {
@@ -33,49 +32,43 @@ limitations under the License.
 .top-section {
   box-sizing: border-box;
   display: flex;
+  flex-grow: 1;
   height: 66%;
-  justify-content: space-between;
   padding: 6px 0;
-  width: 100%;
 }
 
 tf-debugger-v2-alerts {
   border-right: 1px solid rgba(0, 0, 0, 0.12);
   display: inline-block;
-  height: 100%;
   margin-right: 10px;
   min-width: 160px;
-  vertical-align: top;
   width: calc(15% - 11px);
 }
 
 tf-debugger-v2-graph-executions {
   display: inline-block;
-  height: 100%;
+  flex-grow: 1;
   min-width: 540px;
-  vertical-align: top;
-  width: 30%;
+  width: 540px;
 }
 
 tf-debugger-v2-source-files {
   display: inline-block;
   height: 100%;
-  vertical-align: top;
   width: 70%;
 }
 
 tf-debugger-v2-stack-trace {
   display: inline-block;
+  flex-grow: 1;
   height: 100%;
   min-width: 540px;
-  width: 30%;
+  width: 540px;
 }
 
 .top-center-section {
   display: inline-block;
-  height: 100%;
   overflow: auto;
-  vertical-align: top;
   width: 55%;
 }
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.css
@@ -56,7 +56,7 @@ tf-debugger-v2-alerts {
 tf-debugger-v2-graph-executions {
   display: inline-block;
   height: 100%;
-  min-width: 480px;
+  min-width: 540px;
   vertical-align: top;
   width: 30%;
 }
@@ -71,7 +71,7 @@ tf-debugger-v2-source-files {
 tf-debugger-v2-stack-trace {
   display: inline-block;
   height: 100%;
-  min-width: 480px;
+  min-width: 540px;
   width: 30%;
 }
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.css
@@ -16,7 +16,9 @@ limitations under the License.
 .bottom-section {
   box-sizing: border-box;
   border-top: 1px solid rgba(0, 0, 0, 0.12);
+  display: flex;
   height: 34%;
+  justify-content: space-between;
   padding-top: 6px;
   width: 100%;
 }
@@ -28,11 +30,16 @@ limitations under the License.
   overflow: hidden;
 }
 
+.filler-div {
+  display: inline-block;
+}
+
 .top-section {
   box-sizing: border-box;
+  display: flex;
   height: 66%;
+  justify-content: space-between;
   padding: 6px 0;
-  white-space: nowrap;
   width: 100%;
 }
 
@@ -41,6 +48,7 @@ tf-debugger-v2-alerts {
   display: inline-block;
   height: 100%;
   margin-right: 10px;
+  min-width: 160px;
   vertical-align: top;
   width: calc(15% - 11px);
 }
@@ -48,6 +56,7 @@ tf-debugger-v2-alerts {
 tf-debugger-v2-graph-executions {
   display: inline-block;
   height: 100%;
+  min-width: 480px;
   vertical-align: top;
   width: 30%;
 }
@@ -62,6 +71,7 @@ tf-debugger-v2-source-files {
 tf-debugger-v2-stack-trace {
   display: inline-block;
   height: 100%;
+  min-width: 480px;
   width: 30%;
 }
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.css
@@ -30,10 +30,6 @@ limitations under the License.
   overflow: hidden;
 }
 
-.filler-div {
-  display: inline-block;
-}
-
 .top-section {
   box-sizing: border-box;
   display: flex;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.ng.html
@@ -33,6 +33,9 @@ limitations under the License.
 
     <div class="bottom-section">
       <tf-debugger-v2-source-files></tf-debugger-v2-source-files>
+      <!-- This filler div is inserted between the two elemens so that the CSS
+           `justify-content: space-between` may take effect. -->
+      <div class="filler-div"></div>
       <tf-debugger-v2-stack-trace></tf-debugger-v2-stack-trace>
     </div>
     <!-- TODO(cais): Add more elements, such as graph structure etc.-->

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_component.ng.html
@@ -33,9 +33,6 @@ limitations under the License.
 
     <div class="bottom-section">
       <tf-debugger-v2-source-files></tf-debugger-v2-source-files>
-      <!-- This filler div is inserted between the two elemens so that the CSS
-           `justify-content: space-between` may take effect. -->
-      <div class="filler-div"></div>
       <tf-debugger-v2-stack-trace></tf-debugger-v2-stack-trace>
     </div>
     <!-- TODO(cais): Add more elements, such as graph structure etc.-->

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_component.css
@@ -67,6 +67,7 @@ limitations under the License.
   color: #808080;
   font-family: 'Roboto', Arial, Helvetica, sans-serif;
   font-size: 13px;
+  white-space: normal;
 }
 
 .self-op-header {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_component.ng.html
@@ -118,7 +118,7 @@ limitations under the License.
 
   <ng-template #noOpFocused>
     <div class="no-op-focused">
-      No graph op selected. Click a tensor name in Graph Executions table to
+      No graph op selected. Click a tensor name in the Graph Executions table to
       view the neighborhood of the tensor's op in its graph.
     </div>
   </ng-template>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.css
@@ -36,6 +36,7 @@ limitations under the License.
   display: inline-block;
   color: #666;
   padding: 0 20px;
+  white-space: normal;
 }
 
 .source-files-container {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.css
@@ -15,6 +15,7 @@ limitations under the License.
 
 .header-section {
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  display: flex;
   height: 24px;
   padding-bottom: 6px;
   vertical-align: middle;
@@ -27,6 +28,7 @@ limitations under the License.
   font-weight: normal;
   white-space: normal;
   overflow-wrap: anywhere;
+  overflow-y: auto;
   padding: 0 20px;
 }
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.ng.html
@@ -31,7 +31,8 @@ limitations under the License.
 
     <ng-template #noFileSelected>
       <div class="no-file-selected">
-        (No file selected)
+        No file selected. Click a line number in the Stack Trace section to show
+        source code.
       </div>
     </ng-template>
   </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.ng.html
@@ -32,7 +32,7 @@ limitations under the License.
     <ng-template #noFileSelected>
       <div class="no-file-selected">
         No file selected. Click a line number in the Stack Trace section to show
-        source code.
+        the source code.
       </div>
     </ng-template>
   </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_container_test.ts
@@ -78,8 +78,8 @@ describe('Source Files Container', () => {
     const noFileSelectedElement = fixture.debugElement.query(
       By.css('.no-file-selected')
     );
-    expect(noFileSelectedElement.nativeElement.innerText).toBe(
-      '(No file selected)'
+    expect(noFileSelectedElement.nativeElement.innerText).toContain(
+      'No file selected'
     );
 
     const sourceCodeElements = fixture.debugElement.queryAll(

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.css
@@ -77,6 +77,7 @@ limitations under the License.
 .navigation-position-info {
   display: inline-flex;
   font-size: 14px;
+  line-height: 16px;
   max-width: 200px;
   padding-left: 10px;
   padding-right: 10px;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.css
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.css
@@ -77,7 +77,7 @@ limitations under the License.
 .navigation-position-info {
   display: inline-flex;
   font-size: 14px;
-  line-height: 16px;
+  line-height: normal;
   max-width: 200px;
   padding-left: 10px;
   padding-right: 10px;

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.ng.html
@@ -34,8 +34,8 @@ limitations under the License.
         &lt;
       </button>
       <div class="navigation-position-info">
-        Execution: {{ scrollBeginIndex }} ~ {{ scrollBeginIndex + displayCount -
-        1 }} of {{ numExecutions }}
+        {{ scrollBeginIndex }} ~ {{ scrollBeginIndex + displayCount - 1 }} of {{
+        numExecutions }}
       </div>
       <!-- TODO(cais): Apply mat-icon-button. -->
       <button


### PR DESCRIPTION
* Motivation for features / changes
  * Improve the layout of debugger-v2
* Technical description of changes
  * The two rightmost sections in the layout of DebuggerV2, namely
     GraphExecutionsComponent at the top-right corner and the
     StackTraceComponent at the bottom-right, previously did not have a
     min-width, and instead had only a percentage-based width relative
     to their parents. This cause these regions to shrink to a very
     small with when the size of the browser window is limited (e.g.,
     <1400px or so), cutting off important information such as the
     warning-color nan/infinity information.
  * This CL addresses this issue by adding min-width to these two
     components. The two sections grow and shrink in size in sync (see
     screenshot).
  * Also in this CL:
     - Improve no-data message in the GraphComponent and the
       SourceCodeComponent.
* Screenshots of UI changes
  * Before, at screen width ~1300px: ![image](https://user-images.githubusercontent.com/16824702/84910872-6cc1ca80-b085-11ea-9769-729c050594b7.png)
  * After, at screen width ~1300px: ![image](https://user-images.githubusercontent.com/16824702/84910725-3ab06880-b085-11ea-8c3c-b3358a38dd3b.png)
