### PR TITLE
Add overridable sanitize() step to tf-markdown-view.

### DIFF
--- a/tensorboard/components/tf_markdown_view/BUILD
+++ b/tensorboard/components/tf_markdown_view/BUILD
@@ -9,8 +9,15 @@ tf_ts_library(
     srcs = ["tf-markdown-view.ts"],
     strict_checks = False,
     deps = [
+        ":sanitize",
         "//tensorboard/components/polymer:legacy_element_mixin",
         "@npm//@polymer/decorators",
         "@npm//@polymer/polymer",
     ],
+)
+
+tf_ts_library(
+    name = "sanitize",
+    srcs = ["sanitize.ts"],
+    deps = [],
 )

--- a/tensorboard/components/tf_markdown_view/BUILD
+++ b/tensorboard/components/tf_markdown_view/BUILD
@@ -19,5 +19,4 @@ tf_ts_library(
 tf_ts_library(
     name = "sanitize",
     srcs = ["sanitize.ts"],
-    deps = [],
 )

--- a/tensorboard/components/tf_markdown_view/sanitize.ts
+++ b/tensorboard/components/tf_markdown_view/sanitize.ts
@@ -1,0 +1,24 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/**
+ * Does not actually sanitize html.
+ *
+ * This exported function is overriden in the internal Google repository for
+ * compatibility with security libraries used internally at Google.
+ */
+export function sanitize(html: string) {
+  return html;
+}

--- a/tensorboard/components/tf_markdown_view/tf-markdown-view.ts
+++ b/tensorboard/components/tf_markdown_view/tf-markdown-view.ts
@@ -15,7 +15,8 @@ limitations under the License.
 
 import {PolymerElement, html} from '@polymer/polymer';
 import {LegacyElementMixin} from '../polymer/legacy_element_mixin';
-import {customElement, property} from '@polymer/decorators';
+import {computed, customElement, property} from '@polymer/decorators';
+import {sanitize} from './sanitize';
 
 // tf-markdown-view renders raw HTML that has been converted from
 // Markdown by some other agent. The HTML must be sanitized, and must be
@@ -27,7 +28,7 @@ import {customElement, property} from '@polymer/decorators';
 @customElement('tf-markdown-view')
 class TfMarkdownView extends LegacyElementMixin(PolymerElement) {
   static readonly template = html`
-    <div id="markdown" inner-h-t-m-l="[[html]]"></div>
+    <div id="markdown" inner-h-t-m-l="[[sanitizedHtml]]"></div>
     <style>
       /*
        * Reduce topmost and bottommost margins from 16px to 0.3em (renders
@@ -68,6 +69,11 @@ class TfMarkdownView extends LegacyElementMixin(PolymerElement) {
     type: String,
   })
   html: string = '';
+
+  @computed('html')
+  get sanitizedHtml() {
+    return sanitize(this.html);
+  }
 
   attached() {
     window.requestAnimationFrame(() => {


### PR DESCRIPTION
* Motivation for features / changes

  Several Google-internal instances of TensorBoard require an html sanitization step for user-provided markdown.

* Technical description of changes

  Define a sanitize() function for usage by tf-markdown-view before it renders user-provided markdown. The default implementation returns the input html without modification.

  Internally at Google we wil override the implementation of this sanitize() operation.

  Googlers please see cl/336163444 for corresponding internal CL, which will have to be submitted before this PR is merged.

* Detailed steps to verify changes work correctly (as executed by you)

  Ran local tensorboard for OSS with text plugin and ensured user markdown is still rendered properly.

  Patched the changes from this PR into a Google-internal repository with the changes from cl/336163444 and ensured that various versions of TensorBoard both build properly and render user markdown properly.

