### PR TITLE
chore: remove comment after licenses in BUILD

### DIFF
--- a/tensorboard/backend/BUILD
+++ b/tensorboard/backend/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/backend/event_processing/BUILD
+++ b/tensorboard/backend/event_processing/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/compat/BUILD
+++ b/tensorboard/compat/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/compat/proto/BUILD
+++ b/tensorboard/compat/proto/BUILD
@@ -5,7 +5,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/compat/tensorflow_stub/BUILD
+++ b/tensorboard/compat/tensorflow_stub/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/components/tensor_widget/BUILD
+++ b/tensorboard/components/tensor_widget/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 genrule(
     name = "gen_tensor_widget_style",

--- a/tensorboard/components/tf_imports/BUILD
+++ b/tensorboard/components/tf_imports/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_web_library(
     name = "webcomponentsjs",

--- a/tensorboard/components_polymer3/BUILD
+++ b/tensorboard/components_polymer3/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "polymer3_ts_lib",

--- a/tensorboard/components_polymer3/experimental/plugin_lib/BUILD
+++ b/tensorboard/components_polymer3/experimental/plugin_lib/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 # TODO(psybuzz): create a NPM package when a better requirement comes up using
 # tf_js_binary.

--- a/tensorboard/components_polymer3/experimental/plugin_util/BUILD
+++ b/tensorboard/components_polymer3/experimental/plugin_util/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "message",

--- a/tensorboard/components_polymer3/polymer/BUILD
+++ b/tensorboard/components_polymer3/polymer/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "dom",

--- a/tensorboard/components_polymer3/tf_backend/BUILD
+++ b/tensorboard/components_polymer3/tf_backend/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_backend",

--- a/tensorboard/components_polymer3/tf_card_heading/BUILD
+++ b/tensorboard/components_polymer3/tf_card_heading/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_card_heading",

--- a/tensorboard/components_polymer3/tf_categorization_utils/BUILD
+++ b/tensorboard/components_polymer3/tf_categorization_utils/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_categorization_utils",

--- a/tensorboard/components_polymer3/tf_color_scale/BUILD
+++ b/tensorboard/components_polymer3/tf_color_scale/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_color_scale",

--- a/tensorboard/components_polymer3/tf_dashboard_common/BUILD
+++ b/tensorboard/components_polymer3/tf_dashboard_common/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_dashboard_common",

--- a/tensorboard/components_polymer3/tf_globals/BUILD
+++ b/tensorboard/components_polymer3/tf_globals/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_globals",

--- a/tensorboard/components_polymer3/tf_line_chart_data_loader/BUILD
+++ b/tensorboard/components_polymer3/tf_line_chart_data_loader/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_line_chart_data_loader",

--- a/tensorboard/components_polymer3/tf_markdown_view/BUILD
+++ b/tensorboard/components_polymer3/tf_markdown_view/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_markdown_view",

--- a/tensorboard/components_polymer3/tf_paginated_view/BUILD
+++ b/tensorboard/components_polymer3/tf_paginated_view/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_paginated_view",

--- a/tensorboard/components_polymer3/tf_runs_selector/BUILD
+++ b/tensorboard/components_polymer3/tf_runs_selector/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_runs_selector",

--- a/tensorboard/components_polymer3/tf_storage/BUILD
+++ b/tensorboard/components_polymer3/tf_storage/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_storage",

--- a/tensorboard/components_polymer3/tf_utils/BUILD
+++ b/tensorboard/components_polymer3/tf_utils/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_utils",

--- a/tensorboard/components_polymer3/tf_wbr_string/BUILD
+++ b/tensorboard/components_polymer3/tf_wbr_string/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_wbr_string",

--- a/tensorboard/components_polymer3/vz_chart_helpers/BUILD
+++ b/tensorboard/components_polymer3/vz_chart_helpers/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "vz_chart_helpers",

--- a/tensorboard/components_polymer3/vz_line_chart2/BUILD
+++ b/tensorboard/components_polymer3/vz_line_chart2/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "dragZoomInteraction",

--- a/tensorboard/components_polymer3/vz_sorting/BUILD
+++ b/tensorboard/components_polymer3/vz_sorting/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "vz_sorting",

--- a/tensorboard/data/BUILD
+++ b/tensorboard/data/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/data/experimental/BUILD
+++ b/tensorboard/data/experimental/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/defs/BUILD
+++ b/tensorboard/defs/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 filegroup(
     name = "tf_web_library_default_typings",

--- a/tensorboard/examples/plugins/example_basic/BUILD
+++ b/tensorboard/examples/plugins/example_basic/BUILD
@@ -7,7 +7,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 sh_test(
     name = "smoke_test",

--- a/tensorboard/examples/plugins/example_raw_scalars/BUILD
+++ b/tensorboard/examples/plugins/example_raw_scalars/BUILD
@@ -7,7 +7,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 sh_test(
     name = "smoke_test",

--- a/tensorboard/functionaltests/browsers/BUILD
+++ b/tensorboard/functionaltests/browsers/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_webtesting//web:web.bzl", "browser")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 config_setting(
     name = "mac",

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 java_binary(
     name = "Vulcanize",

--- a/tensorboard/logo/BUILD
+++ b/tensorboard/logo/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/pip_package/BUILD
+++ b/tensorboard/pip_package/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//visibility:private"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 genrule(
     name = "pip_package",

--- a/tensorboard/plugins/BUILD
+++ b/tensorboard/plugins/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/audio/BUILD
+++ b/tensorboard/plugins/audio/BUILD
@@ -5,7 +5,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/audio/polymer3/tf_audio_dashboard/BUILD
+++ b/tensorboard/plugins/audio/polymer3/tf_audio_dashboard/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_audio_dashboard",

--- a/tensorboard/plugins/core/BUILD
+++ b/tensorboard/plugins/core/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/custom_scalar/BUILD
+++ b/tensorboard/plugins/custom_scalar/BUILD
@@ -5,7 +5,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/custom_scalar/polymer3/tf_custom_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/custom_scalar/polymer3/tf_custom_scalar_dashboard/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_custom_scalar_dashboard",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ng_web_test_suite", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 # TODO(cais): Consider replacing old debuger plugin with this before launch,
 # instead of having two versions of debugger co-exist, which may be confusing to

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/actions/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.
+licenses(["notice"])
 
 tf_ts_library(
     name = "actions",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "alerts",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "debug_tensor_value",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "execution_data",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "graph",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "graph_executions",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/BUILD
@@ -2,7 +2,7 @@ load("@npm_angular_bazel//:index.bzl", "ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 py_binary(
     name = "inline_images",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "source_code",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/monaco/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_code/monaco/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:web.bzl", "tf_web_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_web_library(
     name = "requirejs",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "source_files",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "stack_trace",

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/BUILD
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "timeline",

--- a/tensorboard/plugins/distribution/BUILD
+++ b/tensorboard/plugins/distribution/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/distribution/polymer3/tf_distribution_dashboard/BUILD
+++ b/tensorboard/plugins/distribution/polymer3/tf_distribution_dashboard/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_distribution_dashboard",

--- a/tensorboard/plugins/distribution/polymer3/vz_distribution_chart/BUILD
+++ b/tensorboard/plugins/distribution/polymer3/vz_distribution_chart/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "vz_distribution_chart",

--- a/tensorboard/plugins/graph/BUILD
+++ b/tensorboard/plugins/graph/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/graph/polymer3/tf_graph/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_graph",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_app/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_app/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_graph_app",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_board/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_board/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_graph_board",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_common/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_common/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_graph_common",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_controls/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_controls/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_graph_controls",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_dashboard/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_dashboard/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_graph_dashboard",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_debugger_data_card/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_debugger_data_card/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_graph_debugger_data_card",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_info/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_info/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_graph_info",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_loader/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_loader/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_graph_loader",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_node_search/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_node_search/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_graph_node_search",

--- a/tensorboard/plugins/graph/polymer3/tf_graph_op_compat_card/BUILD
+++ b/tensorboard/plugins/graph/polymer3/tf_graph_op_compat_card/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_graph_op_compat_card",

--- a/tensorboard/plugins/histogram/BUILD
+++ b/tensorboard/plugins/histogram/BUILD
@@ -5,7 +5,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/histogram/polymer3/tf_histogram_dashboard/BUILD
+++ b/tensorboard/plugins/histogram/polymer3/tf_histogram_dashboard/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_histogram_dashboard",

--- a/tensorboard/plugins/histogram/polymer3/vz_histogram_timeseries/BUILD
+++ b/tensorboard/plugins/histogram/polymer3/vz_histogram_timeseries/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "vz_histogram_timeseries",

--- a/tensorboard/plugins/hparams/BUILD
+++ b/tensorboard/plugins/hparams/BUILD
@@ -6,7 +6,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/hparams/polymer3/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "types",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_backend/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_backend/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_backend",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_dashboard/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_dashboard/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_dashboard",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_main/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_main/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_main",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_parallel_coords_plot/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_parallel_coords_plot/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard/plugins/hparams:__subpackages__"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_parallel_coords_plot",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_parallel_coords_view/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_parallel_coords_view/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 package(default_visibility =
             ["//tensorboard/plugins/hparams:__subpackages__"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_parallel_coords_view",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_query_pane/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_query_pane/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 package(default_visibility =
             ["//tensorboard/plugins/hparams:__subpackages__"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "schema_d_ts",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_scale_and_color_controls/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_scale_and_color_controls/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 package(default_visibility =
             ["//tensorboard/plugins/hparams:__subpackages__"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_scale_and_color_controls",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_scatter_plot_matrix_plot/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_scatter_plot_matrix_plot/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 package(default_visibility =
             ["//tensorboard/plugins/hparams:__subpackages__"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_scatter_plot_matrix_plot",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_scatter_plot_matrix_view/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_scatter_plot_matrix_view/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 package(default_visibility =
             ["//tensorboard/plugins/hparams:__subpackages__"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_scatter_plot_matrix_view",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_session_group_details/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_session_group_details/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 package(default_visibility =
             ["//tensorboard/plugins/hparams:__subpackages__"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_session_group_details",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_session_group_values/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_session_group_values/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 package(default_visibility =
             ["//tensorboard/plugins/hparams:__subpackages__"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_session_group_values",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_sessions_pane/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_sessions_pane/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 package(default_visibility =
             ["//tensorboard/plugins/hparams:__subpackages__"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_sessions_pane",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_table_view/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_table_view/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 package(default_visibility =
             ["//tensorboard/plugins/hparams:__subpackages__"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_table_view",

--- a/tensorboard/plugins/hparams/polymer3/tf_hparams_utils/BUILD
+++ b/tensorboard/plugins/hparams/polymer3/tf_hparams_utils/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 package(default_visibility =
             ["//tensorboard/plugins/hparams:__subpackages__"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_hparams_utils",

--- a/tensorboard/plugins/image/BUILD
+++ b/tensorboard/plugins/image/BUILD
@@ -5,7 +5,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/image/polymer3/tf_image_dashboard/BUILD
+++ b/tensorboard/plugins/image/polymer3/tf_image_dashboard/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_image_dashboard",

--- a/tensorboard/plugins/mesh/BUILD
+++ b/tensorboard/plugins/mesh/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/mesh/polymer3/tf_mesh_dashboard/BUILD
+++ b/tensorboard/plugins/mesh/polymer3/tf_mesh_dashboard/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_mesh_dashboard",

--- a/tensorboard/plugins/pr_curve/BUILD
+++ b/tensorboard/plugins/pr_curve/BUILD
@@ -5,7 +5,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 py_library(
     name = "metadata",

--- a/tensorboard/plugins/pr_curve/polymer3/tf_pr_curve_dashboard/BUILD
+++ b/tensorboard/plugins/pr_curve/polymer3/tf_pr_curve_dashboard/BUILD
@@ -16,7 +16,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_pr_curve_dashboard",

--- a/tensorboard/plugins/profile_redirect/BUILD
+++ b/tensorboard/plugins/profile_redirect/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard/BUILD
+++ b/tensorboard/plugins/profile_redirect/polymer3/tf_profile_redirect_dashboard/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_profile_redirect_dashboard",

--- a/tensorboard/plugins/projector/BUILD
+++ b/tensorboard/plugins/projector/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/projector/polymer3/tf_projector_plugin/BUILD
+++ b/tensorboard/plugins/projector/polymer3/tf_projector_plugin/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_web_library(
     name = "projector_assets",

--- a/tensorboard/plugins/projector/polymer3/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/polymer3/vz_projector/BUILD
@@ -4,7 +4,7 @@ load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "vz_projector",

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -5,7 +5,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/scalar/polymer3/tf_scalar_dashboard/BUILD
+++ b/tensorboard/plugins/scalar/polymer3/tf_scalar_dashboard/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_scalar_dashboard",

--- a/tensorboard/plugins/text/BUILD
+++ b/tensorboard/plugins/text/BUILD
@@ -5,7 +5,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/plugins/text/polymer3/tf_text_dashboard/BUILD
+++ b/tensorboard/plugins/text/polymer3/tf_text_dashboard/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "tf_text_dashboard",

--- a/tensorboard/scripts/BUILD
+++ b/tensorboard/scripts/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/summary/BUILD
+++ b/tensorboard/summary/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 py_library(
     name = "summary",

--- a/tensorboard/summary/writer/BUILD
+++ b/tensorboard/summary/writer/BUILD
@@ -2,7 +2,7 @@
 # Writer interfaces for TensorBoard if tensorflow is not present
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/tools/BUILD
+++ b/tensorboard/tools/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 py_binary(
     name = "import_google_fonts",

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/uploader/proto/BUILD
+++ b/tensorboard/uploader/proto/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/tensorboard/util/BUILD
+++ b/tensorboard/util/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:protos.bzl", "tb_proto_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])  # Needed for internal repo.
 

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -5,7 +5,7 @@ load("//tensorboard/defs:vulcanize.bzl", "tensorboard_html_binary")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "oss_plugins_module",

--- a/tensorboard/webapp/angular/BUILD
+++ b/tensorboard/webapp/angular/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 # This is a dummy rule used as a @angular/common/http dependency.
 # This is not a replacement for @angular/common dependency.

--- a/tensorboard/webapp/header/BUILD
+++ b/tensorboard/webapp/header/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_sass_binary(
     name = "styles",

--- a/tensorboard/webapp/plugins/BUILD
+++ b/tensorboard/webapp/plugins/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "plugins",

--- a/tensorboard/webapp/plugins/npmi/BUILD
+++ b/tensorboard/webapp/plugins/npmi/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_sass_binary(
     name = "npmi_component_styles",

--- a/tensorboard/webapp/plugins/npmi/actions/BUILD
+++ b/tensorboard/webapp/plugins/npmi/actions/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.
+licenses(["notice"])
 
 tf_ts_library(
     name = "actions",

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_sass_binary(
     name = "data_selection_component_styles",

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_sass_binary(
     name = "metric_search_component_styles",

--- a/tensorboard/webapp/plugins/npmi/views/inactive/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/inactive/BUILD
@@ -2,7 +2,7 @@ load("@npm_angular_bazel//:index.bzl", "ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "inactive",

--- a/tensorboard/webapp/plugins/npmi/views/main/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/main/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_sass_binary(
     name = "main_component_styles",

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_sass_binary(
     name = "violin_filters_component_styles",

--- a/tensorboard/webapp/plugins/testing/BUILD
+++ b/tensorboard/webapp/plugins/testing/BUILD
@@ -2,7 +2,7 @@ load("@npm_angular_bazel//:index.bzl", "ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "testing",

--- a/tensorboard/webapp/plugins/text_v2/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "text_v2",

--- a/tensorboard/webapp/plugins/text_v2/actions/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/actions/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.
+licenses(["notice"])
 
 tf_ts_library(
     name = "actions",

--- a/tensorboard/webapp/plugins/text_v2/views/text_dashboard/BUILD
+++ b/tensorboard/webapp/plugins/text_v2/views/text_dashboard/BUILD
@@ -2,7 +2,7 @@ load("@npm_angular_bazel//:index.bzl", "ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "text_dashboard",

--- a/tensorboard/webapp/theme/BUILD
+++ b/tensorboard/webapp/theme/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_sass_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_sass_library(
     name = "theme",

--- a/tensorboard/webapp/third_party/BUILD
+++ b/tensorboard/webapp/third_party/BUILD
@@ -2,7 +2,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_ts_library(
     name = "d3",


### PR DESCRIPTION
Internal rule on no comment on license is becoming a lot more annoying.
This change basically conform to the new standard.

Command used:
```bash
find tensorboard -name BUILD  | xargs sed -i 's|licenses(\["notice"\])  # Apache 2.0|licenses(["notice"])|g'
git diff --name-only | xargs buildifier
```