### PR TITLE
data: add `AuthProvider` and `AuthContext`

### DIFF
--- a/tensorboard/data/BUILD
+++ b/tensorboard/data/BUILD
@@ -18,6 +18,25 @@ py_library(
 )
 
 py_library(
+    name = "auth",
+    srcs = ["auth.py"],
+    srcs_version = "PY3",
+    deps = [],
+)
+
+py_test(
+    name = "auth_test",
+    size = "small",
+    srcs = ["auth_test.py"],
+    srcs_version = "PY3",
+    tags = ["support_notf"],
+    deps = [
+        ":auth",
+        "//tensorboard:test",
+    ],
+)
+
+py_library(
     name = "provider",
     srcs = ["provider.py"],
     srcs_version = "PY3",

--- a/tensorboard/data/auth.py
+++ b/tensorboard/data/auth.py
@@ -1,0 +1,102 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Experimental framework for authentication in TensorBoard."""
+
+import abc
+
+
+class AuthProvider(metaclass=abc.ABCMeta):
+    """Authentication provider for a specific kind of credential."""
+
+    def authenticate(self, environ):
+        """Produce an opaque auth token from a WSGI request environment.
+
+        Args:
+          environ: A WSGI environment `dict`; see PEP 3333.
+
+        Returns:
+          A Python object representing an auth token. The representation
+          and semantics depend on the particular `AuthProvider`
+          implementation.
+
+        Raises:
+          Exception: Any error, usually `tensorboard.errors.PublicError`
+            subclasses (like `PermissionDenied`) but also possibly a
+            custom error type that should propagate to a WSGI middleware
+            for effecting a redirect-driven auth flow.
+        """
+        pass
+
+
+class AuthContext:
+    """Authentication context within the scope of a single request.
+
+    Auth providers are keyed within an `AuthContext` by arbitrary
+    unique keys. It may often make sense for the key used for an
+    auth provider to simply be that provider's type object.
+    """
+
+    def __init__(self, providers, environ):
+        """Create an auth context.
+
+        Args:
+          providers: A mapping from provider keys (opaque values) to
+            `AuthProvider` implementations.
+          environ: A WSGI environment (see PEP 3333).
+        """
+        self._environ = environ
+        self._providers = providers
+        self._cache = {}
+
+    @classmethod
+    def empty(cls):
+        """Create an auth context with no registered providers.
+
+        Returns:
+          A new `AuthContext` value for which any call to `get` will
+          fail with a `KeyError`.
+        """
+        # Use an empty dict for the environ. This is not a valid WSGI
+        # environment, but it doesn't matter because it's never used.
+        return cls({}, {})
+
+    def get(self, provider_key):
+        """Get an auth token from the auth provider with the given key.
+
+        If successful, the result will be cached on this auth context.
+        If unsuccessful, nothing will be cached, so a future call will
+        invoke the underlying `AuthProvider.authenticate` method again.
+
+        This method is not thread-safe. If multiple threads share an
+        auth context for a single request, then they must synchronize
+        externally when calling this method.
+
+        Returns:
+          The result of `provider.authenticate(...)` for the auth
+          provider specified by `provider_key`.
+
+        Raises:
+          KeyError: If the given `provider_key` does not correspond to
+            any registered `AuthProvider`.
+          Exception: As raised by the underlying `AuthProvider`.
+        """
+        provider = self._providers[provider_key]
+        sentinel = object()
+        value = self._cache.get(provider_key, sentinel)
+        if value is not sentinel:
+            return value
+        value = provider.authenticate(self._environ)
+        self._cache[provider_key] = value
+        return value

--- a/tensorboard/data/auth_test.py
+++ b/tensorboard/data/auth_test.py
@@ -1,0 +1,54 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for tensorboard.data.auth."""
+
+from tensorboard import test as tb_test
+from tensorboard.data import auth
+
+
+class AuthContextTest(tb_test.TestCase):
+    def test_cache_success(self):
+        call_count_box = [0]
+
+        class UsernameProvider(auth.AuthProvider):
+            def authenticate(self, environ):
+                call_count_box[0] += 1
+                return environ["username"]
+
+        providers = {UsernameProvider: UsernameProvider()}
+        auth_ctx = auth.AuthContext(providers, {"username": "whoami"})
+        self.assertEqual(auth_ctx.get(UsernameProvider), "whoami")
+        self.assertEqual(auth_ctx.get(UsernameProvider), "whoami")
+        self.assertEqual(call_count_box[0], 1)
+
+    def test_cache_failure(self):
+        call_count_box = [0]
+
+        class FailureProvider(auth.AuthProvider):
+            def authenticate(self, environ):
+                call_count_box[0] += 1
+                raise RuntimeError()
+
+        providers = {FailureProvider: FailureProvider()}
+        auth_ctx = auth.AuthContext(providers, {})
+        with self.assertRaises(RuntimeError):
+            auth_ctx.get(FailureProvider)
+        with self.assertRaises(RuntimeError):
+            auth_ctx.get(FailureProvider)
+        self.assertEqual(call_count_box[0], 2)
+
+
+if __name__ == "__main__":
+    tb_test.main()


### PR DESCRIPTION
Summary:
This patch adds two new types for integrating authentication into the
data provider API. The `AuthProvider` type defines an interface for
extracting a specific kind of credential (say, an OAuth token) from a
WSGI environment. The `AuthContext` type lets clients ask for a
credential from a specific type of `AuthProvider`.

As written, `AuthContext` is not threadsafe. Making it truly threadsafe
is tricky if we assume that the `AuthProvider`s’ `authenticate` methods
do anything that Python code can, including obtaining a reference to the
very same `AuthContext` and calling its `get` method with a different
auth provider. (This would be a Bad Idea on the part of the caller, but
deadlocking would still be unfortunate.) Since most requests are handled
by a single thread, anyway, this shouldn’t be a problem.

Test Plan:
Basic unit tests added. Google-internal proof-of-concept code builds on
this work and shows that the `AuthProvider` interface suffices for now.

wchargin-branch: data-auth
