### PR TITLE
polymer: lock down component visibility

### DIFF
--- a/tensorboard/components/tf_backend/BUILD
+++ b/tensorboard/components/tf_backend/BUILD
@@ -21,7 +21,6 @@ tf_web_library(
         "urlPathHelpers.ts",
     ],
     path = "/tf-backend",
-    visibility = ["//visibility:public"],
     deps = [
         ":type",
         "//tensorboard/components/tf_imports:lodash",

--- a/tensorboard/components/tf_dashboard_common/BUILD
+++ b/tensorboard/components/tf_dashboard_common/BUILD
@@ -29,7 +29,6 @@ tf_web_library(
         "tf-option-selector.html",
     ],
     path = "/tf-dashboard-common",
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_color_scale",

--- a/tensorboard/components/tf_imports/BUILD
+++ b/tensorboard/components/tf_imports/BUILD
@@ -10,7 +10,6 @@ tf_web_library(
     name = "webcomponentsjs",
     srcs = ["@org_definitelytyped//:webcomponents.js.d.ts"],
     path = "/webcomponentsjs",
-    visibility = ["//visibility:public"],
     exports = ["@org_polymer_webcomponentsjs"],
 )
 
@@ -21,7 +20,6 @@ tf_web_library(
         "@org_definitelytyped//:polymer.d.ts",
     ],
     path = "/tf-imports",
-    visibility = ["//visibility:public"],
     exports = ["@org_polymer"],
     deps = [
         ":polymer_externs",
@@ -35,7 +33,6 @@ tf_web_library(
 tensorboard_webcomponent_library(
     name = "polymer_lib",
     srcs = [":polymer"],
-    visibility = ["//visibility:public"],
     destdir = "tf-imports",
     deps = [
         ":polymer_externs_lib",
@@ -82,7 +79,6 @@ tf_web_library(
         "@org_threejs//:three.js",
     ],
     path = "/tf-imports",
-    visibility = ["//visibility:public"],
 )
 
 tf_web_library(

--- a/tensorboard/components/tf_storage/BUILD
+++ b/tensorboard/components/tf_storage/BUILD
@@ -14,7 +14,6 @@ tf_web_library(
         "tf-storage-polymer.ts",
     ],
     path = "/tf-storage",
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_globals",
         "//tensorboard/components/tf_imports:lodash",

--- a/tensorboard/components/tf_tensorboard/BUILD
+++ b/tensorboard/components/tf_tensorboard/BUILD
@@ -12,7 +12,6 @@ tf_web_library(
         "tf-tensorboard.html",
     ],
     path = "/tf-tensorboard",
-    visibility = ["//visibility:public"],
     deps = [
         ":registry",
         "//tensorboard/components/experimental/plugin_util:plugin_host",
@@ -43,7 +42,6 @@ tf_web_library(
         "registry.ts",
     ],
     path = "/tf-tensorboard",
-    visibility = ["//visibility:public"],
 )
 
 tf_web_library(

--- a/tensorboard/components/vz_chart_helpers/BUILD
+++ b/tensorboard/components/vz_chart_helpers/BUILD
@@ -15,7 +15,6 @@ tf_web_library(
         "vz-chart-tooltip.ts",
     ],
     path = "/vz-chart-helpers",
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_imports:d3",
         "//tensorboard/components/tf_imports:lodash",

--- a/tensorboard/components_polymer3/tf_backend/BUILD
+++ b/tensorboard/components_polymer3/tf_backend/BUILD
@@ -20,7 +20,6 @@ tf_ts_library(
         "urlPathHelpers.ts",
     ],
     strict_checks = False,
-    visibility = ["//visibility:public"],
     deps = [
         ":type",
         "//tensorboard/components_polymer3/vz_sorting",

--- a/tensorboard/components_polymer3/tf_dashboard_common/BUILD
+++ b/tensorboard/components_polymer3/tf_dashboard_common/BUILD
@@ -23,7 +23,6 @@ tf_ts_library(
         "tf-option-selector.ts",
     ],
     strict_checks = False,
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components_polymer3/polymer:irons_and_papers",
         "//tensorboard/components_polymer3/polymer:legacy_element_mixin",

--- a/tensorboard/components_polymer3/tf_storage/BUILD
+++ b/tensorboard/components_polymer3/tf_storage/BUILD
@@ -13,7 +13,6 @@ tf_ts_library(
         "tf-storage-polymer.ts",
     ],
     strict_checks = False,
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components_polymer3/tf_globals",
         "@npm//@polymer/decorators",

--- a/tensorboard/components_polymer3/tf_tensorboard/BUILD
+++ b/tensorboard/components_polymer3/tf_tensorboard/BUILD
@@ -12,7 +12,6 @@ tf_web_library(
         "tf-tensorboard.html",
     ],
     path = "/tf-tensorboard",
-    visibility = ["//visibility:public"],
     deps = [
         ":registry",
         "//tensorboard/components/experimental/plugin_util:plugin_host",
@@ -43,7 +42,6 @@ tf_web_library(
         "registry.ts",
     ],
     path = "/tf-tensorboard",
-    visibility = ["//visibility:public"],
 )
 
 tf_web_library(

--- a/tensorboard/components_polymer3/vz_chart_helpers/BUILD
+++ b/tensorboard/components_polymer3/vz_chart_helpers/BUILD
@@ -12,7 +12,6 @@ tf_ts_library(
         "vz-chart-tooltip.ts",
     ],
     strict_checks = False,
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
         "@npm//@polymer/decorators",

--- a/tensorboard/plugins/graph/tf_graph_board/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_board/BUILD
@@ -9,7 +9,6 @@ tf_web_library(
     name = "tf_graph_board",
     srcs = ["tf-graph-board.html"],
     path = "/tf-graph-board",
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_imports:polymer",
         "//tensorboard/plugins/graph/tf_graph",

--- a/tensorboard/plugins/graph/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_common/BUILD
@@ -34,7 +34,6 @@ tf_web_library(
         "util.ts",
     ],
     path = "/tf-graph-common",
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:d3",

--- a/tensorboard/plugins/graph/tf_graph_loader/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_loader/BUILD
@@ -35,7 +35,6 @@ tf_web_library(
         "tf-graph-dashboard-loader.ts",
     ],
     path = "/tf-graph-loader",
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
         "//tensorboard/components/tf_imports:polymer",

--- a/tensorboard/plugins/graph/tf_graph_node_search/BUILD
+++ b/tensorboard/plugins/graph/tf_graph_node_search/BUILD
@@ -9,7 +9,6 @@ tf_web_library(
     name = "tf_graph_node_search",
     srcs = ["tf-graph-node-search.html"],
     path = "/tf-graph-node-search",
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_dashboard_common",
         "//tensorboard/components/tf_imports:polymer",

--- a/tensorboard/plugins/hparams/tf_hparams_backend/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_backend/BUILD
@@ -11,7 +11,6 @@ tf_web_library(
         "tf-hparams-backend.html",
     ],
     path = "/tf-hparams-backend",
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_backend",
     ],

--- a/tensorboard/plugins/hparams/tf_hparams_main/BUILD
+++ b/tensorboard/plugins/hparams/tf_hparams_main/BUILD
@@ -8,7 +8,6 @@ tf_web_library(
     name = "tf_hparams_main",
     srcs = ["tf-hparams-main.html"],
     path = "/tf-hparams-main",
-    visibility = ["//visibility:public"],
     deps = [
         "//tensorboard/components/tf_imports:lodash",
         "//tensorboard/components/tf_imports:polymer",


### PR DESCRIPTION
Summary:
We’ve migrated all internal dependencies off of these targets, so we can
now lock them down to prevent backsliding. Generated via Buildozer with:

```
buildozer 'remove visibility //visibility:public' \
    //tensorboard/components{,_polymer3}/...:\* \
    //tensorboard/plugins/...:%tf_web_library \
    ;
```

…which imposes `//tensorboard:internal` or stricter due to #3566.

Test Plan:
A test sync (<http://cl/326725258>) passes presubmits, and a build graph
query shows that these targets don’t have direct reverse dependencies
from outside the internal package group.

wchargin-branch: polymer-lockdown
