### PR TITLE
ci: pin to non-broken nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - BAZEL_SHA256SUM=e13581d44faad6ac807dd917e682fef20359d26728166ac35dadd8ee653a580d
   matrix:
     - TF_VERSION_ID=tensorflow==1.15.0
-    - TF_VERSION_ID=tf-nightly
+    - TF_VERSION_ID=tf-nightly==2.1.0.dev20200712
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - BAZEL_SHA256SUM=e13581d44faad6ac807dd917e682fef20359d26728166ac35dadd8ee653a580d
   matrix:
     - TF_VERSION_ID=tensorflow==1.15.0
-    - TF_VERSION_ID=tf-nightly==2.1.0.dev20200712
+    - TF_VERSION_ID=tf-nightly==2.4.0.dev20200712
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:


### PR DESCRIPTION
Summary:
Due to <https://github.com/tensorflow/tensorflow/issues/41388>.

This unblocks our CI until the upstream problem is identified and fixed.
We pin to ereyesterday’s nightlies, since yesterday’s didn’t have a
Linux binary for some reason.

Test Plan:
Fingers crossed.

wchargin-branch: pin-20200712-nightly
