### PR TITLE
migration prep: introduce relaxed tsconfig

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,3 +12,12 @@ ts_config(
     ],
     deps = [":tsconfig.json"],
 )
+
+ts_config(
+    name = "tsconfig-lax",
+    src = "tsconfig-lax.json",
+    visibility = [
+        "//tensorboard:internal",
+    ],
+    deps = [],
+)

--- a/BUILD
+++ b/BUILD
@@ -13,6 +13,7 @@ ts_config(
     deps = [":tsconfig.json"],
 )
 
+# Inspired from internal tsconfig generation for project like TensorBoard.
 ts_config(
     name = "tsconfig-lax",
     src = "tsconfig-lax.json",

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -45,10 +45,19 @@ def tf_ts_config(**kwargs):
 
     ts_config(**kwargs)
 
-def tf_ts_library(**kwargs):
-    """TensorBoard wrapper for the rule for a TypeScript library."""
+def tf_ts_library(strict_checks = True, tsconfig = None, **kwargs):
+    """TensorBoard wrapper for the rule for a TypeScript library.
 
-    ts_library(**kwargs)
+    Args:
+      strict_checks: whether to enable stricter type checking. Default is True.
+          Please use `strict_checks = False` for only Polymer based targets.
+      tsconfig: TypeScript configuration. If specified, it overrides strict_checks.
+      **kwargs: keyword arguments to ts_library build rule.
+    """
+    if not strict_checks and not tsconfig:
+        tsconfig = "//:tsconfig-lax"
+
+    ts_library(tsconfig = tsconfig or "//:tsconfig.json", **kwargs)
 
 def tf_ts_devserver(**kwargs):
     """TensorBoard wrapper for the rule for a TypeScript dev server."""

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -54,10 +54,10 @@ def tf_ts_library(strict_checks = True, tsconfig = None, **kwargs):
       tsconfig: TypeScript configuration. If specified, it overrides strict_checks.
       **kwargs: keyword arguments to ts_library build rule.
     """
-    if not strict_checks and not tsconfig:
-        tsconfig = "//:tsconfig-lax"
+    if not tsconfig:
+        tsconfig = "//:tsconfig.json" if strict_checks else "//:tsconfig-lax"
 
-    ts_library(tsconfig = tsconfig or "//:tsconfig.json", **kwargs)
+    ts_library(tsconfig = tsconfig, **kwargs)
 
 def tf_ts_devserver(**kwargs):
     """TensorBoard wrapper for the rule for a TypeScript dev server."""

--- a/tsconfig-lax.json
+++ b/tsconfig-lax.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "downlevelIteration": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "lib": ["dom", "es2018"],
+    "moduleResolution": "node",
+    "noEmitOnError": false,
+    "noErrorTruncation": false,
+    "noResolve": true,
+    "preserveConstEnums": false,
+    "skipLibCheck": true,
+    "sourceMap": false,
+    "target": "es5"
+  }
+}


### PR DESCRIPTION
Our Polymer based UI is currently built by our custom tooling that
incorporates tsc and JSCompiler. The build macro had a built-in tsconfig
which was quite lax and allows improper typing. This change introduces
the relaxed tsconfig based on internal rule, the minimum bar we should
try to meet when migrating.