### PR TITLE
ci: unpin 2020-07-12 nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - BAZEL_SHA256SUM=e13581d44faad6ac807dd917e682fef20359d26728166ac35dadd8ee653a580d
   matrix:
     - TF_VERSION_ID=tensorflow==1.15.0
-    - TF_VERSION_ID=tf-nightly==2.4.0.dev20200712
+    - TF_VERSION_ID=tf-nightly
     - TF_VERSION_ID=  # Do not install TensorFlow in this case
 
 cache:


### PR DESCRIPTION
Summary:
Fixed upstream: <https://github.com/tensorflow/tensorflow/issues/41388>

This reverts commit d24e136ede5bab292afed0e62b813a2740c0a648.

Test Plan:
CI suffices.

wchargin-branch: unpin-20200712-nightly
