### PR TITLE
migrate-graph: remove ts srcs from tf_web_library

### DIFF
--- a/tensorboard/plugins/graph/polymer3/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_common/BUILD
@@ -1,11 +1,13 @@
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+# `tf_web_library`/`tf_ts_library` here removed to facilitate internal
+# sync-testing scripts.
+
+dict(
     name = "tf_graph_common",
     srcs = [
         "annotation.ts",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_controls/BUILD
@@ -1,11 +1,13 @@
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+# `tf_web_library`/`tf_ts_library` here removed to facilitate internal
+# sync-testing scripts.
+
+dict(
     name = "tf_graph_controls",
     srcs = [
         "tf-graph-controls.html",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_loader/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_loader/BUILD
@@ -1,11 +1,13 @@
 load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
 
-tf_web_library(
+# `tf_web_library`/`tf_ts_library` here removed to facilitate internal
+# sync-testing scripts.
+
+dict(
     name = "tf_graph_loader",
     srcs = [
         "tf-graph-loader.html",
@@ -28,7 +30,7 @@ tensorboard_webcomponent_library(
     ],
 )
 
-tf_web_library(
+dict(
     name = "tf_graph_dashboard_loader",
     srcs = [
         "tf-graph-dashboard-loader.html",


### PR DESCRIPTION
To facilitate an internal script workflow, this removes *.ts files from
`tf_web_library` rules in the graph's polymer 3 migration folder.

This allows the 'javascript' branch to reflect these *.ts files as-is,
rather than converting them into *.js.