### PR TITLE
license_test: use `git-grep` to respect gitignore

### DIFF
--- a/tensorboard/tools/license_test.sh
+++ b/tensorboard/tools/license_test.sh
@@ -15,11 +15,10 @@
 # ==============================================================================
 
 # tf_imports/*.html define their respective OSS license.
-files=$(grep -rL "Copyright 20[0-9][0-9] The TensorFlow" \
-    --include=*.* \
-    --exclude=*.{pyc,json,png,wav,proto,pbtxt,md,in,rst,cfg,ipynb,svg} \
-    tensorboard | \
-    grep -v "tensorboard/components/tf_imports/.*.html" )
+files=$(git grep -L "Copyright 20[0-9][0-9] The TensorFlow" \
+    'tensorboard/*.*' \
+    ':!*.'{pyc,json,png,wav,proto,pbtxt,md,in,rst,cfg,ipynb,svg} \
+    ':!tensorboard/components/tf_imports/*.html')
 
 count=$(echo "$files" | wc -l | awk '{print $1}')
 


### PR DESCRIPTION
Summary:
It should be okay to have files without a license header comment in your
working tree if they’re ignored by Git. Now, it is.

Test Plan:
Create an empty file `tensorboard/foo.txt` and add it to `.gitignore`.
Note that the old license test fails and the new one passes.

wchargin-branch: license-test-gitignore