### PR TITLE
Remove pickling of text arrays on export

### DIFF
--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -317,7 +317,7 @@ class TensorBoardExporter(object):
           ndarray: a tensor converted to an ndarray
 
         Returns:
-          The original ndarray if not np.oject, dtype converted to String
+          The original ndarray if not np.object, dtype converted to String
           if np.object.
         """
         if ndarray.dtype != np.object:

--- a/tensorboard/uploader/exporter.py
+++ b/tensorboard/uploader/exporter.py
@@ -300,8 +300,7 @@ class TensorBoardExporter(object):
             tensor_util.make_ndarray(tensor_proto)
             for tensor_proto in points.values
         ]
-        ndarrays = [
-            self._fix_string_types(x) for x in ndarrays]
+        ndarrays = [self._fix_string_types(x) for x in ndarrays]
         np.savez(os.path.join(experiment_dir, tensors_file_path), *ndarrays)
         json_object["tensors_file_path"] = tensors_file_path
         return json_object
@@ -324,7 +323,7 @@ class TensorBoardExporter(object):
         if ndarray.dtype != np.object:
             return ndarray
         else:
-            return ndarray.astype('|S')
+            return ndarray.astype("|S")
 
     def _get_tensor_file_path(self, experiment_dir, wall_time):
         """Get a nonexistent path for a tensor value.

--- a/tensorboard/uploader/exporter_test.py
+++ b/tensorboard/uploader/exporter_test.py
@@ -455,11 +455,10 @@ class TensorBoardExporterTest(tb_test.TestCase):
             )
             tensors = [tensors[key] for key in tensors.keys()]
             self.assertLen(tensors, 2)
-            np.testing.assert_array_equal(tensors[0],
-                                          np.array(["a", "a", "a"], "|S"))
-            np.testing.assert_array_equal(tensors[1],
-                                          np.array(["aa", "aa", "aa"], "|S"))
-
+            np.testing.assert_array_equal(
+                tensors[0], np.array(["a", "a", "a"], "|S"))
+            np.testing.assert_array_equal(
+                tensors[1], np.array(["aa", "aa", "aa"], "|S"))
 
     def test_e2e_success_case_with_blob_sequence_data(self):
         """Covers exporting of complete and incomplete blob sequences

--- a/tensorboard/uploader/exporter_test.py
+++ b/tensorboard/uploader/exporter_test.py
@@ -456,9 +456,11 @@ class TensorBoardExporterTest(tb_test.TestCase):
             tensors = [tensors[key] for key in tensors.keys()]
             self.assertLen(tensors, 2)
             np.testing.assert_array_equal(
-                tensors[0], np.array(["a", "a", "a"], "|S"))
+                tensors[0], np.array(["a", "a", "a"], "|S")
+            )
             np.testing.assert_array_equal(
-                tensors[1], np.array(["aa", "aa", "aa"], "|S"))
+                tensors[1], np.array(["aa", "aa", "aa"], "|S")
+            )
 
     def test_e2e_success_case_with_blob_sequence_data(self):
         """Covers exporting of complete and incomplete blob sequences


### PR DESCRIPTION
* Motivation for features / changes
  The exporter for TB.dev would save arrays containing text in a pickled format rather than an end-user, easily verifiable format.

* Technical description of changes
Force the dtype of the numpy array to a fixed length text dtype, when it was set to np.object, which is only used internally for string/string_refs.

* Screenshots of UI changes
  none.

* Detailed steps to verify changes work correctly (as executed by you)
  Unit tests updated to test the type converson.
  Manually inspected the exported files, loadable without setting allow_pickle. text is relatively easy to inspect with "more".

* Alternate designs / implementations considered
  We can't fix this before the data gets to the client due to the nature of the conversions within the client.  This approach can be a little space-inefficient if the length of the text are highly variable within a single array.
