### PR TITLE
scalars: set data download filenames on backend, not `a` tag

### DIFF
--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -88,6 +88,7 @@ def Respond(
     content_encoding=None,
     encoding="utf-8",
     csp_scripts_sha256s=None,
+    filename=None,
 ):
     """Construct a werkzeug Response.
 
@@ -128,6 +129,10 @@ def Respond(
         elements for script-src of the Content-Security-Policy. If it is None, the
         HTML will disallow any script to execute. It is only be used when the
         content_type is text/html.
+      filename: If non-empty, the `Content-Disposition: attachment` header will
+        be sent specifying this value as the filename. For most user agents this
+        will trigger a file download. Callers should take care to sanitize the
+        filename if derived from user-controlled strings.
 
     Returns:
       A werkzeug Response object (a WSGI application).
@@ -184,6 +189,8 @@ def Respond(
     headers.append(("X-Content-Type-Options", "nosniff"))
     if content_encoding:
         headers.append(("Content-Encoding", content_encoding))
+    if filename:
+        headers.append(("Content-Disposition", 'filename="%s"' % filename))
     if expires > 0:
         e = wsgiref.handlers.format_date_time(time.time() + float(expires))
         headers.append(("Expires", e))

--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -190,7 +190,10 @@ def Respond(
     if content_encoding:
         headers.append(("Content-Encoding", content_encoding))
     if filename:
-        headers.append(("Content-Disposition", 'filename="%s"' % filename))
+        quoted_filename = werkzeug.http.quote_header_value(
+            filename, allow_token=False  # Always use quotes even if not needed.
+        )
+        headers.append(("Content-Disposition", "filename=%s" % quoted_filename))
     if expires > 0:
         e = wsgiref.handlers.format_date_time(time.time() + float(expires))
         headers.append(("Expires", e))

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -219,6 +219,13 @@ class RespondTest(tb_test.TestCase):
         r = http_util.Respond(q, "<b>hello world</b>", "text/html", expires=60)
         self.assertEqual(r.headers.get("Cache-Control"), "private, max-age=60")
 
+    def testFilename_setsContentDisposition(self):
+        q = wrappers.Request(wtest.EnvironBuilder().get_environ())
+        r = http_util.Respond(q, "hi!", "text/html", filename="foo.html")
+        self.assertEqual(
+            r.headers.get("Content-Disposition"), 'filename="foo.html"',
+        )
+
     def testCsp(self):
         q = wrappers.Request(wtest.EnvironBuilder().get_environ())
         r = http_util.Respond(

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -226,6 +226,13 @@ class RespondTest(tb_test.TestCase):
             r.headers.get("Content-Disposition"), 'filename="foo.html"',
         )
 
+    def testFilename_setsContentDisposition_handlesQuoting(self):
+        q = wrappers.Request(wtest.EnvironBuilder().get_environ())
+        r = http_util.Respond(q, "hi!", "text/html", filename=r'\"weird"')
+        self.assertEqual(
+            r.headers.get("Content-Disposition"), r'filename="\\\"weird\""',
+        )
+
     def testCsp(self):
         q = wrappers.Request(wtest.EnvironBuilder().get_environ())
         r = http_util.Respond(

--- a/tensorboard/components/tf_dashboard_common/tf-downloader.html
+++ b/tensorboard/components/tf_dashboard_common/tf-downloader.html
@@ -34,14 +34,9 @@ limitations under the License.
       </paper-listbox>
     </paper-dropdown-menu>
     <template is="dom-if" if="[[_run]]">
-      <a download="[[_csvName(tag, _run)]]" href="[[_csvUrl(tag, _run, urlFn)]]"
-        >CSV</a
+      <a download href="[[_csvUrl(tag, _run, urlFn)]]">CSV</a
       ><!--
-      --><a
-        download="[[_jsonName(tag, _run)]]"
-        href="[[_jsonUrl(tag, _run, urlFn)]]"
-        >JSON</a
-      >
+      --><a download href="[[_jsonUrl(tag, _run, urlFn)]]">JSON</a>
     </template>
     <style>
       :host {
@@ -79,9 +74,9 @@ limitations under the License.
         tag: String,
         // Clients pass `urlFn: (tag: string, run: string) => string`,
         // which should generate a URL to download data for a given
-        // run/tag combination. The data at the URL should be in JSON
-        // form, and the URL should be such that adding a query
-        // parameter `format=csv` instead yields CSV data.
+        // run/tag combination. The URL should allow adding the query
+        // parameter `format=csv` to get CSV data and adding the query
+        // parameter `format=json` to get JSON data.
         urlFn: Function,
       },
       _csvUrl(tag, run, urlFn) {
@@ -90,15 +85,7 @@ limitations under the License.
       },
       _jsonUrl(tag, run, urlFn) {
         if (!run) return '';
-        return urlFn(tag, run);
-      },
-      _csvName(tag, run) {
-        if (!run) return '';
-        return `run-${run}-tag-${tag}.csv`;
-      },
-      _jsonName(tag, run) {
-        if (!run) return '';
-        return `run-${run}-tag-${tag}.json`;
+        return tf_backend.addParams(urlFn(tag, run), {format: 'json'});
       },
     });
   </script>

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -21,6 +21,7 @@ py_library(
         "//tensorboard/backend:http_util",
         "//tensorboard/data:provider",
         "//tensorboard/plugins:base_plugin",
+        "//tensorboard/util:string_util",
         "//tensorboard/util:tensor_util",
         "@org_pocoo_werkzeug",
         "@org_pythonhosted_six",

--- a/tensorboard/plugins/scalar/scalars_plugin.py
+++ b/tensorboard/plugins/scalar/scalars_plugin.py
@@ -144,6 +144,12 @@ class ScalarsPlugin(base_plugin.TBPlugin):
             values = [(x.wall_time, x.step, x.value) for x in scalars]
         else:
             try:
+                # Check that this tag is actually a scalar summary.
+                meta = self._multiplexer.SummaryMetadata(run, tag)
+                if meta.plugin_data.plugin_name != metadata.PLUGIN_NAME:
+                    raise errors.NotFoundError(
+                        "Data for run=%r, tag=%r is not scalar" % (run, tag)
+                    )
                 tensor_events = self._multiplexer.Tensors(run, tag)
             except KeyError:
                 raise errors.NotFoundError(

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -23,12 +23,15 @@ import argparse
 import collections.abc
 import csv
 import functools
+import json
 import os.path
 import unittest
 
 from six import StringIO
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
+from werkzeug import test as werkzeug_test
+from werkzeug import wrappers
 
 from tensorboard import errors
 from tensorboard.backend import application
@@ -168,70 +171,28 @@ class ScalarsPluginTest(tf.test.TestCase):
             plugin.index_impl("eid"),
         )
 
-    @with_runs(
-        [_RUN_WITH_LEGACY_SCALARS, _RUN_WITH_SCALARS, _RUN_WITH_HISTOGRAM]
-    )
-    def _test_scalars_json(self, plugin, run_name, tag_name, should_work=True):
-        if should_work:
-            (data, mime_type) = plugin.scalars_impl(
-                tag_name, run_name, "eid", scalars_plugin.OutputFormat.JSON
+    @with_runs([_RUN_WITH_LEGACY_SCALARS])
+    def test_scalars_with_legacy_scalars(self, plugin):
+        data = plugin.scalars_impl(
+            self._LEGACY_SCALAR_TAG, self._RUN_WITH_LEGACY_SCALARS, "eid"
+        )
+        self.assertEqual(len(data), self._STEPS)
+
+    @with_runs([_RUN_WITH_SCALARS])
+    def test_scalars_with_scalars(self, plugin):
+        data = plugin.scalars_impl(
+            "%s/scalar_summary" % self._SCALAR_TAG,
+            self._RUN_WITH_SCALARS,
+            "eid",
+        )
+        self.assertEqual(len(data), self._STEPS)
+
+    @with_runs([_RUN_WITH_HISTOGRAM])
+    def test_scalars_with_histogram(self, plugin):
+        with self.assertRaises(errors.NotFoundError):
+            plugin.scalars_impl(
+                self._HISTOGRAM_TAG, self._RUN_WITH_HISTOGRAM, "eid",
             )
-            self.assertEqual("application/json", mime_type)
-            self.assertEqual(len(data), self._STEPS)
-        else:
-            with self.assertRaises(errors.NotFoundError):
-                plugin.scalars_impl(
-                    tag_name, run_name, "eid", scalars_plugin.OutputFormat.JSON,
-                )
-
-    @with_runs(
-        [_RUN_WITH_LEGACY_SCALARS, _RUN_WITH_SCALARS, _RUN_WITH_HISTOGRAM]
-    )
-    def _test_scalars_csv(self, plugin, run_name, tag_name, should_work=True):
-        if should_work:
-            (data, mime_type) = plugin.scalars_impl(
-                tag_name, run_name, "eid", scalars_plugin.OutputFormat.CSV
-            )
-            self.assertEqual("text/csv", mime_type)
-            s = StringIO(data)
-            reader = csv.reader(s)
-            self.assertEqual(["Wall time", "Step", "Value"], next(reader))
-            self.assertEqual(len(list(reader)), self._STEPS)
-        else:
-            with self.assertRaises(errors.NotFoundError):
-                plugin.scalars_impl(
-                    tag_name, run_name, "eid", scalars_plugin.OutputFormat.CSV,
-                )
-
-    def test_scalars_json_with_legacy_scalars(self):
-        self._test_scalars_json(
-            self._RUN_WITH_LEGACY_SCALARS, self._LEGACY_SCALAR_TAG
-        )
-
-    def test_scalars_json_with_scalars(self):
-        self._test_scalars_json(
-            self._RUN_WITH_SCALARS, "%s/scalar_summary" % self._SCALAR_TAG
-        )
-
-    def test_scalars_json_with_histogram(self):
-        self._test_scalars_json(
-            self._RUN_WITH_HISTOGRAM, self._HISTOGRAM_TAG, should_work=False
-        )
-
-    def test_scalars_csv_with_legacy_scalars(self):
-        self._test_scalars_csv(
-            self._RUN_WITH_LEGACY_SCALARS, self._LEGACY_SCALAR_TAG
-        )
-
-    def test_scalars_csv_with_scalars(self):
-        self._test_scalars_csv(
-            self._RUN_WITH_SCALARS, "%s/scalar_summary" % self._SCALAR_TAG
-        )
-
-    def test_scalars_csv_with_histogram(self):
-        self._test_scalars_csv(
-            self._RUN_WITH_HISTOGRAM, self._HISTOGRAM_TAG, should_work=False
-        )
 
     @with_runs([_RUN_WITH_LEGACY_SCALARS])
     def test_active_with_legacy_scalars(self, plugin):
@@ -259,6 +220,51 @@ class ScalarsPluginTest(tf.test.TestCase):
             self.assertFalse(plugin.is_active())
         else:
             self.assertTrue(plugin.is_active())
+
+    @with_runs([_RUN_WITH_SCALARS])
+    def test_download_url_json(self, plugin):
+        wsgi_app = application.TensorBoardWSGI([plugin])
+        server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+        expected_filename = (
+            "run-_RUN_WITH_SCALARS-tag-simple-values_scalar_summary"
+        )
+        response = server.get(
+            "/data/plugin/scalars/scalars?run=%s&tag=%s&format=json"
+            % (self._RUN_WITH_SCALARS, "%s/scalar_summary" % self._SCALAR_TAG,)
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("application/json", response.headers["Content-Type"])
+        self.assertEqual(
+            'filename="%s.json"' % expected_filename,
+            response.headers["Content-Disposition"],
+        )
+        payload = json.loads(response.get_data())
+        self.assertEqual(len(payload), self._STEPS)
+
+    @with_runs([_RUN_WITH_SCALARS])
+    def test_download_url_csv(self, plugin):
+        wsgi_app = application.TensorBoardWSGI([plugin])
+        server = werkzeug_test.Client(wsgi_app, wrappers.BaseResponse)
+        expected_filename = (
+            "run-_RUN_WITH_SCALARS-tag-simple-values_scalar_summary"
+        )
+        response = server.get(
+            "/data/plugin/scalars/scalars?run=%s&tag=%s&format=csv"
+            % (self._RUN_WITH_SCALARS, "%s/scalar_summary" % self._SCALAR_TAG,)
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            "text/csv; charset=utf-8", response.headers["Content-Type"]
+        )
+        self.assertEqual(
+            'filename="%s.csv"' % expected_filename,
+            response.headers["Content-Disposition"],
+        )
+        payload = response.get_data()
+        s = StringIO(payload.decode("utf-8"))
+        reader = csv.reader(s)
+        self.assertEqual(["Wall time", "Step", "Value"], next(reader))
+        self.assertEqual(len(list(reader)), self._STEPS)
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/scalar/scalars_plugin_test.py
+++ b/tensorboard/plugins/scalar/scalars_plugin_test.py
@@ -181,10 +181,7 @@ class ScalarsPluginTest(tf.test.TestCase):
         else:
             with self.assertRaises(errors.NotFoundError):
                 plugin.scalars_impl(
-                    self._SCALAR_TAG,
-                    run_name,
-                    "eid",
-                    scalars_plugin.OutputFormat.JSON,
+                    tag_name, run_name, "eid", scalars_plugin.OutputFormat.JSON,
                 )
 
     @with_runs(
@@ -203,10 +200,7 @@ class ScalarsPluginTest(tf.test.TestCase):
         else:
             with self.assertRaises(errors.NotFoundError):
                 plugin.scalars_impl(
-                    self._SCALAR_TAG,
-                    run_name,
-                    "eid",
-                    scalars_plugin.OutputFormat.CSV,
+                    tag_name, run_name, "eid", scalars_plugin.OutputFormat.CSV,
                 )
 
     def test_scalars_json_with_legacy_scalars(self):

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -143,6 +143,24 @@ py_test(
 )
 
 py_library(
+    name = "string_util",
+    srcs = ["string_util.py"],
+    srcs_version = "PY2AND3",
+)
+
+py_test(
+    name = "string_util_test",
+    size = "small",
+    srcs = ["string_util_test.py"],
+    srcs_version = "PY2AND3",
+    tags = ["support_notf"],
+    deps = [
+        ":string_util",
+        "//tensorboard:test",
+    ],
+)
+
+py_library(
     name = "tb_logging",
     srcs = ["tb_logging.py"],
     srcs_version = "PY2AND3",

--- a/tensorboard/util/string_util.py
+++ b/tensorboard/util/string_util.py
@@ -1,0 +1,67 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TensorBoard helper routines for strings."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+import string
+
+
+def sanitize_for_filename(s):
+    """Returns a sanitized filename-friendly version of the input string.
+
+    This discards all characters that are not ASCII letters, digits, or
+    punctuation, and then converts any remaining characters that are not in
+    [-_=,A-Za-z0-9] to "_".
+
+    As a best practice, the caller should still ensure they use a safe
+    prefix and suffix/extension for the filename rather than allowing those
+    to be user-controlled; the return value here should be embedded into a
+    filename pattern rather than used as-is.
+
+    Args:
+      s: text string to sanitize
+
+    Returns:
+      Sanitized version of the string.
+    """
+    return s.translate(_FILENAME_SANITIZER_MAPPING)
+
+
+def _make_filename_sanitizer_mapping():
+    """Helper for `sanitize_for_filename` to construct str.translate() mapping.
+
+    This is used instead of str.maketrans() in order to dynamically return None
+    for all unrecognized characters (and thus discard them) rather than raising
+    lookup errors which would result in preserving those characters.
+
+    Returns:
+      Mapping object compatible with str.translate().
+    """
+    mapping = collections.defaultdict(lambda: None)
+    remapped_chars = string.punctuation
+    allowed_chars = string.ascii_letters + string.digits + "-_="
+    for char in remapped_chars:
+        mapping[ord(char)] = "_"
+    for char in allowed_chars:
+        mapping[ord(char)] = char
+    print(mapping[ord(" ")])
+    return mapping
+
+
+_FILENAME_SANITIZER_MAPPING = _make_filename_sanitizer_mapping()

--- a/tensorboard/util/string_util.py
+++ b/tensorboard/util/string_util.py
@@ -55,7 +55,7 @@ def _make_filename_sanitizer_mapping():
     """
     mapping = collections.defaultdict(lambda: None)
     remapped_chars = string.punctuation
-    allowed_chars = string.ascii_letters + string.digits + "-_="
+    allowed_chars = string.ascii_letters + string.digits + "-_=,"
     for char in remapped_chars:
         mapping[ord(char)] = "_"
     for char in allowed_chars:

--- a/tensorboard/util/string_util_test.py
+++ b/tensorboard/util/string_util_test.py
@@ -27,12 +27,15 @@ class StringUtilTest(tb_test.TestCase):
 
         check("", "")
         check("foo", "foo")
+        check("sub/dir", "sub_dir")
+        check("/rootdir", "_rootdir")
         check("bad.exe", "bad_exe")
         check(
             "punct!#$%&'()*+,-./:;<=>?@[\]^_`{|}~\"uation",
-            "punct___________-_____=______________uation",
+            "punct__________,-_____=______________uation",
         )
         check("w h\ti\nt\re\x0bs\x0cpace", "whitespace")
+        check("uñicode", "uicode")
         check("emo\U0001F95Dji", "emoji")
 
 

--- a/tensorboard/util/string_util_test.py
+++ b/tensorboard/util/string_util_test.py
@@ -1,0 +1,40 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorboard import test as tb_test
+from tensorboard.util import string_util
+
+
+class StringUtilTest(tb_test.TestCase):
+    def test_sanitize_for_filename(self):
+        def check(value, expected):
+            self.assertEqual(string_util.sanitize_for_filename(value), expected)
+
+        check("", "")
+        check("foo", "foo")
+        check("bad.exe", "bad_exe")
+        check(
+            "punct!#$%&'()*+,-./:;<=>?@[\]^_`{|}~\"uation",
+            "punct___________-_____=______________uation",
+        )
+        check("w h\ti\nt\re\x0bs\x0cpace", "whitespace")
+        check("emo\U0001F95Dji", "emoji")
+
+
+if __name__ == "__main__":
+    tb_test.main()


### PR DESCRIPTION
Scalar chart data download URLs use custom filenames that include the user's run and tag names, for ease of identification when downloading from multiple charts.  This PR moves that custom filename support from the frontend, where it used the `download` attribute on `<a>` tags, to the backend, where we use the `Content-Disposition` header.

The intent is to sidestep issues with trying to sanitize the strings going into the `download` attribute so that they aren't intercepted by Polymer Resin; the easiest way I determined to do that was to stop binding to the attribute entirely.  It's a little less elegant in that if we had multiple download widgets for various charts, now each backend location must set the filename rather than having it centralized in the UI component, but right now it's only used in one place anyway and it doesn't seem too onerous even if we had multiple places.

In addition, I actually still implemented some sanitization of the attribute, to eliminate or replace with `_` all characters other than `[-_=A-Za-z0-9]`.  Chrome's auto-downloading behavior already seems to do something fairly similar (using `_` to replace `/`, for instance) but it seemed safest to ensure we're generating innocuous filenames in the first place.

Lastly, the scalar plugin tests for this were a mess, so I unrolled and flattened them a fair bit and added two new tests that explicitly test the `format=` URL behavior end-to-end.

(The first commit on this PR is split out as #3781 since it includes an unrelated behavior change.)