### PR TITLE
cleanup: remove extraneous console.log in test

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/scalar_card_test.ts
@@ -392,7 +392,6 @@ describe('scalar card', () => {
         By.directive(TestableLineChart)
       );
       const {metadata} = lineChartEl.componentInstance.seriesDataList[0];
-      console.log(metadata);
       expect(metadata).toEqual({displayName: 'existing_exp/Foobar'});
     }));
   });


### PR DESCRIPTION
Found the instance with: `rg 'console.log' -g '**/*_test.ts'`
There are no other instance of console.log in test.
