### PR TITLE
polymer3: add indirection for legacy mixin

### DIFF
--- a/tensorboard/components_polymer3/polymer/BUILD
+++ b/tensorboard/components_polymer3/polymer/BUILD
@@ -5,12 +5,11 @@ package(default_visibility = ["//tensorboard:internal"])
 licenses(["notice"])  # Apache 2.0
 
 tf_ts_library(
-    name = "tf_markdown_view",
-    srcs = ["tf-markdown-view.ts"],
-    strict_checks = False,
+    name = "legacy_element_mixin",
+    srcs = [
+        "legacy_element_mixin.ts",
+    ],
     deps = [
-        "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
-        "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",
     ],
 )

--- a/tensorboard/components_polymer3/polymer/legacy_element_mixin.ts
+++ b/tensorboard/components_polymer3/polymer/legacy_element_mixin.ts
@@ -1,0 +1,16 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export * from '@polymer/polymer/lib/legacy/legacy-element-mixin';

--- a/tensorboard/components_polymer3/tf_dashboard_common/BUILD
+++ b/tensorboard/components_polymer3/tf_dashboard_common/BUILD
@@ -26,6 +26,7 @@ tf_ts_library(
     strict_checks = False,
     visibility = ["//visibility:public"],
     deps = [
+        "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
         "//tensorboard/components_polymer3/tf_backend",
         "//tensorboard/components_polymer3/tf_color_scale",
         "//tensorboard/components_polymer3/tf_storage",

--- a/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
@@ -13,11 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {PolymerElement} from '@polymer/polymer';
-import {LegacyElementMixin} from '@polymer/polymer/lib/legacy/legacy-element-mixin';
 import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin';
 import {property, observe} from '@polymer/decorators';
 import * as _ from 'lodash';
 
+import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
 import {Canceller} from '../tf_backend/canceller';
 import {RequestManager} from '../tf_backend/requestManager';
 

--- a/tensorboard/components_polymer3/tf_dashboard_common/tf-dropdown-trigger.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/tf-dropdown-trigger.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {PolymerElement, html} from '@polymer/polymer';
-import {LegacyElementMixin} from '@polymer/polymer/lib/legacy/legacy-element-mixin';
+import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
 import {customElement, property, observe} from '@polymer/decorators';
 import {PaperInkyFocusBehavior} from '@polymer/paper-behaviors/paper-inky-focus-behavior';
 import '@polymer/iron-icon';

--- a/tensorboard/components_polymer3/tf_dashboard_common/tf-filterable-checkbox-dropdown.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/tf-filterable-checkbox-dropdown.ts
@@ -17,7 +17,7 @@ import {computed, customElement, property} from '@polymer/decorators';
 import '@polymer/paper-menu-button';
 import '@polymer/paper-menu-button';
 import {PolymerElement, html} from '@polymer/polymer';
-import {LegacyElementMixin} from '@polymer/polymer/lib/legacy/legacy-element-mixin';
+import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
 
 import './tf-dropdown-trigger';
 import {FilterableCheckboxListItem} from './tf-filterable-checkbox-list';

--- a/tensorboard/components_polymer3/tf_dashboard_common/tf-filterable-checkbox-list.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/tf-filterable-checkbox-list.ts
@@ -18,7 +18,7 @@ import '@polymer/iron-icon';
 import '@polymer/paper-checkbox';
 import {PaperInputElement} from '@polymer/paper-input/paper-input';
 import {PolymerElement, html} from '@polymer/polymer';
-import {LegacyElementMixin} from '@polymer/polymer/lib/legacy/legacy-element-mixin';
+import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
 
 import './run-color-style';
 import './scrollbar-style';

--- a/tensorboard/components_polymer3/tf_dashboard_common/tf-option-selector.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/tf-option-selector.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {PolymerElement, html} from '@polymer/polymer';
-import {LegacyElementMixin} from '@polymer/polymer/lib/legacy/legacy-element-mixin';
+import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
 import {customElement, property} from '@polymer/decorators';
 import './tensorboard-color';
 

--- a/tensorboard/components_polymer3/tf_markdown_view/tf-markdown-view.ts
+++ b/tensorboard/components_polymer3/tf_markdown_view/tf-markdown-view.ts
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {PolymerElement, html} from '@polymer/polymer';
-import {LegacyElementMixin} from '@polymer/polymer/lib/legacy/legacy-element-mixin';
+import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
 import {customElement, property} from '@polymer/decorators';
 
 // tf-markdown-view renders raw HTML that has been converted from

--- a/tensorboard/components_polymer3/tf_paginated_view/BUILD
+++ b/tensorboard/components_polymer3/tf_paginated_view/BUILD
@@ -15,6 +15,7 @@ tf_ts_library(
     ],
     strict_checks = False,
     deps = [
+        "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
         "//tensorboard/components_polymer3/tf_categorization_utils",
         "//tensorboard/components_polymer3/tf_dashboard_common",
         "//tensorboard/components_polymer3/tf_storage",

--- a/tensorboard/components_polymer3/tf_paginated_view/tf-dom-repeat.ts
+++ b/tensorboard/components_polymer3/tf_paginated_view/tf-dom-repeat.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {LegacyElementMixin} from '@polymer/polymer/lib/legacy/legacy-element-mixin';
+import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
 import {
   PolymerDeepPropertyChange,
   PolymerSpliceChange,

--- a/tensorboard/components_polymer3/vz_chart_helpers/BUILD
+++ b/tensorboard/components_polymer3/vz_chart_helpers/BUILD
@@ -14,6 +14,7 @@ tf_ts_library(
     strict_checks = False,
     visibility = ["//visibility:public"],
     deps = [
+        "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
         "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",
         "@npm//@types/d3",

--- a/tensorboard/components_polymer3/vz_chart_helpers/vz-chart-tooltip.ts
+++ b/tensorboard/components_polymer3/vz_chart_helpers/vz-chart-tooltip.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {PolymerElement} from '@polymer/polymer';
-import {LegacyElementMixin} from '@polymer/polymer/lib/legacy/legacy-element-mixin';
+import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
 import {customElement, property} from '@polymer/decorators';
 import * as _ from 'lodash';
 

--- a/tensorboard/components_polymer3/vz_line_chart2/BUILD
+++ b/tensorboard/components_polymer3/vz_line_chart2/BUILD
@@ -32,6 +32,7 @@ tf_ts_library(
     strict_checks = False,
     deps = [
         ":dragZoomInteraction",
+        "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
         "//tensorboard/components_polymer3/vz_chart_helpers",
         "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",

--- a/tensorboard/components_polymer3/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components_polymer3/vz_line_chart2/vz-line-chart2.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {PolymerElement, html} from '@polymer/polymer';
-import {LegacyElementMixin} from '@polymer/polymer/lib/legacy/legacy-element-mixin';
+import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
 import {customElement, observe, property} from '@polymer/decorators';
 import * as _ from 'lodash';
 import * as d3 from 'd3';

--- a/tensorboard/plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard/BUILD
+++ b/tensorboard/plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard/BUILD
@@ -9,6 +9,7 @@ tf_ts_library(
     srcs = ["tf-profile-redirect-dashboard.ts"],
     strict_checks = False,
     deps = [
+        "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
         "@npm//@polymer/decorators",
         "@npm//@polymer/paper-button",
         "@npm//@polymer/polymer",

--- a/tensorboard/plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard.ts
+++ b/tensorboard/plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 import {PolymerElement, html} from '@polymer/polymer';
 import {customElement, property} from '@polymer/decorators';
-import {LegacyElementMixin} from '@polymer/polymer/lib/legacy/legacy-element-mixin';
+import {LegacyElementMixin} from '../../../../components_polymer3/polymer/legacy_element_mixin';
 import '@polymer/paper-button';
 
 /**


### PR DESCRIPTION
Internally, the legacy mixin requires additional build target. In order
to work around that quirk, we decided to use a module and contain the
complexity in it.

Made sure impacted targets build by manually building them.