### PR TITLE
CI to detect the direct dependency to "@npm//d3"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
         # import the indirection in //tensorboard/webapp/angular.
       - run: |
           ! git grep -E '"@npm//@angular/material"|"@npm//@angular/cdk"' 'tensorboard/*/BUILD' ':!tensorboard/webapp/BUILD' ':!tensorboard/webapp/angular/BUILD'
+        # Cannot directly depend on d3 in webapp. Must depend on
+        # `//tensorboard/webapp/third_party:d3` instead.
+      - run: |
+          ! git grep -E '@npm//d3' 'tensorboard/webapp/**/*BUILD' ':!tensorboard/webapp/third_party/**'
 
   lint-build:
     runs-on: ubuntu-16.04


### PR DESCRIPTION
Due to our internal build quirk, we have tensorboard/webapp/third_party.
We would like to guard against direct dependency on d3 using lint.