### PR TITLE
line-chart: create reusable worker

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -275,6 +275,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/widgets:resize_detector_testing",
         "//tensorboard/webapp/widgets/histogram:histogram_test",
         "//tensorboard/webapp/widgets/line_chart:line_chart_test",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:lib_tests",
         "//tensorboard/webapp/widgets/range_input:range_input_tests",
         "//tensorboard/webapp/widgets/text:text_tests",
     ],

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -1,0 +1,30 @@
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+tf_ts_library(
+    name = "worker_pool",
+    srcs = ["worker_pool.ts"],
+    deps = [
+        ":worker",
+    ],
+)
+
+tf_ts_library(
+    name = "worker",
+    srcs = ["worker.ts"],
+    visibility = ["//visibility:private"],
+)
+
+tf_ts_library(
+    name = "lib_tests",
+    testonly = True,
+    srcs = [
+        "worker_pool_test.ts",
+    ],
+    deps = [
+        ":worker",
+        ":worker_pool",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker.ts
@@ -17,6 +17,10 @@ limitations under the License.
  * Creates a new worker that loads and executes the JavaScript at the given URL.
  *
  * This module exists to conform to internal requirements.
+ *
+ * @param workerResourcePath URL pathanme to the JavaScript resource served by
+ *   TensorBoard. TensorBoard disallows fetching JavaScript resources from a differnt
+ *   origin.
  */
 export function getWorker(workerResourcePath: string): Worker {
   return new Worker(workerResourcePath);

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker.ts
@@ -1,0 +1,23 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/**
+ * Creates a new worker that loads and executes the JavaScript at the given URL.
+ *
+ * This module exists to conform to internal requirements.
+ */
+export function getWorker(workerResourcePath: string): Worker {
+  return new Worker(workerResourcePath);
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker_pool.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker_pool.ts
@@ -1,0 +1,106 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {getWorker} from './worker';
+
+/**
+ * An object that that provides facility to interact with a Worker process. Because
+ * WorkerPool maintains lifecycle of a Worker, it does not permit `terminate` or any other
+ * direct binding to Worker events.
+ *
+ * For listening to events from Worker, please use MessageChannel pattern:
+ * https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel
+ */
+export interface WorkerProxy {
+  activeCount: number;
+  postMessage: (message: any, transfer: Transferable[]) => void;
+  free: () => void;
+}
+
+/**
+ * Worker pool load balancing module.
+ *
+ * Module attempts, without knowing the CPU workload, balance number of active users while
+ * minimally instantiating Workers.
+ *
+ * For a transient or for more control over Worker, please instiate one manually.
+ *
+ * Example usage:
+ *
+ * ```ts
+ * const workerPool = new WorkerPool('my_js_path.js');
+ *
+ * @Component({...})
+ * export class MyComponent {
+ *   this.worker = workerPool.getNext();
+ *
+ *   ngOnDestory() {
+ *     this.worker.free();
+ *   }
+ * }
+ * ```
+ */
+export class WorkerPool {
+  private readonly workers: WorkerProxy[] = [];
+  constructor(
+    private readonly workerResourcePath: string,
+    private readonly maxPoolSize = 10,
+    private readonly workerFactory: (resourcePath: string) => Worker = getWorker
+  ) {
+    // TODO(tensorboard-team): consider pre-allocating with the IdleCallback.
+  }
+
+  /**
+   * Returns a worker-like object that can be used to offload computation like Worker.
+   * This method allocates new Worker upto 10 instances. Depending on its usage (not by CPU
+   * utilization but merely number of instance holder), it allocates the freest one. Upon
+   * disposal (e.g., Angular's ngOnDestroy), please invoke `free` for recycle. Failing to
+   * invoke `free` will impact load balancing, but it will not impact correctness of the
+   * program. Similarly, invoking `free` multiple times do not impact correctness but
+   * impacts load balancing; please invoke it correctly.
+   *
+   * Important: to reduce the overhead of fetch and instantiating a worker, we do not
+   * terminate a worker once it is completedly freed up. For more control over the lifecycle
+   * of a Worker, please instantiate a Worker directly.
+   */
+  getNext(): WorkerProxy {
+    let workerLike: WorkerProxy;
+
+    const shouldAllocateNew =
+      this.workers.every(({activeCount}) => activeCount > 0) &&
+      this.workers.length < this.maxPoolSize;
+
+    if (shouldAllocateNew) {
+      const worker = this.workerFactory(this.workerResourcePath);
+      workerLike = {
+        activeCount: 0,
+        postMessage: (message: any, transfer: Transferable[]) => {
+          worker.postMessage(message, transfer);
+        },
+        free: () => {
+          workerLike.activeCount = Math.max(workerLike.activeCount - 1, 0);
+        },
+      };
+      this.workers.push(workerLike);
+    } else {
+      const activeCounts = this.workers.map(({activeCount}) => activeCount);
+      const freestIndex = activeCounts.indexOf(Math.min(...activeCounts));
+      workerLike = this.workers[freestIndex];
+    }
+
+    workerLike.activeCount++;
+    return workerLike;
+  }
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker_pool_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker_pool_test.ts
@@ -1,0 +1,94 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {WorkerPool} from './worker_pool';
+
+describe('line_chart_v2/lib/worker_pool', () => {
+  let workerFactory: jasmine.Spy;
+
+  beforeEach(() => {
+    workerFactory = jasmine.createSpy().and.callFake(() => {
+      return jasmine.createSpyObj(Worker, ['postMessage']);
+    });
+  });
+
+  it('returns a worker like that it can postMessage to', () => {
+    const workerSpy = jasmine.createSpyObj(Worker, ['postMessage']);
+    workerFactory.and.returnValue(workerSpy);
+
+    const workerLike = new WorkerPool('testing', 2, workerFactory).getNext();
+    workerLike.postMessage('foo', []);
+
+    expect(workerFactory).toHaveBeenCalledTimes(1);
+    expect(workerSpy.postMessage).toHaveBeenCalledTimes(1);
+    expect(workerSpy.postMessage).toHaveBeenCalledWith('foo', []);
+  });
+
+  describe('allocation', () => {
+    it('allocates pools even when instantiated pool with the same path', () => {
+      new WorkerPool('a', 1, workerFactory).getNext();
+      new WorkerPool('a', 1, workerFactory).getNext();
+      expect(workerFactory).toHaveBeenCalledTimes(2);
+    });
+
+    it('allocates upto maxPoolSize then allocates from first one again', () => {
+      const pool = new WorkerPool('a', 3, workerFactory);
+      const workers = [...new Array(5)].map(() => {
+        return pool.getNext();
+      });
+
+      expect(workerFactory).toHaveBeenCalledTimes(3);
+      expect(workers[0]).toBe(workers[3]);
+    });
+  });
+
+  describe('freeing', () => {
+    it('supports freeing and allocates freed one first', () => {
+      const pool = new WorkerPool('a', 3, workerFactory);
+
+      const firstWorker = pool.getNext();
+      const secondWorker = pool.getNext();
+      secondWorker.free();
+
+      const thirdWorker = pool.getNext();
+      thirdWorker.postMessage('bar', []);
+
+      expect(firstWorker).not.toBe(thirdWorker);
+      expect(secondWorker).toBe(thirdWorker);
+    });
+
+    it('allocates the freest worker', () => {
+      const pool = new WorkerPool('a', 3, workerFactory);
+      const workers = [...new Array(15)].map(() => pool.getNext());
+
+      workers[1].free();
+      workers[2].free();
+      workers[5].free();
+      workers[8].free();
+
+      // Because 3rd one is the freest, allocating a new instance will return it.
+      expect(pool.getNext()).toBe(workers[2]);
+      // 3rd one is still freest: activeCount = [5, 4, 3].
+      expect(pool.getNext()).toBe(workers[2]);
+      // Now, activeCont is [5, 4, 4]. Because 2nd one comes first in array index,
+      // it wins.
+      expect(pool.getNext()).toBe(workers[1]);
+      // 3rd one is allocated again.
+      expect(pool.getNext()).toBe(workers[2]);
+      // Now that every one has 5 active clients, 0th index one gets returned.
+      expect(pool.getNext()).toBe(workers[0]);
+    });
+  });
+});

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker_pool_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker_pool_test.ts
@@ -20,20 +20,20 @@ describe('line_chart_v2/lib/worker_pool', () => {
 
   beforeEach(() => {
     workerFactory = jasmine.createSpy().and.callFake(() => {
-      return jasmine.createSpyObj(Worker, ['postMessage']);
+      return {postMessage: jasmine.createSpy()};
     });
   });
 
   it('returns a worker like that it can postMessage to', () => {
-    const workerSpy = jasmine.createSpyObj(Worker, ['postMessage']);
-    workerFactory.and.returnValue(workerSpy);
+    const worker = {postMessage: jasmine.createSpy()};
+    workerFactory.and.returnValue(worker);
 
     const workerLike = new WorkerPool('testing', 2, workerFactory).getNext();
     workerLike.postMessage('foo', []);
 
     expect(workerFactory).toHaveBeenCalledTimes(1);
-    expect(workerSpy.postMessage).toHaveBeenCalledTimes(1);
-    expect(workerSpy.postMessage).toHaveBeenCalledWith('foo', []);
+    expect(worker.postMessage).toHaveBeenCalledTimes(1);
+    expect(worker.postMessage).toHaveBeenCalledWith('foo', []);
   });
 
   describe('allocation', () => {


### PR DESCRIPTION
This is one of the foundational library for the new upcoming feature:
Gpu based line chart. In the new line chart, we would like to leverage
OffscreenCanvas which allows worker thread to manipulate the canvas.

In doing so, we are creating a small library that maintains worker
instances so we don't spawn off unbounded number of workers.

This is a roll-forward of a reverted commit 5c82a48 (#4237)

Notice additional changes to doc on worker.ts and minor changes to
worker_pool_test.ts. Internal conformance hate any sight of `Worker`
that is used for non-type purposes.

Reference sync: cl/337249437