### PR TITLE
sync: remove usage of THREE during module resolution

### DIFF
--- a/tensorboard/plugins/projector/polymer3/vz_projector/scatterPlot.ts
+++ b/tensorboard/plugins/projector/polymer3/vz_projector/scatterPlot.ts
@@ -42,10 +42,6 @@ const ORTHO_CAMERA_FRUSTUM_HALF_EXTENT = 1.2;
 // Key presses.
 const SHIFT_KEY = 16;
 const CTRL_KEY = 17;
-const START_CAMERA_POS_3D = new THREE.Vector3(0.45, 0.9, 1.6);
-const START_CAMERA_TARGET_3D = new THREE.Vector3(0, 0, 0);
-const START_CAMERA_POS_2D = new THREE.Vector3(0, 0, 4);
-const START_CAMERA_TARGET_2D = new THREE.Vector3(0, 0, 0);
 const ORBIT_MOUSE_ROTATION_SPEED = 1;
 const ORBIT_ANIMATION_ROTATION_CYCLE_IN_SECONDS = 7;
 export type OnCameraMoveListener = (
@@ -71,6 +67,11 @@ export class CameraDef {
  * array of visualizers and dispatches application events to them.
  */
 export class ScatterPlot {
+  private readonly START_CAMERA_POS_3D = new THREE.Vector3(0.45, 0.9, 1.6);
+  private readonly START_CAMERA_TARGET_3D = new THREE.Vector3(0, 0, 0);
+  private readonly START_CAMERA_POS_2D = new THREE.Vector3(0, 0, 4);
+  private readonly START_CAMERA_TARGET_2D = new THREE.Vector3(0, 0, 0);
+
   private visualizers: ScatterPlotVisualizer[] = [];
   private onCameraMoveListeners: OnCameraMoveListener[] = [];
   private height: number;
@@ -256,25 +257,25 @@ export class ScatterPlot {
     def.zoom = 1;
     if (def.orthographic) {
       def.position = [
-        START_CAMERA_POS_2D.x,
-        START_CAMERA_POS_2D.y,
-        START_CAMERA_POS_2D.z,
+        this.START_CAMERA_POS_2D.x,
+        this.START_CAMERA_POS_2D.y,
+        this.START_CAMERA_POS_2D.z,
       ];
       def.target = [
-        START_CAMERA_TARGET_2D.x,
-        START_CAMERA_TARGET_2D.y,
-        START_CAMERA_TARGET_2D.z,
+        this.START_CAMERA_TARGET_2D.x,
+        this.START_CAMERA_TARGET_2D.y,
+        this.START_CAMERA_TARGET_2D.z,
       ];
     } else {
       def.position = [
-        START_CAMERA_POS_3D.x,
-        START_CAMERA_POS_3D.y,
-        START_CAMERA_POS_3D.z,
+        this.START_CAMERA_POS_3D.x,
+        this.START_CAMERA_POS_3D.y,
+        this.START_CAMERA_POS_3D.z,
       ];
       def.target = [
-        START_CAMERA_TARGET_3D.x,
-        START_CAMERA_TARGET_3D.y,
-        START_CAMERA_TARGET_3D.z,
+        this.START_CAMERA_TARGET_3D.x,
+        this.START_CAMERA_TARGET_3D.y,
+        this.START_CAMERA_TARGET_3D.z,
       ];
     }
     return def;

--- a/tensorboard/plugins/projector/polymer3/vz_projector/scatterPlotVisualizerSprites.ts
+++ b/tensorboard/plugins/projector/polymer3/vz_projector/scatterPlotVisualizerSprites.ts
@@ -25,7 +25,9 @@ const IMAGE_SIZE = 30;
 const RGB_NUM_ELEMENTS = 3;
 const INDEX_NUM_ELEMENTS = 1;
 const XYZ_NUM_ELEMENTS = 3;
-const VERTEX_SHADER = `
+
+function createVertexShader() {
+  return `
   // Index of the specific vertex (passed in as bufferAttribute), and the
   // variable that will be used to pass it to the fragment shader.
   attribute float spriteIndex;
@@ -78,6 +80,8 @@ const VERTEX_SHADER = `
     gl_PointSize =
       max(outputPointSize * scaleFactor, ${MIN_POINT_SIZE.toFixed(1)});
   }`;
+}
+
 const FRAGMENT_SHADER_POINT_TEST_CHUNK = `
   bool point_in_unit_circle(vec2 spriteCoord) {
     vec2 centerToP = spriteCoord - vec2(0.5, 0.5);
@@ -98,7 +102,9 @@ const FRAGMENT_SHADER_POINT_TEST_CHUNK = `
     return true;
   }
 `;
-const FRAGMENT_SHADER = `
+
+function createFragmentShader() {
+  return `
   varying vec2 xyIndex;
   varying vec3 vColor;
 
@@ -126,6 +132,8 @@ const FRAGMENT_SHADER = `
     }
     ${THREE.ShaderChunk['fog_fragment']}
   }`;
+}
+
 const FRAGMENT_SHADER_PICKING = `
   varying vec2 xyIndex;
   varying vec3 vColor;
@@ -145,10 +153,13 @@ const FRAGMENT_SHADER_PICKING = `
       gl_FragColor = vec4(vColor, 1);
     }
   }`;
+
 /**
  * Uses GL point sprites to render the dataset.
  */
 export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
+  private readonly VERTEX_SHADER = createVertexShader();
+  private readonly FRAGMENT_SHADER = createFragmentShader();
   private scene: THREE.Scene;
   private fog: THREE.Fog;
   private texture: THREE.Texture = null;
@@ -207,8 +218,8 @@ export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
     const uniforms = this.createUniforms();
     return new THREE.ShaderMaterial({
       uniforms: uniforms,
-      vertexShader: VERTEX_SHADER,
-      fragmentShader: FRAGMENT_SHADER,
+      vertexShader: this.VERTEX_SHADER,
+      fragmentShader: this.FRAGMENT_SHADER,
       transparent: !haveImage,
       depthTest: haveImage,
       depthWrite: haveImage,
@@ -220,7 +231,7 @@ export class ScatterPlotVisualizerSprites implements ScatterPlotVisualizer {
     const uniforms = this.createUniforms();
     return new THREE.ShaderMaterial({
       uniforms: uniforms,
-      vertexShader: VERTEX_SHADER,
+      vertexShader: this.VERTEX_SHADER,
       fragmentShader: FRAGMENT_SHADER_PICKING,
       transparent: true,
       depthTest: true,


### PR DESCRIPTION
Due to internal quirks, threejs symbols are not available during the
module load time. To work around this issue, we will use it only during
component creation time.
