### PR TITLE
migrate: include paper-spinner-lite in irons_and_papers

### DIFF
--- a/tensorboard/components_polymer3/polymer/irons_and_papers.ts
+++ b/tensorboard/components_polymer3/polymer/irons_and_papers.ts
@@ -38,6 +38,7 @@ import '@polymer/paper-material';
 import '@polymer/paper-menu-button';
 import '@polymer/paper-slider';
 import '@polymer/paper-spinner/paper-spinner';
+import '@polymer/paper-spinner/paper-spinner-lite';
 import '@polymer/paper-styles/paper-styles';
 import '@polymer/paper-tabs';
 import '@polymer/paper-toast';


### PR DESCRIPTION
This component is used in a few places.  Tested against my scalars WIP branch; without including this import, the spinner doesn't actually appear since the custom component isn't found.

I don't actually see any usage of plain `paper-spinner` anywhere, but to play it safe I figure we might as well still include it.