### PR TITLE
reland: preserve domains in line chart when changing settings

### DIFF
--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -1022,6 +1022,16 @@ namespace vz_line_chart2 {
     }
 
     /**
+     * Returns the currently visible domain of the x/y axes.
+     */
+    public getAxisDomains(): AxisDomains {
+      return {
+        x: this.xScale.getTransformationDomain(),
+        y: this.yScale.getTransformationDomain(),
+      };
+    }
+
+    /**
      * Sets the viewport domain.
      */
     public setAxisDomains(domains: AxisDomains) {

--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -52,11 +52,6 @@ namespace vz_line_chart2 {
     meta: any;
   };
 
-  export interface AxisDomains {
-    x: [number, number];
-    y: [number, number];
-  }
-
   /**
    * The maximum number of marker symbols within any line for a data series. Too
    * many markers clutter the chart.
@@ -956,6 +951,14 @@ namespace vz_line_chart2 {
       }
     }
 
+    public setColorScale(colorScale: Plottable.Scales.Color) {
+      this.colorScale = colorScale;
+    }
+
+    public setTooltipColumns(tooltipColumns: vz_chart_helpers.TooltipColumn[]) {
+      this.tooltipColumns = tooltipColumns;
+    }
+
     public setTooltipSortingMethod(method: string) {
       this.tooltipSortingMethod = method;
     }
@@ -1019,24 +1022,6 @@ namespace vz_line_chart2 {
 
     public onAnchor(fn: () => void) {
       if (this.outer) this.outer.onAnchor(fn);
-    }
-
-    /**
-     * Returns the currently visible domain of the x/y axes.
-     */
-    public getAxisDomains(): AxisDomains {
-      return {
-        x: this.xScale.getTransformationDomain(),
-        y: this.yScale.getTransformationDomain(),
-      };
-    }
-
-    /**
-     * Sets the viewport domain.
-     */
-    public setAxisDomains(domains: AxisDomains) {
-      this.xScale.setTransformationDomain(domains.x);
-      this.yScale.setTransformationDomain(domains.y);
     }
 
     /**


### PR DESCRIPTION
When clients of VzLineChart2 update the colorScale externally, the x/y axis
auto-scales to fit the domain. This may be unwanted behavior if clients want
to allow users to change a chart's color frequently without losing a carefully
crafted viewport domain.

This preserves the existing domains upon property changes that recreate
the chart, but do not affect the position of points.

Historical record:
- Introduced in https://github.com/tensorflow/tensorboard/pull/3813
- Reverted in https://github.com/tensorflow/tensorboard/pull/3828
  due to multiple regressions

1) Changing settings that affect position of chart points (e.g. xAxis type)
would not re-fit domain to data. Users may set xAxis to "Relative", and think
that the data was missing, when it was only outside of the viewport.

This is overcome by separating the preserve-domain logic into a separate
callback, which does not fire when properties affecting chart point positions
change.

2) Removing and re-attaching the same vz-line-chart element in DOM
could reset the domain to Plottable's default [0, 1] range. The exact cause of
this is unclear, but the axis domain reset occurs within
`Plottable.Components.Table.prototype.destroy`.

This is overcome by deleting the `_chart` LineChart reference when a
VzLineChart2 is detached from DOM. Dropping the reference is safe:

Re-attaching a previously detached VzLineChart2 does not reuse the old
Line chart:
- attach/detach always updates the `isAttached` property
- `isAttached` changes are wired to trigger `_createChart`
- When `_createChart` renders a chart via `renderTo`, it always renders a brand
  new instance of LineChart
- Thus, re-attaching an old VzLineChart2 element does not rely on its old
LineChart instance

Deleting the `_chart` property is safe:
- Polymer observers fire these methods when the property changes:
  _reloadFromCache, _smoothingChanged, _tooltipSortingMethodChanged,
  _outliersChanged
- All those methods guard against a falsy `_chart` before using it

Manually tested that the regressions are addressed and updating colorScale still
preserves domain.