### PR TITLE
fix data_ingester_test on Python 3.8

### DIFF
--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -134,12 +134,12 @@ class ParseEventFilesSpecTest(tb_test.TestCase):
         )
 
     def testExpandsUser(self):
+        # USERPROFILE is used for simulating Python 3.8 on Windows.
         old_home = os.environ.get("HOME", None)
         old_userprofile = os.environ.get("USERPROFILE", None)
         try:
             test_home_directory = "/usr/eliza"
             os.environ["HOME"] = test_home_directory
-            os.environ["USERPROFILE"] = test_home_directory
             self.assertPlatformSpecificLogdirParsing(
                 posixpath, "~/lol/cat~dog", {"/usr/eliza/lol/cat~dog": None}
             )
@@ -156,12 +156,12 @@ class ParseEventFilesSpecTest(tb_test.TestCase):
                 os.environ["USERPROFILE"] = old_userprofile
 
     def testExpandsUserForMultipleDirectories(self):
+        # USERPROFILE is used for simulating Python 3.8 on Windows.
         old_home = os.environ.get("HOME", None)
         old_userprofile = os.environ.get("USERPROFILE", None)
         try:
             test_home_directory = "/usr/eliza"
             os.environ["HOME"] = test_home_directory
-            os.environ["USERPROFILE"] = test_home_directory
             self.assertPlatformSpecificLogdirParsing(
                 posixpath,
                 "a:~/lol,b:~/cat",

--- a/tensorboard/backend/event_processing/data_ingester_test.py
+++ b/tensorboard/backend/event_processing/data_ingester_test.py
@@ -134,38 +134,52 @@ class ParseEventFilesSpecTest(tb_test.TestCase):
         )
 
     def testExpandsUser(self):
-        oldhome = os.environ.get("HOME", None)
+        old_home = os.environ.get("HOME", None)
+        old_userprofile = os.environ.get("USERPROFILE", None)
         try:
-            os.environ["HOME"] = "/usr/eliza"
+            test_home_directory = "/usr/eliza"
+            os.environ["HOME"] = test_home_directory
+            os.environ["USERPROFILE"] = test_home_directory
             self.assertPlatformSpecificLogdirParsing(
                 posixpath, "~/lol/cat~dog", {"/usr/eliza/lol/cat~dog": None}
             )
-            os.environ["HOME"] = r"C:\Users\eliza"
+            test_home_directory = r"C:\Users\eliza"
+            os.environ["HOME"] = test_home_directory
+            os.environ["USERPROFILE"] = test_home_directory
             self.assertPlatformSpecificLogdirParsing(
                 ntpath, r"~\lol\cat~dog", {r"C:\Users\eliza\lol\cat~dog": None}
             )
         finally:
-            if oldhome is not None:
-                os.environ["HOME"] = oldhome
+            if old_home is not None:
+                os.environ["HOME"] = old_home
+            if old_userprofile is not None:
+                os.environ["USERPROFILE"] = old_userprofile
 
     def testExpandsUserForMultipleDirectories(self):
-        oldhome = os.environ.get("HOME", None)
+        old_home = os.environ.get("HOME", None)
+        old_userprofile = os.environ.get("USERPROFILE", None)
         try:
-            os.environ["HOME"] = "/usr/eliza"
+            test_home_directory = "/usr/eliza"
+            os.environ["HOME"] = test_home_directory
+            os.environ["USERPROFILE"] = test_home_directory
             self.assertPlatformSpecificLogdirParsing(
                 posixpath,
                 "a:~/lol,b:~/cat",
                 {"/usr/eliza/lol": "a", "/usr/eliza/cat": "b"},
             )
-            os.environ["HOME"] = r"C:\Users\eliza"
+            test_home_directory = r"C:\Users\eliza"
+            os.environ["HOME"] = test_home_directory
+            os.environ["USERPROFILE"] = test_home_directory
             self.assertPlatformSpecificLogdirParsing(
                 ntpath,
                 r"aa:~\lol,bb:~\cat",
                 {r"C:\Users\eliza\lol": "aa", r"C:\Users\eliza\cat": "bb"},
             )
         finally:
-            if oldhome is not None:
-                os.environ["HOME"] = oldhome
+            if old_home is not None:
+                os.environ["HOME"] = old_home
+            if old_userprofile is not None:
+                os.environ["USERPROFILE"] = old_userprofile
 
     def testMultipleDirectories(self):
         self.assertPlatformSpecificLogdirParsing(


### PR DESCRIPTION
Python 3.8 includes breaking changes to the `os.path.expanduser` method,
which no longer reads from the `HOME` environment variable on Windows,
but rather uses `USERPROFILE`.

This broke the `data_ingester_test.py`, which tries to emulate platform specific
expansion by setting `os.environ["HOME"]`. To allow this test to run on both
Python 3.8 and before, this change makes the test simulate home directory
expansion by setting both environment variables.

Manually tested that the test fails before and passes after this change, with
`bazel run //tensorboard/backend/event_processing:data_ingester_test`.

Note that our Travis config does not use Python 3.8, so our CI does not validate
whether this change works.

See https://bugs.python.org/issue36264