### PR TITLE
Fix numpy deprecation warnings

### DIFF
--- a/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
+++ b/tensorboard/examples/plugins/example_basic/tensorboard_plugin_example/plugin.py
@@ -101,9 +101,9 @@ class ExamplePlugin(base_plugin.TBPlugin):
             raise werkzeug.exceptions.BadRequest("Must specify run and tag")
         try:
             data = [
-                np.asscalar(
-                    tensor_util.make_ndarray(event.tensor_proto)
-                ).decode("utf-8")
+                tensor_util.make_ndarray(event.tensor_proto)
+                .item()
+                .decode("utf-8")
                 for event in self._multiplexer.Tensors(run, tag)
             ]
         except KeyError:

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
@@ -301,7 +301,7 @@ class CustomScalarsPlugin(base_plugin.TBPlugin):
             string_array = tensor_util.make_ndarray(
                 tensor_events[0].tensor_proto
             )
-            content = np.asscalar(string_array)
+            content = string_array.item()
             layout_proto = layout_pb2.Layout()
             layout_proto.ParseFromString(tf.compat.as_bytes(content))
 

--- a/tensorboard/plugins/custom_scalar/summary_test.py
+++ b/tensorboard/plugins/custom_scalar/summary_test.py
@@ -109,7 +109,7 @@ class LayoutTest(tf.test.TestCase):
 
         # Parse the data.
         string_array = tensor_util.make_ndarray(tensor_events[0].tensor_proto)
-        content = np.asscalar(string_array)
+        content = string_array.item()
         layout_proto_from_disk = layout_pb2.Layout()
         layout_proto_from_disk.ParseFromString(tf.compat.as_bytes(content))
 

--- a/tensorboard/plugins/text/text_plugin.py
+++ b/tensorboard/plugins/text/text_plugin.py
@@ -176,7 +176,7 @@ def text_array_to_html(text_arr):
     """
     if not text_arr.shape:
         # It is a scalar. No need to put it in a table, just apply markdown
-        return plugin_util.markdown_to_safe_html(np.asscalar(text_arr))
+        return plugin_util.markdown_to_safe_html(text_arr.item())
     warning = ""
     if len(text_arr.shape) > 2:
         warning = plugin_util.markdown_to_safe_html(

--- a/tensorboard/util/tensor_util.py
+++ b/tensorboard/util/tensor_util.py
@@ -25,7 +25,7 @@ from tensorboard.compat.tensorflow_stub import dtypes, compat, tensor_shape
 
 
 def ExtractBitsFromFloat16(x):
-    return np.asscalar(np.asarray(x, dtype=np.float16).view(np.uint16))
+    return np.asarray(x, dtype=np.float16).view(np.uint16).item()
 
 
 def SlowAppendFloat16ArrayToTensorProto(tensor_proto, proto_values):
@@ -35,8 +35,10 @@ def SlowAppendFloat16ArrayToTensorProto(tensor_proto, proto_values):
 
 
 def ExtractBitsFromBFloat16(x):
-    return np.asscalar(
-        np.asarray(x, dtype=dtypes.bfloat16.as_numpy_dtype).view(np.uint16)
+    return (
+        np.asarray(x, dtype=dtypes.bfloat16.as_numpy_dtype)
+        .view(np.uint16)
+        .item()
     )
 
 
@@ -47,42 +49,42 @@ def SlowAppendBFloat16ArrayToTensorProto(tensor_proto, proto_values):
 
 
 def SlowAppendFloat32ArrayToTensorProto(tensor_proto, proto_values):
-    tensor_proto.float_val.extend([np.asscalar(x) for x in proto_values])
+    tensor_proto.float_val.extend([x.item() for x in proto_values])
 
 
 def SlowAppendFloat64ArrayToTensorProto(tensor_proto, proto_values):
-    tensor_proto.double_val.extend([np.asscalar(x) for x in proto_values])
+    tensor_proto.double_val.extend([x.item() for x in proto_values])
 
 
 def SlowAppendIntArrayToTensorProto(tensor_proto, proto_values):
-    tensor_proto.int_val.extend([np.asscalar(x) for x in proto_values])
+    tensor_proto.int_val.extend([x.item() for x in proto_values])
 
 
 def SlowAppendInt64ArrayToTensorProto(tensor_proto, proto_values):
-    tensor_proto.int64_val.extend([np.asscalar(x) for x in proto_values])
+    tensor_proto.int64_val.extend([x.item() for x in proto_values])
 
 
 def SlowAppendQIntArrayToTensorProto(tensor_proto, proto_values):
-    tensor_proto.int_val.extend([np.asscalar(x[0]) for x in proto_values])
+    tensor_proto.int_val.extend([x[0].item() for x in proto_values])
 
 
 def SlowAppendUInt32ArrayToTensorProto(tensor_proto, proto_values):
-    tensor_proto.uint32_val.extend([np.asscalar(x) for x in proto_values])
+    tensor_proto.uint32_val.extend([x.item() for x in proto_values])
 
 
 def SlowAppendUInt64ArrayToTensorProto(tensor_proto, proto_values):
-    tensor_proto.uint64_val.extend([np.asscalar(x) for x in proto_values])
+    tensor_proto.uint64_val.extend([x.item() for x in proto_values])
 
 
 def SlowAppendComplex64ArrayToTensorProto(tensor_proto, proto_values):
     tensor_proto.scomplex_val.extend(
-        [np.asscalar(v) for x in proto_values for v in [x.real, x.imag]]
+        [v.item() for x in proto_values for v in [x.real, x.imag]]
     )
 
 
 def SlowAppendComplex128ArrayToTensorProto(tensor_proto, proto_values):
     tensor_proto.dcomplex_val.extend(
-        [np.asscalar(v) for x in proto_values for v in [x.real, x.imag]]
+        [v.item() for x in proto_values for v in [x.real, x.imag]]
     )
 
 
@@ -91,7 +93,7 @@ def SlowAppendObjectArrayToTensorProto(tensor_proto, proto_values):
 
 
 def SlowAppendBoolArrayToTensorProto(tensor_proto, proto_values):
-    tensor_proto.bool_val.extend([np.asscalar(x) for x in proto_values])
+    tensor_proto.bool_val.extend([x.item() for x in proto_values])
 
 
 _NP_TO_APPEND_FN = {
@@ -455,7 +457,7 @@ def make_tensor_proto(values, dtype=None, shape=None, verify_shape=False):
             raise ValueError(
                 "Cannot create a tensor proto whose content is larger than 2GB."
             )
-        tensor_proto.tensor_content = nparray.tostring()
+        tensor_proto.tensor_content = nparray.tobytes()
         return tensor_proto
 
     # If we were not given values as a numpy array, compute the proto_values


### PR DESCRIPTION
This change replaces the following deprecated numpy calls:
- [`numpy.asscalar`](https://numpy.org/doc/stable/reference/generated/numpy.asscalar.html) deprecated since 1.16 --> `numpy.ndarray.item()`
- [`numpy.ndarray.tostring()`](https://numpy.org/devdocs/reference/generated/numpy.ndarray.tostring.html) deprecated since 1.19 --> `numpy.ndarray.tobytes()`