### PR TITLE
Add ability to copy sample command in TensorBoard.dev upload dialog

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -158,6 +158,7 @@ tf_svg_bundle(
     srcs = [
         # When modifying below, please make sure to update
         # //tensorboard/webapp/testing/mat_icon.module.ts.
+        "@com_google_material_design_icon//:content_copy_24px.svg",
         "@com_google_material_design_icon//:help_outline_24px.svg",
         "@com_google_material_design_icon//:info_outline_24px.svg",
         "@com_google_material_design_icon//:refresh_24px.svg",

--- a/tensorboard/webapp/angular/BUILD
+++ b/tensorboard/webapp/angular/BUILD
@@ -30,6 +30,15 @@ tf_ts_library(
     ],
 )
 
+# This is a dummy rule used as a @angular/material/tabs dependency.
+tf_ts_library(
+    name = "expect_angular_cdk_clipboard",
+    srcs = [],
+    deps = [
+        "@npm//@angular/material",
+    ],
+)
+
 # This is a dummy rule used as a @angular/core/testing dependency.
 # This is not a replacement for @angular/core dependency.
 tf_ts_library(

--- a/tensorboard/webapp/tbdev_upload/BUILD
+++ b/tensorboard/webapp/tbdev_upload/BUILD
@@ -15,6 +15,7 @@ ng_module(
         "tbdev_upload_dialog_component.ng.html",
     ],
     deps = [
+        "//tensorboard/webapp/angular:expect_angular_cdk_clipboard",
         "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_dialog",
         "//tensorboard/webapp/angular:expect_angular_material_icon",
@@ -38,6 +39,7 @@ tf_ts_library(
     tsconfig = "//:tsconfig-test",
     deps = [
         ":tbdev_upload",
+        "//tensorboard/webapp/angular:expect_angular_cdk_clipboard",
         "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/angular:expect_angular_material_button",

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ng.html
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ng.html
@@ -30,7 +30,7 @@ limitations under the License.
     mat-icon-button
     class="command-copy"
     [cdkCopyToClipboard]="commandText"
-    title="Copy"
+    title="Click to copy the command"
   >
     <mat-icon svgIcon="content_copy_24px"></mat-icon>
   </button>

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ng.html
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ng.html
@@ -24,8 +24,16 @@ limitations under the License.
 <p>
   To upload a logdir to TensorBoard.dev, run the command:
 </p>
-<div class="snippet">
-  <code>tensorboard dev upload --logdir {{ '{' }}logdir{{ '}' }}</code>
+<div class="command">
+  <code>{{commandText}}</code>
+  <button
+    mat-icon-button
+    class="command-copy"
+    [cdkCopyToClipboard]="commandText"
+    title="Copy"
+  >
+    <mat-icon svgIcon="content_copy_24px"></mat-icon>
+  </button>
 </div>
 <p>
   Only certain plugins are currently supported. Uploaded TensorBoards are public

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
@@ -39,10 +39,13 @@ p {
   line-height: 1.5;
 }
 
-.snippet {
+.command {
+  align-items: center;
   background: #f5f6f7;
   border-radius: 4px;
-  padding: 12px;
+  display: flex;
+  justify-content: space-between;
+  padding: 2px 12px;
 }
 
 code {

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ts
@@ -20,5 +20,5 @@ import {Component} from '@angular/core';
   styleUrls: ['./tbdev_upload_dialog_component.css'],
 })
 export class TbdevUploadDialogComponent {
-  commandText: string = 'tensorboard dev upload --logdir {logdir}';
+  readonly commandText: string = 'tensorboard dev upload --logdir {logdir}';
 }

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ts
@@ -19,4 +19,6 @@ import {Component} from '@angular/core';
   templateUrl: './tbdev_upload_dialog_component.ng.html',
   styleUrls: ['./tbdev_upload_dialog_component.css'],
 })
-export class TbdevUploadDialogComponent {}
+export class TbdevUploadDialogComponent {
+  commandText: string = 'tensorboard dev upload --logdir {logdir}';
+}

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_module.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_module.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {ClipboardModule} from '@angular/cdk/clipboard';
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MatButtonModule} from '@angular/material/button';
@@ -25,6 +26,12 @@ import {TbdevUploadDialogComponent} from './tbdev_upload_dialog_component';
   declarations: [TbdevUploadButtonComponent, TbdevUploadDialogComponent],
   exports: [TbdevUploadButtonComponent],
   entryComponents: [TbdevUploadDialogComponent],
-  imports: [CommonModule, MatButtonModule, MatDialogModule, MatIconModule],
+  imports: [
+    ClipboardModule,
+    CommonModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatIconModule,
+  ],
 })
 export class TbdevUploadModule {}

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {CdkCopyToClipboard, ClipboardModule} from '@angular/cdk/clipboard';
+import {Clipboard, ClipboardModule} from '@angular/cdk/clipboard';
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {TestBed} from '@angular/core/testing';
 import {MatButtonModule} from '@angular/material/button';
@@ -25,7 +25,7 @@ import {TbdevUploadDialogComponent} from './tbdev_upload_dialog_component';
 import {TbdevUploadButtonComponent} from './tbdev_upload_button_component';
 
 describe('tbdev upload test', () => {
-  // const clipboardSpy = jasmine.createSpyObj('CdkCopyToClipboard', ['copy']);
+  const clipboardSpy = jasmine.createSpyObj('Clipboard', ['copy']);
   let overlayContainer: OverlayContainer;
 
   beforeEach(async () => {
@@ -41,16 +41,7 @@ describe('tbdev upload test', () => {
         NoopAnimationsModule,
       ],
       declarations: [TbdevUploadDialogComponent, TbdevUploadButtonComponent],
-      // providers: [
-      //   {
-      //     providers: CdkCopyToClipboard,
-      //     useFactory: () => {
-      //       debugger;
-      //       return clipboardSpy;
-      //     },
-      //   },
-      // ],
-      // providers: [{providers: CdkCopyToClipboard, useValue: clipboardSpy}],
+      providers: [{provide: Clipboard, useValue: clipboardSpy}],
     }).compileComponents();
     overlayContainer = TestBed.inject(OverlayContainer);
   });
@@ -80,12 +71,12 @@ describe('tbdev upload test', () => {
     fixture.detectChanges();
 
     const copyElement = fixture.debugElement.query(By.css('.command-copy'));
-
-    // Is it possible to get a reference to the directive here so I can
-    // spy on it?
-
     copyElement.nativeElement.click();
     fixture.detectChanges();
     await fixture.whenStable();
+
+    expect(clipboardSpy.copy).toHaveBeenCalledWith(
+      'tensorboard dev upload --logdir {logdir}'
+    );
   });
 });

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
@@ -29,9 +29,6 @@ describe('tbdev upload test', () => {
   let overlayContainer: OverlayContainer;
 
   beforeEach(async () => {
-    // I had hoped I could provide a mocked directive implementation using
-    // TestBed providers but the element always constructs a real
-    // instance of CdkCopyToClipboard.
     await TestBed.configureTestingModule({
       imports: [
         ClipboardModule,

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {ClipboardModule} from '@angular/cdk/clipboard';
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {TestBed} from '@angular/core/testing';
 import {MatButtonModule} from '@angular/material/button';
@@ -19,6 +20,7 @@ import {MatDialogModule} from '@angular/material/dialog';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
+import {MatIconTestingModule} from '../testing/mat_icon.module';
 import {TbdevUploadDialogComponent} from './tbdev_upload_dialog_component';
 import {TbdevUploadButtonComponent} from './tbdev_upload_button_component';
 
@@ -27,7 +29,13 @@ describe('tbdev upload test', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MatButtonModule, MatDialogModule, NoopAnimationsModule],
+      imports: [
+        ClipboardModule,
+        MatButtonModule,
+        MatDialogModule,
+        MatIconTestingModule,
+        NoopAnimationsModule,
+      ],
       declarations: [TbdevUploadDialogComponent, TbdevUploadButtonComponent],
     }).compileComponents();
     overlayContainer = TestBed.inject(OverlayContainer);

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
@@ -63,7 +63,7 @@ describe('tbdev upload test', () => {
     expect(tbdevUploadDialogsAfter.length).toBe(1);
   });
 
-  fit('allows command to be copied', async () => {
+  it('allows command to be copied', async () => {
     const fixture = TestBed.createComponent(TbdevUploadDialogComponent);
     fixture.detectChanges();
 

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {ClipboardModule} from '@angular/cdk/clipboard';
+import {CdkCopyToClipboard, ClipboardModule} from '@angular/cdk/clipboard';
 import {OverlayContainer} from '@angular/cdk/overlay';
 import {TestBed} from '@angular/core/testing';
 import {MatButtonModule} from '@angular/material/button';
@@ -25,9 +25,13 @@ import {TbdevUploadDialogComponent} from './tbdev_upload_dialog_component';
 import {TbdevUploadButtonComponent} from './tbdev_upload_button_component';
 
 describe('tbdev upload test', () => {
+  // const clipboardSpy = jasmine.createSpyObj('CdkCopyToClipboard', ['copy']);
   let overlayContainer: OverlayContainer;
 
   beforeEach(async () => {
+    // I had hoped I could provide a mocked directive implementation using
+    // TestBed providers but the element always constructs a real
+    // instance of CdkCopyToClipboard.
     await TestBed.configureTestingModule({
       imports: [
         ClipboardModule,
@@ -37,6 +41,16 @@ describe('tbdev upload test', () => {
         NoopAnimationsModule,
       ],
       declarations: [TbdevUploadDialogComponent, TbdevUploadButtonComponent],
+      // providers: [
+      //   {
+      //     providers: CdkCopyToClipboard,
+      //     useFactory: () => {
+      //       debugger;
+      //       return clipboardSpy;
+      //     },
+      //   },
+      // ],
+      // providers: [{providers: CdkCopyToClipboard, useValue: clipboardSpy}],
     }).compileComponents();
     overlayContainer = TestBed.inject(OverlayContainer);
   });
@@ -59,5 +73,19 @@ describe('tbdev upload test', () => {
       .querySelectorAll('tbdev-upload-dialog');
 
     expect(tbdevUploadDialogsAfter.length).toBe(1);
+  });
+
+  fit('allows command to be copied', async () => {
+    const fixture = TestBed.createComponent(TbdevUploadDialogComponent);
+    fixture.detectChanges();
+
+    const copyElement = fixture.debugElement.query(By.css('.command-copy'));
+
+    // Is it possible to get a reference to the directive here so I can
+    // spy on it?
+
+    copyElement.nativeElement.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
   });
 });

--- a/tensorboard/webapp/testing/mat_icon.module.ts
+++ b/tensorboard/webapp/testing/mat_icon.module.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import {Component, Input, NgModule} from '@angular/core';
 
 const KNOWN_SVG_ICON = new Set([
+  'content_copy_24px',
   'help_outline_24px',
   'info_outline_24px',
   'refresh_24px',

--- a/third_party/js.bzl
+++ b/third_party/js.bzl
@@ -489,6 +489,10 @@ def tensorboard_js_workspace():
         name = "com_google_material_design_icon",
         licenses = ["notice"],  # Apache 2.0
         sha256_urls = {
+            "fa4ad2661739c9ecefa121c41f5c95de878d4990ee86413124585a3af7d7dffb": [
+                "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/3.0.1/content/svg/production/ic_content_copy_24px.svg",
+                "https://raw.githubusercontent.com/google/material-design-icons/3.0.1/content/svg/production/ic_content_copy_24px.svg",
+            ],
             "962aee2433f026ed7843790f6757dc3c25c34f349feb9b4fe816629b1b22442d": [
                 "http://mirror.tensorflow.org/raw.githubusercontent.com/google/material-design-icons/3.0.1/action/svg/production/ic_help_outline_24px.svg",
                 "https://raw.githubusercontent.com/google/material-design-icons/3.0.1/action/svg/production/ic_help_outline_24px.svg",
@@ -507,6 +511,7 @@ def tensorboard_js_workspace():
             ],
         },
         rename = {
+            "ic_content_copy_24px.svg": "content_copy_24px.svg",
             "ic_help_outline_24px.svg": "help_outline_24px.svg",
             "ic_info_outline_24px.svg": "info_outline_24px.svg",
             "ic_refresh_24px.svg": "refresh_24px.svg",


### PR DESCRIPTION
* Motivation for features / changes
TensorBoard.dev upload dialog contains a sample command to upload to TensorBoard.dev. We want to add a button to make it easier for the user to copy.

* Technical description of changes
Add an icon button to the left of the sample text. A click copies it to the clipboard.

* Screenshots of UI changes
![image](https://user-images.githubusercontent.com/17152369/85876729-24e92480-b7a4-11ea-8d47-3ed87866662f.png)

* Detailed steps to verify changes work correctly (as executed by you)
I have local changes (not part of the PR) that embed the TensorBoard.dev upload button and dialog into the app.  I open the dialog.  I press the copy button. I paste text from the clipboard into a text element and note that it is the sample command text.
