### PR TITLE
Show alert on fetch run failures

### DIFF
--- a/tensorboard/webapp/alert/views/alert_snackbar_module.ts
+++ b/tensorboard/webapp/alert/views/alert_snackbar_module.ts
@@ -27,5 +27,9 @@ import {AlertDisplaySnackbarContainer} from './alert_display_snackbar_container'
   declarations: [AlertSnackbarContainer, AlertDisplaySnackbarContainer],
   exports: [AlertSnackbarContainer],
   imports: [CommonModule, MatButtonModule, MatSnackBarModule],
+  entryComponents: [
+    // Required for non-Ivy Angular apps.
+    AlertDisplaySnackbarContainer,
+  ],
 })
 export class AlertSnackbarModule {}

--- a/tensorboard/webapp/runs/BUILD
+++ b/tensorboard/webapp/runs/BUILD
@@ -11,6 +11,8 @@ ng_module(
         "runs_module.ts",
     ],
     deps = [
+        "//tensorboard/webapp/alert:alert_action",
+        "//tensorboard/webapp/runs/actions",
         "//tensorboard/webapp/runs/data_source",
         "//tensorboard/webapp/runs/effects",
         "//tensorboard/webapp/runs/store",

--- a/tensorboard/webapp/runs/runs_module.ts
+++ b/tensorboard/webapp/runs/runs_module.ts
@@ -20,16 +20,33 @@ import {NgModule} from '@angular/core';
 import {EffectsModule} from '@ngrx/effects';
 import {StoreModule} from '@ngrx/store';
 
+import {AlertActionModule} from '../alert/alert_action_module';
+import * as actions from './actions';
 import {RunsDataSourceModule} from './data_source/runs_data_source_module';
 import {RunsEffects} from './effects';
 import {reducers} from './store';
 import {RUNS_FEATURE_KEY} from './store/runs_types';
+
+/** @typehack */ import * as _typeHackModels from '@ngrx/store/src/models';
+/** @typehack */ import * as _typeHackStore from '@ngrx/store/store';
+
+export function alertActionProvider() {
+  return [
+    {
+      actionCreator: actions.fetchRunsFailed,
+      alertFromAction: () => {
+        return {localizedMessage: 'Failed to fetch runs'};
+      },
+    },
+  ];
+}
 
 @NgModule({
   imports: [
     StoreModule.forFeature(RUNS_FEATURE_KEY, reducers),
     EffectsModule.forFeature([RunsEffects]),
     RunsDataSourceModule,
+    AlertActionModule.registerAlertActions(alertActionProvider),
   ],
 })
 export class RunsModule {}


### PR DESCRIPTION
The recently introduced Alerts ngrx feature offers an affordance
for modules to register alerts. This registers the `fetchRunsFailed`
action to show a message to the user when runs fail to fetch.

In non-Ivy Angular, the entryComponents is required so that
the component factory will be generated, even though it is loaded
on-demand (by snackbar).

Googlers, see sync cl/339774223