### PR TITLE
Render PluginLoadState errors in the UI and allow parent components to override error UI

### DIFF
--- a/tensorboard/webapp/plugins/BUILD
+++ b/tensorboard/webapp/plugins/BUILD
@@ -18,6 +18,7 @@ ng_module(
     deps = [
         ":plugin_registry",
         "//tensorboard/webapp/core",
+        "//tensorboard/webapp/core:types",
         "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/types",
         "@npm//@angular/common",

--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -32,18 +32,20 @@ limitations under the License.
     <ng-container *ngSwitchCase="PluginLoadState.ENVIRONMENT_FAILURE_NOT_FOUND">
       <!-- This error template can be injected by the parent component. -->
       <ng-container
-          *ngTemplateOutlet="environmentFailureNotFoundTemplate ?
+        *ngTemplateOutlet="environmentFailureNotFoundTemplate ?
                              environmentFailureNotFoundTemplate :
-                             environmentFailureDefaultTemplate">
+                             environmentFailureDefaultTemplate"
+      >
       </ng-container>
     </ng-container>
 
     <ng-container *ngSwitchCase="PluginLoadState.ENVIRONMENT_FAILURE_UNKNOWN">
       <!-- This error template can be injected by the parent component. -->
       <ng-container
-          *ngTemplateOutlet="environmentFailureUnknownTemplate ?
+        *ngTemplateOutlet="environmentFailureUnknownTemplate ?
                              environmentFailureUnknownTemplate :
-                             environmentFailureDefaultTemplate">
+                             environmentFailureDefaultTemplate"
+      >
       </ng-container>
     </ng-container>
 
@@ -99,12 +101,8 @@ limitations under the License.
   -- In other flavors of TensorBoard the root cause may be different so we allow
   -- this template to be overriden by the parent component. -->
 <ng-template #environmentFailureDefaultTemplate>
-  <h3 class="environment-not-loaded">
-    Data could not be loaded.
-  </h3>
-  <p>
-    The TensorBoard server may be down or inaccessible.
-  </p>
+  <h3 class="environment-not-loaded">Data could not be loaded.</h3>
+  <p>The TensorBoard server may be down or inaccessible.</p>
   <p>
     <ng-container [ngTemplateOutlet]="dateAndDataLocation"></ng-container>
   </p>

--- a/tensorboard/webapp/plugins/plugins_component.ng.html
+++ b/tensorboard/webapp/plugins/plugins_component.ng.html
@@ -23,11 +23,30 @@ limitations under the License.
 </div>
 
 <div
-  *ngIf="pluginLoadState === PluginLoadState.UNKNOWN_PLUGIN_ID || pluginLoadState === PluginLoadState.NO_ENABLED_PLUGINS"
+  *ngIf="pluginLoadState !== PluginLoadState.LOADED
+      && pluginLoadState !== PluginLoadState.LOADING"
   [ngSwitch]="pluginLoadState"
   class="warning"
 >
   <div class="warning-message">
+    <ng-container *ngSwitchCase="PluginLoadState.ENVIRONMENT_FAILURE_NOT_FOUND">
+      <!-- This error template can be injected by the parent component. -->
+      <ng-container
+          *ngTemplateOutlet="environmentFailureNotFoundTemplate ?
+                             environmentFailureNotFoundTemplate :
+                             environmentFailureDefaultTemplate">
+      </ng-container>
+    </ng-container>
+
+    <ng-container *ngSwitchCase="PluginLoadState.ENVIRONMENT_FAILURE_UNKNOWN">
+      <!-- This error template can be injected by the parent component. -->
+      <ng-container
+          *ngTemplateOutlet="environmentFailureUnknownTemplate ?
+                             environmentFailureUnknownTemplate :
+                             environmentFailureDefaultTemplate">
+      </ng-container>
+    </ng-container>
+
     <ng-container *ngSwitchCase="PluginLoadState.UNKNOWN_PLUGIN_ID">
       <h3 class="unknown-plugin">
         There’s no dashboard by the name of “<code>{{activePluginId}}</code>”.
@@ -72,6 +91,24 @@ limitations under the License.
     </ng-container>
   </div>
 </div>
+
+<!-- In core TensorBoard this error likely happens when user has been able to
+  -- successfully load their TensorBoard but the server is inaccessible for some
+  -- subsequent attempt to reload environment data.
+  --
+  -- In other flavors of TensorBoard the root cause may be different so we allow
+  -- this template to be overriden by the parent component. -->
+<ng-template #environmentFailureDefaultTemplate>
+  <h3 class="environment-not-loaded">
+    Data could not be loaded.
+  </h3>
+  <p>
+    The TensorBoard server may be down or inaccessible.
+  </p>
+  <p>
+    <ng-container [ngTemplateOutlet]="dateAndDataLocation"></ng-container>
+  </p>
+</ng-template>
 
 <ng-template #dateAndDataLocation>
   <!-- Class name used to hide this element in screenshot tests. -->

--- a/tensorboard/webapp/plugins/plugins_component.ts
+++ b/tensorboard/webapp/plugins/plugins_component.ts
@@ -28,6 +28,7 @@ import {
   ViewChild,
   ComponentFactoryResolver,
   ViewContainerRef,
+  TemplateRef,
 } from '@angular/core';
 
 import {UiPluginMetadata} from './plugins_container';
@@ -42,6 +43,8 @@ interface ExperimentalPluginHostLib extends HTMLElement {
 }
 
 export enum PluginLoadState {
+  ENVIRONMENT_FAILURE_NOT_FOUND,
+  ENVIRONMENT_FAILURE_UNKNOWN,
   NO_ENABLED_PLUGINS,
   UNKNOWN_PLUGIN_ID,
   LOADED,
@@ -115,6 +118,12 @@ export class PluginsComponent implements OnChanges {
 
   @Input()
   lastUpdated?: number;
+
+  @Input()
+  environmentFailureNotFoundTemplate?: TemplateRef<any>;
+
+  @Input()
+  environmentFailureUnknownTemplate?: TemplateRef<any>;
 
   readonly PluginLoadState = PluginLoadState;
   readonly LoadingMechanismType = LoadingMechanismType;

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -52,7 +52,7 @@ function expectPluginIframe(element: HTMLElement, name: string) {
 
 /**
  * A Component used to test that custom error templates can be passed to
- * PluginComponent.
+ * the `plugins` component.
  */
 @Component({
   template: `
@@ -527,6 +527,9 @@ describe('plugins_component', () => {
         expect(
           fixture.debugElement.query(By.css('.custom-not-found-template'))
         ).not.toBeNull();
+        expect(
+          fixture.debugElement.query(By.css('.custom-unknown-template'))
+        ).toBeNull();
       });
 
       it('shows warning when environment failed UNKNOWN', () => {
@@ -543,6 +546,9 @@ describe('plugins_component', () => {
 
         expect(
           fixture.debugElement.query(By.css('.environment-not-loaded'))
+        ).toBeNull();
+        expect(
+          fixture.debugElement.query(By.css('.custom-not-found-template'))
         ).toBeNull();
         expect(
           fixture.debugElement.query(By.css('.custom-unknown-template'))

--- a/tensorboard/webapp/plugins/plugins_container_test.ts
+++ b/tensorboard/webapp/plugins/plugins_container_test.ts
@@ -57,10 +57,10 @@ function expectPluginIframe(element: HTMLElement, name: string) {
 @Component({
   template: `
     <ng-template #environmentFailureNotFoundTemplate>
-      <h3 class="custom-not-found-template">Custom Not Found</h3>
+      <h3 class="custom-not-found-template">Custom Not Found Error</h3>
     </ng-template>
     <ng-template #environmentFailureUnknownTemplate>
-      <h3 class="custom-unknown-template">Custom Unknown</h3>
+      <h3 class="custom-unknown-template">Custom Unknown Error</h3>
     </ng-template>
     <plugins
       [environmentFailureNotFoundTemplate]="environmentFailureNotFoundTemplate"
@@ -419,9 +419,9 @@ describe('plugins_component', () => {
       const fixture = TestBed.createComponent(PluginsContainer);
       fixture.detectChanges();
 
-      expect(
-        fixture.debugElement.query(By.css('.unknown-plugin'))
-      ).not.toBeNull();
+      expect(fixture.debugElement.nativeElement.textContent).toContain(
+        'There’s no dashboard by the name of “you_do_not_know_me”'
+      );
     });
 
     it(
@@ -438,9 +438,9 @@ describe('plugins_component', () => {
         const fixture = TestBed.createComponent(PluginsContainer);
         fixture.detectChanges();
 
-        expect(
-          fixture.debugElement.query(By.css('.unknown-plugin'))
-        ).not.toBeNull();
+        expect(fixture.debugElement.nativeElement.textContent).toContain(
+          'There’s no dashboard by the name of “you_do_not_know_me”'
+        );
       }
     );
 
@@ -454,9 +454,9 @@ describe('plugins_component', () => {
       const fixture = TestBed.createComponent(PluginsContainer);
       fixture.detectChanges();
 
-      expect(
-        fixture.debugElement.query(By.css('.environment-not-loaded'))
-      ).not.toBeNull();
+      expect(fixture.debugElement.nativeElement.textContent).toContain(
+        'Data could not be loaded.'
+      );
     });
 
     it('shows warning when environment failed UNKNOWN', () => {
@@ -469,9 +469,9 @@ describe('plugins_component', () => {
       const fixture = TestBed.createComponent(PluginsContainer);
       fixture.detectChanges();
 
-      expect(
-        fixture.debugElement.query(By.css('.environment-not-loaded'))
-      ).not.toBeNull();
+      expect(fixture.debugElement.nativeElement.textContent).toContain(
+        'Data could not be loaded.'
+      );
     });
 
     it(
@@ -487,9 +487,9 @@ describe('plugins_component', () => {
         const fixture = TestBed.createComponent(PluginsContainer);
         fixture.detectChanges();
 
-        expect(
-          fixture.debugElement.query(By.css('.no-active-plugin'))
-        ).not.toBeNull();
+        expect(fixture.debugElement.nativeElement.textContent).toContain(
+          'No dashboards are active for the current data set.'
+        );
       }
     );
 
@@ -503,9 +503,9 @@ describe('plugins_component', () => {
       const fixture = TestBed.createComponent(PluginsContainer);
       fixture.detectChanges();
 
-      expect(
-        fixture.debugElement.query(By.css('.no-active-plugin'))
-      ).not.toBeNull();
+      expect(fixture.debugElement.nativeElement.textContent).toContain(
+        'No dashboards are active for the current data set.'
+      );
     });
 
     describe('custom error templates', () => {
@@ -521,15 +521,9 @@ describe('plugins_component', () => {
         );
         fixture.detectChanges();
 
-        expect(
-          fixture.debugElement.query(By.css('.environment-not-loaded'))
-        ).toBeNull();
-        expect(
-          fixture.debugElement.query(By.css('.custom-not-found-template'))
-        ).not.toBeNull();
-        expect(
-          fixture.debugElement.query(By.css('.custom-unknown-template'))
-        ).toBeNull();
+        expect(fixture.debugElement.nativeElement.textContent).toBe(
+          'Custom Not Found Error'
+        );
       });
 
       it('shows warning when environment failed UNKNOWN', () => {
@@ -544,15 +538,9 @@ describe('plugins_component', () => {
         );
         fixture.detectChanges();
 
-        expect(
-          fixture.debugElement.query(By.css('.environment-not-loaded'))
-        ).toBeNull();
-        expect(
-          fixture.debugElement.query(By.css('.custom-not-found-template'))
-        ).toBeNull();
-        expect(
-          fixture.debugElement.query(By.css('.custom-unknown-template'))
-        ).not.toBeNull();
+        expect(fixture.debugElement.nativeElement.textContent).toBe(
+          'Custom Unknown Error'
+        );
       });
     });
 


### PR DESCRIPTION
* Motivation for features / changes

  We want to render more helpful error messages for cases where the TensorBoard server is not responsive or has an error. We want to allow other flavors of TensorBoard to customize these errors.

* Technical description of changes

  In https://github.com/tensorflow/tensorboard/pull/4186 we improved error handling for `data/runs`, `data/plugins_listing` and `data/environment` HTTP requests. Errors from those requests are translated into a `failureCode` field in the `pluginsListLoad` state.

  In this PR we render those errors in the `plugins` component, given that we want to render the errors in a similar way to the errors the component already renders.

  We also provide a mechanism for parent component to specify custom error templates. This will allow other flavors of TensorBoard to customize the error messages.

* Screenshots of UI changes

  ![image](https://user-images.githubusercontent.com/17152369/94148549-c1bf6a80-fe44-11ea-85dc-1ab3f048e737.png)
