### PR TITLE
text_v2: add skeleton to the application

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -31,6 +31,7 @@ ng_module(
         "//tensorboard/webapp/feature_flag",
         "//tensorboard/webapp/header",
         "//tensorboard/webapp/plugins",
+        "//tensorboard/webapp/plugins/text_v2",
         "//tensorboard/webapp/reloader",
         "//tensorboard/webapp/runs",
         "//tensorboard/webapp/settings",

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -28,6 +28,9 @@ import {PluginsModule} from './plugins/plugins_module';
 import {ROOT_REDUCERS, loggerMetaReducerFactory} from './reducer_config';
 import {ReloaderModule} from './reloader/reloader_module';
 import {SettingsModule} from './settings/settings_module';
+import {TextV2Module} from './plugins/text_v2/text_v2_module';
+
+const NG_PLUGIN_MODULES = [TextV2Module];
 
 @NgModule({
   declarations: [AppContainer],
@@ -49,6 +52,7 @@ import {SettingsModule} from './settings/settings_module';
       },
     }),
     EffectsModule.forRoot([]),
+    ...NG_PLUGIN_MODULES,
   ],
   providers: [
     {

--- a/tensorboard/webapp/plugins/text_v2/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/BUILD
@@ -1,0 +1,18 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])  # Apache 2.0
+
+ng_module(
+    name = "text_v2",
+    srcs = [
+        "text_v2_module.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/plugins:plugin_registry",
+        "//tensorboard/webapp/plugins/text_v2/views/text_dashboard",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+    ],
+)

--- a/tensorboard/webapp/plugins/text_v2/text_v2_module.ts
+++ b/tensorboard/webapp/plugins/text_v2/text_v2_module.ts
@@ -1,0 +1,31 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+
+import {PluginRegistryModule} from '../plugin_registry_module';
+import {TextDashboardComponent} from './views/text_dashboard/text_dashboard_component';
+import {TextDashboardModule} from './views/text_dashboard/text_dashboard_module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    TextDashboardModule,
+    PluginRegistryModule.forPlugin('text_v2', TextDashboardComponent),
+  ],
+  entryComponents: [TextDashboardComponent],
+})
+export class TextV2Module {}

--- a/tensorboard/webapp/plugins/text_v2/views/text_dashboard/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/views/text_dashboard/BUILD
@@ -1,0 +1,16 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])  # Apache 2.0
+
+ng_module(
+    name = "text_dashboard",
+    srcs = [
+        "text_dashboard_component.ts",
+        "text_dashboard_module.ts",
+    ],
+    deps = [
+        "@npm//@angular/core",
+    ],
+)

--- a/tensorboard/webapp/plugins/text_v2/views/text_dashboard/text_dashboard_component.ts
+++ b/tensorboard/webapp/plugins/text_v2/views/text_dashboard/text_dashboard_component.ts
@@ -1,0 +1,24 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+
+@Component({
+  selector: 'text-dashboard',
+  template: `
+    This is the text dashboard
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TextDashboardComponent {}

--- a/tensorboard/webapp/plugins/text_v2/views/text_dashboard/text_dashboard_module.ts
+++ b/tensorboard/webapp/plugins/text_v2/views/text_dashboard/text_dashboard_module.ts
@@ -1,0 +1,23 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {NgModule} from '@angular/core';
+
+import {TextDashboardComponent} from './text_dashboard_component';
+
+@NgModule({
+  declarations: [TextDashboardComponent],
+  exports: [TextDashboardComponent],
+})
+export class TextDashboardModule {}


### PR DESCRIPTION
This creates a skeleton for text_v2 plugins upon which we will build features.

Because we only render hard coded string, it is as boring as this:

![image](https://user-images.githubusercontent.com/2547313/89592178-d0a07e00-d800-11ea-86f7-5a7105ecc935.png)
