### PR TITLE
scalars: return not found for existent but non-scalar tags

### DIFF
--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -144,6 +144,12 @@ class ScalarsPlugin(base_plugin.TBPlugin):
             values = [(x.wall_time, x.step, x.value) for x in scalars]
         else:
             try:
+                # Check that this tag is actually a scalar summary.
+                meta = self._multiplexer.SummaryMetadata(run, tag)
+                if meta.plugin_data.plugin_name != metadata.PLUGIN_NAME:
+                    raise errors.NotFoundError(
+                        "Data for run=%r, tag=%r is not scalar" % (run, tag)
+                    )
                 tensor_events = self._multiplexer.Tensors(run, tag)
             except KeyError:
                 raise errors.NotFoundError(

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -181,10 +181,7 @@ class ScalarsPluginTest(tf.test.TestCase):
         else:
             with self.assertRaises(errors.NotFoundError):
                 plugin.scalars_impl(
-                    self._SCALAR_TAG,
-                    run_name,
-                    "eid",
-                    scalars_plugin.OutputFormat.JSON,
+                    tag_name, run_name, "eid", scalars_plugin.OutputFormat.JSON,
                 )
 
     @with_runs(
@@ -203,10 +200,7 @@ class ScalarsPluginTest(tf.test.TestCase):
         else:
             with self.assertRaises(errors.NotFoundError):
                 plugin.scalars_impl(
-                    self._SCALAR_TAG,
-                    run_name,
-                    "eid",
-                    scalars_plugin.OutputFormat.CSV,
+                    tag_name, run_name, "eid", scalars_plugin.OutputFormat.CSV,
                 )
 
     def test_scalars_json_with_legacy_scalars(self):


### PR DESCRIPTION
This makes the scalars plugin `/scalars` route behave consistently for both the legacy bare multiplexer and the new data provider in that it will ignore tags that exist but aren't scalar summaries.  Previously, the bare multiplexer route would instead try to parse the summary data as a scalar tensor value anyway, which would lead to uncaught numpy exceptions.

The existing tests for this were broken and were using the wrong tag name and therefore passing incorrectly; I confirmed that the fixed tests failed before fixing the bug.

(This is pre-work to a later PR that eliminates this weird `should_work` test pattern in the scalars tests entirely.)