### PR TITLE
migrate: enable the converted graph dashboard part 4

### DIFF
--- a/tensorboard/components_polymer3/BUILD
+++ b/tensorboard/components_polymer3/BUILD
@@ -51,6 +51,7 @@ tf_ts_library(
         "//tensorboard/plugins/audio/polymer3/tf_audio_dashboard",
         "//tensorboard/plugins/custom_scalar/polymer3/tf_custom_scalar_dashboard",
         "//tensorboard/plugins/distribution/polymer3/tf_distribution_dashboard",
+        "//tensorboard/plugins/graph/polymer3/tf_graph_dashboard",
         "//tensorboard/plugins/histogram/polymer3/tf_histogram_dashboard",
         "//tensorboard/plugins/image/polymer3/tf_image_dashboard",
         "//tensorboard/plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard",

--- a/tensorboard/components_polymer3/polymer3_lib.ts
+++ b/tensorboard/components_polymer3/polymer3_lib.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import '../plugins/audio/polymer3/tf_audio_dashboard/tf-audio-dashboard';
 import '../plugins/custom_scalar/polymer3/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard';
 import '../plugins/distribution/polymer3/tf_distribution_dashboard/tf-distribution-dashboard';
+import '../plugins/graph/polymer3/tf_graph_dashboard/tf-graph-dashboard';
 import '../plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard';
 import '../plugins/histogram/polymer3/tf_histogram_dashboard/tf-histogram-dashboard';
 import '../plugins/image/polymer3/tf_image_dashboard/tf-image-dashboard';

--- a/tensorboard/plugins/graph/polymer3/tf_graph/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph/BUILD
@@ -13,7 +13,6 @@ tf_ts_library(
         "tf-graph-scene.ts",
     ],
     strict_checks = False,
-    tags = ["manual"],
     deps = [
         "//tensorboard/components_polymer3/polymer:irons_and_papers",
         "//tensorboard/components_polymer3/polymer:legacy_element_mixin",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_app/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_app/BUILD
@@ -12,7 +12,6 @@ tf_ts_library(
         "tf-graph-app.ts",
     ],
     strict_checks = False,
-    tags = ["manual"],
     deps = [
         "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
         "//tensorboard/plugins/graph/polymer3/tf_graph_board",
@@ -27,7 +26,6 @@ tf_js_binary(
     name = "tf_graph_app_js_binary",
     compile = True,
     entry_point = ":tf-graph-app.ts",
-    tags = ["manual"],
     deps = [":tf_graph_app"],
 )
 
@@ -38,7 +36,6 @@ tf_web_library(
         "tf_graph_app_js_binary.js",
     ],
     path = "/",
-    tags = ["manual"],
     deps = [
         "@com_google_fonts_roboto",
     ],
@@ -49,7 +46,6 @@ tensorboard_html_binary(
     compile = False,
     input_path = "/tf-graph-app.html",
     output_path = "/index.html",
-    tags = ["manual"],
     deps = [
         ":tf_graph_app_bundle",
     ],

--- a/tensorboard/plugins/graph/polymer3/tf_graph_board/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_board/BUILD
@@ -8,7 +8,6 @@ tf_ts_library(
     name = "tf_graph_board",
     srcs = ["tf-graph-board.ts"],
     strict_checks = False,
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components_polymer3/polymer:irons_and_papers",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_common/BUILD
@@ -29,7 +29,6 @@ tf_ts_library(
         "util.ts",
     ],
     strict_checks = False,
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components_polymer3/polymer:dom",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_controls/BUILD
@@ -10,7 +10,6 @@ tf_ts_library(
         "tf-graph-controls.ts",
     ],
     strict_checks = False,
-    tags = ["manual"],
     deps = [
         "//tensorboard/components_polymer3/polymer:irons_and_papers",
         "//tensorboard/components_polymer3/polymer:legacy_element_mixin",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_dashboard/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_dashboard/BUILD
@@ -8,7 +8,6 @@ tf_ts_library(
     name = "tf_graph_dashboard",
     srcs = ["tf-graph-dashboard.ts"],
     strict_checks = False,
-    tags = ["manual"],
     deps = [
         "//tensorboard/components_polymer3/polymer:irons_and_papers",
         "//tensorboard/components_polymer3/polymer:legacy_element_mixin",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_debugger_data_card/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_debugger_data_card/BUILD
@@ -10,7 +10,6 @@ tf_ts_library(
         "tf-graph-debugger-data-card.ts",
     ],
     strict_checks = False,
-    tags = ["manual"],
     deps = [
         "//tensorboard/components_polymer3/polymer:dom",
         "//tensorboard/components_polymer3/polymer:irons_and_papers",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_info/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_info/BUILD
@@ -12,7 +12,6 @@ tf_ts_library(
         "tf-node-list-item.ts",
     ],
     strict_checks = False,
-    tags = ["manual"],
     deps = [
         "//tensorboard/components_polymer3/polymer:dom",
         "//tensorboard/components_polymer3/polymer:irons_and_papers",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_loader/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_loader/BUILD
@@ -10,7 +10,6 @@ tf_ts_library(
         "tf-graph-loader.ts",
     ],
     strict_checks = False,
-    tags = ["manual"],
     deps = [
         "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
         "//tensorboard/plugins/graph/polymer3/tf_graph_common",
@@ -25,7 +24,6 @@ tf_ts_library(
         "tf-graph-dashboard-loader.ts",
     ],
     strict_checks = False,
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components_polymer3/polymer:legacy_element_mixin",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_node_search/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_node_search/BUILD
@@ -8,7 +8,6 @@ tf_ts_library(
     name = "tf_graph_node_search",
     srcs = ["tf-graph-node-search.ts"],
     strict_checks = False,
-    tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components_polymer3/polymer:irons_and_papers",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_op_compat_card/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_op_compat_card/BUILD
@@ -11,7 +11,6 @@ tf_ts_library(
         "tf-graph-op-compat-list-item.ts",
     ],
     strict_checks = False,
-    tags = ["manual"],
     deps = [
         "//tensorboard/components_polymer3/polymer:irons_and_papers",
         "//tensorboard/components_polymer3/polymer:legacy_element_mixin",


### PR DESCRIPTION
Diffbase: https://github.com/tensorflow/tensorboard/pull/4004

This is the last in a series of changes to convert plugins/graph to
Polymer 3. This change
- removes `tags=["manual"]`
- enables the dashboard

Tested externally with `TB_POLYMER3=1 bazel run tensorboard`
and internally. Googlers, see cl/325351322.

![image](https://user-images.githubusercontent.com/2322480/89702494-ab8e3700-d8f6-11ea-8a48-197123d94cf4.png)
