### PR TITLE
Improve messaging when uploading empty experiments

### DIFF
--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -116,6 +116,7 @@ class TensorBoardUploader(object):
         self._verbosity = 1 if verbosity is None else verbosity
         self._one_shot = False if one_shot is None else one_shot
         self._request_sender = None
+        self._experiment_id = None
         if logdir_poll_rate_limiter is None:
             self._logdir_poll_rate_limiter = util.RateLimiter(
                 _MIN_LOGDIR_POLL_INTERVAL_SECS
@@ -179,10 +180,19 @@ class TensorBoardUploader(object):
             blob_rpc_rate_limiter=self._blob_rpc_rate_limiter,
             tracker=self._tracker,
         )
+        self._experiment_id = response.experiment_id
         return response.experiment_id
 
     def start_uploading(self):
-        """Blocks forever to continuously upload data from the logdir.
+        """Uploads data from the logdir.
+
+        This will continuously scan the logdir, uploading as data is added
+        unless the uploader was built with the _one_shot option, in which
+        case it will terminate after the first scan.
+
+        Returns:
+            A manifest of what was uploaded, in the case of a `one_shot` upload.
+
 
         Raises:
           RuntimeError: If `create_experiment` has not yet been called.
@@ -199,9 +209,13 @@ class TensorBoardUploader(object):
             if self._one_shot:
                 break
         if self._one_shot and not self._tracker.has_data():
-            logger.warning(
+            print(
                 "One-shot mode was used on a logdir (%s) "
-                "without any uploadable data" % self._logdir
+                "without any uploadable data\n"
+                "As a result, the experiment created will be empty. "
+                "To delete the empty experiment execute the following\n\n"
+                "    tensorboard dev delete --experiment_id=%s\n" %
+                (self._logdir, self._experiment_id)
             )
 
     def _upload_once(self):

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -210,11 +210,11 @@ class TensorBoardUploader(object):
                 break
         if self._one_shot and not self._tracker.has_data():
             print(
-                "One-shot mode was used on a logdir (%s) "
-                "without any uploadable data\n"
-                "As a result, the experiment created will be empty. "
+                "Tensorboard was run in `one_shot` mode, but did not detect "
+                "any known uploadable data types in the specified logdir: %s\n"
+                "An empty experiment was created. "
                 "To delete the empty experiment execute the following\n\n"
-                "    tensorboard dev delete --experiment_id=%s\n" %
+                "    tensorboard dev delete --experiment_id=%s" %
                 (self._logdir, self._experiment_id)
             )
 

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -214,8 +214,8 @@ class TensorBoardUploader(object):
                 "any known uploadable data types in the specified logdir: %s\n"
                 "An empty experiment was created. "
                 "To delete the empty experiment execute the following\n\n"
-                "    tensorboard dev delete --experiment_id=%s" %
-                (self._logdir, self._experiment_id)
+                "    tensorboard dev delete --experiment_id=%s"
+                % (self._logdir, self._experiment_id)
             )
 
     def _upload_once(self):

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -431,13 +431,12 @@ class UploadIntent(_Intent):
             verbosity=self.verbosity,
             one_shot=self.one_shot,
         )
-        if False:
-            if self.one_shot and not os.path.isdir(self.logdir):
-                print("%s: No such directory." % self.logdir)
-                print(
-                    "User specified `one_shot` mode with an unavailable "
-                    "logdir. Exiting without creating an experiment.")
-                return
+        if self.one_shot and not os.path.isdir(self.logdir):
+            print("%s: No such directory." % self.logdir)
+            print(
+                "User specified `one_shot` mode with an unavailable "
+                "logdir. Exiting without creating an experiment.")
+            return
         experiment_id = uploader.create_experiment()
         url = server_info_lib.experiment_url(server_info, experiment_id)
         if self.experiment_url_callback is not None:

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -435,7 +435,8 @@ class UploadIntent(_Intent):
             print("%s: No such directory." % self.logdir)
             print(
                 "User specified `one_shot` mode with an unavailable "
-                "logdir. Exiting without creating an experiment.")
+                "logdir. Exiting without creating an experiment."
+            )
             return
         experiment_id = uploader.create_experiment()
         url = server_info_lib.experiment_url(server_info, experiment_id)

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -431,6 +431,13 @@ class UploadIntent(_Intent):
             verbosity=self.verbosity,
             one_shot=self.one_shot,
         )
+        if False:
+            if self.one_shot and not os.path.isdir(self.logdir):
+                print("%s: No such directory." % self.logdir)
+                print(
+                    "User specified `one_shot` mode with an unavailable "
+                    "logdir. Exiting without creating an experiment.")
+                return
         experiment_id = uploader.create_experiment()
         url = server_info_lib.experiment_url(server_info, experiment_id)
         if self.experiment_url_callback is not None:

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -72,13 +72,12 @@ class UploadIntentTest(tf.test.TestCase):
         mock_uploader = mock.MagicMock()
         mock_stdout_write = mock.MagicMock()
         with mock.patch.object(
-            uploader_lib,
-            "TensorBoardUploader",
-            return_value=mock_uploader,
+            uploader_lib, "TensorBoardUploader", return_value=mock_uploader,
         ), mock.patch.object(
             sys.stdout, "write", mock_stdout_write
-        ),mock.patch.object(
-            write_service_pb2_grpc, "TensorBoardWriterServiceStub"):
+        ), mock.patch.object(
+            write_service_pb2_grpc, "TensorBoardWriterServiceStub"
+        ):
             # Set up an UploadIntent configured with one_shot and a
             # non-existent directory.
             intent = uploader_subcommand.UploadIntent(
@@ -106,14 +105,13 @@ class UploadIntentTest(tf.test.TestCase):
         #    communication.        mock_uploader = mock.MagicMock()
         mock_uploader = mock.MagicMock()
         mock_uploader.create_experiment = mock.MagicMock(
-            return_value="fake_experiment_id")
+            return_value="fake_experiment_id"
+        )
         mock_stdout_write = mock.MagicMock()
         with mock.patch.object(
             sys.stdout, "write", mock_stdout_write
         ), mock.patch.object(
-            uploader_lib,
-            "TensorBoardUploader",
-            return_value=mock_uploader
+            uploader_lib, "TensorBoardUploader", return_value=mock_uploader
         ):
             # Set up an UploadIntent configured with one_shot and an empty temp
             # directory.
@@ -129,13 +127,10 @@ class UploadIntentTest(tf.test.TestCase):
         # Expect that ".*Done scanning logdir.*" is among the things printed.
         stdout_writes = [x[0][0] for x in mock_stdout_write.call_args_list]
         self.assertRegex(
-            ",".join(stdout_writes),
-            ".*Upload started.*",
+            ",".join(stdout_writes), ".*Upload started.*",
         )
         # Expect that the last thing written is the string "\nDone.\n"
-        self.assertEqual(
-            stdout_writes[-1], "\nDone.\n"
-        )
+        self.assertEqual(stdout_writes[-1], "\nDone.\n")
 
     def testUploadIntentWithExperimentUrlCallback(self):
         """Test the upload intent with a callback."""

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import itertools
+import os
 import sys
 
 import grpc_testing

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -18,10 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import itertools
 import sys
-
-import grpc_testing
 
 try:
     # python version >= 3.3

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -34,7 +34,6 @@ from tensorboard.uploader.proto import write_service_pb2_grpc
 from tensorboard.uploader import dry_run_stubs
 from tensorboard.uploader import uploader as uploader_lib
 from tensorboard.uploader import uploader_subcommand
-from tensorboard.uploader import server_info as server_info_lib
 from tensorboard.plugins.histogram import metadata as histograms_metadata
 from tensorboard.plugins.graph import metadata as graphs_metadata
 from tensorboard.plugins.scalar import metadata as scalars_metadata


### PR DESCRIPTION
* Motivation for features / changes
https://github.com/tensorflow/tensorboard/issues/4225

* Technical description of changes
Modifies UploadIntent to quit with a helpful message when executing on a non-existent logdir in `one_shot` mode.
Modifies Uploader to output a message with delete instructions for when a user uploads an empty but existing directory in `one_shot` mode.

* Testing
Adds a unit test.  Simplifies a previous unit test to restrict testing to the UploadIntent behavior, and not test the underlying Uploader behavior.
Manually tested uploading a normal directory, an empty directory, and a missing directory. 

Sample output when one_shot uploading an existing but empty directory.
```
$ bazel run tensorboard -- dev upload --logdir=~/tensorboard-logdirs/emptydir/ --one_shot
INFO: Analyzed target //tensorboard:tensorboard (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tensorboard:tensorboard up-to-date:
  bazel-bin/tensorboard/tensorboard
INFO: Elapsed time: 0.387s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
Upload started and will continue reading any new data as it's added to the logdir.

To stop uploading, press Ctrl-C.

View your TensorBoard live at: https://tensorboard.dev/experiment/5slW7NieSgCMhRD9eSkiaw/

[2020-10-24T01:20:08] Uploader started.
Tensorboard was run in `one_shot` mode, but did not detect any known uploadable data types in the specified logdir: /Users/bileschi/tensorboard-logdirs/emptydir/
An empty experiment was created. To delete the empty experiment execute the following

    tensorboard dev delete --experiment_id=5slW7NieSgCMhRD9eSkiaw


Done. View your TensorBoard at https://tensorboard.dev/experiment/5slW7NieSgCMhRD9eSkiaw/
```

Sample output when one_shot uploading a non-existent directory.
```
$ bazel run tensorboard -- dev upload --logdir=/dev/null/doesntexist --one_shot
INFO: Analyzed target //tensorboard:tensorboard (1 packages loaded, 27 targets configured).
INFO: Found 1 target...
Target //tensorboard:tensorboard up-to-date:
  bazel-bin/tensorboard/tensorboard
INFO: Elapsed time: 0.497s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
/dev/null/doesntexist: No such directory.
User specified `one_shot` mode with an unavailable logdir. Exiting without creating an experiment.
```