### PR TITLE
migrate: enable projector polymer3 with TB_POLYMER3=1

### DIFF
--- a/tensorboard/components_polymer3/BUILD
+++ b/tensorboard/components_polymer3/BUILD
@@ -42,6 +42,7 @@ tf_ts_library(
     name = "polymer3_ts_lib",
     srcs = ["polymer3_lib.ts"],
     deps = [
+        "//tensorboard/components_polymer3/experimental/plugin_util:plugin_host",
         "//tensorboard/components_polymer3/tf_backend",
         "//tensorboard/components_polymer3/tf_globals",
         "//tensorboard/components_polymer3/tf_markdown_view",

--- a/tensorboard/components_polymer3/experimental/plugin_util/BUILD
+++ b/tensorboard/components_polymer3/experimental/plugin_util/BUILD
@@ -25,12 +25,14 @@ tf_ts_library(
     name = "plugin_host",
     srcs = [
         "core-host-impl.ts",
+        "plugin-host.ts",
         "runs-host-impl.ts",
     ],
     deps = [
         ":host_internals",
         "//tensorboard/components_polymer3/tf_backend",
         "//tensorboard/components_polymer3/tf_storage",
+        "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",
     ],
 )

--- a/tensorboard/components_polymer3/polymer3_lib.ts
+++ b/tensorboard/components_polymer3/polymer3_lib.ts
@@ -18,6 +18,7 @@ import '../plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard/tf-pr
 import '../plugins/text/polymer3/tf_text_dashboard/tf-text-dashboard';
 
 // Exported Polymer <-> Angular interop (to be removed).
+import './experimental/plugin_util/plugin-host';
 import './tf_backend/tf-backend-polymer';
 import './tf_globals/globals-polymer';
 import './tf_storage/tf-storage-polymer';

--- a/tensorboard/pip_package/setup.py
+++ b/tensorboard/pip_package/setup.py
@@ -61,6 +61,10 @@ setup(
             "tf_projector_plugin/index.js",
             "tf_projector_plugin/projector_binary.html",
             "tf_projector_plugin/projector_binary.js",
+            # TODO(#3887): Remove after Polymer 3 migration.
+            "polymer3/tf_projector_plugin/index.js",
+            "polymer3/tf_projector_plugin/projector_binary.html",
+            "polymer3/tf_projector_plugin/projector_binary.js",
         ],
     },
     # Disallow python 3.0 and 3.1 which lack a 'futures' module (see above).

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -12,6 +12,7 @@ py_library(
     name = "projector_plugin",
     srcs = ["projector_plugin.py"],
     data = [
+        "//tensorboard/plugins/projector/polymer3/tf_projector_plugin:projector_assets",
         "//tensorboard/plugins/projector/tf_projector_plugin:projector_assets",
     ],
     srcs_version = "PY2AND3",

--- a/tensorboard/plugins/projector/projector_plugin.py
+++ b/tensorboard/plugins/projector/projector_plugin.py
@@ -244,7 +244,6 @@ class ProjectorPlugin(base_plugin.TBPlugin):
         """
         self.multiplexer = context.multiplexer
         self.logdir = context.logdir
-        self._handlers = None
         self.readers = {}
         self.run_paths = None
         self._configs = {}
@@ -265,7 +264,11 @@ class ProjectorPlugin(base_plugin.TBPlugin):
             self.run_paths = self.multiplexer.RunPaths()
 
     def get_plugin_apps(self):
-        self._handlers = {
+        asset_prefix = "tf_projector_plugin"
+        # TODO(#3887): Remove after Polymer 3 migration.
+        if os.getenv("TB_POLYMER3") == "1":
+            asset_prefix = os.path.join("polymer3", asset_prefix)
+        return {
             RUNS_ROUTE: self._serve_runs,
             CONFIG_ROUTE: self._serve_config,
             TENSOR_ROUTE: self._serve_tensor,
@@ -273,19 +276,17 @@ class ProjectorPlugin(base_plugin.TBPlugin):
             BOOKMARKS_ROUTE: self._serve_bookmarks,
             SPRITE_IMAGE_ROUTE: self._serve_sprite_image,
             "/index.js": functools.partial(
-                self._serve_file,
-                os.path.join("tf_projector_plugin", "index.js"),
+                self._serve_file, os.path.join(asset_prefix, "index.js"),
             ),
             "/projector_binary.html": functools.partial(
                 self._serve_file,
-                os.path.join("tf_projector_plugin", "projector_binary.html"),
+                os.path.join(asset_prefix, "projector_binary.html"),
             ),
             "/projector_binary.js": functools.partial(
                 self._serve_file,
-                os.path.join("tf_projector_plugin", "projector_binary.js"),
+                os.path.join(asset_prefix, "projector_binary.js"),
             ),
         }
-        return self._handlers
 
     def is_active(self):
         """Determines whether this plugin is active.


### PR DESCRIPTION
This adds logic similar to #3961 but for the projector plugin (which requires a different approach since it's a dynamic plugin).  Once again we bundle both the Polymer 2 and Polymer 3 assets but under different paths, and then use the `TB_POLYMER3=1` env var condition to select which ones we serve under the canonical routes.

Tested by running locally and verifying that the projector loads normally without any special configuration, and with `TB_POLYMER3=1` it seems to load the Polymer 3 version (but it's still broken because of some three.js error, see below).  At least, the routes resolve and `projector_binary.js` includes what appears to be the polymer3 version.

I also tested building a pip package and installing it to check that the setup.py changes work.

The remaining error on the console is:

```
three.module.js:4102 Uncaught ReferenceError: p is not defined
    at new DownsampleCalculator (three.module.js:4102)
    at createModule (three.module.js:4096)
    at Object.3../globals (three.module.js:4096)
    at s (three.module.js:4091)
    at three.module.js:4091
    at Object.1../lib/globals (three.module.js:4092)
    at s (three.module.js:4091)
    at e (three.module.js:4091)
    at three.module.js:4091
    at three.module.js:4091
```