### PR TITLE
Revert "[Projector] make root directory config default for available runs"

### DIFF
--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -434,22 +434,6 @@ class ProjectorPlugin(base_plugin.TBPlugin):
     def _read_latest_config_files(self, run_path_pairs):
         """Reads and returns the projector config files in every run
         directory."""
-        """If no specific config exists, use the default config provided in
-        the root directory."""
-        default_config_fpath = os.path.join(
-            self.logdir, metadata.PROJECTOR_FILENAME
-        )
-        default_config = ProjectorConfig()
-        if tf.io.gfile.exists(default_config_fpath):
-            with tf.io.gfile.GFile(default_config_fpath, "r") as f:
-                file_content = f.read()
-            text_format.Merge(file_content, default_config)
-            # Relative metadata paths do not work with subdirs, so convert
-            # any metadata paths to absolute paths.
-            for embedding in default_config.embeddings:
-                embedding.metadata_path = _rel_to_abs_asset_path(
-                    embedding.metadata_path, default_config_fpath
-                )
         configs = {}
         config_fpaths = {}
         for run_name, assets_dir in run_path_pairs:
@@ -459,8 +443,6 @@ class ProjectorPlugin(base_plugin.TBPlugin):
                 with tf.io.gfile.GFile(config_fpath, "r") as f:
                     file_content = f.read()
                 text_format.Merge(file_content, config)
-            elif tf.io.gfile.exists(default_config_fpath):
-                config = default_config
             has_tensor_files = False
             for embedding in config.embeddings:
                 if embedding.tensor_path:


### PR DESCRIPTION
This reverts commit 12f6234e0608d7b8703540fb3473372de88f788e.

The changes in https://github.com/tensorflow/tensorboard/pull/3653 allowed TensorBoard to
use the root directory's projector config and apply it to each subdirectory.

If the root dir's config specifies a "sprite" that does not exist in every subdirectory, it
causes the Projector frontend to hang when loading a run.
See https://github.com/tensorflow/tensorboard/issues/3840 for details on the issue.

Confirmed that this fixes the issue by running TB on a directory with:
- ./projector_config.pbtxt
```
embeddings {
  tensor_name: "EMNIST_Letters:0"
  metadata_path: "metadata.tsv"
  sprite {
    image_path: "sprite.png"
    single_image_dim: 28
    single_image_dim: 28
  }
}
```

- alongside a subdirectory `profile_demo_new` that contains a `.profile-empty` event file but no `sprite.png` file
![image](https://user-images.githubusercontent.com/2322480/87711390-0d2a0e00-c75c-11ea-8846-7cec6907ba85.png)
