### PR TITLE
Add "Upload" button to header for local users

### DIFF
--- a/tensorboard/webapp/header/BUILD
+++ b/tensorboard/webapp/header/BUILD
@@ -34,6 +34,7 @@ ng_module(
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/settings",
+        "//tensorboard/webapp/tbdev_upload",
         "//tensorboard/webapp/types",
         "@npm//@angular/common",
         "@npm//@angular/core",

--- a/tensorboard/webapp/header/header_component.ts
+++ b/tensorboard/webapp/header/header_component.ts
@@ -20,6 +20,7 @@ import {Component} from '@angular/core';
     <mat-toolbar color="primary">
       <span class="brand">TensorBoard</span>
       <plugin-selector class="plugins"></plugin-selector>
+      <tbdev-upload-button></tbdev-upload-button>
       <app-header-reload></app-header-reload>
       <settings-button></settings-button>
       <a
@@ -42,6 +43,10 @@ import {Component} from '@angular/core';
         height: 64px;
         overflow: hidden;
         width: 100%;
+      }
+
+      tbdev-upload-button.shown {
+        margin: 0 8px 0 16px;
       }
 
       .brand,

--- a/tensorboard/webapp/header/header_module.ts
+++ b/tensorboard/webapp/header/header_module.ts
@@ -24,6 +24,7 @@ import {MatToolbarModule} from '@angular/material/toolbar';
 
 import {CoreModule} from '../core/core_module';
 import {SettingsModule} from '../settings/settings_module';
+import {TbdevUploadModule} from '../tbdev_upload/tbdev_upload_module';
 
 import {HeaderComponent} from './header_component';
 import {PluginSelectorComponent} from './plugin_selector_component';
@@ -48,6 +49,7 @@ import {ReloadContainer} from './reload_container';
     CommonModule,
     CoreModule,
     SettingsModule,
+    TbdevUploadModule,
   ],
 })
 export class HeaderModule {}

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_button_component.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_button_component.ts
@@ -12,15 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Component} from '@angular/core';
+import {Component, HostBinding, Inject} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 
 import {TbdevUploadDialogComponent} from './tbdev_upload_dialog_component';
 
+// A list of hostname values that will trigger the tbdev-upload-button button to
+// appear.
+const LOCAL_HOSTNAMES: string[] = ['localhost', '127.0.0.1'];
+
 @Component({
   selector: 'tbdev-upload-button',
   template: `
-    <button mat-raised-button color="primary" (click)="openDialog()">
+    <button mat-stroked-button *ngIf="shown" (click)="openDialog()">
       <span class="button-contents">
         <mat-icon svgIcon="info_outline_24px"></mat-icon>
         Upload
@@ -32,6 +36,7 @@ import {TbdevUploadDialogComponent} from './tbdev_upload_dialog_component';
       .button-contents {
         align-items: center;
         display: flex;
+        text-transform: uppercase;
       }
       mat-icon {
         margin-right: 6px;
@@ -40,7 +45,14 @@ import {TbdevUploadDialogComponent} from './tbdev_upload_dialog_component';
   ],
 })
 export class TbdevUploadButtonComponent {
-  constructor(private dialog: MatDialog) {}
+  @HostBinding('class.shown') shown: boolean;
+
+  constructor(
+    @Inject('window') window: Window,
+    private readonly dialog: MatDialog
+  ) {
+    this.shown = LOCAL_HOSTNAMES.includes(window.location.hostname);
+  }
 
   openDialog(): void {
     this.dialog.open(TbdevUploadDialogComponent, {

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ng.html
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ng.html
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<h3>Upload to TensorBoard.dev?</h3>
+<h3>Upload to TensorBoard.dev</h3>
 <p>
   TensorBoard.dev enables you to easily host, track, and share your ML
   experiments with everyone. You can share a link to the uploaded TensorBoard in

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_module.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_module.ts
@@ -33,5 +33,6 @@ import {TbdevUploadDialogComponent} from './tbdev_upload_dialog_component';
     MatDialogModule,
     MatIconModule,
   ],
+  providers: [{provide: 'window', useValue: window}],
 })
 export class TbdevUploadModule {}

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
@@ -26,6 +26,7 @@ import {TbdevUploadButtonComponent} from './tbdev_upload_button_component';
 
 describe('tbdev upload test', () => {
   const clipboardSpy = jasmine.createSpyObj('Clipboard', ['copy']);
+  const fakeWindow: any = {};
   const matDialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
   let overlayContainer: OverlayContainer;
 
@@ -41,10 +42,44 @@ describe('tbdev upload test', () => {
       declarations: [TbdevUploadDialogComponent, TbdevUploadButtonComponent],
       providers: [
         {provide: Clipboard, useValue: clipboardSpy},
+        {provide: 'window', useValue: fakeWindow},
         {provide: MatDialogRef, useValue: matDialogRefSpy},
       ],
     }).compileComponents();
     overlayContainer = TestBed.inject(OverlayContainer);
+    fakeWindow.location = {
+      hostname: 'localhost',
+    };
+  });
+
+  it('does not show upload button if hostname is not localhost', async () => {
+    fakeWindow.location.hostname = 'notlocalhost.com';
+    const fixture = TestBed.createComponent(TbdevUploadButtonComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.debugElement.classes.shown).toBeUndefined();
+    expect(fixture.debugElement.children.length).toEqual(0);
+  });
+
+  it('shows upload button if hostname is localhost', async () => {
+    fakeWindow.location.hostname = 'localhost';
+    const fixture = TestBed.createComponent(TbdevUploadButtonComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.debugElement.classes.shown).toBeDefined();
+    expect(fixture.debugElement.children.length).toEqual(1);
+  });
+
+  it('shows upload button if hostname is 127.0.0.1', async () => {
+    fakeWindow.location.hostname = '127.0.0.1';
+    const fixture = TestBed.createComponent(TbdevUploadButtonComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.debugElement.classes.shown).toBeDefined();
+    expect(fixture.debugElement.children.length).toEqual(1);
   });
 
   it('opens a dialog when clicking on the button', async () => {

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_test.ts
@@ -58,7 +58,7 @@ describe('tbdev upload test', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(fixture.debugElement.classes.shown).toBeUndefined();
+    expect(fixture.debugElement.classes['shown']).toBeUndefined();
     expect(fixture.debugElement.children.length).toEqual(0);
   });
 
@@ -68,7 +68,7 @@ describe('tbdev upload test', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(fixture.debugElement.classes.shown).toBeDefined();
+    expect(fixture.debugElement.classes['shown']).toBeDefined();
     expect(fixture.debugElement.children.length).toEqual(1);
   });
 
@@ -78,7 +78,7 @@ describe('tbdev upload test', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(fixture.debugElement.classes.shown).toBeDefined();
+    expect(fixture.debugElement.classes['shown']).toBeDefined();
     expect(fixture.debugElement.children.length).toEqual(1);
   });
 


### PR DESCRIPTION
This is a revert of a revert of https://github.com/tensorflow/tensorboard/pull/3773 with additional changes to fix Google-internal compilation errors with one of the tests.

See https://github.com/tensorflow/tensorboard/commit/b270a281090cd6e70ed9f92570c96f0b6ff1e0fd for the new changes.

See https://github.com/tensorflow/tensorboard/pull/3786 for the original revert.

Original PR description:

* Motivation for features / changes

  Show the "Upload" button to users who load a TensorBoard on localhost. This Upload button is an entry point to the "Upload to TensorBoard.dev" dialog with instructions on how to create a TensorBoard.dev experiment with the event data.  We restrict to localhost users so we can be more certain that the user is the owner of the TensorBoard.

* Technical description of changes

  In the header, check if window.location.hostname is a "localhost" or "127.0.0.1" value.  If so, show the button.

  Also, improve the styling of the button.

  Also, remove "?" from the "Upload to TensorBoard" dialog.

* Screenshots of UI changes

  On localhost:8080 or 127.0.0.1:
  ![image](https://user-images.githubusercontent.com/17152369/86126795-e78adc80-baac-11ea-962a-089bd830c6d6.png)

  On non-localhost:
  ![image](https://user-images.githubusercontent.com/17152369/86126914-1bfe9880-baad-11ea-85b5-9911a1a89749.png)

* Detailed steps to verify changes work correctly (as executed by you)
  * Write some tests.
  * Manually verify:
    * Edit hosts file so www.nytimes.com points to localhost.
    * Load ng_index.html using localhost:<port>, 127.0.0.1:<port>, and www.nytimes.com:<port>
    * Observe in the the first two instances that the "Upload" button appears, with new styling.
    * Observce in the final instance that the "Upload" button does not appear.
