### PR TITLE
infra: remove sourcemap for sass

### DIFF
--- a/tensorboard/defs/defs.bzl
+++ b/tensorboard/defs/defs.bzl
@@ -125,6 +125,7 @@ def tf_sass_binary(deps = [], include_paths = [], **kwargs):
         include_paths = include_paths + [
             "external/npm/node_modules",
         ],
+        sourcemap = False,
         **kwargs
     )
 


### PR DESCRIPTION
Few details first:
1. TensorBoard uses webfiles.zip to serve assets
2. TensorBoard uses SASS and compiled CSS has sourcemap url to their
    respective original source path
3. TensorBoard yet does not have dev target and does not bundle in
    sourcemaps in the webfiles

Given that we would want to take very different approach when doing dev
assets for bundling reasons too, we should safely turn off sourcemap
options in the sass binary which currently is littering on the console
due to missing resources.
