### PR TITLE
doc: add a note that auto-reload is turned off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,9 @@ tensorboard in inspect mode to inspect the contents of your event files.
 
 ### TensorBoard is showing only some of my data, or isn't properly updating!
 
-> **Update:** After [2.3.0 release][2-3-0], TensorBoard no longer auto uploads
-> every 30 seconds. To re-enable the behavior, please open the settings and
+> **Update:** After [2.3.0 release][2-3-0], TensorBoard no longer auto reloads
+> every 30 seconds. To re-enable the behavior, please open the settings by
+> clicking the gear icon in the top-right of the TensorBoard web interface, and
 > enable "Reload data".
 
 > **Update:** the [experimental `--reload_multifile=true` option][pr-1867] can

--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ tensorboard in inspect mode to inspect the contents of your event files.
 
 ### TensorBoard is showing only some of my data, or isn't properly updating!
 
+> **Update:** After [2.3.0 release][2-3-0], TensorBoard no longer auto uploads
+> every 30 seconds. To re-enable the behavior, please open the settings and
+> enable "Reload data".
+
 > **Update:** the [experimental `--reload_multifile=true` option][pr-1867] can
 > now be used to poll all "active" files in a directory for new data, rather
 > than the most recent one as described below. A file is "active" as long as it
@@ -419,3 +423,4 @@ of `tensorboard --inspect`, etc.).
 
 [stack-overflow]: https://stackoverflow.com/questions/tagged/tensorboard
 [pr-1867]: https://github.com/tensorflow/tensorboard/pull/1867
+[2-3-0]: https://github.com/tensorflow/tensorboard/releases/tag/2.3.0


### PR DESCRIPTION
With the Angular based TensorBoard, we've changed our policy to turn off
the auto reload by default. Unfortunately, due to my oversight, we have
failed to capture this in the change log.

This change adds a warning that it has changed.
