### PR TITLE
bazelrc: use fast Python protos

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,3 +3,7 @@
 build --define=angular_ivy_enabled=True
 
 common --experimental_repo_remote_exec  # from TensorFlow
+
+# Use C++ backing implementations for Python proto parsing and deserialization,
+# which is much faster (~10x).
+build --define=use_fast_cpp_protos=true

--- a/tensorboard/uploader/server_info_test.py
+++ b/tensorboard/uploader/server_info_test.py
@@ -125,14 +125,14 @@ class FetchServerInfoTest(tb_test.TestCase):
         @wrappers.BaseRequest.application
         def app(request):
             del request  # unused
-            return wrappers.BaseResponse(b"an unlikely proto")
+            return wrappers.BaseResponse(b"\x7a\x7ftruncated proto")
 
         origin = self._start_server(app)
         with self.assertRaises(server_info.CommunicationError) as cm:
             server_info.fetch_server_info(origin, [])
         msg = str(cm.exception)
         self.assertIn("Corrupt response from backend", msg)
-        self.assertIn("an unlikely proto", msg)
+        self.assertIn("truncated proto", msg)
 
     def test_user_agent(self):
         @wrappers.BaseRequest.application


### PR DESCRIPTION
Summary:
Python protocol buffer bindings have parsing and serialization
implementations in pure Python and in C++. The C++ ones are much faster.
Our built Pip package already uses those because they’re on by default
in the standard `protobuf` wheel, which we depend on. But our binaries
built with Bazel don’t, because we express protobuf dependencies via
Bazel (rather than just ambiently via the Pip package), and in Bazel
land they are not on by default. This patch flips that flag.

This unfortunately adds a fair amount of buildspam to our logs—on top of
the rest of our build spam, which is already entirely due to protobuf
(and which I have tried and failed to fix in the past). I have tried to
reproduce this to file an upstream issue, but getting a Bazel workspace
to depend on protobuf without going through TensorFlow seems a herculean
effort in itself.

The test change is needed because the fast protos implementation treats
some parse errors as merely warnings(…), albeit with a TODO to fix this:
<https://github.com/protocolbuffers/protobuf/blob/367f3d831ee3186035a14f871cbcbc1b028b6b9a/python/google/protobuf/pyext/message.cc#L1981-L1983>
The new form of the test works both before and after this change.

Test Plan:
Add the following to the top of `tensorboard/main.py`:

```python
from tensorboard.compat.proto import event_pb2
print("fast" if "CMessage" in repr(event_pb2.Event.__mro__) else "slow")
raise SystemExit(77)
```

Then, run `bazel run //tensorboard`. Note that this prints `slow` before
this patch and `fast` after.

wchargin-branch: bazelrc-fast-pyprotos
