### PR TITLE
Use GET instead of POST requests for hparams in colab environment.

### DIFF
--- a/tensorboard/plugins/hparams/tf_hparams_dashboard/tf-hparams-dashboard.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_dashboard/tf-hparams-dashboard.ts
@@ -20,6 +20,10 @@ import '../tf_hparams_main/tf-hparams-main';
 import * as tf_hparams_backend from '../tf_hparams_backend/tf-hparams-backend';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 
+const inColab =
+  new URLSearchParams(window.location.search).get('tensorboardColab') ===
+  'true';
+
 const PLUGIN_NAME = 'hparams';
 @customElement('tf-hparams-dashboard')
 class TfHparamsDashboard extends LegacyElementMixin(PolymerElement) {
@@ -43,7 +47,7 @@ class TfHparamsDashboard extends LegacyElementMixin(PolymerElement) {
     new tf_backend.RequestManager(),
     /* Use GETs if we're running in colab (due to b/126387106).
           Otherwise use POSTs. */
-    /* useHttpGet= */ !!((window as any).TENSORBOARD_ENV || {}).IN_COLAB
+    /* useHttpGet= */ inColab
   );
   // This is called by the tensorboard web framework to refresh the plugin.
   reload() {

--- a/tensorboard/plugins/hparams/tf_hparams_dashboard/tf-hparams-dashboard.ts
+++ b/tensorboard/plugins/hparams/tf_hparams_dashboard/tf-hparams-dashboard.ts
@@ -20,6 +20,7 @@ import '../tf_hparams_main/tf-hparams-main';
 import * as tf_hparams_backend from '../tf_hparams_backend/tf-hparams-backend';
 import {LegacyElementMixin} from '../../../components/polymer/legacy_element_mixin';
 
+// Read URL at module import time, before AppRoutingEffects stomps it.
 const inColab =
   new URLSearchParams(window.location.search).get('tensorboardColab') ===
   'true';


### PR DESCRIPTION
* Motivation for features / changes

  Hparams dashboard does not work in Google-internal colab environments because they do not support POST requests. 

* Technical description of changes

  Reuse mechanism introduced in #4191 that provides a 'tensorboardColab' query parameter in the URL to indicate a colab environment. If the value for the parameter is true then the Hparams dashboard will send GET requests. Otherwise it sends POST requests.

  There already existed code that purported to determine if the hparams dashboard was running in a colab environment but this code has not worked for some time, possibly since #2798. The code in this PR simply replaces that code. The plumbing to pipe this through other layers had already been implemented.

* Tests

  I loaded a local tensorboard with the query parameter 'tensorboardColab=true' and inspected the network tab to confirm that hparams-related calls were GET requests.

  I loaded the local tensorboard without 'tensorboardColab' in the URL and inspected the network tab to confirm that hparams-related calls were POST requests.