### PR TITLE
migrate: fix regressions in hparams table view

### DIFF
--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_session_group_details/tf-hparams-session-group-details.ts
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_session_group_details/tf-hparams-session-group-details.ts
@@ -186,7 +186,7 @@ class TfHparamsSessionGroupDetails extends mixinBehaviors(
   }
   @observe('sessionGroup.*')
   _sessionGroupChanged() {
-    if (!this.sessionGroup) {
+    if (!this.sessionGroup || Object.keys(this.sessionGroup).length == 0) {
       this._indexOfSession = new Map();
       this._sessionGroupNameHash = 0;
     } else {
@@ -222,7 +222,11 @@ class TfHparamsSessionGroupDetails extends mixinBehaviors(
   // Returns an array of the tensorboard 'runs' and 'tags' corresponding to
   // the given metric in each of the sessions in the given session group.
   _computeSeriesForSessionGroupMetric(sessionGroup, metricInfo) {
-    if (sessionGroup === null || metricInfo === null) {
+    if (
+      sessionGroup === null ||
+      Object.keys(sessionGroup).length == 0 ||
+      metricInfo === null
+    ) {
       return [];
     }
     return sessionGroup.sessions

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_table_view/tf-hparams-table-view.ts
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_table_view/tf-hparams-table-view.ts
@@ -175,6 +175,7 @@ class TfHparamsTableView extends LegacyElementMixin(PolymerElement) {
   _sessionGroupHParam(sessionGroup, hparam) {
     if (
       sessionGroup == null ||
+      Object.keys(sessionGroup).length == 0 ||
       !Object.prototype.hasOwnProperty.call(sessionGroup.hparams, hparam)
     ) {
       return '';
@@ -184,8 +185,8 @@ class TfHparamsTableView extends LegacyElementMixin(PolymerElement) {
   // Returns the metric value of the given sessionGroup. The value is
   // returned as a string suitable for display.
   _sessionGroupMetric(sessionGroup, metricName) {
-    if (sessionGroup == null) {
-      return null;
+    if (sessionGroup == null || Object.keys(sessionGroup).length == 0) {
+      return '';
     }
     for (let i = 0; i < sessionGroup.metricValues.length; ++i) {
       let metricVal = sessionGroup.metricValues[i];

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_table_view/tf-hparams-table-view.ts
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_table_view/tf-hparams-table-view.ts
@@ -40,7 +40,7 @@ class TfHparamsTableView extends LegacyElementMixin(PolymerElement) {
         </template>
       </vaadin-grid-column>
       <template is="dom-if" if="[[enableShowMetrics]]">
-        <vaadin-grid-column flex-grow="0" width="5em" resizable="">
+        <vaadin-grid-column flex-grow="0" autoWidth="" resizable="">
           <template class="header">
             <div class="table-header table-cell">Show Metrics</div>
           </template>


### PR DESCRIPTION
This fixes a couple regressions we noticed in the HParams plugin table view:

* The "Show Metrics" column was slightly too narrow in some browsers, pushing the final "s" to the next line.  Rather than just increasing the fixed width up from `5em` I opted to enable `autoWidth` - this is by default just calculated once after the initial load, but that should be sufficient for our case here since the widest part of the column is going to be the header text which will always be included (and the cells just contain checkboxes).

* Broken interactions in `<dom-repeat>` elements nested inside the table view's `vaadin-grid` - various errors would be thrown (typically TypeErrors due to trying to access non-existent properties) when updating the table view contents by selected and deselecting various filters in the left-hand sidebar (`tf-hparams-query-pane`).  It looks like the root cause is that the `dom-repeat` templates get bound at some point when the `vaadin-grid`-generated `item` variable (which is the session group, aka the row object) is set to the empty object `{}`, which is an unexpected input to various helper functions that postprocess the session group to produce contents for the row cell values and details pane.

    It appears that in the older version of VaadinGrid we used prior to the Polymer 3 migration, the same quirky behavior happened, but the value seen was `null` instead of `{}`, and the various helper functions do have null-guards.  So rather than trying to figure out why the quirk is actually happening - presumably some weird internal templatizer business - I've just extended the guards to also guard against the `sessionGroup` being empty.  In my testing that seems to prevent the previously seen issues from occurring.

