### PR TITLE
Allow existing tf_web_library to provide Polymer css without TypeScript

### DIFF
--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -22,7 +22,6 @@ tf_web_library(
     srcs = [
         "tensor-widget.css",
         "tensor-widget.html",
-        "tensor-widget-style.ts",
         ":tensor_widget_binary.js",
     ],
     path = "/tensor-widget",
@@ -67,6 +66,7 @@ tf_ts_library(
         "string-utils.ts",
         "tensor-widget.ts",
         "tensor-widget-impl.ts",
+        "tensor-widget-style.ts",
         "types.ts",
         "version.ts",
     ],

--- a/tensorboard/components/tensor_widget/tensor-widget.html
+++ b/tensorboard/components/tensor_widget/tensor-widget.html
@@ -19,4 +19,8 @@ limitations under the License.
 <script src="tensor_widget_binary.js"></script>
 <link rel="stylesheet" href="tensor-widget.css" />
 
-<script src="tensor-widget-style.js"></script>
+<dom-module id="tensor-widget-style">
+  <template>
+    <link rel="stylesheet" href="tensor-widget.css" />
+  </template>
+</dom-module>


### PR DESCRIPTION
After #3898, we started to require TypeScript in order to provide the
dom-module for the TensorWidget style. This scheme is incompatible with
internal build so we reverted that part.
