### PR TITLE
polymer3: add web-animations-js shim to Polymer 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "rxjs": "^6.5.5",
     "three": "~0.108.0",
     "umap-js": "^1.3.2",
+    "web-animations-js": "^2.3.2",
     "weblas": "^0.9.1",
     "zone.js": "^0.10.2"
   }

--- a/tensorboard/components_polymer3/BUILD
+++ b/tensorboard/components_polymer3/BUILD
@@ -64,10 +64,21 @@ tf_ts_library(
 )
 
 tf_js_binary(
-    name = "polymer3_lib_binary",
+    name = "polymer3_lib_binary_no_shim",
     compile = True,
     entry_point = ":polymer3_lib.ts",
     deps = [":polymer3_ts_lib"],
+)
+
+genrule(
+    name = "polymer3_lib_binary",
+    srcs = [
+        # Do not sort. order is important.
+        "@npm//:node_modules/web-animations-js/web-animations-next-lite.min.js",
+        ":polymer3_lib_binary_no_shim.js",
+    ],
+    outs = ["polymer3_lib_binary.js"],
+    cmd = "for f in $(SRCS); do cat \"$$f\"; echo; done > $@",
 )
 
 tensorboard_html_binary(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5908,6 +5908,11 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+web-animations-js@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/web-animations-js/-/web-animations-js-2.3.2.tgz#a51963a359c543f97b47c7d4bc2d811f9fc9e153"
+  integrity sha512-TOMFWtQdxzjWp8qx4DAraTWTsdhxVSiWa6NkPFSaPtZ1diKUxTn4yTix73A1euG1WbSOMMPcY51cnjTIHrGtDA==
+
 weblas@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/weblas/-/weblas-0.9.1.tgz#aae7ee20fd6b9486e9389d6e1a0771e34fa3885a"


### PR DESCRIPTION
In this change, we use genrule to inline the content since the module
cannot be safely imported from TypeScript internally. In order to have
congruent build system, we just use genrule to concatenate already
compiled sources.
