### PR TITLE
[time series] prevent pinning cards from exceeding limit

### DIFF
--- a/tensorboard/webapp/metrics/BUILD
+++ b/tensorboard/webapp/metrics/BUILD
@@ -11,6 +11,7 @@ ng_module(
         "metrics_module.ts",
     ],
     deps = [
+        "//tensorboard/webapp/alert:alert_action",
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/metrics/effects",
         "//tensorboard/webapp/metrics/store",

--- a/tensorboard/webapp/metrics/BUILD
+++ b/tensorboard/webapp/metrics/BUILD
@@ -12,6 +12,7 @@ ng_module(
     ],
     deps = [
         "//tensorboard/webapp/alert:alert_action",
+        "//tensorboard/webapp/metrics/actions",
         "//tensorboard/webapp/metrics/data_source",
         "//tensorboard/webapp/metrics/effects",
         "//tensorboard/webapp/metrics/store",

--- a/tensorboard/webapp/metrics/actions/index.ts
+++ b/tensorboard/webapp/metrics/actions/index.ts
@@ -128,5 +128,5 @@ export const metricsTagGroupExpansionChanged = createAction(
 
 export const cardPinStateToggled = createAction(
   '[Metrics] Card Pin State Toggled',
-  props<{cardId: CardId}>()
+  props<{cardId: CardId; canCreateNewPins: boolean; wasPinned: boolean}>()
 );

--- a/tensorboard/webapp/metrics/store/metrics_reducers.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers.ts
@@ -46,6 +46,7 @@ import {
 import {
   buildOrReturnStateWithUnresolvedImportedPins,
   buildOrReturnStateWithPinnedCopy,
+  canCreateNewPins,
   createPluginDataWithLoadable,
   createRunToLoadState,
   getCardId,
@@ -694,6 +695,10 @@ const reducer = createReducer(
     const shouldPin = isPinnedCopy
       ? false
       : !state.cardToPinnedCopy.has(cardId);
+
+    if (shouldPin && !canCreateNewPins(state)) {
+      return state;
+    }
 
     let nextCardToPinnedCopy = new Map(state.cardToPinnedCopy);
     let nextPinnedCardToOriginal = new Map(state.pinnedCardToOriginal);

--- a/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_reducers_test.ts
@@ -1243,7 +1243,11 @@ describe('metrics reducers', () => {
       });
       const nextState = reducers(
         beforeState,
-        actions.cardPinStateToggled({cardId: 'pinnedCopy1'})
+        actions.cardPinStateToggled({
+          cardId: 'pinnedCopy1',
+          canCreateNewPins: true,
+          wasPinned: true,
+        })
       );
 
       const expectedState = buildMetricsState({
@@ -1278,6 +1282,8 @@ describe('metrics reducers', () => {
         beforeState,
         actions.cardPinStateToggled({
           cardId: 'card1',
+          canCreateNewPins: true,
+          wasPinned: true,
         })
       );
 
@@ -1327,6 +1333,8 @@ describe('metrics reducers', () => {
         beforeState,
         actions.cardPinStateToggled({
           cardId: 'card1',
+          canCreateNewPins: true,
+          wasPinned: false,
         })
       );
 
@@ -1357,6 +1365,8 @@ describe('metrics reducers', () => {
       });
       const action = actions.cardPinStateToggled({
         cardId: 'card1',
+        canCreateNewPins: true,
+        wasPinned: false,
       });
 
       expect(() => {
@@ -1373,6 +1383,8 @@ describe('metrics reducers', () => {
       });
       const action = actions.cardPinStateToggled({
         cardId: 'cardUnknown',
+        canCreateNewPins: true,
+        wasPinned: false,
       });
 
       expect(() => {

--- a/tensorboard/webapp/metrics/store/metrics_selectors.ts
+++ b/tensorboard/webapp/metrics/store/metrics_selectors.ts
@@ -247,6 +247,17 @@ export const getUnresolvedImportedPinnedCards = createSelector(
 );
 
 /**
+ * Whether the UI is allowed to pin more cards. This may be limited if the URL
+ * contains too many pins already.
+ */
+export const getCanCreateNewPins = createSelector(
+  selectMetricsState,
+  (state: MetricsState): boolean => {
+    return storeUtils.canCreateNewPins(state);
+  }
+);
+
+/**
  * Settings.
  */
 export const getMetricsTooltipSort = createSelector(

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -291,3 +291,17 @@ export function buildOrReturnStateWithPinnedCopy(
     cardMetadataMap: nextCardMetadataMap,
   };
 }
+
+/**
+ * The maximum number of pins we allow the user to create. This is intentionally
+ * finite at the moment to mitigate super long URL lengths, until there is more
+ * durable value storage for pins.
+ */
+const MAX_PIN_COUNT = 10;
+
+export function canCreateNewPins(state: MetricsState) {
+  const pinCountInURL =
+    state.pinnedCardToOriginal.size +
+    state.unresolvedImportedPinnedCards.length;
+  return pinCountInURL < MAX_PIN_COUNT;
+}

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils.ts
@@ -296,12 +296,17 @@ export function buildOrReturnStateWithPinnedCopy(
  * The maximum number of pins we allow the user to create. This is intentionally
  * finite at the moment to mitigate super long URL lengths, until there is more
  * durable value storage for pins.
+ * https://github.com/tensorflow/tensorboard/issues/4242
  */
-const MAX_PIN_COUNT = 10;
+const util = {
+  MAX_PIN_COUNT: 10,
+};
 
 export function canCreateNewPins(state: MetricsState) {
   const pinCountInURL =
     state.pinnedCardToOriginal.size +
     state.unresolvedImportedPinnedCards.length;
-  return pinCountInURL < MAX_PIN_COUNT;
+  return pinCountInURL < util.MAX_PIN_COUNT;
 }
+
+export const TEST_ONLY = {util};

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -15,7 +15,11 @@ limitations under the License.
 import {DataLoadState} from '../../types/data';
 
 import {PluginType} from '../data_source';
-import {buildTagMetadata, createCardMetadata} from '../testing';
+import {
+  buildTagMetadata,
+  createCardMetadata,
+  buildMetricsState,
+} from '../testing';
 
 import {
   buildOrReturnStateWithPinnedCopy,
@@ -26,6 +30,8 @@ import {
   getPinnedCardId,
   getRunIds,
   getTimeSeriesLoadable,
+  canCreateNewPins,
+  TEST_ONLY,
 } from './metrics_store_internal_utils';
 import {ImageTimeSeriesData} from './metrics_types';
 
@@ -431,6 +437,63 @@ describe('metrics store utils', () => {
       );
       expect(result.cardStepIndex).toEqual(originals.cardStepIndexMap);
       expect(result.cardMetadataMap).toEqual(originals.cardMetadataMap);
+    });
+  });
+
+  describe('canCreateNewPins', () => {
+    it('returns true when pins are under the limit', () => {
+      TEST_ONLY.util.MAX_PIN_COUNT = 3;
+      const state = buildMetricsState({
+        pinnedCardToOriginal: new Map([['pinnedCard1', 'card1']]),
+        unresolvedImportedPinnedCards: [
+          {plugin: PluginType.SCALARS, tag: 'loss'},
+        ],
+      });
+
+      expect(canCreateNewPins(state)).toBe(true);
+    });
+
+    it('returns false when resolved pins reaches the limit', () => {
+      TEST_ONLY.util.MAX_PIN_COUNT = 3;
+      const state = buildMetricsState({
+        pinnedCardToOriginal: new Map([
+          ['pinnedCard1', 'card1'],
+          ['pinnedCard2', 'card2'],
+          ['pinnedCard3', 'card3'],
+        ]),
+        unresolvedImportedPinnedCards: [],
+      });
+
+      expect(canCreateNewPins(state)).toBe(false);
+    });
+
+    it('returns false when unresolved pins reaches the limit', () => {
+      TEST_ONLY.util.MAX_PIN_COUNT = 3;
+      const state = buildMetricsState({
+        pinnedCardToOriginal: new Map(),
+        unresolvedImportedPinnedCards: [
+          {plugin: PluginType.SCALARS, tag: 'loss1'},
+          {plugin: PluginType.SCALARS, tag: 'loss2'},
+          {plugin: PluginType.SCALARS, tag: 'loss3'},
+        ],
+      });
+
+      expect(canCreateNewPins(state)).toBe(false);
+    });
+
+    it('returns false when pins + unresolved pins reaches the limit', () => {
+      TEST_ONLY.util.MAX_PIN_COUNT = 3;
+      const state = buildMetricsState({
+        pinnedCardToOriginal: new Map([
+          ['pinnedCard1', 'card1'],
+          ['pinnedCard2', 'card2'],
+        ]),
+        unresolvedImportedPinnedCards: [
+          {plugin: PluginType.SCALARS, tag: 'loss1'},
+        ],
+      });
+
+      expect(canCreateNewPins(state)).toBe(false);
     });
   });
 });

--- a/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
+++ b/tensorboard/webapp/metrics/store/metrics_store_internal_utils_test.ts
@@ -441,6 +441,12 @@ describe('metrics store utils', () => {
   });
 
   describe('canCreateNewPins', () => {
+    const originalMaxPinCount = TEST_ONLY.util.MAX_PIN_COUNT;
+
+    afterEach(() => {
+      TEST_ONLY.util.MAX_PIN_COUNT = originalMaxPinCount;
+    });
+
     it('returns true when pins are under the limit', () => {
       TEST_ONLY.util.MAX_PIN_COUNT = 3;
       const state = buildMetricsState({

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
@@ -92,18 +92,17 @@ export class CardViewContainer {
       .select(selectors.getCardPinnedState, this.cardId)
       .pipe(
         take(1),
-        withLatestFrom(this.store.select(selectors.getCanCreateNewPins)),
-        tap(([wasPinned, canCreateNewPins]) => {
-          this.store.dispatch(
-            actions.cardPinStateToggled({
-              cardId: this.cardId,
-              canCreateNewPins,
-              wasPinned,
-            })
-          );
-        })
+        withLatestFrom(this.store.select(selectors.getCanCreateNewPins))
       )
-      .subscribe(() => {});
+      .subscribe(([wasPinned, canCreateNewPins]) => {
+        this.store.dispatch(
+          actions.cardPinStateToggled({
+            cardId: this.cardId,
+            canCreateNewPins,
+            wasPinned,
+          })
+        );
+      });
   }
 }
 

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_container.ts
@@ -20,7 +20,7 @@ import {
 } from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
-import {map, take, tap, throttleTime, withLatestFrom} from 'rxjs/operators';
+import {map, take, throttleTime, withLatestFrom} from 'rxjs/operators';
 
 import {State} from '../../../app_state';
 import * as selectors from '../../../selectors';

--- a/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
+++ b/tensorboard/webapp/metrics/views/card_renderer/card_view_test.ts
@@ -136,15 +136,29 @@ describe('card view test', () => {
     fixture.detectChanges();
 
     expect(dispatchedActions).toEqual([
-      actions.cardPinStateToggled({cardId: 'cardId'}),
+      actions.cardPinStateToggled({
+        cardId: 'cardId',
+        canCreateNewPins: true,
+        wasPinned: false,
+      }),
     ]);
 
+    store.overrideSelector(selectors.getCardPinnedState, true);
+    store.refreshState();
     scalarCard.componentInstance.pinStateChanged.emit(false);
     fixture.detectChanges();
 
     expect(dispatchedActions).toEqual([
-      actions.cardPinStateToggled({cardId: 'cardId'}),
-      actions.cardPinStateToggled({cardId: 'cardId'}),
+      actions.cardPinStateToggled({
+        cardId: 'cardId',
+        canCreateNewPins: true,
+        wasPinned: false,
+      }),
+      actions.cardPinStateToggled({
+        cardId: 'cardId',
+        canCreateNewPins: true,
+        wasPinned: true,
+      }),
     ]);
   });
 


### PR DESCRIPTION
Diffbase: https://github.com/tensorflow/tensorboard/pull/4244

Prevents the "toggle pin" button from creating a new pin,
if we already have the max number of pins allowed.
Unresolved pins still count towards the quota.

This enforced limit prevents the URL from overflowing,
see https://github.com/tensorflow/tensorboard/issues/4242

Googlers, see test sync cl/338344567

![image](https://user-images.githubusercontent.com/2322480/96626790-cd2b7780-12c4-11eb-92e2-64a133da5258.png)