### PR TITLE
Adding back in a missing dependency

### DIFF
--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -15,6 +15,7 @@ py_library(
     srcs = ["scalars_plugin.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":metadata",
         "//tensorboard:errors",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",


### PR DESCRIPTION
scalars_plugin.py is referencing metadata.py, but the dependency is not set up in the BUILD file.