### PR TITLE
Expose experiment metadata as part of the Environment object in the ngrx store.

### DIFF
--- a/tensorboard/webapp/types/api.ts
+++ b/tensorboard/webapp/types/api.ts
@@ -72,6 +72,12 @@ export interface Environment {
   data_location: string;
   /** @export */
   window_title: string;
+  /** @export */
+  experiment_name?: string;
+  /** @export */
+  experiment_description?: string;
+  /** @export */
+  creation_time?: number;
 }
 
 export type GetRunsResponse = string[];


### PR DESCRIPTION
* Motivation for features / changes

  Certain variants of TensorBoard (TensorBoard.dev, for example) retrieve experiment metadata when loading the "Environment". We want to properly expose that as part of the `Environment` that we store in the ngrx store.

* Technical description of changes

  Add a few new properties to the `Environment` object. The data is already retrieved and stored by TensorBoard.dev - it just needs to be exposed officially in the internal API.

* Detailed steps to verify changes work correctly (as executed by you)

  Mainly make sure this change doesn't break TensorBoard.
  * Build and run TensorBoard from source.
  * Load TensorBoard in a browser.
  * Pay particular attention the TbdevUploadButton, which is the only current Angular component to use `Environment` object.  Make sure it is still functioning properly.