### PR TITLE
Fix URL hash loss upon initial navigation

### DIFF
--- a/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects.ts
@@ -241,18 +241,16 @@ export class AppRoutingEffects {
           });
         }),
         tap(({isFirstNavigation, route}) => {
-          // The Polymer side of TB relies on reading state directly from the
-          // URL. Ideally, the source of truth would be in application JS, and
-          // the Angular side of TB would have enough information to manage the
-          // 'hash' of the URL.
+          // AppRouting's effect to dispatch the initial navigated action is
+          // asynchronous. It is possible to see a race condition, where the
+          // network request for plugins_listing returns first, which sets the
+          // URL hash to '#scalars', only to be discarded by the replaceState
+          // below. Preserving the hash upon initial navigation is a workaround.
 
-          // Currently this is not the case, so important hashes set before the
-          // initial navigation might get unintentionally discarded, unless we
-          // explicitly preserve them.
-
-          // Note: hashes such as the active plugin '#scalars' may be reflected
-          // in the URL before or after this effect runs, due to race
-          // conditions.
+          // TODO(b/169799696): either AppRouting should manage the URL entirely
+          // (including hash), or we make the app wait for AppRouting to
+          // initialize before setting the active plugin hash.
+          // See https://github.com/tensorflow/tensorboard/issues/4207.
           const shouldPreserveHash = isFirstNavigation;
           if (route.navigationOptions.replaceState) {
             this.location.replaceState(

--- a/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
+++ b/tensorboard/webapp/app_routing/effects/app_routing_effects_test.ts
@@ -535,6 +535,7 @@ describe('app_routing_effects', () => {
   describe('changeBrowserUrl$', () => {
     let replaceStateSpy: jasmine.Spy;
     let pushStateSpy: jasmine.Spy;
+    let getHashSpy: jasmine.Spy;
     let getPathSpy: jasmine.Spy;
     let getSearchSpy: jasmine.Spy;
 
@@ -543,6 +544,7 @@ describe('app_routing_effects', () => {
 
       replaceStateSpy = spyOn(location, 'replaceState');
       pushStateSpy = spyOn(location, 'pushState');
+      getHashSpy = spyOn(location, 'getHash');
       getPathSpy = spyOn(location, 'getPath');
       getSearchSpy = spyOn(location, 'getSearch');
     });
@@ -558,6 +560,7 @@ describe('app_routing_effects', () => {
       });
       store.overrideSelector(getActiveRoute, activeRoute);
       store.refreshState();
+      getHashSpy.and.returnValue('');
       getPathSpy.and.returnValue('/experiments');
       getSearchSpy.and.returnValue([]);
 
@@ -583,6 +586,7 @@ describe('app_routing_effects', () => {
       });
       store.overrideSelector(getActiveRoute, activeRoute);
       store.refreshState();
+      getHashSpy.and.returnValue('');
       getPathSpy.and.returnValue('meow');
       getSearchSpy.and.returnValue([]);
 
@@ -607,6 +611,7 @@ describe('app_routing_effects', () => {
       });
       store.overrideSelector(getActiveRoute, activeRoute);
       store.refreshState();
+      getHashSpy.and.returnValue('');
       getPathSpy.and.returnValue('meow');
       getSearchSpy.and.returnValue([]);
 
@@ -619,6 +624,64 @@ describe('app_routing_effects', () => {
 
       expect(pushStateSpy).not.toHaveBeenCalled();
       expect(replaceStateSpy).toHaveBeenCalledWith('/experiments');
+    });
+
+    it('preserves hash upon replace for initial navigation', () => {
+      const activeRoute = buildRoute({
+        routeKind: RouteKind.EXPERIMENTS,
+        pathname: '/experiments',
+        queryParams: [],
+        navigationOptions: {
+          replaceState: true,
+        },
+      });
+      store.overrideSelector(getActiveRoute, activeRoute);
+      store.refreshState();
+      getHashSpy.and.returnValue('#foo');
+      getPathSpy.and.returnValue('meow');
+      getSearchSpy.and.returnValue([]);
+
+      action.next(
+        actions.navigated({
+          before: null,
+          after: activeRoute,
+        })
+      );
+
+      expect(replaceStateSpy).toHaveBeenCalledWith('/experiments#foo');
+    });
+
+    it('does not preserve hash upon replace for non-initial navigation', () => {
+      const activeRoute = buildRoute({
+        routeKind: RouteKind.EXPERIMENTS,
+        pathname: '/experiments',
+        queryParams: [],
+        navigationOptions: {
+          replaceState: true,
+        },
+      });
+      const nextActiveRoute = buildRoute({
+        routeKind: RouteKind.EXPERIMENT,
+        pathname: '/experiment',
+        queryParams: [],
+        navigationOptions: {
+          replaceState: true,
+        },
+      });
+      store.overrideSelector(getActiveRoute, nextActiveRoute);
+      store.refreshState();
+      getHashSpy.and.returnValue('#foo');
+      getPathSpy.and.returnValue('meow');
+      getSearchSpy.and.returnValue([]);
+
+      action.next(
+        actions.navigated({
+          before: activeRoute,
+          after: nextActiveRoute,
+        })
+      );
+
+      expect(replaceStateSpy).toHaveBeenCalledWith('/experiment');
     });
   });
 });

--- a/tensorboard/webapp/app_routing/location.ts
+++ b/tensorboard/webapp/app_routing/location.ts
@@ -98,8 +98,11 @@ export class Location implements LocationInterface {
     return url.pathname;
   }
 
-  getFullPathFromRouteOrNav(routeLike: Route | Navigation): string {
-    // TODO(stephanwlee): support hashes.
+  getFullPathFromRouteOrNav(
+    routeLike: Route | Navigation,
+    shouldPreserveHash?: boolean
+  ): string {
+    // TODO(stephanwlee): support hashes in the routeLike.
     const pathname = this.getResolvedPath(routeLike.pathname);
     let search = '';
     if (!isNavigation(routeLike) && routeLike.queryParams.length) {
@@ -109,7 +112,8 @@ export class Location implements LocationInterface {
           routeLike.queryParams
         ).toString();
     }
-    return `${pathname}${search}`;
+    const hash = shouldPreserveHash ? this.getHash() : '';
+    return `${pathname}${search}${hash}`;
   }
 }
 


### PR DESCRIPTION
Enabling the upcoming Time Series dashboard [1] requires the
AppRoutingModule to be in effect with routes. Internal tests
caught a race condition, in which "setting the plugin hash",
e.g. `/#scalars` was done before the AppRouting effects.
AppRouting then replaced the entire URL hash on initial
navigation, losing important state.

This change adds an exception in AppRouting to allow the
initial navigation to preserve the hash. Non-initial navigations
can still safely discard, as we expect DeepLinkProviders to
manage things.

An alternative considered was to make HashStorageContainer
re-set the hash upon navigations. This also works, but the
drawback is that it introduces a dependency from Core on
AppRouting, and having the HashStorageContainer know about
routing side effects is non-ideal.

Tested both manually and via bazel commands, also internally
with --runs_per_test=20 and on TB embedders.

Internally, a test catching this race condition is sensitive to
execution options. Running
`bazel test ... --test_output=streamed` may pass, while
`bazel test ...` may fail.

Googlers, see test sync cl/334266882

[1] https://github.com/tensorflow/tensorboard/pull/4189