### PR TITLE
Plugin/Projector: Document renaming of standalone build target

### DIFF
--- a/tensorboard/plugins/projector/README.md
+++ b/tensorboard/plugins/projector/README.md
@@ -2,7 +2,7 @@
 
 To develop the Embedding Projector, launch it in standalone mode:
 ```sh
-bazel run tensorboard/plugins/projector/vz_projector:devserver
+bazel run tensorboard/plugins/projector/vz_projector:standalone
 ```
 
 And open <http://localhost:6006/index.html>. The projector points to the local


### PR DESCRIPTION
The mentioned `devserver` target does no longer exist in the build file. It has been renamed to `standalone`.