### PR TITLE
proto_test: on failure, show all non-empty diffs

### DIFF
--- a/tensorboard/compat/proto/proto_test.py
+++ b/tensorboard/compat/proto/proto_test.py
@@ -183,6 +183,7 @@ The proper fix is:
 
 class ProtoMatchTest(tf.test.TestCase):
     def test_each_proto_matches_tensorflow(self):
+        failed_diffs = []
         for tf_path, tb_path in PROTO_IMPORTS:
             tf_pb2 = importlib.import_module(tf_path)
             tb_pb2 = importlib.import_module(tb_path)
@@ -207,7 +208,9 @@ class ProtoMatchTest(tf.test.TestCase):
             diff = "".join(diff)
 
             if diff:
-                self.fail(MATCH_FAIL_MESSAGE_TEMPLATE.format(diff))
+                failed_diffs.append(diff)
+        if failed_diffs:
+            self.fail(MATCH_FAIL_MESSAGE_TEMPLATE.format("".join(failed_diffs)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
We now list the diffs of all proto definitions that aren’t up to date
rather than just the first one.

Test Plan:
This test currently passes, but if you revert #4163 and use current
`tf-nightly`s then it will fail. Do so, then run the test manually
(`bazel test //tensorboard/compat/proto:proto_test`) and note that the
output contains diffs from 9 files.

wchargin-branch: proto-test-show-all-failures
