### PR TITLE
ng: integrate the experimental api

### DIFF
--- a/tensorboard/components/experimental/plugin_util/BUILD
+++ b/tensorboard/components/experimental/plugin_util/BUILD
@@ -36,6 +36,7 @@ tf_web_library(
     deps = [
         ":host_internals",
         "//tensorboard/components/tf_backend",
+        "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/components/tf_storage",
     ],
 )

--- a/tensorboard/components/experimental/plugin_util/plugin-host.html
+++ b/tensorboard/components/experimental/plugin_util/plugin-host.html
@@ -20,3 +20,14 @@ limitations under the License.
 <link rel="import" href="../tf-storage/tf-storage.html" />
 <script src="core-host-impl.js"></script>
 <script src="runs-host-impl.js"></script>
+
+<link rel="import" href="../tf-imports/polymer.html" />
+<script>
+  // HACK: this Polymer component allows the experimental plugin host APIs
+  // to be accessible across bundle binary.
+  Polymer({
+    is: 'tf-experimental-plugin-host-lib',
+    _template: null, // strictTemplatePolicy requires a template (even a null one).
+    registerPluginIframe: tb_plugin.host.registerPluginIframe,
+  });
+</script>

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -37,6 +37,10 @@ import {
 } from '../types/api';
 import {PluginRegistryModule} from './plugin_registry_module';
 
+interface ExperimentalPluginHostLib extends HTMLElement {
+  registerPluginIframe(iframe: HTMLIFrameElement, plugin_id: string): void;
+}
+
 @Component({
   selector: 'plugins-component',
   templateUrl: './plugins_component.ng.html',
@@ -75,6 +79,10 @@ import {PluginRegistryModule} from './plugin_registry_module';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PluginsComponent implements OnChanges {
+  private readonly experimentPluginHostLib = document.createElement(
+    'tf-experimental-plugin-host-lib'
+  ) as ExperimentalPluginHostLib;
+
   constructor(
     private readonly componentFactoryResolver: ComponentFactoryResolver,
     private readonly pluginRegistry: PluginRegistryModule
@@ -157,6 +165,10 @@ export class PluginsComponent implements OnChanges {
         pluginElement.setAttribute(
           'src',
           `data/plugin_entry.html?name=${plugin.id}`
+        );
+        this.experimentPluginHostLib.registerPluginIframe(
+          pluginElement,
+          plugin.id
         );
         this.pluginsContainer.nativeElement.appendChild(pluginElement);
         break;

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -62,6 +62,8 @@ customElements.define('tb-bar', TestableCustomElement);
 
 describe('plugins_component', () => {
   let store: MockStore<State>;
+  let createElementSpy: jasmine.Spy;
+
   const PLUGINS = {
     bar: {
       disable_reload: false,
@@ -114,6 +116,13 @@ describe('plugins_component', () => {
       state: DataLoadState.NOT_LOADED,
       lastLoadedTimeInMs: null,
     });
+
+    createElementSpy = spyOn(document, 'createElement').and.callThrough();
+    createElementSpy
+      .withArgs('tf-experimental-plugin-host-lib')
+      .and.returnValue({
+        registerPluginIframe: () => {},
+      });
   });
 
   describe('plugin DOM creation', () => {
@@ -149,6 +158,12 @@ describe('plugins_component', () => {
     });
 
     it('creates an element for IFRAME type of plugin', async () => {
+      const registerPluginIframeSpy = jasmine.createSpy();
+      createElementSpy
+        .withArgs('tf-experimental-plugin-host-lib')
+        .and.returnValue({
+          registerPluginIframe: registerPluginIframeSpy,
+        });
       const fixture = TestBed.createComponent(PluginsContainer);
       fixture.detectChanges();
 
@@ -161,6 +176,10 @@ describe('plugins_component', () => {
       expect(nativeElement.childElementCount).toBe(1);
       const pluginElement = nativeElement.children[0];
       expectPluginIframe(pluginElement, 'foo');
+      expect(registerPluginIframeSpy).toHaveBeenCalledWith(
+        pluginElement,
+        'foo'
+      );
     });
 
     it('keeps instance of plugin after being inactive but hides it', async () => {


### PR DESCRIPTION
In order to make the experimental plugin API work, we needed to register
an iframe to the experimental host library. This change adds the call
necessary to make it work.

Detail: we now expose the API via the Polymer component hack to cross
the binary boundary.
