### PR TITLE
Support followup actions in alert snackbar

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -109,7 +109,6 @@ ng_module(
         "app_state.ts",
     ],
     deps = [
-        "//tensorboard/webapp/alert/store:types",
         "//tensorboard/webapp/app_routing/store:types",
         "//tensorboard/webapp/core/store",
         "//tensorboard/webapp/experiments/store:types",

--- a/tensorboard/webapp/alert/BUILD
+++ b/tensorboard/webapp/alert/BUILD
@@ -37,6 +37,10 @@ tf_ts_library(
     srcs = [
         "types.ts",
     ],
+    deps = [
+        "@npm//@ngrx/store",
+        "@npm//rxjs",
+    ],
 )
 
 tf_ts_library(

--- a/tensorboard/webapp/alert/BUILD
+++ b/tensorboard/webapp/alert/BUILD
@@ -38,6 +38,7 @@ tf_ts_library(
         "types.ts",
     ],
     deps = [
+        "//tensorboard/webapp:app_state",
         "@npm//@ngrx/store",
         "@npm//rxjs",
     ],

--- a/tensorboard/webapp/alert/alert_action_test.ts
+++ b/tensorboard/webapp/alert/alert_action_test.ts
@@ -17,7 +17,7 @@ import {EffectsModule} from '@ngrx/effects';
 import {provideMockActions} from '@ngrx/effects/testing';
 import {Action, createAction, Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
-import {ReplaySubject} from 'rxjs';
+import {ReplaySubject, of} from 'rxjs';
 import {State} from '../app_state';
 import * as alertActions from './actions';
 import {AlertActionModule} from './alert_action_module';

--- a/tensorboard/webapp/alert/alert_action_test.ts
+++ b/tensorboard/webapp/alert/alert_action_test.ts
@@ -17,7 +17,7 @@ import {EffectsModule} from '@ngrx/effects';
 import {provideMockActions} from '@ngrx/effects/testing';
 import {Action, createAction, Store} from '@ngrx/store';
 import {MockStore, provideMockStore} from '@ngrx/store/testing';
-import {ReplaySubject, of} from 'rxjs';
+import {ReplaySubject} from 'rxjs';
 import {State} from '../app_state';
 import * as alertActions from './actions';
 import {AlertActionModule} from './alert_action_module';

--- a/tensorboard/webapp/alert/types.ts
+++ b/tensorboard/webapp/alert/types.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {Action, Store} from '@ngrx/store';
-import {Observable} from 'rxjs';
+import {State} from '../app_state';
 
 /**
  * An alert structure used when creating newly reported alerts.
@@ -32,13 +32,10 @@ export interface AlertReport {
 
     /**
      * A factory that defines how to create the followup action. At the time
-     * when the followup action is requested, the Observable is subscribed to,
-     * and the resulting action is dispatched.
-     *
-     * Note: clients do not need to subscribe to this observable, but they
-     * should ensure that it completes after 1 emission (e.g. take(1)).
+     * when the followup action is requested, a newly created Promise will be
+     * awaited, and the resulting action is dispatched.
      */
-    getFollowupAction$: (store: Store) => Observable<Action>;
+    getFollowupAction: (store: Store<State>) => Promise<Action>;
   };
 }
 

--- a/tensorboard/webapp/alert/types.ts
+++ b/tensorboard/webapp/alert/types.ts
@@ -12,11 +12,39 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {Action, ActionCreator, Creator, Store} from '@ngrx/store';
+import {Observable} from 'rxjs';
+
 /**
  * An alert structure used when creating newly reported alerts.
  */
 export interface AlertReport {
+  /**
+   * Localized text describing the alert.
+   */
   localizedMessage: string;
+
+  followupAction?: {
+    /**
+     * Localized name of a followup action.
+     */
+    label: string;
+
+    /**
+     * The followup action to be dispatched upon user gesture.
+     */
+    actionCreator: ActionCreator<string, Creator<any[], Action>>;
+
+    /**
+     * A callback to be fired just before the followup action is dispatched.
+     * The result of this observable is provided as the payload to the followup
+     * action.
+     *
+     * Note: clients do not need to subscribe to this observable, but they
+     * should ensure that it completes after 1 emission (e.g. take(1)).
+     */
+    getActionPayload$?: (store: Store) => Observable<{}>;
+  };
 }
 
 /**

--- a/tensorboard/webapp/alert/types.ts
+++ b/tensorboard/webapp/alert/types.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Action, ActionCreator, Creator, Store} from '@ngrx/store';
+import {Action, Store} from '@ngrx/store';
 import {Observable} from 'rxjs';
 
 /**
@@ -28,22 +28,17 @@ export interface AlertReport {
     /**
      * Localized name of a followup action.
      */
-    label: string;
+    localizedLabel: string;
 
     /**
-     * The followup action to be dispatched upon user gesture.
-     */
-    actionCreator: ActionCreator<string, Creator<any[], Action>>;
-
-    /**
-     * A callback to be fired just before the followup action is dispatched.
-     * The result of this observable is provided as the payload to the followup
-     * action.
+     * A factory that defines how to create the followup action. At the time
+     * when the followup action is requested, the Observable is subscribed to,
+     * and the resulting action is dispatched.
      *
      * Note: clients do not need to subscribe to this observable, but they
      * should ensure that it completes after 1 emission (e.g. take(1)).
      */
-    getActionPayload$?: (store: Store) => Observable<{}>;
+    getFollowupAction$: (store: Store) => Observable<Action>;
   };
 }
 

--- a/tensorboard/webapp/alert/views/BUILD
+++ b/tensorboard/webapp/alert/views/BUILD
@@ -22,7 +22,9 @@ ng_module(
     deps = [
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
+        "//tensorboard/webapp/alert:types",
         "//tensorboard/webapp/alert/store",
+        "//tensorboard/webapp/alert/store:types",
         "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_snackbar",
         "@npm//@angular/common",

--- a/tensorboard/webapp/alert/views/BUILD
+++ b/tensorboard/webapp/alert/views/BUILD
@@ -1,18 +1,29 @@
 load("@npm_angular_bazel//:index.bzl", "ng_module")
-load("//tensorboard/defs:defs.bzl", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard:internal"])
+
+tf_sass_binary(
+    name = "alert_display_snackbar_styles",
+    src = "alert_display_snackbar_container.scss",
+)
 
 ng_module(
     name = "alert_snackbar",
     srcs = [
+        "alert_display_snackbar_container.ts",
         "alert_snackbar_container.ts",
         "alert_snackbar_module.ts",
+    ],
+    assets = [
+        ":alert_display_snackbar_styles",
+        "alert_display_snackbar_container.ng.html",
     ],
     deps = [
         "//tensorboard/webapp:app_state",
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/alert/store",
+        "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_snackbar",
         "@npm//@angular/common",
         "@npm//@angular/core",
@@ -32,7 +43,9 @@ tf_ts_library(
         "//tensorboard/webapp:selectors",
         "//tensorboard/webapp/alert/store",
         "//tensorboard/webapp/alert/store:testing",
+        "//tensorboard/webapp/angular:expect_angular_cdk_overlay",
         "//tensorboard/webapp/angular:expect_angular_core_testing",
+        "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_snackbar",
         "//tensorboard/webapp/angular:expect_angular_platform_browser_animations",
         "//tensorboard/webapp/angular:expect_ngrx_store_testing",
@@ -40,5 +53,6 @@ tf_ts_library(
         "@npm//@angular/platform-browser",
         "@npm//@ngrx/store",
         "@npm//@types/jasmine",
+        "@npm//rxjs",
     ],
 )

--- a/tensorboard/webapp/alert/views/alert_display_snackbar_container.ng.html
+++ b/tensorboard/webapp/alert/views/alert_display_snackbar_container.ng.html
@@ -1,0 +1,36 @@
+<!--
+@license
+Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<div class="message">{{ alert.localizedMessage }}</div>
+<div class="controls">
+  <button
+    mat-button
+    class="followup-button"
+    *ngIf="alert.followupAction"
+    (click)="onActionButtonClicked()"
+  >
+    {{ alert.followupAction!.label }}
+  </button>
+  <button
+    mat-button
+    class="dismiss-button"
+    (click)="onCloseButtonClicked()"
+    i18n-aria-label="A button to close the snackbar message"
+    aria-label="Dismiss"
+  >
+    Dismiss
+  </button>
+</div>

--- a/tensorboard/webapp/alert/views/alert_display_snackbar_container.ng.html
+++ b/tensorboard/webapp/alert/views/alert_display_snackbar_container.ng.html
@@ -22,7 +22,7 @@ limitations under the License.
     *ngIf="alert.followupAction"
     (click)="onActionButtonClicked()"
   >
-    {{ alert.followupAction!.label }}
+    {{ alert.followupAction!.localizedLabel }}
   </button>
   <button
     mat-button

--- a/tensorboard/webapp/alert/views/alert_display_snackbar_container.scss
+++ b/tensorboard/webapp/alert/views/alert_display_snackbar_container.scss
@@ -12,20 +12,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {NgModule} from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {MatButtonModule} from '@angular/material/button';
-import {MatSnackBarModule} from '@angular/material/snack-bar';
+:host {
+  display: flex;
+  flex-wrap: wrap;
+}
 
-import {AlertSnackbarContainer} from './alert_snackbar_container';
-import {AlertDisplaySnackbarContainer} from './alert_display_snackbar_container';
+.message {
+  font-size: 14px;
+  align-self: center;
+  margin: 5px 0;
+}
 
-/**
- * Provides the 'alert snackbar' view.
- */
-@NgModule({
-  declarations: [AlertSnackbarContainer, AlertDisplaySnackbarContainer],
-  exports: [AlertSnackbarContainer],
-  imports: [CommonModule, MatButtonModule, MatSnackBarModule],
-})
-export class AlertSnackbarModule {}
+.controls {
+  text-align: right;
+  display: inline-block;
+  white-space: nowrap;
+  margin-left: auto;
+}
+
+button {
+  text-transform: uppercase;
+}

--- a/tensorboard/webapp/alert/views/alert_display_snackbar_container.scss
+++ b/tensorboard/webapp/alert/views/alert_display_snackbar_container.scss
@@ -24,8 +24,6 @@ limitations under the License.
 }
 
 .controls {
-  text-align: right;
-  display: inline-block;
   white-space: nowrap;
   margin-left: auto;
 }

--- a/tensorboard/webapp/alert/views/alert_display_snackbar_container.ts
+++ b/tensorboard/webapp/alert/views/alert_display_snackbar_container.ts
@@ -38,17 +38,10 @@ export class AlertDisplaySnackbarContainer {
   onActionButtonClicked() {
     this.snackBarRef.dismiss();
 
-    const {actionCreator, getActionPayload$} = this.alert.followupAction!;
-    if (!getActionPayload$) {
-      this.store.dispatch(actionCreator());
-      return;
-    }
-
-    // Dispatch with action payload.
-    getActionPayload$(this.store)
+    this.alert
+      .followupAction!.getFollowupAction$(this.store)
       .pipe(take(1))
-      .subscribe((payload) => {
-        const action = payload ? actionCreator(payload) : actionCreator();
+      .subscribe((action) => {
         this.store.dispatch(action);
       });
   }

--- a/tensorboard/webapp/alert/views/alert_display_snackbar_container.ts
+++ b/tensorboard/webapp/alert/views/alert_display_snackbar_container.ts
@@ -14,9 +14,9 @@ limitations under the License.
 ==============================================================================*/
 import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
 import {MAT_SNACK_BAR_DATA, MatSnackBarRef} from '@angular/material/snack-bar';
+import {State} from '../../app_state';
 import {AlertInfo} from '../types';
 import {Store} from '@ngrx/store';
-import {take} from 'rxjs/operators';
 
 @Component({
   selector: 'alert-display-snackbar',
@@ -30,20 +30,18 @@ export class AlertDisplaySnackbarContainer {
   constructor(
     private readonly snackBarRef: MatSnackBarRef<AlertDisplaySnackbarContainer>,
     @Inject(MAT_SNACK_BAR_DATA) readonly unknownData: unknown,
-    private readonly store: Store
+    private readonly store: Store<State>
   ) {
     this.alert = unknownData as AlertInfo;
   }
 
-  onActionButtonClicked() {
+  async onActionButtonClicked() {
     this.snackBarRef.dismiss();
 
-    this.alert
-      .followupAction!.getFollowupAction$(this.store)
-      .pipe(take(1))
-      .subscribe((action) => {
-        this.store.dispatch(action);
-      });
+    const followupAction = await this.alert.followupAction!.getFollowupAction(
+      this.store
+    );
+    this.store.dispatch(followupAction);
   }
 
   onCloseButtonClicked() {

--- a/tensorboard/webapp/alert/views/alert_display_snackbar_container.ts
+++ b/tensorboard/webapp/alert/views/alert_display_snackbar_container.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
 import {MAT_SNACK_BAR_DATA, MatSnackBarRef} from '@angular/material/snack-bar';
 import {AlertInfo} from '../types';
-import {Action, Store, ActionCreator, Creator} from '@ngrx/store';
+import {Store} from '@ngrx/store';
 import {take} from 'rxjs/operators';
 
 @Component({

--- a/tensorboard/webapp/alert/views/alert_display_snackbar_container.ts
+++ b/tensorboard/webapp/alert/views/alert_display_snackbar_container.ts
@@ -1,0 +1,59 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
+import {MAT_SNACK_BAR_DATA, MatSnackBarRef} from '@angular/material/snack-bar';
+import {AlertInfo} from '../types';
+import {Action, Store, ActionCreator, Creator} from '@ngrx/store';
+import {take} from 'rxjs/operators';
+
+@Component({
+  selector: 'alert-display-snackbar',
+  templateUrl: './alert_display_snackbar_container.ng.html',
+  styleUrls: ['./alert_display_snackbar_container.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AlertDisplaySnackbarContainer {
+  readonly alert: AlertInfo;
+
+  constructor(
+    private readonly snackBarRef: MatSnackBarRef<AlertDisplaySnackbarContainer>,
+    @Inject(MAT_SNACK_BAR_DATA) readonly unknownData: unknown,
+    private readonly store: Store
+  ) {
+    this.alert = unknownData as AlertInfo;
+  }
+
+  onActionButtonClicked() {
+    this.snackBarRef.dismiss();
+
+    const {actionCreator, getActionPayload$} = this.alert.followupAction!;
+    if (!getActionPayload$) {
+      this.store.dispatch(actionCreator());
+      return;
+    }
+
+    // Dispatch with action payload.
+    getActionPayload$(this.store)
+      .pipe(take(1))
+      .subscribe((payload) => {
+        const action = payload ? actionCreator(payload) : actionCreator();
+        this.store.dispatch(action);
+      });
+  }
+
+  onCloseButtonClicked() {
+    this.snackBarRef.dismiss();
+  }
+}

--- a/tensorboard/webapp/alert/views/alert_snackbar_container.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_container.ts
@@ -23,7 +23,7 @@ import {Store} from '@ngrx/store';
 import {Subject} from 'rxjs';
 import {filter, takeUntil} from 'rxjs/operators';
 
-import {State} from '../../app_state';
+import {State} from '../store/alert_types';
 import {getLatestAlert} from '../../selectors';
 import {AlertDisplaySnackbarContainer} from './alert_display_snackbar_container';
 import {AlertInfo} from '../types';

--- a/tensorboard/webapp/alert/views/alert_snackbar_container.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_container.ts
@@ -25,6 +25,8 @@ import {filter, takeUntil} from 'rxjs/operators';
 
 import {State} from '../../app_state';
 import {getLatestAlert} from '../../selectors';
+import {AlertDisplaySnackbarContainer} from './alert_display_snackbar_container';
+import {AlertInfo} from '../types';
 
 /**
  * Renders alerts in a 'snackbar' to indicate them to the user.
@@ -50,7 +52,7 @@ export class AlertSnackbarContainer implements OnInit, OnDestroy {
         filter((alert) => Boolean(alert))
       )
       .subscribe((alert) => {
-        this.showAlert(alert!.localizedMessage);
+        this.showAlert(alert!);
       });
   }
 
@@ -59,11 +61,12 @@ export class AlertSnackbarContainer implements OnInit, OnDestroy {
     this.ngUnsubscribe.complete();
   }
 
-  private showAlert(localizedMessage: string) {
-    this.snackBar.open(localizedMessage, '', {
+  private showAlert(alertInfo: AlertInfo) {
+    this.snackBar.openFromComponent(AlertDisplaySnackbarContainer, {
       duration: 5000,
       horizontalPosition: 'start',
       verticalPosition: 'bottom',
+      data: alertInfo,
     });
   }
 }

--- a/tensorboard/webapp/alert/views/alert_snackbar_test.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_test.ts
@@ -18,7 +18,6 @@ import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Action, createAction, props, Store} from '@ngrx/store';
 import {provideMockStore, MockStore} from '@ngrx/store/testing';
-import {of} from 'rxjs';
 import {AlertSnackbarContainer} from './alert_snackbar_container';
 import {State} from '../store';
 import * as selectors from '../../selectors';
@@ -159,7 +158,7 @@ describe('alert snackbar', () => {
       localizedMessage: 'Foo failed',
       followupAction: {
         localizedLabel: 'Try again?',
-        getFollowupAction$: () => of(testAction()),
+        getFollowupAction: async () => testAction(),
       },
       created: 0,
     });
@@ -194,7 +193,7 @@ describe('alert snackbar', () => {
       localizedMessage: 'Foo failed',
       followupAction: {
         localizedLabel: 'Try again?',
-        getFollowupAction$: () => of(testAction()),
+        getFollowupAction: async () => testAction(),
       },
       created: 0,
     });
@@ -221,7 +220,7 @@ describe('alert snackbar', () => {
       localizedMessage: 'Foo failed',
       followupAction: {
         localizedLabel: 'Try again?',
-        getFollowupAction$: () => of(testActionWithProps({foo: true})),
+        getFollowupAction: async () => testActionWithProps({foo: true}),
       },
       created: 0,
     });

--- a/tensorboard/webapp/alert/views/alert_snackbar_test.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_test.ts
@@ -158,8 +158,8 @@ describe('alert snackbar', () => {
     store.overrideSelector(selectors.getLatestAlert, {
       localizedMessage: 'Foo failed',
       followupAction: {
-        label: 'Try again?',
-        actionCreator: testAction,
+        localizedLabel: 'Try again?',
+        getFollowupAction$: () => of(testAction()),
       },
       created: 0,
     });
@@ -193,8 +193,8 @@ describe('alert snackbar', () => {
     store.overrideSelector(selectors.getLatestAlert, {
       localizedMessage: 'Foo failed',
       followupAction: {
-        label: 'Try again?',
-        actionCreator: testAction,
+        localizedLabel: 'Try again?',
+        getFollowupAction$: () => of(testAction()),
       },
       created: 0,
     });
@@ -220,11 +220,8 @@ describe('alert snackbar', () => {
     store.overrideSelector(selectors.getLatestAlert, {
       localizedMessage: 'Foo failed',
       followupAction: {
-        label: 'Try again?',
-        actionCreator: testActionWithProps,
-        getActionPayload$: () => {
-          return of({foo: true}, {foo: false});
-        },
+        localizedLabel: 'Try again?',
+        getFollowupAction$: () => of(testActionWithProps({foo: true})),
       },
       created: 0,
     });

--- a/tensorboard/webapp/alert/views/alert_snackbar_test.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_test.ts
@@ -12,38 +12,61 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {OverlayContainer} from '@angular/cdk/overlay';
 import {TestBed} from '@angular/core/testing';
-import {MatSnackBar} from '@angular/material/snack-bar';
+import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {Store} from '@ngrx/store';
+import {Action, createAction, props, Store} from '@ngrx/store';
 import {provideMockStore, MockStore} from '@ngrx/store/testing';
+import {of} from 'rxjs';
 import {AlertSnackbarContainer} from './alert_snackbar_container';
 import {State} from '../store';
 import * as selectors from '../../selectors';
 import {buildStateFromAlertState, buildAlertState} from '../store/testing';
+import {AlertDisplaySnackbarContainer} from './alert_display_snackbar_container';
+import {MatButtonModule} from '@angular/material/button';
+
+const testAction = createAction('[Test] Action Occurred');
+const testActionWithProps = createAction(
+  '[Test] Action With Props Occurred',
+  props<{foo: boolean}>()
+);
+
+const Selectors = {
+  SNACKBAR: 'alert-display-snackbar',
+  FOLLOWUP_BUTTON: '.followup-button',
+  DISMISS_BUTTON: '.dismiss-button',
+};
 
 describe('alert snackbar', () => {
   let store: MockStore<State>;
   let snackBarOpenSpy: jasmine.Spy;
+  let recordedActions: Action[] = [];
+  let overlayContainer: OverlayContainer;
+  let snackbar: MatSnackBar;
 
   beforeEach(async () => {
-    snackBarOpenSpy = jasmine.createSpy();
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule],
+      imports: [NoopAnimationsModule, MatButtonModule, MatSnackBarModule],
       providers: [
         provideMockStore({
           initialState: buildStateFromAlertState(buildAlertState({})),
         }),
-        {
-          provide: MatSnackBar,
-          useValue: {
-            open: snackBarOpenSpy,
-          },
-        },
       ],
-      declarations: [AlertSnackbarContainer],
+      declarations: [AlertSnackbarContainer, AlertDisplaySnackbarContainer],
     }).compileComponents();
     store = TestBed.inject<Store<State>>(Store) as MockStore<State>;
+    recordedActions = [];
+    spyOn(store, 'dispatch').and.callFake((action: Action) => {
+      recordedActions.push(action);
+    });
+    overlayContainer = TestBed.inject(OverlayContainer);
+    snackbar = TestBed.inject(MatSnackBar);
+    snackBarOpenSpy = spyOn(snackbar, 'openFromComponent').and.callThrough();
+  });
+
+  afterEach(() => {
+    snackbar.dismiss();
   });
 
   it('opens the snackbar on each alert', () => {
@@ -58,7 +81,10 @@ describe('alert snackbar', () => {
     store.refreshState();
 
     expect(snackBarOpenSpy.calls.count()).toBe(1);
-    expect(snackBarOpenSpy.calls.mostRecent().args[0]).toBe('Foo failed');
+    expect(snackBarOpenSpy.calls.mostRecent().args[1].data).toEqual({
+      localizedMessage: 'Foo failed',
+      created: 0,
+    });
 
     store.overrideSelector(selectors.getLatestAlert, {
       localizedMessage: 'Foo2 failed',
@@ -67,7 +93,10 @@ describe('alert snackbar', () => {
     store.refreshState();
 
     expect(snackBarOpenSpy.calls.count()).toBe(2);
-    expect(snackBarOpenSpy.calls.mostRecent().args[0]).toBe('Foo2 failed');
+    expect(snackBarOpenSpy.calls.mostRecent().args[1].data).toEqual({
+      localizedMessage: 'Foo2 failed',
+      created: 1,
+    });
   });
 
   it('opens the snackbar again on receiving the same alert', () => {
@@ -82,7 +111,10 @@ describe('alert snackbar', () => {
     store.refreshState();
 
     expect(snackBarOpenSpy.calls.count()).toBe(1);
-    expect(snackBarOpenSpy.calls.mostRecent().args[0]).toBe('Foo failed again');
+    expect(snackBarOpenSpy.calls.mostRecent().args[1].data).toEqual({
+      localizedMessage: 'Foo failed again',
+      created: 0,
+    });
 
     store.overrideSelector(selectors.getLatestAlert, {
       localizedMessage: 'Foo failed again',
@@ -91,6 +123,124 @@ describe('alert snackbar', () => {
     store.refreshState();
 
     expect(snackBarOpenSpy.calls.count()).toBe(2);
-    expect(snackBarOpenSpy.calls.mostRecent().args[0]).toBe('Foo failed again');
+    expect(snackBarOpenSpy.calls.mostRecent().args[1].data).toEqual({
+      localizedMessage: 'Foo failed again',
+      created: 1,
+    });
+  });
+
+  it('closes the snackbar on click', async () => {
+    const fixture = TestBed.createComponent(AlertSnackbarContainer);
+    fixture.detectChanges();
+    store.overrideSelector(selectors.getLatestAlert, {
+      localizedMessage: 'Foo failed',
+      created: 0,
+    });
+    store.refreshState();
+
+    const dismissEl = overlayContainer
+      .getContainerElement()
+      .querySelector(Selectors.DISMISS_BUTTON);
+    expect(dismissEl).toBeTruthy();
+    (dismissEl as HTMLButtonElement).click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const snackbarAfterEl = overlayContainer
+      .getContainerElement()
+      .querySelector(Selectors.SNACKBAR);
+    expect(snackbarAfterEl).not.toBeTruthy();
+  });
+
+  it('shows the followup action if needed', () => {
+    const fixture = TestBed.createComponent(AlertSnackbarContainer);
+    fixture.detectChanges();
+    store.overrideSelector(selectors.getLatestAlert, {
+      localizedMessage: 'Foo failed',
+      followupAction: {
+        label: 'Try again?',
+        actionCreator: testAction,
+      },
+      created: 0,
+    });
+    store.refreshState();
+
+    expect(
+      overlayContainer
+        .getContainerElement()
+        .querySelector(Selectors.FOLLOWUP_BUTTON)
+    ).toBeTruthy();
+  });
+
+  it('does not show the followup button if there is no followup', () => {
+    const fixture = TestBed.createComponent(AlertSnackbarContainer);
+    fixture.detectChanges();
+    store.overrideSelector(selectors.getLatestAlert, {
+      localizedMessage: 'Foo failed',
+      created: 0,
+    });
+    store.refreshState();
+
+    const followupEl = overlayContainer
+      .getContainerElement()
+      .querySelector(Selectors.FOLLOWUP_BUTTON);
+    expect(followupEl).not.toBeTruthy();
+  });
+
+  it('dispatches a followup action and closes', async () => {
+    const fixture = TestBed.createComponent(AlertSnackbarContainer);
+    fixture.detectChanges();
+    store.overrideSelector(selectors.getLatestAlert, {
+      localizedMessage: 'Foo failed',
+      followupAction: {
+        label: 'Try again?',
+        actionCreator: testAction,
+      },
+      created: 0,
+    });
+    store.refreshState();
+
+    const followupEl = overlayContainer
+      .getContainerElement()
+      .querySelector(Selectors.FOLLOWUP_BUTTON);
+    (followupEl as HTMLButtonElement).click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(recordedActions).toEqual([testAction()]);
+    const snackbarAfterEl = overlayContainer
+      .getContainerElement()
+      .querySelector(Selectors.SNACKBAR);
+    expect(snackbarAfterEl).not.toBeTruthy();
+  });
+
+  it('dispatches a followup action with payload and closes', async () => {
+    const fixture = TestBed.createComponent(AlertSnackbarContainer);
+    fixture.detectChanges();
+    store.overrideSelector(selectors.getLatestAlert, {
+      localizedMessage: 'Foo failed',
+      followupAction: {
+        label: 'Try again?',
+        actionCreator: testActionWithProps,
+        getActionPayload$: () => {
+          return of({foo: true}, {foo: false});
+        },
+      },
+      created: 0,
+    });
+    store.refreshState();
+
+    const followupEl = overlayContainer
+      .getContainerElement()
+      .querySelector(Selectors.FOLLOWUP_BUTTON);
+    (followupEl as HTMLButtonElement).click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(recordedActions).toEqual([testActionWithProps({foo: true})]);
+    const snackbarAfterEl = overlayContainer
+      .getContainerElement()
+      .querySelector(Selectors.SNACKBAR);
+    expect(snackbarAfterEl).not.toBeTruthy();
   });
 });

--- a/tensorboard/webapp/app_state.ts
+++ b/tensorboard/webapp/app_state.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {State as AlertState} from './alert/store/alert_types';
 import {State as AppRoutingState} from './app_routing/store/app_routing_types';
 import {State as CoreState} from './core/store/core_types';
 import {State as ExperimentsState} from './experiments/store/experiments_types';
@@ -23,8 +22,7 @@ import {State as NpmiState} from './plugins/npmi/store/npmi_types';
 import {State as RunsState} from './runs/store/runs_types';
 import {State as TextState} from './plugins/text_v2/store/text_types';
 
-export type State = AlertState &
-  AppRoutingState &
+export type State = AppRoutingState &
   CoreState &
   ExperimentsState &
   FeatureFlagState &


### PR DESCRIPTION
The Alert feature includes a snackbar view, which
renders the alert message. This change adds a 'dismiss'
button to make all alerts close-able on user gesture.

Clients of AlertActionModule may now register a followup
action, which can generate a dispatched action (along
with payload from the store) when the user clicks on the
followup action label.

Googlers, see test sync cl/339525644

Screenshots (hypothetical usage):
![image](https://user-images.githubusercontent.com/2322480/97240552-ccef1880-17ab-11eb-9fc3-7450ca96762b.png)
![image](https://user-images.githubusercontent.com/2322480/97240567-d4162680-17ab-11eb-92b5-e55e150b355f.png)
