### PR TITLE
sync: unblock sync by not using location API

### DIFF
--- a/tensorboard/components_polymer3/tf_storage/storage.ts
+++ b/tensorboard/components_polymer3/tf_storage/storage.ts
@@ -273,7 +273,7 @@ function writeComponent(component: string, useLocationReplace = false) {
     if (useLocationReplace) {
       const url = new URL(window.location.href);
       url.hash = component;
-      window.history.replaceState(undefined, undefined, url.toString());
+      window.history.replaceState(null, '', url.toString());
     } else {
       window.location.hash = component;
     }

--- a/tensorboard/components_polymer3/tf_storage/storage.ts
+++ b/tensorboard/components_polymer3/tf_storage/storage.ts
@@ -271,7 +271,9 @@ function readComponent(): string {
 function writeComponent(component: string, useLocationReplace = false) {
   if (useHash()) {
     if (useLocationReplace) {
-      window.location.replace('#' + component);
+      const url = new URL(window.location.href);
+      url.hash = component;
+      window.history.replaceState(undefined, undefined, url.toString());
     } else {
       window.location.hash = component;
     }


### PR DESCRIPTION
tsetse, internal conformance, complained about use of the location API.
It seems to ignore the history counterpart (although it looks equally bad :)) 