### PR TITLE
application: add injection point for middleware

### DIFF
--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -71,7 +71,7 @@ def TensorBoardWSGIApp(
     assets_zip_provider=None,
     deprecated_multiplexer=None,
     auth_providers=None,
-    middlewares=None,
+    experimental_middlewares=None,
 ):
     """Constructs a TensorBoard WSGI app from plugins and data providers.
 
@@ -92,13 +92,14 @@ def TensorBoardWSGIApp(
       auth_providers: Optional mapping whose values are `AuthProvider` values
         and whose keys are used by (e.g.) data providers to specify
         `AuthProvider`s via the `AuthContext.get` interface. Defaults to `{}`.
-      middlewares: Optional list of WSGI middlewares (i.e., callables that take
-        a WSGI application and return a WSGI application) to apply directly
-        around the core TensorBoard app itself, "inside" the request
-        redirection machinery for `--path_prefix`, experiment IDs, etc. You can
-        use this to add handlers for additional routes. Middlewares are applied
-        in listed order, so the first element of this list is the innermost
-        application. Defaults to `[]`.
+      experimental_middlewares: Optional list of WSGI middlewares (i.e.,
+        callables that take a WSGI application and return a WSGI application)
+        to apply directly around the core TensorBoard app itself, "inside" the
+        request redirection machinery for `--path_prefix`, experiment IDs, etc.
+        You can use this to add handlers for additional routes. Middlewares are
+        applied in listed order, so the first element of this list is the
+        innermost application. Defaults to `[]`. This parameter is experimental
+        and may be reworked or removed.
 
     Returns:
       A WSGI application that implements the TensorBoard backend.
@@ -145,7 +146,7 @@ def TensorBoardWSGIApp(
         data_provider,
         experimental_plugins,
         auth_providers,
-        middlewares,
+        experimental_middlewares,
     )
 
 
@@ -183,7 +184,7 @@ class TensorBoardWSGI(object):
         data_provider=None,
         experimental_plugins=None,
         auth_providers=None,
-        middlewares=None,
+        experimental_middlewares=None,
     ):
         """Constructs TensorBoardWSGI instance.
 
@@ -201,8 +202,9 @@ class TensorBoardWSGI(object):
             values and whose keys are used by (e.g.) data providers to specify
             `AuthProvider`s via the `AuthContext.get` interface.
             Defaults to `{}`.
-          middlewares: Optional list of WSGI middlewares to apply directly
-            around the core TensorBoard app itself. Defaults to `[]`.
+          experimental_middlewares: Optional list of WSGI middlewares to apply
+            directly around the core TensorBoard app itself. Defaults to `[]`.
+            This parameter is experimental and may be reworked or removed.
 
         Returns:
           A WSGI application for the set of all TBPlugin instances.
@@ -222,7 +224,7 @@ class TensorBoardWSGI(object):
         self._data_provider = data_provider
         self._experimental_plugins = frozenset(experimental_plugins or ())
         self._auth_providers = auth_providers or {}
-        self._extra_middlewares = list(middlewares or [])
+        self._extra_middlewares = list(experimental_middlewares or [])
         if self._path_prefix.endswith("/"):
             # Should have been fixed by `fix_flags`.
             raise ValueError(

--- a/tensorboard/backend/application.py
+++ b/tensorboard/backend/application.py
@@ -71,7 +71,7 @@ def TensorBoardWSGIApp(
     assets_zip_provider=None,
     deprecated_multiplexer=None,
     auth_providers=None,
-    extra_routes=None,
+    middlewares=None,
 ):
     """Constructs a TensorBoard WSGI app from plugins and data providers.
 
@@ -92,7 +92,8 @@ def TensorBoardWSGIApp(
       auth_providers: Optional mapping whose values are `AuthProvider` values
         and whose keys are used by (e.g.) data providers to specify
         `AuthProvider`s via the `AuthContext.get` interface. Defaults to `{}`.
-      extra_routes: Optional list of WSGI middlewares to apply directly
+      middlewares: Optional list of WSGI middlewares (i.e., callables that take
+        a WSGI application and return a WSGI application) to apply directly
         around the core TensorBoard app itself, "inside" the request
         redirection machinery for `--path_prefix`, experiment IDs, etc. You can
         use this to add handlers for additional routes. Middlewares are applied
@@ -144,7 +145,7 @@ def TensorBoardWSGIApp(
         data_provider,
         experimental_plugins,
         auth_providers,
-        extra_routes,
+        middlewares,
     )
 
 
@@ -182,7 +183,7 @@ class TensorBoardWSGI(object):
         data_provider=None,
         experimental_plugins=None,
         auth_providers=None,
-        extra_routes=None,
+        middlewares=None,
     ):
         """Constructs TensorBoardWSGI instance.
 
@@ -200,7 +201,7 @@ class TensorBoardWSGI(object):
             values and whose keys are used by (e.g.) data providers to specify
             `AuthProvider`s via the `AuthContext.get` interface.
             Defaults to `{}`.
-          extra_routes: Optional list of WSGI middlewares to apply directly
+          middlewares: Optional list of WSGI middlewares to apply directly
             around the core TensorBoard app itself. Defaults to `[]`.
 
         Returns:
@@ -221,7 +222,7 @@ class TensorBoardWSGI(object):
         self._data_provider = data_provider
         self._experimental_plugins = frozenset(experimental_plugins or ())
         self._auth_providers = auth_providers or {}
-        self._extra_middlewares = list(extra_routes or [])
+        self._extra_middlewares = list(middlewares or [])
         if self._path_prefix.endswith("/"):
             # Should have been fixed by `fix_flags`.
             raise ValueError(

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -712,7 +712,7 @@ class TensorBoardPluginsTest(tb_test.TestCase):
             ],
             data_provider=FakeDataProvider(),
             auth_providers={HeaderAuthProvider: HeaderAuthProvider()},
-            extra_routes=[self._auth_check_middleware],
+            middlewares=[self._auth_check_middleware],
         )
 
         self.server = werkzeug_test.Client(self.app, wrappers.BaseResponse)
@@ -859,7 +859,7 @@ class TensorBoardPluginsTest(tb_test.TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.get_data(), b"top secret access granted")
 
-    def testExtraRoutesMiddleware(self):
+    def testExtraMiddlewares(self):
         # Must have `experiment_id` and auth context middlewares to pass.
         route = "/experiment/123/auth_check"
         res = self.server.get(route, headers=[("Authorization", "got it")])

--- a/tensorboard/backend/application_test.py
+++ b/tensorboard/backend/application_test.py
@@ -712,7 +712,7 @@ class TensorBoardPluginsTest(tb_test.TestCase):
             ],
             data_provider=FakeDataProvider(),
             auth_providers={HeaderAuthProvider: HeaderAuthProvider()},
-            middlewares=[self._auth_check_middleware],
+            experimental_middlewares=[self._auth_check_middleware],
         )
 
         self.server = werkzeug_test.Client(self.app, wrappers.BaseResponse)


### PR DESCRIPTION
Summary:
Clients of `TensorBoardWSGIApp` may now inject middleware around the
core TensorBoard app routing but still within the experiment ID, path
prefix, request context, etc. middlewares. This is useful for handlers
for extra routes that need to access the request context.

Test Plan:
Unit tests included.

wchargin-branch: application-middleware-injection
