### PR TITLE
sync: break circular deps

### DIFF
--- a/tensorboard/plugins/projector/polymer3/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/polymer3/vz_projector/vz-projector-projections-panel.ts
@@ -35,7 +35,6 @@ import {
 } from './data';
 import * as vector from './vector';
 import * as util from './util';
-import './vz-projector';
 
 const NUM_PCA_COMPONENTS = 10;
 


### PR DESCRIPTION
Internal build tool cannot deal with the circular module dependencies
and hard fails us. Since it is not used in a meaningful way aways, we
will remove it.