### PR TITLE
application: simplify `_handling_errors` plumbing

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -526,10 +526,9 @@ class TensorBoardWSGI(object):
 
 
 def _handling_errors(wsgi_app):
-    def wrapper(*args):
-        (environ, start_response) = (args[-2], args[-1])
+    def wrapper(environ, start_response):
         try:
-            return wsgi_app(*args)
+            return wsgi_app(environ, start_response)
         except errors.PublicError as e:
             request = wrappers.Request(environ)
             error_app = http_util.Respond(

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -218,20 +218,6 @@ class HandlingErrorsTest(tb_test.TestCase):
             response = server.get("/")
         self.assertEqual(str(cm.exception), "something borked internally")
 
-    def test_passes_through_non_wsgi_args(self):
-        class C(object):
-            @application._handling_errors
-            def __call__(self, environ, start_response):
-                start_response("200 OK", [("Content-Type", "text/html")])
-                yield b"All is well"
-
-        app = C()
-        server = werkzeug_test.Client(app, wrappers.BaseResponse)
-        response = server.get("/")
-        self.assertEqual(response.get_data(), b"All is well")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.headers.get("Content-Type"), "text/html")
-
 
 class ApplicationTest(tb_test.TestCase):
     def setUp(self):


### PR DESCRIPTION
Summary:
This function used to have some manual argument-munging to facilitate
use as a method decorator (necessary due to the extra `self` argument).
But we removed the only such usage in #2732, so we can now just follow
the standard WSGI interface.

Test Plan:
That unit tests pass suffices.

wchargin-branch: application-simplify-handling-errors
