### PR TITLE
sync: refactor to make exported object more robust

### DIFF
--- a/tensorboard/components_polymer3/experimental/plugin_util/core-host-impl.ts
+++ b/tensorboard/components_polymer3/experimental/plugin_util/core-host-impl.ts
@@ -16,7 +16,7 @@ limitations under the License.
  * Implements core plugin APIs.
  */
 import {listen} from './plugin-host-ipc';
-import {urlDict} from '../../tf_storage';
+import {getUrlDict} from '../../tf_storage';
 
 listen('experimental.GetURLPluginData', (context) => {
   if (!context) {
@@ -26,6 +26,7 @@ listen('experimental.GetURLPluginData', (context) => {
   const result: {
     [key: string]: string;
   } = {};
+  const urlDict = getUrlDict();
   for (let key in urlDict) {
     if (key.startsWith(prefix)) {
       const pluginKey = key.substring(prefix.length);

--- a/tensorboard/components_polymer3/tf_storage/storage.ts
+++ b/tensorboard/components_polymer3/tf_storage/storage.ts
@@ -51,7 +51,11 @@ export const TAB = '__tab__';
 export const DISAMBIGUATOR = 'disambiguator';
 
 // Keep an up-to-date store of URL params, which iframed plugins can request.
-export let urlDict: StringDict = {};
+let urlDict: StringDict = {};
+
+export function getUrlDict(): StringDict {
+  return urlDict;
+}
 
 addHashListener(() => {
   urlDict = componentToDict(readComponent());


### PR DESCRIPTION
Closure compiler mistreats exported object and importing an object by reference. 
Instead of abusing ambiguous behavior, we now return a reference to an object via get method.