### PR TITLE
Update scalars demo for TF2

### DIFF
--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -83,6 +83,19 @@ py_binary(
     ],
 )
 
+py_binary(
+    name = "scalars_demo_eager",
+    srcs = ["scalars_demo_eager.py"],
+    srcs_version = "PY2AND3",
+    deps = [
+        ":summary",
+        "//tensorboard:expect_tensorflow_installed",
+        "//tensorboard/summary:summary",
+        "//tensorboard/summary:tf_summary",
+        "@org_pythonhosted_six",
+    ],
+)
+
 py_library(
     name = "summary",
     srcs = ["summary.py"],

--- a/tensorboard/plugins/scalar/BUILD
+++ b/tensorboard/plugins/scalar/BUILD
@@ -90,7 +90,7 @@ py_binary(
     deps = [
         ":summary",
         "//tensorboard:expect_tensorflow_installed",
-        "//tensorboard/summary:summary",
+        "//tensorboard/summary",
         "//tensorboard/summary:tf_summary",
         "@org_pythonhosted_six",
     ],

--- a/tensorboard/plugins/scalar/scalars_demo_eager.py
+++ b/tensorboard/plugins/scalar/scalars_demo_eager.py
@@ -53,10 +53,8 @@ tf.compat.v1.enable_eager_execution()
 
 def main(unused_argv):
     logdir = FLAGS.logdir
-    # TODO(bileschi): Test for existence of logdir before writing.
     logging.info("Saving output to %s.", logdir)
     for i_run in range(0, FLAGS.num_runs):
-        # TODO(bileschi): Test for existence of logdir before writing.
         run_name = "test-run-name-%.8d" % i_run
         writer = tf.summary.create_file_writer(os.path.join(logdir, run_name))
         with writer.as_default():

--- a/tensorboard/plugins/scalar/scalars_demo_eager.py
+++ b/tensorboard/plugins/scalar/scalars_demo_eager.py
@@ -60,7 +60,8 @@ def main(unused_argv):
         % (FLAGS.num_runs, FLAGS.num_tags_per_run, FLAGS.num_scalars_per_tag)
     )
     logging.info("Output saved to %s." % logdir)
-    logging.info("""
+    logging.info(
+        """
 You can now view the scalars in this logdir:
 
 Run local:
@@ -73,7 +74,10 @@ Upload to TensorBoard.dev:
       --logdir=%s \\
       --name=\"Scalars demo.\" \\
       --one_shot
-""", logdir, logdir)
+""",
+        logdir,
+        logdir,
+    )
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/scalar/scalars_demo_eager.py
+++ b/tensorboard/plugins/scalar/scalars_demo_eager.py
@@ -60,22 +60,20 @@ def main(unused_argv):
         % (FLAGS.num_runs, FLAGS.num_tags_per_run, FLAGS.num_scalars_per_tag)
     )
     logging.info("Output saved to %s." % logdir)
-    logging.info(
-        f"""
+    logging.info("""
 You can now view the scalars in this logdir:
 
 Run local:
 
-    tensorboard --logdir={logdir}
+    tensorboard --logdir=%s
 
 Upload to TensorBoard.dev:
 
     tensorboard dev upload \\
-      --logdir={logdir} \\
+      --logdir=%s \\
       --name=\"Scalars demo.\" \\
       --one_shot
-"""
-    )
+""", logdir, logdir)
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/scalar/scalars_demo_eager.py
+++ b/tensorboard/plugins/scalar/scalars_demo_eager.py
@@ -26,6 +26,7 @@ import os
 
 from absl import app
 from absl import flags
+from absl import logging
 
 from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
@@ -37,9 +38,7 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string(
     "logdir", "/tmp/scalars_logdir", "Where to write the output logdir."
 )
-flags.DEFINE_integer(
-    "num_runs", 1, "How many runs to create."
-    )
+flags.DEFINE_integer("num_runs", 1, "How many runs to create.")
 flags.DEFINE_integer(
     "num_tags_per_run",
     1,
@@ -70,6 +69,22 @@ def main(unused_argv):
         % (FLAGS.num_runs, FLAGS.num_tags_per_run, FLAGS.num_scalars_per_tag)
     )
     logging.info("Output saved to %s." % logdir)
+    logging.info(
+        f"""
+You can now view the scalars in this logdir:
+
+Run local: 
+
+    tensorboard --logdir={logdir}
+
+Upload to TensorBoard.dev:
+
+    tensorboard dev upload \\
+      --logdir={logdir} \\
+      --name=\"Scalars demo.\" \\
+      --one_shot
+"""
+    )
 
 
 if __name__ == "__main__":

--- a/tensorboard/plugins/scalar/scalars_demo_eager.py
+++ b/tensorboard/plugins/scalar/scalars_demo_eager.py
@@ -26,8 +26,6 @@ from absl import flags
 from absl import logging
 import tensorflow as tf
 
-from tensorboard.plugins.scalar import summary
-
 FLAGS = flags.FLAGS
 
 flags.DEFINE_string(
@@ -66,7 +64,7 @@ def main(unused_argv):
         f"""
 You can now view the scalars in this logdir:
 
-Run local: 
+Run local:
 
     tensorboard --logdir={logdir}
 

--- a/tensorboard/plugins/scalar/scalars_demo_eager.py
+++ b/tensorboard/plugins/scalar/scalars_demo_eager.py
@@ -1,0 +1,76 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Write TensorBoard scalar summary data.
+
+This short example illustrates how to use the scalar writing in eager
+mode TensorFlow 2.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+from absl import app
+from absl import flags
+
+from six.moves import xrange  # pylint: disable=redefined-builtin
+import tensorflow as tf
+from tensorboard.plugins.scalar import summary
+import random
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    "logdir", "/tmp/scalars_logdir", "Where to write the output logdir."
+)
+flags.DEFINE_integer(
+    "num_runs", 1, "How many runs to create."
+    )
+flags.DEFINE_integer(
+    "num_tags_per_run",
+    1,
+    "How many tags (named scalar plots) to create per run.",
+)
+flags.DEFINE_integer(
+    "num_scalars_per_tag", 1, "How many scalar values to write per tag."
+)
+
+tf.compat.v1.enable_eager_execution()
+
+
+def main(unused_argv):
+    logdir = FLAGS.logdir
+    # TODO(bileschi): Test for existence of logdir before writing.
+    logging.info("Saving output to %s.", logdir)
+    for i_run in range(0, FLAGS.num_runs):
+        # TODO(bileschi): Test for existence of logdir before writing.
+        run_name = "test-run-name-%.8d" % i_run
+        writer = tf.summary.create_file_writer(os.path.join(logdir, run_name))
+        with writer.as_default():
+            for i_tag in range(0, FLAGS.num_tags_per_run):
+                tag_name = "cool tag %.8d" % i_tag
+                for i_scalar in range(0, FLAGS.num_scalars_per_tag):
+                    tf.summary.scalar(tag_name, random.random(), step=i_scalar)
+    logging.info(
+        "Created %d runs, each with %d tags, and %d scalar values in each tag"
+        % (FLAGS.num_runs, FLAGS.num_tags_per_run, FLAGS.num_scalars_per_tag)
+    )
+    logging.info("Output saved to %s." % logdir)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/tensorboard/plugins/scalar/scalars_demo_eager.py
+++ b/tensorboard/plugins/scalar/scalars_demo_eager.py
@@ -18,20 +18,15 @@ This short example illustrates how to use the scalar writing in eager
 mode TensorFlow 2.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
+import random
 
 from absl import app
 from absl import flags
 from absl import logging
-
-from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
+
 from tensorboard.plugins.scalar import summary
-import random
 
 FLAGS = flags.FLAGS
 


### PR DESCRIPTION
* Motivation for features / changes

Previous demo worked with TF 1 mode.  New demo illustrates how to work in simpler eager mode. 

* Technical description of changes

Creates a new binary `scalars_demo_eager` which, when executed, creates a logdir with a user configurable set of random scalars.

* Screenshots of UI changes

cmd
```
$ bazel run tensorboard/plugins/scalar:scalars_demo_eager
```

output
```
0917 17:00:43.593062 4585397696 scalars_demo_eager.py:67] Created 1 runs, each with 1 tags, and 1 scalar values in each tag
I0917 17:00:43.593160 4585397696 scalars_demo_eager.py:69] Output saved to /tmp/scalars_logdir.
I0917 17:00:43.593215 4585397696 scalars_demo_eager.py:84] 
You can now view the scalars in this logdir:

Run local: 

    tensorboard --logdir=/tmp/scalars_logdir

Upload to TensorBoard.dev:

    tensorboard dev upload \
      --logdir=/tmp/scalars_logdir \
      --name="Scalars demo." \
      --one_shot

```


* Detailed steps to verify changes work correctly (as executed by you)

* Alternate designs / implementations considered

Considered testing for existence of output directory, so as not to inject additional scalars into that directory, but decided that may be a desirable feature.