### PR TITLE
migrate: fix tf-multi-checkbox to use LegacyElementMixin

### DIFF
--- a/tensorboard/components_polymer3/tf_dashboard_common/tf-multi-checkbox.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/tf-multi-checkbox.ts
@@ -15,10 +15,10 @@ limitations under the License.
 
 import {PolymerElement, html} from '@polymer/polymer';
 import {computed, observe, customElement, property} from '@polymer/decorators';
+import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
+import '../polymer/irons_and_papers';
 
 import * as _ from 'lodash';
-
-import '../polymer/irons_and_papers';
 
 import './run-color-style';
 import './scrollbar-style';
@@ -33,7 +33,7 @@ of the checkbox, and the number of names may also be very large, and works to
 handle these situations gracefully.
 */
 @customElement('tf-multi-checkbox')
-class TfMultiCheckbox extends PolymerElement {
+class TfMultiCheckbox extends LegacyElementMixin(PolymerElement) {
   static readonly template = html`
     <style include="scrollbar-style"></style>
     <style include="run-color-style"></style>


### PR DESCRIPTION
This fixes the run selector run name regex filtering; without this you get `Uncaught TypeError: this.$$ is not a function`.

Tested via `TB_POLYMER3=1 bazel run tensorboard -- --bind_all --logdir /tmp/text_demo`