### PR TITLE
rust: regenerate build with cargo-raze 0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         rust_version: ['1.47.0']
-        cargo_raze_version: ['0.6.1']
+        cargo_raze_version: ['0.7.0']
     steps:
       - uses: actions/checkout@v1
       - name: 'Cache Cargo home directory'

--- a/tensorboard/data/server/Cargo.toml
+++ b/tensorboard/data/server/Cargo.toml
@@ -32,9 +32,9 @@ path = "main.rs"
 name = "rustboard_core"
 path = "lib.rs"
 
-[raze]
+[package.metadata.raze]
 workspace_path = "//third_party/rust"
 genmode = "Remote"
 
-[raze.crates.crc.'1.8.1']
+[package.metadata.raze.crates.crc.'1.8.1']
 gen_buildrs = true

--- a/third_party/rust/BUILD.bazel
+++ b/third_party/rust/BUILD.bazel
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze workspace build file.
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """

--- a/third_party/rust/crates.bzl
+++ b/third_party/rust/crates.bzl
@@ -1,6 +1,6 @@
 """
 @generated
-cargo-raze crate workspace functions
+cargo-raze generated Bazel file.
 
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
@@ -18,7 +18,7 @@ def raze_fetch_remote_crates():
         type = "tar.gz",
         sha256 = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39",
         strip_prefix = "build_const-0.2.1",
-        build_file = Label("//third_party/rust/remote:build_const-0.2.1.BUILD.bazel"),
+        build_file = Label("//third_party/rust/remote:BUILD.build_const-0.2.1.bazel"),
     )
 
     maybe(
@@ -28,5 +28,5 @@ def raze_fetch_remote_crates():
         type = "tar.gz",
         sha256 = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb",
         strip_prefix = "crc-1.8.1",
-        build_file = Label("//third_party/rust/remote:crc-1.8.1.BUILD.bazel"),
+        build_file = Label("//third_party/rust/remote:BUILD.crc-1.8.1.bazel"),
     )

--- a/third_party/rust/remote/BUILD.build_const-0.2.1.bazel
+++ b/third_party/rust/remote/BUILD.build_const-0.2.1.bazel
@@ -28,27 +28,27 @@ licenses([
     "notice",  # MIT from expression "MIT"
 ])
 
-# Generated targets
+# Generated Targets
 
-# buildifier: leave-alone
 rust_library(
     name = "build_const",
-    crate_type = "lib",
-    deps = [
-    ],
     srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
     crate_root = "src/lib.rs",
+    crate_type = "lib",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.2.1",
     tags = [
         "cargo-raze",
         "manual",
     ],
-    crate_features = [
-        "default",
-        "std",
+    version = "0.2.1",
+    # buildifier: leave-alone
+    deps = [
     ],
 )

--- a/third_party/rust/remote/BUILD.crc-1.8.1.bazel
+++ b/third_party/rust/remote/BUILD.crc-1.8.1.bazel
@@ -28,64 +28,64 @@ licenses([
     "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
-# Generated targets
-# buildifier: disable=load-on-top
+# Generated Targets# buildifier: disable=load-on-top
 load(
     "@io_bazel_rules_rust//cargo:cargo_build_script.bzl",
     "cargo_build_script",
 )
 
-# buildifier: leave-alone
 cargo_build_script(
     name = "crc_build_script",
     srcs = glob(["**/*.rs"]),
-    crate_root = "build.rs",
-    edition = "2015",
-    deps = [
-        "@raze__build_const__0_2_1//:build_const",
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "std",
     ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    crate_features = [
-      "default",
-      "std",
-    ],
-    build_script_env = {
-    },
-    data = glob(["**"]),
     tags = [
         "cargo-raze",
         "manual",
     ],
     version = "1.8.1",
     visibility = ["//visibility:private"],
+    deps = [
+        "@raze__build_const__0_2_1//:build_const",
+    ],
 )
 
 # Unsupported target "bench" with type "bench" omitted
 
-# buildifier: leave-alone
 rust_library(
     name = "crc",
-    crate_type = "lib",
-    deps = [
-        ":crc_build_script",
-    ],
     srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
-    edition = "2015",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    version = "1.8.1",
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
     crate_features = [
         "default",
         "std",
     ],
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.8.1",
+    # buildifier: leave-alone
+    deps = [
+        ":crc_build_script",
+    ],
 )
+
 # Unsupported target "crc" with type "test" omitted
+
 # Unsupported target "hash" with type "test" omitted


### PR DESCRIPTION
Summary:
Version 0.7.0 of `cargo-raze` was just released. Some visible changes:

  - can now set `[package.metadata.raze]` instead of `[raze]` to avoid a
    Cargo warning: <https://github.com/google/cargo-raze/pull/274>
  - build files have been renamed and restructured to be more compliant
    with Buildifier: <https://github.com/google/cargo-raze/pull/260>

If you have an old version installed, run `cargo install cargo-raze` to
update to the most recent version.

Changes to `third_party/rust/` generated with:

```
(rm -rf third_party/rust/ && cd tensorboard/data/server && cargo raze)
```

The changes to `Cargo.toml` and `third_party/rust/` are independent.

Test Plan:
Run `(cd tensorboard/data/server && cargo test)` and note that the tests
run without an “unused manifest key: raze” warning. Note further that
everything still builds with Bazel.

wchargin-branch: rust-regen-raze-0.7.0
