### PR TITLE
Remove unnecessary py_binary loader

### DIFF
--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -1,4 +1,3 @@
-load("@rules_python//python:defs.bzl", "py_binary")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ng_web_test_suite", "tf_ts_library")
 


### PR DESCRIPTION
Internally, py_binary exists in the ambiently, and will cause errors if
loaded manually. This removes the unnecessary `load` for py_binary.

Tested internally with: cl/325902456