### PR TITLE
Polymer style for tensor widget in TypeScript

### DIFF
--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -6,11 +6,23 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
+genrule(
+    name = "gen_tensor_widget_style",
+    srcs = [
+        "tensor-widget-style.uninlined.ts",
+        "tensor-widget.css",
+    ],
+    outs = ["tensor-widget-style.ts"],
+    cmd = "$(execpath //tensorboard/tools:inline_file_content) $(SRCS) >'$@'",
+    tools = ["//tensorboard/tools:inline_file_content"],
+)
+
 tf_web_library(
     name = "tensor_widget",
     srcs = [
         "tensor-widget.css",
         "tensor-widget.html",
+        "tensor-widget-style.ts",
         ":tensor_widget_binary.js",
     ],
     path = "/tensor-widget",

--- a/tensorboard/components/tensor_widget/tensor-widget-style.uninlined.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-style.uninlined.ts
@@ -1,7 +1,4 @@
-<!DOCTYPE html>
-<!--
-@license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,9 +11,16 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
+==============================================================================*/
 
-<script src="tensor_widget_binary.js"></script>
-<link rel="stylesheet" href="tensor-widget.css" />
-
-<script src="tensor-widget-style.js"></script>
+customElements.whenDefined('dom-module').then(() => {
+  const styleElement = document.createElement('dom-module');
+  styleElement.innerHTML = `
+  <template>
+    <style>
+      %tensor-widget.css%
+    </style>
+  </template>
+  `;
+  (styleElement as any).register('tensor-widget-style');
+});

--- a/tensorboard/tools/BUILD
+++ b/tensorboard/tools/BUILD
@@ -15,3 +15,8 @@ sh_binary(
         "//tensorboard:internal",
     ],
 )
+
+py_binary(
+    name = "inline_file_content",
+    srcs = ["inline_file_content.py"],
+)

--- a/tensorboard/tools/inline_file_content.py
+++ b/tensorboard/tools/inline_file_content.py
@@ -1,0 +1,44 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Inline file contents in destination file.
+
+Replaces special template syntax (e.g., `%filename.ext%`) in the destination file.
+"""
+
+import os
+import sys
+
+
+def inline_content():
+    dest_file_path = sys.argv[1]
+    src_paths = sys.argv[2:]
+    with open(dest_file_path, "r") as f:
+        html = f.read()
+    for src_path in src_paths:
+        with open(src_path, "rb") as f:
+            content = f.read().decode("utf-8")
+        src_basename = os.path.basename(src_path)
+        template_string = "%" + src_basename + "%"
+        if template_string not in html:
+            raise ValueError(
+                "Cannot find %s in dest file %s"
+                % (template_string, dest_file_path)
+            )
+        html = html.replace(template_string, content)
+    sys.stdout.write(html)
+
+
+if __name__ == "__main__":
+    inline_content()


### PR DESCRIPTION
Now, the TypeScript code can import the CSS for tensor widget in Polymer
3 compatible way.
