### PR TITLE
data-loader-behavior: define `reload` on interface

### DIFF
--- a/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
@@ -30,6 +30,7 @@ export interface DataLoaderBehaviorInterface<Item, Data>
   extends PolymerElement {
   active: boolean;
   reset(): void;
+  reload(): void;
   dataToLoad: Item[];
 }
 


### PR DESCRIPTION
Summary:
A component that extends `DataLoaderBehavior` gains a `reload` method.
This patch declares that on the interface so that clients can call
`reload` even if the component doesn’t override it. Extracted from #3659
as this is needed by both histograms and distributions, and this change
is safer to land.

wchargin-branch: dlb-reload
