### PR TITLE
Added the Angular wrapper for tf-runs-selector 

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -32,6 +32,7 @@ ng_module(
         "//tensorboard/webapp/header",
         "//tensorboard/webapp/plugins",
         "//tensorboard/webapp/reloader",
+        "//tensorboard/webapp/runs",
         "//tensorboard/webapp/settings",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser",

--- a/tensorboard/webapp/core/store/core_reducers.ts
+++ b/tensorboard/webapp/core/store/core_reducers.ts
@@ -112,14 +112,7 @@ const reducer = createReducer(
     return {...state, polymerInteropRuns: runs};
   }),
   on(actions.polymerInteropRunSelectionChanged, (state, {nextSelection}) => {
-    const selectionSet = new Set(nextSelection);
-    const newSelection = new Map();
-
-    state.polymerInteropRuns.forEach(({id}) => {
-      newSelection.set(id, selectionSet.has(id));
-    });
-
-    return {...state, polymerInteropRunSelection: newSelection};
+    return {...state, polymerInteropRunSelection: new Set(nextSelection)};
   })
 );
 

--- a/tensorboard/webapp/core/store/core_reducers_test.ts
+++ b/tensorboard/webapp/core/store/core_reducers_test.ts
@@ -265,7 +265,7 @@ describe('core reducer', () => {
           {id: '3', name: 'Run name 3'},
           {id: '4', name: 'Run name 4'},
         ],
-        polymerInteropRunSelection: new Map(),
+        polymerInteropRunSelection: new Set(),
       });
 
       const nextState = reducers(
@@ -276,7 +276,7 @@ describe('core reducer', () => {
       );
 
       expect(nextState.polymerInteropRunSelection).toEqual(
-        new Map([['1', true], ['2', true], ['3', false], ['4', true]])
+        new Set(['1', '2', '4'])
       );
     });
   });

--- a/tensorboard/webapp/core/store/core_selectors.ts
+++ b/tensorboard/webapp/core/store/core_selectors.ts
@@ -89,10 +89,14 @@ const selectSelection = createSelector(
   }
 );
 
+/**
+ * runSelection can be `null` when information is yet missing; e.g., run selection for an
+ * experiment that is not yet fetched.
+ */
 export const getRunSelection = createSelector(
   getRuns,
   selectSelection,
-  (runs: Run[], selection: Set<RunId>): Map<RunId, boolean> => {
+  (runs: Run[], selection: Set<RunId>): Map<RunId, boolean> | null => {
     const runSelection = new Map();
 
     for (const {id} of runs) {

--- a/tensorboard/webapp/core/store/core_selectors.ts
+++ b/tensorboard/webapp/core/store/core_selectors.ts
@@ -82,9 +82,23 @@ export const getRuns = createSelector(
   }
 );
 
-export const getRunSelection = createSelector(
+const selectSelection = createSelector(
   selectCoreState,
-  (state: CoreState): Map<RunId, boolean> => {
+  (state: CoreState): Set<RunId> => {
     return state.polymerInteropRunSelection;
+  }
+);
+
+export const getRunSelection = createSelector(
+  getRuns,
+  selectSelection,
+  (runs: Run[], selection: Set<RunId>): Map<RunId, boolean> => {
+    const runSelection = new Map();
+
+    for (const {id} of runs) {
+      runSelection.set(id, selection.has(id));
+    }
+
+    return runSelection;
   }
 );

--- a/tensorboard/webapp/core/store/core_selectors_test.ts
+++ b/tensorboard/webapp/core/store/core_selectors_test.ts
@@ -39,11 +39,30 @@ describe('core selectors', () => {
     it('returns state', () => {
       const state = createState(
         createCoreState({
-          polymerInteropRunSelection: new Map([['1', false], ['2', true]]),
+          polymerInteropRuns: [
+            {id: '1', name: 'Run name'},
+            {id: '2', name: 'Run 2 name'},
+          ],
+          polymerInteropRunSelection: new Set(['2']),
         })
       );
       expect(selectors.getRunSelection(state)).toEqual(
         new Map([['1', false], ['2', true]])
+      );
+    });
+
+    it('omits selection when run is not in the list', () => {
+      const state = createState(
+        createCoreState({
+          polymerInteropRuns: [
+            {id: '1', name: 'Run name'},
+            {id: '2', name: 'Run 2 name'},
+          ],
+          polymerInteropRunSelection: new Set(['1', '5']),
+        })
+      );
+      expect(selectors.getRunSelection(state)).toEqual(
+        new Map([['1', true], ['2', false]])
       );
     });
   });

--- a/tensorboard/webapp/core/store/core_types.ts
+++ b/tensorboard/webapp/core/store/core_types.ts
@@ -38,7 +38,7 @@ export interface CoreState {
   // TODO(stephanwlee): move these state to the `runs` features.
   // For now, we want them here for Polymer interop states reasons, too.
   polymerInteropRuns: Run[];
-  polymerInteropRunSelection: Map<RunId, boolean>;
+  polymerInteropRunSelection: Set<RunId>;
 }
 
 export interface State {
@@ -60,5 +60,5 @@ export const initialState: CoreState = {
     window_title: '',
   },
   polymerInteropRuns: [],
-  polymerInteropRunSelection: new Map(),
+  polymerInteropRunSelection: new Set(),
 };

--- a/tensorboard/webapp/core/testing/index.ts
+++ b/tensorboard/webapp/core/testing/index.ts
@@ -64,7 +64,7 @@ export function createCoreState(override?: Partial<CoreState>): CoreState {
     pageSize: 10,
     environment: createEnvironment(),
     polymerInteropRuns: [],
-    polymerInteropRunSelection: new Map(),
+    polymerInteropRunSelection: new Set(),
     ...override,
   };
 }

--- a/tensorboard/webapp/runs/BUILD
+++ b/tensorboard/webapp/runs/BUILD
@@ -1,0 +1,14 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "runs",
+    srcs = [
+        "runs_module.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/runs/views/legacy_runs_selector",
+        "@npm//@angular/core",
+    ],
+)

--- a/tensorboard/webapp/runs/runs_module.ts
+++ b/tensorboard/webapp/runs/runs_module.ts
@@ -1,0 +1,22 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {NgModule} from '@angular/core';
+
+import {LegacyRunsSelectorModule as LegacyRunsSelectorViewModule} from './views/legacy_runs_selector/legacy_runs_selector_module';
+
+@NgModule({
+  exports: [LegacyRunsSelectorViewModule],
+})
+export class RunsModule {}

--- a/tensorboard/webapp/runs/views/legacy_runs_selector/BUILD
+++ b/tensorboard/webapp/runs/views/legacy_runs_selector/BUILD
@@ -1,0 +1,43 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "legacy_runs_selector",
+    srcs = [
+        "legacy_runs_selector_component.ts",
+        "legacy_runs_selector_container.ts",
+        "legacy_runs_selector_module.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp/core/actions",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = [
+        "legacy_runs_selector_test.ts",
+    ],
+    tsconfig = "//:tsconfig-test",
+    deps = [
+        ":legacy_runs_selector",
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
+        "//tensorboard/webapp/core/actions",
+        "//tensorboard/webapp/core/testing",
+        "@npm//@angular/common",
+        "@npm//@angular/compiler",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_component.ts
+++ b/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_component.ts
@@ -1,0 +1,49 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  ViewChild,
+  Output,
+} from '@angular/core';
+
+interface PolymerChangeEvent extends CustomEvent {
+  detail: {value: any};
+}
+
+@Component({
+  selector: 'tb-legacy-runs-selector-component',
+  template: `
+    <tf-runs-selector #selector></tf-runs-selector>
+  `,
+})
+export class LegacyRunsSelectorComponent implements AfterViewInit {
+  @Output()
+  onSelectionChange = new EventEmitter<string[]>();
+
+  @ViewChild('selector', {static: true})
+  private selector!: ElementRef;
+
+  ngAfterViewInit() {
+    this.selector.nativeElement.addEventListener(
+      'selected-runs-changed',
+      (event: PolymerChangeEvent) => {
+        this.onSelectionChange.emit(event.detail.value as string[]);
+      }
+    );
+  }
+}

--- a/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_component.ts
+++ b/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_component.ts
@@ -39,6 +39,10 @@ export class LegacyRunsSelectorComponent implements AfterViewInit {
   private selector!: ElementRef;
 
   ngAfterViewInit() {
+    /**
+     * The event is dispatched by Polymer when `selectedRuns` prop changes because it
+     * notifies (it is implicitly fired by Polymer library).
+     */
     this.selector.nativeElement.addEventListener(
       'selected-runs-changed',
       (event: PolymerChangeEvent) => {

--- a/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_container.ts
+++ b/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_container.ts
@@ -1,0 +1,37 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Component} from '@angular/core';
+import {Store} from '@ngrx/store';
+
+import {State} from '../../../app_state';
+import {polymerInteropRunSelectionChanged} from '../../../core/actions';
+
+@Component({
+  selector: 'tb-legacy-runs-selector',
+  template: `
+    <tb-legacy-runs-selector-component
+      (onSelectionChange)="onSelectionChange($event)"
+    ></tb-legacy-runs-selector-component>
+  `,
+})
+export class LegacyRunsSelectorContainer {
+  constructor(private readonly store: Store<State>) {}
+
+  onSelectionChange(runs: string[]) {
+    this.store.dispatch(
+      polymerInteropRunSelectionChanged({nextSelection: runs})
+    );
+  }
+}

--- a/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_module.ts
+++ b/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_module.ts
@@ -1,0 +1,25 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {NgModule, CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
+
+import {LegacyRunsSelectorComponent} from './legacy_runs_selector_component';
+import {LegacyRunsSelectorContainer} from './legacy_runs_selector_container';
+
+@NgModule({
+  declarations: [LegacyRunsSelectorComponent, LegacyRunsSelectorContainer],
+  exports: [LegacyRunsSelectorContainer],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class LegacyRunsSelectorModule {}

--- a/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_test.ts
+++ b/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_test.ts
@@ -1,0 +1,88 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {By} from '@angular/platform-browser';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Store, Action} from '@ngrx/store';
+import {provideMockStore, MockStore} from '@ngrx/store/testing';
+
+import {State} from '../../../app_state';
+import {createState, createCoreState} from '../../../core/testing';
+import {polymerInteropRunSelectionChanged} from '../../../core/actions';
+
+import {LegacyRunsSelectorContainer} from './legacy_runs_selector_container';
+import {LegacyRunsSelectorComponent} from './legacy_runs_selector_component';
+
+/** @typehack */ import * as _typeHackStore from '@ngrx/store';
+
+describe('legacy_runs_selector test', () => {
+  let store: MockStore<State>;
+  let recordedActions: Action[];
+  let testableRunSelector: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule],
+      providers: [
+        provideMockStore({
+          initialState: createState(createCoreState({})),
+        }),
+      ],
+      declarations: [LegacyRunsSelectorContainer, LegacyRunsSelectorComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+
+    recordedActions = [];
+    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+      recordedActions.push(action);
+    });
+
+    testableRunSelector = document.createElement('div');
+    testableRunSelector.classList.add('test');
+    spyOn(document, 'createElement')
+      .and.callThrough()
+      .withArgs('tf-runs-selector')
+      .and.returnValue(testableRunSelector);
+  });
+
+  it('creates the tf-runs-selector', () => {
+    const fixture = TestBed.createComponent(LegacyRunsSelectorContainer);
+    fixture.detectChanges();
+
+    const element = fixture.debugElement.query(By.css('.test'));
+
+    expect(element.nativeElement).toBe(testableRunSelector);
+  });
+
+  it('dispatches action when polymer component dispatches change', () => {
+    const fixture = TestBed.createComponent(LegacyRunsSelectorContainer);
+    fixture.detectChanges();
+
+    const event = new CustomEvent('selected-runs-changed', {
+      detail: {
+        value: ['foo', 'bar'],
+      },
+    });
+    testableRunSelector.dispatchEvent(event);
+
+    expect(recordedActions).toEqual([
+      polymerInteropRunSelectionChanged({
+        nextSelection: ['foo', 'bar'],
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
For the ease of our development in Angular, especially for porting a
fixing dashboard without any functional differences, we decided to just
wrap a Polymer based runs selector. This change introduced that.

However, do note that the selection state is in the ngrx store so you
must use the regular Angular pattern to render and access the data
related to runs.

Demo of it being applied to the app_container.ng.html.

![image](https://user-images.githubusercontent.com/2547313/87094560-f03d8a00-c1f3-11ea-92d5-2810785cedfd.png)
