### PR TITLE
refactor: tease out plugin enumeration from plugins_module

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -7,6 +7,19 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
+ng_module(
+    name = "oss_plugins_module",
+    srcs = [
+        "oss_plugins_module.ts",
+    ],
+    deps = [
+        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin:debugger_v2",
+        "//tensorboard/webapp/plugins/npmi",
+        "//tensorboard/webapp/plugins/text_v2",
+        "@npm//@angular/core",
+    ],
+)
+
 # Angular module for the top-level app component together with all of its
 # injectable dependencies.  I.e., the entire Angular app.
 ng_module(
@@ -22,6 +35,7 @@ ng_module(
         "app_container.ng.html",
     ],
     deps = [
+        ":oss_plugins_module",
         "//tensorboard/webapp/angular:expect_angular_material_icon",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "//tensorboard/webapp/core",

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -20,6 +20,17 @@ ng_module(
     ],
 )
 
+ng_module(
+    name = "reducer_config",
+    srcs = [
+        "reducer_config.ts",
+    ],
+    deps = [
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+    ],
+)
+
 # Angular module for the top-level app component together with all of its
 # injectable dependencies.  I.e., the entire Angular app.
 ng_module(
@@ -28,7 +39,6 @@ ng_module(
         "app_container.ts",
         "app_module.ts",
         "mat_icon_module.ts",
-        "reducer_config.ts",
     ],
     assets = [
         "app_container.css",
@@ -36,6 +46,7 @@ ng_module(
     ],
     deps = [
         ":oss_plugins_module",
+        ":reducer_config",
         "//tensorboard/webapp/angular:expect_angular_material_icon",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "//tensorboard/webapp/core",

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -56,7 +56,6 @@ ng_module(
         "//tensorboard/webapp/feature_flag",
         "//tensorboard/webapp/header",
         "//tensorboard/webapp/plugins",
-        "//tensorboard/webapp/plugins/text_v2",
         "//tensorboard/webapp/reloader",
         "//tensorboard/webapp/runs",
         "//tensorboard/webapp/settings",

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -28,9 +28,7 @@ import {PluginsModule} from './plugins/plugins_module';
 import {ROOT_REDUCERS, loggerMetaReducerFactory} from './reducer_config';
 import {ReloaderModule} from './reloader/reloader_module';
 import {SettingsModule} from './settings/settings_module';
-import {TextV2Module} from './plugins/text_v2/text_v2_module';
-
-const NG_PLUGIN_MODULES = [TextV2Module];
+import {OssPluginsModule} from './oss_plugins_module';
 
 @NgModule({
   declarations: [AppContainer],
@@ -52,7 +50,7 @@ const NG_PLUGIN_MODULES = [TextV2Module];
       },
     }),
     EffectsModule.forRoot([]),
-    ...NG_PLUGIN_MODULES,
+    OssPluginsModule,
   ],
   providers: [
     {

--- a/tensorboard/webapp/oss_plugins_module.ts
+++ b/tensorboard/webapp/oss_plugins_module.ts
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,17 +12,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {NgModule} from '@angular/core';
-import {CommonModule} from '@angular/common';
 
-import {PluginsContainer} from './plugins_container';
-import {PluginsComponent} from './plugins_component';
-import {CoreModule} from '../core/core_module';
-import {PluginRegistryModule} from './plugin_registry_module';
+/**
+ * @fileoverview This module enumerates all Angular based plugins TensorBoard supports.
+ */
+
+import {NgModule} from '@angular/core';
+
+import {TextV2Module} from './plugins/text_v2/text_v2_module';
+import {DebuggerModule} from '../plugins/debugger_v2/tf_debugger_v2_plugin/debugger_module';
+import {NpmiModule} from './plugins/npmi/npmi_module';
 
 @NgModule({
-  declarations: [PluginsContainer, PluginsComponent],
-  exports: [PluginsContainer],
-  imports: [CoreModule, CommonModule, PluginRegistryModule],
+  imports: [TextV2Module, DebuggerModule, NpmiModule],
 })
-export class PluginsModule {}
+export class OssPluginsModule {}

--- a/tensorboard/webapp/plugins/BUILD
+++ b/tensorboard/webapp/plugins/BUILD
@@ -17,10 +17,8 @@ ng_module(
     ],
     deps = [
         ":plugin_registry",
-        "//tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin:debugger_v2",
         "//tensorboard/webapp/core",
         "//tensorboard/webapp/core/store",
-        "//tensorboard/webapp/plugins/npmi",
         "//tensorboard/webapp/types",
         "@npm//@angular/common",
         "@npm//@angular/core",


### PR DESCRIPTION
plugins_module is responsible for providing plugins registry and view
for rendering a plugin. Now, this module should not have enumeration of
all possible plugins in TensorBoard because whether an application wants
to embed a plugin or not is an application logic. For instance, we do
not intend to show debugger_v2 in TB.dev for now.

Diffbase #3984.