### PR TITLE
migrate: fix irons_and_papers import in tf-multi-checkbox.ts

### DIFF
--- a/tensorboard/components_polymer3/tf_dashboard_common/tf-multi-checkbox.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/tf-multi-checkbox.ts
@@ -18,7 +18,7 @@ import {computed, observe, customElement, property} from '@polymer/decorators';
 
 import * as _ from 'lodash';
 
-import '../../../../components_polymer3/polymer/irons_and_papers';
+import '../polymer/irons_and_papers';
 
 import './run-color-style';
 import './scrollbar-style';


### PR DESCRIPTION
Followup to #3958, the import has a few two many `..`'s.