### PR TITLE
Fix getURLPluginData in Angular entry point

### DIFF
--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -49,7 +49,7 @@ namespace tf_storage {
   export const DISAMBIGUATOR = 'disambiguator';
 
   // Keep an up-to-date store of URL params, which iframed plugins can request.
-  export let urlDict: StringDict = componentToDict(readComponent());
+  export let urlDict: StringDict = {};
 
   tf_storage.addHashListener(() => {
     tf_storage.urlDict = componentToDict(readComponent());
@@ -218,7 +218,7 @@ namespace tf_storage {
     return {get, set, getInitializer, getObserver, disposeBinding};
   }
 
-  export function migrateLegacyURLScheme() {
+  export function initialize() {
     /**
      * TODO(psybuzz): move to some compatibility file.
      * For each WIT URL param in the legacy scheme, create another URL param

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -218,7 +218,7 @@ namespace tf_storage {
     return {get, set, getInitializer, getObserver, disposeBinding};
   }
 
-  export function initialize() {
+  export function migrateLegacyURLScheme() {
     /**
      * TODO(psybuzz): move to some compatibility file.
      * For each WIT URL param in the legacy scheme, create another URL param

--- a/tensorboard/components/tf_tensorboard/tf-tensorboard.html
+++ b/tensorboard/components/tf_tensorboard/tf-tensorboard.html
@@ -988,6 +988,7 @@ limitations under the License.
           }
         });
 
+        // Migration must happen after calling `setUseHash`.
         tf_storage.migrateLegacyURLScheme();
 
         this._reloadData();

--- a/tensorboard/webapp/deeplink/hash.ts
+++ b/tensorboard/webapp/deeplink/hash.ts
@@ -31,6 +31,7 @@ interface TfStorageElement extends HTMLElement {
   tf_storage: {
     setString(key: string, value: string, options?: SetStringOption): void;
     getString(key: string): string;
+    initialize(): void;
   };
 }
 
@@ -42,7 +43,10 @@ export class HashDeepLinker implements DeepLinkerInterface {
     this.tfStorage = document.createElement('tf-storage') as TfStorageElement;
     const tfGlobals = document.createElement('tf-globals') as TfGlobalsElement;
 
+    // Note: `initialize()` must be called before `setUseHash`, so that
+    // tfStorage reads from the actual URL, not the fake hash for tests only.
     tfGlobals.tf_globals.setUseHash(true);
+    this.tfStorage.tf_storage.initialize();
   }
 
   getString(key: string): string {

--- a/tensorboard/webapp/deeplink/hash.ts
+++ b/tensorboard/webapp/deeplink/hash.ts
@@ -31,7 +31,7 @@ interface TfStorageElement extends HTMLElement {
   tf_storage: {
     setString(key: string, value: string, options?: SetStringOption): void;
     getString(key: string): string;
-    initialize(): void;
+    migrateLegacyURLScheme(): void;
   };
 }
 
@@ -43,10 +43,11 @@ export class HashDeepLinker implements DeepLinkerInterface {
     this.tfStorage = document.createElement('tf-storage') as TfStorageElement;
     const tfGlobals = document.createElement('tf-globals') as TfGlobalsElement;
 
-    // Note: `initialize()` must be called before `setUseHash`, so that
-    // tfStorage reads from the actual URL, not the fake hash for tests only.
+    // Note: `migrateLegacyURLScheme()` must be called before `setUseHash`, so
+    // that tfStorage reads from the actual URL, not the fake hash for tests
+    // only.
     tfGlobals.tf_globals.setUseHash(true);
-    this.tfStorage.tf_storage.initialize();
+    this.tfStorage.tf_storage.migrateLegacyURLScheme();
   }
 
   getString(key: string): string {


### PR DESCRIPTION
This fixes the broken dynamic plugin API method `getURLPluginData`, which was
broken after the Angular entry point switch. `storage.ts` has an initial call to read
from the URL hash, but this is actually a no-op, since before `setUseHash(true)`
is called, it assumes it should use the "fake hash" by default (for tests only).

In the Polymer entry point world, `tf-tensorboard.html`'s `ready` callback will
`setUseHash(true)` before calling `migrateLegacyURLScheme`, which will
read from the real URL hash and normalize it.

This adds a similar call to the Angular side, in HashDeepLinker.  See #3809.

Manually checked that the repro steps now pass:
![image](https://user-images.githubusercontent.com/2322480/86953818-d162c900-c109-11ea-939d-bbf28832053a.png)
