### PR TITLE
[nPMI] Fixed MinBuffer for Scrolling when PC gets minimized.

### DIFF
--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_component.ng.html
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_component.ng.html
@@ -29,6 +29,7 @@ limitations under the License.
   <cdk-virtual-scroll-viewport
     itemSize="{{numActiveRuns * runHeight + 25}}"
     class="annotation-rows"
+    minBufferPx="300"
   >
     <npmi-annotation
       *cdkVirtualFor="let annotation of sortedAnnotations"


### PR DESCRIPTION
* Motivation for features / changes
When the PC plot was minimized, the annotations list showed whitespace at the bottom. This has been fixed by increasing the buffer size.

* Detailed steps to verify changes work correctly (as executed by you)
`bazel run tensorboard -- --logdir [your logdir]`
Go to http://localhost:6007/?experimentalPlugin=npmi