### PR TITLE
Projector Plugin: Fix bookmark loading (issue #4159)

### DIFF
--- a/tensorboard/plugins/projector/vz_projector/vz-projector-bookmark-panel.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector-bookmark-panel.ts
@@ -197,9 +197,12 @@ class BookmarkPanel extends LegacyElementMixin(PolymerElement) {
    */
   private getParentDataIndex(evt: Event) {
     for (let i = 0; i < (evt as any).path.length; i++) {
-      let dataIndex = (evt as any).path[i].getAttribute('data-index');
-      if (dataIndex != null) {
-        return +dataIndex;
+      let elem = (evt as any).path[i];
+      if (elem instanceof HTMLElement) {
+        let dataIndex = elem.getAttribute('data-index');
+        if (dataIndex != null) {
+          return +dataIndex;
+        }
       }
     }
     return -1;


### PR DESCRIPTION
* Motivation for features / changes

Bookmark loading currently fails in the projector plugin (see issue #4159)

* Technical description of changes

The failure is because of a missing type check in `getParentDataIndex()`, crashing on `getAttribute()`. This change makes sure the object that is checked against is actually an HTMLElement.

* Detailed steps to verify changes work correctly (as executed by you)

Same as described in issue #4159 

* Alternate designs / implementations considered

There is probably be a better way to find the data-index of the selected bookmark. The current approach seems a bit hackish. But that's beyond the scope of the bug fixed here.