### PR TITLE
sync: remove export on class that extends LegacyElementMixin

### DIFF
--- a/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
@@ -28,7 +28,7 @@ enum LoadState {
   LOADED,
 }
 
-export class DataLoader<Item, Data> extends LegacyElementMixin(PolymerElement) {
+class DataLoader<Item, Data> extends LegacyElementMixin(PolymerElement) {
   @property({type: Boolean, observer: '_loadDataIfActive'})
   active!: boolean;
 

--- a/tensorboard/components_polymer3/tf_paginated_view/tf-category-paginated-view.ts
+++ b/tensorboard/components_polymer3/tf_paginated_view/tf-category-paginated-view.ts
@@ -542,7 +542,7 @@ class TfCategoryPaginatedView<CategoryItem> extends TfDomRepeat<CategoryItem> {
   }
   _updatePageInputValue(newValue) {
     // Force two-way binding.
-    const pageInput = this.$$('#page-input input') as any;
+    const pageInput = this.shadowRoot.querySelector('#page-input input') as any;
     if (pageInput) {
       pageInput.value = newValue;
     }

--- a/tensorboard/components_polymer3/tf_paginated_view/tf-dom-repeat.ts
+++ b/tensorboard/components_polymer3/tf_paginated_view/tf-dom-repeat.ts
@@ -44,9 +44,7 @@ import {ArrayUpdateHelper} from '../tf_dashboard_common/array-update-helper';
  * `this.updateDom(newItems)`. Other protected APIs are `setGetItemKey` and
  * `setCacheSize` (please see respective doc for details).
  */
-export class TfDomRepeat<T extends {}> extends LegacyElementMixin(
-  ArrayUpdateHelper
-) {
+export class TfDomRepeat<T extends {}> extends ArrayUpdateHelper {
   @property({type: String})
   as = 'item';
 
@@ -91,6 +89,14 @@ export class TfDomRepeat<T extends {}> extends LegacyElementMixin(
   @property({type: Object})
   _getItemKey = (item: T) => JSON.stringify(item);
 
+  @property({type: Boolean})
+  _isConnected = false;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._isConnected = true;
+  }
+
   /**
    * Sets the size of the DOM cache used for optimizing performance. The
    * default cache size is 10.
@@ -118,7 +124,7 @@ export class TfDomRepeat<T extends {}> extends LegacyElementMixin(
   _ensureTemplatized() {
     // Polymer is not ready (and props/DOM for the components are not
     // populated)
-    if (!this.isAttached) return false;
+    if (!this.isConnected) return false;
     if (!this._ctor) {
       const templateNode = this.querySelector('template');
       this._ctor = templatize(templateNode!, this, {
@@ -137,7 +143,7 @@ export class TfDomRepeat<T extends {}> extends LegacyElementMixin(
     return true;
   }
 
-  @observe('isAttached')
+  @observe('_isConnected')
   _bootstrapDom() {
     if (!this._ensureTemplatized() || this._domBootstrapped) {
       return;

--- a/tensorboard/components_polymer3/vz_chart_helpers/vz-chart-tooltip.ts
+++ b/tensorboard/components_polymer3/vz_chart_helpers/vz-chart-tooltip.ts
@@ -44,7 +44,7 @@ const DEFAULT_TOOLTIP_STYLE = {
 };
 
 @customElement('vz-chart-tooltip')
-export class VzChartTooltip extends LegacyElementMixin(PolymerElement) {
+class VzChartTooltip extends LegacyElementMixin(PolymerElement) {
   @property({type: String})
   contentComponentName: string;
 

--- a/tensorboard/components_polymer3/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components_polymer3/vz_line_chart2/line-chart.ts
@@ -89,6 +89,7 @@ export class LineChart {
   private tooltipColumns: Array<
     LineChartTooltipColumn | LineChartTooltipColumn
   >;
+  // VzChartTooltip; strong type removed to work around legacy element mixin export issue
   private tooltip: any;
   private tooltipInteraction: Plottable.Interactions.Pointer;
   private tooltipPointsComponent: Plottable.Component;
@@ -123,7 +124,7 @@ export class LineChart {
     yValueAccessor: Plottable.IAccessor<number>,
     yScaleType: YScaleType,
     colorScale: Plottable.Scales.Color,
-    tooltip: any,
+    tooltip: any, // VzChartTooltip
     tooltipColumns: TooltipColumn[],
     fillArea: FillArea,
     defaultXRange?: number[],

--- a/tensorboard/components_polymer3/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components_polymer3/vz_line_chart2/line-chart.ts
@@ -23,7 +23,7 @@ import {
   XComponents,
   TooltipColumn,
 } from '../vz_chart_helpers/vz-chart-helpers';
-import {VzChartTooltip} from '../vz_chart_helpers/vz-chart-tooltip';
+import '../vz_chart_helpers/vz-chart-tooltip';
 
 import {LinearScale} from './linear-scale';
 import {LogScale} from './log-scale';
@@ -89,7 +89,7 @@ export class LineChart {
   private tooltipColumns: Array<
     LineChartTooltipColumn | LineChartTooltipColumn
   >;
-  private tooltip: VzChartTooltip;
+  private tooltip: any;
   private tooltipInteraction: Plottable.Interactions.Pointer;
   private tooltipPointsComponent: Plottable.Component;
   private linePlot: Plottable.Plots.Line<number | Date>;
@@ -123,7 +123,7 @@ export class LineChart {
     yValueAccessor: Plottable.IAccessor<number>,
     yScaleType: YScaleType,
     colorScale: Plottable.Scales.Color,
-    tooltip: VzChartTooltip,
+    tooltip: any,
     tooltipColumns: TooltipColumn[],
     fillArea: FillArea,
     defaultXRange?: number[],


### PR DESCRIPTION
Internally, our build fails when you export a class that extends the
LegacyElementMixin. While the details are unclear, we see no evidence
that it works.

Example of error:
```
error TS4020: 'extends' clause of exported class 'DataLoader' has or is using private name 'LegacyElementMixinConstructor'.
error TS4020: 'extends' clause of exported class 'DataLoader' has or is using private name 'PropertiesChangedConstructor'.
error TS4020: 'extends' clause of exported class 'DataLoader' has or is using private name 'PropertiesMixinConstructor'.
error TS4020: 'extends' clause of exported class 'DataLoader' has or is using private name 'PropertyAccessorsConstructor'.
error TS4020: 'extends' clause of exported class 'DataLoader' has or is using private name 'PropertyEffectsConstructor'.
error TS4020: 'extends' clause of exported class 'DataLoader' has or is using private name 'TemplateStampConstructor'.

30 export class DataLoader<Item, Data> extends LegacyElementMixin(PolymerElement) {
```
