### PR TITLE
[WIP] Speedup data loading for tensorflow_stub by threading and caching

### DIFF
--- a/tensorboard/backend/event_processing/data_ingester.py
+++ b/tensorboard/backend/event_processing/data_ingester.py
@@ -101,8 +101,14 @@ class LocalDataIngester(object):
                 logger.info(
                     "TensorBoard reload process: Reload the whole Multiplexer"
                 )
-                self._multiplexer.Reload()
+                print("multiplexer.AddRunsFromDirectory(path, name) completed")
                 duration = time.time() - start
+                print('AddRunsFromDirectory done. Load took {} secs'.format(duration))
+                start2 = time.time()
+                self._multiplexer.Reload()
+                duration = time.time() - start2
+                print('TensorBoard done reloading. Load took {} secs'.format(duration))
+
                 logger.info(
                     "TensorBoard done reloading. Load took %0.3f secs", duration
                 )

--- a/tensorboard/backend/event_processing/io_wrapper.py
+++ b/tensorboard/backend/event_processing/io_wrapper.py
@@ -31,6 +31,8 @@ logger = tb_logging.get_logger()
 
 _ESCAPE_GLOB_CHARACTERS_REGEX = re.compile("([*?[])")
 
+directory_cache = {}
+use_bfs_and_build_cache_MT = True
 
 def IsCloudPath(path):
     return (
@@ -85,9 +87,12 @@ def ListDirectoryAbsolute(directory):
 
     The paths are absolute.
     """
-    return (
-        os.path.join(directory, path) for path in tf.io.gfile.listdir(directory)
-    )
+    if len(directory_cache) > 0:
+        return directory_cache[directory]
+    else:
+        return (
+            os.path.join(directory, path) for path in tf.io.gfile.listdir(directory)
+        )
 
 
 def _EscapeGlobCharacters(path):
@@ -162,6 +167,59 @@ def ListRecursivelyViaGlobbing(top):
         current_glob_string = os.path.join(current_glob_string, "*")
         level += 1
 
+import queue
+import time
+import os
+import threading
+class listdir_bfs:
+    def __init__(self, baseDir, list_dir_function=None):
+        # list_dir_function = listdirWithDelay
+        self.return_structure = []
+        self.list_dir_function = list_dir_function
+        start = time.time()
+        list_dir_function(".")
+        self.max_idle_time_in_sec = time.time() - start
+        self.max_idle_time_in_sec = self.max_idle_time_in_sec * 5
+        self.unwalked_dirs = queue.Queue()
+        self.unwalked_dirs.put(baseDir)
+        self.threads = []
+        for i in range(20):
+            t = threading.Thread(name="thread"+str(i), target=self.worker)
+            self.threads.append(t)
+            t.start()
+
+        for t in self.threads:
+            t.join()
+
+    def worker(self):
+        """thread worker function"""
+        if "last_job_time" not in locals():
+            last_job_time = time.time()
+        while True:
+            try:
+                current = self.unwalked_dirs.get(False)
+                last_job_time = time.time()
+            except queue.Empty:
+                if time.time() - last_job_time > self.max_idle_time_in_sec : # and last_job_time > 0:
+                    # print('Worker '+threading.current_thread().getName() + " is stopped")
+                    break
+                # print('Worker '+threading.current_thread().getName() + " slept for 0.1s")
+                time.sleep(0.1)
+                continue
+
+            children = self.list_dir_function(current)
+            file_paths = []
+            dir_paths = []
+            for c in children:
+                fullpath = os.path.join(current, c)
+                # check symbolic link?
+                if os.path.isdir(fullpath):
+                    self.unwalked_dirs.put(fullpath)
+                    dir_paths.append(fullpath)
+                else:
+                    file_paths.append(fullpath)
+            self.return_structure.append((current, tuple(dir_paths), tuple(file_paths)))
+            # print(self.return_structure)
 
 def ListRecursivelyViaWalking(top):
     """Walks a directory tree, yielding (dir_path, file_paths) tuples.
@@ -180,11 +238,22 @@ def ListRecursivelyViaWalking(top):
     Yields:
       A (dir_path, file_paths) tuple for each directory/subdirectory.
     """
-    for dir_path, _, filenames in tf.io.gfile.walk(top, topdown=True):
-        yield (
-            dir_path,
-            (os.path.join(dir_path, filename) for filename in filenames),
-        )
+    if use_bfs_and_build_cache_MT:
+        global directory_cache
+
+        xx = listdir_bfs(top, list_dir_function=tf.io.gfile.listdir)
+        directory_cache = {}
+        
+        for key, dirs, files in xx.return_structure:
+            directory_cache[key] = dirs+files
+        for dir_path, _,  filename in xx.return_structure:
+            yield (dir_path, filename)
+    else:
+        for dir_path, _, filenames in tf.io.gfile.walk(top, topdown=True):
+            yield (
+                dir_path,
+                (os.path.join(dir_path, filename) for filename in filenames),
+            )
 
 
 def GetLogdirSubdirectories(path):

--- a/tensorboard/compat/tensorflow_stub/io/gfile.py
+++ b/tensorboard/compat/tensorflow_stub/io/gfile.py
@@ -182,6 +182,7 @@ class LocalFileSystem(object):
         return os.path.isdir(compat.as_bytes(dirname))
 
     def listdir(self, dirname):
+        import time; time.sleep(0.1) # simulate the network latency
         """Returns a list of entries contained within a directory."""
         if not self.isdir(dirname):
             raise errors.NotFoundError(None, None, "Could not find directory")


### PR DESCRIPTION
* Motivation for features / changes
As described in #4023 , `tf.io.gfile.listdir` may suffer from network latency. This is a POC that caching the directory structure and travel the with multiple threads can speed it up. 
* Technical description of changes
  1a. To simulate the latency, I inserted the `time.sleep(0.1)` before each os.listdir() is called.
  1b. Added some print statement to compare the time spent.
  2. The original implementation of walk() is depth-first traversal, I implemented a `listdir_bfs` class so that the traversal can be concurrent.
  3. The traversal result is cached so that tensorboard reloading is very fast.
  4. [TODO] Find a proper location for `listdir_bfs` class and expose the `use_bfs_and_build_cache_MT` flag.
  5. [TODO] Unit test.
  6. [TODO] determine the number of concurrent threads, and the timeout for `listdir()`; expose the settings to the launch args.

* Detailed steps to verify changes work correctly (as executed by you)

`bazelisk run tensorboard -- --logdir runs`

```
with `use_bfs_and_build_cache_MT = True`
AddRunsFromDirectory done. Load took 2.502 secs
TensorBoard done reloading. Load took 80.473  <- first time load, slow because the deserialization of event file? This is not parallelized on my PC.
multiplexer.AddRunsFromDirectory(path, name) completed
AddRunsFromDirectory done. Load took 2.499 secs
TensorBoard done reloading. Load took 0.017secs
...
with `use_bfs_and_build_cache_MT = False`
AddRunsFromDirectory done. Load took 31.620 secs
TensorBoard done reloading. Load took 98.740 secs
AddRunsFromDirectory done. Load took 31.782 secs
TensorBoard done reloading. Load took 10.455 secs
...
```

  <details><summary>Testing folder structure</summary>
<p>

```bash
runs
├── a
│   ├── Aug05_09-09-17_twhuang-mbp
│   │   ├── 00000
│   │   │   └── default
│   │   │       ├── metadata.tsv
│   │   │       ├── sprite.png
│   │   │       └── tensors.tsv
│   │   ├── 00001
│   │   │   └── noMetadata
│   │   │       └── tensors.tsv
│   │   ├── 00002
│   │   │   └── default
│   │   │       ├── metadata.tsv
│   │   │       ├── sprite.png
│   │   │       └── tensors.tsv
│   │   ├── data
│   │   │   └── scalar_group
│   │   │       ├── arctanx
│   │   │       │   └── events.out.tfevents.1596589757.twhuang-mbp
│   │   │       ├── xcosx
│   │   │       │   └── events.out.tfevents.1596589757.twhuang-mbp
│   │   │       └── xsinx
│   │   │           └── events.out.tfevents.1596589757.twhuang-mbp
│   │   ├── events.out.tfevents.1596589757.twhuang-mbp
│   │   └── projector_config.pbtxt
│   ├── Aug05_09-09-36_twhuang-mbp
│   │   ├── 00000
│   │   │   └── default
│   │   │       ├── metadata.tsv
│   │   │       ├── sprite.png
│   │   │       └── tensors.tsv
│   │   ├── 00001
│   │   │   └── noMetadata
│   │   │       └── tensors.tsv
│   │   ├── 00002
│   │   │   └── default
│   │   │       ├── metadata.tsv
│   │   │       ├── sprite.png
│   │   │       └── tensors.tsv
│   │   ├── data
│   │   │   └── scalar_group
│   │   │       ├── arctanx
│   │   │       │   └── events.out.tfevents.1596589776.twhuang-mbp
│   │   │       ├── xcosx
│   │   │       │   └── events.out.tfevents.1596589776.twhuang-mbp
│   │   │       └── xsinx
│   │   │           └── events.out.tfevents.1596589776.twhuang-mbp
│   │   ├── events.out.tfevents.1596589776.twhuang-mbp
│   │   └── projector_config.pbtxt
│   ├── Aug05_09-09-56_twhuang-mbp
│   │   ├── 00000
│   │   │   └── default
│   │   │       ├── metadata.tsv
│   │   │       ├── sprite.png
│   │   │       └── tensors.tsv
│   │   ├── 00001
│   │   │   └── noMetadata
│   │   │       └── tensors.tsv
│   │   ├── 00002
│   │   │   └── default
│   │   │       ├── metadata.tsv
│   │   │       ├── sprite.png
│   │   │       └── tensors.tsv
│   │   ├── data
│   │   │   └── scalar_group
│   │   │       ├── arctanx
│   │   │       │   └── events.out.tfevents.1596589796.twhuang-mbp
│   │   │       ├── xcosx
│   │   │       │   └── events.out.tfevents.1596589796.twhuang-mbp
│   │   │       └── xsinx
│   │   │           └── events.out.tfevents.1596589796.twhuang-mbp
│   │   ├── events.out.tfevents.1596589796.twhuang-mbp
│   │   └── projector_config.pbtxt
│   ├── Aug05_09-10-15_twhuang-mbp
│   │   ├── 00000
│   │   │   └── default
│   │   │       ├── metadata.tsv
│   │   │       ├── sprite.png
│   │   │       └── tensors.tsv
│   │   ├── 00001
│   │   │   └── noMetadata
│   │   │       └── tensors.tsv
│   │   ├── 00002
│   │   │   └── default
│   │   │       ├── metadata.tsv
│   │   │       ├── sprite.png
│   │   │       └── tensors.tsv
│   │   ├── data
│   │   │   └── scalar_group
│   │   │       ├── arctanx
│   │   │       │   └── events.out.tfevents.1596589815.twhuang-mbp
│   │   │       ├── xcosx
│   │   │       │   └── events.out.tfevents.1596589815.twhuang-mbp
│   │   │       └── xsinx
│   │   │           └── events.out.tfevents.1596589815.twhuang-mbp
│   │   ├── events.out.tfevents.1596589815.twhuang-mbp
│   │   └── projector_config.pbtxt
│   └── Aug05_09-10-34_twhuang-mbp
│       ├── 00000
│       │   └── default
│       │       ├── metadata.tsv
│       │       ├── sprite.png
│       │       └── tensors.tsv
│       ├── 00001
│       │   └── noMetadata
│       │       └── tensors.tsv
│       ├── 00002
│       │   └── default
│       │       ├── metadata.tsv
│       │       ├── sprite.png
│       │       └── tensors.tsv
│       ├── data
│       │   └── scalar_group
│       │       ├── arctanx
│       │       │   └── events.out.tfevents.1596589834.twhuang-mbp
│       │       ├── xcosx
│       │       │   └── events.out.tfevents.1596589834.twhuang-mbp
│       │       └── xsinx
│       │           └── events.out.tfevents.1596589834.twhuang-mbp
│       ├── events.out.tfevents.1596589834.twhuang-mbp
│       └── projector_config.pbtxt
├── b
├── c
├── d
├── e
```
Where b, c, d, e have similar structure like `a`
</p>
</details>



cc @cryptopic
