### PR TITLE
program: note Google-internal signal handling patch

### DIFF
--- a/tensorboard/program.py
+++ b/tensorboard/program.py
@@ -365,6 +365,10 @@ class TensorBoard(object):
             `signal.SIGTERM`.
           signal_name: The human-readable signal name.
         """
+        # Note to maintainers: Google-internal code overrides this
+        # method (cf. cl/334534610). Double-check changes before
+        # modifying API.
+
         old_signal_handler = None  # set below
 
         def handler(handled_signal_number, frame):


### PR DESCRIPTION
Summary:
Recent changes (<http://cl/334534610>) override this function in the
Google-internal build of TensorBoard, so changes in OSS should be
careful if making backward-incompatible changes to it, even though it
looks to be a private API.

wchargin-branch: program-note-google-sigterm-patch
