### PR TITLE
Roll forward "Automatically Change sorting when Metric Filter Added (#4133)"

### DIFF
--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
@@ -230,13 +230,10 @@ const reducer = createReducer(
             includeNaN: false,
           },
         },
-<<<<<<< HEAD
         sort: {
           metric,
           order: SortOrder.DOWN,
         },
-=======
->>>>>>> 033c8adecf67021eb9fd2e1993ceb49e74f2339e
       };
     }
   ),

--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
@@ -230,10 +230,6 @@ const reducer = createReducer(
             includeNaN: false,
           },
         },
-        sorting: {
-          metric,
-          order: SortingOrder.DOWN,
-        },
       };
     }
   ),

--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers.ts
@@ -230,6 +230,10 @@ const reducer = createReducer(
             includeNaN: false,
           },
         },
+        sort: {
+          metric,
+          order: SortOrder.DOWN,
+        },
       };
     }
   ),

--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers_test.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers_test.ts
@@ -472,7 +472,7 @@ describe('npmi_reducers', () => {
         expect(nextState.metricArithmetic).toEqual([
           {kind: ArithmeticKind.METRIC, metric: 'nPMI@test'},
         ]);
-        expect(nextState.sorting).toEqual({
+        expect(nextState.sort).toEqual({
           metric: 'nPMI@test',
           order: SortOrder.DOWN,
         });

--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers_test.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers_test.ts
@@ -456,7 +456,7 @@ describe('npmi_reducers', () => {
 
   describe('Metric Filters', () => {
     describe('Adding Filters', () => {
-      it('adds a new metric filter with none present', () => {
+      it('adds a new metric filter with none present, and adjusts sorting', () => {
         const state = createNpmiState();
         const nextState = reducers(
           state,
@@ -472,13 +472,10 @@ describe('npmi_reducers', () => {
         expect(nextState.metricArithmetic).toEqual([
           {kind: ArithmeticKind.METRIC, metric: 'nPMI@test'},
         ]);
-<<<<<<< HEAD
         expect(nextState.sorting).toEqual({
           metric: 'nPMI@test',
           order: SortOrder.DOWN,
         });
-=======
->>>>>>> 033c8adecf67021eb9fd2e1993ceb49e74f2339e
       });
 
       it('adds a new metric filter after the first one', () => {

--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers_test.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers_test.ts
@@ -456,7 +456,7 @@ describe('npmi_reducers', () => {
 
   describe('Metric Filters', () => {
     describe('Adding Filters', () => {
-      it('adds a new metric filter with none present', () => {
+      it('adds a new metric filter with none present, and adjusts sorting', () => {
         const state = createNpmiState();
         const nextState = reducers(
           state,
@@ -472,6 +472,10 @@ describe('npmi_reducers', () => {
         expect(nextState.metricArithmetic).toEqual([
           {kind: ArithmeticKind.METRIC, metric: 'nPMI@test'},
         ]);
+        expect(nextState.sorting).toEqual({
+          metric: 'nPMI@test',
+          order: SortOrder.DOWN,
+        });
       });
 
       it('adds a new metric filter after the first one', () => {

--- a/tensorboard/webapp/plugins/npmi/store/npmi_reducers_test.ts
+++ b/tensorboard/webapp/plugins/npmi/store/npmi_reducers_test.ts
@@ -456,7 +456,7 @@ describe('npmi_reducers', () => {
 
   describe('Metric Filters', () => {
     describe('Adding Filters', () => {
-      it('adds a new metric filter with none present, and adjusts sorting', () => {
+      it('adds a new metric filter with none present', () => {
         const state = createNpmiState();
         const nextState = reducers(
           state,
@@ -472,10 +472,6 @@ describe('npmi_reducers', () => {
         expect(nextState.metricArithmetic).toEqual([
           {kind: ArithmeticKind.METRIC, metric: 'nPMI@test'},
         ]);
-        expect(nextState.sorting).toEqual({
-          metric: 'nPMI@test',
-          order: SortingOrder.DOWN,
-        });
       });
 
       it('adds a new metric filter after the first one', () => {


### PR DESCRIPTION
Summary:
This rolls forward commit 19e23ed79e18d1cc3e7d69368fc505d168d127bf with
minor name changes (`sorting` to `sort`, `SortingOrder` to `SortOrder`)
so that it builds.

Test Plan:
Running `bazel build //tensorboard` still completes successfully.

wchargin-branch: roll-forward-4133
