### PR TITLE
Make `auth` and `context` py2-compatible

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -85,7 +85,9 @@ py_library(
     name = "auth",
     srcs = ["auth.py"],
     srcs_version = "PY2AND3",
-    deps = [],
+    deps = [
+        "@org_pythonhosted_six",
+    ],
 )
 
 py_test(

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -84,7 +84,7 @@ py_test(
 py_library(
     name = "auth",
     srcs = ["auth.py"],
-    srcs_version = "PY3",
+    srcs_version = "PY2AND3",
     deps = [],
 )
 
@@ -103,7 +103,7 @@ py_test(
 py_library(
     name = "context",
     srcs = ["context.py"],
-    srcs_version = "PY3",
+    srcs_version = "PY2AND3",
     deps = [
         ":auth",
     ],

--- a/tensorboard/auth.py
+++ b/tensorboard/auth.py
@@ -16,8 +16,11 @@
 
 import abc
 
+import six
 
-class AuthProvider(metaclass=abc.ABCMeta):
+
+@six.add_metaclass(abc.ABCMeta)
+class AuthProvider(object):
     """Authentication provider for a specific kind of credential."""
 
     def authenticate(self, environ):
@@ -40,7 +43,7 @@ class AuthProvider(metaclass=abc.ABCMeta):
         pass
 
 
-class AuthContext:
+class AuthContext(object):
     """Authentication context within the scope of a single request.
 
     Auth providers are keyed within an `AuthContext` by arbitrary

--- a/tensorboard/context.py
+++ b/tensorboard/context.py
@@ -26,7 +26,7 @@ class _TensorBoardRequestContextKey:
 _WSGI_KEY = _TensorBoardRequestContextKey()
 
 
-class RequestContext:
+class RequestContext(object):
     """Container of request-scoped values.
 
     This context is for cross-cutting concerns: authentication,
@@ -39,8 +39,12 @@ class RequestContext:
       auth: An `AuthContext`, which may be empty but is never `None`.
     """
 
-    def __init__(self, *, auth=None):
+    def __init__(self, auth=None):
         """Create a request context.
+
+        The argument list is sorted and may be extended in the future;
+        therefore, callers must pass only named arguments to this
+        initializer.
 
         Args:
           See "Fields" on class docstring. All arguments are optional


### PR DESCRIPTION
Summary:
Some straggling transitive Google-internal dependencies still require
Python 2 source…

Test Plan:

```
$ python2 -c 'import ast; print(ast.parse(open("tensorboard/auth.py").read()))'
<_ast.Module object at 0x7f796a5c1050>
$ python2 -c 'import ast; print(ast.parse(open("tensorboard/context.py").read()))'
<_ast.Module object at 0x7f44c4c23c90>
$ bazel query 'attr(srcs_version, PY3, deps(//tensorboard:plugin_util))'
INFO: Empty results
```

wchargin-branch: auth-context-py2
