### PR TITLE
Revert logic that preserves axis domains

### DIFF
--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -1022,16 +1022,6 @@ namespace vz_line_chart2 {
     }
 
     /**
-     * Returns the currently visible domain of the x/y axes.
-     */
-    public getAxisDomains(): AxisDomains {
-      return {
-        x: this.xScale.getTransformationDomain(),
-        y: this.yScale.getTransformationDomain(),
-      };
-    }
-
-    /**
      * Sets the viewport domain.
      */
     public setAxisDomains(domains: AxisDomains) {

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -425,19 +425,11 @@ namespace vz_line_chart2 {
         );
         var div = d3.select(this.$.chartdiv);
         chart.renderTo(div);
-        let prevAxisDomains = null;
         if (this._chart) {
-          prevAxisDomains = this._chart.getAxisDomains();
           this._chart.destroy();
         }
         this._chart = chart;
         this._chart.onAnchor(() => this.fire('chart-attached'));
-
-        // If the new chart replaces an old one, preserve the old chart's
-        // pan/zoom transformation.
-        if (prevAxisDomains) {
-          this._chart.setAxisDomains(prevAxisDomains);
-        }
       }, 350);
     },
 


### PR DESCRIPTION
Domain preservation logic added in https://github.com/tensorflow/tensorboard/pull/3813
introduced a regression where changing the tag filter, tooltip sort settings
would reset the domain of axes to Plottable's default [0, 1] range.

This results in charts that appear blank, because it's out of view.