### PR TITLE
[Debugger] Fix a failing test due to usage of deprecated numpy API

### DIFF
--- a/tensorboard/plugins/debugger/health_pill_calc.py
+++ b/tensorboard/plugins/debugger/health_pill_calc.py
@@ -59,7 +59,7 @@ def calc_health_pill(tensor):
     health_pill[0] = 1.0
 
     if not (
-        np.issubdtype(tensor.dtype, np.float)
+        np.issubdtype(tensor.dtype, np.floating)
         or np.issubdtype(tensor.dtype, np.complex)
         or np.issubdtype(tensor.dtype, np.integer)
         or tensor.dtype == np.bool


### PR DESCRIPTION
* Motivation for features / changes
  * Fix https://github.com/tensorflow/tensorboard/issues/3775
* Technical description of changes
  * `np.float` and `np.floating` don't mean the same thing exactly.
  * The former is a concrete dtype; the latter is a super class of dtypes
    such as float32, float64, etc.
  * `np.issubdtype()` used to allow the second arg to be `np.float` and it would
     interpret it as `np.floating`. But that deprecated behavior has been
     removed in the latest release of numpy (1.19.0).
  * This PR brings the code up to date with that by removing the usage
    of the deprecated behavior of `np.issubdtype()`.
* Tested:
  * Tested the code against a local virtualenv of tensorflow 1.15.0 and numpy
    1.19.0.