### PR TITLE
Update protos for TF v2.3.0-rc2

### DIFF
--- a/tensorboard/compat/proto/config.proto
+++ b/tensorboard/compat/proto/config.proto
@@ -110,6 +110,18 @@ message GPUOptions {
       // For the concept of "visible" and "virtual" GPU, see the comments for
       // "visible_device_list" above for more information.
       repeated float memory_limit_mb = 1;
+
+      // Priority values to use with the virtual devices. Use the cuda function
+      // cudaDeviceGetStreamPriorityRange to query for valid range of values for
+      // priority.
+      //
+      // On a P4000 GPU with cuda 10.1, the priority range reported was 0 for
+      // least priority and -1 for greatest priority.
+      //
+      // If this field is not specified, then the virtual devices will be
+      // created with the default. If this field has values set, then the size
+      // of this must match with the above memory_limit_mb.
+      repeated int32 priority = 2;
     }
 
     // The multi virtual device settings. If empty (not set), it will create
@@ -569,6 +581,13 @@ message ConfigProto {
     // to lower the encapsulated graph to a particular device.
     bool enable_mlir_bridge = 13;
 
+    // Whether to enable the MLIR-based Graph optimizations.
+    //
+    // This will become a part of standard Tensorflow graph optimization
+    // pipeline, currently this is only used for gradual migration and testing
+    // new passes that are replacing existing optimizations in Grappler.
+    bool enable_mlir_graph_optimization = 16;
+
     // If true, the session will not store an additional copy of the graph for
     // each subgraph.
     //
@@ -640,6 +659,13 @@ message RunOptions {
     // and tail) latency.
     // Consider using this option for CPU-bound workloads like inference.
     bool use_run_handler_pool = 2;
+    // Options for run handler thread pool.
+    message RunHandlerPoolOptions {
+      // Priority of the request. The run handler thread pool will schedule ops
+      // based on the priority number. The larger number means higher priority.
+      int64 priority = 1;
+    }
+    RunHandlerPoolOptions run_handler_pool_options = 3;
   }
 
   Experimental experimental = 8;

--- a/tensorboard/compat/proto/cost_graph.proto
+++ b/tensorboard/compat/proto/cost_graph.proto
@@ -76,4 +76,14 @@ message CostGraphDef {
     bool inaccurate = 17;
   }
   repeated Node node = 1;
+
+  // Total cost of this graph, typically used for balancing decisions.
+  message AggregatedCost {
+    // Aggregated cost value.
+    float cost = 1;
+
+    // Aggregated cost dimension (e.g. 'memory', 'compute', 'network').
+    string dimension = 2;
+  }
+  repeated AggregatedCost cost = 2;
 }

--- a/tensorboard/compat/proto/resource_handle.proto
+++ b/tensorboard/compat/proto/resource_handle.proto
@@ -41,7 +41,5 @@ message ResourceHandleProto {
   // Data types and shapes for the underlying resource.
   repeated DtypeAndShape dtypes_and_shapes = 6;
 
-  // A set of devices containing the resource. If empty, the resource only
-  // exists on `device`.
-  repeated string allowed_devices = 7;
+  reserved 7;
 }

--- a/tensorboard/compat/proto/rewriter_config.proto
+++ b/tensorboard/compat/proto/rewriter_config.proto
@@ -60,6 +60,9 @@ message RewriterConfig {
   // Remapping (default is ON)
   // Remap subgraphs onto more efficient implementations.
   Toggle remapping = 14;
+  // Common subgraph elimination (default is ON)
+  // e.g. Simplify arithmetic ops; merge ops with same value (like constants).
+  Toggle common_subgraph_elimination = 24;
   // Arithmetic optimizations (default is ON)
   // e.g. Simplify arithmetic ops; merge ops with same value (like constants).
   Toggle arithmetic_optimization = 7;
@@ -82,11 +85,15 @@ message RewriterConfig {
   // Enable the swap of kernel implementations based on the device placement
   // (default is ON).
   Toggle implementation_selector = 22;
-  // Optimize data types (default is OFF).
-  // e.g., This will try to use float16 on GPU which is faster.
+  // Optimize data types for CUDA (default is OFF).
+  // This will try to use float16 on GPU which is faster.
   // Note that this can change the numerical stability of the graph and may
   // require the use of loss scaling to maintain model convergence.
   Toggle auto_mixed_precision = 23;
+  // Optimize data types for MKL (default is OFF).
+  // This will try to use bfloat16 on CPUs, which is faster.
+  // Note that this can change the numerical stability of the graph.
+  Toggle auto_mixed_precision_mkl = 25;
   // Disable the entire meta optimizer (off by default).
   bool disable_meta_optimizer = 19;
 

--- a/tensorboard/compat/proto/saved_object_graph.proto
+++ b/tensorboard/compat/proto/saved_object_graph.proto
@@ -61,6 +61,8 @@ message SavedObject {
     SavedConstant constant = 9;
     SavedResource resource = 10;
   }
+
+  map<string, SaveableObject> saveable_objects = 11;
 }
 
 // A SavedUserObject is an object (in the object-oriented language of the
@@ -161,4 +163,10 @@ message SavedResource {
   // creation function, e.g. "CPU". An empty string allows the user to select a
   // device.
   string device = 1;
+}
+
+message SaveableObject {
+  // Node ids of concrete functions for saving and loading from a checkpoint.
+  int32 save_function = 2;
+  int32 restore_function = 3;
 }

--- a/tensorboard/compat/proto/struct.proto
+++ b/tensorboard/compat/proto/struct.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package tensorboard;
 
+import "tensorboard/compat/proto/tensor.proto";
 import "tensorboard/compat/proto/tensor_shape.proto";
 import "tensorboard/compat/proto/types.proto";
 
@@ -60,6 +61,8 @@ message StructuredValue {
     TensorSpecProto tensor_spec_value = 33;
     // Represents a value for tf.TypeSpec.
     TypeSpecProto type_spec_value = 34;
+    // Represents a value for tf.BoundedTensorSpec.
+    BoundedTensorSpecProto bounded_tensor_spec_value = 35;
 
     // Represents a list of `Value`.
     ListValue list_value = 51;
@@ -103,11 +106,20 @@ message NamedTupleValue {
   repeated PairValue values = 2;
 }
 
-// A protobuf to tf.TensorSpec.
+// A protobuf to represent tf.TensorSpec.
 message TensorSpecProto {
   string name = 1;
   tensorboard.TensorShapeProto shape = 2;
   tensorboard.DataType dtype = 3;
+}
+
+// A protobuf to represent tf.BoundedTensorSpec.
+message BoundedTensorSpecProto {
+  string name = 1;
+  tensorboard.TensorShapeProto shape = 2;
+  tensorboard.DataType dtype = 3;
+  tensorboard.TensorProto minimum = 4;
+  tensorboard.TensorProto maximum = 5;
 }
 
 // Represents a tf.TypeSpec
@@ -123,6 +135,7 @@ message TypeSpecProto {
     OPTIONAL_SPEC = 7;        // tf.OptionalSpec
     PER_REPLICA_SPEC = 8;     // PerReplicaSpec from distribute/values.py
     VARIABLE_SPEC = 9;        // tf.VariableSpec
+    ROW_PARTITION_SPEC = 10;  // RowPartitionSpec from ragged/row_partition.py
   }
   TypeSpecClass type_spec_class = 1;
 

--- a/tensorboard/compat/proto/update.sh
+++ b/tensorboard/compat/proto/update.sh
@@ -37,6 +37,7 @@ find tensorboard/compat/proto/ -type f  -name '*.proto' -exec perl -pi \
   -e 's|package tensorflow.tfprof;|package tensorboard;|g;' \
   -e 's|package tensorflow;|package tensorboard;|g;' \
   -e 's|tensorflow\.DataType|tensorboard.DataType|g;' \
+  -e 's|tensorflow\.TensorProto|tensorboard.TensorProto|g;' \
   -e 's|tensorflow\.TensorShapeProto|tensorboard.TensorShapeProto|g;' \
   {} +
 


### PR DESCRIPTION
While testing the pip candidate locally, it fails on the proto_test.

The helpful message says this expected when TF's protos update.
This change was created by checking out `git checkout v2.2.0-rc0`
in a TensorFlow local repo, and running
`./tensorboard/compat/proto/update.sh PATH_TO_TENSORFLOW_REPO`.