### PR TITLE
[infra] updating Travis cache with fetch-only flow (1/3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,14 +92,16 @@ before_script:
 # categorize them as 'failed', rather than 'error' for other sections.
 script:
   - elapsed "script"
+  # TODO: re-enable the bazel build, tests by 8/28/20.
+  # See https://github.com/tensorflow/tensorboard/issues/4091
   # Note: bazel test implies fetch+build, but this gives us timing.
   - elapsed && bazel fetch //tensorboard/...
-  - elapsed && bazel build //tensorboard/...
-  - elapsed && bazel test //tensorboard/... --test_tag_filters="${test_tag_filters}"
-  - elapsed && bazel run //tensorboard/pip_package:test_pip_package -- --tf-version "${TF_VERSION_ID}"
-  # Run manual S3 test
-  - elapsed && bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test
-  - elapsed && bazel test //tensorboard/summary/writer:event_file_writer_s3_test
+  # - elapsed && bazel build //tensorboard/...
+  # - elapsed && bazel test //tensorboard/... --test_tag_filters="${test_tag_filters}"
+  # - elapsed && bazel run //tensorboard/pip_package:test_pip_package -- --tf-version "${TF_VERSION_ID}"
+  # # Run manual S3 test
+  # - elapsed && bazel test //tensorboard/compat/tensorflow_stub:gfile_s3_test
+  # - elapsed && bazel test //tensorboard/summary/writer:event_file_writer_s3_test
   - elapsed "script (done)"
 
 after_script:


### PR DESCRIPTION
This change should have no visible effect to the product.
The Travis flow is updated to ignore the build, test steps that
come after the `bazel fetch`.

2 followups will re-add bazel build, test steps to rebuild the
Travis cache.

See https://github.com/tensorflow/tensorboard/issues/4091