### PR TITLE
migrate: misc fixes

### DIFF
--- a/tensorboard/components_polymer3/tf_dashboard_common/tf-multi-checkbox.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/tf-multi-checkbox.ts
@@ -13,13 +13,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {PolymerElement, html} from '@polymer/polymer';
 import {computed, observe, customElement, property} from '@polymer/decorators';
-import '@polymer/iron-icons';
 import {PaperCheckboxElement} from '@polymer/paper-checkbox';
 import {PaperIconButtonElement} from '@polymer/paper-icon-button';
-import '@polymer/paper-input';
-import {PolymerElement, html} from '@polymer/polymer';
 import * as _ from 'lodash';
+import '@polymer/iron-icons';
+import '@polymer/paper-checkbox';
+import '@polymer/paper-icon-button';
+import '@polymer/paper-input/paper-input';
 
 import './run-color-style';
 import './scrollbar-style';

--- a/tensorboard/components_polymer3/tf_paginated_view/tf-category-paginated-view.ts
+++ b/tensorboard/components_polymer3/tf_paginated_view/tf-category-paginated-view.ts
@@ -18,7 +18,7 @@ import {customElement, property, observe, computed} from '@polymer/decorators';
 import '@polymer/iron-icon';
 import '@polymer/iron-collapse';
 import '@polymer/paper-button';
-import '@polymer/paper-input';
+import '@polymer/paper-input/paper-input';
 
 import {
   Category,
@@ -277,7 +277,6 @@ class TfCategoryPaginatedView<CategoryItem> extends TfDomRepeat<CategoryItem> {
   @property({
     type: Boolean,
     notify: true,
-    readOnly: true,
   })
   opened: boolean;
 
@@ -420,6 +419,7 @@ class TfCategoryPaginatedView<CategoryItem> extends TfDomRepeat<CategoryItem> {
     return compositeSearch && type === CategoryType.SEARCH_RESULTS;
   }
   ready() {
+    super.ready();
     this.opened = this.initialOpened == null ? true : this.initialOpened;
     this._limitListener = () => {
       this.set('_limit', getLimit());

--- a/tensorboard/components_polymer3/tf_paginated_view/tf-dom-repeat.ts
+++ b/tensorboard/components_polymer3/tf_paginated_view/tf-dom-repeat.ts
@@ -51,7 +51,7 @@ export class TfDomRepeat<T extends {}> extends ArrayUpdateHelper {
    * @protected
    */
   @property({type: Boolean})
-  protected _contentActive = true;
+  protected _contentActive: boolean;
 
   @property({type: Boolean})
   _domBootstrapped = false;


### PR DESCRIPTION
Details:
- we add redundant import to cause side-effect of importing Polymer module. Previously, we were importing specific symbols for type checking and the Polymer modules were tree shaken
- Removed `readOnly`. Even in Polymer 3, `readOnly` creates an implicit method (if prop name was `foo`, Polymer creates `_setFoo`) which is impossible to type. We just removed it for now.
- Removed the default value on `_contentActive` so the consumer can override it with a getter.

Co-authored-by: William Chargin <wchargin@gmail.com>