### PR TITLE
[infra] bump 'virtualenv' dev dependency version

### DIFF
--- a/tensorboard/pip_package/requirements_dev.txt
+++ b/tensorboard/pip_package/requirements_dev.txt
@@ -28,4 +28,4 @@ flake8==3.7.8
 yamllint==1.17.0
 
 # For building Pip package
-virtualenv==16.7.7
+virtualenv==20.0.31

--- a/tensorboard/pip_package/test_pip_package.sh
+++ b/tensorboard/pip_package/test_pip_package.sh
@@ -113,7 +113,7 @@ smoke() (
   set -x
 
   command -v "${smoke_python}" >/dev/null
-  virtualenv -qp "${smoke_python}" "${smoke_venv}"
+  virtualenv -q -p "${smoke_python}" "${smoke_venv}"
   cd "${smoke_venv}"
 
   export VIRTUAL_ENV=venv


### PR DESCRIPTION
On 8/31/2020, CI runs for PRs started failing with the error (see [1])
on tf-nightly jobs.
`ModuleNotFoundError: No module named 'setuptools'`

This unblocks the broken CI by bumping the dev dependency on
`virtualenv`. One side effect is we now need to specify arguments
to virtualenv separately, otherwise `virtualenv -qp ...` throws:

`virtualenv: error: argument -q/--quiet: ignored explicit argument 'p'`

Tested locally by running these:
`bazel run //tensorboard/pip_package:test_pip_package -- --tf-version ""`
`bazel run //tensorboard/pip_package:test_pip_package -- --tf-version tf-nightly`

[1] https://travis-ci.org/github/tensorflow/tensorboard/jobs/722758663