### PR TITLE
[DebuggerV2] Remove experimental status of plugin

### DIFF
--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -58,14 +58,6 @@ from tensorboard.plugins.mesh import mesh_plugin
 logger = logging.getLogger(__name__)
 
 
-class ExperimentalDebuggerV2Plugin(
-    debugger_v2_plugin.DebuggerV2Plugin, experimental_plugin.ExperimentalPlugin
-):
-    """Debugger v2 plugin marked as experimental."""
-
-    pass
-
-
 class ExperimentalTextV2Plugin(
     text_v2_plugin.TextV2Plugin, experimental_plugin.ExperimentalPlugin
 ):
@@ -80,10 +72,10 @@ _PLUGINS = [
     core_plugin.CorePluginLoader,
     scalars_plugin.ScalarsPlugin,
     custom_scalars_plugin.CustomScalarsPlugin,
-    ExperimentalDebuggerV2Plugin,
     images_plugin.ImagesPlugin,
     audio_plugin.AudioPlugin,
     debugger_plugin_loader.DebuggerPluginLoader,
+    debugger_v2_plugin.DebuggerV2Plugin,
     graphs_plugin.GraphsPlugin,
     distributions_plugin.DistributionsPlugin,
     histograms_plugin.HistogramsPlugin,


### PR DESCRIPTION
* Motivation for features / changes
  * Remove the requirement to use the `experimentalPlugin=debugger-v2` in the
    URL in order to see the Debugger V2 plugin, as discussed offline.
    This is a part of the plan to launch the plugin with tensorflow and tensorboard 2.3.
* Technical description of changes
  * Remove the `ExperimentalPlugin` wrapper for the Python class of
    `DebuggerV2Plugin` in tensorboard/default.py.
* Screenshots of UI changes
  * When *no* DebuggerV2 data is found:
    * ![image](https://user-images.githubusercontent.com/16824702/87050795-c0c75700-c1cc-11ea-9f61-a8ee4b502c1e.png)
  * When Debugger V2 data is found
    * ![image](https://user-images.githubusercontent.com/16824702/87050893-df2d5280-c1cc-11ea-8d10-2474d7e262f6.png)
* Detailed steps to verify changes work correctly (as executed by you)
* Tested:
  * Manual testing of the Debugger V2 plugin and other common plugins including scalar, graph, and histogram/distribution
  * See screenshots above