### PR TITLE
polymer3: remove `readOnly` from initialized props

### DIFF
--- a/tensorboard/components_polymer3/tf_runs_selector/tf-runs-selector.ts
+++ b/tensorboard/components_polymer3/tf_runs_selector/tf-runs-selector.ts
@@ -150,7 +150,6 @@ class TfRunsSelector extends LegacyElementMixin(PolymerElement) {
 
   @property({
     type: Number,
-    readOnly: true,
   })
   _dataLocationClipLength: number = 250;
 

--- a/tensorboard/plugins/graph/polymer3/tf_graph_dashboard/tf-graph-dashboard.ts
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_dashboard/tf-graph-dashboard.ts
@@ -268,7 +268,6 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
   // involve slow disk reads. Hence, we throttle to 1 of those requests every this many ms.
   @property({
     type: Number,
-    readOnly: true,
   })
   _healthPillStepRequestTimerDelay: number = 500;
   @property({type: Array})

--- a/tensorboard/plugins/graph/polymer3/tf_graph_debugger_data_card/tf-graph-debugger-data-card.ts
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_debugger_data_card/tf-graph-debugger-data-card.ts
@@ -329,7 +329,6 @@ class TfGraphDebuggerDataCard extends LegacyElementMixin(PolymerElement) {
   areHealthPillsLoading: any;
   @property({
     type: Array,
-    readOnly: true,
   })
   healthPillEntries: unknown[] = tf_graph_scene.healthPillEntries;
   // When all-steps mode is enabled, the user can request health pills for any step. In this

--- a/tensorboard/plugins/graph/polymer3/tf_graph_node_search/tf-graph-node-search.ts
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_node_search/tf-graph-node-search.ts
@@ -97,7 +97,6 @@ class TfGraphNodeSearch extends LegacyElementMixin(PolymerElement) {
   _previousRegexInput: string = '';
   @property({
     type: Number,
-    readOnly: true,
   })
   _searchTimeoutDelay: number = 150;
   @property({type: Boolean})

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_parallel_coords_plot/tf-hparams-parallel-coords-plot.ts
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_parallel_coords_plot/tf-hparams-parallel-coords-plot.ts
@@ -146,7 +146,6 @@ class TfHparamsParallelCoordsPlot extends LegacyElementMixin(PolymerElement) {
    */
   @property({
     type: Object,
-    readOnly: true,
     notify: true,
   })
   selectedSessionGroup: object = null;
@@ -159,7 +158,6 @@ class TfHparamsParallelCoordsPlot extends LegacyElementMixin(PolymerElement) {
    */
   @property({
     type: Object,
-    readOnly: true,
     notify: true,
   })
   closestSessionGroup: object = null;

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_scatter_plot_matrix_plot/tf-hparams-scatter-plot-matrix-plot.ts
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_scatter_plot_matrix_plot/tf-hparams-scatter-plot-matrix-plot.ts
@@ -83,7 +83,6 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
   // threshold, this property will be null.
   @property({
     type: Object,
-    readOnly: true,
     notify: true,
   })
   closestSessionGroup: object = null;


### PR DESCRIPTION
Summary:
In Polymer 3, using `@property({readOnly: true})` on a property that
also has a TypeScript initializer is always a silent error: the Polymer
decorator will add a getter, causing the initialization code added to
constructor by `tsc` to be a no-op. This patch removes all such
occurrences, as identified by running

```
git grep readOnly \
    'tensorboard/plugins/*polymer3*.ts' \
    'tensorboard/components_polymer3/*.ts' \
    ;
```

and checking manually for initializers.

Test Plan:
Not manually tested. As for completeness, with `-A4` added to the above
`git grep`, the only `=`-sign is a false positive.

wchargin-branch: polymer3-no-readonly
