### PR TITLE
data-loader-behavior: rename `Item`/`Data` to `K`/`V`

### DIFF
--- a/tensorboard/components_polymer3/tf_line_chart_data_loader/tf-line-chart-data-loader.ts
+++ b/tensorboard/components_polymer3/tf_line_chart_data_loader/tf-line-chart-data-loader.ts
@@ -208,7 +208,7 @@ class _TfLineChartDataLoader<ScalarMetadata>
 
   onLoadFinish() {
     this.commitChanges();
-    if (this.dataToLoad.length > 0 && this._resetDomainOnNextLoad) {
+    if (this.keysToLoad.length > 0 && this._resetDomainOnNextLoad) {
       // (Don't unset _resetDomainOnNextLoad when we didn't
       // load any runs: this has the effect that if all our
       // runs are deselected, then we toggle them all on, we

--- a/tensorboard/plugins/custom_scalar/polymer3/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.ts
+++ b/tensorboard/plugins/custom_scalar/polymer3/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.ts
@@ -84,7 +84,7 @@ class _TfCustomScalarMarginChartCard extends LegacyElementMixin(PolymerElement)
         fill-area="[[_fillArea]]"
         ignore-y-outliers="[[ignoreYOutliers]]"
         load-key="[[_tagFilter]]"
-        data-to-load="[[runs]]"
+        keys-to-load="[[runs]]"
         request-data="[[_requestData]]"
         log-scale-active="[[_logScaleActive]]"
         load-data-callback="[[_createProcessDataFunction(marginChartSeries)]]"
@@ -357,20 +357,20 @@ class _TfCustomScalarMarginChartCard extends LegacyElementMixin(PolymerElement)
 
   @property({type: Object})
   _requestData: RequestDataCallback<RunItem, CustomScalarsDatum> = (
-    items,
+    keys,
     onLoad,
     onFinish
   ) => {
     const router = getRouter();
     const baseUrl = router.pluginRoute('custom_scalars', '/scalars');
     Promise.all(
-      items.map((item) => {
-        const run = item;
+      keys.map((key) => {
+        const run = key;
         const tag = this._tagFilter;
         const url = addParams(baseUrl, {tag, run});
         return this.requestManager
           .request(url)
-          .then((data) => void onLoad({item, data}));
+          .then((value) => void onLoad({key, value}));
       })
     ).finally(() => void onFinish());
   };

--- a/tensorboard/plugins/custom_scalar/polymer3/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.ts
+++ b/tensorboard/plugins/custom_scalar/polymer3/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.ts
@@ -44,7 +44,7 @@ export interface TfCustomScalarMultiLineChartCard extends HTMLElement {
   reload(): void;
 }
 
-type RunItem = string;
+type RunKey = string;
 type CustomScalarsDatum = {
   regex_valid: boolean;
   tag_to_events: Record<string, ScalarDatum[]>;
@@ -64,7 +64,7 @@ class _TfCustomScalarMultiLineChartCard
         data-series="[[_seriesNames]]"
         ignore-y-outliers="[[ignoreYOutliers]]"
         load-key="[[_tagFilter]]"
-        data-to-load="[[runs]]"
+        keys-to-load="[[runs]]"
         request-data="[[_requestData]]"
         log-scale-active="[[_logScaleActive]]"
         load-data-callback="[[_createProcessDataFunction()]]"
@@ -245,21 +245,21 @@ class _TfCustomScalarMultiLineChartCard
   _logScaleActive: boolean;
 
   @property({type: Object})
-  _requestData: RequestDataCallback<RunItem, CustomScalarsDatum> = (
-    items,
+  _requestData: RequestDataCallback<RunKey, CustomScalarsDatum> = (
+    keys,
     onLoad,
     onFinish
   ) => {
     const router = getRouter();
     const baseUrl = router.pluginRoute('custom_scalars', '/scalars');
     Promise.all(
-      items.map((item) => {
-        const run = item;
+      keys.map((key) => {
+        const run = key;
         const tag = this._tagFilter;
         const url = addParams(baseUrl, {tag, run});
         return this.requestManager
           .request(url)
-          .then((data) => void onLoad({item, data}));
+          .then((value) => void onLoad({key, value}));
       })
     ).finally(() => void onFinish());
   };

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.html
@@ -51,7 +51,7 @@ limitations under the License.
         fill-area="[[_fillArea]]"
         ignore-y-outliers="[[ignoreYOutliers]]"
         load-key="[[_tagFilter]]"
-        data-to-load="[[runs]]"
+        keys-to-load="[[runs]]"
         log-scale-active="[[_logScaleActive]]"
         load-data-callback="[[_createProcessDataFunction(marginChartSeries)]]"
         request-manager="[[requestManager]]"

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.html
@@ -50,7 +50,7 @@ limitations under the License.
         get-data-load-url="[[_dataUrl]]"
         ignore-y-outliers="[[ignoreYOutliers]]"
         load-key="[[_tagFilter]]"
-        data-to-load="[[runs]]"
+        keys-to-load="[[runs]]"
         log-scale-active="[[_logScaleActive]]"
         load-data-callback="[[_createProcessDataFunction()]]"
         request-manager="[[requestManager]]"

--- a/tensorboard/plugins/distribution/polymer3/tf_distribution_dashboard/tf-distribution-loader.ts
+++ b/tensorboard/plugins/distribution/polymer3/tf_distribution_dashboard/tf-distribution-loader.ts
@@ -120,21 +120,22 @@ class _TfDistributionLoader
   xType: string;
 
   @property({type: Object})
-  getDataLoadName = ({run}) => run;
+  getCacheKey = ({run}) => run;
 
   requestData: RequestDataCallback<RunTagItem, unknown> = (
-    items,
+    keys,
     onLoad,
     onFinish
   ) => {
     const router = getRouter();
     const baseUrl = router.pluginRoute('distributions', '/distributions');
     Promise.all(
-      items.map((item) => {
-        const url = addParams(baseUrl, {tag: item.tag, run: item.run});
+      keys.map((key) => {
+        const {tag, run} = key;
+        const url = addParams(baseUrl, {tag, run});
         return this.requestManager
           .request(url)
-          .then((data) => void onLoad({item, data}));
+          .then((value) => void onLoad({key, value}));
       })
     ).finally(() => void onFinish());
   };
@@ -149,7 +150,7 @@ class _TfDistributionLoader
       bins.step = step;
       return bins;
     });
-    const name = this.getDataLoadName(datum);
+    const name = this.getCacheKey(datum);
     (this.$.chart as VzDistributionChart).setSeriesData(name, data);
     (this.$.chart as VzDistributionChart).setVisibleSeries([name]);
   };
@@ -178,7 +179,7 @@ class _TfDistributionLoader
   _updateDataToLoad(): void {
     var run = this.run;
     var tag = this.tag;
-    this.dataToLoad = [{run, tag}];
+    this.keysToLoad = [{run, tag}];
   }
 
   @computed('run')

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_session_group_details/tf-hparams-session-group-details.ts
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_session_group_details/tf-hparams-session-group-details.ts
@@ -29,7 +29,7 @@ import '../../../scalar/polymer3/tf_scalar_dashboard/tf-scalar-card';
 // TODO: add dependency once the Polymer 3 scalar dashboard is migrated.
 // import '../tf_scalar_dashboard/tf-scalar-card';
 
-type RunTagItem = {
+type RunTagKey = {
   run: string;
   tag: string;
 };
@@ -76,7 +76,7 @@ class TfHparamsSessionGroupDetails extends mixinBehaviors(
           <tf-scalar-card
             class="scalar-card"
             color-scale="[[_colorScale]]"
-            data-to-load="[[_computeSeriesForSessionGroupMetric(sessionGroup, metricInfo)]]"
+            keys-to-load="[[_computeSeriesForSessionGroupMetric(sessionGroup, metricInfo)]]"
             tag="[[metricInfo.name.tag]]"
             tag-metadata="[[_computeTagMetadata(metricInfo)]]"
             x-type="[[_xType]]"
@@ -132,19 +132,19 @@ class TfHparamsSessionGroupDetails extends mixinBehaviors(
     type: Object,
   })
   _requestData: RequestDataCallback<
-    RunTagItem,
+    RunTagKey,
     vz_chart_helpers.ScalarDatum[]
-  > = (items, onLoad, onFinish) => {
+  > = (keys, onLoad, onFinish) => {
     Promise.all(
-      items.map((item) => {
+      keys.map((key) => {
         const request = {
           experimentName: this.experimentName,
-          sessionName: item.run,
-          metricName: item.tag,
+          sessionName: key.run,
+          metricName: key.tag,
         };
         return this.backend
           .listMetricEvals(request)
-          .then((data) => void onLoad({item, data}));
+          .then((value) => void onLoad({key, value}));
       })
     ).finally(() => void onFinish());
   };

--- a/tensorboard/plugins/hparams/tf_hparams_session_group_details/tf-hparams-session-group-details.html
+++ b/tensorboard/plugins/hparams/tf_hparams_session_group_details/tf-hparams-session-group-details.html
@@ -65,7 +65,7 @@ clicks on a row in table-view or a curve in parallel-coords view.
           <tf-scalar-card
             class="scalar-card"
             color-scale="[[_colorScale]]"
-            data-to-load="[[_computeSeriesForSessionGroupMetric(sessionGroup,
+            keys-to-load="[[_computeSeriesForSessionGroupMetric(sessionGroup,
                           metricInfo)]]"
             tag="[[metricInfo.name.tag]]"
             tag-metadata="[[_computeTagMetadata(metricInfo)]]"

--- a/tensorboard/plugins/pr_curve/polymer3/tf_pr_curve_dashboard/tf-pr-curve-card.ts
+++ b/tensorboard/plugins/pr_curve/polymer3/tf_pr_curve_dashboard/tf-pr-curve-card.ts
@@ -30,7 +30,7 @@ import * as vz_chart_helpers from '../../../../components_polymer3/vz_chart_help
 import * as _ from 'lodash';
 import * as Plottable from 'plottable';
 
-type RunItem = string;
+type RunKey = string;
 
 interface PrCurveDatum {
   wall_time: number;
@@ -57,7 +57,7 @@ export class TfPrCurveCard extends PolymerElement {
       default-y-range="[[_defaultYRange]]"
       smoothing-enabled="[[_smoothingEnabled]]"
       request-manager="[[requestManager]]"
-      data-to-load="[[runs]]"
+      keys-to-load="[[runs]]"
       data-series="[[runs]]"
       load-key="[[tag]]"
       request-data="[[_requestData]]"
@@ -274,21 +274,21 @@ export class TfPrCurveCard extends PolymerElement {
   _defaultYRange: number[] = [-0.05, 1.05];
 
   @property({type: Object})
-  _requestData: RequestDataCallback<RunItem, PrCurveDatum[]> = (
-    items,
+  _requestData: RequestDataCallback<RunKey, PrCurveDatum[]> = (
+    keys,
     onLoad,
     onFinish
   ) => {
     const router = getRouter();
     const baseUrl = router.pluginRoute('pr_curves', '/pr_curves');
     Promise.all(
-      items.map((item) => {
-        const run = item;
+      keys.map((key) => {
+        const run = key;
         const tag = this.tag;
         const url = addParams(baseUrl, {tag, run});
         return this.requestManager
           .request(url)
-          .then((data) => void onLoad({item, data}));
+          .then((value) => void onLoad({key, value}));
       })
     ).finally(() => void onFinish());
   };

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.html
@@ -46,7 +46,7 @@ limitations under the License.
       default-y-range="[[_defaultYRange]]"
       smoothing-enabled="[[_smoothingEnabled]]"
       request-manager="[[requestManager]]"
-      data-to-load="[[runs]]"
+      keys-to-load="[[runs]]"
       data-series="[[runs]]"
       load-key="[[tag]]"
       get-data-load-url="[[_dataUrl]]"

--- a/tensorboard/plugins/scalar/polymer3/tf_scalar_dashboard/tf-scalar-dashboard.ts
+++ b/tensorboard/plugins/scalar/polymer3/tf_scalar_dashboard/tf-scalar-dashboard.ts
@@ -155,7 +155,7 @@ class TfScalarDashboard extends LegacyElementMixin(ArrayUpdateHelper) {
               <template>
                 <tf-scalar-card
                   active="[[active]]"
-                  data-to-load="[[item.series]]"
+                  keys-to-load="[[item.series]]"
                   ignore-y-outliers="[[_ignoreYOutliers]]"
                   multi-experiments="[[_getMultiExperiments(dataSelection)]]"
                   request-manager="[[_requestManager]]"

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.html
@@ -46,7 +46,7 @@ limitations under the License.
         active="[[active]]"
         color-scale="[[_getColorScale(colorScale)]]"
         data-series="[[_getDataSeries(dataToLoad.*)]]"
-        data-to-load="[[dataToLoad]]"
+        keys-to-load="[[dataToLoad]]"
         get-data-load-name="[[_getDataLoadName]]"
         get-data-load-url="[[getDataLoadUrl]]"
         request-data="[[requestData]]"

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-dashboard.html
@@ -162,7 +162,7 @@ limitations under the License.
               <template>
                 <tf-scalar-card
                   active="[[active]]"
-                  data-to-load="[[item.series]]"
+                  keys-to-load="[[item.series]]"
                   ignore-y-outliers="[[_ignoreYOutliers]]"
                   multi-experiments="[[_getMultiExperiments(dataSelection)]]"
                   request-manager="[[_requestManager]]"


### PR DESCRIPTION
Summary:
These names were a bit confusing, especially since identifiers like
`dataToLoad` actually referred to “items” rather than “data”. Since the
module basically provides a key-value store, `K` and `V` should be
straightforward enough names.

Related replacements:

  - `s/dataToLoad/keysToLoad/`
  - `s/data-to-load/keys-to-load/`
  - `s/getDataLoadName/getCacheKey/`

Test Plan:
Checked the scalars, custom scalars, distributions, histograms, hparams,
and PR curves dashboards with their respective demo datasets.

wchargin-branch: dlb-rename-kv
