### PR TITLE
deps: upgrade Prettier to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postinstall": "ngcc -p main es2015",
     "build": "bazel build //...",
     "test": "ibazel test //...",
-    "lint": "prettier --check 'tensorboard/**/*.'{css,html,js,ts,scss} .github/**/*.yml",
+    "lint": "prettier --check 'tensorboard/**/*.'{css,html,js,ts,scss} .github/**/*.yml || echo 'Failures OK during Prettier upgrade'",
     "fix-lint": "prettier --write 'tensorboard/**/*.'{css,html,js,ts,scss} .github/**/*.yml"
   },
   "repository": {
@@ -57,7 +57,7 @@
     "karma-jasmine": "^3.1.0",
     "karma-requirejs": "^1.1.0",
     "karma-sourcemap-loader": "^0.3.7",
-    "prettier": "1.18.2",
+    "prettier": "2.1.1",
     "requirejs": "^2.3.6",
     "rollup": "^2.26.4",
     "sinon": "^7.4.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postinstall": "ngcc -p main es2015",
     "build": "bazel build //...",
     "test": "ibazel test //...",
-    "lint": "prettier --check 'tensorboard/**/*.'{css,html,js,ts,scss} .github/**/*.yml || echo 'Failures OK during Prettier upgrade'",
+    "lint": "prettier --check 'tensorboard/**/*.'{css,html,js,ts,scss} .github/**/*.yml",
     "fix-lint": "prettier --write 'tensorboard/**/*.'{css,html,js,ts,scss} .github/**/*.yml"
   },
   "repository": {

--- a/tensorboard/components/analytics.ts
+++ b/tensorboard/components/analytics.ts
@@ -17,4 +17,4 @@ limitations under the License.
 // We fake the global 'ga' object, so the object is a noop. The
 // google.analytics typing gives the object a type of UniversalAnalytics.ga.
 // We do not track open source users.
-(window as any)['ga'] = function() {};
+(window as any)['ga'] = function () {};

--- a/tensorboard/components/experimental/plugin_lib/test/test.ts
+++ b/tensorboard/components/experimental/plugin_lib/test/test.ts
@@ -27,21 +27,21 @@ async function createIframe(): Promise<HTMLIFrameElement> {
 describe('plugin lib integration', () => {
   const {expect} = chai;
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     this.sandbox = sinon.sandbox.create({useFakeServer: true});
     this.sandbox.server.respondImmediately = true;
     this.iframe = await createIframe();
     this.lib = (this.iframe.contentWindow as any).tb_plugin_lib.experimental;
   });
 
-  afterEach(function() {
+  afterEach(function () {
     document.body.removeChild(this.iframe);
     this.sandbox.restore();
   });
 
   describe('lib.run', () => {
     describe('#getRuns', () => {
-      it('returns list of runs', async function() {
+      it('returns list of runs', async function () {
         this.sandbox
           .stub(tf_backend.runsStore, 'getRuns')
           .returns(['foo', 'bar', 'baz']);
@@ -51,7 +51,7 @@ describe('plugin lib integration', () => {
       });
     });
     describe('#setOnRunsChanged', () => {
-      it('lets plugins subscribe to runs change', async function() {
+      it('lets plugins subscribe to runs change', async function () {
         const runsChanged = this.sandbox.stub();
         const promise = new Promise((resolve) => {
           this.lib.runs.setOnRunsChanged(resolve);
@@ -68,7 +68,7 @@ describe('plugin lib integration', () => {
         expect(runsChanged).to.have.been.calledOnce;
         expect(runsChanged).to.have.been.calledWith(['foo', 'bar']);
       });
-      it('lets plugins unsubscribe to runs change', async function() {
+      it('lets plugins unsubscribe to runs change', async function () {
         const runsChanged = this.sandbox.stub();
         const promise = new Promise((resolve) => {
           this.lib.runs.setOnRunsChanged(resolve);
@@ -97,7 +97,7 @@ describe('plugin lib integration', () => {
        * These tests use tf_globals' fake hash to make tf_storage think that the
        * host's URL has been updated.
        */
-      it('returns URL data', async function() {
+      it('returns URL data', async function () {
         const hash = [
           'sample_plugin',
           'p.sample_plugin.foo=bar',
@@ -113,7 +113,7 @@ describe('plugin lib integration', () => {
         });
       });
 
-      it('ignores unrelated URL data', async function() {
+      it('ignores unrelated URL data', async function () {
         const hash = [
           'sample_plugin',
           'tagFilter=loss',
@@ -133,7 +133,7 @@ describe('plugin lib integration', () => {
         });
       });
 
-      it('handles incomplete URL data', async function() {
+      it('handles incomplete URL data', async function () {
         const hash = [
           'sample_plugin',
           'tagFilter=loss',
@@ -147,7 +147,7 @@ describe('plugin lib integration', () => {
         expect(data).to.deep.equal({});
       });
 
-      it('handles non alphanumeric data', async function() {
+      it('handles non alphanumeric data', async function () {
         const hash = [
           'sample_plugin',
           'p.sample_plugin.foo=bar%20baz',

--- a/tensorboard/components/experimental/plugin_util/test/plugin-test.ts
+++ b/tensorboard/components/experimental/plugin_util/test/plugin-test.ts
@@ -20,7 +20,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
   ) as HTMLTemplateElement;
 
   describe('plugin-util', () => {
-    beforeEach(function(done) {
+    beforeEach(function (done) {
       const iframeFrag = document.importNode(template.content, true);
       const iframe = iframeFrag.firstElementChild as HTMLIFrameElement;
       document.body.appendChild(iframe);
@@ -32,12 +32,12 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
       this.sandbox = sinon.sandbox.create();
     });
 
-    afterEach(function() {
+    afterEach(function () {
       document.body.removeChild(this.guestFrame);
       this.sandbox.restore();
     });
 
-    it('setUp sanity check', function() {
+    it('setUp sanity check', function () {
       expect(this.guestWindow.plugin_internal)
         .to.have.property('sendMessage')
         .that.is.a('function');
@@ -52,7 +52,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
     [
       {
         spec: 'host (src) to guest (dest)',
-        beforeEachFunc: function() {
+        beforeEachFunc: function () {
           this.destWindow = this.guestWindow;
           this.destListen = this.guestWindow.plugin_internal.listen;
           this.destUnlisten = this.guestWindow.plugin_internal.unlisten;
@@ -66,7 +66,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
       },
       {
         spec: 'guest (src) to host (dest)',
-        beforeEachFunc: function() {
+        beforeEachFunc: function () {
           this.destWindow = window;
           this.destListen = (
             type: lib.DO_NOT_USE_INTERNAL.MessageType,
@@ -92,18 +92,18 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
       describe(spec, () => {
         beforeEach(beforeEachFunc);
 
-        beforeEach(function() {
+        beforeEach(function () {
           this.onMessage = this.sandbox.stub();
           this.destListen('messageType', this.onMessage);
         });
 
-        it('sends a message to dest', async function() {
+        it('sends a message to dest', async function () {
           await this.srcSendMessage('messageType', 'hello');
           expect(this.onMessage.callCount).to.equal(1);
           expect(this.onMessage.firstCall.args).to.deep.equal(['hello']);
         });
 
-        it('sends a message a random payload not by ref', async function() {
+        it('sends a message a random payload not by ref', async function () {
           const payload = {
             foo: 'foo',
             bar: {
@@ -117,7 +117,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
           expect(this.onMessage.firstCall.args[0]).to.deep.equal(payload);
         });
 
-        it('resolves when dest replies with ack', async function() {
+        it('resolves when dest replies with ack', async function () {
           const sendMessageP = this.srcSendMessage('messageType', 'hello');
 
           expect(this.onMessage.callCount).to.equal(0);
@@ -127,7 +127,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
           expect(this.onMessage.firstCall.args).to.deep.equal(['hello']);
         });
 
-        it('triggers, on dest, a cb for the matching type', async function() {
+        it('triggers, on dest, a cb for the matching type', async function () {
           const barCb = this.sandbox.stub();
           this.destListen('bar', barCb);
 
@@ -138,7 +138,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
           expect(barCb.firstCall.args).to.deep.equal(['soap']);
         });
 
-        it('supports single listener for a type', async function() {
+        it('supports single listener for a type', async function () {
           const barCb1 = this.sandbox.stub();
           const barCb2 = this.sandbox.stub();
           this.destListen('bar', barCb1);
@@ -160,7 +160,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
             {specName: 'object', payload: {some: 'object'}, expectDeep: true},
             {specName: 'array', payload: ['a', 'b', 'c'], expectDeep: true},
           ].forEach(({specName, payload, expectDeep}) => {
-            it(specName, async function() {
+            it(specName, async function () {
               this.destListen('bar', () => payload);
 
               const response = await this.srcSendMessage('bar', 'soap');
@@ -174,7 +174,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
           });
         });
 
-        it('unregister a callback with unlisten', async function() {
+        it('unregister a callback with unlisten', async function () {
           const barCb = this.sandbox.stub();
           this.destListen('bar', barCb);
           await this.srcSendMessage('bar', 'soap');
@@ -186,7 +186,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
           expect(barCb.callCount).to.equal(1);
         });
 
-        it('ignores foreign postMessages', async function() {
+        it('ignores foreign postMessages', async function () {
           const barCb = this.sandbox.stub();
           this.destListen('bar', barCb);
           const fakeMessage: Message = {
@@ -203,7 +203,7 @@ namespace tb_plugin.lib.DO_NOT_USE_INTERNAL {
           expect(barCb).to.not.have.been.called;
         });
 
-        it('processes messages while waiting for a reponse', async function() {
+        it('processes messages while waiting for a reponse', async function () {
           let resolveLongTask = null;
           this.destListen('longTask', () => {
             return new Promise((resolve) => {

--- a/tensorboard/components/tensor_widget/tensor-widget-impl.ts
+++ b/tensorboard/components/tensor_widget/tensor-widget-impl.ts
@@ -339,8 +339,10 @@ export class TensorWidgetImpl implements TensorWidget {
       } as SingleActionMenuItemConfig);
     }
     if (this.menuConfig !== null && this.menuConfig.items.length > 0) {
-      this.menu = new Menu(this.menuConfig, this
-        .headerSection as HTMLDivElement);
+      this.menu = new Menu(
+        this.menuConfig,
+        this.headerSection as HTMLDivElement
+      );
       this.renderMenuThumb();
     }
   }

--- a/tensorboard/components/tf_backend/backend.ts
+++ b/tensorboard/components/tf_backend/backend.ts
@@ -61,7 +61,7 @@ function timeToDate(x: number): Date {
 }
 /**  Just a curryable map to make things cute and tidy. */
 function map<T, U>(f: (x: T) => U): (arr: T[]) => U[] {
-  return function(arr: T[]): U[] {
+  return function (arr: T[]): U[] {
     return arr.map(f);
   };
 }
@@ -71,7 +71,7 @@ function map<T, U>(f: (x: T) => U): (arr: T[]) => U[] {
  * them into the intersection of a G and a Datum.
  */
 function detupler<T, G>(xform: (x: T) => G): (t: TupleData<T>) => Datum & G {
-  return function(x: TupleData<T>): Datum & G {
+  return function (x: TupleData<T>): Datum & G {
     // Create a G, assert it has type <G & Datum>
     let obj = <G & Datum>xform(x[2]);
     // ... patch in the properties of datum

--- a/tensorboard/components/tf_backend/requestManager.ts
+++ b/tensorboard/components/tf_backend/requestManager.ts
@@ -240,14 +240,14 @@ export class RequestManager {
         requestOptions.withCredentials,
         requestOptions.contentType
       );
-      req.onload = function() {
+      req.onload = function () {
         if (req.status === 200) {
           resolve(JSON.parse(req.responseText));
         } else {
           reject(new RequestNetworkError(req, url));
         }
       };
-      req.onerror = function() {
+      req.onerror = function () {
         reject(new RequestNetworkError(req, url));
       };
       if (requestOptions.body) {

--- a/tensorboard/components/tf_backend/test/requestManagerTests.ts
+++ b/tensorboard/components/tf_backend/test/requestManagerTests.ts
@@ -241,7 +241,10 @@ namespace tf_backend {
 
         // When the first request rejects, it should decrement nActiveRequests
         // and then launch remaining requests in queue (i.e. this one)
-        r1.then((success) => done(), (failure) => done(new Error(failure)));
+        r1.then(
+          (success) => done(),
+          (failure) => done(new Error(failure))
+        );
       });
 
       it('queue is LIFO', (done) => {
@@ -312,9 +315,7 @@ namespace tf_backend {
           );
           done();
         };
-        rm.request('0')
-          .then(success, failure)
-          .then(finishTheTest);
+        rm.request('0').then(success, failure).then(finishTheTest);
         rm.request('1').then(success, failure);
         rm.request('2').then(success, failure);
         rm.request('3').then(success, failure);
@@ -334,7 +335,7 @@ namespace tf_backend {
         });
       });
 
-      it('throws an error when a GET request has a body', function() {
+      it('throws an error when a GET request has a body', function () {
         const rm = new RequestManager();
         const badOptions = new RequestOptions();
         badOptions.methodType = HttpMethodType.GET;
@@ -345,20 +346,20 @@ namespace tf_backend {
         );
       });
 
-      describe('tests using sinon.fakeServer', function() {
+      describe('tests using sinon.fakeServer', function () {
         let server;
 
-        beforeEach(function() {
+        beforeEach(function () {
           server = sinon.fakeServer.create();
           server.respondImmediately = true;
           server.respondWith('{}');
         });
 
-        afterEach(function() {
+        afterEach(function () {
           server.restore();
         });
 
-        it('builds correct XMLHttpRequest when request(url) is called', function() {
+        it('builds correct XMLHttpRequest when request(url) is called', function () {
           const rm = new RequestManager();
           return rm.request('my_url').then(() => {
             chai.assert.lengthOf(server.requests, 1);
@@ -372,7 +373,7 @@ namespace tf_backend {
           });
         });
 
-        it('builds correct XMLHttpRequest when request(url, postData) is called', function() {
+        it('builds correct XMLHttpRequest when request(url, postData) is called', function () {
           const rm = new RequestManager();
           return rm
             .request('my_url', {key1: 'value1', key2: 'value2'})
@@ -383,12 +384,15 @@ namespace tf_backend {
               chai.assert.instanceOf(server.requests[0].requestBody, FormData);
               chai.assert.sameDeepMembers(
                 Array.from(server.requests[0].requestBody.entries()),
-                [['key1', 'value1'], ['key2', 'value2']]
+                [
+                  ['key1', 'value1'],
+                  ['key2', 'value2'],
+                ]
               );
             });
         });
 
-        it('builds correct XMLHttpRequest when requestWithOptions is called', function() {
+        it('builds correct XMLHttpRequest when requestWithOptions is called', function () {
           const rm = new RequestManager();
           const requestOptions = new RequestOptions();
           requestOptions.methodType = HttpMethodType.POST;
@@ -408,11 +412,11 @@ namespace tf_backend {
       });
 
       describe('fetch', () => {
-        beforeEach(function() {
+        beforeEach(function () {
           this.stubbedFetch = sandbox.stub(window, 'fetch');
           this.clock = sandbox.useFakeTimers();
 
-          this.resolvesAfter = function(
+          this.resolvesAfter = function (
             value: any,
             timeInMs: number
           ): Promise<any> {
@@ -422,7 +426,7 @@ namespace tf_backend {
           };
         });
 
-        it('resolves', async function() {
+        it('resolves', async function () {
           this.stubbedFetch.returns(
             Promise.resolve(new Response('Success', {status: 200}))
           );
@@ -436,7 +440,7 @@ namespace tf_backend {
           expect(body).to.equal('Success');
         });
 
-        it('retries', async function() {
+        it('retries', async function () {
           this.stubbedFetch
             .onCall(0)
             .returns(Promise.resolve(new Response('Error 1', {status: 500})));
@@ -456,7 +460,7 @@ namespace tf_backend {
           expect(body).to.equal('Success');
         });
 
-        it('gives up after max retries', async function() {
+        it('gives up after max retries', async function () {
           const failure = new Response('Error', {status: 500});
           this.stubbedFetch.returns(Promise.resolve(failure));
           const rm = new RequestManager();
@@ -470,7 +474,7 @@ namespace tf_backend {
           expect(body).to.equal('Error');
         });
 
-        it('sends requests concurrently', async function() {
+        it('sends requests concurrently', async function () {
           this.stubbedFetch
             .onCall(0)
             .returns(
@@ -496,7 +500,7 @@ namespace tf_backend {
           expect(firstBody).to.equal('nay');
         });
 
-        it('queues requests', async function() {
+        it('queues requests', async function () {
           this.stubbedFetch
             .onCall(0)
             .returns(

--- a/tensorboard/components/tf_backend/urlPathHelpers.ts
+++ b/tensorboard/components/tf_backend/urlPathHelpers.ts
@@ -58,7 +58,5 @@ export function addParams(baseURL: string, params: QueryParams): string {
 
 function _encodeURIComponent(x: string): string {
   // Replace parentheses for consistency with Python's urllib.urlencode.
-  return encodeURIComponent(x)
-    .replace(/\(/g, '%28')
-    .replace(/\)/g, '%29');
+  return encodeURIComponent(x).replace(/\(/g, '%28').replace(/\)/g, '%29');
 }

--- a/tensorboard/components/tf_card_heading/tf-card-heading.ts
+++ b/tensorboard/components/tf_card_heading/tf-card-heading.ts
@@ -43,9 +43,7 @@ class TfCardHeading extends PolymerElement {
       <figcaption class="content">
         <div class="heading-row">
           <template is="dom-if" if="[[_nameLabel]]">
-            <div itemprop="name" class="heading-label name">
-              [[_nameLabel]]
-            </div>
+            <div itemprop="name" class="heading-label name">[[_nameLabel]]</div>
           </template>
           <template is="dom-if" if="[[run]]">
             <!-- Extra wrapping span needed to avoid flexbox blockification. -->

--- a/tensorboard/components/tf_color_scale/test/colorScaleTests.ts
+++ b/tensorboard/components/tf_color_scale/test/colorScaleTests.ts
@@ -15,21 +15,21 @@ limitations under the License.
 namespace tf_color_scale {
   const {assert} = chai;
 
-  describe('ColorScale', function() {
+  describe('ColorScale', function () {
     let ccs: ColorScale;
 
-    beforeEach(function() {
+    beforeEach(function () {
       ccs = new ColorScale();
     });
 
-    it('Returns consistent colors', function() {
+    it('Returns consistent colors', function () {
       ccs.setDomain(['train', 'eval', 'test']);
       let trainColor = ccs.getColor('train');
       let trainColor2 = ccs.getColor('train');
       assert.equal(trainColor, trainColor2);
     });
 
-    it('Returns consistent colors after new domain', function() {
+    it('Returns consistent colors after new domain', function () {
       ccs.setDomain(['train', 'eval']);
       let trainColor = ccs.getColor('train');
       ccs.setDomain(['train', 'eval', 'test']);
@@ -37,7 +37,7 @@ namespace tf_color_scale {
       assert.equal(trainColor, trainColor2);
     });
 
-    it('Throws an error if string is not in the domain', function() {
+    it('Throws an error if string is not in the domain', function () {
       ccs.setDomain(['red', 'yellow', 'green']);
       assert.throws(() => {
         ccs.getColor('WAT');

--- a/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
+++ b/tensorboard/components/tf_dashboard_common/data-loader-behavior.ts
@@ -54,7 +54,8 @@ export interface RequestDataCallback<Item, Data> {
 export function DataLoaderBehavior<Item, Data>(
   superClass: new () => PolymerElement
 ): new () => DataLoaderBehaviorInterface<Item, Data> {
-  return class DataLoaderBehaviorImpl<Item, Data> extends superClass
+  return class DataLoaderBehaviorImpl<Item, Data>
+    extends superClass
     implements DataLoaderBehaviorInterface<Item, Data> {
     active!: boolean;
 

--- a/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-list.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-filterable-checkbox-list.ts
@@ -63,9 +63,7 @@ class TfFilterableCheckboxList extends LegacyElementMixin(PolymerElement) {
     </div>
     <div class="matches">
       <template is="dom-if" if="[[!_itemsMatchingRegex.length]]">
-        <div class="item empty-match">
-          No matches
-        </div>
+        <div class="item empty-match">No matches</div>
       </template>
       <template
         is="dom-repeat"

--- a/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-multi-checkbox.ts
@@ -222,7 +222,7 @@ class TfMultiCheckbox extends LegacyElementMixin(PolymerElement) {
       150,
       {leading: false}
     );
-    return function() {
+    return function () {
       var r = this.$$('#names-regex').value;
       if (r == '') {
         // If the user cleared the field, they may be done typing, so
@@ -260,7 +260,7 @@ class TfMultiCheckbox extends LegacyElementMixin(PolymerElement) {
     var buttons = Array.prototype.slice.call(
       this.root.querySelectorAll('.isolator')
     );
-    buttons.forEach(function(b) {
+    buttons.forEach(function (b) {
       if (numChecked === 1 && selectionMap[b.name]) {
         b.icon = 'radio-button-checked';
       } else {
@@ -313,7 +313,7 @@ class TfMultiCheckbox extends LegacyElementMixin(PolymerElement) {
     // names.
     var name = (e.target as any).name;
     var selectionState = {};
-    this.names.forEach(function(n) {
+    this.names.forEach(function (n) {
       selectionState[n] = n == name;
     });
     this.selectionState = selectionState;

--- a/tensorboard/components/tf_dashboard_common/tf-no-data-warning.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-no-data-warning.ts
@@ -22,17 +22,13 @@ class TfNoDataWarning extends PolymerElement {
     <template is="dom-if" if="[[showWarning]]">
       <div class="warning">
         <h3>No <span>[[dataType]]</span> data was found.</h3>
-        <p>
-          Probable causes:
-        </p>
+        <p>Probable causes:</p>
         <ul>
           <li>
             You haven't written any <span>[[dataType]]</span> data to your event
             files.
           </li>
-          <li>
-            TensorBoard can't find your event files.
-          </li>
+          <li>TensorBoard can't find your event files.</li>
         </ul>
         <p>
           If you're new to using TensorBoard, and want to find out how to add

--- a/tensorboard/components/tf_dashboard_common/tf-option-selector.ts
+++ b/tensorboard/components/tf_dashboard_common/tf-option-selector.ts
@@ -67,9 +67,9 @@ class TfOptionSelector extends LegacyElementMixin(PolymerElement) {
   selectedId: string;
 
   attached() {
-    this.async(function() {
+    this.async(function () {
       this.getEffectiveChildren().forEach(
-        function(node) {
+        function (node) {
           this.listen(node, 'tap', '_selectTarget');
         }.bind(this)
       );
@@ -85,7 +85,7 @@ class TfOptionSelector extends LegacyElementMixin(PolymerElement) {
     if (!selected) {
       return;
     }
-    this.getEffectiveChildren().forEach(function(node) {
+    this.getEffectiveChildren().forEach(function (node) {
       (node as HTMLElement).classList.remove('selected');
     });
     (selected as HTMLElement).classList.add('selected');

--- a/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
+++ b/tensorboard/components/tf_line_chart_data_loader/tf-line-chart-data-loader.html
@@ -97,7 +97,7 @@ limitations under the License.
   </template>
   <script src="../vz-line-chart2/line-chart-exporter.js"></script>
   <script>
-    (function() {
+    (function () {
       // The chart can sometimes get in a bad state, when it redraws while
       // it is display: none due to the user having switched to a different
       // page. This code implements a cascading queue to redraw the bad charts
@@ -105,7 +105,7 @@ limitations under the License.
       // We use a cascading queue becuase we don't want to block the UI / make the
       // ripples very slow while everything synchronously redraws.
       const redrawQueue = [];
-      const cascadingRedraw = (function() {
+      const cascadingRedraw = (function () {
         let redrawRaf = 0;
         return _.throttle(function internalRedraw() {
           if (redrawQueue.length == 0) return;

--- a/tensorboard/components/tf_paginated_view/tf-dom-repeat.ts
+++ b/tensorboard/components/tf_paginated_view/tf-dom-repeat.ts
@@ -128,7 +128,7 @@ export class TfDomRepeat<T extends {}> extends ArrayUpdateHelper {
           [this.as]: true,
           active: this._contentActive,
         },
-        forwardHostProp: function(prop: string, value: any) {
+        forwardHostProp: function (prop: string, value: any) {
           this._renderedTemplateInst.forEach((inst: TemplateInstanceBase) => {
             inst.forwardHostProp(prop, value);
           });

--- a/tensorboard/components/tf_storage/storage.ts
+++ b/tensorboard/components/tf_storage/storage.ts
@@ -67,7 +67,10 @@ export const {
   getInitializer: getStringInitializer,
   getObserver: getStringObserver,
   disposeBinding: disposeStringBinding,
-} = makeBindings((x) => x, (x) => x);
+} = makeBindings(
+  (x) => x,
+  (x) => x
+);
 export const {
   get: getBoolean,
   set: setBoolean,
@@ -84,14 +87,20 @@ export const {
   getInitializer: getNumberInitializer,
   getObserver: getNumberObserver,
   disposeBinding: disposeNumberBinding,
-} = makeBindings((s) => +s, (n) => n.toString());
+} = makeBindings(
+  (s) => +s,
+  (n) => n.toString()
+);
 export const {
   get: getObject,
   set: setObject,
   getInitializer: getObjectInitializer,
   getObserver: getObjectObserver,
   disposeBinding: disposeObjectBinding,
-} = makeBindings((s) => JSON.parse(atob(s)), (o) => btoa(JSON.stringify(o)));
+} = makeBindings(
+  (s) => JSON.parse(atob(s)),
+  (o) => btoa(JSON.stringify(o))
+);
 export interface StorageOptions<T> {
   defaultValue?: T;
   useLocalStorage?: boolean;
@@ -158,7 +167,7 @@ export function makeBindings<T>(
       useLocalStorage: false,
       ...options,
     };
-    return function() {
+    return function () {
       const uriStorageName = getURIStorageName(this, key);
       // setComponentValue will be called every time the underlying storage
       // changes and is responsible for ensuring that new state will propagate
@@ -199,7 +208,7 @@ export function makeBindings<T>(
       useLocalStorage: false,
       ...options,
     };
-    return function() {
+    return function () {
       const uriStorageName = getURIStorageName(this, key);
       const newVal = this[fullOptions.polymerProperty];
       set(uriStorageName, newVal, fullOptions);

--- a/tensorboard/components/vz_chart_helpers/plottable-interactions.ts
+++ b/tensorboard/components/vz_chart_helpers/plottable-interactions.ts
@@ -116,17 +116,11 @@ class MouseDispatcher extends (Plottable.Dispatchers as any).Mouse {
   constructor(component) {
     super(component);
     // eventTarget is `document` by default. Change it to the root of chart.
-    this._eventTarget = component
-      .root()
-      .rootElement()
-      .node();
+    this._eventTarget = component.root().rootElement().node();
     // Requires custom translator that uses correct DOM traversal (with
     // WebComponents) to change pointer position to relative to the root node.
     (this as any)._translator = new CustomTranslator(
-      component
-        .root()
-        .rootElement()
-        .node()
+      component.root().rootElement().node()
     );
   }
   static getDispatcher(component) {
@@ -144,17 +138,11 @@ class TouchDispatcher extends Plottable.Dispatchers.Touch {
   constructor(component) {
     super(component);
     // eventTarget is `document` by default. Change it to the root of chart.
-    this._eventTarget = component
-      .root()
-      .rootElement()
-      .node();
+    this._eventTarget = component.root().rootElement().node();
     // Requires custom translator that uses correct DOM traversal (with
     // WebComponents) to change pointer position to relative to the root node.
     (this as any)._translator = new CustomTranslator(
-      component
-        .root()
-        .rootElement()
-        .node()
+      component.root().rootElement().node()
     );
   }
   static getDispatcher(component) {
@@ -196,7 +184,7 @@ class TouchDispatcher extends Plottable.Dispatchers.Touch {
  * manifest since event delegation on the entire document will eventually
  * trigger mouse out when cursor is at, for instance, <101, 100>.
  */
-(Plottable.Interaction.prototype as any)._isInsideComponent = function(p) {
+(Plottable.Interaction.prototype as any)._isInsideComponent = function (p) {
   return (
     0 <= p.x &&
     0 <= p.y &&

--- a/tensorboard/components/vz_chart_helpers/vz-chart-helpers.ts
+++ b/tensorboard/components/vz_chart_helpers/vz-chart-helpers.ts
@@ -174,11 +174,7 @@ export function computeDomain(values: number[], ignoreOutliers: boolean) {
     lower = a - padding;
   }
   let domain = [lower, b + padding];
-  domain = d3
-    .scaleLinear()
-    .domain(domain)
-    .nice()
-    .domain();
+  domain = d3.scaleLinear().domain(domain).nice().domain();
   return domain;
 }
 

--- a/tensorboard/components/vz_line_chart2/dragZoomInteraction.ts
+++ b/tensorboard/components/vz_line_chart2/dragZoomInteraction.ts
@@ -172,18 +172,10 @@ export class DragZoomLayer extends Plottable.Components.SelectionBoxLayer {
     this._doubleClickInteraction.enabled(!isZooming);
   }
   private interpolateZoom(x0f: number, x1f: number, y0f: number, y1f: number) {
-    let x0s: number = this.xScale()
-      .domain()[0]
-      .valueOf();
-    let x1s: number = this.xScale()
-      .domain()[1]
-      .valueOf();
-    let y0s: number = this.yScale()
-      .domain()[0]
-      .valueOf();
-    let y1s: number = this.yScale()
-      .domain()[1]
-      .valueOf();
+    let x0s: number = this.xScale().domain()[0].valueOf();
+    let x1s: number = this.xScale().domain()[1].valueOf();
+    let y0s: number = this.yScale().domain()[0].valueOf();
+    let y1s: number = this.yScale().domain()[1].valueOf();
     // Copy a ref to the ease fn, so that changing ease wont affect zooms in
     // progress.
     let ease = this.easeFn;

--- a/tensorboard/components/vz_line_chart2/line-chart.ts
+++ b/tensorboard/components/vz_line_chart2/line-chart.ts
@@ -484,10 +484,7 @@ export class LineChart {
             ptsToCircle,
             (p: vz_chart_helpers.Point) => p.dataset.metadata().name
           );
-        ptsSelection
-          .enter()
-          .append('circle')
-          .classed('point', true);
+        ptsSelection.enter().append('circle').classed('point', true);
         ptsSelection
           .attr('r', vz_chart_helpers.TOOLTIP_CIRCLE_SIZE)
           .attr('cx', (p) => p.x)
@@ -507,10 +504,7 @@ export class LineChart {
     window.cancelAnimationFrame(this._tooltipUpdateAnimationFrame);
     this.tooltip.hide();
     this.scatterPlot.attr('display', 'block');
-    this.tooltipPointsComponent
-      .content()
-      .selectAll('.point')
-      .remove();
+    this.tooltipPointsComponent.content().selectAll('.point').remove();
   }
   private setupTooltips(plot: Plottable.XYPlot<number | Date, number>): void {
     plot.onDetach(() => {
@@ -615,7 +609,7 @@ export class LineChart {
         return target.x < firstX || target.x > lastX || isNaN(s);
       })
       .classed('closest', (p) => dist(p) === closestDist)
-      .each(function(point) {
+      .each(function (point) {
         self.drawTooltipRow(this, tooltipColumns, point);
       })
       // reorders DOM to match the ordering of the `data`.
@@ -624,7 +618,7 @@ export class LineChart {
     rows
       .enter()
       .append('tr')
-      .each(function(point) {
+      .each(function (point) {
         self.drawTooltipRow(this, tooltipColumns, point);
       })
       .nodes();
@@ -636,11 +630,8 @@ export class LineChart {
     point: vz_chart_helpers.Point
   ) {
     const self = this;
-    const columns = d3
-      .select(row)
-      .selectAll('td')
-      .data(tooltipColumns);
-    columns.each(function(col: TooltipColumn) {
+    const columns = d3.select(row).selectAll('td').data(tooltipColumns);
+    columns.each(function (col: TooltipColumn) {
       // Skip column value update when the column is static.
       if (col.static) return;
       self.drawTooltipColumn.call(self, this, col, point);
@@ -649,7 +640,7 @@ export class LineChart {
     columns
       .enter()
       .append('td')
-      .each(function(col: TooltipColumn | LineChartTooltipColumn) {
+      .each(function (col: TooltipColumn | LineChartTooltipColumn) {
         if ('enter' in col && col.enter) {
           const customTooltip = col as LineChartTooltipColumn;
           customTooltip.enter.call(this, point);

--- a/tensorboard/components/vz_line_chart2/test/log-scale-test.ts
+++ b/tensorboard/components/vz_line_chart2/test/log-scale-test.ts
@@ -16,18 +16,18 @@ namespace vz_line_chart2 {
   const {expect} = chai;
 
   describe('LogScale', () => {
-    beforeEach(function() {
+    beforeEach(function () {
       this.scale = new LogScale();
       this.scale.range([0, 1]);
       this.scale.setValueProviderForDomain(() => [1, 1000]);
     });
 
     describe('manual domain', () => {
-      beforeEach(function() {
+      beforeEach(function () {
         this.scale.domain([1, 1000]);
       });
 
-      it('returns scales input correctly to an output between 0-1', function() {
+      it('returns scales input correctly to an output between 0-1', function () {
         expect(this.scale.scale(1)).to.equal(0);
         expect(this.scale.scale(1000)).to.equal(1);
       });
@@ -35,14 +35,14 @@ namespace vz_line_chart2 {
       it(
         'returns value outside of range when given input smaller/larger ' +
           'than the domain',
-        function() {
+        function () {
           expect(this.scale.scale(1e-3)).to.equal(-1);
           expect(this.scale.scale(1e6)).to.equal(2);
           expect(this.scale.scale(1e9)).to.equal(3);
         }
       );
 
-      it('returns NaN for non-positive values', function() {
+      it('returns NaN for non-positive values', function () {
         expect(this.scale.scale(0)).to.be.NaN;
         expect(this.scale.scale(-1)).to.be.NaN;
         expect(this.scale.scale(-0.00001)).to.be.NaN;
@@ -50,7 +50,7 @@ namespace vz_line_chart2 {
         expect(this.scale.scale(NaN)).to.be.NaN;
       });
 
-      it('ignores padProportion', function() {
+      it('ignores padProportion', function () {
         this.scale.padProportion(0.3);
         expect(this.scale.scale(1)).to.equal(0);
         expect(this.scale.scale(1000)).to.equal(1);
@@ -62,16 +62,16 @@ namespace vz_line_chart2 {
     });
 
     describe('auto domain', () => {
-      beforeEach(function() {
+      beforeEach(function () {
         this.scale.autoDomain();
       });
 
       describe('padding-less', () => {
-        beforeEach(function() {
+        beforeEach(function () {
           this.scale.padProportion(0);
         });
 
-        it('returns scales input correctly to an output between 0-1', function() {
+        it('returns scales input correctly to an output between 0-1', function () {
           expect(this.scale.scale(1)).to.equal(0);
           expect(this.scale.scale(1000)).to.equal(1);
         });
@@ -79,14 +79,14 @@ namespace vz_line_chart2 {
         it(
           'returns value outside of range when given input smaller/larger ' +
             'than the domain',
-          function() {
+          function () {
             expect(this.scale.scale(1e-3)).to.equal(-1);
             expect(this.scale.scale(1e6)).to.equal(2);
             expect(this.scale.scale(1e9)).to.equal(3);
           }
         );
 
-        it('returns NaN for non-positive values', function() {
+        it('returns NaN for non-positive values', function () {
           expect(this.scale.scale(0)).to.be.NaN;
           expect(this.scale.scale(-1)).to.be.NaN;
           expect(this.scale.scale(-0.00001)).to.be.NaN;
@@ -96,19 +96,19 @@ namespace vz_line_chart2 {
       });
 
       describe('padding-full', () => {
-        beforeEach(function() {
+        beforeEach(function () {
           // Spread is 3 = log_10(1000) - log_10(1) and since we want 33% of the
           // spread to be the padding, pad = 3 * .33333 ~ 1, the domain should be
           // from ~0.1 to ~1e4
           this.scale.padProportion(0.33333);
         });
 
-        it('pads domain', function() {
+        it('pads domain', function () {
           expect(this.scale.invert(0)).to.be.closeTo(0.1, 0.01);
           expect(this.scale.invert(1)).to.be.closeTo(1e4, 10);
         });
 
-        it('puts some padding even if there is no spread', function() {
+        it('puts some padding even if there is no spread', function () {
           this.scale.setValueProviderForDomain(() => [1, 1]);
           this.scale.autoDomain();
           expect(this.scale.invert(0)).to.equal(0.1);
@@ -133,7 +133,7 @@ namespace vz_line_chart2 {
           expect(this.scale.invert(1)).to.be.equal(5e-323);
         });
 
-        it('puts padding even if values are very even number', function() {
+        it('puts padding even if values are very even number', function () {
           // domain of [1, 1000] result in very clean mapping between domain and
           // the range -- i.e., 1 -> 0 and 1000 to 1. If naively use ceil or floor
           // to compute a "nice domain" for [1, 1000], it can lead to no padding

--- a/tensorboard/components/vz_line_chart2/tf-scale.ts
+++ b/tensorboard/components/vz_line_chart2/tf-scale.ts
@@ -44,7 +44,8 @@ export interface ITfScale extends Plottable.QuantitativeScale<number> {
   ignoreOutlier(): boolean;
   ignoreOutlier(ignore: boolean): this;
 }
-export abstract class TfScale extends Plottable.QuantitativeScale<number>
+export abstract class TfScale
+  extends Plottable.QuantitativeScale<number>
   implements ITfScale {
   protected _ignoreOutlier: boolean = false;
   protected _valueProviderForDomain: ValueProviderForDomain;

--- a/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
+++ b/tensorboard/components/vz_line_chart2/vz-line-chart2.ts
@@ -455,7 +455,7 @@ class VzLineChart2<SeriesMetadata = {}> extends LegacyElementMixin(
       this.cancelAsync(this._makeChartAsyncCallbackId);
       this._makeChartAsyncCallbackId = null;
     }
-    this._makeChartAsyncCallbackId = this.async(function() {
+    this._makeChartAsyncCallbackId = this.async(function () {
       this._makeChartAsyncCallbackId = null;
       // Find the actual xComponentsCreationMethod.
       let normalXComponentsCreationMethod = this.xComponentsCreationMethod;

--- a/tensorboard/java/org/tensorflow/tensorboard/vulcanize/externs.js
+++ b/tensorboard/java/org/tensorflow/tensorboard/vulcanize/externs.js
@@ -63,4 +63,4 @@ var HTMLImports;
  * @param {function()} callback
  * @param {!HTMLDocument=} opt_doc
  */
-HTMLImports.whenReady = function(callback, opt_doc) {};
+HTMLImports.whenReady = function (callback, opt_doc) {};

--- a/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.ts
+++ b/tensorboard/plugins/audio/tf_audio_dashboard/tf-audio-loader.ts
@@ -62,7 +62,8 @@ tf-audio-loader loads an individual audio clip from the TensorBoard
 backend.
 */
 @customElement('tf-audio-loader')
-class _TfAudioLoader extends LegacyElementMixin(PolymerElement)
+class _TfAudioLoader
+  extends LegacyElementMixin(PolymerElement)
   implements TfAudioLoader {
   static readonly template = html`
     <tf-card-heading

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.ts
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-margin-chart-card.ts
@@ -71,7 +71,8 @@ export interface TfCustomScalarMarginChartCard extends HTMLElement {
 }
 
 @customElement('tf-custom-scalar-margin-chart-card')
-class _TfCustomScalarMarginChartCard extends LegacyElementMixin(PolymerElement)
+class _TfCustomScalarMarginChartCard
+  extends LegacyElementMixin(PolymerElement)
   implements TfCustomScalarMarginChartCard {
   static readonly template = html`
     <tf-card-heading display-name="[[_titleDisplayString]]"></tf-card-heading>

--- a/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.ts
+++ b/tensorboard/plugins/custom_scalar/tf_custom_scalar_dashboard/tf-custom-scalar-multi-line-chart-card.ts
@@ -138,9 +138,7 @@ class _TfCustomScalarMultiLineChartCard
           </paper-icon-button>
         </template>
 
-        <span class="matches-text">
-          Matches ([[_seriesNames.length]])
-        </span>
+        <span class="matches-text"> Matches ([[_seriesNames.length]]) </span>
       </div>
       <template is="dom-if" if="[[_seriesNames.length]]">
         <iron-collapse opened="[[_matchesListOpened]]">

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/debugger_container.ts
@@ -36,9 +36,8 @@ export class DebuggerContainer implements OnInit, OnDestroy {
 
   readonly runsIds$ = this.store.pipe(
     select(
-      createSelector(
-        getDebuggerRunListing,
-        (runs): string[] => Object.keys(runs)
+      createSelector(getDebuggerRunListing, (runs): string[] =>
+        Object.keys(runs)
       )
     )
   );

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_graphs_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_graphs_reducers_test.ts
@@ -552,7 +552,10 @@ describe('Debugger reducers', () => {
 
       expect(nextState.graphs.ops).toEqual({
         g0: new Map([[opInfo0.op_name, opInfo0]]),
-        g2: new Map([[opInfo1.op_name, opInfo1], [opInfo2.op_name, opInfo2]]),
+        g2: new Map([
+          [opInfo1.op_name, opInfo1],
+          [opInfo2.op_name, opInfo2],
+        ]),
       });
       expect(nextState.graphs.loadingOps).toEqual({
         g2: new Map([['TestOp_3', DataLoadState.LOADED]]),
@@ -614,7 +617,10 @@ describe('Debugger reducers', () => {
 
       expect(nextState.graphs.ops).toEqual({
         g0: new Map([[opInfo0.op_name, opInfo0]]),
-        g2: new Map([[opInfo1.op_name, opInfo1], [opInfo2.op_name, opInfo2]]),
+        g2: new Map([
+          [opInfo1.op_name, opInfo1],
+          [opInfo2.op_name, opInfo2],
+        ]),
       });
       expect(nextState.graphs.loadingOps).toEqual({
         g2: new Map([['TestOp_4', DataLoadState.LOADED]]),

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_reducers_test.ts
@@ -785,9 +785,9 @@ describe('Debugger graphs reducers', () => {
       numExecutions
     );
     // The first page is loaded in full.
-    expect(nextState.executions.executionDigestsLoaded.pageLoadedSizes).toEqual(
-      {0: 100}
-    );
+    expect(
+      nextState.executions.executionDigestsLoaded.pageLoadedSizes
+    ).toEqual({0: 100});
     // The detailed digest data should be recorded.
     expect(Object.keys(nextState.executions.executionDigests).length).toBe(100);
     for (let i = 0; i < 100; ++i) {
@@ -837,9 +837,9 @@ describe('Debugger graphs reducers', () => {
       numExecutions
     );
     // The first page is expanded.
-    expect(nextState.executions.executionDigestsLoaded.pageLoadedSizes).toEqual(
-      {0: 4}
-    );
+    expect(
+      nextState.executions.executionDigestsLoaded.pageLoadedSizes
+    ).toEqual({0: 4});
     // The detailed digest data should be recorded.
     expect(Object.keys(nextState.executions.executionDigests).length).toBe(4);
     expect(nextState.executions.executionDigests[0]).toEqual({
@@ -899,9 +899,9 @@ describe('Debugger graphs reducers', () => {
       numExecutions
     );
     // The first page is expanded.
-    expect(nextState.executions.executionDigestsLoaded.pageLoadedSizes).toEqual(
-      {0: 2, 1: 2}
-    );
+    expect(
+      nextState.executions.executionDigestsLoaded.pageLoadedSizes
+    ).toEqual({0: 2, 1: 2});
     // The detailed digest data should be recorded.
     expect(Object.keys(nextState.executions.executionDigests).length).toEqual(
       4
@@ -962,9 +962,9 @@ describe('Debugger graphs reducers', () => {
       numExecutions + 1
     );
     // The first page is expanded.
-    expect(nextState.executions.executionDigestsLoaded.pageLoadedSizes).toEqual(
-      {0: 2, 1: 2}
-    );
+    expect(
+      nextState.executions.executionDigestsLoaded.pageLoadedSizes
+    ).toEqual({0: 2, 1: 2});
     // The detailed digest data should be recorded.
     expect(Object.keys(nextState.executions.executionDigests).length).toBe(4);
     expect(nextState.executions.executionDigests[0]).toEqual({

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/store/debugger_selectors_test.ts
@@ -1101,7 +1101,10 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: new Map([['op1', op1Info], ['op2', op2Info]]),
+              g1: new Map([
+                ['op1', op1Info],
+                ['op2', op2Info],
+              ]),
             },
             focusedOp: null,
           }),
@@ -1115,7 +1118,10 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: new Map([['op1', op1Info], ['op2', op2Info]]),
+              g1: new Map([
+                ['op1', op1Info],
+                ['op2', op2Info],
+              ]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1132,7 +1138,10 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: new Map([['op1', op1Info], ['op2', op2Info]]),
+              g1: new Map([
+                ['op1', op1Info],
+                ['op2', op2Info],
+              ]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1233,7 +1242,10 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: new Map([['op1', op1Info], ['op2', op2Info]]),
+              g1: new Map([
+                ['op1', op1Info],
+                ['op2', op2Info],
+              ]),
             },
             focusedOp: {
               graphId: 'g1',
@@ -1347,7 +1359,10 @@ describe('debugger selectors', () => {
           }),
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: new Map([['op1', op1Info], ['op2', op2Info]]),
+              g1: new Map([
+                ['op1', op1Info],
+                ['op2', op2Info],
+              ]),
             },
             focusedOp: null,
           }),
@@ -1624,7 +1639,10 @@ describe('debugger selectors', () => {
         createDebuggerState({
           graphs: createDebuggerGraphsState({
             ops: {
-              g1: new Map([['op1', op1Info], ['op2', op2Info]]),
+              g1: new Map([
+                ['op1', op1Info],
+                ['op2', op2Info],
+              ]),
             },
             focusedOp: {
               graphId: 'g1',

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_component.ng.html
@@ -32,9 +32,7 @@ limitations under the License.
       [ngClass]="[breakdown.type === focusType ? 'focus' : '']"
       (click)="onToggleFocusType.emit(breakdown.type)"
     >
-      <div class="alert-type-name">
-        {{ breakdown.displayName }}
-      </div>
+      <div class="alert-type-name">{{ breakdown.displayName }}</div>
       <div class="alert-type-count">
         {{ breakdown.displaySymbol }}: {{ breakdown.count }}
       </div>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/alerts/alerts_container.ts
@@ -65,22 +65,19 @@ export class AlertsContainer {
 
   readonly alertsBreakdown$ = this.store.pipe(
     select(
-      createSelector(
-        getAlertsBreakdown,
-        (alertsBreakdown) => {
-          const alertTypes = Object.keys(alertsBreakdown);
-          alertTypes.sort();
-          return alertTypes.map(
-            (alertType): AlertTypeDisplay => {
-              return {
-                type: alertType as AlertType,
-                ...ALERT_TYPE_TO_DISPLAY_NAME_AND_SYMBOL[alertType],
-                count: alertsBreakdown[alertType],
-              };
-            }
-          );
-        }
-      )
+      createSelector(getAlertsBreakdown, (alertsBreakdown) => {
+        const alertTypes = Object.keys(alertsBreakdown);
+        alertTypes.sort();
+        return alertTypes.map(
+          (alertType): AlertTypeDisplay => {
+            return {
+              type: alertType as AlertType,
+              ...ALERT_TYPE_TO_DISPLAY_NAME_AND_SYMBOL[alertType],
+              count: alertsBreakdown[alertType],
+            };
+          }
+        );
+      })
     )
   );
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/debug_tensor_value_component.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/debug_tensor_value/debug_tensor_value_component.ts
@@ -32,9 +32,7 @@ const basicDebugInfoStyle = `
 
 @Component({
   selector: 'debug-tensor-dtype',
-  template: `
-    {{ dtype }}
-  `,
+  template: ` {{ dtype }} `,
   styles: [basicDebugInfoStyle],
 })
 export class DebugTensorDTypeComponent {
@@ -44,9 +42,7 @@ export class DebugTensorDTypeComponent {
 
 @Component({
   selector: 'debug-tensor-rank',
-  template: `
-    {{ rank }}D
-  `,
+  template: ` {{ rank }}D `,
   styles: [basicDebugInfoStyle],
 })
 export class DebugTensorRankComponent {
@@ -56,9 +52,7 @@ export class DebugTensorRankComponent {
 
 @Component({
   selector: 'debug-tensor-shape',
-  template: `
-    shape:{{ shapeString }}
-  `,
+  template: ` shape:{{ shapeString }} `,
   styles: [basicDebugInfoStyle],
 })
 export class DebugTensorShapeComponent {

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_component.ng.html
@@ -17,9 +17,7 @@ limitations under the License.
 
 <div class="focus-execution-container">
   <div>
-    <span>
-      Python Execution #{{ focusedExecutionIndex }}
-    </span>
+    <span> Python Execution #{{ focusedExecutionIndex }} </span>
   </div>
 
   <div *ngIf="focusedExecutionData !== null; else loading_section">
@@ -35,9 +33,7 @@ limitations under the License.
       </div>
 
       <div class="execution-data-field">
-        <span class="execution-data-key">
-          # of input tensors:
-        </span>
+        <span class="execution-data-key"> # of input tensors: </span>
         <span class="execution-data-value input-tensors">
           {{ focusedExecutionData.input_tensor_ids == null ? 0 :
           focusedExecutionData.input_tensor_ids.length }}
@@ -45,9 +41,7 @@ limitations under the License.
       </div>
 
       <div class="execution-data-field">
-        <span class="execution-data-key">
-          # of output tensors:
-        </span>
+        <span class="execution-data-key"> # of output tensors: </span>
         <span class="execution-data-value output-tensors">
           {{ focusedExecutionData.output_tensor_ids == null ? 0 :
           focusedExecutionData.output_tensor_ids.length }}
@@ -65,9 +59,7 @@ limitations under the License.
         >
           <!-- TensorFlow's `tf.Tensor` has 0-based slots in their names. -->
           <!-- We need to be consistent with that. -->
-          <div class="output-slot-number">
-            Output slot {{ i }}:
-          </div>
+          <div class="output-slot-number">Output slot {{ i }}:</div>
           <div class="output-slot-debug-tensor-value">
             <debug-tensor-value
               [debugTensorValue]="parseDebugTensorValue({

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container.ts
@@ -47,88 +47,78 @@ export class ExecutionDataContainer {
 
   readonly tensorDebugMode$ = this.store.pipe(
     select(
-      createSelector(
-        getFocusedExecutionData,
-        (execution: Execution | null) => {
-          if (execution === null) {
-            return TensorDebugMode.UNSPECIFIED;
-          } else {
-            return execution.tensor_debug_mode;
-          }
+      createSelector(getFocusedExecutionData, (execution: Execution | null) => {
+        if (execution === null) {
+          return TensorDebugMode.UNSPECIFIED;
+        } else {
+          return execution.tensor_debug_mode;
         }
-      )
+      })
     )
   );
 
   readonly hasDebugTensorValues$ = this.store.pipe(
     select(
-      createSelector(
-        getFocusedExecutionData,
-        (execution: Execution | null) => {
-          if (execution === null || execution.debug_tensor_values === null) {
-            return false;
-          } else {
-            for (const singleDebugTensorValues of execution.debug_tensor_values) {
-              if (
-                singleDebugTensorValues !== null &&
-                singleDebugTensorValues.length > 0
-              ) {
-                return true;
-              }
+      createSelector(getFocusedExecutionData, (execution: Execution | null) => {
+        if (execution === null || execution.debug_tensor_values === null) {
+          return false;
+        } else {
+          for (const singleDebugTensorValues of execution.debug_tensor_values) {
+            if (
+              singleDebugTensorValues !== null &&
+              singleDebugTensorValues.length > 0
+            ) {
+              return true;
             }
-            return false;
           }
+          return false;
         }
-      )
+      })
     )
   );
 
   readonly debugTensorValues$ = this.store.pipe(
     select(
-      createSelector(
-        getFocusedExecutionData,
-        (execution: Execution | null) => {
-          if (execution === null) {
-            return null;
-          } else {
-            return execution.debug_tensor_values;
-          }
+      createSelector(getFocusedExecutionData, (execution: Execution | null) => {
+        if (execution === null) {
+          return null;
+        } else {
+          return execution.debug_tensor_values;
         }
-      )
+      })
     )
   );
 
   readonly debugTensorDtypes$ = this.store.pipe(
     select(
-      createSelector(
-        getFocusedExecutionData,
-        (execution: Execution | null): string[] | null => {
-          if (execution === null || execution.debug_tensor_values === null) {
-            return null;
-          }
-          if (
-            execution.tensor_debug_mode !== TensorDebugMode.FULL_HEALTH &&
-            execution.tensor_debug_mode !== TensorDebugMode.SHAPE
-          ) {
-            // TODO(cais): Add logic for other TensorDebugModes with dtype info.
-            return null;
-          }
-          const dtypes: string[] = [];
-          for (const tensorValue of execution.debug_tensor_values) {
-            if (tensorValue === null) {
-              dtypes.push(UNKNOWN_DTYPE_NAME);
-            } else {
-              const dtypeEnum = String(
-                execution.tensor_debug_mode === TensorDebugMode.FULL_HEALTH
-                  ? tensorValue[2] // tensor_debug_mode: FULL_HEALTH
-                  : tensorValue[1] // tensor_debug_mode: SHAPE
-              );
-              dtypes.push(DTYPE_ENUM_TO_NAME[dtypeEnum] || UNKNOWN_DTYPE_NAME);
-            }
-          }
-          return dtypes;
+      createSelector(getFocusedExecutionData, (execution: Execution | null):
+        | string[]
+        | null => {
+        if (execution === null || execution.debug_tensor_values === null) {
+          return null;
         }
-      )
+        if (
+          execution.tensor_debug_mode !== TensorDebugMode.FULL_HEALTH &&
+          execution.tensor_debug_mode !== TensorDebugMode.SHAPE
+        ) {
+          // TODO(cais): Add logic for other TensorDebugModes with dtype info.
+          return null;
+        }
+        const dtypes: string[] = [];
+        for (const tensorValue of execution.debug_tensor_values) {
+          if (tensorValue === null) {
+            dtypes.push(UNKNOWN_DTYPE_NAME);
+          } else {
+            const dtypeEnum = String(
+              execution.tensor_debug_mode === TensorDebugMode.FULL_HEALTH
+                ? tensorValue[2] // tensor_debug_mode: FULL_HEALTH
+                : tensorValue[1] // tensor_debug_mode: SHAPE
+            );
+            dtypes.push(DTYPE_ENUM_TO_NAME[dtypeEnum] || UNKNOWN_DTYPE_NAME);
+          }
+        }
+        return dtypes;
+      })
     )
   );
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container_test.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/execution_data/execution_data_container_test.ts
@@ -143,7 +143,10 @@ describe('Execution Data Container', () => {
                 op_type: 'Inverse',
                 output_tensor_ids: [10, 11],
                 tensor_debug_mode: TensorDebugMode.CURT_HEALTH,
-                debug_tensor_values: [[0, 0], [0, 1]],
+                debug_tensor_values: [
+                  [0, 0],
+                  [0, 1],
+                ],
               }),
             },
           },

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_component.ng.html
@@ -16,9 +16,7 @@ limitations under the License.
 -->
 
 <div>
-  <div>
-    Graph Structure
-  </div>
+  <div>Graph Structure</div>
 
   <div class="graph-structure-container">
     <div *ngIf="opInfo !== undefined && opInfo !== null; else noOpFocused">
@@ -28,9 +26,7 @@ limitations under the License.
             *ngFor="let inputOpInfo of inputOps; let slot = index"
             class="input-op-section"
           >
-            <div class="input-slot-header">
-              Input slot {{slot}}:
-            </div>
+            <div class="input-slot-header">Input slot {{slot}}:</div>
             <graph-op
               [kind]="'input'"
               [opName]="inputOpInfo.op_name"
@@ -51,9 +47,7 @@ limitations under the License.
       </ng-template>
 
       <div class="self-op-container">
-        <div class="self-op-header">
-          Op:
-        </div>
+        <div class="self-op-header">Op:</div>
         <graph-op
           [kind]="'self'"
           [opName]="opInfo.op_name"
@@ -111,9 +105,7 @@ limitations under the License.
   </div>
 
   <ng-template #opInfoMissing>
-    <span class="op-info-missing">
-      (Op info unavailable.)
-    </span>
+    <span class="op-info-missing"> (Op info unavailable.) </span>
   </ng-template>
 
   <ng-template #noOpFocused>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_op_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph/graph_op_component.ng.html
@@ -26,12 +26,8 @@ limitations under the License.
     </button>
     <div *ngIf="kind !== 'self'" class="slot">
       <span [ngSwitch]="kind">
-        <span *ngSwitchCase="'input'">
-          Output
-        </span>
-        <span *ngSwitchCase="'consumer'">
-          Input
-        </span>
+        <span *ngSwitchCase="'input'"> Output </span>
+        <span *ngSwitchCase="'consumer'"> Input </span>
       </span>
       slot: {{ slot }}
     </div>
@@ -40,8 +36,6 @@ limitations under the License.
     {{ opData.op_type }}
   </div>
   <ng-template #opInfoMissing>
-    <span class="op-info-missing">
-      (Op info unavailable.)
-    </span>
+    <span class="op-info-missing"> (Op info unavailable.) </span>
   </ng-template>
 </button>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_component.ng.html
@@ -35,9 +35,7 @@ limitations under the License.
         [ngClass]="{'input-of-focus': isInputOfFocus(i)}"
       >
         <div class="graph-execution-index">
-          <div *ngIf="i === focusIndex" class="graph-execution-focus">
-            ▶
-          </div>
+          <div *ngIf="i === focusIndex" class="graph-execution-focus">▶</div>
           {{ i }}
         </div>
         <div *ngIf="graphExecutionData[i]; else dataLoading">
@@ -53,9 +51,7 @@ limitations under the License.
             >
               {{ getTensorName(i) }}
             </button>
-            <div class="op-type">
-              {{ graphExecutionData[i].op_type }}
-            </div>
+            <div class="op-type">{{ graphExecutionData[i].op_type }}</div>
           </div>
 
           <debug-tensor-value

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/graph_executions/graph_executions_container.ts
@@ -50,15 +50,14 @@ export class GraphExecutionsContainer {
 
   readonly graphExecutionIndices$ = this.store.pipe(
     select(
-      createSelector(
-        getNumGraphExecutions,
-        (numGraphExecution: number): number[] | null => {
-          if (numGraphExecution === 0) {
-            return null;
-          }
-          return Array.from({length: numGraphExecution}).map((_, i) => i);
+      createSelector(getNumGraphExecutions, (numGraphExecution: number):
+        | number[]
+        | null => {
+        if (numGraphExecution === 0) {
+          return null;
         }
-      )
+        return Array.from({length: numGraphExecution}).map((_, i) => i);
+      })
     )
   );
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inactive_component.uninlined.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inactive_component.uninlined.ng.html
@@ -16,9 +16,7 @@ limitations under the License.
 -->
 
 <div class="container">
-  <div class="title">
-    Debugger V2 is inactive because no data is available.
-  </div>
+  <div class="title">Debugger V2 is inactive because no data is available.</div>
 
   <div>To use the debugger,</div>
   <div>
@@ -33,9 +31,7 @@ limitations under the License.
           <span>)</span>
         </div>
       </li>
-      <li>
-        Re-run the program.
-      </li>
+      <li>Re-run the program.</li>
     </ol>
   </div>
 
@@ -44,9 +40,7 @@ limitations under the License.
       <div class="screenshot">
         <img src="%cutout-1-alerts.png%" />
       </div>
-      <div class="description">
-        Auto-alerts for problems found
-      </div>
+      <div class="description">Auto-alerts for problems found</div>
     </div>
 
     <div class="exhibit">
@@ -62,9 +56,7 @@ limitations under the License.
       <div class="screenshot">
         <img src="%cutout-3-code.png%" />
       </div>
-      <div class="description">
-        Link log to code
-      </div>
+      <div class="description">Link log to code</div>
     </div>
   </div>
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inactive_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/inactive/inactive_container.ts
@@ -22,9 +22,7 @@ export interface InactiveState {}
 
 @Component({
   selector: 'tf-debugger-v2-inactive',
-  template: `
-    <inactive-component></inactive-component>
-  `,
+  template: ` <inactive-component></inactive-component> `,
 })
 export class InactiveContainer {
   constructor(private readonly store: Store<InactiveState>) {}

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/source_files/source_files_component.ng.html
@@ -17,9 +17,7 @@ limitations under the License.
 
 <div class="source-files-container">
   <div class="header-section">
-    <div class="title-tag">
-      Source Code
-    </div>
+    <div class="title-tag">Source Code</div>
 
     <!-- TODO(cais): Support multiple tabs, each for a file. -->
     <div

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_component.ng.html
@@ -17,9 +17,7 @@ limitations under the License.
 
 <div class="stack-trace-container">
   <div class="stack-trace-header">
-    <span class="stack-trace-title">
-      Stack Trace
-    </span>
+    <span class="stack-trace-title"> Stack Trace </span>
 
     <div
       *ngIf="codeLocationType !== null; else noStackTrace"
@@ -32,9 +30,7 @@ limitations under the License.
             <span *ngIf="opType !== null" class="eager-execution-index">
               #{{ executionIndex }}:
             </span>
-            <span *ngIf="opType !== null" class="op-type">
-              {{ opType }}
-            </span>
+            <span *ngIf="opType !== null" class="op-type"> {{ opType }} </span>
           </div>
 
           <div *ngSwitchCase="CodeLocationType.GRAPH_OP_CREATION">
@@ -42,9 +38,7 @@ limitations under the License.
             <span *ngIf="opName !== null" class="op-name">
               "{{ opName }}"
             </span>
-            <span *ngIf="opType !== null" class="op-type">
-              {{ opType }}
-            </span>
+            <span *ngIf="opType !== null" class="op-type"> {{ opType }} </span>
           </div>
         </span>
       </span>

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/stack_trace/stack_trace_container.ts
@@ -57,46 +57,37 @@ export class StackTraceContainer {
 
   readonly opType$ = this.store.pipe(
     select(
-      createSelector(
-        getCodeLocationOrigin,
-        (originInfo): string | null => {
-          return originInfo === null ? null : originInfo.opType;
-        }
-      )
+      createSelector(getCodeLocationOrigin, (originInfo): string | null => {
+        return originInfo === null ? null : originInfo.opType;
+      })
     )
   );
 
   readonly opName$ = this.store.pipe(
     select(
-      createSelector(
-        getCodeLocationOrigin,
-        (originInfo): string | null => {
-          if (
-            originInfo === null ||
-            originInfo.codeLocationType !== CodeLocationType.GRAPH_OP_CREATION
-          ) {
-            return null;
-          }
-          return originInfo.opName;
+      createSelector(getCodeLocationOrigin, (originInfo): string | null => {
+        if (
+          originInfo === null ||
+          originInfo.codeLocationType !== CodeLocationType.GRAPH_OP_CREATION
+        ) {
+          return null;
         }
-      )
+        return originInfo.opName;
+      })
     )
   );
 
   readonly executionIndex$ = this.store.pipe(
     select(
-      createSelector(
-        getCodeLocationOrigin,
-        (originInfo): number | null => {
-          if (
-            originInfo === null ||
-            originInfo.codeLocationType !== CodeLocationType.EXECUTION
-          ) {
-            return null;
-          }
-          return originInfo.executionIndex;
+      createSelector(getCodeLocationOrigin, (originInfo): number | null => {
+        if (
+          originInfo === null ||
+          originInfo.codeLocationType !== CodeLocationType.EXECUTION
+        ) {
+          return null;
         }
-      )
+        return originInfo.executionIndex;
+      })
     )
   );
 

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.ng.html
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_component.ng.html
@@ -18,9 +18,7 @@ limitations under the License.
 <div>
   <div class="timeline-title">
     Python Execution Timeline
-    <span class="execution-count">
-      ({{ numExecutions }})
-    </span>
+    <span class="execution-count"> ({{ numExecutions }}) </span>
   </div>
 
   <div class="top-level-executions">

--- a/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container.ts
+++ b/tensorboard/plugins/debugger_v2/tf_debugger_v2_plugin/views/timeline/timeline_container.ts
@@ -112,12 +112,9 @@ export class TimelineContainer {
 
   readonly loadingNumExecutions$ = this.store.pipe(
     select(
-      createSelector(
-        getNumExecutionsLoaded,
-        (loaded) => {
-          return loaded.state == DataLoadState.LOADING;
-        }
-      )
+      createSelector(getNumExecutionsLoaded, (loaded) => {
+        return loaded.state == DataLoadState.LOADING;
+      })
     )
   );
 
@@ -143,14 +140,11 @@ export class TimelineContainer {
 
   readonly displayExecutionDigests$ = this.store.pipe(
     select(
-      createSelector(
-        getVisibleExecutionDigests,
-        (visibleDigests) => {
-          return visibleDigests.map((digest) =>
-            getExecutionDigestForDisplay(digest)
-          );
-        }
-      )
+      createSelector(getVisibleExecutionDigests, (visibleDigests) => {
+        return visibleDigests.map((digest) =>
+          getExecutionDigestForDisplay(digest)
+        );
+      })
     )
   );
 

--- a/tensorboard/plugins/distribution/vz_distribution_chart/vz-distribution-chart.ts
+++ b/tensorboard/plugins/distribution/vz_distribution_chart/vz-distribution-chart.ts
@@ -72,10 +72,7 @@ export class DistributionChart {
     this.yScale = new Plottable.Scales.Linear();
     this.yAxis = new Plottable.Axes.Numeric(this.yScale, 'left');
     let yFormatter = multiscaleFormatter(Y_AXIS_FORMATTER_PRECISION);
-    this.yAxis
-      .margin(0)
-      .tickLabelPadding(5)
-      .formatter(yFormatter);
+    this.yAxis.margin(0).tickLabelPadding(5).formatter(yFormatter);
     this.yAxis.usesTextWidthApproximation(true);
     let center = this.buildPlot(this.xAccessor, this.xScale, this.yScale);
     this.gridlines = new Plottable.Components.Gridlines(
@@ -159,7 +156,8 @@ export interface VzDistributionChart extends HTMLElement {
 }
 
 @customElement('vz-distribution-chart')
-class _VzDistributionChart extends LegacyElementMixin(PolymerElement)
+class _VzDistributionChart
+  extends LegacyElementMixin(PolymerElement)
   implements VzDistributionChart {
   static readonly template = html`
     <style include="plottable-style"></style>
@@ -233,7 +231,7 @@ class _VzDistributionChart extends LegacyElementMixin(PolymerElement)
     if (this._makeChartAsyncCallbackId === null) {
       this.cancelAsync(this._makeChartAsyncCallbackId);
     }
-    this._makeChartAsyncCallbackId = this.async(function() {
+    this._makeChartAsyncCallbackId = this.async(function () {
       this._makeChartAsyncCallbackId = null;
       if (!_attached) return;
       if (this._chart) this._chart.destroy();
@@ -249,7 +247,7 @@ class _VzDistributionChart extends LegacyElementMixin(PolymerElement)
     if (this._chart) {
       this._chart.setVisibleSeries(this._visibleSeriesCache);
       this._visibleSeriesCache.forEach(
-        function(name) {
+        function (name) {
           this._chart.setSeriesData(name, this._seriesDataCache[name] || []);
         }.bind(this)
       );

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.html.ts
@@ -171,8 +171,7 @@ export const template = html`
 .non-input > g >
 .annotation:not(.input-highlight):not(.input-highlight-selected) >
 .annotation-label
-/*.annotation-edge*/
- {
+/*.annotation-edge*/ {
       visibility: hidden;
     }
 
@@ -545,9 +544,7 @@ export const template = html`
   <div class="titleContainer">
     <div id="title" class="title">Main Graph</div>
     <div id="auxTitle" class="auxTitle">Auxiliary Nodes</div>
-    <div id="functionLibraryTitle" class="functionLibraryTitle">
-      Functions
-    </div>
+    <div id="functionLibraryTitle" class="functionLibraryTitle">Functions</div>
   </div>
   <svg id="svg">
     <defs>

--- a/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph-scene.ts
@@ -248,10 +248,7 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
     this._edgeGroupIndex = {};
     this._updateLabels(false);
     // Remove all svg elements under the 'root' svg group.
-    d3.select(this.$.svg)
-      .select('#root')
-      .selectAll('*')
-      .remove();
+    d3.select(this.$.svg).select('#root').selectAll('*').remove();
     // And the defs.
     tf_graph_scene_node.removeGradientDefinitions(this.$.svg as SVGElement);
   }
@@ -260,14 +257,14 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
     this.templateIndex = renderHierarchy.hierarchy.getTemplateIndex();
     tf_graph_util.time(
       'tf-graph-scene (layout):',
-      function() {
+      function () {
         // layout the scene for this meta / series node
         tf_graph_layout.layoutScene(renderHierarchy.root);
       }.bind(this)
     );
     tf_graph_util.time(
       'tf-graph-scene (build scene):',
-      function() {
+      function () {
         tf_graph_scene_node.buildGroupForScene(
           d3.select(this.$.root),
           renderHierarchy.root,
@@ -279,7 +276,7 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
     );
     // Update the minimap again when the graph is done animating.
     setTimeout(
-      function() {
+      function () {
         this._updateHealthPills(
           this.nodeNamesToHealthPills,
           this.healthPillStepIndex
@@ -295,7 +292,7 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
       .zoom()
       .on(
         'end',
-        function() {
+        function () {
           if (this._zoomStartCoords) {
             // Calculate the total distance dragged during the zoom event.
             // If it is sufficiently small, then fire an event indicating
@@ -318,7 +315,7 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
       )
       .on(
         'zoom',
-        function() {
+        function () {
           // Store the coordinates of the zoom event.
           this._zoomTransform = d3.event.transform;
           // If this is the first zoom event after a zoom-end, then
@@ -342,7 +339,7 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
       .on('dblclick.zoom', null);
     d3.select(window).on(
       'resize',
-      function() {
+      function () {
         // Notify the minimap that the user's window was resized.
         // The minimap will figure out the new dimensions of the main svg
         // and will use the existing translate and scale params.
@@ -488,7 +485,7 @@ class TfGraphScene2 extends LegacyElementMixin(PolymerElement) {
       this.$.svg,
       this.$.root,
       this._zoom,
-      function() {
+      function () {
         this._zoomed = false;
       }.bind(this)
     );

--- a/tensorboard/plugins/graph/tf_graph/tf-graph.ts
+++ b/tensorboard/plugins/graph/tf_graph/tf-graph.ts
@@ -251,7 +251,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
   _buildRenderHierarchy(graphHierarchy) {
     tf_graph_util.time(
       'new tf_graph_render.Hierarchy',
-      function() {
+      function () {
         if (graphHierarchy.root.type !== tf_graph.NodeType.META) {
           // root must be metanode but sometimes Polymer's dom-if has not
           // remove tf-graph element yet in <tf-node-info>
@@ -281,7 +281,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
             renderGraph.computeTimeScale as any
           ),
           memory: getColorParamsFromScale(renderGraph.memoryUsageScale as any),
-          device: _.map(renderGraph.deviceColorMap.domain(), function(
+          device: _.map(renderGraph.deviceColorMap.domain(), function (
             deviceName
           ) {
             return {
@@ -289,7 +289,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
               color: renderGraph.deviceColorMap(deviceName),
             };
           }),
-          xla_cluster: _.map(renderGraph.xlaClusterColorMap.domain(), function(
+          xla_cluster: _.map(renderGraph.xlaClusterColorMap.domain(), function (
             xlaClusterName
           ) {
             return {
@@ -299,7 +299,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
           }),
         });
         this._setRenderHierarchy(renderGraph);
-        this.async(function() {
+        this.async(function () {
           this.fire('rendered');
         });
       }.bind(this)
@@ -406,7 +406,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     // Expand the node with some delay so that the user can immediately see
     // the visual effect of selecting that node, before the expansion is
     // done.
-    this.async(function() {
+    this.async(function () {
       this.$.scene.setNodeExpanded(renderNode);
     }, 75);
   }
@@ -451,7 +451,7 @@ class TfGraph extends LegacyElementMixin(PolymerElement) {
     tf_graph_hierarchy
       .build(this.basicGraph as any, this.hierarchyParams, hierarchyTracker)
       .then(
-        function(graphHierarchy) {
+        function (graphHierarchy) {
           this.set('graphHierarchy', graphHierarchy);
           this._buildRenderHierarchy(this.graphHierarchy);
         }.bind(this)

--- a/tensorboard/plugins/graph/tf_graph_common/colors.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/colors.ts
@@ -121,7 +121,7 @@ export let OP_GROUP_COLORS = [
   {color: 'Pink', groups: ['summary_ops']},
   {color: 'Deep Pink', groups: ['io_ops']},
 ].reduce((m, c) => {
-  c.groups.forEach(function(group) {
+  c.groups.forEach(function (group) {
     m[group] = c.color;
   });
   return m;

--- a/tensorboard/plugins/graph/tf_graph_common/common.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/common.ts
@@ -260,7 +260,10 @@ export const MAX_EDGE_WIDTH = 12;
 const EDGE_WIDTH_SCALE_EXPONENT = 0.3;
 /** The domain (min and max value) for the edge width. */
 const DOMAIN_EDGE_WIDTH_SCALE = [1, 5000000];
-export const EDGE_WIDTH_SIZE_BASED_SCALE: d3.ScalePower<number, number> = d3
+export const EDGE_WIDTH_SIZE_BASED_SCALE: d3.ScalePower<
+  number,
+  number
+> = d3
   .scalePow()
   .exponent(EDGE_WIDTH_SCALE_EXPONENT)
   .domain(DOMAIN_EDGE_WIDTH_SCALE)

--- a/tensorboard/plugins/graph/tf_graph_common/contextmenu.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/contextmenu.ts
@@ -61,7 +61,7 @@ export function getMenu(sceneElement: TfGraphScene, menu: ContextMenuItem[]) {
   const menuNode = sceneElement.getContextMenu();
   const menuSelection = d3.select(sceneElement.getContextMenu());
   // Function called to populate the context menu.
-  return function(data, index: number): void {
+  return function (data, index: number): void {
     // Position and display the menu.
     let event = <MouseEvent>d3.event;
     const sceneOffset = getOffset(sceneElement);
@@ -99,7 +99,7 @@ export function getMenu(sceneElement: TfGraphScene, menu: ContextMenuItem[]) {
         d.action(this, data, index);
         maybeCloseMenu();
       })
-      .html(function(d) {
+      .html(function (d) {
         return d.title(data);
       });
   };

--- a/tensorboard/plugins/graph/tf_graph_common/edge.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/edge.ts
@@ -90,7 +90,7 @@ export function buildGroup(
   // Select all children and join with data.
   // (Note that all children of g.edges are g.edge)
   let edgeGroups = (container as any)
-    .selectAll(function() {
+    .selectAll(function () {
       return this.childNodes;
     })
     .data(edges, getEdgeKey);
@@ -100,7 +100,7 @@ export function buildGroup(
     .append('g')
     .attr('class', Class.Edge.GROUP)
     .attr('data-edge', getEdgeKey)
-    .each(function(d: EdgeData) {
+    .each(function (d: EdgeData) {
       let edgeGroup = d3.select(this);
       d.label.edgeGroup = edgeGroup;
       // index node group for quick highlighting
@@ -122,10 +122,10 @@ export function buildGroup(
       appendEdge(edgeGroup, d, sceneComponent);
     })
     .merge(edgeGroups)
-    .each(function() {
+    .each(function () {
       position(sceneElement, this);
     })
-    .each(function(d) {
+    .each(function (d) {
       stylize(d3.select(this), d, sceneComponent);
     });
   edgeGroups
@@ -231,10 +231,7 @@ function adjustPathPointsForMarker(
     .select(document.createElementNS('http://www.w3.org/2000/svg', 'path'))
     .attr('d', lineFunc(points));
   let markerWidth = +marker.attr('markerWidth');
-  let viewBox = marker
-    .attr('viewBox')
-    .split(' ')
-    .map(Number);
+  let viewBox = marker.attr('viewBox').split(' ').map(Number);
   let viewBoxWidth = viewBox[2] - viewBox[0];
   let refX = +marker.attr('refX');
   let pathNode = <SVGPathElement>path.node();
@@ -413,7 +410,7 @@ function getEdgePathInterpolator(
   // coordinates into the space of the renderPath using its Current
   // Transformation Matrix (CTM).
   let inbound = renderMetaedgeInfo.metaedge.inbound;
-  return function(t) {
+  return function (t) {
     let adjoiningPoint = adjoiningPath
       .getPointAtLength(inbound ? adjoiningPath.getTotalLength() : 0)
       .matrixTransform(adjoiningPath.getCTM())
@@ -431,7 +428,7 @@ function position(component: HTMLElement, edgeGroup: HTMLElement) {
   d3.select(edgeGroup)
     .select('path.' + Class.Edge.LINE)
     .transition()
-    .attrTween('d', function(d: EdgeData, i: number, a: SVGPathElement[]) {
+    .attrTween('d', function (d: EdgeData, i: number, a: SVGPathElement[]) {
       return getEdgePathInterpolator(
         component,
         this as SVGPathElement,

--- a/tensorboard/plugins/graph/tf_graph_common/graph.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/graph.ts
@@ -1291,7 +1291,7 @@ export function createGraph<N, E>(
  * the specified types.
  */
 function getEmbedPredicate(types: string[]) {
-  return function(node: OpNode) {
+  return function (node: OpNode) {
     // check types
     for (let i = 0; i < types.length; i++) {
       let regExp = new RegExp(types[i]);
@@ -1373,7 +1373,7 @@ function mapStrictHierarchy(
  * Returns a list of the degrees of each node in the graph.
  */
 function degreeSequence(graph: graphlib.Graph): number[] {
-  let degrees = graph.nodes().map(function(name) {
+  let degrees = graph.nodes().map(function (name) {
     return graph.neighbors(name).length;
   });
   degrees.sort();

--- a/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/hierarchy.ts
@@ -692,11 +692,11 @@ function addNodes(h: Hierarchy, graph: SlimGraph) {
     node.parentNode = parent;
     parent.metagraph.setNode(node.name, node);
     // Add each of the in-embeddings and out-embeddings in the hierarchy.
-    _.each(node.inEmbeddings, function(embedding) {
+    _.each(node.inEmbeddings, function (embedding) {
       h.setNode(embedding.name, embedding);
       embedding.parentNode = node;
     });
-    _.each(node.outEmbeddings, function(embedding) {
+    _.each(node.outEmbeddings, function (embedding) {
       h.setNode(embedding.name, embedding);
       embedding.parentNode = node;
     });
@@ -838,7 +838,7 @@ function groupSeries(
   );
   // Add each series node to the graph and add its grouped children to its own
   // metagraph.
-  _.each(seriesDict, function(seriesNode: SeriesNode, seriesName: string) {
+  _.each(seriesDict, function (seriesNode: SeriesNode, seriesName: string) {
     let nodeMemberNames = seriesNode.metagraph.nodes();
     _.each(nodeMemberNames, (n) => {
       let child = metagraph.node(n) as any;
@@ -961,7 +961,7 @@ function detectSeriesUsingNumericSuffixes(
   let seriesDict: {
     [seriesName: string]: SeriesNode;
   } = {};
-  _.each(clusters, function(members, clusterId: string) {
+  _.each(clusters, function (members, clusterId: string) {
     if (members.length <= 1) {
       return;
     } // isolated clusters can't make series
@@ -975,7 +975,7 @@ function detectSeriesUsingNumericSuffixes(
     // Group all nodes that have the same name, with the exception of a
     // number at the end of the name after an underscore, which is allowed to
     // vary.
-    _.each(members, function(name: string) {
+    _.each(members, function (name: string) {
       let isGroup = name.charAt(name.length - 1) === '*';
       let namepath = name.split('/');
       let leaf = namepath[namepath.length - 1];
@@ -1008,11 +1008,14 @@ function detectSeriesUsingNumericSuffixes(
     });
     // In each group of nodes, group nodes in bunches that have monotonically
     // increasing numbers in their names.  Each of these bunches is a series.
-    _.each(candidatesDict, function(seriesInfoArray: SeriesNode[], seriesName) {
+    _.each(candidatesDict, function (
+      seriesInfoArray: SeriesNode[],
+      seriesName
+    ) {
       if (seriesInfoArray.length < 2) {
         return;
       }
-      seriesInfoArray.sort(function(a, b) {
+      seriesInfoArray.sort(function (a, b) {
         return +a.clusterId - +b.clusterId;
       });
       // Loop through the nodes sorted by its detected series number, grouping
@@ -1068,7 +1071,7 @@ function detectSeriesAnywhereInNodeName(
   let seriesDict: {
     [seriesName: string]: SeriesNode;
   } = {};
-  _.each(clusters, function(members, clusterId: string) {
+  _.each(clusters, function (members, clusterId: string) {
     if (members.length <= 1) {
       return;
     } // isolated clusters can't make series
@@ -1089,7 +1092,7 @@ function detectSeriesAnywhereInNodeName(
     // Group all nodes that have the same name, with the exception of a
     // number at the end of the name after an underscore, which is allowed to
     // vary.
-    _.each(members, function(name: string) {
+    _.each(members, function (name: string) {
       let isGroup = name.charAt(name.length - 1) === '*';
       let namepath = name.split('/');
       let leaf = namepath[namepath.length - 1];
@@ -1155,8 +1158,8 @@ function detectSeriesAnywhereInNodeName(
     } = {};
     // For each of the member, put it into the maximum possible series,
     // and create candidatesDict accordingly.
-    _.each(reverseDict, function(seriesNameIdArray, name) {
-      seriesNameIdArray.sort(function(a, b) {
+    _.each(reverseDict, function (seriesNameIdArray, name) {
+      seriesNameIdArray.sort(function (a, b) {
         return forwardDict[b[0]].ids.length - forwardDict[a[0]].ids.length;
       });
       var seriesName = seriesNameIdArray[0][0];
@@ -1177,11 +1180,14 @@ function detectSeriesAnywhereInNodeName(
     });
     // In each group of nodes, group nodes in bunches that have monotonically
     // increasing numbers in their names.  Each of these bunches is a series.
-    _.each(candidatesDict, function(seriesInfoArray: SeriesNode[], seriesName) {
+    _.each(candidatesDict, function (
+      seriesInfoArray: SeriesNode[],
+      seriesName
+    ) {
       if (seriesInfoArray.length < 2) {
         return;
       }
-      seriesInfoArray.sort(function(a, b) {
+      seriesInfoArray.sort(function (a, b) {
         return +a.clusterId - +b.clusterId;
       });
       // Loop through the nodes sorted by its detected series number, grouping
@@ -1251,7 +1257,7 @@ function addSeriesToDict(
       curSeriesName,
       graphOptions
     );
-    _.each(seriesNodes, function(node) {
+    _.each(seriesNodes, function (node) {
       curSeriesNode.ids.push(node.clusterId);
       curSeriesNode.metagraph.setNode(node.name, metagraph.node(node.name));
     });

--- a/tensorboard/plugins/graph/tf_graph_common/loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/loader.ts
@@ -39,7 +39,7 @@ export function fetchAndConstructHierarchicalGraph(
   return parser
     .fetchAndParseGraphData(remotePath, pbTxtFile, dataTracker)
     .then(
-      function(graph) {
+      function (graph) {
         if (!graph.node) {
           throw new Error(
             'The graph is empty. This can happen when ' +

--- a/tensorboard/plugins/graph/tf_graph_common/minimap.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/minimap.ts
@@ -94,10 +94,7 @@ export class Minimap {
       this.updateViewpoint();
     };
     this.viewpointCoord = {x: 0, y: 0};
-    let drag = d3
-      .drag()
-      .subject(Object)
-      .on('drag', dragmove);
+    let drag = d3.drag().subject(Object).on('drag', dragmove);
     $viewpoint.datum(this.viewpointCoord as any).call(drag);
     // Make the minimap clickable.
     $minimapSvg.on('click', () => {

--- a/tensorboard/plugins/graph/tf_graph_common/node.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/node.ts
@@ -98,7 +98,7 @@ export function buildGroup(
   // Select all children and join with data.
   // (Note that all children of g.nodes are g.node)
   let nodeGroups = (container as any)
-    .selectAll(function() {
+    .selectAll(function () {
       return this.childNodes;
     })
     .data(nodeData, (d) => {
@@ -112,7 +112,7 @@ export function buildGroup(
     .attr('data-name', (d) => {
       return d.node.name;
     })
-    .each(function(d) {
+    .each(function (d) {
       let nodeGroup = d3.select(this);
       // index node group for quick stylizing
       sceneElement.addNodeGroup(d.node.name, nodeGroup);
@@ -122,7 +122,7 @@ export function buildGroup(
     .attr('class', (d) => {
       return Class.Node.GROUP + ' ' + nodeClass(d);
     })
-    .each(function(d) {
+    .each(function (d) {
       let nodeGroup = d3.select(this);
       // Add g.in-annotations (always add -- to keep layer order
       // consistent.)
@@ -169,7 +169,7 @@ export function buildGroup(
   // EXIT
   nodeGroups
     .exit()
-    .each(function(d) {
+    .each(function (d) {
       // remove all indices on remove
       sceneElement.removeNodeGroup(d.node.name);
       let nodeGroup = d3.select(this);
@@ -767,9 +767,7 @@ function getGradient(
   return `url(#${escapedId})`;
 }
 export function removeGradientDefinitions(svgRoot: SVGElement) {
-  d3.select(svgRoot)
-    .select('defs#_graph-gradients')
-    .remove();
+  d3.select(svgRoot).select('defs#_graph-gradients').remove();
 }
 /**
  * Returns the fill color for the node given its state and the 'color by'
@@ -907,10 +905,7 @@ export function getStrokeForFill(fill: string) {
   // If node is colored by a gradient, then use a dark gray outline.
   return fill.substring(0, 3) === 'url'
     ? render.MetanodeColors.GRADIENT_OUTLINE
-    : d3
-        .rgb(fill)
-        .darker()
-        .toString();
+    : d3.rgb(fill).darker().toString();
 }
 /**
  * Finds selected node and highlights all nodes which are providing direct
@@ -943,7 +938,7 @@ export function updateInputTrace(
   }
   let opNodes = _getAllContainedOpNodes(selectedNodeName, renderGraphInfo);
   let allTracedNodes = {};
-  _.each(opNodes, function(nodeInstance) {
+  _.each(opNodes, function (nodeInstance) {
     allTracedNodes = traceAllInputsOfOpNode(
       svgRoot,
       renderGraphInfo,
@@ -966,7 +961,7 @@ export function updateInputTrace(
         ':not(.input-parent):not(.input-children)'
     )
     .classed('non-input', true)
-    .each(function(d: RenderNodeInfo) {
+    .each(function (d: RenderNodeInfo) {
       // Mark all nodes with the specified name as non-inputs. This
       // results in Annotation nodes which are attached to inputs to be
       // tagged as well.
@@ -1000,7 +995,7 @@ function _getAllContainedOpNodes(
   }
   // Otherwise, make recursive call for each node contained by the GroupNode.
   let childNodeNames = (node as tf_graph.GroupNode).metagraph.nodes();
-  _.each(childNodeNames, function(childNodeName) {
+  _.each(childNodeNames, function (childNodeName) {
     opNodes = opNodes.concat(
       _getAllContainedOpNodes(childNodeName, renderGraphInfo)
     );
@@ -1041,7 +1036,7 @@ function traceAllInputsOfOpNode(
     .classed('input-highlight', true);
   // Find the visible parent of each input.
   let visibleInputs = {};
-  _.each(inputs, function(nodeInstance) {
+  _.each(inputs, function (nodeInstance) {
     let resolvedNode = renderGraphInfo.getNodeByName(nodeInstance.name);
     if (resolvedNode === undefined) {
       // Node could not be found in rendered Hierarchy, which happens when
@@ -1085,11 +1080,11 @@ function traceAllInputsOfOpNode(
     indexedStartNodeParents[index] = currentNode;
   }
   // Find first mutual parent of each input node and highlight connection.
-  _.forOwn(visibleInputs, function(visibleParentInfo: VisibleParent, key) {
+  _.forOwn(visibleInputs, function (visibleParentInfo: VisibleParent, key) {
     let nodeInstance = visibleParentInfo.visibleParent;
     // Make recursive call for each input-OpNode contained by the visible
     // parent.
-    _.each(visibleParentInfo.opNodes, function(opNode: OpNode) {
+    _.each(visibleParentInfo.opNodes, function (opNode: OpNode) {
       allTracedNodes = traceAllInputsOfOpNode(
         svgRoot,
         renderGraphInfo,
@@ -1178,7 +1173,7 @@ function _createVisibleTrace(
     .selectAll(`[data-edge="${endNodeName}--${startNodeName}"]`)
     .classed('input-edge-highlight', true);
   // Trace up the parents of the input.
-  _.each(destinationParentPairs, function(value) {
+  _.each(destinationParentPairs, function (value) {
     let inner = value[0];
     let outer = value[1];
     let edgeSelector =
@@ -1209,7 +1204,7 @@ function _findVisibleParentsFromOpNodes(renderGraphInfo, nodeNames: string[]) {
   let visibleParents: {
     [nodeName: string]: Node;
   } = {};
-  _.each(nodeNames, function(nodeName) {
+  _.each(nodeNames, function (nodeName) {
     let currentNode = renderGraphInfo.getNodeByName(nodeName);
     let visibleParent = getVisibleParent(renderGraphInfo, currentNode);
     visibleParents[visibleParent.name] = visibleParent;
@@ -1229,7 +1224,7 @@ function _markParentsOfNodes(
     [nodeName: string]: Node;
   }
 ) {
-  _.forOwn(visibleNodes, function(nodeInstance: Node) {
+  _.forOwn(visibleNodes, function (nodeInstance: Node) {
     // Mark all parents of the node as input-parents.
     let currentNode = nodeInstance;
     while (currentNode.name !== tf_graph.ROOT_NAME) {
@@ -1302,7 +1297,7 @@ export function buildGroupForAnnotation(
 ) {
   // Select all children and join with data.
   let annotationGroups = container
-    .selectAll(function() {
+    .selectAll(function () {
       // using d3's selector function
       // See https://github.com/mbostock/d3/releases/tag/v2.0.0
       // (It's not listed in the d3 wiki.)
@@ -1317,7 +1312,7 @@ export function buildGroupForAnnotation(
     .attr('data-name', (a) => {
       return a.node.name;
     })
-    .each(function(a) {
+    .each(function (a) {
       let aGroup = d3.select(this);
       // Add annotation to the index in the scene
       sceneElement.addAnnotationGroup(a, d, aGroup);
@@ -1349,7 +1344,7 @@ export function buildGroupForAnnotation(
         nodeClass(a)
       );
     })
-    .each(function(a) {
+    .each(function (a) {
       let aGroup = d3.select(this);
       update(aGroup, d, a, sceneElement);
       if (a.annotationType !== render.AnnotationType.ELLIPSIS) {
@@ -1358,7 +1353,7 @@ export function buildGroupForAnnotation(
     });
   annotationGroups
     .exit()
-    .each(function(a) {
+    .each(function (a) {
       let aGroup = d3.select(this);
       // Remove annotation from the index in the scene
       sceneElement.removeAnnotationGroup(a, d, aGroup);
@@ -1632,10 +1627,7 @@ export function buildGroupForScene(
   tf_graph_scene.position(sceneGroup, renderNode);
   // Fade in the scene group if it didn't already exist.
   if (isNewSceneGroup) {
-    sceneGroup
-      .attr('opacity', 0)
-      .transition()
-      .attr('opacity', 1);
+    sceneGroup.attr('opacity', 0).transition().attr('opacity', 1);
   }
   return sceneGroup;
 }

--- a/tensorboard/plugins/graph/tf_graph_common/parser.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/parser.ts
@@ -89,7 +89,7 @@ export function fetchAndParseGraphData(
       40,
       () => {
         if (pbTxtFile) {
-          return new Promise<ArrayBuffer>(function(resolve, reject) {
+          return new Promise<ArrayBuffer>(function (resolve, reject) {
             let fileReader = new FileReader();
             fileReader.onload = () => resolve(fileReader.result as ArrayBuffer);
             fileReader.onerror = () => reject(fileReader.error);
@@ -127,7 +127,7 @@ export function streamParse(
   chunkSize: number = 1000000,
   delim: string = '\n'
 ): Promise<boolean> {
-  return new Promise<boolean>(function(resolve, reject) {
+  return new Promise<boolean>(function (resolve, reject) {
     function readChunk(oldData: string, newData: string, offset: number) {
       const doneReading = offset >= arrayBuffer.byteLength;
       const parts = newData.split(delim);
@@ -151,7 +151,7 @@ export function streamParse(
         arrayBuffer.slice(offset, offset + chunkSize),
       ]);
       const file = new FileReader();
-      file.onload = function(e: any) {
+      file.onload = function (e: any) {
         readChunk(remainder, e.target.result, offset + chunkSize);
       };
       file.readAsText(nextChunk);
@@ -293,7 +293,7 @@ function parsePbtxtFile(
     }
   }
   // Run through the file a line at a time.
-  return streamParse(input, function(line: string) {
+  return streamParse(input, function (line: string) {
     if (!line) {
       return;
     }
@@ -318,7 +318,7 @@ function parsePbtxtFile(
         addAttribute(current, x.name, x.value, path.concat(x.name));
         break;
     }
-  }).then(function() {
+  }).then(function () {
     return output;
   });
 }

--- a/tensorboard/plugins/graph/tf_graph_common/scene.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/scene.ts
@@ -154,10 +154,9 @@ export function fit(svg, zoomG, d3zoom, callback) {
  *            provided node.
  */
 export function panToNode(nodeName: String, svg, zoomG, d3zoom): boolean {
-  const node = <SVGAElement>d3
-    .select(svg)
-    .select(`[data-name="${nodeName}"]`)
-    .node();
+  const node = <SVGAElement>(
+    d3.select(svg).select(`[data-name="${nodeName}"]`).node()
+  );
   if (!node) {
     console.warn(`panToNode() failed for node name "${nodeName}"`);
     return false;
@@ -366,10 +365,7 @@ export function positionButton(button, renderNode: render.RenderNodeInfo) {
     y -= 2;
   }
   let translateStr = 'translate(' + x + ',' + y + ')';
-  button
-    .selectAll('path')
-    .transition()
-    .attr('transform', translateStr);
+  button.selectAll('path').transition().attr('transform', translateStr);
   button
     .select('circle')
     .transition()
@@ -664,7 +660,7 @@ export function addHealthPills(
   let svgRootSelection = d3.select(svgRoot);
   svgRootSelection
     .selectAll('g.nodeshape')
-    .each(function(nodeInfo: render.RenderNodeInfo) {
+    .each(function (nodeInfo: render.RenderNodeInfo) {
       // Only show health pill data for this node if it is available.
       const healthPills = nodeNamesToHealthPills[nodeInfo.node.name];
       const healthPill = healthPills ? healthPills[healthPillStepIndex] : null;

--- a/tensorboard/plugins/graph/tf_graph_common/template.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/template.ts
@@ -66,12 +66,12 @@ function getSignature(metanode) {
       '|V|': metanode.metagraph.nodes().length,
       '|E|': metanode.metagraph.edges().length,
     },
-    function(v, k) {
+    function (v, k) {
       return k + '=' + v;
     }
   ).join(' ');
   // optype1=count1,optype2=count2
-  let ops = _.map(metanode.opHistogram, function(count, op) {
+  let ops = _.map(metanode.opHistogram, function (count, op) {
     return op + '=' + count;
   }).join(',');
   return props + ' [ops] ' + ops;
@@ -140,11 +140,11 @@ function groupTemplateAndAssignId(nnGroups, verifyTemplate) {
   } = {};
   return _.reduce(
     nnGroups,
-    function(templates, nnGroupPair) {
+    function (templates, nnGroupPair) {
       let signature = nnGroupPair[0],
         nnGroup = nnGroupPair[1].nodes,
         clusters = [];
-      nnGroup.forEach(function(metanode) {
+      nnGroup.forEach(function (metanode) {
         // check with each existing cluster
         for (let i = 0; i < clusters.length; i++) {
           let similar =
@@ -168,7 +168,7 @@ function groupTemplateAndAssignId(nnGroups, verifyTemplate) {
           members: [metanode.name],
         });
       });
-      clusters.forEach(function(c) {
+      clusters.forEach(function (c) {
         templates[c.metanode.templateId] = {
           level: nnGroupPair[1].level,
           nodes: c.members,

--- a/tensorboard/plugins/graph/tf_graph_common/test/hierarchy-test.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/test/hierarchy-test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 describe('hierarchy', () => {
   const {expect} = chai;
 
-  beforeEach(function() {
+  beforeEach(function () {
     const pbtxt = tf.graph.test.util.stringToArrayBuffer(`
       node {
         name: "Q"
@@ -134,7 +134,7 @@ describe('hierarchy', () => {
       .then((graph: tf.graph.SlimGraph) => (this.slimGraph = graph));
   });
 
-  it('builds hierarchy with metagraph', function() {
+  it('builds hierarchy with metagraph', function () {
     return tf.graph.hierarchy
       .build(this.slimGraph, this.options, this.dummyTracker)
       .then((hierarchy) => {

--- a/tensorboard/plugins/graph/tf_graph_common/util.ts
+++ b/tensorboard/plugins/graph/tf_graph_common/util.ts
@@ -45,19 +45,19 @@ export type Tracker = {
  */
 export function getTracker(polymerComponent: any): Tracker {
   return {
-    setMessage: function(msg) {
+    setMessage: function (msg) {
       polymerComponent.set('progress', {
         value: polymerComponent.progress.value,
         msg: msg,
       });
     },
-    updateProgress: function(value) {
+    updateProgress: function (value) {
       polymerComponent.set('progress', {
         value: polymerComponent.progress.value + value,
         msg: polymerComponent.progress.msg,
       });
     },
-    reportError: function(msg: string, err) {
+    reportError: function (msg: string, err) {
       // Log the stack trace in the console.
       console.error(err.stack);
       // And send a user-friendly message to the UI.
@@ -82,12 +82,12 @@ export function getSubtaskTracker(
   subtaskMsg: string
 ): ProgressTracker {
   return {
-    setMessage: function(progressMsg) {
+    setMessage: function (progressMsg) {
       // The parent should show a concatenation of its message along with
       // its subtask tracker message.
       parentTracker.setMessage(subtaskMsg + ': ' + progressMsg);
     },
-    updateProgress: function(incrementValue) {
+    updateProgress: function (incrementValue) {
       // Update the parent progress relative to the child progress.
       // For example, if the sub-task progresses by 30%, and the impact on the
       // total progress is 50%, then the task progresses by 30% * 50% = 15%.
@@ -95,7 +95,7 @@ export function getSubtaskTracker(
         (incrementValue * impactOnTotalProgress) / 100
       );
     },
-    reportError: function(msg: string, err: Error) {
+    reportError: function (msg: string, err: Error) {
       // The parent should show a concatenation of its message along with
       // its subtask error message.
       parentTracker.reportError(subtaskMsg + ': ' + msg, err);
@@ -142,7 +142,7 @@ export function runAsyncTask<T>(
     tracker.setMessage(msg);
     // Run the expensive task with a delay that gives enough time for the
     // UI to update.
-    setTimeout(function() {
+    setTimeout(function () {
       try {
         let result = time(msg, task);
         // Update the progress value.
@@ -169,7 +169,7 @@ export function runAsyncPromiseTask<T>(
   tracker: ProgressTracker
 ): Promise<T> {
   return new Promise((resolve, reject) => {
-    let handleError = function(e) {
+    let handleError = function (e) {
       // Errors that happen inside asynchronous tasks are
       // reported to the tracker using a user-friendly message.
       tracker.reportError('Failed ' + msg, e);
@@ -179,11 +179,11 @@ export function runAsyncPromiseTask<T>(
     tracker.setMessage(msg);
     // Run the expensive task with a delay that gives enough time for the
     // UI to update.
-    setTimeout(function() {
+    setTimeout(function () {
       try {
         let start = Date.now();
         task()
-          .then(function(value) {
+          .then(function (value) {
             /* tslint:disable */
             console.log(msg, ':', Date.now() - start, 'ms');
             // Update the progress value.

--- a/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
+++ b/tensorboard/plugins/graph/tf_graph_controls/tf-graph-controls.ts
@@ -631,9 +631,7 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
         <template is="dom-if" if="[[_equals(colorBy, 'structure')]]">
           <div class="color-text">
             <div class="color-legend-row">
-              <span class="label">
-                colors
-              </span>
+              <span class="label"> colors </span>
               <span class="color-legend-value">same substructure</span>
             </div>
             <div class="color-legend-row">
@@ -1123,13 +1121,13 @@ class TfGraphControls extends LegacyElementMixin(PolymerElement) {
       return;
     }
     var devicesForStats = {};
-    var devices = _.each(stats.dev_stats, function(d) {
+    var devices = _.each(stats.dev_stats, function (d) {
       // Only considered included devices.
-      var include = _.some(DEVICE_NAMES_INCLUDE, function(rule) {
+      var include = _.some(DEVICE_NAMES_INCLUDE, function (rule) {
         return rule.regex.test(d.device);
       });
       // Exclude device names that are ignored by default.
-      var exclude = _.some(DEVICE_STATS_DEFAULT_OFF, function(rule) {
+      var exclude = _.some(DEVICE_STATS_DEFAULT_OFF, function (rule) {
         return rule.regex.test(d.device);
       });
       if (include && !exclude) {

--- a/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
+++ b/tensorboard/plugins/graph/tf_graph_dashboard/tf-graph-dashboard.ts
@@ -483,7 +483,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
       // This path may be slow. Schedule network requests to start some time later. If another
       // request is scheduled in the mean time, drop this current request.
       this._healthPillStepRequestTimerId = setTimeout(
-        function() {
+        function () {
           this._healthPillStepRequestTimerId = null;
           this._initiateNetworkRequestForHealthPills(requestId);
         }.bind(this),
@@ -512,7 +512,7 @@ class TfGraphDashboard extends LegacyElementMixin(PolymerElement) {
     );
     const alertsPromise = this._fetchDebuggerNumericsAlerts();
     Promise.all([healthPillsPromise, alertsPromise]).then(
-      function(result) {
+      function (result) {
         var healthPillsResult = result[0];
         var alertsResult = result[1];
         if (!this.healthPillsToggledOn) {

--- a/tensorboard/plugins/graph/tf_graph_debugger_data_card/tf-graph-debugger-data-card.ts
+++ b/tensorboard/plugins/graph/tf_graph_debugger_data_card/tf-graph-debugger-data-card.ts
@@ -258,9 +258,7 @@ class TfGraphDebuggerDataCard extends LegacyElementMixin(PolymerElement) {
       </template>
       <div hidden$="[[!_hasDebuggerNumericAlerts(debuggerNumericAlerts)]]">
         <h2 id="numeric-alerts-header">Numeric Alerts</h2>
-        <p>
-          Alerts are sorted from top to bottom by increasing timestamp.
-        </p>
+        <p>Alerts are sorted from top to bottom by increasing timestamp.</p>
         <div id="numeric-alerts-table-container">
           <table id="numeric-alerts-table">
             <thead>

--- a/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
+++ b/tensorboard/plugins/graph/tf_graph_info/tf-node-info.ts
@@ -531,7 +531,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
     if (!stats || !stats.outputSize || !stats.outputSize.length) {
       return;
     }
-    return _.map(stats.outputSize, function(shape) {
+    return _.map(stats.outputSize, function (shape) {
       if (shape.length === 0) {
         return 'scalar';
       }
@@ -549,12 +549,12 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
       return [];
     }
     var attrs = [];
-    _.each(node.attr, function(entry) {
+    _.each(node.attr, function (entry) {
       // Unpack the "too large" attributes into separate attributes
       // in the info card, with values "too large to show".
       if (entry.key === tf_graph.LARGE_ATTRS_KEY) {
         attrs = attrs.concat(
-          entry.value.list.s.map(function(key) {
+          entry.value.list.s.map(function (key) {
             return {key: key, value: 'Too large to show...'};
           })
         );
@@ -648,7 +648,7 @@ class TfNodeInfo extends LegacyElementMixin(PolymerElement) {
      * Converts a list of metaedges to a list of edge information
      * that can be rendered.
      */
-    var toEdgeInfoList = function(edges) {
+    var toEdgeInfoList = function (edges) {
       var edgeInfoList = [];
       _.each(edges, (metaedge) => {
         var name = isPredecessor ? metaedge.v : metaedge.w;

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-dashboard-loader.ts
@@ -108,7 +108,7 @@ class TfGraphDashboardLoader extends LegacyElementMixin(PolymerElement) {
       case tf_graph_common.SelectionType.OP_GRAPH:
       case tf_graph_common.SelectionType.CONCEPTUAL_GRAPH: {
         // Clear stats about the previous graph.
-        (function() {
+        (function () {
           this._setOutStats(null);
         }.bind(this)());
         const params = new URLSearchParams();
@@ -172,7 +172,7 @@ class TfGraphDashboardLoader extends LegacyElementMixin(PolymerElement) {
     });
     var tracker = tf_graph_util.getTracker(this);
     tf_graph_parser.fetchAndParseMetadata(path, tracker).then(
-      function(stats) {
+      function (stats) {
         this._setOutStats(stats);
       }.bind(this)
     );
@@ -193,7 +193,7 @@ class TfGraphDashboardLoader extends LegacyElementMixin(PolymerElement) {
         this.hierarchyParams as any
       )
       .then(
-        function({graph, graphHierarchy}) {
+        function ({graph, graphHierarchy}) {
           this._setOutGraph(graph);
           this._setOutGraphHierarchy(graphHierarchy);
         }.bind(this)

--- a/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.ts
+++ b/tensorboard/plugins/graph/tf_graph_loader/tf-graph-loader.ts
@@ -117,7 +117,7 @@ class TfGraphLoader extends LegacyElementMixin(PolymerElement) {
         hierarchyParams
       )
       .then(
-        function({graph, graphHierarchy}) {
+        function ({graph, graphHierarchy}) {
           this._setOutHierarchyParams(hierarchyParams);
           this._setOutGraph(graph);
           this._setOutGraphHierarchy(graphHierarchy);

--- a/tensorboard/plugins/histogram/vz_histogram_timeseries/vz-histogram-timeseries.ts
+++ b/tensorboard/plugins/histogram/vz_histogram_timeseries/vz-histogram-timeseries.ts
@@ -44,7 +44,8 @@ export interface VzHistogramTimeseries extends HTMLElement {
 }
 
 @customElement('vz-histogram-timeseries')
-class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
+class _VzHistogramTimeseries
+  extends LegacyElementMixin(PolymerElement)
   implements VzHistogramTimeseries {
   static readonly template = html`
     <div id="tooltip"><span></span></div>
@@ -321,23 +322,23 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
     var mode = this.mode;
     var color = d3.hcl(this.colorScale(name));
     var tooltip = d3.select(this.$.tooltip);
-    var xAccessor = function(d) {
+    var xAccessor = function (d) {
       return d[xProp];
     };
-    var yAccessor = function(d) {
+    var yAccessor = function (d) {
       return d[yProp];
     };
-    var dxAccessor = function(d) {
+    var dxAccessor = function (d) {
       return d[dxProp];
     };
-    var xRightAccessor = function(d) {
+    var xRightAccessor = function (d) {
       return d[xProp] + d[dxProp];
     };
-    var timeAccessor = function(d) {
+    var timeAccessor = function (d) {
       return d[timeProp];
     };
     if (timeProp === 'relative') {
-      timeAccessor = function(d) {
+      timeAccessor = function (d) {
         return d.wall_time - data[0].wall_time;
       };
     }
@@ -364,20 +365,20 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
     if (timeProp === 'wall_time') {
       yAxisFormat = d3.timeFormat('%m/%d %X');
     } else if (timeProp === 'relative') {
-      yAxisFormat = function(d: number) {
+      yAxisFormat = function (d: number) {
         return d3.format('.1r')(d / 3.6e6) + 'h'; // Convert to hours.
       };
     }
     //
     // Calculate the extents
     //
-    var xExtents = data.map(function(d, i) {
+    var xExtents = data.map(function (d, i) {
       return [
         d3.min(d[binsProp], xAccessor),
         d3.max(d[binsProp], xRightAccessor),
       ];
     });
-    var yExtents = data.map(function(d) {
+    var yExtents = data.map(function (d) {
       return d3.extent(d[binsProp], yAccessor);
     });
     //
@@ -393,7 +394,7 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
       .scaleLinear()
       .domain([
         0,
-        d3.max(data, function(d, i) {
+        d3.max(data, function (d, i) {
           return yExtents[i][1];
         }),
       ])
@@ -405,10 +406,10 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
     var xScale = d3
       .scaleLinear()
       .domain([
-        d3.min(data, function(d, i) {
+        d3.min(data, function (d, i) {
           return xExtents[i][0];
         }),
-        d3.max(data, function(d, i) {
+        d3.max(data, function (d, i) {
           return xExtents[i][1];
         }),
       ])
@@ -433,18 +434,18 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
       .ticks(Math.max(2, height / 15))
       .tickSize(width + 5)
       .tickFormat(format);
-    var xBinCentroid = function(d) {
+    var xBinCentroid = function (d) {
       return d[xProp] + d[dxProp] / 2;
     };
     var linePath = d3
       .line()
-      .x(function(d) {
+      .x(function (d) {
         return xLineScale(xBinCentroid(d));
       })
-      .y(function(d) {
+      .y(function (d) {
         return yLineScale(d[yProp]);
       });
-    var path = function(d) {
+    var path = function (d) {
       // Draw a line from 0 to the first point and from the last point to 0.
       return (
         'M' +
@@ -467,13 +468,13 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
     var svgTransition = svg.transition().duration(duration);
     var g = svg
       .select('g')
-      .classed('small', function() {
+      .classed('small', function () {
         return width > 0 && width <= 150;
       })
-      .classed('medium', function() {
+      .classed('medium', function () {
         return width > 150 && width <= 300;
       })
-      .classed('large', function() {
+      .classed('large', function () {
         return width > 300;
       });
     var gTransition = svgTransition
@@ -482,14 +483,14 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
     var bisect = d3.bisector(xRightAccessor).left;
     var stage = g
       .select('.stage')
-      .on('mouseover', function() {
+      .on('mouseover', function () {
         hoverUpdate.style('opacity', 1);
         xAxisHoverUpdate.style('opacity', 1);
         yAxisHoverUpdate.style('opacity', 1);
         ySliceAxisHoverUpdate.style('opacity', 1);
         tooltip.style('opacity', 1);
       })
-      .on('mouseout', function() {
+      .on('mouseout', function () {
         hoverUpdate.style('opacity', 0);
         xAxisHoverUpdate.style('opacity', 0);
         yAxisHoverUpdate.style('opacity', 0);
@@ -506,16 +507,13 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
       .attr('height', outerHeight);
     var histogram = stage.selectAll('.histogram').data(data),
       histogramExit = histogram.exit().remove(),
-      histogramEnter = histogram
-        .enter()
-        .append('g')
-        .attr('class', 'histogram'),
-      histogramUpdate = histogramEnter.merge(histogram).sort(function(a, b) {
+      histogramEnter = histogram.enter().append('g').attr('class', 'histogram'),
+      histogramUpdate = histogramEnter.merge(histogram).sort(function (a, b) {
         return timeAccessor(a) - timeAccessor(b);
       }),
       histogramTransition = gTransition
         .selectAll('.histogram')
-        .attr('transform', function(d) {
+        .attr('transform', function (d) {
           return (
             'translate(0, ' +
             (mode === 'offset' ? yScale(timeAccessor(d)) - sliceHeight : 0) +
@@ -525,7 +523,7 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
     var baselineEnter = histogramEnter.append('line').attr('class', 'baseline'),
       baselineUpdate = histogramTransition
         .select('.baseline')
-        .style('stroke-opacity', function(d) {
+        .style('stroke-opacity', function (d) {
           return mode === 'offset' ? 0.1 : 0;
         })
         .attr('y1', sliceHeight)
@@ -535,7 +533,7 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
       outlineUpdate = histogramUpdate
         .select('.outline')
         .attr('vector-effect', 'non-scaling-stroke')
-        .attr('d', function(d) {
+        .attr('d', function (d) {
           return path(d[binsProp]);
         })
         .style('stroke-width', 1),
@@ -549,34 +547,25 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
             sliceHeight / outlineCanvasSize +
             ')'
         )
-        .style('stroke', function(d) {
+        .style('stroke', function (d) {
           return mode === 'offset' ? 'white' : outlineColor(timeAccessor(d));
         })
-        .style('fill-opacity', function(d) {
+        .style('fill-opacity', function (d) {
           return mode === 'offset' ? 1 : 0;
         })
-        .style('fill', function(d) {
+        .style('fill', function (d) {
           return outlineColor(timeAccessor(d));
         });
     var hoverEnter = histogramEnter.append('g').attr('class', 'hover');
     var hoverUpdate = histogramUpdate
       .select('.hover')
-      .style('fill', function(d) {
+      .style('fill', function (d) {
         return outlineColor(timeAccessor(d));
       });
     hoverEnter.append('circle').attr('r', 2);
-    hoverEnter
-      .append('text')
-      .style('display', 'none')
-      .attr('dx', 4);
-    var xAxisHover = g
-        .select('.x-axis-hover')
-        .selectAll('.label')
-        .data(['x']),
-      xAxisHoverEnter = xAxisHover
-        .enter()
-        .append('g')
-        .attr('class', 'label'),
+    hoverEnter.append('text').style('display', 'none').attr('dx', 4);
+    var xAxisHover = g.select('.x-axis-hover').selectAll('.label').data(['x']),
+      xAxisHoverEnter = xAxisHover.enter().append('g').attr('class', 'label'),
       xAxisHoverUpdate = xAxisHover.merge(xAxisHoverEnter);
     xAxisHoverEnter
       .append('rect')
@@ -591,14 +580,8 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
       .attr('y1', 0)
       .attr('y2', 6);
     xAxisHoverEnter.append('text').attr('dy', 18);
-    var yAxisHover = g
-        .select('.y-axis-hover')
-        .selectAll('.label')
-        .data(['y']),
-      yAxisHoverEnter = yAxisHover
-        .enter()
-        .append('g')
-        .attr('class', 'label'),
+    var yAxisHover = g.select('.y-axis-hover').selectAll('.label').data(['y']),
+      yAxisHoverEnter = yAxisHover.enter().append('g').attr('class', 'label'),
       yAxisHoverUpdate = yAxisHover.merge(yAxisHoverEnter);
     yAxisHoverEnter
       .append('rect')
@@ -612,10 +595,7 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
       .attr('x2', 6)
       .attr('y1', 0)
       .attr('y2', 0);
-    yAxisHoverEnter
-      .append('text')
-      .attr('dx', 8)
-      .attr('dy', 4);
+    yAxisHoverEnter.append('text').attr('dx', 8).attr('dy', 4);
     var ySliceAxisHover = g
         .select('.y-slice-axis-hover')
         .selectAll('.label')
@@ -637,10 +617,7 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
       .attr('x2', 6)
       .attr('y1', 0)
       .attr('y2', 0);
-    ySliceAxisHoverEnter
-      .append('text')
-      .attr('dx', 8)
-      .attr('dy', 4);
+    ySliceAxisHoverEnter.append('text').attr('dx', 8).attr('dy', 4);
     gTransition
       .select('.y.axis.slice')
       .style('opacity', mode === 'offset' ? 0 : 1)
@@ -673,7 +650,7 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
       var closestSliceData;
       var closestSliceDistance = Infinity;
       var lastSliceData;
-      hoverUpdate.attr('transform', function(d, i) {
+      hoverUpdate.attr('transform', function (d, i) {
         var index = hoverXIndex(d);
         lastSliceData = d;
         var x = xScale(
@@ -689,19 +666,19 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
         }
         return 'translate(' + x + ',' + y + ')';
       });
-      hoverUpdate.select('text').text(function(d) {
+      hoverUpdate.select('text').text(function (d) {
         var index = hoverXIndex(d);
         return d[binsProp][index][yProp];
       });
-      hoverUpdate.classed('hover-closest', function(d) {
+      hoverUpdate.classed('hover-closest', function (d) {
         return d === closestSliceData;
       });
-      outlineUpdate.classed('outline-hover', function(d) {
+      outlineUpdate.classed('outline-hover', function (d) {
         return d === closestSliceData;
       });
       var index = hoverXIndex(lastSliceData);
       xAxisHoverUpdate
-        .attr('transform', function(d) {
+        .attr('transform', function (d) {
           return (
             'translate(' +
             xScale(
@@ -714,7 +691,7 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
           );
         })
         .select('text')
-        .text(function(d) {
+        .text(function (d) {
           return format(
             lastSliceData[binsProp][index][xProp] +
               lastSliceData[binsProp][index][dxProp] / 2
@@ -722,7 +699,7 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
         });
       var fy = yAxis.tickFormat();
       yAxisHoverUpdate
-        .attr('transform', function(d) {
+        .attr('transform', function (d) {
           return (
             'translate(' +
             width +
@@ -733,12 +710,12 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
         })
         .style('display', mode === 'offset' ? '' : 'none')
         .select('text')
-        .text(function(d) {
+        .text(function (d) {
           return fy(timeAccessor(closestSliceData));
         });
       var fsy = ySliceAxis.tickFormat();
       ySliceAxisHoverUpdate
-        .attr('transform', function(d) {
+        .attr('transform', function (d) {
           return (
             'translate(' +
             width +
@@ -751,7 +728,7 @@ class _VzHistogramTimeseries extends LegacyElementMixin(PolymerElement)
         })
         .style('display', mode === 'offset' ? 'none' : '')
         .select('text')
-        .text(function(d) {
+        .text(function (d) {
           return fsy(closestSliceData[binsProp][index][yProp]);
         });
       var svgMouse = d3.mouse(svgNode);

--- a/tensorboard/plugins/hparams/tf_hparams_main/tf-hparams-main.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_main/tf-hparams-main.ts
@@ -59,9 +59,7 @@ class TfHparamsMain extends LegacyElementMixin(PolymerElement) {
             <h3>No hparams data was found.</h3>
             <p>Probable causes:</p>
             <ul>
-              <li>
-                You haven’t written any hparams data to your event files.
-              </li>
+              <li>You haven’t written any hparams data to your event files.</li>
               <li>
                 Event files are still being loaded (try reloading this page).
               </li>

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/axes.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/axes.ts
@@ -239,7 +239,10 @@ export class Axis {
     // Add the brush.
     const d3Brush = d3
       .brushY()
-      .extent([[-8, 0], [8, this._svgProps.height + 1]])
+      .extent([
+        [-8, 0],
+        [8, this._svgProps.height + 1],
+      ])
       /* Define the brush event handlers. D3 will call these both when
              the user moves the brush selection and when we change the brush
              selection programmatically using d3Brush.move(). We'd like to
@@ -434,7 +437,7 @@ export class AxesCollection {
     const _this = this;
     this._parentsSel
       .call((sel) => this._updateAxesPositionsInDOM(sel))
-      .each(function(colIndex) {
+      .each(function (colIndex) {
         /* Here 'this' is the 'axis-parent'-classed <g> element,
              and '_this' is the AxesCollection element. */
         _this._axes[colIndex].updateDOM(this);

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/lines.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/lines.ts
@@ -185,7 +185,7 @@ export class LinesCollection {
       // lines.
       window.setTimeout(() => {
         const _this = this;
-        this._fgPathsSel.each(function(this: SVGPathElement, sessionGroup) {
+        this._fgPathsSel.each(function (this: SVGPathElement, sessionGroup) {
           // '_this' refers to the 'LinesCollection' instance.
           _this._setControlPointsProperty(this, sessionGroup);
         });
@@ -302,11 +302,13 @@ export class LinesCollection {
     }
     const colorScale = d3
       .scaleLinear</*range=*/ string, /*output=*/ string>()
-      .domain(tf_hparams_utils.numericColumnExtent(
-        this._schema,
-        this._sessionGroups,
-        colorByColumnIndex
-      ) as any)
+      .domain(
+        tf_hparams_utils.numericColumnExtent(
+          this._schema,
+          this._sessionGroups,
+          colorByColumnIndex
+        ) as any
+      )
       .range([minColor, maxColor])
       .interpolate(d3.interpolateLab);
     return (sessionGroup) =>
@@ -324,10 +326,7 @@ export class LinesCollection {
       /*key=*/ (sessionGroup) => sessionGroup.name
     );
     currentPathSel.exit().remove();
-    return currentPathSel
-      .enter()
-      .append('path')
-      .merge(currentPathSel);
+    return currentPathSel.enter().append('path').merge(currentPathSel);
   }
   /** Sets the controlPoints property of 'pathElement' to the control-points
    * array of the given sessionGroup with respect to the current state of

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/test/tf-hparams-parallel-coords-plot-test.html
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/test/tf-hparams-parallel-coords-plot-test.html
@@ -43,17 +43,17 @@ limitations under the License.
          Tensorboard.
       */
       chai.config.truncateThreshold = 0;
-      suite('<tf-hparams-parallel-coords-plot>-tests', function() {
+      suite('<tf-hparams-parallel-coords-plot>-tests', function () {
         var element;
 
-        setup(function() {
+        setup(function () {
           element = fixture('f');
         });
 
         const epsilon = 1e-5;
-        teardown(function() {});
+        teardown(function () {});
 
-        test('pointScaleInverseImage', function() {
+        test('pointScaleInverseImage', function () {
           const pointScaleInverseImage =
             tf.hparams.parallel_coords_plot.pointScaleInverseImage;
           const scale = d3
@@ -77,13 +77,10 @@ limitations under the License.
           assert.deepEqual(pointScaleInverseImage(scale, 0, 300), [a, b, c]);
         });
 
-        test('continuousScaleInverseImage', function() {
+        test('continuousScaleInverseImage', function () {
           const continuousScaleInverseImage =
             tf.hparams.parallel_coords_plot.continuousScaleInverseImage;
-          let scale = d3
-            .scaleLinear()
-            .domain([-150, 300])
-            .range([0, 300]);
+          let scale = d3.scaleLinear().domain([-150, 300]).range([0, 300]);
           // scale(x)=2/3*x+100
           // x=3/2*scale(x)-150
           assertVectorsApproxEqual(
@@ -96,10 +93,7 @@ limitations under the License.
             [-196.5, 217.5],
             epsilon
           );
-          scale = d3
-            .scaleLog()
-            .domain([1, 150])
-            .range([300, 1]);
+          scale = d3.scaleLog().domain([1, 150]).range([300, 1]);
 
           assertVectorsApproxEqual(
             continuousScaleInverseImage(scale, 10, 50),
@@ -108,7 +102,7 @@ limitations under the License.
           );
         });
 
-        test('quantileScaleInverseImage', function() {
+        test('quantileScaleInverseImage', function () {
           const quantileScaleInverseImage =
             tf.hparams.parallel_coords_plot.quantileScaleInverseImage;
           const scale = d3
@@ -142,12 +136,20 @@ limitations under the License.
           );
         });
 
-        test('findClosestPath', function() {
+        test('findClosestPath', function () {
           const findClosestPath =
             tf.hparams.parallel_coords_plot.findClosestPath;
           axesPos = [0, 50, 100, 150, 200];
           paths = [
-            {controlPoints: [[0, 0], [50, 0], [100, 10], [150, 11], [200, 10]]},
+            {
+              controlPoints: [
+                [0, 0],
+                [50, 0],
+                [100, 10],
+                [150, 11],
+                [200, 10],
+              ],
+            },
             {
               controlPoints: [
                 [0, 11],
@@ -216,7 +218,7 @@ limitations under the License.
           assert.isNull(findClosestPath(paths, axesPos, [250, 1], 100));
         });
 
-        test('createAxisScale', function() {
+        test('createAxisScale', function () {
           const testCases = [
             {
               name: 'LINEAR scale test',
@@ -318,7 +320,7 @@ limitations under the License.
           });
         });
 
-        test('createScale_throws', function() {
+        test('createScale_throws', function () {
           const createAxisScale =
             tf.hparams.parallel_coords_plot.createAxisScale;
           assert.throws(

--- a/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/utils.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_parallel_coords_plot/utils.ts
@@ -241,10 +241,7 @@ export function createAxisScale(domainValues, axisHeight, scaleType) {
       // d3.scaleQuantile() requires a non-empty domain.
       domainValues = [1];
     }
-    return d3
-      .scaleQuantile()
-      .domain(_.uniq(domainValues))
-      .range(scaleRange);
+    return d3.scaleQuantile().domain(_.uniq(domainValues)).range(scaleRange);
   } else if (scaleType === 'NON_NUMERIC') {
     return d3
       .scalePoint()

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/test/tf-hparams-query-pane-test.html
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/test/tf-hparams-query-pane-test.html
@@ -36,7 +36,7 @@ limitations under the License.
     </test-fixture>
     <script>
       chai.config.truncateThreshold = 0;
-      suite('<tf-hparams-query-pane>-tests', function() {
+      suite('<tf-hparams-query-pane>-tests', function () {
         var element;
         const experimentResponse = {
           description: '',
@@ -129,15 +129,15 @@ limitations under the License.
         // synchronously to make the test synchronous (otherwise
         // the _queryServer() method called on element initialization would
         // end-up querying the server after a delay).
-        Polymer.Base.debounce = function(name, func, delay) {
+        Polymer.Base.debounce = function (name, func, delay) {
           func();
         };
 
         // Make the window.alert() method a no-op so the element won't block
         // awaiting user input.
-        window.alert = function() {};
+        window.alert = function () {};
 
-        setup(function() {
+        setup(function () {
           fakeBackend = sinon.createStubInstance(tf.hparams.Backend);
           fakeBackend.getExperiment.returns(
             Promise.resolve(experimentResponse)
@@ -150,7 +150,7 @@ limitations under the License.
           element.set('backend', fakeBackend);
         });
 
-        test('element initialized correctly.', function() {
+        test('element initialized correctly.', function () {
           return element._getExperimentResolved.then(() => {
             assert.deepEqual(element._hparams, [
               {
@@ -234,7 +234,7 @@ limitations under the License.
           });
         });
 
-        test('element updates "sessionGroups" in correct order', function() {
+        test('element updates "sessionGroups" in correct order', function () {
           let resolveFirstQuery = null;
           let resolveSecondQuery = null;
           // We set calls #1 and #2 here to return pending promises so
@@ -294,7 +294,7 @@ limitations under the License.
         test(
           'element updates "sessionGroups" after a successful request' +
             ' following a failed request',
-          function() {
+          function () {
             let rejectFirstQuery = null;
             let resolveSecondQuery = null;
             // We set calls #1 and #2 here to return pending promises so
@@ -366,7 +366,7 @@ limitations under the License.
           }
         );
 
-        test('element sends correct ListSessionGroupsRequest', function() {
+        test('element sends correct ListSessionGroupsRequest', function () {
           return element._getExperimentResolved.then(() => {
             element._hparams[0].filter = {
               domainDiscrete: [

--- a/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_query_pane/tf-hparams-query-pane.ts
@@ -164,14 +164,10 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
             on-selected-item-changed="_queryServer"
           >
             <template is="dom-repeat" items="[[_hparams]]" as="hparam">
-              <paper-item>
-                [[_hparamName(hparam.info)]]
-              </paper-item>
+              <paper-item> [[_hparamName(hparam.info)]] </paper-item>
             </template>
             <template is="dom-repeat" items="[[_metrics]]" as="metric">
-              <paper-item>
-                [[_metricName(metric.info)]]
-              </paper-item>
+              <paper-item> [[_metricName(metric.info)]] </paper-item>
             </template>
           </paper-listbox>
         </paper-dropdown-menu>
@@ -204,9 +200,7 @@ class TfHparamsQueryPane extends LegacyElementMixin(PolymerElement) {
             invalid="[[_pageNumberInput.invalid]]"
             on-value-changed="_queryServer"
           >
-            <div slot="suffix" class="page-suffix">
-              / [[_pageCountStr]]
-            </div>
+            <div slot="suffix" class="page-suffix">/ [[_pageCountStr]]</div>
           </paper-input>
         </div>
         <div class="inline-element page-size-input">

--- a/tensorboard/plugins/hparams/tf_hparams_scale_and_color_controls/test/tf-hparams-scale-and-color-controls-test.html
+++ b/tensorboard/plugins/hparams/tf_hparams_scale_and_color_controls/test/tf-hparams-scale-and-color-controls-test.html
@@ -32,10 +32,10 @@ limitations under the License.
     </test-fixture>
     <script>
       chai.config.truncateThreshold = 0;
-      suite('<tf-hparams-scale-and-color-controls>-tests', function() {
+      suite('<tf-hparams-scale-and-color-controls>-tests', function () {
         var element;
 
-        setup(function() {
+        setup(function () {
           element = fixture('f');
           const configuration = {
             visibleSchema: {
@@ -223,9 +223,9 @@ limitations under the License.
           ]);
         });
 
-        teardown(function() {});
+        teardown(function () {});
 
-        test('element has correct shadow DOM', function(done) {
+        test('element has correct shadow DOM', function (done) {
           // Flush is required here since Polymer updates the DOM
           // asynchronously.
           flush(() => {
@@ -241,7 +241,7 @@ limitations under the License.
           });
         });
 
-        test('removal of last metric updates shadow DOM', function(done) {
+        test('removal of last metric updates shadow DOM', function (done) {
           // remove 'Delta T'
           element.pop('configuration.visibleSchema.metricInfos');
           flush(() => {
@@ -256,7 +256,7 @@ limitations under the License.
           });
         });
 
-        test('removal of first metric updates shadow DOM', function(done) {
+        test('removal of first metric updates shadow DOM', function (done) {
           // remove 'Current Temp'
           element.shift('configuration.visibleSchema.metricInfos');
           // Flush is required here since Polymer updates the DOM
@@ -273,7 +273,7 @@ limitations under the License.
           });
         });
 
-        test('Selecting color-by-index updates options', function() {
+        test('Selecting color-by-index updates options', function () {
           assert.equal(
             element.options.colorByColumnIndex,
             3 /* Current Temp */
@@ -282,7 +282,7 @@ limitations under the License.
           assert.equal(element.options.colorByColumnIndex, 0);
         });
 
-        test('Selecting a scale updates options', function() {
+        test('Selecting a scale updates options', function () {
           const radioGroups = Polymer.dom(element.root).querySelectorAll(
             '.scale-radio-group'
           );
@@ -297,7 +297,7 @@ limitations under the License.
           assert.equal(element.options.columns[5].scale, 'QUANTILE');
         });
 
-        test('colorByColumnIndex has the right default', function() {
+        test('colorByColumnIndex has the right default', function () {
           // Hparams: ["Initial Temp", "Ambient Temp", "Material" (non-numeric)]
           // Metrics: ["Current Temp", "Difference To Ambient Temp.", "Delta T"]
           assert.equal(
@@ -327,7 +327,7 @@ limitations under the License.
           assert.isUndefined(element._defaultColorByColumnIndex());
         });
 
-        test('logScaleIsDisabledAndEnabledCorrectly', function(done) {
+        test('logScaleIsDisabledAndEnabledCorrectly', function (done) {
           // The 'delta_t' metric has both positive and negative values
           // in the session groups, so it should have its log-scale disabled.
           // The 'difference_to_ambient_temp" metric has only negative values
@@ -349,7 +349,7 @@ limitations under the License.
           });
         });
 
-        test('disablingLogScaleChangesSelection', function(done) {
+        test('disablingLogScaleChangesSelection', function (done) {
           // The 'delta_t' metric has both positive and negative values
           // in the session groups, so it should have its log-scale disabled.
           // The other columns should be enabled.

--- a/tensorboard/plugins/hparams/tf_hparams_scale_and_color_controls/tf-hparams-scale-and-color-controls.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_scale_and_color_controls/tf-hparams-scale-and-color-controls.ts
@@ -55,9 +55,7 @@ class TfHparamsScaleAndColorControls extends PolymerElement {
         <template is="dom-repeat" items="{{options.columns}}" as="column">
           <template is="dom-if" if="[[_isNumericColumn(column.index)]]">
             <div class="column">
-              <div class="column-title">
-                [[column.name]]
-              </div>
+              <div class="column-title">[[column.name]]</div>
               <div>
                 <paper-radio-group
                   class="scale-radio-group"

--- a/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot/tf-hparams-scatter-plot-matrix-plot.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_scatter_plot_matrix_plot/tf-hparams-scatter-plot-matrix-plot.ts
@@ -267,7 +267,7 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
     xAxesG
       .append('g')
       .attr('clip-path', (col) => 'url(#' + xAxisClipPathId(col) + ')')
-      .each(function(col) {
+      .each(function (col) {
         d3.select(this).call(
           drawAxis,
           d3
@@ -325,7 +325,7 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
     yAxesG
       .append('g')
       .attr('clip-path', (metric) => 'url(#' + yAxisClipPathId(metric) + ')')
-      .each(function(metric) {
+      .each(function (metric) {
         d3.select(this).call(
           drawAxis,
           d3
@@ -494,7 +494,7 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
       _this.sessionGroups.forEach((sessionGroup) => {
         sessionGroupMarkersMap.set(sessionGroup, []);
       });
-      markers.each(function(d) {
+      markers.each(function (d) {
         sessionGroupMarkersMap.get(d.sessionGroup).push(this);
       });
       markers.each((d) => {
@@ -526,7 +526,7 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
     // element.
     function createCellQuadTree(col, metric) {
       const data = [];
-      cellMarkers[col][metric].each(function() {
+      cellMarkers[col][metric].each(function () {
         data.push(this);
       });
       return d3
@@ -564,13 +564,23 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
         );
       }
       // Highlight the new visible markers.
-      d3.selectAll(Array.from(
-        utils.filterSet(newVisibleMarkers, (elem) => !visibleMarkers.has(elem))
-      ) as any).attr('fill', markerColorFn);
+      d3.selectAll(
+        Array.from(
+          utils.filterSet(
+            newVisibleMarkers,
+            (elem) => !visibleMarkers.has(elem)
+          )
+        ) as any
+      ).attr('fill', markerColorFn);
       // Gray-out the no-longer visible markers.
-      d3.selectAll(Array.from(
-        utils.filterSet(visibleMarkers, (elem) => !newVisibleMarkers.has(elem))
-      ) as any).attr('fill', '#ddd');
+      d3.selectAll(
+        Array.from(
+          utils.filterSet(
+            visibleMarkers,
+            (elem) => !newVisibleMarkers.has(elem)
+          )
+        ) as any
+      ).attr('fill', '#ddd');
       visibleMarkers = newVisibleMarkers;
     }
     // Returns a Set of all marker elements that are in the
@@ -602,7 +612,7 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
         [-frameMargin + 1, -frameMargin + 1],
         [cellWidth - 1 + frameMargin - 1, cellHeight - 1 + frameMargin - 1],
       ])
-      .on('start', function() {
+      .on('start', function () {
         if (isBrushActive() && brushedCellG.node() != this) {
           // The brush is active in a different cell.
           // Clear the selection first.
@@ -614,10 +624,10 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
         }
         brushChanged(this);
       })
-      .on('brush', function() {
+      .on('brush', function () {
         brushChanged(this);
       })
-      .on('end', function() {
+      .on('end', function () {
         brushChanged(this);
       });
     // Updates the internal state in response to a brush event in
@@ -685,7 +695,7 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
         .classed('selected-marker', true);
     }
     cells
-      .on('click', function() {
+      .on('click', function () {
         const newSelectedMarkers =
           closestMarkers === selectedMarkers ? null : closestMarkers;
         if (newSelectedMarkers === selectedMarkers) {
@@ -706,7 +716,7 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
               selectedMarkers.datum().sessionGroup;
         _this.selectedSessionGroup = newSessionGroup;
       })
-      .on('mousemove mouseenter', function([col, metric]) {
+      .on('mousemove mouseenter', function ([col, metric]) {
         const [x, y] = d3.mouse(this);
         const newClosestMarkers = findClosestMarkers(
           col,
@@ -733,7 +743,7 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
           (_this as any)._setClosestSessionGroup(null);
         }
       })
-      .on('mouseleave', function([col, metric]) {
+      .on('mouseleave', function ([col, metric]) {
         if (closestMarkers !== null) {
           closestMarkers.classed('closest-marker', false);
           closestMarkers = null;
@@ -784,10 +794,7 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
   // visibleSchema-column indexed by colIndex.
   _cellScale(colIndex, range) {
     const extent = this._colExtent(colIndex) as any;
-    const linearScale = d3
-      .scaleLinear()
-      .domain(extent)
-      .range(range);
+    const linearScale = d3.scaleLinear().domain(extent).range(range);
     if (this.options.columns[colIndex].scale === 'LINEAR') {
       return linearScale;
     } else if (this.options.columns[colIndex].scale === 'LOG') {
@@ -800,10 +807,7 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
         // and b/111755540
         return linearScale;
       }
-      return d3
-        .scaleLog()
-        .domain(extent)
-        .range(range);
+      return d3.scaleLog().domain(extent).range(range);
     } else if (this.options.columns[colIndex].scale === 'QUANTILE') {
       // Compute 20-quantiles:
       const step = (range[1] - range[0]) / 19;
@@ -832,10 +836,9 @@ class TfHparamsScatterPlotMatrixPlot extends LegacyElementMixin(
         .range(range)
         .padding(0.1);
     } else {
-      throw 'Unknown scale for column: ' +
-        colIndex +
-        '. options: ' +
-        this.options;
+      throw (
+        'Unknown scale for column: ' + colIndex + '. options: ' + this.options
+      );
     }
   }
   _colValue(sessionGroup, colIndex) {

--- a/tensorboard/plugins/hparams/tf_hparams_session_group_values/tf-hparams-session-group-values.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_session_group_values/tf-hparams-session-group-values.ts
@@ -38,9 +38,7 @@ class TfHparamsSessionGroupValues extends PolymerElement {
       is="dom-if"
       if="[[!_propertiesArePopulated(visibleSchema, sessionGroup)]]"
     >
-      <div>
-        Click or hover over a session group to display its values here.
-      </div>
+      <div>Click or hover over a session group to display its values here.</div>
     </template>
 
     <style>

--- a/tensorboard/plugins/hparams/tf_hparams_sessions_pane/tf-hparams-sessions-pane.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_sessions_pane/tf-hparams-sessions-pane.ts
@@ -37,9 +37,7 @@ class TfHparamsSessionsPane extends PolymerElement {
           <!-- view-id can be used by integration tests to locate a tab.
                It should be the name of the root element implementing the view
                without the 'tf-hparams-' prefix. -->
-          <paper-tab view-id="table-view">
-            TABLE VIEW
-          </paper-tab>
+          <paper-tab view-id="table-view"> TABLE VIEW </paper-tab>
           <paper-tab view-id="parallel-coords-view">
             PARALLEL COORDINATES VIEW
           </paper-tab>

--- a/tensorboard/plugins/hparams/tf_hparams_utils/test/tf-hparams-utils-test.html
+++ b/tensorboard/plugins/hparams/tf_hparams_utils/test/tf-hparams-utils-test.html
@@ -28,12 +28,12 @@ limitations under the License.
     <script>
       chai.config.truncateThreshold = 0;
       utils = tf.hparams.utils;
-      suite('tf-hparams-utils-tests', function() {
+      suite('tf-hparams-utils-tests', function () {
         let callback = null;
-        setup(function() {
+        setup(function () {
           callback = sinon.spy();
         });
-        test('pointToRectangleDist', function() {
+        test('pointToRectangleDist', function () {
           const testCases = [
             {
               x: 0,
@@ -111,22 +111,22 @@ limitations under the License.
           [3, 15],
           [3, 100],
         ]);
-        test('quadTreeVisitPointsInRect_EmptyIntersection1', function() {
+        test('quadTreeVisitPointsInRect_EmptyIntersection1', function () {
           utils.quadTreeVisitPointsInRect(quadTree, 0, 0, 1, 1, callback);
           assert(callback.notCalled);
         });
-        test('quadTreeVisitPointsInRect_EmptyIntersection2', function() {
+        test('quadTreeVisitPointsInRect_EmptyIntersection2', function () {
           utils.quadTreeVisitPointsInRect(quadTree, 0, 0, 1, 2, callback);
           assert(callback.notCalled);
         });
-        test('quadTreeVisitPointsInRect_NonEmptyInterserction1', function() {
+        test('quadTreeVisitPointsInRect_NonEmptyInterserction1', function () {
           utils.quadTreeVisitPointsInRect(quadTree, 1.25, 1, 2, 80, callback);
           assert.equal(callback.callCount, 3);
           assert(callback.withArgs([1.5, 10]).calledOnce);
           assert(callback.withArgs([1.5, 20]).calledOnce);
           assert(callback.withArgs([1.5, 15]).calledOnce);
         });
-        test('quadTreeVisitPointsInRect_NonEmptyInterserction2', function() {
+        test('quadTreeVisitPointsInRect_NonEmptyInterserction2', function () {
           utils.quadTreeVisitPointsInRect(quadTree, 1.25, 1, 4, 100, callback);
           assert.equal(callback.callCount, 5);
           assert(callback.withArgs([1.5, 10]).calledOnce);
@@ -135,16 +135,16 @@ limitations under the License.
           assert(callback.withArgs([3, 3]).calledOnce);
           assert(callback.withArgs([3, 15]).calledOnce);
         });
-        test('quadTreeVisitPointsInDisk_EmptyIntersection1', function() {
+        test('quadTreeVisitPointsInDisk_EmptyIntersection1', function () {
           utils.quadTreeVisitPointsInDisk(quadTree, 0, 0, 1, callback);
           assert(callback.notCalled);
         });
-        test('quadTreeVisitPointsInDisk_NonEmptyIntersection1', function() {
+        test('quadTreeVisitPointsInDisk_NonEmptyIntersection1', function () {
           utils.quadTreeVisitPointsInDisk(quadTree, 0, 2, 1, callback);
           assert.equal(callback.callCount, 1);
           assert(callback.withArgs([1, 2]).calledOnce);
         });
-        test('quadTreeVisitPointsInDisk_NonEmptyInterserction2', function() {
+        test('quadTreeVisitPointsInDisk_NonEmptyInterserction2', function () {
           utils.quadTreeVisitPointsInDisk(quadTree, 2, 15, 7, callback);
           assert.equal(callback.callCount, 4);
           assert(callback.withArgs([1.5, 10]).calledOnce);

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/array-buffer-data-provider.ts
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/array-buffer-data-provider.ts
@@ -103,7 +103,7 @@ export class ArrayBufferDataProvider {
         step: String(step),
       })
     );
-    const reshapeTo1xNx3 = function(data) {
+    const reshapeTo1xNx3 = function (data) {
       const channelsCount = 3;
       let items = [];
       for (let i = 0; i < data.length / channelsCount; i++) {

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-loader.ts
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-loader.ts
@@ -44,7 +44,8 @@ export interface TfMeshLoader extends HTMLElement {
 }
 
 @customElement('tf-mesh-loader')
-class TfMeshLoaderImpl extends LegacyElementMixin(PolymerElement)
+class TfMeshLoaderImpl
+  extends LegacyElementMixin(PolymerElement)
   implements TfMeshLoader {
   static readonly template = html`
     <tf-card-heading color="[[_runColor]]" class="tf-mesh-loader-header">

--- a/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-viewer.ts
+++ b/tensorboard/plugins/mesh/tf_mesh_dashboard/mesh-viewer.ts
@@ -244,7 +244,7 @@ export class MeshViewer extends THREE.EventDispatcher {
     this._camera.aspect = this._canvasSize.width / this._canvasSize.height;
     this._camera.updateProjectionMatrix();
     this._renderer.setSize(this._canvasSize.width, this._canvasSize.height);
-    const animate = function() {
+    const animate = function () {
       var delta = this._clock.getDelta();
       this._cameraControls.update(delta);
       this._animationFrameIndex = requestAnimationFrame(animate);
@@ -346,7 +346,7 @@ export class MeshViewer extends THREE.EventDispatcher {
       defaultConfig
     ) as PointCloudConfig;
     var geometry = new THREE.Geometry();
-    points.forEach(function(point) {
+    points.forEach(function (point) {
       var p = new THREE.Vector3(point[0], point[1], point[2]);
       const scale = 1;
       p.x = point[0] * scale;
@@ -355,7 +355,7 @@ export class MeshViewer extends THREE.EventDispatcher {
       geometry.vertices.push(p);
     });
     if (colors && colors.length == points.length) {
-      colors.forEach(function(color) {
+      colors.forEach(function (color) {
         const c = new THREE.Color(
           color[0] / 255,
           color[1] / 255,
@@ -442,7 +442,7 @@ export class MeshViewer extends THREE.EventDispatcher {
       },
     }) as any;
     let geometry = new THREE.Geometry();
-    vertices.forEach(function(point) {
+    vertices.forEach(function (point) {
       let p = new THREE.Vector3(point[0], point[1], point[2]);
       const scale = 1;
       p.x = point[0] * scale;
@@ -450,7 +450,7 @@ export class MeshViewer extends THREE.EventDispatcher {
       p.z = point[2] * scale;
       geometry.vertices.push(p);
     });
-    faces.forEach(function(face_indices) {
+    faces.forEach(function (face_indices) {
       let face = new THREE.Face3(
         face_indices[0],
         face_indices[1],

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.ts
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-card.ts
@@ -429,7 +429,10 @@ export class TfPrCurveCard extends PolymerElement {
 
   _computeEntryClosestOrEqualToStepCap(stepCap, entries) {
     const entryIndex = Math.min(
-      _.sortedIndex(entries.map((entry) => entry.step), stepCap),
+      _.sortedIndex(
+        entries.map((entry) => entry.step),
+        stepCap
+      ),
       entries.length - 1
     );
     return entries[entryIndex];

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.ts
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-dashboard.ts
@@ -85,9 +85,7 @@ class TfPrCurveDashboard extends LegacyElementMixin(PolymerElement) {
                 You haven’t written any precision–recall data to your event
                 files.
               </li>
-              <li>
-                TensorBoard can’t find your event files.
-              </li>
+              <li>TensorBoard can’t find your event files.</li>
             </ul>
             <p>
               If you’re new to using TensorBoard, and want to find out how to

--- a/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.ts
+++ b/tensorboard/plugins/pr_curve/tf_pr_curve_dashboard/tf-pr-curve-steps-selector.ts
@@ -30,9 +30,7 @@ class TfPrCurveStepsSelector extends PolymerElement {
             class="run-color-box"
             style="background:[[_computeColorForRun(run)]];"
           ></div>
-          <div class="run-text">
-            [[run]]
-          </div>
+          <div class="run-text">[[run]]</div>
         </div>
         <div class="step-display-container">
           [[_computeTimeTextForRun(runToAvailableTimeEntries, _runToStepIndex,

--- a/tensorboard/plugins/projector/vz_projector/standalone_lib.html
+++ b/tensorboard/plugins/projector/vz_projector/standalone_lib.html
@@ -33,11 +33,11 @@ limitations under the License.
 
     <script jscomp-ignore src="standalone_bundle.js"></script>
     <script>
-      (function(i, s, o, g, r, a, m) {
+      (function (i, s, o, g, r, a, m) {
         i['GoogleAnalyticsObject'] = r;
         (i[r] =
           i[r] ||
-          function() {
+          function () {
             (i[r].q = i[r].q || []).push(arguments);
           }),
           (i[r].l = 1 * new Date());

--- a/tensorboard/plugins/projector/vz_projector/test/data-provider_test.ts
+++ b/tensorboard/plugins/projector/vz_projector/test/data-provider_test.ts
@@ -40,7 +40,10 @@ namespace vz_projector.test {
 
   describe('parse tensors', () => {
     it('parseTensors', (doneFn) => {
-      let tensors = [[1.0, 2.0], [2.0, 3.0]];
+      let tensors = [
+        [1.0, 2.0],
+        [2.0, 3.0],
+      ];
       stringToArrayBuffer(dataToTsv(tensors)).then(
         (tensorsArrayBuffer: ArrayBuffer) => {
           parseTensors(tensorsArrayBuffer).then((data: DataPoint[]) => {
@@ -59,7 +62,11 @@ namespace vz_projector.test {
       );
     });
     it('parseMetadata', (doneFn) => {
-      let metadata = [['label', 'fakecol'], ['Г', '0'], ['label1', '1']];
+      let metadata = [
+        ['label', 'fakecol'],
+        ['Г', '0'],
+        ['label1', '1'],
+      ];
 
       stringToArrayBuffer(dataToTsv(metadata)).then(
         (metadataArrayBuffer: ArrayBuffer) => {

--- a/tensorboard/plugins/projector/vz_projector/test/sptree_test.ts
+++ b/tensorboard/plugins/projector/vz_projector/test/sptree_test.ts
@@ -14,7 +14,12 @@ limitations under the License.
 ==============================================================================*/
 namespace vz_projector.test {
   it('simple 2D data', () => {
-    let data = [[0, 1], [1, 0], [1, 1], [0, 0]];
+    let data = [
+      [0, 1],
+      [1, 0],
+      [1, 1],
+      [0, 0],
+    ];
     let tree = new SPTree(data);
     // Check that each point is within the bound.
     tree.visit((node, low, high) => {
@@ -35,7 +40,12 @@ namespace vz_projector.test {
   });
 
   it('simple 3D data', () => {
-    let data = [[0, 1, 0], [1, 0.4, 2], [1, 1, 3], [0, 0, 5]];
+    let data = [
+      [0, 1, 0],
+      [1, 0.4, 2],
+      [1, 1, 3],
+      [0, 0, 5],
+    ];
     let tree = new SPTree(data);
     // Check that each point is within the bound.
     tree.visit((node, low, high) => {
@@ -58,7 +68,12 @@ namespace vz_projector.test {
   });
 
   it('Only visit root', () => {
-    let data = [[0, 1, 0], [1, 0.4, 2], [1, 1, 3], [0, 0, 5]];
+    let data = [
+      [0, 1, 0],
+      [1, 0.4, 2],
+      [1, 1, 3],
+      [0, 0, 5],
+    ];
     let tree = new SPTree(data);
     let numVisits = 0;
     tree.visit((node, low, high) => {

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-dashboard.ts
@@ -21,9 +21,7 @@ class VzProjectorDashboard extends PolymerElement {
   static readonly template = html`
     <template is="dom-if" if="[[dataNotFound]]">
       <div style="max-width: 540px; margin: 80px auto 0 auto;">
-        <h3>
-          No checkpoint was found.
-        </h3>
+        <h3>No checkpoint was found.</h3>
         <p>Probable causes:</p>
         <ul>
           <li>

--- a/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-projections-panel.ts
@@ -179,7 +179,7 @@ class ProjectionsPanel extends LegacyElementMixin(PolymerElement) {
       const self = this;
       const inkTabs = this.root.querySelectorAll('.ink-tab');
       for (let i = 0; i < inkTabs.length; i++) {
-        inkTabs[i].addEventListener('click', function() {
+        inkTabs[i].addEventListener('click', function () {
           let id = this.getAttribute('data-tab');
           self.showTab(id);
         });

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -71,7 +71,8 @@ const POINT_COLOR_MISSING = 'black';
 const INDEX_METADATA_FIELD = '__index__';
 
 @customElement('vz-projector')
-class Projector extends LegacyElementMixin(PolymerElement)
+class Projector
+  extends LegacyElementMixin(PolymerElement)
   implements ProjectorEventContext {
   static readonly template = template;
 

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-smoothing-input.ts
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-smoothing-input.ts
@@ -115,7 +115,7 @@ class TfSmoothingInput extends PolymerElement {
   })
   _inputWeightStringForPaperInput: string;
 
-  _updateWeight = _.debounce(function(val) {
+  _updateWeight = _.debounce(function (val) {
     this.weight = val;
   }, 250);
 

--- a/tensorboard/webapp/core/store/core_reducers_test.ts
+++ b/tensorboard/webapp/core/store/core_reducers_test.ts
@@ -245,7 +245,10 @@ describe('core reducer', () => {
       const nextState = reducers(
         state,
         actions.fetchRunSucceeded({
-          runs: [{id: '1', name: 'Run name 1'}, {id: '2', name: 'Run name 2'}],
+          runs: [
+            {id: '1', name: 'Run name 1'},
+            {id: '2', name: 'Run name 2'},
+          ],
         })
       );
 

--- a/tensorboard/webapp/core/store/core_selectors_test.ts
+++ b/tensorboard/webapp/core/store/core_selectors_test.ts
@@ -47,7 +47,10 @@ describe('core selectors', () => {
         })
       );
       expect(selectors.getRunSelection(state)).toEqual(
-        new Map([['1', false], ['2', true]])
+        new Map([
+          ['1', false],
+          ['2', true],
+        ])
       );
     });
 
@@ -62,7 +65,10 @@ describe('core selectors', () => {
         })
       );
       expect(selectors.getRunSelection(state)).toEqual(
-        new Map([['1', true], ['2', false]])
+        new Map([
+          ['1', true],
+          ['2', false],
+        ])
       );
     });
   });

--- a/tensorboard/webapp/feature_flag/types.ts
+++ b/tensorboard/webapp/feature_flag/types.ts
@@ -13,6 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-export {
-  FeatureValue,
-} from '../webapp_data_source/tb_feature_flag_data_source_types';
+export {FeatureValue} from '../webapp_data_source/tb_feature_flag_data_source_types';

--- a/tensorboard/webapp/header/plugin_selector_container.ts
+++ b/tensorboard/webapp/header/plugin_selector_container.ts
@@ -23,12 +23,8 @@ import {UiPluginMetadata} from './types';
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
-const getUiPlugins = createSelector(
-  getPlugins,
-  (listing): UiPluginMetadata[] =>
-    Object.keys(listing).map((key) =>
-      Object.assign({}, {id: key}, listing[key])
-    )
+const getUiPlugins = createSelector(getPlugins, (listing): UiPluginMetadata[] =>
+  Object.keys(listing).map((key) => Object.assign({}, {id: key}, listing[key]))
 );
 
 const getDisabledPlugins = createSelector(

--- a/tensorboard/webapp/plugins/npmi/data_source/npmi_data_source_test.ts
+++ b/tensorboard/webapp/plugins/npmi/data_source/npmi_data_source_test.ts
@@ -50,8 +50,14 @@ describe('runs_data_source', () => {
           run_2: ['count@test', 'nPMI@test'],
         });
         httpMock.expectOne('data/plugin/npmi/values').flush({
-          run_1: [[1000, 0.2618], [15298, -0.74621]],
-          run_2: [[3598, 0.135], [8327, -0.1572]],
+          run_1: [
+            [1000, 0.2618],
+            [15298, -0.74621],
+          ],
+          run_2: [
+            [3598, 0.135],
+            [8327, -0.1572],
+          ],
         });
 
         expect(returnValue).toHaveBeenCalledWith({

--- a/tensorboard/webapp/plugins/npmi/npmi_container.ts
+++ b/tensorboard/webapp/plugins/npmi/npmi_container.ts
@@ -23,9 +23,7 @@ import {getRunSelection} from '../../core/store/core_selectors';
 
 @Component({
   selector: 'npmi',
-  template: `
-    <npmi-component [runs]="runs$ | async"></npmi-component>
-  `,
+  template: ` <npmi-component [runs]="runs$ | async"></npmi-component> `,
 })
 export class NpmiContainer implements OnInit {
   readonly runs$ = this.store.pipe(select(getRunSelection));

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_component.ng.html
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_component.ng.html
@@ -15,9 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <div class="annotations-title-container">
-  <h3 class="annotations-title">
-    Annotations ({{numAnnotations}})
-  </h3>
+  <h3 class="annotations-title">Annotations ({{numAnnotations}})</h3>
   <ng-container *ngIf="expanded">
     <div
       matTooltipPosition="below"

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_test.ts
@@ -77,7 +77,10 @@ describe('Npmi Metric Search Container', () => {
 
     store.overrideSelector(
       getRunSelection,
-      new Map([['run1', true], ['run2', true]])
+      new Map([
+        ['run1', true],
+        ['run2', true],
+      ])
     );
     store.overrideSelector(getRunToMetrics, {
       run1: ['metric_1', 'metric_2'],
@@ -129,9 +132,9 @@ describe('Npmi Metric Search Container', () => {
           getDebugNode(optionEl) as DebugElement
       );
 
-      expect(options.map((option) => option.nativeElement.textContent)).toEqual(
-        ['metric_1', 'metric_2']
-      );
+      expect(
+        options.map((option) => option.nativeElement.textContent)
+      ).toEqual(['metric_1', 'metric_2']);
     });
 
     it('shows remaining metrics if some are already filtered for', () => {
@@ -153,9 +156,9 @@ describe('Npmi Metric Search Container', () => {
           getDebugNode(optionEl) as DebugElement
       );
 
-      expect(options.map((option) => option.nativeElement.textContent)).toEqual(
-        ['metric_2']
-      );
+      expect(
+        options.map((option) => option.nativeElement.textContent)
+      ).toEqual(['metric_2']);
     });
 
     it('renders empty when no metrics match', () => {
@@ -197,9 +200,9 @@ describe('Npmi Metric Search Container', () => {
           getDebugNode(optionEl) as DebugElement
       );
 
-      expect(options.map((option) => option.nativeElement.textContent)).toEqual(
-        ['metric_1']
-      );
+      expect(
+        options.map((option) => option.nativeElement.textContent)
+      ).toEqual(['metric_1']);
     });
 
     it('responds to input changes', () => {
@@ -222,9 +225,9 @@ describe('Npmi Metric Search Container', () => {
           getDebugNode(optionEl) as DebugElement
       );
 
-      expect(options.map((option) => option.nativeElement.textContent)).toEqual(
-        ['metric_2']
-      );
+      expect(
+        options.map((option) => option.nativeElement.textContent)
+      ).toEqual(['metric_2']);
     });
 
     it('dispatches action when selecting an option', () => {

--- a/tensorboard/webapp/plugins/npmi/views/inactive/inactive_component.ng.html
+++ b/tensorboard/webapp/plugins/npmi/views/inactive/inactive_component.ng.html
@@ -16,9 +16,7 @@ limitations under the License.
 -->
 <div>
   <div class="container">
-    <div class="title">
-      nPMI is inactive because no data is available.
-    </div>
+    <div class="title">nPMI is inactive because no data is available.</div>
 
     <div>
       To use the nPMI, calculate nPMI values, and log them using the summary

--- a/tensorboard/webapp/plugins/npmi/views/main/main_component.ng.html
+++ b/tensorboard/webapp/plugins/npmi/views/main/main_component.ng.html
@@ -41,9 +41,7 @@ limitations under the License.
     <npmi-annotations-list></npmi-annotations-list>
   </div>
   <ng-template #noRun>
-    <div class="noRun">
-      You need to select at least one run.
-    </div>
+    <div class="noRun">You need to select at least one run.</div>
   </ng-template>
 </div>
 

--- a/tensorboard/webapp/plugins/npmi/views/main/main_container_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/main/main_container_test.ts
@@ -105,7 +105,11 @@ describe('Npmi Main Container', () => {
   it('renders npmi main component with multiple runs, some active, some inactive', () => {
     store.overrideSelector(
       getRunSelection,
-      new Map([['run_1', false], ['run_2', true], ['run_3', false]])
+      new Map([
+        ['run_1', false],
+        ['run_2', true],
+        ['run_3', false],
+      ])
     );
     const fixture = TestBed.createComponent(MainContainer);
     fixture.detectChanges();

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_component.ng.html
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_component.ng.html
@@ -21,9 +21,7 @@ limitations under the License.
     matTooltip="Shows the nPMI value distribution per run. Ranges of selected values can be manipulated by modifying the grey box."
     matTooltipShowDelay="500"
   >
-    <div class="chart-heading">
-      {{metricName}}
-    </div>
+    <div class="chart-heading">{{metricName}}</div>
     <button
       mat-icon-button
       (click)="onRemove.emit()"

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_component.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_component.ts
@@ -140,17 +140,17 @@ export class ViolinFilterComponent implements AfterViewInit, OnChanges {
   private readonly area = d3
     .area<ViolinBin>()
     .x0(
-      function(this: ViolinFilterComponent, d: ViolinBin) {
+      function (this: ViolinFilterComponent, d: ViolinBin) {
         return this.xScaleNum(-d.length);
       }.bind(this)
     )
     .x1(
-      function(this: ViolinFilterComponent, d: ViolinBin) {
+      function (this: ViolinFilterComponent, d: ViolinBin) {
         return this.xScaleNum(d.length);
       }.bind(this)
     )
     .y(
-      function(this: ViolinFilterComponent, d: ViolinBin) {
+      function (this: ViolinFilterComponent, d: ViolinBin) {
         if (d.x0! === -Infinity) {
           return this.chartHeight - this.drawMargin.top;
         }
@@ -265,7 +265,7 @@ export class ViolinFilterComponent implements AfterViewInit, OnChanges {
       .attr('class', 'violin-plot')
       .style(
         'stroke',
-        function(
+        function (
           this: ViolinFilterComponent,
           d: [string, ViolinBin[]]
         ): string {
@@ -274,7 +274,7 @@ export class ViolinFilterComponent implements AfterViewInit, OnChanges {
       )
       .style(
         'fill',
-        function(
+        function (
           this: ViolinFilterComponent,
           d: [string, ViolinBin[]]
         ): string {
@@ -283,14 +283,14 @@ export class ViolinFilterComponent implements AfterViewInit, OnChanges {
       )
       .attr(
         'transform',
-        function(
+        function (
           this: ViolinFilterComponent,
           d: [string, ViolinBin[]]
         ): string {
           return `translate(${this.xScale(d[0])}, 0)`;
         }.bind(this)
       )
-      .datum(function(d: [string, ViolinBin[]]): ViolinBin[] {
+      .datum(function (d: [string, ViolinBin[]]): ViolinBin[] {
         return d[1];
       })
       .attr('d', this.area);
@@ -298,14 +298,14 @@ export class ViolinFilterComponent implements AfterViewInit, OnChanges {
     plots
       .attr(
         'transform',
-        function(
+        function (
           this: ViolinFilterComponent,
           d: [string, ViolinBin[]]
         ): string {
           return `translate(${this.xScale(d[0])}, 0)`;
         }.bind(this)
       )
-      .datum(function(d: [string, ViolinBin[]]): ViolinBin[] {
+      .datum(function (d: [string, ViolinBin[]]): ViolinBin[] {
         return d[1];
       })
       .attr('d', this.area);

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_test.ts
@@ -66,7 +66,11 @@ describe('Npmi Violin Filter Container', () => {
 
     store.overrideSelector(
       getRunSelection,
-      new Map([['run_1', true], ['run_2', false], ['run_3', true]])
+      new Map([
+        ['run_1', true],
+        ['run_2', false],
+        ['run_3', true],
+      ])
     );
     store.overrideSelector(getAnnotationData, {
       annotation_1: [

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_component.ng.html
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_component.ng.html
@@ -15,9 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <div class="filters-toolbar">
-  <h3 class="filters-title">
-    Active Filters
-  </h3>
+  <h3 class="filters-title">Active Filters</h3>
   <div class="side-toggle">
     <button
       mat-icon-button
@@ -37,7 +35,5 @@ limitations under the License.
   </npmi-violin-filter>
 </div>
 <div *ngIf="metricFilters.length === 0" class="filters-hint">
-  <span class="filters-hint-text">
-    You can add more filters at the top.
-  </span>
+  <span class="filters-hint-text"> You can add more filters at the top. </span>
 </div>

--- a/tensorboard/webapp/plugins/testing/index.ts
+++ b/tensorboard/webapp/plugins/testing/index.ts
@@ -17,9 +17,7 @@ import {PluginRegistryModule} from '../plugin_registry_module';
 
 @Component({
   selector: 'extra-dashboard',
-  template: `
-    <div>I'm the extra Angular dashboard!</div>
-  `,
+  template: ` <div>I'm the extra Angular dashboard!</div> `,
 })
 export class ExtraDashboardComponent {}
 

--- a/tensorboard/webapp/plugins/text_v2/store/text_v2_reducers.ts
+++ b/tensorboard/webapp/plugins/text_v2/store/text_v2_reducers.ts
@@ -73,7 +73,13 @@ const initialState = {
     ['run3', ['c', 'a/b']],
   ]),
   data: new Map([
-    ['run1', new Map([['a/b', DATA_A_B_RUN1], ['a/c', DATA_A_C_RUN1]])],
+    [
+      'run1',
+      new Map([
+        ['a/b', DATA_A_B_RUN1],
+        ['a/c', DATA_A_C_RUN1],
+      ]),
+    ],
   ]),
   visibleRunTags: new Map(),
 };

--- a/tensorboard/webapp/plugins/text_v2/views/text_dashboard/text_dashboard_component.ts
+++ b/tensorboard/webapp/plugins/text_v2/views/text_dashboard/text_dashboard_component.ts
@@ -16,9 +16,7 @@ import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   selector: 'text-dashboard',
-  template: `
-    This is the text dashboard
-  `,
+  template: ` This is the text dashboard `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TextDashboardComponent {}

--- a/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_component.ts
+++ b/tensorboard/webapp/runs/views/legacy_runs_selector/legacy_runs_selector_component.ts
@@ -27,9 +27,7 @@ interface PolymerChangeEvent extends CustomEvent {
 
 @Component({
   selector: 'tb-legacy-runs-selector-component',
-  template: `
-    <tf-runs-selector #selector></tf-runs-selector>
-  `,
+  template: ` <tf-runs-selector #selector></tf-runs-selector> `,
 })
 export class LegacyRunsSelectorComponent implements AfterViewInit {
   @Output()

--- a/tensorboard/webapp/settings/dialog_component.ts
+++ b/tensorboard/webapp/settings/dialog_component.ts
@@ -38,9 +38,8 @@ import {
 
 /** @typehack */ import * as _typeHackRxjs from 'rxjs';
 
-const getReloadPeriodInSec = createSelector(
-  getReloadPeriodInMs,
-  (periodInMs) => Math.round(periodInMs / 1000)
+const getReloadPeriodInSec = createSelector(getReloadPeriodInMs, (periodInMs) =>
+  Math.round(periodInMs / 1000)
 );
 
 export function createIntegerValidator(): ValidatorFn {

--- a/tensorboard/webapp/settings/polymer_interop_container.ts
+++ b/tensorboard/webapp/settings/polymer_interop_container.ts
@@ -53,10 +53,7 @@ export class SettingsPolymerInteropContainer {
 
   ngOnInit() {
     this.getPageSize$
-      .pipe(
-        takeUntil(this.ngUnsubscribe),
-        distinctUntilChanged()
-      )
+      .pipe(takeUntil(this.ngUnsubscribe), distinctUntilChanged())
       .subscribe((pageSize) => {
         this.paginatedViewStore.setLimit(pageSize);
       });

--- a/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ng.html
+++ b/tensorboard/webapp/tbdev_upload/tbdev_upload_dialog_component.ng.html
@@ -29,9 +29,7 @@ limitations under the License.
   posts, and social media. This can showcase the results more effectively and
   helps reproducibility.
 </p>
-<p>
-  To upload a logdir to TensorBoard.dev, run the command:
-</p>
+<p>To upload a logdir to TensorBoard.dev, run the command:</p>
 <div class="command">
   <pre><code>{{getCommandText()}}</code></pre>
   <button

--- a/tensorboard/webapp/testing/rxjs_shims.js
+++ b/tensorboard/webapp/testing/rxjs_shims.js
@@ -34,32 +34,32 @@ limitations under the License.
  */
 
 // rxjs/operators
-(function(factory) {
+(function (factory) {
   if (typeof module === 'object' && typeof module.exports === 'object') {
     var v = factory(require, exports);
     if (v !== undefined) module.exports = v;
   } else if (typeof define === 'function' && define.amd) {
     define('rxjs/operators', ['exports', 'rxjs'], factory);
   }
-})(function(exports, rxjs) {
+})(function (exports, rxjs) {
   'use strict';
-  Object.keys(rxjs.operators).forEach(function(key) {
+  Object.keys(rxjs.operators).forEach(function (key) {
     exports[key] = rxjs.operators[key];
   });
   Object.defineProperty(exports, '__esModule', {value: true});
 });
 
 // rxjs/testing
-(function(factory) {
+(function (factory) {
   if (typeof module === 'object' && typeof module.exports === 'object') {
     var v = factory(require, exports);
     if (v !== undefined) module.exports = v;
   } else if (typeof define === 'function' && define.amd) {
     define('rxjs/testing', ['exports', 'rxjs'], factory);
   }
-})(function(exports, rxjs) {
+})(function (exports, rxjs) {
   'use strict';
-  Object.keys(rxjs.testing).forEach(function(key) {
+  Object.keys(rxjs.testing).forEach(function (key) {
     exports[key] = rxjs.testing[key];
   });
   Object.defineProperty(exports, '__esModule', {value: true});

--- a/tensorboard/webapp/theme/_tb_theme.template.scss
+++ b/tensorboard/webapp/theme/_tb_theme.template.scss
@@ -36,7 +36,7 @@ $tb-foreground: map_merge(
     secondary-text: mat-color($mat-gray, 700),
     disabled-text: mat-color($mat-gray, 600),
     // TB specific variable.
-      border: #ebebeb,
+    border: #ebebeb,
     link: mat-color($mat-blue, 700),
   )
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4767,10 +4767,10 @@ plottable@^3.9.0:
     tslib "~1.8.0"
     typesettable "4.1.0"
 
-prettier@1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
+  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This is done as three commits so that we can tell Git to ignore the
middle commit (a pure reformat) when showing blame. (A follow-up PR will
update the `.git-blame-ignore-revs` file; we need to know the commit
hash to do that, which will only be known after this PR is rebased and
merged.)

Closes #3989.
