### PR TITLE
ui: add 'regex' to the run and tag filter

### DIFF
--- a/tensorboard/webapp/metrics/views/main_view/filter_input_component.ng.html
+++ b/tensorboard/webapp/metrics/views/main_view/filter_input_component.ng.html
@@ -19,7 +19,7 @@ limitations under the License.
   <input
     matInput
     autocomplete="off"
-    placeholder="Filter tags"
+    placeholder="Filter tags (regex)"
     [value]="regexFilterValue"
     (input)="onRegexFilterValueChange.emit($event.target.value)"
     (keyup)="onFilterKeyUp($event)"

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -22,7 +22,7 @@ limitations under the License.
       matInput
       autocomplete="off"
       (keyup)="onFilterKeyUp($event)"
-      placeholder="Filter runs"
+      placeholder="Filter runs (regex)"
     />
   </div>
 </div>


### PR DESCRIPTION
Current copies are a bit ambiguous as to whether it supports regex or
not. This change makes it a bit more explicit.
