### PR TITLE
Clarifies output during `--one_shot` upload.

### DIFF
--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -263,7 +263,7 @@ class UploadTracker(object):
 
     _SUPPORTED_VERBISITY_VALUES = (0, 1)
 
-    def __init__(self, verbosity):
+    def __init__(self, verbosity, one_shot=False):
         if verbosity not in self._SUPPORTED_VERBISITY_VALUES:
             raise ValueError(
                 "Unsupported verbosity value %s (supported values: %s)"
@@ -272,6 +272,7 @@ class UploadTracker(object):
         self._verbosity = verbosity
         self._stats = UploadStats()
         self._send_count = 0
+        self._one_shot = one_shot
 
     def _dummy_generator(self):
         while True:
@@ -342,7 +343,10 @@ class UploadTracker(object):
         finally:
             self._update_cumulative_status()
             self._update_uploading_status(
-                "Listening for new data in logdir", color_code=_STYLE_YELLOW
+                "Done scanning logdir"
+                if self._one_shot
+                else "Listening for new data in logdir",
+                color_code=_STYLE_YELLOW,
             )
 
     @contextlib.contextmanager

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -166,7 +166,9 @@ class TensorBoardUploader(object):
         response = grpc_util.call_with_retries(
             self._api.CreateExperiment, request
         )
-        self._tracker = upload_tracker.UploadTracker(verbosity=self._verbosity)
+        self._tracker = upload_tracker.UploadTracker(
+            verbosity=self._verbosity, one_shot=self._one_shot
+        )
         self._request_sender = _BatchedRequestSender(
             response.experiment_id,
             self._api,

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -915,7 +915,9 @@ class TensorboardUploaderTest(tf.test.TestCase):
             uploader.start_uploading()
 
         self.assertEqual(mock_constructor.call_count, 1)
-        self.assertEqual(mock_constructor.call_args[1], {"verbosity": 0, "one_shot": False})
+        self.assertEqual(
+            mock_constructor.call_args[1], {"verbosity": 0, "one_shot": False}
+        )
         self.assertEqual(mock_tracker.scalars_tracker.call_count, 1)
 
 
@@ -2019,7 +2021,8 @@ class UploadIntentTest(tf.test.TestCase):
             intent.execute(mock_server_info, mock_channel)
         self.assertEqual(mock_dry_run_stub.call_count, 1)
         self.assertRegex(
-            mock_stdout_write.call_args_list[-2][0][0], ".*Done scanning logdir.*"
+            mock_stdout_write.call_args_list[-2][0][0],
+            ".*Done scanning logdir.*",
         )
         self.assertEqual(
             mock_stdout_write.call_args_list[-1][0][0], "\nDone.\n"

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -292,7 +292,7 @@ class TensorboardUploaderTest(tf.test.TestCase):
         mock_client = _create_mock_client()
         new_description = """
         **description**"
-        may have "strange" unicode chars 🌴 \/<>
+        may have "strange" unicode chars 🌴 \\/<>
         """
         new_name = "This is a cool name."
         uploader = _create_uploader(
@@ -915,7 +915,7 @@ class TensorboardUploaderTest(tf.test.TestCase):
             uploader.start_uploading()
 
         self.assertEqual(mock_constructor.call_count, 1)
-        self.assertEqual(mock_constructor.call_args[1], {"verbosity": 0})
+        self.assertEqual(mock_constructor.call_args[1], {"verbosity": 0, "one_shot": False})
         self.assertEqual(mock_tracker.scalars_tracker.call_count, 1)
 
 
@@ -2018,6 +2018,9 @@ class UploadIntentTest(tf.test.TestCase):
             )
             intent.execute(mock_server_info, mock_channel)
         self.assertEqual(mock_dry_run_stub.call_count, 1)
+        self.assertRegex(
+            mock_stdout_write.call_args_list[-2][0][0], ".*Done scanning logdir.*"
+        )
         self.assertEqual(
             mock_stdout_write.call_args_list[-1][0][0], "\nDone.\n"
         )


### PR DESCRIPTION
When `--one_shot` flag is provided, the user expects the uploader
to pass through the logdir exactly once and then quit.

This change replaces the log line "Listening for new data in logdir"
with a more accurate line "Done passing through logdir", but only
when `--one_shot` is provided.

Tested:
*  Adds a unit test.  
*  Checked uploading from my account.