### PR TITLE
ng: turn off state serialiability check

### DIFF
--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -44,7 +44,7 @@ import {SettingsModule} from './settings/settings_module';
     SettingsModule,
     StoreModule.forRoot(ROOT_REDUCERS, {
       runtimeChecks: {
-        strictStateSerializability: true,
+        strictStateSerializability: false,
         strictActionSerializability: true,
       },
     }),


### PR DESCRIPTION
We started to use `Map` in the store. This change turns off the runtime check.