### PR TITLE
Uploader messaging oneshot

### DIFF
--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -297,7 +297,7 @@ class UploadTracker(object):
             _STYLE_BOLD,
             readable_time_string(),
             _STYLE_RESET,
-            message
+            message,
         )
         sys.stdout.write(start_message)
         sys.stdout.flush()
@@ -350,7 +350,7 @@ class UploadTracker(object):
                 self._overwrite_line_message(
                     "Listening for new data in logdir",
                     color_code=_STYLE_YELLOW,
-            )
+                )
 
     @contextlib.contextmanager
     def scalars_tracker(self, num_scalars):

--- a/tensorboard/uploader/upload_tracker.py
+++ b/tensorboard/uploader/upload_tracker.py
@@ -279,7 +279,8 @@ class UploadTracker(object):
             # Yield an arbitrary value 0: The progress bar is indefinite.
             yield 0
 
-    def _update_uploading_status(self, message, color_code=_STYLE_GREEN):
+    def _overwrite_line_message(self, message, color_code=_STYLE_GREEN):
+        """Overwrite the current line with a stylized message."""
         if not self._verbosity:
             return
         message += "." * 3
@@ -288,14 +289,15 @@ class UploadTracker(object):
         )
         sys.stdout.flush()
 
-    def _upload_start(self):
-        """Write an update indicating the start of the uploading."""
+    def _single_line_message(self, message):
+        """Write a timestamped single line, with newline, to stdout."""
         if not self._verbosity:
             return
-        start_message = "%s[%s]%s Uploader started.\n" % (
+        start_message = "%s[%s]%s %s\n" % (
             _STYLE_BOLD,
             readable_time_string(),
             _STYLE_RESET,
+            message
         )
         sys.stdout.write(start_message)
         sys.stdout.flush()
@@ -335,18 +337,19 @@ class UploadTracker(object):
         """Create a context manager for a round of data sending."""
         self._send_count += 1
         if self._send_count == 1:
-            self._upload_start()
+            self._single_line_message("Started scanning logdir.")
         try:
             # self._reset_bars()
-            self._update_uploading_status("Data upload starting")
+            self._overwrite_line_message("Data upload starting")
             yield
         finally:
             self._update_cumulative_status()
-            self._update_uploading_status(
-                "Done scanning logdir"
-                if self._one_shot
-                else "Listening for new data in logdir",
-                color_code=_STYLE_YELLOW,
+            if self._one_shot:
+                self._single_line_message("Done scanning logdir.")
+            else:
+                self._overwrite_line_message(
+                    "Listening for new data in logdir",
+                    color_code=_STYLE_YELLOW,
             )
 
     @contextlib.contextmanager
@@ -356,7 +359,7 @@ class UploadTracker(object):
         Args:
           num_scalars: Number of scalars in the batch.
         """
-        self._update_uploading_status("Uploading %d scalars" % num_scalars)
+        self._overwrite_line_message("Uploading %d scalars" % num_scalars)
         try:
             yield
         finally:
@@ -392,7 +395,7 @@ class UploadTracker(object):
                 num_tensors,
                 readable_bytes_string(tensor_bytes),
             )
-        self._update_uploading_status(message)
+        self._overwrite_line_message(message)
         try:
             yield
         finally:
@@ -410,7 +413,7 @@ class UploadTracker(object):
         Args:
           blob_bytes: Total byte size of the blob being uploaded.
         """
-        self._update_uploading_status(
+        self._overwrite_line_message(
             "Uploading binary object (%s)" % readable_bytes_string(blob_bytes)
         )
         try:

--- a/tensorboard/uploader/upload_tracker_test.py
+++ b/tensorboard/uploader/upload_tracker_test.py
@@ -165,7 +165,7 @@ class UploadStatsTest(tb_test.TestCase):
         )
         self.assertEqual(stats.has_new_data_since_last_summarize(), True)
 
-    def testHasNewDataSinceLastSummarizeReturnsTrueAfterNewTensors(self):
+    def testHasNewDataSinceLastSummarizeReturnsTrueAfterNewBlob(self):
         stats = upload_tracker.UploadStats()
         self.assertEqual(stats.has_new_data_since_last_summarize(), False)
         stats.add_scalars(1234)
@@ -352,7 +352,7 @@ class UploadTrackerTest(tb_test.TestCase):
             self.assertEqual(self.mock_write.call_count, 2)
             self.assertEqual(self.mock_flush.call_count, 2)
             self.assertIn(
-                "Uploader started.", self.mock_write.call_args_list[0][0][0],
+                "Started scanning", self.mock_write.call_args_list[0][0][0],
             )
             with tracker.blob_tracker(
                 blob_bytes=2048 * 1024 * 1024

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -219,7 +219,6 @@ class TensorBoardUploader(object):
             if self._one_shot:
                 break
 
-
     def _upload_once(self):
         """Runs one upload cycle, sending zero or more RPCs."""
         logger.info("Starting an upload cycle")

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -157,6 +157,23 @@ class TensorBoardUploader(object):
         self._logdir_loader = logdir_loader.LogdirLoader(
             self._logdir, directory_loader_factory
         )
+        self._tracker = upload_tracker.UploadTracker(
+            verbosity=self._verbosity, one_shot=self._one_shot
+        )
+
+    @property
+    def tracker(self) -> upload_tracker.UploadTracker:
+        """Returns this object's upload tracker."""
+        return self._tracker
+
+    @property
+    def experiment_id(self) -> str:
+        """Returns the experiment_id associated with this uploader.
+
+        May be none if no experiment is set, for instance, if
+        `create_experiment` has not been called.
+        """
+        return self._experiment_id
 
     def create_experiment(self):
         """Creates an Experiment for this upload session and returns the ID."""
@@ -166,9 +183,6 @@ class TensorBoardUploader(object):
         )
         response = grpc_util.call_with_retries(
             self._api.CreateExperiment, request
-        )
-        self._tracker = upload_tracker.UploadTracker(
-            verbosity=self._verbosity, one_shot=self._one_shot
         )
         self._request_sender = _BatchedRequestSender(
             response.experiment_id,
@@ -190,10 +204,6 @@ class TensorBoardUploader(object):
         unless the uploader was built with the _one_shot option, in which
         case it will terminate after the first scan.
 
-        Returns:
-            A manifest of what was uploaded, in the case of a `one_shot` upload.
-
-
         Raises:
           RuntimeError: If `create_experiment` has not yet been called.
           ExperimentNotFoundError: If the experiment is deleted during the
@@ -208,15 +218,7 @@ class TensorBoardUploader(object):
             self._upload_once()
             if self._one_shot:
                 break
-        if self._one_shot and not self._tracker.has_data():
-            print(
-                "Tensorboard was run in `one_shot` mode, but did not detect "
-                "any known uploadable data types in the specified logdir: %s\n"
-                "An empty experiment was created. "
-                "To delete the empty experiment execute the following\n\n"
-                "    tensorboard dev delete --experiment_id=%s"
-                % (self._logdir, self._experiment_id)
-            )
+
 
     def _upload_once(self):
         """Runs one upload cycle, sending zero or more RPCs."""

--- a/tensorboard/uploader/uploader.py
+++ b/tensorboard/uploader/uploader.py
@@ -161,10 +161,9 @@ class TensorBoardUploader(object):
             verbosity=self._verbosity, one_shot=self._one_shot
         )
 
-    @property
-    def tracker(self) -> upload_tracker.UploadTracker:
+    def has_data(self) -> bool:
         """Returns this object's upload tracker."""
-        return self._tracker
+        return self._tracker.has_data()
 
     @property
     def experiment_id(self) -> str:

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -444,7 +444,7 @@ class UploadIntent(_Intent):
             self.experiment_url_callback(url)
         if self.one_shot:
             print(
-                "Upload started.\n\nTo stop uploading, press Ctrl-C."
+                "Upload started."
             )
         else:
             print(
@@ -467,12 +467,24 @@ class UploadIntent(_Intent):
         except KeyboardInterrupt:
             interrupted = True
         finally:
+            if self.one_shot and not uploader.tracker.has_data():
+                print(
+                    "Tensorboard was run in `one_shot` mode, but did not detect "
+                    "any known uploadable data types in the specified "
+                    "logdir: %s\n"
+                    "An empty experiment was created. "
+                    "To delete the empty experiment execute the following\n\n"
+                    "    tensorboard dev delete --experiment_id=%s"
+                    % (self.logdir, uploader.experiment_id)
+                )
             end_message = "\n"
             if interrupted:
                 end_message += "Interrupted."
             else:
                 end_message += "Done."
-            if not self.dry_run:
+            # Only Add the "View your TensorBoard" message if there was any
+            # data added at all.
+            if not self.dry_run and not uploader.tracker.has_data():
                 end_message += " View your TensorBoard at %s" % url
             sys.stdout.write(end_message + "\n")
             sys.stdout.flush()

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -453,7 +453,9 @@ class UploadIntent(_Intent):
                 "No data will be sent to tensorboard.dev. **\n"
             )
         else:
-            print("\nNew experiment created. View your TensorBoard at: %s\n" % url)
+            print(
+                "\nNew experiment created. View your TensorBoard at: %s\n" % url
+            )
         interrupted = False
         try:
             uploader.start_uploading()

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -465,7 +465,7 @@ class UploadIntent(_Intent):
         except KeyboardInterrupt:
             interrupted = True
         finally:
-            if self.one_shot and not uploader.tracker.has_data():
+            if self.one_shot and not uploader.has_data():
                 print(
                     "TensorBoard was run in `one_shot` mode, but did not find "
                     "any uploadable data in the specified logdir: %s\n"
@@ -482,7 +482,7 @@ class UploadIntent(_Intent):
                 end_message += "Done."
             # Only Add the "View your TensorBoard" message if there was any
             # data added at all.
-            if not self.dry_run and uploader.tracker.has_data():
+            if not self.dry_run and uploader.has_data():
                 end_message += " View your TensorBoard at %s" % url
             sys.stdout.write(end_message + "\n")
             sys.stdout.flush()

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -467,14 +467,15 @@ class UploadIntent(_Intent):
         finally:
             if self.one_shot and not uploader.tracker.has_data():
                 print(
-                    "Tensorboard was run in `one_shot` mode, but did not find "
+                    "TensorBoard was run in `one_shot` mode, but did not find "
                     "any uploadable data in the specified logdir: %s\n"
                     "An empty experiment was created. "
-                    "To delete the empty experiment execute the following\n\n"
+                    "To delete the empty experiment you can execute the "
+                    "following\n\n"
                     "    tensorboard dev delete --experiment_id=%s"
                     % (self.logdir, uploader.experiment_id)
                 )
-            end_message = "\n"
+            end_message = "\n\n"
             if interrupted:
                 end_message += "Interrupted."
             else:

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -442,10 +442,15 @@ class UploadIntent(_Intent):
         url = server_info_lib.experiment_url(server_info, experiment_id)
         if self.experiment_url_callback is not None:
             self.experiment_url_callback(url)
-        print(
-            "Upload started and will continue reading any new data as it's "
-            "added to the logdir.\n\nTo stop uploading, press Ctrl-C."
-        )
+        if self.one_shot:
+            print(
+                "Upload started.\n\nTo stop uploading, press Ctrl-C."
+            )
+        else:
+            print(
+                "Upload started and will continue reading any new data as it's "
+                "added to the logdir.\n\nTo stop uploading, press Ctrl-C."
+            )
         if self.dry_run:
             print(
                 "\n** This is a dry run. "

--- a/tensorboard/uploader/uploader_subcommand.py
+++ b/tensorboard/uploader/uploader_subcommand.py
@@ -442,11 +442,7 @@ class UploadIntent(_Intent):
         url = server_info_lib.experiment_url(server_info, experiment_id)
         if self.experiment_url_callback is not None:
             self.experiment_url_callback(url)
-        if self.one_shot:
-            print(
-                "Upload started."
-            )
-        else:
+        if not self.one_shot:
             print(
                 "Upload started and will continue reading any new data as it's "
                 "added to the logdir.\n\nTo stop uploading, press Ctrl-C."
@@ -457,7 +453,7 @@ class UploadIntent(_Intent):
                 "No data will be sent to tensorboard.dev. **\n"
             )
         else:
-            print("\nView your TensorBoard live at: %s\n" % url)
+            print("\nNew experiment created. View your TensorBoard at: %s\n" % url)
         interrupted = False
         try:
             uploader.start_uploading()
@@ -469,9 +465,8 @@ class UploadIntent(_Intent):
         finally:
             if self.one_shot and not uploader.tracker.has_data():
                 print(
-                    "Tensorboard was run in `one_shot` mode, but did not detect "
-                    "any known uploadable data types in the specified "
-                    "logdir: %s\n"
+                    "Tensorboard was run in `one_shot` mode, but did not find "
+                    "any uploadable data in the specified logdir: %s\n"
                     "An empty experiment was created. "
                     "To delete the empty experiment execute the following\n\n"
                     "    tensorboard dev delete --experiment_id=%s"
@@ -484,7 +479,7 @@ class UploadIntent(_Intent):
                 end_message += "Done."
             # Only Add the "View your TensorBoard" message if there was any
             # data added at all.
-            if not self.dry_run and not uploader.tracker.has_data():
+            if not self.dry_run and uploader.tracker.has_data():
                 end_message += " View your TensorBoard at %s" % url
             sys.stdout.write(end_message + "\n")
             sys.stdout.flush()

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -174,8 +174,8 @@ class UploadIntentTest(tf.test.TestCase):
                 self.get_temp_dir(), dry_run=True, one_shot=False
             )
             intent.execute(mock_server_info, mock_channel)
-        self.assertEqual(
-            mock_stdout_write.call_args_list[-1][0][0], "\nInterrupted.\n"
+        self.assertRegex(
+            mock_stdout_write.call_args_list[-1][0][0], ".*Interrupted.*"
         )
 
     def testUploadIntentNonDryRunNonOneShotInterrupted(self):

--- a/tensorboard/uploader/uploader_subcommand_test.py
+++ b/tensorboard/uploader/uploader_subcommand_test.py
@@ -124,7 +124,7 @@ class UploadIntentTest(tf.test.TestCase):
         # Expect that ".*Done scanning logdir.*" is among the things printed.
         stdout_writes = [x[0][0] for x in mock_stdout_write.call_args_list]
         self.assertRegex(
-            ",".join(stdout_writes), ".*Upload started.*",
+            ",".join(stdout_writes), ".*experiment created.*",
         )
         # Expect that the last thing written is the string "Done" and the
         # experiment_id.


### PR DESCRIPTION
Motivation for features / changes
Clarify some uploader messaging when using oneshot.

**Oneshot — Upload an existing but empty directory.**

*  No longer tells the user we will continue to upload new data as it is added to the logdir (oneshot).
*  timestamped "Uploader started" is replaced with "Started scanning" and paired with "Done scanning"
*  Empty directory message language is slightly simplified.

```
$ bazel-bin/tensorboard/tensorboard dev upload --logdir=~/tensorboard-logdirs/emptydir/ --one_shot
New experiment created. View your TensorBoard at: 
https://tensorboard.dev/experiment/peQEJLy7QymNaZwRmK5T2A/

[2020-10-28T12:48:35] Started scanning logdir.
[2020-10-28T12:48:35] Done scanning logdir.
Tensorboard was run in `one_shot` mode, but did not find any uploadable data in the specified logdir: /Users/bileschi/tensorboard-logdirs/emptydir/
An empty experiment was created. To delete the empty experiment execute the following

    tensorboard dev delete --experiment_id=peQEJLy7QymNaZwRmK5T2A

Done.
```

**Oneshot — Upload a non-existing directory**

*  No change.

```
$ bazel-bin/tensorboard/tensorboard dev upload --logdir=~/tensorboard-logdirs/this-dir-does-not-exist/ --one_shot/Users/bileschi/tensorboard-logdirs/this-dir-does-not-exist/: No such directory.
User specified `one_shot` mode with an unavailable logdir. Exiting without creating an experiment.
```

**Oneshot — Upload an existing and full directory**

*  No longer tells the user we will continue to upload new data as it is added to the logdir (oneshot).
*  timestamped "Uploader started" is replaced with "Started scanning" and paired with "Done scanning", which now more closely matches the start message.

```
$ bazel-bin/tensorboard/tensorboard dev upload --logdir=~/tensorboard-logdirs/scalars_demo/ --one_shot

New experiment created. View your TensorBoard at: https://tensorboard.dev/experiment/pVz69CMSQY6jvEP1g88cgQ/

[2020-10-28T12:53:02] Started scanning logdir.
[2020-10-28T12:54:01] Total uploaded: 54011 scalars, 0 tensors, 18 binary objects (69.6 kB)
[2020-10-28T12:54:01] Done scanning logdir.
Done. View your TensorBoard at https://tensorboard.dev/experiment/pVz69CMSQY6jvEP1g88cgQ/
```

**Streaming —  (not one shot) — Upload an existing and full directory**
```
$ bazel-bin/tensorboard/tensorboard dev upload --logdir=~/tensorboard-logdirs/scalars_demo/
Upload started and will continue reading any new data as it's added to the logdir.

To stop uploading, press Ctrl-C.

New experiment created. View your TensorBoard at: https://tensorboard.dev/experiment/7VegMXFXSpyu9P4y9gNvew/
[2020-10-28T13:01:12] Started scanning logdir.
[2020-10-28T13:02:12] Total uploaded: 54011 scalars, 0 tensors, 18 binary objects (69.6 kB)
^Cstening for new data in logdir...
Interrupted. View your TensorBoard at https://tensorboard.dev/experiment/7VegMXFXSpyu9P4y9gNvew/
```