### PR TITLE
refactor: runs-table from mat-table to ngFor

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -30,9 +30,13 @@ limitations under the License.
   <div role="table">
     <ng-container *ngTemplateOutlet="header"></ng-container>
     <ng-container *ngTemplateOutlet="selectAll"></ng-container>
-    <ng-container *ngFor="let item of pageItems; trackBy: tableTrackBy">
-      <ng-container *ngTemplateOutlet="row; context:{item: item}"></ng-container
-    ></ng-container>
+    <div role="rowgroup">
+      <ng-container *ngFor="let item of pageItems; trackBy: tableTrackBy">
+        <ng-container
+          *ngTemplateOutlet="row; context:{item: item}"
+        ></ng-container
+      ></ng-container>
+    </div>
   </div>
 
   <div *ngIf="loading" class="loading">
@@ -75,70 +79,135 @@ limitations under the License.
 </ng-template>
 
 <ng-template #header>
-  <div
-    class="header"
-    matSort
-    (matSortChange)="handleSortChange($event)"
-    [matSortActive]="sortOption.column"
-    role="row"
-  >
-    <span *ngFor="let columnId of columns" role="columnheader" class="column">
-      <ng-container [ngSwitch]="columnId">
-        <span *ngSwitchCase="RunsTableColumn.CHECKBOX"
-          ><mat-checkbox
+  <div class="header" role="rowgroup">
+    <div
+      matSort
+      (matSortChange)="handleSortChange($event)"
+      [matSortActive]="sortOption.column"
+      role="row"
+    >
+      <span
+        *ngFor="let columnId of columns"
+        role="columnheader"
+        [ngClass]="['column', 'tb-column-' + columnId]"
+      >
+        <ng-container [ngSwitch]="columnId">
+          <mat-checkbox
+            *ngSwitchCase="RunsTableColumn.CHECKBOX"
             [checked]="allPageItemsSelected()"
             [indeterminate]="!allPageItemsSelected() && somePageItemsSelected()"
             (change)="handlePageToggle()"
-          ></mat-checkbox
-        ></span>
+          ></mat-checkbox>
 
-        <span
-          *ngSwitchCase="RunsTableColumn.EXPERIMENT_NAME"
-          [mat-sort-header]="RunsTableColumn.EXPERIMENT_NAME"
-          class="name"
-          >Experiment</span
-        >
-
-        <span
-          *ngSwitchCase="RunsTableColumn.RUN_NAME"
-          [mat-sort-header]="RunsTableColumn.RUN_NAME"
-          class="name"
-          >Run</span
-        >
-
-        <span *ngSwitchCase="RunsTableColumn.RUN_COLOR"></span>
-      </ng-container>
-    </span>
-
-    <span
-      *ngFor="let column of hparamColumns; trackBy: trackByHparamColumn"
-      role="columnheader"
-      class="column"
-    >
-      <span class="name">{{ column.displayName || column.name }}</span>
-      <ng-container *ngIf="column.filter">
-        <button
-          mat-icon-button
-          [matMenuTriggerFor]="filterMenu"
-          i18n-aria-label="A button that opens a menu that lets user set hparam filter conditions"
-          [attr.aria-label]="'Filter hparam ' + (column.displayName || column.name)"
-        >
-          <mat-icon svgIcon="filter_alt_24px"></mat-icon>
-        </button>
-        <mat-menu #filterMenu="matMenu">
-          <div
-            mat-menu-item
-            (click)="$event.stopPropagation()"
-            role="menuitemcheckbox"
-            disableRipple
+          <span
+            *ngSwitchCase="RunsTableColumn.EXPERIMENT_NAME"
+            [mat-sort-header]="RunsTableColumn.EXPERIMENT_NAME"
+            class="name"
+            >Experiment</span
           >
-            <mat-checkbox
-              [checked]="column.filter.includeUndefined"
-              (change)="handleHparamIncludeUndefinedToggled(column)"
-              ><span>(show empty value)</span></mat-checkbox
+
+          <span
+            *ngSwitchCase="RunsTableColumn.RUN_NAME"
+            [mat-sort-header]="RunsTableColumn.RUN_NAME"
+            class="name"
+            >Run</span
+          >
+
+          <span *ngSwitchCase="RunsTableColumn.RUN_COLOR"></span>
+        </ng-container>
+      </span>
+
+      <span
+        *ngFor="let column of hparamColumns; trackBy: trackByHparamColumn"
+        role="columnheader"
+        class="column"
+      >
+        <span class="name">{{ column.displayName || column.name }}</span>
+        <ng-container *ngIf="column.filter">
+          <button
+            mat-icon-button
+            [matMenuTriggerFor]="filterMenu"
+            i18n-aria-label="A button that opens a menu that lets user set hparam filter conditions"
+            [attr.aria-label]="'Filter hparam ' + (column.displayName || column.name)"
+          >
+            <mat-icon svgIcon="filter_alt_24px"></mat-icon>
+          </button>
+          <mat-menu #filterMenu="matMenu">
+            <div
+              mat-menu-item
+              (click)="$event.stopPropagation()"
+              role="menuitemcheckbox"
+              disableRipple
             >
-          </div>
-          <ng-container *ngIf="column.filter.type === DomainType.INTERVAL">
+              <mat-checkbox
+                [checked]="column.filter.includeUndefined"
+                (change)="handleHparamIncludeUndefinedToggled(column)"
+                ><span>(show empty value)</span></mat-checkbox
+              >
+            </div>
+            <ng-container *ngIf="column.filter.type === DomainType.INTERVAL">
+              <div
+                (click)="$event.stopPropagation()"
+                class="range-input-container"
+                disableRipple
+                mat-menu-item
+              >
+                <tb-range-input
+                  [min]="column.filter.minValue"
+                  [max]="column.filter.maxValue"
+                  [lowerValue]="column.filter.filterLowerValue"
+                  [upperValue]="column.filter.filterUpperValue"
+                  (value)="handleHparamIntervalChanged(column, $event)"
+                ></tb-range-input>
+              </div>
+            </ng-container>
+            <ng-container *ngIf="column.filter.type === DomainType.DISCRETE">
+              <div
+                *ngFor="let value of column.filter.possibleValues"
+                mat-menu-item
+                role="menuitemcheckbox"
+                (click)="$event.stopPropagation()"
+              >
+                <mat-checkbox
+                  [checked]="column.filter.filterValues.includes(value)"
+                  (change)="handleHparamDiscreteChanged(column, value)"
+                  ><span>{{ value }}</span></mat-checkbox
+                >
+              </div>
+            </ng-container>
+          </mat-menu>
+        </ng-container>
+      </span>
+
+      <span
+        *ngFor="let column of metricColumns; trackBy: trackByMetricColumn"
+        role="columnheader"
+        class="column"
+      >
+        <span class="name">{{ column.displayName || column.tag }}</span>
+        <ng-container *ngIf="column.filter">
+          <button
+            mat-icon-button
+            [matMenuTriggerFor]="filterMenu"
+            i18n-aria-label="A button that opens a menu that lets user set metric filter conditions"
+            [attr.aria-label]="'Filter metric ' + (column.displayName || column.tag)"
+          >
+            <mat-icon svgIcon="filter_alt_24px"></mat-icon>
+          </button>
+
+          <mat-menu #filterMenu="matMenu">
+            <div
+              mat-menu-item
+              (click)="$event.stopPropagation()"
+              role="menuitemcheckbox"
+              disableRipple
+            >
+              <mat-checkbox
+                [checked]="column.filter.includeUndefined"
+                (change)="handleMetricIncludeUndefinedChanged(column)"
+                ><span>(show empty value)</span></mat-checkbox
+              >
+            </div>
             <div
               (click)="$event.stopPropagation()"
               class="range-input-container"
@@ -150,80 +219,23 @@ limitations under the License.
                 [max]="column.filter.maxValue"
                 [lowerValue]="column.filter.filterLowerValue"
                 [upperValue]="column.filter.filterUpperValue"
-                (value)="handleHparamIntervalChanged(column, $event)"
+                (value)="handleMetricFilterChanged(column, $event)"
               ></tb-range-input>
             </div>
-          </ng-container>
-          <ng-container *ngIf="column.filter.type === DomainType.DISCRETE">
-            <div
-              *ngFor="let value of column.filter.possibleValues"
-              mat-menu-item
-              role="menuitemcheckbox"
-              (click)="$event.stopPropagation()"
-            >
-              <mat-checkbox
-                [checked]="column.filter.filterValues.includes(value)"
-                (change)="handleHparamDiscreteChanged(column, value)"
-                ><span>{{ value }}</span></mat-checkbox
-              >
-            </div>
-          </ng-container>
-        </mat-menu>
-      </ng-container>
-    </span>
-
-    <span
-      *ngFor="let column of metricColumns; trackBy: trackByMetricColumn"
-      role="columnheader"
-      class="column"
-    >
-      <span class="name">{{ column.displayName || column.tag }}</span>
-      <ng-container *ngIf="column.filter">
-        <button
-          mat-icon-button
-          [matMenuTriggerFor]="filterMenu"
-          i18n-aria-label="A button that opens a menu that lets user set metric filter conditions"
-          [attr.aria-label]="'Filter metric ' + (column.displayName || column.tag)"
-        >
-          <mat-icon svgIcon="filter_alt_24px"></mat-icon>
-        </button>
-
-        <mat-menu #filterMenu="matMenu">
-          <div
-            mat-menu-item
-            (click)="$event.stopPropagation()"
-            role="menuitemcheckbox"
-            disableRipple
-          >
-            <mat-checkbox
-              [checked]="column.filter.includeUndefined"
-              (change)="handleMetricIncludeUndefinedChanged(column)"
-              ><span>(show empty value)</span></mat-checkbox
-            >
-          </div>
-          <div
-            (click)="$event.stopPropagation()"
-            class="range-input-container"
-            disableRipple
-            mat-menu-item
-          >
-            <tb-range-input
-              [min]="column.filter.minValue"
-              [max]="column.filter.maxValue"
-              [lowerValue]="column.filter.filterLowerValue"
-              [upperValue]="column.filter.filterUpperValue"
-              (value)="handleMetricFilterChanged(column, $event)"
-            ></tb-range-input>
-          </div>
-        </mat-menu>
-      </ng-container>
-    </span>
+          </mat-menu>
+        </ng-container>
+      </span>
+    </div>
   </div>
 </ng-template>
 
 <ng-template #row let-item="item">
   <div role="row">
-    <span *ngFor="let columnId of columns" role="cell" class="column">
+    <span
+      *ngFor="let columnId of columns"
+      role="cell"
+      [ngClass]="['column', 'tb-column-' + columnId]"
+    >
       <ng-container [ngSwitch]="columnId">
         <span *ngSwitchCase="RunsTableColumn.CHECKBOX">
           <mat-checkbox

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -82,11 +82,7 @@ limitations under the License.
     [matSortActive]="sortOption.column"
     role="row"
   >
-    <span
-      *ngFor="let columnId of columns"
-      role="columnheader"
-      [ngClass]="['column', columnId]"
-    >
+    <span *ngFor="let columnId of columns" role="columnheader" class="column">
       <ng-container [ngSwitch]="columnId">
         <span *ngSwitchCase="RunsTableColumn.CHECKBOX"
           ><mat-checkbox
@@ -99,21 +95,18 @@ limitations under the License.
         <span
           *ngSwitchCase="RunsTableColumn.EXPERIMENT_NAME"
           [mat-sort-header]="RunsTableColumn.EXPERIMENT_NAME"
-          [class]="columnId"
+          class="name"
           >Experiment</span
         >
 
         <span
           *ngSwitchCase="RunsTableColumn.RUN_NAME"
           [mat-sort-header]="RunsTableColumn.RUN_NAME"
-          [class]="columnId"
+          class="name"
           >Run</span
         >
 
-        <span
-          *ngSwitchCase="RunsTableColumn.RUN_COLOR"
-          [class]="columnId"
-        ></span>
+        <span *ngSwitchCase="RunsTableColumn.RUN_COLOR"></span>
       </ng-container>
     </span>
 
@@ -230,13 +223,9 @@ limitations under the License.
 
 <ng-template #row let-item="item">
   <div role="row">
-    <span
-      *ngFor="let columnId of columns"
-      role="cell"
-      [ngClass]="['column', columnId]"
-    >
+    <span *ngFor="let columnId of columns" role="cell" class="column">
       <ng-container [ngSwitch]="columnId">
-        <span *ngSwitchCase="RunsTableColumn.CHECKBOX" [class]="columnId">
+        <span *ngSwitchCase="RunsTableColumn.CHECKBOX">
           <mat-checkbox
             [checked]="item.selected"
             (change)="onSelectionToggle.emit(item)"
@@ -244,16 +233,16 @@ limitations under the License.
         </span>
         <span
           *ngSwitchCase="RunsTableColumn.EXPERIMENT_NAME"
-          [class]="columnId"
+          class="name"
           [attr.title]="item.experimentName"
           >{{ item.experimentAlias }}</span
         >
 
-        <span *ngSwitchCase="RunsTableColumn.RUN_NAME" [class]="columnId"
+        <span *ngSwitchCase="RunsTableColumn.RUN_NAME" class="name"
           >{{ item.run.name }}</span
         >
 
-        <span *ngSwitchCase="RunsTableColumn.RUN_COLOR" [class]="columnId">
+        <span *ngSwitchCase="RunsTableColumn.RUN_COLOR">
           <button
             [ngClass]="{
               'run-color-swatch': true,

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -30,7 +30,7 @@ limitations under the License.
   <div role="table">
     <ng-container *ngTemplateOutlet="header"></ng-container>
     <ng-container *ngTemplateOutlet="selectAll"></ng-container>
-    <div role="rowgroup">
+    <div role="rowgroup" class="rows">
       <ng-container *ngFor="let item of pageItems; trackBy: tableTrackBy">
         <ng-container
           *ngTemplateOutlet="row; context:{item: item}"
@@ -102,14 +102,12 @@ limitations under the License.
           <span
             *ngSwitchCase="RunsTableColumn.EXPERIMENT_NAME"
             [mat-sort-header]="RunsTableColumn.EXPERIMENT_NAME"
-            class="name"
             >Experiment</span
           >
 
           <span
             *ngSwitchCase="RunsTableColumn.RUN_NAME"
             [mat-sort-header]="RunsTableColumn.RUN_NAME"
-            class="name"
             >Run</span
           >
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -27,224 +27,13 @@ limitations under the License.
   </div>
 </div>
 <div class="table-container">
-  <table
-    mat-table
-    [dataSource]="dataSource"
-    matSort
-    (matSortChange)="handleSortChange($event)"
-    [matSortActive]="sortOption.column"
-    [matSortDirection]="sortOption.direction"
-    [trackBy]="tableTrackBy"
-  >
-    <!-- Note that matColumnDef has to be static and cannot be bound to enum -->
-    <ng-container matColumnDef="checkbox">
-      <th mat-header-cell *matHeaderCellDef>
-        <mat-checkbox
-          [checked]="allPageItemsSelected()"
-          [indeterminate]="!allPageItemsSelected() && somePageItemsSelected()"
-          (change)="handlePageToggle()"
-        ></mat-checkbox>
-      </th>
-      <td mat-cell *matCellDef="let item">
-        <mat-checkbox
-          [checked]="item.selected"
-          (change)="onSelectionToggle.emit(item)"
-        ></mat-checkbox>
-      </td>
-    </ng-container>
-
-    <ng-container matColumnDef="experiment_name">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header class="name">
-        Experiment
-      </th>
-      <td mat-cell *matCellDef="let item" class="name">
-        <span [attr.title]="item.experimentName"
-          >{{ item.experimentAlias }}</span
-        >
-      </td>
-    </ng-container>
-
-    <ng-container matColumnDef="run_name">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header class="name">
-        Run
-      </th>
-      <td mat-cell *matCellDef="let item" class="name">{{ item.run.name }}</td>
-    </ng-container>
-
-    <ng-container matColumnDef="run_color">
-      <th mat-header-cell *matHeaderCellDef></th>
-      <td mat-cell *matCellDef="let item">
-        <button
-          [ngClass]="{
-            'run-color-swatch': true,
-            'no-color': !item.runColor
-          }"
-          [style.background]="item.runColor"
-          [colorPicker]="item.runColor"
-          [cpDialogDisplay]="'popup'"
-          [cpPosition]="'bottom-right'"
-          [cpPositionOffset]="-20"
-          [cpUseRootViewContainer]="true"
-          [cpOutputFormat]="'hex'"
-          (colorPickerChange)="onRunColorChange.emit({runId: item.run.id, newColor: $event})"
-        ></button>
-      </td>
-    </ng-container>
-
-    <ng-container matColumnDef="select_all">
-      <th
-        mat-header-cell
-        *matHeaderCellDef
-        [attr.colspan]="getColumnIds().length"
-      >
-        <div
-          class="select-all-content"
-          *ngIf="allPageItemsSelected() && numSelectedItems !== allItemsLength"
-        >
-          <span
-            >All runs in this page are selected but not all runs ({{
-            numSelectedItems }} of {{ allItemsLength }}) are selected.</span
-          ><button mat-button (click)="onSelectAllPages.emit()">
-            Select all runs
-          </button>
-        </div>
-      </th>
-    </ng-container>
-
-    <ng-container
-      *ngFor="let column of hparamColumns; trackBy: trackByHparamColumn"
-      [matColumnDef]="getHparamColumnId(column)"
-    >
-      <th mat-header-cell *matHeaderCellDef>
-        <span class="name">{{ column.displayName || column.name }}</span>
-        <ng-container *ngIf="column.filter">
-          <button
-            mat-icon-button
-            [matMenuTriggerFor]="filterMenu"
-            i18n-aria-label="A button that opens a menu that lets user set hparam filter conditions"
-            [attr.aria-label]="'Filter hparam ' + (column.displayName || column.name)"
-          >
-            <mat-icon svgIcon="filter_alt_24px"></mat-icon>
-          </button>
-          <mat-menu #filterMenu="matMenu">
-            <div
-              mat-menu-item
-              (click)="$event.stopPropagation()"
-              role="menuitemcheckbox"
-              disableRipple
-            >
-              <mat-checkbox
-                [checked]="column.filter.includeUndefined"
-                (change)="handleHparamIncludeUndefinedToggled(column)"
-                ><span>(show empty value)</span></mat-checkbox
-              >
-            </div>
-            <ng-container *ngIf="column.filter.type === DomainType.INTERVAL">
-              <div
-                (click)="$event.stopPropagation()"
-                class="range-input-container"
-                disableRipple
-                mat-menu-item
-              >
-                <tb-range-input
-                  [min]="column.filter.minValue"
-                  [max]="column.filter.maxValue"
-                  [lowerValue]="column.filter.filterLowerValue"
-                  [upperValue]="column.filter.filterUpperValue"
-                  (value)="handleHparamIntervalChanged(column, $event)"
-                ></tb-range-input>
-              </div>
-            </ng-container>
-            <ng-container *ngIf="column.filter.type === DomainType.DISCRETE">
-              <div
-                *ngFor="let value of column.filter.possibleValues"
-                mat-menu-item
-                role="menuitemcheckbox"
-                (click)="$event.stopPropagation()"
-              >
-                <mat-checkbox
-                  [checked]="column.filter.filterValues.includes(value)"
-                  (change)="handleHparamDiscreteChanged(column, value)"
-                  ><span>{{ value }}</span></mat-checkbox
-                >
-              </div>
-            </ng-container>
-          </mat-menu>
-        </ng-container>
-      </th>
-
-      <td mat-cell *matCellDef="let item">
-        {{ item.hparams.get(column.name) }}
-      </td>
-    </ng-container>
-
-    <ng-container
-      *ngFor="let column of metricColumns; trackBy: trackByMetricColumn"
-      [matColumnDef]="getMetricColumnId(column)"
-    >
-      <th mat-header-cell *matHeaderCellDef>
-        <span class="name">{{ column.displayName || column.tag }}</span>
-        <ng-container *ngIf="column.filter">
-          <button
-            mat-icon-button
-            [matMenuTriggerFor]="filterMenu"
-            i18n-aria-label="A button that opens a menu that lets user set metric filter conditions"
-            [attr.aria-label]="'Filter metric ' + (column.displayName || column.tag)"
-          >
-            <mat-icon svgIcon="filter_alt_24px"></mat-icon>
-          </button>
-
-          <mat-menu #filterMenu="matMenu">
-            <div
-              mat-menu-item
-              (click)="$event.stopPropagation()"
-              role="menuitemcheckbox"
-              disableRipple
-            >
-              <mat-checkbox
-                [checked]="column.filter.includeUndefined"
-                (change)="handleMetricIncludeUndefinedChanged(column)"
-                ><span>(show empty value)</span></mat-checkbox
-              >
-            </div>
-            <div
-              (click)="$event.stopPropagation()"
-              class="range-input-container"
-              disableRipple
-              mat-menu-item
-            >
-              <tb-range-input
-                [min]="column.filter.minValue"
-                [max]="column.filter.maxValue"
-                [lowerValue]="column.filter.filterLowerValue"
-                [upperValue]="column.filter.filterUpperValue"
-                (value)="handleMetricFilterChanged(column, $event)"
-              ></tb-range-input>
-            </div>
-          </mat-menu>
-        </ng-container>
-      </th>
-      <td mat-cell *matCellDef="let item">
-        {{ item.metrics.get(column.tag) }}
-      </td>
-    </ng-container>
-
-    <tr class="columns" mat-header-row *matHeaderRowDef="getColumnIds()"></tr>
-    <tr
-      mat-header-row
-      *matHeaderRowDef="['select_all']"
-      [ngClass]="{
-        'select-all': true,
-        'show-select-all': allPageItemsSelected() && numSelectedItems !== allItemsLength
-      }"
-    ></tr>
-    <tr
-      mat-row
-      *matRowDef="let row; columns: getColumnIds()"
-      [attr.data-id]="row.run.id"
-    ></tr>
-    <tr></tr>
-  </table>
+  <div role="grid">
+    <ng-container *ngTemplateOutlet="header"></ng-container>
+    <ng-container *ngTemplateOutlet="selectAll"></ng-container>
+    <ng-container *ngFor="let item of pageItems; trackBy: tableTrackBy">
+      <ng-container *ngTemplateOutlet="row; context:{item: item}"></ng-container
+    ></ng-container>
+  </div>
 
   <div *ngIf="loading" class="loading">
     <mat-spinner mode="indeterminate" diameter="28"></mat-spinner>
@@ -269,3 +58,232 @@ limitations under the License.
   showFirstLastButtons
   (page)="onPaginationChange.emit($event)"
 ></mat-paginator>
+
+<ng-template #selectAll>
+  <div
+    *ngIf="allPageItemsSelected() && numSelectedItems !== allItemsLength"
+    class="select-all"
+    role="rowheader"
+  >
+    <span
+      >All runs in this page are selected but not all runs ({{ numSelectedItems
+      }} of {{ allItemsLength }}) are selected.</span
+    ><button mat-button (click)="onSelectAllPages.emit()">
+      Select all runs
+    </button>
+  </div>
+</ng-template>
+
+<ng-template #header>
+  <div
+    class="header"
+    matSort
+    (matSortChange)="handleSortChange($event)"
+    [matSortActive]="sortOption.column"
+    role="rowheader"
+  >
+    <span
+      *ngFor="let columnId of columns"
+      role="cell"
+      [ngClass]="['column', columnId]"
+    >
+      <ng-container [ngSwitch]="columnId">
+        <span *ngSwitchCase="RunsTableColumn.CHECKBOX"
+          ><mat-checkbox
+            [checked]="allPageItemsSelected()"
+            [indeterminate]="!allPageItemsSelected() && somePageItemsSelected()"
+            (change)="handlePageToggle()"
+          ></mat-checkbox
+        ></span>
+
+        <span
+          *ngSwitchCase="RunsTableColumn.EXPERIMENT_NAME"
+          [mat-sort-header]="RunsTableColumn.EXPERIMENT_NAME"
+          [class]="columnId"
+          >Experiment</span
+        >
+
+        <span
+          *ngSwitchCase="RunsTableColumn.RUN_NAME"
+          [mat-sort-header]="RunsTableColumn.RUN_NAME"
+          [class]="columnId"
+          >Run</span
+        >
+
+        <span
+          *ngSwitchCase="RunsTableColumn.RUN_COLOR"
+          [class]="columnId"
+        ></span>
+      </ng-container>
+    </span>
+
+    <span
+      *ngFor="let column of hparamColumns; trackBy: trackByHparamColumn"
+      role="cell"
+      [ngClass]="['column', column.name]"
+    >
+      <span class="name">{{ column.displayName || column.name }}</span>
+      <ng-container *ngIf="column.filter">
+        <button
+          mat-icon-button
+          [matMenuTriggerFor]="filterMenu"
+          i18n-aria-label="A button that opens a menu that lets user set hparam filter conditions"
+          [attr.aria-label]="'Filter hparam ' + (column.displayName || column.name)"
+        >
+          <mat-icon svgIcon="filter_alt_24px"></mat-icon>
+        </button>
+        <mat-menu #filterMenu="matMenu">
+          <div
+            mat-menu-item
+            (click)="$event.stopPropagation()"
+            role="menuitemcheckbox"
+            disableRipple
+          >
+            <mat-checkbox
+              [checked]="column.filter.includeUndefined"
+              (change)="handleHparamIncludeUndefinedToggled(column)"
+              ><span>(show empty value)</span></mat-checkbox
+            >
+          </div>
+          <ng-container *ngIf="column.filter.type === DomainType.INTERVAL">
+            <div
+              (click)="$event.stopPropagation()"
+              class="range-input-container"
+              disableRipple
+              mat-menu-item
+            >
+              <tb-range-input
+                [min]="column.filter.minValue"
+                [max]="column.filter.maxValue"
+                [lowerValue]="column.filter.filterLowerValue"
+                [upperValue]="column.filter.filterUpperValue"
+                (value)="handleHparamIntervalChanged(column, $event)"
+              ></tb-range-input>
+            </div>
+          </ng-container>
+          <ng-container *ngIf="column.filter.type === DomainType.DISCRETE">
+            <div
+              *ngFor="let value of column.filter.possibleValues"
+              mat-menu-item
+              role="menuitemcheckbox"
+              (click)="$event.stopPropagation()"
+            >
+              <mat-checkbox
+                [checked]="column.filter.filterValues.includes(value)"
+                (change)="handleHparamDiscreteChanged(column, value)"
+                ><span>{{ value }}</span></mat-checkbox
+              >
+            </div>
+          </ng-container>
+        </mat-menu>
+      </ng-container>
+    </span>
+
+    <span
+      *ngFor="let column of metricColumns; trackBy: trackByMetricColumn"
+      role="cell"
+      [ngClass]="['column', column.tag]"
+    >
+      <span class="name">{{ column.displayName || column.tag }}</span>
+      <ng-container *ngIf="column.filter">
+        <button
+          mat-icon-button
+          [matMenuTriggerFor]="filterMenu"
+          i18n-aria-label="A button that opens a menu that lets user set metric filter conditions"
+          [attr.aria-label]="'Filter metric ' + (column.displayName || column.tag)"
+        >
+          <mat-icon svgIcon="filter_alt_24px"></mat-icon>
+        </button>
+
+        <mat-menu #filterMenu="matMenu">
+          <div
+            mat-menu-item
+            (click)="$event.stopPropagation()"
+            role="menuitemcheckbox"
+            disableRipple
+          >
+            <mat-checkbox
+              [checked]="column.filter.includeUndefined"
+              (change)="handleMetricIncludeUndefinedChanged(column)"
+              ><span>(show empty value)</span></mat-checkbox
+            >
+          </div>
+          <div
+            (click)="$event.stopPropagation()"
+            class="range-input-container"
+            disableRipple
+            mat-menu-item
+          >
+            <tb-range-input
+              [min]="column.filter.minValue"
+              [max]="column.filter.maxValue"
+              [lowerValue]="column.filter.filterLowerValue"
+              [upperValue]="column.filter.filterUpperValue"
+              (value)="handleMetricFilterChanged(column, $event)"
+            ></tb-range-input>
+          </div>
+        </mat-menu>
+      </ng-container>
+    </span>
+  </div>
+</ng-template>
+
+<ng-template #row let-item="item">
+  <div class="run-row" role="row">
+    <span
+      *ngFor="let columnId of columns"
+      role="cell"
+      [ngClass]="['column', columnId]"
+    >
+      <ng-container [ngSwitch]="columnId">
+        <span *ngSwitchCase="RunsTableColumn.CHECKBOX" [class]="columnId">
+          <mat-checkbox
+            [checked]="item.selected"
+            (change)="onSelectionToggle.emit(item)"
+          ></mat-checkbox>
+        </span>
+        <span
+          *ngSwitchCase="RunsTableColumn.EXPERIMENT_NAME"
+          [class]="columnId"
+          [attr.title]="item.experimentName"
+          >{{ item.experimentAlias }}</span
+        >
+
+        <span *ngSwitchCase="RunsTableColumn.RUN_NAME" [class]="columnId"
+          >{{ item.run.name }}</span
+        >
+
+        <span *ngSwitchCase="RunsTableColumn.RUN_COLOR" [class]="columnId">
+          <button
+            [ngClass]="{
+              'run-color-swatch': true,
+              'no-color': !item.runColor
+            }"
+            [style.background]="item.runColor"
+            [colorPicker]="item.runColor"
+            [cpDialogDisplay]="'popup'"
+            [cpPosition]="'bottom-right'"
+            [cpPositionOffset]="-20"
+            [cpUseRootViewContainer]="true"
+            [cpOutputFormat]="'hex'"
+            (colorPickerChange)="onRunColorChange.emit({runId: item.run.id, newColor: $event})"
+          ></button>
+        </span>
+      </ng-container>
+    </span>
+
+    <span
+      *ngFor="let column of hparamColumns"
+      role="cell"
+      [ngClass]="['column', column.name]"
+      >{{ item.hparams.get(column.name) }}</span
+    >
+
+    <span
+      *ngFor="let column of metricColumns"
+      role="cell"
+      [ngClass]="['column', column.tag]"
+      >{{ item.metrics.get(column.tag) }}</span
+    >
+  </div>
+</ng-template>

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -27,7 +27,7 @@ limitations under the License.
   </div>
 </div>
 <div class="table-container">
-  <div role="grid">
+  <div role="table">
     <ng-container *ngTemplateOutlet="header"></ng-container>
     <ng-container *ngTemplateOutlet="selectAll"></ng-container>
     <ng-container *ngFor="let item of pageItems; trackBy: tableTrackBy">
@@ -63,9 +63,9 @@ limitations under the License.
   <div
     *ngIf="allPageItemsSelected() && numSelectedItems !== allItemsLength"
     class="select-all"
-    role="rowheader"
+    role="row"
   >
-    <span
+    <span role="columnheader"
       >All runs in this page are selected but not all runs ({{ numSelectedItems
       }} of {{ allItemsLength }}) are selected.</span
     ><button mat-button (click)="onSelectAllPages.emit()">
@@ -80,11 +80,11 @@ limitations under the License.
     matSort
     (matSortChange)="handleSortChange($event)"
     [matSortActive]="sortOption.column"
-    role="rowheader"
+    role="row"
   >
     <span
       *ngFor="let columnId of columns"
-      role="cell"
+      role="columnheader"
       [ngClass]="['column', columnId]"
     >
       <ng-container [ngSwitch]="columnId">
@@ -119,8 +119,8 @@ limitations under the License.
 
     <span
       *ngFor="let column of hparamColumns; trackBy: trackByHparamColumn"
-      role="cell"
-      [ngClass]="['column', column.name]"
+      role="columnheader"
+      class="column"
     >
       <span class="name">{{ column.displayName || column.name }}</span>
       <ng-container *ngIf="column.filter">
@@ -181,8 +181,8 @@ limitations under the License.
 
     <span
       *ngFor="let column of metricColumns; trackBy: trackByMetricColumn"
-      role="cell"
-      [ngClass]="['column', column.tag]"
+      role="columnheader"
+      class="column"
     >
       <span class="name">{{ column.displayName || column.tag }}</span>
       <ng-container *ngIf="column.filter">
@@ -229,7 +229,7 @@ limitations under the License.
 </ng-template>
 
 <ng-template #row let-item="item">
-  <div class="run-row" role="row">
+  <div role="row">
     <span
       *ngFor="let columnId of columns"
       role="cell"
@@ -272,17 +272,11 @@ limitations under the License.
       </ng-container>
     </span>
 
-    <span
-      *ngFor="let column of hparamColumns"
-      role="cell"
-      [ngClass]="['column', column.name]"
+    <span *ngFor="let column of hparamColumns" role="cell" class="column"
       >{{ item.hparams.get(column.name) }}</span
     >
 
-    <span
-      *ngFor="let column of metricColumns"
-      role="cell"
-      [ngClass]="['column', column.tag]"
+    <span *ngFor="let column of metricColumns" role="cell" class="column"
       >{{ item.metrics.get(column.tag) }}</span
     >
   </div>

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -33,11 +33,9 @@ $_font-size: 13px;
 }
 
 :host.flex-layout {
-  .exp_name,
-  .run_name {
+  .name {
     word-break: break-word;
     overflow-wrap: break-word;
-    width: 100%;
   }
 
   mat-paginator {

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -26,9 +26,11 @@ $_font-size: 13px;
 }
 
 .table-container {
+  contain: layout paint;
   height: 100%;
   max-width: 100%;
   overflow-x: auto;
+  overflow-y: auto;
   will-change: scroll-position;
 }
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -16,33 +16,28 @@ limitations under the License.
 
 // 42px + 1px for border.
 $_table-content-row-min-height: 43px;
+$_font-size: 13px;
 
 :host {
-  display: block;
-  overflow: hidden;
   background-color: #fff;
+  display: block;
+  font-size: $_font-size;
+  overflow: hidden;
 }
 
 .table-container {
-  contain: layout paint;
+  height: 100%;
   max-width: 100%;
   overflow-x: auto;
-  will-change: transform;
+  will-change: scroll-position;
 }
 
 :host.flex-layout {
-  display: flex;
-  flex-direction: column;
-
-  .table-container {
-    flex: 1 1 0;
-    overflow-x: hidden;
-    overflow-y: auto;
-
-    td.name {
-      word-break: break-word;
-      overflow-wrap: break-word;
-    }
+  .exp_name,
+  .run_name {
+    word-break: break-word;
+    overflow-wrap: break-word;
+    width: 100%;
   }
 
   mat-paginator {
@@ -51,38 +46,35 @@ $_table-content-row-min-height: 43px;
   }
 }
 
-table {
-  width: 100%;
+$_border-color: #0000001f;
 
-  th,
-  td {
-    font-size: 13px;
-    padding: 5px;
-
-    &:not(.name) {
-      text-align: center;
-    }
-
-    &:first-of-type {
-      padding-left: 24px;
-    }
-
-    &:last-of-type {
-      padding-right: 24px;
-    }
-  }
-
-  th {
+[role='grid'] {
+  .header {
     color: mat-color($tb-foreground, text);
-  }
-
-  tr:not(.select-all) th {
     white-space: nowrap;
   }
 
-  .mat-header-row,
-  .mat-row {
+  .header,
+  .run-row {
+    contain: strict;
+    display: table-row;
     height: $_table-content-row-min-height;
+
+    .column {
+      border-bottom: 1px solid $_border-color;
+      display: table-cell;
+
+      padding: 5px;
+      vertical-align: middle;
+
+      &:first-child {
+        padding-left: 24px;
+      }
+
+      &:last-child {
+        padding-right: 24px;
+      }
+    }
   }
 }
 
@@ -91,7 +83,7 @@ table {
   align-items: center;
   border: 0;
   border-bottom-width: 1px;
-  border-color: #0000001f;
+  border-color: $_border-color;
   border-style: solid;
   display: flex;
   height: 48px;
@@ -107,13 +99,8 @@ table {
   padding-top: 12px;
 }
 
-:host tr.select-all:not(.show-select-all) {
-  display: none;
-}
-
 .select-all-content,
 .select-all-content button {
-  font-size: 13px;
   font-weight: 400;
   line-height: 1.6;
   text-align: left;
@@ -135,7 +122,6 @@ table {
 .run-filter {
   display: flex;
   color: mat-color($tb-foreground, text);
-  font-size: 13px;
   flex: 1;
 
   mat-icon {

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -48,14 +48,13 @@ $_font-size: 13px;
 
 $_border-color: #0000001f;
 
-[role='grid'] {
+[role='table'] {
   .header {
     color: mat-color($tb-foreground, text);
     white-space: nowrap;
   }
 
-  .header,
-  .run-row {
+  [role='row'] {
     contain: strict;
     display: table-row;
     height: $_table-content-row-min-height;

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -49,6 +49,9 @@ $_font-size: 13px;
 $_border-color: #0000001f;
 
 [role='table'] {
+  display: table;
+  width: 100%;
+
   .header {
     color: mat-color($tb-foreground, text);
     white-space: nowrap;
@@ -74,6 +77,14 @@ $_border-color: #0000001f;
         padding-right: 24px;
       }
     }
+  }
+}
+
+[role='rowgroup'] {
+  display: table-row-group;
+
+  &.header {
+    display: table-header-group;
   }
 }
 
@@ -133,8 +144,8 @@ $_border-color: #0000001f;
 
 // Prevents the table column for checkbox and run_color from growing beyond
 // their sizes.
-.mat-column-checkbox,
-.mat-column-run_color {
+.tb-column-checkbox,
+.tb-column-run_color {
   width: 20px;
 }
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ts
@@ -79,6 +79,7 @@ export interface IntervalFilterChange {
 export class RunsTableComponent implements OnChanges {
   readonly dataSource = new MatTableDataSource<RunTableItem>();
   readonly DomainType = DomainType;
+  readonly RunsTableColumn = RunsTableColumn;
 
   @Input() showExperimentName!: boolean;
   @Input() columns!: RunsTableColumn[];

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_module.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_module.ts
@@ -30,7 +30,6 @@ import {MatTableModule} from '@angular/material/table';
 import {ColorPickerModule} from 'ngx-color-picker';
 
 import {RangeInputModule} from '../../../widgets/range_input/range_input_module';
-
 import {RunsTableComponent} from './runs_table_component';
 import {RunsTableContainer} from './runs_table_container';
 

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -129,10 +129,10 @@ class TestableColorPicker {
 }
 
 const Selector = {
-  ROW: '[role="row"]',
+  ITEM_ROW: '[role="row"]:not(.header)',
   COLUMN: '[role="cell"]',
-  HEADER_COLUMN: '[role="rowheader"] .column',
-  HEADER_CHECKBOX: '[role="rowheader"] mat-checkbox',
+  HEADER_COLUMN: '[role="columnheader"]',
+  HEADER_CHECKBOX: '[role="columnheader"] mat-checkbox',
   SELECT_ALL_ROW: '.select-all',
 };
 
@@ -160,7 +160,7 @@ describe('runs_table', () => {
   function getTableRowTextContent(
     fixture: ComponentFixture<RunsTableContainer>
   ) {
-    const rows = [...fixture.nativeElement.querySelectorAll(Selector.ROW)];
+    const rows = [...fixture.nativeElement.querySelectorAll(Selector.ITEM_ROW)];
     return rows.map((row) => {
       const columns = [...row.querySelectorAll(Selector.COLUMN)];
       return columns.map((column) => column.textContent.trim());
@@ -259,7 +259,7 @@ describe('runs_table', () => {
       await fixture.whenStable();
 
       // mat-table's content somehow does not end up in DebugElement.
-      const rows = fixture.nativeElement.querySelectorAll(Selector.ROW);
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ITEM_ROW);
       expect(rows.length).toBe(2);
 
       const [book1, book2] = rows;
@@ -341,7 +341,7 @@ describe('runs_table', () => {
       await fixture.whenStable();
 
       // mat-table's content somehow does not end up in DebugElement.
-      const rows = fixture.nativeElement.querySelectorAll(Selector.ROW);
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ITEM_ROW);
       expect(rows.length).toBe(3);
 
       const [book1, book2, book3] = rows;
@@ -382,7 +382,7 @@ describe('runs_table', () => {
       await fixture.whenStable();
 
       // mat-table's content somehow does not end up in DebugElement.
-      const [book1] = fixture.nativeElement.querySelectorAll(Selector.ROW);
+      const [book1] = fixture.nativeElement.querySelectorAll(Selector.ITEM_ROW);
       expect(
         [...book1.querySelectorAll(Selector.COLUMN)].map(
           (node) => node.textContent
@@ -406,13 +406,17 @@ describe('runs_table', () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
-      const rowsBefore = fixture.nativeElement.querySelectorAll(Selector.ROW);
+      const rowsBefore = fixture.nativeElement.querySelectorAll(
+        Selector.ITEM_ROW
+      );
       expect(rowsBefore.length).toBe(2);
 
       runs.next([buildRun({id: 'Potter', name: 'Potter'})]);
       fixture.detectChanges();
 
-      const rowsAfter = fixture.nativeElement.querySelectorAll(Selector.ROW);
+      const rowsAfter = fixture.nativeElement.querySelectorAll(
+        Selector.ITEM_ROW
+      );
       expect(rowsAfter.length).toBe(1);
       const [potter] = rowsAfter;
       expect(potter.querySelector(Selector.COLUMN).textContent).toBe('Potter');
@@ -448,7 +452,7 @@ describe('runs_table', () => {
 
       // mat-table's content somehow does not end up in DebugElement.
       const [book1, book2] = fixture.nativeElement.querySelectorAll(
-        Selector.ROW
+        Selector.ITEM_ROW
       );
       expect(book1.querySelector('mat-checkbox input').checked).toBe(true);
       expect(book2.querySelector('mat-checkbox input').checked).toBe(false);
@@ -487,7 +491,7 @@ describe('runs_table', () => {
       fixture.detectChanges();
 
       const [book1, book2] = fixture.nativeElement.querySelectorAll(
-        Selector.ROW
+        Selector.ITEM_ROW
       );
       const [book1Name, book1Color] = book1.querySelectorAll(Selector.COLUMN);
       expect(book1Name.textContent).toBe("The Philosopher's Stone");
@@ -657,7 +661,7 @@ describe('runs_table', () => {
       const fixture = createComponent(['book']);
       fixture.detectChanges();
 
-      const rows = fixture.nativeElement.querySelectorAll(Selector.ROW);
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ITEM_ROW);
       expect(rows.length).toBe(5);
       expect(
         fixture.debugElement.query(By.css('mat-paginator'))
@@ -700,7 +704,7 @@ describe('runs_table', () => {
       );
       updateTableAndPaginator(fixture);
 
-      const rows = fixture.nativeElement.querySelectorAll(Selector.ROW);
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ITEM_ROW);
       // By default, mat-paginator take the lowest pageSizeOptions.
       expect(rows.length).toBe(PAGE_SIZE);
       const [beforeFirstEl] = rows;
@@ -753,7 +757,7 @@ describe('runs_table', () => {
       );
       updateTableAndPaginator(fixture);
 
-      const rows = fixture.nativeElement.querySelectorAll(Selector.ROW);
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ITEM_ROW);
       // By default, mat-paginator take the lowest pageSizeOptions.
       expect(rows.length).toBe(5);
       const [beforeFirstEl] = rows;
@@ -1354,7 +1358,7 @@ describe('runs_table', () => {
       await fixture.whenStable();
 
       // mat-table's content somehow does not end up in DebugElement.
-      const rows = fixture.nativeElement.querySelectorAll(Selector.ROW);
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ITEM_ROW);
       const [book1, book2] = rows;
       book2.querySelector('mat-checkbox input').click();
       book1.querySelector('mat-checkbox input').click();

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -128,6 +128,14 @@ class TestableColorPicker {
   }
 }
 
+const Selector = {
+  ROW: '[role="row"]',
+  COLUMN: '[role="cell"]',
+  HEADER_COLUMN: '[role="rowheader"] .column',
+  HEADER_CHECKBOX: '[role="rowheader"] mat-checkbox',
+  SELECT_ALL_ROW: '.select-all',
+};
+
 describe('runs_table', () => {
   let store: MockStore<State>;
   let dispatchSpy: jasmine.Spy;
@@ -152,9 +160,9 @@ describe('runs_table', () => {
   function getTableRowTextContent(
     fixture: ComponentFixture<RunsTableContainer>
   ) {
-    const rows = [...fixture.nativeElement.querySelectorAll('tbody tr')];
+    const rows = [...fixture.nativeElement.querySelectorAll(Selector.ROW)];
     return rows.map((row) => {
-      const columns = [...row.querySelectorAll('td')];
+      const columns = [...row.querySelectorAll(Selector.COLUMN)];
       return columns.map((column) => column.textContent.trim());
     });
   }
@@ -251,16 +259,20 @@ describe('runs_table', () => {
       await fixture.whenStable();
 
       // mat-table's content somehow does not end up in DebugElement.
-      const rows = fixture.nativeElement.querySelectorAll('tbody tr');
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ROW);
       expect(rows.length).toBe(2);
 
       const [book1, book2] = rows;
       expect(
-        [...book1.querySelectorAll('td')].map((node) => node.textContent)
+        [...book1.querySelectorAll(Selector.COLUMN)].map(
+          (node) => node.textContent
+        )
       ).toEqual(['Harry Potter', "The Philosopher's Stone"]);
 
       expect(
-        [...book2.querySelectorAll('td')].map((node) => node.textContent)
+        [...book2.querySelectorAll(Selector.COLUMN)].map(
+          (node) => node.textContent
+        )
       ).toEqual(['Harry Potter', 'The Chamber Of Secrets']);
     });
 
@@ -329,18 +341,24 @@ describe('runs_table', () => {
       await fixture.whenStable();
 
       // mat-table's content somehow does not end up in DebugElement.
-      const rows = fixture.nativeElement.querySelectorAll('tbody tr');
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ROW);
       expect(rows.length).toBe(3);
 
       const [book1, book2, book3] = rows;
       expect(
-        [...book1.querySelectorAll('td')].map((node) => node.textContent)
+        [...book1.querySelectorAll(Selector.COLUMN)].map(
+          (node) => node.textContent
+        )
       ).toEqual(['LoTR', 'The Fellowship of the Ring']);
       expect(
-        [...book2.querySelectorAll('td')].map((node) => node.textContent)
+        [...book2.querySelectorAll(Selector.COLUMN)].map(
+          (node) => node.textContent
+        )
       ).toEqual(['HP', "The Philosopher's Stone"]);
       expect(
-        [...book3.querySelectorAll('td')].map((node) => node.textContent)
+        [...book3.querySelectorAll(Selector.COLUMN)].map(
+          (node) => node.textContent
+        )
       ).toEqual(['HP', 'The Chamber Of Secrets']);
     });
 
@@ -364,9 +382,11 @@ describe('runs_table', () => {
       await fixture.whenStable();
 
       // mat-table's content somehow does not end up in DebugElement.
-      const [book1] = fixture.nativeElement.querySelectorAll('tbody tr');
+      const [book1] = fixture.nativeElement.querySelectorAll(Selector.ROW);
       expect(
-        [...book1.querySelectorAll('td')].map((node) => node.textContent)
+        [...book1.querySelectorAll(Selector.COLUMN)].map(
+          (node) => node.textContent
+        )
       ).toEqual(['The Fellowship of the Ring', 'The Lord of the Rings']);
     });
 
@@ -386,16 +406,16 @@ describe('runs_table', () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
-      const rowsBefore = fixture.nativeElement.querySelectorAll('tbody tr');
+      const rowsBefore = fixture.nativeElement.querySelectorAll(Selector.ROW);
       expect(rowsBefore.length).toBe(2);
 
       runs.next([buildRun({id: 'Potter', name: 'Potter'})]);
       fixture.detectChanges();
 
-      const rowsAfter = fixture.nativeElement.querySelectorAll('tbody tr');
+      const rowsAfter = fixture.nativeElement.querySelectorAll(Selector.ROW);
       expect(rowsAfter.length).toBe(1);
       const [potter] = rowsAfter;
-      expect(potter.querySelector('td').textContent).toBe('Potter');
+      expect(potter.querySelector(Selector.COLUMN).textContent).toBe('Potter');
     });
 
     it('renders checkboxes according to the map', async () => {
@@ -427,7 +447,9 @@ describe('runs_table', () => {
       await fixture.whenStable();
 
       // mat-table's content somehow does not end up in DebugElement.
-      const [book1, book2] = fixture.nativeElement.querySelectorAll('tbody tr');
+      const [book1, book2] = fixture.nativeElement.querySelectorAll(
+        Selector.ROW
+      );
       expect(book1.querySelector('mat-checkbox input').checked).toBe(true);
       expect(book2.querySelector('mat-checkbox input').checked).toBe(false);
     });
@@ -464,8 +486,10 @@ describe('runs_table', () => {
       );
       fixture.detectChanges();
 
-      const [book1, book2] = fixture.nativeElement.querySelectorAll('tbody tr');
-      const [book1Name, book1Color] = book1.querySelectorAll('td');
+      const [book1, book2] = fixture.nativeElement.querySelectorAll(
+        Selector.ROW
+      );
+      const [book1Name, book1Color] = book1.querySelectorAll(Selector.COLUMN);
       expect(book1Name.textContent).toBe("The Philosopher's Stone");
       expect(book1Color.querySelector('button').style.background).toBe(
         'rgb(0, 0, 0)'
@@ -474,7 +498,7 @@ describe('runs_table', () => {
         book1Color.querySelector('button').classList.contains('no-color')
       ).toBe(false);
 
-      const [book2Name, book2Color] = book2.querySelectorAll('td');
+      const [book2Name, book2Color] = book2.querySelectorAll(Selector.COLUMN);
       expect(book2Name.textContent).toBe('The Chamber Of Secrets');
       expect(book2Color.querySelector('button').style.background).toBe('');
       expect(
@@ -633,7 +657,7 @@ describe('runs_table', () => {
       const fixture = createComponent(['book']);
       fixture.detectChanges();
 
-      const rows = fixture.nativeElement.querySelectorAll('tbody tr');
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ROW);
       expect(rows.length).toBe(5);
       expect(
         fixture.debugElement.query(By.css('mat-paginator'))
@@ -676,11 +700,13 @@ describe('runs_table', () => {
       );
       updateTableAndPaginator(fixture);
 
-      const rows = fixture.nativeElement.querySelectorAll('tbody tr');
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ROW);
       // By default, mat-paginator take the lowest pageSizeOptions.
       expect(rows.length).toBe(PAGE_SIZE);
       const [beforeFirstEl] = rows;
-      expect(beforeFirstEl.querySelector('td').textContent).toBe('run_5');
+      expect(beforeFirstEl.querySelector(Selector.COLUMN).textContent).toBe(
+        'run_5'
+      );
 
       fixture.debugElement
         .query(By.css('[aria-label="Next page"]'))
@@ -727,11 +753,13 @@ describe('runs_table', () => {
       );
       updateTableAndPaginator(fixture);
 
-      const rows = fixture.nativeElement.querySelectorAll('tbody tr');
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ROW);
       // By default, mat-paginator take the lowest pageSizeOptions.
       expect(rows.length).toBe(5);
       const [beforeFirstEl] = rows;
-      expect(beforeFirstEl.querySelector('td').textContent).toBe('run_0');
+      expect(beforeFirstEl.querySelector(Selector.COLUMN).textContent).toBe(
+        'run_0'
+      );
 
       store.overrideSelector(getRunSelectorPaginationOption, {
         pageIndex: 1,
@@ -821,7 +849,7 @@ describe('runs_table', () => {
       fixture.detectChanges();
 
       const [expButton, runButton] = fixture.nativeElement.querySelectorAll(
-        'th .mat-sort-header-container'
+        Selector.HEADER_COLUMN + ' .mat-sort-header-container'
       );
 
       expButton.click();
@@ -1174,7 +1202,7 @@ describe('runs_table', () => {
       expect(getTableRowTextContent(fixture)).toEqual([]);
 
       expect(
-        fixture.nativeElement.querySelector('.show-select-all')
+        fixture.nativeElement.querySelector(Selector.SELECT_ALL_ROW)
       ).toBeNull();
     });
 
@@ -1265,7 +1293,7 @@ describe('runs_table', () => {
       fixture.detectChanges();
 
       const checkbox = fixture.nativeElement.querySelector(
-        'thead mat-checkbox'
+        Selector.HEADER_CHECKBOX
       );
 
       expect(checkbox.classList.contains('mat-checkbox-checked')).toBe(true);
@@ -1301,7 +1329,7 @@ describe('runs_table', () => {
         fixture.detectChanges();
 
         const checkbox = fixture.nativeElement.querySelector(
-          'thead mat-checkbox'
+          Selector.HEADER_CHECKBOX
         );
 
         expect(checkbox.classList.contains('mat-checkbox-indeterminate')).toBe(
@@ -1326,10 +1354,10 @@ describe('runs_table', () => {
       await fixture.whenStable();
 
       // mat-table's content somehow does not end up in DebugElement.
-      const rows = fixture.nativeElement.querySelectorAll('tbody tr');
+      const rows = fixture.nativeElement.querySelectorAll(Selector.ROW);
       const [book1, book2] = rows;
-      book2.querySelector('td mat-checkbox input').click();
-      book1.querySelector('td mat-checkbox input').click();
+      book2.querySelector('mat-checkbox input').click();
+      book1.querySelector('mat-checkbox input').click();
 
       expect(dispatchSpy).toHaveBeenCalledWith(
         runSelectionToggled({
@@ -1366,7 +1394,10 @@ describe('runs_table', () => {
         );
         fixture.detectChanges();
 
-        fixture.nativeElement.querySelector('thead mat-checkbox input').click();
+        fixture.nativeElement
+          .querySelector(Selector.HEADER_CHECKBOX)
+          .querySelector('input')
+          .click();
 
         expect(dispatchSpy).toHaveBeenCalledWith(
           runPageSelectionToggled({
@@ -1404,7 +1435,7 @@ describe('runs_table', () => {
       fixture.detectChanges();
 
       const showAll = fixture.nativeElement.querySelector(
-        '.select-all.show-select-all'
+        Selector.SELECT_ALL_ROW
       );
       expect(showAll).not.toBeTruthy();
     });
@@ -1436,7 +1467,7 @@ describe('runs_table', () => {
       fixture.detectChanges();
 
       const showAll = fixture.nativeElement.querySelector(
-        '.select-all.show-select-all'
+        Selector.SELECT_ALL_ROW
       );
       expect(showAll.textContent).toContain(
         'All runs in this page are selected but not all runs (2 of 3)'
@@ -1470,7 +1501,7 @@ describe('runs_table', () => {
       fixture.detectChanges();
 
       const showAll = fixture.nativeElement.querySelector(
-        '.select-all.show-select-all'
+        Selector.SELECT_ALL_ROW
       );
       expect(showAll).toBeNull();
     });
@@ -1502,7 +1533,7 @@ describe('runs_table', () => {
       fixture.detectChanges();
 
       const showAll = fixture.nativeElement.querySelector(
-        '.select-all.show-select-all'
+        Selector.SELECT_ALL_ROW
       );
       expect(showAll).toBeNull();
     });
@@ -1535,7 +1566,7 @@ describe('runs_table', () => {
       fixture.detectChanges();
 
       const showAll = fixture.nativeElement.querySelector(
-        '.select-all.show-select-all'
+        Selector.SELECT_ALL_ROW
       );
       expect(showAll.textContent).toContain(
         'All runs in this page are selected but not all runs (2 of 3)'
@@ -1675,7 +1706,7 @@ describe('runs_table', () => {
 
       const fixture = createComponent(hparamSpecs, metricSpecs);
       const columnHeaders = fixture.nativeElement.querySelectorAll(
-        '.columns th .name'
+        Selector.HEADER_COLUMN + ' .name'
       );
       expect([...columnHeaders].map((header) => header.textContent)).toEqual([
         'Batch size',
@@ -2120,7 +2151,9 @@ describe('runs_table', () => {
           const fixture = createComponent(TEST_HPARAM_SPECS, TEST_METRIC_SPECS);
           fixture.detectChanges();
 
-          const columnHeaders = fixture.nativeElement.querySelectorAll('th');
+          const columnHeaders = fixture.nativeElement.querySelectorAll(
+            Selector.HEADER_COLUMN
+          );
           columnHeaders[3].querySelector('button').click();
           const menuItems = getOverlayMenuItems();
 
@@ -2151,7 +2184,9 @@ describe('runs_table', () => {
           const fixture = createComponent(TEST_HPARAM_SPECS, TEST_METRIC_SPECS);
           fixture.detectChanges();
 
-          const columnHeaders = fixture.nativeElement.querySelectorAll('th');
+          const columnHeaders = fixture.nativeElement.querySelectorAll(
+            Selector.HEADER_COLUMN
+          );
           columnHeaders[3].querySelector('button').click();
           const [, menuItemFoo] = getOverlayMenuItems();
 
@@ -2185,7 +2220,9 @@ describe('runs_table', () => {
           const fixture = createComponent(TEST_HPARAM_SPECS, TEST_METRIC_SPECS);
           fixture.detectChanges();
 
-          const columnHeaders = fixture.nativeElement.querySelectorAll('th');
+          const columnHeaders = fixture.nativeElement.querySelectorAll(
+            Selector.HEADER_COLUMN
+          );
           columnHeaders[3].querySelector('button').click();
           const [includeUndefined] = getOverlayMenuItems();
 
@@ -2219,7 +2256,9 @@ describe('runs_table', () => {
           const fixture = createComponent(TEST_HPARAM_SPECS, TEST_METRIC_SPECS);
           fixture.detectChanges();
 
-          const columnHeaders = fixture.nativeElement.querySelectorAll('th');
+          const columnHeaders = fixture.nativeElement.querySelectorAll(
+            Selector.HEADER_COLUMN
+          );
           columnHeaders[1].querySelector('button').click();
           const menuItems = getOverlayMenuItems();
 
@@ -2246,7 +2285,9 @@ describe('runs_table', () => {
           const fixture = createComponent(TEST_HPARAM_SPECS, TEST_METRIC_SPECS);
           fixture.detectChanges();
 
-          const columnHeaders = fixture.nativeElement.querySelectorAll('th');
+          const columnHeaders = fixture.nativeElement.querySelectorAll(
+            Selector.HEADER_COLUMN
+          );
           columnHeaders[1].querySelector('button').click();
           const [, slider] = getOverlayMenuItems();
 
@@ -2282,7 +2323,9 @@ describe('runs_table', () => {
           const fixture = createComponent(TEST_HPARAM_SPECS, TEST_METRIC_SPECS);
           fixture.detectChanges();
 
-          const columnHeaders = fixture.nativeElement.querySelectorAll('th');
+          const columnHeaders = fixture.nativeElement.querySelectorAll(
+            Selector.HEADER_COLUMN
+          );
           columnHeaders[1].querySelector('button').click();
           const [includeUndefined] = getOverlayMenuItems();
 
@@ -2317,7 +2360,9 @@ describe('runs_table', () => {
           const fixture = createComponent(TEST_HPARAM_SPECS, TEST_METRIC_SPECS);
           fixture.detectChanges();
 
-          const columnHeaders = fixture.nativeElement.querySelectorAll('th');
+          const columnHeaders = fixture.nativeElement.querySelectorAll(
+            Selector.HEADER_COLUMN
+          );
           columnHeaders[4].querySelector('button').click();
           const menuItems = getOverlayMenuItems();
 
@@ -2344,7 +2389,9 @@ describe('runs_table', () => {
           const fixture = createComponent(TEST_HPARAM_SPECS, TEST_METRIC_SPECS);
           fixture.detectChanges();
 
-          const columnHeaders = fixture.nativeElement.querySelectorAll('th');
+          const columnHeaders = fixture.nativeElement.querySelectorAll(
+            Selector.HEADER_COLUMN
+          );
           columnHeaders[4].querySelector('button').click();
           const [, slider] = getOverlayMenuItems();
 
@@ -2380,7 +2427,9 @@ describe('runs_table', () => {
           const fixture = createComponent(TEST_HPARAM_SPECS, TEST_METRIC_SPECS);
           fixture.detectChanges();
 
-          const columnHeaders = fixture.nativeElement.querySelectorAll('th');
+          const columnHeaders = fixture.nativeElement.querySelectorAll(
+            Selector.HEADER_COLUMN
+          );
           columnHeaders[4].querySelector('button').click();
           const [checkbox] = getOverlayMenuItems();
           const input = checkbox.querySelector('input') as HTMLInputElement;

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -136,7 +136,7 @@ const Selector = {
   SELECT_ALL_ROW: '.select-all',
 };
 
-fdescribe('runs_table', () => {
+describe('runs_table', () => {
   let store: MockStore<State>;
   let dispatchSpy: jasmine.Spy;
   let overlayContainer: OverlayContainer;

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_test.ts
@@ -129,14 +129,14 @@ class TestableColorPicker {
 }
 
 const Selector = {
-  ITEM_ROW: '[role="row"]:not(.header)',
+  ITEM_ROW: '.rows [role="row"]',
   COLUMN: '[role="cell"]',
   HEADER_COLUMN: '[role="columnheader"]',
   HEADER_CHECKBOX: '[role="columnheader"] mat-checkbox',
   SELECT_ALL_ROW: '.select-all',
 };
 
-describe('runs_table', () => {
+fdescribe('runs_table', () => {
   let store: MockStore<State>;
   let dispatchSpy: jasmine.Spy;
   let overlayContainer: OverlayContainer;


### PR DESCRIPTION
This change is in preparation for potential virtual scrolling in the
runs table.

About virtual scroll: Run selector can possibly render many runs; in
real user cases, the run selector had to render more than a thousand
runs. While minor in the grand scheme of things, Angular rendering
thousands of elements with nested components can contribute to AFT or
initial meaning paint.

Virtual scroll module does not seemingly support mat-table and it
requires the items to be rendered via cdkVirtualFor. This change, for
now, renders using ngFor which is API compatible with cdkVirtualFor.

