### PR TITLE
line chart: data drawable, a class that renders

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -60,19 +60,45 @@ tf_ts_library(
 )
 
 tf_ts_library(
+    name = "drawable",
+    srcs = [
+        "drawable.ts",
+        "paint_brush.ts",
+    ],
+    deps = [
+        ":coordinator",
+        ":types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib/renderer:types",
+    ],
+)
+
+tf_ts_library(
+    name = "series_line_view",
+    srcs = [
+        "series_line_view.ts",
+    ],
+    deps = [
+        ":drawable",
+    ],
+)
+
+tf_ts_library(
     name = "lib_tests",
     testonly = True,
     srcs = [
         "coordinator_test.ts",
+        "drawable_test.ts",
         "scale_test.ts",
         "worker_pool_test.ts",
     ],
     deps = [
         ":coordinator",
+        ":drawable",
         ":scale",
         ":types",
         ":worker",
         ":worker_pool",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib/renderer",
         "@npm//@types/jasmine",
     ],
 )

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/drawable.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/drawable.ts
@@ -1,0 +1,186 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Coordinator} from './coordinator';
+import {PaintBrush} from './paint_brush';
+import {ObjectRenderer} from './renderer/renderer_types';
+import {
+  DataInternalSeries,
+  DataSeries,
+  DataSeriesMetadataMap,
+  Rect,
+} from './types';
+
+class RenderCacheContainer {
+  private prevFrameCache = new Map<string, any>();
+  private currFrameCache = new Map<string, any>();
+
+  getFromPreviousFrame(key: string): any {
+    return this.prevFrameCache.get(key);
+  }
+
+  setToCurrentFrame(key: string, value: any) {
+    this.currFrameCache.set(key, value);
+  }
+
+  /**
+   * Flush the current frame cache into previous frame cache. At this point, you should
+   * not update the current frame cache with `set` calls.
+   *
+   * It returns cached objects that got removed from the new frame.
+   */
+  finalizeFrameAndGetRemoved(): ReadonlyArray<any> {
+    const removed = [];
+
+    for (const [key, value] of this.prevFrameCache.entries()) {
+      if (!this.currFrameCache.has(key)) {
+        removed.push(value);
+      }
+    }
+
+    this.prevFrameCache = this.currFrameCache;
+    this.currFrameCache = new Map();
+
+    return removed;
+  }
+}
+
+export interface DrawableConfig {
+  coordinator: Coordinator;
+  getMetadataMap: () => DataSeriesMetadataMap;
+  renderer: ObjectRenderer;
+}
+
+/**
+ * A view that renders data in a rectangular region. A client of DataDrawable is expected
+ * to subclass DataDrawable and implement `redraw` method.
+ *
+ * The base class maintains cache of coordinate mapped data, `series` and rendered scene.
+ *
+ * Example:
+ *
+ * class LineView extends DataDrawable {
+ *   redraw() {
+ *     for (const line of this.series) {
+ *       this.paintBrush.setLine('uniqId', line, ...);
+ *     }
+ *   }
+ * }
+ */
+export abstract class DataDrawable {
+  private rawSeriesData: DataSeries[] = [];
+  // UI coordinate mapped data.
+  protected series: DataInternalSeries[] = [];
+  protected readonly coordinator: Coordinator;
+  protected readonly paintBrush: PaintBrush;
+
+  private paintDirty = true;
+  private readonly getMetadataMapImpl: () => DataSeriesMetadataMap;
+  private readonly renderer: ObjectRenderer;
+  private coordinateIdentifier: number | null = null;
+  private layout: Rect = {x: 0, width: 1, y: 0, height: 1};
+  private renderCache = new RenderCacheContainer();
+
+  constructor(config: DrawableConfig) {
+    this.getMetadataMapImpl = config.getMetadataMap;
+    this.coordinator = config.coordinator;
+    this.renderer = config.renderer;
+    this.paintBrush = new PaintBrush(
+      {renderCache: this.renderCache},
+      this.renderer
+    );
+  }
+
+  setLayoutRect(layout: Rect) {
+    if (
+      this.layout.x !== layout.x ||
+      this.layout.width !== layout.width ||
+      this.layout.y !== layout.y ||
+      this.layout.height !== layout.height
+    ) {
+      this.paintDirty = true;
+    }
+    this.layout = layout;
+  }
+
+  private getLayoutRect(): Rect {
+    return this.layout;
+  }
+
+  protected getMetadataMap(): DataSeriesMetadataMap {
+    return this.getMetadataMapImpl();
+  }
+
+  markAsPaintDirty() {
+    this.paintDirty = true;
+  }
+
+  internalOnlyDrawFrame() {
+    this.internalOnlyTransformCoordinatesIfStale();
+
+    if (!this.paintDirty) return;
+
+    this.renderFrame();
+
+    for (const removedObj of this.renderCache.finalizeFrameAndGetRemoved()) {
+      this.renderer.destroyObject(removedObj);
+    }
+
+    this.paintDirty = false;
+  }
+
+  private isCoordinateUpdated() {
+    return this.coordinator.getUpdateIdentifier() !== this.coordinateIdentifier;
+  }
+
+  private clearCoordinateIdentifier() {
+    this.coordinateIdentifier = null;
+  }
+
+  setData(data: DataSeries[]) {
+    this.clearCoordinateIdentifier();
+    this.rawSeriesData = data;
+  }
+
+  internalOnlyTransformCoordinatesIfStale(): void {
+    if (!this.isCoordinateUpdated()) {
+      return;
+    }
+
+    const layoutRect = this.getLayoutRect();
+    this.series = new Array(this.rawSeriesData.length);
+
+    for (let i = 0; i < this.rawSeriesData.length; i++) {
+      const datum = this.rawSeriesData[i];
+      this.series[i] = {
+        id: datum.id,
+        polyline: new Float32Array(datum.points.length * 2),
+      };
+      for (let pointIndex = 0; pointIndex < datum.points.length; pointIndex++) {
+        const [x, y] = this.coordinator.transformDataToUiCoord(layoutRect, [
+          datum.points[pointIndex].x,
+          datum.points[pointIndex].y,
+        ]);
+        this.series[i].polyline[pointIndex * 2] = x;
+        this.series[i].polyline[pointIndex * 2 + 1] = y;
+      }
+    }
+
+    this.coordinateIdentifier = this.coordinator.getUpdateIdentifier();
+    this.markAsPaintDirty();
+  }
+
+  protected abstract renderFrame(): void;
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/drawable.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/drawable.ts
@@ -132,8 +132,13 @@ export abstract class DataDrawable {
     this.paintDirty = true;
   }
 
-  internalOnlyDrawFrame() {
-    this.internalOnlyTransformCoordinatesIfStale();
+  /**
+   * Renders a rectangular region if paint is dirty.
+   *
+   * @final Do not override.
+   */
+  render() {
+    this.transformCoordinatesIfStale();
 
     if (!this.paintDirty) return;
 
@@ -159,7 +164,7 @@ export abstract class DataDrawable {
     this.rawSeriesData = data;
   }
 
-  internalOnlyTransformCoordinatesIfStale(): void {
+  private transformCoordinatesIfStale(): void {
     if (!this.isCoordinateUpdated()) {
       return;
     }
@@ -187,5 +192,9 @@ export abstract class DataDrawable {
     this.markAsPaintDirty();
   }
 
+  /**
+   * Draws a rectangular region with coordinate system transformed `this.series` and
+   * `this.paintBrush`.
+   */
   protected abstract redraw(): void;
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/drawable.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/drawable.ts
@@ -123,6 +123,11 @@ export abstract class DataDrawable {
     return this.getMetadataMapImpl();
   }
 
+  /**
+   * Manually marks paint as dirty. Drawable automatically marks paint as dirty when data
+   * or layout changes. If there are other conditions in which redraw must happen, invoke
+   * this method.
+   */
   markAsPaintDirty() {
     this.paintDirty = true;
   }
@@ -132,7 +137,7 @@ export abstract class DataDrawable {
 
     if (!this.paintDirty) return;
 
-    this.renderFrame();
+    this.redraw();
 
     for (const removedObj of this.renderCache.finalizeFrameAndGetRemoved()) {
       this.renderer.destroyObject(removedObj);
@@ -182,5 +187,5 @@ export abstract class DataDrawable {
     this.markAsPaintDirty();
   }
 
-  protected abstract renderFrame(): void;
+  protected abstract redraw(): void;
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/drawable_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/drawable_test.ts
@@ -1,0 +1,261 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Coordinator} from './coordinator';
+import {SvgRenderer} from './renderer/svg_renderer';
+import {DataDrawable, DrawableConfig} from './drawable';
+import {DataSeries} from './types';
+
+class TestableDataDrawable extends DataDrawable {
+  renderFrame(): void {
+    const metadataMap = this.getMetadataMap();
+    for (const data of this.series) {
+      const metadata = metadataMap[data.id];
+      this.paintBrush.setLine(data.id, data.polyline, {
+        width: 1,
+        color: metadata.color,
+        visible: metadata.visible,
+      });
+    }
+  }
+  getSeriesData() {
+    return this.series;
+  }
+}
+
+function buildSeries(override: Partial<DataSeries>): DataSeries {
+  return {
+    id: 'foo',
+    points: [
+      {x: 0, y: -1},
+      {x: 1, y: -0.5},
+      {x: 2, y: 0},
+      {x: 3, y: 0.5},
+      {x: 4, y: 1},
+    ],
+    ...override,
+  };
+}
+
+describe('line_chart_v2/lib/drawable test', () => {
+  let option: DrawableConfig;
+  let root: TestableDataDrawable;
+  let renderFrameSpy: jasmine.Spy;
+  let svg: SVGElement;
+  let getMetadataMap: jasmine.Spy;
+
+  beforeEach(() => {
+    svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+
+    getMetadataMap = jasmine.createSpy().and.returnValue({
+      foo: {
+        color: '#f00',
+        visible: true,
+      },
+    });
+
+    option = {
+      coordinator: new Coordinator(),
+      renderer: new SvgRenderer(svg),
+      getMetadataMap,
+    };
+    root = new TestableDataDrawable(option);
+    root.setData([buildSeries({id: 'foo'})]);
+    option.coordinator.setViewBoxRect({x: 0, y: -1, width: 5, height: 1});
+    root.setLayoutRect({x: 0, y: 0, width: 100, height: 100});
+    renderFrameSpy = spyOn(root, 'renderFrame');
+  });
+
+  describe('draw frame', () => {
+    it('invokes redraw on empty data', () => {
+      root.internalOnlyDrawFrame();
+
+      expect(renderFrameSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-render if paint is not dirty', () => {
+      root.internalOnlyDrawFrame();
+
+      expect(renderFrameSpy).toHaveBeenCalledTimes(1);
+
+      // Nothing changed for paint to be dirty.
+      root.internalOnlyDrawFrame();
+      expect(renderFrameSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-renders if explictly marked as dirty', () => {
+      root.internalOnlyDrawFrame();
+      root.markAsPaintDirty();
+      root.internalOnlyDrawFrame();
+
+      expect(renderFrameSpy).toHaveBeenCalledTimes(2);
+    });
+
+    // If the dimension of the DOM changes, even if the data has not changed, we need to
+    // repaint.
+    it('re-renders if layout has changed', () => {
+      root.internalOnlyDrawFrame();
+      root.setLayoutRect({x: 0, y: 0, width: 200, height: 200});
+
+      expect(renderFrameSpy).toHaveBeenCalledTimes(1);
+
+      root.internalOnlyDrawFrame();
+
+      expect(renderFrameSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('manages the DOM cache', () => {
+      // Use the real redraw and update SVG.
+      renderFrameSpy.and.callThrough();
+      getMetadataMap = getMetadataMap.and.returnValue({
+        foo: {
+          color: '#f00',
+          visible: true,
+        },
+        bar: {
+          color: '#0f0',
+          visible: true,
+        },
+      });
+
+      root.setData([buildSeries({id: 'foo', points: [{x: 0, y: 1}]})]);
+      root.internalOnlyDrawFrame();
+
+      expect(svg.children.length).toBe(1);
+      const path1 = svg.children[0];
+      // Sanity check; real test is in renderer_test.
+      expect(path1.tagName).toBe('path');
+      const pathD1 = path1.getAttribute('d')!;
+
+      root.setData([
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 1},
+            {x: 0, y: 0},
+          ],
+        }),
+      ]);
+      root.internalOnlyDrawFrame();
+      expect(svg.children.length).toBe(1);
+      const path2 = svg.children[0];
+      const pathD2 = path2.getAttribute('d')!;
+      // Same DOM node
+      expect(path2).toBe(path1);
+      expect(pathD2).not.toBe(pathD1);
+      expect(pathD2.length).toBeGreaterThan(pathD1.length);
+
+      root.setData([
+        buildSeries({
+          id: 'bar',
+          points: [{x: 0, y: 0}],
+        }),
+      ]);
+      root.internalOnlyDrawFrame();
+      expect(svg.children.length).toBe(1);
+      const path3 = svg.children[0];
+      expect(path3).not.toEqual(path2);
+    });
+  });
+
+  describe('data coordinate transformation', () => {
+    beforeEach(() => {
+      const domRect = {x: 0, y: 0, width: 100, height: 100};
+      root.setLayoutRect(domRect);
+
+      const dataSeries = [
+        buildSeries({
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: 1},
+            {x: 2, y: -1},
+          ],
+        }),
+        buildSeries({
+          id: 'bar',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: -10},
+            {x: 2, y: 10},
+          ],
+        }),
+      ];
+      root.setData(dataSeries);
+      option.coordinator.setViewBoxRect({x: 0, y: -50, width: 2, height: 100});
+      option.coordinator.setDomContainerRect(domRect);
+    });
+
+    it('updates the data coordinate on redraw', () => {
+      root.internalOnlyDrawFrame();
+      // Notice that data.x = 0 got map to dom.x = 50. That is because we are rendering
+      // both TestableDrawable and TestableDataDrawable, both of which are flex layout,
+      // and TestableDataDrawable has rect of {x: 50, y: 0, width: 50, height: 100}.
+      expect(root.getSeriesData()).toEqual([
+        {id: 'foo', polyline: new Float32Array([0, 50, 50, 49, 100, 51])},
+        {id: 'bar', polyline: new Float32Array([0, 50, 50, 60, 100, 40])},
+      ]);
+    });
+
+    it('updates and redraws when the data changes', () => {
+      root.internalOnlyDrawFrame();
+
+      root.setData([
+        {
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: 10},
+            {x: 2, y: -10},
+          ],
+        },
+        {
+          id: 'bar',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: 50},
+            {x: 2, y: -50},
+          ],
+        },
+      ]);
+      expect(renderFrameSpy).toHaveBeenCalledTimes(1);
+      root.setData([
+        {
+          id: 'foo',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: 50},
+            {x: 2, y: -50},
+          ],
+        },
+        {
+          id: 'bar',
+          points: [
+            {x: 0, y: 0},
+            {x: 1, y: 0},
+            {x: 2, y: 0},
+          ],
+        },
+      ]);
+
+      root.internalOnlyDrawFrame();
+      expect(root.getSeriesData()).toEqual([
+        {id: 'foo', polyline: new Float32Array([0, 50, 50, 0, 100, 100])},
+        {id: 'bar', polyline: new Float32Array([0, 50, 50, 50, 100, 50])},
+      ]);
+      expect(renderFrameSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/paint_brush.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/paint_brush.ts
@@ -1,0 +1,39 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {LinePaintOption, ObjectRenderer} from './renderer/renderer_types';
+
+export interface PaintBrushContext {
+  renderCache: {
+    getFromPreviousFrame<T>(cacheKey: string): T;
+    setToCurrentFrame<T>(cacheKey: string, obj: T): void;
+  };
+}
+
+export class PaintBrush {
+  constructor(
+    private readonly context: PaintBrushContext,
+    private readonly renderer: ObjectRenderer
+  ) {}
+
+  setLine(cacheId: string, polyline: Float32Array, paintOpt: LinePaintOption) {
+    const newCacheValue = this.renderer.createOrUpdateLineObject(
+      this.context.renderCache.getFromPreviousFrame(cacheId),
+      polyline,
+      paintOpt
+    );
+    this.context.renderCache.setToCurrentFrame(cacheId, newCacheValue);
+  }
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/paint_brush.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/paint_brush.ts
@@ -15,10 +15,10 @@ limitations under the License.
 
 import {LinePaintOption, ObjectRenderer} from './renderer/renderer_types';
 
-export interface PaintBrushContext {
+export interface PaintBrushContext<T = any> {
   renderCache: {
-    getFromPreviousFrame<T>(cacheKey: string): T;
-    setToCurrentFrame<T>(cacheKey: string, obj: T): void;
+    getFromPreviousFrame(cacheKey: string): T;
+    setToCurrentFrame(cacheKey: string, obj: T): void;
   };
 }
 

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
@@ -1,0 +1,33 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {DataDrawable} from './drawable';
+
+export class SeriesLineView extends DataDrawable {
+  renderFrame() {
+    for (const series of this.series) {
+      const map = this.getMetadataMap();
+      const metadata = map[series.id];
+      if (!metadata) continue;
+
+      this.paintBrush.setLine(series.id, series.polyline, {
+        color: metadata.color,
+        visible: metadata.visible || false,
+        opacity: metadata.opacity ?? 1,
+        width: 1,
+      });
+    }
+  }
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/series_line_view.ts
@@ -16,7 +16,7 @@ limitations under the License.
 import {DataDrawable} from './drawable';
 
 export class SeriesLineView extends DataDrawable {
-  renderFrame() {
+  redraw() {
     for (const series of this.series) {
       const map = this.getMetadataMap();
       const metadata = map[series.id];

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/types.ts
@@ -32,7 +32,43 @@ export interface Extent {
   y: [number, number];
 }
 
+export interface DataSeriesMetadata {
+  id: string;
+  displayName: string;
+  visible: boolean;
+  color: string;
+  // Number between 0-1. Default is 1.
+  opacity?: number;
+  /**
+   * Whether the series is auxiliary. When a datum is auxiliary, it is visible in the
+   * chart but will not be used for calculating the data extent and will not be
+   * interactable.
+   */
+  aux?: boolean;
+}
+
+export interface DataSeriesMetadataMap<
+  Metadata extends DataSeriesMetadata = DataSeriesMetadata
+> {
+  [id: string]: Metadata;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface DataSeries<T extends Point = Point> {
+  id: string;
+  points: T[];
+}
+
 /**
  * Flattened array of 2d coordinates: [x0, y0, x1, y1, ..., xn, yn].
  */
 export type Polyline = Float32Array;
+
+export interface DataInternalSeries {
+  id: string;
+  polyline: Polyline;
+}


### PR DESCRIPTION
This change introduces a concept of a drawable. A drawable is a region
in a view where an implementation can draw shapes using PaintBrush with
coordinate converted data.

The DataDrawable abstract class manages data (and its coordinate system
conversion) and render caching on behalf of a subclass. As a subclass,
you only need to implement `renderFrame` and focus on drawing operations
taking coordinate system converted data and render cache maintenance.