### PR TITLE
Introduce alert snackbar UI

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -38,6 +38,7 @@ ng_module(
         "selectors.ts",
     ],
     deps = [
+        "//tensorboard/webapp/alert/store",
         "//tensorboard/webapp/app_routing/store",
         "//tensorboard/webapp/experiments/store:selectors",
         "//tensorboard/webapp/metrics/store",
@@ -74,6 +75,8 @@ ng_module(
         ":mat_icon",
         ":oss_plugins_module",
         ":reducer_config",
+        "//tensorboard/webapp/alert",
+        "//tensorboard/webapp/alert/views:alert_snackbar",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "//tensorboard/webapp/app_routing",
         "//tensorboard/webapp/app_routing:route_registry",
@@ -106,6 +109,7 @@ ng_module(
         "app_state.ts",
     ],
     deps = [
+        "//tensorboard/webapp/alert/store:types",
         "//tensorboard/webapp/app_routing/store:types",
         "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/experiments/store:types",
@@ -204,6 +208,9 @@ tensorboard_html_binary(
 tf_ng_web_test_suite(
     name = "karma_test",
     deps = [
+        "//tensorboard/webapp/alert:test_lib",
+        "//tensorboard/webapp/alert/store:test_lib",
+        "//tensorboard/webapp/alert/views:views_test",
         "//tensorboard/webapp/app_routing:app_routing_test",
         "//tensorboard/webapp/app_routing:route_config_test",
         "//tensorboard/webapp/app_routing:testing",

--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -259,6 +259,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/plugins/text_v2/effects:effects_test_lib",
         "//tensorboard/webapp/plugins/text_v2/store:store_test_lib",
         "//tensorboard/webapp/reloader:test_lib",
+        "//tensorboard/webapp/routes:routes_test_lib",
         "//tensorboard/webapp/runs/data_source:runs_data_source_test",
         "//tensorboard/webapp/runs/effects:effects_test",
         "//tensorboard/webapp/runs/store:store_test",

--- a/tensorboard/webapp/alert/BUILD
+++ b/tensorboard/webapp/alert/BUILD
@@ -9,10 +9,13 @@ ng_module(
         "alert_module.ts",
     ],
     deps = [
+        ":alert_action",
         "//tensorboard/webapp/alert/effects",
         "//tensorboard/webapp/alert/store",
+        "//tensorboard/webapp/alert/store:types",
         "//tensorboard/webapp/alert/views:alert_snackbar",
         "@npm//@angular/core",
+        "@npm//@ngrx/effects",
         "@npm//@ngrx/store",
     ],
 )
@@ -48,6 +51,8 @@ tf_ts_library(
         "//tensorboard/webapp/alert/actions",
         "//tensorboard/webapp/alert/effects",
         "//tensorboard/webapp/alert/store",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
         "@npm//@angular/common",
         "@npm//@angular/compiler",
         "@npm//@angular/core",

--- a/tensorboard/webapp/alert/BUILD
+++ b/tensorboard/webapp/alert/BUILD
@@ -1,0 +1,59 @@
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "alert",
+    srcs = [
+        "alert_module.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/alert/effects",
+        "//tensorboard/webapp/alert/store",
+        "//tensorboard/webapp/alert/views:alert_snackbar",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+    ],
+)
+
+ng_module(
+    name = "alert_action",
+    srcs = [
+        "alert_action_module.ts",
+    ],
+    deps = [
+        ":types",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ts_library(
+    name = "types",
+    srcs = [
+        "types.ts",
+    ],
+)
+
+tf_ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = [
+        "alert_action_test.ts",
+    ],
+    deps = [
+        ":alert_action",
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp/alert/actions",
+        "//tensorboard/webapp/alert/effects",
+        "//tensorboard/webapp/alert/store",
+        "@npm//@angular/common",
+        "@npm//@angular/compiler",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+        "@npm//rxjs",
+    ],
+)

--- a/tensorboard/webapp/alert/actions/BUILD
+++ b/tensorboard/webapp/alert/actions/BUILD
@@ -1,0 +1,14 @@
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+tf_ts_library(
+    name = "actions",
+    srcs = [
+        "index.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/alert:types",
+        "@npm//@ngrx/store",
+    ],
+)

--- a/tensorboard/webapp/alert/actions/BUILD
+++ b/tensorboard/webapp/alert/actions/BUILD
@@ -7,6 +7,9 @@ tf_ts_library(
     srcs = [
         "index.ts",
     ],
+    visibility = [
+        "//tensorboard/webapp/alert:__subpackages__",
+    ],
     deps = [
         "//tensorboard/webapp/alert:types",
         "@npm//@ngrx/store",

--- a/tensorboard/webapp/alert/actions/index.ts
+++ b/tensorboard/webapp/alert/actions/index.ts
@@ -1,6 +1,4 @@
-<!--
-@license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,13 +11,18 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
+==============================================================================*/
+import {createAction, props} from '@ngrx/store';
 
-<app-header></app-header>
-<main #main>
-  <router-outlet></router-outlet>
-</main>
-<alert-snackbar></alert-snackbar>
-<hash-storage></hash-storage>
-<page-title></page-title>
-<settings-polymer-interop></settings-polymer-interop>
+import {AlertReport} from '../types';
+
+/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
+/** @typehack */ import * as _typeHackStore from '@ngrx/store';
+
+/**
+ * Fires when an alert is to be reported.
+ */
+export const alertReported = createAction(
+  '[Alert] Alert Reported',
+  props<AlertReport>()
+);

--- a/tensorboard/webapp/alert/alert_action_module.ts
+++ b/tensorboard/webapp/alert/alert_action_module.ts
@@ -52,13 +52,13 @@ export interface ActionToAlertConfig {
  *     AlertActionModule.registerAlertActions([
  *       {
  *         action: fetchKeysFailed,
- *         alertFromAction: () => {details: "Keys failed to fetch."},
+ *         alertFromAction: () => {localizedMessage: "Keys failed to fetch."},
  *       },
  *       {
  *         action: greenButtonClicked,
  *         alertFromAction: (actionPayload) => {
  *           if (!actionPayload.wasButtonEnabled) {
- *             return {details: "Green button failed."};
+ *             return {localizedMessage: "Green button failed."};
  *           }
  *           return null;
  *         }

--- a/tensorboard/webapp/alert/alert_action_module.ts
+++ b/tensorboard/webapp/alert/alert_action_module.ts
@@ -22,9 +22,11 @@ import {
 import {Action, ActionCreator, Creator} from '@ngrx/store';
 import {AlertReport} from './types';
 
-const ACTION_TO_ALERT_PROVIDER = new InjectionToken<ActionToAlertConfig[]>(
-  '[Alert] Action-To-Alert Provider'
-);
+// While this token is not used outside, it must be exported so that stricter
+// build tools may discover it during compilation.
+export const ACTION_TO_ALERT_PROVIDER = new InjectionToken<
+  ActionToAlertConfig[]
+>('[Alert] Action-To-Alert Provider');
 
 export type ActionToAlertTransformer = (action: Action) => AlertReport | null;
 
@@ -101,7 +103,7 @@ export class AlertActionModule {
   }
 
   static registerAlertActions(
-    configs: ActionToAlertConfig[]
+    providerFactory: () => ActionToAlertConfig[]
   ): ModuleWithProviders<AlertActionModule> {
     return {
       ngModule: AlertActionModule,
@@ -109,7 +111,7 @@ export class AlertActionModule {
         {
           provide: ACTION_TO_ALERT_PROVIDER,
           multi: true,
-          useValue: configs,
+          useFactory: providerFactory,
         },
       ],
     };

--- a/tensorboard/webapp/alert/alert_action_module.ts
+++ b/tensorboard/webapp/alert/alert_action_module.ts
@@ -1,0 +1,117 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  Inject,
+  ModuleWithProviders,
+  NgModule,
+  Optional,
+  InjectionToken,
+} from '@angular/core';
+import {Action, ActionCreator, Creator} from '@ngrx/store';
+import {AlertReport} from './types';
+
+const ACTION_TO_ALERT_PROVIDER = new InjectionToken<ActionToAlertConfig[]>(
+  '[Alert] Action-To-Alert Provider'
+);
+
+export type ActionToAlertTransformer = (action: Action) => AlertReport | null;
+
+export interface ActionToAlertConfig {
+  /**
+   * The action to listen for.
+   */
+  actionCreator: ActionCreator<string, Creator>;
+
+  /**
+   * A function that returns an alert report, or null, when the action is
+   * received.
+   */
+  alertFromAction: ActionToAlertTransformer;
+}
+
+/**
+ * An NgModule that provides alert-producing actions. These action configs are
+ * collected by AlertModule, which tracks application alerts.
+ *
+ * When the configured action fires, the AlertModule may respond.
+ *
+ * @NgModule({
+ *   imports: [
+ *     AlertActionModule.registerAlertActions([
+ *       {
+ *         action: fetchKeysFailed,
+ *         alertFromAction: () => {details: "Keys failed to fetch."},
+ *       },
+ *       {
+ *         action: greenButtonClicked,
+ *         alertFromAction: (actionPayload) => {
+ *           if (!actionPayload.wasButtonEnabled) {
+ *             return {details: "Green button failed."};
+ *           }
+ *           return null;
+ *         }
+ *       }
+ *     ]),
+ *   ],
+ * })
+ */
+@NgModule({})
+export class AlertActionModule {
+  /**
+   * Map from action creator type to transformer function.
+   */
+  private readonly providers = new Map<string, ActionToAlertTransformer>();
+
+  constructor(
+    @Optional()
+    @Inject(ACTION_TO_ALERT_PROVIDER)
+    providers: ActionToAlertConfig[][]
+  ) {
+    for (const configs of providers || []) {
+      for (const config of configs) {
+        if (this.providers.has(config.actionCreator.type)) {
+          throw new RangeError(
+            `"${config.actionCreator.type}" is already registered for alerts.` +
+              ' Multiple alerts for the same action is not allowed.'
+          );
+        }
+        this.providers.set(config.actionCreator.type, config.alertFromAction);
+      }
+    }
+  }
+
+  getAlertFromAction(action: Action): AlertReport | null {
+    const lambda = this.providers.get(action.type);
+    if (!lambda) {
+      return null;
+    }
+    return lambda(action);
+  }
+
+  static registerAlertActions(
+    configs: ActionToAlertConfig[]
+  ): ModuleWithProviders<AlertActionModule> {
+    return {
+      ngModule: AlertActionModule,
+      providers: [
+        {
+          provide: ACTION_TO_ALERT_PROVIDER,
+          multi: true,
+          useValue: configs,
+        },
+      ],
+    };
+  }
+}

--- a/tensorboard/webapp/alert/alert_action_test.ts
+++ b/tensorboard/webapp/alert/alert_action_test.ts
@@ -43,7 +43,7 @@ describe('alert_effects', () => {
             actionCreator: alertActionOccurred,
             alertFromAction: (action: Action) => {
               if (shouldReportAlert) {
-                return {details: 'alert details'};
+                return {localizedMessage: 'alert details'};
               }
               return null;
             },
@@ -67,7 +67,7 @@ describe('alert_effects', () => {
     actions$.next(alertActionOccurred);
 
     expect(recordedActions).toEqual([
-      alertActions.alertReported({details: 'alert details'}),
+      alertActions.alertReported({localizedMessage: 'alert details'}),
     ]);
   });
 

--- a/tensorboard/webapp/alert/alert_action_test.ts
+++ b/tensorboard/webapp/alert/alert_action_test.ts
@@ -1,0 +1,87 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TestBed} from '@angular/core/testing';
+import {EffectsModule} from '@ngrx/effects';
+import {provideMockActions} from '@ngrx/effects/testing';
+import {Action, createAction, Store} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {ReplaySubject} from 'rxjs';
+import {State} from '../app_state';
+import * as alertActions from './actions';
+import {AlertActionModule} from './alert_action_module';
+import {AlertEffects} from './effects';
+
+const alertActionOccurred = createAction('[Test] Action Occurred (need alert)');
+const noAlertActionOccurred = createAction('[Test] Action Occurred (no alert)');
+
+describe('alert_effects', () => {
+  let actions$: ReplaySubject<Action>;
+  let store: MockStore<Partial<State>>;
+  let recordedActions: Action[] = [];
+  let shouldReportAlert: boolean;
+
+  beforeEach(async () => {
+    shouldReportAlert = false;
+    actions$ = new ReplaySubject<Action>(1);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        AlertActionModule.registerAlertActions([
+          {
+            actionCreator: alertActionOccurred,
+            alertFromAction: (action: Action) => {
+              if (shouldReportAlert) {
+                return {details: 'alert details'};
+              }
+              return null;
+            },
+          },
+        ]),
+        EffectsModule.forFeature([AlertEffects]),
+        EffectsModule.forRoot([]),
+      ],
+      providers: [provideMockActions(actions$), provideMockStore({})],
+    }).compileComponents();
+
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    recordedActions = [];
+    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+      recordedActions.push(action);
+    });
+  });
+
+  it(`reports an alert when 'alertFromAction' returns a report`, () => {
+    shouldReportAlert = true;
+    actions$.next(alertActionOccurred);
+
+    expect(recordedActions).toEqual([
+      alertActions.alertReported({details: 'alert details'}),
+    ]);
+  });
+
+  it(`does not alert when 'alertFromAction' returns null`, () => {
+    shouldReportAlert = false;
+    actions$.next(alertActionOccurred);
+
+    expect(recordedActions).toEqual([]);
+  });
+
+  it(`does not alert when a non-matching action is fired`, () => {
+    shouldReportAlert = true;
+    actions$.next(noAlertActionOccurred);
+
+    expect(recordedActions).toEqual([]);
+  });
+});

--- a/tensorboard/webapp/alert/alert_action_test.ts
+++ b/tensorboard/webapp/alert/alert_action_test.ts
@@ -38,7 +38,7 @@ describe('alert_effects', () => {
 
     await TestBed.configureTestingModule({
       imports: [
-        AlertActionModule.registerAlertActions([
+        AlertActionModule.registerAlertActions(() => [
           {
             actionCreator: alertActionOccurred,
             alertFromAction: (action: Action) => {

--- a/tensorboard/webapp/alert/alert_module.ts
+++ b/tensorboard/webapp/alert/alert_module.ts
@@ -15,6 +15,7 @@ limitations under the License.
 import {NgModule} from '@angular/core';
 import {EffectsModule} from '@ngrx/effects';
 import {StoreModule} from '@ngrx/store';
+import {AlertActionModule} from './alert_action_module';
 import {AlertEffects} from './effects';
 import {reducers} from './store';
 import {ALERT_FEATURE_KEY} from './store/alert_types';
@@ -22,9 +23,10 @@ import {AlertSnackbarModule} from './views/alert_snackbar_module';
 
 @NgModule({
   imports: [
+    AlertActionModule,
+    AlertSnackbarModule,
     StoreModule.forFeature(ALERT_FEATURE_KEY, reducers),
     EffectsModule.forFeature([AlertEffects]),
-    AlertSnackbarModule,
   ],
 })
 export class AlertModule {}

--- a/tensorboard/webapp/alert/alert_module.ts
+++ b/tensorboard/webapp/alert/alert_module.ts
@@ -12,9 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-export * from './app_routing/store/app_routing_selectors';
-export * from './experiments/store/experiments_selectors';
-export * from './alert/store/alert_selectors';
-export * from './metrics/store/metrics_selectors';
-export * from './runs/store/runs_selectors';
-export * from './util/ui_selectors';
+import {NgModule} from '@angular/core';
+import {EffectsModule} from '@ngrx/effects';
+import {StoreModule} from '@ngrx/store';
+import {AlertEffects} from './effects';
+import {reducers} from './store';
+import {ALERT_FEATURE_KEY} from './store/alert_types';
+import {AlertSnackbarModule} from './views/alert_snackbar_module';
+
+@NgModule({
+  imports: [
+    StoreModule.forFeature(ALERT_FEATURE_KEY, reducers),
+    EffectsModule.forFeature([AlertEffects]),
+    AlertSnackbarModule,
+  ],
+})
+export class AlertModule {}

--- a/tensorboard/webapp/alert/effects/BUILD
+++ b/tensorboard/webapp/alert/effects/BUILD
@@ -1,0 +1,19 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "effects",
+    srcs = [
+        "index.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp/alert:alert_action",
+        "//tensorboard/webapp/alert/actions",
+        "@npm//@angular/core",
+        "@npm//@ngrx/effects",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)

--- a/tensorboard/webapp/alert/effects/index.ts
+++ b/tensorboard/webapp/alert/effects/index.ts
@@ -1,0 +1,49 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Injectable} from '@angular/core';
+import {Actions, createEffect} from '@ngrx/effects';
+import {Store} from '@ngrx/store';
+import {tap} from 'rxjs/operators';
+import {State} from '../../app_state';
+import {alertReported} from '../actions';
+import {AlertActionModule} from '../alert_action_module';
+
+/** @typehack */ import * as _typeHackNgrxEffects from '@ngrx/effects/effects';
+/** @typehack */ import * as _typeHackStore from '@ngrx/store';
+/** @typehack */ import * as _typeHackRxjs from 'rxjs';
+
+@Injectable()
+export class AlertEffects {
+  constructor(
+    private readonly actions$: Actions,
+    private readonly store: Store<State>,
+    private readonly alertActionModule: AlertActionModule
+  ) {}
+
+  /** @export */
+  reportRegisteredActionAlerts$ = createEffect(
+    () => {
+      return this.actions$.pipe(
+        tap((action) => {
+          const alertInfo = this.alertActionModule.getAlertFromAction(action);
+          if (alertInfo) {
+            this.store.dispatch(alertReported(alertInfo));
+          }
+        })
+      );
+    },
+    {dispatch: false}
+  );
+}

--- a/tensorboard/webapp/alert/store/BUILD
+++ b/tensorboard/webapp/alert/store/BUILD
@@ -1,0 +1,53 @@
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+tf_ts_library(
+    name = "store",
+    srcs = [
+        "alert_reducers.ts",
+        "alert_selectors.ts",
+        "index.ts",
+    ],
+    deps = [
+        ":types",
+        "//tensorboard/webapp/alert:types",
+        "//tensorboard/webapp/alert/actions",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ts_library(
+    name = "types",
+    srcs = [
+        "alert_types.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/alert:types",
+    ],
+)
+
+tf_ts_library(
+    name = "testing",
+    testonly = True,
+    srcs = ["testing.ts"],
+    deps = [
+        ":types",
+    ],
+)
+
+tf_ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = [
+        "alert_reducers_test.ts",
+        "alert_selectors_test.ts",
+    ],
+    deps = [
+        ":store",
+        ":testing",
+        ":types",
+        "//tensorboard/webapp/alert/actions",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/alert/store/alert_reducers.ts
+++ b/tensorboard/webapp/alert/store/alert_reducers.ts
@@ -12,9 +12,29 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-export * from './app_routing/store/app_routing_selectors';
-export * from './experiments/store/experiments_selectors';
-export * from './alert/store/alert_selectors';
-export * from './metrics/store/metrics_selectors';
-export * from './runs/store/runs_selectors';
-export * from './util/ui_selectors';
+import {Action, createReducer, on} from '@ngrx/store';
+import * as actions from '../actions';
+import {AlertState} from './alert_types';
+
+/** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
+
+const initialState: AlertState = {
+  latestAlert: null,
+};
+
+const reducer = createReducer(
+  initialState,
+  on(
+    actions.alertReported,
+    (state: AlertState, {details}): AlertState => {
+      return {
+        ...state,
+        latestAlert: {details, created: Date.now()},
+      };
+    }
+  )
+);
+
+export function reducers(state: AlertState | undefined, action: Action) {
+  return reducer(state, action);
+}

--- a/tensorboard/webapp/alert/store/alert_reducers.ts
+++ b/tensorboard/webapp/alert/store/alert_reducers.ts
@@ -26,10 +26,10 @@ const reducer = createReducer(
   initialState,
   on(
     actions.alertReported,
-    (state: AlertState, {details}): AlertState => {
+    (state: AlertState, {localizedMessage}): AlertState => {
       return {
         ...state,
-        latestAlert: {details, created: Date.now()},
+        latestAlert: {localizedMessage, created: Date.now()},
       };
     }
   )

--- a/tensorboard/webapp/alert/store/alert_reducers_test.ts
+++ b/tensorboard/webapp/alert/store/alert_reducers_test.ts
@@ -19,26 +19,34 @@ import {buildAlertState} from './testing';
 describe('alert_reducers', () => {
   it('saves alerts with a timestamp', () => {
     spyOn(Date, 'now').and.returnValues(123, 234);
-    const action1 = alertActions.alertReported({details: 'Foo1 failed'});
-    const action2 = alertActions.alertReported({details: 'Foo2 failed'});
+    const action1 = alertActions.alertReported({
+      localizedMessage: 'Foo1 failed',
+    });
+    const action2 = alertActions.alertReported({
+      localizedMessage: 'Foo2 failed',
+    });
     const state1 = buildAlertState({latestAlert: null});
 
     const state2 = alertReducers.reducers(state1, action1);
     expect(state2.latestAlert!).toEqual({
-      details: 'Foo1 failed',
+      localizedMessage: 'Foo1 failed',
       created: 123,
     });
 
     const state3 = alertReducers.reducers(state2, action2);
     expect(state3.latestAlert!).toEqual({
-      details: 'Foo2 failed',
+      localizedMessage: 'Foo2 failed',
       created: 234,
     });
   });
 
   it('updates state with a different alert if the report is the same', () => {
-    const action1 = alertActions.alertReported({details: 'Foo failed again'});
-    const action2 = alertActions.alertReported({details: 'Foo failed again'});
+    const action1 = alertActions.alertReported({
+      localizedMessage: 'Foo failed again',
+    });
+    const action2 = alertActions.alertReported({
+      localizedMessage: 'Foo failed again',
+    });
     const state1 = buildAlertState({latestAlert: null});
 
     const state2 = alertReducers.reducers(state1, action1);

--- a/tensorboard/webapp/alert/store/alert_reducers_test.ts
+++ b/tensorboard/webapp/alert/store/alert_reducers_test.ts
@@ -1,0 +1,52 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import * as alertActions from '../actions';
+import * as alertReducers from './alert_reducers';
+import {buildAlertState} from './testing';
+
+describe('alert_reducers', () => {
+  it('saves alerts with a timestamp', () => {
+    spyOn(Date, 'now').and.returnValues(123, 234);
+    const action1 = alertActions.alertReported({details: 'Foo1 failed'});
+    const action2 = alertActions.alertReported({details: 'Foo2 failed'});
+    const state1 = buildAlertState({latestAlert: null});
+
+    const state2 = alertReducers.reducers(state1, action1);
+    expect(state2.latestAlert!).toEqual({
+      details: 'Foo1 failed',
+      created: 123,
+    });
+
+    const state3 = alertReducers.reducers(state2, action2);
+    expect(state3.latestAlert!).toEqual({
+      details: 'Foo2 failed',
+      created: 234,
+    });
+  });
+
+  it('updates state with a different alert if the report is the same', () => {
+    const action1 = alertActions.alertReported({details: 'Foo failed again'});
+    const action2 = alertActions.alertReported({details: 'Foo failed again'});
+    const state1 = buildAlertState({latestAlert: null});
+
+    const state2 = alertReducers.reducers(state1, action1);
+    const state2LatestAlert = state2.latestAlert;
+
+    const state3 = alertReducers.reducers(state2, action2);
+    const state3LatestAlert = state3.latestAlert;
+
+    expect(state2LatestAlert).not.toBe(state3LatestAlert);
+  });
+});

--- a/tensorboard/webapp/alert/store/alert_selectors.ts
+++ b/tensorboard/webapp/alert/store/alert_selectors.ts
@@ -12,9 +12,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-export * from './app_routing/store/app_routing_selectors';
-export * from './experiments/store/experiments_selectors';
-export * from './alert/store/alert_selectors';
-export * from './metrics/store/metrics_selectors';
-export * from './runs/store/runs_selectors';
-export * from './util/ui_selectors';
+import {createSelector, createFeatureSelector} from '@ngrx/store';
+import {AlertInfo} from '../types';
+import {AlertState, State, ALERT_FEATURE_KEY} from './alert_types';
+
+/** @typehack */ import * as _typeHackSelector from '@ngrx/store/src/selector';
+/** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
+
+const selectAlertState = createFeatureSelector<State, AlertState>(
+  ALERT_FEATURE_KEY
+);
+
+export const getLatestAlert = createSelector(
+  selectAlertState,
+  (state: AlertState): AlertInfo | null => {
+    return state.latestAlert;
+  }
+);

--- a/tensorboard/webapp/alert/store/alert_selectors_test.ts
+++ b/tensorboard/webapp/alert/store/alert_selectors_test.ts
@@ -35,13 +35,13 @@ describe('alert_selectors', () => {
       const state = buildStateFromAlertState(
         buildAlertState({
           latestAlert: {
-            details: 'The sky is orange',
+            localizedMessage: 'The sky is orange',
             created: 2020,
           },
         })
       );
       expect(selectors.getLatestAlert(state)).toEqual({
-        details: 'The sky is orange',
+        localizedMessage: 'The sky is orange',
         created: 2020,
       });
     });

--- a/tensorboard/webapp/alert/store/alert_selectors_test.ts
+++ b/tensorboard/webapp/alert/store/alert_selectors_test.ts
@@ -1,0 +1,49 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import * as selectors from './alert_selectors';
+import {buildAlertState, buildStateFromAlertState} from './testing';
+
+describe('alert_selectors', () => {
+  describe('getAlert', () => {
+    beforeEach(() => {
+      // Clear the memoization.
+      selectors.getLatestAlert.release();
+    });
+
+    it('returns null when there is no alert', () => {
+      const state = buildStateFromAlertState(
+        buildAlertState({
+          latestAlert: null,
+        })
+      );
+      expect(selectors.getLatestAlert(state)).toBe(null);
+    });
+
+    it('returns the current alert', () => {
+      const state = buildStateFromAlertState(
+        buildAlertState({
+          latestAlert: {
+            details: 'The sky is orange',
+            created: 2020,
+          },
+        })
+      );
+      expect(selectors.getLatestAlert(state)).toEqual({
+        details: 'The sky is orange',
+        created: 2020,
+      });
+    });
+  });
+});

--- a/tensorboard/webapp/alert/store/alert_types.ts
+++ b/tensorboard/webapp/alert/store/alert_types.ts
@@ -1,6 +1,4 @@
-<!--
-@license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,13 +11,15 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
+==============================================================================*/
+import {AlertInfo} from '../types';
 
-<app-header></app-header>
-<main #main>
-  <router-outlet></router-outlet>
-</main>
-<alert-snackbar></alert-snackbar>
-<hash-storage></hash-storage>
-<page-title></page-title>
-<settings-polymer-interop></settings-polymer-interop>
+export const ALERT_FEATURE_KEY = 'alerts';
+
+export interface AlertState {
+  latestAlert: AlertInfo | null;
+}
+
+export interface State {
+  [ALERT_FEATURE_KEY]?: AlertState;
+}

--- a/tensorboard/webapp/alert/store/index.ts
+++ b/tensorboard/webapp/alert/store/index.ts
@@ -1,6 +1,4 @@
-<!--
-@license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,13 +11,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
+==============================================================================*/
 
-<app-header></app-header>
-<main #main>
-  <router-outlet></router-outlet>
-</main>
-<alert-snackbar></alert-snackbar>
-<hash-storage></hash-storage>
-<page-title></page-title>
-<settings-polymer-interop></settings-polymer-interop>
+export * from './alert_reducers';
+export * from './alert_selectors';
+export {State} from './alert_types';

--- a/tensorboard/webapp/alert/store/testing.ts
+++ b/tensorboard/webapp/alert/store/testing.ts
@@ -1,6 +1,4 @@
-<!--
-@license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,13 +11,16 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
+==============================================================================*/
+import {ALERT_FEATURE_KEY, AlertState, State} from './alert_types';
 
-<app-header></app-header>
-<main #main>
-  <router-outlet></router-outlet>
-</main>
-<alert-snackbar></alert-snackbar>
-<hash-storage></hash-storage>
-<page-title></page-title>
-<settings-polymer-interop></settings-polymer-interop>
+export function buildAlertState(override: Partial<AlertState>): AlertState {
+  return {
+    latestAlert: null,
+    ...override,
+  };
+}
+
+export function buildStateFromAlertState(runsState: AlertState): State {
+  return {[ALERT_FEATURE_KEY]: runsState};
+}

--- a/tensorboard/webapp/alert/types.ts
+++ b/tensorboard/webapp/alert/types.ts
@@ -1,6 +1,4 @@
-<!--
-@license
-Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,13 +11,15 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
+==============================================================================*/
+/**
+ * An alert structure used when creating newly reported alerts.
+ */
+export interface AlertReport {
+  details: string;
+}
 
-<app-header></app-header>
-<main #main>
-  <router-outlet></router-outlet>
-</main>
-<alert-snackbar></alert-snackbar>
-<hash-storage></hash-storage>
-<page-title></page-title>
-<settings-polymer-interop></settings-polymer-interop>
+/**
+ * An alert exposed by the feature's selectors.
+ */
+export type AlertInfo = AlertReport & {created: number};

--- a/tensorboard/webapp/alert/types.ts
+++ b/tensorboard/webapp/alert/types.ts
@@ -16,7 +16,7 @@ limitations under the License.
  * An alert structure used when creating newly reported alerts.
  */
 export interface AlertReport {
-  details: string;
+  localizedMessage: string;
 }
 
 /**

--- a/tensorboard/webapp/alert/views/BUILD
+++ b/tensorboard/webapp/alert/views/BUILD
@@ -1,0 +1,43 @@
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+ng_module(
+    name = "alert_snackbar",
+    srcs = [
+        "alert_snackbar_container.ts",
+        "alert_snackbar_module.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp/alert/store",
+        "//tensorboard/webapp/angular:expect_angular_material_snackbar",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+    ],
+)
+
+tf_ts_library(
+    name = "views_test",
+    testonly = True,
+    srcs = [
+        "alert_snackbar_test.ts",
+    ],
+    deps = [
+        ":alert_snackbar",
+        "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp/alert/store",
+        "//tensorboard/webapp/alert/store:testing",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_angular_material_snackbar",
+        "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/alert/views/BUILD
+++ b/tensorboard/webapp/alert/views/BUILD
@@ -17,6 +17,7 @@ ng_module(
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@ngrx/store",
+        "@npm//rxjs",
     ],
 )
 

--- a/tensorboard/webapp/alert/views/alert_snackbar_container.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_container.ts
@@ -21,7 +21,7 @@ import {
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {Store} from '@ngrx/store';
 import {Subject} from 'rxjs';
-import {filter, takeUntil, tap} from 'rxjs/operators';
+import {filter, takeUntil} from 'rxjs/operators';
 
 import {State} from '../../app_state';
 import {getLatestAlert} from '../../selectors';

--- a/tensorboard/webapp/alert/views/alert_snackbar_container.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_container.ts
@@ -1,0 +1,70 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {Store} from '@ngrx/store';
+import {Subject} from 'rxjs';
+import {filter, takeUntil, tap} from 'rxjs/operators';
+
+import {State} from '../../app_state';
+import {getLatestAlert} from '../../selectors';
+
+/**
+ * Renders alerts in a 'snackbar' to indicate them to the user.
+ */
+@Component({
+  selector: 'alert-snackbar',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AlertSnackbarContainer implements OnInit, OnDestroy {
+  private readonly ngUnsubscribe = new Subject();
+
+  constructor(
+    private readonly store: Store<State>,
+    private readonly snackBar: MatSnackBar
+  ) {}
+
+  ngOnInit() {
+    this.store
+      .select(getLatestAlert)
+      .pipe(
+        takeUntil(this.ngUnsubscribe),
+        filter((alert) => Boolean(alert)),
+        tap((alert) => {
+          this.showAlert(alert!.details);
+        })
+      )
+      .subscribe(() => {});
+  }
+
+  ngOnDestroy() {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
+  }
+
+  private showAlert(details: string) {
+    this.snackBar.open(details, '', {
+      duration: 5000,
+      horizontalPosition: 'start',
+      verticalPosition: 'bottom',
+    });
+  }
+}

--- a/tensorboard/webapp/alert/views/alert_snackbar_container.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_container.ts
@@ -49,7 +49,7 @@ export class AlertSnackbarContainer implements OnInit, OnDestroy {
         takeUntil(this.ngUnsubscribe),
         filter((alert) => Boolean(alert)),
         tap((alert) => {
-          this.showAlert(alert!.details);
+          this.showAlert(alert!.localizedMessage);
         })
       )
       .subscribe(() => {});
@@ -60,8 +60,8 @@ export class AlertSnackbarContainer implements OnInit, OnDestroy {
     this.ngUnsubscribe.complete();
   }
 
-  private showAlert(details: string) {
-    this.snackBar.open(details, '', {
+  private showAlert(localizedMessage: string) {
+    this.snackBar.open(localizedMessage, '', {
       duration: 5000,
       horizontalPosition: 'start',
       verticalPosition: 'bottom',

--- a/tensorboard/webapp/alert/views/alert_snackbar_container.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_container.ts
@@ -47,12 +47,11 @@ export class AlertSnackbarContainer implements OnInit, OnDestroy {
       .select(getLatestAlert)
       .pipe(
         takeUntil(this.ngUnsubscribe),
-        filter((alert) => Boolean(alert)),
-        tap((alert) => {
-          this.showAlert(alert!.localizedMessage);
-        })
+        filter((alert) => Boolean(alert))
       )
-      .subscribe(() => {});
+      .subscribe((alert) => {
+        this.showAlert(alert!.localizedMessage);
+      });
   }
 
   ngOnDestroy() {

--- a/tensorboard/webapp/alert/views/alert_snackbar_module.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_module.ts
@@ -12,9 +12,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-export * from './app_routing/store/app_routing_selectors';
-export * from './experiments/store/experiments_selectors';
-export * from './alert/store/alert_selectors';
-export * from './metrics/store/metrics_selectors';
-export * from './runs/store/runs_selectors';
-export * from './util/ui_selectors';
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
+
+import {AlertSnackbarContainer} from './alert_snackbar_container';
+
+/**
+ * Provides the 'alert snackbar' view.
+ */
+@NgModule({
+  declarations: [AlertSnackbarContainer],
+  exports: [AlertSnackbarContainer],
+  imports: [CommonModule, MatSnackBarModule],
+})
+export class AlertSnackbarModule {}

--- a/tensorboard/webapp/alert/views/alert_snackbar_test.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_test.ts
@@ -46,13 +46,13 @@ describe('alert snackbar', () => {
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
   });
 
-  it('should open the snackbar on each alert', () => {
+  it('opens the snackbar on each alert', () => {
     const fixture = TestBed.createComponent(AlertSnackbarContainer);
     fixture.detectChanges();
     expect(snackBarOpenSpy).not.toHaveBeenCalled();
 
     store.overrideSelector(selectors.getLatestAlert, {
-      details: 'Foo failed',
+      localizedMessage: 'Foo failed',
       created: 0,
     });
     store.refreshState();
@@ -61,7 +61,7 @@ describe('alert snackbar', () => {
     expect(snackBarOpenSpy.calls.mostRecent().args[0]).toBe('Foo failed');
 
     store.overrideSelector(selectors.getLatestAlert, {
-      details: 'Foo2 failed',
+      localizedMessage: 'Foo2 failed',
       created: 1,
     });
     store.refreshState();
@@ -70,13 +70,13 @@ describe('alert snackbar', () => {
     expect(snackBarOpenSpy.calls.mostRecent().args[0]).toBe('Foo2 failed');
   });
 
-  it('should open the snackbar again on receiving the same alert', () => {
+  it('opens the snackbar again on receiving the same alert', () => {
     const fixture = TestBed.createComponent(AlertSnackbarContainer);
     fixture.detectChanges();
     expect(snackBarOpenSpy).not.toHaveBeenCalled();
 
     store.overrideSelector(selectors.getLatestAlert, {
-      details: 'Foo failed again',
+      localizedMessage: 'Foo failed again',
       created: 0,
     });
     store.refreshState();
@@ -85,7 +85,7 @@ describe('alert snackbar', () => {
     expect(snackBarOpenSpy.calls.mostRecent().args[0]).toBe('Foo failed again');
 
     store.overrideSelector(selectors.getLatestAlert, {
-      details: 'Foo failed again',
+      localizedMessage: 'Foo failed again',
       created: 1,
     });
     store.refreshState();

--- a/tensorboard/webapp/alert/views/alert_snackbar_test.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_test.ts
@@ -1,0 +1,96 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TestBed} from '@angular/core/testing';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {Store} from '@ngrx/store';
+import {provideMockStore, MockStore} from '@ngrx/store/testing';
+import {AlertSnackbarContainer} from './alert_snackbar_container';
+import {State} from '../store';
+import * as selectors from '../../selectors';
+import {buildStateFromAlertState, buildAlertState} from '../store/testing';
+
+describe('alert snackbar', () => {
+  let store: MockStore<State>;
+  let snackBarOpenSpy: jasmine.Spy;
+
+  beforeEach(async () => {
+    snackBarOpenSpy = jasmine.createSpy();
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule],
+      providers: [
+        provideMockStore({
+          initialState: buildStateFromAlertState(buildAlertState({})),
+        }),
+        {
+          provide: MatSnackBar,
+          useValue: {
+            open: snackBarOpenSpy,
+          },
+        },
+      ],
+      declarations: [AlertSnackbarContainer],
+    }).compileComponents();
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+  });
+
+  it('should open the snackbar on each alert', () => {
+    const fixture = TestBed.createComponent(AlertSnackbarContainer);
+    fixture.detectChanges();
+    expect(snackBarOpenSpy).not.toHaveBeenCalled();
+
+    store.overrideSelector(selectors.getLatestAlert, {
+      details: 'Foo failed',
+      created: 0,
+    });
+    store.refreshState();
+
+    expect(snackBarOpenSpy.calls.count()).toBe(1);
+    expect(snackBarOpenSpy.calls.mostRecent().args[0]).toBe('Foo failed');
+
+    store.overrideSelector(selectors.getLatestAlert, {
+      details: 'Foo2 failed',
+      created: 1,
+    });
+    store.refreshState();
+
+    expect(snackBarOpenSpy.calls.count()).toBe(2);
+    expect(snackBarOpenSpy.calls.mostRecent().args[0]).toBe('Foo2 failed');
+  });
+
+  it('should open the snackbar again on receiving the same alert', () => {
+    const fixture = TestBed.createComponent(AlertSnackbarContainer);
+    fixture.detectChanges();
+    expect(snackBarOpenSpy).not.toHaveBeenCalled();
+
+    store.overrideSelector(selectors.getLatestAlert, {
+      details: 'Foo failed again',
+      created: 0,
+    });
+    store.refreshState();
+
+    expect(snackBarOpenSpy.calls.count()).toBe(1);
+    expect(snackBarOpenSpy.calls.mostRecent().args[0]).toBe('Foo failed again');
+
+    store.overrideSelector(selectors.getLatestAlert, {
+      details: 'Foo failed again',
+      created: 1,
+    });
+    store.refreshState();
+
+    expect(snackBarOpenSpy.calls.count()).toBe(2);
+    expect(snackBarOpenSpy.calls.mostRecent().args[0]).toBe('Foo failed again');
+  });
+});

--- a/tensorboard/webapp/angular/BUILD
+++ b/tensorboard/webapp/angular/BUILD
@@ -184,6 +184,15 @@ tf_ts_library(
     ],
 )
 
+# This is a dummy rule used as a @angular/material/snackbar dependency.
+tf_ts_library(
+    name = "expect_angular_material_snackbar",
+    srcs = [],
+    deps = [
+        "@npm//@angular/material",
+    ],
+)
+
 # This is a dummy rule used as a @angular/material/sort dependency.
 tf_ts_library(
     name = "expect_angular_material_sort",

--- a/tensorboard/webapp/app_module.ts
+++ b/tensorboard/webapp/app_module.ts
@@ -23,6 +23,8 @@ import {AppRoutingModule} from './app_routing/app_routing_module';
 import {AppRoutingViewModule} from './app_routing/views/app_routing_view_module';
 import {CoreModule} from './core/core_module';
 import {ExperimentsModule} from './experiments/experiments_module';
+import {AlertModule} from './alert/alert_module';
+import {AlertSnackbarModule} from './alert/views/alert_snackbar_module';
 import {HashStorageModule} from './core/views/hash_storage_module';
 import {PageTitleModule} from './core/views/page_title_module';
 import {FeatureFlagModule} from './feature_flag/feature_flag_module';
@@ -30,7 +32,6 @@ import {HeaderModule} from './header/header_module';
 import {MatIconModule} from './mat_icon_module';
 import {PluginsModule} from './plugins/plugins_module';
 import {ROOT_REDUCERS, loggerMetaReducerFactory} from './reducer_config';
-import {ReloaderModule} from './reloader/reloader_module';
 import {RunsModule} from './runs/runs_module';
 import {SettingsModule} from './settings/settings_module';
 import {TensorBoardWrapperModule} from './tb_wrapper/tb_wrapper_module';
@@ -49,6 +50,8 @@ import {routesFactory} from './routes';
     AppRoutingModule,
     AppRoutingViewModule,
     RouteRegistryModule.registerRoutes(routesFactory),
+    AlertModule,
+    AlertSnackbarModule,
     TensorBoardWrapperModule,
     CoreModule,
     ExperimentsModule,

--- a/tensorboard/webapp/app_state.ts
+++ b/tensorboard/webapp/app_state.ts
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+import {State as AlertState} from './alert/store/alert_types';
 import {State as AppRoutingState} from './app_routing/store/app_routing_types';
 import {State as CoreState} from './core/store/core_types';
 import {State as ExperimentsState} from './experiments/store/experiments_types';
@@ -22,7 +23,8 @@ import {State as NpmiState} from './plugins/npmi/store/npmi_types';
 import {State as RunsState} from './runs/store/runs_types';
 import {State as TextState} from './plugins/text_v2/store/text_types';
 
-export type State = AppRoutingState &
+export type State = AlertState &
+  AppRoutingState &
   CoreState &
   ExperimentsState &
   FeatureFlagState &

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -20,6 +20,7 @@ import {DeepReadonly} from '../../util/types';
 import {
   CardId,
   CardIdWithMetadata,
+  CardUniqueInfo,
   CardMetadata,
   HistogramMode,
   NonPinnedCardId,
@@ -235,6 +236,13 @@ export const getCardPinnedState = createSelector(
     cardId: NonPinnedCardId | PinnedCardId
   ): boolean => {
     return cardToPinnedCopy.has(cardId) || pinnedCardToOriginal.has(cardId);
+  }
+);
+
+export const getUnresolvedImportedPinnedCards = createSelector(
+  selectMetricsState,
+  (state: MetricsState): CardUniqueInfo[] => {
+    return state.unresolvedImportedPinnedCards;
   }
 );
 

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -513,7 +513,7 @@ describe('metrics selectors', () => {
   });
 
   describe('getUnresolvedImportedPinnedCards', () => {
-    it('returns false if no card exists', () => {
+    it('returns unresolved imported pinned cards', () => {
       selectors.getUnresolvedImportedPinnedCards.release();
 
       const state = appStateFromMetricsState(

--- a/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors_test.ts
@@ -512,6 +512,35 @@ describe('metrics selectors', () => {
     });
   });
 
+  describe('getUnresolvedImportedPinnedCards', () => {
+    it('returns false if no card exists', () => {
+      selectors.getUnresolvedImportedPinnedCards.release();
+
+      const state = appStateFromMetricsState(
+        buildMetricsState({
+          unresolvedImportedPinnedCards: [
+            {plugin: PluginType.SCALARS, tag: 'accuracy'},
+            {
+              plugin: PluginType.IMAGES,
+              tag: 'output',
+              runId: 'exp1/run1',
+              sample: 5,
+            },
+          ],
+        })
+      );
+      expect(selectors.getUnresolvedImportedPinnedCards(state)).toEqual([
+        {plugin: PluginType.SCALARS, tag: 'accuracy'},
+        {
+          plugin: PluginType.IMAGES,
+          tag: 'output',
+          runId: 'exp1/run1',
+          sample: 5,
+        },
+      ]);
+    });
+  });
+
   describe('settings', () => {
     it('returns tooltipSort when called getMetricsTooltipSort', () => {
       selectors.getMetricsTooltipSort.release();

--- a/tensorboard/webapp/reducer_config.ts
+++ b/tensorboard/webapp/reducer_config.ts
@@ -37,12 +37,11 @@ function logger(reducer: ActionReducer<any>): ActionReducer<any> {
 }
 
 export function loggerMetaReducerFactory(): MetaReducer {
-  return logger;
-  // return !isDevMode()
-  //   ? (reducer) => (state, action) => {
-  //       return reducer(state, action);
-  //     }
-  //   : logger;
+  return !isDevMode()
+    ? (reducer) => (state, action) => {
+        return reducer(state, action);
+      }
+    : logger;
 }
 
 export const ROOT_REDUCERS = new InjectionToken<

--- a/tensorboard/webapp/reducer_config.ts
+++ b/tensorboard/webapp/reducer_config.ts
@@ -37,11 +37,12 @@ function logger(reducer: ActionReducer<any>): ActionReducer<any> {
 }
 
 export function loggerMetaReducerFactory(): MetaReducer {
-  return !isDevMode()
-    ? (reducer) => (state, action) => {
-        return reducer(state, action);
-      }
-    : logger;
+  return logger;
+  // return !isDevMode()
+  //   ? (reducer) => (state, action) => {
+  //       return reducer(state, action);
+  //     }
+  //   : logger;
 }
 
 export const ROOT_REDUCERS = new InjectionToken<

--- a/tensorboard/webapp/routes/BUILD
+++ b/tensorboard/webapp/routes/BUILD
@@ -10,9 +10,53 @@ tf_ts_library(
         "index.ts",
     ],
     deps = [
+        ":core_deeplink_provider",
         "//tensorboard/webapp/app_routing:route_config",
         "//tensorboard/webapp/app_routing:types",
         "//tensorboard/webapp/tb_wrapper",
         "@npm//@angular/core",
+    ],
+)
+
+tf_ts_library(
+    name = "core_deeplink_provider",
+    srcs = [
+        "core_deeplink_provider.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp/app_routing:deep_link_provider",
+        "//tensorboard/webapp/app_routing:route_config",
+        "//tensorboard/webapp/app_routing:types",
+        "//tensorboard/webapp/metrics:types",
+        "//tensorboard/webapp/metrics/data_source:types",
+        "//tensorboard/webapp/tb_wrapper",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
+)
+
+tf_ts_library(
+    name = "routes_test_lib",
+    testonly = True,
+    srcs = [
+        "core_deeplink_provider_test.ts",
+    ],
+    deps = [
+        ":core_deeplink_provider",
+        "//tensorboard/webapp:app_state",
+        "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_ngrx_store_testing",
+        "//tensorboard/webapp/app_routing:deep_link_provider",
+        "//tensorboard/webapp/app_routing:types",
+        "//tensorboard/webapp/metrics:test_lib",
+        "//tensorboard/webapp/metrics/data_source:types",
+        "@npm//@angular/core",
+        "@npm//@ngrx/store",
+        "@npm//@types/jasmine",
+        "@npm//rxjs",
     ],
 )

--- a/tensorboard/webapp/routes/core_deeplink_provider.ts
+++ b/tensorboard/webapp/routes/core_deeplink_provider.ts
@@ -1,0 +1,162 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Injectable} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {DeepLinkProvider} from '../app_routing/deep_link_provider';
+import {SerializableQueryParams} from '../app_routing/types';
+import {
+  CardUniqueInfo,
+  URLDeserializedState as MetricsURLDeserializedState,
+} from '../metrics/types';
+import {
+  isSampledPlugin,
+  isSingleRunPlugin,
+  isPluginType,
+} from '../metrics/data_source/types';
+import {combineLatest, Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
+
+import {State} from '../app_state';
+import * as selectors from '../selectors';
+
+export type DeserializedState = MetricsURLDeserializedState;
+
+/**
+ * Provides deeplinking for the core dashboards page.
+ */
+@Injectable()
+export class CoreDeepLinkProvider extends DeepLinkProvider {
+  private getMetricsPinnedCards(
+    store: Store<State>
+  ): Observable<SerializableQueryParams> {
+    return combineLatest([
+      store.select(selectors.getPinnedCardsWithMetadata),
+      store.select(selectors.getUnresolvedImportedPinnedCards),
+    ]).pipe(
+      map(([pinnedCards, unresolvedImportedPinnedCards]) => {
+        if (!pinnedCards.length && !unresolvedImportedPinnedCards.length) {
+          return [];
+        }
+
+        const pinnedCardsToStore = pinnedCards.map(
+          ({plugin, tag, sample, runId}) => {
+            const info = {plugin, tag} as CardUniqueInfo;
+            if (isSingleRunPlugin(plugin)) {
+              info.runId = runId!;
+            }
+            if (isSampledPlugin(plugin)) {
+              info.sample = sample!;
+            }
+            return info;
+          }
+        );
+        // Intentionally order unresolved cards last, so that cards pinned by
+        // the user in this session have priority.
+        const cardsToStore = [
+          ...pinnedCardsToStore,
+          ...unresolvedImportedPinnedCards,
+        ];
+        return [{key: 'pinnedCards', value: JSON.stringify(cardsToStore)}];
+      })
+    );
+  }
+
+  serializeStateToQueryParams(
+    store: Store<State>
+  ): Observable<SerializableQueryParams> {
+    return this.getMetricsPinnedCards(store);
+  }
+
+  deserializeQueryParams(
+    queryParams: SerializableQueryParams
+  ): DeserializedState {
+    let pinnedCards = null;
+    for (const {key, value} of queryParams) {
+      if (key === 'pinnedCards') {
+        pinnedCards = pinnedCards || extractPinnedCardsFromURLText(value);
+      }
+    }
+    return {
+      metrics: {
+        pinnedCards: pinnedCards || [],
+      },
+    };
+  }
+}
+
+function extractPinnedCardsFromURLText(
+  urlText: string
+): CardUniqueInfo[] | null {
+  // Check that the URL text parses.
+  let object;
+  try {
+    object = JSON.parse(urlText) as unknown;
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(object)) {
+    return null;
+  }
+
+  const result = [];
+  for (const item of object) {
+    // Validate types.
+    const isPluginString = typeof item.plugin === 'string';
+    const isRunString = typeof item.runId === 'string';
+    const isSampleNumber = typeof item.sample === 'number';
+    const isTagTypeValid = typeof item.tag === 'string';
+    const isRunTypeValid = isRunString || typeof item.runId === 'undefined';
+    const isSampleTypeValid =
+      isSampleNumber || typeof item.sample === 'undefined';
+    if (
+      !isPluginString ||
+      !isTagTypeValid ||
+      !isRunTypeValid ||
+      !isSampleTypeValid
+    ) {
+      continue;
+    }
+
+    // Required fields and range errors.
+    if (!isPluginType(item.plugin)) {
+      continue;
+    }
+    if (!item.tag) {
+      continue;
+    }
+    if (isRunString && (!item.runId || !isSingleRunPlugin(item.plugin))) {
+      continue;
+    }
+    if (isSampleNumber) {
+      if (!isSampledPlugin(item.plugin)) {
+        continue;
+      }
+      if (!Number.isInteger(item.sample) || item.sample < 0) {
+        continue;
+      }
+    }
+
+    // Assemble result.
+    const resultItem = {plugin: item.plugin, tag: item.tag} as CardUniqueInfo;
+    if (isRunString) {
+      resultItem.runId = item.runId;
+    }
+    if (isSampleNumber) {
+      resultItem.sample = item.sample;
+    }
+    result.push(resultItem);
+  }
+  return result;
+}

--- a/tensorboard/webapp/routes/core_deeplink_provider.ts
+++ b/tensorboard/webapp/routes/core_deeplink_provider.ts
@@ -85,7 +85,8 @@ export class CoreDeepLinkProvider extends DeepLinkProvider {
     let pinnedCards = null;
     for (const {key, value} of queryParams) {
       if (key === 'pinnedCards') {
-        pinnedCards = pinnedCards || extractPinnedCardsFromURLText(value);
+        pinnedCards = extractPinnedCardsFromURLText(value);
+        break;
       }
     }
     return {
@@ -116,13 +117,13 @@ function extractPinnedCardsFromURLText(
     const isPluginString = typeof item.plugin === 'string';
     const isRunString = typeof item.runId === 'string';
     const isSampleNumber = typeof item.sample === 'number';
-    const isTagTypeValid = typeof item.tag === 'string';
+    const isTagString = typeof item.tag === 'string';
     const isRunTypeValid = isRunString || typeof item.runId === 'undefined';
     const isSampleTypeValid =
       isSampleNumber || typeof item.sample === 'undefined';
     if (
       !isPluginString ||
-      !isTagTypeValid ||
+      !isTagString ||
       !isRunTypeValid ||
       !isSampleTypeValid
     ) {
@@ -136,8 +137,16 @@ function extractPinnedCardsFromURLText(
     if (!item.tag) {
       continue;
     }
-    if (isRunString && (!item.runId || !isSingleRunPlugin(item.plugin))) {
-      continue;
+    if (isSingleRunPlugin(item.plugin)) {
+      // A single run plugin must specify a non-empty run.
+      if (!item.runId) {
+        continue;
+      }
+    } else {
+      // A multi run plugin must not specify a run.
+      if (item.runId) {
+        continue;
+      }
     }
     if (isSampleNumber) {
       if (!isSampledPlugin(item.plugin)) {

--- a/tensorboard/webapp/routes/core_deeplink_provider_test.ts
+++ b/tensorboard/webapp/routes/core_deeplink_provider_test.ts
@@ -15,7 +15,6 @@ limitations under the License.
 import {TestBed} from '@angular/core/testing';
 import {Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
-import {Observable} from 'rxjs';
 import {skip} from 'rxjs/operators';
 
 import * as selectors from '../selectors';
@@ -151,6 +150,7 @@ describe('core deeplink provider', () => {
     it('sanitizes pinned cards on deserialization', () => {
       const cases = [
         {
+          // malformed URL value
           serializedValue: 'blah[{"plugin":"scalars","tag":"accuracy"}]',
           expectedPinnedCards: [],
         },
@@ -188,6 +188,12 @@ describe('core deeplink provider', () => {
           // runId is empty
           serializedValue:
             '[{"plugin":"images","tag":"loss","runId":""},{"plugin":"scalars","tag":"default"}]',
+          expectedPinnedCards: [{plugin: PluginType.SCALARS, tag: 'default'}],
+        },
+        {
+          // runId provided with multi-run plugin
+          serializedValue:
+            '[{"plugin":"scalars","tag":"loss","runId":"123"},{"plugin":"scalars","tag":"default"}]',
           expectedPinnedCards: [{plugin: PluginType.SCALARS, tag: 'default'}],
         },
         {

--- a/tensorboard/webapp/routes/core_deeplink_provider_test.ts
+++ b/tensorboard/webapp/routes/core_deeplink_provider_test.ts
@@ -1,0 +1,227 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {TestBed} from '@angular/core/testing';
+import {Store} from '@ngrx/store';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {Observable} from 'rxjs';
+import {skip} from 'rxjs/operators';
+
+import * as selectors from '../selectors';
+import {DeepLinkProvider} from '../app_routing/deep_link_provider';
+import {SerializableQueryParams} from '../app_routing/types';
+import {State} from '../app_state';
+import {appStateFromMetricsState, buildMetricsState} from '../metrics/testing';
+import {PluginType} from '../metrics/data_source/types';
+import {CoreDeepLinkProvider} from './core_deeplink_provider';
+
+describe('core deeplink provider', () => {
+  let store: MockStore<State>;
+  let provider: DeepLinkProvider;
+  let queryParamsSerialized: SerializableQueryParams[];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [
+        provideMockStore({
+          initialState: {
+            ...appStateFromMetricsState(buildMetricsState()),
+          },
+        }),
+      ],
+    }).compileComponents();
+
+    store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    queryParamsSerialized = [];
+
+    provider = new CoreDeepLinkProvider();
+    provider
+      .serializeStateToQueryParams(store)
+      .pipe(
+        // Skip the initial bootstrap.
+        skip(1)
+      )
+      .subscribe((queryParams) => {
+        queryParamsSerialized.push(queryParams);
+      });
+  });
+
+  describe('time series', () => {
+    it('serializes pinned card state when store updates', () => {
+      store.overrideSelector(selectors.getPinnedCardsWithMetadata, [
+        {
+          cardId: 'card1',
+          plugin: PluginType.SCALARS,
+          tag: 'accuracy',
+          runId: null,
+        },
+      ]);
+      store.overrideSelector(selectors.getUnresolvedImportedPinnedCards, [
+        {
+          plugin: PluginType.SCALARS,
+          tag: 'loss',
+        },
+      ]);
+      store.refreshState();
+
+      expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual([
+        {
+          key: 'pinnedCards',
+          value:
+            '[{"plugin":"scalars","tag":"accuracy"},{"plugin":"scalars","tag":"loss"}]',
+        },
+      ]);
+
+      store.overrideSelector(selectors.getPinnedCardsWithMetadata, [
+        {
+          cardId: 'card1',
+          plugin: PluginType.SCALARS,
+          tag: 'accuracy2',
+          runId: null,
+        },
+      ]);
+      store.overrideSelector(selectors.getUnresolvedImportedPinnedCards, [
+        {
+          plugin: PluginType.SCALARS,
+          tag: 'loss2',
+        },
+      ]);
+      store.refreshState();
+
+      expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual([
+        {
+          key: 'pinnedCards',
+          value:
+            '[{"plugin":"scalars","tag":"accuracy2"},{"plugin":"scalars","tag":"loss2"}]',
+        },
+      ]);
+    });
+
+    it('serializes nothing when states are empty', () => {
+      store.overrideSelector(selectors.getPinnedCardsWithMetadata, []);
+      store.overrideSelector(selectors.getUnresolvedImportedPinnedCards, []);
+      store.refreshState();
+
+      expect(queryParamsSerialized[queryParamsSerialized.length - 1]).toEqual(
+        []
+      );
+    });
+
+    it('deserializes empty pinned cards', () => {
+      const state = provider.deserializeQueryParams([]);
+
+      expect(state).toEqual({metrics: {pinnedCards: []}});
+    });
+
+    it('deserializes valid pinned cards', () => {
+      const state = provider.deserializeQueryParams([
+        {
+          key: 'pinnedCards',
+          value:
+            '[{"plugin":"scalars","tag":"accuracy"},{"plugin":"images","tag":"loss","runId":"exp1/123","sample":5}]',
+        },
+      ]);
+
+      expect(state).toEqual({
+        metrics: {
+          pinnedCards: [
+            {plugin: PluginType.SCALARS, tag: 'accuracy'},
+            {
+              plugin: PluginType.IMAGES,
+              tag: 'loss',
+              runId: 'exp1/123',
+              sample: 5,
+            },
+          ],
+        },
+      });
+    });
+
+    it('sanitizes pinned cards on deserialization', () => {
+      const cases = [
+        {
+          serializedValue: 'blah[{"plugin":"scalars","tag":"accuracy"}]',
+          expectedPinnedCards: [],
+        },
+        {
+          // no plugin
+          serializedValue:
+            '[{"tag":"loss"},{"plugin":"scalars","tag":"default"}]',
+          expectedPinnedCards: [{plugin: PluginType.SCALARS, tag: 'default'}],
+        },
+        {
+          // unknown plugin
+          serializedValue:
+            '[{"plugin":"unknown","tag":"loss"},{"plugin":"scalars","tag":"default"}]',
+          expectedPinnedCards: [{plugin: PluginType.SCALARS, tag: 'default'}],
+        },
+        {
+          // tag is not a string
+          serializedValue:
+            '[{"plugin":"scalars","tag":5},{"plugin":"scalars","tag":"default"}]',
+          expectedPinnedCards: [{plugin: PluginType.SCALARS, tag: 'default'}],
+        },
+        {
+          // tag is empty
+          serializedValue:
+            '[{"plugin":"scalars","tag":""},{"plugin":"scalars","tag":"default"}]',
+          expectedPinnedCards: [{plugin: PluginType.SCALARS, tag: 'default'}],
+        },
+        {
+          // runId is not a string
+          serializedValue:
+            '[{"plugin":"images","tag":"loss","runId":123},{"plugin":"scalars","tag":"default"}]',
+          expectedPinnedCards: [{plugin: PluginType.SCALARS, tag: 'default'}],
+        },
+        {
+          // runId is empty
+          serializedValue:
+            '[{"plugin":"images","tag":"loss","runId":""},{"plugin":"scalars","tag":"default"}]',
+          expectedPinnedCards: [{plugin: PluginType.SCALARS, tag: 'default'}],
+        },
+        {
+          // sample provided with non-sampled plugin
+          serializedValue:
+            '[{"plugin":"scalars","tag":"loss","sample":5},{"plugin":"scalars","tag":"default"}]',
+          expectedPinnedCards: [{plugin: PluginType.SCALARS, tag: 'default'}],
+        },
+        {
+          // sample is not a number
+          serializedValue:
+            '[{"plugin":"images","tag":"loss","sample":"5"},{"plugin":"scalars","tag":"default"}]',
+          expectedPinnedCards: [{plugin: PluginType.SCALARS, tag: 'default'}],
+        },
+        {
+          // sample is not an integer
+          serializedValue:
+            '[{"plugin":"images","tag":"loss","sample":5.5},{"plugin":"scalars","tag":"default"}]',
+          expectedPinnedCards: [{plugin: PluginType.SCALARS, tag: 'default'}],
+        },
+        {
+          // sample is negative
+          serializedValue:
+            '[{"plugin":"images","tag":"loss","sample":-5},{"plugin":"scalars","tag":"default"}]',
+          expectedPinnedCards: [{plugin: PluginType.SCALARS, tag: 'default'}],
+        },
+      ];
+      for (const {serializedValue, expectedPinnedCards} of cases) {
+        const state = provider.deserializeQueryParams([
+          {key: 'pinnedCards', value: serializedValue},
+        ]);
+
+        expect(state).toEqual({metrics: {pinnedCards: expectedPinnedCards}});
+      }
+    });
+  });
+});

--- a/tensorboard/webapp/routes/index.ts
+++ b/tensorboard/webapp/routes/index.ts
@@ -17,6 +17,7 @@ import {Component, Type} from '@angular/core';
 import {TensorBoardWrapperComponent} from '../tb_wrapper/tb_wrapper_component';
 import {RouteDef} from '../app_routing/route_config_types';
 import {RouteKind} from '../app_routing/types';
+import {CoreDeepLinkProvider} from './core_deeplink_provider';
 
 export function routesFactory(): RouteDef[] {
   return [
@@ -25,6 +26,7 @@ export function routesFactory(): RouteDef[] {
       path: '/',
       ngComponent: TensorBoardWrapperComponent as Type<Component>,
       defaultRoute: true,
+      deepLinkProvider: new CoreDeepLinkProvider(),
     },
   ];
 }


### PR DESCRIPTION
Diffbase: https://github.com/tensorflow/tensorboard/pull/4221
Followup: https://github.com/tensorflow/tensorboard/pull/4245

Introduces an alert snackbar UI, which surfaces application
errors to the user in the corner of the screen.

Technical design discussion:

On the surface, there are many ways to architect an alert/error
system in ngrx, where our goal is to allow any feature in TB or
a TB embedder to trigger alerts in the snackbar UI.

Creating an 'Alert' feature store, whose reducer listens to other
features' actions would work for TB, but not embedders, since
TB core does not have access to ngrx actions from external
features.

One way to workaround this composability problem is to force
embedders to override the Alerts module and `composeReducers`.
Upon receiving an embedder-specific error, the embedder's
Alerts module can set the latest error accordingly. However,
this approach assumes that a reducer can determine whether
an action should produce an alert or not, based on the action's
payload.

In the followup, the 'cardPinStateToggled' action provides a
counterexample: it should only trigger an alert if there are too
many current pinned cards.

One way to workaround this is to introduce AlertEffects as a
layer that listens to actions from all features, and converts them
into generic 'alertReported' actions (assuming effects can be
composed, similar to reducers). However, this leads us to a world
where AlertModule depends heavily on other features. For
example, if AlertModule depends on feature F, it becomes
difficult to create a TB application / embedder that needs Alerts
without needing F. This is a design constraint we'd like to follow,
as it gives flexibility in bundling TB with only a subset of the
current features.

One might imagine that specific features can do the translation
themselves, using specific effects to convert actions into
'alertReported' actions. However, this synchronous dispatch of
composite actions goes against a best practice. In other
scenarios, it is known to lead to hard-to-reason-about in-between
states, and makes undoing or reverting state changes difficult
due to the processing of multiple actions.

Thus, we finally land on the existing patch. Essentially, it hides
away the composite action using Angular's DI framework. The
actions that should trigger alerts are registered once, and are
dispatched by the AlertEffects, rather than specific features.

Googlers, see test sync cl/338344258