### PR TITLE
sync: create indirection for roboto

### DIFF
--- a/tensorboard/components/tf_imports/BUILD
+++ b/tensorboard/components/tf_imports/BUILD
@@ -587,3 +587,14 @@ genrule(
     outs = ["d3-transition.d.ts"],
     cmd = "sed '/^declare module/d' $< | awk '/^}$$/ && !p {p++;next}1' >$@",
 )
+
+tf_web_library(
+    name = "roboto",
+    srcs = [
+        "roboto.html",
+    ],
+    path = "/tf-imports",
+    deps = [
+        "@com_google_fonts_roboto",
+    ],
+)

--- a/tensorboard/components/tf_imports/roboto.html
+++ b/tensorboard/components/tf_imports/roboto.html
@@ -1,6 +1,6 @@
 <!--
 @license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,20 +14,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<!-- Configures polymer and requires to be loaded at the top. -->
-<link rel="import" href="../tf-imports/roboto.html" />
 
-<style>
-  html,
-  body {
-    height: 100%;
-    margin: 0;
-    width: 100%;
-    font-family: Roboto, sans-serif;
-  }
-</style>
-<script jscomp-ignore src="../standalone_bundle.js"></script>
-
-<body>
-  <vz-projector-dashboard></vz-projector-dashboard>
-</body>
+<link rel="import" href="../font-roboto/roboto.html" />

--- a/tensorboard/plugins/projector/polymer3/tf_projector_plugin/BUILD
+++ b/tensorboard/plugins/projector/polymer3/tf_projector_plugin/BUILD
@@ -35,7 +35,7 @@ tf_web_library(
     ],
     path = "/tf-projector",
     deps = [
+        "//tensorboard/components/tf_imports:roboto",
         "//tensorboard/plugins/projector/polymer3/vz_projector:standalone_lib",
-        "@com_google_fonts_roboto",
     ],
 )

--- a/tensorboard/plugins/projector/polymer3/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/polymer3/vz_projector/BUILD
@@ -109,8 +109,8 @@ tf_web_library(
     ],
     path = "/",
     deps = [
+        "//tensorboard/components/tf_imports:roboto",
         "//tensorboard/components_polymer3:analytics_html",
-        "@com_google_fonts_roboto",
     ],
 )
 

--- a/tensorboard/plugins/projector/polymer3/vz_projector/standalone_lib.html
+++ b/tensorboard/plugins/projector/polymer3/vz_projector/standalone_lib.html
@@ -29,7 +29,7 @@ limitations under the License.
     <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
     <meta http-equiv="pragma" content="no-cache" />
 
-    <link rel="import" href="../font-roboto/roboto.html" />
+    <link rel="import" href="../tf-imports/roboto.html" />
     <link rel="import" href="../analytics.html" />
     <script>
       (function(i, s, o, g, r, a, m) {

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -131,7 +131,6 @@ tf_web_library(
         ":tb_webapp",
         "//tensorboard/components:polymer_lib_binary",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/monaco:requirejs",
-        "@com_google_fonts_roboto",
     ],
 )
 
@@ -147,8 +146,8 @@ tf_web_library(
     path = "/",
     deps = [
         ":tb_webapp",
+        "//tensorboard/components/tf_imports:roboto",
         "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/monaco:requirejs",
-        "@com_google_fonts_roboto",
     ],
 )
 
@@ -166,8 +165,8 @@ tensorboard_html_binary(
 tensorboard_html_binary(
     name = "index_polymer3",
     input_path = "/index_polymer3.inlined.html",
-    js_path = "index_polymer3.js",
-    output_path = "index_polymer3.html",
+    js_path = "/index_polymer3.js",
+    output_path = "/index_polymer3.html",
     deps = [":tensorboard-webapp-polymer3"],
 )
 

--- a/tensorboard/webapp/index.uninlined.html
+++ b/tensorboard/webapp/index.uninlined.html
@@ -20,7 +20,6 @@ limitations under the License.
 <link rel="shortcut icon" href="%TENSORBOARD_FAVICON_URI%" />
 <link rel="apple-touch-icon" href="%TENSORBOARD_FAVICON_URI%" />
 
-<link rel="import" href="font-roboto/roboto.html" />
 <link rel="import" href="polymer_lib_binary.html" />
 <link rel="stylesheet" href="styles.css" />
 

--- a/tensorboard/webapp/index_polymer3.uninlined.html
+++ b/tensorboard/webapp/index_polymer3.uninlined.html
@@ -20,7 +20,7 @@ limitations under the License.
 <link rel="shortcut icon" href="%TENSORBOARD_FAVICON_URI%" />
 <link rel="apple-touch-icon" href="%TENSORBOARD_FAVICON_URI%" />
 
-<link rel="import" href="font-roboto/roboto.html" />
+<link rel="import" href="tf-imports/roboto.html" />
 <link rel="stylesheet" href="styles.css" />
 
 <style>


### PR DESCRIPTION
Roboto internally is bundled very differently; instead of downloading
the source of the roboto file, it uses the CDN approach. As such, we
need to use a different strategy when bundling the roboto and for that
reason, we will create a stable roboto re-export.

Note that it is okay to remove roboto dependency for index.unlined.html because
roboto is bundled as part of the polymer_lib.html (tf-tensorboard/style.html)