### PR TITLE
nbfmt updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,14 +83,12 @@ jobs:
       - name: 'Lint YAML for gotchas with yamllint'
         # Use '# yamllint disable-line rule:foo' to suppress.
         run: yamllint -c docs/.yamllint docs docs/.yamllint
-      - name: 'Install nbfmt.py for checking notebook formatting'
+      - name: 'Install the TensorFlow docs notebook tools'
         run: |
-          nbfmt_version="78692e5013fe070a33c7501245157b395c2e7e84"
-          wget "https://raw.githubusercontent.com/tensorflow/docs/${nbfmt_version}/tools/nbfmt.py"
-          pip install absl-py
-          chmod +x ./nbfmt.py
-      - name: 'Check Colab notebooks for formatting'
-        run: git ls-files -z '*.ipynb' | xargs -0 ./nbfmt.py --test
+          nbfmt_version="174c9a5c1cc51a3af1de98d84824c811ecd49029"
+          python3 -m pip install -U git+https://github.com/tensorflow/docs@${nbfmt_version}
+      - name: 'Use nbfmt to check Colab notebooks for formatting'
+        run: git ls-files -z '*.ipynb' | xargs -0 python3 -m tensorflow_docs.tools.nbfmt --test
 
   lint-frontend:
     runs-on: ubuntu-16.04

--- a/docs/dataframe_api.ipynb
+++ b/docs/dataframe_api.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "djUvWu41mtXa"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "su2RaORHpReL"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "NztQK2uFpXT-"
       },
       "source": [
@@ -47,7 +43,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "eDXRFe_qp5C3"
       },
       "source": [
@@ -64,7 +59,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "a6E4sB4Qulnz"
+      },
       "source": [
         "## Setup\n",
         "\n",
@@ -77,7 +74,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab_type": "text",
         "id": "dG-nnZK9qW9z"
       },
       "outputs": [],
@@ -90,8 +86,6 @@
       "cell_type": "code",
       "execution_count": 1,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "3U5gdCw_nSG3"
       },
       "outputs": [],
@@ -109,13 +103,7 @@
       "cell_type": "code",
       "execution_count": 2,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "colab_type": "code",
-        "id": "1qIKtOBrqc9Y",
-        "outputId": "cb1b3125-6f75-4fe7-ac5e-07954b5d6847"
+        "id": "1qIKtOBrqc9Y"
       },
       "outputs": [
         {
@@ -135,7 +123,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "V-aYbmaS74Xs"
+      },
       "source": [
         "## Loading TensorBoard scalars as a `pandas.DataFrame`\n",
         "\n",
@@ -146,7 +136,9 @@
     {
       "cell_type": "code",
       "execution_count": 3,
-      "metadata": {},
+      "metadata": {
+        "id": "S39rRajbyOqc"
+      },
       "outputs": [
         {
           "data": {
@@ -289,7 +281,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "ZzF2c0QFTCB5"
+      },
       "source": [
         "`df` is a [`pandas.DataFrame`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html) that contains all scalar logs of the experiment.\n",
         "\n",
@@ -303,7 +297,9 @@
     {
       "cell_type": "code",
       "execution_count": 4,
-      "metadata": {},
+      "metadata": {
+        "id": "fpsCq3_uf37q"
+      },
       "outputs": [
         {
           "name": "stdout",
@@ -331,7 +327,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "lAC-w8W5quOr"
+      },
       "source": [
         "## Getting a pivoted (wide-form) DataFrame\n",
         "\n",
@@ -343,7 +341,9 @@
     {
       "cell_type": "code",
       "execution_count": 5,
-      "metadata": {},
+      "metadata": {
+        "id": "-a38EZqyutD2"
+      },
       "outputs": [
         {
           "data": {
@@ -484,14 +484,18 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "qNnEA5Sywzo0"
+      },
       "source": [
         "Notice that instead of a single \"value\" column, the wide-form DataFrame includes the two tags (metrics) as its columns explicitly: `epoch_accuracy` and `epoch_loss`."
       ]
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "PEenTH7QEfP8"
+      },
       "source": [
         "## Saving the DataFrame as CSV\n",
         "\n",
@@ -501,7 +505,9 @@
     {
       "cell_type": "code",
       "execution_count": 6,
-      "metadata": {},
+      "metadata": {
+        "id": "_O4OaPJeckwT"
+      },
       "outputs": [],
       "source": [
         "csv_path = '/tmp/tb_experiment_1.csv'\n",
@@ -512,7 +518,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "hAUURz84q0gB"
+      },
       "source": [
         "## Performing custom visualization and statistical analysis"
       ]
@@ -520,7 +528,9 @@
     {
       "cell_type": "code",
       "execution_count": 7,
-      "metadata": {},
+      "metadata": {
+        "id": "iKKioeyjARS7"
+      },
       "outputs": [
         {
           "data": {
@@ -563,7 +573,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "8CF8g6znMwxN"
+      },
       "source": [
         "The plots above show the timecourses of validation accuracy and validation loss. Each curve shows the average across 5 runs under an optimizer type. Thanks to a built-in feature of `seaborn.lineplot()`, each curve also displays ±1 standard deviation around the mean, which gives us a clear sense of the variability in these curves and the significance of the differences among the three optimizer types. This visualization of variability is not yet supported in TensorBoard's GUI.\n",
         "\n",
@@ -575,7 +587,9 @@
     {
       "cell_type": "code",
       "execution_count": 8,
-      "metadata": {},
+      "metadata": {
+        "id": "A4X4XF-GRMBO"
+      },
       "outputs": [
         {
           "data": {
@@ -616,7 +630,9 @@
     {
       "cell_type": "code",
       "execution_count": 9,
-      "metadata": {},
+      "metadata": {
+        "id": "CIWdPx45eSIe"
+      },
       "outputs": [
         {
           "name": "stdout",
@@ -647,7 +663,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "TcrwpKdNm-nN"
+      },
       "source": [
         "Therefore, at a significance level of 0.05, our analysis confirms our hypothesis that the minimum validation loss is significantly higher (i.e., worse) in the rmsprop optimizer compared to the other two optimizers included in our experiment. \n",
         "\n",
@@ -659,13 +677,10 @@
     "colab": {
       "collapsed_sections": [],
       "name": "dataframe_api.ipynb",
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",
-      "language": "python",
       "name": "python3"
     }
   },

--- a/docs/get_started.ipynb
+++ b/docs/get_started.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "SB93Ge748VQs"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "0sK8X2O9bTlz"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "HEYuO5NFwDK9"
       },
       "source": [
@@ -59,7 +55,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "56V5oun18ZdZ"
       },
       "source": [
@@ -72,8 +67,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "6B95Hb6YVgPZ"
       },
       "outputs": [],
@@ -86,8 +79,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "_wqSAZExy6xV"
       },
       "outputs": [],
@@ -100,8 +91,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "Ao7fJW1Pyiza"
       },
       "outputs": [],
@@ -113,7 +102,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "z5pr9vuHVgXY"
       },
       "source": [
@@ -124,12 +112,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "height": 51
-        },
-        "colab_type": "code",
-        "id": "j-DHsby18cot",
-        "outputId": "4c910ebd-2c93-4138-fec7-0a36ae3d90bf"
+        "id": "j-DHsby18cot"
       },
       "outputs": [
         {
@@ -159,7 +142,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "XKUjdIoV87um"
       },
       "source": [
@@ -169,7 +151,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "8CL_lxdn8-Sv"
       },
       "source": [
@@ -182,12 +163,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "height": 221
-        },
-        "colab_type": "code",
-        "id": "WAQThq539CEJ",
-        "outputId": "73a348aa-504c-48a7-f720-5dd0478e2aa9"
+        "id": "WAQThq539CEJ"
       },
       "outputs": [
         {
@@ -239,7 +215,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "asjGpmD09dRl"
       },
       "source": [
@@ -250,8 +225,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "A4UKgTLb9fKI"
       },
       "outputs": [],
@@ -262,7 +235,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MCsoUNb6YhGc"
       },
       "source": [
@@ -272,7 +244,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Gi4PaRm39of2"
       },
       "source": [
@@ -288,7 +259,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "nB718NOH95yG"
       },
       "source": [
@@ -298,7 +268,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "IKNt0nWs-Ekt"
       },
       "source": [
@@ -311,8 +280,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "nnHx4DsMezy1"
       },
       "outputs": [],
@@ -327,7 +294,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "SzpmTmJafJ10"
       },
       "source": [
@@ -338,8 +304,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "H2Y5-aPbAANs"
       },
       "outputs": [],
@@ -351,7 +315,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "cKhIIDj9Hbfy"
       },
       "source": [
@@ -362,8 +325,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "jD0tEWrgH0TL"
       },
       "outputs": [],
@@ -378,7 +339,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "szw_KrgOg-OT"
       },
       "source": [
@@ -389,8 +349,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "TTWcJO35IJgK"
       },
       "outputs": [],
@@ -416,7 +374,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "nucPZBKPJR3A"
       },
       "source": [
@@ -427,8 +384,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "3Qp-exmbWf4w"
       },
       "outputs": [],
@@ -443,7 +398,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "qgUJgDdKWUKF"
       },
       "source": [
@@ -454,12 +408,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "height": 102
-        },
-        "colab_type": "code",
-        "id": "odWvHPpKJvb_",
-        "outputId": "cff49dc7-2c87-4ea0-f36f-f0af948d7a65"
+        "id": "odWvHPpKJvb_"
       },
       "outputs": [
         {
@@ -509,7 +458,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "JikosQ84fzcA"
       },
       "source": [
@@ -520,8 +468,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "-Iue509kgOyE"
       },
       "outputs": [],
@@ -532,7 +478,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "NVpnilhEgQXk"
       },
       "source": [
@@ -542,7 +487,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "ozbwXgPIkCKV"
       },
       "source": [
@@ -552,7 +496,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "vsowjhkBdkbK"
       },
       "source": [
@@ -567,8 +510,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "Q3nupQL24E5E"
       },
       "outputs": [],
@@ -583,7 +524,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "lAgEh_Ow4EX6"
       },
       "source": [
@@ -600,7 +540,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "get_started.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/docs/graphs.ipynb
+++ b/docs/graphs.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "SB93Ge748VQs"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": 1,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "0sK8X2O9bTlz"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "HEYuO5NFwDK9"
       },
       "source": [
@@ -59,7 +55,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "56V5oun18ZdZ"
       },
       "source": [
@@ -71,7 +66,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "TOSJ-4nteBYG"
       },
       "source": [
@@ -81,7 +75,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "zNI1-dflrAo0"
       },
       "source": [
@@ -92,8 +85,6 @@
       "cell_type": "code",
       "execution_count": 2,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "6B95Hb6YVgPZ"
       },
       "outputs": [],
@@ -106,13 +97,7 @@
       "cell_type": "code",
       "execution_count": 3,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "colab_type": "code",
-        "id": "_wqSAZExy6xV",
-        "outputId": "4558e63e-513d-4f64-dc1c-92937710e68c"
+        "id": "_wqSAZExy6xV"
       },
       "outputs": [
         {
@@ -138,7 +123,9 @@
     {
       "cell_type": "code",
       "execution_count": 4,
-      "metadata": {},
+      "metadata": {
+        "id": "qRZlYIEcJ56Z"
+      },
       "outputs": [
         {
           "data": {
@@ -160,8 +147,6 @@
       "cell_type": "code",
       "execution_count": 5,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "Ao7fJW1Pyiza"
       },
       "outputs": [],
@@ -173,7 +158,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "e25E37vd1xEW"
       },
       "source": [
@@ -186,8 +170,6 @@
       "cell_type": "code",
       "execution_count": 6,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "skqORzvE3Egy"
       },
       "outputs": [],
@@ -209,7 +191,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "qbjuoz9E3VC_"
       },
       "source": [
@@ -220,8 +201,6 @@
       "cell_type": "code",
       "execution_count": 7,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "6TDmc41z3g38"
       },
       "outputs": [],
@@ -233,7 +212,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "8DV0xibO3bRC"
       },
       "source": [
@@ -246,13 +224,7 @@
       "cell_type": "code",
       "execution_count": 8,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 204
-        },
-        "colab_type": "code",
-        "id": "TU_L_u9SqQdH",
-        "outputId": "210b42ed-25ea-4c78-d4c1-2ddab616b175"
+        "id": "TU_L_u9SqQdH"
       },
       "outputs": [
         {
@@ -299,7 +271,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "IRX5OIsi4TTV"
       },
       "source": [
@@ -312,10 +283,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "PFgFjlPEqXb9",
-        "scrolled": false
+        "id": "PFgFjlPEqXb9"
       },
       "outputs": [],
       "source": [
@@ -325,7 +293,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "EGlOqRp54ufD"
       },
       "source": [
@@ -343,7 +310,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "F-2yw5qd7OpK"
       },
       "source": [
@@ -353,7 +319,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "jDRynpVw53SJ"
       },
       "source": [
@@ -363,7 +328,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Oj9FSPdz6SO2"
       },
       "source": [
@@ -377,7 +341,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Qw9rbEcE6eZB"
       },
       "source": [
@@ -388,7 +351,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "zVuaKBifu-qF"
       },
       "source": [
@@ -402,7 +364,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "JIuhJnQ8w-dT"
       },
       "source": [
@@ -420,8 +381,6 @@
       "cell_type": "code",
       "execution_count": 10,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "woI67Stgv_uY"
       },
       "outputs": [],
@@ -457,8 +416,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "zCArnWzP0VuZ"
       },
       "outputs": [],
@@ -469,7 +426,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "WDl1PBFQ64xi"
       },
       "source": [
@@ -479,7 +435,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "1pLRaf3q6Nku"
       },
       "source": [
@@ -493,13 +448,10 @@
         "SB93Ge748VQs"
       ],
       "name": "graphs.ipynb",
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",
-      "language": "python",
       "name": "python3"
     }
   },

--- a/docs/hyperparameter_tuning_with_hparams.ipynb
+++ b/docs/hyperparameter_tuning_with_hparams.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "TsHV-7cpVkyK"
       },
       "source": [
@@ -12,11 +11,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "atWM-s8yVnfX"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "TB0wBWfcVqHz"
       },
       "source": [
@@ -59,7 +55,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "elH58gbhWAmn"
       },
       "source": [
@@ -83,8 +78,6 @@
       "cell_type": "code",
       "execution_count": 1,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "8p3Tbx8cWEFA"
       },
       "outputs": [],
@@ -95,10 +88,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "lEWCCQYkWIdA"
       },
       "outputs": [],
@@ -110,7 +101,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "9GtR_cTTkf9G"
       },
       "source": [
@@ -119,10 +109,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "mVtYvbbIWRkV"
       },
       "outputs": [],
@@ -134,7 +122,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "XfCa27_8kov6"
       },
       "source": [
@@ -143,15 +130,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 153
-        },
-        "colab_type": "code",
-        "id": "z8b82G7YksOS",
-        "outputId": "8d018f2d-7574-4af2-b8cb-0452f8d54724"
+        "id": "z8b82G7YksOS"
       },
       "outputs": [
         {
@@ -179,7 +160,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "0tsTxO85WaYq"
       },
       "source": [
@@ -196,10 +176,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "5Euw0agpWb4V"
       },
       "outputs": [],
@@ -220,7 +198,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "T_T95RrSIVO6"
       },
       "source": [
@@ -230,7 +207,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "va9XMh-dW4_f"
       },
       "source": [
@@ -241,10 +217,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "hG-zalNfW5Zl"
       },
       "outputs": [],
@@ -270,7 +244,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "46oJF8seXM7v"
       },
       "source": [
@@ -279,10 +252,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "8j-fO6nEXRfW"
       },
       "outputs": [],
@@ -297,7 +268,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "2mYdW0VKLbFE"
       },
       "source": [
@@ -317,7 +287,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "u2nOgIKAXdcb"
       },
       "source": [
@@ -332,15 +301,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 649
-        },
-        "colab_type": "code",
-        "id": "KbqT5n-AXd0h",
-        "outputId": "f906b680-f941-4c7c-9b15-4dcc760bf2bb"
+        "id": "KbqT5n-AXd0h"
       },
       "outputs": [
         {
@@ -403,7 +366,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "qSyjWQ3mPKT9"
       },
       "source": [
@@ -413,7 +375,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "5VBvplwyP8Vy"
       },
       "source": [
@@ -422,10 +383,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "Xf4KM-U2bbP_"
       },
       "outputs": [],
@@ -436,7 +395,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "UTWg9nXnxWWI"
       },
       "source": [
@@ -446,7 +404,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "4RPGbR9EWd4o"
       },
       "source": [
@@ -462,7 +419,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Z3Q5v28XaCt8"
       },
       "source": [
@@ -478,7 +434,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "fh3p0DtcdOK1"
       },
       "source": [
@@ -487,10 +442,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "oxrSUAnCeFmQ"
       },
       "outputs": [],
@@ -503,7 +456,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "__8xQhjqgr3D"
       },
       "source": [
@@ -512,10 +464,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "KBHp6M_zgjp4"
       },
       "outputs": [],
@@ -526,7 +476,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Po7rTfQswAMT"
       },
       "source": [
@@ -536,7 +485,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "IlDz2oXBgnZ9"
       },
       "source": [
@@ -550,9 +498,7 @@
     "colab": {
       "collapsed_sections": [],
       "name": "hyperparameter_tuning_with_hparams.ipynb",
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/docs/image_summaries.ipynb
+++ b/docs/image_summaries.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "djUvWu41mtXa"
       },
       "source": [
@@ -12,11 +11,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "su2RaORHpReL"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "NztQK2uFpXT-"
       },
       "source": [
@@ -59,7 +55,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "eDXRFe_qp5C3"
       },
       "source": [
@@ -73,7 +68,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "dG-nnZK9qW9z"
       },
       "source": [
@@ -84,13 +78,7 @@
       "cell_type": "code",
       "execution_count": 1,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 102
-        },
-        "colab_type": "code",
-        "id": "3U5gdCw_nSG3",
-        "outputId": "4a37496e-b653-431d-fb70-f916ae227d99"
+        "id": "3U5gdCw_nSG3"
       },
       "outputs": [
         {
@@ -116,13 +104,7 @@
       "cell_type": "code",
       "execution_count": 4,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "colab_type": "code",
-        "id": "1qIKtOBrqc9Y",
-        "outputId": "f57988e5-8333-45ba-ef74-1e48995ee1c8"
+        "id": "1qIKtOBrqc9Y"
       },
       "outputs": [
         {
@@ -155,7 +137,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Tq0gyXOGZ3-h"
       },
       "source": [
@@ -170,13 +151,7 @@
       "cell_type": "code",
       "execution_count": 5,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 153
-        },
-        "colab_type": "code",
-        "id": "VmEQwCon3i7m",
-        "outputId": "41db92f3-905f-4121-d906-a7baa1629dbb"
+        "id": "VmEQwCon3i7m"
       },
       "outputs": [
         {
@@ -209,7 +184,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "qNsjMY0364j4"
       },
       "source": [
@@ -224,13 +198,7 @@
       "cell_type": "code",
       "execution_count": 6,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
-        },
-        "colab_type": "code",
-        "id": "FxMPcdmvBn9t",
-        "outputId": "0de21cb0-3649-4a3b-a293-1b0e4f38c57e"
+        "id": "FxMPcdmvBn9t"
       },
       "outputs": [
         {
@@ -250,7 +218,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "4F8zbUKfBuUt"
       },
       "source": [
@@ -263,10 +230,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "5yPh-7EWB8IK"
       },
       "outputs": [],
@@ -278,7 +243,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "JAdJDY3FCCwt"
       },
       "source": [
@@ -287,10 +251,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "IJNpyVyxbVtT"
       },
       "outputs": [],
@@ -311,7 +273,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "rngALbRogXe6"
       },
       "source": [
@@ -320,10 +281,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "T_X-wIy-lD9f"
       },
       "outputs": [],
@@ -334,7 +293,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "c8n8YqGlT3-c"
       },
       "source": [
@@ -344,7 +302,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "34enxJjjgWi7"
       },
       "source": [
@@ -358,7 +315,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "bjACE1lAsqUd"
       },
       "source": [
@@ -371,10 +327,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "iHUjCXbetIpb"
       },
       "outputs": [],
@@ -390,7 +344,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Fr6LFQG9UD6z"
       },
       "source": [
@@ -400,7 +353,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "c-7sZs3XuBBy"
       },
       "source": [
@@ -415,10 +367,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "F5U_5WKt8bdQ"
       },
       "outputs": [],
@@ -471,7 +421,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "o_tIghRsXY7S"
       },
       "source": [
@@ -481,7 +430,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "vZx70BC1zhgW"
       },
       "source": [
@@ -496,10 +444,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "R74hPWJHzgvZ"
       },
       "outputs": [],
@@ -520,7 +466,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "SdT_PpZB1UMn"
       },
       "source": [
@@ -531,10 +476,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "rBiXP8-UO8t6"
       },
       "outputs": [],
@@ -573,7 +516,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "6lOAl_v26QGq"
       },
       "source": [
@@ -590,10 +532,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "utd-vH6hn5RY"
       },
       "outputs": [],
@@ -609,10 +549,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "bXQ7-9CF0TPA"
       },
       "outputs": [],
@@ -638,10 +576,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "k6CV7dy-oJZu"
       },
       "outputs": [],
@@ -663,7 +599,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "o7PnxGf8Ur6F"
       },
       "source": [
@@ -675,7 +610,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "6URWgszz9Jut"
       },
       "source": [
@@ -696,9 +630,7 @@
     "colab": {
       "collapsed_sections": [],
       "name": "image_summaries.ipynb",
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/docs/migrate.ipynb
+++ b/docs/migrate.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "SB93Ge748VQs"
       },
       "source": [
@@ -12,11 +11,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "0sK8X2O9bTlz"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "HEYuO5NFwDK9"
       },
       "source": [
@@ -59,7 +55,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "56V5oun18ZdZ"
       },
       "source": [
@@ -68,10 +63,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "c50hsFk2MiWs"
       },
       "outputs": [],
@@ -82,7 +75,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "56XvRdPy-ewT"
       },
       "source": [
@@ -92,7 +84,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "V_JOBTVzU5Cx"
       },
       "source": [
@@ -107,7 +98,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "9-rVv-EYU8_E"
       },
       "source": [
@@ -119,7 +109,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "rh8R2g5FWbsQ"
       },
       "source": [
@@ -131,7 +120,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "em7GQju5VA0I"
       },
       "source": [
@@ -140,10 +128,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "GgFXOtSeVFqP"
       },
       "outputs": [],
@@ -159,10 +145,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "h5fk_NG7QKve"
       },
       "outputs": [],
@@ -173,7 +157,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "FvBBeFxZVLzW"
       },
       "source": [
@@ -182,10 +165,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "kovK0LEEVKjR"
       },
       "outputs": [],
@@ -205,10 +186,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "Qw5nHhRUSM7_"
       },
       "outputs": [],
@@ -219,7 +198,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "5SY6eYitUJH_"
       },
       "source": [
@@ -228,10 +206,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "OyQgeqZhVRNB"
       },
       "outputs": [],
@@ -258,10 +234,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "iqKOyawnNQSH"
       },
       "outputs": [],
@@ -272,7 +246,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "xEJIh4btVVRb"
       },
       "source": [
@@ -284,7 +257,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Pq4Fy1bSUdrZ"
       },
       "source": [
@@ -319,7 +291,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "1GUZRWSkW3ZC"
       },
       "source": [
@@ -341,7 +312,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "9VMYrKn4Uh52"
       },
       "source": [
@@ -354,7 +324,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "UGItA6U0UkDx"
       },
       "source": [
@@ -366,7 +335,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "d7BQJVcsUnMp"
       },
       "source": [
@@ -381,8 +349,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "migrate.ipynb",
-      "private_outputs": true,
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/docs/scalars_and_keras.ipynb
+++ b/docs/scalars_and_keras.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "djUvWu41mtXa"
       },
       "source": [
@@ -12,11 +11,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "su2RaORHpReL"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "NztQK2uFpXT-"
       },
       "source": [
@@ -59,7 +55,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "eDXRFe_qp5C3"
       },
       "source": [
@@ -73,7 +68,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "dG-nnZK9qW9z"
       },
       "source": [
@@ -84,8 +78,6 @@
       "cell_type": "code",
       "execution_count": 1,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "3U5gdCw_nSG3"
       },
       "outputs": [],
@@ -98,13 +90,7 @@
       "cell_type": "code",
       "execution_count": 3,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "colab_type": "code",
-        "id": "1qIKtOBrqc9Y",
-        "outputId": "cb1b3125-6f75-4fe7-ac5e-07954b5d6847"
+        "id": "1qIKtOBrqc9Y"
       },
       "outputs": [
         {
@@ -132,7 +118,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "6YDAoNCN3ZNS"
       },
       "source": [
@@ -147,10 +132,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "j-ryO6OxnQH_"
       },
       "outputs": [],
@@ -177,7 +160,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Je59_8Ts3rq0"
       },
       "source": [
@@ -199,13 +181,7 @@
       "cell_type": "code",
       "execution_count": 5,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
-        },
-        "colab_type": "code",
-        "id": "VmEQwCon3i7m",
-        "outputId": "edf1eca5-a759-41cf-d3f3-8ac734a06099"
+        "id": "VmEQwCon3i7m"
       },
       "outputs": [
         {
@@ -248,7 +224,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "042k7GMERVkx"
       },
       "source": [
@@ -261,10 +236,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "6pck56gKReON"
       },
       "outputs": [],
@@ -275,7 +248,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "QmQHlG10Kpu2"
       },
       "source": [
@@ -285,7 +257,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "ciSIRibhRi6N"
       },
       "source": [
@@ -303,7 +274,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "finK0GfYyefe"
       },
       "source": [
@@ -316,13 +286,7 @@
       "cell_type": "code",
       "execution_count": 7,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 68
-        },
-        "colab_type": "code",
-        "id": "EuiLgxQstt32",
-        "outputId": "0a957477-58fe-47b4-c366-06520250b59d"
+        "id": "EuiLgxQstt32"
       },
       "outputs": [
         {
@@ -346,7 +310,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "bom4MdeewRKS"
       },
       "source": [
@@ -356,7 +319,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "vvwGmJK9XWmh"
       },
       "source": [
@@ -376,10 +338,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "XB95ltRiXVXk"
       },
       "outputs": [],
@@ -430,7 +390,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "pck8OQEjayDM"
       },
       "source": [
@@ -439,10 +398,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "0sjM2wXGa0mF"
       },
       "outputs": [],
@@ -453,7 +410,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "GkIahGZKK9I7"
       },
       "source": [
@@ -463,7 +419,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "RRlUDnhlkN_q"
       },
       "source": [
@@ -475,7 +430,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "l0TTI16Nl0nk"
       },
       "source": [
@@ -486,13 +440,7 @@
       "cell_type": "code",
       "execution_count": 10,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 68
-        },
-        "colab_type": "code",
-        "id": "97T4vT3QkQJH",
-        "outputId": "fe4614dc-f58d-4804-9e48-d62dcbb9a8ea"
+        "id": "97T4vT3QkQJH"
       },
       "outputs": [
         {
@@ -518,9 +466,7 @@
     "colab": {
       "collapsed_sections": [],
       "name": "scalars_and_keras.ipynb",
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/docs/tbdev_getting_started.ipynb
+++ b/docs/tbdev_getting_started.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "h3Nuf-G4xJ0u"
       },
       "source": [
@@ -15,8 +14,6 @@
       "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "zZ81_4tLxSvd"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "wNBP_f0QUTfO"
       },
       "source": [
@@ -47,7 +43,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "DLXZ3t1PWdOp"
       },
       "source": [
@@ -59,7 +54,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "yjBn-ptXTppA"
       },
       "source": [
@@ -72,8 +66,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "L3ns52Luracm"
       },
       "outputs": [],
@@ -86,7 +78,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "GqUABmUTT1Cl"
       },
       "source": [
@@ -97,8 +88,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "LZExSr2Qrc5S"
       },
       "outputs": [],
@@ -120,7 +109,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "FSv4C0dBrmAx"
       },
       "source": [
@@ -131,8 +119,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "dsVjm5CrUtXm"
       },
       "outputs": [],
@@ -162,7 +148,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "TgF35qdzIC3T"
       },
       "source": [
@@ -180,7 +165,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "oKW8V5chyx6e"
       },
       "source": [
@@ -197,8 +181,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "n2PvxhOkW7vn"
       },
       "outputs": [],
@@ -212,7 +194,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "5QH5k4AUNE27"
       },
       "source": [
@@ -227,8 +208,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "C2Pj3RQCNQvP"
       },
       "outputs": [],
@@ -239,7 +218,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "NyJsD3Ypyx6m"
       },
       "source": [
@@ -253,7 +231,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "JcZOGmjQNWk_"
       },
       "source": [
@@ -267,8 +244,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "VSkJTT9rNWJq"
       },
       "outputs": [],
@@ -285,12 +260,10 @@
     "colab": {
       "collapsed_sections": [],
       "name": "tbdev_getting_started.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",
-      "language": "python",
       "name": "python3"
     }
   },

--- a/docs/tensorboard_in_notebooks.ipynb
+++ b/docs/tensorboard_in_notebooks.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "TsHV-7cpVkyK"
       },
       "source": [
@@ -12,11 +11,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "atWM-s8yVnfX"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "TB0wBWfcVqHz"
       },
       "source": [
@@ -59,7 +55,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "elH58gbhWAmn"
       },
       "source": [
@@ -69,7 +64,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "VszJNloY3ZU3"
       },
       "source": [
@@ -79,7 +73,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "E6QhA_dp3eRq"
       },
       "source": [
@@ -99,7 +92,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "9w7Baxc8aCtJ"
       },
       "source": [
@@ -119,13 +111,7 @@
       "cell_type": "code",
       "execution_count": 1,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
-        },
-        "colab_type": "code",
-        "id": "8p3Tbx8cWEFA",
-        "outputId": "508ab43d-1282-49a4-ba4e-a04f7778865f"
+        "id": "8p3Tbx8cWEFA"
       },
       "outputs": [],
       "source": [
@@ -136,7 +122,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "9GtR_cTTkf9G"
       },
       "source": [
@@ -145,10 +130,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "mVtYvbbIWRkV"
       },
       "outputs": [],
@@ -160,7 +143,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Cu1fbH-S3oAX"
       },
       "source": [
@@ -170,7 +152,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "XfCa27_8kov6"
       },
       "source": [
@@ -181,13 +162,7 @@
       "cell_type": "code",
       "execution_count": 4,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 153
-        },
-        "colab_type": "code",
-        "id": "z8b82G7YksOS",
-        "outputId": "69f33eef-0951-4426-d77b-f208bac3d843"
+        "id": "z8b82G7YksOS"
       },
       "outputs": [
         {
@@ -215,7 +190,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "lBk1BqAZKEKd"
       },
       "source": [
@@ -224,10 +198,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "OS7qGYiMKGQl"
       },
       "outputs": [],
@@ -244,7 +216,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "RNaPPs5ZKNOV"
       },
       "source": [
@@ -255,13 +226,7 @@
       "cell_type": "code",
       "execution_count": 6,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 204
-        },
-        "colab_type": "code",
-        "id": "lpUO9HqUKP6z",
-        "outputId": "40acf9dc-919d-4dca-8f83-fd11ac53f45c"
+        "id": "lpUO9HqUKP6z"
       },
       "outputs": [
         {
@@ -305,7 +270,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "SxvXc4hoKW7d"
       },
       "source": [
@@ -314,10 +278,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "KBHp6M_zgjp4"
       },
       "outputs": [],
@@ -328,7 +290,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Po7rTfQswAMT"
       },
       "source": [
@@ -338,7 +299,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "aQq3UHgmLBpC"
       },
       "source": [
@@ -350,7 +310,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "NiIMwOG8MR_g"
       },
       "source": [
@@ -359,10 +318,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "qyI5lrXoMw9K"
       },
       "outputs": [],
@@ -373,7 +330,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "ALxC8BbWWV91"
       },
       "source": [
@@ -383,7 +339,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "GUSM8yLrO2yZ"
       },
       "source": [
@@ -396,13 +351,7 @@
       "cell_type": "code",
       "execution_count": 9,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 204
-        },
-        "colab_type": "code",
-        "id": "ixZlmtWhMyr4",
-        "outputId": "ed0662ab-9904-4ae8-9764-7b79b488ca76"
+        "id": "ixZlmtWhMyr4"
       },
       "outputs": [
         {
@@ -430,7 +379,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "IlDz2oXBgnZ9"
       },
       "source": [
@@ -441,13 +389,7 @@
       "cell_type": "code",
       "execution_count": 10,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
-        },
-        "colab_type": "code",
-        "id": "ko9qeSQHLrEh",
-        "outputId": "909d2925-7dda-46a2-de5e-c6aba71973bc"
+        "id": "ko9qeSQHLrEh"
       },
       "outputs": [
         {
@@ -466,10 +408,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "hzm9DNVILxJe"
       },
       "outputs": [],
@@ -482,7 +422,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "za2GqzKiWY-R"
       },
       "source": [
@@ -494,9 +433,7 @@
     "colab": {
       "collapsed_sections": [],
       "name": "tensorboard_in_notebooks.ipynb",
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/docs/tensorboard_projector_plugin.ipynb
+++ b/docs/tensorboard_projector_plugin.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "cFloNx163DCr"
       },
       "source": [
@@ -12,11 +11,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "iSdwTGPc3Hpj"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "BE2AKncl3QJZ"
       },
       "source": [
@@ -59,7 +55,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "v4s3Sf2I3mJr"
       },
       "source": [
@@ -75,7 +70,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "6-0rhuaW9f2-"
       },
       "source": [
@@ -86,10 +80,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "TjRkD3r3etuL"
       },
       "outputs": [],
@@ -105,10 +97,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "mh22cCoM8t7e"
       },
       "outputs": [],
@@ -122,7 +112,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "xlp6ZASQB5go"
       },
       "source": [
@@ -135,10 +124,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "s0Yiw05gIgqS"
       },
       "outputs": [],
@@ -164,7 +151,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "RpvPVCwO7bDj"
       },
       "source": [
@@ -179,13 +165,7 @@
       "cell_type": "code",
       "execution_count": 9,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "colab_type": "code",
-        "id": "Fgoq5haqw8Z5",
-        "outputId": "3f9936c7-aad1-4aa2-f571-841c1e011b28"
+        "id": "Fgoq5haqw8Z5"
       },
       "outputs": [
         {
@@ -226,7 +206,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "s9HmC29hdMnH"
       },
       "source": [
@@ -239,10 +218,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "Pi8_SCYRdn9x"
       },
       "outputs": [],
@@ -281,10 +258,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "PtL_KzYMBIzP"
       },
       "outputs": [],
@@ -295,7 +270,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "YtzW8mr_wmbD"
       },
       "source": [
@@ -305,7 +279,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "MG4hcUzQQoWA"
       },
       "source": [
@@ -324,7 +297,6 @@
     "colab": {
       "collapsed_sections": [],
       "name": "tensorboard_projector_plugin.ipynb",
-      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {

--- a/tensorboard/plugins/mesh/Mesh_Plugin_Tensorboard.ipynb
+++ b/tensorboard/plugins/mesh/Mesh_Plugin_Tensorboard.ipynb
@@ -3,7 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "djUvWu41mtXa"
       },
       "source": [
@@ -12,11 +11,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
         "id": "su2RaORHpReL"
       },
       "outputs": [],
@@ -37,7 +34,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "Jp9JqDRqxVWU"
       },
       "source": [
@@ -47,7 +43,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "b8eIstD1wuol"
       },
       "source": [
@@ -57,7 +52,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "PPRzYdGDaVUH"
       },
       "source": [
@@ -66,10 +60,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "1a_Qfm_OZrtf"
       },
       "outputs": [],
@@ -107,7 +99,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "GeQsREQFabgx"
       },
       "source": [
@@ -116,10 +107,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "WEJe1bebajDX"
       },
       "outputs": [],
@@ -161,7 +150,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "5N_SfPiia0zn"
       },
       "source": [
@@ -172,13 +160,7 @@
       "cell_type": "code",
       "execution_count": 3,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 122
-        },
-        "colab_type": "code",
-        "id": "ODi7QiLPa1AR",
-        "outputId": "443a9fe8-4b6e-4b0c-d931-8960c0e2565e"
+        "id": "ODi7QiLPa1AR"
       },
       "outputs": [
         {
@@ -211,7 +193,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "wUVbZ-I-a76w"
       },
       "source": [
@@ -220,10 +201,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "sBcDE1jRa8FZ"
       },
       "outputs": [],
@@ -241,7 +220,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "huft1mbibF21"
       },
       "source": [
@@ -250,10 +228,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
+      "execution_count": null,
       "metadata": {
-        "colab": {},
-        "colab_type": "code",
         "id": "4rLrgb3EbGAp"
       },
       "outputs": [],
@@ -266,9 +242,7 @@
     "colab": {
       "collapsed_sections": [],
       "name": "Mesh_Plugin_Tensorboard.ipynb",
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
+      "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION
This formatting change scrubs notebooks with the latest `nbfmt`. The updated behavior removes any field not explicitly allowed. In https://github.com/tensorflow/docs/commit/174c9a5c1cc51a3af1de98d84824c811ecd49029 I've accounted for `metadata.colab.resources` used by the TensorBoard-in-Colab UI. It also makes sure all cells have a `metadata.id` (used by the new translation workflow).

This also updates the `nbfmt`CI test to use a recent version from the [TensorFlow docs notebook tools](https://github.com/tensorflow/docs/tree/master/tools/tensorflow_docs/tools).