### PR TITLE
uploader: move UploadIntent tests to uploader_subcommand_test.py

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -84,6 +84,18 @@ py_library(
     ],
 )
 
+py_test(
+    name = "uploader_subcommand_test",
+    srcs = ["uploader_subcommand_test.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":dry_run_stubs",
+        ":server_info",
+        ":uploader",
+        ":uploader_subcommand",
+    ],
+)
+
 py_library(
     name = "uploader",
     srcs = ["uploader.py"],
@@ -141,18 +153,6 @@ py_test(
         "//tensorboard/util:test_util",
         "@com_google_protobuf//:protobuf_python",
         "@org_pythonhosted_mock",
-    ],
-)
-
-py_test(
-    name = "uploader_subcommand_test",
-    srcs = ["uploader_subcommand_test.py"],
-    srcs_version = "PY3",
-    deps = [
-        ":dry_run_stubs",
-        ":server_info",
-        ":uploader",
-        ":uploader_subcommand",
     ],
 )
 

--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -123,7 +123,6 @@ py_test(
         ":test_util",
         ":upload_tracker",
         ":uploader",
-        ":uploader_subcommand",
         ":util",
         "//tensorboard:data_compat",
         "//tensorboard:dataclass_compat",
@@ -142,6 +141,18 @@ py_test(
         "//tensorboard/util:test_util",
         "@com_google_protobuf//:protobuf_python",
         "@org_pythonhosted_mock",
+    ],
+)
+
+py_test(
+    name = "uploader_subcommand_test",
+    srcs = ["uploader_subcommand_test.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":dry_run_stubs",
+        ":server_info",
+        ":uploader",
+        ":uploader_subcommand",
     ],
 )
 

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ def _create_mock_client():
     )
     return mock_client
 
+
 # By default allow at least one plugin for each upload type: Scalar, Tensor, and
 # Blobs.
 _SCALARS_HISTOGRAMS_AND_GRAPHS = frozenset(
@@ -76,6 +77,7 @@ _SCALARS_HISTOGRAMS_AND_GRAPHS = frozenset(
         graphs_metadata.PLUGIN_NAME,
     )
 )
+
 
 class UploadIntentTest(tf.test.TestCase):
     def testUploadIntentUnderDryRunOneShot(self):
@@ -156,6 +158,7 @@ class UploadIntentTest(tf.test.TestCase):
             "\nInterrupted. View your TensorBoard at ",
             mock_stdout_write.call_args_list[-1][0][0],
         )
+
 
 if __name__ == "__main__":
     tf.test.main()

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -1,0 +1,161 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for tensorboard.uploader.uploader_subcommand."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import itertools
+import os
+import re
+import sys
+
+import grpc
+import grpc_testing
+
+try:
+    # python version >= 3.3
+    from unittest import mock
+except ImportError:
+    import mock  # pylint: disable=unused-import
+
+import tensorflow as tf
+
+from tensorboard.uploader.proto import server_info_pb2
+from tensorboard.uploader.proto import write_service_pb2
+from tensorboard.uploader.proto import write_service_pb2_grpc
+from tensorboard.uploader import dry_run_stubs
+from tensorboard.uploader import uploader as uploader_lib
+from tensorboard.uploader import uploader_subcommand
+from tensorboard.uploader import server_info as server_info_lib
+from tensorboard.plugins.histogram import metadata as histograms_metadata
+from tensorboard.plugins.graph import metadata as graphs_metadata
+from tensorboard.plugins.scalar import metadata as scalars_metadata
+
+
+def _create_mock_client():
+    # Create a stub instance (using a test channel) in order to derive a mock
+    # from it with autospec enabled. Mocking TensorBoardWriterServiceStub itself
+    # doesn't work with autospec because grpc constructs stubs via metaclassing.
+    test_channel = grpc_testing.channel(
+        service_descriptors=[], time=grpc_testing.strict_real_time()
+    )
+    stub = write_service_pb2_grpc.TensorBoardWriterServiceStub(test_channel)
+    mock_client = mock.create_autospec(stub)
+    fake_exp_response = write_service_pb2.CreateExperimentResponse(
+        experiment_id="123", url="should not be used!"
+    )
+    mock_client.CreateExperiment.return_value = fake_exp_response
+    mock_client.GetOrCreateBlobSequence.side_effect = (
+        write_service_pb2.GetOrCreateBlobSequenceResponse(
+            blob_sequence_id="blob%d" % i
+        )
+        for i in itertools.count()
+    )
+    return mock_client
+
+# By default allow at least one plugin for each upload type: Scalar, Tensor, and
+# Blobs.
+_SCALARS_HISTOGRAMS_AND_GRAPHS = frozenset(
+    (
+        scalars_metadata.PLUGIN_NAME,
+        histograms_metadata.PLUGIN_NAME,
+        graphs_metadata.PLUGIN_NAME,
+    )
+)
+
+class UploadIntentTest(tf.test.TestCase):
+    def testUploadIntentUnderDryRunOneShot(self):
+        """Test the upload intent under the dry-run + one-shot mode."""
+        mock_server_info = mock.MagicMock()
+        mock_channel = mock.MagicMock()
+        upload_limits = server_info_pb2.UploadLimits(
+            max_scalar_request_size=128000,
+            max_tensor_request_size=128000,
+            max_tensor_point_size=11111,
+            max_blob_request_size=128000,
+            max_blob_size=128000,
+        )
+        mock_stdout_write = mock.MagicMock()
+        with mock.patch.object(
+            server_info_lib,
+            "allowed_plugins",
+            return_value=_SCALARS_HISTOGRAMS_AND_GRAPHS,
+        ), mock.patch.object(
+            server_info_lib, "upload_limits", return_value=upload_limits
+        ), mock.patch.object(
+            sys.stdout, "write", mock_stdout_write
+        ), mock.patch.object(
+            dry_run_stubs,
+            "DryRunTensorBoardWriterStub",
+            side_effect=dry_run_stubs.DryRunTensorBoardWriterStub,
+        ) as mock_dry_run_stub:
+            intent = uploader_subcommand.UploadIntent(
+                self.get_temp_dir(), dry_run=True, one_shot=True
+            )
+            intent.execute(mock_server_info, mock_channel)
+        self.assertEqual(mock_dry_run_stub.call_count, 1)
+        self.assertRegex(
+            mock_stdout_write.call_args_list[-2][0][0],
+            ".*Done scanning logdir.*",
+        )
+        self.assertEqual(
+            mock_stdout_write.call_args_list[-1][0][0], "\nDone.\n"
+        )
+
+    def testUploadIntentDryRunNonOneShotInterrupted(self):
+        mock_server_info = mock.MagicMock()
+        mock_channel = mock.MagicMock()
+        mock_stdout_write = mock.MagicMock()
+        mock_uploader = mock.MagicMock()
+        with mock.patch.object(
+            mock_uploader, "start_uploading", side_effect=KeyboardInterrupt(),
+        ), mock.patch.object(
+            uploader_lib, "TensorBoardUploader", return_value=mock_uploader
+        ), mock.patch.object(
+            sys.stdout, "write", mock_stdout_write
+        ):
+            intent = uploader_subcommand.UploadIntent(
+                self.get_temp_dir(), dry_run=True, one_shot=False
+            )
+            intent.execute(mock_server_info, mock_channel)
+        self.assertEqual(
+            mock_stdout_write.call_args_list[-1][0][0], "\nInterrupted.\n"
+        )
+
+    def testUploadIntentNonDryRunNonOneShotInterrupted(self):
+        mock_server_info = mock.MagicMock()
+        mock_channel = mock.MagicMock()
+        mock_stdout_write = mock.MagicMock()
+        mock_uploader = mock.MagicMock()
+        with mock.patch.object(
+            mock_uploader, "start_uploading", side_effect=KeyboardInterrupt(),
+        ), mock.patch.object(
+            uploader_lib, "TensorBoardUploader", return_value=mock_uploader
+        ), mock.patch.object(
+            sys.stdout, "write", mock_stdout_write
+        ):
+            intent = uploader_subcommand.UploadIntent(
+                self.get_temp_dir(), dry_run=False, one_shot=False
+            )
+            intent.execute(mock_server_info, mock_channel)
+        self.assertIn(
+            "\nInterrupted. View your TensorBoard at ",
+            mock_stdout_write.call_args_list[-1][0][0],
+        )
+
+if __name__ == "__main__":
+    tf.test.main()

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -19,11 +19,8 @@ from __future__ import division
 from __future__ import print_function
 
 import itertools
-import os
-import re
 import sys
 
-import grpc
 import grpc_testing
 
 try:

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 import itertools
 import os
 import re
-import sys
 
 import grpc
 import grpc_testing

--- a/tensorboard/uploader/uploader_test.py
+++ b/tensorboard/uploader/uploader_test.py
@@ -43,13 +43,10 @@ from tensorboard.uploader.proto import scalar_pb2
 from tensorboard.uploader.proto import server_info_pb2
 from tensorboard.uploader.proto import write_service_pb2
 from tensorboard.uploader.proto import write_service_pb2_grpc
-from tensorboard.uploader import dry_run_stubs
 from tensorboard.uploader import test_util
 from tensorboard.uploader import upload_tracker
 from tensorboard.uploader import uploader as uploader_lib
-from tensorboard.uploader import uploader_subcommand
 from tensorboard.uploader import logdir_loader
-from tensorboard.uploader import server_info as server_info_lib
 from tensorboard.uploader import util
 from tensorboard.compat.proto import event_pb2
 from tensorboard.compat.proto import graph_pb2
@@ -1987,87 +1984,6 @@ class VarintCostTest(tf.test.TestCase):
         self.assertEqual(uploader_lib._varint_cost(128), 2)
         self.assertEqual(uploader_lib._varint_cost(128 * 128 - 1), 2)
         self.assertEqual(uploader_lib._varint_cost(128 * 128), 3)
-
-
-class UploadIntentTest(tf.test.TestCase):
-    def testUploadIntentUnderDryRunOneShot(self):
-        """Test the upload intent under the dry-run + one-shot mode."""
-        mock_server_info = mock.MagicMock()
-        mock_channel = mock.MagicMock()
-        upload_limits = server_info_pb2.UploadLimits(
-            max_scalar_request_size=128000,
-            max_tensor_request_size=128000,
-            max_tensor_point_size=11111,
-            max_blob_request_size=128000,
-            max_blob_size=128000,
-        )
-        mock_stdout_write = mock.MagicMock()
-        with mock.patch.object(
-            server_info_lib,
-            "allowed_plugins",
-            return_value=_SCALARS_HISTOGRAMS_AND_GRAPHS,
-        ), mock.patch.object(
-            server_info_lib, "upload_limits", return_value=upload_limits
-        ), mock.patch.object(
-            sys.stdout, "write", mock_stdout_write
-        ), mock.patch.object(
-            dry_run_stubs,
-            "DryRunTensorBoardWriterStub",
-            side_effect=dry_run_stubs.DryRunTensorBoardWriterStub,
-        ) as mock_dry_run_stub:
-            intent = uploader_subcommand.UploadIntent(
-                self.get_temp_dir(), dry_run=True, one_shot=True
-            )
-            intent.execute(mock_server_info, mock_channel)
-        self.assertEqual(mock_dry_run_stub.call_count, 1)
-        self.assertRegex(
-            mock_stdout_write.call_args_list[-2][0][0],
-            ".*Done scanning logdir.*",
-        )
-        self.assertEqual(
-            mock_stdout_write.call_args_list[-1][0][0], "\nDone.\n"
-        )
-
-    def testUploadIntentDryRunNonOneShotInterrupted(self):
-        mock_server_info = mock.MagicMock()
-        mock_channel = mock.MagicMock()
-        mock_stdout_write = mock.MagicMock()
-        mock_uploader = mock.MagicMock()
-        with mock.patch.object(
-            mock_uploader, "start_uploading", side_effect=KeyboardInterrupt(),
-        ), mock.patch.object(
-            uploader_lib, "TensorBoardUploader", return_value=mock_uploader
-        ), mock.patch.object(
-            sys.stdout, "write", mock_stdout_write
-        ):
-            intent = uploader_subcommand.UploadIntent(
-                self.get_temp_dir(), dry_run=True, one_shot=False
-            )
-            intent.execute(mock_server_info, mock_channel)
-        self.assertEqual(
-            mock_stdout_write.call_args_list[-1][0][0], "\nInterrupted.\n"
-        )
-
-    def testUploadIntentNonDryRunNonOneShotInterrupted(self):
-        mock_server_info = mock.MagicMock()
-        mock_channel = mock.MagicMock()
-        mock_stdout_write = mock.MagicMock()
-        mock_uploader = mock.MagicMock()
-        with mock.patch.object(
-            mock_uploader, "start_uploading", side_effect=KeyboardInterrupt(),
-        ), mock.patch.object(
-            uploader_lib, "TensorBoardUploader", return_value=mock_uploader
-        ), mock.patch.object(
-            sys.stdout, "write", mock_stdout_write
-        ):
-            intent = uploader_subcommand.UploadIntent(
-                self.get_temp_dir(), dry_run=False, one_shot=False
-            )
-            intent.execute(mock_server_info, mock_channel)
-        self.assertIn(
-            "\nInterrupted. View your TensorBoard at ",
-            mock_stdout_write.call_args_list[-1][0][0],
-        )
 
 
 def _clear_wall_times(request):


### PR DESCRIPTION
I thought UploadIntent was untested before because I didn't notice it at the bottom of `uploader_test.py` (and apparently neglected to search for it).