### PR TITLE
Revert "Automatically Change sorting when Metric Filter Added (#4133)"

### DIFF
--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
@@ -230,10 +230,6 @@ const reducer = createReducer(
             includeNaN: false,
           },
         },
-        sorting: {
-          metric,
-          order: SortingOrder.DOWN,
-        },
       };
     }
   ),

--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers_test.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers_test.ts
@@ -456,7 +456,7 @@ describe('npmi_reducers', () => {
 
   describe('Metric Filters', () => {
     describe('Adding Filters', () => {
-      it('adds a new metric filter with none present, and adjusts sorting', () => {
+      it('adds a new metric filter with none present', () => {
         const state = createNpmiState();
         const nextState = reducers(
           state,
@@ -472,10 +472,6 @@ describe('npmi_reducers', () => {
         expect(nextState.metricArithmetic).toEqual([
           {kind: ArithmeticKind.METRIC, metric: 'nPMI@test'},
         ]);
-        expect(nextState.sorting).toEqual({
-          metric: 'nPMI@test',
-          order: SortingOrder.DOWN,
-        });
       });
 
       it('adds a new metric filter after the first one', () => {


### PR DESCRIPTION
Summary:
Legitimate build failure due to presubmit-submit skew.

This reverts commit 19e23ed79e18d1cc3e7d69368fc505d168d127bf.

Test Plan:
Running `bazel build //tensorboard` now completes successfully; before,
it failed as in this build log:
<https://travis-ci.org/github/tensorflow/tensorboard/jobs/725312692>

Errors were:

  - Object literal may only specify known properties, and 'sorting' does
    not exist in type 'NpmiState'.
  - Cannot find name 'SortingOrder'.

wchargin-branch: revert-4133
