### PR TITLE
Linkify text in alert message UI

### DIFF
--- a/tensorboard/webapp/alert/views/BUILD
+++ b/tensorboard/webapp/alert/views/BUILD
@@ -27,6 +27,7 @@ ng_module(
         "//tensorboard/webapp/alert/store:types",
         "//tensorboard/webapp/angular:expect_angular_material_button",
         "//tensorboard/webapp/angular:expect_angular_material_snackbar",
+        "//tensorboard/webapp/util:string",
         "@npm//@angular/common",
         "@npm//@angular/core",
         "@npm//@ngrx/store",

--- a/tensorboard/webapp/alert/views/alert_display_snackbar_container.ng.html
+++ b/tensorboard/webapp/alert/views/alert_display_snackbar_container.ng.html
@@ -14,7 +14,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div class="message">{{ alert.localizedMessage }}</div>
+<div class="message">
+  <ng-container *ngFor="let piece of splitByURL(alert.localizedMessage)">
+    <ng-container *ngIf="!piece.isURL; else linkPiece">
+      {{ piece.text }}
+    </ng-container>
+    <ng-template #linkPiece>
+      <a href="{{ piece.text }}" rel="noreferrer noopener" target="_blank"
+        >{{ piece.text }}</a
+      >
+    </ng-template>
+  </ng-container>
+</div>
 <div class="controls">
   <button
     mat-button

--- a/tensorboard/webapp/alert/views/alert_display_snackbar_container.scss
+++ b/tensorboard/webapp/alert/views/alert_display_snackbar_container.scss
@@ -21,6 +21,11 @@ limitations under the License.
   font-size: 14px;
   align-self: center;
   margin: 5px 0;
+  word-break: break-word;
+}
+
+.message a {
+  color: inherit;
 }
 
 .controls {

--- a/tensorboard/webapp/alert/views/alert_display_snackbar_container.ts
+++ b/tensorboard/webapp/alert/views/alert_display_snackbar_container.ts
@@ -17,6 +17,7 @@ import {MAT_SNACK_BAR_DATA, MatSnackBarRef} from '@angular/material/snack-bar';
 import {State} from '../../app_state';
 import {AlertInfo} from '../types';
 import {Store} from '@ngrx/store';
+import {splitByURL} from '../../util/string';
 
 @Component({
   selector: 'alert-display-snackbar',
@@ -26,6 +27,7 @@ import {Store} from '@ngrx/store';
 })
 export class AlertDisplaySnackbarContainer {
   readonly alert: AlertInfo;
+  readonly splitByURL = splitByURL;
 
   constructor(
     private readonly snackBarRef: MatSnackBarRef<AlertDisplaySnackbarContainer>,

--- a/tensorboard/webapp/util/string.ts
+++ b/tensorboard/webapp/util/string.ts
@@ -28,3 +28,97 @@ export function escapeForRegex(value: string): string {
   // '$&' in a regex replacement indicates the last match.
   return value.replace(REGEXP_ESCAPE_CHARS, '\\$&');
 }
+
+/**
+ * Processes text from left-to-right, splitting it into pieces based on the
+ * regex. Each piece is either an unmatched or a matched substring.
+ *
+ * For example,
+ * splitByRegex("a input1 b input2 c input3", /input\d/)
+ * returns
+ * [
+ *    {index: 0,  matchesRegex: false, text: "a "},
+ *    {index: 2,  matchesRegex: true,  text: "input1"},
+ *    {index: 8,  matchesRegex: false, text: " b "},
+ *    {index: 11, matchesRegex: true,  text: "input2"},
+ *    {index: 17, matchesRegex: false, text: " c "},
+ *    {index: 20, matchesRegex: true,  text: "input3"},
+ * ]
+ */
+export function splitByRegex(
+  text: string,
+  regex: RegExp
+): Array<{index: number; matchesRegex: boolean; text: string}> {
+  // 'matchAll' requires a regex with the 'global' flag.
+  if (!regex.flags.includes('g')) {
+    regex = new RegExp(regex, regex.flags + 'g');
+  }
+
+  const result = [];
+
+  // Index of the earliest unvisited character.
+  let lastIndex = 0;
+  for (const match of text.matchAll(regex)) {
+    const index = match.index as number;
+    const matchingText = match[0];
+
+    // Add any text between the last match and this current one.
+    if (index > lastIndex) {
+      result.push({
+        index: lastIndex,
+        text: text.substring(lastIndex, index),
+        matchesRegex: false,
+      });
+    }
+
+    result.push({
+      index,
+      text: matchingText,
+      matchesRegex: true,
+    });
+
+    lastIndex = index + matchingText.length;
+  }
+
+  // Add the remaining text piece, if any.
+  if (text.length > lastIndex) {
+    result.push({
+      index: lastIndex,
+      text: text.substring(lastIndex, text.length),
+      matchesRegex: false,
+    });
+  }
+
+  return result;
+}
+
+// Based on
+// https://cs.chromium.org/chromium/src/third_party/devtools-frontend/src/front_end/console/ConsoleViewMessage.js?q=linkstringregex
+const URL_CONTROL_CODES = '\\u0000-\\u0020\\u007f-\\u009f';
+const LINKIFY_URL_REGEX = new RegExp(
+  '(?:[a-zA-Z][a-zA-Z0-9+.-]{2,}:\\/\\/|data:|www\\.)[^\\s' +
+    URL_CONTROL_CODES +
+    '"]{2,}[^\\s' +
+    URL_CONTROL_CODES +
+    '"\')}\\],:;.!?]',
+  'gu'
+);
+
+/**
+ * Splits the string into pieces that are URLs and non-URLs for linkification.
+ * Invalid links (e.g. 'javascript:') are not linkified.
+ *
+ * For example,
+ * splitByURL("visit http://example.com today")
+ * Returns
+ * [
+ *   {isUrl: false, text: "visit "},
+ *   {isUrl: true,  text: "http://example.com"},
+ *   {isUrl: false, text: " today"},
+ * ]
+ */
+export function splitByURL(text: string): {isURL: boolean; text: string}[] {
+  return splitByRegex(text, LINKIFY_URL_REGEX).map(({matchesRegex, text}) => {
+    return {isURL: matchesRegex, text};
+  });
+}

--- a/tensorboard/webapp/util/string_test.ts
+++ b/tensorboard/webapp/util/string_test.ts
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {escapeForRegex} from './string';
+import {escapeForRegex, splitByRegex, splitByURL} from './string';
 
 describe('escapeForRegex test', () => {
   it('escapes unsafe characters', () => {
@@ -29,5 +29,85 @@ describe('escapeForRegex test', () => {
     expect(escapeForRegex('foo://bar@baz')).toEqual('foo://bar@baz');
     expect(escapeForRegex('1 - 2')).toEqual('1 - 2');
     expect(escapeForRegex('a_b')).toEqual('a_b');
+  });
+});
+
+describe('splitByRegex', () => {
+  it('properly splits when there is no match', () => {
+    expect(splitByRegex('foo', /bar/g)).toEqual([
+      {index: 0, matchesRegex: false, text: 'foo'},
+    ]);
+  });
+
+  it('properly splits when there is a match', () => {
+    expect(splitByRegex('bar', /bar/g)).toEqual([
+      {index: 0, matchesRegex: true, text: 'bar'},
+    ]);
+  });
+
+  it('properly splits on match - nomatch', () => {
+    expect(splitByRegex('bar foo', /bar/g)).toEqual([
+      {index: 0, matchesRegex: true, text: 'bar'},
+      {index: 3, matchesRegex: false, text: ' foo'},
+    ]);
+  });
+
+  it('properly splits on nomatch - match', () => {
+    expect(splitByRegex('foo bar', /bar/g)).toEqual([
+      {index: 0, matchesRegex: false, text: 'foo '},
+      {index: 4, matchesRegex: true, text: 'bar'},
+    ]);
+  });
+
+  it('properly splits on match - nomatch - match', () => {
+    expect(splitByRegex('bar foo bar', /bar/g)).toEqual([
+      {index: 0, matchesRegex: true, text: 'bar'},
+      {index: 3, matchesRegex: false, text: ' foo '},
+      {index: 8, matchesRegex: true, text: 'bar'},
+    ]);
+  });
+
+  it('properly splits multiple matches from left to right', () => {
+    expect(splitByRegex('aaaaa', /aa/g)).toEqual([
+      {index: 0, matchesRegex: true, text: 'aa'},
+      {index: 2, matchesRegex: true, text: 'aa'},
+      {index: 4, matchesRegex: false, text: 'a'},
+    ]);
+  });
+
+  it('adds the global flag if needed', () => {
+    expect(splitByRegex('aaaaa', /aa/)).toEqual([
+      {index: 0, matchesRegex: true, text: 'aa'},
+      {index: 2, matchesRegex: true, text: 'aa'},
+      {index: 4, matchesRegex: false, text: 'a'},
+    ]);
+  });
+});
+
+describe('splitByURL', () => {
+  it('properly extracts proper URLs', () => {
+    expect(splitByURL('hi http://hello bye')).toEqual([
+      {isURL: false, text: 'hi '},
+      {isURL: true, text: 'http://hello'},
+      {isURL: false, text: ' bye'},
+    ]);
+
+    expect(splitByURL('hi http://hello:6006 bye')).toEqual([
+      {isURL: false, text: 'hi '},
+      {isURL: true, text: 'http://hello:6006'},
+      {isURL: false, text: ' bye'},
+    ]);
+
+    expect(splitByURL('hi www.example.com bye')).toEqual([
+      {isURL: false, text: 'hi '},
+      {isURL: true, text: 'www.example.com'},
+      {isURL: false, text: ' bye'},
+    ]);
+  });
+
+  it('does not extract invalid URLs', () => {
+    expect(splitByURL('hi javascript:foo bye')).toEqual([
+      {isURL: false, text: 'hi javascript:foo bye'},
+    ]);
   });
 });


### PR DESCRIPTION
Diffbase: https://github.com/tensorflow/tensorboard/pull/4257

Note to reviewer: please review only the commits *after* the diffbase.
e.g. all commits after the one titled "unused":
https://github.com/tensorflow/tensorboard/pull/4260/commits/39313de17480687eb24d87326c9dc4638e1db0bf
I made a mistake and should have pushed these branches to the source
repo rather than my own.


In the recently added Alert snackbar view, messages may include
URLs that could be linkified to benefit the user. This change
automatically linkifies URLs within the message.

Googlers, see test sync cl/339528257

![image](https://user-images.githubusercontent.com/2322480/97291242-e8d3d800-1806-11eb-8d0e-d353e025534b.png)
