### PR TITLE
ci: enforce `constant-glob` lint warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         # TODO(tensorboard-team): address all lint warnings and remove the exemption.
         run:
           git ls-files -z '*BUILD' third_party/js.bzl | xargs -0 buildifier --mode=check --lint=warn
-          --warnings=-native-py,-native-java,-constant-glob
+          --warnings=-native-py,-native-java
       - run: ./tensorboard/tools/mirror_urls_test.sh
       - name: 'Lint for no py2 BUILD targets'
         # Use | to start a literal so YAML doesn't complain about the '!' character.

--- a/tensorboard/compat/tensorflow_stub/BUILD
+++ b/tensorboard/compat/tensorflow_stub/BUILD
@@ -9,13 +9,12 @@ exports_files(["LICENSE"])
 
 py_library(
     name = "tensorflow_stub",
-    srcs = glob([
-        "*.py",
+    srcs = glob(["*.py"]) + [
         "compat/__init__.py",
         "compat/v1/__init__.py",
         "io/__init__.py",
         "io/gfile.py",
-    ]),
+    ],
     srcs_version = "PY2AND3",
     deps = [
         "//tensorboard:expect_absl_flags_installed",


### PR DESCRIPTION
Summary:
This exemption only had one offender, so we just fix it.

Test Plan:
The output of

```
bazel query 'labels(srcs, //tensorboard/compat/tensorflow_stub)' | sort
```

is unchanged by this patch.

wchargin-branch: ci-enforce-constant-glob
