### PR TITLE
line chart: sub view for axis and grid

### DIFF
--- a/tensorboard/webapp/BUILD
+++ b/tensorboard/webapp/BUILD
@@ -285,6 +285,7 @@ tf_ng_web_test_suite(
         "//tensorboard/webapp/widgets/line_chart_v2/lib:lib_tests",
         "//tensorboard/webapp/widgets/line_chart_v2/lib/renderer:renderer_test",
         "//tensorboard/webapp/widgets/line_chart_v2/lib/worker:worker_test",
+        "//tensorboard/webapp/widgets/line_chart_v2/sub_view:sub_view_tests",
         "//tensorboard/webapp/widgets/range_input:range_input_tests",
         "//tensorboard/webapp/widgets/text:text_tests",
     ],

--- a/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/lib/BUILD
@@ -79,6 +79,11 @@ tf_ts_library(
     srcs = [
         "scale.ts",
     ],
+    visibility = [
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:__subpackages__",
+        # test uses it
+        "//tensorboard/webapp/widgets/line_chart_v2/sub_view:__pkg__",
+    ],
     deps = [
         ":internal_types",
         "//tensorboard/webapp/third_party:d3",

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -1,0 +1,47 @@
+load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("@npm_angular_bazel//:index.bzl", "ng_module")
+
+package(default_visibility = ["//tensorboard:internal"])
+
+licenses(["notice"])  # Apache 2.0
+
+tf_sass_binary(
+    name = "line_chart_interactive_layer_styles",
+    src = "line_chart_interactive_layer.scss",
+)
+
+ng_module(
+    name = "sub_view",
+    srcs = [
+        "axis_formatter.ts",
+        "chart_view_utils.ts",
+        "line_chart_axis_view.ts",
+        "line_chart_grid_view.ts",
+        "sub_view_module.ts",
+    ],
+    deps = [
+        "//tensorboard/webapp/third_party:d3",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+    ],
+)
+
+tf_ts_library(
+    name = "sub_view_tests",
+    testonly = True,
+    srcs = [
+        "axis_formatter_test.ts",
+        "line_chart_axis_view_test.ts",
+        "line_chart_grid_view_test.ts",
+    ],
+    deps = [
+        ":sub_view",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
+        "//tensorboard/webapp/widgets/line_chart_v2/lib:scale",
+        "@npm//@angular/common",
+        "@npm//@angular/core",
+        "@npm//@angular/platform-browser",
+        "@npm//@types/jasmine",
+    ],
+)

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -3,8 +3,6 @@ load("@npm_angular_bazel//:index.bzl", "ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
 
-licenses(["notice"])  # Apache 2.0
-
 tf_sass_binary(
     name = "line_chart_interactive_layer_styles",
     src = "line_chart_interactive_layer.scss",

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -1,12 +1,7 @@
-load("//tensorboard/defs:defs.bzl", "tf_sass_binary", "tf_ts_library")
+load("//tensorboard/defs:defs.bzl", "tf_ts_library")
 load("@npm_angular_bazel//:index.bzl", "ng_module")
 
 package(default_visibility = ["//tensorboard:internal"])
-
-tf_sass_binary(
-    name = "line_chart_interactive_layer_styles",
-    src = "line_chart_interactive_layer.scss",
-)
 
 ng_module(
     name = "sub_view",

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/BUILD
@@ -30,6 +30,7 @@ tf_ts_library(
     ],
     deps = [
         ":sub_view",
+        "//tensorboard/webapp/angular:expect_angular_core_testing",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:public_types",
         "//tensorboard/webapp/widgets/line_chart_v2/lib:scale",
         "@npm//@angular/common",

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/axis_formatter.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/axis_formatter.ts
@@ -12,15 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {format} from '../../../third_party/d3';
 
-export * from './chart_types';
-export {
-  DataSeries,
-  DataSeriesMetadata,
-  DataSeriesMetadataMap,
-  Dimension,
-  Extent,
-  Point,
-} from './internal_types';
-export {RendererType} from './renderer/renderer_types';
-export {Scale, ScaleType} from './scale_types';
+const d3AxisFormatter = format('.2~e');
+const d3AxisIntFormatter = format('~');
+
+export function formatAxisNumber(num: number): string {
+  if (num === 0) {
+    return '0';
+  }
+
+  const absNum = Math.abs(num);
+  if (absNum >= 100000 || absNum < 0.001) {
+    return d3AxisFormatter(num);
+  }
+  return d3AxisIntFormatter(num);
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/axis_formatter_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/axis_formatter_test.ts
@@ -1,0 +1,39 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {formatAxisNumber} from './axis_formatter';
+
+describe('line_chart_v2/sub_view/axis_formatter test', () => {
+  describe('#formatAxisNumber', () => {
+    it('formats small numbers without trailing decimals', () => {
+      expect(formatAxisNumber(1)).toBe('1');
+      expect(formatAxisNumber(5)).toBe('5');
+      expect(formatAxisNumber(-100.4)).toBe('-100.4');
+      expect(formatAxisNumber(3.01)).toBe('3.01');
+      expect(formatAxisNumber(9999)).toBe('9999');
+      expect(formatAxisNumber(0.09)).toBe('0.09');
+    });
+
+    it('formats larger/small numbers in exponential format', () => {
+      expect(formatAxisNumber(1.004e6)).toBe('1e+6');
+      expect(formatAxisNumber(-1.004e6)).toBe('-1e+6');
+      expect(formatAxisNumber(0.00005)).toBe('5e-5');
+    });
+
+    it('fails to format large number with many decimals nicely', () => {
+      // This causes
+      expect(formatAxisNumber(1e9 + 0.00000001)).toBe('1e+9');
+    });
+  });
+});

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/axis_formatter_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/axis_formatter_test.ts
@@ -32,7 +32,9 @@ describe('line_chart_v2/sub_view/axis_formatter test', () => {
     });
 
     it('fails to format large number with many decimals nicely', () => {
-      // This causes
+      // This causes TensorBoard to format axis in less than ideal when spread of a
+      // viewBox is miniscule compared to the number. e.g., you see axis that says,
+      // "1e9", "1e9", "1e9" which is quite meaningless. It will be addressed in the future.
       expect(formatAxisNumber(1e9 + 0.00000001)).toBe('1e+9');
     });
   });

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/chart_view_utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/chart_view_utils.ts
@@ -1,0 +1,59 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {Dimension, Extent, Scale} from '../lib/public_types';
+
+export interface XDimChartView {
+  viewExtent: Extent;
+  domDim: Dimension;
+  xScale: Scale;
+}
+
+export interface YDimChartView {
+  viewExtent: Extent;
+  domDim: Dimension;
+  yScale: Scale;
+}
+
+export function getDomX(chartView: XDimChartView, dataCoord: number): number {
+  return chartView.xScale.forward(
+    chartView.viewExtent.x,
+    [0, chartView.domDim.width],
+    dataCoord
+  );
+}
+
+export function getDataX(chartView: XDimChartView, uiCoord: number): number {
+  return chartView.xScale.reverse(
+    chartView.viewExtent.x,
+    [0, chartView.domDim.width],
+    uiCoord
+  );
+}
+
+export function getDomY(chartView: YDimChartView, dataCoord: number): number {
+  return chartView.yScale.forward(
+    chartView.viewExtent.y,
+    [chartView.domDim.height, 0],
+    dataCoord
+  );
+}
+
+export function getDataY(chartView: YDimChartView, uiCoord: number): number {
+  return chartView.yScale.reverse(
+    chartView.viewExtent.y,
+    [chartView.domDim.height, 0],
+    uiCoord
+  );
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/chart_view_utils.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/chart_view_utils.ts
@@ -12,48 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-import {Dimension, Extent, Scale} from '../lib/public_types';
+import {Dimension} from '../lib/public_types';
 
-export interface XDimChartView {
-  viewExtent: Extent;
-  domDim: Dimension;
-  xScale: Scale;
+export function getScaleRangeFromDomDim(
+  domDim: Dimension,
+  axis: 'x' | 'y'
+): [number, number] {
+  return axis === 'x' ? [0, domDim.width] : [domDim.height, 0];
 }
 
-export interface YDimChartView {
-  viewExtent: Extent;
-  domDim: Dimension;
-  yScale: Scale;
-}
-
-export function getDomX(chartView: XDimChartView, dataCoord: number): number {
-  return chartView.xScale.forward(
-    chartView.viewExtent.x,
-    [0, chartView.domDim.width],
-    dataCoord
-  );
-}
-
-export function getDataX(chartView: XDimChartView, uiCoord: number): number {
-  return chartView.xScale.reverse(
-    chartView.viewExtent.x,
-    [0, chartView.domDim.width],
-    uiCoord
-  );
-}
-
-export function getDomY(chartView: YDimChartView, dataCoord: number): number {
-  return chartView.yScale.forward(
-    chartView.viewExtent.y,
-    [chartView.domDim.height, 0],
-    dataCoord
-  );
-}
-
-export function getDataY(chartView: YDimChartView, uiCoord: number): number {
-  return chartView.yScale.reverse(
-    chartView.viewExtent.y,
-    [chartView.domDim.height, 0],
-    uiCoord
-  );
+export function getDomSizeInformedTickCount(
+  domSize: number,
+  tickCount: number
+): number {
+  const guidance = Math.floor(domSize / 50);
+  return Math.min(guidance, tickCount);
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view.ts
@@ -1,0 +1,183 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+
+import {Dimension, Extent, Scale} from '../lib/public_types';
+import {formatAxisNumber} from './axis_formatter';
+import {
+  getDomX,
+  getDomY,
+  XDimChartView,
+  YDimChartView,
+} from './chart_view_utils';
+
+export abstract class AxisView {
+  trackByTick(index: number, tick: number) {
+    return tick;
+  }
+
+  getTickString(tick: number): string {
+    return formatAxisNumber(tick);
+  }
+
+  private getDomSizeInformedTickCount(
+    domSize: number,
+    tickCount: number
+  ): number {
+    const guidance = Math.floor(domSize / 50);
+    return Math.min(guidance, tickCount);
+  }
+
+  protected getTicks(
+    scale: Scale,
+    domain: [number, number],
+    domSize: number,
+    preferredCount: number
+  ): number[] {
+    return scale.ticks(
+      domain,
+      this.getDomSizeInformedTickCount(domSize, preferredCount)
+    );
+  }
+}
+
+const AXIS_COMMON_STYLES = `
+  :host {
+    display: block;
+    overflow: hidden;
+  }
+
+  svg {
+    height: 100%;
+    width: 100%;
+  }
+
+  line {
+    stroke: #333;
+    stroke-width: 1px;
+  }
+
+  text {
+    font-size: 11px;
+    user-select: none;
+  }
+`;
+
+@Component({
+  selector: 'line-chart-x-axis',
+  template: `<svg>
+    <line x1="0" y1="0" [attr.x2]="domDim.width" y2="0"></line>
+    <ng-container *ngFor="let tick of getXTicks(); trackBy: trackByTick">
+      <g>
+        <text [attr.x]="getDomX(tick)" [attr.y]="5">
+          {{ getTickString(tick) }}
+        </text>
+        <title>{{ tick }}</title>
+      </g>
+    </ng-container>
+  </svg>`,
+  styles: [
+    AXIS_COMMON_STYLES,
+    `
+      text {
+        dominant-baseline: hanging;
+        text-anchor: middle;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LineChartXAxisComponent extends AxisView implements XDimChartView {
+  @Input()
+  viewExtent!: Extent;
+
+  @Input()
+  xScale!: Scale;
+
+  @Input()
+  xGridCount!: number;
+
+  @Input()
+  domDim!: Dimension;
+
+  getDomX(data: number): number {
+    return getDomX(this, data);
+  }
+
+  getXTicks() {
+    return this.getTicks(
+      this.xScale,
+      this.viewExtent.x,
+      this.domDim.width,
+      this.xGridCount
+    );
+  }
+}
+
+@Component({
+  selector: 'line-chart-y-axis',
+  template: `<svg>
+    <line
+      [attr.x1]="domDim.width"
+      y1="0"
+      [attr.x2]="domDim.width"
+      [attr.y2]="domDim.height"
+    ></line>
+    <ng-container *ngFor="let tick of getYTicks(); trackBy: trackByTick">
+      <g>
+        <text [attr.x]="domDim.width - 5" [attr.y]="getDomY(tick)">
+          {{ getTickString(tick) }}
+        </text>
+        <title>{{ tick }}</title>
+      </g>
+    </ng-container>
+  </svg>`,
+  styles: [
+    AXIS_COMMON_STYLES,
+    `
+      text {
+        dominant-baseline: central;
+        text-anchor: end;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LineChartYAxisComponent extends AxisView implements YDimChartView {
+  @Input()
+  viewExtent!: Extent;
+
+  @Input()
+  yScale!: Scale;
+
+  @Input()
+  yGridCount!: number;
+
+  @Input()
+  domDim!: Dimension;
+
+  getDomY(data: number): number {
+    return getDomY(this, data);
+  }
+
+  getYTicks() {
+    return this.getTicks(
+      this.yScale,
+      this.viewExtent.y,
+      this.domDim.height,
+      this.yGridCount
+    );
+  }
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
@@ -82,17 +82,16 @@ describe('line_chart_v2/sub_view/axis test', () => {
     debugElements: DebugElement[],
     expectedLocs: Array<{x: number; y: number}>
   ) {
-    expect(debugElements.length).toBe(expectedLocs.length);
+    const expected = expectedLocs.map((loc) => ({
+      x: String(loc.x),
+      y: String(loc.y),
+    }));
+    const actuals = debugElements.map((el) => ({
+      x: el.attributes['x'],
+      y: el.attributes['y'],
+    }));
 
-    const actuals: typeof expectedLocs = [];
-    for (const el of debugElements) {
-      actuals.push({
-        x: Number(el.attributes['x']),
-        y: Number(el.attributes['y']),
-      });
-    }
-
-    expect(expectedLocs).toEqual(actuals);
+    expect(expected).toEqual(actuals);
   }
 
   it('renders tick in human readable format', () => {

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
@@ -87,8 +87,8 @@ describe('line_chart_v2/sub_view/axis test', () => {
       y: String(loc.y),
     }));
     const actuals = debugElements.map((el) => ({
-      x: el.attributes['x'],
-      y: el.attributes['y'],
+      x: String(el.attributes['x']),
+      y: String(el.attributes['y']),
     }));
 
     expect(expected).toEqual(actuals);

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
@@ -1,0 +1,164 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {CommonModule} from '@angular/common';
+import {Component, DebugElement, Input} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+import {createScale} from '../lib/scale';
+import {Extent, ScaleType} from '../lib/public_types';
+import {
+  LineChartXAxisComponent,
+  LineChartYAxisComponent,
+} from './line_chart_axis_view';
+
+@Component({
+  selector: 'testable-comp',
+  template: `
+    <line-chart-x-axis
+      [viewExtent]="viewBox"
+      [xScale]="scale"
+      [xGridCount]="10"
+      [domDim]="domDim"
+    ></line-chart-x-axis>
+    <line-chart-y-axis
+      [viewExtent]="viewBox"
+      [yScale]="scale"
+      [yGridCount]="5"
+      [domDim]="domDim"
+    ></line-chart-y-axis>
+  `,
+})
+class TestableComponent {
+  scale = createScale(ScaleType.LINEAR);
+
+  @Input()
+  viewBox: Extent = {
+    x: [100, 300],
+    y: [-1, 1],
+  };
+
+  domDim = {
+    width: 100,
+    height: 200,
+  };
+}
+
+describe('line_chart_v2/sub_view/axis test', () => {
+  const ByCss = {
+    X_AXIS_LABEL: By.css('line-chart-x-axis text'),
+    Y_AXIS_LABEL: By.css('line-chart-y-axis text'),
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        TestableComponent,
+        LineChartXAxisComponent,
+        LineChartYAxisComponent,
+      ],
+      imports: [CommonModule],
+    }).compileComponents();
+  });
+
+  function assertLabels(debugElements: DebugElement[], axisLabels: string[]) {
+    const actualLabels = debugElements.map((el) =>
+      el.nativeElement.textContent.trim()
+    );
+    expect(actualLabels).toEqual(axisLabels);
+  }
+
+  function assertLabelLoc(
+    debugElements: DebugElement[],
+    expectedLocs: Array<{x: number; y: number}>
+  ) {
+    expect(debugElements.length).toBe(expectedLocs.length);
+    for (const [index, el] of debugElements.entries()) {
+      const actual = {x: el.attributes['x'], y: el.attributes['y']};
+      expect(actual).toEqual({
+        x: String(expectedLocs[index].x),
+        y: String(expectedLocs[index].y),
+      });
+    }
+  }
+
+  it('renders tick in human readable format', () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.detectChanges();
+
+    assertLabels(fixture.debugElement.queryAll(ByCss.X_AXIS_LABEL), [
+      '100',
+      '200',
+      '300',
+    ]);
+
+    assertLabels(fixture.debugElement.queryAll(ByCss.Y_AXIS_LABEL), [
+      '-1',
+      '-0.5',
+      '0',
+      '0.5',
+      '1',
+    ]);
+  });
+
+  it('updates to viewBox changes', () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.detectChanges();
+
+    fixture.componentInstance.viewBox = {x: [1e6, 5e6], y: [0, 1]};
+    fixture.detectChanges();
+
+    assertLabels(fixture.debugElement.queryAll(ByCss.X_AXIS_LABEL), [
+      '2e+6',
+      '4e+6',
+    ]);
+
+    assertLabels(fixture.debugElement.queryAll(ByCss.Y_AXIS_LABEL), [
+      '0',
+      '0.2',
+      '0.4',
+      '0.6',
+      '0.8',
+      '1',
+    ]);
+  });
+
+  it('aligns y axis to the right edge of its dom', () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.detectChanges();
+
+    assertLabelLoc(fixture.debugElement.queryAll(ByCss.Y_AXIS_LABEL), [
+      // -1 is at the bottom of the DOM
+      {x: 95, y: 200},
+      {x: 95, y: 150},
+      {x: 95, y: 100},
+      {x: 95, y: 50},
+      // 1 is at the top.
+      {x: 95, y: 0},
+    ]);
+  });
+
+  it('aligns x axis to the top edge of its dom', () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.detectChanges();
+
+    assertLabelLoc(fixture.debugElement.queryAll(ByCss.X_AXIS_LABEL), [
+      {x: 0, y: 5},
+      {x: 50, y: 5},
+      {x: 100, y: 5},
+    ]);
+  });
+});

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_axis_view_test.ts
@@ -20,26 +20,27 @@ import {By} from '@angular/platform-browser';
 
 import {createScale} from '../lib/scale';
 import {Extent, ScaleType} from '../lib/public_types';
-import {
-  LineChartXAxisComponent,
-  LineChartYAxisComponent,
-} from './line_chart_axis_view';
+import {LineChartAxisComponent} from './line_chart_axis_view';
 
 @Component({
   selector: 'testable-comp',
   template: `
-    <line-chart-x-axis
-      [viewExtent]="viewBox"
-      [xScale]="scale"
-      [xGridCount]="10"
+    <line-chart-axis
+      class="x"
+      axis="x"
+      [axisExtent]="viewBox.x"
+      [scale]="scale"
+      [gridCount]="10"
       [domDim]="domDim"
-    ></line-chart-x-axis>
-    <line-chart-y-axis
-      [viewExtent]="viewBox"
-      [yScale]="scale"
-      [yGridCount]="5"
+    ></line-chart-axis>
+    <line-chart-axis
+      class="y"
+      axis="y"
+      [axisExtent]="viewBox.y"
+      [scale]="scale"
+      [gridCount]="5"
       [domDim]="domDim"
-    ></line-chart-y-axis>
+    ></line-chart-axis>
   `,
 })
 class TestableComponent {
@@ -59,17 +60,13 @@ class TestableComponent {
 
 describe('line_chart_v2/sub_view/axis test', () => {
   const ByCss = {
-    X_AXIS_LABEL: By.css('line-chart-x-axis text'),
-    Y_AXIS_LABEL: By.css('line-chart-y-axis text'),
+    X_AXIS_LABEL: By.css('line-chart-axis.x text'),
+    Y_AXIS_LABEL: By.css('line-chart-axis.y text'),
   };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [
-        TestableComponent,
-        LineChartXAxisComponent,
-        LineChartYAxisComponent,
-      ],
+      declarations: [TestableComponent, LineChartAxisComponent],
       imports: [CommonModule],
     }).compileComponents();
   });
@@ -86,13 +83,16 @@ describe('line_chart_v2/sub_view/axis test', () => {
     expectedLocs: Array<{x: number; y: number}>
   ) {
     expect(debugElements.length).toBe(expectedLocs.length);
-    for (const [index, el] of debugElements.entries()) {
-      const actual = {x: el.attributes['x'], y: el.attributes['y']};
-      expect(actual).toEqual({
-        x: String(expectedLocs[index].x),
-        y: String(expectedLocs[index].y),
+
+    const actuals: typeof expectedLocs = [];
+    for (const el of debugElements) {
+      actuals.push({
+        x: Number(el.attributes['x']),
+        y: Number(el.attributes['y']),
       });
     }
+
+    expect(expectedLocs).toEqual(actuals);
   }
 
   it('renders tick in human readable format', () => {

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view.ts
@@ -16,12 +16,9 @@ import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 
 import {Extent, Scale} from '../lib/public_types';
 import {
-  getDomX,
-  getDomY,
-  XDimChartView,
-  YDimChartView,
+  getDomSizeInformedTickCount,
+  getScaleRangeFromDomDim,
 } from './chart_view_utils';
-import {AxisView} from './line_chart_axis_view';
 
 @Component({
   selector: 'line-chart-grid-view',
@@ -68,9 +65,7 @@ import {AxisView} from './line_chart_axis_view';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LineChartGridView
-  extends AxisView
-  implements XDimChartView, YDimChartView {
+export class LineChartGridView {
   @Input()
   viewExtent!: Extent;
 
@@ -90,28 +85,32 @@ export class LineChartGridView
   domDim!: {width: number; height: number};
 
   getDomX(dataX: number): number {
-    return getDomX(this, dataX);
+    return this.xScale.forward(
+      this.viewExtent.x,
+      getScaleRangeFromDomDim(this.domDim, 'x'),
+      dataX
+    );
   }
 
   getDomY(dataY: number): number {
-    return getDomY(this, dataY);
+    return this.xScale.forward(
+      this.viewExtent.y,
+      getScaleRangeFromDomDim(this.domDim, 'y'),
+      dataY
+    );
   }
 
   getXTicks() {
-    return this.getTicks(
-      this.xScale,
+    return this.xScale.ticks(
       this.viewExtent.x,
-      this.domDim.width,
-      this.xGridCount
+      getDomSizeInformedTickCount(this.domDim.width, this.xGridCount)
     );
   }
 
   getYTicks() {
-    return this.getTicks(
-      this.yScale,
+    return this.xScale.ticks(
       this.viewExtent.y,
-      this.domDim.height,
-      this.yGridCount
+      getDomSizeInformedTickCount(this.domDim.height, this.yGridCount)
     );
   }
 }

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view.ts
@@ -1,0 +1,117 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+
+import {Extent, Scale} from '../lib/public_types';
+import {
+  getDomX,
+  getDomY,
+  XDimChartView,
+  YDimChartView,
+} from './chart_view_utils';
+import {AxisView} from './line_chart_axis_view';
+
+@Component({
+  selector: 'line-chart-grid-view',
+  template: `<svg>
+    <line
+      *ngFor="let tick of getXTicks()"
+      [class.zero]="tick === 0"
+      [attr.x1]="getDomX(tick)"
+      y1="0"
+      [attr.x2]="getDomX(tick)"
+      [attr.y2]="domDim.height"
+    ></line>
+    <line
+      *ngFor="let tick of getYTicks()"
+      [class.zero]="tick === 0"
+      x1="0"
+      [attr.y1]="getDomY(tick)"
+      [attr.x2]="domDim.width"
+      [attr.y2]="getDomY(tick)"
+    ></line>
+  </svg>`,
+  styles: [
+    `
+      :host {
+        display: block;
+        overflow: hidden;
+      }
+
+      svg {
+        height: 100%;
+        width: 100%;
+      }
+
+      line {
+        stroke: #ccc;
+        stroke-width: 1px;
+      }
+
+      .zero {
+        stroke: #aaa;
+        stroke-width: 1.5px;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LineChartGridView
+  extends AxisView
+  implements XDimChartView, YDimChartView {
+  @Input()
+  viewExtent!: Extent;
+
+  @Input()
+  xScale!: Scale;
+
+  @Input()
+  xGridCount!: number;
+
+  @Input()
+  yScale!: Scale;
+
+  @Input()
+  yGridCount!: number;
+
+  @Input()
+  domDim!: {width: number; height: number};
+
+  getDomX(dataX: number): number {
+    return getDomX(this, dataX);
+  }
+
+  getDomY(dataY: number): number {
+    return getDomY(this, dataY);
+  }
+
+  getXTicks() {
+    return this.getTicks(
+      this.xScale,
+      this.viewExtent.x,
+      this.domDim.width,
+      this.xGridCount
+    );
+  }
+
+  getYTicks() {
+    return this.getTicks(
+      this.yScale,
+      this.viewExtent.y,
+      this.domDim.height,
+      this.yGridCount
+    );
+  }
+}

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view_test.ts
@@ -120,20 +120,16 @@ describe('line_chart_v2/sub_view/grid test', () => {
 
   // We tweak the size guidance to approximately allows around 50 pixel gap between the
   // lines so the axis labels do not overlap.
-  it(
-    'renders less number of grids when DOM is tiny and allows at least 50 pixel ' +
-      'between lines',
-    () => {
-      const fixture = TestBed.createComponent(TestableComponent);
-      fixture.componentInstance.domDim = {width: 100, height: 50};
-      fixture.detectChanges();
+  it('renders fewer grid lines when DOM is smaller and spaces them min. 50 pixel', () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.componentInstance.domDim = {width: 100, height: 50};
+    fixture.detectChanges();
 
-      assertLines(fixture.debugElement.queryAll(ByCss.GRID_LINE), [
-        {x1: 0, y1: 0, x2: 0, y2: 50},
-        {x1: 50, y1: 0, x2: 50, y2: 50},
-        {x1: 100, y1: 0, x2: 100, y2: 50},
-        {x1: 0, y1: 25, x2: 100, y2: 25},
-      ]);
-    }
-  );
+    assertLines(fixture.debugElement.queryAll(ByCss.GRID_LINE), [
+      {x1: 0, y1: 0, x2: 0, y2: 50},
+      {x1: 50, y1: 0, x2: 50, y2: 50},
+      {x1: 100, y1: 0, x2: 100, y2: 50},
+      {x1: 0, y1: 25, x2: 100, y2: 25},
+    ]);
+  });
 });

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view_test.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/line_chart_grid_view_test.ts
@@ -1,0 +1,139 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+import {Component, DebugElement, Input} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+import {createScale} from '../lib/scale';
+import {Extent, ScaleType} from '../lib/public_types';
+import {LineChartGridView} from './line_chart_grid_view';
+
+@Component({
+  selector: 'testable-comp',
+  template: `
+    <line-chart-grid-view
+      [viewExtent]="viewBox"
+      [xScale]="scale"
+      [xGridCount]="10"
+      [yScale]="scale"
+      [yGridCount]="5"
+      [domDim]="domDim"
+    ></line-chart-grid-view>
+  `,
+})
+class TestableComponent {
+  scale = createScale(ScaleType.LINEAR);
+
+  @Input()
+  viewBox: Extent = {
+    x: [100, 300],
+    y: [-1, 1],
+  };
+
+  @Input()
+  domDim = {
+    width: 100,
+    height: 200,
+  };
+}
+
+describe('line_chart_v2/sub_view/grid test', () => {
+  const ByCss = {
+    GRID_LINE: By.css('line'),
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestableComponent, LineChartGridView],
+    }).compileComponents();
+  });
+
+  function assertLines(
+    debugElements: DebugElement[],
+    expectedLines: Array<{x1: number; y1: number; x2: number; y2: number}>
+  ) {
+    expect(debugElements.length).toBe(expectedLines.length);
+    for (const [index, el] of debugElements.entries()) {
+      expect({
+        x1: el.attributes['x1'],
+        y1: el.attributes['y1'],
+        x2: el.attributes['x2'],
+        y2: el.attributes['y2'],
+      }).toEqual({
+        x1: String(expectedLines[index].x1),
+        y1: String(expectedLines[index].y1),
+        x2: String(expectedLines[index].x2),
+        y2: String(expectedLines[index].y2),
+      });
+    }
+  }
+
+  it('renders grid lines', () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.detectChanges();
+
+    assertLines(fixture.debugElement.queryAll(ByCss.GRID_LINE), [
+      {x1: 0, y1: 0, x2: 0, y2: 200},
+      {x1: 50, y1: 0, x2: 50, y2: 200},
+      {x1: 100, y1: 0, x2: 100, y2: 200},
+      {x1: 0, y1: 200, x2: 100, y2: 200},
+      {x1: 0, y1: 150, x2: 100, y2: 150},
+      {x1: 0, y1: 100, x2: 100, y2: 100},
+      {x1: 0, y1: 50, x2: 100, y2: 50},
+      {x1: 0, y1: 0, x2: 100, y2: 0},
+    ]);
+  });
+
+  it('updates grid lines on dom changes', () => {
+    const fixture = TestBed.createComponent(TestableComponent);
+    fixture.detectChanges();
+
+    fixture.componentInstance.domDim = {width: 200, height: 1000};
+    fixture.detectChanges();
+
+    assertLines(fixture.debugElement.queryAll(ByCss.GRID_LINE), [
+      {x1: 0, y1: 0, x2: 0, y2: 1000},
+      {x1: 50, y1: 0, x2: 50, y2: 1000},
+      {x1: 100, y1: 0, x2: 100, y2: 1000},
+      {x1: 150, y1: 0, x2: 150, y2: 1000},
+      {x1: 200, y1: 0, x2: 200, y2: 1000},
+      {x1: 0, y1: 1000, x2: 200, y2: 1000},
+      {x1: 0, y1: 750, x2: 200, y2: 750},
+      {x1: 0, y1: 500, x2: 200, y2: 500},
+      {x1: 0, y1: 250, x2: 200, y2: 250},
+      {x1: 0, y1: 0, x2: 200, y2: 0},
+    ]);
+  });
+
+  // We tweak the size guidance to approximately allows around 50 pixel gap between the
+  // lines so the axis labels do not overlap.
+  it(
+    'renders less number of grids when DOM is tiny and allows at least 50 pixel ' +
+      'between lines',
+    () => {
+      const fixture = TestBed.createComponent(TestableComponent);
+      fixture.componentInstance.domDim = {width: 100, height: 50};
+      fixture.detectChanges();
+
+      assertLines(fixture.debugElement.queryAll(ByCss.GRID_LINE), [
+        {x1: 0, y1: 0, x2: 0, y2: 50},
+        {x1: 50, y1: 0, x2: 50, y2: 50},
+        {x1: 100, y1: 0, x2: 100, y2: 50},
+        {x1: 0, y1: 25, x2: 100, y2: 25},
+      ]);
+    }
+  );
+});

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/sub_view_module.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/sub_view_module.ts
@@ -15,23 +15,12 @@ limitations under the License.
 import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 
-import {
-  LineChartXAxisComponent,
-  LineChartYAxisComponent,
-} from './line_chart_axis_view';
+import {LineChartAxisComponent} from './line_chart_axis_view';
 import {LineChartGridView} from './line_chart_grid_view';
 
 @NgModule({
-  declarations: [
-    LineChartXAxisComponent,
-    LineChartYAxisComponent,
-    LineChartGridView,
-  ],
-  exports: [
-    LineChartXAxisComponent,
-    LineChartYAxisComponent,
-    LineChartGridView,
-  ],
+  declarations: [LineChartAxisComponent, LineChartGridView],
+  exports: [LineChartAxisComponent, LineChartGridView],
   imports: [CommonModule],
 })
 export class SubViewModule {}

--- a/tensorboard/webapp/widgets/line_chart_v2/sub_view/sub_view_module.ts
+++ b/tensorboard/webapp/widgets/line_chart_v2/sub_view/sub_view_module.ts
@@ -12,15 +12,26 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
 
-export * from './chart_types';
-export {
-  DataSeries,
-  DataSeriesMetadata,
-  DataSeriesMetadataMap,
-  Dimension,
-  Extent,
-  Point,
-} from './internal_types';
-export {RendererType} from './renderer/renderer_types';
-export {Scale, ScaleType} from './scale_types';
+import {
+  LineChartXAxisComponent,
+  LineChartYAxisComponent,
+} from './line_chart_axis_view';
+import {LineChartGridView} from './line_chart_grid_view';
+
+@NgModule({
+  declarations: [
+    LineChartXAxisComponent,
+    LineChartYAxisComponent,
+    LineChartGridView,
+  ],
+  exports: [
+    LineChartXAxisComponent,
+    LineChartYAxisComponent,
+    LineChartGridView,
+  ],
+  imports: [CommonModule],
+})
+export class SubViewModule {}


### PR DESCRIPTION
Sub-view is a region in a chart that allows content rendering or adding
interactivity. In this instance, we are writing these sub-views in
Angular for drawing axis and grid.

This design choice absolves us from inventing our own layout system
within canvas while allowing us to add interactivity in line chart and
axis in the future.

Other implicit pros:
- do not have to render text in WebGL which is a bit challenging
- interactivity, which occurs in the main thread, does not have to be
  propagated to the worker based canvas renderer.
