### PR TITLE
core: fix `--window_title` in Angular TensorBoard

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -53,6 +53,7 @@ ng_module(
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/core/views:hash_storage",
+        "//tensorboard/webapp/core/views:page_title",
         "//tensorboard/webapp/feature_flag",
         "//tensorboard/webapp/header",
         "//tensorboard/webapp/plugins",

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -21,6 +21,7 @@ import {EffectsModule} from '@ngrx/effects';
 import {AppContainer} from './app_container';
 import {CoreModule} from './core/core_module';
 import {HashStorageModule} from './core/views/hash_storage_module';
+import {PageTitleModule} from './core/views/page_title_module';
 import {FeatureFlagModule} from './feature_flag/feature_flag_module';
 import {HeaderModule} from './header/header_module';
 import {MatIconModule} from './mat_icon_module';
@@ -40,6 +41,7 @@ import {OssPluginsModule} from './oss_plugins_module';
     HashStorageModule,
     HeaderModule,
     MatIconModule,
+    PageTitleModule,
     PluginsModule,
     ReloaderModule,
     SettingsModule,

--- a/tensorboard/webapp/core/views/BUILD
+++ b/tensorboard/webapp/core/views/BUILD
@@ -20,6 +20,22 @@ ng_module(
     ],
 )
 
+ng_module(
+    name = "page_title",
+    srcs = [
+        "page_title_component.ts",
+        "page_title_container.ts",
+        "page_title_module.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/core/store",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)
+
 tf_ts_library(
     name = "test_lib",
     testonly = True,

--- a/tensorboard/webapp/core/views/page_title_component.ts
+++ b/tensorboard/webapp/core/views/page_title_component.ts
@@ -1,0 +1,37 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
+
+@Component({
+  selector: 'page-title-component',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PageTitleComponent implements OnChanges {
+  @Input()
+  title!: string | null;
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['title'] != null) {
+      document.title = changes['title'].currentValue;
+    }
+  }
+}

--- a/tensorboard/webapp/core/views/page_title_component.ts
+++ b/tensorboard/webapp/core/views/page_title_component.ts
@@ -27,10 +27,10 @@ import {
 })
 export class PageTitleComponent implements OnChanges {
   @Input()
-  title!: string | null;
+  title!: string;
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes['title'] != null) {
+    if (changes['title']) {
       document.title = changes['title'].currentValue;
     }
   }

--- a/tensorboard/webapp/core/views/page_title_container.ts
+++ b/tensorboard/webapp/core/views/page_title_container.ts
@@ -24,7 +24,7 @@ import {State} from '../store/core_types';
 @Component({
   selector: 'page-title',
   template: `
-    <page-title-component [title]="title$ | async"> </page-title-component>
+    <page-title-component [title]="title$ | async"></page-title-component>
   `,
   styles: [
     `

--- a/tensorboard/webapp/core/views/page_title_container.ts
+++ b/tensorboard/webapp/core/views/page_title_container.ts
@@ -1,0 +1,47 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {Store, select} from '@ngrx/store';
+import {distinctUntilChanged, map} from 'rxjs/operators';
+
+import {getEnvironment} from '../store';
+import {State} from '../store/core_types';
+
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+
+@Component({
+  selector: 'page-title',
+  template: `
+    <page-title-component [title]="title$ | async"> </page-title-component>
+  `,
+  styles: [
+    `
+      :host {
+        display: none;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PageTitleContainer {
+  readonly title$ = this.store.pipe(
+    select(getEnvironment),
+    map((env) => env.window_title || 'TensorBoard'),
+    // (it's an empty string when the `--window_title` flag is not set)
+    distinctUntilChanged()
+  );
+
+  constructor(private readonly store: Store<State>) {}
+}

--- a/tensorboard/webapp/core/views/page_title_module.ts
+++ b/tensorboard/webapp/core/views/page_title_module.ts
@@ -1,6 +1,4 @@
-<!--
-@license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,11 +11,16 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
+==============================================================================*/
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
-<app-header></app-header>
-<plugins class="plugins"></plugins>
-<reloader></reloader>
-<hash-storage></hash-storage>
-<page-title></page-title>
-<settings-polymer-interop></settings-polymer-interop>
+import {PageTitleContainer} from './page_title_container';
+import {PageTitleComponent} from './page_title_component';
+
+@NgModule({
+  declarations: [PageTitleContainer, PageTitleComponent],
+  exports: [PageTitleContainer],
+  imports: [CommonModule],
+})
+export class PageTitleModule {}


### PR DESCRIPTION
Summary:
This behavior is slightly different from Polymer TensorBoard, in that if
the window title is set but then the server restarts and the window
title is no longer set, it will revert to “TensorBoard” instead of
retaining its previous value.

This implementation uses a new view instead of an effect so that we can
read the environment information from the store without violating our
policies about composite actions.

Test Plan:
Launch TensorBoard with `--window_title one`, and note that the title is
properly set. Keep the frontend open, and relaunch the server with
`--window_title two`. Press the in-app “Reload” button, and verify that
the title updates. Finally, relaunch the server with no `--window_title`
and verify that the frontend resets the title to “TensorBoard”.

No TypeScript tests because I can’t think of anything that would go
wrong without being caught by the type system.

wchargin-branch: ng-window-title
