### PR TITLE
histogram: update symbol name for TPU summary special-case

### DIFF
--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -99,7 +99,8 @@ def histogram(name, data, step=None, buckets=None, description=None):
     # TODO(https://github.com/tensorflow/tensorboard/issues/2885): Remove this special
     # handling once dynamic shapes are supported on TPU's.
     if isinstance(
-        tf.distribute.get_strategy(), tf.distribute.experimental.TPUStrategy
+        tf.distribute.get_strategy(),
+        (tf.distribute.experimental.TPUStrategy, tf.distribute.TPUStrategy)
     ):
         return tf.compat.v1.tpu.outside_compilation(
             histogram_summary, data, buckets, summary_metadata, step

--- a/tensorboard/plugins/histogram/summary_v2.py
+++ b/tensorboard/plugins/histogram/summary_v2.py
@@ -100,7 +100,7 @@ def histogram(name, data, step=None, buckets=None, description=None):
     # handling once dynamic shapes are supported on TPU's.
     if isinstance(
         tf.distribute.get_strategy(),
-        (tf.distribute.experimental.TPUStrategy, tf.distribute.TPUStrategy)
+        (tf.distribute.experimental.TPUStrategy, tf.distribute.TPUStrategy),
     ):
         return tf.compat.v1.tpu.outside_compilation(
             histogram_summary, data, buckets, summary_metadata, step


### PR DESCRIPTION
Check for tf.distribute.TPUStrategy for special handling since tf.distribute.experimental.TPUStrategy was renamed/deprecated.

* Motivation for features / changes
Fix failures when writing histogram summaries on TPUs.

* Technical description of changes
See Summary.

* Screenshots of UI changes:
N/A

* Detailed steps to verify changes work correctly (as executed by you)
Ran a test in tensorflow, confirmed that TPUs

* Alternate designs / implementations considered
Supporting dynamic shapes on TPU.  Large amount of future work.