### PR TITLE
line chart: refactor to move interface for Scale to types file

### DIFF
--- a/tensorboard/webapp/widgets/line_chart_v2/lib/coordinator.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/coordinator.ts
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {createScale, Scale} from './scale';
-import {Rect, ScaleType} from './internal_types';
+import {Rect, Scale, ScaleType} from './internal_types';
+import {createScale} from './scale';
 import {convertRectToExtent} from './utils';
 
 /**

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale.ts
@@ -13,54 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 import {scaleLinear, scaleLog} from '../../../third_party/d3';
-
-import {ScaleType} from './scale_types';
-
-/**
- * A `Scale` takes `domain` and sometimes `range` and provide coordinate system
- * transformation and convenience method around interval. Similar abstraction as d3.scale.
- *
- * Unlike d3.scale, it is pure and does not have performance impact.
- *
- * Important: both `domain` and `range` require to be finite numbers. The order of the
- * values do not matter (e.g., domain[1] < domain[0] is okay).
- */
-export interface Scale {
-  /**
-   * Converts `x` in `domain` coordinates into `range` coordinates.
-   */
-  forward(domain: [number, number], range: [number, number], x: number): number;
-
-  /**
-   * Converts `x` in `range` coordinates into `domain` coordinates.
-   */
-  reverse(domain: [number, number], range: [number, number], x: number): number;
-
-  /**
-   * Attempts to transform domain into nice round numbers. Analogous to `d3.nice`.
-   *
-   * @param domain Two finite numbers to compuute round number from.
-   */
-  niceDomain(domain: [number, number]): [number, number];
-
-  /**
-   * Returns "human friendly" numbers between the `domain` that can be used for ticks and
-   * grid.
-   *
-   * In case the spread of an interval is 0 or negligible, it can return an empty array
-   * depending on an implementation.
-   *
-   * Examples:
-   *   ticks([0, 10], 5) -> [0, 2, 4, 6, 8, 10]
-   *   ticks([10, 0], 5) -> [10, 8, 6, 4, 2, 0]
-   *   ticks([10, 10], 5) -> []
-   *
-   * @param domain Interval in which tick should be created.
-   * @param sizeGuidance approximate number of the ticks. Depending on the domain, it
-   *    may return less or more ticks.
-   */
-  ticks(domain: [number, number], sizeGuidance: number): number[];
-}
+import {Scale, ScaleType} from './scale_types';
 
 export function createScale(type: ScaleType): Scale {
   switch (type) {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_test.ts
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {Scale, createScale} from './scale';
-import {ScaleType} from './scale_types';
+import {createScale} from './scale';
+import {Scale, ScaleType} from './scale_types';
 
 describe('line_chart_v2/lib/scale test', () => {
   describe('linear', () => {

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/scale_types.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/scale_types.ts
@@ -17,3 +17,49 @@ export enum ScaleType {
   LINEAR,
   LOG10,
 }
+
+/**
+ * A `Scale` takes `domain` and sometimes `range` and provide coordinate system
+ * transformation and convenience method around interval. Similar abstraction as d3.scale.
+ *
+ * Unlike d3.scale, it is pure and does not have performance impact.
+ *
+ * Important: both `domain` and `range` require to be finite numbers. The order of the
+ * values do not matter (e.g., domain[1] < domain[0] is okay).
+ */
+export interface Scale {
+  /**
+   * Converts `x` in `domain` coordinates into `range` coordinates.
+   */
+  forward(domain: [number, number], range: [number, number], x: number): number;
+
+  /**
+   * Converts `x` in `range` coordinates into `domain` coordinates.
+   */
+  reverse(domain: [number, number], range: [number, number], x: number): number;
+
+  /**
+   * Attempts to transform domain into nice round numbers. Analogous to `d3.nice`.
+   *
+   * @param domain Two finite numbers to compuute round number from.
+   */
+  niceDomain(domain: [number, number]): [number, number];
+
+  /**
+   * Returns "human friendly" numbers between the `domain` that can be used for ticks and
+   * grid.
+   *
+   * In case the spread of an interval is 0 or negligible, it can return an empty array
+   * depending on an implementation.
+   *
+   * Examples:
+   *   ticks([0, 10], 5) -> [0, 2, 4, 6, 8, 10]
+   *   ticks([10, 0], 5) -> [10, 8, 6, 4, 2, 0]
+   *   ticks([10, 10], 5) -> []
+   *
+   * @param domain Interval in which tick should be created.
+   * @param sizeGuidance approximate number of the ticks. Depending on the domain, it
+   *    may return less or more ticks.
+   */
+  ticks(domain: [number, number], sizeGuidance: number): number[];
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/worker/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/worker/BUILD
@@ -2,6 +2,8 @@ load("//tensorboard/defs:defs.bzl", "tf_js_binary", "tf_ts_library")
 
 package(default_visibility = ["//tensorboard/webapp/widgets/line_chart_v2/lib:__subpackages__"])
 
+licenses(["notice"])
+
 tf_ts_library(
     name = "message_types",
     srcs = [


### PR DESCRIPTION
Moved the Scale interface definition to the type so dependents do
not have to load the implementation and keep it private to the `lib`.