### PR TITLE
[oss-timeseries] add testing/, types/, util/

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -209,6 +209,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/reloader:test_lib",
         "//tensorboard/webapp/settings:test_lib",
         "//tensorboard/webapp/tbdev_upload:test_lib",
+        "//tensorboard/webapp/util:util_tests",
         "//tensorboard/webapp/webapp_data_source:feature_flag_test_lib",
         "//tensorboard/webapp/webapp_data_source:webapp_data_source_test_lib",
     ],

--- a/tensorboard/webapp/testing/BUILD
+++ b/tensorboard/webapp/testing/BUILD
@@ -1,7 +1,10 @@
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
-package(default_visibility = ["//tensorboard:internal"])
+package(
+    default_testonly = True,
+    default_visibility = ["//tensorboard:internal"],
+)
 
 licenses(["notice"])
 
@@ -16,7 +19,6 @@ filegroup(
 
 tf_ts_library(
     name = "initialize_testbed",
-    testonly = 1,
     srcs = [
         "initialize_testbed.ts",
     ],
@@ -28,11 +30,39 @@ tf_ts_library(
 
 ng_module(
     name = "mat_icon",
-    testonly = 1,
     srcs = [
         "mat_icon_module.ts",
     ],
     deps = [
+        "@npm//@angular/core",
+    ],
+)
+
+ng_module(
+    name = "dom",
+    srcs = [
+        "dom.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "@npm//@angular/core",
+    ],
+)
+
+tf_ts_library(
+    name = "lang",
+    srcs = [
+        "lang.ts",
+    ],
+)
+
+ng_module(
+    name = "material",
+    srcs = [
+        "material.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
         "@npm//@angular/core",
     ],
 )

--- a/tensorboard/webapp/testing/dom.ts
+++ b/tensorboard/webapp/testing/dom.ts
@@ -1,0 +1,179 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {DebugElement} from '@angular/core';
+import {ComponentFixture} from '@angular/core/testing';
+
+export enum KeyType {
+  SPECIAL,
+  CHARACTER,
+}
+
+export interface SendKeyCharArgs {
+  type: KeyType.CHARACTER;
+  key: string;
+  prevString: string;
+  startingCursorIndex: number;
+}
+
+export interface SendKeySpecialArg {
+  type: KeyType.SPECIAL;
+  key:
+    | 'Backspace'
+    | 'Space'
+    | 'Tab'
+    | 'Enter'
+    | 'ArrowLeft'
+    | 'ArrowRight'
+    | 'Escape';
+  prevString: string;
+  startingCursorIndex: number;
+}
+
+export type SendKeyArgs = SendKeyCharArgs | SendKeySpecialArg;
+
+/**
+ * Poorman's webdriver sendKey. Sends a character simulating keyboard key
+ * presses.
+ */
+export function sendKey<T>(
+  fixture: ComponentFixture<T>,
+  eventTarget: DebugElement,
+  args: SendKeyArgs
+) {
+  const {prevString, key, startingCursorIndex} = args;
+
+  const el = eventTarget.nativeElement;
+  const canSetCursor =
+    el instanceof HTMLInputElement &&
+    el.type !== 'date' &&
+    el.type !== 'number';
+
+  let nextString: string;
+  let nextCursorIndex: number;
+  // KeyCode is deprecated but some Angular material components make use of it.
+  let keyCode: number;
+  let emitKeyPressAndInput = true;
+
+  switch (key) {
+    case 'Backspace':
+      nextString =
+        prevString.slice(0, startingCursorIndex - 1) +
+        prevString.slice(startingCursorIndex);
+      nextCursorIndex = startingCursorIndex - 1;
+      keyCode = 0x08;
+      break;
+    case 'Space':
+      nextString =
+        prevString.slice(0, startingCursorIndex) +
+        ' ' +
+        prevString.slice(startingCursorIndex);
+      nextCursorIndex = startingCursorIndex + 1;
+      keyCode = 0x20;
+      break;
+    case 'ArrowLeft':
+      nextString = prevString;
+      nextCursorIndex = startingCursorIndex - 1;
+      keyCode = 0x25;
+      emitKeyPressAndInput = false;
+      break;
+    case 'ArrowRight':
+      nextString = prevString;
+      nextCursorIndex = startingCursorIndex + 1;
+      keyCode = 0x27;
+      emitKeyPressAndInput = false;
+      break;
+    case 'Tab':
+      nextString = prevString;
+      nextCursorIndex = startingCursorIndex;
+      keyCode = 0x09;
+      break;
+    case 'Enter':
+      nextString = prevString;
+      nextCursorIndex = startingCursorIndex;
+      keyCode = 0x0d;
+      break;
+    case 'Escape':
+      nextString = prevString;
+      nextCursorIndex = startingCursorIndex;
+      keyCode = 0x1b;
+      emitKeyPressAndInput = false;
+      break;
+    default:
+      nextString =
+        prevString.slice(0, startingCursorIndex) +
+        key +
+        prevString.slice(startingCursorIndex);
+      nextCursorIndex = startingCursorIndex + 1;
+      keyCode = key.charCodeAt(0);
+      break;
+  }
+
+  el.focus();
+  el.value = prevString;
+  if (canSetCursor) {
+    el.setSelectionRange(startingCursorIndex, startingCursorIndex);
+  }
+
+  // Convert typing to object. Sadly, because keyCode is deprecated, it is not
+  // typed properly.
+  const keyboardEventArg = {key, keyCode} as {};
+  el.dispatchEvent(new KeyboardEvent('keydown', keyboardEventArg));
+
+  // This is technically incorrect. For modifier key event, the keydown triggers
+  // but the keypress does not.
+
+  if (emitKeyPressAndInput) {
+    el.dispatchEvent(new KeyboardEvent('keypress', keyboardEventArg));
+  }
+
+  el.value = nextString;
+  if (canSetCursor) {
+    el.setSelectionRange(nextCursorIndex, nextCursorIndex);
+  }
+
+  if (emitKeyPressAndInput) {
+    el.dispatchEvent(new InputEvent('input', {data: key}));
+  }
+
+  document.dispatchEvent(new Event('selectionchange'));
+
+  el.dispatchEvent(new KeyboardEvent('keyup', keyboardEventArg));
+  fixture.detectChanges();
+}
+
+/**
+ * Send keys to an input target.
+ *
+ * It makes sure fixture is up-to-date by triggering the change detection.
+ * It clears the value, then type each character in `str` one by one.
+ */
+export function sendKeys<T>(
+  fixture: ComponentFixture<T>,
+  eventTarget: DebugElement,
+  str: string
+) {
+  let prevString = '';
+  let cursorIndex = 0;
+  for (const key of str) {
+    sendKey(fixture, eventTarget, {
+      type: KeyType.CHARACTER,
+      prevString,
+      key,
+      startingCursorIndex: cursorIndex,
+    });
+    cursorIndex++;
+    prevString += key;
+  }
+}

--- a/tensorboard/webapp/testing/lang.ts
+++ b/tensorboard/webapp/testing/lang.ts
@@ -1,0 +1,26 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * Recursively freezes an object and all of its fields. The given object is
+ * assumed not to have reference loops.
+ */
+export function deepFreeze<T>(obj: T): T {
+  for (const val of Object.values(obj)) {
+    if (val && typeof val === 'object') {
+      deepFreeze(val);
+    }
+  }
+  return Object.freeze(obj);
+}

--- a/tensorboard/webapp/testing/mat_icon_module.ts
+++ b/tensorboard/webapp/testing/mat_icon_module.ts
@@ -15,31 +15,47 @@ limitations under the License.
 import {Component, Input, NgModule} from '@angular/core';
 
 const KNOWN_SVG_ICON = new Set([
-  'content_copy_24px',
-  'help_outline_24px',
-  'info_outline_24px',
-  'refresh_24px',
-  'settings_24px',
-  'search_24px',
-  'error_24px',
+  'arrow_downward_24px',
+  'arrow_upward_24px',
+  'bug_report_24px',
+  'cancel_24px',
   'chevron_left_24px',
   'chevron_right_24px',
-  'visibility_off_24px.svg',
-  'flag_24px.svg',
   'clear_24px',
-  'expand_more_24px.svg',
-  'expand_less_24px.svg',
-  'cancel_24px',
-  'arrow_downward_24px.svg',
-  'arrow_upward_24px.svg',
-  'get_app_24px.svg',
+  'close_24px',
+  'content_copy_24px',
+  'error_24px',
+  'expand_less_24px',
+  'expand_more_24px',
+  'filter_alt_24px',
+  'flag_24px',
+  'fullscreen_24px',
+  'fullscreen_exit_24px',
+  'get_app_24px',
+  'help_outline_24px',
+  'image_search_24px',
+  'info_outline_24px',
+  'line_weight_24px',
+  'more_vert_24px',
+  'refresh_24px',
+  'search_24px',
+  'settings_24px',
+  'settings_backup_restore_24px',
+  'settings_overscan_24px',
+  'warning_24px',
+  'visibility_off_24px',
 ]);
 
 /**
  * Requires to be exported for AOT. Do not use it otherwise.
+ *
+ * Does not extend MatIcon since its implementation detail (such as ngOnChanges)
+ * can interfere with the stub implementation. If TensorBoard makes use of a new
+ * input on MatIcon that is not present here, it will fail at the test
+ * compilation time due to unknown input onto the template.
  */
 @Component({
-  template: '<ng-container>{{ svgIcon }}</ng-container>',
+  template: '<ng-container>{{svgIcon}}</ng-container>',
   selector: 'mat-icon',
 })
 export class MatIcon {
@@ -51,7 +67,8 @@ export class MatIcon {
       const humanReadableIconNames = Array.from(KNOWN_SVG_ICON.values()).join(
         ', '
       );
-      // Below will cause test to fail if a component makes use of unknown SVG.
+      // Below will cause test to fail if a component makes use of unknown
+      // SVG.
       throw new RangeError(
         [
           `Unknown SVG mat-icon, "${svgIcon}".`,
@@ -61,9 +78,23 @@ export class MatIcon {
     }
     this.internalSvgIcon = svgIcon;
   }
-
   get svgIcon() {
     return this.internalSvgIcon;
+  }
+
+  @Input()
+  set fontSet(value: string) {
+    throw new Error(
+      'Usage of fontSet is disallowed in TensorBoard. Use svgIcon.'
+    );
+  }
+
+  /** Name of an icon within a font set. */
+  @Input()
+  set fontIcon(icon: string) {
+    throw new Error(
+      'Usage of fontIcon is disallowed in TensorBoard. Use svgIcon.'
+    );
   }
 }
 

--- a/tensorboard/webapp/testing/material.ts
+++ b/tensorboard/webapp/testing/material.ts
@@ -1,0 +1,25 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {OverlayContainer} from '@angular/cdk/overlay';
+import {DebugElement, getDebugNode} from '@angular/core';
+
+export function getAutocompleteOptions(overlayContainer: OverlayContainer) {
+  const options = overlayContainer
+    .getContainerElement()
+    .querySelectorAll('mat-option');
+  return Array.from(options).map(
+    (optionEl: Element): DebugElement => getDebugNode(optionEl) as DebugElement
+  );
+}

--- a/tensorboard/webapp/types/BUILD
+++ b/tensorboard/webapp/types/BUILD
@@ -2,6 +2,8 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
 
+licenses(["notice"])
+
 # TODO(stephanwlee): move this into shareable place and use it in Polymer-based
 # modules when Angular is ready to be built as part of TensorBoard.
 tf_ts_library(
@@ -10,4 +12,9 @@ tf_ts_library(
         "api.ts",
         "data.ts",
     ],
+)
+
+tf_ts_library(
+    name = "ui",
+    srcs = ["ui.ts"],
 )

--- a/tensorboard/webapp/types/ui.ts
+++ b/tensorboard/webapp/types/ui.ts
@@ -1,0 +1,60 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * @fileoverview Type definition of the UI data that spans action, store, view,
+ * and data sources.
+ */
+
+export enum SortDirection {
+  ASC = 'asc',
+  DESC = 'desc',
+  UNSET = '',
+}
+
+export enum SearchTokenKey {
+  USER = 'user',
+  BEFORE = 'before',
+  AFTER = 'after',
+  REGEX = 'regex',
+}
+
+interface Token {
+  key: SearchTokenKey;
+  stringValue: string;
+}
+
+export interface UserSearchToken extends Token {
+  key: SearchTokenKey.USER;
+}
+
+export interface DateSearchToken extends Token {
+  key: SearchTokenKey.BEFORE | SearchTokenKey.AFTER;
+}
+
+export interface RegexSearchToken extends Token {
+  key: SearchTokenKey.REGEX;
+}
+
+/**
+ * key-value token for queries in the search input box. For instance, Gmail has
+ * from:foo@gmail.com where "from" would be the key and "foo@gmail.com" would be
+ * the value.
+ */
+export type SearchToken = UserSearchToken | DateSearchToken | RegexSearchToken;
+
+/**
+ * Returns run color for a given runId in hex.
+ */
+export type RunColorScale = (runId: string) => string;

--- a/tensorboard/webapp/util/BUILD
+++ b/tensorboard/webapp/util/BUILD
@@ -1,0 +1,69 @@
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])
+
+tf_ts_library(
+    name = "lang",
+    srcs = [
+        "lang.ts",
+    ],
+)
+
+tf_ts_library(
+    name = "string",
+    srcs = [
+        "string.ts",
+    ],
+)
+
+tf_ts_library(
+    name = "types",
+    srcs = [
+        "types.ts",
+    ],
+)
+
+tf_ts_library(
+    name = "ngrx",
+    srcs = [
+        "ngrx.ts",
+    ],
+    deps = ["@npm//@ngrx/store"],
+)
+
+tf_ts_library(
+    name = "value_formatter",
+    srcs = [
+        "value_formatter.ts",
+    ],
+)
+
+tf_ts_library(
+    name = "colors",
+    srcs = [
+        "colors.ts",
+    ],
+)
+
+tf_ts_library(
+    name = "util_tests",
+    testonly = True,
+    srcs = [
+        "colors_test.ts",
+        "lang_test.ts",
+        "ngrx_test.ts",
+        "string_test.ts",
+        "value_formatter_test.ts",
+    ],
+    deps = [
+        ":colors",
+        ":lang",
+        ":ngrx",
+        ":string",
+        ":value_formatter",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/util/colors.ts
+++ b/tensorboard/webapp/util/colors.ts
@@ -1,0 +1,34 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+const CHART_COLOR_PALLETE = [
+  '#425066', // Slate 1
+  '#12b5cb', // Cyan 600
+  '#e52592', // Pink 600
+  '#f9ab00', // Yellow 600
+  '#9334e6', // Purple 600
+  '#7cb342', // Lt green 600
+  '#e8710a', // Orange 600
+];
+
+let colorIndex = 0;
+
+/**
+ * Returns hex color for charts.
+ */
+export function getNextChartColor(): string {
+  const color = CHART_COLOR_PALLETE[colorIndex];
+  colorIndex = (colorIndex + 1) % CHART_COLOR_PALLETE.length;
+  return color;
+}

--- a/tensorboard/webapp/util/colors_test.ts
+++ b/tensorboard/webapp/util/colors_test.ts
@@ -1,0 +1,26 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {getNextChartColor} from './colors';
+
+describe('colors test', () => {
+  it('returns new color when called', () => {
+    expect(getNextChartColor()).not.toBe(getNextChartColor());
+  });
+
+  it('returns 7 colors', () => {
+    const uniqueColors = new Set([...new Array(20)].map(getNextChartColor));
+    expect(uniqueColors.size).toBe(7);
+  });
+});

--- a/tensorboard/webapp/util/lang.ts
+++ b/tensorboard/webapp/util/lang.ts
@@ -16,8 +16,10 @@ type MapObjectValuesTransformer = (value: any, key: string) => any;
 
 /**
  * Returns a new object where all values have been transformed.
- * Similar to https://lodash.com/docs/#mapValues or
- * https://underscorejs.org/#mapObject
+ * For familiarity, the API signature was made to be as close as possible to the
+ * signatures of equivalent functions in popular libraries:
+ * - https://lodash.com/docs/#mapValues
+ * - https://underscorejs.org/#mapObject
  */
 export function mapObjectValues<T extends {} = {}>(
   object: Record<keyof T, any>,

--- a/tensorboard/webapp/util/lang.ts
+++ b/tensorboard/webapp/util/lang.ts
@@ -1,0 +1,32 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+type MapObjectValuesTransformer = (value: any, key: string) => any;
+
+/**
+ * Returns a new object where all values have been transformed.
+ * Similar to https://lodash.com/docs/#mapValues or
+ * https://underscorejs.org/#mapObject
+ */
+export function mapObjectValues<T extends {} = {}>(
+  object: Record<keyof T, any>,
+  transform: MapObjectValuesTransformer
+) {
+  const result = {} as Record<keyof T, T[keyof T]>;
+  for (const key of Object.keys(object)) {
+    const typedKey = key as keyof T;
+    result[typedKey] = transform(object[typedKey], key);
+  }
+  return result as T;
+}

--- a/tensorboard/webapp/util/lang_test.ts
+++ b/tensorboard/webapp/util/lang_test.ts
@@ -1,0 +1,28 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {mapObjectValues} from './lang';
+
+describe('mapObjectValues test', () => {
+  it('returns a newly transformed object', () => {
+    const obj = {x: 'a', y: 'b'};
+    const result = mapObjectValues(obj, (value: string, key: string) => {
+      return key + value;
+    });
+
+    expect(obj).toEqual({x: 'a', y: 'b'});
+    expect(result).not.toBe(obj);
+    expect(result).toEqual({x: 'xa', y: 'yb'});
+  });
+});

--- a/tensorboard/webapp/util/ngrx.ts
+++ b/tensorboard/webapp/util/ngrx.ts
@@ -1,0 +1,27 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Action, ActionReducer} from '@ngrx/store';
+
+export function composeReducers<S, A extends Action>(
+  ...actionReducers: Array<ActionReducer<S, A>>
+): ActionReducer<S, A> {
+  return (state, action) => {
+    let intermediateState = state;
+    for (const reducer of actionReducers) {
+      intermediateState = reducer(intermediateState, action);
+    }
+    return intermediateState!;
+  };
+}

--- a/tensorboard/webapp/util/ngrx_test.ts
+++ b/tensorboard/webapp/util/ngrx_test.ts
@@ -1,0 +1,82 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {createAction, createReducer, on} from '@ngrx/store';
+
+import {composeReducers} from './ngrx';
+
+const incrementFoo = createAction('[UTIL TEST] Increment Foo');
+const incrementBar = createAction('[UTIL TEST] Increment Bar');
+const incrementBaz = createAction('[UTIL TEST] Increment Baz');
+
+interface State {
+  foo: number;
+  bar: number;
+  baz: number;
+}
+
+function buildState({foo = 10, bar = 100, baz = 5}: Partial<State> = {}) {
+  return {foo, bar, baz};
+}
+
+const reducer1 = createReducer(
+  buildState(),
+  on(incrementFoo, (state) => {
+    return {...state, foo: state.foo + 1};
+  }),
+  on(incrementBaz, (state) => {
+    return {...state, baz: state.baz + 1};
+  }),
+  // This is legal in Ngrx.
+  on(incrementBaz, (state) => {
+    return {...state, baz: state.baz + 2};
+  })
+);
+
+const reducer2 = createReducer(
+  buildState(),
+  on(incrementFoo, (state) => {
+    return {...state, foo: state.foo + 5};
+  }),
+  on(incrementBar, (state) => {
+    return {...state, bar: state.bar + 5};
+  })
+);
+
+describe('ngrx util', () => {
+  it('composes multiple reducers and run all their reducers', () => {
+    const reducers = composeReducers(reducer1, reducer2);
+
+    const newState = reducers(buildState({bar: 10}), incrementBar());
+
+    expect(newState.bar).toBe(15);
+  });
+
+  it('calls incrementFoo handler on all reducers', () => {
+    const reducers = composeReducers(reducer1, reducer2);
+
+    const newState = reducers(buildState({foo: 3}), incrementFoo());
+
+    // 3 + 5 + 1
+    expect(newState.foo).toBe(9);
+  });
+
+  it('supports multiple handlers handling same action within a reducer', () => {
+    const reducers = composeReducers(reducer1, reducer2);
+
+    const newState = reducers(buildState({baz: 4}), incrementBaz());
+
+    expect(newState.baz).toBe(7);
+  });
+});

--- a/tensorboard/webapp/util/string.ts
+++ b/tensorboard/webapp/util/string.ts
@@ -1,0 +1,30 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * This regex escape character set is also used in lodash's `escapeRegExp`.
+ */
+const REGEXP_ESCAPE_CHARS = /[\\^$.*+?()[\]{}|]/g;
+
+/**
+ * Converts a string into a form that has been escaped for use as a literal
+ * argument to a regular expression constructor.
+ *
+ * Takes a string V and escapes characters to produce a new string E, such that
+ * new RegExp(E).test(V) === true.
+ */
+export function escapeForRegex(value: string): string {
+  // '$&' in a regex replacement indicates the last match.
+  return value.replace(REGEXP_ESCAPE_CHARS, '\\$&');
+}

--- a/tensorboard/webapp/util/string_test.ts
+++ b/tensorboard/webapp/util/string_test.ts
@@ -1,0 +1,33 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {escapeForRegex} from './string';
+
+describe('escapeForRegex test', () => {
+  it('escapes unsafe characters', () => {
+    expect(escapeForRegex('.')).toEqual('\\.');
+
+    // Multiple occurrences.
+    expect(escapeForRegex('...')).toEqual('\\.\\.\\.');
+
+    // Multiple different characters.
+    expect(escapeForRegex('\\foo.bar[baz]')).toEqual('\\\\foo\\.bar\\[baz\\]');
+  });
+
+  it('does not alter safe characters', () => {
+    expect(escapeForRegex('foo://bar@baz')).toEqual('foo://bar@baz');
+    expect(escapeForRegex('1 - 2')).toEqual('1 - 2');
+    expect(escapeForRegex('a_b')).toEqual('a_b');
+  });
+});

--- a/tensorboard/webapp/util/types.ts
+++ b/tensorboard/webapp/util/types.ts
@@ -1,0 +1,21 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * @fileoverview General utility types.
+ */
+
+export type DeepReadonly<T> = {
+  readonly [P in keyof T]: DeepReadonly<T[P]>;
+};

--- a/tensorboard/webapp/util/value_formatter.ts
+++ b/tensorboard/webapp/util/value_formatter.ts
@@ -1,0 +1,73 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+/**
+ * @fileoverview Utilities related to formatting values.
+ */
+
+/**
+ * Formats a time, given as number of hours. e.g.
+ * > formatRelativeTimeInMs(10555 * 60 * 60)
+ * "10h 33m 17s"
+ */
+export function formatRelativeTimeInMs(timeInMs: number): string {
+  // We will always show 2 units of precision, e.g days and hours, or
+  // minutes and seconds, but not hours and minutes and seconds.
+  const result: string[] = [];
+  const timeInHours = timeInMs / (1000 * 60 * 60);
+  const days = Math.floor(timeInHours / 24);
+  if (days) {
+    result.push(days.toString() + 'd');
+  }
+
+  const remainingHours = timeInHours - days * 24;
+  const hours = Math.floor(remainingHours);
+  if (hours || days) {
+    result.push(hours.toString() + 'h');
+  }
+
+  const remainingMinutes = (remainingHours - hours) * 60;
+  const minutes = Math.floor(remainingMinutes);
+  if (minutes || hours || days) {
+    result.push(minutes.toString() + 'm');
+  }
+
+  const remainingSeconds = (remainingMinutes - minutes) * 60;
+  const seconds = Math.floor(remainingSeconds);
+  result.push(seconds.toString() + 's');
+
+  return result.join(' ');
+}
+
+/**
+ * Integers less than this number can be safely formatted as-is.
+ */
+const MAX_SMALL_INTEGER = Math.pow(10, 4);
+
+/**
+ * This numeric formatter currently covers common cases only.
+ *
+ * The Polymer version relies on D3, which gives more features for free:
+ * selecting decimal vs exponent notation, rounding to significant digits, and
+ * removing insignificant trailing zeros.
+ */
+export function formatNumber(value: number): string {
+  if (isNaN(value) || !Number.isFinite(value)) {
+    return value.toString();
+  }
+  if (Number.isInteger(value) && Math.abs(value) < MAX_SMALL_INTEGER) {
+    return value.toString();
+  }
+  return value.toPrecision(4);
+}

--- a/tensorboard/webapp/util/value_formatter_test.ts
+++ b/tensorboard/webapp/util/value_formatter_test.ts
@@ -1,0 +1,41 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {formatNumber, formatRelativeTimeInMs} from './value_formatter';
+
+describe('value formatter test', () => {
+  it('formatHoursRelative properly formats', () => {
+    const oneHourInMs = 1000 * 60 * 60;
+    expect(formatRelativeTimeInMs(oneHourInMs * 10.555)).toBe('10h 33m 17s');
+    expect(formatRelativeTimeInMs(oneHourInMs * NaN)).toBe('NaNs');
+    expect(formatRelativeTimeInMs(oneHourInMs * 10)).toBe('10h 0m 0s');
+    expect(formatRelativeTimeInMs(oneHourInMs * 0.5)).toBe('30m 0s');
+    expect(formatRelativeTimeInMs(oneHourInMs * 0.01)).toBe('36s');
+    expect(formatRelativeTimeInMs(oneHourInMs * 0.0001)).toBe('0s');
+  });
+
+  it('formatNumber properly formats', () => {
+    expect(formatNumber(1)).toBe('1');
+    expect(formatNumber(10.55)).toBe('10.55');
+    expect(formatNumber(-10.55)).toBe('-10.55');
+    expect(formatNumber(-10.555555)).toBe('-10.56');
+    expect(formatNumber(10.555555)).toBe('10.56');
+    expect(formatNumber(0.000001234567)).toBe('0.000001235');
+    expect(formatNumber(0.0000001234567)).toBe('1.235e-7');
+    expect(formatNumber(100000.123456789)).toBe('1.000e+5');
+    expect(formatNumber(NaN)).toBe('NaN');
+    expect(formatNumber(2e23)).toBe('2.000e+23');
+    expect(formatNumber(-2e-23)).toBe('-2.000e-23');
+  });
+});


### PR DESCRIPTION
Diffbase: https://github.com/tensorflow/tensorboard/pull/4171

Adds testing/, types/, util/ folders for Time Series.

The 1st commit contains pre-reviewed code. Manual changes
to be reviewed are found in this PR's commits after the 1st.

Googlers, see test sync cl/332324994 for confidence that this
does not block the sync.
