### PR TITLE
bug: fix AppRouting interference with URL queryParam-reading components

### DIFF
--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -29,6 +29,14 @@ export interface Router {
   runs: () => string;
   runsForExperiment: (id: ExperimentId) => string;
 }
+
+/**
+ * Save the initial URL query params, before the AppRoutingEffects initialize,
+ * and before creating the router.
+ * Ideally, AppRouting would manage all URL params.
+ * https://github.com/tensorflow/tensorboard/issues/4207
+ */
+const initialURLSearchParams = new URLSearchParams(window.location.search);
 let _router: Router = createRouter();
 
 /**
@@ -39,7 +47,7 @@ let _router: Router = createRouter();
  */
 export function createRouter(
   dataDir = 'data',
-  urlSearchParams = new URLSearchParams(window.location.search)
+  urlSearchParams = initialURLSearchParams
 ): Router {
   if (dataDir[dataDir.length - 1] === '/') {
     dataDir = dataDir.slice(0, dataDir.length - 1);

--- a/tensorboard/components/tf_backend/router.ts
+++ b/tensorboard/components/tf_backend/router.ts
@@ -33,8 +33,6 @@ export interface Router {
 /**
  * Save the initial URL query params, before the AppRoutingEffects initialize,
  * and before creating the router.
- * Ideally, AppRouting would manage all URL params.
- * https://github.com/tensorflow/tensorboard/issues/4207
  */
 const initialURLSearchParams = new URLSearchParams(window.location.search);
 let _router: Router = createRouter();

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -70,6 +70,13 @@ const THRESHOLD_DIM_NORMALIZE = 50;
 const POINT_COLOR_MISSING = 'black';
 const INDEX_METADATA_FIELD = '__index__';
 
+/**
+ * Save the initial URL query params, before the AppRoutingEffects initialize.
+ * Ideally, AppRouting would manage all URL params.
+ * https://github.com/tensorflow/tensorboard/issues/4207
+ */
+const initialURLQueryString = window.location.search;
+
 @customElement('vz-projector')
 class Projector
   extends LegacyElementMixin(PolymerElement)
@@ -440,7 +447,7 @@ class Projector
     if (this.servingMode === 'demo') {
       let projectorConfigUrl: string;
       // Only in demo mode do we allow the config being passed via URL.
-      let urlParams = util.getURLParams(window.location.search);
+      let urlParams = util.getURLParams(initialURLQueryString);
       if ('config' in urlParams) {
         projectorConfigUrl = urlParams['config'];
       } else {

--- a/tensorboard/plugins/projector/vz_projector/vz-projector.ts
+++ b/tensorboard/plugins/projector/vz_projector/vz-projector.ts
@@ -72,8 +72,6 @@ const INDEX_METADATA_FIELD = '__index__';
 
 /**
  * Save the initial URL query params, before the AppRoutingEffects initialize.
- * Ideally, AppRouting would manage all URL params.
- * https://github.com/tensorflow/tensorboard/issues/4207
  */
 const initialURLQueryString = window.location.search;
 

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
@@ -32,8 +32,6 @@ type RunTagItem = {run: string; tag: string};
 
 /**
  * Save the initial URL query params, before the AppRoutingEffects initialize.
- * Ideally, AppRouting would manage all URL params.
- * https://github.com/tensorflow/tensorboard/issues/4207
  */
 const initialURLSearchParams = new URLSearchParams(window.location.search);
 

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
@@ -31,6 +31,13 @@ import {DEFAULT_TOOLTIP_COLUMNS} from '../../../components/vz_line_chart2/vz-lin
 type RunTagItem = {run: string; tag: string};
 
 /**
+ * Save the initial URL query params, before the AppRoutingEffects initialize.
+ * Ideally, AppRouting would manage all URL params.
+ * https://github.com/tensorflow/tensorboard/issues/4207
+ */
+const initialURLSearchParams = new URLSearchParams(window.location.search);
+
+/**
  * A card that handles loading data (at the right times), rendering a scalar
  * chart, and providing UI affordances (such as buttons) for scalar data.
  */
@@ -265,9 +272,7 @@ export class TfScalarCard extends PolymerElement {
     onLoad,
     onFinish
   ) => {
-    const inColab =
-      new URLSearchParams(window.location.search).get('tensorboardColab') ===
-      'true';
+    const inColab = initialURLSearchParams.get('tensorboardColab') === 'true';
     if (inColab) {
       // Google-internal Colab doesn't support HTTP POST requests, so we fall
       // back to HTTP GET (even though public Colab supports POST).

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -16,9 +16,16 @@ import {Injectable} from '@angular/core';
 
 import {TBFeatureFlagDataSource} from './tb_feature_flag_data_source_types';
 
+/**
+ * Save the initial URL query params, before the AppRoutingEffects initialize.
+ * Ideally, AppRouting would manage all URL params.
+ * https://github.com/tensorflow/tensorboard/issues/4207
+ */
+const initialURLSearchParams = new URLSearchParams(window.location.search);
+
 const util = {
   getParams() {
-    return new URLSearchParams(window.location.search);
+    return initialURLSearchParams;
   },
 };
 

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -18,8 +18,6 @@ import {TBFeatureFlagDataSource} from './tb_feature_flag_data_source_types';
 
 /**
  * Save the initial URL query params, before the AppRoutingEffects initialize.
- * Ideally, AppRouting would manage all URL params.
- * https://github.com/tensorflow/tensorboard/issues/4207
  */
 const initialURLSearchParams = new URLSearchParams(window.location.search);
 


### PR DESCRIPTION
See https://github.com/tensorflow/tensorboard/issues/4207 for details.

Several callsites in TB's Angular and Polymer codebases read
directly from `window.location.search`. For example, scalar cards
read the `?tensorboardColab=true` param at arbitrary times in
the TB session, to know whether TB is running inside Colab.

AppRoutingEffects has an initialization step that clears/discards
all existing URL queryParams, causing breaking behavior.

Since AppRouting is not yet a complete source of truth for URL
query params, this change makes all callsites that read from
`window.location.search` do so on the initial app load, before
AppRouting can interfere.

An alternative considered was making AppRoutingEffects aware
of a hardcoded list of reserved queryParam keys, and preserving
them whenever updating the URL. In that approach, there are
some unknown questions, e.g. if a user navigates to a different
route and returns to the original route, do we still need to preserve
queryParams?

Manually tested that running TB with `?tensorboardColab=true`
and opening scalar cards results in network requests to
the `/scalars` endpoint, not `/scalars_multirun.`