### PR TITLE
polymer3: integrate mesh plugin to the migrated code

### DIFF
--- a/tensorboard/components_polymer3/BUILD
+++ b/tensorboard/components_polymer3/BUILD
@@ -54,6 +54,7 @@ tf_ts_library(
         "//tensorboard/plugins/graph/polymer3/tf_graph_dashboard",
         "//tensorboard/plugins/histogram/polymer3/tf_histogram_dashboard",
         "//tensorboard/plugins/image/polymer3/tf_image_dashboard",
+        "//tensorboard/plugins/mesh/polymer3/tf_mesh_dashboard",
         "//tensorboard/plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard",
         "//tensorboard/plugins/scalar/polymer3/tf_scalar_dashboard",
         "//tensorboard/plugins/text/polymer3/tf_text_dashboard",

--- a/tensorboard/components_polymer3/polymer3_lib.ts
+++ b/tensorboard/components_polymer3/polymer3_lib.ts
@@ -18,11 +18,12 @@ import '../plugins/audio/polymer3/tf_audio_dashboard/tf-audio-dashboard';
 import '../plugins/custom_scalar/polymer3/tf_custom_scalar_dashboard/tf-custom-scalar-dashboard';
 import '../plugins/distribution/polymer3/tf_distribution_dashboard/tf-distribution-dashboard';
 import '../plugins/graph/polymer3/tf_graph_dashboard/tf-graph-dashboard';
-import '../plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard';
 import '../plugins/histogram/polymer3/tf_histogram_dashboard/tf-histogram-dashboard';
 import '../plugins/image/polymer3/tf_image_dashboard/tf-image-dashboard';
-import '../plugins/text/polymer3/tf_text_dashboard/tf-text-dashboard';
+import '../plugins/mesh/polymer3/tf_mesh_dashboard/tf-mesh-dashboard';
+import '../plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard/tf-profile-redirect-dashboard';
 import '../plugins/scalar/polymer3/tf_scalar_dashboard/tf-scalar-dashboard';
+import '../plugins/text/polymer3/tf_text_dashboard/tf-text-dashboard';
 
 // Exported Polymer <-> Angular interop (to be removed).
 import './experimental/plugin_util/plugin-host';


### PR DESCRIPTION
This change enables mesh plugin in the Polymer 3 world.