### PR TITLE
bug: show warning when pluginId do not match known ids

### DIFF
--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -21,38 +21,66 @@ limitations under the License.
   <!-- render Angular built-in plugins with a dynamic component resolver. -->
   <ng-container #ngPluginContainer></ng-container>
 </div>
-<div *ngIf="noEnabledPlugin" class="no-plugin">
+
+<div
+  *ngIf="pluginLoadState !== PluginLoadState.LOADED && pluginLoadState !== PluginLoadState.LOADING"
+  [ngSwitch]="pluginLoadState"
+  class="warning"
+>
   <div class="warning-message">
-    <h3>No dashboards are active for the current data set.</h3>
-    <p>Probable causes:</p>
-    <ul>
-      <li>You haven’t written any data to your event files.</li>
-      <li>TensorBoard can’t find your event files.</li>
-    </ul>
+    <ng-container *ngSwitchCase="PluginLoadState.UNKNOWN_PLUGIN_ID">
+      <h3 class="unknown-plugin">
+        There’s no dashboard by the name of “<code>{{activePluginId}}</code>”.
+      </h3>
+      <div>
+        <p>You can select a dashboard from the list above.</p>
+      </div>
+      <p>
+        <ng-container [ngTemplateOutlet]="dateAndDataLocation"></ng-container>
+      </p>
+    </ng-container>
 
-    If you’re new to using TensorBoard, and want to find out how to add data and
-    set up your event files, check out the
-    <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md"
-      >README</a
-    >
-    and perhaps the
-    <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard"
-      >TensorBoard tutorial</a
-    >.
-    <p>
-      If you think TensorBoard is configured properly, please see
-      <a
-        href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong"
-        >the section of the README devoted to missing data problems</a
-      >
-      and consider filing an issue on GitHub.
-    </p>
+    <ng-container *ngSwitchCase="PluginLoadState.NO_ENABLED_PLUGINS">
+      <h3 class="no-active-plugin">
+        No dashboards are active for the current data set.
+      </h3>
+      <p>Probable causes:</p>
+      <ul>
+        <li>You haven’t written any data to your event files.</li>
+        <li>TensorBoard can’t find your event files.</li>
+      </ul>
 
-    <p>
-      <!-- Class name used to hide this element in screenshot tests. -->
-      <span class="last-reload-time"
-        >Last reload: {{lastUpdated | date: 'medium'}}</span
+      If you’re new to using TensorBoard, and want to find out how to add data
+      and set up your event files, check out the
+      <a href="https://github.com/tensorflow/tensorboard/blob/master/README.md"
+        >README</a
       >
-    </p>
+      and perhaps the
+      <a href="https://www.tensorflow.org/get_started/summaries_and_tensorboard"
+        >TensorBoard tutorial</a
+      >.
+      <p>
+        If you think TensorBoard is configured properly, please see
+        <a
+          href="https://github.com/tensorflow/tensorboard/blob/master/README.md#my-tensorboard-isnt-showing-any-data-whats-wrong"
+          >the section of the README devoted to missing data problems</a
+        >
+        and consider filing an issue on GitHub.
+      </p>
+
+      <p>
+        <ng-container [ngTemplateOutlet]="dateAndDataLocation"></ng-container>
+      </p>
+    </ng-container>
   </div>
 </div>
+
+<ng-template #dateAndDataLocation>
+  <!-- Class name used to hide this element in screenshot tests. -->
+  <span class="last-reload-time"
+    >Last reload: {{lastUpdated | date: 'medium'}}</span
+  >
+  <p *ngIf="dataLocation" class="data-location">
+    <i>Log directory: <span>{{dataLocation}}</span></i>
+  </p>
+</ng-template>

--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -23,7 +23,7 @@ limitations under the License.
 </div>
 
 <div
-  *ngIf="pluginLoadState !== PluginLoadState.LOADED && pluginLoadState !== PluginLoadState.LOADING"
+  *ngIf="pluginLoadState === PluginLoadState.UNKNOWN_PLUGIN_ID || pluginLoadState === PluginLoadState.NO_ENABLED_PLUGINS"
   [ngSwitch]="pluginLoadState"
   class="warning"
 >
@@ -32,9 +32,7 @@ limitations under the License.
       <h3 class="unknown-plugin">
         There’s no dashboard by the name of “<code>{{activePluginId}}</code>”.
       </h3>
-      <div>
-        <p>You can select a dashboard from the list above.</p>
-      </div>
+      <p>You can select a dashboard from the list above.</p>
       <p>
         <ng-container [ngTemplateOutlet]="dateAndDataLocation"></ng-container>
       </p>

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -41,6 +41,13 @@ interface ExperimentalPluginHostLib extends HTMLElement {
   registerPluginIframe(iframe: HTMLIFrameElement, plugin_id: string): void;
 }
 
+export enum PluginLoadState {
+  NO_ENABLED_PLUGINS,
+  UNKNOWN_PLUGIN_ID,
+  LOADED,
+  LOADING,
+}
+
 @Component({
   selector: 'plugins-component',
   templateUrl: './plugins_component.ng.html',
@@ -54,7 +61,7 @@ interface ExperimentalPluginHostLib extends HTMLElement {
         height: 100%;
         position: relative;
       }
-      .no-plugin {
+      .warning {
         background-color: #fff;
         bottom: 0;
         left: 0;
@@ -95,14 +102,21 @@ export class PluginsComponent implements OnChanges {
   private readonly ngPluginContainer!: ViewContainerRef;
 
   @Input()
+  activePluginId!: string | null;
+
+  @Input()
   activePlugin!: UiPluginMetadata | null;
 
   @Input()
-  noEnabledPlugin!: boolean;
+  pluginLoadState!: PluginLoadState;
+
+  @Input()
+  dataLocation!: string;
 
   @Input()
   lastUpdated?: number;
 
+  readonly PluginLoadState = PluginLoadState;
   readonly LoadingMechanismType = LoadingMechanismType;
 
   private readonly pluginInstances = new Map<string, HTMLElement>();

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -105,7 +105,7 @@ export class PluginsComponent implements OnChanges {
   activePluginId!: string | null;
 
   @Input()
-  activePlugin!: UiPluginMetadata | null;
+  activeKnownPlugin!: UiPluginMetadata | null;
 
   @Input()
   pluginLoadState!: PluginLoadState;
@@ -122,8 +122,8 @@ export class PluginsComponent implements OnChanges {
   private readonly pluginInstances = new Map<string, HTMLElement>();
 
   ngOnChanges(change: SimpleChanges): void {
-    if (change['activePlugin'] && this.activePlugin) {
-      this.renderPlugin(this.activePlugin!);
+    if (change['activeKnownPlugin'] && this.activeKnownPlugin) {
+      this.renderPlugin(this.activeKnownPlugin!);
     }
     if (change['lastUpdated']) {
       this.reload();
@@ -212,12 +212,12 @@ export class PluginsComponent implements OnChanges {
   }
 
   private reload() {
-    if (!this.activePlugin || this.activePlugin.disable_reload) {
+    if (!this.activeKnownPlugin || this.activeKnownPlugin.disable_reload) {
       return;
     }
 
     const maybeDashboard = this.pluginInstances.get(
-      this.activePlugin.id
+      this.activeKnownPlugin.id
     ) as any;
     if (maybeDashboard.reload) {
       maybeDashboard.reload();

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -13,14 +13,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {ChangeDetectionStrategy, Component} from '@angular/core';
-import {Store, select, createSelector} from '@ngrx/store';
+import {Store, createSelector} from '@ngrx/store';
 import {combineLatest} from 'rxjs';
 import {map} from 'rxjs/operators';
 
-import {getPlugins, getActivePlugin, getPluginsListLoaded} from '../core/store';
+import {
+  getPlugins,
+  getActivePlugin,
+  getPluginsListLoaded,
+  getEnvironment,
+} from '../core/store';
 import {PluginMetadata} from '../types/api';
 import {LoadState, DataLoadState} from '../types/data';
 import {State} from '../core/store/core_types';
+
+import {PluginLoadState} from './plugins_component';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
@@ -49,28 +56,50 @@ const lastLoadedTimeInMs = createSelector(
   template: `
     <plugins-component
       [activePlugin]="activePlugin$ | async"
-      [noEnabledPlugin]="noEnabledPlugin$ | async"
+      [activePluginId]="activePluginId$ | async"
+      [dataLocation]="dataLocation$ | async"
       [lastUpdated]="lastLoadedTimeInMs$ | async"
+      [pluginLoadState]="pluginLoadState$ | async"
     ></plugins-component>
   `,
   styles: ['plugins-component { height: 100%; }'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PluginsContainer {
-  readonly activePlugin$ = this.store.pipe(select(activePlugin));
-  readonly noEnabledPlugin$ = combineLatest(
-    this.store.select(activePlugin),
+  readonly activePlugin$ = this.store.select(activePlugin);
+  readonly activePluginId$ = this.store.select(getActivePlugin);
+
+  readonly pluginLoadState$ = combineLatest(
+    this.activePlugin$,
+    this.activePluginId$,
     this.store.select(getPluginsListLoaded)
   ).pipe(
-    map(([activePlugin, loadState]) => {
-      return (
-        activePlugin === null &&
-        (loadState.state === DataLoadState.LOADED ||
-          loadState.state === DataLoadState.FAILED)
-      );
+    map(([activePlugin, activePluginId, loadState]) => {
+      if (activePlugin !== null) {
+        return PluginLoadState.LOADED;
+      }
+
+      if (
+        loadState.lastLoadedTimeInMs === null &&
+        loadState.state === DataLoadState.LOADING
+      ) {
+        return PluginLoadState.LOADING;
+      }
+
+      if (activePluginId) {
+        return PluginLoadState.UNKNOWN_PLUGIN_ID;
+      }
+
+      return PluginLoadState.NO_ENABLED_PLUGINS;
     })
   );
-  readonly lastLoadedTimeInMs$ = this.store.pipe(select(lastLoadedTimeInMs));
+
+  readonly lastLoadedTimeInMs$ = this.store.select(lastLoadedTimeInMs);
+  readonly dataLocation$ = this.store.select(getEnvironment).pipe(
+    map((env) => {
+      return env.data_location;
+    })
+  );
 
   constructor(private readonly store: Store<State>) {}
 }

--- a/tensorboard/webapp/plugins/plugins_container.ts
+++ b/tensorboard/webapp/plugins/plugins_container.ts
@@ -55,7 +55,7 @@ const lastLoadedTimeInMs = createSelector(
   selector: 'plugins',
   template: `
     <plugins-component
-      [activePlugin]="activePlugin$ | async"
+      [activeKnownPlugin]="activeKnownPlugin$ | async"
       [activePluginId]="activePluginId$ | async"
       [dataLocation]="dataLocation$ | async"
       [lastUpdated]="lastLoadedTimeInMs$ | async"
@@ -66,11 +66,11 @@ const lastLoadedTimeInMs = createSelector(
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PluginsContainer {
-  readonly activePlugin$ = this.store.select(activePlugin);
+  readonly activeKnownPlugin$ = this.store.select(activePlugin);
   readonly activePluginId$ = this.store.select(getActivePlugin);
 
   readonly pluginLoadState$ = combineLatest(
-    this.activePlugin$,
+    this.activeKnownPlugin$,
     this.activePluginId$,
     this.store.select(getPluginsListLoaded)
   ).pipe(


### PR DESCRIPTION
Previously, we only showed a warning when a given logdir does not
result in activePlugin selection. This change introduces similar warning
for the case when a user erroneously typed incorrect plugin id that we
do not know about.

This change also renders the data location in the warning page.

Fixes #3856.