### PR TITLE
cleanup: added missing ngrx/store/testing deps

### DIFF
--- a/tensorboard/webapp/tbdev_upload/BUILD
+++ b/tensorboard/webapp/tbdev_upload/BUILD
@@ -49,6 +49,7 @@ tf_ts_library(
         "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_dialog",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/core/testing",


### PR DESCRIPTION
This adds missing dependency in the BUILD file to unblock syncing (internally, we require strict deps).