### PR TITLE
custom-scalars: activate iff custom layout exists

### DIFF
--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin.py
@@ -90,26 +90,8 @@ class CustomScalarsPlugin(base_plugin.TBPlugin):
         }
 
     def is_active(self):
-        """This plugin is active if 2 conditions hold.
-
-        1. The scalars plugin is registered and active.
-        2. There is a custom layout for the dashboard.
-
-        Returns: A boolean. Whether the plugin is active.
-        """
-        if not self._multiplexer:
-            return False
-
-        scalars_plugin_instance = self._get_scalars_plugin()
-        if not (
-            scalars_plugin_instance and scalars_plugin_instance.is_active()
-        ):
-            return False
-
-        # This plugin is active if any run has a layout.
-        return bool(
-            self._multiplexer.PluginRunToTagToContent(metadata.PLUGIN_NAME)
-        )
+        """Plugin is active if there is a custom layout for the dashboard."""
+        return False  # `list_plugins` as called by TB core suffices
 
     def frontend_metadata(self):
         return base_plugin.FrontendMetadata(

--- a/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
+++ b/tensorboard/plugins/custom_scalar/custom_scalars_plugin_test.py
@@ -302,25 +302,7 @@ class CustomScalarsPluginTest(tf.test.TestCase):
         self.assertDictEqual({}, local_plugin.layout_impl())
 
     def testIsActive(self):
-        self.assertTrue(self.plugin.is_active())
-
-    def testIsNotActiveDueToNoLayout(self):
-        # The bar directory contains scalar data but no layout.
-        local_plugin = self.createPlugin(os.path.join(self.logdir, "bar"))
-        self.assertFalse(local_plugin.is_active())
-
-    def testIsNotActiveDueToNoScalarsData(self):
-        # Generate a directory with a layout but no scalars data.
-        directory = os.path.join(self.logdir, "no_scalars")
-        with test_util.FileWriterCache.get(directory) as writer:
-            writer.add_summary(
-                test_util.ensure_tb_summary_proto(
-                    summary.pb(self.logdir_layout)
-                )
-            )
-
-        local_plugin = self.createPlugin(directory)
-        self.assertFalse(local_plugin.is_active())
+        self.assertFalse(self.plugin.is_active())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Currently, the logic for the custom scalars plugin’s `is_active` method
checks that there is data for both the `scalars` and `custom_scalars`
plugins. This doesn’t fit directly into the `data_plugin_names` approach
to determining activity, which requires a disjunction rather than a
conjunction. We could enhance that approach to support more complex
activity conditions, but in this case it seems fine to just stipulate
that the custom scalars dashboard is active whenever `custom_scalars`
data exists; the case where a custom layout exists but there is no
scalar data seems like only a transient edge case, and the failure mode
is just that an empty dashboard appears.

Test Plan:
When pointing at a directory without custom scalar layout data, the
plugin appears as inactive; when pointing at a directory with custom
scalar layout data, the plugin appears as active.

wchargin-branch: custom-scalars-simplify-active
