### PR TITLE
Allow developers to prevent Karma from launching its own browser window

### DIFF
--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -100,6 +100,11 @@ def tf_ng_web_test_suite(runtime_deps = [], bootstrap = [], deps = [], **kwargs)
             "@npm//:node_modules/lodash/lodash.js",
             "@npm//:node_modules/d3/dist/d3.js",
         ],
+        # Allows user to pass `--define DISPLAY=false` to bazel so that
+        # `bazel run` won't open up a Chrome browser. Note that it will lead to
+        # console errors of the form `ERROR [launcher]: Cannot start Chrome`
+        # that should be ignored.
+        configuration_env_vars = ["DISPLAY"],
         **kwargs
     )
 


### PR DESCRIPTION
* Motivation for features / changes

  When invoking `bazel run //tensorboard/webapp:karma_test_chromium-local` to debug tests in local browser, Karma will open up its own browser window after some ~30s delay. This browser window is not useful since a developer is likely already debugging Karma tests in an existing window. This browser window can also be quite annoying, since it pops up after some delay and takes up a significant portion of the screen. 

* Technical description of changes

  This approach uses hints provided in a recent change to bazel documentation:
https://github.com/bazelbuild/rules_nodejs/pull/2202/files

  User can now run the following to disable Karma's browser launcher:
  ```
  bazel run --define DISPLAY=false //tensorboard/webapp:karma_test_chromium-local
  ```

  An unfortunate side effect is that some error messages are printed to console and might confuse the developer:
  ```
  21 09 2020 16:09:39.208:ERROR [launcher]: Cannot start Chrome
	
  (chrome:2144130): Gtk-WARNING **: 16:09:39.205: cannot open display: false

  21 09 2020 16:09:39.208:ERROR [launcher]: Chrome stdout: 
  21 09 2020 16:09:39.208:ERROR [launcher]: Chrome stderr: 
  (chrome:2144130): Gtk-WARNING **: 16:09:39.205: cannot open display: false

  ```

