### PR TITLE
Temporarily disable usage of scalars_multirun endpoint

### DIFF
--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
@@ -277,7 +277,7 @@ export class TfScalarCard extends PolymerElement {
 
     // TODO(b/170675710): Stop unconditionally forcing legacy endpoint when
     // fixed.
-    const forceLegacyEnpoint = true;
+    const forceLegacyEndpoint = true;
     if (inColab || forceLegacyEndpoint) {
       return this._requestDataGet(items, onLoad, onFinish);
     } else {

--- a/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
+++ b/tensorboard/plugins/scalar/tf_scalar_dashboard/tf-scalar-card.ts
@@ -36,6 +36,18 @@ type RunTagItem = {run: string; tag: string};
 const initialURLSearchParams = new URLSearchParams(window.location.search);
 
 /**
+ * Whether TensorBoard is running in a Colab environment.
+ *
+ * Google-internal Colab doesn't support HTTP POST requests, so we can use this
+ * to fallback to HTTP GET (even though public Colab supports POST).
+ * See b/126387106.
+ *
+ * Currently unused due to b/170675710 rendering the multirun endpoint unusable
+ * temporarily.
+ */
+const inColab = initialURLSearchParams.get('tensorboardColab') === 'true';
+
+/**
  * A card that handles loading data (at the right times), rendering a scalar
  * chart, and providing UI affordances (such as buttons) for scalar data.
  */
@@ -270,14 +282,19 @@ export class TfScalarCard extends PolymerElement {
     onLoad,
     onFinish
   ) => {
-    const inColab = initialURLSearchParams.get('tensorboardColab') === 'true';
-    if (inColab) {
-      // Google-internal Colab doesn't support HTTP POST requests, so we fall
-      // back to HTTP GET (even though public Colab supports POST).
-      return this._requestDataGet(items, onLoad, onFinish);
-    } else {
-      return this._requestDataPost(items, onLoad, onFinish);
-    }
+    // TODO(psybuzz): Ideally, we would always make use of `_requestDataPost`,
+    // which implements an optimization that reduces the overall # of network
+    // requests.
+
+    // However, the /scalars_multirun endpoint triggers errors when TensorBoard
+    // is hosted with a Google Cloud Spanner backend. Thus, we temporarily use
+    // `_requestDataGet` unconditionally until [1] is synced into Google.
+    // See b/170675710.
+    // [1] https://github.com/googleapis/python-spanner/pull/144
+
+    // Furthermore, once the multirun endpoint is safe to call, we cannot use it
+    // unconditionally. See `inColab` above on why it should be gated.
+    return this._requestDataGet(items, onLoad, onFinish);
   };
 
   _requestDataGet: RequestDataCallback<RunTagItem, ScalarDatum[] | null> = (


### PR DESCRIPTION
The /scalars_multirun endpoint triggers errors when TensorBoard is
hosted with a Google Cloud Spanner backend. This change reverts
TensorBoard back to using `_requestDataGet` unconditionally.

Once [1] is synced into Google, we plan to re-enable the
`_requestDataPost` path for non-Colab environments.

Manually checked that the scalars dashboard makes GET requests
to `/data/plugin/scalars/scalars` with and without the
`?tensorboardColab=true` flag.

Googlers, see b/170675710.

[1] https://github.com/googleapis/python-spanner/pull/144