### PR TITLE
npmi: add missing `expect_*` Angular deps

### DIFF
--- a/tensorboard/webapp/angular/BUILD
+++ b/tensorboard/webapp/angular/BUILD
@@ -10,6 +10,7 @@ tf_ts_library(
     name = "expect_angular_common_http",
     srcs = [],
     visibility = [
+        "//tensorboard/webapp/plugins/npmi/data_source:__subpackages__",
         "//tensorboard/webapp/webapp_data_source:__subpackages__",
     ],
     deps = [
@@ -23,6 +24,7 @@ tf_ts_library(
     name = "expect_angular_common_http_testing",
     srcs = [],
     visibility = [
+        "//tensorboard/webapp/plugins/npmi/data_source:__subpackages__",
         "//tensorboard/webapp/webapp_data_source:__subpackages__",
     ],
     deps = [

--- a/tensorboard/webapp/plugins/npmi/data_source/BUILD
+++ b/tensorboard/webapp/plugins/npmi/data_source/BUILD
@@ -10,6 +10,7 @@ ng_module(
         "npmi_data_source_module.ts",
     ],
     deps = [
+        "//tensorboard/webapp/angular:expect_angular_common_http",
         "//tensorboard/webapp/plugins/npmi/store:types",
         "//tensorboard/webapp/plugins/npmi/util:metric_type",
         "//tensorboard/webapp/webapp_data_source:http_client",
@@ -27,6 +28,7 @@ tf_ts_library(
     ],
     deps = [
         ":data_source",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/webapp_data_source:http_client",
         "//tensorboard/webapp/webapp_data_source:http_client_testing",
         "@npm//@angular/common",


### PR DESCRIPTION
Summary:
Needed to unblock internal sync.

Test Plan:
Test sync CL: <http://cl/327722605>

wchargin-branch: npmi-data-source-angular-deps
