### PR TITLE
add 'data:' to font-src CSP

### DIFF
--- a/tensorboard/backend/security_validator.py
+++ b/tensorboard/backend/security_validator.py
@@ -43,6 +43,7 @@ _CSP_IGNORE = {
     # Used by numericjs.
     # TODO(stephanwlee): remove it eventually.
     "script-src": ["'unsafe-eval'"],
+    "font-src": ["data:"],
 }
 
 


### PR DESCRIPTION
TensorBoard depends on vaadin package and it uses data uri to bundle the
font icons.

This change also removes the global CSP whitelist validation since we
already have validation in the security validator module.
