### PR TITLE
[oss-timeseries] fix missed app_routing/ dep needed for sync

### DIFF
--- a/tensorboard/webapp/app_routing/BUILD
+++ b/tensorboard/webapp/app_routing/BUILD
@@ -16,6 +16,7 @@ ng_module(
         ":route_registry",
         "//tensorboard/webapp/app_routing/effects",
         "//tensorboard/webapp/app_routing/store",
+        "//tensorboard/webapp/app_routing/store:types",
         "@npm//@angular/core",
         "@npm//@ngrx/effects",
         "@npm//@ngrx/store",


### PR DESCRIPTION
PR [1] introduced a sync-breaking change, due to app_routing/
having a transitive dependency that it did not depend on
explicitly. This change fixes the strict dep.

The test sync cl/332324994 from PR [1] actually failed.

Googlers, see the newer test sync cl/332491049, which should
actually work this time.

[1] https://github.com/tensorflow/tensorboard/pull/4173