### PR TITLE
migrate: tf-line-chart-data-loader

### DIFF
--- a/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
@@ -13,210 +13,227 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {PolymerElement} from '@polymer/polymer';
-import {property, observe} from '@polymer/decorators';
 import * as _ from 'lodash';
 
-import {dedupingMixin} from '../polymer/utils_mixin';
-import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
 import {Canceller} from '../tf_backend/canceller';
 import {RequestManager} from '../tf_backend/requestManager';
 
 type CacheKey = string;
+
 // NOT_LOADED is implicit
-enum LoadState {
+export enum LoadState {
   LOADING,
   LOADED,
 }
 
-class DataLoader<Item, Data> extends LegacyElementMixin(PolymerElement) {
-  @property({type: Boolean, observer: '_loadDataIfActive'})
-  active!: boolean;
-
-  /**
-   * A unique identifiable string. When changes, it expunges the data
-   * cache.
-   */
-  @property({type: String})
-  loadKey = '';
-
-  // List of data to be loaded. By default, a datum is passed to
-  // `requestData` to fetch data. When the request resolves, invokes
-  // `loadDataCallback` with the datum and its response.
-  @property({type: Array})
-  dataToLoad: Item[] = [];
-
-  /**
-   * A function that takes a datum as an input and returns a unique
-   * identifiable string. Used for caching purposes.
-   */
-  @property({type: Object})
-  getDataLoadName = (datum: Item): CacheKey => String(datum);
-
-  /**
-   * A function that takes as inputs:
-   * 1. Implementing component of data-loader-behavior.
-   * 2. datum of the request.
-   * 3. The response received from the data URL.
-   * This function will be called when a response from a request to that
-   * data URL is successfully received.
-   */
-  @property({type: Object})
-  loadDataCallback!: (component: this, datum: Item, data: Data) => void;
-
-  public requestManager!: RequestManager;
-
-  // A function that takes a datum as argument and makes the HTTP
-  // request to fetch the data associated with the datum. It should return
-  // a promise that either fullfills with the data or rejects with an error.
-  // If the function doesn't bind 'this', then it will reference the element
-  // that includes this behavior.
-  // The default implementation calls this.requestManager.request with
-  // the value returned by this.getDataLoadUrl(datum) (see below).
-  // The only place getDataLoadUrl() is called is in the default
-  // implementation of this method. So if you override this method with
-  // an implementation that doesn't call getDataLoadUrl, it need not be
-  // provided.
-  @property({type: Object})
-  requestData = (datum: Item) => {
-    return this.requestManager.request(this.getDataLoadUrl(datum));
-  };
-
-  // A function that takes a datum and returns a string URL for fetching
-  // data.
-  @property({type: Object})
-  getDataLoadUrl!: (datum: Item) => string;
-
-  @property({type: Boolean, reflectToAttribute: true})
-  dataLoading = false;
-
-  /*
-   * A map of a cache key to LoadState. If a cacheKey does not exist in the
-   * map, it is considered NOT_LOADED.
-   * Invoking `reload` or a change in `loadKey` clears the cache.
-   */
-
-  private _dataLoadState = new Map<CacheKey, LoadState>();
-
-  private _canceller = new Canceller();
-
-  private _loadDataAsync: null | number = null;
-
-  _loadData = _.throttle(this._loadDataImpl, 100, {
-    leading: true,
-    trailing: true,
-  });
-
-  onLoadFinish() {
-    // Override to do something useful.
-  }
-
-  reload() {
-    this._dataLoadState.clear();
-    this._loadData();
-  }
-
-  reset() {
-    // https://github.com/tensorflow/tensorboard/issues/1499
-    // Cannot use the observer to observe `loadKey` changes directly.
-    if (this._loadDataAsync != null) {
-      this.cancelAsync(this._loadDataAsync);
-      this._loadDataAsync = null;
-    }
-    if (this._canceller) this._canceller.cancelAll();
-    if (this._dataLoadState) this._dataLoadState.clear();
-    if (this.isAttached) this._loadData();
-  }
-
-  @observe('isAttached', 'dataToLoad.*')
-  _dataToLoadChanged() {
-    if (this.isAttached) this._loadData();
-  }
-
-  detached() {
-    // Note: Cannot call canceller.cancelAll since it will poison the cache.
-    // detached gets called when a component gets unmounted from the document
-    // but it can be re-mounted. When remounted, poisoned cache will manifest.
-    // t=0: dataLoadState: 'a' = loading
-    // t=10: unmount
-    // t=20: request for 'a' resolves but we do not change the loadState
-    // because we do not want to set one if, instead, it was resetted at t=10.
-    if (this._loadDataAsync != null) {
-      this.cancelAsync(this._loadDataAsync);
-      this._loadDataAsync = null;
-    }
-  }
-  _loadDataIfActive() {
-    if (this.active) {
-      this._loadData();
-    }
-  }
-  _loadDataImpl() {
-    if (!this.active) return;
-    if (this._loadDataAsync !== null) this.cancelAsync(this._loadDataAsync);
-    this._loadDataAsync = this.async(
-      this._canceller.cancellable((result) => {
-        if (result.cancelled) {
-          return;
-        }
-        // Read-only property have a special setter.
-        this.dataLoading = true;
-        // Promises return cacheKeys of the data that were fetched.
-        const promises = this.dataToLoad
-          .filter((datum) => {
-            const cacheKey = this.getDataLoadName(datum);
-            return !this._dataLoadState.has(cacheKey);
-          })
-          .map((datum) => {
-            const cacheKey = this.getDataLoadName(datum);
-            this._dataLoadState.set(cacheKey, LoadState.LOADING);
-            return this.requestData(datum).then(
-              this._canceller.cancellable((result) => {
-                // It was resetted. Do not notify of the response.
-                if (!result.cancelled) {
-                  this._dataLoadState.set(cacheKey, LoadState.LOADED);
-                  this.loadDataCallback(this, datum, result.value as any);
-                }
-                return cacheKey;
-              })
-            );
-          });
-        return Promise.all(promises)
-          .then(
-            this._canceller.cancellable((result) => {
-              // It was resetted. Do not notify of the data load.
-              if (!result.cancelled) {
-                const keysFetched = result.value as any;
-                const fetched = new Set(keysFetched);
-                const shouldNotify = this.dataToLoad.some((datum) =>
-                  fetched.has(this.getDataLoadName(datum))
-                );
-                if (shouldNotify) {
-                  this.onLoadFinish();
-                }
-              }
-              const isDataFetchPending = Array.from(
-                this._dataLoadState.values()
-              ).some((loadState) => loadState === LoadState.LOADING);
-              if (!isDataFetchPending) {
-                // Read-only property have a special setter.
-                this.dataLoading = false;
-              }
-            }),
-            // TODO(stephanwlee): remove me when we can use  Promise.prototype.finally
-            // instead
-            () => {}
-          )
-          .then(
-            this._canceller.cancellable(({cancelled}) => {
-              if (cancelled) {
-                return;
-              }
-              this._loadDataAsync = null;
-            })
-          );
-      })
-    );
-  }
+export interface DataLoaderBehaviorInterface<Item, Data>
+  extends PolymerElement {
+  active: boolean;
+  reset(): void;
+  dataToLoad: Item[];
 }
 
-export const DataLoaderBehavior = dedupingMixin(() => DataLoader);
+export function DataLoaderBehavior<Item, Data>(
+  superClass: new () => PolymerElement
+): new () => DataLoaderBehaviorInterface<Item, Data> {
+  return class DataLoaderBehaviorImpl<Item, Data> extends superClass
+    implements DataLoaderBehaviorInterface<Item, Data> {
+    active!: boolean;
+
+    /**
+     * A unique identifiable string. When changes, it expunges the data
+     * cache.
+     */
+    loadKey = '';
+
+    // List of data to be loaded. By default, a datum is passed to
+    // `requestData` to fetch data. When the request resolves, invokes
+    // `loadDataCallback` with the datum and its response.
+    dataToLoad: Item[] = [];
+
+    /**
+     * A function that takes a datum as an input and returns a unique
+     * identifiable string. Used for caching purposes.
+     */
+    getDataLoadName = (datum: Item): CacheKey => String(datum);
+
+    /**
+     * A function that takes as inputs:
+     * 1. Implementing component of data-loader-behavior.
+     * 2. datum of the request.
+     * 3. The response received from the data URL.
+     * This function will be called when a response from a request to that
+     * data URL is successfully received.
+     */
+    loadDataCallback!: (component: this, datum: Item, data: Data) => void;
+
+    public requestManager!: RequestManager;
+
+    // A function that takes a datum as argument and makes the HTTP
+    // request to fetch the data associated with the datum. It should return
+    // a promise that either fullfills with the data or rejects with an error.
+    // If the function doesn't bind 'this', then it will reference the element
+    // that includes this behavior.
+    // The default implementation calls this.requestManager.request with
+    // the value returned by this.getDataLoadUrl(datum) (see below).
+    // The only place getDataLoadUrl() is called is in the default
+    // implementation of this method. So if you override this method with
+    // an implementation that doesn't call getDataLoadUrl, it need not be
+    // provided.
+    requestData = (datum: Item) => {
+      return this.requestManager.request(this.getDataLoadUrl(datum));
+    };
+
+    // A function that takes a datum and returns a string URL for fetching
+    // data.
+    getDataLoadUrl!: (datum: Item) => string;
+
+    dataLoading = false;
+
+    static get properties() {
+      return {
+        active: {
+          type: Boolean,
+          observer: '_loadDataIfActive',
+        },
+        loadKey: {type: String},
+        dataToLoad: {type: Array},
+        getDataLoadName: {type: Object},
+        loadDataCallback: {type: Object},
+        requestData: {type: Object},
+      };
+    }
+
+    static get observers() {
+      return ['_dataToLoadChanged(isConnected', 'dataToLoad.*)'];
+    }
+
+    /*
+     * A map of a cache key to LoadState. If a cacheKey does not exist in the
+     * map, it is considered NOT_LOADED.
+     * Invoking `reload` or a change in `loadKey` clears the cache.
+     */
+
+    _dataLoadState = new Map<CacheKey, LoadState>();
+
+    _canceller = new Canceller();
+
+    _loadDataAsync: null | number = null;
+
+    _loadData = _.throttle(this._loadDataImpl, 100, {
+      leading: true,
+      trailing: true,
+    });
+
+    onLoadFinish() {
+      // Override to do something useful.
+    }
+
+    reload() {
+      this._dataLoadState.clear();
+      this._loadData();
+    }
+
+    reset() {
+      // https://github.com/tensorflow/tensorboard/issues/1499
+      // Cannot use the observer to observe `loadKey` changes directly.
+      if (this._loadDataAsync != null) {
+        clearTimeout(this._loadDataAsync);
+        this._loadDataAsync = null;
+      }
+      if (this._canceller) this._canceller.cancelAll();
+      if (this._dataLoadState) this._dataLoadState.clear();
+      if (this.isConnected) this._loadData();
+    }
+
+    _dataToLoadChanged() {
+      if (this.isConnected) this._loadData();
+    }
+
+    detached() {
+      // Note: Cannot call canceller.cancelAll since it will poison the cache.
+      // detached gets called when a component gets unmounted from the document
+      // but it can be re-mounted. When remounted, poisoned cache will manifest.
+      // t=0: dataLoadState: 'a' = loading
+      // t=10: unmount
+      // t=20: request for 'a' resolves but we do not change the loadState
+      // because we do not want to set one if, instead, it was resetted at t=10.
+      if (this._loadDataAsync != null) {
+        clearTimeout(this._loadDataAsync);
+        this._loadDataAsync = null;
+      }
+    }
+    _loadDataIfActive() {
+      if (this.active) {
+        this._loadData();
+      }
+    }
+    _loadDataImpl() {
+      if (!this.active) return;
+      if (this._loadDataAsync !== null) clearTimeout(this._loadDataAsync);
+      this._loadDataAsync = setTimeout(
+        this._canceller.cancellable((result) => {
+          if (result.cancelled) {
+            return;
+          }
+          // Read-only property have a special setter.
+          this.dataLoading = true;
+          // Promises return cacheKeys of the data that were fetched.
+          const promises = this.dataToLoad
+            .filter((datum) => {
+              const cacheKey = this.getDataLoadName(datum);
+              return !this._dataLoadState.has(cacheKey);
+            })
+            .map((datum) => {
+              const cacheKey = this.getDataLoadName(datum);
+              this._dataLoadState.set(cacheKey, LoadState.LOADING);
+              return this.requestData(datum).then(
+                this._canceller.cancellable((result) => {
+                  // It was resetted. Do not notify of the response.
+                  if (!result.cancelled) {
+                    this._dataLoadState.set(cacheKey, LoadState.LOADED);
+                    this.loadDataCallback(this, datum, result.value as any);
+                  }
+                  return cacheKey;
+                })
+              );
+            });
+          return Promise.all(promises)
+            .then(
+              this._canceller.cancellable((result) => {
+                // It was resetted. Do not notify of the data load.
+                if (!result.cancelled) {
+                  const keysFetched = result.value as any;
+                  const fetched = new Set(keysFetched);
+                  const shouldNotify = this.dataToLoad.some((datum) =>
+                    fetched.has(this.getDataLoadName(datum))
+                  );
+                  if (shouldNotify) {
+                    this.onLoadFinish();
+                  }
+                }
+                const isDataFetchPending = Array.from(
+                  this._dataLoadState.values()
+                ).some((loadState) => loadState === LoadState.LOADING);
+                if (!isDataFetchPending) {
+                  // Read-only property have a special setter.
+                  this.dataLoading = false;
+                }
+              }),
+              // TODO(stephanwlee): remove me when we can use
+              // Promise.prototype.finally instead
+              () => {}
+            )
+            .then(
+              this._canceller.cancellable(({cancelled}) => {
+                if (cancelled) {
+                  return;
+                }
+                this._loadDataAsync = null;
+              })
+            );
+        })
+      );
+    }
+  };
+}

--- a/tensorboard/components_polymer3/tf_line_chart_data_loader/BUILD
+++ b/tensorboard/components_polymer3/tf_line_chart_data_loader/BUILD
@@ -1,38 +1,27 @@
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "tf_web_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+tf_ts_library(
     name = "tf_line_chart_data_loader",
     srcs = [
-        "tf-line-chart-data-loader.html",
+        "tf-line-chart-data-loader.ts",
     ],
-    path = "/tf-line-chart-data-loader",
+    strict_checks = False,
     deps = [
-        "//tensorboard/components/tf_backend",
-        "//tensorboard/components/tf_color_scale",
-        "//tensorboard/components/tf_dashboard_common",
-        "//tensorboard/components/tf_imports:lodash",
-        "//tensorboard/components/tf_imports:polymer",
-        "//tensorboard/components/vz_line_chart2",
-        "@org_polymer_paper_spinner",
-    ],
-)
-
-tensorboard_webcomponent_library(
-    name = "legacy",
-    srcs = [":tf_line_chart_data_loader"],
-    destdir = "tf-line-chart-data-loader",
-    deps = [
-        "//tensorboard/components/tf_backend:legacy",
-        "//tensorboard/components/tf_color_scale:legacy",
-        "//tensorboard/components/tf_dashboard_common:legacy",
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/components/tf_imports_google:lib",
-        "//tensorboard/components/vz_line_chart2:legacy",
-        "//third_party/javascript/polymer/v2/paper-spinner:lib",
+        "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
+        "//tensorboard/components_polymer3/tf_backend",
+        "//tensorboard/components_polymer3/tf_color_scale",
+        "//tensorboard/components_polymer3/tf_dashboard_common",
+        "//tensorboard/components_polymer3/vz_chart_helpers",
+        "//tensorboard/components_polymer3/vz_line_chart2",
+        "@npm//@polymer/decorators",
+        "@npm//@polymer/paper-spinner",
+        "@npm//@polymer/polymer",
+        "@npm//@types/lodash",
+        "@npm//lodash",
+        "@npm//plottable",
     ],
 )

--- a/tensorboard/components_polymer3/tf_line_chart_data_loader/tf-line-chart-data-loader.ts
+++ b/tensorboard/components_polymer3/tf_line_chart_data_loader/tf-line-chart-data-loader.ts
@@ -1,0 +1,290 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {PolymerElement, html} from '@polymer/polymer';
+import * as Plottable from 'plottable';
+import {customElement, property, observe} from '@polymer/decorators';
+import * as _ from 'lodash';
+import '@polymer/paper-spinner/paper-spinner';
+
+import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
+import {runsColorScale} from '../tf_color_scale/colorScale';
+import {RequestManager} from '../tf_backend/requestManager';
+import {
+  XType,
+  TooltipColumn,
+  SymbolFn,
+  ScalarDatum,
+} from '../vz_chart_helpers/vz-chart-helpers';
+import {DataLoaderBehavior} from '../tf_dashboard_common/data-loader-behavior';
+import '../vz_line_chart2/vz-line-chart2';
+import {YScaleType, FillArea} from '../vz_line_chart2/line-chart';
+
+// The chart can sometimes get in a bad state, when it redraws while
+// it is display: none due to the user having switched to a different
+// page. This code implements a cascading queue to redraw the bad charts
+// one-by-one once they are active again.
+// We use a cascading queue becuase we don't want to block the UI / make the
+// ripples very slow while everything synchronously redraws.
+const redrawQueue: TfLineChartDataLoader<any>[] = [];
+let redrawRaf = 0;
+const cascadingRedraw = _.throttle(function internalRedraw() {
+  if (redrawQueue.length == 0) return;
+  const x = redrawQueue.shift();
+  if (x && x.active) {
+    x.redraw();
+    x._maybeRenderedInBadState = false;
+  }
+  window.cancelAnimationFrame(redrawRaf);
+  window.requestAnimationFrame(internalRedraw);
+}, 100);
+
+// A component that fetches data from the TensorBoard server and renders it into
+// a vz-line-chart.
+@customElement('tf-line-chart-data-loader')
+class TfLineChartDataLoader<ScalarMetadata> extends DataLoaderBehavior<
+  string,
+  ScalarDatum[]
+>(LegacyElementMixin(PolymerElement)) {
+  static readonly template = html`
+    <div id="chart-and-spinner-container">
+      <vz-line-chart2
+        id="chart"
+        data-loading$="[[dataLoading]]"
+        color-scale="[[colorScale]]"
+        default-x-range="[[defaultXRange]]"
+        default-y-range="[[defaultYRange]]"
+        fill-area="[[fillArea]]"
+        ignore-y-outliers="[[ignoreYOutliers]]"
+        on-chart-attached="_onChartAttached"
+        smoothing-enabled="[[smoothingEnabled]]"
+        smoothing-weight="[[smoothingWeight]]"
+        symbol-function="[[symbolFunction]]"
+        tooltip-columns="[[tooltipColumns]]"
+        tooltip-position="[[tooltipPosition]]"
+        tooltip-sorting-method="[[tooltipSortingMethod]]"
+        x-components-creation-method="[[xComponentsCreationMethod]]"
+        x-type="[[xType]]"
+        y-value-accessor="[[yValueAccessor]]"
+      ></vz-line-chart2>
+      <template is="dom-if" if="[[dataLoading]]">
+        <div id="loading-spinner-container">
+          <paper-spinner-lite active=""></paper-spinner-lite>
+        </div>
+      </template>
+    </div>
+    <style>
+      :host {
+        height: 100%;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+
+      :host([_maybe-rendered-in-bad-state]) vz-line-chart {
+        visibility: hidden;
+      }
+
+      #chart-and-spinner-container {
+        display: flex;
+        flex-grow: 1;
+        position: relative;
+      }
+
+      #loading-spinner-container {
+        align-items: center;
+        bottom: 0;
+        display: flex;
+        display: flex;
+        justify-content: center;
+        left: 0;
+        pointer-events: none;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+
+      vz-line-chart2 {
+        -webkit-user-select: none;
+        -moz-user-select: none;
+      }
+
+      vz-line-chart2[data-loading] {
+        opacity: 0.3;
+      }
+    </style>
+  `;
+
+  private _redrawRaf: number | null = null;
+
+  @property({
+    type: Boolean,
+    observer: '_fixBadStateWhenActive',
+  })
+  active: boolean = false;
+
+  @property({type: Array})
+  dataSeries!: string[];
+
+  @property({type: Object})
+  requestManager!: RequestManager;
+
+  @property({
+    type: Boolean,
+    observer: '_logScaleChanged',
+  })
+  logScaleActive: boolean = false;
+
+  @property({type: Object})
+  xComponentsCreationMethod?: any;
+
+  @property({type: String})
+  xType?: XType;
+
+  @property({type: Object})
+  yValueAccessor?: Plottable.IAccessor<number>;
+
+  @property({type: Object})
+  fillArea?: FillArea;
+
+  @property({type: Boolean})
+  smoothingEnabled?: boolean;
+
+  @property({type: Number})
+  smoothingWeight?: number;
+
+  @property({type: Array})
+  tooltipColumns?: TooltipColumn[];
+
+  @property({type: String})
+  tooltipSortingMethod?: any;
+
+  @property({type: String})
+  tooltipPosition?: string;
+
+  @property({type: Boolean})
+  ignoreYOutliers?: boolean;
+
+  @property({type: Array})
+  defaultXRange?: number[];
+
+  @property({type: Array})
+  defaultYRange?: number[];
+
+  @property({type: Object})
+  symbolFunction?: SymbolFn;
+
+  @property({type: Object})
+  colorScale = {scale: runsColorScale};
+
+  @property({type: Boolean})
+  _resetDomainOnNextLoad: boolean = true;
+
+  @property({
+    type: Boolean,
+    reflectToAttribute: true,
+  })
+  _maybeRenderedInBadState: boolean = false;
+
+  onLoadFinish() {
+    if (this.dataToLoad.length > 0 && this._resetDomainOnNextLoad) {
+      // (Don't unset _resetDomainOnNextLoad when we didn't
+      // load any runs: this has the effect that if all our
+      // runs are deselected, then we toggle them all on, we
+      // properly size the domain once all the data is loaded
+      // instead of just when we're first rendered.)
+      this._resetDomainOnNextLoad = false;
+      this.getChart().resetDomain();
+    }
+    this.redraw();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._redrawRaf !== null) cancelAnimationFrame(this._redrawRaf);
+  }
+
+  exportAsSvgString() {
+    const exporter = this.getChart().getExporter();
+    return exporter.exportAsString();
+  }
+
+  private getChart(): any {
+    return (this.$.chart as unknown) as any;
+  }
+
+  resetDomain() {
+    this.getChart().resetDomain();
+  }
+
+  setSeriesData(name: string, data: ScalarDatum[]) {
+    this.getChart().setSeriesData(name, data);
+  }
+
+  setSeriesMetadata(name: string, metadata: ScalarMetadata) {
+    this.getChart().setSeriesMetadata(name, metadata);
+  }
+
+  commitChanges() {
+    this.getChart().commitChanges();
+  }
+
+  redraw() {
+    if (this._redrawRaf !== null) cancelAnimationFrame(this._redrawRaf);
+    this._redrawRaf = window.requestAnimationFrame(() => {
+      if (this.active) {
+        this.getChart().redraw();
+      } else {
+        // If we reached a point where we should render while the page
+        // is not active, we've gotten into a bad state.
+        this._maybeRenderedInBadState = true;
+      }
+    });
+  }
+
+  @observe('loadKey')
+  _loadKeyChanged() {
+    this.reset();
+    this._resetDomainOnNextLoad = true;
+  }
+
+  @observe('dataSeries.*')
+  _dataSeriesChanged() {
+    // Setting visible series redraws the chart.
+    this.getChart().setVisibleSeries(this.dataSeries);
+  }
+
+  private _logScaleChanged(logScaleActive: boolean) {
+    const chart = this.getChart();
+    chart.yScaleType = logScaleActive ? YScaleType.LOG : YScaleType.LINEAR;
+    this.redraw();
+  }
+
+  private _fixBadStateWhenActive() {
+    // When the chart enters a potentially bad state (because it should
+    // redraw, but the page is not currently active), we set the
+    // _maybeRenderedInBadState flag. Whenever the chart becomes active,
+    // we test this and schedule a redraw of the bad charts.
+    if (this.active && this._maybeRenderedInBadState) {
+      redrawQueue.push(this);
+      cascadingRedraw();
+    }
+  }
+
+  private _onChartAttached() {
+    if (!this.active) {
+      this._maybeRenderedInBadState = true;
+    }
+  }
+}

--- a/tensorboard/components_polymer3/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components_polymer3/vz_line_chart2/vz-line-chart2.ts
@@ -81,7 +81,9 @@ export const DEFAULT_TOOLTIP_COLUMNS = [
 ];
 
 @customElement('vz-line-chart2')
-class VzLineChart2 extends LegacyElementMixin(PolymerElement) {
+class VzLineChart2<SeriesMetadata = {}> extends LegacyElementMixin(
+  PolymerElement
+) {
   static readonly template = html`
     <div id="chartdiv"></div>
     <vz-chart-tooltip
@@ -408,7 +410,7 @@ class VzLineChart2 extends LegacyElementMixin(PolymerElement) {
    * @param {string} name Name of the series.
    * @param {*} meta Metadata of the dataset used for later
    */
-  setSeriesMetadata(name: string, meta: any) {
+  setSeriesMetadata(name: string, meta: SeriesMetadata) {
     this._seriesMetadataCache[name] = meta;
     if (this._chart) {
       this._chart.setSeriesMetadata(name, meta);


### PR DESCRIPTION
This is a roll forward from #3927.

Cause of the bad CI:
- two PRs that were related were merged one after another
  - one removed `export` from `DataLoader` while another made changes to use the symbol.
- both CIs ran against master before each other's submission

Confirmed that the new change builds internally and, this time, CI should be enough to catch
the build breakage.