### PR TITLE
line chart: added scale libraries

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -3,6 +3,14 @@ load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 package(default_visibility = ["//tensorboard:internal"])
 
 tf_ts_library(
+    name = "types",
+    srcs = [
+        "scale_types.ts",
+        "types.ts",
+    ],
+)
+
+tf_ts_library(
     name = "worker_pool",
     srcs = ["worker_pool.ts"],
     deps = [
@@ -17,12 +25,27 @@ tf_ts_library(
 )
 
 tf_ts_library(
+    name = "scale",
+    srcs = [
+        "scale.ts",
+    ],
+    deps = [
+        ":types",
+        "@npm//@types/d3",
+        "@npm//d3",
+    ],
+)
+
+tf_ts_library(
     name = "lib_tests",
     testonly = True,
     srcs = [
+        "scale_test.ts",
         "worker_pool_test.ts",
     ],
     deps = [
+        ":scale",
+        ":types",
         ":worker",
         ":worker_pool",
         "@npm//@types/jasmine",

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
@@ -1,0 +1,196 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {scaleLinear, scaleLog} from 'd3';
+
+import {ScaleType} from './scale_types';
+
+export interface Scale {
+  forward(domain: [number, number], range: [number, number], x: number): number;
+
+  reverse(domain: [number, number], range: [number, number], x: number): number;
+
+  nice(minAndMax: [number, number]): [number, number];
+
+  /**
+   * @param lowAndHigh bounds of the tick
+   * @param sizeGuidance approximate number of the ticks. Depending on the lowAndHigh, it
+   * may return less or more ticks.
+   */
+  ticks(lowAndHigh: [number, number], sizeGuidance: number): number[];
+}
+
+export function createScale(type: ScaleType): Scale {
+  switch (type) {
+    case ScaleType.LINEAR:
+      return new LinearScale();
+    case ScaleType.LOG10:
+      return new Log10Scale();
+    default:
+      throw new RangeError(`ScaleType ${type} not supported.`);
+  }
+}
+
+const PADDING_RATIO = 0.05;
+const MIN_SIGNIFICANT_PADDING = 0.01;
+
+class LinearScale implements Scale {
+  private transform(
+    inputSpace: [number, number],
+    outputSpace: [number, number],
+    x: number
+  ): number {
+    const [inputMin, inputMax] = inputSpace;
+    const inputSpread = inputMax - inputMin;
+    const [outputMin, outputMax] = outputSpace;
+    const outputSpread = outputMax - outputMin;
+
+    if (inputSpread === 0) {
+      return outputMin;
+    }
+
+    return (outputSpread / inputSpread) * (x - inputMin) + outputMin;
+  }
+
+  forward(
+    domain: [number, number],
+    range: [number, number],
+    x: number
+  ): number {
+    return this.transform(domain, range, x);
+  }
+
+  reverse(
+    domain: [number, number],
+    range: [number, number],
+    x: number
+  ): number {
+    return this.transform(range, domain, x);
+  }
+
+  nice(minAndMax: [number, number]): [number, number] {
+    let [min, max] = minAndMax;
+    if (max < min) {
+      throw new Error('Unexpected input: min is larger than max');
+    }
+
+    const scale = scaleLinear();
+    const padding =
+      max === min
+        ? // In case both `min` and `max` are 0, we want some padding.
+          Math.max(min * PADDING_RATIO, MIN_SIGNIFICANT_PADDING)
+        : (max - min + Number.EPSILON) * PADDING_RATIO;
+    const [niceMin, niceMax] = scale
+      .domain([min - padding, max + padding])
+      .nice()
+      .domain();
+    return [niceMin, niceMax];
+  }
+
+  ticks(lowAndHigh: [number, number], sizeGuidance: number): number[] {
+    return scaleLinear().domain(lowAndHigh).ticks(sizeGuidance);
+  }
+}
+
+class Log10Scale implements Scale {
+  private transform(x: number): number {
+    return Math.log10(x > 0 ? x : Number.MIN_VALUE);
+  }
+
+  private untransform(x: number): number {
+    return Math.exp(x / Math.LOG10E);
+  }
+
+  forward(
+    domain: [number, number],
+    range: [number, number],
+    x: number
+  ): number {
+    if (x <= 0) {
+      return range[0];
+    }
+
+    const [domainMin, domainMax] = domain;
+    const [rangeMin, rangeMax] = range;
+
+    const transformedMin = this.transform(domainMin);
+    const transformedMax = this.transform(domainMax);
+    const domainSpread = transformedMax - transformedMin;
+    const rangeSpread = rangeMax - rangeMin;
+    x = this.transform(x);
+
+    return (
+      (rangeSpread / (domainSpread + Number.EPSILON)) * (x - transformedMin) +
+      rangeMin
+    );
+  }
+
+  reverse(
+    domain: [number, number],
+    range: [number, number],
+    x: number
+  ): number {
+    const [domainMin, domainMax] = domain;
+    const [rangeMin, rangeMax] = range;
+
+    const transformedMin = this.transform(domainMin);
+    const transformedMax = this.transform(domainMax);
+    const domainSpread = transformedMax - transformedMin;
+    const rangeSpread = rangeMax - rangeMin;
+
+    const val =
+      (domainSpread / (rangeSpread + Number.EPSILON)) * (x - rangeMin) +
+      transformedMin;
+    return this.untransform(val);
+  }
+
+  nice(minAndMax: [number, number]): [number, number] {
+    const [min, max] = minAndMax;
+    if (min > max) {
+      throw new Error('Unexpected input: min is larger than max');
+    }
+
+    const adjustedMin = Math.max(min, Number.MIN_VALUE);
+    const adjustedMax = Math.max(max, Number.MIN_VALUE);
+    if (min <= 0 || max <= 0) {
+      return [adjustedMin, adjustedMax];
+    }
+
+    const numericMinLogValue = this.transform(Number.MIN_VALUE);
+    const minLogValue = this.transform(adjustedMin);
+    const maxLogValue = this.transform(adjustedMax);
+
+    const spreadInLog = maxLogValue - minLogValue;
+    const padInLog =
+      spreadInLog > 0
+        ? spreadInLog * PADDING_RATIO
+        : // In case `minLogValue` is 0 (i.e., log_10(1) = 0), we want some padding.
+          Math.max(
+            Math.abs(minLogValue * PADDING_RATIO),
+            MIN_SIGNIFICANT_PADDING
+          );
+
+    return [
+      this.untransform(Math.max(numericMinLogValue, minLogValue - padInLog)),
+      this.untransform(maxLogValue + padInLog),
+    ];
+  }
+
+  ticks(lowAndHigh: [number, number], sizeGuidance: number): number[] {
+    const low = lowAndHigh[0] <= 0 ? Number.MIN_VALUE : lowAndHigh[0];
+    const high = lowAndHigh[1] <= 0 ? Number.MIN_VALUE : lowAndHigh[1];
+    const ticks = scaleLog().domain([low, high]).ticks(sizeGuidance);
+    return ticks.length ? ticks : lowAndHigh;
+  }
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
@@ -47,9 +47,17 @@ export interface Scale {
    * Returns "human friendly" numbers between the `domain` that can be used for ticks and
    * grid.
    *
-   * @param domain bounds of the tick
+   * In case the spread of an interval is 0 or negligible, it can return an empty array
+   * depending on an implementation.
+   *
+   * Examples:
+   *   ticks([0, 10], 5) -> [0, 2, 4, 6, 8, 10]
+   *   ticks([10, 0], 5) -> [10, 8, 6, 4, 2, 0]
+   *   ticks([10, 10], 5) -> []
+   *
+   * @param domain Interval in which tick should be created.
    * @param sizeGuidance approximate number of the ticks. Depending on the domain, it
-   * may return less or more ticks.
+   *    may return less or more ticks.
    */
   ticks(domain: [number, number], sizeGuidance: number): number[];
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
@@ -1,0 +1,296 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Scale, createScale} from './scale';
+import {ScaleType} from './scale_types';
+
+describe('line_chart_v2/lib/scale test', () => {
+  describe('linear', () => {
+    let scale: Scale;
+
+    beforeEach(() => {
+      scale = createScale(ScaleType.LINEAR);
+    });
+
+    describe('#forward and #reverse', () => {
+      it('converts value from domain space to range space', () => {
+        expect(scale.forward([0, 1], [-100, 100], 0)).toBe(-100);
+        expect(scale.forward([0, 1], [-100, 100], 0.5)).toBe(0);
+        expect(scale.forward([0, 1], [-100, 100], 1)).toBe(100);
+
+        expect(scale.forward([0, 1], [-100, 100], -1)).toBe(-300);
+        expect(scale.forward([0, 1], [-100, 100], 5)).toBe(900);
+      });
+
+      it('allows flippping order of the range', () => {
+        expect(scale.forward([0, 1], [100, -100], 0)).toBe(100);
+        expect(scale.forward([0, 1], [100, -100], 0.5)).toBe(0);
+        expect(scale.forward([0, 1], [100, -100], 1)).toBe(-100);
+
+        expect(scale.forward([0, 1], [100, -100], -1)).toBe(300);
+        expect(scale.forward([0, 1], [100, -100], 5)).toBe(-900);
+      });
+
+      it('returns range min value when domain spread is 0', () => {
+        expect(scale.forward([1, 1], [0, 100], 1)).toBe(0);
+        expect(scale.forward([1, 1], [0, 100], 0)).toBe(0);
+      });
+
+      it('does not choke when range spread is 0', () => {
+        expect(scale.forward([0, 1], [100, 100], 0)).toBe(100);
+        expect(scale.forward([0, 1], [100, 100], 1)).toBe(100);
+      });
+
+      it('reverse the scale from range to domain', () => {
+        expect(scale.reverse([0, 1], [-100, 100], 0)).toBe(0.5);
+        expect(scale.reverse([0, 1], [-100, 100], -100)).toBe(0);
+        expect(scale.reverse([0, 1], [-100, 100], 100)).toBe(1);
+
+        expect(scale.reverse([0, 1], [-100, 100], -101)).toBe(-0.005);
+        expect(scale.reverse([0, 1], [-100, 100], 500)).toBe(3);
+      });
+    });
+
+    describe('#nice', () => {
+      it('puts "nice" (~5%) padding around and round value of min and max', () => {
+        expect(scale.nice([0, 100])).toEqual([-10, 110]);
+        expect(scale.nice([-0.011, 99.5])).toEqual([-10, 110]);
+        expect(scale.nice([5.44, 95.12])).toEqual([0, 100]);
+      });
+
+      it('puts padding of 5% of value when min == max', () => {
+        expect(scale.nice([100, 100])).toEqual([95, 105]);
+        expect(scale.nice([1, 1])).toEqual([0.95, 1.05]);
+        expect(scale.nice([10000, 10000])).toEqual([9500, 10500]);
+        expect(scale.nice([0, 0])).toEqual([-0.01, 0.01]);
+      });
+
+      it('throws an error when min is larger than max', () => {
+        expect(() => void scale.nice([100, 0])).toThrowError(Error);
+      });
+    });
+
+    // This is basically exercising d3.scale#ticks but it is good to test so we are not
+    // surprised by any behavior changes.
+    describe('#tick', () => {
+      it('returns ticks in between min and max', () => {
+        expect(scale.ticks([0, 100], 5)).toEqual([0, 20, 40, 60, 80, 100]);
+        expect(scale.ticks([300, 1000], 5)).toEqual([
+          300,
+          400,
+          500,
+          600,
+          700,
+          800,
+          900,
+          1000,
+        ]);
+        expect(scale.ticks([0.01, 0.05], 5)).toEqual([
+          0.01,
+          0.02,
+          0.03,
+          0.04,
+          0.05,
+        ]);
+        // Another example of sizeGuidance not being exact.
+        expect(scale.ticks([0.01, 0.05], 3)).toEqual([
+          0.01,
+          0.02,
+          0.03,
+          0.04,
+          0.05,
+        ]);
+      });
+    });
+  });
+
+  describe('log10', () => {
+    let scale: Scale;
+
+    beforeEach(() => {
+      scale = createScale(ScaleType.LOG10);
+    });
+
+    describe('#forward and #reverse', () => {
+      it('converts value from domain space to range space', () => {
+        expect(scale.forward([0, 1], [-100, 100], 0)).toBe(-100);
+        expect(scale.forward([0, 1], [-100, 0], 0.5)).toBeCloseTo(-0.09, 2);
+        expect(scale.forward([0, 1], [-100, 100], 1)).toBe(100);
+
+        expect(scale.forward([0, 1], [-100, 100], -1)).toBe(-100);
+        expect(scale.forward([0, 1], [-100, 100], 5)).toBeCloseTo(100, -1);
+
+        expect(scale.forward([1, 1000], [0, 1], 100)).toBeCloseTo(0.666, 2);
+        expect(scale.forward([0.00001, 1], [0, 5], 0.01)).toBeCloseTo(3);
+      });
+
+      // Kind of tentative behavior: it is more correct to return NaN and let
+      // UI elements show the right treatment; we would also need to exclude it
+      // when computed extents but it is out of scope for now.
+      it('handles negative value by treating it min float value', () => {
+        expect(scale.forward([1, 100], [0, 3], -3)).toBe(0);
+      });
+
+      it('permits negative value in domain by clipping it to min number', () => {
+        // Because -100 is treated as min number, the domain is effectively
+        // [Number.MIN_VALUE, 100] and log of MIN_VALUE is about -324. So, `1` is much
+        // closer to the end of the range.
+        expect(scale.forward([-100, 100], [0, 1], 1)).toBeCloseTo(1, 1);
+      });
+
+      it('allows flippping order of the range', () => {
+        expect(scale.forward([0, 1], [100, -100], 0)).toBe(100);
+        expect(scale.forward([0, 1], [100, -100], 0.5)).toBeCloseTo(-100, 0);
+        expect(scale.forward([0, 1], [100, -100], 1)).toBe(-100);
+
+        // -1 is illegal in especially log domain so it is clipped to min range.
+        expect(scale.forward([0, 1], [100, -100], -1)).toBe(100);
+        expect(scale.forward([0, 1], [100, -100], 5)).toBeCloseTo(-100, 0);
+      });
+
+      it('returns range min value when domain spread is 0', () => {
+        expect(scale.forward([1, 1], [0, 100], 1)).toBe(0);
+        expect(scale.forward([1, 1], [0, 100], 0)).toBe(0);
+      });
+
+      it('does not choke when range spread is 0', () => {
+        expect(scale.forward([0, 1], [100, 100], 0)).toBe(100);
+        expect(scale.forward([0, 1], [100, 100], 1)).toBe(100);
+      });
+
+      it('reverse the scale from range to domain', () => {
+        expect(scale.reverse([1, 1000], [-100, 100], 0)).toBeCloseTo(31.6, 0);
+        expect(scale.reverse([1, 1000], [-100, 100], -100)).toBe(1);
+        expect(scale.reverse([1, 1000], [-100, 100], 100)).toBeCloseTo(1000, 0);
+
+        expect(scale.reverse([1, 1000], [-100, 100], -101)).toBeCloseTo(
+          0.966,
+          1
+        );
+        expect(scale.reverse([1, 1000], [-100, 100], 300)).toBeCloseTo(
+          1000000,
+          0
+        );
+      });
+
+      it('returns cyclic consistent value', () => {
+        const initialX = 100;
+        const forward = scale.forward([1, 1000], [-100, 100], initialX);
+        const inverse = scale.reverse([1, 1000], [-100, 100], forward);
+        expect(inverse).toBeCloseTo(initialX, 0);
+      });
+    });
+
+    describe('#nice', () => {
+      // Carrying over the behavior from existing vz_line_chart
+      it('puts "nice" (~5%) padding around but does not round values', () => {
+        let low: number;
+        let high: number;
+
+        [low, high] = scale.nice([0, 100]);
+        expect(low).toBe(Number.MIN_VALUE);
+        expect(high).toBeCloseTo(100, 0);
+
+        [low, high] = scale.nice([0.001, 75]);
+        // spread is about log_10(75) - log_10(0.001) = 4.875
+        // We add 5% padding with that spread (~0.2438) before we convert it back with
+        // exponential. low turns into -3.244, so we exp(-3.244 / log_10(E)) ~ 0.00057.
+        expect(low).toBeCloseTo(0.00057, 4);
+        expect(high).toBeCloseTo(131, 0);
+
+        [low, high] = scale.nice([100, 1e6]);
+        expect(low).toBeCloseTo(63, 0);
+        expect(high).toBeCloseTo(1.585e6, -4);
+      });
+
+      it('puts padding of 5% of value when min == max', () => {
+        let low: number;
+        let high: number;
+        [low, high] = scale.nice([100, 100]);
+        expect(low).toBeCloseTo(79, 0);
+        expect(high).toBeCloseTo(126, 0);
+
+        [low, high] = scale.nice([1, 1]);
+        expect(low).toBeCloseTo(0.977, 2);
+        expect(high).toBeCloseTo(1.023, 2);
+
+        [low, high] = scale.nice([10000, 10000]);
+        expect(low).toBeCloseTo(6310, 0);
+        expect(high).toBeCloseTo(15849, 0);
+      });
+
+      it('throws an error when min is larger than max', () => {
+        expect(() => void scale.nice([100, 0])).toThrowError(Error);
+      });
+    });
+
+    describe('#tick', () => {
+      it('returns ticks in between min and max', () => {
+        expect(scale.ticks([1, 100], 5)).toEqual([
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          20,
+          30,
+          40,
+          50,
+          60,
+          70,
+          80,
+          90,
+          100,
+        ]);
+        expect(scale.ticks([300, 1000], 5)).toEqual([
+          300,
+          400,
+          500,
+          600,
+          700,
+          800,
+          900,
+          1000,
+        ]);
+        expect(scale.ticks([0.01, 0.05], 5)).toEqual([
+          0.01,
+          0.02,
+          0.03,
+          0.04,
+          0.05,
+        ]);
+        // Another example of sizeGuidance not being exact.
+        expect(scale.ticks([0.01, 0.05], 3)).toEqual([
+          0.01,
+          0.02,
+          0.03,
+          0.04,
+          0.05,
+        ]);
+      });
+
+      // This is less than ideal; with any zeros, we will be stuck on 1e-324.
+      it('handles non-positive values correctly', () => {
+        expect(scale.ticks([0, 0.01], 3)).toEqual([1e-300, 1e-200, 1e-100]);
+        expect(scale.ticks([-100, 0.01], 3)).toEqual([1e-300, 1e-200, 1e-100]);
+      });
+    });
+  });
+});

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
@@ -34,7 +34,7 @@ describe('line_chart_v2/lib/scale test', () => {
         expect(scale.forward([0, 1], [-100, 100], 5)).toBe(900);
       });
 
-      it('allows flippping order of the range', () => {
+      it('allows flipping order of the range', () => {
         expect(scale.forward([0, 1], [100, -100], 0)).toBe(100);
         expect(scale.forward([0, 1], [100, -100], 0.5)).toBe(0);
         expect(scale.forward([0, 1], [100, -100], 1)).toBe(-100);
@@ -65,20 +65,20 @@ describe('line_chart_v2/lib/scale test', () => {
 
     describe('#nice', () => {
       it('puts "nice" (~5%) padding around and round value of min and max', () => {
-        expect(scale.nice([0, 100])).toEqual([-10, 110]);
-        expect(scale.nice([-0.011, 99.5])).toEqual([-10, 110]);
-        expect(scale.nice([5.44, 95.12])).toEqual([0, 100]);
+        expect(scale.niceDomain([0, 100])).toEqual([-10, 110]);
+        expect(scale.niceDomain([-0.011, 99.5])).toEqual([-10, 110]);
+        expect(scale.niceDomain([5.44, 95.12])).toEqual([0, 100]);
       });
 
       it('puts padding of 5% of value when min == max', () => {
-        expect(scale.nice([100, 100])).toEqual([95, 105]);
-        expect(scale.nice([1, 1])).toEqual([0.95, 1.05]);
-        expect(scale.nice([10000, 10000])).toEqual([9500, 10500]);
-        expect(scale.nice([0, 0])).toEqual([-0.01, 0.01]);
+        expect(scale.niceDomain([100, 100])).toEqual([95, 105]);
+        expect(scale.niceDomain([1, 1])).toEqual([0.95, 1.05]);
+        expect(scale.niceDomain([10000, 10000])).toEqual([9500, 10500]);
+        expect(scale.niceDomain([0, 0])).toEqual([-0.01, 0.01]);
       });
 
       it('throws an error when min is larger than max', () => {
-        expect(() => void scale.nice([100, 0])).toThrowError(Error);
+        expect(() => void scale.niceDomain([100, 0])).toThrowError(Error);
       });
     });
 
@@ -150,7 +150,7 @@ describe('line_chart_v2/lib/scale test', () => {
         expect(scale.forward([-100, 100], [0, 1], 1)).toBeCloseTo(1, 1);
       });
 
-      it('allows flippping order of the range', () => {
+      it('allows flipping order of the range', () => {
         expect(scale.forward([0, 1], [100, -100], 0)).toBe(100);
         expect(scale.forward([0, 1], [100, -100], 0.5)).toBeCloseTo(-100, 0);
         expect(scale.forward([0, 1], [100, -100], 1)).toBe(-100);
@@ -199,18 +199,18 @@ describe('line_chart_v2/lib/scale test', () => {
         let low: number;
         let high: number;
 
-        [low, high] = scale.nice([0, 100]);
+        [low, high] = scale.niceDomain([0, 100]);
         expect(low).toBe(Number.MIN_VALUE);
         expect(high).toBeCloseTo(100, 0);
 
-        [low, high] = scale.nice([0.001, 75]);
+        [low, high] = scale.niceDomain([0.001, 75]);
         // spread is about log_10(75) - log_10(0.001) = 4.875
         // We add 5% padding with that spread (~0.2438) before we convert it back with
         // exponential. low turns into -3.244, so we exp(-3.244 / log_10(E)) ~ 0.00057.
         expect(low).toBeCloseTo(0.00057, 4);
         expect(high).toBeCloseTo(131, 0);
 
-        [low, high] = scale.nice([100, 1e6]);
+        [low, high] = scale.niceDomain([100, 1e6]);
         expect(low).toBeCloseTo(63, 0);
         expect(high).toBeCloseTo(1.585e6, -4);
       });
@@ -218,21 +218,21 @@ describe('line_chart_v2/lib/scale test', () => {
       it('puts padding of 5% of value when min == max', () => {
         let low: number;
         let high: number;
-        [low, high] = scale.nice([100, 100]);
+        [low, high] = scale.niceDomain([100, 100]);
         expect(low).toBeCloseTo(79, 0);
         expect(high).toBeCloseTo(126, 0);
 
-        [low, high] = scale.nice([1, 1]);
+        [low, high] = scale.niceDomain([1, 1]);
         expect(low).toBeCloseTo(0.977, 2);
         expect(high).toBeCloseTo(1.023, 2);
 
-        [low, high] = scale.nice([10000, 10000]);
+        [low, high] = scale.niceDomain([10000, 10000]);
         expect(low).toBeCloseTo(6310, 0);
         expect(high).toBeCloseTo(15849, 0);
       });
 
       it('throws an error when min is larger than max', () => {
-        expect(() => void scale.nice([100, 0])).toThrowError(Error);
+        expect(() => void scale.niceDomain([100, 0])).toThrowError(Error);
       });
     });
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
@@ -63,7 +63,7 @@ describe('line_chart_v2/lib/scale test', () => {
       });
     });
 
-    describe('#nice', () => {
+    describe('#niceDomain', () => {
       it('puts "nice" (~5%) padding around and round value of min and max', () => {
         expect(scale.niceDomain([0, 100])).toEqual([-10, 110]);
         expect(scale.niceDomain([-0.011, 99.5])).toEqual([-10, 110]);
@@ -193,7 +193,7 @@ describe('line_chart_v2/lib/scale test', () => {
       });
     });
 
-    describe('#nice', () => {
+    describe('#niceDomain', () => {
       // Carrying over the behavior from existing vz_line_chart
       it('puts "nice" (~5%) padding around but does not round values', () => {
         let low: number;

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_types.ts
@@ -1,0 +1,19 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export enum ScaleType {
+  LINEAR,
+  LOG10,
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/types.ts
@@ -1,0 +1,33 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+export * from './scale_types';
+
+export interface Dimension {
+  width: number;
+  height: number;
+}
+
+export interface Rect {
+  x: number;
+  width: number;
+  y: number;
+  height: number;
+}
+
+export interface Extent {
+  x: [number, number];
+  y: [number, number];
+}


### PR DESCRIPTION
This module is anaologous to d3.scale. While doing performance
explorations, we found d3.scale operations to cause a lot of GC
impacting performance very significantly; a simple math operations were
taking a significant time that we would be spending more time converting
coordinate system than drawing.

This change introduces two kinds of scale; linear and log based 10. Some
utility method on the scales are pure wrapper around d3 method but for
the critical path, we wroute our own.

For posterity, we did look into using GPGPU to support mass coordinate
conversions but it introduced more noises and, near half the time, it
was slower than simple CPU based implementation.
