### PR TITLE
migrate: enable dynamic plugin host API for polymer3 app

### DIFF
--- a/tensorboard/components_polymer3/BUILD
+++ b/tensorboard/components_polymer3/BUILD
@@ -42,6 +42,7 @@ tf_ts_library(
     name = "polymer3_ts_lib",
     srcs = ["polymer3_lib.ts"],
     deps = [
+        "//tensorboard/components_polymer3/experimental/plugin_util:plugin_host",
         "//tensorboard/components_polymer3/tf_backend",
         "//tensorboard/components_polymer3/tf_globals",
         "//tensorboard/components_polymer3/tf_markdown_view",

--- a/tensorboard/components_polymer3/experimental/plugin_util/BUILD
+++ b/tensorboard/components_polymer3/experimental/plugin_util/BUILD
@@ -25,12 +25,14 @@ tf_ts_library(
     name = "plugin_host",
     srcs = [
         "core-host-impl.ts",
+        "plugin-host.ts",
         "runs-host-impl.ts",
     ],
     deps = [
         ":host_internals",
         "//tensorboard/components_polymer3/tf_backend",
         "//tensorboard/components_polymer3/tf_storage",
+        "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",
     ],
 )

--- a/tensorboard/components_polymer3/polymer3_lib.ts
+++ b/tensorboard/components_polymer3/polymer3_lib.ts
@@ -18,6 +18,7 @@ import '../plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard/tf-pr
 import '../plugins/text/polymer3/tf_text_dashboard/tf-text-dashboard';
 
 // Exported Polymer <-> Angular interop (to be removed).
+import './experimental/plugin_util/plugin-host';
 import './tf_backend/tf-backend-polymer';
 import './tf_globals/globals-polymer';
 import './tf_storage/tf-storage-polymer';


### PR DESCRIPTION
This includes a few fixes to enable the dynamic plugin host API (without this, the `tf-experimental-plugin-host-lib` custom element definition cannot be found, so we see a failure like `TypeError: this.experimentPluginHostLib.registerPluginIframe is not a function`).

I'm not entirely sure that the way this is linked in makes sense in the long term, since the actual dependency seems to come from Angular (plugins_component in particular), but as it exists today this mechanism seemed most similar to the other Angular<->Polymer interop bits and importing it there worked, so that's what I went with.

Tested by enabling the projector plugin (see dependent PR #3963) and confirming this fixes the TypeError.