### PR TITLE
migrate: replace Node.isConnected with manually wired property

### DIFF
--- a/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
@@ -96,10 +96,12 @@ export function DataLoaderBehavior<Item, Data>(
     _isConnected = false;
 
     connectedCallback() {
+      super.connectedCallback();
       this._isConnected = true;
     }
 
     disconnectedCallback() {
+      super.disconnectedCallback();
       this._isConnected = false;
     }
 

--- a/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components_polymer3/tf_dashboard_common/data-loader-behavior.ts
@@ -91,12 +91,25 @@ export function DataLoaderBehavior<Item, Data>(
 
     dataLoading = false;
 
+    // The standard Node.isConnected doesn't seem to be set reliably, so we
+    // wire up our own property manually.
+    _isConnected = false;
+
+    connectedCallback() {
+      this._isConnected = true;
+    }
+
+    disconnectedCallback() {
+      this._isConnected = false;
+    }
+
     static get properties() {
       return {
         active: {
           type: Boolean,
           observer: '_loadDataIfActive',
         },
+        _isConnected: {type: Boolean},
         loadKey: {type: String},
         dataToLoad: {type: Array},
         getDataLoadName: {type: Object},
@@ -106,7 +119,7 @@ export function DataLoaderBehavior<Item, Data>(
     }
 
     static get observers() {
-      return ['_dataToLoadChanged(isConnected, dataToLoad.*)'];
+      return ['_dataToLoadChanged(_isConnected, dataToLoad.*)'];
     }
 
     /*
@@ -144,11 +157,11 @@ export function DataLoaderBehavior<Item, Data>(
       }
       if (this._canceller) this._canceller.cancelAll();
       if (this._dataLoadState) this._dataLoadState.clear();
-      if (this.isConnected) this._loadData();
+      if (this._isConnected) this._loadData();
     }
 
     _dataToLoadChanged() {
-      if (this.isConnected) this._loadData();
+      if (this._isConnected) this._loadData();
     }
 
     detached() {


### PR DESCRIPTION
This fixes an issue in `DataLoaderBehavior` that was noticed with `tf-line-chart-data-loader` where it doesn't reload data when `data-to-load` changes (I haven't checked if it affects other elements that mix in `DataLoaderBehavior`).  The most obvious way to trigger this is to try to add a new time series to the chart (i.e. if you start with runs deselected at load, and then select new runs, they don't appear on the chart).  This seems to be caused by the fact that the [`Node.isConnected`](https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected) property on `tf-line-chart-data-loader` is returning `undefined` when it should be `true`, which is a problem since `DataLoaderBehavior` gates data loading in response to `dataToLoad` changes using `if (this.isConnected)`.

My best guess is that this has something to do with the complicated inheritance hierarchy for `TfLineChartDataLoader` but it's a bit unclear.  @stephanwlee suggested just replacing `Node.isConnected` with a property wired up to the callbacks, so I've done that instead here.