### PR TITLE
fix: call *Initializer with reference to

### DIFF
--- a/tensorboard/components_polymer3/tf_categorization_utils/tf-tag-filterer.ts
+++ b/tensorboard/components_polymer3/tf_categorization_utils/tf-tag-filterer.ts
@@ -53,7 +53,7 @@ class TfTagFilterer extends PolymerElement {
     defaultValue: '',
     useLocalStorage: false,
     polymerProperty: '_tagFilter',
-  })();
+  }).call(this);
 
   _tagFilterObserver = getStringObserver('tagFilter', {
     defaultValue: '',

--- a/tensorboard/components_polymer3/tf_runs_selector/tf-runs-selector.ts
+++ b/tensorboard/components_polymer3/tf_runs_selector/tf-runs-selector.ts
@@ -118,20 +118,21 @@ class TfRunsSelector extends LegacyElementMixin(PolymerElement) {
     type: Object,
     observer: '_storeRunSelectionState',
   })
-  runSelectionState: object = storage.getObjectInitializer(
-    'runSelectionState',
-    {
+  runSelectionState: object = storage
+    .getObjectInitializer('runSelectionState', {
       defaultValue: {},
-    }
-  )();
+    })
+    .call(this);
 
   @property({
     type: String,
     observer: '_regexObserver',
   })
-  regexInput: string = storage.getStringInitializer('regexInput', {
-    defaultValue: '',
-  })();
+  regexInput: string = storage
+    .getStringInitializer('regexInput', {
+      defaultValue: '',
+    })
+    .call(this);
 
   @property({
     type: Array,


### PR DESCRIPTION
Our Polymer based storage utility required Polymer class instance for
the initializer (so we can set the component prop value when hash
changes). This broke in the class syntax so we reinstated it by
explicitly passing `this`.

Co-authored-by: William Chargin <wchargin@gmail.com>