### PR TITLE
cleanup: remove the legacy build in the TensorBoard

### DIFF
--- a/tensorboard/BUILD
+++ b/tensorboard/BUILD
@@ -331,8 +331,6 @@ tensorboard_zip_file(
 tf_web_library(
     name = "assets",
     srcs = [
-        "//tensorboard/components:legacy.html",
-        "//tensorboard/components:legacy.js",
         "//tensorboard/webapp:index.html",
         "//tensorboard/webapp:index.js",
         "//tensorboard/webapp:svg_bundle",


### PR DESCRIPTION
When TensorBoard 2.3.0 shipped Angular based entry, we supported the
legacy Polymer based entry via "/legacy.html" route. Since the endpoint
was meant to be used very temporary, and since the release is already
cut and released, we are now removing the legacy entry point.
