### PR TITLE
Add feature flag ngrx selector for Colab environment

### DIFF
--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -42,6 +42,8 @@ import {routesFactory} from './routes';
 @NgModule({
   declarations: [AppContainer],
   imports: [
+    // Ensure feature flags are enabled before they are consumed.
+    FeatureFlagModule,
     BrowserModule,
     BrowserAnimationsModule,
     AppRoutingModule,
@@ -50,7 +52,6 @@ import {routesFactory} from './routes';
     TensorBoardWrapperModule,
     CoreModule,
     ExperimentsModule,
-    FeatureFlagModule,
     HashStorageModule,
     HeaderModule,
     MatIconModule,

--- a/tensorboard/webapp/feature_flag/actions/BUILD
+++ b/tensorboard/webapp/feature_flag/actions/BUILD
@@ -9,6 +9,7 @@ ng_module(
     ],
     deps = [
         "//tensorboard/webapp/feature_flag:types",
+        "//tensorboard/webapp/feature_flag/store:types",
         "@npm//@ngrx/store",
     ],
 )

--- a/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
+++ b/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
@@ -24,6 +24,6 @@ import {FeatureValue} from '../types';
 export const featuresLoaded = createAction(
   '[FEATURE FLAG] Features Loaded',
   props<{
-    features: Partial<FeatureFlags>;
+    features: FeatureFlags;
   }>()
 );

--- a/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
+++ b/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
@@ -15,6 +15,7 @@ limitations under the License.
 
 import {createAction, props} from '@ngrx/store';
 
+import {FeatureFlags} from '../store/feature_flag_types';
 import {FeatureValue} from '../types';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
@@ -23,6 +24,6 @@ import {FeatureValue} from '../types';
 export const featuresLoaded = createAction(
   '[FEATURE FLAG] Features Loaded',
   props<{
-    features: {[featureKey: string]: FeatureValue};
+    features: Partial<FeatureFlags>;
   }>()
 );

--- a/tensorboard/webapp/feature_flag/store/BUILD
+++ b/tensorboard/webapp/feature_flag/store/BUILD
@@ -10,7 +10,6 @@ ng_module(
     ],
     deps = [
         ":types",
-        "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/feature_flag:types",
         "//tensorboard/webapp/feature_flag/actions",
         "//tensorboard/webapp/webapp_data_source:feature_flag",

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -19,13 +19,24 @@ import {FeatureFlagState} from './feature_flag_types';
 /** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
 
 const initialState: FeatureFlagState = {
-  enabledExperimentalPlugins: [],
+  isFeatureFlagsLoaded: false,
+  features: {
+    enabledExperimentalPlugins: [],
+    inColab: false,
+  },
 };
 
 const reducer = createReducer<FeatureFlagState>(
   initialState,
   on(actions.featuresLoaded, (state, {features}) => {
-    return {...state, ...features};
+    return {
+      ...state,
+      isFeatureFlagsLoaded: true,
+      features: {
+        ...state.features,
+        ...features,
+      },
+    };
   })
 );
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
@@ -20,7 +20,10 @@ describe('feature_flag_reducers', () => {
   describe('featuresLoaded', () => {
     it('sets the new feature flags onto the state', () => {
       const prevState = buildFeatureFlagState({
-        enabledExperimentalPlugins: ['foo'],
+        isFeatureFlagsLoaded: false,
+        features: {
+          enabledExperimentalPlugins: ['foo'],
+        },
       });
       const nextState = reducers(
         prevState,
@@ -31,12 +34,17 @@ describe('feature_flag_reducers', () => {
         })
       );
 
-      expect(nextState.enabledExperimentalPlugins).toEqual(['foo', 'bar']);
+      expect(nextState.features.enabledExperimentalPlugins).toEqual([
+        'foo',
+        'bar',
+      ]);
     });
 
     it('sets the feature value of other features', () => {
       const prevState = buildFeatureFlagState({
-        enabledExperimentalPlugins: [],
+        features: {
+          enabledExperimentalPlugins: [],
+        },
       });
       const nextState = reducers(
         prevState,
@@ -48,7 +56,7 @@ describe('feature_flag_reducers', () => {
         })
       );
 
-      expect(nextState['enableMagicalFeature']).toBe(true);
+      expect(nextState.features['enableMagicalFeature']).toBe(true);
     });
   });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -16,6 +16,7 @@ limitations under the License.
 import {createSelector, createFeatureSelector} from '@ngrx/store';
 
 import {
+  FeatureFlags,
   FeatureFlagState,
   FEAUTURE_FLAG_FEATURE_KEY,
   State,
@@ -28,19 +29,30 @@ const selectFeatureFlagState = createFeatureSelector<State, FeatureFlagState>(
   FEAUTURE_FLAG_FEATURE_KEY
 );
 
+export const getIsFeatureFlagsLoaded = createSelector(
+  selectFeatureFlagState,
+  (state) => {
+    return state.isFeatureFlagsLoaded;
+  }
+);
+
 export const getFeature = createSelector(
   selectFeatureFlagState,
   (
     state: FeatureFlagState,
-    featureId: keyof FeatureFlagState
+    featureId: keyof FeatureFlags
   ): FeatureValue | null => {
-    return state[featureId] || null;
+    return state.features[featureId] || null;
   }
 );
 
 export const getEnabledExperimentalPlugins = createSelector(
   selectFeatureFlagState,
   (state) => {
-    return state.enabledExperimentalPlugins as string[];
+    return state.features.enabledExperimentalPlugins || [];
   }
 );
+
+export const getIsInColab = createSelector(selectFeatureFlagState, (state) => {
+  return !!state.features.inColab;
+});

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -58,4 +58,26 @@ describe('feature_flag_selectors', () => {
       expect(actual).toEqual(['bar']);
     });
   });
+
+  describe('getIsInColab', () => {
+    it('returns the proper value', () => {
+      let state = buildState(
+        buildFeatureFlagState({
+          features: {
+            inColab: true,
+          },
+        })
+      );
+      expect(selectors.getIsInColab(state)).toEqual(true);
+
+      state = buildState(
+        buildFeatureFlagState({
+          features: {
+            inColab: false,
+          },
+        })
+      );
+      expect(selectors.getIsInColab(state)).toEqual(false);
+    });
+  });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -20,7 +20,9 @@ describe('feature_flag_selectors', () => {
     it('returns a current feature', () => {
       const state = buildState(
         buildFeatureFlagState({
-          enableMagicFeature: true,
+          features: {
+            enableMagicFeature: true,
+          },
         })
       );
       const actual = selectors.getFeature(state, 'enableMagicFeature');
@@ -31,7 +33,9 @@ describe('feature_flag_selectors', () => {
     it('returns null if the value is not present', () => {
       const state = buildState(
         buildFeatureFlagState({
-          enabledExperimentalPlugins: ['foo'],
+          features: {
+            enabledExperimentalPlugins: ['foo'],
+          },
         })
       );
       const actual = selectors.getFeature(state, 'bar');
@@ -44,7 +48,9 @@ describe('feature_flag_selectors', () => {
     it('returns value in array', () => {
       const state = buildState(
         buildFeatureFlagState({
-          enabledExperimentalPlugins: ['bar'],
+          features: {
+            enabledExperimentalPlugins: ['bar'],
+          },
         })
       );
       const actual = selectors.getFeature(state, 'enabledExperimentalPlugins');

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -17,9 +17,15 @@ import {FeatureValue} from '../types';
 
 export const FEAUTURE_FLAG_FEATURE_KEY = 'feature';
 
+export interface FeatureFlags {
+  enabledExperimentalPlugins?: string[];
+  inColab?: boolean;
+  [featureId: string]: FeatureValue | undefined;
+}
+
 export interface FeatureFlagState {
-  enabledExperimentalPlugins: string[];
-  [featureId: string]: FeatureValue;
+  isFeatureFlagsLoaded: boolean;
+  features: FeatureFlags;
 }
 
 export interface State {

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -18,10 +18,18 @@ import {
   FEAUTURE_FLAG_FEATURE_KEY,
 } from './feature_flag_types';
 
-export function buildFeatureFlagState(override: Partial<FeatureFlagState>) {
+export function buildFeatureFlagState(
+  override: Partial<FeatureFlagState> = {}
+) {
+  const {features: featuresOverride, ...restOverride} = override;
   return {
-    enabledExperimentalPlugins: ['foo'],
-    ...override,
+    isFeatureFlagsLoaded: false,
+    ...restOverride,
+    features: {
+      enabledExperimentalPlugins: ['foo'],
+      inColab: false,
+      ...featuresOverride,
+    },
   };
 }
 

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -33,6 +33,7 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
     const params = util.getParams();
     return {
       enabledExperimentalPlugins: params.getAll('experimentalPlugin'),
+      inColab: params.get('tensorboardColab') === 'true',
     };
   }
 }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -37,6 +37,27 @@ describe('tb_feature_flag_data_source', () => {
         );
         expect(dataSource.getFeatures()).toEqual({
           enabledExperimentalPlugins: ['a', 'b'],
+          inColab: false,
+        });
+      });
+
+      it('returns isInColab when true', () => {
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+          new URLSearchParams('tensorboardColab=true')
+        );
+        expect(dataSource.getFeatures()).toEqual({
+          enabledExperimentalPlugins: [],
+          inColab: true,
+        });
+      });
+
+      it('returns isInColab when false', () => {
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+          new URLSearchParams('tensorboardColab=false')
+        );
+        expect(dataSource.getFeatures()).toEqual({
+          enabledExperimentalPlugins: [],
+          inColab: false,
         });
       });
 
@@ -46,6 +67,7 @@ describe('tb_feature_flag_data_source', () => {
         );
         expect(dataSource.getFeatures()).toEqual({
           enabledExperimentalPlugins: [],
+          inColab: false,
         });
       });
     });


### PR DESCRIPTION
Followup: https://github.com/tensorflow/tensorboard/pull/4224

Introduces a selector on the ngrx FeatureFlagModule to detect
whether the app is opened within a Colab environment, using
the existing `?tensorboardColab=true` scheme.

Code in both Angular and Polymer codebases already detect
this URL queryParam. This change just makes it readable from
the ngrx store.

Googlers, see test sync cl/336078907