### PR TITLE
Remove setRemoveUnusedPrototypePropertiesInExterns

### DIFF
--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/Vulcanize.java
@@ -466,7 +466,6 @@ public final class Vulcanize {
     options.setPropertyRenaming(PropertyRenamingPolicy.OFF);
     options.setCheckGlobalThisLevel(CheckLevel.OFF);
     options.setRemoveUnusedPrototypeProperties(false);
-    options.setRemoveUnusedPrototypePropertiesInExterns(false);
     options.setRemoveUnusedClassProperties(false);
     // Prevent Polymer bound method (invisible to JSComp) to be over-optimized.
     options.setInlineFunctions(CompilerOptions.Reach.NONE);


### PR DESCRIPTION
Remove references to CompilerOptions#setRemoveUnusedPrototypePropertiesInExterns for Closure Compiler compatibility

CompilerOptions#setRemoveUnusedPrototypePropertiesInExterns is becoming a noop (internal change cl/322445084).   Even before the change "remove unused prototype properties in externs" would do nothing if "remove unused prototype properties" was disabling so this isn't necessary.

