### PR TITLE
errors: add `UnauthenticatedError`

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -127,7 +127,7 @@ py_test(
 py_library(
     name = "errors",
     srcs = ["errors.py"],
-    srcs_version = "PY2AND3",
+    srcs_version = "PY3",
 )
 
 py_test(

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -551,7 +551,11 @@ def _handling_errors(wsgi_app):
         except errors.PublicError as e:
             request = wrappers.Request(environ)
             error_app = http_util.Respond(
-                request, str(e), "text/plain", code=e.http_code
+                request,
+                str(e),
+                "text/plain",
+                code=e.http_code,
+                headers=e.headers,
             )
             return error_app(environ, start_response)
         # Let other exceptions be handled by the server, as an opaque

--- a/tensorboard/backend/http_util.py
+++ b/tensorboard/backend/http_util.py
@@ -88,6 +88,7 @@ def Respond(
     content_encoding=None,
     encoding="utf-8",
     csp_scripts_sha256s=None,
+    headers=None,
 ):
     """Construct a werkzeug Response.
 
@@ -128,6 +129,9 @@ def Respond(
         elements for script-src of the Content-Security-Policy. If it is None, the
         HTML will disallow any script to execute. It is only be used when the
         content_type is text/html.
+      headers: Any additional headers to include on the response, as a
+        list of key-value tuples: e.g., `[("Allow", "GET")]`. In case of
+        conflict, these may be overridden with headers added by this function.
 
     Returns:
       A werkzeug Response object (a WSGI application).
@@ -179,7 +183,7 @@ def Respond(
         content_encoding = None
         direct_passthrough = True
 
-    headers = []
+    headers = list(headers or [])
     headers.append(("Content-Length", str(content_length)))
     headers.append(("X-Content-Type-Options", "nosniff"))
     if content_encoding:

--- a/tensorboard/backend/http_util_test.py
+++ b/tensorboard/backend/http_util_test.py
@@ -219,6 +219,20 @@ class RespondTest(tb_test.TestCase):
         r = http_util.Respond(q, "<b>hello world</b>", "text/html", expires=60)
         self.assertEqual(r.headers.get("Cache-Control"), "private, max-age=60")
 
+    def testHeaders(self):
+        q = wrappers.Request(wtest.EnvironBuilder().get_environ())
+        body = "No GET, only POST"
+        r = http_util.Respond(
+            q,
+            body,
+            "text/plain",
+            code=405,
+            headers=[("Allow", "POST"), ("Content-Length", "777")],
+        )
+        # non-conflicting headers passed through, conflicts overridden
+        self.assertEqual(r.headers.get("Allow"), "POST")
+        self.assertEqual(r.headers.get("Content-Length"), str(len(body)))
+
     def testCsp(self):
         q = wrappers.Request(wtest.EnvironBuilder().get_environ())
         r = http_util.Respond(

--- a/tensorboard/errors_test.py
+++ b/tensorboard/errors_test.py
@@ -36,6 +36,12 @@ class InvalidArgumentErrorTest(tb_test.TestCase):
     def test_http_code(self):
         self.assertEqual(errors.InvalidArgumentError().http_code, 400)
 
+    def test_headers(self):
+        e1 = errors.InvalidArgumentError()
+        e2 = errors.InvalidArgumentError()
+        self.assertEmpty(e1.headers)
+        self.assertIsNot(e1.headers, e2.headers)
+
 
 class NotFoundErrorTest(tb_test.TestCase):
     def test_no_details(self):
@@ -51,6 +57,42 @@ class NotFoundErrorTest(tb_test.TestCase):
     def test_http_code(self):
         self.assertEqual(errors.NotFoundError().http_code, 404)
 
+    def test_headers(self):
+        e1 = errors.NotFoundError()
+        e2 = errors.NotFoundError()
+        self.assertEmpty(e1.headers)
+        self.assertIsNot(e1.headers, e2.headers)
+
+
+class UnauthenticatedErrorTest(tb_test.TestCase):
+    def test_no_details(self):
+        e = errors.UnauthenticatedError(challenge="Digest")
+        expected_msg = "Unauthenticated"
+        self.assertEqual(str(e), expected_msg)
+
+    def test_with_details(self):
+        e = errors.UnauthenticatedError(
+            "don't you know who I am?", challenge="Digest"
+        )
+        expected_msg = "Unauthenticated: don't you know who I am?"
+        self.assertEqual(str(e), expected_msg)
+
+    def test_http_code(self):
+        self.assertEqual(
+            errors.UnauthenticatedError(challenge="Digest").http_code, 401
+        )
+
+    def test_headers(self):
+        details = "hmm"
+        challenge = 'Bearer realm="https://example.com"'
+        e1 = errors.UnauthenticatedError(details, challenge=challenge)
+        e2 = errors.UnauthenticatedError(details, challenge=challenge)
+        self.assertEqual(
+            e1.headers,
+            [("WWW-Authenticate", 'Bearer realm="https://example.com"')],
+        )
+        self.assertIsNot(e1.headers, e2.headers)
+
 
 class PermissionDeniedErrorTest(tb_test.TestCase):
     def test_no_details(self):
@@ -65,6 +107,12 @@ class PermissionDeniedErrorTest(tb_test.TestCase):
 
     def test_http_code(self):
         self.assertEqual(errors.PermissionDeniedError().http_code, 403)
+
+    def test_headers(self):
+        e1 = errors.PermissionDeniedError()
+        e2 = errors.PermissionDeniedError()
+        self.assertEmpty(e1.headers)
+        self.assertIsNot(e1.headers, e2.headers)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
We add a new type to distinguish authentication errors (“we can’t
confirm who you are”) from authorization errors (“we know who you are,
but you’re not allowed to perform this operation”). This was omitted
from the initial draft of the `errors` module because the natural status
code is HTTP 401, but HTTP 401 responses are required by RFC 7235, §3.1
to include a `WWW-Authenticate` challenge header. In this patch, we add
the necessary error handling machinery to support that header.

Test Plan:
Unit tests suffice for the core implementation. As a manual test,
changing a `NotFoundError` to an `UnauthorizedError` with an arbitrary
challenge in `scalars_plugin.py` properly sends a 401 with the intended
response and challenge header. Since this patch changes `:errors` to
include Python 3 syntax, Google-internal <http://cl/321666883> witnesses
that there are no more internal Python 2 dependents after #3851.

wchargin-branch: errors-unauthenticated
