### PR TITLE
data-loader-behavior: add fine-grained batching support

### DIFF
--- a/tensorboard/components_polymer3/tf_backend/canceller.ts
+++ b/tensorboard/components_polymer3/tf_backend/canceller.ts
@@ -13,6 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+export interface CancelResult<T> {
+  value: T;
+  cancelled: boolean;
+}
+
 /**
  * A class that allows marking promises as cancelled.
  *
@@ -45,9 +50,7 @@ export class Canceller {
    * a `cancelled` argument. This argument will be `false` unless and
    * until `cancelAll` is invoked after the creation of this task.
    */
-  public cancellable<T, U>(
-    f: (result: {value: T; cancelled: boolean}) => U
-  ): (T) => U {
+  public cancellable<T, U>(f: (result: CancelResult<T>) => U): (T) => U {
     const originalCancellationCount = this.cancellationCount;
     return (value) => {
       const cancelled = this.cancellationCount !== originalCancellationCount;

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_session_group_details/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_session_group_details/BUILD
@@ -16,6 +16,7 @@ tf_ts_library(
         "//tensorboard/components_polymer3/polymer:legacy_class",
         "//tensorboard/components_polymer3/tf_backend",
         "//tensorboard/components_polymer3/tf_color_scale",
+        "//tensorboard/components_polymer3/tf_dashboard_common",
         "//tensorboard/components_polymer3/vz_chart_helpers",
         "//tensorboard/plugins/hparams/polymer3/tf_hparams_utils",
         "//tensorboard/plugins/scalar/polymer3/tf_scalar_dashboard:tf_scalar_card",

--- a/tensorboard/plugins/scalar/polymer3/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/polymer3/tf_scalar_dashboard/BUILD
@@ -54,6 +54,7 @@ tf_ts_library(
         "//tensorboard/components_polymer3/tf_color_scale",
         "//tensorboard/components_polymer3/tf_dashboard_common",
         "//tensorboard/components_polymer3/tf_line_chart_data_loader",
+        "//tensorboard/components_polymer3/vz_chart_helpers",
         "//tensorboard/components_polymer3/vz_line_chart2",
         "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",


### PR DESCRIPTION
Summary:
The data loader behavior maintains a fine-grained cache of key-value
pairs. This is useful because when the set of requested keys expands,
only the new keys need to be fetched. But, until now, the behavior has
been hard-coded to fire a separate request for each key-value pair.
Clients can have either fine-grained cache invalidation or efficient
batched requests, but not both at the same time. This patch enriches the
behavior to support just that.

In a future change, the scalars dashboard will take advantage of this to
batch requests for multiple runs and a single tag. This will only
require changing the `requestData` function in `tf-scalar-card`.

In doing so, we need to shuffle around the API a bit. Instead of asking
clients to provide `getDataLoadUrl: (Item) => string` plus a separate
function `requestData: (url: string) => Promise<Data>` (where “`Item`”
and “`Data`” are the keys and values, respectively), clients now provide
a single function `requestData` that takes raw `Item`s (now plural),
performs the request(s), and returns the data. The function provides a
stream of key-value pairs, which is represented in callback style for
convenience. (We don’t want to drag Observable into this.)

The purpose of this approach, as opposed to a perhaps more natural
approach that simply adapts `getDataLoadUrl` to return some kind of
request struct with a callback to map a response into key-value pairs,
is to accommodate the variety of existing clients. The structures get
pretty wild: e.g., `tf-line-chart-data-loader` mixes in the behavior but
doesn’t actually provide the needed properties; they’re provided instead
by `tf-scalar-card`, but then `tf-hparams-session-group-details` further
overrides some of those properties of `tf-scalar-card` with an entirely
different backend. It’s a bit wordier for clients, but at least there
are fewer moving pieces to keep track of.

Test Plan:
The scalars, custom scalars, distributions, histograms, PR curves, and
hparams dashboards all work. The fine-grained invalidation on the
scalars dashboard works: e.g., set the tag filter to `mnist` and then to
`mnist|hparams`, and watch only the hparams demo data load; then, set it
to `hparams` and watch the MNIST charts disappear without any repaints
to the hparams demo charts. The post-load callback properly causes
scalar charts’ domains to adjust. The refresh button in the dashboard UI
properly invalidates and re-fetches data.

(Make sure to run with `TB_POLYMER3=1` until that’s the default.)

wchargin-branch: dlb-batch-finegrained
