### PR TITLE
Fixed the broken link for "summary_iterator" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ download links for the data it contains.
 
 If you need access to the full dataset, you can read the event files that
 TensorBoard consumes by using the [`summary_iterator`](
-https://www.tensorflow.org/api_docs/python/tf/train/summary_iterator)
+https://www.tensorflow.org/api_docs/python/tf/compat/v1/train/summary_iterator)
 method.
 
 ### Can I make my own plugin?


### PR DESCRIPTION
Fixed the broken link for "summary_iterator"

* Motivation for features / changes: The hyperlink of the documentation should be working

* Technical description of changes: Corrected the Hyperlink

* Screenshots of UI changes

* Detailed steps to verify changes work correctly (as executed by you): Opened the New Link and ensured that it is working

* Alternate designs / implementations considered
