### PR TITLE
Expect grpc_testing to be included in internal BUILD files.

### DIFF
--- a/tensorboard/uploader/BUILD
+++ b/tensorboard/uploader/BUILD
@@ -91,6 +91,7 @@ py_test(
         ":server_info",
         ":uploader",
         ":uploader_subcommand",
+        "//tensorboard:expect_grpc_testing_installed",
     ],
 )
 


### PR DESCRIPTION
* Motivation for features / changes

Internal tests are broken by https://github.com/tensorflow/tensorboard/pull/4199. Internally we expect grpc_testing to be an explicit dependency in the BUILD file.

* Technical description of changes

Use appropriate placeholder BUILD dependency.
