### PR TITLE
[nPMI] Showing Hidden Annotations on Toggle

### DIFF
--- a/tensorboard/webapp/plugins/npmi/util/filter_annotations.ts
+++ b/tensorboard/webapp/plugins/npmi/util/filter_annotations.ts
@@ -61,7 +61,7 @@ export function removeHiddenAnnotations(
   if (showHidden) {
     return annotationData;
   }
-  const data = annotationData;
+  const data = {...annotationData};
   hiddenAnnotations.forEach((annotation) => delete data[annotation]);
   return data;
 }


### PR DESCRIPTION
* Motivation for features / changes
Fixed incorrect behaviour of hidden annotations toggle. When turned of, then on, annotations did not come back.

* Detailed steps to verify changes work correctly (as executed by you)
`bazel run tensorboard -- --logdir [your logdir]`
Go to http://localhost:6007/?experimentalPlugin=npmi