### PR TITLE
misc: fix sync warnings for LICENSE and TS

### DIFF
--- a/tensorboard/compat/tensorflow_stub/BUILD
+++ b/tensorboard/compat/tensorflow_stub/BUILD
@@ -5,8 +5,6 @@ package(default_visibility = ["//tensorboard:internal"])
 
 licenses(["notice"])
 
-exports_files(["LICENSE"])
-
 py_library(
     name = "tensorflow_stub",
     srcs = glob(["*.py"]) + [

--- a/tensorboard/webapp/runs/data_source/runs_data_source_test.ts
+++ b/tensorboard/webapp/runs/data_source/runs_data_source_test.ts
@@ -25,7 +25,6 @@ import {RunsDataSource} from './runs_data_source_types';
 describe('TBRunsDataSource test', () => {
   let httpMock: HttpTestingController;
   let dataSource: RunsDataSource;
-  let tbBackend: any;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({


### PR DESCRIPTION
The Google internal sync warns on a couple
miscellaneous changes. This removes an incorrect
LICENSE export line and removes an unused TS
variable.

Merge plan: rebase, resulting in 2 commits

[1] https://github.com/tensorflow/tensorboard/pull/4204