### PR TITLE
[infra] update Travis cache with built components_polymer3 (part 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,11 +92,13 @@ before_script:
 # categorize them as 'failed', rather than 'error' for other sections.
 script:
   - elapsed "script"
-  # TODO: re-enable the bazel tests by 8/28/20.
+  # [cache-update] TODO: re-enable the bazel tests by 8/28/20.
   # See https://github.com/tensorflow/tensorboard/issues/4091
   # Note: bazel test implies fetch+build, but this gives us timing.
   - elapsed && bazel fetch //tensorboard/...
-  - elapsed && bazel build //tensorboard/...
+  - elapsed && bazel build //tensorboard/components_polymer3/...
+  # [cache-update] Original workflow below
+  # - elapsed && bazel build //tensorboard/...
   # - elapsed && bazel test //tensorboard/... --test_tag_filters="${test_tag_filters}"
   # - elapsed && bazel run //tensorboard/pip_package:test_pip_package -- --tf-version "${TF_VERSION_ID}"
   # # Run manual S3 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,11 +92,11 @@ before_script:
 # categorize them as 'failed', rather than 'error' for other sections.
 script:
   - elapsed "script"
-  # TODO: re-enable the bazel build, tests by 8/28/20.
+  # TODO: re-enable the bazel tests by 8/28/20.
   # See https://github.com/tensorflow/tensorboard/issues/4091
   # Note: bazel test implies fetch+build, but this gives us timing.
   - elapsed && bazel fetch //tensorboard/...
-  # - elapsed && bazel build //tensorboard/...
+  - elapsed && bazel build //tensorboard/...
   # - elapsed && bazel test //tensorboard/... --test_tag_filters="${test_tag_filters}"
   # - elapsed && bazel run //tensorboard/pip_package:test_pip_package -- --tf-version "${TF_VERSION_ID}"
   # # Run manual S3 test


### PR DESCRIPTION
This change should have no visible effect to the product.
The Travis flow is updated to reinstate the build step, but
keep ignored the test steps that come after the `bazel build`.

This PR adds the components_polymer3/ dir to the bazel build
step.  Followups will re-add remaining steps.

See https://github.com/tensorflow/tensorboard/issues/4091