### PR TITLE
run selector interop: populate initial state

### DIFF
--- a/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_component.ts
+++ b/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_component.ts
@@ -49,5 +49,9 @@ export class LegacyRunsSelectorComponent implements AfterViewInit {
         this.onSelectionChange.emit(event.detail.value as string[]);
       }
     );
+    setTimeout(() => {
+      // Dispatch the initial value from the component.
+      this.onSelectionChange.emit(this.selector.nativeElement.selectedRuns);
+    });
   }
 }

--- a/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_test.ts
+++ b/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_test.ts
@@ -68,7 +68,20 @@ describe('legacy_runs_selector test', () => {
     expect(element.nativeElement).toBe(testableRunSelector);
   });
 
+  it('dispatches initial selection from the Polymer component', () => {
+    (testableRunSelector as any).selectedRuns = ['foo'];
+    const fixture = TestBed.createComponent(LegacyRunsSelectorContainer);
+    fixture.detectChanges();
+
+    expect(recordedActions).toEqual([
+      polymerInteropRunSelectionChanged({
+        nextSelection: ['foo'],
+      }),
+    ]);
+  });
+
   it('dispatches action when polymer component dispatches change', () => {
+    (testableRunSelector as any).selectedRuns = ['foo'];
     const fixture = TestBed.createComponent(LegacyRunsSelectorContainer);
     fixture.detectChanges();
 
@@ -80,6 +93,7 @@ describe('legacy_runs_selector test', () => {
     testableRunSelector.dispatchEvent(event);
 
     expect(recordedActions).toEqual([
+      jasmine.any(Object),
       polymerInteropRunSelectionChanged({
         nextSelection: ['foo', 'bar'],
       }),


### PR DESCRIPTION
Bug: currently, the initial state of the legacy runs selector is not reflected in the store.
Fix: read the state from the Polymer component and fire an action.