### PR TITLE
rollup: remove useless success spam

### DIFF
--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -34,13 +34,9 @@ def tf_js_binary(compile, deps, **kwargs):
     rollup_bundle(
         config_file = "//tensorboard/defs:rollup_config.js",
         # Must pass `true` here specifically, else the input file argument to
-        # Rollup (added by `rollup_binary`) is interpreted as an option-value
-        # for `--failAfterWarnings`.
-<<<<<<< HEAD
+        # Rollup (appended by `rollup_binary`) is interpreted as a value for
+        # the preceding option.
         args = ["--failAfterWarnings", "true", "--silent", "true"],
-=======
-        args = ["--failAfterWarnings", "true"],
->>>>>>> 89fc8d0beafec8879adca8878b5dedbda14234a8
         deps = deps + [
             "@npm//@rollup/plugin-commonjs",
             "@npm//@rollup/plugin-node-resolve",

--- a/test.js
+++ b/test.js
@@ -1,1 +1,0 @@
-console.log('hey');


### PR DESCRIPTION
Summary:
By default, Rollup prints a bunch of messages whenever it successfully
processes a file. This patch disables that.

So, previously, running `bazel build //tensorboard` printed the
following output:

```
INFO: From Bundling JavaScript tensorboard/plugins/projector/polymer3/vz_projector/standalone_bundle.js [rollup]:

bazel-out/k8-fastbuild/bin/tensorboard/plugins/projector/polymer3/vz_projector/bundle.mjs → bazel-out/k8-fastbuild/bin/tensorboard/plugins/projector/polymer3/vz_projector/standalone_bundle.js...
created bazel-out/k8-fastbuild/bin/tensorboard/plugins/projector/polymer3/vz_projector/standalone_bundle.js in 12.6s
INFO: From Bundling JavaScript tensorboard/components_polymer3/polymer3_lib_binary_no_shim.js [rollup]:

bazel-out/k8-fastbuild/bin/tensorboard/components_polymer3/polymer3_lib.mjs → bazel-out/k8-fastbuild/bin/tensorboard/components_polymer3/polymer3_lib_binary_no_shim.js...
created bazel-out/k8-fastbuild/bin/tensorboard/components_polymer3/polymer3_lib_binary_no_shim.js in 14s
INFO: From Bundling JavaScript tensorboard/webapp/tb_webapp_binary.js [rollup]:

bazel-out/k8-fastbuild/bin/tensorboard/webapp/main_prod.mjs → bazel-out/k8-fastbuild/bin/tensorboard/webapp/tb_webapp_binary.js...
created bazel-out/k8-fastbuild/bin/tensorboard/webapp/tb_webapp_binary.js in 5.2s
```

Now, it prints nothing of the sort.

Note that although Rollup’s `--silent` generally suppresses warnings, we
also set `--failAfterWarnings`, and these interact in the desired
fashion: i.e., warnings still fail the build, and are still printed.

Test Plan:
Change the `onwarn` handler in `rollup_config.js` to stop suppressing
some of the warnings, and note that `bazel build //tensorboard` still
fails accordingly.

wchargin-branch: rollup-remove-success-spam
