### PR TITLE
Avoid POST requests in TBHttpClient when in Colab

### DIFF
--- a/tensorboard/plugins/metrics/metrics_plugin.py
+++ b/tensorboard/plugins/metrics/metrics_plugin.py
@@ -332,7 +332,10 @@ class MetricsPlugin(base_plugin.TBPlugin):
     def _serve_time_series(self, request):
         ctx = plugin_util.context(request.environ)
         experiment = plugin_util.experiment_id(request.environ)
-        series_requests_string = request.form.get("requests")
+        if request.method == "POST":
+            series_requests_string = request.form.get("requests")
+        else:
+            series_requests_string = request.args.get("requests")
         if not series_requests_string:
             raise errors.InvalidArgumentError("Missing 'requests' field")
         try:

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -258,6 +258,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/tbdev_upload:test_lib",
         "//tensorboard/webapp/util:util_tests",
         "//tensorboard/webapp/webapp_data_source:feature_flag_test_lib",
+        "//tensorboard/webapp/webapp_data_source:http_client_test",
         "//tensorboard/webapp/webapp_data_source:webapp_data_source_test_lib",
         "//tensorboard/webapp/widgets:resize_detector_test",
         "//tensorboard/webapp/widgets:resize_detector_testing",

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -42,6 +42,8 @@ import {routesFactory} from './routes';
 @NgModule({
   declarations: [AppContainer],
   imports: [
+    // Ensure feature flags are enabled before they are consumed.
+    FeatureFlagModule,
     BrowserModule,
     BrowserAnimationsModule,
     AppRoutingModule,
@@ -50,7 +52,6 @@ import {routesFactory} from './routes';
     TensorBoardWrapperModule,
     CoreModule,
     ExperimentsModule,
-    FeatureFlagModule,
     HashStorageModule,
     HeaderModule,
     MatIconModule,

--- a/tensorboard/webapp/feature_flag/actions/BUILD
+++ b/tensorboard/webapp/feature_flag/actions/BUILD
@@ -9,6 +9,7 @@ ng_module(
     ],
     deps = [
         "//tensorboard/webapp/feature_flag:types",
+        "//tensorboard/webapp/feature_flag/store:types",
         "@npm//@ngrx/store",
     ],
 )

--- a/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
+++ b/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
@@ -24,6 +24,6 @@ import {FeatureValue} from '../types';
 export const featuresLoaded = createAction(
   '[FEATURE FLAG] Features Loaded',
   props<{
-    features: Partial<FeatureFlags>;
+    features: FeatureFlags;
   }>()
 );

--- a/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
+++ b/tensorboard/webapp/feature_flag/actions/feature_flag_actions.ts
@@ -15,6 +15,7 @@ limitations under the License.
 
 import {createAction, props} from '@ngrx/store';
 
+import {FeatureFlags} from '../store/feature_flag_types';
 import {FeatureValue} from '../types';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
@@ -23,6 +24,6 @@ import {FeatureValue} from '../types';
 export const featuresLoaded = createAction(
   '[FEATURE FLAG] Features Loaded',
   props<{
-    features: {[featureKey: string]: FeatureValue};
+    features: Partial<FeatureFlags>;
   }>()
 );

--- a/tensorboard/webapp/feature_flag/store/BUILD
+++ b/tensorboard/webapp/feature_flag/store/BUILD
@@ -10,7 +10,6 @@ ng_module(
     ],
     deps = [
         ":types",
-        "//tensorboard/webapp:app_state",
         "//tensorboard/webapp/feature_flag:types",
         "//tensorboard/webapp/feature_flag/actions",
         "//tensorboard/webapp/webapp_data_source:feature_flag",

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers.ts
@@ -19,13 +19,24 @@ import {FeatureFlagState} from './feature_flag_types';
 /** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
 
 const initialState: FeatureFlagState = {
-  enabledExperimentalPlugins: [],
+  isFeatureFlagsLoaded: false,
+  features: {
+    enabledExperimentalPlugins: [],
+    inColab: false,
+  },
 };
 
 const reducer = createReducer<FeatureFlagState>(
   initialState,
   on(actions.featuresLoaded, (state, {features}) => {
-    return {...state, ...features};
+    return {
+      ...state,
+      isFeatureFlagsLoaded: true,
+      features: {
+        ...state.features,
+        ...features,
+      },
+    };
   })
 );
 

--- a/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_reducers_test.ts
@@ -20,7 +20,10 @@ describe('feature_flag_reducers', () => {
   describe('featuresLoaded', () => {
     it('sets the new feature flags onto the state', () => {
       const prevState = buildFeatureFlagState({
-        enabledExperimentalPlugins: ['foo'],
+        isFeatureFlagsLoaded: false,
+        features: {
+          enabledExperimentalPlugins: ['foo'],
+        },
       });
       const nextState = reducers(
         prevState,
@@ -31,12 +34,17 @@ describe('feature_flag_reducers', () => {
         })
       );
 
-      expect(nextState.enabledExperimentalPlugins).toEqual(['foo', 'bar']);
+      expect(nextState.features.enabledExperimentalPlugins).toEqual([
+        'foo',
+        'bar',
+      ]);
     });
 
     it('sets the feature value of other features', () => {
       const prevState = buildFeatureFlagState({
-        enabledExperimentalPlugins: [],
+        features: {
+          enabledExperimentalPlugins: [],
+        },
       });
       const nextState = reducers(
         prevState,
@@ -48,7 +56,7 @@ describe('feature_flag_reducers', () => {
         })
       );
 
-      expect(nextState['enableMagicalFeature']).toBe(true);
+      expect(nextState.features['enableMagicalFeature']).toBe(true);
     });
   });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors.ts
@@ -16,6 +16,7 @@ limitations under the License.
 import {createSelector, createFeatureSelector} from '@ngrx/store';
 
 import {
+  FeatureFlags,
   FeatureFlagState,
   FEAUTURE_FLAG_FEATURE_KEY,
   State,
@@ -28,19 +29,30 @@ const selectFeatureFlagState = createFeatureSelector<State, FeatureFlagState>(
   FEAUTURE_FLAG_FEATURE_KEY
 );
 
+export const getIsFeatureFlagsLoaded = createSelector(
+  selectFeatureFlagState,
+  (state) => {
+    return state.isFeatureFlagsLoaded;
+  }
+);
+
 export const getFeature = createSelector(
   selectFeatureFlagState,
   (
     state: FeatureFlagState,
-    featureId: keyof FeatureFlagState
+    featureId: keyof FeatureFlags
   ): FeatureValue | null => {
-    return state[featureId] || null;
+    return state.features[featureId] || null;
   }
 );
 
 export const getEnabledExperimentalPlugins = createSelector(
   selectFeatureFlagState,
   (state) => {
-    return state.enabledExperimentalPlugins as string[];
+    return state.features.enabledExperimentalPlugins || [];
   }
 );
+
+export const getIsInColab = createSelector(selectFeatureFlagState, (state) => {
+  return !!state.features.inColab;
+});

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -58,4 +58,26 @@ describe('feature_flag_selectors', () => {
       expect(actual).toEqual(['bar']);
     });
   });
+
+  describe('getIsInColab', () => {
+    it('returns the proper value', () => {
+      let state = buildState(
+        buildFeatureFlagState({
+          features: {
+            inColab: true,
+          },
+        })
+      );
+      expect(selectors.getIsInColab(state)).toEqual(true);
+
+      state = buildState(
+        buildFeatureFlagState({
+          features: {
+            inColab: false,
+          },
+        })
+      );
+      expect(selectors.getIsInColab(state)).toEqual(false);
+    });
+  });
 });

--- a/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_selectors_test.ts
@@ -20,7 +20,9 @@ describe('feature_flag_selectors', () => {
     it('returns a current feature', () => {
       const state = buildState(
         buildFeatureFlagState({
-          enableMagicFeature: true,
+          features: {
+            enableMagicFeature: true,
+          },
         })
       );
       const actual = selectors.getFeature(state, 'enableMagicFeature');
@@ -31,7 +33,9 @@ describe('feature_flag_selectors', () => {
     it('returns null if the value is not present', () => {
       const state = buildState(
         buildFeatureFlagState({
-          enabledExperimentalPlugins: ['foo'],
+          features: {
+            enabledExperimentalPlugins: ['foo'],
+          },
         })
       );
       const actual = selectors.getFeature(state, 'bar');
@@ -44,7 +48,9 @@ describe('feature_flag_selectors', () => {
     it('returns value in array', () => {
       const state = buildState(
         buildFeatureFlagState({
-          enabledExperimentalPlugins: ['bar'],
+          features: {
+            enabledExperimentalPlugins: ['bar'],
+          },
         })
       );
       const actual = selectors.getFeature(state, 'enabledExperimentalPlugins');

--- a/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
+++ b/tensorboard/webapp/feature_flag/store/feature_flag_types.ts
@@ -17,9 +17,15 @@ import {FeatureValue} from '../types';
 
 export const FEAUTURE_FLAG_FEATURE_KEY = 'feature';
 
+export interface FeatureFlags {
+  enabledExperimentalPlugins?: string[];
+  inColab?: boolean;
+  [featureId: string]: FeatureValue | undefined;
+}
+
 export interface FeatureFlagState {
-  enabledExperimentalPlugins: string[];
-  [featureId: string]: FeatureValue;
+  isFeatureFlagsLoaded: boolean;
+  features: FeatureFlags;
 }
 
 export interface State {

--- a/tensorboard/webapp/feature_flag/store/testing.ts
+++ b/tensorboard/webapp/feature_flag/store/testing.ts
@@ -18,10 +18,18 @@ import {
   FEAUTURE_FLAG_FEATURE_KEY,
 } from './feature_flag_types';
 
-export function buildFeatureFlagState(override: Partial<FeatureFlagState>) {
+export function buildFeatureFlagState(
+  override: Partial<FeatureFlagState> = {}
+) {
+  const {features: featuresOverride, ...restOverride} = override;
   return {
-    enabledExperimentalPlugins: ['foo'],
-    ...override,
+    isFeatureFlagsLoaded: false,
+    ...restOverride,
+    features: {
+      enabledExperimentalPlugins: ['foo'],
+      inColab: false,
+      ...featuresOverride,
+    },
   };
 }
 

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -64,9 +64,12 @@ ng_module(
         ":http_client",
         ":http_client_testing",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/core:types",
         "//tensorboard/webapp/feature_flag/store",
         "//tensorboard/webapp/feature_flag/store:store_test_lib",
+        "//tensorboard/webapp/feature_flag/store:types",
+        "@npm//@ngrx/store",
         "@npm//@types/jasmine",
     ],
 )
@@ -121,6 +124,9 @@ ng_module(
     deps = [
         ":http_client",
         "//tensorboard/webapp/angular:expect_angular_common_http_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
+        "//tensorboard/webapp/feature_flag/store:store_test_lib",
         "@npm//@angular/core",
+        "@npm//@ngrx/store",
     ],
 )

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -67,7 +67,6 @@ ng_module(
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "//tensorboard/webapp/core:types",
         "//tensorboard/webapp/feature_flag/store",
-        "//tensorboard/webapp/feature_flag/store:store_test_lib",
         "//tensorboard/webapp/feature_flag/store:types",
         "@npm//@ngrx/store",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/webapp_data_source/BUILD
+++ b/tensorboard/webapp/webapp_data_source/BUILD
@@ -42,9 +42,32 @@ ng_module(
     ],
     deps = [
         "//tensorboard/webapp/angular:expect_angular_common_http",
+        "//tensorboard/webapp/feature_flag",
+        "//tensorboard/webapp/feature_flag:types",
+        "//tensorboard/webapp/feature_flag/store",
+        "//tensorboard/webapp/feature_flag/store:types",
         "@npm//@angular/common",
         "@npm//@angular/core",
+        "@npm//@ngrx/store",
         "@npm//rxjs",
+    ],
+)
+
+ng_module(
+    name = "http_client_test",
+    testonly = True,
+    srcs = [
+        "tb_http_client_test.ts",
+    ],
+    deps = [
+        ":feature_flag_testing",
+        ":http_client",
+        ":http_client_testing",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/core:types",
+        "//tensorboard/webapp/feature_flag/store",
+        "//tensorboard/webapp/feature_flag/store:store_test_lib",
+        "@npm//@types/jasmine",
     ],
 )
 

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source.ts
@@ -33,6 +33,7 @@ export class QueryParamsFeatureFlagDataSource extends TBFeatureFlagDataSource {
     const params = util.getParams();
     return {
       enabledExperimentalPlugins: params.getAll('experimentalPlugin'),
+      inColab: params.get('tensorboardColab') === 'true',
     };
   }
 }

--- a/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_feature_flag_data_source_test.ts
@@ -37,6 +37,27 @@ describe('tb_feature_flag_data_source', () => {
         );
         expect(dataSource.getFeatures()).toEqual({
           enabledExperimentalPlugins: ['a', 'b'],
+          inColab: false,
+        });
+      });
+
+      it('returns isInColab when true', () => {
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+          new URLSearchParams('tensorboardColab=true')
+        );
+        expect(dataSource.getFeatures()).toEqual({
+          enabledExperimentalPlugins: [],
+          inColab: true,
+        });
+      });
+
+      it('returns isInColab when false', () => {
+        spyOn(TEST_ONLY.util, 'getParams').and.returnValue(
+          new URLSearchParams('tensorboardColab=false')
+        );
+        expect(dataSource.getFeatures()).toEqual({
+          enabledExperimentalPlugins: [],
+          inColab: false,
         });
       });
 
@@ -46,6 +67,7 @@ describe('tb_feature_flag_data_source', () => {
         );
         expect(dataSource.getFeatures()).toEqual({
           enabledExperimentalPlugins: [],
+          inColab: false,
         });
       });
     });

--- a/tensorboard/webapp/webapp_data_source/tb_http_client.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client.ts
@@ -14,7 +14,18 @@ limitations under the License.
 ==============================================================================*/
 import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
+import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
+import {filter, mergeMap, take, withLatestFrom} from 'rxjs/operators';
+
+// Intentionally import directly from feature_flag/, not the hourglass
+// AppState/selectors. AppState depends on code from feature directories that
+// use TBHttpClient themselves, so we avoid a possible circular dependency.
+import {State} from '../feature_flag/store/feature_flag_types';
+import {
+  getIsFeatureFlagsLoaded,
+  getIsInColab,
+} from '../feature_flag/store/feature_flag_selectors';
 
 import {
   DeleteOptions,
@@ -26,9 +37,20 @@ import {
 
 export {HttpErrorResponse} from '@angular/common/http';
 
+function convertFormDataToObject(formData: FormData) {
+  const result = {} as {[param: string]: string | string[]};
+  for (const [key, value] of formData.entries()) {
+    result[key] = value as string;
+  }
+  return result;
+}
+
 @Injectable()
 export class TBHttpClient implements TBHttpClientInterface {
-  constructor(private http: HttpClient) {}
+  constructor(
+    private readonly http: HttpClient,
+    private readonly store: Store<State>
+  ) {}
 
   get<ResponseType>(
     path: string,
@@ -42,7 +64,24 @@ export class TBHttpClient implements TBHttpClientInterface {
     body: any,
     options: PostOptions = {}
   ): Observable<ResponseType> {
-    return this.http.post<ResponseType>(path, body, options);
+    // Google-internal Colab does not support HTTP POST requests, so we fall
+    // back to HTTP GET (even though public Colab supports POST)
+    // See b/72932164.
+    return this.store.select(getIsFeatureFlagsLoaded).pipe(
+      filter((isLoaded) => Boolean(isLoaded)),
+      take(1),
+      withLatestFrom(this.store.select(getIsInColab)),
+      mergeMap(([, isInColab]) => {
+        if (isInColab) {
+          const optionsForGet = {headers: options.headers} as GetOptions;
+          optionsForGet.params =
+            body instanceof FormData ? convertFormDataToObject(body) : body;
+          return this.http.get<ResponseType>(path, optionsForGet);
+        } else {
+          return this.http.post<ResponseType>(path, body, options);
+        }
+      })
+    );
   }
 
   put<ResponseType>(

--- a/tensorboard/webapp/webapp_data_source/tb_http_client_module.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client_module.ts
@@ -15,10 +15,9 @@ limitations under the License.
 import {NgModule} from '@angular/core';
 import {HttpClientModule} from '@angular/common/http';
 import {TBHttpClient} from './tb_http_client';
-import {FeatureFlagModule} from '../feature_flag/feature_flag_module';
 
 @NgModule({
-  imports: [HttpClientModule, FeatureFlagModule],
+  imports: [HttpClientModule],
   providers: [TBHttpClient],
 })
 export class TBHttpClientModule {}

--- a/tensorboard/webapp/webapp_data_source/tb_http_client_module.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client_module.ts
@@ -15,9 +15,10 @@ limitations under the License.
 import {NgModule} from '@angular/core';
 import {HttpClientModule} from '@angular/common/http';
 import {TBHttpClient} from './tb_http_client';
+import {FeatureFlagModule} from '../feature_flag/feature_flag_module';
 
 @NgModule({
-  imports: [HttpClientModule],
+  imports: [HttpClientModule, FeatureFlagModule],
   providers: [TBHttpClient],
 })
 export class TBHttpClientModule {}

--- a/tensorboard/webapp/webapp_data_source/tb_http_client_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client_test.ts
@@ -45,7 +45,8 @@ describe('TBHttpClient', () => {
   });
 
   it('waits for feature flags before making POST request', () => {
-    const body = {formKey: 'value'};
+    const body = new FormData();
+    body.append('formKey', 'value');
     store.overrideSelector(getIsFeatureFlagsLoaded, false);
     tbHttpClient.post('foo', body).subscribe(jasmine.createSpy());
     httpMock.expectNone('foo');
@@ -62,7 +63,8 @@ describe('TBHttpClient', () => {
   });
 
   it('makes POST requests when not in Colab', () => {
-    const body = {formKey: 'value'};
+    const body = new FormData();
+    body.append('formKey', 'value');
     store.overrideSelector(getIsFeatureFlagsLoaded, true);
     store.overrideSelector(getIsInColab, false);
     tbHttpClient.post('foo', body).subscribe(jasmine.createSpy());
@@ -76,20 +78,6 @@ describe('TBHttpClient', () => {
   });
 
   it('converts POST requests to GET when in Colab', () => {
-    const body = {formKey: 'value'};
-    store.overrideSelector(getIsFeatureFlagsLoaded, true);
-    store.overrideSelector(getIsInColab, true);
-    tbHttpClient.post('foo', body).subscribe(jasmine.createSpy());
-    httpMock.expectOne((req) => {
-      return (
-        req.method === 'GET' &&
-        req.urlWithParams === 'foo?formKey=value' &&
-        !req.body
-      );
-    });
-  });
-
-  it('converts POST requests with FormData to GET when in Colab', () => {
     const body = new FormData();
     body.append('formKey', 'value');
     store.overrideSelector(getIsFeatureFlagsLoaded, true);

--- a/tensorboard/webapp/webapp_data_source/tb_http_client_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client_test.ts
@@ -18,15 +18,14 @@ import {MockStore} from '@ngrx/store/testing';
 
 import {State} from '../feature_flag/store/feature_flag_types';
 import {
-  buildState as buildFeatureFlagAppState,
-  buildFeatureFlagState,
-} from '../feature_flag/store/testing';
-import {
   getIsFeatureFlagsLoaded,
   getIsInColab,
 } from '../feature_flag/store/feature_flag_selectors';
 import {TBFeatureFlagTestingModule} from './tb_feature_flag_testing';
-import {HttpTestingController, TBHttpClientTestingModule} from './tb_http_client_testing';
+import {
+  HttpTestingController,
+  TBHttpClientTestingModule,
+} from './tb_http_client_testing';
 import {TBHttpClient} from './tb_http_client';
 
 describe('TBHttpClient', () => {
@@ -37,9 +36,7 @@ describe('TBHttpClient', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TBFeatureFlagTestingModule, TBHttpClientTestingModule],
-      providers: [
-        TBHttpClient,
-      ],
+      providers: [TBHttpClient],
     }).compileComponents();
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;

--- a/tensorboard/webapp/webapp_data_source/tb_http_client_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client_test.ts
@@ -1,0 +1,112 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TestBed} from '@angular/core/testing';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {Store} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+
+import {State} from '../feature_flag/store/feature_flag_types';
+import {
+  buildState as buildFeatureFlagAppState,
+  buildFeatureFlagState,
+} from '../feature_flag/store/testing';
+import {
+  getIsFeatureFlagsLoaded,
+  getIsInColab,
+} from '../feature_flag/store/feature_flag_selectors';
+import {TBFeatureFlagTestingModule} from './tb_feature_flag_testing';
+import {HttpTestingController} from './tb_http_client_testing';
+import {TBHttpClient} from './tb_http_client';
+
+describe('TBHttpClient', () => {
+  let tbHttpClient: TBHttpClient;
+  let httpMock: HttpTestingController;
+  let store: MockStore<State>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TBFeatureFlagTestingModule, HttpClientTestingModule],
+      providers: [
+        provideMockStore({
+          initialState: buildFeatureFlagAppState(buildFeatureFlagState()),
+        }),
+        TBHttpClient,
+      ],
+    }).compileComponents();
+
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    httpMock = TestBed.inject(HttpTestingController);
+    tbHttpClient = TestBed.inject(TBHttpClient);
+  });
+
+  it('waits for feature flags before making POST request', () => {
+    const body = {formKey: 'value'};
+    tbHttpClient.post('foo', body).subscribe(jasmine.createSpy());
+    httpMock.expectNone('foo');
+
+    store.overrideSelector(getIsFeatureFlagsLoaded, true);
+    store.refreshState();
+    httpMock.expectOne((req) => {
+      return (
+        req.method === 'POST' &&
+        req.urlWithParams === 'foo' &&
+        JSON.stringify(req.body) === JSON.stringify(body)
+      );
+    });
+  });
+
+  it('makes POST requests when not in Colab', () => {
+    const body = {formKey: 'value'};
+    store.overrideSelector(getIsFeatureFlagsLoaded, true);
+    store.overrideSelector(getIsInColab, false);
+    tbHttpClient.post('foo', body).subscribe(jasmine.createSpy());
+    httpMock.expectOne((req) => {
+      return (
+        req.method === 'POST' &&
+        req.urlWithParams === 'foo' &&
+        JSON.stringify(req.body) === JSON.stringify(body)
+      );
+    });
+  });
+
+  it('converts POST requests to GET when in Colab', () => {
+    const body = {formKey: 'value'};
+    store.overrideSelector(getIsFeatureFlagsLoaded, true);
+    store.overrideSelector(getIsInColab, true);
+    tbHttpClient.post('foo', body).subscribe(jasmine.createSpy());
+    httpMock.expectOne((req) => {
+      return (
+        req.method === 'GET' &&
+        req.urlWithParams === 'foo?formKey=value' &&
+        !req.body
+      );
+    });
+  });
+
+  it('converts POST requests with FormData to GET when in Colab', () => {
+    const body = new FormData();
+    body.append('formKey', 'value');
+    store.overrideSelector(getIsFeatureFlagsLoaded, true);
+    store.overrideSelector(getIsInColab, true);
+    tbHttpClient.post('foo', body).subscribe(jasmine.createSpy());
+    httpMock.expectOne((req) => {
+      return (
+        req.method === 'GET' &&
+        req.urlWithParams === 'foo?formKey=value' &&
+        !req.body
+      );
+    });
+  });
+});

--- a/tensorboard/webapp/webapp_data_source/tb_http_client_test.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client_test.ts
@@ -13,9 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {TestBed} from '@angular/core/testing';
-import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {Store} from '@ngrx/store';
-import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {MockStore} from '@ngrx/store/testing';
 
 import {State} from '../feature_flag/store/feature_flag_types';
 import {
@@ -27,7 +26,7 @@ import {
   getIsInColab,
 } from '../feature_flag/store/feature_flag_selectors';
 import {TBFeatureFlagTestingModule} from './tb_feature_flag_testing';
-import {HttpTestingController} from './tb_http_client_testing';
+import {HttpTestingController, TBHttpClientTestingModule} from './tb_http_client_testing';
 import {TBHttpClient} from './tb_http_client';
 
 describe('TBHttpClient', () => {
@@ -37,11 +36,8 @@ describe('TBHttpClient', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TBFeatureFlagTestingModule, HttpClientTestingModule],
+      imports: [TBFeatureFlagTestingModule, TBHttpClientTestingModule],
       providers: [
-        provideMockStore({
-          initialState: buildFeatureFlagAppState(buildFeatureFlagState()),
-        }),
         TBHttpClient,
       ],
     }).compileComponents();
@@ -53,6 +49,7 @@ describe('TBHttpClient', () => {
 
   it('waits for feature flags before making POST request', () => {
     const body = {formKey: 'value'};
+    store.overrideSelector(getIsFeatureFlagsLoaded, false);
     tbHttpClient.post('foo', body).subscribe(jasmine.createSpy());
     httpMock.expectNone('foo');
 

--- a/tensorboard/webapp/webapp_data_source/tb_http_client_testing.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client_testing.ts
@@ -29,9 +29,11 @@ import {TBHttpClientModule} from './tb_http_client_module';
   imports: [TBHttpClientModule, HttpClientTestingModule],
   providers: [
     provideMockStore({
-      initialState: buildFeatureFlagAppState(buildFeatureFlagState({
-        isFeatureFlagsLoaded: true,
-      })),
+      initialState: buildFeatureFlagAppState(
+        buildFeatureFlagState({
+          isFeatureFlagsLoaded: true,
+        })
+      ),
     }),
   ],
 })

--- a/tensorboard/webapp/webapp_data_source/tb_http_client_testing.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client_testing.ts
@@ -16,10 +16,23 @@ export {HttpTestingController} from '@angular/common/http/testing';
 
 import {NgModule} from '@angular/core';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {provideMockStore} from '@ngrx/store/testing';
+
+import {
+  buildState as buildFeatureFlagAppState,
+  buildFeatureFlagState,
+} from '../feature_flag/store/testing';
 
 import {TBHttpClientModule} from './tb_http_client_module';
 
 @NgModule({
   imports: [TBHttpClientModule, HttpClientTestingModule],
+  providers: [
+    provideMockStore({
+      initialState: buildFeatureFlagAppState(buildFeatureFlagState({
+        isFeatureFlagsLoaded: true,
+      })),
+    }),
+  ],
 })
 export class TBHttpClientTestingModule {}

--- a/tensorboard/webapp/webapp_data_source/tb_http_client_types.ts
+++ b/tensorboard/webapp/webapp_data_source/tb_http_client_types.ts
@@ -16,7 +16,7 @@ import {HttpHeaders, HttpParams} from '@angular/common/http';
 import {Observable} from 'rxjs';
 
 export interface HttpOptions {
-  header?: HttpHeaders;
+  headers?: HttpHeaders;
   params?: HttpParams | {[paramKey: string]: string | string[]};
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "inlineSourceMap": true,
-    "lib": ["dom", "es2020"],
+    "lib": ["dom", "es2020", "dom.iterable"],
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
Diffbase: https://github.com/tensorflow/tensorboard/pull/4223

Time Series relies mainly on POST requests to the /timeSeries
endpoint. This change updates the Python plugin backend to
support GET requests.

In general, we'd like to fallback to GET instead of POST for any
frontend components that make network requests while in a
Colab environment, until internal Colab supports POST.

Manually checked via the DevTools network panel that opening
the Time Series dashboard makes GET requests when the URL
contains `?tensorboardColab=true`, and POST requests when
it does not.

Googlers, see test sync cl/336394977