### PR TITLE
Preserve domains in line chart when changing settings

### DIFF
--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -52,6 +52,11 @@ namespace vz_line_chart2 {
     meta: any;
   };
 
+  export interface AxisDomains {
+    x: [number, number];
+    y: [number, number];
+  }
+
   /**
    * The maximum number of marker symbols within any line for a data series. Too
    * many markers clutter the chart.
@@ -1014,6 +1019,51 @@ namespace vz_line_chart2 {
 
     public onAnchor(fn: () => void) {
       if (this.outer) this.outer.onAnchor(fn);
+    }
+
+    /**
+     * Returns the currently visible domain of the x/y axes.
+     */
+    public getAxisDomains(): AxisDomains {
+      return {
+        x: this.xScale.getTransformationDomain(),
+        y: this.yScale.getTransformationDomain(),
+      };
+    }
+
+    /**
+     * Sets the viewport domain.
+     */
+    public setAxisDomains(domains: AxisDomains) {
+      this.xScale.setTransformationDomain(domains.x);
+      this.yScale.setTransformationDomain(domains.y);
+    }
+
+    /**
+     * Returns whether the extent of rendered data values fits the current
+     * chart viewport domain (includes smoothing and outlier detection).
+     *
+     * This is true when there is no data, and false when the domain has been
+     * transformed from the extent via transformations (pan, zoom).
+     */
+    public isDataFitToDomain(): boolean {
+      return (
+        isDataFitToDomain(this.xAxis.getScale()) &&
+        isDataFitToDomain(this.yAxis.getScale())
+      );
+
+      function isDataFitToDomain(scale) {
+        /**
+         * Domain represents the currently displayed region, possibly a zoomed
+         * in or zoomed out view of the data.
+         *
+         * Extent represents the extent of the data, the range of all provided
+         * datum values.
+         */
+        const domain = scale.getTransformationDomain();
+        const extent = scale.getTransformationExtent();
+        return extent[0] === domain[0] && extent[1] === domain[1];
+      }
     }
   }
 } // namespace vz_line_chart2

--- a/tensorboard/components/vz_line_chart2/log-scale.ts
+++ b/tensorboard/components/vz_line_chart2/log-scale.ts
@@ -64,6 +64,10 @@ namespace vz_line_chart2 {
       return this.domain() as [number, number];
     }
 
+    public setTransformationDomain(domain: [number, number]) {
+      this.domain(domain);
+    }
+
     public getTransformationExtent(): [number, number] {
       return this._getUnboundedExtent(true) as [number, number];
     }

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -444,9 +444,23 @@ namespace vz_line_chart2 {
         );
         var div = d3.select(this.$.chartdiv);
         chart.renderTo(div);
-        if (this._chart) this._chart.destroy();
+        let prevAxisDomains = null;
+        if (this._chart) {
+          prevAxisDomains = {
+            x: this._chart.xScale.getTransformationDomain(),
+            y: this._chart.yScale.getTransformationDomain(),
+          };
+          this._chart.destroy();
+        }
         this._chart = chart;
         this._chart.onAnchor(() => this.fire('chart-attached'));
+
+        // If the new chart replaces an old one, preserve the old chart's
+        // pan/zoom transformation.
+        if (prevAxisDomains) {
+          this._chart.xScale.setTransformationDomain(prevAxisDomains.x);
+          this._chart.yScale.setTransformationDomain(prevAxisDomains.y);
+        }
       }, 350);
     },
 

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -303,26 +303,7 @@ namespace vz_line_chart2 {
      * transformed from the extent via transformations (pan, zoom).
      */
     isDataFitToDomain() {
-      if (!this._chart) {
-        return true;
-      }
-      return (
-        isDataFitToDomain(this._chart.xAxis.getScale()) &&
-        isDataFitToDomain(this._chart.yAxis.getScale())
-      );
-
-      function isDataFitToDomain(scale) {
-        /**
-         * Domain represents the currently displayed region, possibly a zoomed
-         * in or zoomed out view of the data.
-         *
-         * Extent represents the extent of the data, the range of all provided
-         * datum values.
-         */
-        const domain = scale.getTransformationDomain();
-        const extent = scale.getTransformationExtent();
-        return extent[0] === domain[0] && extent[1] === domain[1];
-      }
+      return this._chart ? this._chart.isDataFitToDomain() : true;
     },
 
     /**
@@ -446,10 +427,7 @@ namespace vz_line_chart2 {
         chart.renderTo(div);
         let prevAxisDomains = null;
         if (this._chart) {
-          prevAxisDomains = {
-            x: this._chart.xScale.getTransformationDomain(),
-            y: this._chart.yScale.getTransformationDomain(),
-          };
+          prevAxisDomains = this._chart.getAxisDomains();
           this._chart.destroy();
         }
         this._chart = chart;
@@ -458,8 +436,7 @@ namespace vz_line_chart2 {
         // If the new chart replaces an old one, preserve the old chart's
         // pan/zoom transformation.
         if (prevAxisDomains) {
-          this._chart.xScale.setTransformationDomain(prevAxisDomains.x);
-          this._chart.yScale.setTransformationDomain(prevAxisDomains.y);
+          this._chart.setAxisDomains(prevAxisDomains);
         }
       }, 350);
     },


### PR DESCRIPTION
When clients of VzLineChart2 update the `colorScale` externally, the x/y axis
auto-scales to fit the domain. This may be unwanted behavior if clients want
to allow users to change a chart's color frequently without losing a carefully
crafted viewport domain.

This preserves the existing domains upon changes that recreate the
entire chart (color, xAxisType, yScaleType, tooltipColumns).