### PR TITLE
cleanup: remove dangling type import on d3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         # Cannot directly depend on d3 in webapp. Must depend on
         # `//tensorboard/webapp/third_party:d3` instead.
       - run: |
-          ! git grep -E '@npm//d3' 'tensorboard/webapp/**/*BUILD' ':!tensorboard/webapp/third_party/**'
+          ! git grep -E '"@npm//d3"|"@npm//@types/d3"' 'tensorboard/webapp/**/*BUILD' ':!tensorboard/webapp/third_party/**'
 
   lint-build:
     runs-on: ubuntu-16.04

--- a/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/BUILD
+++ b/tensorboard/webapp/plugins/npmi/views/violin_filters/violin_filter/BUILD
@@ -36,7 +36,6 @@ ng_module(
         "@npm//@angular/core",
         "@npm//@angular/forms",
         "@npm//@ngrx/store",
-        "@npm//@types/d3",
         "@npm//rxjs",
     ],
 )


### PR DESCRIPTION
We use a layer of indirection when importing d3 that makes sure d3 and
its types are imported correctly in all environments.

This change cleans up a manual typing import.

