### PR TITLE
polymer3: add indirection for `dom-repeat`

### DIFF
--- a/tensorboard/components_polymer3/polymer/BUILD
+++ b/tensorboard/components_polymer3/polymer/BUILD
@@ -15,6 +15,16 @@ tf_ts_library(
 )
 
 tf_ts_library(
+    name = "dom-repeat",
+    srcs = [
+        "dom-repeat.ts",
+    ],
+    deps = [
+        "@npm//@polymer/polymer",
+    ],
+)
+
+tf_ts_library(
     name = "legacy_element_mixin",
     srcs = [
         "legacy_element_mixin.ts",

--- a/tensorboard/components_polymer3/polymer/dom-repeat.ts
+++ b/tensorboard/components_polymer3/polymer/dom-repeat.ts
@@ -1,0 +1,16 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export * from '@polymer/polymer/lib/elements/dom-repeat';


### PR DESCRIPTION
Summary:
The `dom-repeat` module, which provides typings for the `DomRepeat`
interface, requires special treatment for syncing into google3, so we
route it through an indirection module.

Googlers, see <http://cl/325485393> for corresponding internal change.

Test Plan:
Work-in-progress migration for the custom scalars dashboard seems to be
happy with these type definitions.

wchargin-branch: polymer3-indirect-dom-repeat
