### PR TITLE
migrate: enable Polymer 3 frontend with `TB_POLYMER3=1`

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -336,6 +336,8 @@ tf_web_library(
         "//tensorboard/components:legacy.js",
         "//tensorboard/webapp:index.html",
         "//tensorboard/webapp:index.js",
+        "//tensorboard/webapp:index_polymer3.html",
+        "//tensorboard/webapp:index_polymer3.js",
         "//tensorboard/webapp:svg_bundle",
     ],
     path = "/",

--- a/tensorboard/components_polymer3/BUILD
+++ b/tensorboard/components_polymer3/BUILD
@@ -1,4 +1,4 @@
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
@@ -36,6 +36,27 @@ tf_web_library(
     deps = [
         ":polymer_lib_binary",
     ],
+)
+
+tf_ts_library(
+    name = "polymer3_ts_lib",
+    srcs = ["polymer3_lib.ts"],
+    deps = [
+        "//tensorboard/components_polymer3/tf_backend",
+        "//tensorboard/components_polymer3/tf_globals",
+        "//tensorboard/components_polymer3/tf_markdown_view",
+        "//tensorboard/components_polymer3/tf_paginated_view",
+        "//tensorboard/components_polymer3/tf_storage",
+        "//tensorboard/plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard",
+        "//tensorboard/plugins/text/polymer3/tf_text_dashboard",
+    ],
+)
+
+tf_js_binary(
+    name = "polymer3_lib_binary",
+    compile = True,
+    entry_point = ":polymer3_lib.ts",
+    deps = [":polymer3_ts_lib"],
 )
 
 tensorboard_html_binary(

--- a/tensorboard/components_polymer3/polymer3_lib.ts
+++ b/tensorboard/components_polymer3/polymer3_lib.ts
@@ -1,0 +1,24 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Add dashboards here.
+import '../plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard';
+import '../plugins/text/polymer3/tf_text_dashboard/tf-text-dashboard';
+
+// Exported Polymer <-> Angular interop (to be removed).
+import './tf_backend/tf-backend-polymer';
+import './tf_globals/globals-polymer';
+import './tf_storage/tf-storage-polymer';
+import './tf_paginated_view/tf-paginated-view-store';

--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -37,6 +37,7 @@ def tf_js_binary(compile, deps, **kwargs):
             "@npm//@rollup/plugin-commonjs",
             "@npm//@rollup/plugin-node-resolve",
         ],
+        format = "iife",
         **kwargs
     )
 

--- a/tensorboard/plugins/core/core_plugin.py
+++ b/tensorboard/plugins/core/core_plugin.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import functools
 import gzip
 import mimetypes
+import os
 import zipfile
 
 import six
@@ -100,7 +101,11 @@ class CorePlugin(base_plugin.TBPlugin):
                         self._serve_asset, path, gzipped_asset_bytes
                     )
                     apps["/" + path] = wsgi_app
-        apps["/"] = apps["/index.html"]
+        # TODO(#3887): Remove after Polymer 3 migration.
+        if os.getenv("TB_POLYMER3") == "1":
+            apps["/"] = apps["/index_polymer3.html"]
+        else:
+            apps["/"] = apps["/index.html"]
         return apps
 
     @wrappers.Request.application

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -101,6 +101,24 @@ tf_web_library(
     ],
 )
 
+genrule(
+    name = "gen_index.html",
+    srcs = ["index.uninlined.html"],
+    outs = ["index.inlined.html"],
+    cmd = "$(execpath //tensorboard/logo:inline_favicon) $< >$@",
+    tools = ["//tensorboard/logo:inline_favicon"],
+)
+
+# Polymer 3 version of above.
+# TODO(#3887): Remove after Polymer 3 migration.
+genrule(
+    name = "gen_index_polymer3.html",
+    srcs = ["index_polymer3.uninlined.html"],
+    outs = ["index_polymer3.inlined.html"],
+    cmd = "$(execpath //tensorboard/logo:inline_favicon) $< >$@",
+    tools = ["//tensorboard/logo:inline_favicon"],
+)
+
 # Bundle the Angular app with the Polymer components and plugins, as a library.
 tf_web_library(
     name = "tensorboard-webapp",
@@ -117,12 +135,21 @@ tf_web_library(
     ],
 )
 
-genrule(
-    name = "gen_index.html",
-    srcs = ["index.uninlined.html"],
-    outs = ["index.inlined.html"],
-    cmd = "$(execpath //tensorboard/logo:inline_favicon) $< >$@",
-    tools = ["//tensorboard/logo:inline_favicon"],
+# Polymer 3 version of above.
+# TODO(#3887): Remove after Polymer 3 migration.
+tf_web_library(
+    name = "tensorboard-webapp-polymer3",
+    srcs = [
+        "index_polymer3.inlined.html",
+        ":styles.css",
+        "//tensorboard/components_polymer3:polymer3_lib_binary.js",
+    ],
+    path = "/",
+    deps = [
+        ":tb_webapp",
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/monaco:requirejs",
+        "@com_google_fonts_roboto",
+    ],
 )
 
 # A Vulcanized html binary for the complete app (both Angular and Polymer parts)
@@ -132,6 +159,16 @@ tensorboard_html_binary(
     js_path = "/index.js",
     output_path = "/index.html",
     deps = [":tensorboard-webapp"],
+)
+
+# Polymer 3 version of above.
+# TODO(#3887): Remove after Polymer 3 migration.
+tensorboard_html_binary(
+    name = "index_polymer3",
+    input_path = "/index_polymer3.inlined.html",
+    js_path = "index_polymer3.js",
+    output_path = "index_polymer3.html",
+    deps = [":tensorboard-webapp-polymer3"],
 )
 
 # Karma has overhead of bootstrap/tearDown. Combine as much testcases

--- a/tensorboard/webapp/index_polymer3.uninlined.html
+++ b/tensorboard/webapp/index_polymer3.uninlined.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<!--
+@license
+Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<meta charset="utf-8" />
+<title>TensorBoard</title>
+<link rel="shortcut icon" href="%TENSORBOARD_FAVICON_URI%" />
+<link rel="apple-touch-icon" href="%TENSORBOARD_FAVICON_URI%" />
+
+<link rel="import" href="font-roboto/roboto.html" />
+<link rel="stylesheet" href="styles.css" />
+
+<style>
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    font-family: Roboto, sans-serif;
+    color: var(--primary-text-color);
+
+    /* Legacy mechanism to avoid issues with subpixel anti-aliasing on macOS.
+     *
+     * In the past [1], macOS subpixel AA caused excessive bolding for light-on-dark text; this rule
+     * avoids that by requesting non-subpixel AA always, rather than the default behavior, which is
+     * to use subpixel AA when available. The original issue was "fixed" by removing subpixel AA in
+     * macOS 14 (Mojave), but for legacy reasons they preserved the bolding effect as an option.
+     * Chrome then in turn updated its font rendering to apply that bolding effect [2], which means
+     * that even though the `-webkit-font-smoothing` docs [3] suggest that setting `antialiased`
+     * would have no effect for recent versions of macOS, it still is needed to avoid the bolding.
+     *
+     * [1]: http://www.lighterra.com/articles/macosxtextaabug/
+     * [2]: https://bugs.chromium.org/p/chromium/issues/detail?id=858861
+     * [3]: https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth
+     *
+     */
+
+    -webkit-font-smoothing: antialiased;
+  }
+</style>
+
+<body>
+  <script jscomp-nocompile src="tf-imports/require.js"></script>
+  <script jscomp-nocompile src="tb-webapp/tb_webapp_binary.js"></script>
+  <script jscomp-nocompile src="polymer3_lib_binary.js"></script>
+  <tb-webapp></tb-webapp>
+</body>


### PR DESCRIPTION
This adds a parallel set of build rules to build Polymer 3 versions of `index.html` and `index.js` and bundle them into `webfiles.zip`, and then updates the WSGI app to map `/` to that `index.html` if it detects the `TB_POLYMER3` environment variable set to `1`.

The goal is to make it possible to check in the converted Polymer 3 dashboards and test them without having to maintain patches.

Tested by spot-checking the binary as executed without any special env vars, and it seemed to still behave normally.  With `TB_POLYMER3=1` it can successfully load the text and profile_redirect dashboards (though profile_redirect seems like its copy-paste command is not working correctly).  The projector plugin has also been converted but requires a bit of extra plumbing in order for this to work, which I'll send another PR for.

