### PR TITLE
polymer3: fixed vz-projector-dashboard

### DIFF
--- a/tensorboard/plugins/projector/polymer3/vz_projector/vz-projector-dashboard.ts
+++ b/tensorboard/plugins/projector/polymer3/vz_projector/vz-projector-dashboard.ts
@@ -77,16 +77,20 @@ class VzProjectorDashboard extends PolymerElement {
   `;
   @property({type: Boolean})
   dataNotFound: boolean;
-  @property({
-    type: String,
-  })
+
+  @property({type: String})
   _routePrefix: string = '.';
+
   @property({type: Boolean})
   _initialized: boolean;
+
   reload() {
     // Do not reload the embedding projector. Reloading could take a long time.
   }
-  attached() {
+
+  connectedCallback() {
+    super.connectedCallback();
+
     if (this._initialized) {
       return;
     }


### PR DESCRIPTION
It was not bootstrapping correctly because it was using `attached` that
was not invoked (suspect that we need to use the LegacyElementMixin).
Instead of the mixin, we use `connectedCallback`, a web component API.

This is an alternative proposal to #4062. 