### PR TITLE
experiments: add `related_links` field

### DIFF
--- a/tensorboard/webapp/experiments/types.ts
+++ b/tensorboard/webapp/experiments/types.ts
@@ -20,4 +20,5 @@ export interface Experiment {
   description?: string;
   hparams?: string;
   tags?: string[];
+  related_links?: Array<{name: string; url: string}>;
 }


### PR DESCRIPTION
Summary:
Google-internal TensorBoard instances want to show some related links in
the UI for the header card: think, “link to logdir in online filesystem
viewer”, or “link to training job health status”. This patch updates the
types to permit the backend to send down such links.

Test Plan:
That TypeScript is still happy suffices.

wchargin-branch: experiments-related-links
