### PR TITLE
Load polymer3 portions of app JavaScript before Angular portions.

### DIFF
--- a/tensorboard/webapp/index_polymer3.uninlined.html
+++ b/tensorboard/webapp/index_polymer3.uninlined.html
@@ -54,7 +54,7 @@ limitations under the License.
 
 <body>
   <script jscomp-nocompile src="tf-imports/require.js"></script>
-  <script jscomp-nocompile src="tb-webapp/tb_webapp_binary.js"></script>
   <script jscomp-nocompile src="polymer3_lib_binary.js"></script>
+  <script jscomp-nocompile src="tb-webapp/tb_webapp_binary.js"></script>
   <tb-webapp></tb-webapp>
 </body>


### PR DESCRIPTION
* Motivation for features / changes

  An internal build of tensorboard does not properly load UI because dependencies are loaded in an incorrect order.

* Technical description of changes

  Load polymer3 portions of app before angular portions.

* Detailed steps to verify changes work correctly (as executed by you)

  * Verify `bazel run tensorboard -- --logdir <logdir>` continues to work.
  * Verify that internal builds now work.