### PR TITLE
Fix missing metadata in tbdev getting started notebook.

### DIFF
--- a/docs/tbdev_getting_started.ipynb
+++ b/docs/tbdev_getting_started.ipynb
@@ -166,7 +166,7 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
-        "id": "TgF35qdzIC3T"
+        "id": "oKW8V5chyx6e"
       },
       "source": [
         "### Upload to TensorBoard.dev\n",
@@ -201,8 +201,7 @@
         "id": "5QH5k4AUNE27"
       },
       "source": [
-        "Each individual upload has a unique experiment ID. This means ",
-        "that if you start a new upload with the same directory, you will get a new experiment ID.\n",
+        "Each individual upload has a unique experiment ID. This means that if you start a new upload with the same directory, you will get a new experiment ID.\n",
         "You can list all the experiments you have uploaded using \n",
         "```\n",
         "tensorboard dev list\n",
@@ -224,7 +223,10 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "colab_type": "text",
+        "id": "NyJsD3Ypyx6m"
+      },
       "source": [
         "### Screenshot of TensorBoard.dev\n",
         "\n",


### PR DESCRIPTION
Missing metadata was breaking import.
Fixed by:

*  Open the notebook in colab
*  Download the notebook from colab using 'download ipynb'
*  Reformat the downloaded notebook using `nbfmt`

Tested:
*  Uploaded to colab and ran.