### PR TITLE
migrate: add plottable-style DOM module for vz-line-chart2

### DIFF
--- a/tensorboard/components_polymer3/polymer/BUILD
+++ b/tensorboard/components_polymer3/polymer/BUILD
@@ -25,6 +25,23 @@ tf_ts_library(
 )
 
 tf_ts_library(
+    name = "plottable_style",
+    srcs = ["plottable-style.ts"],
+    deps = [":register_style_dom_module"],
+)
+
+genrule(
+    name = "gen_plottable_style",
+    srcs = [
+        "plottable-style.uninlined.ts",
+        "@npm//:node_modules/plottable/plottable.css",
+    ],
+    outs = ["plottable-style.ts"],
+    cmd = "$(execpath //tensorboard/tools:inline_file_content) $(SRCS) >'$@'",
+    tools = ["//tensorboard/tools:inline_file_content"],
+)
+
+tf_ts_library(
     name = "register_style_dom_module",
     srcs = [
         "register_style_dom_module.ts",

--- a/tensorboard/components_polymer3/polymer/plottable-style.uninlined.ts
+++ b/tensorboard/components_polymer3/polymer/plottable-style.uninlined.ts
@@ -1,0 +1,23 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {registerStyleDomModule} from './register_style_dom_module';
+
+registerStyleDomModule({
+  moduleName: 'plottable-style',
+  styleContent: `
+    %plottable.css%
+`,
+});

--- a/tensorboard/components_polymer3/vz_line_chart2/BUILD
+++ b/tensorboard/components_polymer3/vz_line_chart2/BUILD
@@ -33,6 +33,7 @@ tf_ts_library(
     deps = [
         ":dragZoomInteraction",
         "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
+        "//tensorboard/components_polymer3/polymer:plottable_style",
         "//tensorboard/components_polymer3/polymer:register_style_dom_module",
         "//tensorboard/components_polymer3/vz_chart_helpers",
         "@npm//@polymer/decorators",

--- a/tensorboard/components_polymer3/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components_polymer3/vz_line_chart2/vz-line-chart2.ts
@@ -18,6 +18,7 @@ import {customElement, observe, property} from '@polymer/decorators';
 import * as _ from 'lodash';
 import * as d3 from 'd3';
 import * as Plottable from 'plottable';
+import '../polymer/plottable-style';
 
 import {LineChart, LineChartStatus} from './line-chart';
 import {LineChartExporter} from './line-chart-exporter';


### PR DESCRIPTION
This fills in the missing `<style include="plottable-style"></style>` dep for `vz-line-chart2`.  It will also probably be needed for the distributions plugin chart which has a similar dep, but that isn't migrated yet so no changes here.

TESTED=scalars dashboard is marginally closer to working locally with this change