### PR TITLE
Use exec mode instead of host mode for these Python tools

### DIFF
--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -14,7 +14,7 @@ genrule(
     ],
     outs = ["tensor-widget-style.ts"],
     cmd = "$(execpath //tensorboard/tools:inline_file_content) $(SRCS) >'$@'",
-    tools = ["//tensorboard/tools:inline_file_content"],
+    exec_tools = ["//tensorboard/tools:inline_file_content"],
 )
 
 tf_web_library(

--- a/tensorboard/components_polymer3/polymer/BUILD
+++ b/tensorboard/components_polymer3/polymer/BUILD
@@ -58,7 +58,7 @@ genrule(
     ],
     outs = ["plottable-style.ts"],
     cmd = "$(execpath //tensorboard/tools:inline_file_content) $(SRCS) >'$@'",
-    tools = ["//tensorboard/tools:inline_file_content"],
+    exec_tools = ["//tensorboard/tools:inline_file_content"],
 )
 
 tf_ts_library(

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -105,7 +105,7 @@ genrule(
     name = "generate_dtypes",
     outs = ["tf_dtypes.ts"],
     cmd = "$(execpath :extract_dtypes_from_python) $@",
-    tools = [
+    exec_tools = [
         ":extract_dtypes_from_python",
     ],
 )

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/BUILD
@@ -16,7 +16,7 @@ genrule(
     srcs = ["inactive_component.uninlined.ng.html"] + glob(["images/*.png"]),
     outs = ["inactive_component.ng.html"],
     cmd = "$(execpath //tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive:inline_images) $(SRCS) >'$@'",
-    tools = [":inline_images"],
+    exec_tools = [":inline_images"],
 )
 
 ng_module(


### PR DESCRIPTION
* Motivation for features / changes

We were asked to help with an internal Large Scale Change. Some excerpts:

> Migrate genrules that use a Python 3 tool from tools to exec_tools.
>
> genrule.tools uses blaze's host mode and forces to be Python 2, ignoring the py_binary.python_version attribute. <snip>
>
> This CL corrects the use of the Python 3 tool so that it runs Python 3 instead of Python 2 by using exec_tools (if there are 
> no upstream host dependencies).
> 
> Difference between tools and exec_tools:
>
> genrule.tools uses host mode, which ignores the py_binary.python_version attribute and always use Python 2 (to be
> changed to Python 3)
> genrule.exec_tools uses exec mode, which respects the py_binary.python_version attribute (unless an upstream host 
> dependency forces all downstream targets to stay in host)

It's not clear to me if these limitations apply to bazel as well but given these targets are also built internally we do need to perform the change.

* Detailed steps to verify changes work correctly (as executed by you)

Make the changes; Run the following commands:

```shell
$ bazel clean
$ bazel build tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive:gen_inactive_component.ng.html
$ bazel build tensorboard/components_polymer3/polymer:gen_plottable_style
$ bazel build tensorboard/components/tensor_widget:gen_tensor_widget_style
$ bazel build tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin:generate_dtypes
```