### PR TITLE
polymer3: fix data location rendering

### DIFF
--- a/tensorboard/components_polymer3/tf_runs_selector/tf-runs-selector.ts
+++ b/tensorboard/components_polymer3/tf_runs_selector/tf-runs-selector.ts
@@ -156,9 +156,8 @@ class TfRunsSelector extends LegacyElementMixin(PolymerElement) {
 
   @property({
     type: String,
-    readOnly: true,
   })
-  _dataLocationDelimiterPattern: string = '[/=_,-]';
+  readonly _dataLocationDelimiterPattern: string = '[/=_,-]';
 
   @property({
     type: Object,


### PR DESCRIPTION
Because we were using readOnly and was setting the value in the
constructor, the delimiter pattern was never set.
