### PR TITLE
Change default FE to Angular TB

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -276,12 +276,6 @@ py_test(
     ],
 )
 
-config_setting(
-    name = "dev_build",
-    # consider changing this to fastbuild
-    values = {"compilation_mode": "dbg"},
-)
-
 tensorboard_zip_file(
     name = "webfiles",
     deps = [":assets"],
@@ -296,23 +290,16 @@ monaco_imports = [
 tf_web_library(
     name = "assets",
     srcs = [
-        "//tensorboard/components:index.html",
-        "//tensorboard/components:index.js",
-    ] + select({
-        "//tensorboard:dev_build": [
-            "//tensorboard/webapp:ng_index.html",
-            "//tensorboard/webapp:ng_index.js",
-            "//tensorboard/webapp:svg_bundle",
-        ],
-        "//conditions:default": [],
-    }),
+        "//tensorboard/components:legacy.html",
+        "//tensorboard/components:legacy.js",
+        "//tensorboard/webapp:index.html",
+        "//tensorboard/webapp:index.js",
+        "//tensorboard/webapp:svg_bundle",
+    ],
     path = "/",
     deps = [
         "@com_google_fonts_roboto",
-    ] + select({
-        "//tensorboard:dev_build": monaco_imports,
-        "//conditions:default": [],
-    }),
+    ] + monaco_imports,
 )
 
 # This is a dummy rule used as a numpy dependency in open-source.

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -281,12 +281,6 @@ tensorboard_zip_file(
     deps = [":assets"],
 )
 
-monaco_imports = [
-    "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/monaco:monaco_editor",
-    "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/monaco:monaco_languages",
-]
-
-# TODO(stephanwlee): add ng_index.html to the srcs when it is ready for mass consumption.
 tf_web_library(
     name = "assets",
     srcs = [
@@ -298,8 +292,10 @@ tf_web_library(
     ],
     path = "/",
     deps = [
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/monaco:monaco_editor",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/monaco:monaco_languages",
         "@com_google_fonts_roboto",
-    ] + monaco_imports,
+    ],
 )
 
 # This is a dummy rule used as a numpy dependency in open-source.

--- a/tensorboard/components/BUILD
+++ b/tensorboard/components/BUILD
@@ -38,11 +38,11 @@ tf_web_library(
 )
 
 tensorboard_html_binary(
-    name = "index",
+    name = "legacy",
     compile = False,
     input_path = "/tensorboard.html",
-    js_path = "/index.js",
-    output_path = "/index.html",
+    js_path = "/legacy.js",
+    output_path = "/legacy.html",
     deps = [":tensorboard"],
 )
 

--- a/tensorboard/pip_package/test_pip_package.sh
+++ b/tensorboard/pip_package/test_pip_package.sh
@@ -134,7 +134,7 @@ smoke() (
   tensorboard --port=0 --logdir=smokedir 2>pipe &
   perl -ne 'print STDERR;/http:.*:(\d+)/ and print $1.v10 and exit 0' <pipe >port
   curl -fs "http://localhost:$(cat port)" >index.html
-  grep '<tf-tensorboard' index.html
+  grep '<tb-webapp' index.html
   curl -fs "http://localhost:$(cat port)/data/logdir" >logdir.json
   grep 'smokedir' logdir.json
   curl -fs "http://localhost:$(cat port)/data/plugin/projector/runs" >projector_runs.json

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -104,7 +104,7 @@ tf_web_library(
 tf_web_library(
     name = "tensorboard-webapp",
     srcs = [
-        "index.html",
+        "index.inlined.html",
         ":styles.css",
     ],
     path = "/",
@@ -118,17 +118,17 @@ tf_web_library(
 genrule(
     name = "gen_index.html",
     srcs = ["index.uninlined.html"],
-    outs = ["index.html"],
+    outs = ["index.inlined.html"],
     cmd = "$(execpath //tensorboard/logo:inline_favicon) $< >$@",
     tools = ["//tensorboard/logo:inline_favicon"],
 )
 
 # A Vulcanized html binary for the complete app (both Angular and Polymer parts)
 tensorboard_html_binary(
-    name = "ng_index",
-    input_path = "/index.html",
-    js_path = "/ng_index.js",
-    output_path = "/ng_index.html",
+    name = "index",
+    input_path = "/index.inlined.html",
+    js_path = "/index.js",
+    output_path = "/index.html",
     deps = [":tensorboard-webapp"],
 )
 


### PR DESCRIPTION
This commit changes the default route (e.g., localhost:6006/) to the
Angular based TensorBoard.

More an entire minor version, we intend to keep the legacy build around
as an escape hatch.

- This PR will be submitted only after July 6th for the tb-nightly on July 7th.
- Propose this change to make it into TensorBoard 2.3.0 release.
- We should cut TB 2.3.0 release by July 17th (should confirm the real date with TF).

WANT_LGTM=all+date
