### PR TITLE
[time series] render images as pixelated

### DIFF
--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
@@ -113,6 +113,9 @@ $_second-row-height: 15px;
 }
 
 .img-container img {
+  // Avoid the 'smooth' image scaling provided in browsers by default.
+  // Instead, choose rendering modes that are closer to pixel representation.
+  // See b/32560663.
   image-rendering: -moz-crisp-edges;
   image-rendering: pixelated;
 }

--- a/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
+++ b/tensorboard/webapp/metrics/views/card_renderer/image_card_component.scss
@@ -112,6 +112,11 @@ $_second-row-height: 15px;
   position: relative;
 }
 
+.img-container img {
+  image-rendering: -moz-crisp-edges;
+  image-rendering: pixelated;
+}
+
 :host.actual-size .img-container {
   overflow: auto;
   flex: none;


### PR DESCRIPTION
Image cards rendered in Time Series may appear blurry, which
can be misleading if the written image is composed of discrete
values-per-pixel. This changes the Time Series image cards to
use the same 'image-rendering' CSS prop as the Image dashboard.

See [plugins/image/tf_image_dashboard/tf-image-loader.ts](https://cs.opensource.google/tensorflow/tensorboard/+/master:tensorboard/plugins/image/tf_image_dashboard/tf-image-loader.ts;l=169?q=image-rendering%20pixelated&sq=)

Manually checked in Chrome and Firefox that the image looks
pixelated.

Googlers, see b/32560663, cl/113307097.

(Screenshot of image-rendering: pixelated for above image (below
image is default) in Chrome).
![image](https://user-images.githubusercontent.com/2322480/97933546-f4a02c80-1d27-11eb-8a90-91ffb5291686.png)


