### PR TITLE
Update dots when changing histogram color scale

### DIFF
--- a/tensorboard/plugins/histogram/vz_histogram_timeseries/vz-histogram-timeseries.html
+++ b/tensorboard/plugins/histogram/vz_histogram_timeseries/vz-histogram-timeseries.html
@@ -650,11 +650,12 @@ visualization.
 
         var hoverEnter = histogramEnter
             .append('g')
-            .attr('class', 'hover')
+            .attr('class', 'hover');
+
+        var hoverUpdate = histogramUpdate.select('.hover')
             .style('fill', function(d) {
               return outlineColor(timeAccessor(d));
-            }),
-          hoverUpdate = histogramUpdate.select('.hover');
+            });
 
         hoverEnter.append('circle').attr('r', 2);
 

--- a/tensorboard/plugins/histogram/vz_histogram_timeseries/vz-histogram-timeseries.html
+++ b/tensorboard/plugins/histogram/vz_histogram_timeseries/vz-histogram-timeseries.html
@@ -648,14 +648,13 @@ visualization.
               return outlineColor(timeAccessor(d));
             });
 
-        var hoverEnter = histogramEnter
-            .append('g')
-            .attr('class', 'hover');
+        var hoverEnter = histogramEnter.append('g').attr('class', 'hover');
 
-        var hoverUpdate = histogramUpdate.select('.hover')
-            .style('fill', function(d) {
-              return outlineColor(timeAccessor(d));
-            });
+        var hoverUpdate = histogramUpdate
+          .select('.hover')
+          .style('fill', function(d) {
+            return outlineColor(timeAccessor(d));
+          });
 
         hoverEnter.append('circle').attr('r', 2);
 


### PR DESCRIPTION
When clients of `vz-histogram-timeseries` change the color by setting the
`colorscale` property on the element, the histogram lines and fill colors
update, but the circles that appear on hover/mousemove do not.

This updates the redraw logic to ensure that colors for the mouse-tracking
circles also update.

Manually tested by setting `.colorscale` on a histogram and observing that
the dots change color in both Overlay and Offset mode.

![image](https://user-images.githubusercontent.com/2322480/86661829-f5ef6180-bfa0-11ea-9759-66ce0c5e7e18.png)
