### PR TITLE
migrate: fix vz-line-chart2 to call super.ready()

### DIFF
--- a/tensorboard/components_polymer3/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components_polymer3/vz_line_chart2/vz-line-chart2.ts
@@ -317,6 +317,7 @@ class VzLineChart2<SeriesMetadata = {}> extends LegacyElementMixin(
   private _makeChartAsyncCallbackId: number = null;
 
   ready() {
+    super.ready();
     this.scopeSubtree(this.$.chartdiv, true);
   }
 


### PR DESCRIPTION
Fixes the usual issues, i.e. the component doesn't actual attach correctly.