### PR TITLE
Mark new tbdev_upload class members as readonly

### DIFF
--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_button_component.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_button_component.ts
@@ -48,7 +48,7 @@ export class TbdevUploadButtonComponent {
   @HostBinding('class.shown') shown: boolean;
 
   constructor(
-    @Inject('window') window: Window,
+    @Inject('window') readonly window: Window,
     private readonly dialog: MatDialog
   ) {
     this.shown = LOCAL_HOSTNAMES.includes(window.location.hostname);

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ts
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ts
@@ -23,7 +23,9 @@ import {MatDialogRef} from '@angular/material/dialog';
 export class TbdevUploadDialogComponent {
   readonly commandText: string = 'tensorboard dev upload --logdir {logdir}';
 
-  constructor(private dialogRef: MatDialogRef<TbdevUploadDialogComponent>) {}
+  constructor(
+    private readonly dialogRef: MatDialogRef<TbdevUploadDialogComponent>
+  ) {}
 
   onClose(): void {
     this.dialogRef.close();


### PR DESCRIPTION
* Motivation for features / change
Google-internal linter says some recently added members in the tbdev_upload code should be marked as readonly.

* Technical description of changes
Add readonly modifier to some members in tbdev_upload code.