### PR TITLE
bug: fix broken contentActive in tf-dom-repeat

### DIFF
--- a/tensorboard/components_polymer3/tf_paginated_view/tf-category-paginated-view.ts
+++ b/tensorboard/components_polymer3/tf_paginated_view/tf-category-paginated-view.ts
@@ -378,10 +378,11 @@ class TfCategoryPaginatedView<CategoryItem> extends TfDomRepeat<CategoryItem> {
     this.opened = !this.opened;
   }
 
-  @computed('opened')
-  get _contentActive(): boolean {
-    return this.opened;
+  @observe('opened')
+  _changeContentActive(opened: boolean): void {
+    this._contentActive = opened;
   }
+
   _onPaneRenderedChanged(newRendered, oldRendered) {
     if (newRendered && newRendered !== oldRendered) {
       // Force dom-if render without waiting for one rAF.

--- a/tensorboard/components_polymer3/tf_paginated_view/tf-dom-repeat.ts
+++ b/tensorboard/components_polymer3/tf_paginated_view/tf-dom-repeat.ts
@@ -51,7 +51,7 @@ export class TfDomRepeat<T extends {}> extends ArrayUpdateHelper {
    * @protected
    */
   @property({type: Boolean})
-  protected _contentActive: boolean;
+  protected _contentActive: boolean = true;
 
   @property({type: Boolean})
   _domBootstrapped = false;


### PR DESCRIPTION
tf-dom-repeat and tf-category-paginated-view were weird because the sub
class was implementing `_contentActive` protected Polymer property via
getter (because it was a computed property). It looks like it is
impossible for subclass to override a property using a getter.

For instance, in pure JavaScript,
```js
(function() {
  class Foo {
    foo = 'foo';
  }

  class Bar extends Foo {
    foo =  'bar';
  }

  class Baz extends Foo {
    get foo() {
      return 'baz';
    }
  }

  console.log(new Bar().foo); // 'bar'
  console.log(new Baz().foo); // 'foo'
})();
```

This change no longer implements `_contentActive` setting via getter.
