### PR TITLE
beholder: add deprecation warning and UI banner

### DIFF
--- a/tensorboard/plugins/beholder/README.md
+++ b/tensorboard/plugins/beholder/README.md
@@ -1,5 +1,11 @@
 # The Beholder Plugin
 
+NOTE: The Beholder plugin is deprecated and will be removed in a future release
+of TensorBoard. Please see https://github.com/tensorflow/tensorboard/issues/3843
+for recommendations if you want to keep using the plugin or adopt it yourself.
+
+---
+
 The Beholder plugin shows a live video feed of tensor data in TensorBoard during
 model training. It can display model variable values, arbitrary NumPy arrays
 (e.g. for gradients or activations), or pre-existing image frames.

--- a/tensorboard/plugins/beholder/beholder.py
+++ b/tensorboard/plugins/beholder/beholder.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import os
 import time
+import warnings
 
 import numpy as np
 import tensorflow as tf
@@ -44,8 +45,20 @@ from tensorboard.util import tb_logging
 logger = tb_logging.get_logger()
 
 
+def _log_deprecation_warning():
+    separator = "=" * 70
+    lines = [
+        separator,
+        "Beholder is deprecated and will be removed in a future TensorBoard",
+        "release. See https://github.com/tensorflow/tensorboard/issues/3843",
+        separator,
+    ]
+    warnings.warn("\n" + "\n".join(lines), stacklevel=3)
+
+
 class Beholder(object):
     def __init__(self, logdir):
+        _log_deprecation_warning()
         self.PLUGIN_LOGDIR = logdir + "/plugins/" + PLUGIN_NAME
 
         self.is_recording = False
@@ -226,6 +239,7 @@ class BeholderHook(tf.estimator.SessionRunHook):
         Args:
           logdir: Directory where Beholder should write data.
         """
+        _log_deprecation_warning()
         self._logdir = logdir
         self.beholder = None
 

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -32,6 +32,12 @@ limitations under the License.
 <dom-module id="tf-beholder-dashboard">
   <template>
     <tf-plugin-dialog id="initialDialog"></tf-plugin-dialog>
+    <div class="deprecation-warning">
+      Beholder is deprecated and will be removed in a future TensorBoard
+      release. Please see
+      <a href="https://github.com/tensorflow/tensorboard/issues/3843">#3842</a>
+      for details.
+    </div>
     <tf-dashboard-layout>
       <div class="sidebar" slot="sidebar">
         <template is="dom-if" if="[[_controls_disabled]]">
@@ -261,6 +267,21 @@ with MonitoredSession(..., hooks=[beholder_hook]) as sess:
     </tf-dashboard-layout>
     <style include="dashboard-style"></style>
     <style>
+      .deprecation-warning {
+        background-color: #c6cad1; /* $tf-slate 300 */
+        border-bottom: 1px solid var(--tb-ui-dark-accent);
+        box-sizing: border-box;
+        font-style: italic;
+        height: 60px;
+        padding: 20px;
+        text-align: center;
+      }
+
+      tf-dashboard-layout {
+        /* Leave space for .deprecation-warning top bar. */
+        height: calc(100% - 60px);
+      }
+
       .center {
         height: 100%;
         display: flex;

--- a/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
+++ b/tensorboard/plugins/beholder/tf_beholder_dashboard/tf-beholder-dashboard.html
@@ -35,7 +35,7 @@ limitations under the License.
     <div class="deprecation-warning">
       Beholder is deprecated and will be removed in a future TensorBoard
       release. Please see
-      <a href="https://github.com/tensorflow/tensorboard/issues/3843">#3842</a>
+      <a href="https://github.com/tensorflow/tensorboard/issues/3843">#3843</a>
       for details.
     </div>
     <tf-dashboard-layout>


### PR DESCRIPTION
This marks the Beholder dashboard and plugin as deprecated, for the reasons outlined in https://github.com/tensorflow/tensorboard/issues/3843.

For the Python APIs (the `Beholder` and `BeholderHook`) classes we add a warning emitted at the callsite with a link to this issue, for example:

```
tensorboard/plugins/beholder/beholder_demo.py:215: UserWarning:
======================================================================
Beholder is deprecated and will be removed in a future TensorBoard
release. See https://github.com/tensorflow/tensorboard/issues/3843
======================================================================
  beholder = beholder_lib.Beholder(logdir=LOG_DIRECTORY)
```

For the dashboard, we add a deprecation message in a banner with a link to this issue:

![image](https://user-images.githubusercontent.com/710113/87611765-b968e780-c6bd-11ea-9db5-d7d290ba8f5f.png)



