### PR TITLE
sync: relax rollup config for imperfect deps

### DIFF
--- a/tensorboard/defs/rollup_config.js
+++ b/tensorboard/defs/rollup_config.js
@@ -23,4 +23,7 @@ module.exports = {
     }),
     commonjs(),
   ],
+  output: {
+    strict: false,
+  },
 };


### PR DESCRIPTION
Projector depends on Weblas, a 3rd party dependency that throws runtime
errors when run in a browser's strict mode: https://github.com/waylonflinn/weblas/issues/52

To workaround the error, this changes our Rollup config to generate output
files in non-strict mode.  Manually checked that the standalone target now
works (errored with `p is not defined` before):

blaze run tensorboard/plugins/projector/polymer3/vz_projector:standalone

![image](https://user-images.githubusercontent.com/2322480/89469713-e5acdc80-d72e-11ea-9967-f119a985030b.png)
