### PR TITLE
docs: add bind_all to allow docker access

### DIFF
--- a/docs/tensorboard_in_notebooks.ipynb
+++ b/docs/tensorboard_in_notebooks.ipynb
@@ -95,18 +95,14 @@
         "id": "9w7Baxc8aCtJ"
       },
       "source": [
-        "**For Docker users:** In case you are running a [Docker](https://docs.docker.com/install/) image of [Jupyter Notebook server using TensorFlow's nightly](https://www.tensorflow.org/install/docker#examples_using_cpu-only_images), it is necessary to expose not only the notebook's port, but the TensorBoard's port.\n",
-        "\n",
-        "Thus, run the container with the following command:\n",
+        "**For Docker users:** In case you are running a [Docker](https://docs.docker.com/install/) image of [Jupyter Notebook server using TensorFlow's nightly](https://www.tensorflow.org/install/docker#examples_using_cpu-only_images), it is necessary to expose not only the notebook's port, but the TensorBoard's port. Thus, run the container with the following command:\n",
         "\n",
         "```\n",
         "docker run -it -p 8888:8888 -p 6006:6006 \\\n",
         "tensorflow/tensorflow:nightly-py3-jupyter \n",
         "```\n",
         "\n",
-        "where the `-p 6006` is the default port of TensorBoard. This will allocate a port for you to run one TensorBoard instance. To have concurrent instances, it is necessary to allocate more ports.\n",
-        "\n",
-        "Also, pass `--bind_all` to `%tensorboard` to expose the port outside the container."
+        "where the `-p 6006` is the default port of TensorBoard. This will allocate a port for you to run one TensorBoard instance. To have concurrent instances, it is necessary to allocate more ports. Also, pass `--bind_all` to `%tensorboard` to expose the port outside the container."
       ]
     },
     {

--- a/docs/tensorboard_in_notebooks.ipynb
+++ b/docs/tensorboard_in_notebooks.ipynb
@@ -95,7 +95,7 @@
         "id": "9w7Baxc8aCtJ"
       },
       "source": [
-        "In case you are running a [Docker](https://docs.docker.com/install/) image of [Jupyter Notebook server using TensorFlow's nightly](https://www.tensorflow.org/install/docker#examples_using_cpu-only_images), it is necessary to expose not only the notebook's port, but the TensorBoard's port.\n",
+        "**For Docker users:** In case you are running a [Docker](https://docs.docker.com/install/) image of [Jupyter Notebook server using TensorFlow's nightly](https://www.tensorflow.org/install/docker#examples_using_cpu-only_images), it is necessary to expose not only the notebook's port, but the TensorBoard's port.\n",
         "\n",
         "Thus, run the container with the following command:\n",
         "\n",
@@ -104,7 +104,9 @@
         "tensorflow/tensorflow:nightly-py3-jupyter \n",
         "```\n",
         "\n",
-        "where the `-p 6006` is the default port of TensorBoard. This will allocate a port for you to run one TensorBoard instance. To have concurrent instances, it is necessary to allocate more ports.\n"
+        "where the `-p 6006` is the default port of TensorBoard. This will allocate a port for you to run one TensorBoard instance. To have concurrent instances, it is necessary to allocate more ports.\n",
+        "\n",
+        "Also, pass `--bind_all` to `%tensorboard` to expose the port outside the container."
       ]
     },
     {


### PR DESCRIPTION
This addresses #4169

This allows the local browser to access tensorboard running inside docker, as the guide does. Without this, tensorboard UI will not be accessible from outside the container