### PR TITLE
ng: make brand styling consistent

### DIFF
--- a/tensorboard/webapp/header/header_component.ts
+++ b/tensorboard/webapp/header/header_component.ts
@@ -54,6 +54,9 @@ import {Component} from '@angular/core';
       app-header-reload,
       settings-button {
         flex: 0 0 auto;
+      }
+
+      .brand {
         letter-spacing: -0.025em;
         margin-left: 10px;
         text-rendering: optimizeLegibility;

--- a/tensorboard/webapp/header/header_component.ts
+++ b/tensorboard/webapp/header/header_component.ts
@@ -54,6 +54,9 @@ import {Component} from '@angular/core';
       app-header-reload,
       settings-button {
         flex: 0 0 auto;
+        letter-spacing: -0.025em;
+        margin-left: 10px;
+        text-rendering: optimizeLegibility;
       }
 
       .plugins {


### PR DESCRIPTION
Summary:
This updates the top-left “TensorBoard” wordmark to use the standard
tracking and positioning. This is consistent with the TensorBoard.dev
wordmark and is also consistent with the legacy Polymer interface.
Styles cribbed from `tf-tensorboard.html`.

The margin to the right, between the brand and the plugin list, is still
inconsistent, but this is fine because the TensorBoard.dev word mark is
a different width, anyway (because of the “.dev” suffix).

Test Plan:
Open both `/` and `/legacy.html` in tabs, and note that the text is
aligned when switching between them.

wchargin-branch: ng-brand-styling
