### PR TITLE
license: extract bh_tsne license out and bundle it

### DIFF
--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -94,6 +94,7 @@ genrule(
         "@org_mozilla_bleach//:LICENSE",
         "@org_html5lib//:LICENSE",
         "@org_pythonhosted_webencodings//:LICENSE",
+        "//third_party:bh_tsne.LICENSE",
     ],
     outs = ["LICENSE"],
     cmd = "\n".join([

--- a/tensorboard/plugins/projector/vz_projector/bh_tsne.ts
+++ b/tensorboard/plugins/projector/vz_projector/bh_tsne.ts
@@ -18,29 +18,9 @@ namespace vz_projector {
    * This fork implements Barnes-Hut approximation and runs in O(NlogN)
    * time, as opposed to the Karpathy's O(N^2) version.
    *
-   * @author smilkov@google.com (Daniel Smilkov)
-   */
-
-  /**
-   * @license
-   * The MIT License (MIT)
-   * Copyright (c) 2015 Andrej Karpathy
-   * Permission is hereby granted, free of charge, to any person obtaining a copy
-   * of this software and associated documentation files (the "Software"), to deal
-   * in the Software without restriction, including without limitation the rights
-   * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   * copies of the Software, and to permit persons to whom the Software is
-   * furnished to do so, subject to the following conditions:
+   * Please refer to third_party/bh_tsne.LICENSE for the original license.
    *
-   * The above copyright notice and this permission notice shall be included in
-   * all copies or substantial portions of the Software.
-   * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   * THE SOFTWARE.
+   * @author smilkov@google.com (Daniel Smilkov)
    */
 
   type AugmSPNode = SPNode & {numCells: number; yCell: number[]; rCell: number};

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -5,3 +5,5 @@ filegroup(
     srcs = ["jspbfix.js"],
     visibility = ["//visibility:public"],
 )
+
+exports_files(glob(["*.LICENSE"]))

--- a/third_party/bh_tsne.LICENSE
+++ b/third_party/bh_tsne.LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Andrej Karpathy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
We currently have two licenses for our pip package: (1) one on LICENSE
in pip package and (2) inlined in JavaScript bundle. For ease of our
conformance to the rules, we decided to inline Karpathy's TSNE license
to (1).
