### PR TITLE
blame: ignore Prettier 2.1.1 reformatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -87,3 +87,6 @@ ea4e9bbc885784a283b8b79974132df7c6cdcc50  # Reformat all `*BUILD` files with `bu
 
 # third_party/js.bzl reformat (<https://github.com/tensorflow/tensorboard/pull/3332>)
 3e17c44d5bc3c7af72f14059e39d4b872e95d573  # Buildifier format js.bzl for future edits (#3332)
+
+# Prettier 1.18.2 to 2.1.1 upgrade (<https://github.com/tensorflow/tensorboard/pull/4122>)
+e42a7f18b33c7a85b51db28d465ec01915a8e725  # prettier: reformat code for 2.1.1


### PR DESCRIPTION
Summary:
Merged in #4122.

Test Plan:
The output of `git blame tensorboard/components/tf_backend/backend.ts`
no longer has any lines blaming to the commit in question.

wchargin-branch: prettier-2.1.1-unblame
