### PR TITLE
Add the run state in the core state

### DIFF
--- a/tensorboard/webapp/core/BUILD
+++ b/tensorboard/webapp/core/BUILD
@@ -18,3 +18,10 @@ ng_module(
         "@npm//@ngrx/store",
     ],
 )
+
+ng_module(
+    name = "types",
+    srcs = [
+        "types.ts",
+    ],
+)

--- a/tensorboard/webapp/core/actions/BUILD
+++ b/tensorboard/webapp/core/actions/BUILD
@@ -9,6 +9,7 @@ tf_ts_library(
         "index.ts",
     ],
     deps = [
+        "//tensorboard/webapp/core:types",
         "//tensorboard/webapp/types",
         "@npm//@ngrx/store",
     ],

--- a/tensorboard/webapp/core/actions/core_actions.ts
+++ b/tensorboard/webapp/core/actions/core_actions.ts
@@ -84,6 +84,11 @@ export const changePageSize = createAction(
   props<{size: number}>()
 );
 
+/**
+ * Action for when user wants to change the runs selection in the tf-runs-selector.
+ *
+ * Action is reserved for the wrapper for the Polymer based tf-runs-selector.
+ */
 export const polymerInteropRunSelectionChanged = createAction(
   '[Core] Run Selection Changed',
   props<{nextSelection: RunId[]}>()

--- a/tensorboard/webapp/core/actions/core_actions.ts
+++ b/tensorboard/webapp/core/actions/core_actions.ts
@@ -15,6 +15,8 @@ limitations under the License.
 import {createAction, props} from '@ngrx/store';
 import {Environment, PluginId, PluginsListing} from '../../types/api';
 
+import {Run, RunId} from '../types';
+
 // HACK: Below import is for type inference.
 // https://github.com/bazelbuild/rules_nodejs/issues/1013
 /** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
@@ -80,4 +82,14 @@ export const changeReloadPeriod = createAction(
 export const changePageSize = createAction(
   '[Core] Page Size Change',
   props<{size: number}>()
+);
+
+export const polymerInteropRunSelectionChanged = createAction(
+  '[Core] Run Selection Changed',
+  props<{nextSelection: RunId[]}>()
+);
+
+export const fetchRunSucceeded = createAction(
+  '[Core] Run Fetch Successful',
+  props<{runs: Run[]}>()
 );

--- a/tensorboard/webapp/core/store/BUILD
+++ b/tensorboard/webapp/core/store/BUILD
@@ -13,6 +13,7 @@ ng_module(
         "index.ts",
     ],
     deps = [
+        "//tensorboard/webapp/core:types",
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/deeplink",
         "//tensorboard/webapp/types",
@@ -28,6 +29,7 @@ tf_ts_library(
     srcs = [
         "core_initial_state_provider_test.ts",
         "core_reducers_test.ts",
+        "core_selectors_test.ts",
     ],
     tsconfig = "//:tsconfig-test",
     deps = [

--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -108,7 +108,7 @@ const reducer = createReducer(
   }),
   on(actions.fetchRunSucceeded, (state, {runs}) => {
     // Do not modify the runSelection since the Polymer component is the
-    // force of truth for the Polymer Interop.
+    // source of truth for the Polymer Interop.
     return {...state, polymerInteropRuns: runs};
   }),
   on(actions.polymerInteropRunSelectionChanged, (state, {nextSelection}) => {

--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -105,6 +105,21 @@ const reducer = createReducer(
       ...state,
       pageSize: nextPageSize,
     };
+  }),
+  on(actions.fetchRunSucceeded, (state, {runs}) => {
+    // Do not modify the runSelection since the Polymer component is the
+    // force of truth for the Polymer Interop.
+    return {...state, polymerInteropRuns: runs};
+  }),
+  on(actions.polymerInteropRunSelectionChanged, (state, {nextSelection}) => {
+    const selectionSet = new Set(nextSelection);
+    const newSelection = new Map();
+
+    state.polymerInteropRuns.forEach(({id}) => {
+      newSelection.set(id, selectionSet.has(id));
+    });
+
+    return {...state, polymerInteropRunSelection: newSelection};
   })
 );
 

--- a/tensorboard/webapp/core/store/core_reducers_test.ts
+++ b/tensorboard/webapp/core/store/core_reducers_test.ts
@@ -237,4 +237,47 @@ describe('core reducer', () => {
       expect(state2.reloadPeriodInMs).toBe(1);
     });
   });
+
+  describe('#fetchRunSucceeded', () => {
+    it('sets polymerInteropRuns', () => {
+      const state = createCoreState({polymerInteropRuns: []});
+
+      const nextState = reducers(
+        state,
+        actions.fetchRunSucceeded({
+          runs: [{id: '1', name: 'Run name 1'}, {id: '2', name: 'Run name 2'}],
+        })
+      );
+
+      expect(nextState.polymerInteropRuns).toEqual([
+        {id: '1', name: 'Run name 1'},
+        {id: '2', name: 'Run name 2'},
+      ]);
+    });
+  });
+
+  describe('#polymerInteropRunSelectionChanged', () => {
+    it('changes the polymerInteropRunSelection', () => {
+      const state = createCoreState({
+        polymerInteropRuns: [
+          {id: '1', name: 'Run name 1'},
+          {id: '2', name: 'Run name 2'},
+          {id: '3', name: 'Run name 3'},
+          {id: '4', name: 'Run name 4'},
+        ],
+        polymerInteropRunSelection: new Map(),
+      });
+
+      const nextState = reducers(
+        state,
+        actions.polymerInteropRunSelectionChanged({
+          nextSelection: ['1', '2', '4'],
+        })
+      );
+
+      expect(nextState.polymerInteropRunSelection).toEqual(
+        new Map([['1', true], ['2', true], ['3', false], ['4', true]])
+      );
+    });
+  });
 });

--- a/tensorboard/webapp/core/store/core_selectors.ts
+++ b/tensorboard/webapp/core/store/core_selectors.ts
@@ -17,6 +17,7 @@ import {createSelector, createFeatureSelector} from '@ngrx/store';
 import {Environment, PluginId, PluginsListing} from '../../types/api';
 import {LoadState} from '../../types/data';
 import {CoreState, State, CORE_FEATURE_KEY} from './core_types';
+import {Run, RunId} from '../types';
 
 // HACK: These imports are for type inference.
 // https://github.com/bazelbuild/rules_nodejs/issues/1013
@@ -71,5 +72,19 @@ export const getPageSize = createSelector(
   selectCoreState,
   (state: CoreState): number => {
     return state.pageSize;
+  }
+);
+
+export const getRuns = createSelector(
+  selectCoreState,
+  (state: CoreState): Run[] => {
+    return state.polymerInteropRuns;
+  }
+);
+
+export const getRunSelection = createSelector(
+  selectCoreState,
+  (state: CoreState): Map<RunId, boolean> => {
+    return state.polymerInteropRunSelection;
   }
 );

--- a/tensorboard/webapp/core/store/core_selectors_test.ts
+++ b/tensorboard/webapp/core/store/core_selectors_test.ts
@@ -1,0 +1,50 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import * as selectors from './core_selectors';
+import {createState, createCoreState} from '../testing';
+
+describe('core selectors', () => {
+  describe('#getRuns', () => {
+    beforeEach(() => {
+      selectors.getRuns.release();
+    });
+
+    it('returns state', () => {
+      const state = createState(
+        createCoreState({
+          polymerInteropRuns: [{id: '1', name: 'Run name'}],
+        })
+      );
+      expect(selectors.getRuns(state)).toEqual([{id: '1', name: 'Run name'}]);
+    });
+  });
+
+  describe('#getRunSelection', () => {
+    beforeEach(() => {
+      selectors.getRunSelection.release();
+    });
+
+    it('returns state', () => {
+      const state = createState(
+        createCoreState({
+          polymerInteropRunSelection: new Map([['1', false], ['2', true]]),
+        })
+      );
+      expect(selectors.getRunSelection(state)).toEqual(
+        new Map([['1', false], ['2', true]])
+      );
+    });
+  });
+});

--- a/tensorboard/webapp/core/store/core_types.ts
+++ b/tensorboard/webapp/core/store/core_types.ts
@@ -21,6 +21,8 @@ limitations under the License.
 import {Environment, PluginId, PluginsListing} from '../../types/api';
 import {DataLoadState, LoadState} from '../../types/data';
 
+import {Run, RunId} from '../types';
+
 export const CORE_FEATURE_KEY = 'core';
 
 export interface CoreState {
@@ -33,6 +35,10 @@ export interface CoreState {
   // settings.
   pageSize: number;
   environment: Environment;
+  // TODO(stephanwlee): move these state to the `runs` features.
+  // For now, we want them here for Polymer interp states reasons, too.
+  polymerInteropRuns: Run[];
+  polymerInteropRunSelection: Map<RunId, boolean>;
 }
 
 export interface State {
@@ -53,4 +59,6 @@ export const initialState: CoreState = {
     data_location: '',
     window_title: '',
   },
+  polymerInteropRuns: [],
+  polymerInteropRunSelection: new Map(),
 };

--- a/tensorboard/webapp/core/store/core_types.ts
+++ b/tensorboard/webapp/core/store/core_types.ts
@@ -36,7 +36,7 @@ export interface CoreState {
   pageSize: number;
   environment: Environment;
   // TODO(stephanwlee): move these state to the `runs` features.
-  // For now, we want them here for Polymer interp states reasons, too.
+  // For now, we want them here for Polymer interop states reasons, too.
   polymerInteropRuns: Run[];
   polymerInteropRunSelection: Map<RunId, boolean>;
 }

--- a/tensorboard/webapp/core/testing/index.ts
+++ b/tensorboard/webapp/core/testing/index.ts
@@ -63,6 +63,8 @@ export function createCoreState(override?: Partial<CoreState>): CoreState {
     reloadEnabled: true,
     pageSize: 10,
     environment: createEnvironment(),
+    polymerInteropRuns: [],
+    polymerInteropRunSelection: new Map(),
     ...override,
   };
 }

--- a/tensorboard/webapp/core/types.ts
+++ b/tensorboard/webapp/core/types.ts
@@ -1,0 +1,20 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+export type RunId = string;
+
+export interface Run {
+  id: RunId;
+  name: string;
+}


### PR DESCRIPTION
This change adds a concept of `runs` in Angular so we can render the runs selector.

## Goal
- We would like to port Polymer dashboards into Angular
- While transitioning, there will be a mixture of Angular and Polymer component
- For consistency, while transitioning, we want to use Polymer based tf-runs-selector
  rendered in the Angular
- tf-runs-selector takes current runs as an input and we should supply that in Angular
- Angular should, more and more, understand the notion of runs.

## Detail:
- Add a `runs` state in the store
- [in farther future] create a `runs` feature separate from the `core` feature.
