### PR TITLE
Integration with Databricks notebooks

### DIFF
--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -57,6 +57,7 @@ def _get_context():
 
     Returns:
       _CONTEXT_COLAB: If in Colab with an IPython notebook context.
+      _CONTEXT_DATABRICKS: If in Databricks with an IPython notebook context.
       _CONTEXT_IPYTHON: If not in Colab, but we are in an IPython notebook
         context (e.g., from running `jupyter notebook` at the command
         line).
@@ -381,6 +382,10 @@ def _display_colab(port, height, display_handle):
 
 
 def _display_databricks(port, height, display_handle):
+    """Display a TensorBoard instance in a Databricks notebook.
+
+    Note: `dbutils.tensorboard.display` only uses the `port` and `height` parameters.
+    """
     import IPython
 
     ip_shell = IPython.get_ipython()

--- a/tensorboard/notebook.py
+++ b/tensorboard/notebook.py
@@ -379,11 +379,14 @@ def _display_colab(port, height, display_handle):
     else:
         IPython.display.display(script)
 
+
 def _display_databricks(port, height, display_handle):
     import IPython
+
     ip_shell = IPython.get_ipython()
     dbutils = ip_shell.ns_table["user_global"]["dbutils"]
     dbutils.tensorboard.display(port, height, display_handle)
+
 
 def _display_ipython(port, height, display_handle):
     import IPython.display


### PR DESCRIPTION
## Motivation for features / changes

At Databricks, we want to support the `%tensorboard` API. In order to do so, we need specialized TensorBoard display functionality. Our current integration involves monkey patches private APIs of the notebook module. To prevent our current integration from regressing, we want to contribute a Databricks integration.

## Technical description of changes

Our integration follows the pattern of the Colab integration. To detect that we are in a Databricks context, we check if `dbutils`, a Python module only available in Databricks notebooks, is loaded.
We wrote a `_display_databricks` display function that calls a Databricks API to display TensorBoard inline to Databricks notebook.

Screenshots of UI changes: N/A

## Detailed steps to verify changes work correctly (as executed by you)

In the following steps, we use end to end manual tests to verify that the contribution integrates with Databricks, while preserving previous integrations.

### Build TensorBoard
In root of my TensorBoard repo, run `bazel run //tensorboard/pip_package:extract_pip_package` to get a wheel file for TensorBoard.
 
### Databricks
1. Create an account with Databricks community edition. Log into to your Community edition workspace.
2. Go to the cluster creation page. Open the browser javascript console and run `window.prefs.set("enableCustomSparkVersions", true)` in it. Refresh the page. A "custom spark version" field should appear.
3. Paste this DBR (not MLR) runtime image into the custom spark version field: `custom:custom-local__7.x-snapshot-scala2.12__unknown__ml-11816__3e423ba__e0a3e49__jerry.liang__435a42c__format-2.lz4`. Start the cluster.
4. After the cluster has started, go to the libraries view of the cluster configuration UI. Click the "install new" button. A modal will pop-up. Use it to upload your TensorBoard wheel file and install it.
5. Run
    ```python
    from tensorboard import notebook
    notebook._get_context()
    ```
    which returns `'_CONTEXT_DATABRICKS'`
6. Run
    ```python
    %load_ext tensorboard
    %tensorboard --logdir logs
    ```
    Result screenshot:
<img width="1406" alt="Screen Shot 2020-08-14 at 2 30 26 AM" src="https://user-images.githubusercontent.com/66143562/90235437-244d3180-ddd6-11ea-9b85-560d4c419e06.png">

Note: this HTTP error is specific to the community edition Databricks workspace. The community edition is feature limited, so TensorBoard doesn't work. However, from the result of `_get_context()` and the "open in a new tab" link, we know that the Databricks TensorBoard display function has been called, as desired.

### Jupyter
1. Create a new python3 virtual environment on your computer. In it, install `Jupyter` and your wheelfile.
2. Open a Jupyter notebook.
3. `pip install` the wheel file.
4. Run
    ```python
    from tensorboard import notebook
    notebook._get_context()
    ```
    which returns `'_CONTEXT_IPYTHON'`
5. Run
    ```python
    %load_ext tensorboard
    %tensorboard --logdir logs
    ```
    Result screenshot:
<img width="1093" alt="Screen Shot 2020-08-14 at 12 05 08 AM" src="https://user-images.githubusercontent.com/66143562/90222904-d9292380-ddc1-11ea-8dc0-1f825853ce3c.png">


### IPython

1. In the same virtual environment as the Jupyter step above, run `IPython`.
2. In IPython shell, run
    ```python
    %load_ext tensorboard
    %tensorboard --logdir logs
    ```
    Result screenshots:
<img width="800" alt="Screen Shot 2020-08-14 at 12 06 39 AM" src="https://user-images.githubusercontent.com/66143562/90223027-1ee5ec00-ddc2-11ea-9526-cd4748925bdf.png">
<img width="1504" alt="Screen Shot 2020-08-14 at 12 06 35 AM" src="https://user-images.githubusercontent.com/66143562/90223032-20afaf80-ddc2-11ea-8aa7-94e3ea413d8c.png">

### Colab
1. Open a new notebook.
2. Run `!pip uninstall tensorboard`
3. Upload the TensorBoard wheel file to the file directory.
4. Run
    ```python
    from tensorboard import notebook
    notebook._get_context()
    ```
    which returns `'_CONTEXT_COLAB'`
5. Run
    ```python
    %load_ext tensorboard
    %tensorboard --logdir logs
    ```
    Result screenshots:
<img width="1426" alt="Screen Shot 2020-08-14 at 12 25 46 AM" src="https://user-images.githubusercontent.com/66143562/90224608-c401c400-ddc4-11ea-92b6-890da7d10c45.png">

## Alternate designs / implementations considered
In https://github.com/tensorflow/tensorboard/pull/3770, we proposed creating a new notebook API for TensorBoard users to could specify custom display functionality. This not only fulfill our own integration needs but also provide value to other vendors who might be facing similar problems. We concluded that approach is not appropriate because it locks down the display function signature, has a high API surface area, and adds state to the notebook module.