### PR TITLE
[DebuggerV2] Add title to tensor names in GraphExecutionComponent

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
@@ -44,14 +44,14 @@ limitations under the License.
           <div class="tensor-name-and-op-type">
             <button
               class="tensor-name"
+              title="{{ getTensorName(i) }}"
               (click)="onTensorNameClick.emit({
                 index: i,
                 graph_id: graphExecutionData[i].graph_id,
                 op_name: graphExecutionData[i].op_name
               })"
             >
-              {{ graphExecutionData[i].op_name }}:{{
-              graphExecutionData[i].output_slot }}
+              {{ getTensorName(i) }}
             </button>
             <div class="op-type">
               {{ graphExecutionData[i].op_type }}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ts
@@ -91,6 +91,13 @@ export class GraphExecutionsComponent implements OnChanges {
     }
   }
 
+  getTensorName(graphExecutionIndex: number): string {
+    return (
+      `${this.graphExecutionData[graphExecutionIndex].op_name}:` +
+      `${this.graphExecutionData[graphExecutionIndex].output_slot}`
+    );
+  }
+
   /**
    * Computes if given graph-execution index is an immediate input tensor to
    * the graph execution currently focused on.

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container_test.ts
@@ -152,6 +152,7 @@ describe('Graph Executions Container', () => {
           expect(focusElement).toBeNull();
         }
         expect(tensorNames[i].nativeElement.innerText).toBe(`TestOp_${i}:0`);
+        expect(tensorNames[i].nativeElement.title).toBe(`TestOp_${i}:0`);
         expect(opTypes[i].nativeElement.innerText).toBe(`OpType_${i}`);
       }
       const debugTensorValueElements = fixture.debugElement.queryAll(


### PR DESCRIPTION
* Motivation for features / changes
  * Improve the usability of DebuggerV2's GraphExecutionComponent
  * The tensor names in GraphExecutionComponent are displayed with a
    `button` of fixed length and automatic ellipses, which makes long tensor
    names (common in large model) are to understand. This PR improves
    the situation by adding a title to those `button`s
* Technical description of changes
  * Add a `title` attribute to the `button` element that holds the tensor name
     in the GraphExecutionComponent
  * Refactor the code that computes the tensor name based on op name
     and output slot to a helper method in `GraphExecutionComponent`
* Screenshots of UI changes
  * ![image](https://user-images.githubusercontent.com/16824702/87226548-78da3880-c362-11ea-8b4f-6a0e44d5925e.png)
