### PR TITLE
Linkify first mention of "TensorBoard.dev" in Upload dialog

### DIFF
--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ng.html
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ng.html
@@ -22,10 +22,12 @@ limitations under the License.
     rel="noreferrer noopener"
     class="anchor-text"
   >
-  TensorBoard.dev</a> enables you to easily host, track, and share your ML
-  experiments with everyone. You can share a link to the uploaded TensorBoard in
-  papers, blog posts, and social media. This can showcase the results more
-  effectively and helps reproducibility.
+    TensorBoard.dev</a
+  >
+  enables you to easily host, track, and share your ML experiments with
+  everyone. You can share a link to the uploaded TensorBoard in papers, blog
+  posts, and social media. This can showcase the results more effectively and
+  helps reproducibility.
 </p>
 <p>
   To upload a logdir to TensorBoard.dev, run the command:

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ng.html
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ng.html
@@ -16,7 +16,13 @@ limitations under the License.
 -->
 <h3>Upload to TensorBoard.dev</h3>
 <p>
-  TensorBoard.dev enables you to easily host, track, and share your ML
+  <a
+    href="https://tensorboard.dev"
+    target="_blank"
+    rel="noreferrer noopener"
+    class="anchor-text"
+  >
+  TensorBoard.dev</a> enables you to easily host, track, and share your ML
   experiments with everyone. You can share a link to the uploaded TensorBoard in
   papers, blog posts, and social media. This can showcase the results more
   effectively and helps reproducibility.

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.scss
@@ -39,6 +39,11 @@ p {
   line-height: 1.5;
 }
 
+.anchor-text {
+  color: map-get($tb-foreground, link);
+  text-decoration: none;
+}
+
 .command {
   align-items: center;
   background: #f5f6f7;


### PR DESCRIPTION
* Motivation for features / changes
First mention of "TensorBoard.dev" in "Upload" dialog description should be a link to "http://TensorBoard.dev". 

* Technical description
Add link; Use Angular theming to color the link; Remove the underline by request of UX designers.

* Screenshots of UI changes
![image](https://user-images.githubusercontent.com/17152369/86938762-c52d3a80-c10e-11ea-97cb-da79d883af8e.png)

