### PR TITLE
tsc: set `importHelpers` to avoid top-level `this`

### DIFF
--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -60,6 +60,7 @@ def tf_ts_library(strict_checks = True, **kwargs):
         tsconfig = "//:tsconfig-lax"
     elif "test_only" in kwargs and kwargs.get("test_only"):
         tsconfig = "//:tsconfig-test"
+    kwargs.setdefault("deps", []).append("@npm//tslib")
 
     ts_library(tsconfig = tsconfig, **kwargs)
 

--- a/tsconfig-lax.json
+++ b/tsconfig-lax.json
@@ -3,6 +3,7 @@
     "downlevelIteration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "importHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "lib": ["dom", "es2018"],

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "importHelpers": true,
     "types": ["jasmine"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "downlevelIteration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "importHelpers": true,
     "inlineSourceMap": true,
     "lib": ["dom", "es2018"],
     "moduleResolution": "node",


### PR DESCRIPTION
Summary:
By default, TypeScript’s downleveling helpers are inlined into each
source file, creating functions like `__decorate` and `__assign`. The
definition of `__decorate` in particular refers to `this` at top level,
which is `window` in non-strict mode and `undefined` in strict mode;
this causes a Rollup warning (or 80). This has been reported upstream,
but hasn’t yet been addressed:
<https://github.com/microsoft/TypeScript/issues/35802>

Fixes #4046.

By setting `"importHelpers": true` in the compiler config, we instruct
`tsc` to instead import these helpers from `tslib`, avoiding this issue.

Test Plan:
A spot-check of both statically loaded plugins and the projector plugin
doesn’t reveal any issues, and decorators are used for all custom
element registration so we know that the wiring is being exercised.
Rollup no longer issues this flavor of warning, as listed in #4046.

A test sync also indicates no issues, which is expected since these
configs and build rules are only used externally.

wchargin-branch: tsc-importhelpers
