### PR TITLE
sync: depend on third_party d3 indirection

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -31,8 +31,7 @@ tf_ts_library(
     ],
     deps = [
         ":types",
-        "@npm//@types/d3",
-        "@npm//d3",
+        "//tensorboard/webapp/third_party:d3",
     ],
 )
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {scaleLinear, scaleLog} from 'd3';
+import {scaleLinear, scaleLog} from '../../../third_party/d3';
 
 import {ScaleType} from './scale_types';
 


### PR DESCRIPTION
Due to the build quirk, our webapp cannot depend on d3 directly. To work
around, we can depend on our indirection under
//tensorboard/webapp/third_party. This change does that.
