### PR TITLE
fix: import iron-flex by depending on appropriate module

### DIFF
--- a/tensorboard/components_polymer3/tf_dashboard_common/dashboard-style.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/dashboard-style.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import '@polymer/iron-flex-layout/iron-flex-layout-classes';
 
 import {registerStyleDomModule} from '../polymer/register_style_dom_module';
 


### PR DESCRIPTION
When using `iron-flex` style dom-module, we need to have hard dependency
on the `iron-flex-layout-classes` for the dom-module definition to be
pulled in.
