### PR TITLE
cleanup: NO_ERRORS_SCHEMA to avoid noise in test

### DIFF
--- a/tensorboard/webapp/plugins/npmi/npmi_container_test.ts
+++ b/tensorboard/webapp/plugins/npmi/npmi_container_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 /**
  * Unit tests for the NPMI Container.
  */
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -34,8 +35,8 @@ describe('Npmi Container', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [NpmiComponent, NpmiContainer],
-      imports: [],
       providers: [provideMockStore({}), NpmiContainer],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
   });

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotation/annotation_test.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -102,6 +103,7 @@ describe('Npmi Annotations List Row', () => {
           initialState: appStateFromNpmiState(createNpmiState()),
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
 

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_test.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -49,6 +50,7 @@ describe('Npmi Annotations List Container', () => {
           },
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(selectors.getCurrentRouteRunSelection, new Map());

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_list_toolbar_test.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -23,9 +24,9 @@ import {AnnotationsListToolbarComponent} from './annotations_list_toolbar_compon
 import {AnnotationsListToolbarContainer} from './annotations_list_toolbar_container';
 import {appStateFromNpmiState, createNpmiState} from '../../../testing';
 import * as npmiActions from '../../../actions';
+import {getSelectedAnnotations} from '../../../store';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
-import {getSelectedAnnotations} from '../../../store';
 
 describe('Npmi Annotations List Toolbar Container', () => {
   let store: MockStore<State>;
@@ -50,6 +51,7 @@ describe('Npmi Annotations List Toolbar Container', () => {
           initialState: appStateFromNpmiState(createNpmiState()),
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
 

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/annotations_list_toolbar/annotations_search/annotations_search_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 /**
  * Unit tests for the Annotations Search.
  */
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {FormsModule} from '@angular/forms';
@@ -30,9 +31,9 @@ import * as npmiActions from '../../../../actions';
 import {appStateFromNpmiState, createNpmiState} from '../../../../testing';
 import {AnnotationsSearchContainer} from './annotations_search_container';
 import {AnnotationsSearchComponent} from './annotations_search_component';
+import {getAnnotationsRegex} from '../../../../store';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
-import {getAnnotationsRegex} from '../../../../store';
 
 describe('Npmi Annotations Search Container', () => {
   let store: MockStore<State>;
@@ -51,6 +52,7 @@ describe('Npmi Annotations Search Container', () => {
           initialState: appStateFromNpmiState(createNpmiState()),
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/header/header_test.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -50,6 +51,7 @@ describe('Npmi Annotations List Header Container', () => {
           initialState: appStateFromNpmiState(createNpmiState()),
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
 

--- a/tensorboard/webapp/plugins/npmi/views/annotations_list/legend/legend_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/annotations_list/legend/legend_test.ts
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -21,8 +22,7 @@ describe('Npmi Annotations Legend Container', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [LegendComponent],
-      imports: [],
-      providers: [],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });
 

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/data_selection_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/data_selection_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 /**
  * Unit tests for the data selection.
  */
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -43,6 +44,7 @@ describe('Npmi Data Selection Container', () => {
           },
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
   });

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_element/metric_arithmetic_element_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 /**
  * Unit tests for the metric arithmetic element.
  */
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
@@ -61,6 +62,7 @@ describe('Npmi Metric Arithmetic Element Container', () => {
           initialState: appStateFromNpmiState(createNpmiState()),
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_operator/metric_arithmetic_operator_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_operator/metric_arithmetic_operator_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 /**
  * Unit tests for the metric arithmetic operator.
  */
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import {MetricArithmeticOperatorComponent} from './metric_arithmetic_operator_component';
@@ -26,8 +27,7 @@ describe('Npmi Metric Arithmetic Operator Component', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [MetricArithmeticOperatorComponent],
-      imports: [],
-      providers: [],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });
 

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_arithmetic/metric_arithmetic_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 /**
  * Unit tests for the metric arithmetic.
  */
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -45,6 +46,7 @@ describe('Npmi Metric Arithmetic Container', () => {
           initialState: appStateFromNpmiState(createNpmiState()),
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
   });

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/metric_search/metric_search_test.ts
@@ -20,7 +20,7 @@ import {By} from '@angular/platform-browser';
 import {FormsModule} from '@angular/forms';
 import {CommonModule} from '@angular/common';
 import {OverlayContainer} from '@angular/cdk/overlay';
-import {DebugElement, getDebugNode} from '@angular/core';
+import {DebugElement, getDebugNode, NO_ERRORS_SCHEMA} from '@angular/core';
 
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatInputModule} from '@angular/material/input';
@@ -65,6 +65,7 @@ describe('Npmi Metric Search Container', () => {
           initialState: appStateFromNpmiState(createNpmiState()),
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
     overlayContainer = TestBed.inject(OverlayContainer);

--- a/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/data_selection/results_download/results_download_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 /**
  * Unit tests for the Result Downloads.
  */
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -50,6 +51,7 @@ describe('Npmi Results Download', () => {
           },
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(selectors.getCurrentRouteRunSelection, new Map());

--- a/tensorboard/webapp/plugins/npmi/views/main/main_container_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/main/main_container_test.ts
@@ -31,6 +31,7 @@ import {MainContainer} from './main_container';
 import * as npmiActions from '../../actions';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 
 describe('Npmi Main Container', () => {
   let store: MockStore<State>;
@@ -57,6 +58,7 @@ describe('Npmi Main Container', () => {
           },
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
     store.overrideSelector(getCurrentRouteRunSelection, new Map());

--- a/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/selected_annotations/selected_annotations_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 /**
  * Unit tests for the Selected Annotations.
  */
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -26,9 +27,9 @@ import {appStateFromNpmiState, createNpmiState} from '../../testing';
 import {SelectedAnnotationsContainer} from './selected_annotations_container';
 import {SelectedAnnotationsComponent} from './selected_annotations_component';
 import * as npmiActions from '../../actions';
+import {getPCExpanded, getSelectedAnnotations} from '../../store';
 
 /** @typehack */ import * as _typeHackStore from '@ngrx/store';
-import {getPCExpanded, getSelectedAnnotations} from '../../store';
 
 describe('Npmi Selected Annotations', () => {
   let store: MockStore<State>;
@@ -54,6 +55,7 @@ describe('Npmi Selected Annotations', () => {
           initialState: appStateFromNpmiState(createNpmiState()),
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
 

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/violin_filter_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 /**
  * Unit tests for a violin filter.
  */
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -56,6 +57,7 @@ describe('Npmi Violin Filter Container', () => {
           },
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
 

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_test.ts
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filters_test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 /**
  * Unit tests for the violin filters.
  */
+import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -54,6 +55,7 @@ describe('Npmi Violin Filters Container', () => {
           },
         }),
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
 


### PR DESCRIPTION
Angular test specs have their own way of compiling and specifying
modules. As a result, when building Angular template, it can resolve to
a different implementation or nothing (e.g., <mat-icon> without
importing MatIconModule resolves to nothing). This makes Angular's *Ivy*
compiler write warning (instead of throwing exception and halting the
build) and litters our test.

Ideally, there should be a way to assert on console.warn and fail the
test but we will not invest much time in infrastructure in this PR, at
least.

Used this script to modify BUILD files (which resulted in no-op)
```sh
test_files="$(git show --pretty="format:" --name-only HEAD | grep _test.ts)"

for test_file in $test_files; do
  fullname=$(bazel query "$test_file")
  target=$(bazel query "attr('srcs', $fullname, ${fullname//:*/}:*)")
  buildozer 'add deps @npm//@angular/core' $target
done
```