### PR TITLE
readme: remove reference to `backend/application.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,9 +376,7 @@ TensorBoard uses [reservoir
 sampling](https://en.wikipedia.org/wiki/Reservoir_sampling) to downsample your
 data so that it can be loaded into RAM. You can modify the number of elements it
 will keep per tag by using the `--samples_per_plugin` command line argument (ex:
-`--samples_per_plugin=scalars=500,images=20`). Alternatively, you can change the
-source code in
-[tensorboard/backend/application.py](tensorboard/backend/application.py).
+`--samples_per_plugin=scalars=500,images=20`).
 See this [Stack Overflow question](http://stackoverflow.com/questions/43702546/tensorboard-doesnt-show-all-data-points/)
 for some more information.
 


### PR DESCRIPTION
Summary:
Before `--samples_per_plugin` existed, the only way to change the
sampling thresholds was to patch `application.py` manually. But the flag
has been the right way to do this since #1138, and manual patching has
been insufficient since the flag value was exposed to plugins in #3271.
There’s no need to discuss this implementation detail any more.

wchargin-branch: readme-remove-application-reference
