### PR TITLE
fix register_style_dom_module for styleIncludes

### DIFF
--- a/tensorboard/components_polymer3/polymer/BUILD
+++ b/tensorboard/components_polymer3/polymer/BUILD
@@ -29,6 +29,9 @@ tf_ts_library(
     srcs = [
         "register_style_dom_module.ts",
     ],
+    deps = [
+        "@npm//@polymer/polymer",
+    ],
 )
 
 tf_ts_library(

--- a/tensorboard/components_polymer3/polymer/register_style_dom_module.ts
+++ b/tensorboard/components_polymer3/polymer/register_style_dom_module.ts
@@ -45,7 +45,7 @@ export function registerStyleDomModule(args: DomModuleOptions): void {
   Object.assign(style, {textContent: styleContent});
 
   styleIncludes.forEach((styleElement) => {
-    template.appendChild(styleElement);
+    template.content.appendChild(styleElement);
   });
   template.content.appendChild(style);
   domModule.appendChild(template);


### PR DESCRIPTION
Two issues:
- When adding children to template, we need to set it to `dom.template`. Added the style include in the appropriate part of the DOM
- added explicit dependency on `@polymer/polymer`