### PR TITLE
Support transformation extent method for log scale charts

### DIFF
--- a/tensorboard/components/vz_line_chart2/log-scale.ts
+++ b/tensorboard/components/vz_line_chart2/log-scale.ts
@@ -64,6 +64,10 @@ namespace vz_line_chart2 {
       return this.domain() as [number, number];
     }
 
+    public getTransformationExtent(): [number, number] {
+      return this._getUnboundedExtent(true) as [number, number];
+    }
+
     protected _getDomain() {
       return this._untransformedDomain;
     }


### PR DESCRIPTION
The recently added `isDataFitToDomain` relies on computing the transformed
viewport domain and extent of values. Calling `getTransformationExtent()`
works on TensorBoard's LinearScale because it extends
`extends Plottable.Scales.Linear`, but fails for LogScale which doesn't have
the method.

This adds the missing `getTransformationExtent()` so that LogScale supports
`isDataFitToDomain`.

![image](https://user-images.githubusercontent.com/2322480/85088065-04adda00-b194-11ea-98f9-58ef381fb58b.png)