### PR TITLE
migrate: remove graph `tensorboard_webcomponent_library`s

### DIFF
--- a/tensorboard/plugins/graph/polymer3/tf_graph/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph/BUILD
@@ -1,4 +1,3 @@
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
@@ -25,24 +24,5 @@ tf_web_library(
         "@org_polymer_paper_radio_group",
         "@org_polymer_paper_toggle_button",
         "@org_polymer_paper_tooltip",
-    ],
-)
-
-tensorboard_webcomponent_library(
-    name = "legacy",
-    srcs = [":tf_graph"],
-    destdir = "tf-graph",
-    deps = [
-        "//tensorboard/components/tf_dashboard_common:legacy",
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/plugins/graph/tf_graph_common:legacy",
-        "//third_party/javascript/polymer/v2/iron-flex-layout:lib",
-        "//third_party/javascript/polymer/v2/iron-icons:lib",
-        "//third_party/javascript/polymer/v2/paper-button:lib",
-        "//third_party/javascript/polymer/v2/paper-dropdown-menu:lib",
-        "//third_party/javascript/polymer/v2/paper-input:lib",
-        "//third_party/javascript/polymer/v2/paper-radio-group:lib",
-        "//third_party/javascript/polymer/v2/paper-toggle-button:lib",
-        "//third_party/javascript/polymer/v2/paper-tooltip:lib",
     ],
 )

--- a/tensorboard/plugins/graph/polymer3/tf_graph_app/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_app/BUILD
@@ -1,4 +1,3 @@
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
@@ -26,10 +25,4 @@ tensorboard_html_binary(
     input_path = "/tf-graph-app/tf-graph-app.html",
     output_path = "/tf-graph-app/binary.html",
     deps = [":tf_graph_app"],
-)
-
-tensorboard_webcomponent_library(
-    name = "legacy",
-    srcs = [":binary"],
-    destdir = "tf-graph-app",
 )

--- a/tensorboard/plugins/graph/polymer3/tf_graph_board/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_board/BUILD
@@ -1,4 +1,3 @@
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
@@ -16,18 +15,5 @@ tf_web_library(
         "//tensorboard/plugins/graph/tf_graph_common",
         "//tensorboard/plugins/graph/tf_graph_info",
         "@org_polymer_paper_progress",
-    ],
-)
-
-tensorboard_webcomponent_library(
-    name = "legacy",
-    srcs = [":tf_graph_board"],
-    destdir = "tf-graph-board",
-    deps = [
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/plugins/graph/tf_graph:legacy",
-        "//tensorboard/plugins/graph/tf_graph_common:legacy",
-        "//tensorboard/plugins/graph/tf_graph_info:legacy",
-        "//third_party/javascript/polymer/v2/paper-progress:lib",
     ],
 )

--- a/tensorboard/plugins/graph/polymer3/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_common/BUILD
@@ -1,5 +1,3 @@
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
@@ -44,16 +42,5 @@ dict(
         "//tensorboard/components/tf_imports:graphlib",
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",
-    ],
-)
-
-tensorboard_webcomponent_library(
-    name = "legacy",
-    srcs = [":tf_graph_common"],
-    destdir = "tf-graph-common",
-    deps = [
-        "//tensorboard/components/tf_dashboard_common:legacy",
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/components/tf_imports_google:lib",
     ],
 )

--- a/tensorboard/plugins/graph/polymer3/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_controls/BUILD
@@ -1,5 +1,3 @@
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
@@ -28,26 +26,5 @@ dict(
         "@org_polymer_paper_radio_group",
         "@org_polymer_paper_toggle_button",
         "@org_polymer_paper_tooltip",
-    ],
-)
-
-tensorboard_webcomponent_library(
-    name = "legacy",
-    srcs = [":tf_graph_controls"],
-    destdir = "tf-graph-controls",
-    deps = [
-        "//tensorboard/components/tf_dashboard_common:legacy",
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/plugins/graph/tf_graph_common:legacy",
-        "//tensorboard/plugins/graph/tf_graph_node_search:legacy",
-        "//third_party/javascript/polymer/v2/iron-icon:lib",
-        "//third_party/javascript/polymer/v2/paper-button:lib",
-        "//third_party/javascript/polymer/v2/paper-dropdown-menu:lib",
-        "//third_party/javascript/polymer/v2/paper-icon-button:lib",
-        "//third_party/javascript/polymer/v2/paper-item:lib",
-        "//third_party/javascript/polymer/v2/paper-listbox:lib",
-        "//third_party/javascript/polymer/v2/paper-radio-group:lib",
-        "//third_party/javascript/polymer/v2/paper-toggle-button:lib",
-        "//third_party/javascript/polymer/v2/paper-tooltip:lib",
     ],
 )

--- a/tensorboard/plugins/graph/polymer3/tf_graph_dashboard/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_dashboard/BUILD
@@ -1,4 +1,3 @@
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
@@ -20,21 +19,5 @@ tf_web_library(
         "//tensorboard/plugins/graph/tf_graph_board",
         "//tensorboard/plugins/graph/tf_graph_controls",
         "//tensorboard/plugins/graph/tf_graph_loader:tf_graph_dashboard_loader",
-    ],
-)
-
-tensorboard_webcomponent_library(
-    name = "legacy",
-    srcs = [":tf_graph_dashboard"],
-    destdir = "tf-graph-dashboard",
-    deps = [
-        "//tensorboard/components/tf_backend:legacy",
-        "//tensorboard/components/tf_dashboard_common:legacy",
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/components/vz_sorting:legacy",
-        "//tensorboard/plugins/graph/tf_graph:legacy",
-        "//tensorboard/plugins/graph/tf_graph_board:legacy",
-        "//tensorboard/plugins/graph/tf_graph_controls:legacy",
-        "//tensorboard/plugins/graph/tf_graph_loader:legacy_dashboard_loader",
     ],
 )

--- a/tensorboard/plugins/graph/polymer3/tf_graph_debugger_data_card/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_debugger_data_card/BUILD
@@ -1,4 +1,3 @@
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
@@ -19,20 +18,5 @@ tf_web_library(
         "@org_polymer_paper_slider",
         "@org_polymer_paper_spinner",
         "@org_polymer_paper_toggle_button",
-    ],
-)
-
-tensorboard_webcomponent_library(
-    name = "legacy",
-    srcs = [":tf_graph_debugger_data_card"],
-    destdir = "tf-graph-debugger-data-card",
-    deps = [
-        "//tensorboard/components/tf_dashboard_common:legacy",
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/plugins/graph/tf_graph_common:legacy",
-        "//third_party/javascript/polymer/v2/paper-material:lib",
-        "//third_party/javascript/polymer/v2/paper-slider:lib",
-        "//third_party/javascript/polymer/v2/paper-spinner:lib",
-        "//third_party/javascript/polymer/v2/paper-toggle-button:lib",
     ],
 )

--- a/tensorboard/plugins/graph/polymer3/tf_graph_info/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_info/BUILD
@@ -1,4 +1,3 @@
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
@@ -28,26 +27,5 @@ tf_web_library(
         "@org_polymer_paper_material",
         "@org_polymer_paper_slider",
         "@org_polymer_paper_spinner",
-    ],
-)
-
-tensorboard_webcomponent_library(
-    name = "legacy",
-    srcs = [":tf_graph_info"],
-    destdir = "tf-graph-info",
-    deps = [
-        "//tensorboard/components/tf_dashboard_common:legacy",
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/plugins/graph/tf_graph_common:legacy",
-        "//tensorboard/plugins/graph/tf_graph_debugger_data_card:legacy",
-        "//tensorboard/plugins/graph/tf_graph_op_compat_card:legacy",
-        "//third_party/javascript/polymer/v2/iron-collapse:lib",
-        "//third_party/javascript/polymer/v2/iron-list:lib",
-        "//third_party/javascript/polymer/v2/paper-button:lib",
-        "//third_party/javascript/polymer/v2/paper-icon-button:lib",
-        "//third_party/javascript/polymer/v2/paper-item:lib",
-        "//third_party/javascript/polymer/v2/paper-material:lib",
-        "//third_party/javascript/polymer/v2/paper-slider:lib",
-        "//third_party/javascript/polymer/v2/paper-spinner:lib",
     ],
 )

--- a/tensorboard/plugins/graph/polymer3/tf_graph_loader/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_loader/BUILD
@@ -1,5 +1,3 @@
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
-
 package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])  # Apache 2.0
@@ -20,16 +18,6 @@ dict(
     ],
 )
 
-tensorboard_webcomponent_library(
-    name = "legacy",
-    srcs = [":tf_graph_loader"],
-    destdir = "tf-graph-loader",
-    deps = [
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/plugins/graph/tf_graph_common:legacy",
-    ],
-)
-
 dict(
     name = "tf_graph_dashboard_loader",
     srcs = [
@@ -43,17 +31,5 @@ dict(
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/plugins/graph/tf_graph_common",
         "//tensorboard/plugins/graph/tf_graph_controls",
-    ],
-)
-
-tensorboard_webcomponent_library(
-    name = "legacy_dashboard_loader",
-    srcs = [":tf_graph_dashboard_loader"],
-    destdir = "tf-graph-loader",
-    deps = [
-        "//tensorboard/components/tf_backend:legacy",
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/plugins/graph/tf_graph_common:legacy",
-        "//tensorboard/plugins/graph/tf_graph_controls:legacy",
     ],
 )

--- a/tensorboard/plugins/graph/polymer3/tf_graph_node_search/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_node_search/BUILD
@@ -1,4 +1,3 @@
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
@@ -16,18 +15,5 @@ tf_web_library(
         "//tensorboard/plugins/graph/tf_graph_common",
         "@org_polymer_paper_input",
         "@org_polymer_paper_styles",
-    ],
-)
-
-tensorboard_webcomponent_library(
-    name = "legacy",
-    srcs = [":tf_graph_node_search"],
-    destdir = "tf-graph-node-search",
-    deps = [
-        "//tensorboard/components/tf_dashboard_common:legacy",
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/plugins/graph/tf_graph_common:legacy",
-        "//third_party/javascript/polymer/v2/paper-input:lib",
-        "//third_party/javascript/polymer/v2/paper-styles:lib",
     ],
 )

--- a/tensorboard/plugins/graph/polymer3/tf_graph_op_compat_card/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_op_compat_card/BUILD
@@ -1,4 +1,3 @@
-load("//tensorboard/defs:defs.bzl", "tensorboard_webcomponent_library")
 load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
@@ -20,20 +19,5 @@ tf_web_library(
         "@org_polymer_iron_list",
         "@org_polymer_paper_icon_button",
         "@org_polymer_paper_item",
-    ],
-)
-
-tensorboard_webcomponent_library(
-    name = "legacy",
-    srcs = [":tf_graph_op_compat_card"],
-    destdir = "tf-graph-op-compat-card",
-    deps = [
-        "//tensorboard/components/tf_dashboard_common:legacy",
-        "//tensorboard/components/tf_imports:polymer_lib",
-        "//tensorboard/plugins/graph/tf_graph_common:legacy",
-        "//third_party/javascript/polymer/v2/iron-collapse:lib",
-        "//third_party/javascript/polymer/v2/iron-list:lib",
-        "//third_party/javascript/polymer/v2/paper-icon-button:lib",
-        "//third_party/javascript/polymer/v2/paper-item:lib",
     ],
 )


### PR DESCRIPTION
Summary:
Unblocks sync. Some of these generate Google-internal test targets that
fail to build due to the sibling deps that no longer exist. These would
be removed in the migration process, anyway.

Follow-up to #3999.

Test Plan:
A test sync at this commit now succeeds: <http://cl/325560211>.

wchargin-branch: migrate-remove-graph-legacies
