### PR TITLE
infra: upgrade FE deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "numeric": "^1.2.6",
     "plottable": "^3.9.0",
     "requirejs": "^2.3.6",
-    "rxjs": "^6.5.5",
+    "rxjs": "7.0.0-beta.0",
     "three": "~0.108.0",
     "umap-js": "^1.3.2",
     "web-animations-js": "^2.3.2",

--- a/tensorboard/webapp/testing/BUILD
+++ b/tensorboard/webapp/testing/BUILD
@@ -9,7 +9,7 @@ filegroup(
     name = "test_support_lib",
     srcs = [
         ":rxjs_shims.js",
-        "@npm//:node_modules/rxjs/bundles/rxjs.umd.js",
+        "@npm//:node_modules/rxjs/dist/bundles/rxjs.umd.js",
         "@npm//:node_modules/tslib/tslib.js",
     ],
 )

--- a/tsconfig-lax.json
+++ b/tsconfig-lax.json
@@ -6,7 +6,7 @@
     "importHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "lib": ["dom", "es2019"],
+    "lib": ["dom", "es2020"],
     "moduleResolution": "node",
     "noEmitOnError": false,
     "noErrorTruncation": false,

--- a/tsconfig-lax.json
+++ b/tsconfig-lax.json
@@ -6,7 +6,7 @@
     "importHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "lib": ["dom", "es2018"],
+    "lib": ["dom", "es2019"],
     "moduleResolution": "node",
     "noEmitOnError": false,
     "noErrorTruncation": false,

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
-    "lib": ["dom", "es2019"],
     "types": ["jasmine"]
   }
 }

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "importHelpers": true,
+    "lib": ["dom", "es2019"],
     "types": ["jasmine"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,10 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "inlineSourceMap": true,
-    "lib": ["dom", "es2019"],
+    "lib": ["dom", "es2020"],
     "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
     "skipLibCheck": true,
     "strict": true,
     // Don't scan the node_modules/@types folder for ambient types.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "inlineSourceMap": true,
-    "lib": ["dom", "es2018"],
+    "lib": ["dom", "es2019"],
     "moduleResolution": "node",
     "skipLibCheck": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5120,7 +5120,14 @@ rxjs@6.5.4:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^6.5.3, rxjs@^6.5.5:
+rxjs@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.0.0-beta.0.tgz#41f730761e00ba7b5a28955e0f177afba8e2a134"
+  integrity sha512-MMsqDczs2RzsTvBiH6SKjJkdAh7WaI6Q0axP/DX+1ljwFm6+18AhQ3kVT8gD7G0dHIVfh5hDFoqLaW79pkiGag==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.5.3:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
   integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==


### PR DESCRIPTION
Changes a few frontend dependencies:

- tsconfigs now pull in 'es2020' rather than 'es2018' typedefs.
  Despite TS docs [1] not mentioning es2020 as an option, our
  version of TS supports this option [2]. Notably this adds
  typing support for `Array.prototype.flat()` (part of ES2019).
- tsconfigs have some more strict options that were not
  part of the flags [3] included by `"strict": true`.
- rxjs bumped to 7.0.0beta0. The changelog [4] notes several
  breaking changes, but none seem to affect us. Notably this
  new version includes the `combineLatestWith` operator.

Manually clicked around the UI, and behavior seems unaffected.

[1] https://www.typescriptlang.org/docs/handbook/compiler-options.html
[2] https://github.com/microsoft/TypeScript/pull/29167
[3] https://github.com/microsoft/TypeScript/blob/b0011feee125b8945f7ae97711fdacc38769e069/src/compiler/utilities.ts#L5922
[4] https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md