### PR TITLE
migrate: fix data-loader-behavior.ts observer spec

### DIFF
--- a/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
@@ -105,7 +105,7 @@ export function DataLoaderBehavior<Item, Data>(
     }
 
     static get observers() {
-      return ['_dataToLoadChanged(isConnected', 'dataToLoad.*)'];
+      return ['_dataToLoadChanged(isConnected, dataToLoad.*)'];
     }
 
     /*


### PR DESCRIPTION
Bad quoting; caught when getting the scalars dashboard working.  Correct syntax has no internal quotes: https://polymer-library.polymer-project.org/3.0/docs/devguide/observers#complex-observers