### PR TITLE
chore: misc sync fixes (unused in workspace.bzl, license comments)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: 'Lint BUILD files'
         # TODO(tensorboard-team): address all lint warnings and remove the exemption.
         run:
-          git ls-files -z '*BUILD' third_party/js.bzl | xargs -0 buildifier --mode=check --lint=warn
+          git ls-files -z '*BUILD' third_party/js.bzl third_party/workspace.bzl | xargs -0 buildifier --mode=check --lint=warn
           --warnings=-native-py,-native-java
       - run: ./tensorboard/tools/mirror_urls_test.sh
       - name: 'Lint for no py2 BUILD targets'

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_sass_binary(
     name = "metric_arithmetic_component_styles",

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 tf_sass_binary(
     name = "metric_arithmetic_element_component_styles",

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_operator/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_operator/BUILD
@@ -3,7 +3,7 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 ng_module(
     name = "metric_arithmetic_operator",

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -16,7 +16,6 @@
 TensorBoard external dependencies that can be loaded in WORKSPACE files.
 """
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 load("@io_bazel_rules_webtesting//web/internal:platform_http_file.bzl", "platform_http_file")
 load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
@@ -36,18 +35,6 @@ def tensorboard_workspace():
 
     # Set up TypeScript toolchain.
     ts_setup_workspace()
-
-    http_archive(
-        name = "com_google_protobuf_js",
-        # NOTE: keep the version in sync with the protobuf/protoc version from TF in WORKSPACE.
-        sha256 = "1fbf1c2962af287607232b2eddeaec9b4f4a7a6f5934e1a9276e9af76952f7e0",
-        strip_prefix = "protobuf-3.9.2/js",
-        urls = [
-            "http://mirror.tensorflow.org/github.com/google/protobuf/archive/v3.9.2.tar.gz",
-            "https://github.com/google/protobuf/archive/v3.9.2.tar.gz",
-        ],
-        build_file = "@io_bazel_rules_closure//closure/protobuf:protobuf_js.BUILD",
-    )
 
     # Protobuf's BUILD file depends on //external:six.
     native.bind(

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -17,7 +17,7 @@ TensorBoard external dependencies that can be loaded in WORKSPACE files.
 """
 
 load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
-load("@io_bazel_rules_webtesting//web/internal:platform_http_file.bzl", "platform_http_file")
+load("@io_bazel_rules_webtesting//web/internal:platform_http_file.bzl", "platform_http_file")  # buildifier: disable=bzl-visibility
 load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
 load("//third_party:fonts.bzl", "tensorboard_fonts_workspace")
 load("//third_party:polymer.bzl", "tensorboard_polymer_workspace")
@@ -25,8 +25,12 @@ load("//third_party:python.bzl", "tensorboard_python_workspace")
 load("//third_party:js.bzl", "tensorboard_js_workspace")
 load("//third_party:typings.bzl", "tensorboard_typings_workspace")
 
-def tensorboard_workspace():
-    """Add repositories needed to build TensorBoard."""
+def tensorboard_workspace(name = ""):
+    """Add repositories needed to build TensorBoard.
+
+    Args:
+        name: name of Bazel rule passed to this macro. The value is ignored.
+    """
     tensorboard_fonts_workspace()
     tensorboard_polymer_workspace()
     tensorboard_python_workspace()

--- a/third_party/workspace.bzl
+++ b/third_party/workspace.bzl
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TensorBoard external dependencies that can be loaded in WORKSPACE files.
+"""
+TensorBoard external dependencies that can be loaded in WORKSPACE files.
+"""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
-load("@io_bazel_rules_closure//closure:defs.bzl", "filegroup_external")
-load("@io_bazel_rules_closure//closure:defs.bzl", "web_library_external")
 load("@io_bazel_rules_webtesting//web/internal:platform_http_file.bzl", "platform_http_file")
 load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
 load("//third_party:fonts.bzl", "tensorboard_fonts_workspace")
@@ -27,90 +27,90 @@ load("//third_party:js.bzl", "tensorboard_js_workspace")
 load("//third_party:typings.bzl", "tensorboard_typings_workspace")
 
 def tensorboard_workspace():
-  """Add repositories needed to build TensorBoard."""
-  tensorboard_fonts_workspace()
-  tensorboard_polymer_workspace()
-  tensorboard_python_workspace()
-  tensorboard_typings_workspace()
-  tensorboard_js_workspace()
+    """Add repositories needed to build TensorBoard."""
+    tensorboard_fonts_workspace()
+    tensorboard_polymer_workspace()
+    tensorboard_python_workspace()
+    tensorboard_typings_workspace()
+    tensorboard_js_workspace()
 
-  # Set up TypeScript toolchain.
-  ts_setup_workspace()
+    # Set up TypeScript toolchain.
+    ts_setup_workspace()
 
-  http_archive(
-      name = "com_google_protobuf_js",
-      # NOTE: keep the version in sync with the protobuf/protoc version from TF in WORKSPACE.
-      sha256 = "1fbf1c2962af287607232b2eddeaec9b4f4a7a6f5934e1a9276e9af76952f7e0",
-      strip_prefix = "protobuf-3.9.2/js",
-      urls = [
-          "http://mirror.tensorflow.org/github.com/google/protobuf/archive/v3.9.2.tar.gz",
-          "https://github.com/google/protobuf/archive/v3.9.2.tar.gz",
-      ],
-      build_file = "@io_bazel_rules_closure//closure/protobuf:protobuf_js.BUILD",
-  )
+    http_archive(
+        name = "com_google_protobuf_js",
+        # NOTE: keep the version in sync with the protobuf/protoc version from TF in WORKSPACE.
+        sha256 = "1fbf1c2962af287607232b2eddeaec9b4f4a7a6f5934e1a9276e9af76952f7e0",
+        strip_prefix = "protobuf-3.9.2/js",
+        urls = [
+            "http://mirror.tensorflow.org/github.com/google/protobuf/archive/v3.9.2.tar.gz",
+            "https://github.com/google/protobuf/archive/v3.9.2.tar.gz",
+        ],
+        build_file = "@io_bazel_rules_closure//closure/protobuf:protobuf_js.BUILD",
+    )
 
-  # Protobuf's BUILD file depends on //external:six.
-  native.bind(
-      name = "six",
-      actual = "@org_pythonhosted_six",
-  )
+    # Protobuf's BUILD file depends on //external:six.
+    native.bind(
+        name = "six",
+        actual = "@org_pythonhosted_six",
+    )
 
-  platform_http_file(
-      name = "org_chromium_chromium",
-      licenses = ["notice"],  # BSD 3-clause (maybe more?)
-      amd64_sha256 =
-          "6933d0afce6e17304b62029fbbd246cbe9e130eb0d90d7682d3765d3dbc8e1c8",
-      amd64_urls = [
-          "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/561732/chrome-linux.zip",
-      ],
-      macos_sha256 =
-          "084884e91841a923d7b6e81101f0105bbc3b0026f9f6f7a3477f5b313ee89e32",
-      macos_urls = [
-          "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/561733/chrome-mac.zip",
-      ],
-      windows_sha256 =
-          "d1bb728118c12ea436d8ea07dba980789e7d860aa664dd1fad78bc20e8d9391c",
-      windows_urls = [
-          "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/540270/chrome-win32.zip",
-      ],
-  )
+    platform_http_file(
+        name = "org_chromium_chromium",
+        licenses = ["notice"],  # BSD 3-clause (maybe more?)
+        amd64_sha256 =
+            "6933d0afce6e17304b62029fbbd246cbe9e130eb0d90d7682d3765d3dbc8e1c8",
+        amd64_urls = [
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/561732/chrome-linux.zip",
+        ],
+        macos_sha256 =
+            "084884e91841a923d7b6e81101f0105bbc3b0026f9f6f7a3477f5b313ee89e32",
+        macos_urls = [
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/561733/chrome-mac.zip",
+        ],
+        windows_sha256 =
+            "d1bb728118c12ea436d8ea07dba980789e7d860aa664dd1fad78bc20e8d9391c",
+        windows_urls = [
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win_x64/540270/chrome-win32.zip",
+        ],
+    )
 
-  platform_http_file(
-      name = "org_chromium_chromedriver",
-      licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
-      amd64_sha256 =
-          "71eafe087900dbca4bc0b354a1d172df48b31a4a502e21f7c7b156d7e76c95c7",
-      amd64_urls = [
-          "https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip",
-      ],
-      macos_sha256 =
-          "fd32a27148f44796a55f5ce3397015c89ebd9f600d9dda2bcaca54575e2497ae",
-      macos_urls = [
-          "https://chromedriver.storage.googleapis.com/2.41/chromedriver_mac64.zip",
-      ],
-      windows_sha256 =
-          "a8fa028acebef7b931ef9cb093f02865f9f7495e49351f556e919f7be77f072e",
-      windows_urls = [
-          "https://chromedriver.storage.googleapis.com/2.38/chromedriver_win32.zip",
-      ],
-  )
+    platform_http_file(
+        name = "org_chromium_chromedriver",
+        licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
+        amd64_sha256 =
+            "71eafe087900dbca4bc0b354a1d172df48b31a4a502e21f7c7b156d7e76c95c7",
+        amd64_urls = [
+            "https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip",
+        ],
+        macos_sha256 =
+            "fd32a27148f44796a55f5ce3397015c89ebd9f600d9dda2bcaca54575e2497ae",
+        macos_urls = [
+            "https://chromedriver.storage.googleapis.com/2.41/chromedriver_mac64.zip",
+        ],
+        windows_sha256 =
+            "a8fa028acebef7b931ef9cb093f02865f9f7495e49351f556e919f7be77f072e",
+        windows_urls = [
+            "https://chromedriver.storage.googleapis.com/2.38/chromedriver_win32.zip",
+        ],
+    )
 
-  java_import_external(
-      name = "org_apache_commons_lang3",
-      jar_sha256 = "de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
-      jar_urls = [
-          "http://mirror.tensorflow.org/repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar",
-          "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar",
-      ],
-      licenses = ["notice"],  # Apache 2.0
-  )
+    java_import_external(
+        name = "org_apache_commons_lang3",
+        jar_sha256 = "de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+        jar_urls = [
+            "http://mirror.tensorflow.org/repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar",
+            "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar",
+        ],
+        licenses = ["notice"],  # Apache 2.0
+    )
 
-  java_import_external(
-      name = "org_apache_commons_text",
-      jar_sha256 = "df45e56549b63e0fe716953c9d43cc158f8bf008baf60498e7c17f3faa00a70b",
-      jar_urls = [
-          "http://mirror.tensorflow.org/repo1.maven.org/maven2/org/apache/commons/commons-text/1.6/commons-text-1.6.jar",
-          "https://repo1.maven.org/maven2/org/apache/commons/commons-text/1.6/commons-text-1.6.jar",
-      ],
-      licenses = ["notice"],  # Apache 2.0
-  )
+    java_import_external(
+        name = "org_apache_commons_text",
+        jar_sha256 = "df45e56549b63e0fe716953c9d43cc158f8bf008baf60498e7c17f3faa00a70b",
+        jar_urls = [
+            "http://mirror.tensorflow.org/repo1.maven.org/maven2/org/apache/commons/commons-text/1.6/commons-text-1.6.jar",
+            "https://repo1.maven.org/maven2/org/apache/commons/commons-text/1.6/commons-text-1.6.jar",
+        ],
+        licenses = ["notice"],  # Apache 2.0
+    )


### PR DESCRIPTION
This change unbreaks the sync with some misc fixes:
- Removes licenses() comments under npmi's metric_arithmetic/
- Removes unused 'loads' in workspace.bzl

Drive by changes to workspace.bzl:
- Added to CI lint checks, to catch future instances where it may
  not pass Buildifier
- Reformatting slightly via Buildifier
- Remove unused 'com_google_protobuf_js'

Googlers, see
example failure: cl/329551428
example success: cl/329569832