### PR TITLE
bug: make hparam/metric filter option click target wider

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -117,6 +117,13 @@ ng_module(
     ],
 )
 
+ng_module(
+    name = "app_config",
+    srcs = [
+        "app_config.ts",
+    ],
+)
+
 # TODO(stephanwlee): at the moment, there is no development build. Reinstate it.
 # Wrapper that prepares Angular app for deployment, dealing with browser
 # compatibility, Vulcanization, and configuration (e.g. prod vs. dev).

--- a/tensorboard/webapp/app_config.ts
+++ b/tensorboard/webapp/app_config.ts
@@ -1,0 +1,51 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/**
+ * WARNING: This file serves as an escape hatch. Ideally all app configuration
+ * would take place in app_module.ts. Prefer adding top-level configuration
+ * there, instead of here.
+ *
+ * Every exported symbol in this file must be accompanied by a `RATIONALE`.
+ */
+
+/**
+ * RATIONALE:
+ *
+ * It is not sufficient for app_module.ts to use DI to provide
+ * `MAT_CHECKBOX_DEFAULT_OPTIONS` from '@angular/material/checkbox'.
+ *
+ * Individual components may wish to override `MAT_CHECKBOX_DEFAULT_OPTIONS`
+ * with {clickAction: 'noop'}. However, doing so would override the 'color'
+ * property. In order to preserve the color property defined at the app-level,
+ * we need to store the app's default checkbox color option. Then, components
+ * can provide like so:
+ *
+ * // GOOD
+ * {
+ *   provide: MAT_CHECKBOX_DEFAULT_OPTIONS,
+ *   useValue: {
+ *     clickAction: 'noop',
+ *     color: MAT_CHECKBOX_DEFAULT_COLOR,
+ *   },
+ * }
+ *
+ * // BAD
+ * {
+ *   provide: MAT_CHECKBOX_DEFAULT_OPTIONS,
+ *   useValue: {color: 'primary'},
+ * }
+ */
+export const MAT_CHECKBOX_DEFAULT_COLOR = 'accent';

--- a/tensorboard/webapp/runs/views/runs_table/BUILD
+++ b/tensorboard/webapp/runs/views/runs_table/BUILD
@@ -23,6 +23,7 @@ ng_module(
         "runs_table_component.ng.html",
     ],
     deps = [
+        "//tensorboard/webapp:app_config",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/angular:expect_angular_material_button",

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -129,13 +129,11 @@ limitations under the License.
           <mat-menu #filterMenu="matMenu">
             <div
               mat-menu-item
-              (click)="$event.stopPropagation()"
+              (click)="handleHparamIncludeUndefinedChanged($event, column)"
               role="menuitemcheckbox"
               disableRipple
             >
-              <mat-checkbox
-                [checked]="column.filter.includeUndefined"
-                (change)="handleHparamIncludeUndefinedToggled(column)"
+              <mat-checkbox [checked]="column.filter.includeUndefined"
                 ><span>(show empty value)</span></mat-checkbox
               >
             </div>
@@ -160,11 +158,10 @@ limitations under the License.
                 *ngFor="let value of column.filter.possibleValues"
                 mat-menu-item
                 role="menuitemcheckbox"
-                (click)="$event.stopPropagation()"
+                (click)="handleHparamDiscreteChanged($event, column, value)"
               >
                 <mat-checkbox
                   [checked]="column.filter.filterValues.includes(value)"
-                  (change)="handleHparamDiscreteChanged(column, value)"
                   ><span>{{ value }}</span></mat-checkbox
                 >
               </div>
@@ -197,13 +194,11 @@ limitations under the License.
           <mat-menu #filterMenu="matMenu">
             <div
               mat-menu-item
-              (click)="$event.stopPropagation()"
+              (click)="handleMetricIncludeUndefinedChanged($event, column)"
               role="menuitemcheckbox"
               disableRipple
             >
-              <mat-checkbox
-                [checked]="column.filter.includeUndefined"
-                (change)="handleMetricIncludeUndefinedChanged(column)"
+              <mat-checkbox [checked]="column.filter.includeUndefined"
                 ><span>(show empty value)</span></mat-checkbox
               >
             </div>

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ts
@@ -27,7 +27,9 @@ import {MatPaginator} from '@angular/material/paginator';
 import {MatPaginatorIntl} from '@angular/material/paginator';
 import {MatSort, Sort} from '@angular/material/sort';
 import {MatTableDataSource} from '@angular/material/table';
+import {MAT_CHECKBOX_DEFAULT_OPTIONS} from '@angular/material/checkbox';
 
+import {MAT_CHECKBOX_DEFAULT_COLOR} from '../../../app_config';
 import {SortDirection} from '../../../types/ui';
 import {
   DiscreteFilter,
@@ -73,8 +75,17 @@ export interface IntervalFilterChange {
   },
   styleUrls: ['runs_table_component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  // Use Element Provider since this text is unique to this element hierarchy.
-  providers: [{provide: MatPaginatorIntl, useClass: RunsPaginatorIntl}],
+  providers: [
+    // Use Element Provider since this text is unique to this element hierarchy.
+    {provide: MatPaginatorIntl, useClass: RunsPaginatorIntl},
+    {
+      provide: MAT_CHECKBOX_DEFAULT_OPTIONS,
+      useValue: {
+        clickAction: 'noop',
+        color: MAT_CHECKBOX_DEFAULT_COLOR,
+      },
+    },
+  ],
 })
 export class RunsTableComponent implements OnChanges {
   readonly dataSource = new MatTableDataSource<RunTableItem>();
@@ -201,7 +212,11 @@ export class RunsTableComponent implements OnChanges {
     return item.run.id;
   }
 
-  handleHparamIncludeUndefinedToggled(hparamColumn: HparamColumn) {
+  handleHparamIncludeUndefinedChanged(
+    event: MouseEvent,
+    hparamColumn: HparamColumn
+  ) {
+    event.stopPropagation();
     const {name, filter} = hparamColumn;
 
     if (!filter) {
@@ -247,9 +262,11 @@ export class RunsTableComponent implements OnChanges {
   }
 
   handleHparamDiscreteChanged(
+    event: MouseEvent,
     hparamColumn: HparamColumn,
     toggledValue: DiscreteHparamValue
   ) {
+    event.stopPropagation();
     const {name, filter} = hparamColumn;
 
     if (!filter) {
@@ -277,7 +294,11 @@ export class RunsTableComponent implements OnChanges {
     });
   }
 
-  handleMetricIncludeUndefinedChanged(metricColumn: MetricColumn) {
+  handleMetricIncludeUndefinedChanged(
+    event: MouseEvent,
+    metricColumn: MetricColumn
+  ) {
+    event.stopPropagation();
     if (!metricColumn.filter) {
       throw new RangeError(
         'Invariant error: require filter to exist for it to change'


### PR DESCRIPTION
The RunsTableComponent UI features dropdowns to allow filtering the
list of runs by specific hparam/metric values. Currently, the event
listeners are on the mat-checkbox shown on each option row in the
dropdown. Clicking the row itself results in a Material "ripple" visual
effect, but does nothing.

This makes the entire row the click target, so that the visual effect
actually produces the desired effect.

Googlers, see b/169282111 and test sync cl/335059530