### PR TITLE
text_v2: actions and effects

### DIFF
--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -76,7 +76,9 @@ def tf_ng_web_test_suite(runtime_deps = [], bootstrap = [], deps = [], **kwargs)
 
     kwargs.setdefault("tags", []).append("webtest")
     karma_web_test_suite(
-        srcs = [],
+        srcs = [
+            "//tensorboard/webapp/testing:require_js_karma_config.js",
+        ],
         bootstrap = bootstrap + [
             "@npm//:node_modules/zone.js/dist/zone-testing-bundle.js",
             "@npm//:node_modules/reflect-metadata/Reflect.js",
@@ -87,6 +89,10 @@ def tf_ng_web_test_suite(runtime_deps = [], bootstrap = [], deps = [], **kwargs)
         ],
         deps = deps + [
             "//tensorboard/webapp/testing:test_support_lib",
+        ],
+        # Lodash runtime dependency that is compatible with requirejs for karma.
+        static_files = [
+            "@npm//:node_modules/lodash/lodash.js",
         ],
         **kwargs
     )

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -212,6 +212,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/plugins/npmi:npmi_test_lib",
         "//tensorboard/webapp/plugins/npmi/views/main:main_test_lib",
         "//tensorboard/webapp/plugins/text_v2/data_source:data_source_test_lib",
+        "//tensorboard/webapp/plugins/text_v2/effects:effects_test_lib",
         "//tensorboard/webapp/plugins/text_v2/store:store_test_lib",
         "//tensorboard/webapp/reloader:test_lib",
         "//tensorboard/webapp/settings:test_lib",

--- a/tensorboard/webapp/plugins/text_v2/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/BUILD
@@ -13,10 +13,12 @@ ng_module(
     deps = [
         "//tensorboard/webapp/plugins:plugin_registry",
         "//tensorboard/webapp/plugins/text_v2/data_source",
+        "//tensorboard/webapp/plugins/text_v2/effects",
         "//tensorboard/webapp/plugins/text_v2/store",
         "//tensorboard/webapp/plugins/text_v2/views/text_dashboard",
         "@npm//@angular/common",
         "@npm//@angular/core",
+        "@npm//@ngrx/effects",
         "@npm//@ngrx/store",
     ],
 )
@@ -29,5 +31,15 @@ tf_ts_library(
     ],
     deps = [
         "//tensorboard/webapp/plugins/text_v2/data_source",
+    ],
+)
+
+tf_ts_library(
+    name = "types",
+    srcs = [
+        "types.ts",
+    ],
+    deps = [
+        "//tensorboard/components_polymer3/tf_categorization_utils",
     ],
 )

--- a/tensorboard/webapp/plugins/text_v2/actions/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/actions/BUILD
@@ -1,0 +1,19 @@
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])  # Apache 2.
+
+tf_ts_library(
+    name = "actions",
+    srcs = [
+        "index.ts",
+        "text_actions.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/plugins/text_v2:types",
+        "//tensorboard/webapp/plugins/text_v2/data_source",
+        "//tensorboard/webapp/plugins/text_v2/store:types",
+        "@npm//@ngrx/store",
+    ],
+)

--- a/tensorboard/webapp/plugins/text_v2/actions/index.ts
+++ b/tensorboard/webapp/plugins/text_v2/actions/index.ts
@@ -12,19 +12,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {StepDatum} from '../data_source';
 
-export const TEXT_FEATURE_KEY = 'text';
-
-type RunId = string;
-type TagId = string;
-
-export interface TextState {
-  visibleRunTags: Map<string, Array<{run: string; tag: string}>>;
-  runToTags: Map<RunId, TagId[]>;
-  data: Map<RunId, Map<TagId, StepDatum[]>>;
-}
-
-export interface State {
-  [TEXT_FEATURE_KEY]: TextState;
-}
+export * from './text_actions';

--- a/tensorboard/webapp/plugins/text_v2/actions/text_actions.ts
+++ b/tensorboard/webapp/plugins/text_v2/actions/text_actions.ts
@@ -1,0 +1,50 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {createAction, props} from '@ngrx/store';
+
+import {StepDatum} from '../data_source';
+import {TagGroup} from '../types';
+
+// HACK: Below import is for type inference.
+// https://github.com/bazelbuild/rules_nodejs/issues/1013
+/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
+
+export const textPluginLoaded = createAction('[Text] Text Plugin Loaded');
+
+export const textRunToTagsLoaded = createAction(
+  '[Text] Runs To Tag Loaded',
+  props<{runToTags: Map<string, string[]>}>()
+);
+
+export const textTagGroupVisibilityChanged = createAction(
+  '[Text] Tag Group Visibility Changed',
+  props<{
+    tagGroup: TagGroup;
+    visibileTextCards: Array<{
+      run: string;
+      tag: string;
+    }>;
+  }>()
+);
+
+export const textDataLoaded = createAction(
+  '[Text] Text Data Loaded Loaded',
+  props<{
+    run: string;
+    tag: string;
+    stepData: StepDatum[];
+  }>()
+);

--- a/tensorboard/webapp/plugins/text_v2/actions/text_actions.ts
+++ b/tensorboard/webapp/plugins/text_v2/actions/text_actions.ts
@@ -33,7 +33,7 @@ export const textTagGroupVisibilityChanged = createAction(
   '[Text] Tag Group Visibility Changed',
   props<{
     tagGroup: TagGroup;
-    visibileTextCards: Array<{
+    visibleTextCards: Array<{
       run: string;
       tag: string;
     }>;

--- a/tensorboard/webapp/plugins/text_v2/data_source/text_v2_server_data_source.ts
+++ b/tensorboard/webapp/plugins/text_v2/data_source/text_v2_server_data_source.ts
@@ -46,7 +46,6 @@ export class TextV2ServerDataSource implements TextV2DataSource {
         map((runToTagObject) => {
           const runToTag = new Map();
           Object.entries(runToTagObject).forEach(([runName, tags]) => {
-            debugger;
             runToTag.set(runName, tags);
           });
           return runToTag;

--- a/tensorboard/webapp/plugins/text_v2/effects/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/effects/BUILD
@@ -31,7 +31,6 @@ tf_ts_library(
     srcs = [
         "text_effects_test.ts",
     ],
-    tsconfig = "//:tsconfig-test",
     deps = [
         ":effects",
         "//tensorboard/components_polymer3/tf_categorization_utils",

--- a/tensorboard/webapp/plugins/text_v2/effects/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/effects/BUILD
@@ -1,0 +1,51 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "effects",
+    srcs = [
+        "index.ts",
+        "text_effects.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp/core/actions",
+        "//tensorboard/webapp/plugins/text_v2:types",
+        "//tensorboard/webapp/plugins/text_v2/actions",
+        "//tensorboard/webapp/plugins/text_v2/data_source",
+        "//tensorboard/webapp/plugins/text_v2/store",
+        "//tensorboard/webapp/plugins/text_v2/store:types",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)
+
+tf_ts_library(
+    name = "effects_test_lib",
+    testonly = True,
+    srcs = [
+        "text_effects_test.ts",
+    ],
+    tsconfig = "//:tsconfig-test",
+    deps = [
+        ":effects",
+        "//tensorboard/components_polymer3/tf_categorization_utils",
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
+        "//tensorboard/webapp/core/actions",
+        "//tensorboard/webapp/plugins/text_v2/actions",
+        "//tensorboard/webapp/plugins/text_v2/data_source",
+        "//tensorboard/webapp/plugins/text_v2/store",
+        "//tensorboard/webapp/webapp_data_source:http_client_testing",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+        "@npm//rxjs",
+    ],
+)

--- a/tensorboard/webapp/plugins/text_v2/effects/index.ts
+++ b/tensorboard/webapp/plugins/text_v2/effects/index.ts
@@ -12,19 +12,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {StepDatum} from '../data_source';
 
-export const TEXT_FEATURE_KEY = 'text';
-
-type RunId = string;
-type TagId = string;
-
-export interface TextState {
-  visibleRunTags: Map<string, Array<{run: string; tag: string}>>;
-  runToTags: Map<RunId, TagId[]>;
-  data: Map<RunId, Map<TagId, StepDatum[]>>;
-}
-
-export interface State {
-  [TEXT_FEATURE_KEY]: TextState;
-}
+export * from './text_effects';

--- a/tensorboard/webapp/plugins/text_v2/effects/text_effects.ts
+++ b/tensorboard/webapp/plugins/text_v2/effects/text_effects.ts
@@ -52,11 +52,7 @@ export class TextEffects {
         ofType(textPluginLoaded),
         switchMap(() => {
           return this.dataSource.fetchRunToTag().pipe(
-            tap((runToTagsObject) => {
-              const runToTags = new Map();
-              Object.entries(runToTagsObject).forEach(([run, tags]) => {
-                runToTags.set(run, tags);
-              });
+            tap((runToTags) => {
               this.store.dispatch(textRunToTagsLoaded({runToTags}));
             }),
             map(() => void null)
@@ -72,9 +68,9 @@ export class TextEffects {
     () => {
       const fetchOnNewCardVisible = this.actions$.pipe(
         ofType(textTagGroupVisibilityChanged),
-        switchMap(({visibileTextCards}) => {
+        switchMap(({visibleTextCards}) => {
           // Fetch existing data.
-          const existingTextData = visibileTextCards.map(({run, tag}) => {
+          const existingTextData = visibleTextCards.map(({run, tag}) => {
             return this.store.select(getTextData, {run, tag}).pipe(
               last(),
               map((textData) => {

--- a/tensorboard/webapp/plugins/text_v2/effects/text_effects.ts
+++ b/tensorboard/webapp/plugins/text_v2/effects/text_effects.ts
@@ -1,0 +1,130 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Injectable} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {Actions, createEffect, ofType} from '@ngrx/effects';
+import {forkJoin, Observable, merge} from 'rxjs';
+import {
+  map,
+  mergeMap,
+  tap,
+  switchMap,
+  last,
+  withLatestFrom,
+} from 'rxjs/operators';
+
+import {
+  textPluginLoaded,
+  textRunToTagsLoaded,
+  textTagGroupVisibilityChanged,
+  textDataLoaded,
+} from '../actions';
+import {TextV2DataSource} from '../data_source/text_v2_data_source';
+import {State} from '../../../app_state';
+import {
+  getTextData,
+  getTextAllVisibleRunTags,
+} from '../store/text_v2_selectors';
+import {manualReload, reload} from '../../../core/actions';
+
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+/** @typehack */ import * as _typeHackNgrxStore from '@ngrx/store/src/models';
+/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects/effects';
+
+@Injectable()
+export class TextEffects {
+  /** @export */
+  readonly loadRunToTags$ = createEffect(
+    () => {
+      return this.actions$.pipe(
+        ofType(textPluginLoaded),
+        switchMap(() => {
+          return this.dataSource.fetchRunToTag().pipe(
+            tap((runToTagsObject) => {
+              const runToTags = new Map();
+              Object.entries(runToTagsObject).forEach(([run, tags]) => {
+                runToTags.set(run, tags);
+              });
+              this.store.dispatch(textRunToTagsLoaded({runToTags}));
+            }),
+            map(() => void null)
+          );
+        })
+      );
+    },
+    {dispatch: false}
+  );
+
+  /** @export */
+  readonly loadData$ = createEffect(
+    () => {
+      const fetchOnNewCardVisible = this.actions$.pipe(
+        ofType(textTagGroupVisibilityChanged),
+        switchMap(({visibileTextCards}) => {
+          // Fetch existing data.
+          const existingTextData = visibileTextCards.map(({run, tag}) => {
+            return this.store.select(getTextData, {run, tag}).pipe(
+              last(),
+              map((textData) => {
+                return {run, tag, textData};
+              })
+            );
+          });
+          return forkJoin(existingTextData).pipe(
+            map((textData) => {
+              // Filter out the <run, tag> tuple if the data already exists.
+              return textData
+                .filter(({textData}) => textData === null)
+                .map(({run, tag}) => ({run, tag}));
+            })
+          );
+        })
+      );
+
+      const fetchVisibleCardsOnReload = this.actions$.pipe(
+        ofType(manualReload, reload),
+        withLatestFrom(this.store.select(getTextAllVisibleRunTags)),
+        map(([, runTagList]) => runTagList)
+      );
+
+      return merge(fetchOnNewCardVisible, fetchVisibleCardsOnReload).pipe(
+        mergeMap((runTagPairs) => {
+          return forkJoin(
+            runTagPairs.map((runAndTag) => {
+              return this.fetchTextData(runAndTag);
+            })
+          );
+        })
+      );
+    },
+    {dispatch: false}
+  );
+
+  private fetchTextData(props: {run: string; tag: string}): Observable<void> {
+    const {run, tag} = props;
+    return this.dataSource.fetchTextData(run, tag).pipe(
+      tap((stepData) => {
+        this.store.dispatch(textDataLoaded({run, tag, stepData}));
+      }),
+      map(() => void null)
+    );
+  }
+
+  constructor(
+    private readonly actions$: Actions,
+    private readonly store: Store<State>,
+    private readonly dataSource: TextV2DataSource
+  ) {}
+}

--- a/tensorboard/webapp/plugins/text_v2/effects/text_effects_test.ts
+++ b/tensorboard/webapp/plugins/text_v2/effects/text_effects_test.ts
@@ -28,10 +28,10 @@ import {
 } from '../actions';
 import {State} from '../../../app_state';
 import {
-  TextDataSource,
-  BackendRunToTagsMap,
+  TextV2DataSource,
+  RunToTags,
   StepDatum,
-} from '../data_source/text_v2_types';
+} from '../data_source/text_v2_data_source';
 import {CategoryType} from '../../../../components_polymer3/tf_categorization_utils/categorizationUtils';
 import {
   getTextData,
@@ -40,12 +40,12 @@ import {
 import {reload, manualReload} from '../../../core/actions';
 import {TextV2DataSourceModule} from '../data_source/text_v2_data_source_module';
 
-fdescribe('text_effects', () => {
+describe('text_effects', () => {
   let textEffects: TextEffects;
   let action: ReplaySubject<Action>;
   let store: MockStore<Partial<State>>;
   let recordedActions: Action[] = [];
-  let fetchRunToTagsSubjects: ReplaySubject<BackendRunToTagsMap>[];
+  let fetchRunToTagsSubjects: ReplaySubject<RunToTags>[];
   let fetchDataSujects: ReplaySubject<StepDatum[]>[];
   let fetchTextDataSpy: jasmine.Spy;
   let selectSpy: jasmine.Spy;
@@ -68,11 +68,11 @@ fdescribe('text_effects', () => {
       recordedActions.push(action);
     });
 
-    const dataSource = TestBed.inject(TextDataSource);
+    const dataSource = TestBed.inject(TextV2DataSource);
 
     fetchRunToTagsSubjects = [];
     spyOn(dataSource, 'fetchRunToTag').and.callFake(() => {
-      const subject = new ReplaySubject<BackendRunToTagsMap>(1);
+      const subject = new ReplaySubject<RunToTags>(1);
       fetchRunToTagsSubjects.push(subject);
       return subject;
     });
@@ -93,7 +93,7 @@ fdescribe('text_effects', () => {
   it('fetches run to tags on plugins loaded', () => {
     action.next(textPluginLoaded());
 
-    fetchRunToTagsSubjects[0].next({run1: ['tag1', 'tag2']});
+    fetchRunToTagsSubjects[0].next(new Map([['run1', ['tag1', 'tag2']]]));
     fetchRunToTagsSubjects[0].complete();
 
     expect(recordedActions).toEqual([
@@ -114,7 +114,7 @@ fdescribe('text_effects', () => {
       action.next(
         textTagGroupVisibilityChanged({
           tagGroup: {type: CategoryType.PREFIX_GROUP, name: 'foo'},
-          visibileTextCards: [
+          visibleTextCards: [
             {run: 'run1', tag: 'tag1'},
             {run: 'run1', tag: 'tag2'},
           ],

--- a/tensorboard/webapp/plugins/text_v2/effects/text_effects_test.ts
+++ b/tensorboard/webapp/plugins/text_v2/effects/text_effects_test.ts
@@ -1,0 +1,158 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TestBed} from '@angular/core/testing';
+
+import {provideMockActions} from '@ngrx/effects/testing';
+import {Action, Store} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {ReplaySubject, of} from 'rxjs';
+
+import {TextEffects} from './text_effects';
+import {
+  textRunToTagsLoaded,
+  textPluginLoaded,
+  textTagGroupVisibilityChanged,
+  textDataLoaded,
+} from '../actions';
+import {State} from '../../../app_state';
+import {
+  TextDataSource,
+  BackendRunToTagsMap,
+  StepDatum,
+} from '../data_source/text_v2_types';
+import {CategoryType} from '../../../../components_polymer3/tf_categorization_utils/categorizationUtils';
+import {
+  getTextData,
+  getTextAllVisibleRunTags,
+} from '../store/text_v2_selectors';
+import {reload, manualReload} from '../../../core/actions';
+import {TextV2DataSourceModule} from '../data_source/text_v2_data_source_module';
+
+fdescribe('text_effects', () => {
+  let textEffects: TextEffects;
+  let action: ReplaySubject<Action>;
+  let store: MockStore<Partial<State>>;
+  let recordedActions: Action[] = [];
+  let fetchRunToTagsSubjects: ReplaySubject<BackendRunToTagsMap>[];
+  let fetchDataSujects: ReplaySubject<StepDatum[]>[];
+  let fetchTextDataSpy: jasmine.Spy;
+  let selectSpy: jasmine.Spy;
+
+  beforeEach(async () => {
+    action = new ReplaySubject<Action>(1);
+    await TestBed.configureTestingModule({
+      imports: [TextV2DataSourceModule],
+      providers: [provideMockActions(action), provideMockStore(), TextEffects],
+    }).compileComponents();
+
+    textEffects = TestBed.inject(TextEffects);
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+
+    store.overrideSelector(getTextAllVisibleRunTags, []);
+    selectSpy = spyOn(store, 'select').and.callThrough();
+
+    recordedActions = [];
+    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+      recordedActions.push(action);
+    });
+
+    const dataSource = TestBed.inject(TextDataSource);
+
+    fetchRunToTagsSubjects = [];
+    spyOn(dataSource, 'fetchRunToTag').and.callFake(() => {
+      const subject = new ReplaySubject<BackendRunToTagsMap>(1);
+      fetchRunToTagsSubjects.push(subject);
+      return subject;
+    });
+
+    fetchDataSujects = [];
+    fetchTextDataSpy = spyOn(dataSource, 'fetchTextData').and.callFake(() => {
+      const fetchDataSuject = new ReplaySubject<StepDatum[]>();
+      fetchDataSujects.push(fetchDataSuject);
+      return fetchDataSuject;
+    });
+  });
+
+  beforeEach(() => {
+    textEffects.loadRunToTags$.subscribe(() => {});
+    textEffects.loadData$.subscribe(() => {});
+  });
+
+  it('fetches run to tags on plugins loaded', () => {
+    action.next(textPluginLoaded());
+
+    fetchRunToTagsSubjects[0].next({run1: ['tag1', 'tag2']});
+    fetchRunToTagsSubjects[0].complete();
+
+    expect(recordedActions).toEqual([
+      textRunToTagsLoaded({runToTags: new Map([['run1', ['tag1', 'tag2']]])}),
+    ]);
+  });
+
+  describe('on visibility changed', () => {
+    it('fetches data for run tag tuple that has not been loaded yet', () => {
+      selectSpy
+        .withArgs(getTextData, {run: 'run1', tag: 'tag1'})
+        .and.returnValue(of([]));
+      selectSpy
+        .withArgs(getTextData, {run: 'run1', tag: 'tag2'})
+        .and.returnValue(of(null));
+      store.refreshState();
+
+      action.next(
+        textTagGroupVisibilityChanged({
+          tagGroup: {type: CategoryType.PREFIX_GROUP, name: 'foo'},
+          visibileTextCards: [
+            {run: 'run1', tag: 'tag1'},
+            {run: 'run1', tag: 'tag2'},
+          ],
+        })
+      );
+
+      expect(fetchDataSujects.length).toBe(1);
+      fetchDataSujects[0].next([]);
+      fetchDataSujects[0].complete();
+
+      expect(recordedActions).toEqual([
+        textDataLoaded({run: 'run1', tag: 'tag2', stepData: []}),
+      ]);
+    });
+
+    [
+      {name: 'auto reload', actionPayload: reload()},
+      {name: 'manual reload', actionPayload: manualReload()},
+    ].forEach(({name, actionPayload}) => {
+      it(`fetches data for visible cards when ${name} fires`, () => {
+        selectSpy
+          .withArgs(getTextData, {run: 'run1', tag: 'tag1'})
+          .and.returnValue(of([]));
+        store.overrideSelector(getTextAllVisibleRunTags, [
+          {run: 'run1', tag: 'tag1'},
+        ]);
+        store.refreshState();
+
+        action.next(actionPayload);
+
+        expect(fetchDataSujects.length).toBe(1);
+        fetchDataSujects[0].next([]);
+        fetchDataSujects[0].complete();
+
+        expect(recordedActions).toEqual([
+          textDataLoaded({run: 'run1', tag: 'tag1', stepData: []}),
+        ]);
+      });
+    });
+  });
+});

--- a/tensorboard/webapp/plugins/text_v2/store/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/store/BUILD
@@ -12,6 +12,7 @@ ng_module(
     ],
     deps = [
         ":types",
+        "//tensorboard/webapp/plugins/text_v2:types",
         "//tensorboard/webapp/plugins/text_v2/data_source",
         "@npm//@ngrx/store",
     ],

--- a/tensorboard/webapp/plugins/text_v2/store/testing.ts
+++ b/tensorboard/webapp/plugins/text_v2/store/testing.ts
@@ -19,6 +19,7 @@ export function buildTextState(override: Partial<TextState>) {
   return {
     runToTags: new Map(),
     data: new Map(),
+    visibleRunTags: new Map(),
     ...override,
   };
 }

--- a/tensorboard/webapp/plugins/text_v2/store/text_v2_reducers.ts
+++ b/tensorboard/webapp/plugins/text_v2/store/text_v2_reducers.ts
@@ -75,6 +75,7 @@ const initialState = {
   data: new Map([
     ['run1', new Map([['a/b', DATA_A_B_RUN1], ['a/c', DATA_A_C_RUN1]])],
   ]),
+  visibleRunTags: new Map(),
 };
 
 const reducer = createReducer(initialState);

--- a/tensorboard/webapp/plugins/text_v2/store/text_v2_selectors.ts
+++ b/tensorboard/webapp/plugins/text_v2/store/text_v2_selectors.ts
@@ -16,6 +16,7 @@ import {createSelector, createFeatureSelector} from '@ngrx/store';
 import {TextState, State, TEXT_FEATURE_KEY} from './text_types';
 
 import {StepDatum} from '../data_source';
+import {RunTag} from '../types';
 
 // HACK: These imports are for type inference.
 // https://github.com/bazelbuild/rules_nodejs/issues/1013
@@ -29,6 +30,29 @@ const selectTextState = createFeatureSelector<State, TextState>(
 export const getTextRunToTags = createSelector(
   selectTextState,
   (state: TextState) => state.runToTags
+);
+
+/**
+ * Returns de-duplicated list of <run, tag> tuple for cards that are visible
+ * in the UI.
+ */
+export const getTextAllVisibleRunTags = createSelector(
+  selectTextState,
+  (state: TextState): RunTag[] => {
+    const serializedRunTagTuples = new Set<string>();
+    const allVisibleRunTagTuples = new Set<RunTag>();
+    for (const runTagTuples of state.visibleRunTags.values()) {
+      for (const runTag of runTagTuples) {
+        const serializedRunTag = JSON.stringify(runTag);
+        if (serializedRunTagTuples.has(serializedRunTag)) {
+          continue;
+        }
+        serializedRunTagTuples.add(serializedRunTag);
+        allVisibleRunTagTuples.add(runTag);
+      }
+    }
+    return [...allVisibleRunTagTuples];
+  }
 );
 
 export const getTextData = createSelector(

--- a/tensorboard/webapp/plugins/text_v2/text_v2_module.ts
+++ b/tensorboard/webapp/plugins/text_v2/text_v2_module.ts
@@ -15,12 +15,14 @@ limitations under the License.
 
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
+import {EffectsModule} from '@ngrx/effects';
 import {StoreModule} from '@ngrx/store';
 
 import {PluginRegistryModule} from '../plugin_registry_module';
 import {TextDashboardComponent} from './views/text_dashboard/text_dashboard_component';
 import {TextDashboardModule} from './views/text_dashboard/text_dashboard_module';
 import {TextV2DataSourceModule} from './data_source/text_v2_data_source_module';
+import {TextEffects} from './effects/text_effects';
 import {reducers} from './store/text_v2_reducers';
 import {TEXT_FEATURE_KEY} from './store';
 
@@ -31,6 +33,7 @@ import {TEXT_FEATURE_KEY} from './store';
     PluginRegistryModule.forPlugin('text_v2', TextDashboardComponent),
     TextV2DataSourceModule,
     StoreModule.forFeature(TEXT_FEATURE_KEY, reducers),
+    EffectsModule.forFeature([TextEffects]),
   ],
   entryComponents: [TextDashboardComponent],
 })

--- a/tensorboard/webapp/plugins/text_v2/types.ts
+++ b/tensorboard/webapp/plugins/text_v2/types.ts
@@ -12,19 +12,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {StepDatum} from '../data_source';
 
-export const TEXT_FEATURE_KEY = 'text';
+import {CategoryType} from '../../../components_polymer3/tf_categorization_utils/categorizationUtils';
 
-type RunId = string;
-type TagId = string;
+export const PLUGIN_ID = 'text_v2';
 
-export interface TextState {
-  visibleRunTags: Map<string, Array<{run: string; tag: string}>>;
-  runToTags: Map<RunId, TagId[]>;
-  data: Map<RunId, Map<TagId, StepDatum[]>>;
+export interface TagGroup {
+  type: CategoryType;
+  name: string;
 }
 
-export interface State {
-  [TEXT_FEATURE_KEY]: TextState;
+export interface RunTag {
+  run: string;
+  tag: string;
 }

--- a/tensorboard/webapp/testing/BUILD
+++ b/tensorboard/webapp/testing/BUILD
@@ -36,3 +36,5 @@ ng_module(
         "@npm//@angular/core",
     ],
 )
+
+exports_files(["require_js_karma_config.js"])

--- a/tensorboard/webapp/testing/require_js_karma_config.js
+++ b/tensorboard/webapp/testing/require_js_karma_config.js
@@ -12,19 +12,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {StepDatum} from '../data_source';
-
-export const TEXT_FEATURE_KEY = 'text';
-
-type RunId = string;
-type TagId = string;
-
-export interface TextState {
-  visibleRunTags: Map<string, Array<{run: string; tag: string}>>;
-  runToTags: Map<RunId, TagId[]>;
-  data: Map<RunId, Map<TagId, StepDatum[]>>;
-}
-
-export interface State {
-  [TEXT_FEATURE_KEY]: TextState;
-}
+require.config({paths: {lodash: '/base/npm/node_modules/lodash/lodash'}});


### PR DESCRIPTION
Note that we still are not implementing reducers.

Details:
- sample data flow:
  1. load the text plugin, it fires pluginChanged action. That fetches
  runTag map
  2. based on the run tag map, we draw few tag groups. Few tag groups
  will be opened by default and some won't. The opened ones fire action
  for their visibility changes with <run, tag> tuple of current page
  3. that will trigger data fetches
  4. on reload, we will reload what is currently on screen

About somewhat extraneous looking karma change:
transitive dependency uses lodash and it does not exist on the global without it.
While our build toolchain uses node resolve (rollup), karma uses concatjs (for faster build)
and requires all of our dependencies to be loaded by requirejs. The karma configuration
essentially provides a mapping between module name (lodash) to file path served by
the karma server.

Notice that there is no good way to test the whole thing end-to-end as there is no FE
that fires actions and leverages the reducers.