### PR TITLE
ng: dispatch changePlugin action when store change

### DIFF
--- a/tensorboard/webapp/core/effects/core_effects.ts
+++ b/tensorboard/webapp/core/effects/core_effects.ts
@@ -88,12 +88,14 @@ export class CoreEffects {
   );
 
   /**
-   * HACK: COMPOSITE ACTION -- rationale: most plugins want to be able to tell
-   * when it becomes active in order to, for example, fetch necessary data. By
-   * firing changePlugin on activePlugin value set, we can prevent (1) other
-   * feature developer from responding to values changes from the store (creates
-   * composite actions) and (2) re-implement complex and brittle observable
-   * pattern.
+   * HACK: COMPOSITE ACTION -- Fire `changePlugin` on first truthy value of
+   * activePlugin on coreLoaded or pluginsListingLoaded.
+   *
+   * Rationale: most plugins want to be able to tell when it becomes active in
+   * order to, for example, fetch necessary data. By firing changePlugin on
+   * activePlugin first value set, we can prevent (1) other feature developer
+   * from responding to values changes from the store (creates composite
+   * actions) and (2) re-implement complex and brittle observable pattern.
    *
    * @export
    */

--- a/tensorboard/webapp/core/effects/core_effects_test.ts
+++ b/tensorboard/webapp/core/effects/core_effects_test.ts
@@ -330,7 +330,7 @@ describe('core_effects', () => {
 
     it(
       'ignores plugins listing loaded when activePlugin was present at the time of' +
-        ' coreLaoded',
+        ' coreLoaded',
       () => {
         store.overrideSelector(getActivePlugin, 'bar');
         store.refreshState();

--- a/tensorboard/webapp/core/effects/core_effects_test.ts
+++ b/tensorboard/webapp/core/effects/core_effects_test.ts
@@ -39,6 +39,7 @@ import {
   TBHttpClientTestingModule,
   HttpTestingController,
 } from '../../webapp_data_source/tb_http_client_testing';
+import {getActivePlugin} from '../store';
 
 describe('core_effects', () => {
   let httpMock: HttpTestingController;
@@ -244,5 +245,117 @@ describe('core_effects', () => {
         httpMock.expectNone('data/plugins_listing');
       });
     });
+  });
+
+  describe('#dispatchChangePlugin', () => {
+    function createPluginsListing(): PluginsListing {
+      return {foo: createPluginMetadata('Foo')};
+    }
+
+    beforeEach(() => {
+      coreEffects.dispatchChangePlugin$.subscribe(() => {});
+    });
+
+    it('dispatches changePlugin when coreLoaded and activePlugin exists', () => {
+      store.overrideSelector(getActivePlugin, 'foo');
+      store.refreshState();
+
+      action.next(coreActions.coreLoaded());
+
+      expect(recordedActions).toEqual([
+        coreActions.changePlugin({
+          plugin: 'foo',
+        }),
+      ]);
+    });
+
+    it('does not dispatch when coreLoaded but activePlugin DNE', () => {
+      store.overrideSelector(getActivePlugin, null);
+      store.refreshState();
+
+      action.next(coreActions.coreLoaded());
+
+      expect(recordedActions).toEqual([]);
+    });
+
+    it('dispatches when plugins listing is loaded', () => {
+      store.overrideSelector(getActivePlugin, 'foo');
+      store.refreshState();
+
+      action.next(
+        coreActions.pluginsListingLoaded({plugins: createPluginsListing()})
+      );
+
+      expect(recordedActions).toEqual([
+        coreActions.changePlugin({
+          plugin: 'foo',
+        }),
+      ]);
+    });
+
+    it('does not dispatch when plugins listing loads no active plugin', () => {
+      store.overrideSelector(getActivePlugin, null);
+      store.refreshState();
+
+      action.next(
+        coreActions.pluginsListingLoaded({plugins: createPluginsListing()})
+      );
+
+      expect(recordedActions).toEqual([]);
+    });
+
+    it('does not dispatch on repeated plugins listing loads', () => {
+      store.overrideSelector(getActivePlugin, 'foo');
+      store.refreshState();
+
+      action.next(
+        coreActions.pluginsListingLoaded({plugins: createPluginsListing()})
+      );
+
+      expect(recordedActions).toEqual([
+        coreActions.changePlugin({
+          plugin: 'foo',
+        }),
+      ]);
+
+      store.overrideSelector(getActivePlugin, 'bar');
+      store.refreshState();
+
+      expect(recordedActions).toEqual([
+        coreActions.changePlugin({
+          plugin: 'foo',
+        }),
+      ]);
+    });
+
+    it(
+      'ignores plugins listing loaded when activePlugin was present at the time of' +
+        ' coreLaoded',
+      () => {
+        store.overrideSelector(getActivePlugin, 'bar');
+        store.refreshState();
+
+        action.next(coreActions.coreLoaded());
+
+        expect(recordedActions).toEqual([
+          coreActions.changePlugin({
+            plugin: 'bar',
+          }),
+        ]);
+
+        store.overrideSelector(getActivePlugin, 'foo');
+        store.refreshState();
+
+        action.next(
+          coreActions.pluginsListingLoaded({plugins: createPluginsListing()})
+        );
+
+        expect(recordedActions).toEqual([
+          coreActions.changePlugin({
+            plugin: 'bar',
+          }),
+        ]);
+      }
+    );
   });
 });


### PR DESCRIPTION
This change on purpose introduces one of the anti-pattern of ngrx usage
in our app: composite action.

Background: plugins are rendered when user interacts with the plugins
selector on the header and plugins know to fetch data (if empty) when
`changePlugin` action fires. However, there is other condition in
which the activePlugin can change: (1) user launched with specific
plugin id deep link or (2) plugins listing is loaded. In the past, for
plugins to fetch the data on load, it had to write necessary code for
detecting such nuances which has been a source of pain and a source of
bug.

This change: in the core effects, that understands the core reducers the
best, detects the condition in which the initial non-null value of
activePlugin is set to dispatch `changePlugin` action without user
interaction on the header.

Alternative design: we can subscribe to the store value and listen to
the change but it is actually no different than other composite action:
a state only changes when an action fires and listening to a change in
the store essentially creates a chain between multiple actions (e.g.,
action A -> state change -> action B -> state change -> ...).
