### PR TITLE
proto: sync to TensorFlow e1a7896aaf93 (2020-09-14)

### DIFF
--- a/tensorboard/compat/proto/cluster.proto
+++ b/tensorboard/compat/proto/cluster.proto
@@ -21,7 +21,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "ClusterProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.distruntime";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
 // This file contains protos to be used when defining a TensorFlow
 // cluster.

--- a/tensorboard/compat/proto/config.proto
+++ b/tensorboard/compat/proto/config.proto
@@ -13,7 +13,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "ConfigProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
 message GPUOptions {
   // Fraction of the available GPU memory to allocate for each process.

--- a/tensorboard/compat/proto/cpp_shape_inference.proto
+++ b/tensorboard/compat/proto/cpp_shape_inference.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package tensorboard;
 option cc_enable_arenas = true;
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/python/framework/cpp_shape_inference_go_proto";
 
 import "tensorboard/compat/proto/types.proto";
 import "tensorboard/compat/proto/tensor_shape.proto";

--- a/tensorboard/compat/proto/debug.proto
+++ b/tensorboard/compat/proto/debug.proto
@@ -6,7 +6,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "DebugProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
 // Option for watching a node in TensorFlow Debugger (tfdbg).
 message DebugTensorWatch {

--- a/tensorboard/compat/proto/event.proto
+++ b/tensorboard/compat/proto/event.proto
@@ -8,6 +8,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "EventProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.util";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/util/event_go_proto";
 
 // Protocol buffer representing an event that happened during
 // the execution of a Brain model.

--- a/tensorboard/compat/proto/meta_graph.proto
+++ b/tensorboard/compat/proto/meta_graph.proto
@@ -15,7 +15,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "MetaGraphProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
 // NOTE: This protocol buffer is evolving, and will go through revisions in the
 // coming months.

--- a/tensorboard/compat/proto/rewriter_config.proto
+++ b/tensorboard/compat/proto/rewriter_config.proto
@@ -9,7 +9,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "RewriterConfigProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
 message AutoParallelOptions {
   bool enable = 1;
@@ -39,6 +39,13 @@ message RewriterConfig {
     AGGRESSIVE = 3;
   }
 
+  // Enum for layout conversion between NCHW and NHWC on CPU. Default is OFF.
+  enum CpuLayout {
+    NO_CONVERSION_ON_CPU = 0;
+    NCHW_TO_NHWC = 1;
+    NHWC_TO_NCHW = 2;
+  }
+
   // Enum controlling the number of times to run optimizers. The default is to
   // run them twice.
   enum NumIterationsType {
@@ -46,6 +53,9 @@ message RewriterConfig {
     ONE = 1;
     TWO = 2;
   }
+
+  // CPU Conversion settings between NHCW and NCHW.
+  CpuLayout cpu_layout_conversion = 50;
 
   // Optimize tensor layouts (default is ON)
   // e.g. This will try to use NCHW layout on GPU which is faster.
@@ -106,6 +116,10 @@ message RewriterConfig {
   // 0 means the system picks an appropriate number.
   // < 0 means do not skip optimization.
   int32 min_graph_nodes = 17;
+
+  // Disable optimizations that assume compressed tensors. Note that this flag
+  // is experimental and may be removed in the future.
+  bool experimental_disable_compressed_tensor_optimization = 26;
 
   enum MemOptType {
     // The default setting (SCHEDULING and SWAPPING HEURISTICS only)

--- a/tensorboard/compat/proto/saved_object_graph.proto
+++ b/tensorboard/compat/proto/saved_object_graph.proto
@@ -10,7 +10,7 @@ import "tensorboard/compat/proto/struct.proto";
 import "tensorboard/compat/proto/trackable_object_graph.proto";
 
 option cc_enable_arenas = true;
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
 // A SavedObjectGraph is part of object-based SavedModels in TF 2.0. It
 // describes the directed graph of Python objects (or equivalent in other
@@ -140,6 +140,7 @@ message SavedVariable {
   VariableSynchronization synchronization = 4;
   VariableAggregation aggregation = 5;
   string name = 6;
+  string device = 7;
 }
 
 // Represents `FunctionSpec` used in `Function`. This represents a

--- a/tensorboard/compat/proto/saver.proto
+++ b/tensorboard/compat/proto/saver.proto
@@ -6,7 +6,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "SaverProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.util";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
 // Protocol buffer representing the configuration of a Saver.
 message SaverDef {

--- a/tensorboard/compat/proto/struct.proto
+++ b/tensorboard/compat/proto/struct.proto
@@ -6,7 +6,7 @@ import "tensorboard/compat/proto/tensor.proto";
 import "tensorboard/compat/proto/tensor_shape.proto";
 import "tensorboard/compat/proto/types.proto";
 
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
 // `StructuredValue` represents a dynamically typed value representing various
 // data structures that are inspired by Python data structures typically used in
@@ -136,6 +136,7 @@ message TypeSpecProto {
     PER_REPLICA_SPEC = 8;     // PerReplicaSpec from distribute/values.py
     VARIABLE_SPEC = 9;        // tf.VariableSpec
     ROW_PARTITION_SPEC = 10;  // RowPartitionSpec from ragged/row_partition.py
+    NDARRAY_SPEC = 11;        // TF Numpy NDarray spec
   }
   TypeSpecClass type_spec_class = 1;
 

--- a/tensorboard/compat/proto/tfprof_log.proto
+++ b/tensorboard/compat/proto/tfprof_log.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package tensorboard;
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/profiler/tfprof_log_go_proto";
 
 import "tensorboard/compat/proto/attr_value.proto";
 import "tensorboard/compat/proto/step_stats.proto";

--- a/tensorboard/compat/proto/trackable_object_graph.proto
+++ b/tensorboard/compat/proto/trackable_object_graph.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package tensorboard;
 
 option cc_enable_arenas = true;
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
 // A TensorBundle addition which saves extra information about the objects which
 // own variables, allowing for more robust checkpoint loading into modified

--- a/tensorboard/compat/proto/verifier_config.proto
+++ b/tensorboard/compat/proto/verifier_config.proto
@@ -6,7 +6,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "VerifierConfigProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
 // The config for graph verifiers.
 message VerifierConfig {


### PR DESCRIPTION
Summary:
This pulls in routine updates since v2.3.0-rc2, plus new `go_package`
directives just added in:
<https://github.com/tensorflow/tensorflow/commit/e1a7896aaf934632eceefaaedb3f4fb9b91cfd67>

Test Plan:
The `proto_test` actually still fails with today’s nightly, because some
changes are fresh in TensorFlow head today. But the test diff, as
rendered with #4162, shows only `go_package` additions, as expected. The
test should pass on tomorrow’s `tf-nightly==2.4.0.dev20200915`.

wchargin-branch: proto-sync-e1a7896aaf93
