### PR TITLE
[nPMI] Automatically Change sorting when Metric Filter Added

### DIFF
--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
@@ -230,6 +230,10 @@ const reducer = createReducer(
             includeNaN: false,
           },
         },
+        sorting: {
+          metric,
+          order: SortingOrder.DOWN,
+        },
       };
     }
   ),

--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers_test.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers_test.ts
@@ -461,7 +461,7 @@ describe('npmi_reducers', () => {
 
   describe('Metric Filters', () => {
     describe('Adding Filters', () => {
-      it('adds a new metric filter with none present', () => {
+      it('adds a new metric filter with none present, and adjusts sorting', () => {
         const state = createNpmiState();
         const nextState = reducers(
           state,
@@ -477,6 +477,10 @@ describe('npmi_reducers', () => {
         expect(nextState.metricArithmetic).toEqual([
           {kind: ArithmeticKind.METRIC, metric: 'nPMI@test'},
         ]);
+        expect(nextState.sorting).toEqual({
+          metric: 'nPMI@test',
+          order: SortingOrder.DOWN,
+        });
       });
 
       it('adds a new metric filter after the first one', () => {


### PR DESCRIPTION
* Motivation for features / changes
When a metric filter is added, now automatically sorts by this filter.

* Detailed steps to verify changes work correctly (as executed by you)
`bazel run tensorboard -- --logdir [your logdir]`
Go to http://localhost:6007/?experimentalPlugin=npmi