### PR TITLE
ci: disallow importing directly from angular/material and cdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,10 @@ jobs:
         # Make sure no tests are skipped with "focused" tests.
       - run: |
           ! git grep -E 'f(it|describe)\(' 'tensorboard/*_test.ts'
+        # Make sure no one depends on Angular material and CDK directly. Please
+        # import the indirection in //tensorboard/webapp/angular.
+      - run: |
+          ! git grep -E '"@npm//@angular/material"|"@npm//@angular/cdk"' 'tensorboard/*/BUILD' ':!tensorboard/webapp/BUILD' ':!tensorboard/webapp/angular/BUILD'
 
   lint-build:
     runs-on: ubuntu-16.04


### PR DESCRIPTION
Due to the internal build quirks, we cannot import the hourglass dependency for the
angular material using "@npm//@angular/material" (and likewise for cdk). Instead,
we need to import a specific module and the indirection helps with that.

Over some time, we've made the same mistake over and over and this change catches
the mistake at the PR time. 

This change is expected to fail since npmi currently violates the rule.
The issue is expected to be addressed in #4082