### PR TITLE
[nPMI] React to both Sidebar Width and Window Width Changes

### DIFF
--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_component.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_component.ts
@@ -23,6 +23,7 @@ import {
   ElementRef,
   ViewEncapsulation,
   HostBinding,
+  HostListener,
 } from '@angular/core';
 import {ValueData} from '../../../store/npmi_types';
 import * as d3 from '../../../../../third_party/d3';
@@ -45,11 +46,16 @@ export class AnnotationComponent implements AfterViewInit, OnChanges {
   @Input() showCounts!: boolean;
   @Input() annotation!: string;
   @Input() runHeight!: number;
+  @Input() sidebarWidth!: number;
   @ViewChild('chart', {static: true, read: ElementRef})
   private readonly annotationContainer!: ElementRef<HTMLDivElement>;
   @ViewChild('hintClip', {static: true, read: ElementRef})
   private readonly clipPathElement!: ElementRef<SVGClipPathElement>;
   @HostBinding('class.selected-row') selected = false;
+  @HostListener('window:resize', ['$event'])
+  onResize(event: Event) {
+    this.redraw();
+  }
   private width: number = 10;
   private height: number = 10;
   private chartWidth: number = 10;

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_component.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_component.ts
@@ -46,13 +46,14 @@ export class AnnotationComponent implements AfterViewInit, OnChanges {
   @Input() showCounts!: boolean;
   @Input() annotation!: string;
   @Input() runHeight!: number;
+  // Only to trigger OnChanges to re-render the component.
   @Input() sidebarWidth!: number;
   @ViewChild('chart', {static: true, read: ElementRef})
   private readonly annotationContainer!: ElementRef<HTMLDivElement>;
   @ViewChild('hintClip', {static: true, read: ElementRef})
   private readonly clipPathElement!: ElementRef<SVGClipPathElement>;
   @HostBinding('class.selected-row') selected = false;
-  @HostListener('window:resize', ['$event'])
+  @HostListener('window:resize')
   onResize(event: Event) {
     this.redraw();
   }

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_container.ts
@@ -21,6 +21,7 @@ import {
   getFlaggedAnnotations,
   getHiddenAnnotations,
   getShowCounts,
+  getSidebarWidth,
 } from '../../../store';
 import {ValueData} from '../../../store/npmi_types';
 
@@ -39,6 +40,7 @@ import {ValueData} from '../../../store/npmi_types';
       [flaggedAnnotations]="flaggedAnnotations$ | async"
       [hiddenAnnotations]="hiddenAnnotations$ | async"
       [showCounts]="showCounts$ | async"
+      [sidebarWidth]="sidebarWidth$ | async"
     ></annotation-component>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -54,6 +56,7 @@ export class AnnotationContainer {
   readonly hiddenAnnotations$ = this.store.select(getHiddenAnnotations);
   readonly selectedAnnotations$ = this.store.select(getSelectedAnnotations);
   readonly showCounts$ = this.store.select(getShowCounts);
+  readonly sidebarWidth$ = this.store.select(getSidebarWidth);
 
   constructor(private readonly store: Store<State>) {}
 }

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_component.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_component.ts
@@ -39,6 +39,7 @@ export class ParallelCoordinatesComponent implements AfterViewInit, OnChanges {
     coordinates: Coordinate[];
     extremes: {max: number; min: number};
   };
+  // Only to trigger OnChanges to re-render the component.
   @Input() sidebarWidth!: number;
   @ViewChild('chart', {static: true, read: ElementRef})
   private readonly svgElement!: ElementRef<SVGElement>;

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_component.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_component.ts
@@ -21,6 +21,7 @@ import {
   Input,
   ViewChild,
   ElementRef,
+  HostListener,
 } from '@angular/core';
 import * as d3 from '../../../../../third_party/d3';
 import {Coordinate} from '../../../util/coordinate_data';
@@ -33,13 +34,18 @@ import {ValueData} from './../../../store/npmi_types';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ParallelCoordinatesComponent implements AfterViewInit, OnChanges {
+  @Input() activeMetrics!: string[];
   @Input() coordinateData!: {
     coordinates: Coordinate[];
     extremes: {max: number; min: number};
   };
-  @Input() activeMetrics!: string[];
+  @Input() sidebarWidth!: number;
   @ViewChild('chart', {static: true, read: ElementRef})
   private readonly svgElement!: ElementRef<SVGElement>;
+  @HostListener('window:resize', ['$event'])
+  onResize(event: Event) {
+    this.redraw();
+  }
   private width: number = 0;
   private chartWidth: number = 0;
   private readonly height: number = 300;

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_container.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/parallel_coordinates/parallel_coordinates_container.ts
@@ -24,6 +24,7 @@ import {
   getRunToMetrics,
   getMetricFilters,
   getAnnotationData,
+  getSidebarWidth,
 } from '../../../store';
 import {getRunSelection} from '../../../../../core/store/core_selectors';
 import {metricIsNpmiAndNotDiff} from '../../../util/metric_type';
@@ -38,6 +39,7 @@ import {stripMetricString} from '../../../util/metric_type';
     <parallel-coordinates-component
       [activeMetrics]="activeMetrics$ | async"
       [coordinateData]="coordinateData$ | async"
+      [sidebarWidth]="sidebarWidth$ | async"
     ></parallel-coordinates-component>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -84,6 +86,7 @@ export class ParallelCoordinatesContainer {
       );
     })
   );
+  readonly sidebarWidth$ = this.store.select(getSidebarWidth);
 
   constructor(private readonly store: Store<State>) {}
 }


### PR DESCRIPTION
* Motivation for features / changes
The two views on the right (annotations list and parallel coordinates) now react to window and sidebar width changes.

* Detailed steps to verify changes work correctly (as executed by you)
`bazel run tensorboard -- --logdir [your logdir]`
Go to http://localhost:6007/?experimentalPlugin=npmi