### PR TITLE
bug: widen click target for hparam/metric filter checkboxes

### DIFF
--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.ng.html
@@ -129,6 +129,7 @@ limitations under the License.
           <mat-menu #filterMenu="matMenu">
             <div
               mat-menu-item
+              class="filter-menu-checkbox-row"
               (click)="$event.stopPropagation()"
               role="menuitemcheckbox"
               disableRipple
@@ -159,6 +160,7 @@ limitations under the License.
               <div
                 *ngFor="let value of column.filter.possibleValues"
                 mat-menu-item
+                class="filter-menu-checkbox-row"
                 role="menuitemcheckbox"
                 (click)="$event.stopPropagation()"
               >
@@ -197,6 +199,7 @@ limitations under the License.
           <mat-menu #filterMenu="matMenu">
             <div
               mat-menu-item
+              class="filter-menu-checkbox-row"
               (click)="$event.stopPropagation()"
               role="menuitemcheckbox"
               disableRipple

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -176,3 +176,23 @@ table {
 :host ::ng-deep mat-paginator mat-form-field {
   margin: 0;
 }
+
+.filter-menu-checkbox-row mat-checkbox ::ng-deep label {
+  // Make mat-checkboxes in menus take up full row.
+  display: flex;
+  height: 100%;
+  align-items: center;
+}
+
+.filter-menu-checkbox-row
+  mat-checkbox
+  ::ng-deep
+  label
+  .mat-checkbox-inner-container {
+  margin-left: 0;
+}
+
+.filter-menu-checkbox-row mat-checkbox ::ng-deep label .mat-checkbox-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
+++ b/tensorboard/webapp/runs/views/runs_table/runs_table_component.scss
@@ -182,17 +182,13 @@ table {
   display: flex;
   height: 100%;
   align-items: center;
-}
 
-.filter-menu-checkbox-row
-  mat-checkbox
-  ::ng-deep
-  label
   .mat-checkbox-inner-container {
-  margin-left: 0;
-}
+    margin-left: 0;
+  }
 
-.filter-menu-checkbox-row mat-checkbox ::ng-deep label .mat-checkbox-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
+  .mat-checkbox-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }


### PR DESCRIPTION
The RunsTableComponent offers a filtering UI with checkboxes
for discrete hparams and metrics. When the filter menu opens,
row items with checkboxes have a small click target, so clicking
the empty space will not toggle.

This expands the clickable region for usability.

Previous click target:
![image](https://user-images.githubusercontent.com/2322480/98422994-1e1bc980-2042-11eb-8eb4-8a2d0a8f39f5.png)

New click target:
![image](https://user-images.githubusercontent.com/2322480/98423005-2c69e580-2042-11eb-8c7a-0799a6a6fbbf.png)

While investigating this bug, I went down a rabbit hole of trying
to make the menu item row element (not the mat-checkbox)
be the clickable target.  However, this turned out to fail unless we
provide `clickAction: 'noop'` via DI for the
`MAT_CHECKBOX_DEFAULT_OPTIONS` token. Doing so would
require new injection tokens, since providing options:
`{clickAction: 'noop'}` overrides the color/ThemePalette property
on checkboxes, and also requires splitting out the hparam checkboxes
from the other checkboxes in RunsTableComponent, which would
break under `clickAction: 'noop'`.