### PR TITLE
tf-dom-repeat: port `MutationObserver` to Polymer 3

### DIFF
--- a/tensorboard/components_polymer3/tf_paginated_view/tf-dom-repeat.ts
+++ b/tensorboard/components_polymer3/tf_paginated_view/tf-dom-repeat.ts
@@ -143,6 +143,20 @@ export class TfDomRepeat<T extends {}> extends ArrayUpdateHelper {
     if (!this._ensureTemplatized() || this._domBootstrapped) {
       return;
     }
+
+    const observer = new MutationObserver((mutationsList) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'childList') {
+          for (const node of Array.from(mutation.addedNodes)) {
+            if (node instanceof Element) {
+              node.setAttribute('slot', 'items');
+            }
+          }
+        }
+      }
+    });
+    observer.observe(this, {childList: true});
+
     Array.from(this.children).forEach((child) => {
       this.removeChild(child);
     });


### PR DESCRIPTION
Summary:
In #3719, we taught `tf-dom-repeat` to properly set `slot="items"` on
children dynamically added by other templating elements, like `dom-if`.
This patch forward-ports that fix to the Polymer 3 version. This is
needed for the custom scalars dashboard.

Test Plan:
Works in an upcoming custom scalars migration.

Co-authored-by: Stephan Lee <stephanwlee@gmail.com>
wchargin-branch: tfdr-mutation-observer
