### PR TITLE
lib: make `errors` submodule lazy

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -43,6 +43,7 @@ py_library(
     visibility = ["//tensorboard:internal"],
     deps = [
         ":lib_init_only",
+        ":errors",
         ":notebook",
         ":program",
         "//tensorboard/data:lib_init_only",
@@ -62,7 +63,6 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//tensorboard:internal"],
     deps = [
-        ":errors",
         ":lazy",
         ":version",
     ],

--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -42,8 +42,8 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//tensorboard:internal"],
     deps = [
-        ":lib_init_only",
         ":errors",
+        ":lib_init_only",
         ":notebook",
         ":program",
         "//tensorboard/data:lib_init_only",

--- a/tensorboard/__init__.py
+++ b/tensorboard/__init__.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorboard import errors  # public export
 from tensorboard import lazy as _lazy
 from tensorboard import version as _version
 
@@ -80,6 +79,13 @@ def data():
     import importlib
 
     return importlib.import_module("tensorboard.data")
+
+
+@_lazy.lazy_load("tensorboard.errors")
+def errors():
+    import importlib
+
+    return importlib.import_module("tensorboard.errors")
 
 
 @_lazy.lazy_load("tensorboard.notebook")


### PR DESCRIPTION
Summary:
All the other submodules are lazy. We originally made `errors` eager
because it seemed like a small surface (#2631), but some Google-internal
Python 2 binaries unnecessarily transitively depend on `errors` because
of this edge. Moving it to a lazy dependency makes it easier to make
`errors` use py3-only features.

Test Plan:
Existing smoke test in `test_pip_package.sh` suffices.

wchargin-branch: lib-lazy-errors
