### PR TITLE
sync: allow InkyBehavior to be imported internally

### DIFF
--- a/tensorboard/components_polymer3/polymer/BUILD
+++ b/tensorboard/components_polymer3/polymer/BUILD
@@ -13,3 +13,13 @@ tf_ts_library(
         "@npm//@polymer/polymer",
     ],
 )
+
+tf_ts_library(
+    name = "paper_inky_focus_behavior",
+    srcs = [
+        "paper_inky_focus_behavior.ts",
+    ],
+    deps = [
+        "@npm//@polymer/paper-behaviors",
+    ],
+)

--- a/tensorboard/components_polymer3/polymer/paper_inky_focus_behavior.ts
+++ b/tensorboard/components_polymer3/polymer/paper_inky_focus_behavior.ts
@@ -1,0 +1,16 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export * from '@polymer/paper-behaviors/paper-inky-focus-behavior';

--- a/tensorboard/components_polymer3/tf_dashboard_common/BUILD
+++ b/tensorboard/components_polymer3/tf_dashboard_common/BUILD
@@ -27,6 +27,7 @@ tf_ts_library(
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
+        "//tensorboard/components_polymer3/polymer:paper_inky_focus_behavior",
         "//tensorboard/components_polymer3/tf_backend",
         "//tensorboard/components_polymer3/tf_color_scale",
         "//tensorboard/components_polymer3/tf_storage",
@@ -36,7 +37,6 @@ tf_ts_library(
         "@npm//@polymer/iron-flex-layout",
         "@npm//@polymer/iron-icon",
         "@npm//@polymer/iron-icons",
-        "@npm//@polymer/paper-behaviors",
         "@npm//@polymer/paper-button",
         "@npm//@polymer/paper-checkbox",
         "@npm//@polymer/paper-dialog",

--- a/tensorboard/components_polymer3/tf_dashboard_common/tf-dropdown-trigger.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/tf-dropdown-trigger.ts
@@ -16,8 +16,9 @@ limitations under the License.
 import {PolymerElement, html} from '@polymer/polymer';
 import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
 import {customElement, property, observe} from '@polymer/decorators';
-import {PaperInkyFocusBehavior} from '@polymer/paper-behaviors/paper-inky-focus-behavior';
 import '@polymer/iron-icon';
+
+import {PaperInkyFocusBehavior} from '../polymer/paper_inky_focus_behavior';
 
 /**
  * tf-dropdown-trigger is a paper-menu-button trigger that has similar asthetics


### PR DESCRIPTION
Internally, the `paper-behaviors` package dependencies are divided up
into more modular parts. As a result, we need to make sure the part that
depends on InkyBehavior depend explicitly on something stable that we
can safely search and replace.
