### PR TITLE
cleanup: remove extraneous license header

### DIFF
--- a/tensorboard/components/vz_chart_helpers/plottable-interactions.ts
+++ b/tensorboard/components/vz_chart_helpers/plottable-interactions.ts
@@ -12,29 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-/**
-The MIT License (MIT)
-
-Copyright (c) 2014-2017 Palantir Technologies, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
+// License of the forked code is covered by one in
+// tensorboard/components/tf_imports/plottable.html.
 
 /**
  * Reason for the fork: Plottable interactions are not compatible with the Web


### PR DESCRIPTION
This change removes Plottable license from our forked code.
Our policy is that the release unit (built binary) should contain
licenses of our libraries but not all libraries.

After this change, we had made sure that the Pottable licenses are kept
in the built binary.

Confirmed manually that the licenses are coming from `@license` in our
tf_imports module like https://github.com/tensorflow/tensorboard/blob/master/tensorboard/components/tf_imports/plottable.html#L1-L23.

Do note that we are able to provide licenses from their respective sources
for few packages (like d3) but not all dependencies would automatically
get the license in the built binary without explicit license statements in
tf_imports.