### PR TITLE
Custom display API

### DIFF
--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -53,9 +53,11 @@ _CONTEXT_CUSTOM = "_CONTEXT_CUSTOM"
 
 _custom_display = None
 
+
 def register_custom_display(func):
     global _custom_display
     _custom_display = func
+
 
 def _get_context():
     """Determine the most specific context that we're in.

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -55,7 +55,7 @@ _custom_display = None
 
 
 def register_custom_display(func):
-    """Register a custom inline display function
+    """Register a custom function to display a running TensorBoard instance.
 
     Args:
       func: a function that takes in the following parameters and renders the

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -54,6 +54,7 @@ _CONTEXT_CUSTOM = "_CONTEXT_CUSTOM"
 _custom_display = None
 
 def register_custom_display(func):
+    global _custom_display
     _custom_display = func
 
 def _get_context():

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -55,6 +55,17 @@ _custom_display = None
 
 
 def register_custom_display(func):
+    """Register a custom inline display function
+
+    Args:
+      func: a function that takes in the following parameters and renders the
+            Tensorboard UI.
+            port:           The port that the Tensorboard process listens to.
+            height:         The height of the frame into which to render the
+                            TensorBoard UI.
+            display_handle: If not None, an IPython display handle into which
+                            to render TensorBoard.
+    """
     global _custom_display
     _custom_display = func
 

--- a/tensorboard/notebook_test.py
+++ b/tensorboard/notebook_test.py
@@ -32,8 +32,8 @@ class CustomDisplayAPITest(tb_test.TestCase):
 
     counter = 0
 
-    # Mock a StartLaunched result so to prevent starting a Tensorboard
-    # process in the following tests
+    # Mock a StartLaunched result to prevent starting a Tensorboard process
+    # when calling notebook.start()
     _info = manager.TensorBoardInfo(
         version="x.x",
         start_time=0,

--- a/tensorboard/notebook_test.py
+++ b/tensorboard/notebook_test.py
@@ -1,0 +1,79 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorboard import notebook
+from tensorboard import manager
+from tensorboard import test as tb_test
+
+try:
+    # python version >= 3.3
+    from unittest import mock
+except ImportError:
+    import mock  # pylint: disable=unused-import
+
+
+class CustomDisplayAPITest(tb_test.TestCase):
+    """Tests for `notebook.register_custom_display()`."""
+
+    counter = 0
+
+    # Mock a StartLaunched result so to prevent starting a Tensorboard
+    # process in the following tests
+    _info = manager.TensorBoardInfo(
+        version="x.x",
+        start_time=0,
+        pid=0,
+        port=6006,
+        path_prefix="prefix",
+        logdir="dir",
+        db="db",
+        cache_key="key",
+    )
+    _startup_result = manager.StartLaunched(info=_info)
+
+    def custom_display(self, port, height, display_handle):
+        del port
+        del height
+        del display_handle
+        self.counter = 1
+
+    def reset(self):
+        self.counter = 0
+
+    def test_get_context(self):
+        notebook.register_custom_display(self.custom_display)
+        self.assertEqual(notebook._get_context(), "_CONTEXT_CUSTOM")
+
+    def test_display(self):
+        notebook.register_custom_display(self.custom_display)
+        notebook.display(6006)
+        self.assertEqual(self.counter, 1)
+        self.reset()
+
+    def test_start(self):
+        with mock.patch(
+            "tensorboard.manager.start", lambda _: self._startup_result
+        ):
+            notebook.register_custom_display(self.custom_display)
+            notebook.start("--logdir test")
+        self.assertEqual(self.counter, 1)
+        self.reset()
+
+
+if __name__ == "__main__":
+    tb_test.main()


### PR DESCRIPTION
* Motivation for features / changes
    - This feature lets users to directly set an inline display function for the notebook API that works in their environment, providing more flexibility for Tensorboard to be used on various notebook environments. See RFC https://github.com/tensorflow/tensorboard/issues/3752 for more details.

* Technical description of changes
    - Added a public API to the notebook module that allows users to set a custom display function.
    -  In `_get_context` ([link](https://github.com/jerrylian-db/tensorboard/blob/ed147694346da9c1553c2da1a705cc03c38b3298/tensorboard/notebook.py#L60)), we add a context type that is returned when the library detects that the custom display function is set. This new context type then causes the `_display` function ([link](https://github.com/jerrylian-db/tensorboard/blob/ed147694346da9c1553c2da1a705cc03c38b3298/tensorboard/notebook.py#L283)) to use the custom display function to display Tensorboard inline to python notebooks.

* Screenshots of UI changes
    - N/A

* Detailed steps to verify changes work correctly (as executed by you)
    1. Clone the repo.
    2. In the repo root directory, start a Jupyter notebook process and create a notebook inside of it. (Make sure that your environment has Tensorboard installed as the following code depends on having a Tensorboard binary in the environment.)
    3. Run the following code..
```python
import tensorboard
import random, IPython
def custom_display(port, height, display_handle):
    del display_handle

    frame_id = "tensorboard-frame-{:08x}".format(random.getrandbits(64))
    html_string = """
        <h1>Custom Inline Display</h1>
        <iframe id="%ID%" width="100%" height="%HEIGHT%" frameborder="0"></iframe>
        <script>
            (function() {
                const frame = document.getElementById("%ID%");
                const url = new URL("/", window.location);
                const port = %PORT%;
                if (port) {
                  url.port = port;
                }
                frame.src = url;
            })();
        </script>
    </html>
    """

    replacements = [
        ("ID%", frame_id),
        ("%HEIGHT%", "%d" % height),
        ("%PORT%", "%d" % port),
    ]

    for (k, v) in replacements:
        html_string = html_string.replace(k, v)
    iframe = IPython.display.HTML(html_string)
    IPython.display.display(iframe)
tensorboard.notebook.register_custom_display(custom_display)
tensorboard.notebook.start("--logdir test")
```
Result:
<img width="1092" alt="Screen Shot 2020-06-29 at 3 49 40 PM" src="https://user-images.githubusercontent.com/66143562/86063644-29ba0c80-ba20-11ea-8882-e7ef04a4c751.png">

* Alternate designs / implementations considered
    - We considered directly modifying the `_display` function to return the custom display if it detects it is set, rather than modifying `_get_context`. But we thought that the presented solution matches existing patterns better.