### PR TITLE
polymer3: add indirection for polymer/lib/legacy/class

### DIFF
--- a/tensorboard/components_polymer3/polymer/BUILD
+++ b/tensorboard/components_polymer3/polymer/BUILD
@@ -118,3 +118,13 @@ tf_ts_library(
         "@npm//@polymer/paper-tooltip",
     ],
 )
+
+tf_ts_library(
+    name = "legacy_class",
+    srcs = [
+        "legacy_class.ts",
+    ],
+    deps = [
+        "@npm//@polymer/polymer",
+    ],
+)

--- a/tensorboard/components_polymer3/polymer/legacy_class.ts
+++ b/tensorboard/components_polymer3/polymer/legacy_class.ts
@@ -1,0 +1,16 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export * from '@polymer/polymer/lib/legacy/class';


### PR DESCRIPTION
Allows TensorBoard to use mixin.