### PR TITLE
refactor: remove analytics.html dependency

### DIFF
--- a/tensorboard/plugins/projector/polymer3/vz_projector/BUILD
+++ b/tensorboard/plugins/projector/polymer3/vz_projector/BUILD
@@ -55,6 +55,7 @@ tf_ts_library(
         ":bh_tsne",
         ":heap",
         ":sptree",
+        "//tensorboard/components_polymer3:analytics",
         "//tensorboard/components_polymer3:security",
         "//tensorboard/components_polymer3/polymer:irons_and_papers",
         "//tensorboard/components_polymer3/polymer:legacy_element_mixin",
@@ -110,7 +111,6 @@ tf_web_library(
     path = "/",
     deps = [
         "//tensorboard/components/tf_imports:roboto",
-        "//tensorboard/components_polymer3:analytics_html",
     ],
 )
 

--- a/tensorboard/plugins/projector/polymer3/vz_projector/bundle.ts
+++ b/tensorboard/plugins/projector/polymer3/vz_projector/bundle.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import '../../../../components_polymer3/analytics';
 import '../../../../components_polymer3/security';
 
 import './styles';

--- a/tensorboard/plugins/projector/polymer3/vz_projector/standalone_lib.html
+++ b/tensorboard/plugins/projector/polymer3/vz_projector/standalone_lib.html
@@ -30,7 +30,8 @@ limitations under the License.
     <meta http-equiv="pragma" content="no-cache" />
 
     <link rel="import" href="../tf-imports/roboto.html" />
-    <link rel="import" href="../analytics.html" />
+
+    <script jscomp-ignore src="standalone_bundle.js"></script>
     <script>
       (function(i, s, o, g, r, a, m) {
         i['GoogleAnalyticsObject'] = r;
@@ -54,7 +55,6 @@ limitations under the License.
 
       ga('create', 'UA-46457317-5', 'auto');
     </script>
-    <script jscomp-ignore src="standalone_bundle.js"></script>
 
     <title>Embedding projector - visualization of high-dimensional data</title>
     <style>


### PR DESCRIPTION
Remove dependency on HTML based analytics.

Because now we need to provide `ga` symbol, we moved the import order.