### PR TITLE
[Debuggger V1] Remove external reference to the deprecated plugin

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -266,7 +266,6 @@ py_library(
         "//tensorboard/plugins/audio:audio_plugin",
         "//tensorboard/plugins/core:core_plugin",
         "//tensorboard/plugins/custom_scalar:custom_scalars_plugin",
-        "//tensorboard/plugins/debugger:debugger_plugin_loader",
         "//tensorboard/plugins/debugger_v2:debugger_v2_plugin",
         "//tensorboard/plugins/distribution:distributions_plugin",
         "//tensorboard/plugins/graph:graphs_plugin",

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -65,7 +65,6 @@ tf_web_library(
     deps = [
         "//tensorboard/plugins/audio/tf_audio_dashboard",
         "//tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard",
-        "//tensorboard/plugins/debugger/tf_debugger_dashboard",
         "//tensorboard/plugins/distribution/tf_distribution_dashboard",
         "//tensorboard/plugins/graph/tf_graph_dashboard",
         "//tensorboard/plugins/histogram/tf_histogram_dashboard",

--- a/tensorboard/components/tf_tensorboard/default-plugins.html
+++ b/tensorboard/components/tf_tensorboard/default-plugins.html
@@ -28,7 +28,6 @@ limitations under the License.
 />
 <link rel="import" href="../tf-image-dashboard/tf-image-dashboard.html" />
 <link rel="import" href="../tf-audio-dashboard/tf-audio-dashboard.html" />
-<link rel="import" href="../tf-debugger-dashboard/tf-debugger-dashboard.html" />
 <link rel="import" href="../tf-graph-dashboard/tf-graph-dashboard.html" />
 <link
   rel="import"

--- a/tensorboard/components_polymer3/tf_tensorboard/BUILD
+++ b/tensorboard/components_polymer3/tf_tensorboard/BUILD
@@ -65,7 +65,6 @@ tf_web_library(
     deps = [
         "//tensorboard/plugins/audio/tf_audio_dashboard",
         "//tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard",
-        "//tensorboard/plugins/debugger/tf_debugger_dashboard",
         "//tensorboard/plugins/distribution/tf_distribution_dashboard",
         "//tensorboard/plugins/graph/tf_graph_dashboard",
         "//tensorboard/plugins/histogram/tf_histogram_dashboard",

--- a/tensorboard/components_polymer3/tf_tensorboard/default-plugins.html
+++ b/tensorboard/components_polymer3/tf_tensorboard/default-plugins.html
@@ -28,7 +28,6 @@ limitations under the License.
 />
 <link rel="import" href="../tf-image-dashboard/tf-image-dashboard.html" />
 <link rel="import" href="../tf-audio-dashboard/tf-audio-dashboard.html" />
-<link rel="import" href="../tf-debugger-dashboard/tf-debugger-dashboard.html" />
 <link rel="import" href="../tf-graph-dashboard/tf-graph-dashboard.html" />
 <link
   rel="import"

--- a/tensorboard/default.py
+++ b/tensorboard/default.py
@@ -36,7 +36,6 @@ from tensorboard.backend import experimental_plugin
 from tensorboard.plugins.audio import audio_plugin
 from tensorboard.plugins.core import core_plugin
 from tensorboard.plugins.custom_scalar import custom_scalars_plugin
-from tensorboard.plugins.debugger import debugger_plugin_loader
 from tensorboard.plugins.debugger_v2 import debugger_v2_plugin
 from tensorboard.plugins.distribution import distributions_plugin
 from tensorboard.plugins.graph import graphs_plugin
@@ -79,7 +78,6 @@ _PLUGINS = [
     custom_scalars_plugin.CustomScalarsPlugin,
     images_plugin.ImagesPlugin,
     audio_plugin.AudioPlugin,
-    debugger_plugin_loader.DebuggerPluginLoader,
     debugger_v2_plugin.DebuggerV2Plugin,
     graphs_plugin.GraphsPlugin,
     distributions_plugin.DistributionsPlugin,

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -14,6 +14,7 @@ py_library(
     srcs = ["audio_plugin.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":metadata",
         "//tensorboard:errors",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -14,6 +14,7 @@ py_library(
     srcs = ["images_plugin.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":metadata",
         "//tensorboard:expect_numpy_installed",
         "//tensorboard:plugin_util",
         "//tensorboard/backend:http_util",


### PR DESCRIPTION
* Motivation for features / changes
  * This PR removes the references to the deprecated debugger (v1) plugin.
    This plugin has been marked as deprecated and for removal in the 2.3.0
    release notes. The code itself will be removed in a follow-up change.
* Technical description of changes
  * Removes external references to tensorboard/plugins/debugger, from
     BUILD files, Python modules and Polymer .html files that are not a part of
     plugins/debugger.
 * During testing, it was discovered that the BUILD files in plugins/audio and plugins/images
     needed to be fixed (i.e., dependency on the ":metadata" BUILD target added in
     each respective BUILD file) after plugins/debugger is removed. This probably was due
     to an unmasking of transitive dependencies of some sort.
* Detailed steps to verify changes work correctly (as executed by you)
  * Verified that Debugger V2 still functions properly