### PR TITLE
[nPMI] Changed to Use Template Colors throughout CSS

### DIFF
--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_component.scss
@@ -28,7 +28,7 @@ limitations under the License.
 }
 
 .selected-row {
-  background-color: mat-color($mat-light-theme-background, selected-button);
+  background-color: mat-color($tb-background, selected-button);
   display: block;
 }
 

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_component.scss
@@ -22,7 +22,7 @@ limitations under the License.
 
 .metric-arithmetic-element-range {
   align-items: center;
-  background-color: mat-color($mat-light-theme-background, card);
+  background-color: mat-color($tb-background, card);
   font-size: 0.8em;
   height: 30px;
   justify-content: center;
@@ -39,7 +39,7 @@ limitations under the License.
   transition: width 1s;
 
   &:focus {
-    background-color: mat-color($mat-light-theme-background, focused-button);
+    background-color: mat-color($tb-background, focused-button);
     border: none;
     outline: none;
   }

--- a/tensorboard/webapp/plugins/npmi/views/main/main_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/main/main_component.scss
@@ -62,7 +62,6 @@ limitations under the License.
   position: absolute;
   left: 10px;
   bottom: 10px;
-  background-color: white;
   border: 1px solid mat-color($tb-foreground, border);
   border-radius: 3px;
   display: flex;
@@ -76,7 +75,7 @@ limitations under the License.
   height: 100%;
   width: 3px;
   overflow: hidden;
-  background-color: grey;
+  background-color: mat-color($tb-foreground, divider);
 }
 
 .annotations-list {

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_component.scss
@@ -15,7 +15,7 @@ limitations under the License.
 @import 'tensorboard/webapp/theme/tb_theme';
 
 .chart-container {
-  background-color: #fff;
+  background-color: mat-color($tb-background, card);
   border-bottom: 1px solid mat-color($tb-foreground, border);
   display: flex;
   flex-direction: column;
@@ -45,6 +45,6 @@ limitations under the License.
 }
 
 .stroked-line {
-  stroke: grey;
+  stroke: mat-color($tb-foreground, divider);
   stroke-dasharray: 3 3;
 }

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_component.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_component.ts
@@ -335,7 +335,7 @@ export class ViolinFilterComponent implements AfterViewInit, OnChanges {
       .style('stroke-dasharray', '3, 3')
       .attr('x1', 0)
       .attr('y1', this.chartHeight - this.drawMargin.top)
-      .attr('x2', this.chartWidth)
+      .attr('x2', this.drawWidth)
       .attr('y2', this.chartHeight - this.drawMargin.top);
   }
 
@@ -347,7 +347,7 @@ export class ViolinFilterComponent implements AfterViewInit, OnChanges {
     this.nanText.attr('y', this.chartHeight - this.drawMargin.top);
     this.nanLine
       .attr('y1', this.drawHeight + this.drawMargin.top)
-      .attr('x2', this.chartWidth)
+      .attr('x2', this.drawWidth)
       .attr('y2', this.drawHeight + this.drawMargin.top);
   }
 

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_component.scss
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_component.scss
@@ -37,7 +37,7 @@ limitations under the License.
 
 .side-toggle {
   align-items: center;
-  background-color: white;
+  background-color: mat-color($tb-background, raised-button);
   border-radius: 3px;
   border: 1px solid mat-color($tb-foreground, border);
   display: flex;
@@ -58,5 +58,5 @@ limitations under the License.
 }
 
 .filters-hint-text {
-  color: lightgray;
+  color: mat-color($tb-foreground, hint-text);
 }


### PR DESCRIPTION
* Motivation for features / changes
Changed remiaining css throughout the plugin where color templates were not yet used.

* Detailed steps to verify changes work correctly (as executed by you)
`bazel run tensorboard -- --logdir [your logdir]`
Go to http://localhost:6007/?experimentalPlugin=npmi