### PR TITLE
workspace: upgrade to Bazel 3.0.0, rules_rust latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
   # Grab the BAZEL_SHA256SUM from the Bazel releases page; e.g.:
   # bazel-0.20.0-linux-x86_64.sha256
   global:
-    - BAZEL=2.1.0
-    - BAZEL_SHA256SUM=e13581d44faad6ac807dd917e682fef20359d26728166ac35dadd8ee653a580d
+    - BAZEL=3.0.0
+    - BAZEL_SHA256SUM=3efb903ef885339a271445a9940642df704f97297fbe268f131d4fe36b02ea80
   matrix:
     - TF_VERSION_ID=tf-nightly
     - TF_VERSION_ID=  # Do not install TensorFlow in this case

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,7 +89,7 @@ tf_workspace()
 load("@bazel_skylib//lib:versions.bzl", "versions")
 # Keep this version in sync with the BAZEL environment variable defined
 # in our .travis.yml config.
-versions.check(minimum_bazel_version = "2.1.0")
+versions.check(minimum_bazel_version = "3.0.0")
 
 load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
 
@@ -109,12 +109,12 @@ bazel_version_repository(name = "bazel_version")
 
 http_archive(
     name = "io_bazel_rules_rust",
-    sha256 = "9beda941ab076d15428d8615475329bd65002a13a26c2837932af0fb3dc582c5",
-    strip_prefix = "rules_rust-9426a3820093e75ea07d14f875e42f789632507f",
+    sha256 = "17dbf791f4dab0fd4496ce5345af35e9ce2f6d011c1c8423436da517d019a3ea",
+    strip_prefix = "rules_rust-2f97db595b05b1ee8cc44bde5bdf03c00bd169fb",
     urls = [
-        # Master branch as of 2020-10-23
-        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_rust/archive/9426a3820093e75ea07d14f875e42f789632507f.tar.gz",
-        "https://github.com/bazelbuild/rules_rust/archive/9426a3820093e75ea07d14f875e42f789632507f.tar.gz",
+        # Master branch as of 2020-11-05
+        "http://mirror.tensorflow.org/github.com/bazelbuild/rules_rust/archive/2f97db595b05b1ee8cc44bde5bdf03c00bd169fb.tar.gz",
+        "https://github.com/bazelbuild/rules_rust/archive/2f97db595b05b1ee8cc44bde5bdf03c00bd169fb.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Summary:
Bazel rule repositories (Go, Rust, protobuf, …) are migrating to a new
linker API introduced as a breaking Bazel change:
<https://github.com/bazelbuild/bazel/issues/10860>

This API requires Bazel 3.0.0, which is fine for us.

Test Plan:
Everything builds, all tests pass, and TensorBoard looks okay enough,
including the dynamically loaded projector plugin.

wchargin-branch: bazel-3.0.0
