### PR TITLE
Update ngrx store for pinned cards from storage

### DIFF
--- a/tensorboard/webapp/metrics/data_source/types.ts
+++ b/tensorboard/webapp/metrics/data_source/types.ts
@@ -52,6 +52,14 @@ export enum PluginType {
   IMAGES = 'images',
 }
 
+export function isPluginType(text: string): text is PluginType {
+  return (
+    text === PluginType.SCALARS ||
+    text === PluginType.HISTOGRAMS ||
+    text === PluginType.IMAGES
+  );
+}
+
 export type SampledPluginType = PluginType.IMAGES;
 const sampledPluginTypes = [PluginType.IMAGES];
 

--- a/tensorboard/webapp/metrics/store/BUILD
+++ b/tensorboard/webapp/metrics/store/BUILD
@@ -14,6 +14,8 @@ tf_ts_library(
         ":types",
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/app_routing:route_contexted_reducer_helper",
+        "//tensorboard/webapp/app_routing:types",
+        "//tensorboard/webapp/app_routing/actions",
         "//tensorboard/webapp/core/actions",
         "//tensorboard/webapp/metrics:types",
         "//tensorboard/webapp/metrics/actions",

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -297,7 +297,7 @@ const reducer = createReducer(
     // We need to include previous unresolved imported pins, because the new
     // hydrated state might not include them. For example, navigating from
     // experiment A (with pins) --> B --> A, we want to ensure that rehydration
-    // does not drop the old pins on A.
+    // does not drop the old unresolved pins on A.
     const hydratedState = partialState as URLDeserializedState;
     const unresolvedImportedPinnedCards = [] as CardUniqueInfo[];
     for (const card of [
@@ -400,9 +400,7 @@ const reducer = createReducer(
         }
       }
 
-      const nextCardList = newCardIds.length
-        ? [...state.cardList, ...newCardIds]
-        : state.cardList;
+      const nextCardList = [...state.cardList, ...newCardIds];
 
       const resolvedResult = buildOrReturnStateWithUnresolvedImportedPins(
         state.unresolvedImportedPinnedCards,

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1495,6 +1495,7 @@ describe('metrics reducers', () => {
       expect(nextState.cardToPinnedCopy).toEqual(
         new Map([['card1', pinnedCopyId]])
       );
+      expect(nextState.unresolvedImportedPinnedCards).toEqual([]);
     });
 
     it('does not add resolved pins to the unresolved imported pins', () => {

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -272,7 +272,7 @@ describe('metrics reducers', () => {
         },
         cardToPinnedCopy: new Map(),
         pinnedCardToOriginal: new Map(),
-        prePinnedCards: [{tag: 'tagA'}, {tag: 'tagB'}],
+        unresolvedImportedPinnedCards: [{tag: 'tagA'}, {tag: 'tagB'}],
       });
       const nextState = reducers(
         beforeState,
@@ -293,7 +293,7 @@ describe('metrics reducers', () => {
         cardStepIndex,
         cardToPinnedCopy,
         pinnedCardToOriginal,
-        prePinnedCards,
+        unresolvedImportedPinnedCards,
       } = nextState;
       expect({
         cardMetadataMap,
@@ -301,7 +301,7 @@ describe('metrics reducers', () => {
         cardStepIndex,
         cardToPinnedCopy,
         pinnedCardToOriginal,
-        prePinnedCards,
+        unresolvedImportedPinnedCards,
       }).toEqual({
         cardMetadataMap: {
           [expectedCardId]: fakeCardMetadata,
@@ -314,7 +314,7 @@ describe('metrics reducers', () => {
         },
         cardToPinnedCopy: new Map([[expectedCardId, expectedPinnedCopyId]]),
         pinnedCardToOriginal: new Map([[expectedPinnedCopyId, expectedCardId]]),
-        prePinnedCards: [{tag: 'tagB'}],
+        unresolvedImportedPinnedCards: [{tag: 'tagB'}],
       });
     });
 
@@ -1380,7 +1380,9 @@ describe('metrics reducers', () => {
 
   describe('pinned card hydration', () => {
     it('ignores RouteKind EXPERIMENTS', () => {
-      const beforeState = buildMetricsState({prePinnedCards: []});
+      const beforeState = buildMetricsState({
+        unresolvedImportedPinnedCards: [],
+      });
       const action = routingActions.stateRehydratedFromUrl({
         routeKind: RouteKind.EXPERIMENTS,
         partialState: {
@@ -1391,11 +1393,13 @@ describe('metrics reducers', () => {
       });
       const nextState = reducers(beforeState, action);
 
-      expect(nextState.prePinnedCards).toEqual([]);
+      expect(nextState.unresolvedImportedPinnedCards).toEqual([]);
     });
 
     it('populates ngrx store with pre-pinned cards from storage', () => {
-      const beforeState = buildMetricsState({prePinnedCards: []});
+      const beforeState = buildMetricsState({
+        unresolvedImportedPinnedCards: [],
+      });
       const action = routingActions.stateRehydratedFromUrl({
         routeKind: RouteKind.EXPERIMENT,
         partialState: {
@@ -1406,7 +1410,9 @@ describe('metrics reducers', () => {
       });
       const nextState = reducers(beforeState, action);
 
-      expect(nextState.prePinnedCards).toEqual([{tag: 'accuracy'}]);
+      expect(nextState.unresolvedImportedPinnedCards).toEqual([
+        {tag: 'accuracy'},
+      ]);
     });
 
     it('does not populate pre-pinned store with already pinned cards', () => {
@@ -1417,7 +1423,7 @@ describe('metrics reducers', () => {
           card1: fakeMetadata,
         },
         pinnedCardToOriginal: new Map([['card-pin1', 'card1']]),
-        prePinnedCards: [],
+        unresolvedImportedPinnedCards: [],
       });
       const action = routingActions.stateRehydratedFromUrl({
         routeKind: RouteKind.EXPERIMENT,
@@ -1429,12 +1435,12 @@ describe('metrics reducers', () => {
       });
       const nextState = reducers(beforeState, action);
 
-      expect(nextState.prePinnedCards).toEqual([]);
+      expect(nextState.unresolvedImportedPinnedCards).toEqual([]);
     });
 
     it('does not populate pre-pinned store with duplicates', () => {
       const beforeState = buildMetricsState({
-        prePinnedCards: [{tag: 'accuracy'}],
+        unresolvedImportedPinnedCards: [{tag: 'accuracy'}],
       });
       const action = routingActions.stateRehydratedFromUrl({
         routeKind: RouteKind.EXPERIMENT,
@@ -1446,12 +1452,14 @@ describe('metrics reducers', () => {
       });
       const nextState = reducers(beforeState, action);
 
-      expect(nextState.prePinnedCards).toEqual([{tag: 'accuracy'}]);
+      expect(nextState.unresolvedImportedPinnedCards).toEqual([
+        {tag: 'accuracy'},
+      ]);
     });
 
     it('does not clear pre-pinned store if hydration is empty', () => {
       const beforeState = buildMetricsState({
-        prePinnedCards: [{tag: 'accuracy'}],
+        unresolvedImportedPinnedCards: [{tag: 'accuracy'}],
       });
       const action = routingActions.stateRehydratedFromUrl({
         routeKind: RouteKind.EXPERIMENT,
@@ -1463,7 +1471,9 @@ describe('metrics reducers', () => {
       });
       const nextState = reducers(beforeState, action);
 
-      expect(nextState.prePinnedCards).toEqual([{tag: 'accuracy'}]);
+      expect(nextState.unresolvedImportedPinnedCards).toEqual([
+        {tag: 'accuracy'},
+      ]);
     });
   });
 });

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -187,6 +187,9 @@ function cardMatchesCardUniqueInfo(
 /**
  * Attempts to resolve the imported pins against the list of non-pinned cards
  * provided. Returns the resulting state.
+ *
+ * Note: this assumes input has already been sanitized and validated. Untrusted
+ * data from URLs must be cleaned before being passed to the store.
  */
 export function buildOrReturnStateWithUnresolvedImportedPins(
   unresolvedImportedPinnedCards: CardUniqueInfo[],

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -19,14 +19,27 @@ limitations under the License.
 import {DataLoadState} from '../../types/data';
 
 import {isSampledPlugin, PluginType, SampledPluginType} from '../data_source';
-import {CardId, CardMetadata} from '../types';
+import {CardId, CardMetadata, CardUniqueInfo, NonPinnedCardId} from '../types';
 
 import {
+  CardMetadataMap,
+  CardStepIndexMap,
+  CardToPinnedCard,
+  MetricsState,
+  PinnedCardToCard,
   RunToLoadState,
   TagMetadata,
   TimeSeriesData,
   TimeSeriesLoadables,
 } from './metrics_types';
+
+type ResolvedPinPartialState = Pick<
+  MetricsState,
+  | 'cardMetadataMap'
+  | 'cardToPinnedCopy'
+  | 'pinnedCardToOriginal'
+  | 'cardStepIndex'
+>;
 
 /**
  * Returns the loadable information for a specific tag, containing its series
@@ -152,4 +165,126 @@ export function getRunIds(
   }
   const tagToRunIds = tagMetadata[plugin].tagToRuns;
   return tagToRunIds.hasOwnProperty(tag) ? tagToRunIds[tag] : [];
+}
+
+/**
+ * Returns whether the CardMetadata exactly matches the pinned card from
+ * storage.
+ */
+function cardMatchesCardUniqueInfo(
+  cardMetadata: CardMetadata,
+  cardUniqueInfo: CardUniqueInfo
+): boolean {
+  const noRunId = !cardMetadata.runId && !cardUniqueInfo.runId;
+  return (
+    cardMetadata.plugin === cardUniqueInfo.plugin &&
+    cardMetadata.tag === cardUniqueInfo.tag &&
+    cardMetadata.sample === cardUniqueInfo.sample &&
+    (cardMetadata.runId === cardUniqueInfo.runId || noRunId)
+  );
+}
+
+/**
+ * Attempts to resolve the imported pins against the list of non-pinned cards
+ * provided. Returns the resulting state.
+ */
+export function buildOrReturnStateWithUnresolvedImportedPins(
+  unresolvedImportedPinnedCards: CardUniqueInfo[],
+  nonPinnedCards: NonPinnedCardId[],
+  cardMetadataMap: CardMetadataMap,
+  cardToPinnedCopy: CardToPinnedCard,
+  pinnedCardToOriginal: PinnedCardToCard,
+  cardStepIndexMap: CardStepIndexMap
+): ResolvedPinPartialState & {unresolvedImportedPinnedCards: CardUniqueInfo[]} {
+  const unresolvedPinSet = new Set(unresolvedImportedPinnedCards);
+  const nonPinnedCardsWithMatch = [];
+  for (const unresolvedPin of unresolvedImportedPinnedCards) {
+    for (const nonPinnedCardId of nonPinnedCards) {
+      const cardMetadata = cardMetadataMap[nonPinnedCardId];
+      if (cardMatchesCardUniqueInfo(cardMetadata, unresolvedPin)) {
+        nonPinnedCardsWithMatch.push(nonPinnedCardId);
+        unresolvedPinSet.delete(unresolvedPin);
+        break;
+      }
+    }
+  }
+
+  if (!nonPinnedCardsWithMatch.length) {
+    return {
+      unresolvedImportedPinnedCards,
+      cardMetadataMap,
+      cardToPinnedCopy,
+      pinnedCardToOriginal,
+      cardStepIndex: cardStepIndexMap,
+    };
+  }
+
+  let stateWithResolvedPins = {
+    cardToPinnedCopy,
+    pinnedCardToOriginal,
+    cardStepIndex: cardStepIndexMap,
+    cardMetadataMap,
+  };
+  for (const cardToPin of nonPinnedCardsWithMatch) {
+    stateWithResolvedPins = buildOrReturnStateWithPinnedCopy(
+      cardToPin,
+      stateWithResolvedPins.cardToPinnedCopy,
+      stateWithResolvedPins.pinnedCardToOriginal,
+      stateWithResolvedPins.cardStepIndex,
+      stateWithResolvedPins.cardMetadataMap
+    );
+  }
+
+  return {
+    ...stateWithResolvedPins,
+    unresolvedImportedPinnedCards: [...unresolvedPinSet],
+  };
+}
+
+/**
+ * Return the state produced by creating a new pinned copy of the provided card.
+ * May throw if the card provided has no metadata.
+ */
+export function buildOrReturnStateWithPinnedCopy(
+  cardId: NonPinnedCardId,
+  cardToPinnedCopy: CardToPinnedCard,
+  pinnedCardToOriginal: PinnedCardToCard,
+  cardStepIndexMap: CardStepIndexMap,
+  cardMetadataMap: CardMetadataMap
+): ResolvedPinPartialState {
+  // No-op if the card already has a pinned copy.
+  if (cardToPinnedCopy.has(cardId)) {
+    return {
+      cardToPinnedCopy,
+      pinnedCardToOriginal,
+      cardStepIndex: cardStepIndexMap,
+      cardMetadataMap,
+    };
+  }
+
+  const nextCardToPinnedCopy = new Map(cardToPinnedCopy);
+  const nextPinnedCardToOriginal = new Map(pinnedCardToOriginal);
+  const nextCardStepIndexMap = {...cardStepIndexMap};
+  const nextCardMetadataMap = {...cardMetadataMap};
+
+  // Create a pinned copy. Copies step index from the original card.
+  const pinnedCardId = getPinnedCardId(cardId);
+  nextCardToPinnedCopy.set(cardId, pinnedCardId);
+  nextPinnedCardToOriginal.set(pinnedCardId, cardId);
+  if (cardStepIndexMap.hasOwnProperty(cardId)) {
+    nextCardStepIndexMap[pinnedCardId] = cardStepIndexMap[cardId];
+  }
+
+  const metadata = cardMetadataMap[cardId];
+  if (!metadata) {
+    throw new Error('Cannot pin a card without metadata');
+  }
+  nextCardMetadataMap[pinnedCardId] = metadata;
+
+  return {
+    cardToPinnedCopy: nextCardToPinnedCopy,
+    pinnedCardToOriginal: nextPinnedCardToOriginal,
+    cardStepIndex: nextCardStepIndexMap,
+    cardMetadataMap: nextCardMetadataMap,
+  };
 }

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -15,12 +15,15 @@ limitations under the License.
 import {DataLoadState} from '../../types/data';
 
 import {PluginType} from '../data_source';
-import {buildTagMetadata} from '../testing';
+import {buildTagMetadata, createCardMetadata} from '../testing';
 
 import {
+  buildOrReturnStateWithPinnedCopy,
+  buildOrReturnStateWithUnresolvedImportedPins,
   createPluginDataWithLoadable,
   createRunToLoadState,
   getCardId,
+  getPinnedCardId,
   getRunIds,
   getTimeSeriesLoadable,
 } from './metrics_store_internal_utils';
@@ -341,6 +344,93 @@ describe('metrics store utils', () => {
           4 /* sample */
         )
       ).toEqual(['run1', 'run3']);
+    });
+  });
+
+  describe('buildOrReturnStateWithUnresolvedImportedPins', () => {
+    it('resolves imported pins', () => {
+      const matchingInfo = {plugin: PluginType.SCALARS, tag: 'accuracy'};
+      const nonMatchingInfo = {plugin: PluginType.SCALARS, tag: 'accuracy2'};
+      const result = buildOrReturnStateWithUnresolvedImportedPins(
+        [matchingInfo, nonMatchingInfo],
+        ['card1'],
+        {card1: {plugin: PluginType.SCALARS, tag: 'accuracy', runId: null}},
+        new Map(),
+        new Map(),
+        {card1: 2}
+      );
+
+      const pinnedCardId = getPinnedCardId('card1');
+      expect(result.unresolvedImportedPinnedCards).toEqual([nonMatchingInfo]);
+      expect(result.cardToPinnedCopy).toEqual(
+        new Map([['card1', pinnedCardId]])
+      );
+      expect(result.pinnedCardToOriginal).toEqual(
+        new Map([[pinnedCardId, 'card1']])
+      );
+    });
+  });
+
+  describe('buildOrReturnStateWithPinnedCopy', () => {
+    it('adds a pinned copy properly', () => {
+      const {
+        cardToPinnedCopy,
+        pinnedCardToOriginal,
+        cardStepIndex,
+        cardMetadataMap,
+      } = buildOrReturnStateWithPinnedCopy(
+        'card1',
+        new Map(),
+        new Map(),
+        {card1: 2},
+        {card1: createCardMetadata()}
+      );
+      const pinnedCardId = getPinnedCardId('card1');
+
+      expect(cardToPinnedCopy).toEqual(new Map([['card1', pinnedCardId]]));
+      expect(pinnedCardToOriginal).toEqual(new Map([[pinnedCardId, 'card1']]));
+      expect(cardStepIndex).toEqual({
+        card1: 2,
+        [pinnedCardId]: 2,
+      });
+      expect(cardMetadataMap).toEqual({
+        card1: createCardMetadata(),
+        [pinnedCardId]: createCardMetadata(),
+      });
+    });
+
+    it('throws if the original card does not have metadata', () => {
+      expect(() => {
+        buildOrReturnStateWithPinnedCopy('card1', new Map(), new Map(), {}, {});
+      }).toThrow();
+    });
+
+    it('no-ops if the card already has a pinned copy', () => {
+      const cardToPinnedCopy = new Map([['card1', 'card-pin1']]);
+      const pinnedCardToOriginal = new Map([['card-pin1', 'card1']]);
+      const cardStepIndexMap = {};
+      const cardMetadataMap = {card1: createCardMetadata()};
+      const originals = {
+        cardToPinnedCopy: new Map(cardToPinnedCopy),
+        pinnedCardToOriginal: new Map(pinnedCardToOriginal),
+        cardStepIndexMap: {...cardStepIndexMap},
+        cardMetadataMap: {...cardMetadataMap},
+      };
+
+      const result = buildOrReturnStateWithPinnedCopy(
+        'card1',
+        cardToPinnedCopy,
+        pinnedCardToOriginal,
+        cardStepIndexMap,
+        cardMetadataMap
+      );
+
+      expect(result.cardToPinnedCopy).toEqual(originals.cardToPinnedCopy);
+      expect(result.pinnedCardToOriginal).toEqual(
+        originals.pinnedCardToOriginal
+      );
+      expect(result.cardStepIndex).toEqual(originals.cardStepIndexMap);
+      expect(result.cardMetadataMap).toEqual(originals.cardMetadataMap);
     });
   });
 });

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -27,7 +27,7 @@ import {
 } from '../data_source';
 import {
   CardId,
-  CardInStorage,
+  CardUniqueInfo,
   CardMetadata,
   HistogramMode,
   NonPinnedCardId,
@@ -138,11 +138,13 @@ export interface MetricsRoutefulState {
   cardToPinnedCopy: CardToPinnedCard;
   pinnedCardToOriginal: PinnedCardToCard;
   /**
-   * Pinned cards from storage that do not yet have a corresponding card
-   * (e.g. tag metadata might not be loaded yet). A pinned card exists either in
-   * prePinnedCards or in pinnedCardToOriginal, but not both.
+   * Pinned cards imported from storage that do not yet have a corresponding
+   * card (e.g. tag metadata might not be loaded yet). Resolving an imported
+   * card requires comparing its CardUniqueInfo to a resolved card. After
+   * resolution, it is removed from this collection and added to the
+   * appropriate data structures (e.g. pinnedCardToOriginal).
    */
-  prePinnedCards: CardInStorage[];
+  unresolvedImportedPinnedCards: CardUniqueInfo[];
   cardMetadataMap: CardMetadataMap;
   cardStepIndex: CardStepIndexMap;
   tagFilter: string;

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -27,6 +27,7 @@ import {
 } from '../data_source';
 import {
   CardId,
+  CardInStorage,
   CardMetadata,
   HistogramMode,
   NonPinnedCardId,
@@ -125,13 +126,23 @@ export type CardStepIndexMap = Record<
   number | null
 >;
 
+export type CardToPinnedCard = Map<NonPinnedCardId, PinnedCardId>;
+
+export type PinnedCardToCard = Map<PinnedCardId, NonPinnedCardId>;
+
 export interface MetricsRoutefulState {
   tagMetadataLoaded: DataLoadState;
   tagMetadata: TagMetadata;
   // A list of card ids in the main content area, excluding pinned copies.
   cardList: NonPinnedCardId[];
-  cardToPinnedCopy: Map<NonPinnedCardId, PinnedCardId>;
-  pinnedCardToOriginal: Map<PinnedCardId, NonPinnedCardId>;
+  cardToPinnedCopy: CardToPinnedCard;
+  pinnedCardToOriginal: PinnedCardToCard;
+  /**
+   * Pinned cards from storage that do not yet have a corresponding card
+   * (e.g. tag metadata might not be loaded yet). A pinned card exists either in
+   * prePinnedCards or in pinnedCardToOriginal, but not both.
+   */
+  prePinnedCards: CardInStorage[];
   cardMetadataMap: CardMetadataMap;
   cardStepIndex: CardStepIndexMap;
   tagFilter: string;

--- a/tensorboard/webapp/metrics/store/metrics_types.ts
+++ b/tensorboard/webapp/metrics/store/metrics_types.ts
@@ -143,6 +143,8 @@ export interface MetricsRoutefulState {
    * card requires comparing its CardUniqueInfo to a resolved card. After
    * resolution, it is removed from this collection and added to the
    * appropriate data structures (e.g. pinnedCardToOriginal).
+   *
+   * These may become stale if runs are deleted from the experiment.
    */
   unresolvedImportedPinnedCards: CardUniqueInfo[];
   cardMetadataMap: CardMetadataMap;

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -83,6 +83,7 @@ function buildBlankState(): MetricsState {
     cardList: [],
     cardToPinnedCopy: new Map(),
     pinnedCardToOriginal: new Map(),
+    prePinnedCards: [],
     cardMetadataMap: {},
     cardStepIndex: {},
     visibleCards: new Set(),

--- a/tensorboard/webapp/metrics/testing.ts
+++ b/tensorboard/webapp/metrics/testing.ts
@@ -83,7 +83,7 @@ function buildBlankState(): MetricsState {
     cardList: [],
     cardToPinnedCopy: new Map(),
     pinnedCardToOriginal: new Map(),
-    prePinnedCards: [],
+    unresolvedImportedPinnedCards: [],
     cardMetadataMap: {},
     cardStepIndex: {},
     visibleCards: new Set(),

--- a/tensorboard/webapp/metrics/types.ts
+++ b/tensorboard/webapp/metrics/types.ts
@@ -51,3 +51,21 @@ export type CardId = NonPinnedCardId | PinnedCardId;
 export type CardIdWithMetadata = CardMetadata & {
   cardId: CardId;
 };
+
+/**
+ * The normal representation of a card, for storage layers.
+ */
+export interface CardInStorage {
+  tag: string;
+  runId?: string;
+  sample?: number;
+}
+
+/**
+ * The state after deserializing a URL for hydration.
+ */
+export interface URLDeserializedState {
+  metrics: {
+    pinnedCards: CardInStorage[];
+  };
+}

--- a/tensorboard/webapp/metrics/types.ts
+++ b/tensorboard/webapp/metrics/types.ts
@@ -58,18 +58,19 @@ export type CardIdWithMetadata = CardMetadata & {
 };
 
 /**
- * The most minimal representation of a card that uniquely identifies it.
- * This information can be used in storage layers (e.g. URL) and may be matched
- * against an existing card with the same metadata.
+ * The most minimal representation of a card that uniquely identifies it across
+ * a browser session. This information may be persisted in storage, retrieved,
+ * and used to match against an existing card with the same metadata.
  */
 export interface CardUniqueInfo {
+  plugin: string;
   tag: string;
   runId?: string;
   sample?: number;
 }
 
 /**
- * The state after deserializing a URL for hydration.
+ * The metrics-related state created by deserializing a URL.
  */
 export interface URLDeserializedState {
   metrics: {

--- a/tensorboard/webapp/metrics/types.ts
+++ b/tensorboard/webapp/metrics/types.ts
@@ -46,6 +46,11 @@ export type NonPinnedCardId = string;
 
 export type PinnedCardId = string;
 
+/**
+ * A unique identifier to a specific card instance in the UI. This is an opaque
+ * ID, meaning that consumers should never peer into/parse it and never assume
+ * that it will always be a string.
+ */
 export type CardId = NonPinnedCardId | PinnedCardId;
 
 export type CardIdWithMetadata = CardMetadata & {
@@ -53,9 +58,11 @@ export type CardIdWithMetadata = CardMetadata & {
 };
 
 /**
- * The normal representation of a card, for storage layers.
+ * The most minimal representation of a card that uniquely identifies it.
+ * This information can be used in storage layers (e.g. URL) and may be matched
+ * against an existing card with the same metadata.
  */
-export interface CardInStorage {
+export interface CardUniqueInfo {
   tag: string;
   runId?: string;
   sample?: number;
@@ -66,6 +73,6 @@ export interface CardInStorage {
  */
 export interface URLDeserializedState {
   metrics: {
-    pinnedCards: CardInStorage[];
+    pinnedCards: CardUniqueInfo[];
   };
 }


### PR DESCRIPTION
Diffbase: https://github.com/tensorflow/tensorboard/pull/4219
Followup: https://github.com/tensorflow/tensorboard/pull/4221

Adds ngrx reducer logic and types to support storing
pinned cards that originate from URL storage. Before
'tagMetadataLoaded' creates real cards, TensorBoard is now
able to keep track of pinned cards from the URL, in the ngrx
store.

A followup will implement the actual deeplink provider.

Googlers, see test sync cl/335717460